### PR TITLE
CAM: LeadInOut - Fix isActive()

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -1257,7 +1257,7 @@ class CommandPathDressupLeadInOut:
             return False
         if not selection[0].isDerivedFrom("Path::Feature"):
             return False
-        if selection.Name.startswith("Job"):
+        if selection[0].Name.startswith("Job"):
             return False
 
         return True


### PR DESCRIPTION
Fix little mistake in `isActive` function which done LeadInOut totally unusable