### PR TITLE
Gui: Fix too enthusiastic auto-collapse

### DIFF
--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -239,9 +239,12 @@ void PropertyView::slotAppendDynamicProperty(const App::Property& prop)
         return;
 
     App::PropertyContainer* parent = prop.getContainer();
-    if (propertyEditorData->propOwners.contains(parent)
-            || propertyEditorView->propOwners.contains(parent))
-    {
+    if (propertyEditorData->propOwners.contains(parent)) {
+        propertyEditorData->blockCollapseAll();
+        timer->start(ViewParams::instance()->getPropertyViewTimer());
+    }
+    if ( propertyEditorView->propOwners.contains(parent)) {
+        propertyEditorView->blockCollapseAll();
         timer->start(ViewParams::instance()->getPropertyViewTimer());
     }
 }

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -672,6 +672,11 @@ void Gui::PropertyEditor::PropertyEditor::drawRow(QPainter* painter,
     QTreeView::drawRow(painter, options, index);
 }
 
+void PropertyEditor::blockCollapseAll()
+{
+    blockCollapse = true;
+}
+
 void PropertyEditor::buildUp(PropertyModel::PropertyList&& props, bool _checkDocument)
 {
     checkDocument = _checkDocument;
@@ -723,7 +728,10 @@ void PropertyEditor::buildUp(PropertyModel::PropertyList&& props, bool _checkDoc
         expandAll();
         break;
     case ExpansionMode::AutoCollapse:
-        collapseAll();
+        if (!blockCollapse) {
+            collapseAll();
+        }
+        blockCollapse = false;
         break;
     }
 }
@@ -734,6 +742,7 @@ void PropertyEditor::updateProperty(const App::Property& prop)
     if (!committing) {
         propertyModel->updateProperty(prop);
     }
+    blockCollapseAll();
 }
 
 void PropertyEditor::setEditorMode(const QModelIndex& parent, int start, int end)
@@ -750,10 +759,9 @@ void PropertyEditor::setEditorMode(const QModelIndex& parent, int start, int end
 
 void PropertyEditor::removeProperty(const App::Property& prop)
 {
-    for (PropertyModel::PropertyList::iterator it = propList.begin(); it != propList.end(); ++it) {
+    for (auto it = propList.begin(); it != propList.end(); ++it) {
         // find the given property in the list and remove it if it's there
-        std::vector<App::Property*>::iterator pos =
-            std::ranges::find(it->second, &prop);
+        auto pos = std::ranges::find(it->second, &prop);
         if (pos != it->second.end()) {
             it->second.erase(pos);
             // if the last property of this name is removed then also remove the whole group
@@ -764,6 +772,7 @@ void PropertyEditor::removeProperty(const App::Property& prop)
             break;
         }
     }
+    blockCollapseAll();
 }
 
 void PropertyEditor::renameProperty(const App::Property& prop)
@@ -776,6 +785,7 @@ void PropertyEditor::renameProperty(const App::Property& prop)
             break;
         }
     }
+    blockCollapseAll();
 }
 
 enum MenuAction

--- a/src/Gui/propertyeditor/PropertyEditor.h
+++ b/src/Gui/propertyeditor/PropertyEditor.h
@@ -82,6 +82,7 @@ public:
     /** Builds up the list view with the properties. */
     void buildUp(PropertyModel::PropertyList&& props = PropertyModel::PropertyList(),
                  bool checkDocument = false);
+    void blockCollapseAll();
     void updateProperty(const App::Property&);
     void removeProperty(const App::Property&);
     void renameProperty(const App::Property&);
@@ -160,6 +161,7 @@ private:
     bool autoupdate;
     bool committing;
     bool delaybuild;
+    bool blockCollapse;
     bool binding;
     bool checkDocument;
     bool closingEditor;


### PR DESCRIPTION
The Property View auto-collapse checkbox, collapses all groups and properties on each rebuild of the property editor. A rebuild of the property editor is also being done when you change the value of the property which makes the property view basically unusable with this feature on. This has now been solved by blocking the autocollapse in cases such as these.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
https://github.com/FreeCAD/FreeCAD/issues/24472

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
