### PR TITLE
CAM: LeadInOut - Fix ZeroDivisionError for LineZ

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -194,8 +194,9 @@ class ObjectDressup:
         if obj.PercentageRadiusOut < 1:
             obj.PercentageRadiusOut = 1
 
-        limit_angle_in = 1 if "Arc" in obj.StyleIn or "Helix" == obj.StyleIn else 0
-        limit_angle_out = 1 if "Arc" in obj.StyleOut or "Helix" == obj.StyleOut else 0
+        nonZeroAngleStyles = ("Arc", "Arc3d", "ArcZ", "Helix", "LineZ")
+        limit_angle_in = 1 if obj.StyleIn in nonZeroAngleStyles else 0
+        limit_angle_out = 1 if obj.StyleOut in nonZeroAngleStyles else 0
         if obj.AngleIn > 180:
             obj.AngleIn = 180
         if obj.AngleIn < limit_angle_in:


### PR DESCRIPTION
Fix `ZeroDivisionError` described in #24318