### PR TITLE
CI (crowdin synchronization): Removed committing unneeded log file

### DIFF
--- a/.github/workflows/fetch_crowdin_translations.yml
+++ b/.github/workflows/fetch_crowdin_translations.yml
@@ -62,3 +62,6 @@ jobs:
           title: "Update translations from Crowdin"
           body: "Automatic Crowdin update."
           labels: "translations, automated"
+          delete-branch: true
+          add-paths: |
+            src


### PR DESCRIPTION
This PR removes committing unneeded log file by `Fetch Crowdin Translations` Action.