### PR TITLE
BIM: Fix IFC import options dialog not showing until Preferences are opened

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_import.py
+++ b/src/Mod/BIM/nativeifc/ifc_import.py
@@ -148,7 +148,7 @@ def get_options(strategy=None, shapemode=None, switchwb=None, silent=False):
         switchwb = PARAMS.GetBool("SwitchWB", True)
     if silent:
         return strategy, shapemode, switchwb
-    ask = PARAMS.GetBool("AskAgain", False)
+    ask = PARAMS.GetBool("AskAgain", True)
     if ask and FreeCAD.GuiUp:
         import FreeCADGui
 


### PR DESCRIPTION
Problem:
The IFC import options dialog was not displayed when importing an IFC file
until the Preferences window was opened and closed once.

Changes:
Corrected the default value for the "AskAgain" parameter in ifc_import.py
to True instead of False, matching the expected default preference.

Before:
The IFC import options dialog did not appear on first import
and only showed after opening Preferences.

After:
The IFC import options dialog now appears immediately
on the first import without requiring any user interaction.

Fixes #24549
