### PR TITLE
Core: remove obsolete Tux pythonToolbars function

### DIFF
--- a/src/Mod/Tux/PersistentToolbarsGui.py
+++ b/src/Mod/Tux/PersistentToolbarsGui.py
@@ -29,21 +29,6 @@ timer = QtCore.QTimer()
 mw = Gui.getMainWindow()
 
 
-def pythonToolbars():
-    """Manage Python based toolbar in BIM workbench."""
-
-    active = Gui.activeWorkbench().__class__.__name__
-
-    if active == "BIMWorkbench" and hasattr(Gui, "Snapper"):
-        try:
-            Gui.Snapper.show()
-        except Exception:
-            m = "Persistent toolbars: Snapper toolbar not managed.\n"
-            App.Console.PrintMessage(m)
-    else:
-        pass
-
-
 def isConnected(i):
     """Connect toolbar to onSave function."""
 
@@ -228,7 +213,6 @@ def onWorkbenchActivated():
     active = Gui.activeWorkbench().__class__.__name__
 
     if active:
-        pythonToolbars()
         onRestore(active)
     else:
         pass


### PR DESCRIPTION
The Snap toolbar used to be a special Python-generated toolbar. This has meanwhile been changed to a normal toolbar in both the Draft and BIM workbenches. The dedicated Tux code is therefore obsolete.