### PR TITLE
[TD]fix zero value on multi-face dimension

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -2231,6 +2231,11 @@ void execDim(Gui::Command* cmd, std::string type, StringVector acceptableGeometr
             return;
         }
     }
+    if (geometryRefs2d == DimensionGeometry::isFace &&
+        references2d.size() > 1) {
+        Base::Console().warning("Multiple faces are selected. Using first.\n");
+        references2d.resize(1);
+    }
 
     //build the dimension
     DrawViewDimension* dim = dimensionMaker(partFeat, type, references2d, references3d);


### PR DESCRIPTION
This PR implements a fix for an issue raised in the discussion of PR 
https://github.com/FreeCAD/FreeCAD/pull/24245#issuecomment-3355361095.

If the area dimension tool was invoked directly with multiple faces selected, the value of the dimension was being returned as 0.