### PR TITLE
Draft: add formatting off comments

### DIFF
--- a/src/Mod/Draft/DraftVecUtils.py
+++ b/src/Mod/Draft/DraftVecUtils.py
@@ -58,7 +58,7 @@ def precision():
 
     This function is deprecated since it is a doublette of
     Draft.precision()
-       
+
     Returns
     -------
     int
@@ -492,9 +492,11 @@ def rotate(u, angle, axis=Vector(0, 0, 1)):
     ys = y * s
     zs = z * s
 
+    # fmt: off
     m = FreeCAD.Matrix(c + x*x*t,   xyt - zs,   xzt + ys,   0,
                        xyt + zs,    c + y*y*t,  yzt - xs,   0,
                        xzt - ys,    yzt + xs,   c + z*z*t,  0)
+    # fmt: on
 
     return m.multiply(u)
 
@@ -787,10 +789,12 @@ def getPlaneRotation(u, v, _ = None):
     w.normalize()
     v = w.cross(u)
 
+    # fmt: off
     m = FreeCAD.Matrix(u.x, v.x, w.x, 0,
                        u.y, v.y, w.y, 0,
                        u.z, v.z, w.z, 0,
                        0.0, 0.0, 0.0, 1.0)
+    # fmt: on
     return m
 
 
@@ -817,7 +821,7 @@ def removeDoubles(vlist, precision=None):
     precision : int | None
                 mathematical precision - if None use configured draft
                 precision
-               
+
     Returns
     -------
     list of Base::Vector3

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -126,6 +126,7 @@ class Snapper:
 
         # snap keys, it's important that they are in this order for
         # saving in preferences and for properly restoring the toolbar
+        # fmt: off
         self.snaps = ['Lock',           # 0
                       'Near',           # 1 former "passive" snap
                       'Extension',      # 2
@@ -142,6 +143,7 @@ class Snapper:
                       'Dimensions',     # 13
                       'WorkingPlane'    # 14
                      ]
+        # fmt: on
 
         self.init_active_snaps()
         self.set_snap_style()

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -249,7 +249,7 @@ class lineTracker(Tracker):
         p1 = Vector(self.coords.point.getValues()[0].getValue())
         p2 = Vector(self.coords.point.getValues()[-1].getValue())
         return (p2.sub(p1)).Length
-    
+
 
 class polygonTracker(Tracker):
     """A Polygon tracker, used by the polygon tool."""
@@ -261,10 +261,12 @@ class polygonTracker(Tracker):
         self.base_angle = None
         self.line.numVertices.setValue(self.sides + 1)
         self.coords = coin.SoCoordinate3()  # this is the coordinate
+        # fmt: off
         self.coords.point.setValues(0, 50, [[0, 0, 0],
                                             [2, 0, 0],
                                             [1, 2, 0],
                                             [0, 0, 0]])
+        # fmt: on
         if face:
             m1 = coin.SoMaterial()
             m1.transparency.setValue(0.5)
@@ -278,7 +280,7 @@ class polygonTracker(Tracker):
             super().__init__(dotted, scolor, swidth,
                              [self.coords, self.line],
                              name="polygonTracker")
-    
+
     def setNumVertices(self, num):
         self.line.numVertices.setValue(num + 1)
         self.sides = num
@@ -318,11 +320,13 @@ class rectangleTracker(Tracker):
         line = coin.SoLineSet()
         line.numVertices.setValue(5)
         self.coords = coin.SoCoordinate3()  # this is the coordinate
+        # fmt: off
         self.coords.point.setValues(0, 50, [[0, 0, 0],
                                             [2, 0, 0],
                                             [2, 2, 0],
                                             [0, 2, 0],
                                             [0, 0, 0]])
+        # fmt: on
         if face:
             m1 = coin.SoMaterial()
             m1.transparency.setValue(0.5)
@@ -424,11 +428,13 @@ class dimTracker(Tracker):
         line = coin.SoLineSet()
         line.numVertices.setValue(4)
         self.coords = coin.SoCoordinate3()  # this is the coordinate
+        # fmt: off
         self.coords.point.setValues(0, 4,
                                     [[0, 0, 0],
                                      [0, 0, 0],
                                      [0, 0, 0],
                                      [0, 0, 0]])
