### PR TITLE
BIM: fix shortcut for Arch_IfcSpreadsheet

### DIFF
--- a/src/Mod/BIM/bimcommands/BimArchUtils.py
+++ b/src/Mod/BIM/bimcommands/BimArchUtils.py
@@ -459,7 +459,7 @@ class Arch_IfcSpreadsheet:
         return {
             "Pixmap": "Arch_Schedule",
             "MenuText": QT_TRANSLATE_NOOP("Arch_IfcSpreadsheet", "New IFC Spreadsheet"),
-            "Accel": "I, P",
+            "Accel": "I, S",
             "ToolTip": QT_TRANSLATE_NOOP(
                 "Arch_IfcSpreadsheet", "Creates a spreadsheet to store IFC properties of an object"
             ),


### PR DESCRIPTION
Fixes #24742.

Change keyboard shortcut from 'I, P' to 'I, S' to avoid conflict with IFC_MakeProject.