### PR TITLE
BIM: BIM_ProjectManager: add missing self.project check

### DIFF
--- a/src/Mod/BIM/bimcommands/BimProjectManager.py
+++ b/src/Mod/BIM/bimcommands/BimProjectManager.py
@@ -130,13 +130,18 @@ class BIM_ProjectManager:
             if not buildings:
                 buildings = [o for o in doc.Objects if getattr(o, "IfcType", "") == "Building"]
             if buildings:
-                from nativeifc import ifc_tools
-
                 self.building = buildings[0]
                 self.form.buildingName.setText(self.building.Label)
+            levels = []
+            if self.building and self.project:
+                from nativeifc import ifc_tools
+
                 levels = ifc_tools.get_children(self.building, ifctype="IfcBuildingStorey")
-                if levels:
-                    self.form.countLevels.setValue(len(levels))
+                levels = list(filter(None, [ifc_tools.get_object(l) for l in levels]))
+            if not levels:
+                levels = [o for o in doc.Objects if getattr(o, "IfcType", "") == "Building Storey"]
+            if levels:
+                self.form.countLevels.setValue(len(levels))
 
         # show dialog
         self.form.show()


### PR DESCRIPTION
Fixes #24558.

`ifc_tools` should only be used for a native IFC project. The required `self.project` check was missing when levels were processed.

The new code follows the pattern used after `buildings = []`. That seemed the most obvious choice.

Note that the code is probably still a work in process. When reopening the dialog in a file that already has a site, building and levels, I would expect different behaviors. For example the number of existing levels is displayed, you would therefore expect that increasing that number would add the missing levels, but in fact a set of new levels is created.