### PR TITLE
Build: Use date as revision when using a shallow clone

### DIFF
--- a/src/Tools/SubWCRev.py
+++ b/src/Tools/SubWCRev.py
@@ -8,7 +8,7 @@
 # 2012/02/01: The script was extended to support git
 # 2011/02/05: The script was extended to support also Bazaar
 
-import os, sys, re, time, getopt
+import os, sys, re, datetime, time, getopt
 from urllib.parse import urlparse
 import xml.sax
 import xml.sax.handler
@@ -305,8 +305,10 @@ class GitControl(VersionControl):
         result = None
         countallfh = os.popen("git rev-list --count %s..HEAD" % referencecommit)
         countallstr = countallfh.read().strip()
-        if countallfh.close() is not None:  # reference commit not present
-            self.rev = "%04d (Git shallow)" % referencerevision
+        if countallfh.close() is not None:  # reference commit not present, use the date
+            date_object = datetime.datetime.strptime(self.date, "%Y/%m/%d %H:%M:%S")
+            formatted_date = date_object.strftime("%Y%m%d")
+            self.rev = f"{formatted_date} (Git shallow)"
             return
         else:
             countall = int(countallstr)


### PR DESCRIPTION
Our recent change to the weekly build system uses a shallow clone to speed up production and be more efficient with our CI resources. This means that the "build revision" is no longer meaningful, always resulting in the use of the "reference" revision. Of course that revision was always a bit fictional since it doesn't refer to a specific git commit -- my read of various forums posts is that people basically use "revision" to figure out whether a reported bug is from a newer or older build than the one they are testing on. So this PR codifies that by replacing revision with the build date when building from a shallow clone. It will result in revisions that are clearly different from the old-style (because they will be far larger numerically), and will allow at-a-glance build date determination. For example, now a revision will be "202510221" instead of "52132".