### PR TITLE
[GUI] Reimplementation of background

### DIFF
--- a/src/Gui/Inventor/SoFCBackgroundGradient.cpp
+++ b/src/Gui/Inventor/SoFCBackgroundGradient.cpp
@@ -20,45 +20,17 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <array>
-#include <boost/math/constants/constants.hpp>
-#include <cmath>
-#include <numbers>
-
-#include <FCConfig.h>
-
-#ifdef FC_OS_WIN32
-#include <windows.h>
-#endif
-
-#ifdef FC_OS_MACOSX
-#include <OpenGL/gl.h>
-#else
-#include <GL/gl.h>
-#endif
+#include <span>
+#include <QPainter>
+#include <QOpenGLTexture>
+#include <QFutureWatcher>
+#include <QRandomGenerator>
+#include <QGraphicsPixmapItem>
+#include <QGraphicsBlurEffect>
+#include <QtConcurrent/QtConcurrentRun>
 
 #include "SoFCBackgroundGradient.h"
 
-static const std::array <GLfloat[2], 32> big_circle = []{
-    constexpr float pi = std::numbers::pi_v<float>;
-    constexpr float sqrt2 = std::numbers::sqrt2_v<float>;
-    std::array <GLfloat[2], 32> result; int c = 0;
-    for (GLfloat i = 0; i < 2 * pi; i += 2 * pi / 32, c++) {
-        result[c][0] = sqrt2 * cosf(i);
-        result[c][1] = sqrt2 * sinf(i);
-    }
-    return result; }();
-static const std::array <GLfloat[2], 32> small_oval = []{
-    constexpr float pi = std::numbers::pi_v<float>;
-    constexpr float sqrt2 = std::numbers::sqrt2_v<float>;
-    static const float sqrt1_2 = std::sqrt(1 / 2.F);
-
-    std::array <GLfloat[2], 32> result; int c = 0;
-    for (GLfloat i = 0; i < 2 * pi; i += 2 * pi / 32, c++) {
-        result[c][0] = 0.3 * sqrt2 * cosf(i);
-        result[c][1] = sqrt1_2 * sinf(i);
-    }
-    return result; }();
 
 using namespace Gui;
 
@@ -75,10 +47,25 @@ void SoFCBackgroundGradient::finish()
 SoFCBackgroundGradient::SoFCBackgroundGradient()
 {
     SO_NODE_CONSTRUCTOR(SoFCBackgroundGradient);
-    fCol.setValue(0.5f, 0.5f, 0.8f);
-    tCol.setValue(0.7f, 0.7f, 0.9f);
-    mCol.setValue(1.0f, 1.0f, 1.0f);
+    fCol.setRgbF(0.5, 0.5, 0.8);
+    tCol.setRgbF(0.7, 0.7, 0.9);
+    mCol.setRgbF(1.0, 1.0, 1.0);
     gradient = Gradient::LINEAR;
+
+    SO_NODE_ADD_FIELD(redrawTrigger, ());
+
+    setupUpdater();
+
+    if (bgImage.isNull()){
+        QPixmap pix{1, 1};
+        pix.fill(Qt::GlobalColor::white);
+        bgImage = pix.toImage();
+    }
+
+    if (noiseImage.isNull()){
+        noiseImage = whiteNoise(noise_size);
+        checkerboardPattern(noiseImage);
+    }
 }
 
 /*!
@@ -104,57 +91,46 @@ void SoFCBackgroundGradient::GLRender (SoGLRenderAction * /*action*/)
     glPushAttrib(GL_ENABLE_BIT);
     glDisable(GL_DEPTH_TEST);
     glDisable(GL_LIGHTING);
-    glDisable(GL_TEXTURE_2D);
+    glEnable(GL_TEXTURE_2D);
 
