### PR TITLE
PartDesign: Use `AllowCompound` user parameter along the workbench - fixes #23596

### DIFF
--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -43,7 +43,7 @@ PROPERTY_SOURCE(PartDesign::Body, Part::BodyBase)
 
 Body::Body()
 {
-    ADD_PROPERTY_TYPE(AllowCompound, (false), "Experimental", App::Prop_None, "Allow multiple solids in Body (experimental)");
+    ADD_PROPERTY_TYPE(AllowCompound, (true), "Experimental", App::Prop_None, "Allow multiple solids in Body (experimental)");
 
     _GroupTouched.setStatus(App::Property::Output, true);
 }

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -460,11 +460,19 @@ void CmdPartDesignClone::activated(int iMsg)
         auto bodyObj = obj->getDocument()->getObject(bodyName.c_str());
         auto cloneObj = obj->getDocument()->getObject(cloneName.c_str());
 
+        Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+            .GetUserParameter()
+            .GetGroup("BaseApp/Preferences/Mod/PartDesign");
+
+        bool allowCompound = hGrp->GetBool("AllowCompoundDefault", true);
+
         // In the first step set the group link and tip of the body
         Gui::cmdAppObject(bodyObj, std::stringstream()
                           << "Group = [" << getObjectCmd(cloneObj) << "]");
         Gui::cmdAppObject(bodyObj, std::stringstream()
                           << "Tip = " << getObjectCmd(cloneObj));
+        Gui::cmdAppObject(bodyObj, std::stringstream()
+                          << "AllowCompound = " << (allowCompound ? "True" : "False"));
 
         // In the second step set the link of the base feature
         Gui::cmdAppObject(cloneObj, std::stringstream()

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -473,8 +473,15 @@ void CmdPartDesignMigrate::activated(int iMsg)
         std::string bodyName = getUniqueObjectName (
                 std::string ( chainIt->back()->getNameInDocument() ).append ( "Body" ).c_str () ) ;
 
+        Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+            .GetUserParameter()
+            .GetGroup("BaseApp/Preferences/Mod/PartDesign");
+
+        bool allowCompound = hGrp->GetBool("AllowCompoundDefault", true);
+
         // Create a body for the chain
         doCommand ( Doc,"App.activeDocument().addObject('PartDesign::Body','%s')", bodyName.c_str () );
+        doCommand ( Doc,"App.ActiveDocument.getObject('%s').AllowCompound = %s", bodyName.c_str(), allowCompound ? "True" : "False");
         doCommand ( Doc,"App.activeDocument().%s.addObject(App.ActiveDocument.%s)",
                 actPart->getNameInDocument (), bodyName.c_str () );
         if (base) {

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -191,11 +191,22 @@ void needActiveBodyError()
 
 PartDesign::Body * makeBody(App::Document *doc)
 {
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+        .GetUserParameter()
+        .GetGroup("BaseApp/Preferences/Mod/PartDesign");
+
+    bool allowCompound = hGrp->GetBool("AllowCompoundDefault", true);
+
     // This is intended as a convenience when starting a new document.
     auto bodyName( doc->getUniqueObjectName("Body") );
     Gui::Command::doCommand( Gui::Command::Doc,
                              "App.getDocument('%s').addObject('PartDesign::Body','%s')",
                              doc->getName(), bodyName.c_str() );
+    Gui::Command::doCommand( Gui::Command::Doc,
+                             "App.getDocument('%s').getObject('%s').AllowCompound = %s",
+                             doc->getName(), bodyName.c_str(), allowCompound ? "True" : "False" );
+
+
     auto body = dynamic_cast<PartDesign::Body*>(doc->getObject(bodyName.c_str()));
     if(body)
         makeBodyActive(body, doc);


### PR DESCRIPTION
As mentioned, if a user parameter exists to control this property, for consistency, it must be used everywhere a `PartDesign::Body` is created.
It is also set to `true` by default in the constructor.
It may be worth considering removing this property; it can cause some headaches if a specific value is assumed: https://github.com/FreeCAD/FreeCAD/pull/22389#issuecomment-3253753837

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #23596
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
