### PR TITLE
TechDraw: fix for #18165 (axonometric dimensions too far away)

### DIFF
--- a/src/Mod/TechDraw/TechDrawTools/CommandAxoLengthDimension.py
+++ b/src/Mod/TechDraw/TechDrawTools/CommandAxoLengthDimension.py
@@ -89,8 +89,8 @@ class CommandAxoLengthDimension:
             distanceDim.AngleOverride = True
             distanceDim.LineAngle = lineAngle
             distanceDim.ExtensionAngle = extAngle
-            distanceDim.X = (vertexes[0].Point.x+vertexes[1].Point.x)/2
-            distanceDim.Y = (vertexes[0].Point.y+vertexes[1].Point.y)/2
+            distanceDim.X = scale*(vertexes[0].Point.x+vertexes[1].Point.x)/2
+            distanceDim.Y = scale*(vertexes[0].Point.y+vertexes[1].Point.y)/2
             distanceDim.recompute()
 
             (px,py,pz) = Utils.getCoordinateVectors(view)


### PR DESCRIPTION
file /Mod/TechDraw/TechDrawTools/CommandAxoLengthDimension.py
calculation changed to incorporate scale for distanceDim.X and distanceDim.Y

