### PR TITLE
Update .git-blame-ignore-revs for BIM and Draft .pre-commit and Black format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -103,3 +103,5 @@ d472927bba7b2d8d151c99fb29cf1d8dd099ea7d # Correct PartDesign Helix feature nega
 b93c02e07da4990482b9d927506901e6f5d624e1 # Black updated to 24.3.0
 cbea6b60942f8327e6105b12e8c1d5db4647984c # FEM: Apply pre-commit to FEM files
 f9d66096878c7d89c273522b9ca57bdb14fee3bc # Rearranged CommandCreateGeo.cpp
+b23d5809414d63ea90bcc744212c126645051438 # BIM: add to pre-commit and apply Black formatting
+50e4864efb06faf3e2126e8cb9ff9058a08a54b2 # Draft: add to pre-commit and apply Black formatting


### PR DESCRIPTION
Following the merge of [Add BIM workbench to .pre-commit-config.yaml](https://github.com/FreeCAD/FreeCAD/pull/21591) that also formatted the whole BIM module with Black, .git-blame-ignore-revs is updated to include the relevant commit hash, so git history prior this change takes precedence.