+        # fmt: on
         super().__init__(dotted, scolor, swidth,
                          [self.coords, line], name="dimTracker")
         self.p1 = self.p2 = self.p3 = None
@@ -450,10 +456,12 @@ class dimTracker(Tracker):
         """Calculate the new points from p1 and p2."""
         import Part
         if (self.p1 is not None) and (self.p2 is not None):
+            # fmt: off
             points = [DraftVecUtils.tup(self.p1, True),
                       DraftVecUtils.tup(self.p2, True),
                       DraftVecUtils.tup(self.p1, True),
                       DraftVecUtils.tup(self.p2, True)]
+            # fmt: on
             if self.p3 is not None:
                 p1 = self.p1
                 p4 = self.p2
@@ -468,10 +476,12 @@ class dimTracker(Tracker):
                 else:
                     p2 = p1.add(proj.negative())
                     p3 = p4.add(proj.negative())
+                # fmt: off
                 points = [DraftVecUtils.tup(p1),
                           DraftVecUtils.tup(p2),
                           DraftVecUtils.tup(p3),
                           DraftVecUtils.tup(p4)]
+                # fmt: on
             self.coords.point.setValues(0, 4, points)
 
 
@@ -881,10 +891,12 @@ class ghostTracker(Tracker):
         m = self.trans.getMatrix(v)
         if m:
             m = m.getValue()
+            # fmt: off
             return FreeCAD.Matrix(m[0][0], m[0][1], m[0][2], m[0][3],
                                   m[1][0], m[1][1], m[1][2], m[1][3],
                                   m[2][0], m[2][1], m[2][2], m[2][3],
                                   m[3][0], m[3][1], m[3][2], m[3][3])
+            # fmt: on
         else:
             return FreeCAD.Matrix()
 
