### PR TITLE
SPDX [ 17 ][ Src / Base ]

### DIFF
--- a/src/Base/Axis.cpp
+++ b/src/Base/Axis.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Axis.h
+++ b/src/Base/Axis.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Axis.pyi
+++ b/src/Base/Axis.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export
 from PyObjectBase import PyObjectBase
 from Vector import Vector

--- a/src/Base/AxisPyImp.cpp
+++ b/src/Base/AxisPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Base64.cpp
+++ b/src/Base/Base64.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Zlib
+
 /*
 base64.cpp and base64.h
 

--- a/src/Base/Base64.h
+++ b/src/Base/Base64.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Zlib
+
 /*
 base64.cpp and base64.h
 

--- a/src/Base/Base64Filter.h
+++ b/src/Base/Base64Filter.h
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+
 /****************************************************************************
  *                                                                          *
  *   Copyright (c) 2019 Zheng Lei (realthunder.dev@gmail.com)               *

--- a/src/Base/BaseClass.cpp
+++ b/src/Base/BaseClass.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/BaseClass.h
+++ b/src/Base/BaseClass.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/BaseClass.pyi
+++ b/src/Base/BaseClass.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import constmethod
 from PyObjectBase import PyObjectBase
 from typing import List, Final

--- a/src/Base/BaseClassPyImp.cpp
+++ b/src/Base/BaseClassPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2007 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/BindingManager.cpp
+++ b/src/Base/BindingManager.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2021 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/BindingManager.h
+++ b/src/Base/BindingManager.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2021 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Bitmask.h
+++ b/src/Base/Bitmask.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/BoundBox.h
+++ b/src/Base/BoundBox.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/BoundBox.pyi
+++ b/src/Base/BoundBox.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export, constmethod
 from PyObjectBase import PyObjectBase
 from Vector import Vector

--- a/src/Base/BoundBoxPyImp.cpp
+++ b/src/Base/BoundBoxPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Builder3D.cpp
+++ b/src/Base/Builder3D.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Builder3D.h
+++ b/src/Base/Builder3D.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 add_library(FreeCADBase SHARED)
 
 if(WIN32)

--- a/src/Base/Color.cpp
+++ b/src/Base/Color.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Color.h
+++ b/src/Base/Color.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Console.cpp
+++ b/src/Base/Console.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Console.h
+++ b/src/Base/Console.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/ConsoleObserver.cpp
+++ b/src/Base/ConsoleObserver.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/ConsoleObserver.h
+++ b/src/Base/ConsoleObserver.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Converter.h
+++ b/src/Base/Converter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2019 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/CoordinateSystem.cpp
+++ b/src/Base/CoordinateSystem.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2014 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/CoordinateSystem.h
+++ b/src/Base/CoordinateSystem.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2014 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/CoordinateSystem.pyi
+++ b/src/Base/CoordinateSystem.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export, constmethod
 from PyObjectBase import PyObjectBase
 from Axis import Axis as AxisPy

--- a/src/Base/CoordinateSystemPyImp.cpp
+++ b/src/Base/CoordinateSystemPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2017 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Debugger.cpp
+++ b/src/Base/Debugger.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2012 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Debugger.h
+++ b/src/Base/Debugger.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2012 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/DualNumber.h
+++ b/src/Base/DualNumber.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2019 Viktor Titov (DeepSOIC) <vv.titov@gmail.com>       *
  *                                                                         *

--- a/src/Base/DualQuaternion.cpp
+++ b/src/Base/DualQuaternion.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2019 Viktor Titov (DeepSOIC) <vv.titov@gmail.com>       *
  *                                                                         *

--- a/src/Base/DualQuaternion.h
+++ b/src/Base/DualQuaternion.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2019 Viktor Titov (DeepSOIC) <vv.titov@gmail.com>       *
  *                                                                         *

--- a/src/Base/Exception.cpp
+++ b/src/Base/Exception.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Exception.h
+++ b/src/Base/Exception.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/ExceptionFactory.cpp
+++ b/src/Base/ExceptionFactory.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2017 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
  *                                                                         *

--- a/src/Base/ExceptionFactory.h
+++ b/src/Base/ExceptionFactory.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2017 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
  *                                                                         *

--- a/src/Base/Factory.cpp
+++ b/src/Base/Factory.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Factory.h
+++ b/src/Base/Factory.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/FileInfo.cpp
+++ b/src/Base/FileInfo.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/FileInfo.h
+++ b/src/Base/FileInfo.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/FutureWatcherProgress.cpp
+++ b/src/Base/FutureWatcherProgress.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/FutureWatcherProgress.h
+++ b/src/Base/FutureWatcherProgress.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/GeometryPyCXX.cpp
+++ b/src/Base/GeometryPyCXX.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/GeometryPyCXX.h
+++ b/src/Base/GeometryPyCXX.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Handle.cpp
+++ b/src/Base/Handle.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Handle.h
+++ b/src/Base/Handle.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/InputSource.cpp
+++ b/src/Base/InputSource.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/InputSource.h
+++ b/src/Base/InputSource.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Interpreter.h
+++ b/src/Base/Interpreter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Matrix.cpp
+++ b/src/Base/Matrix.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/Matrix.h
+++ b/src/Base/Matrix.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/Matrix.pyi
+++ b/src/Base/Matrix.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Vector import Vector
 from Metadata import export, constmethod, class_declarations, no_args
 from PyObjectBase import PyObjectBase

--- a/src/Base/MatrixPyImp.cpp
+++ b/src/Base/MatrixPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Metadata.pyi
+++ b/src/Base/Metadata.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 """
 This file keeps auxiliary metadata to be used by the Python API stubs.
 """

--- a/src/Base/Observer.cpp
+++ b/src/Base/Observer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2023 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
  *                                                                         *

--- a/src/Base/Observer.h
+++ b/src/Base/Observer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Parameter.h
+++ b/src/Base/Parameter.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/ParameterPy.cpp
+++ b/src/Base/ParameterPy.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Parser.sh
+++ b/src/Base/Parser.sh
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 (cd "$(dirname "$0")" && \
   flex -oQuantity.lex.c Quantity.l && \
   bison -oQuantity.tab.c Quantity.y && \

--- a/src/Base/Persistence.cpp
+++ b/src/Base/Persistence.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Persistence.h
+++ b/src/Base/Persistence.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Persistence.pyi
+++ b/src/Base/Persistence.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import constmethod
 from BaseClass import BaseClass
 from typing import Final

--- a/src/Base/PersistencePyImp.cpp
+++ b/src/Base/PersistencePyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2007 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Placement.cpp
+++ b/src/Base/Placement.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2006 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Placement.h
+++ b/src/Base/Placement.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2006 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Placement.pyi
+++ b/src/Base/Placement.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export, constmethod, class_declarations
 from PyObjectBase import PyObjectBase
 from Matrix import Matrix as MatrixPy

--- a/src/Base/PlacementPyImp.cpp
+++ b/src/Base/PlacementPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/PreCompiled.h
+++ b/src/Base/PreCompiled.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Precision.h
+++ b/src/Base/Precision.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Precision.pyi
+++ b/src/Base/Precision.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from PyObjectBase import PyObjectBase
 
 class Precision(PyObjectBase):

--- a/src/Base/PrecisionPyImp.cpp
+++ b/src/Base/PrecisionPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/ProgressIndicatorPy.cpp
+++ b/src/Base/ProgressIndicatorPy.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/ProgressIndicatorPy.h
+++ b/src/Base/ProgressIndicatorPy.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/PyExport.cpp
+++ b/src/Base/PyExport.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/PyExport.h
+++ b/src/Base/PyExport.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/PyObjectBase.cpp
+++ b/src/Base/PyObjectBase.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/PyObjectBase.h
+++ b/src/Base/PyObjectBase.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/PyObjectBase.pyi
+++ b/src/Base/PyObjectBase.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 class PyObjectBase:
     """
     The most base class for Python bindings.

--- a/src/Base/Quantity.cpp
+++ b/src/Base/Quantity.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2013 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Quantity.h
+++ b/src/Base/Quantity.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2013 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Quantity.l
+++ b/src/Base/Quantity.l
@@ -1,4 +1,6 @@
 %{
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
 /***************************************************************************
  *   Copyright (c) 2013 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Quantity.lex.c
+++ b/src/Base/Quantity.lex.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 // clang-format off
 #line 2 "Quantity.lex.c"
 

--- a/src/Base/Quantity.pyi
+++ b/src/Base/Quantity.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export, constmethod
 from PyObjectBase import PyObjectBase
 from typing import overload, Final, Tuple, Union

--- a/src/Base/Quantity.tab.c
+++ b/src/Base/Quantity.tab.c
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 // clang-format off
 /* A Bison parser, made by GNU Bison 3.8.2.  */
 

