### PR TITLE
BIM: prevent dialogs being opened twice

### DIFF
--- a/src/Mod/BIM/bimcommands/BimClassification.py
+++ b/src/Mod/BIM/bimcommands/BimClassification.py
@@ -54,6 +54,12 @@ class BIM_Classification:
         return v
 
     def Activated(self):
+
+        # only raise the dialog if it is already open
+        if getattr(self, "form", None):
+            self.form.raise_()
+            return
+
         import Draft
         from PySide import QtCore, QtGui
         from bimcommands import BimMaterial
@@ -156,6 +162,7 @@ class BIM_Classification:
         self.form.buttonRename.clicked.connect(self.rename)
         self.form.search.textEdited.connect(self.updateClasses)
         self.form.buttonBox.accepted.connect(self.accept)
+        self.form.buttonBox.rejected.connect(self.reject)
         self.form.groupMode.currentIndexChanged.connect(self.updateObjects)
         self.form.treeClass.itemDoubleClicked.connect(self.apply)
         self.form.search.up.connect(self.onUpArrow)
@@ -657,6 +664,11 @@ class BIM_Classification:
         p.SetInt("BimClassificationDialogWidth", self.form.width())
         p.SetInt("BimClassificationDialogHeight", self.form.height())
         self.form.hide()
+        return self.reject()
+
+    def reject(self):
+        self.form.hide()
+        del self.form
         return True
 
     def onUpArrow(self):

--- a/src/Mod/BIM/bimcommands/BimIfcElements.py
+++ b/src/Mod/BIM/bimcommands/BimIfcElements.py
@@ -48,6 +48,12 @@ class BIM_IfcElements:
         return v
 
     def Activated(self):
+
+        # only raise the dialog if it is already open
+        if getattr(self, "form", None):
+            self.form.raise_()
+            return
+
         import Draft
         from PySide import QtGui
 
@@ -100,6 +106,7 @@ class BIM_IfcElements:
         else: # Qt version < 6.7.0
             self.form.onlyVisible.stateChanged.connect(self.update)
         self.form.buttonBox.accepted.connect(self.accept)
+        self.form.buttonBox.rejected.connect(self.reject)
         self.form.globalMode.currentIndexChanged.connect(self.onObjectTypeChanged)
         self.form.globalMaterial.currentIndexChanged.connect(self.onMaterialChanged)
 
@@ -544,10 +551,15 @@ class BIM_IfcElements:
                                 )
                                 changed = True
                             obj.Material = mobj
-
         if changed:
             FreeCAD.ActiveDocument.commitTransaction()
             FreeCAD.ActiveDocument.recompute()
+        return self.reject()
+
+    def reject(self):
+        self.form.hide()
+        del self.form
+        return True
 
 
 if FreeCAD.GuiUp:

--- a/src/Mod/BIM/bimcommands/BimIfcProperties.py
+++ b/src/Mod/BIM/bimcommands/BimIfcProperties.py
@@ -55,6 +55,12 @@ class BIM_IfcProperties:
         return v
 
     def Activated(self):
+
+        # only raise the dialog if it is already open
+        if getattr(self, "form", None):
+            self.form.raise_()
+            return
+
         from PySide import QtGui
 
         try:
@@ -148,6 +154,7 @@ class BIM_IfcProperties:
             self.form.onlySelected.stateChanged.connect(self.onSelected)
             self.form.onlyMatches.stateChanged.connect(self.update)
         self.form.buttonBox.accepted.connect(self.accept)
+        self.form.buttonBox.rejected.connect(self.reject)
         self.form.searchField.currentIndexChanged.connect(self.update)
         self.form.searchField.editTextChanged.connect(self.update)
         self.form.comboProperty.currentIndexChanged.connect(self.addProperty)
@@ -427,6 +434,12 @@ class BIM_IfcProperties:
         if changed:
             FreeCAD.ActiveDocument.commitTransaction()
             FreeCAD.ActiveDocument.recompute()
+        return self.reject()
+
+    def reject(self):
+        self.form.hide()
+        del self.form
+        return True
 
     def getNativeIfcProperties(self, obj):
         props = {}

--- a/src/Mod/BIM/bimcommands/BimIfcQuantities.py
+++ b/src/Mod/BIM/bimcommands/BimIfcQuantities.py
@@ -83,6 +83,12 @@ class BIM_IfcQuantities:
         return v
 
     def Activated(self):
+
+        # only raise the dialog if it is already open
+        if getattr(self, "form", None):
+            self.form.raise_()
+            return
+
         from PySide import QtGui
 
         # build objects list