@@ -893,10 +905,12 @@ class ghostTracker(Tracker):
 
         The 4th column of the matrix (the position) is ignored.
         """
+        # fmt: off
         m = coin.SbMatrix(matrix.A11, matrix.A12, matrix.A13, matrix.A14,
                           matrix.A21, matrix.A22, matrix.A23, matrix.A24,
                           matrix.A31, matrix.A32, matrix.A33, matrix.A34,
                           matrix.A41, matrix.A42, matrix.A43, matrix.A44)
+        # fmt: on
         self.trans.setMatrix(m)
 
     def flip_normals(self, flip):
@@ -1019,21 +1033,25 @@ class PlaneTracker(Tracker):
         m1.transparency.setValue(0.8)
         m1.diffuseColor.setValue([0.4, 0.4, 0.6])
         c1 = coin.SoCoordinate3()
+        # fmt: off
         c1.point.setValues([[-bl, -bl, 0],
                             [bl, -bl, 0],
                             [bl, bl, 0],
                             [-bl, bl, 0]])
+        # fmt: on
         f = coin.SoIndexedFaceSet()
         f.coordIndex.setValues([0, 1, 2, 3])
         m2 = coin.SoMaterial()
         m2.transparency.setValue(0.7)
         m2.diffuseColor.setValue([0.2, 0.2, 0.3])
         c2 = coin.SoCoordinate3()
+        # fmt: off
         c2.point.setValues([[0, bl, 0], [0, 0, 0],
                             [bl, 0, 0], [-0.05*bl, 0.95*bl, 0],
                             [0, bl, 0], [0.05*bl, 0.95*bl, 0],
                             [0.95*bl, 0.05*bl, 0], [bl, 0, 0],
                             [0.95*bl, -0.05*bl, 0]])
+        # fmt: on
         l = coin.SoLineSet()
         l.numVertices.setValues([3, 3, 3])
         s = coin.SoSeparator()

--- a/src/Mod/Draft/draftobjects/hatch.py
+++ b/src/Mod/Draft/draftobjects/hatch.py
@@ -146,10 +146,12 @@ class Hatch(DraftObject):
                             if u.Length > 0.001:
                                 u = u.normalize()
                                 v = w.cross(u)
+                                # fmt: off
                                 mtx = App.Matrix(u.x, v.x, w.x, sta.x,
                                                  u.y, v.y, w.y, sta.y,
                                                  u.z, v.z, w.z, sta.z,
                                                  0.0, 0.0, 0.0, 1.0)
+                                # fmt: on
                                 break
                     # If no suitable straight edge was found use a default matrix:
                     if not mtx:

--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -436,6 +436,7 @@ def _get_param_dictionary():
             + "/Mod/TechDraw/PAT/FCPAT.pat"
 
     # Draft parameters that are not in the preferences:
+    # fmt: off
     param_dict["Mod/Draft"] = {
         "AnnotationStyleEditorHeight": ("int",       450),
         "AnnotationStyleEditorWidth":  ("int",       450),
@@ -514,14 +515,14 @@ def _get_param_dictionary():
 
     start_val = App.Units.Quantity(100.0, App.Units.Length).Value
     param_dict["Mod/Draft/OrthoArrayLinearMode"] = {
-        "LinearModeOn": ("bool", True),
-        "AxisSelected": ("string", "X"),
-        "XInterval": ("float", start_val),
-        "YInterval": ("float", start_val),
-        "ZInterval": ("float", start_val),
-        "XNumOfElements": ("int", 2),
-        "YNumOfElements": ("int", 2),
-        "ZNumOfElements": ("int", 2)
+        "LinearModeOn":                ("bool",      True),
+        "AxisSelected":                ("string",    "X"),
+        "XInterval":                   ("float",     start_val),
+        "YInterval":                   ("float",     start_val),
+        "ZInterval":                   ("float",     start_val),
+        "XNumOfElements":              ("int",       2),
+        "YNumOfElements":              ("int",       2),
+        "ZNumOfElements":              ("int",       2)
     }
 
     # Arch parameters that are not in the preferences:
@@ -630,6 +631,7 @@ def _get_param_dictionary():
         "MarkerSize":                  ("int",       9),
         "NewDocumentCameraScale":      ("float",     100.0),
     }
+    # fmt: on
 
 
     # Preferences ui files are stored in resource files.

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -626,19 +626,23 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
                                                        spacing)
             self.p2b = self.p3 + DraftVecUtils.scaleTo(self.p2 - self.p3,
                                                        spacing)
+            # fmt: off
             self.coords.point.setValues([[self.p1.x, self.p1.y, self.p1.z],
                                          [self.p2.x, self.p2.y, self.p2.z],
                                          [self.p2a.x, self.p2a.y, self.p2a.z],
                                          [self.p2b.x, self.p2b.y, self.p2b.z],
                                          [self.p3.x, self.p3.y, self.p3.z],
                                          [self.p4.x, self.p4.y, self.p4.z]])
+            # fmt: on
             # self.line.numVertices.setValues([3, 3])
             self.line.coordIndex.setValues(0, 7, (0, 1, 2, -1, 3, 4, 5))
         else:
+            # fmt: off
             self.coords.point.setValues([[self.p1.x, self.p1.y, self.p1.z],
                                          [self.p2.x, self.p2.y, self.p2.z],
                                          [self.p3.x, self.p3.y, self.p3.z],
                                          [self.p4.x, self.p4.y, self.p4.z]])
+            # fmt: on
             # self.line.numVertices.setValue(4)
             self.line.coordIndex.setValues(0, 4, (0, 1, 2, 3))
 

--- a/src/Mod/Draft/draftviewproviders/view_wpproxy.py
+++ b/src/Mod/Draft/draftviewproviders/view_wpproxy.py
@@ -135,7 +135,21 @@ class ViewProviderWorkingPlaneProxy:
         self.lcoords = coin.SoCoordinate3()
         import PartGui # Required for "SoBrepEdgeSet" (because a WorkingPlaneProxy is not a Part::FeaturePython object).
         ls = coin.SoType.fromName("SoBrepEdgeSet").createInstance()
-        ls.coordIndex.setValues(0,28,[0,1,-1,2,3,4,5,-1,6,7,-1,8,9,10,11,-1,12,13,-1,14,15,16,17,-1,18,19,20,21])
+        # fmt: off
+        ls.coordIndex.setValues(
+            0,
+            28,
+            [
+                0, 1, -1,
+                2, 3, 4, 5, -1,
+                6, 7, -1,
+                8, 9, 10, 11, -1,
+                12, 13, -1,
+                14, 15, 16, 17, -1,
+                18, 19, 20, 21
+            ],
+        )
+        # fmt: on
         sep = coin.SoSeparator()
         psep = coin.SoSeparator()
         fsep = coin.SoSeparator()

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -454,7 +454,7 @@ def getrgb(color):
 
 class svgHandler(xml.sax.ContentHandler):
     """Parse SVG files and create FreeCAD objects."""
-    
+
     def __init__(self):
         super().__init__()
         """Retrieve Draft parameters and initialize."""
@@ -497,8 +497,8 @@ class svgHandler(xml.sax.ContentHandler):
                 v.LineWidth = self.width
             if self.fill:
                 v.ShapeColor = self.fill
-     
-     
+
+
     def __addFaceToDoc(self, named_face):
         """Create a named document object from a name/face tuple
 
