### PR TITLE
CAM: remove old supplemental fixture command

### DIFF
--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -131,7 +131,6 @@ class CAMWorkbench(Workbench):
             "CAM_OpActiveToggle",
         ]
         prepcmdlist = [
-            "CAM_Fixture",
             "CAM_Comment",
             "CAM_Stop",
             "CAM_Custom",


### PR DESCRIPTION
Partially fixes #24594

The 'supplemental commands' menu contains a command for fixture.  This is a very old and AFAIK unused feature that conflicts with the primary use of fixtures  (WCS) in the Job setup.

This PR removes the supplemental fixture command from the GUI but does not remove the operation or code.  This should be removed in a future version.

[ ] Wiki should be updated to remove the fixture supplemental command page
[ ] Better wiki description of how WCSs are actually handled.

I've created a draft wiki page: https://wiki.freecad.org/User:Sliptonic/Work_Coordinate_Systems