@@ -121,6 +127,7 @@ class BIM_IfcQuantities:
         self.form.quantities.setItemDelegate(QtGui.QStyledItemDelegate())
         self.qmodel.dataChanged.connect(self.setChecked)
         self.form.buttonBox.accepted.connect(self.accept)
+        self.form.buttonBox.rejected.connect(self.reject)
         self.form.quantities.clicked.connect(self.onClickTree)
         if hasattr(self.form.onlyVisible, "checkStateChanged"): # Qt version >= 6.7.0
             self.form.onlyVisible.checkStateChanged.connect(self.update)
@@ -449,6 +456,13 @@ class BIM_IfcQuantities:
         if changed:
             FreeCAD.ActiveDocument.commitTransaction()
             FreeCAD.ActiveDocument.recompute()
+
+        return self.reject()
+
+    def reject(self):
+        self.form.hide()
+        del self.form
+        return True
 
     def setChecked(self, id1, id2):
         sel = self.form.quantities.selectedIndexes()

--- a/src/Mod/BIM/bimcommands/BimLayers.py
+++ b/src/Mod/BIM/bimcommands/BimLayers.py
@@ -66,12 +66,13 @@ class BIM_Layers:
 
     def Activated(self):
 
-        from PySide import QtGui
-
-        # check if the dialog is running)
+        # only raise the dialog if it is already open
         if getattr(self, "dialog", None):
+            self.dialog.raise_()
             return
-
+            
+        from PySide import QtGui
+        
         # store changes to be committed
         self.deleteList = []
 

--- a/src/Mod/BIM/bimcommands/BimMaterial.py
+++ b/src/Mod/BIM/bimcommands/BimMaterial.py
@@ -71,6 +71,11 @@ class BIM_Material:
 
     def Activated(self):
 
+        # only raise the dialog if it is already open
+        if getattr(self, "dlg", None):
+            self.dlg.raise_()
+            return
+
         self.dlg = None
         self.dlg = QtGui.QDialog()
         self.dlg.objects = [
@@ -453,13 +458,13 @@ class BIM_Material:
             p = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
             p.SetInt("BimMaterialDialogWidth", self.dlg.width())
             p.SetInt("BimMaterialDialogHeight", self.dlg.height())
-            from draftutils import todo
-
-            todo.ToDo.delay(self.dlg.hide, None)
+            return self.onReject()
 
     def onReject(self):
-        if self.dlg:
+        if getattr(self, "dlg", None):
             self.dlg.hide()
+            del self.dlg
+        return True
 
     def onUpArrow(self):
         if self.dlg:

--- a/src/Mod/BIM/bimcommands/BimProjectManager.py
+++ b/src/Mod/BIM/bimcommands/BimProjectManager.py
@@ -48,6 +48,11 @@ class BIM_ProjectManager:
 
     def Activated(self):
 
+        # only raise the dialog if it is already open
+        if getattr(self, "form", None):
+            self.form.raise_()
+            return
+
         import FreeCADGui
         import ArchBuildingPart
         from PySide import QtGui
@@ -139,6 +144,7 @@ class BIM_ProjectManager:
     def reject(self):
 
         self.form.hide()
+        del self.form
         return True
 
     def accept(self):
@@ -400,7 +406,7 @@ class BIM_ProjectManager:
         if self.form.radioNative3.isChecked():
             from nativeifc import ifc_status
             ifc_status.set_button(True,True)
-        return True
+        return self.reject()
 
     def addGroup(self):
         from PySide import QtCore, QtGui

--- a/src/Mod/BIM/bimcommands/BimSetup.py
+++ b/src/Mod/BIM/bimcommands/BimSetup.py
@@ -47,6 +47,11 @@ class BIM_Setup:
 
     def Activated(self):
 
+        # only raise the dialog if it is already open
+        if getattr(self, "form", None):
+            self.form.raise_()
+            return
+
         TARGETVERSION = 0.19
         TECHDRAWDIMFACTOR = (
             0.16  # How many times TechDraw dim arrows are smaller than Draft
@@ -169,6 +174,8 @@ class BIM_Setup:
         result = self.form.exec_()
         del FreeCADGui.BIMSetupDialog
         if not result:
+            self.form.hide()
+            del self.form
             return
 
         # set preference values
@@ -387,6 +394,8 @@ class BIM_Setup:
         FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM").SetBool(
             "FirstTime", False
         )
+        self.form.hide()
+        del self.form
 
     def setPreset(self, preset=None):
         from PySide import QtGui


### PR DESCRIPTION
Fixes #20403
Partly fixes issue #17983

I have basically copied Yorik's solution (#22446), but have added a call to `raise_()`.
