### PR TITLE
Assembly: Fix rename of joints not possible

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -579,11 +579,6 @@ QWidget* TreeWidgetItemDelegate::createEditor(
     App::DocumentObject* obj = item->object()->getObject();
     auto& prop = index.column() ? obj->Label2 : obj->Label;
 
-    std::ostringstream str;
-    str << "Change " << obj->getNameInDocument() << '.' << prop.getName();
-    App::GetApplication().setActiveTransaction(str.str().c_str());
-    FC_LOG("create editor transaction " << App::GetApplication().getActiveTransaction());
-
     DynamicQLineEdit *editor;
     if(TreeParams::getLabelExpression()) {
         DynamicQLineEdit *le = new DynamicQLineEdit(parent);
@@ -5953,3 +5948,4 @@ void DocumentObjectItem::applyExpandedSnapshot(const std::vector<bool>& snapshot
 }
 
 #include "moc_Tree.cpp"
+


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/24576

So why this bug happened :

- when you select a joint, it starts isolate mode.
- Press F2 triggers rename.
- Rename opens a transaction.
- The transaction opening emits a signal that is caught by the assembly and which cancels the isolate mode. (this behavior is needed to prevent transactions from wrongly capturing the temporary isolate visibilities or undoing that transaction is nuking the assembly).
- The isolate cancellation does a lot of things, which breaks the focus on the item and cancels the item renaming operation

After looking at tree.cpp, I found out that the transaction was opened in `TreeWidgetItemDelegate::createEditor`.
To fix this I thought, well no point in starting the command until AFTER the user validates the new name.
And so I found `DocumentObjectItem::setData`. where the Label property is being set.

And there surprise!!! A command is already being created and commited:

```
        std::ostringstream str;
        str << TreeWidget::tr("Rename").toStdString() << ' ' << getName() << '.' << label.getName();

        // Explicitly open and commit a transaction since this is a single change here
        // For more details: https://forum.freecad.org/viewtopic.php?f=3&t=72351
        App::Document* doc = obj->getDocument();
        doc->openTransaction(str.str().c_str());
        label.setValue(value.toString().toUtf8().constData());
        doc->commitTransaction();
```

So the transaction opening in `createEditor` is totally useless.
Checking the git blame we can see that indeed the transaction open in `createEditor` is 6 years old. While the one in `setData` is only 3 years old. So what happened 3 years ago is that the transaction was not working (proably it was never commited). So a contributor came and added the open/commit in `setData`. But he has not seen the legacy command opening in `createEditor`, and so he has not removed it.

Long story short, removing this useless command opening fix the bug.