### PR TITLE
CAM: Fix expression editor so that widgets refresh after closing

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -659,6 +659,7 @@ static App::Document* getPreselectedDocument()
     return doc;
 }
 
+
 int DlgExpressionInput::getVarSetIndex(const App::Document* doc) const
 {
     auto paramExpressionEditor = App::GetApplication().GetParameterGroupByPath(

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -607,6 +607,7 @@ void QuantitySpinBox::openFormulaDialog()
         else if (box->discardedFormula())
             setExpression(std::shared_ptr<Expression>());
 
+        updateExpression();
         box->deleteLater();
         Q_EMIT showFormulaDialog(false);
     });

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -196,6 +196,7 @@ void ExpressionSpinBox::openFormulaDialog()
         else if (box->discardedFormula())
             setExpression(std::shared_ptr<Expression>());
 
+        updateExpression();
         box->deleteLater();
     });
     box->show();

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1621,6 +1621,7 @@ void ExpLineEdit::finishFormulaDialog()
     else if (box->discardedFormula())
         setExpression(std::shared_ptr<Expression>());
 
+    onChange();
     box->deleteLater();
 
     if(autoClose)

--- a/src/Mod/CAM/Path/Base/Gui/Util.py
+++ b/src/Mod/CAM/Path/Base/Gui/Util.py
@@ -131,6 +131,21 @@ class QuantitySpinBox(QtCore.QObject):
         self.widget.installEventFilter(self)
         # Connect local class method as slot
         self.widget.textChanged.connect(self.onWidgetValueChanged)
+        # Connect to showFormulaDialog signal to track dialog open/close
+        try:
+            self.widget.showFormulaDialog.connect(self.onFormulaDialogStateChanged)
+        except AttributeError:
+            # Widget may not have this signal
+            pass
+
+    def onFormulaDialogStateChanged(self, isOpen):
+        """
+        Slot called when the formula dialog is opened or closed.
+        When the dialog closes (isOpen=False), refresh the widget.
+        """
+        if not isOpen:
+            # Dialog has closed, update the widget to reflect any changes
+            self.updateWidget()
 
     def eventFilter(self, obj, event):
         if event.type() == QtCore.QEvent.Type.FocusIn:


### PR DESCRIPTION
src/Gui/QuantitySpinBox.cpp:
- Call updateExpression() after setExpression() in QuantitySpinBox

src/Gui/SpinBox.cpp:
- Call updateExpression() after setExpression() in ExpressionSpinBox

src/Gui/Widgets.cpp:
- Call onChange() after setExpression() in ExpLineEdit

src/Mod/CAM/Path/Base/Gui/Util.py:
- Connect to showFormulaDialog signal and refresh CAM QuantitySpinBox Python wrapper when dialog closes

Fixes: #24410 