### PR TITLE
Gui: Fix supporting links in add property dialog

### DIFF
--- a/src/Gui/Dialogs/DlgAddProperty.h
+++ b/src/Gui/Dialogs/DlgAddProperty.h
@@ -95,6 +95,7 @@ public:
                                   QLayout* layout);
 
 public Q_SLOTS:
+    void valueChanged();
     void valueChangedEnum();
 
 private:
@@ -122,6 +123,7 @@ private:
     void removeSelectionEditor();
     QVariant getEditorData() const;
     void setEditorData(const QVariant& data);
+    bool isSubLinkPropertyItem() const;
     bool isEnumPropertyItem() const;
     void addEnumEditor(PropertyEditor::PropertyItem* propertyItem);
     void addNormalEditor(PropertyEditor::PropertyItem* propertyItem);


### PR DESCRIPTION
In the process of removing support for properties that don't have editors, I accidentally forgot to include link properties as being supported.  In #24446, I simplified the logic of setting values from editors, logic that was needed specifically for link properties. Those simplifications have been reverted in this PR to make sure that link properties capture their values.

In addition, I disabled opening an editor for sublink properties as users should pick edges and faces in the 3D view. Since the add property dialog is modal, it is not possible to access the 3D view. This does not mean that the add property dialog cannot create sublink properties, it just means that the values should be set in the property view when full access to the 3D view is possible.

The add property dialog is modal for a good reason. Otherwise, the add property dialog can interfere with transactions in different parts of the application.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
fixes https://github.com/FreeCAD/FreeCAD/issues/24563

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
