### PR TITLE
BIM: Fix beam rotation when Base property is cleared

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -1306,13 +1306,23 @@ class _Structure(ArchComponent.Component):
                                     # TODO use Part.Shape() rather than shape.copy() ... ?
                                     baseface = f.copy()
         elif length and width and height:
+            # check if this was a profil based arch structure
+            # profile-based structures should use XY plane orientation
+            use_profile_orientation = hasattr(obj, "Profile") and obj.Profile
+
             if (length > height) and (IfcType in ["Beam", "Column"]):
                 h2 = height / 2 or 0.5
                 w2 = width / 2 or 0.5
-                v1 = Vector(0, -w2, -h2)
-                v4 = Vector(0, -w2, h2)
-                v3 = Vector(0, w2, h2)
-                v2 = Vector(0, w2, -h2)
+                if use_profile_orientation:
+                    v1 = Vector(-w2, -h2, 0)
+                    v2 = Vector(w2, -h2, 0)
+                    v3 = Vector(w2, h2, 0)
+                    v4 = Vector(-w2, h2, 0)
+                else:
+                    v1 = Vector(0, -w2, -h2)
+                    v2 = Vector(0, w2, -h2)
+                    v3 = Vector(0, w2, h2)
+                    v4 = Vector(0, -w2, h2)
             else:
                 l2 = length / 2 or 0.5
                 w2 = width / 2 or 0.5


### PR DESCRIPTION
When a profile-based beam had its Base property cleared and the model was recomputed, the beam would rotate 90 degrees, changing its direction completely.

Profile objects are always created in the XY plane with Width along X, height along Y and normal along Z. However, if Base is cleared, fallback code always used YZ plane orientation for beams. This resulted in a different orientation during cleaned Base property.

Fix is to check if we are profile-based or not and if yes, use XY plane orientation, while we don't have this property then just use YZ plane orientation (preserving traditional horizontal behavior).

Demo:

https://github.com/user-attachments/assets/12f845f1-bf37-4cb3-a93f-71bf760605a0

Note: I'm still confused whether we should flip axises at all after assigning a profile, so I can change that as well, but didn't want to touch that additionally as the issue was reported about clearing, not assigning.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/22890