### PR TITLE
Gui: fix null handling logic in Application::setEditDocument

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1370,11 +1370,10 @@ Gui::MDIView* Application::editViewOfNode(SoNode* node) const
 
 void Application::setEditDocument(Gui::Document* doc)
 {
-    if (doc == d->editDocument) {
-        return;
-    }
     if (!doc) {
         d->editDocument = nullptr;
+    } else if (doc == d->editDocument) {
+        return;
     }
     for (auto& v : d->documents) {
         v.second->_resetEdit();


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/23417

See this comment for the reason: https://github.com/FreeCAD/FreeCAD/issues/23417#issuecomment-3403626659