@@ -510,7 +510,7 @@ class svgHandler(xml.sax.ContentHandler):
         name, face = named_face
         if not face:
             return
-        
+
         face = self.applyTrans(face)
         obj = self.doc.addObject("Part::Feature", name)
         obj.Shape = face
@@ -603,7 +603,7 @@ class svgHandler(xml.sax.ContentHandler):
                      "the dpi could not be determined; "
                      "assuming 96 dpi")
                 self.svgdpi = 96.0
-            
+
         if 'style' in data:
             if not data['style']:
                 # Empty style attribute stops inheriting from parent
@@ -659,7 +659,7 @@ class svgHandler(xml.sax.ContentHandler):
                         if sx != sy:
                             _wrn('Non-uniform scaling with probably degenerating '
                                   + 'effects on Edges. ({} vs. {}).'.format(sx, sy))
-    
+
                     else:
                         # preserve aspect ratio - svg default is 'x/y-mid meet'
                         if preserve_ar.endswith('slice'):
@@ -752,7 +752,7 @@ class svgHandler(xml.sax.ContentHandler):
                 self.format(obj)
                 self.lastdim = obj
                 data['d'] = []
-                
+
             if "d" in data:
                 svgPath = SvgPathParser(data, pathname)
                 svgPath.parse()
@@ -762,7 +762,7 @@ class svgHandler(xml.sax.ContentHandler):
                 shapes = svgPath.getShapeList()
                 for named_shape in shapes:
                     self.__addFaceToDoc(named_shape)
-        
+
         # Process rects
         if name == "rect":
             if not pathname:
@@ -1119,10 +1119,12 @@ class svgHandler(xml.sax.ContentHandler):
                 # (+0 -0 +0 +1)           (0 0 0 1)
                 #
                 # Put the first two rows of the matrix
+                # fmt: off
                 _m = FreeCAD.Matrix(argsplit[0], -argsplit[2],
                                     0, argsplit[4],
                                     -argsplit[1], argsplit[3],
                                     0, -argsplit[5])
+                # fmt: on
                 m = m.multiply(_m)
             # else:
             #    print('SKIPPED %s' % transformation)
@@ -1402,7 +1404,7 @@ def replace_use_with_reference(file_path):
         while True:
             uses = element.findall(".//{http://www.w3.org/2000/svg}use")
             if uses == []:
-                break   
+                break
             # create parent map
             parent_map = {child: parent for parent in tree.iter() for child in parent}
             for use in uses:
@@ -1436,7 +1438,7 @@ def replace_use_with_reference(file_path):
                             if "id" in child.attrib:
                                 del child.attrib["id"]
                         new_element.append(ref_element)
-                        # replace use tag by freecad:used tag. 
+                        # replace use tag by freecad:used tag.
                         parent.append(new_element)
                 #remove use when referenced element is not found.
                 parent.remove(use)
@@ -1466,6 +1468,6 @@ def replace_use_with_reference(file_path):
         id_map[elem.attrib["id"]] = elem
 
     replace_use(root, tree)
-    
+
     # return tree as xml string with namespace declaration.
     return ET.tostring(root, encoding='unicode',xml_declaration=True)


### PR DESCRIPTION
In preparation for [Add Draft workbench to .pre-commit-config.yaml](https://github.com/FreeCAD/FreeCAD/pull/21591)

Replaces [Draft: format whole Module with Black](https://github.com/FreeCAD/FreeCAD/pull/24331)

Adds `# fmt: off` and `# fmt: on` where original formatting is to be kept for readability reasons.