### PR TITLE
Fix rotation issue in Attacher mmTangentPlane mode (#24599)

### DIFF
--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -1503,7 +1503,7 @@ AttachEngine3D::_calculateAttachedPlacement(const std::vector<App::DocumentObjec
                 dirX = dirY.Crossed(SketchNormal);
             }
 
-            SketchXAxis = gp_Vec(dirX).Reversed();  // yields upside-down sketches less often.
+            SketchXAxis = gp_Vec(dirX);
 
             if (bThruVertex) {
                 SketchBasePoint = p;


### PR DESCRIPTION
## Summary

In the new Attacher code in 1.1.0dev, orientations can be calculated based on the correct face orientation.
The legacy .Reversed() call, which was based on outdated face assumptions, is no longer needed and caused objects (e.g., DatumPlane) to rotate 180° around the Plane normal.
This PR removes that call, ensuring proper alignment with the reference Plane.

Note: The related issue (#24599) is still under triage. This PR is submitted in advance.

## Issues
#24599