### PR TITLE
Part/PD: Send user edit mode to cmdSetEdit

### DIFF
--- a/src/Mod/Part/Gui/ViewProvider.cpp
+++ b/src/Mod/Part/Gui/ViewProvider.cpp
@@ -50,7 +50,7 @@ bool ViewProviderPart::doubleClicked()
     try {
         QString text = QObject::tr("Edit %1").arg(QString::fromUtf8(getObject()->Label.getValue()));
         Gui::Command::openCommand(text.toUtf8());
-        Gui::cmdSetEdit(pcObject);
+        Gui::cmdSetEdit(pcObject, Gui::Application::Instance->getUserEditMode());
         return true;
     }
     catch (const Base::Exception& e) {

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -90,7 +90,7 @@ bool ViewProvider::doubleClicked()
     try {
         QString text = QObject::tr("Edit %1").arg(QString::fromUtf8(getObject()->Label.getValue()));
         Gui::Command::openCommand(text.toUtf8());
-        Gui::cmdSetEdit(pcObject);
+        Gui::cmdSetEdit(pcObject, Gui::Application::Instance->getUserEditMode());
     }
     catch (const Base::Exception&) {
         Gui::Command::abortCommand();

--- a/src/Mod/PartDesign/Gui/ViewProviderBase.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBase.cpp
@@ -53,7 +53,7 @@ bool ViewProviderBase::doubleClicked()
             std::string Msg("Edit ");
             Msg += base->Label.getValue();
             Gui::Command::openCommand(Msg.c_str());
-            Gui::cmdSetEdit(base);
+            Gui::cmdSetEdit(base, Gui::Application::Instance->getUserEditMode());
         }
         catch (const Base::Exception&) {
             Gui::Command::abortCommand();


### PR DESCRIPTION
Somewhere in or around the switch from `FCMD_SET_EDIT` to `Gui::cmdSetEdit`, the setting of the current user edit mode was lost. This restores it (leaving any discussion about whether we *want* `userEditMode` for another time). Fixes #23777.