### PR TITLE
FEM: Fix small title case typo with "all"

### DIFF
--- a/src/Mod/Fem/femcommands/commands.py
+++ b/src/Mod/Fem/femcommands/commands.py
@@ -156,7 +156,7 @@ class _ClippingPlaneRemoveAll(CommandManager):
     def __init__(self):
         super().__init__()
         self.menutext = Qt.QT_TRANSLATE_NOOP(
-            "FEM_ClippingPlaneRemoveAll", "Remove all Clipping Planes"
+            "FEM_ClippingPlaneRemoveAll", "Remove All Clipping Planes"
         )
         self.tooltip = Qt.QT_TRANSLATE_NOOP(
             "FEM_ClippingPlaneRemoveAll", "Removes all clipping planes"


### PR DESCRIPTION
Fixes a small title case typo/inconsistency - all should be capitalized here despite being a 3-letter word