-    if (gradient == Gradient::LINEAR) {
-        glBegin(GL_TRIANGLE_STRIP);
-        if (mCol[0] < 0) {
-            glColor3f(fCol[0],fCol[1],fCol[2]); glVertex2f(-1, 1);
-            glColor3f(tCol[0],tCol[1],tCol[2]); glVertex2f(-1,-1);
-            glColor3f(fCol[0],fCol[1],fCol[2]); glVertex2f( 1, 1);
-            glColor3f(tCol[0],tCol[1],tCol[2]); glVertex2f( 1,-1);
-        }
-        else {
-            glColor3f(fCol[0],fCol[1],fCol[2]); glVertex2f(-1, 1);
-            glColor3f(mCol[0],mCol[1],mCol[2]); glVertex2f(-1, 0);
-            glColor3f(fCol[0],fCol[1],fCol[2]); glVertex2f( 1, 1);
-            glColor3f(mCol[0],mCol[1],mCol[2]); glVertex2f( 1, 0);
-            glEnd();
-            glBegin(GL_TRIANGLE_STRIP);
-            glColor3f(mCol[0],mCol[1],mCol[2]); glVertex2f(-1, 0);
-            glColor3f(tCol[0],tCol[1],tCol[2]); glVertex2f(-1,-1);
-            glColor3f(mCol[0],mCol[1],mCol[2]); glVertex2f( 1, 0);
-            glColor3f(tCol[0],tCol[1],tCol[2]); glVertex2f( 1,-1);
-        }
+
+    glEnable(GL_BLEND);
+    glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    if(noiseTex == nullptr){
+        noiseTex.reset(new QOpenGLTexture(noiseImage));
+        noiseTex->setMinMagFilters(QOpenGLTexture::Filter::Nearest, QOpenGLTexture::Filter::Nearest);
+        noiseTex->setWrapMode(QOpenGLTexture::WrapMode::Repeat);
+        noiseTex->generateMipMaps();
     }
-    else { // radial gradient
-        glBegin(GL_TRIANGLE_FAN);
-        glColor3f(fCol[0], fCol[1], fCol[2]); glVertex2f(0.0f, 0.0f);
+    noiseTex->bind();
 
-        if (mCol[0] < 0) { // simple radial gradient
-            glColor3f(tCol[0], tCol[1], tCol[2]);
-            for (const GLfloat *vertex : big_circle)
-                glVertex2fv( vertex );
-            glVertex2fv( big_circle.front() );
-        } else {
-            glColor3f(mCol[0], mCol[1], mCol[2]);
-            for (const GLfloat *vertex : small_oval)
-                glVertex2fv( vertex );
-            glVertex2fv( small_oval.front() );
-            glEnd();
-
-            glBegin(GL_TRIANGLE_STRIP);
-            for (std::size_t i = 0; i < small_oval.size(); i++) {
-                glColor3f(mCol[0], mCol[1], mCol[2]); glVertex2fv( small_oval[i] );
-                glColor3f(tCol[0], tCol[1], tCol[2]); glVertex2fv( big_circle[i] );
-            }
-
-            glColor3f(mCol[0], mCol[1], mCol[2]); glVertex2fv( small_oval.front() );
-            glColor3f(tCol[0], tCol[1], tCol[2]); glVertex2fv( big_circle.front() );
-        }
-    } // end of radial gradient
+    glBegin(GL_QUADS);
+    glColor4d(1.0, 1.0, 1.0, 1.0);
+    glTexCoord2d(0.0, 0.0); glVertex2d(-1.0, -1.0);
+    glTexCoord2d(0.0, 1.0); glVertex2d(-1.0, +1.0);
+    glTexCoord2d(1.0, 1.0); glVertex2d(+1.0, +1.0);
+    glTexCoord2d(1.0, 0.0); glVertex2d(+1.0, -1.0);
     glEnd();
 
+
+    if(bgTex == nullptr){
+        bgTex.reset(new QOpenGLTexture(bgImage));
+        bgTex->setMinMagFilters(QOpenGLTexture::Linear, QOpenGLTexture::Linear);
+        bgTex->setWrapMode(QOpenGLTexture::ClampToEdge);
+        bgTex->generateMipMaps();
+    }
+    bgTex->bind();
+
+    glBegin(GL_QUADS);
+    glColor4d(1.0, 1.0, 1.0, bgTex_opacity);
+    glTexCoord2d(0.0, 0.0); glVertex2d(-1.0, -1.0);
+    glTexCoord2d(0.0, 1.0); glVertex2d(-1.0, +1.0);
+    glTexCoord2d(1.0, 1.0); glVertex2d(+1.0, +1.0);
+    glTexCoord2d(1.0, 0.0); glVertex2d(+1.0, -1.0);
+    glEnd();
+
+    glDisable(GL_TEXTURE_2D);
     glPopAttrib();
     glPopMatrix(); // restore modelview
     glMatrixMode(GL_PROJECTION);
@@ -165,6 +141,8 @@ void SoFCBackgroundGradient::GLRender (SoGLRenderAction * /*action*/)
 void SoFCBackgroundGradient::setGradient(SoFCBackgroundGradient::Gradient grad)
 {
     gradient = grad;
+
+    updater.start();
 }
 
 SoFCBackgroundGradient::Gradient SoFCBackgroundGradient::getGradient() const
@@ -175,16 +153,180 @@ SoFCBackgroundGradient::Gradient SoFCBackgroundGradient::getGradient() const
 void SoFCBackgroundGradient::setColorGradient(const SbColor& fromColor,
                                               const SbColor& toColor)
 {
-    fCol = fromColor;
-    tCol = toColor;
-    mCol[0] = -1.0f;
+    fCol = QColor::fromRgbF(fromColor[0], fromColor[1], fromColor[2]);
+    tCol = QColor::fromRgbF(toColor[0], toColor[1], toColor[2]);
+    mCol = QColor{};
+
+    updater.start();
 }
 
 void SoFCBackgroundGradient::setColorGradient(const SbColor& fromColor,
                                               const SbColor& toColor,
                                               const SbColor& midColor)
 {
-    fCol = fromColor;
-    tCol = toColor;
-    mCol = midColor;
+    fCol = QColor::fromRgbF(fromColor[0], fromColor[1], fromColor[2]);
+    tCol = QColor::fromRgbF(toColor[0], toColor[1], toColor[2]);
+    mCol = QColor::fromRgbF(midColor[0], midColor[1], midColor[2]);
+
+    updater.start();
 }
+
+static
+QImage createLinearGradient(const QSize &&size, const QList <QColor> &colors)
+{
+    const int w = size.width(), h = size.height();
+    const QColor &fromColor = colors.first(),
+                 &toColor = colors.at(1),
+                 &midColor = colors.last();
+    const QPointF start(0, h/2), finalStop(w, h/2);
+
+    QLinearGradient linearGrad(start, finalStop);
+    if (midColor.isValid()){
+        linearGrad.setStops({{0.0, fromColor}, {0.5, midColor}, {1.0, toColor}});
+    }else {
+        linearGrad.setStops({{0.0, fromColor}, {1.0, toColor}});
+    }
+
+   QPixmap pix{w, h};
+   QPainter painter{&pix};
+   painter.fillRect(0, 0, w, h, linearGrad);
+
+   return pix.toImage();
+}
+
+static
+QImage createRadialGradient(const QSize &&size, const QList <QColor> &colors)
+{
+    const int w = size.width(), h = size.height();
+    const QColor &fromColor = colors.first(),
+                 &toColor = colors.at(1),
+                 &midColor = colors.last();
+    const qreal cx = static_cast <qreal> (w) / 2.0,
+                cy = static_cast <qreal> (h) / 2.0,
+                r  = static_cast <qreal> (w) / 2.0;
+
+    QRadialGradient radialGrad(cx, cy, r);
+    if (midColor.isValid()){
+        radialGrad.setStops({{0.0, fromColor}, {0.5, midColor}, {1.0, toColor}});
+    }else {
+        radialGrad.setStops({{0.0, fromColor}, {1.0, toColor}});
+    }
+
+    QPixmap pix{w, h};
+    QPainter painter{&pix};
+    painter.fillRect(0, 0, w, h, radialGrad);
+
+    return pix.toImage();
+}
+
+static
+void horizontalShuffle(QImage &img, const qreal percent)
+{
+    const int w = img.width(), h = img.height();
+    const int shuffle_distance = static_cast <int> (static_cast <qreal> (w) * percent / 100.0);
+    QRandomGenerator rng{QRandomGenerator::system()->generate()};
+
+    for (int y = 1; y + 2 < h; y += 3){
+        std::span <QRgb> f_span(reinterpret_cast <QRgb *> (img.scanLine(y)), w);
+        std::span <QRgb> b_span(reinterpret_cast <QRgb *> (img.scanLine(y + 1)), w);
+        for(int f = 1, b = w - shuffle_distance - 1; f + shuffle_distance < w - 1; f++, b--){
+            auto f_subspan = f_span.subspan(f, shuffle_distance);
+            std::shuffle(f_subspan.begin(), f_subspan.end(), rng);
+            auto b_subspan = b_span.subspan(b, shuffle_distance);
+            std::shuffle(b_subspan.begin(), b_subspan.end(), rng);
+        }
+    }
+}
+
+static
+QImage createBgImage(const QSize &size,
+                     SoFCBackgroundGradient::Gradient type,
+                     const QList <QColor> &colors)
+{
+    Q_ASSERT_X(colors.count() == 3, "bgImage generation", "Three colors must be provided to create an image."
+                                                          "If you are unsure, the third color can be invalid.");
+
+    const int w = size.width(), h = size.height();
+    constexpr qreal shuffle_percent = 1;
+    QImage bgImage;
+
+    switch(type){
+        case SoFCBackgroundGradient::Gradient::LINEAR:{
+            QImage hor_grad = createLinearGradient({h, w}, colors);
+            horizontalShuffle(hor_grad, shuffle_percent);
+            QImage rotated = hor_grad.transformed(QTransform().rotate(270.0));
+            bgImage.swap(rotated);
+        }break;
+        case SoFCBackgroundGradient::Gradient::RADIAL:{
+            QImage rad_grad = createRadialGradient({h, w}, colors);
+            horizontalShuffle(rad_grad, shuffle_percent);
+            QImage rotated = rad_grad.transformed(QTransform().rotate(90.0));
+            horizontalShuffle(rotated, shuffle_percent*9.0/16.0);
+            bgImage.swap(rotated);
+        }break;
+    }
+
+    return bgImage;
+}
+
+QImage Gui::whiteNoise(const int width, const int height)
+{
+    QImage image(width, height, QImage::Format_RGB32);
+    QRandomGenerator::global()->fillRange(reinterpret_cast <quint32 *> (image.scanLine(0)), width * height);
+    return image;
+}
+
+QImage Gui::whiteNoise(const QSize &size)
+{
+    return whiteNoise(size.width(), size.height());
+}
+
+void Gui::checkerboardPattern(QImage &img)
+{
+    const int w = img.width(), h = img.height();
+    auto pixelData = reinterpret_cast <quint32 *> (img.scanLine(0));
+
+    for (int y = 0, i = 0; y < h; y++)
+        for (int x = 0; x < w; x++, i++)
+            if ( (x + y) % 2 == 0 )
+                pixelData[i] = qRgb(128, 128, 128);
+}
+
+/* FreeCAD sets gradient and colors many times per several milliseconds.
+ * QTimer updater "waits" till FreeCAD stops setting them and only then
+ * generates the background image if the values have changed. After the generation
+ * it sets the background image and updates the viewer. */
+void SoFCBackgroundGradient::setupUpdater(void)
+{
+    updater.setSingleShot(true);
+    updater.setInterval(pre_update_delay);
+
+    /* If there are N 3D viewers, when user changes colors or gradient,
+     * there will be N + 2 regenerations of the background image.
+     * Background image generation is supposed to prevent the UI from freezing. */
+    auto *watcher = new QFutureWatcher <QImage> (&updater);
+    auto createFun = [this, watcher](){
+        if (old_fCol == fCol && old_tCol == tCol && old_mCol == mCol &&
+            old_gradient == gradient){
+            return;
+        }
+
+        old_fCol = fCol; old_tCol = tCol; old_mCol = mCol;
+        old_gradient = gradient;
+
+        const QList <QColor> colors_lst{fCol, tCol, mCol};
+        QFuture <QImage> future = QtConcurrent::run(createBgImage, bgTex_size, gradient, colors_lst);
+        watcher->setFuture(future);
+    };
+
+    auto resetFun = [this, watcher](){
+        bgImage = watcher->result();
+        bgTex.reset();
+        this->redrawTrigger.touch();
+    };
+    QObject::connect(watcher, &QFutureWatcher<QImage>::finished, resetFun);
+    updater.callOnTimeout(createFun);
+}
+
+
+

--- a/src/Gui/Inventor/SoFCBackgroundGradient.h
+++ b/src/Gui/Inventor/SoFCBackgroundGradient.h
@@ -26,10 +26,12 @@
 #include <Inventor/SbColor.h>
 #include <Inventor/nodes/SoNode.h>
 #include <Inventor/nodes/SoSubNode.h>
+#include <Inventor/fields/SoSFTrigger.h>
 #include <FCGlobal.h>
+#include <QImage>
+#include <QTimer>
 
-
-class SbColor;
+class QOpenGLTexture;
 class SoGLRenderAction;
 
 namespace Gui {
@@ -56,15 +58,50 @@ public:
     void setColorGradient(const SbColor& fromColor,
                           const SbColor& toColor,
                           const SbColor& midColor);
+    void setupUpdater(void);
 
+    SoSFTrigger redrawTrigger;
 private:
     Gradient gradient;
 
 protected:
     ~SoFCBackgroundGradient() override;
 
-    SbColor fCol, tCol, mCol;
+    QColor fCol, tCol, mCol;
+
+    Gradient old_gradient{};
+    QColor old_fCol{}, old_tCol{}, old_mCol{};
+
+    QScopedPointer <QOpenGLTexture> bgTex{};    // background texture
+    QScopedPointer <QOpenGLTexture> noiseTex{}; // interleaved white noise texture with which the background texture is mixed
+
+    QImage bgImage{};
+    inline static QImage noiseImage{};
+
+    inline static constexpr QSize bgTex_size{1280, 720}; // Coin3D may report incorrect values of the size of the viewport
+    inline static constexpr QSize noise_size{1280, 720};
+    inline static constexpr double bgTex_opacity = 0.97;
+
+    inline static constexpr int pre_update_delay = 300;
+    QTimer updater;
 };
+
+/*!
+ * \brief A function to generate 2D white noise
+ * \param size
+ * \return QImage containing 2D white noise
+ * Generates 2D white noise of QImage::Format_RGB32.
+ */
+QImage whiteNoise(const QSize &size);
+QImage whiteNoise(const int width, const int height);
+
+/*!
+ * \brief A function to generate grey checkerboard pattern
+ * \param img
+ * The creators of Call of Duty: Advanced Warfare recommend using interleaved gradient noise, possessing properties from both dithering and random approaches. It has rich range of values like random noise, but at the same time it produces temporally coherent results.
+This function creates interleaved white noise invisible to the naked eye, but making big areas of the same color pleasant to the eyes with spatial coherency.
+ */
+void checkerboardPattern(QImage &img);
 
 } // namespace Gui
 


