### PR TITLE
CAM: Fix SpindleDirection and Material not updating from toolbit files; reduce log noise

### DIFF
--- a/src/Mod/CAM/Path/Tool/shape/doc.py
+++ b/src/Mod/CAM/Path/Tool/shape/doc.py
@@ -127,7 +127,8 @@ def update_shape_object_properties(
                     f" ({obj.Name}) with value '{value}': {e}"
                 )
         else:
-            Path.Log.warning(
+            # This simply means that the Shape File doesn't have this property in it.
+            Path.Log.debug(
                 f"Property '{name}' not found on object '{obj.Label}' ({obj.Name}). Skipping."
             )
 

--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -711,6 +711,38 @@ class ToolBit(Asset, ABC):
             PathUtil.setProperty(self.obj, name, value)
             self.obj.setEditorMode(name, 0)
 
+        # 3. Ensure SpindleDirection property exists and is set
+        # Maybe this could be done with a global schema or added to each
+        # shape schema?
+        if not hasattr(self.obj, "SpindleDirection"):
+            self.obj.addProperty(
+                "App::PropertyEnumeration",
+                "SpindleDirection",
+                "Attributes",
+                QT_TRANSLATE_NOOP("App::Property", "Direction of spindle rotation"),
+            )
+            self.obj.SpindleDirection = ["Forward", "Reverse", "None"]
+            self.obj.SpindleDirection = "Forward"  # Default value
+
+        spindle_value = self._tool_bit_shape.get_parameters().get("SpindleDirection")
+        if spindle_value in ("Forward", "Reverse", "None"):
+            self.obj.SpindleDirection = spindle_value
+
+        # 4. Ensure Material property exists and is set
+        if not hasattr(self.obj, "Material"):
+            self.obj.addProperty(
+                "App::PropertyEnumeration",
+                "Material",
+                "Attributes",
+                QT_TRANSLATE_NOOP("App::Property", "Tool material"),
+            )
+            self.obj.Material = ["HSS", "Carbide"]
+            self.obj.Material = "HSS"  # Default value
+
+        material_value = self._tool_bit_shape.get_parameters().get("Material")
+        if material_value in ("HSS", "Carbide"):
+            self.obj.Material = material_value
+
     def _update_visual_representation(self):
         """
         Updates the visual representation of the tool bit based on the current


### PR DESCRIPTION
Changing the Spindle Direction or Material in the tool library editor didn't work correctly.  You select the option and save, and option wouldn't stick.  The toolbit file would be updated correctly, but the UI wouldn't reflect the proper value.  This PR fixes this.

Also change the missing property log message from warning to debug.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/22972