### PR TITLE
Sketcher: remove edit tools from toolbar

### DIFF
--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -140,11 +140,6 @@ Gui::ToolBarItem* Workbench::setupToolBars() const
     visual->setCommand("Visual Helpers");
     addSketcherWorkbenchVisual(*visual);
 
-    Gui::ToolBarItem* edittools =
-        new Gui::ToolBarItem(root, Gui::ToolBarItem::DefaultVisibility::Unavailable);
-    edittools->setCommand("Sketcher Edit Tools");
-    addSketcherWorkbenchEditTools(*edittools);
-
     return root;
 }
 
@@ -640,17 +635,6 @@ inline void SketcherAddWorkbenchVisual<Gui::ToolBarItem>(Gui::ToolBarItem& visua
            << "Sketcher_SwitchVirtualSpace";
 }
 
-template<typename T>
-inline void SketcherAddWorkbenchEditTools(T& virtualspedittoolsace);
-
-template<>
-inline void SketcherAddWorkbenchEditTools<Gui::ToolBarItem>(Gui::ToolBarItem& edittools)
-{
-    edittools << "Sketcher_Grid"
-              << "Sketcher_Snap"
-              << "Sketcher_RenderingOrder";
-}
-
 void addSketcherWorkbenchSketchActions(Gui::MenuItem& sketch)
 {
     SketcherAddWorkbenchSketchActions(sketch);
@@ -721,9 +705,5 @@ void addSketcherWorkbenchVisual(Gui::ToolBarItem& visual)
     SketcherAddWorkbenchVisual(visual);
 }
 
-void addSketcherWorkbenchEditTools(Gui::ToolBarItem& edittools)
-{
-    SketcherAddWorkbenchEditTools(edittools);
-}
-
 } /* namespace SketcherGui */
+

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -706,4 +706,3 @@ void addSketcherWorkbenchVisual(Gui::ToolBarItem& visual)
 }
 
 } /* namespace SketcherGui */
-

--- a/src/Mod/Sketcher/Gui/Workbench.h
+++ b/src/Mod/Sketcher/Gui/Workbench.h
@@ -73,4 +73,3 @@ SketcherGuiExport void addSketcherWorkbenchVisual(Gui::ToolBarItem& visual);
 }  // namespace SketcherGui
 
 #endif  // SKETCHER_WORKBENCH_H
-

--- a/src/Mod/Sketcher/Gui/Workbench.h
+++ b/src/Mod/Sketcher/Gui/Workbench.h
@@ -69,8 +69,8 @@ SketcherGuiExport void addSketcherWorkbenchConstraints(Gui::ToolBarItem& cons);
 SketcherGuiExport void addSketcherWorkbenchTools(Gui::ToolBarItem& consaccel);
 SketcherGuiExport void addSketcherWorkbenchBSplines(Gui::ToolBarItem& bspline);
 SketcherGuiExport void addSketcherWorkbenchVisual(Gui::ToolBarItem& visual);
-SketcherGuiExport void addSketcherWorkbenchEditTools(Gui::ToolBarItem& edittools);
 
 }  // namespace SketcherGui
 
 #endif  // SKETCHER_WORKBENCH_H
+


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/23931 by removing the edit tool toolbar as per @Roy-043 's preference