### PR TITLE
[TD]fix area anno positioning

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewBalloon.h
+++ b/src/Mod/TechDraw/Gui/QGIViewBalloon.h
@@ -207,6 +207,9 @@ public:
         return dvBalloon;
     }
 
+    // balloons handle their own dragging
+    void dragFinished() override { };
+
 public Q_SLOTS:
     void balloonLabelDragged(bool ctrl);
     void balloonLabelDragFinished();


### PR DESCRIPTION
This PR implements a fix for issue #24585.

The default (from ancestor QGIView) dragFinished method was being executed after QGIViewBalloon::balloonLabelDragged had correctly set the annotation's X and Y property.  QGIView::dragFinished was setting the annotation's position to (0,0).
