### PR TITLE
Import: Make sure to not convert text height from draw units to points

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2172,8 +2172,7 @@ bool CDxfRead::ReadText()
     ResolveEntityAttributes();
 
     if ((this->*stringToUTF8)(textPrefix)) {
-        OnReadText(insertionPoint, height * 25.4 / 72.0, textPrefix, rotation);
-        // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
+        OnReadText(insertionPoint, height, textPrefix, rotation);
     }
     else {
         ImportError("Unable to process encoding for TEXT/MTEXT '%s'\n", textPrefix);


### PR DESCRIPTION
When importing DXF files using the C++ importer, TEXT and MTEXT entities had incorrect heights. For example:
- text with height 100mm in the DXF file was imported as 35.28mm in FC. The scaling factor was consistent to be 0.3528.

The issue was that we were applying a point-to-millimeter conversion to the text height , but that seems to be incorrect since according to DXF spec, TEXT and MTEXT entity heights are always specified in drawing units, not in points, so just remove that code.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/22779