### PR TITLE
Sketcher: rename DeriVector2::crossProdNorm to DeriVector2::crossProdZ

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -2968,7 +2968,7 @@ void ConstraintC2LDistance::errorgrad(double* err, double* grad, double* param)
 
     // center to line distance (=h) and its derivative (=dh)
     double darea = 0.0;
-    double area = v_line.crossProdNorm(v_p1ct, darea);  // parallelogram oriented area
+    double area = v_line.crossProdZ(v_p1ct, darea);  // parallelogram oriented area
 
     double dlength;
     double length = v_line.length(dlength);

--- a/src/Mod/Sketcher/App/planegcs/Geo.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Geo.cpp
@@ -109,7 +109,7 @@ DeriVector2 DeriVector2::divD(double val, double dval) const
     return {x / val, y / val, dx / val - x * dval / (val * val), dy / val - y * dval / (val * val)};
 }
 
-double DeriVector2::crossProdNorm(const DeriVector2& v2, double& dprd) const
+double DeriVector2::crossProdZ(const DeriVector2& v2, double& dprd) const
 {
     dprd = dx * v2.y + x * v2.dy - dy * v2.x - y * v2.dx;
     return x * v2.y - y * v2.x;

--- a/src/Mod/Sketcher/App/planegcs/Geo.h
+++ b/src/Mod/Sketcher/App/planegcs/Geo.h
@@ -107,10 +107,10 @@ public:
     // of the result is written into argument dprd.
     double scalarProd(const DeriVector2& v2, double* dprd = nullptr) const;
 
-    // calculates the norm of the cross product of the two vectors.
+    // calculates the z coordinate of the cross product of the two vectors.
     // DeriVector2 are considered as 3d vectors with null z. The derivative
     // of the result is written into argument dprd.
-    double crossProdNorm(const DeriVector2& v2, double& dprd) const;
+    double crossProdZ(const DeriVector2& v2, double& dprd) const;
 
     // adds two vectors and returns result
     DeriVector2 sum(const DeriVector2& v2) const

--- a/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/tests/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -174,7 +174,7 @@ TEST_F(ConstraintsTest, tangentBSplineAndArc)  // NOLINT
     double dprd;
     // FIXME: This error is probably too high. Fixing this may require improving the solver,
     // however.
-    EXPECT_NEAR(std::fabs(centerToPoint.crossProdNorm(tangentBSplineAtPoint, dprd))
+    EXPECT_NEAR(std::fabs(centerToPoint.crossProdZ(tangentBSplineAtPoint, dprd))
                     / (centerToPoint.length() * tangentBSplineAtPoint.length()),
                 1.0,
                 0.005);


### PR DESCRIPTION
Fix #24332