### PR TITLE
SPDX [ 4 ][ Src / GUI / 3DConnexion ]

### DIFF
--- a/src/Gui/3Dconnexion/GuiAbstractNativeEvent.cpp
+++ b/src/Gui/3Dconnexion/GuiAbstractNativeEvent.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/GuiAbstractNativeEvent.h
+++ b/src/Gui/3Dconnexion/GuiAbstractNativeEvent.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.h
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.h
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/GuiNativeEventMac.h
+++ b/src/Gui/3Dconnexion/GuiNativeEventMac.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/GuiNativeEventWin32.h
+++ b/src/Gui/3Dconnexion/GuiNativeEventWin32.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/GuiRawInputEventFilter.h
+++ b/src/Gui/3Dconnexion/GuiRawInputEventFilter.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2018 Torsten Sadowski <tsadowski[at]gmx.net>            *
  *                                                                         *

--- a/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2014-2023 3Dconnexion.                                  *
  *                                                                         *

--- a/src/Gui/3Dconnexion/navlib/NavlibInterface.h
+++ b/src/Gui/3Dconnexion/navlib/NavlibInterface.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2014-2023 3Dconnexion.                                  *
  *                                                                         *

--- a/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2014-2023 3Dconnexion.                                  *
  *                                                                         *

--- a/src/Gui/3Dconnexion/navlib/NavlibPivot.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibPivot.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2014-2023 3Dconnexion.                                  *
  *                                                                         *


### PR DESCRIPTION
Added missing SPDX license identifiers.

The following files have unknown licensing:
- `GuiNativeEventMac.cpp`
- `GuiNativeEventWin32.cpp`
- `I3dMouseParams.h`
- `MouseParameters.cpp`
- `MouseParameters.h`

Some or all code in these files seems to come from 3DConnexion, 
however their copyright header is unclear about what 'licensing' 
they are talking about.

```txt
/*
Development tools and related technology provided under license from 3Dconnexion.
(c) 1992 - 2012 3Dconnexion. All rights reserved
*/
```
