### PR TITLE
Sketcher: Prevent non-edit toolbars from showing up when switching tab

### DIFF
--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -730,4 +730,3 @@ void addSketcherWorkbenchEditTools(Gui::ToolBarItem& edittools)
 }
 
 } /* namespace SketcherGui */
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/9859