### PR TITLE
BIM: TestArch.py remove unused 'tpath' variable

### DIFF
--- a/src/Mod/BIM/bimtests/TestArch.py
+++ b/src/Mod/BIM/bimtests/TestArch.py
@@ -156,7 +156,6 @@ class TestArch(TestArchBase.TestArchBase):
         App.ActiveDocument.recompute()
 
         # Create a TD page
-        tpath = os.path.join(App.getResourceDir(),"Mod","TechDraw","Templates","ISO","A3_Landscape_blank.svg")
         page = App.ActiveDocument.addObject("TechDraw::DrawPage", "Page")
         template = App.ActiveDocument.addObject("TechDraw::DrawSVGTemplate", "Template")
         template.Template = tpath


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/pull/23719#discussion_r2374853534