### PR TITLE
TechDraw: Fix centerlines being double Y-axis transformed

### DIFF
--- a/src/Mod/TechDraw/App/AppTechDrawPy.cpp
+++ b/src/Mod/TechDraw/App/AppTechDrawPy.cpp
@@ -629,7 +629,7 @@ private:
             shape = mkTrf.Shape();
             writer.exportShape(shape);
         }
-        //add the cosmetic edges also
+        //add the cosmetic edges also (centerlines, cosmetic lines, etc)
         std::vector<TechDraw::BaseGeomPtr> geoms = dvp->getEdgeGeometry();
         std::vector<TopoDS_Edge> cosmeticEdges;
         for (auto& g : geoms) {
@@ -638,9 +638,14 @@ private:
             }
         }
         if (!cosmeticEdges.empty()) {
-            shape = ShapeUtils::mirrorShape(DrawUtil::vectorToCompound(cosmeticEdges));
-            mkTrf.Perform(shape);
-            shape = mkTrf.Shape();
+            // cosmetic edges (centerlines, etc) are already in correct Y orientation
+            // so they only need translation, not mirroring like the regular geometry
+            // issue #22470
+            shape = DrawUtil::vectorToCompound(cosmeticEdges);
+            gp_Trsf xLateCosmetics;
+            xLateCosmetics.SetTranslation(gp_Vec(dvpX, dvpY, 0.0));
+            BRepBuilderAPI_Transform mkTrfCosmetics(shape, xLateCosmetics);
+            shape = mkTrfCosmetics.Shape();
             writer.exportShape(shape);
         }
     }


### PR DESCRIPTION
As the title says. Currently when user exports to DXF, centerlines and cosmetic edges appeared offset below their correct positions. The offset was visible when opening exported DXF file in CAD software - centerlines were displaced downward where they should be.

The issue was that cosmetic edges are already stored with the correct Y orientation and should not be mirrored during export, so this caused centerlines to be mirrored when they shouldn't be, resulting in incorrect Y position.

So this is just a small modification to cosmetic edge export to skip the Y-axis mirroring step.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/22470