### PR TITLE
PartDesign: Alphabetize order of Pad parameter types in dialog

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePad.cpp
+++ b/src/Mod/PartDesign/App/FeaturePad.cpp
@@ -40,7 +40,7 @@ using namespace PartDesign;
 // because the files store the enum index. So it is not possible to migrate files if the 
 // enum entry is removed (see #23612). In the distant future, when all files are reasonably
 // migrated we can drop this.
-const char* Pad::TypeEnums[]= {"Length", "UpToLast", "UpToFirst", "UpToFace", "?TwoLengths", "UpToShape", nullptr};
+const char* Pad::TypeEnums[]= {"Length", "UpToFirst", "UpToLast", "UpToFace", "?TwoLengths", "UpToShape", nullptr};
 
 PROPERTY_SOURCE(PartDesign::Pad, PartDesign::FeatureExtrude)
 

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -104,11 +104,11 @@ void TaskPadParameters::onModeChanged(int index, Side side)
                 }
             }
             break;
-        case Mode::ToLast:
-            sideCtrl.Type->setValue("UpToLast");
-            break;
         case Mode::ToFirst:
             sideCtrl.Type->setValue("UpToFirst");
+            break;
+        case Mode::ToLast:
+            sideCtrl.Type->setValue("UpToLast");
             break;
         case Mode::ToFace:
             sideCtrl.Type->setValue("UpToFace");
@@ -146,3 +146,4 @@ TaskDlgPadParameters::TaskDlgPadParameters(ViewProviderPad *PadView, bool /*newO
 //==== calls from the TaskView ===============================================================
 
 #include "moc_TaskPadParameters.cpp"
+

--- a/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPadParameters.cpp
@@ -69,8 +69,8 @@ void TaskPadParameters::translateModeList(QComboBox* box, int index)
 {
     box->clear();
     box->addItem(tr("Dimension"));
-    box->addItem(tr("To last"));
     box->addItem(tr("To first"));
+    box->addItem(tr("To last"));
     box->addItem(tr("Up to face"));
     box->addItem(tr("Up to shape"));
     box->setCurrentIndex(index);


### PR DESCRIPTION
Fixes #24315

Note: this has not been tested.