### PR TITLE
Sketcher: Fix toggle construction not undoable

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -11785,4 +11785,3 @@ template class SketcherExport FeaturePythonT<Sketcher::SketchObject>;
 }// namespace App
 
 // clang-format on
-


### PR DESCRIPTION
Fix second issue described in https://github.com/FreeCAD/FreeCAD/issues/24482#issuecomment-3382410425

Which is that currently toggle construction geometry cannot be undone.