### PR TITLE
BIM: Update sketch command name to be consistent with other workbenches

### DIFF
--- a/src/Mod/BIM/bimcommands/BimSketch.py
+++ b/src/Mod/BIM/bimcommands/BimSketch.py
@@ -31,11 +31,10 @@ QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 
 
 class BIM_Sketch:
-
     def GetResources(self):
         return {
             "Pixmap": "Sketch",
-            "MenuText": QT_TRANSLATE_NOOP("BIM_Sketch", "Sketch"),
+            "MenuText": QT_TRANSLATE_NOOP("BIM_Sketch", "New Sketch"),
             "ToolTip": QT_TRANSLATE_NOOP(
                 "BIM_Sketch", "Creates a new sketch in the current working plane"
             ),
@@ -49,6 +48,7 @@ class BIM_Sketch:
     def Activated(self):
         import WorkingPlane
         from draftutils import params
+
         issnap = False
         if hasattr(FreeCAD, "DraftWorkingPlane"):
             FreeCAD.DraftWorkingPlane.setup()


### PR DESCRIPTION
Since recent UI string overhaul, the word "New" has become standardised, meaning the creation of some "meta" object. 

This PR makes BIM use the same command name has other workbenches for consistency.

`Sketch` -> `New Sketch`

## BIM WB

<img width="1126" height="633" alt="bim" src="https://github.com/user-attachments/assets/8c85762a-90dc-4f19-aa6d-588db49483c7" />

## Part Design WB

<img width="1025" height="576" alt="pd" src="https://github.com/user-attachments/assets/2be19801-ccb0-4510-bc37-2a93db63dbfa" />

## Sketcher WB

<img width="1047" height="589" alt="s" src="https://github.com/user-attachments/assets/a6ce2193-8ce9-47c6-9588-da1d10ca4b25" />

