### PR TITLE
TechDraw: Fix Detail View - Angle Dimension Problem

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -38,6 +38,7 @@
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
 #include <Gui/Command.h>
+#include <Mod/TechDraw/App/DrawViewDetail.h>
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawViewDimension.h>
 #include <Mod/TechDraw/App/DrawViewPart.h>
@@ -2041,6 +2042,9 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
     double labelAngle = 0.0;
 
     anglePoints anglePoints = dimension->getAnglePoints();
+    if (auto* detail = dynamic_cast<const TechDraw::DrawViewDetail*>(dimension->getViewPart())) {
+        anglePoints.vertex(detail->AnchorPoint.getValue());
+    }
 
     Base::Vector2d angleVertex = fromQtApp(anglePoints.vertex());
     Base::Vector2d startPoint = fromQtApp(anglePoints.first());


### PR DESCRIPTION
The leader lines for angle dimensions in a detail view were being drawn relative to the original model's vertex instead of the detail view's center.

The issue was traced to the `drawAngle` function within `src/Mod/TechDraw/Gui/QGIViewDimension.cpp`

Modified `drawAngle` to check if the dimension is part of a DrawViewDetail. If it is, the function now uses the detail view's AnchorPoint as the vertex for calculating the leader lines. This ensures the lines are drawn correctly within the bounds of the detail view.

## Issues
Fixes https://github.com/FreeCAD/FreeCAD/issues/23848
