### PR TITLE
[Base] fix some unit tests that where dependent on user config

### DIFF
--- a/tests/src/Base/Quantity.cpp
+++ b/tests/src/Base/Quantity.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include <Base/Exception.h>
 #include <Base/Quantity.h>
+#include "Base/UnitsApi.h"
 #include <QLocale>
 
 using Base::ParserError;
@@ -209,13 +210,21 @@ TEST_F(BaseQuantityLoc, psi_parse_no_space)
 
 TEST_F(BaseQuantityLoc, psi_parse_user_str)
 {
-    const auto qParsed = Quantity::parse("1 psi");
+    Base::UnitsApi::setSchema("Internal");
+    auto qParsed = Quantity::parse("1 psi");
+    auto format = qParsed.getFormat();
+    format.setPrecision(2);
+    qParsed.setFormat(format);
     EXPECT_EQ(qParsed.getUserString(), "6894.76 Pa");
 }
 
 TEST_F(BaseQuantityLoc, psi_parse_safe_user_str)
 {
-    const auto qParsed = Quantity::parse("1 psi");
+    Base::UnitsApi::setSchema("Internal");
+    auto qParsed = Quantity::parse("1 psi");
+    auto format = qParsed.getFormat();
+    format.setPrecision(2);
+    qParsed.setFormat(format);
     EXPECT_EQ(qParsed.getSafeUserString(), "6894.76 Pa");
 }
 

--- a/tests/src/Base/SchemaTests.cpp
+++ b/tests/src/Base/SchemaTests.cpp
@@ -74,6 +74,19 @@ protected:
         return quantity.getSafeUserString();
     }
 
+    static std::string setWithDenominator(const std::string& name,
+                                          const double value,
+                                          const Unit unit,
+                                          const int denominator)
+    {
+        UnitsApi::setSchema(name);
+        Quantity quantity {value, unit};
+        QuantityFormat format = quantity.getFormat();
+        format.setDenominator(denominator);
+        quantity.setFormat(format);
+        return quantity.getSafeUserString();
+    }
+
     std::unique_ptr<UnitsSchemas> schemas;  // NOLINT
 };
 
@@ -186,14 +199,6 @@ TEST_F(SchemaTest, mks_123456000_m_s_precision_6)
 {
     const std::string result = setWithPrecision("MKS", 123.456, Unit::Velocity, 6);
     const auto expect {"0.123456 m/s"};
-
-    EXPECT_EQ(result, expect);
-}
-
-TEST_F(SchemaTest, imperial_decimal_1_mm_default_precision)
-{
-    const std::string result = set("ImperialDecimal", Unit::Length, 1.0);
-    const auto expect {"0.04 in"};
 
     EXPECT_EQ(result, expect);
 }
@@ -378,7 +383,7 @@ TEST_F(SchemaTest, imperial_decimal_1_mm_precision_4)
 TEST_F(SchemaTest, imperial_safe_user_str_same)
 {
     constexpr auto val {304.8};
-    const auto result = set("Imperial", Unit::Length, val);
+    const auto result = setWithPrecision("Imperial", val, Unit::Length, 2);
     const auto expect = Tools::escapeQuotesFromString("1.00'");
 
     EXPECT_EQ(result, expect);
@@ -387,7 +392,7 @@ TEST_F(SchemaTest, imperial_safe_user_str_same)
 TEST_F(SchemaTest, imperial_safe_user_str_more)
 {
     constexpr auto val {310.0};
-    const auto result = set("Imperial", Unit::Length, val);
+    const auto result = setWithPrecision("Imperial", val, Unit::Length, 2);
     const auto expect = Tools::escapeQuotesFromString("1.02'");
 
     EXPECT_EQ(result, expect);
@@ -396,7 +401,7 @@ TEST_F(SchemaTest, imperial_safe_user_str_more)
 TEST_F(SchemaTest, imperial_safe_user_str_less)
 {
     constexpr auto val {300.0};
-    const auto result = set("Imperial", Unit::Length, val);
+    const auto result = setWithPrecision("Imperial", val, Unit::Length, 2);
     const auto expect = Tools::escapeQuotesFromString("11.81\"");
 
     EXPECT_EQ(result, expect);
@@ -405,7 +410,7 @@ TEST_F(SchemaTest, imperial_safe_user_str_less)
 TEST_F(SchemaTest, imperial_safe_user_str_one_inch)
 {
     constexpr auto val {25.4};
-    const auto result = set("Imperial", Unit::Length, val);
+    const auto result = setWithPrecision("Imperial", val, Unit::Length, 2);
     const auto expect = Tools::escapeQuotesFromString("1.00\"");
 
     EXPECT_EQ(result, expect);
@@ -440,7 +445,7 @@ TEST_F(SchemaTest, imperial_building_special_function_zero_length)
 TEST_F(SchemaTest, imperial_building_special_function_length_negative_fraction_only)
 {
     constexpr auto val {(-1.0 / 8.0) * 25.4};  // -1/8 inch in mm
-    const auto result = set("ImperialBuilding", Unit::Length, val);
+    const auto result = setWithDenominator("ImperialBuilding", val, Unit::Length, 8);
     const auto expect = Tools::escapeQuotesFromString("-1/8\"");
 
     EXPECT_EQ(result, expect);
@@ -458,7 +463,7 @@ TEST_F(SchemaTest, imperial_building_special_function_negative_inches_and_fracti
 TEST_F(SchemaTest, imperial_building_special_function_high_precision_rounding)
 {
     constexpr auto val {25.396};  // Very close to exactly 1 inch
-    const auto result = set("ImperialBuilding", Unit::Length, val);
+    const auto result = setWithDenominator("ImperialBuilding", val, Unit::Length, 8);
     const auto expect = Tools::escapeQuotesFromString("1\"");
 
     EXPECT_EQ(result, expect);
@@ -478,7 +483,7 @@ TEST_F(SchemaTest, imperial_building_special_function_length)
 TEST_F(SchemaTest, imperial_building_special_function_length_neg)
 {
     constexpr auto val {-360.6};
-    const auto result = set("ImperialBuilding", Unit::Length, val);
+    const auto result = setWithDenominator("ImperialBuilding", val, Unit::Length, 8);
     const auto expect = Tools::escapeQuotesFromString("-1' 2\" - 1/4\"");
 
     EXPECT_EQ(result, expect);


### PR DESCRIPTION
These tests would fail if the user has configured a different precision or denominator for imperial units

redundant and faulty test `imperial_decimal_1_mm_default_precision` removed, it is already covered by `imperial_decimal_1_mm_precision_2` and despite it's name the test does not actually use default precision but rather user configured precision
