### PR TITLE
CAM: Inspect - decrease default Max Highlighter Size

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Inspect.py
+++ b/src/Mod/CAM/Path/Main/Gui/Inspect.py
@@ -214,8 +214,8 @@ def show(obj):
     "show(obj): shows the G-code data of the given Path object in a dialog"
 
     prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
-    # default Max Highlighter Size = 512 Ko
-    defaultMHS = 512 * 1024
+    # default Max Highlighter Size = 256 Ko
+    defaultMHS = 256 * 1024
     mhs = prefs.GetUnsigned("inspecteditorMaxHighlighterSize", defaultMHS)
 
     if hasattr(obj, "Path"):


### PR DESCRIPTION
default `Max Highlighter Size` is too high

Also need to add information to wiki about how user can change this value 
Unsigned parameter `inspecteditorMaxHighlighterSize` in the group `BaseApp/Preferences/Mod/CAM`
