### PR TITLE
PartDesign: iso10642-fine.json wrong M5 diameter

### DIFF
--- a/src/Mod/PartDesign/Resources/Hole/iso10642-fine.json
+++ b/src/Mod/PartDesign/Resources/Hole/iso10642-fine.json
@@ -9,7 +9,7 @@
     { "thread": "M2.5x0.35", "diameter":  5.6 },
     { "thread": "M3x0.35",   "diameter":  6.7 },
     { "thread": "M4x0.5",    "diameter":  9.0 },
-    { "thread": "M5x0.5",    "diameter": 12.2 },
+    { "thread": "M5x0.5",    "diameter": 11.2 },
     { "thread": "M6x0.75",   "diameter": 13.5 },
     { "thread": "M8x0.75",   "diameter": 18.0 },
     { "thread": "M8x1.0",    "diameter": 18.0 },


### PR DESCRIPTION
Reported on the forum:
https://forum.freecad.org/viewtopic.php?t=96250

Compare iso10642.json:
https://github.com/FreeCAD/FreeCAD/blob/efbe579e25b993a9a26ef45491387a19b14d1f59/src/Mod/PartDesign/Resources/Hole/iso10642.json#L8-L13