### PR TITLE
Sketcher: PointOnSegment and PointOnArcRange constraints

### DIFF
--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -70,6 +70,7 @@ enum ConstraintType : int
     Block = 17,
     Diameter = 18,
     Weight = 19,
+    PointOnSegment = 20,
     NumConstraintTypes  // must be the last item!
 };
 

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -71,6 +71,7 @@ enum ConstraintType : int
     Diameter = 18,
     Weight = 19,
     PointOnSegment = 20,
+    PointOnArcRange = 21,
     NumConstraintTypes  // must be the last item!
 };
 

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -294,6 +294,10 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 constraint->Type = PointOnObject;
                 valid = true;
             }
+            else if (strcmp("PointOnSegment", ConstraintType) == 0) {
+                constraint->Type = PointOnSegment;
+                valid = true;
+            }
             else if (strstr(ConstraintType, "InternalAlignment")) {
                 constraint->Type = InternalAlignment;
 

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -298,6 +298,10 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 constraint->Type = PointOnSegment;
                 valid = true;
             }
+            else if (strcmp("PointOnArcRange", ConstraintType) == 0) {
+                constraint->Type = PointOnArcRange;
+                valid = true;
+            }
             else if (strstr(ConstraintType, "InternalAlignment")) {
                 constraint->Type = InternalAlignment;
 

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -2469,16 +2469,20 @@ int Sketch::addConstraint(const Constraint* constraint)
             );
         } break;
         case PointOnSegment: {
-            rtn = addPointOnSegmentConstraint(constraint->First,
-                                              constraint->FirstPos,
-                                              constraint->Second,
-                                              c.driving);
+            rtn = addPointOnSegmentConstraint(
+                constraint->First,
+                constraint->FirstPos,
+                constraint->Second,
+                c.driving
+            );
         } break;
         case PointOnArcRange: {
-            rtn = addPointOnArcRangeConstraint(constraint->First,
-                                               constraint->FirstPos,
-                                               constraint->Second,
-                                               c.driving);
+            rtn = addPointOnArcRangeConstraint(
+                constraint->First,
+                constraint->FirstPos,
+                constraint->Second,
+                c.driving
+            );
         } break;
         case Sketcher::None:   // ambiguous enum value
         case Sketcher::Block:  // handled separately while adding geometry

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -2468,6 +2468,12 @@ int Sketch::addConstraint(const Constraint* constraint)
                 c.driving
             );
         } break;
+        case PointOnSegment: {
+            rtn = addPointOnSegmentConstraint(constraint->First,
+                                              constraint->FirstPos,
+                                              constraint->Second,
+                                              c.driving);
+        } break;
         case Sketcher::None:   // ambiguous enum value
         case Sketcher::Block:  // handled separately while adding geometry
         case NumConstraintTypes:
@@ -3659,6 +3665,28 @@ int Sketch::addAngleConstraint(int geoId1, PointPos pos1, int geoId2, PointPos p
     return ConstraintsCounter;
 }
 
+// point on segment constraint
+int Sketch::addPointOnSegmentConstraint(int geoId1, PointPos pos1, int geoId2, bool driving)
+{
+    geoId1 = checkGeoId(geoId1);
+    geoId2 = checkGeoId(geoId2);
+
+    if (Geoms[geoId2].type != Line) {
+        return -1;
+    }
+    GCS::Line l = Lines[Geoms[geoId2].index];
+
+    int pointId = getPointId(geoId1, pos1);
+
+    if (pointId >= 0 && pointId < int(Points.size())) {
+        GCS::Point p = Points[pointId];
+
+        int tag = ++ConstraintsCounter;
+        GCSsys.addConstraintPointOnSegment(p, l, tag, driving);
+        return ConstraintsCounter;
+    }
+    return -1;
+}
 
 int Sketch::addEqualConstraint(int geoId1, int geoId2)
 {

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -2474,6 +2474,12 @@ int Sketch::addConstraint(const Constraint* constraint)
                                               constraint->Second,
                                               c.driving);
         } break;
+        case PointOnArcRange: {
+            rtn = addPointOnArcRangeConstraint(constraint->First,
+                                               constraint->FirstPos,
+                                               constraint->Second,
+                                               c.driving);
+        } break;
         case Sketcher::None:   // ambiguous enum value
         case Sketcher::Block:  // handled separately while adding geometry
         case NumConstraintTypes:
@@ -3683,6 +3689,29 @@ int Sketch::addPointOnSegmentConstraint(int geoId1, PointPos pos1, int geoId2, b
 
         int tag = ++ConstraintsCounter;
         GCSsys.addConstraintPointOnSegment(p, l, tag, driving);
+        return ConstraintsCounter;
+    }
+    return -1;
+}
+
+// point on arc range constraint
+int Sketch::addPointOnArcRangeConstraint(int geoId1, PointPos pos1, int geoId2, bool driving)
+{
+    geoId1 = checkGeoId(geoId1);
+    geoId2 = checkGeoId(geoId2);
+
+    if (Geoms[geoId2].type != Arc) {
+        return -1;
+    }
+    GCS::Arc a = Arcs[Geoms[geoId2].index];
+
+    int pointId = getPointId(geoId1, pos1);
+
+    if (pointId >= 0 && pointId < int(Points.size())) {
+        GCS::Point p = Points[pointId];
+
+        int tag = ++ConstraintsCounter;
+        GCSsys.addConstraintPointOnArcRange(p, a, tag, driving);
         return ConstraintsCounter;
     }
     return -1;

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -495,6 +495,10 @@ public:
      *   add a point on a segment line constraint
      */
     int addPointOnSegmentConstraint(int geoId1, PointPos pos1, int geoId2, bool driving = true);
+    /**
+     *   add a point on an arc range constraint
+     */
+    int addPointOnArcRangeConstraint(int geoId1, PointPos pos1, int geoId2, bool driving = true);
     //@}
 
     /// Internal Alignment constraints

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -490,8 +490,11 @@ public:
         int geoIdBnd,
         double* value,
         double* second,
-        bool driving = true
-    );
+        bool driving = true);
+    /**
+     *   add a point on a segment line constraint
+     */
+    int addPointOnSegmentConstraint(int geoId1, PointPos pos1, int geoId2, bool driving = true);
     //@}
 
     /// Internal Alignment constraints

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -490,7 +490,8 @@ public:
         int geoIdBnd,
         double* value,
         double* second,
-        bool driving = true);
+        bool driving = true
+    );
     /**
      *   add a point on a segment line constraint
      */

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -2358,6 +2358,7 @@ double ConstraintAngleViaPoint::error()
         ReconstructGeomPointers();
     }
     double ang = *angle();
+
     DeriVector2 n1 = crv1->CalculateNormal(poa);
     DeriVector2 n2 = crv2->CalculateNormal(poa);
 
@@ -2573,7 +2574,6 @@ double ConstraintAngleViaPointAndParam::grad(double* param)
     if (findParamInPvec(param) == -1) {
         return 0.0;
     }
-
     double deriv = 0.;
 
     if (pvecChangedFlag) {
@@ -3164,6 +3164,75 @@ void ConstraintArcLength::errorgrad(double* err, double* grad, double* param)
             double dEndA = param == arc.endAngle ? 1. : 0.;
             *grad = rad * (dEndA - dStartA) + dRad * (endA - startA);
         }
