### PR TITLE
[TechDraw]somewhat language agnostic ProjectionType

### DIFF
--- a/src/Mod/TechDraw/App/DrawPage.h
+++ b/src/Mod/TechDraw/App/DrawPage.h
@@ -109,6 +109,11 @@ public:
 
     void translateLabel(std::string context, std::string baseName, std::string uniqueName);
 
+    enum class PageProjectionConvention {
+        FirstAngle = 0,
+        ThirdAngle
+    };
+
 
 protected:
     void onBeforeChange(const App::Property* prop) override;

--- a/src/Mod/TechDraw/App/DrawProjGroup.cpp
+++ b/src/Mod/TechDraw/App/DrawProjGroup.cpp
@@ -49,6 +49,8 @@
 
 using namespace TechDraw;
 
+// this needs to be kept in the same sequence as the enum in the h file and with the QComboBox
+// in TaskProjGroup.ui.
 const char* DrawProjGroup::ProjectionTypeEnums[] = {"First angle", "Third angle",
                                                     "Default",//Use Page setting
                                                     nullptr};

--- a/src/Mod/TechDraw/App/DrawProjGroup.h
+++ b/src/Mod/TechDraw/App/DrawProjGroup.h
@@ -23,7 +23,6 @@
 #ifndef TECHDRAW_FEATUREVIEWGROUP_H_
 #define TECHDRAW_FEATUREVIEWGROUP_H_
 
-#include <string>
 #include <QRectF>
 
 #include <App/DocumentObject.h>
@@ -73,6 +72,14 @@ public:
     App::PropertyLength spacingY;
 
     App::PropertyLink Anchor; /// Anchor Element to align views to
+
+    // this needs to be kept in the same sequence as the literals in the cpp file and with the QComboBox
+    // in TaskProjGroup.ui.
+    enum class ViewProjectionConvention {
+        FirstAngle = 0,
+        ThirdAngle,
+        Page
+    };
 
     double autoScale() const override;
     double autoScale(double w, double h) const override;

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -32,7 +32,7 @@
 #include <Base/Parameter.h>
 
 #include "Preferences.h"
-#include "DrawBrokenView.h"
+#include "DrawProjGroup.h"
 #include "LineGenerator.h"
 
 //getters for parameters used in multiple places.
@@ -151,7 +151,9 @@ bool Preferences::useGlobalDecimals()
 
 int Preferences::projectionAngle()
 {
-    return getPreferenceGroup("General")->GetInt("ProjectionAngle", 0);  //First angle
+    int defaultConvention = (int)DrawProjGroup::ViewProjectionConvention::FirstAngle;
+    return getPreferenceGroup("General")->GetInt("ProjectionAngle",
+                                                 defaultConvention);
 }
 
 bool Preferences::groupAutoDistribute()

--- a/src/Mod/TechDraw/Gui/TaskProjGroup.h
+++ b/src/Mod/TechDraw/Gui/TaskProjGroup.h
@@ -99,7 +99,7 @@ protected Q_SLOTS:
 
     void customDirectionClicked();
 
-    void projectionTypeChanged(QString qText);
+    void projectionTypeChanged(int index);
     void scaleTypeChanged(int index);
     void AutoDistributeClicked(bool clicked);
     /// Updates item spacing
@@ -127,7 +127,7 @@ private:
     QPushButton* m_btnCancel{nullptr};
 
     std::vector<App::DocumentObject*> m_saveSource;
-    std::string    m_saveProjType;
+    long           m_saveProjType;
     std::string    m_saveScaleType;
     double         m_saveScale{1};
     bool           m_saveAutoDistribute{false};


### PR DESCRIPTION
This PR implements an additional fix for issue #24738.  This PR should follow PR #24762.

The fix uses an enum for comparisons instead of the original text comparisons using isValue() or asString.  This eliminates the requirement that ui strings match DrawProjGroup::ProjectionTypeEnums which causes issues for languages other than the default.

The original text values for ProjectionType will still be displayed untranslated in the property editor (like
all PropertyEnumerations)

![ProjectionTypeInUi](https://github.com/user-attachments/assets/59375ce8-13e0-400c-a281-d19f18e062ff)
