### PR TITLE
BIM: Prevent editing label on double-clicking an Arch MultiMaterial object

### DIFF
--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -778,6 +778,7 @@ class _ViewProviderArchMultiMaterial:
 
     def doubleClicked(self, vobj):
         self.edit()
+        return True
 
     def setupContextMenu(self, vobj, menu):
         if FreeCADGui.activeWorkbench().name() != "BIMWorkbench":


### PR DESCRIPTION
Before this fix, double-clicking on an ArchMultimaterial object opened its task panel as expected. Unexpectedly, its label was selected and set for edit.

- The tree view's double-click handling expects the view-provider to declare whether it handled the double-click.
- The ViewProvider API's doubleClicked() is documented to return bool (True if handled).
- If a view provider's doubleClicked method returns None/False, the tree falls back to the default Qt behavior (which is beginning inline editing of the item label).
- In ArchMaterial.py the view provider calls self.edit() (or FreeCADGui.ActiveDocument.setEdit(...)) but the method that the tree actually calls (the view provider's doubleClicked) does not return True. Because the method returns None, the tree continues and starts inline label-editing.

In summary: setEdit returning True is fine, but doubleClicked is the method the tree checks; it must return True to suppress the default inline rename.

This is the same fix as https://github.com/FreeCAD/FreeCAD/pull/23805 and https://github.com/FreeCAD/FreeCAD/pull/23756. We might want to scan the code for other locations that are missing the return value.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
