### PR TITLE
Make Subclasses of Part::Feature objects repr as their derived Type

### DIFF
--- a/src/Mod/Part/App/PartFeaturePyImp.cpp
+++ b/src/Mod/Part/App/PartFeaturePyImp.cpp
@@ -37,7 +37,7 @@ using namespace Part;
 // returns a string which represent the object e.g. when printed in python
 std::string PartFeaturePy::representation() const
 {
-    return fmt::format( "<{}>", static_cast<std::string>(getTypeId()) );
+    return fmt::format("<{}>", static_cast<std::string>(getTypeId()));
 }
 
 PyObject* PartFeaturePy::getElementHistory(PyObject* args, PyObject* kwds) const


### PR DESCRIPTION
Currently, all subclasses of PartFeature are represented as <Part::Feature>. This exposes the subclass, such as:
<Part::Sphere>, <Part::FeaturePython>, etc.