### PR TITLE
CAM: Refactor LeadInOut task panel to use QuantitySpinBox and improve migration/visibility logic

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/DressUpLeadInOutEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DressUpLeadInOutEdit.ui
@@ -62,20 +62,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QDoubleSpinBox" name="dspRadiusIn">
-          <property name="toolTip">
-           <string>Length of the Lead-in</string>
-          </property>
-          <property name="minimum">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>999999.000000000000000</double>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
+         <widget class="Gui::QuantitySpinBox" name="dspRadiusIn"/>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_1">
@@ -85,20 +72,7 @@
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QDoubleSpinBox" name="dspAngleIn">
-          <property name="toolTip">
-           <string>Angular extent of the lead in arc (degrees)</string>
-          </property>
-          <property name="maximum">
-           <double>180.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
+         <widget class="Gui::QuantitySpinBox" name="dspAngleIn"/>
         </item>
         <item row="4" column="0">
          <widget class="QLabel" name="label_7">
@@ -108,17 +82,7 @@
          </widget>
         </item>
         <item row="4" column="1">
-         <widget class="QDoubleSpinBox" name="dspOffsetIn">
-          <property name="minimum">
-           <double>-999999.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>999999.000000000000000</double>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
+         <widget class="Gui::QuantitySpinBox" name="dspOffsetIn"/>
         </item>
         <item row="5" column="0">
          <widget class="QCheckBox" name="chkInvertDirectionIn">
@@ -174,20 +138,7 @@
          </widget>
         </item>
         <item row="1" column="1">
-         <widget class="QDoubleSpinBox" name="dspRadiusOut">
-          <property name="toolTip">
-           <string>Length of the Lead-out</string>
-          </property>
-          <property name="minimum">
-           <double>0.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>999999.000000000000000</double>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
+         <widget class="Gui::QuantitySpinBox" name="dspRadiusOut"/>
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="label_11">
@@ -197,20 +148,7 @@
          </widget>
         </item>
         <item row="2" column="1">
-         <widget class="QDoubleSpinBox" name="dspAngleOut">
-          <property name="toolTip">
-           <string>Angular extent of the lead out arc (degrees)</string>
-          </property>
-          <property name="maximum">
-           <double>180.000000000000000</double>
-          </property>
-          <property name="singleStep">
-           <double>10.000000000000000</double>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
+         <widget class="Gui::QuantitySpinBox" name="dspAngleOut"/>
         </item>
         <item row="4" column="0">
          <widget class="QLabel" name="label_17">
@@ -220,17 +158,7 @@
          </widget>
         </item>
         <item row="4" column="1">
-         <widget class="QDoubleSpinBox" name="dspOffsetOut">
-          <property name="minimum">
-           <double>-999999.000000000000000</double>
-          </property>
-          <property name="maximum">
-           <double>999999.000000000000000</double>
-          </property>
-          <property name="unit" stdset="0">
-           <string notr="true"/>
-          </property>
-         </widget>
+         <widget class="Gui::QuantitySpinBox" name="dspOffsetOut"/>
         </item>
         <item row="5" column="0">
          <widget class="QCheckBox" name="chkInvertDirectionOut">
@@ -262,16 +190,6 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="chkLayers">
-       <property name="toolTip">
-        <string>Apply lead-in/out on all layers</string>
-       </property>
-       <property name="text">
-        <string>Include layers</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_8">
        <property name="text">
@@ -280,10 +198,7 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="dspRetractThreshold">
-       <property name="maximum">
-        <double>999999.000000000000000</double>
-       </property>
+      <widget class="Gui::QuantitySpinBox" name="dspRetractThreshold">
        <property name="unit" stdset="0">
         <string notr="true"/>
        </property>
@@ -308,4 +223,11 @@
  </widget>
  <resources/>
  <connections/>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
 </ui>


### PR DESCRIPTION
- Replace QDoubleSpinBox widgets with Gui::QuantitySpinBox in DressUpLeadInOutEdit.ui for all lead-in/out numeric fields, enabling unit/expressions support.
- Register QuantitySpinBox as a custom widget in the .ui file.
- Refactor TaskDressupLeadInOut panel setup:
  - Add setupSpinBoxes, setupGroupBoxes, setupDynamicVisibility for cleaner UI initialization.
  - Use PathGuiUtil.QuantitySpinBox for all numeric fields and ensure updateWidget() is called for each.
  - Centralize signal registration and field updates using getSignalsForUpdate and pageGetFields.
  - Move group box signal handler to a class method.
  - Share hideModes dictionary for field visibility logic.
  - Add dynamic label switching for "Radius"/"Length" with translation placeholders.
- Improve ObjectDressup migration:
  - Use shared hideModes from TaskDressupLeadInOut.
  - Set default angles to 90 instead of 45.
  - Preserve previous style values when migrating StyleOn/StyleOff.
  - Ensure field visibility is updated after migration.
- Add Perpendicular and Tangent to lead_styles in correct order.

Fixes #24415
Fixes #24413 
Fixes #24412