### PR DESCRIPTION
This commit reimplements background gradient. Closes #10210.


Both linear and radial gradient now look better. End user will notice the difference in radial, but now, I think, it looks radialer than before.


The most important thing here is that now the background is generated with Qt and is set later. Interleaved white noise texture is generated and set as underlay, while the gradient is set as overlay, creating eye-pleasing experience. You can compare before and after:


<details>
<img width="1718" height="968" alt="lin_grad-before" src="https://github.com/user-attachments/assets/7acd3fad-7112-46ba-87b1-bfb172b90ba9" />


<img width="1718" height="968" alt="lin_grad-after" src="https://github.com/user-attachments/assets/13ea3207-3359-4990-9733-be595d28350f" />


<img width="1718" height="968" alt="rad_grad-before" src="https://github.com/user-attachments/assets/c114221c-4b43-4d3e-993d-dc6524780c95" />


<img width="1718" height="968" alt="rad_grad-after" src="https://github.com/user-attachments/assets/f6ba3943-c4e0-4ef0-aa93-1a8b0d253144" />
</details>


<img width="256" height="129" alt="enlargened comparison" src="https://github.com/user-attachments/assets/f13110f5-8c9a-4666-9566-dad55825a5af" />


You might want to magnify it a few times to see the difference.

This PR should be tested on _Windows_ and _MacOS_. If it works, I suggest its merge before the next release.


