### PR TITLE
Core: 'Stop-macro-recording' menu text to Title Case

### DIFF
--- a/src/Gui/CommandMacro.cpp
+++ b/src/Gui/CommandMacro.cpp
@@ -63,7 +63,7 @@ void StdCmdDlgMacroRecord::activated(int iMsg)
         Gui::Dialog::DlgMacroRecordImp cDlg(getMainWindow());
         if (cDlg.exec() && getAction()) {
             getAction()->setIcon(Gui::BitmapFactory().iconFromTheme("media-playback-stop"));
-            getAction()->setText(QCoreApplication::translate("StdCmdDlgMacroRecord", "S&top macro recording"));
+            getAction()->setText(QCoreApplication::translate("StdCmdDlgMacroRecord", "S&top Macro Recording"));
             getAction()->setToolTip(QCoreApplication::translate("StdCmdDlgMacroRecord", "Stop the macro recording session"));
         }
     }


### PR DESCRIPTION
The modified text appears in the menu during a recording session.