### PR TITLE
BIM: add formatting off comments

### DIFF
--- a/src/Mod/BIM/ArchBuilding.py
+++ b/src/Mod/BIM/ArchBuilding.py
@@ -54,6 +54,7 @@ else:
     # \endcond
 
 
+# fmt: off
 BuildingTypes = ['Undefined',
 'Agricultural - Barn',
 'Agricultural - Chicken coop or chickenhouse',
@@ -194,6 +195,7 @@ BuildingTypes = ['Undefined',
 'Other - Workshop',
 'Other - World trade centre'
 ]
+# fmt: on
 
 
 def makeBuilding(objectslist=None,name=None):

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -60,6 +60,7 @@ else:
 unicode = str
 
 
+# fmt: off
 BuildingTypes = ['Undefined',
 'Agricultural - Barn',
 'Agricultural - Chicken coop or chickenhouse',
@@ -200,6 +201,7 @@ BuildingTypes = ['Undefined',
 'Other - Workshop',
 'Other - World trade centre'
 ]
+# fmt: on
 
 
 class BuildingPart(ArchIFC.IfcProduct):

--- a/src/Mod/BIM/importers/importIFClegacy.py
+++ b/src/Mod/BIM/importers/importIFClegacy.py
@@ -663,10 +663,12 @@ def getMesh(obj):
     me = Mesh.Mesh(meshdata)
     # get transformation matrix
     m = obj.matrix
+    # fmt: off
     mat = FreeCAD.Matrix(m[0], m[3], m[6], m[9],
                          m[1], m[4], m[7], m[10],
                          m[2], m[5], m[8], m[11],
                          0, 0, 0, 1)
+    # fmt: on
     pl = FreeCAD.Placement(mat)
     return me,pl
 
@@ -733,10 +735,12 @@ def getShape(obj,objid):
             if DEBUG: print("    object ", objid, " does not contain any geometry")
     if not IFCOPENSHELL5:
         m = obj.matrix
+        # fmt: off
         mat = FreeCAD.Matrix(m[0], m[3], m[6], m[9],
                              m[1], m[4], m[7], m[10],
                              m[2], m[5], m[8], m[11],
                              0, 0, 0, 1)
+        # fmt: on
         sh.Placement = FreeCAD.Placement(mat)
     # if DEBUG: print("getting Shape from ",obj)
     #print("getting shape: ",sh,sh.Solids,sh.Volume,sh.isValid(),sh.isNull())


### PR DESCRIPTION
In preparation for [Add BIM workbench to .pre-commit-config.yaml](https://github.com/FreeCAD/FreeCAD/pull/21591)

Replaces [BIM: format whole Module with Black](https://github.com/FreeCAD/FreeCAD/pull/24330)

Adds `# fmt: off` and `# fmt: on` where original formatting is to be kept for readability reasons.