<details><summary>Some long read for those ones who cares. </summary>


If you take a look at the source code, you will see that it appears logical and correct, though it is unclear why the texture is loaded within the render function, but you can explain it with my corrupt perspective. The commit results from incredibly hard beating the head against the wall for months.

I have reimplemented the background generation, greatly simplifying the code. The code now creates a picture using Qt and sets it as the background texture overlaying white noise with 95% opacity. Interleaved white noise adds spatial coherency to flat surface, while shuffling the colors makes sure that no color banding appears. The most obvious implementation does not work. Whatever you think, it does not work. What do you think of? Perhaps, you are thinking about the following plan:

1. Create a texture
2. Render it

Right? Three times haha! It does not work! Whatever I tried it does not work. Apparently, a Qt texture created outside of the current context of OpenGL cannot be displayed or shown outside the Qt OpenGL context and destroyed without showing an error in console.
I tried to do offscreen rendering and showing it, it does not work as well. I have been trying things for months, occasionally returning to this issue, however, it simply does not work. Seemingly, Qt OpenGL cannot be intermixed with _Coin3D_ OpenGL, except for the case implemented in this commit.


_Coin3D_ uses draw pixels function to display an image:

https://github.com/coin3d/coin/blob/a33214c5f7dfff1dbc4822fb6866f44bc6f881a1/src/shapenodes/SoImage.cpp#L502-L503


