### PR TITLE
Import: Fix crash in glTF importer when removeSplitter() fails

### DIFF
--- a/src/Mod/Import/App/ReaderGltf.cpp
+++ b/src/Mod/Import/App/ReaderGltf.cpp
@@ -153,7 +153,12 @@ TopoDS_Shape ReaderGltf::fixShape(TopoDS_Shape shape)  // NOLINT
 
     if (cleanup()) {
         sh.sewShape();
-        return sh.removeSplitter();
+        try {
+            return sh.removeSplitter();
+        }
+        catch (const Standard_Failure& e) {
+            return sh.getShape();
+        }
     }
 
     return sh.getShape();


### PR DESCRIPTION
Currently `removeSplitter()` function attempts to merge coplanar faces by using `ModelRefine::FaceUniter`, which internally uses `BRepBuilderAPI_Sewing`. This can fail in several scenarios, like inability to produce a valid shell, failing in face unification due to geometry incompatibilities, or when we have tolerance issue in the reconstructed geometry from glTF triangulation that prevent us from face merging.

That leads to the exception, which we are not handling correctly where it's being handled the same way as this patch introduces in other parts of FreeCAD.

So, this patch adds a try-catch block around `removeSplitter()` to gracefully handle `Standard_Failure` exception and return the sewn shape instead of crashing. Imported model will contain more individual faces than necessary (since coplanar won't be merged), resulting in a more complex topology in the places of those fails, but geometry and visual appearance will be preserved.

NOTE: After making this patch I've also discovered that OCCT has problem with reading uniform scaling from the files (which results in scale equal to 1 in every axis), I will open a separate issue for this one, and I also have prepared fix for OCCT. In the example file that was provided in issue it results in beams that are thrown throughout viewport.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/21703