### PR TITLE
CAM: Toggle Operation improve

### DIFF
--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -173,24 +173,31 @@ class _ToggleOperation:
         }
 
     def IsActive(self):
-        if bool(FreeCADGui.Selection.getSelection()) is False:
-            return False
-        try:
-            for sel in FreeCADGui.Selection.getSelectionEx():
-                selProxy = Path.Dressup.Utils.baseOp(sel.Object).Proxy
-                if not isinstance(selProxy, Path.Op.Base.ObjectOp) and not isinstance(
-                    selProxy, Path.Op.Gui.Array.ObjectArray
-                ):
-                    return False
-            return True
-        except (IndexError, AttributeError):
+        selection = FreeCADGui.Selection.getSelection()
+        if not selection:
             return False
 
+        for sel in selection:
+            baseOp = Path.Dressup.Utils.baseOp(sel)
+            if not hasattr(baseOp, "Active"):
+                return False
+
+        return True
+
     def Activated(self):
-        for sel in FreeCADGui.Selection.getSelectionEx():
-            op = Path.Dressup.Utils.baseOp(sel.Object)
-            op.Active = not op.Active
-            op.ViewObject.Visibility = op.Active
+        selection = FreeCADGui.Selection.getSelection()
+        for sel in selection:
+            baseOp = Path.Dressup.Utils.baseOp(sel)
+            baseOp.Active = not baseOp.Active
+            if sel == baseOp:
+                # selected not a Dressup
+                baseOp.ViewObject.Visibility = baseOp.Active
+            elif not baseOp.Active:
+                # only hide operation under Dressup
+                baseOp.ViewObject.Visibility = False
+            elif baseOp.Active:
+                # only unhide Dressup
+                sel.ViewObject.Visibility = True
 
         FreeCAD.ActiveDocument.recompute()
 


### PR DESCRIPTION
Make behavior of `CAM_OpActiveToggle` more universal
After this changes can be use not only for operations based on `Path.Op.Base.ObjectOp`,
but with any operations which has attribute `Active`

E.g. `MillFacing`, `PathShape`, `Array`

This PR related with #24661