### PR TITLE
Assembly: Fix errors on solve when limits

### DIFF
--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -163,7 +163,7 @@ int AssemblyObject::solve(bool enableRedo, bool updateJCS)
     }
 
     try {
-        mbdAssembly->runKINEMATIC();
+        mbdAssembly->runPreDrag();
     }
     catch (const std::exception& e) {
         FC_ERR("Solve failed: " << e.what());
@@ -286,8 +286,6 @@ void AssemblyObject::preDrag(std::vector<App::DocumentObject*> dragParts)
 
         draggedParts.push_back(part);
     }
-
-    mbdAssembly->runPreDrag();
 }
 
 void AssemblyObject::doDragStep()


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/23901

Following @aiksiongkoh recommandations, to just assemble we should use the `runPreDrag` function. And it is actually redundant in our `AssemblyObject::preDrag` function

Tested and confirm it fixes the issue. The assembly solves without the warning.