--- a/src/Base/Quantity.y
+++ b/src/Base/Quantity.y
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+
 /***************************************************************************
  *   Copyright (c) 2013 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/QuantityPyImp.cpp
+++ b/src/Base/QuantityPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2013 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Reader.h
+++ b/src/Base/Reader.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Rotation.cpp
+++ b/src/Base/Rotation.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2006 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Rotation.h
+++ b/src/Base/Rotation.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2006 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Rotation.pyi
+++ b/src/Base/Rotation.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export, constmethod, class_declarations
 from PyObjectBase import PyObjectBase
 from Vector import Vector

--- a/src/Base/RotationPyImp.cpp
+++ b/src/Base/RotationPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Sequencer.cpp
+++ b/src/Base/Sequencer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Sequencer.h
+++ b/src/Base/Sequencer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/SmartPtrPy.cpp
+++ b/src/Base/SmartPtrPy.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2020 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/SmartPtrPy.h
+++ b/src/Base/SmartPtrPy.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2020 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/StackWalker.cpp
+++ b/src/Base/StackWalker.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 // clang-format off
 // NOLINTBEGIN
 /**********************************************************************

--- a/src/Base/StackWalker.h
+++ b/src/Base/StackWalker.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
 // clang-format off
 // NOLINTBEGIN
 #ifndef __STACKWALKER_H__

--- a/src/Base/Stream.cpp
+++ b/src/Base/Stream.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2007 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Stream.h
+++ b/src/Base/Stream.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2007 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Swap.cpp
+++ b/src/Base/Swap.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/Swap.h
+++ b/src/Base/Swap.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/TimeInfo.h
+++ b/src/Base/TimeInfo.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *   Copyright (c) 2024 Ladislav Michl <ladis@linux-mips.org>              *

--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2009 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2009 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Tools2D.cpp
+++ b/src/Base/Tools2D.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/Tools2D.h
+++ b/src/Base/Tools2D.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/Tools3D.cpp
+++ b/src/Base/Tools3D.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Tools3D.h
+++ b/src/Base/Tools3D.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Translate.cpp
+++ b/src/Base/Translate.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2018 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Translate.h
+++ b/src/Base/Translate.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2018 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Type.pyi
+++ b/src/Base/Type.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export, forward_declarations, constmethod
 from PyObjectBase import PyObjectBase
 from typing import List, Final

--- a/src/Base/TypePyImp.cpp
+++ b/src/Base/TypePyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2019 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/UniqueNameManager.cpp
+++ b/src/Base/UniqueNameManager.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2024 Kevin Martin <kpmartin@papertrail.ca>              *
  *                                                                         *

--- a/src/Base/UniqueNameManager.h
+++ b/src/Base/UniqueNameManager.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2024 Kevin Martin <kpmartin@papertrail.ca>              *
  *                                                                         *

--- a/src/Base/Unit.pyi
+++ b/src/Base/Unit.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export
 from PyObjectBase import PyObjectBase
 from Quantity import Quantity

--- a/src/Base/UnitPyImp.cpp
+++ b/src/Base/UnitPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2013 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/UnitsApi.cpp
+++ b/src/Base/UnitsApi.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2009 Jürgen Riegel <FreeCAD@juergen-riegel.net>         *
  *                                                                         *

--- a/src/Base/UnitsApi.h
+++ b/src/Base/UnitsApi.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2009 Jürgen Riegel <FreeCAD@juergen-riegel.net>         *
  *                                                                         *

--- a/src/Base/UnitsApiPy.cpp
+++ b/src/Base/UnitsApiPy.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) Jürgen Riegel <juergen.riegel@web.de>                   *
  *                                                                         *

--- a/src/Base/UnitsConvData.h
+++ b/src/Base/UnitsConvData.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /************************************************************************
  *                                                                      *
  *   This file is part of the FreeCAD CAx development system.           *

--- a/src/Base/UnitsSchema.cpp
+++ b/src/Base/UnitsSchema.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /************************************************************************
  *                                                                      *
  *   This file is part of the FreeCAD CAx development system.           *

--- a/src/Base/UnitsSchema.h
+++ b/src/Base/UnitsSchema.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2009 Jürgen Riegel <FreeCAD@juergen-riegel.net>         *
  *                                                                         *

--- a/src/Base/UnitsSchemas.cpp
+++ b/src/Base/UnitsSchemas.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /************************************************************************
  *                                                                      *
  *   This file is part of the FreeCAD CAx development system.           *

--- a/src/Base/UnitsSchemas.h
+++ b/src/Base/UnitsSchemas.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /************************************************************************
  *                                                                      *
  *   This file is part of the FreeCAD CAx development system.           *

--- a/src/Base/UnitsSchemasData.h
+++ b/src/Base/UnitsSchemasData.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /************************************************************************
  *                                                                      *
  *   This file is part of the FreeCAD CAx development system.           *

--- a/src/Base/UnitsSchemasSpecs.h
+++ b/src/Base/UnitsSchemasSpecs.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /************************************************************************
  *                                                                      *
  *   This file is part of the FreeCAD CAx development system.           *

--- a/src/Base/UnlimitedUnsigned.h
+++ b/src/Base/UnlimitedUnsigned.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2025 Kevin Martin <kpmartin@papertrail.ca>              *
  *                                                                         *

--- a/src/Base/Uuid.cpp
+++ b/src/Base/Uuid.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Uuid.h
+++ b/src/Base/Uuid.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Vector.pyi
+++ b/src/Base/Vector.pyi
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
 from Metadata import export, constmethod, sequence_protocol, class_declarations
 from PyObjectBase import PyObjectBase
 from typing import overload, Sequence, TYPE_CHECKING

--- a/src/Base/Vector3D.cpp
+++ b/src/Base/Vector3D.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/Vector3D.h
+++ b/src/Base/Vector3D.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/VectorPyImp.cpp
+++ b/src/Base/VectorPyImp.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/ViewProj.cpp
+++ b/src/Base/ViewProj.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/ViewProj.h
+++ b/src/Base/ViewProj.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2005 Imetric 3D GmbH                                    *
  *                                                                         *

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/Writer.h
+++ b/src/Base/Writer.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/XMLTools.cpp
+++ b/src/Base/XMLTools.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2011 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/XMLTools.h
+++ b/src/Base/XMLTools.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2002 Jürgen Riegel <juergen.riegel@web.de>              *
  *                                                                         *

--- a/src/Base/ZipHeader.cpp
+++ b/src/Base/ZipHeader.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/ZipHeader.h
+++ b/src/Base/ZipHeader.h
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2022 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/swigpyrun.cpp
+++ b/src/Base/swigpyrun.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *

--- a/src/Base/swigpyrun.inl
+++ b/src/Base/swigpyrun.inl
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
 /***************************************************************************
  *   Copyright (c) 2009 Werner Mayer <wmayer[at]users.sourceforge.net>     *
  *                                                                         *


### PR DESCRIPTION
Added missing SPDX license identifiers.

Left out the `PyTools` files 
as they have a custom license.

Changes contain a ZLib licensed 
Base64 encoding / decoding snippet.

Waiting on #24528