### PR TITLE
Repr fix

### DIFF
--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -116,7 +116,7 @@ PyObject* DocumentPy::removeProperty(PyObject* args)
 std::string DocumentPy::representation() const
 {
     std::stringstream str;
-    str << "<Document object at " << getDocumentPtr() << ">";
+    str << "<Document '" << getDocumentPtr()->getName() << "' (" << getDocumentPtr()->Label.getValue() << ") >";
 
     return str.str();
 }

--- a/src/Gui/DocumentPyImp.cpp
+++ b/src/Gui/DocumentPyImp.cpp
@@ -49,7 +49,7 @@ using namespace Gui;
 std::string DocumentPy::representation() const
 {
     std::stringstream str;
-    str << "<GUI Document object at " << getDocumentPtr() << ">";
+    str << "<GUI Document object for " << getDocumentPtr()->getDocument()->getName() << ">";
 
     return str.str();
 }

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -364,7 +364,9 @@ TaskDialogPy::~TaskDialogPy() = default;
 
 Py::Object TaskDialogPy::repr()
 {
-    return Py::String("Task Dialog");
+    std::stringstream str;
+    str << "<Task Dialog for '" << dialog->getDocumentName() << "' >";
+    return Py::String( str.str() );
 }
 
 Py::Object TaskDialogPy::getattr(const char * attr)


### PR DESCRIPTION

Make the repr for Document indicate the Name and Label of the Document
Make the repr for the Gui Document show the associated Document Name
repr for a task dialog shows the associated Document name. Also formatted consistent with Python as in:
<Task Dialog for 'Test3' >

fixes #17059 
