### PR TITLE
Zero-4 machine controller don't like two M-commands in one line

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -130,7 +130,8 @@ POST_OPERATION = """"""
 
 # Tool Change commands will be inserted before a tool change
 TOOL_CHANGE = """M05
-M09"""
+M09
+"""
 
 
 def processArguments(argstring):


### PR DESCRIPTION
The zero-4 machine controller don't like two M-commands in one line. This as already fixed in the postamble (#23602). However, the constant for the tool change still creates two M-commands in one line.

## Issues
no issues addressed

## Before and After Images
G-Code before the change:
M05
M09M6 T1
M3 S14323

G-Code after the change with new line:
M05
M09
M6 T1
M3 S14323