This is highly inefficient, since it causes noticeable slowdown if the image is more than 256 bytes. Drawing pixels also requires to use zoom which creates other problem, which in turn, is needed to be solved.

It also has _SoGLImage_ class that seems to be a sophisticated wrapper of _glTexImage2D_:

https://github.com/coin3d/coin/blob/a33214c5f7dfff1dbc4822fb6866f44bc6f881a1/src/rendering/SoGLImage.cpp#L1861


I don't know how to integrate it into the background implementation.


This commit:
- Creates an interleaved white noise image and sets it as underlay.
- Creates a background picture with Qt methods. Since the picture is created manually it can be greatly modified in any way. I implemented a shuffle algorithm to remove the color banding. Strictly speaking, since the background picture is created with Qt, it can be anything, for example, an SVG or a PNG file.
- Sets the picture as the background texture. The code responsible for the painting is greatly simplified and easier to read.


Some adjustments can be made.


I chose the shuffling coefficient of 1% as good. The bigger the texture the less shuffling it requires. For 4k 0.5% is top.
If you take a look at the source code, the final image resolution is 1280x720. With lower values, I can easily spot pixels with my keen eyes, however, if I set bigger values to generate a picture, it takes longer. I think that users may consider this lag unexpected. On the bright side, stretching the texture to a larger screen introduces some blur, which actually works well for a smooth background gradient.


