### PR TITLE
PartDesign: Fix warnings

### DIFF
--- a/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
+++ b/src/Mod/PartDesign/App/FeatureLinearPattern.cpp
@@ -464,13 +464,13 @@ void LinearPattern::updateSpacings(LinearPatternDirection dir)
     if (spacings.size() == targetCount) {
         return;
     }
-    else if (spacings.size() < targetCount) {
+    if (spacings.size() < targetCount) {
         spacings.reserve(targetCount);
         while (spacings.size() < targetCount) {
             spacings.push_back(-1.0);
         }
     }
-    else if ((int)spacings.size() > targetCount) {
+    else {
         spacings.resize(targetCount);
     }
 

--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -320,13 +320,13 @@ void PolarPattern::updateSpacings()
     if (spacings.size() == targetCount) {
         return;
     }
-    else if (spacings.size() < targetCount) {
+    if (spacings.size() < targetCount) {
         spacings.reserve(targetCount);
         while (spacings.size() < targetCount) {
             spacings.push_back(-1.0);
         }
     }
-    else if ((int)spacings.size() > targetCount) {
+    else {
         spacings.resize(targetCount);
     }
 


### PR DESCRIPTION
Fix GCC warnings:
```
src/Mod/PartDesign/App/FeatureLinearPattern.cpp: In member function ‘void PartDesign::LinearPattern::updateSpacings(PartDesign::LinearPatternDirection)’:
src/Mod/PartDesign/App/FeatureLinearPattern.cpp:477:35: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  477 |     else if ((int)spacings.size() > targetCount) {
      |              ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
src/Mod/PartDesign/App/FeaturePolarPattern.cpp: In member function ‘void PartDesign::PolarPattern::updateSpacings()’:
src/Mod/PartDesign/App/FeaturePolarPattern.cpp:329:35: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  329 |     else if ((int)spacings.size() > targetCount) {
      |              ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```
@PaddleStroke, FYI