### PR TITLE
Gui: Fix clarify selection menu HiDPI positioning issues

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -3998,8 +3998,10 @@ void StdCmdClarifySelection::activated(int iMsg)
     } else {
         QPoint pos = QCursor::pos();
         QPoint local = widget->mapFromGlobal(pos);
-        point = SbVec2s(static_cast<short>(local.x()),
-                        static_cast<short>(widget->height() - local.y() - 1));
+
+        qreal devicePixelRatio = widget->devicePixelRatioF();
+        point = SbVec2s(static_cast<short>(local.x() * devicePixelRatio),
+                        static_cast<short>((widget->height() - local.y() - 1) * devicePixelRatio));
     }
     
     // Use ray picking to get all objects under cursor
@@ -4071,7 +4073,11 @@ void StdCmdClarifySelection::activated(int iMsg)
     
     QPoint globalPos;
     if (storedPosition.has_value()) {
-        globalPos = widget->mapToGlobal(QPoint(point[0], widget->height() - point[1] - 1));
+        qreal devicePixelRatio = widget->devicePixelRatioF();
+        int logicalHeight = static_cast<int>(widget->height());
+        QPoint localPos(static_cast<int>(point[0] / devicePixelRatio), 
+	                    logicalHeight - static_cast<int>(point[1] / devicePixelRatio) - 1);
+        globalPos = widget->mapToGlobal(localPos);
     } else {
         globalPos = QCursor::pos();
     }


### PR DESCRIPTION
On HiDPI screens, the Clarify Selection context menu appears far to the right of the intended position when triggered via right-click, which was making it really problematic to select entities.

So the easiest solution is to apply `devicePixeLRatio` scaling when converting the stored right-click postiion from device pixels to Qt logical coordinates before calling `mapToGlobal()`.


Before:

https://github.com/user-attachments/assets/f8a36898-1f31-4c56-ad9b-a89dc5bbe233

After:

https://github.com/user-attachments/assets/1d947bcc-cf8b-4318-a7ae-17a57656c4b3


@depthoffocus @maxwxyz please, if you can - test it

Resolves: https://github.com/FreeCAD/FreeCAD/issues/24154