### PR TITLE
SPDX [ 8 ][ Src / GUI / QSint ]

### DIFF
--- a/src/Gui/QSint/actionpanel/actionbox.cpp
+++ b/src/Gui/QSint/actionpanel/actionbox.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actionbox.h
+++ b/src/Gui/QSint/actionpanel/actionbox.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actiongroup.cpp
+++ b/src/Gui/QSint/actionpanel/actiongroup.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actiongroup.h
+++ b/src/Gui/QSint/actionpanel/actiongroup.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actionlabel.cpp
+++ b/src/Gui/QSint/actionpanel/actionlabel.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actionlabel.h
+++ b/src/Gui/QSint/actionpanel/actionlabel.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actionpanel.cpp
+++ b/src/Gui/QSint/actionpanel/actionpanel.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actionpanel.h
+++ b/src/Gui/QSint/actionpanel/actionpanel.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actionpanelscheme.cpp
+++ b/src/Gui/QSint/actionpanel/actionpanelscheme.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/actionpanelscheme.h
+++ b/src/Gui/QSint/actionpanel/actionpanelscheme.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/qsint_global.h
+++ b/src/Gui/QSint/actionpanel/qsint_global.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/taskgroup_p.cpp
+++ b/src/Gui/QSint/actionpanel/taskgroup_p.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/taskgroup_p.h
+++ b/src/Gui/QSint/actionpanel/taskgroup_p.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/taskheader_p.cpp
+++ b/src/Gui/QSint/actionpanel/taskheader_p.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/actionpanel/taskheader_p.h
+++ b/src/Gui/QSint/actionpanel/taskheader_p.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: LGPL-3.0-only
 /***************************************************************************
  *                                                                         *
  *   Copyright: https://code.google.com/p/qsint/                           *

--- a/src/Gui/QSint/include/QSint
+++ b/src/Gui/QSint/include/QSint
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 #include "../actionpanel/actionlabel.h"
 #include "../actionpanel/actionbox.h"
 #include "../actionpanel/actiongroup.h"


### PR DESCRIPTION
Added missing SPDX license identifiers.

SourceForge project page only specifies 
`LGPLv3` not whether its `only` or `or-later`.
-> Went with the safe option ( `only` )

https://sourceforge.net/projects/qsint/