### PR TITLE
SPDX [ Src/Main ]

### DIFF
--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
 
 configure_file(freecad.rc.cmake ${CMAKE_CURRENT_BINARY_DIR}/freecad.rc)
 configure_file(freecadCmd.rc.cmake ${CMAKE_CURRENT_BINARY_DIR}/freecadCmd.rc)

--- a/src/Main/FreeCADGuiPy.cpp
+++ b/src/Main/FreeCADGuiPy.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2009 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Main/MainCmd.cpp
+++ b/src/Main/MainCmd.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Main/MainPy.cpp
+++ b/src/Main/MainPy.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Main/freecad.rc.cmake
+++ b/src/Main/freecad.rc.cmake
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /////////////////////////////////////////////////////////////////////////////
 // For info about the file structrure see
 // https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource

--- a/src/Main/freecadCmd.rc.cmake
+++ b/src/Main/freecadCmd.rc.cmake
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /////////////////////////////////////////////////////////////////////////////
 // For info about the file structrure see
 // https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource


### PR DESCRIPTION
Added missing SPDX license identifiers.

Didn't find any conflicting licenses.

( Didn't add an identifier in the `.dox` 
file as I'm not familiar with it )