### PR TITLE
BIM: Remove icon after unclone

### DIFF
--- a/src/Mod/BIM/bimcommands/BimUnclone.py
+++ b/src/Mod/BIM/bimcommands/BimUnclone.py
@@ -69,6 +69,8 @@ class BIM_Unclone:
                 else:
                     newobj = obj
                     newobj.CloneOf = None
+                    if hasattr(newobj, "ViewObject") and newobj.ViewObject:
+                        newobj.ViewObject.signalChangeIcon()
 
                 # copy properties over, except special ones
                 for prop in cloned.PropertiesList:


### PR DESCRIPTION
As the title says - upon unclone icon is not being removed, but the cloned item stops mirroring original item which is correct, so this just aligns the icon removal logic with the correct behavior.

Just remove the sheep 🐑 , man

Demo: 

https://github.com/user-attachments/assets/d8e95661-5ea7-48ad-949a-635e58319149

@semhustej plx check and give some insights if you see something not working correct

Resolves: https://github.com/FreeCAD/FreeCAD/issues/24401