### PR TITLE
CAM: Profile - Select object in document tree

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -61,7 +61,7 @@ FeatureLinking = 0x0080  # Linking
 FeatureBaseVertexes = 0x0100  # Base
 FeatureBaseEdges = 0x0200  # Base
 FeatureBaseFaces = 0x0400  # Base
-FeatureBasePanels = 0x0800  # Base
+FeatureBaseModels = 0x0800  # Base
 FeatureLocations = 0x1000  # Locations
 FeatureCoolant = 0x2000  # Coolant
 FeatureDiameters = 0x4000  # Turning Diameters
@@ -98,6 +98,7 @@ class ObjectOp(object):
         FeatureBaseVertexes  ... Base geometry support for vertexes
         FeatureBaseEdges     ... Base geometry support for edges
         FeatureBaseFaces     ... Base geometry support for faces
+        FeatureBaseModels    ... Base geometry support for whole shape
         FeatureLocations     ... Base location support
         FeatureCoolant       ... Support for operation coolant
         FeatureDiameters     ... Support for turning operation diameters

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -854,8 +854,8 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
     def supportsFaces(self):
         return self.features & PathOp.FeatureBaseFaces
 
-    def supportsPanels(self):
-        return self.features & PathOp.FeatureBasePanels
+    def supportsModels(self):
+        return self.features & PathOp.FeatureBaseModels
 
     def featureName(self):
         if self.supportsEdges() and self.supportsFaces():
@@ -875,7 +875,7 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
             if not self.supportsFaces() and sel.SubObjects[0].ShapeType == "Face":
                 return False
         else:
-            if not self.supportsPanels() or "Panel" not in sel.Object.Name:
+            if not self.supportsModels() and sel.Object.isDerivedFrom("Part::Feature"):
                 return False
         return True
 
@@ -886,8 +886,12 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
             # check each selection
             if self.selectionSupportedAsBaseGeometry(sel, False):
                 added = True
-                for sub in sel.SubElementNames:
-                    self.obj.Proxy.addBase(self.obj, sel.Object, sub)
+                if sel.SubElementNames:
+                    for sub in sel.SubElementNames:
+                        self.obj.Proxy.addBase(self.obj, sel.Object, sub)
+                else:
+                    self.obj.Proxy.addBase(self.obj, sel.Object, "")
+
         return added
 
     def addBase(self):
@@ -917,6 +921,8 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
             if sub:
                 base = (obj, str(sub))
                 newlist.append(base)
+            else:
+                newlist.append(obj)
         Path.Log.debug("Setting new base: %s -> %s" % (self.obj.Base, newlist))
         self.obj.Base = newlist
 

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -57,7 +57,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
     def areaOpFeatures(self, obj):
         """areaOpFeatures(obj) ... returns operation-specific features"""
-        return PathOp.FeatureBaseFaces | PathOp.FeatureBaseEdges
+        return PathOp.FeatureBaseFaces | PathOp.FeatureBaseEdges | PathOp.FeatureBaseModels
 
     def initAreaOp(self, obj):
         """initAreaOp(obj) ... creates all profile specific properties."""


### PR DESCRIPTION
Allows add models as Base to `Profile` operation without sub selection

Fixes #24189
- #24189

---

### Changes
- Replaced legacy <ins>PathOp.FeatureBase**Panels**</ins> by <ins>PathOp.FeatureBase**Models**</ins>
- Only GUI touched here, because processing models already included in #27236 

---

https://github.com/user-attachments/assets/401f8c89-0222-427c-96e2-2ea6252678fa
