### PR TITLE
CAM: Ensure pre-/postamble help text matches active values by avoiding duplication.

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -57,6 +57,18 @@ import KineticNCBeamicon2_post
 KineticNCBeamicon2_post.export(object,"/path/to/file.ncc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+PREAMBLE = """%
+G17 G21 G40 G49 G80 G90
+"""
+
+# Postamble text will appear following the last operation.
+POSTAMBLE = """M05
+M09
+G17 G90 G80 G40
+M30
+"""
+
 now = datetime.datetime.now()
 
 parser = argparse.ArgumentParser(
@@ -74,11 +86,15 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help=r'set commands to be issued before the first command, default="%%\nG17 G21 G40 G49 G80 G90\nM08\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help=r'set commands to be issued after the last command, default="M05 M09\nG17 G90 G80 G40\nM30\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
@@ -111,18 +127,6 @@ MACHINE_NAME = "not set"
 CORNER_MIN = {"x": 0, "y": 0, "z": 0}
 CORNER_MAX = {"x": 1000, "y": 600, "z": 300}
 PRECISION = 3
-
-# Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """%
-G17 G21 G40 G49 G80 G90
-"""
-
-# Postamble text will appear following the last operation.
-POSTAMBLE = """M05
-M09
-G17 G90 G80 G40
-M30
-"""
 
 # Pre operation text will be inserted before every operation
 PRE_OPERATION = """"""

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_4060_post.py
@@ -50,6 +50,22 @@ import delta_4060_post
 delta_4060_post.export(object,"/path/to/file.ncc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+PREAMBLE = """G17
+G90
+G80
+G40
+"""
+
+# Postamble text will appear following the last operation.
+POSTAMBLE = """M05
+G80
+G40
+G17
+G90
+M30
+"""
+
 parser = argparse.ArgumentParser(prog="delta_4060", add_help=False)
 parser.add_argument("--no-header", action="store_true", help="suppress header output")
 parser.add_argument("--no-comments", action="store_true", help="suppress comment output")
@@ -62,11 +78,17 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\\nG90\\nG80\\nG40\\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
+    default=PREAMBLE,
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M09\\nM05\\nG80\\nG40\\nG17\\nG90\\nM30\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
+    default=POSTAMBLE,
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G70)"
@@ -129,21 +151,6 @@ GCODE_MAP = {
     "G59": "E06",
 }
 
-# Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """G17
-G90
-G80
-G40
-"""
-
-# Postamble text will appear following the last operation.
-POSTAMBLE = """M05
-G80
-G40
-G17
-G90
-M30
-"""
 # Create following variable for use with the 2nd reference plane.
 clearanceHeight = None
 

--- a/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/dynapath_post.py
@@ -76,6 +76,24 @@ import dynapath_post
 dynapath_post.export(object,"/path/to/file.ncc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+PREAMBLE = """G17
+G90
+;G90.1 ;needed for simulation only
+G80
+G40
+"""
+
+# Postamble text will appear following the last operation.
+POSTAMBLE = """M09
+M05
+G80
+G40
+G17
+G90
+M30
+"""
+
 parser = argparse.ArgumentParser(prog="dynapath_post", add_help=False)
 parser.add_argument("--no-header", action="store_true", help="suppress header output")
 parser.add_argument("--no-comments", action="store_true", help="suppress comment output")
@@ -88,11 +106,17 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\\nG90\\nG80\\nG40\\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
+    default=PREAMBLE,
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M09\\nM05\\nG80\\nG40\\nG17\\nG90\\nM30\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
+    default=POSTAMBLE,
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
@@ -120,24 +144,6 @@ UNITS = "G21"  # G21 for metric, G20 for us standard
 MACHINE_NAME = "Tree MM"
 CORNER_MIN = {"x": -340, "y": 0, "z": 0}
 CORNER_MAX = {"x": 340, "y": -355, "z": -150}
-
-# Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """G17
-G90
-;G90.1 ;needed for simulation only
-G80
-G40
-"""
-
-# Postamble text will appear following the last operation.
-POSTAMBLE = """M09
-M05
-G80
-G40
-G17
-G90
-M30
-"""
 
 
 # Pre operation text will be inserted before every operation

--- a/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/estlcam_post.py
@@ -115,11 +115,15 @@ parser.add_argument(
 )
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default=""',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M5\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument("--inches", action="store_true", help="convert output for US imperial mode")

--- a/src/Mod/CAM/Path/Post/scripts/fangling_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fangling_post.py
@@ -57,6 +57,18 @@ import FangLing_post
 FangLing_post.export(object,"/path/to/file.ncc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+# PREAMBLE = '''G17 G54 G40 G49 G80 G90'''
+# Changed to match preamble produced by Fusion 360
+PREAMBLE = """G90
+"""
+
+# Postamble text will appear following the last operation.
+POSTAMBLE = """M8
+G90 G40
+M2
+"""
+
 now = datetime.datetime.now()
 
 parser = argparse.ArgumentParser(prog="FangLing", add_help=False)
@@ -68,11 +80,16 @@ parser.add_argument(
 )
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
-    "--preamble", help='set commands to be issued before the first command, default="G90\\n"'
+    "--preamble",
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M8\\nG90 G40\\nM2\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
@@ -107,18 +124,6 @@ MACHINE_NAME = "FangLing"
 CORNER_MIN = {"x": 0, "y": 0, "z": 0}
 CORNER_MAX = {"x": 500, "y": 300, "z": 300}
 PRECISION = 3
-
-# Preamble text will appear at the beginning of the GCODE output file.
-# PREAMBLE = '''G17 G54 G40 G49 G80 G90'''
-# Changed to match preamble produced by Fusion 360
-PREAMBLE = """G90
-"""
-
-# Postamble text will appear following the last operation.
-POSTAMBLE = """M8
-G90 G40
-M2
-"""
 
 # Pre operation text will be inserted before every operation
 PRE_OPERATION = """"""

--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -49,6 +49,16 @@ import fanuc_post
 fanuc_post.export(object,"/path/to/file.ncc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+DEFAULT_PREAMBLE = """G17 G54 G40 G49 G80 G90
+"""
+
+# Postamble text will appear following the last operation.
+DEFAULT_POSTAMBLE = """M05
+G17 G54 G90 G80 G40
+M30
+"""
+
 now = datetime.datetime.now()
 
 parser = argparse.ArgumentParser(prog="fanuc", add_help=False)
@@ -63,11 +73,15 @@ parser.add_argument(
 parser.add_argument("--precision", help="number of digits of precision, default=3 (mm) or 4 (in)")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90\\n"',
+    help='set commands to be issued before the first command, default="'
+    + DEFAULT_PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM30\\n"',
+    help='set commands to be issued after the last command, default="'
+    + DEFAULT_POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
@@ -122,15 +136,8 @@ PRECISION = 3
 # rigid tapping.
 tapSpeed = 0
 
-# Preamble text will appear at the beginning of the GCODE output file.
-DEFAULT_PREAMBLE = """G17 G54 G40 G49 G80 G90
-"""
-
-# Postamble text will appear following the last operation.
-DEFAULT_POSTAMBLE = """M05
-G17 G54 G90 G80 G40
-M30
-"""
+PREAMBLE = DEFAULT_PREAMBLE
+POSTAMBLE = DEFAULT_POSTAMBLE
 
 # Pre operation text will be inserted before every operation
 PRE_OPERATION = """"""
@@ -150,6 +157,8 @@ def processArguments(argstring):
     global OUTPUT_LINE_NUMBERS
     global SHOW_EDITOR
     global PRECISION
+    global DEFAULT_PREAMBLE
+    global DEFAULT_POSTAMBLE
     global PREAMBLE
     global POSTAMBLE
     global UNITS

--- a/src/Mod/CAM/Path/Post/scripts/grbl_legacy_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/grbl_legacy_post.py
@@ -122,11 +122,15 @@ parser.add_argument(
 )
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G90\\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M5\\nG17 G90\\nM2\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"

--- a/src/Mod/CAM/Path/Post/scripts/jtech_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/jtech_post.py
@@ -44,6 +44,16 @@ import jtech_post
 jtech_post.export(object,"/path/to/file.ngc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+PREAMBLE = """M05 S0
+G90
+"""
+
+# Postamble text will appear following the last operation.
+POSTAMBLE = """M05 S0
+M2
+"""
+
 now = datetime.datetime.now()
 
 parser = argparse.ArgumentParser(prog="jtech", add_help=False)
@@ -58,11 +68,15 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="M05 S0\\nG90\\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05 S0\\nM2\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
@@ -99,16 +113,6 @@ UNIT_FORMAT = "mm"
 
 MACHINE_NAME = "JTECH Photonic Laser"
 PRECISION = 3
-
-# Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """M05 S0
-G90
-"""
-
-# Postamble text will appear following the last operation.
-POSTAMBLE = """M05 S0
-M2
-"""
 
 PRE_FEED = """M03
 G4 P{}

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_legacy_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_legacy_post.py
@@ -45,6 +45,16 @@ import linuxcnc_legacy_post
 linuxcnc_legacy_post.export(object,"/path/to/file.ncc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+PREAMBLE = """G17 G54 G40 G49 G80 G90
+"""
+
+# Postamble text will appear following the last operation.
+POSTAMBLE = """M05
+G17 G54 G90 G80 G40
+M2
+"""
+
 now = datetime.datetime.now()
 
 parser = argparse.ArgumentParser(prog="linuxcnc", add_help=False)
@@ -59,11 +69,15 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90\\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
@@ -105,16 +119,6 @@ CORNER_MAX = {"x": 500, "y": 300, "z": 300}
 PRECISION = 3
 
 RIGID_TAP = False
-
-# Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """G17 G54 G40 G49 G80 G90
-"""
-
-# Postamble text will appear following the last operation.
-POSTAMBLE = """M05
-G17 G54 G90 G80 G40
-M2
-"""
 
 # Pre operation text will be inserted before every operation
 PRE_OPERATION = """"""

--- a/src/Mod/CAM/Path/Post/scripts/mach3_mach4_legacy_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/mach3_mach4_legacy_post.py
@@ -43,6 +43,16 @@ import mach3_4_legacy_post
 mach3_4_legacy_post.export(object,"/path/to/file.ncc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+PREAMBLE = """G17 G54 G40 G49 G80 G90
+"""
+
+# Postamble text will appear following the last operation.
+POSTAMBLE = """M05
+G17 G54 G90 G80 G40
+M2
+"""
+
 now = datetime.datetime.now()
 
 parser = argparse.ArgumentParser(prog="mach3_4", add_help=False)
@@ -57,11 +67,15 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90\\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
@@ -100,16 +114,6 @@ MACHINE_NAME = "mach3_4"
 CORNER_MIN = {"x": 0, "y": 0, "z": 0}
 CORNER_MAX = {"x": 500, "y": 300, "z": 300}
 PRECISION = 3
-
-# Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """G17 G54 G40 G49 G80 G90
-"""
-
-# Postamble text will appear following the last operation.
-POSTAMBLE = """M05
-G17 G54 G90 G80 G40
-M2
-"""
 
 # Pre operation text will be inserted before every operation
 PRE_OPERATION = """"""

--- a/src/Mod/CAM/Path/Post/scripts/marlin_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/marlin_post.py
@@ -88,6 +88,13 @@ POST_OPERATION = """"""  # Post operation text will be inserted after
 TOOL_CHANGE = """"""  # Tool Change commands will be inserted
 # before a tool change
 
+# Default preamble text will appear at the beginning of the gcode output file.
+PREAMBLE = """"""
+
+# Default postamble text will appear following the last operation.
+POSTAMBLE = """M5
+"""
+
 # *****************************************************************************
 # * Initial gcode output options, changeable via command line arguments       *
 # *****************************************************************************
@@ -155,10 +162,16 @@ parser.add_argument(
     help="do not translate drill cycles G81, G82, G83 into G0/G1 movements",
 )
 parser.add_argument(
-    "--preamble", help='set commands to be issued before the first command, default=""'
+    "--preamble",
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
-    "--postamble", help='set commands to be issued after the last command, default="M5\\n"'
+    "--postamble",
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument("--tool-change", action="store_true", help="Insert M6 for all tool changes")
 parser.add_argument(
@@ -192,13 +205,6 @@ TOOLTIP_ARGS = parser.format_help()
 # * Marlin 2.x ignores the ENTIRE COMMAND LINE if there is more than          *
 # * one command per line.                                                     *
 # *****************************************************************************
-
-# Default preamble text will appear at the beginning of the gcode output file.
-PREAMBLE = """"""
-
-# Default postamble text will appear following the last operation.
-POSTAMBLE = """M5
-"""
 
 # *****************************************************************************
 # * Internal global variables                                                 *

--- a/src/Mod/CAM/Path/Post/scripts/rrf_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/rrf_post.py
@@ -99,6 +99,14 @@ OUTPUT_BCNC = False  # Add bCNC operation block headers in output
 # gcode file
 SHOW_EDITOR = True  # Display the resulting gcode file
 OUTPUT_TOOL_CHANGE = True
+
+# Default preamble text will appear at the beginning of the gcode output file.
+PREAMBLE = """"""
+
+# Default postamble text will appear following the last operation.
+POSTAMBLE = """M5
+"""
+
 # *****************************************************************************
 # * Command line arguments                                                    *
 # *****************************************************************************
@@ -153,10 +161,16 @@ parser.add_argument(
     help="do not translate drill cycles G81, G82, G83 into G0/G1 movements",
 )
 parser.add_argument(
-    "--preamble", help='set commands to be issued before the first command, default=""'
+    "--preamble",
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
-    "--postamble", help='set commands to be issued after the last command, default="M5\\n"'
+    "--postamble",
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument("--tool-change", action="store_true", help="Insert M6 for all tool changes")
 parser.add_argument(
@@ -190,13 +204,6 @@ TOOLTIP_ARGS = parser.format_help()
 # * RRF ignores the ENTIRE COMMAND LINE if there is more than          *
 # * one command per line.                                                     *
 # *****************************************************************************
-
-# Default preamble text will appear at the beginning of the gcode output file.
-PREAMBLE = """"""
-
-# Default postamble text will appear following the last operation.
-POSTAMBLE = """M5
-"""
 
 # *****************************************************************************
 # * Internal global variables                                                 *

--- a/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/uccnc_post.py
@@ -257,11 +257,15 @@ parser.add_argument(
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17\\nG54\\G40\\nG49\\nG90\\nG80\\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE_DEFAULT_NO_COMMENT.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17\\nG54\\nG0\\nG90\\nG80\\nM30\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE_DEFAULT_NO_COMMENT.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument("--inches", action="store_true", help="lengths in [in], G20")
 parser.add_argument("--metric", action="store_true", help="lengths in [mm], G21")

--- a/src/Mod/CAM/Path/Post/scripts/wedm_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/wedm_post.py
@@ -48,6 +48,17 @@ import wedm_post
 wedm_post.export(object,"/path/to/file.ncc","")
 """
 
+# Preamble text will appear at the beginning of the GCODE output file.
+PREAMBLE = """G17 G54 G40 G49 G80 G90
+"""
+
+
+# Postamble text will appear following the last operation.
+POSTAMBLE = """M05
+G17 G54 G90 G80 G40
+M2
+"""
+
 now = datetime.datetime.now()
 
 parser = argparse.ArgumentParser(prog="wedm", add_help=False)
@@ -71,11 +82,15 @@ parser.add_argument("--precision", default="3", help="number of digits of precis
 parser.add_argument("--fixed-length", default="0", help="use fixed length coordinates, default=0")
 parser.add_argument(
     "--preamble",
-    help='set commands to be issued before the first command, default="G17 G54 G40 G49 G80 G90\\n"',
+    help='set commands to be issued before the first command, default="'
+    + PREAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="M05\\nG17 G54 G90 G80 G40\\nM2\\n"',
+    help='set commands to be issued after the last command, default="'
+    + POSTAMBLE.replace("\n", "\\n")
+    + '"',
 )
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
@@ -143,17 +158,6 @@ MACHINE_NAME = "Wire EDM"
 CORNER_MIN = {"x": 0, "y": 0, "z": 0}
 CORNER_MAX = {"x": 500, "y": 300, "z": 300}
 PRECISION = 3
-
-# Preamble text will appear at the beginning of the GCODE output file.
-PREAMBLE = """G17 G54 G40 G49 G80 G90
-"""
-
-
-# Postamble text will appear following the last operation.
-POSTAMBLE = """M05
-G17 G54 G90 G80 G40
-M2
-"""
 
 # Pre operation text will be inserted before every operation
 PRE_OPERATION = """"""


### PR DESCRIPTION
Make sure to use the active default values for preamble and postamble in the help text, and provide the current default values as the default in the add_argument().

The only exception is uccnc_post.py, where the real default value depend on the use of --no-comments, and sending the default argument to add_argument() would change behaviour.

This change was inspired by the changes done to fix (#20792) in d84d9c9bd19eff174a6a5de29282be5808ff1be4.