### PR TITLE
Do not use the object's Name as a Label if that Label already exists

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -824,12 +824,11 @@ DocumentObject::onProposedLabelChange(std::string& newLabel)
     }
     if (doc && !newLabel.empty() && !_hPGrp->GetBool("DuplicateLabels") && !allowDuplicateLabel()
         && doc->containsLabel(newLabel)) {
-        // We must ensure the Label is unique in the document (well, sort of...).
+        // The label already exists but settings are such that duplicate labels should not be assigned.
         std::string objName = getNameInDocument();
-        if (doc->haveSameBaseName(objName, newLabel)) {
-            // The base name of the proposed label equals the base name of the object Name, so we
-            // use the object Name, which could actually be identical to another object's Label, but
-            // probably isn't.
+        if (!doc->containsLabel(objName) && doc->haveSameBaseName(objName, newLabel)) {
+            // The object name is not already a Label and the base name of the proposed label
+            // equals the base name of the object Name, so we use the object Name as the replacement Label.
             newLabel = objName;
         }
         else {


### PR DESCRIPTION
Fixes #24490
This removes long-standing handling of the creation of unique Labels for `DocumentObject`s when the Preference "Allow duplicate object labels in one document" in the General/Document section is unchecked.

With the old code, when the proposed label already existed, but the proposed label and the object's Name had the same base-name (i.e. they differed only in the uniqueness digits). the object's Name would be used as the replacement Label even if this duplicated another existing Label.

This change may have the minor regression of changing the Labels assigned to some document objects, but that should have little impact, except for rare cases where a user or some code expects objects to have a particular label