+    }
+}
+
+// --------------------------------------------------------
+// ConstraintPointOnSegment
+ConstraintPointOnSegment::ConstraintPointOnSegment(Point& p, Line& l)
+    : point(p)
+    , line(l)
+{
+    point.PushOwnParams(pvec);
+    line.PushOwnParams(pvec);
+
+    origpvec = pvec;
+    pvecChangedFlag = true;
+    rescale();
+}
+
+void ConstraintPointOnSegment::ReconstructGeomPointers()
+{
+    int i = 0;
+    point.ReconstructOnNewPvec(pvec, i);
+    line.ReconstructOnNewPvec(pvec, i);
+    pvecChangedFlag = false;
+}
+
+void ConstraintPointOnSegment::errorgrad(double* err, double* grad, double* param)
+{
+    if (pvecChangedFlag) {
+        ReconstructGeomPointers();
+    }
+
+    const DeriVector2 p(point, param);
+    const DeriVector2 l1(line.p1, param);
+    const DeriVector2 l2(line.p2, param);
+
+    const DeriVector2 v_line = l2.subtr(l1);
+    const DeriVector2 v_l1p = p.subtr(l1);
+    const DeriVector2 v_l2p = p.subtr(l2);
+
+    // point to line distance (=h) and its derivative (=dh)
+    // see ConstraintC2LDistance::errorgrad for explanation
+    double darea = 0.0;
+    const double area = v_line.crossProdZ(v_l1p, darea);
+    darea = std::signbit(area) ? -darea : darea;
+
+    double dlength = 0.;
+    const double length = v_line.length(dlength);
+
+    const double h = std::abs(area) / length;
+    const double dh = (darea - h * dlength) / length;
+
+    // if on the line but not on segment, this vector point to the nearest end
+    // if on segment, is null
+    DeriVector2 v_toNearest = v_l1p.getNormalized().sum(v_l2p.getNormalized()).mult(-0.5);
+
+    if (v_toNearest.sum(v_l1p.getNormalized()).length() == 0) {
+        v_toNearest = v_l1p;
+    }
+    else if (v_toNearest.sum(v_l2p.getNormalized()).length() == 0) {
+        v_toNearest = v_l2p;
+    }
+    double dDist;
+    const double dist = v_toNearest.length(dDist);
+
+    if (err) {
+        *err = h + dist;
+    }
+    if (grad) {
+        *grad = dh + dDist;
     }
 }
 

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -85,6 +85,7 @@ enum ConstraintType
     AngleViaPointAndTwoParams = 34,
     AngleViaTwoPoints = 35,
     ArcLength = 36,
+    PointOnSegment = 37,
 };
 
 enum InternalAlignmentType
@@ -209,6 +210,7 @@ public:
     // Returns -1 if not found.
     int findParamInPvec(double* param);
 };
+
 
 // Equal
 class ConstraintEqual: public Constraint
@@ -1355,6 +1357,22 @@ private:
 public:
     ConstraintArcLength(Arc& a, double* d);
     ConstraintType getTypeId() override;
+};
+
+// PointOnSegment
+class ConstraintPointOnSegment: public Constraint
+{
+    Point point;
+    Line line;
+    void ReconstructGeomPointers();  // writes pointers in pvec to the parameters of p and l
+    void errorgrad(double* err, double* grad, double* param) override;
+
+public:
+    ConstraintPointOnSegment(Point& p, Line& l);
+    ConstraintType getTypeId() override
+    {
+        return PointOnSegment;
+    };
 };
 
 }  // namespace GCS

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -86,6 +86,7 @@ enum ConstraintType
     AngleViaTwoPoints = 35,
     ArcLength = 36,
     PointOnSegment = 37,
+    PointOnArcRange = 38,
 };
 
 enum InternalAlignmentType
@@ -193,7 +194,7 @@ public:
     };
     virtual double grad(double* param)
     {
-        if (findParamInPvec(param) == -1) {
+        if (!param || findParamInPvec(param) == -1) {
             return 0.0;
         }
 
@@ -1372,6 +1373,22 @@ public:
     ConstraintType getTypeId() override
     {
         return PointOnSegment;
+    };
+};
+
+// PointOnArcRange
+class ConstraintPointOnArcRange: public Constraint
+{
+    Point point;
+    Arc arc;
+    void ReconstructGeomPointers();  // writes pointers in pvec to the parameters of p and l
+    void errorgrad(double* err, double* grad, double* param) override;
+
+public:
+    ConstraintPointOnArcRange(Point& p, Arc& a);
+    ConstraintType getTypeId() override
+    {
+        return PointOnArcRange;
     };
 };
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -899,6 +899,14 @@ int System::addConstraintPointOnSegment(Point& p, Line& l, int tagId, bool drivi
     return addConstraint(constr);
 }
 
+int System::addConstraintPointOnArcRange(Point& p, Arc& a, int tagId, bool driving)
+{
+    Constraint* constr = new ConstraintPointOnArcRange(p, a);
+    constr->setTag(tagId);
+    constr->setDriving(driving);
+    return addConstraint(constr);
+}
+
 
 // derived constraints
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -891,6 +891,14 @@ int System::addConstraintArcLength(Arc& a, double* distance, int tagId, bool dri
     return addConstraint(constr);
 }
 
+int System::addConstraintPointOnSegment(Point& p, Line& l, int tagId, bool driving)
+{
+    Constraint* constr = new ConstraintPointOnSegment(p, l);
+    constr->setTag(tagId);
+    constr->setDriving(driving);
+    return addConstraint(constr);
+}
+
 
 // derived constraints
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -392,6 +392,7 @@ public:
         int tagId = 0,
         bool driving = true
     );
