### PR TITLE
[bindings] Added generic twin pointer accessor

### DIFF
--- a/src/Tools/bindings/templates/templateClassPyExport.py
+++ b/src/Tools/bindings/templates/templateClassPyExport.py
@@ -334,6 +334,7 @@ public:
 
     /// getter for the object handled by this class
     @self.export.TwinPointer@ *get@self.export.Twin@Ptr() const;
+    @self.export.TwinPointer@ *getTwinPtr() const;
 
 + if(self.export.ClassDeclarations != ""):
     /** @name additional declarations and methods for the wrapper class */
@@ -889,6 +890,11 @@ int @self.export.Name@::_setattr(const char *attr, PyObject *value) // __setattr
 @self.export.TwinPointer@ *@self.export.Name@::get@self.export.Twin@Ptr() const
 {
     return static_cast<@self.export.TwinPointer@ *>(_pcTwinPointer);
+}
+
+@self.export.TwinPointer@ *@self.export.Name@::getTwinPtr() const
+{
+    return get@self.export.Twin@Ptr();
 }
 
 #if defined(__clang__)


### PR DESCRIPTION
## Enhancement

Provides access to twin pointer with a common interface `getTwinPtr()` in addition to the existing heterogeneous accessors `getDocumentPtr(), getPlacementPtr(), getXxxPtr()`

## Why

- This enables c++ templates to use generic access when required allowing better APIs.
- Prepares for the upcoming changes intending to make the Python bindings code more type safe and easy to maintain.

## Breaking changes

- **None**. This PR just adds a common accessor to the twin pointer (underlying Object) . Existing code or behavior is untouched.