### PR TITLE
Gui: Enable quick measure and input hints by default

### DIFF
--- a/src/Gui/StatusBarLabel.cpp
+++ b/src/Gui/StatusBarLabel.cpp
@@ -42,7 +42,7 @@ StatusBarLabel::StatusBarLabel(QWidget *parent, const std::string& parameterName
             "User parameter:BaseApp/Preferences/MainWindow");
 
         // set visibility before storing parameterName to avoid saving it immediately
-        setVisible(hGrp->GetBool(parameterName.c_str(), false));
+        setVisible(hGrp->GetBool(parameterName.c_str(), true));
 
         // now we can store parameterName
         this->parameterName = parameterName;


### PR DESCRIPTION
This enables quick measure and input hints by default.

I've looked at the config produced by the old version and it doesn't save the value when it is off by default, so we shouldn't need any workarounds to enable it for users who has installed the previous version.
But it would be lovely if someone else could try it out too.

Fixes issue mentioned in https://github.com/FreeCAD/FreeCAD/pull/23620#issuecomment-3380107867