+    int addConstraintPointOnSegment(Point& p, Line& l, int tagId, bool driving = true);
 
     // derived constraints
     int addConstraintP2PCoincident(Point& p1, Point& p2, int tagId = 0, bool driving = true);

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -393,6 +393,7 @@ public:
         bool driving = true
     );
     int addConstraintPointOnSegment(Point& p, Line& l, int tagId, bool driving = true);
+    int addConstraintPointOnArcRange(Point& p, Arc& a, int tagId, bool driving = true);
 
     // derived constraints
     int addConstraintP2PCoincident(Point& p1, Point& p2, int tagId = 0, bool driving = true);

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -4757,6 +4757,142 @@ void CmdSketcherConstrainPointOnObject::applyConstraint(std::vector<SelIdPair>& 
 
 // ======================================================================================
 
+class CmdSketcherConstrainPointOnSegment: public CmdSketcherConstraint
+{
+public:
+    CmdSketcherConstrainPointOnSegment();
+    ~CmdSketcherConstrainPointOnSegment() override
+    {}
+    const char* className() const override
+    {
+        return "CmdSketcherConstrainPointOnSegment";
+    }
+
+protected:
+    void activated(int iMsg) override;
+    void applyConstraint(std::vector<SelIdPair>& selSeq, int seqIndex) override;
+};
+
+CmdSketcherConstrainPointOnSegment::CmdSketcherConstrainPointOnSegment()
+    : CmdSketcherConstraint("Sketcher_ConstrainPointOnSegment")
+{
+    sAppModule = "Sketcher";
+    sGroup = "Sketcher";
+    sMenuText = QT_TR_NOOP("Point-On-Segment Constraint");
+    sToolTipText = QT_TR_NOOP("Constrains the selected point onto the selected line segment");
+    sWhatsThis = "Sketcher_ConstrainPointOnSegment";
+    sStatusTip = sToolTipText;
+    sPixmap = "Constraint_PointOnSegment";
+    //sAccel = "O";
+    eType = ForEdit;
+
+    allowedSelSequences = {{SelVertex, SelEdge},
+                           {SelRoot, SelEdge},
+                           {SelVertex, SelExternalEdge},
+                           {SelEdge, SelVertexOrRoot},
+                           {SelEdge, SelVertex},
+                           {SelExternalEdge, SelVertex}};
+}
+
+void CmdSketcherConstrainPointOnSegment::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    // get the selection
+    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+
+    // only one sketch with its subelements are allowed to be selected
+    if (selection.size() != 1
+        || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Sketcher");
+        bool constraintMode = hGrp->GetBool("ContinuousConstraintMode", true);
+
+        if (constraintMode) {
+            ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerGenConstraint>(this));
+            getSelection().clearSelection();
+        }
+        else {
+            Gui::TranslatedUserWarning(getActiveGuiDocument(), QObject::tr("Wrong selection"), "");
+        }
+        return;
+    }
+
+    // get the needed lists and objects
+    const std::vector<std::string>& SubNames = selection[0].getSubNames();
+    auto* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
+
+    // count curves and points
+    std::vector<SelIdPair> points;
+    std::vector<SelIdPair> curves;
+    for (std::size_t i = 0; i < SubNames.size(); i++) {
+        SelIdPair id;
+        getIdsFromName(SubNames[i], Obj, id.GeoId, id.PosId);
+        if (isEdge(id.GeoId, id.PosId)) {
+            curves.push_back(id);
+        }
+        if (isVertex(id.GeoId, id.PosId)) {
+            points.push_back(id);
+        }
+    }
+
+    if (points.size() != 1 || curves.empty())  {
+        Gui::TranslatedUserWarning(Obj, QObject::tr("Wrong selection"), "");
+    }
+
+    openCommand(QT_TRANSLATE_NOOP("Command", "Add point on segment constraint"));
+    int cnt = 0;
+    for (std::size_t iPnt = 0; iPnt < points.size(); iPnt++) {
+        for (std::size_t iCrv = 0; iCrv < curves.size(); iCrv++) {
+            if (areBothPointsOrSegmentsFixed(Obj, points[iPnt].GeoId, curves[iCrv].GeoId)) {
+                showNoConstraintBetweenFixedGeometry(Obj);
+                continue;
+            }
+            if (points[iPnt].GeoId == curves[iCrv].GeoId) {
+                continue;// constraining a point of an element onto the element is a bad idea...
+            }
+
+            const Part::Geometry* geom = Obj->getGeometry(curves[iCrv].GeoId);
+
+            if (! geom || ! isLineSegment(*geom)) {
+                Gui::TranslatedUserWarning(
+                    Obj,
+                    QObject::tr("Wrong selection"),
+                    QObject::tr("Select a line segment."));
+                abortCommand();
+
+                continue;
+            }
+
+            cnt++;
+            Gui::cmdAppObjectArgs(
+                Obj,
+                "addConstraint(Sketcher.Constraint('PointOnSegment',%d,%d,%d))",
+                points[iPnt].GeoId,
+                static_cast<int>(points[iPnt].PosId),
+                curves[iCrv].GeoId);
+        }
+    }
+    if (cnt) {
+        commitCommand();
+        getSelection().clearSelection();
+    }
+    else {
+        abortCommand();
+        Gui::TranslatedUserWarning(Obj,
+            QObject::tr("Wrong selection"),
+            QObject::tr("None of the selected points were constrained onto the respective curves, because they are part of the same element, they are both external geometry, or the edge is not eligible."));
+    }
+    return;
+}
+
+void CmdSketcherConstrainPointOnSegment::applyConstraint(std::vector<SelIdPair>& selSeq,
+                                                        int seqIndex)
+{
+    ;
+}
+
+// ======================================================================================
+
 class CmdSketcherConstrainDistance : public CmdSketcherConstraint
 {
 public:

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -4890,6 +4890,141 @@ void CmdSketcherConstrainPointOnSegment::applyConstraint(std::vector<SelIdPair>&
 {
     ;
 }
+// ======================================================================================
+
+class CmdSketcherConstrainPointOnArcRange: public CmdSketcherConstraint
+{
+public:
+    CmdSketcherConstrainPointOnArcRange();
+    ~CmdSketcherConstrainPointOnArcRange() override
+    {}
+    const char* className() const override
+    {
+        return "CmdSketcherConstrainPointOnArcRange";
+    }
+
+protected:
+    void activated(int iMsg) override;
+    void applyConstraint(std::vector<SelIdPair>& selSeq, int seqIndex) override;
+};
+
+CmdSketcherConstrainPointOnArcRange::CmdSketcherConstrainPointOnArcRange()
+    : CmdSketcherConstraint("CmdSketcherConstrainPointOnArcRange")
+{
+    sAppModule = "Sketcher";
+    sGroup = "Sketcher";
+    sMenuText = QT_TR_NOOP("Point-On-ArcRange Constraint");
+    sToolTipText = QT_TR_NOOP("Constrains the selected point onto the selected arc segment");
+    sWhatsThis = "Sketcher_ConstrainPointOnArcRange";
+    sStatusTip = sToolTipText;
+    sPixmap = "Constraint_PointOnArcRange";
+    //sAccel = "O";
+    eType = ForEdit;
+
+    allowedSelSequences = {{SelVertex, SelEdge},
+                           {SelRoot, SelEdge},
+                           {SelVertex, SelExternalEdge},
+                           {SelEdge, SelVertexOrRoot},
+                           {SelEdge, SelVertex},
+                           {SelExternalEdge, SelVertex}};
+}
+
+void CmdSketcherConstrainPointOnArcRange::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    // get the selection
+    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+
+    // only one sketch with its subelements are allowed to be selected
+    if (selection.size() != 1
+        || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
+        ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Sketcher");
+        bool constraintMode = hGrp->GetBool("ContinuousConstraintMode", true);
+
+        if (constraintMode) {
+            ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerGenConstraint>(this));
+            getSelection().clearSelection();
+        }
+        else {
+            Gui::TranslatedUserWarning(getActiveGuiDocument(), QObject::tr("Wrong selection"), "");
+        }
+        return;
+    }
+
+    // get the needed lists and objects
+    const std::vector<std::string>& SubNames = selection[0].getSubNames();
+    auto* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
+
+    // count curves and points
+    std::vector<SelIdPair> points;
+    std::vector<SelIdPair> curves;
+    for (std::size_t i = 0; i < SubNames.size(); i++) {
+        SelIdPair id;
+        getIdsFromName(SubNames[i], Obj, id.GeoId, id.PosId);
+        if (isEdge(id.GeoId, id.PosId)) {
+            curves.push_back(id);
+        }
+        if (isVertex(id.GeoId, id.PosId)) {
+            points.push_back(id);
+        }
+    }
+
+    if (points.size() != 1 || curves.empty())  {
+        Gui::TranslatedUserWarning(Obj, QObject::tr("Wrong selection"), "");
+    }
+
+    openCommand(QT_TRANSLATE_NOOP("Command", "Add point on arc range constraint"));
+    int cnt = 0;
+    for (std::size_t iPnt = 0; iPnt < points.size(); iPnt++) {
+        for (std::size_t iCrv = 0; iCrv < curves.size(); iCrv++) {
+            if (areBothPointsOrSegmentsFixed(Obj, points[iPnt].GeoId, curves[iCrv].GeoId)) {
+                showNoConstraintBetweenFixedGeometry(Obj);
+                continue;
+            }
+            if (points[iPnt].GeoId == curves[iCrv].GeoId) {
+                continue;// constraining a point of an element onto the element is a bad idea...
+            }
+
+            const Part::Geometry* geom = Obj->getGeometry(curves[iCrv].GeoId);
+
+            if (! geom || ! isArcOfCircle(*geom)) {
+                Gui::TranslatedUserWarning(
+                    Obj,
+                    QObject::tr("Wrong selection"),
+                    QObject::tr("Select a line segment."));
+                abortCommand();
+
+                continue;
+            }
+
+            cnt++;
+            Gui::cmdAppObjectArgs(
+                Obj,
+                "addConstraint(Sketcher.Constraint('PointOnArcRange',%d,%d,%d))",
+                points[iPnt].GeoId,
+                static_cast<int>(points[iPnt].PosId),
+                curves[iCrv].GeoId);
+        }
+    }
+    if (cnt) {
+        commitCommand();
+        getSelection().clearSelection();
+    }
+    else {
+        abortCommand();
+        Gui::TranslatedUserWarning(Obj,
+            QObject::tr("Wrong selection"),
+            QObject::tr("None of the selected points were constrained onto the respective curves, because they are part of the same element, they are both external geometry, or the edge is not eligible."));
+    }
+    return;
+}
+
+void CmdSketcherConstrainPointOnArcRange::applyConstraint(std::vector<SelIdPair>& selSeq,
+                                                        int seqIndex)
+{
+    ;
+}
 
 // ======================================================================================
 

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -376,6 +376,7 @@ public:
             case Sketcher::Coincident:
             case Sketcher::Block:
             case Sketcher::PointOnObject:
+            case Sketcher::PointOnSegment:
             case Sketcher::Parallel:
             case Sketcher::Perpendicular:
             case Sketcher::Tangent:

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -377,6 +377,7 @@ public:
             case Sketcher::Block:
             case Sketcher::PointOnObject:
             case Sketcher::PointOnSegment:
+            case Sketcher::PointOnArcRange:
             case Sketcher::Parallel:
             case Sketcher::Perpendicular:
             case Sketcher::Tangent:


### PR DESCRIPTION
This PR introduce the PointOnSegment and PointOnArcRange constraints, they act as the PointOnObject but only for a line or an arc and restricts the point position between the object ends.
On the screenshot below the reference distance will never exceed 57mm.
<img width="986" height="376" alt="image" src="https://github.com/user-attachments/assets/fcdedb1b-a6f2-4732-81bd-eca018cdcfe1" />

Please note the GUI part is not done but you can still create PointOnDistance and PointOnArcRange constraint throw python.

Help is required for GUI integration (@PaddleStroke ?), including icon drawing.

This PR is based on #24334 