### PR TITLE
[PartDesign] Fix symmetrical Pad following symmetrical Pad

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -5875,8 +5875,6 @@ TopoShape& TopoShape::makeElementBoolean(const char* maker,
     mk->SetTools(shapeTools);
     if (tolerance > 0.0) {
         mk->SetFuzzyValue(tolerance);
-    } else if (tolerance < 0.0) {
-        FCBRepAlgoAPIHelper::setAutoFuzzy(mk.get());
     }
 #if OCC_VERSION_HEX >= 0x070600
     mk->Build(OCCTProgressIndicator::getAppIndicator().Start());

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -5779,6 +5779,7 @@ TopoShape& TopoShape::makeElementBoolean(const char* maker,
     bool buildShell = true;
 
     std::vector<TopoShape> _shapes;
+    bool isFuseCompound = false;
     if (strcmp(maker, Part::OpCodes::Fuse) == 0) {
         for (auto it = shapes.begin(); it != shapes.end(); ++it) {
             auto& s = *it;
@@ -5789,6 +5790,7 @@ TopoShape& TopoShape::makeElementBoolean(const char* maker,
                 FC_THROWM(NullShapeException, "Null input shape");
             }
             if (s.shapeType() == TopAbs_COMPOUND) {
+                isFuseCompound = true;
                 if (_shapes.empty()) {
                     _shapes.insert(_shapes.end(), shapes.begin(), it);
                 }
@@ -5875,6 +5877,9 @@ TopoShape& TopoShape::makeElementBoolean(const char* maker,
     mk->SetTools(shapeTools);
     if (tolerance > 0.0) {
         mk->SetFuzzyValue(tolerance);
+    }
+    if (tolerance < 0.0 && !isFuseCompound) {
+        FCBRepAlgoAPIHelper::setAutoFuzzy(mk.get());
     }
 #if OCC_VERSION_HEX >= 0x070600
     mk->Build(OCCTProgressIndicator::getAppIndicator().Start());


### PR DESCRIPTION
See forum report https://forum.freecad.org/viewtopic.php?t=100093

The only complex Part Design model I have to regression test is a cylinder head which passed error free.

@AIRCAP @CalligaroV @FlachyJoe if you're aware of specific reasons for this particular code that was added as part of PR https://github.com/FreeCAD/FreeCAD/pull/17119 please advise how it should be handled as it was never needed when `tolerance` was `-1.0` in versions prior to Release 1.0.0