### PR TITLE
SPDX [ 6 ][ Src / GUI / Navigation ] 

### DIFF
--- a/src/Gui/Navigation/BlenderNavigationStyle.cpp
+++ b/src/Gui/Navigation/BlenderNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/CADNavigationStyle.cpp
+++ b/src/Gui/Navigation/CADNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/GestureNavigationStyle.cpp
+++ b/src/Gui/Navigation/GestureNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2019 Victor Titov (DeepSOIC) <vv.titov@gmail.com>       *
  *                                                                         *

--- a/src/Gui/Navigation/GestureNavigationStyle.h
+++ b/src/Gui/Navigation/GestureNavigationStyle.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2019 Victor Titov (DeepSOIC) <vv.titov@gmail.com>       *
  *                                                                         *

--- a/src/Gui/Navigation/InventorNavigationStyle.cpp
+++ b/src/Gui/Navigation/InventorNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/MayaGestureNavigationStyle.cpp
+++ b/src/Gui/Navigation/MayaGestureNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2015 Victor Titov (DeepSOIC) <vv.titov@gmail.com>       *
  *                                                                         *

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/NavigationStyle.pyi
+++ b/src/Gui/Navigation/NavigationStyle.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Base.Metadata import export
 from Base.BaseClass import BaseClass
 

--- a/src/Gui/Navigation/NavigationStylePyImp.cpp
+++ b/src/Gui/Navigation/NavigationStylePyImp.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *

--- a/src/Gui/Navigation/OpenCascadeNavigationStyle.cpp
+++ b/src/Gui/Navigation/OpenCascadeNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2015 Kirill Gavrilov <kirill.gavrilov@opencascade.com>  *
  *                                                                         *

--- a/src/Gui/Navigation/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/Navigation/OpenSCADNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2021 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/RevitNavigationStyle.cpp
+++ b/src/Gui/Navigation/RevitNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/SolidWorksNavigationStyle.cpp
+++ b/src/Gui/Navigation/SolidWorksNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2021 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Gui/Navigation/TouchpadNavigationStyle.cpp
+++ b/src/Gui/Navigation/TouchpadNavigationStyle.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
 /***************************************************************************
  *   Copyright (c) 2012 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *


### PR DESCRIPTION
Added missing SPDX license identifiers.

- `NavigationStyle.pyi` contains `Licence: LGPL`
  -> Assumed `LGPLv2.1`