### PR TITLE
Gui: Fix unreadable button in Customize Dialog

### DIFF
--- a/src/Gui/Dialogs/DlgActions.ui
+++ b/src/Gui/Dialogs/DlgActions.ui
@@ -115,7 +115,7 @@
             <item row="6" column="0">
              <widget class="QLabel" name="TextLabel5_2">
               <property name="text">
-               <string>Pixmap</string>
+               <string>Icon</string>
               </property>
              </widget>
             </item>
@@ -141,8 +141,11 @@
                   <height>30</height>
                  </size>
                 </property>
+                <property name="toolTip">
+                 <string>Choose an icon</string>
+                </property>
                 <property name="text">
-                 <string>Choose Icon</string>
+                 <string>…</string>
                 </property>
                </widget>
               </item>

--- a/src/Gui/Dialogs/DlgActions.ui
+++ b/src/Gui/Dialogs/DlgActions.ui
@@ -145,7 +145,7 @@
                  <string>Choose an icon</string>
                 </property>
                 <property name="text">
-                 <string>…</string>
+                 <string notr="true">…</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Use folder icon as suggested in #24260. If the icon is not found, the fallback text now is "Choose ..." with the
button correctly sized.

Also renamed Pixmap to Icon

## Issues
Fixes: https://github.com/FreeCAD/FreeCAD/issues/24260

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

### Before

<img width="778" height="438" alt="image" src="https://github.com/user-attachments/assets/72cf41be-92ba-4bf9-b3bd-95a4721fbd15" />

### After 
<img width="770" height="450" alt="image" src="https://github.com/user-attachments/assets/df02ca70-38e2-45b1-a8f2-986eeb3ab0f6" />

#### Fallback text

<img width="770" height="450" alt="image" src="https://github.com/user-attachments/assets/70f09993-005f-49a9-a4eb-2920d879a761" />