I tested the code on KUbuntu 24.04, it must be tested on _Windows_ and _MacOS_. Since I have already encountered difference in OpenGL on various platform, I expect trouble.


One can see that the picture looks rimier. If people suggest to tweak coefficients, the picture can be bigger and blurrier, reminding _Acrylic_ effect from _Fluent Design_. However, the bigger the picture, the more time it requires to create. Users might find a one-second delay in creating a 3D view rather unpleasant.


On my computer the colors and the gradient are set 300 times per 400 ms. Almost all the values are the same, that is why I introduced a timer that simply waits when all the values are set before checking if the image regeneration required.


Further work can be done.
- Replacement of the white noise with pink or Perlin. They are more suitable and visually appealing. In this case the visual has an incredible paper-like texture. I think paper-like texture is suitable for _TechDraw_. I recommend adding at least interleaved white noise to TechDraw in the same fashion. This will greatly reduce eye strain.
- It is easy to implement change of the size of the background depending on screen resolution. However, setting of 3D view on HiDPI, requires 1.7 s with a debug version of _FreeCAD_. Perhaps, release version will be faster, but the most time-consuming operation is loading of the texture, not the creation of the background image. I'm not sure that this can be optimized.
- I could not find the right way to refresh the scene. The viewer now sets its pointer and the background refreshes the viewer once the textures are set. I'm sure there is be a better way to do this.
- Some things I don't understand, for example, why it sets 400 hundred times settings in 300 ms or why it sets the background color and then gradient, like these snippets:

https://github.com/FreeCAD/FreeCAD/blob/aef287cbb6ea8fe510dd1dbafe8a1bd02fbed613/src/Gui/View3DSettings.cpp#L541-L552

https://github.com/FreeCAD/FreeCAD/blob/aef287cbb6ea8fe510dd1dbafe8a1bd02fbed613/src/Gui/View3DInventorViewer.cpp#L577-L578


If you slow down _FreeCAD_, you will see that the settings are set, then they are reset.


Basically, this is insufficient _Acrylic_ with three layers-less:
https://learn.microsoft.com/en-gb/windows/apps/design/style/acrylic#how-we-designed-acrylic

The code slightly reminds the one implemented in KDE:
https://invent.kde.org/plasma/kwin/-/tree/master/src/plugins/blur

This approach was taken from Jorge Jimenez' presentation named "_Next generation post processing in Call of Duty: Advanced Warfare_".

</details>