### PR TITLE
Gui: Fix window restoration after Edit->Alignment completion

### DIFF
--- a/src/Gui/ManualAlignment.h
+++ b/src/Gui/ManualAlignment.h
@@ -262,6 +262,10 @@ private:
     int myPickPoints;
     Base::Placement myTransform;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+    Qt::WindowStates previousWindowState;
+#endif
+
     class Private;
     Private* d;
 };


### PR DESCRIPTION
After completing Edit->Alignment, main window remains small instead of maximized. It looks like this is Qt 6 regression as the automatic maximization behavior was somehow changed. Previously it didn't need explicit handling to restore the maximisation.

So, this patch preserves the previous window state before entering Alignment editor and restores window being maximized/minimized or normal upon finishing the operation.

Demo after:

https://github.com/user-attachments/assets/b9ab18d9-69e9-4570-812d-137b799b9d73

Resolves: https://github.com/FreeCAD/FreeCAD/issues/24293
Resolves: https://github.com/FreeCAD/FreeCAD/issues/21780