### PR TITLE
[CAM] fix bug opening job ui panel

### DIFF
--- a/src/Mod/CAM/Path/Op/Adaptive.py
+++ b/src/Mod/CAM/Path/Op/Adaptive.py
@@ -1849,8 +1849,8 @@ class PathAdaptive(PathOp.ObjectOp):
                 "Enable the experimental model awareness feature to respect 3D geometry and prevent cutting under overhangs",
             ),
         )
-        obj.setEditorMode("OrderCutsByRegion", 0 if obj.ModelAwareExperiment else 2)
-        obj.setEditorMode("ZStockToLeave", 0 if obj.ModelAwareExperiment else 2)
+        obj.setEditorMode("OrderCutsByRegion", 2)
+        obj.setEditorMode("ZStockToLeave", 2)
 
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])


### PR DESCRIPTION
@sliptonic bugfix for issue introduced in fix for #24553 

For whatever reason, opening the job panel initializes setup sheets which instantiates the adaptive operation, but in some way where it is not ok to access a property immediately after creating it. I have modified the Adaptive init code to not do that access, even though I think it should be fine, and it _is_ fine when we actually create adaptive operations. It's somewhat of a silly fix, but it produces correct behavior (the check wasn't actually necessary there; I'd copy-pasted it from elsewhere).
