### PR TITLE
CAM: LeadInOut - Fix RetractThreshold in Task panel

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -1123,6 +1123,7 @@ class TaskDressupLeadInOut(SimpleEditPanel):
         self.connectWidget("OffsetIn", self.form.dspOffsetIn)
         self.connectWidget("OffsetOut", self.form.dspOffsetOut)
         self.connectWidget("RapidPlunge", self.form.chkRapidPlunge)
+        self.connectWidget("RetractThreshold", self.form.dspRetractThreshold)
         self.setFields()
 
         styleEnum = self.obj.getEnumerationsOfProperty("StyleIn")

--- a/src/Mod/CAM/PathPythonGui/simple_edit_panel.py
+++ b/src/Mod/CAM/PathPythonGui/simple_edit_panel.py
@@ -6,9 +6,10 @@ translate = FreeCAD.Qt.translate
 
 PROP_TYPE_QTYES = ["App::PropertyDistance", "App::PropertyAngle"]
 PROP_TYPE_NUMERIC = PROP_TYPE_QTYES + [
-    "App::PropertyPercent",
+    "App::PropertyFloat",
     "App::PropertyInteger",
-    "App:PropertyFloat",
+    "App::PropertyLength",
+    "App::PropertyPercent",
 ]
 
 


### PR DESCRIPTION
`Retract Threshold` in Task panel do not change property value
Fixed this

Also there is a mistake in `Mod/CAM/PathPythonGui/simple_edit_panel.py`
instead of `App:PropertyFloat` should be `App::PropertyFloat`
missed `:`