### PR TITLE
The Ubuntu build environment needs python3-pyside2.qtnetwork for testing

### DIFF
--- a/tools/build/Docker/Dockerfile.Ubuntu
+++ b/tools/build/Docker/Dockerfile.Ubuntu
@@ -10,7 +10,7 @@ COPY ubuntu.sh /tmp
 RUN apt-get update && \
     apt-get upgrade --yes && \
     sh /tmp/ubuntu.sh && \
-    mkdir /builds
+    mkdir -p /builds
 
 WORKDIR /builds
 

--- a/tools/build/Docker/ubuntu.sh
+++ b/tools/build/Docker/ubuntu.sh
@@ -13,4 +13,4 @@ apt-get install --no-install-recommends --yes build-essential cmake doxygen git 
     libyaml-cpp-dev libzipios++-dev netgen netgen-headers pyside2-tools python3-dev \
     python3-matplotlib python3-pivy python3-ply python3-pyside2.qtsvg \
     python3-pyside2.qtuitools qtchooser qttools5-dev shiboken2 swig \
-    qtwayland5 python3-pyside2.qtnetwork
+    qtwayland5 python3-pyside2.qtnetwork python3-yaml


### PR DESCRIPTION
Added python3-pyside2.qtnetwork to the pakage inst in ubuntu.sh to build it in to the Docker image.