### PR TITLE
Gui: Do not accept changes when pressing ESC key in 3D view

### DIFF
--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -23,6 +23,7 @@
 
 
 # include <QApplication>
+# include <QKeyEvent>
 # include <QTimer>
 # include <Inventor/SoPickedPoint.h>
 # include <Inventor/actions/SoGetBoundingBoxAction.h>
@@ -48,6 +49,7 @@
 #include "Application.h"
 #include "BitmapFactory.h"
 #include "Document.h"
+#include "DockWindowManager.h"
 #include "SoFCDB.h"
 #include "View3DInventor.h"
 #include "View3DInventorViewer.h"
@@ -232,6 +234,12 @@ void ViewProvider::eventCallback(void * ud, SoEventCallback * node)
                             if (viewer->isSelecting()) {
                                 return;
                             }
+                        }
+
+                        DockWindowManager* pDockMgr = DockWindowManager::instance();
+                        if (QWidget* widget = pDockMgr->getDockWindow("Tasks")) {
+                            QKeyEvent ev(QEvent::KeyPress, Qt::Key_Escape, Qt::NoModifier);
+                            qApp->sendEvent(widget, &ev);
                         }
 
                         auto func = new Gui::TimerFunction();


### PR DESCRIPTION
Code cherry picked from @wwmayer's fork
https://codeberg.org/wwmayer/FreeCAD11/commit/3465ccdb9c50f2efe4b498c86e8c9b9bed27e124

This PR introduces new behaviour, such that when the `Esc` key is pressed after interacting with the 3D view, the pending changes are now correctly reverted, instead of accepted. The `Esc` key still closes the task panel.

## Issues
Fixes https://github.com/FreeCAD/FreeCAD/issues/23504