### PR TITLE
Sketcher: Fix crash on constraint selection

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -353,6 +353,10 @@ bool isCommandNeedingBSplineKnotActive(Gui::Document* doc)
         PointPos posId {PointPos::none};
         getIdsFromName(name, Obj, geoId, posId);
 
+        if (geoId == GeoEnum::GeoUndef) {
+            return false;
+        }
+
         int splineGeoId {GeoEnum::GeoUndef};
         int knotIndexOCC {-1};
 


### PR DESCRIPTION
Fix crash on constraint selection generated by https://github.com/FreeCAD/FreeCAD/pull/24124

@chennes @kadet1090 this needs to get in ASAP as currently freecad crashes on constraint selection.