### PR TITLE
Sketcher: Fix ctrlA with filter vertex index issue

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2804,7 +2804,7 @@ bool ViewProviderSketch::selectAll()
             if (focusedList && std::ranges::find(ids, GeoId) == ids.end()) {
                 continue;
             }
-            
+
             if ((*it)->is<Part::GeomPoint>()) {
                 selectVertex(GeoId, Sketcher::PointPos::start);
             }


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/24554

ViewProviderSketch::selectAll was finding the VertexId to add by just incrementing a value. So it fails with filters since we are skipping some geometries.