### PR TITLE
Sketcher: Element Task : clear selection when list selection is cleared

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -830,6 +830,19 @@ void ElementView::contextMenuEvent(QContextMenuEvent* event)
     menu.exec(event->globalPos());
 }
 
+void ElementView::mousePressEvent(QMouseEvent* event)
+{
+    // If the click is on an empty area (not on an item), it should
+    // clear the global selection.
+    if (!itemAt(event->pos())) {
+        Gui::Selection().clearSelection();
+    }
+
+    // Always call the base class implementation to ensure normal behavior
+    // like item clicks and the widget's own selection management continues to work.
+    QListWidget::mousePressEvent(event);
+}
+
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainCoincident", doPointCoincidence)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainPointOnObject", doPointOnObjectConstraint)
 CONTEXT_MEMBER_DEF("Sketcher_ConstrainHorizontal", doHorizontalConstraint)

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.h
@@ -68,6 +68,7 @@ public:
 
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
 
 protected Q_SLOTS:
     // Constraints


### PR DESCRIPTION
Currently if you select items in Element task, the elements get selected. If you click on empty space, the selection in the list gets cleared, but not in the 3DView.

I can't remember where this was reported.

This PR fixes that.