### PR TITLE
Gui: Fix FreeTurntable orbit style not constraining vertical axis

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -1061,11 +1061,11 @@ void NavigationStyle::spin(const SbVec2f & pointerpos)
 
     if (getOrbitStyle() == FreeTurntable) {
         SbVec2f midpos(lastpos[0], pointerpos[1]);
-        spin_internal(pointerpos, midpos);
-        spin_internal(midpos, lastpos);
+        spinInternal(pointerpos, midpos);
+        spinInternal(midpos, lastpos);
     }
     else {
-        spin_internal(pointerpos, lastpos);
+        spinInternal(pointerpos, lastpos);
     }
 
     if (this->currentmode != NavigationStyle::IDLE) {
@@ -1073,7 +1073,7 @@ void NavigationStyle::spin(const SbVec2f & pointerpos)
     }
 }
 
-void NavigationStyle::spin_internal(const SbVec2f & pointerpos, const SbVec2f & lastpos)
+void NavigationStyle::spinInternal(const SbVec2f & pointerpos, const SbVec2f & lastpos)
 {
     float sensitivity = getSensitivity();
 
@@ -1158,17 +1158,17 @@ void NavigationStyle::spin_simplified(SbVec2f curpos, SbVec2f prevpos)
 
     if (getOrbitStyle() == FreeTurntable) {
         SbVec2f midpos(prevpos[0], curpos[1]);
-        spin_simplified_internal(curpos, midpos);
-        spin_simplified_internal(midpos, prevpos);
+        spinSimplifiedInternal(curpos, midpos);
+        spinSimplifiedInternal(midpos, prevpos);
     }
     else {
-        spin_simplified_internal(curpos, prevpos);
+        spinSimplifiedInternal(curpos, prevpos);
     }
 
     hasDragged = true;
 }
 
-void NavigationStyle::spin_simplified_internal(SbVec2f curpos, SbVec2f prevpos)
+void NavigationStyle::spinSimplifiedInternal(SbVec2f curpos, SbVec2f prevpos)
 {
     // 0000333: Turntable camera rotation
     SbMatrix mat;

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -254,8 +254,8 @@ protected:
     virtual void openPopupMenu(const SbVec2s& position);
 
 private:
-    void spin_internal(const SbVec2f & pointerpos, const SbVec2f & lastpos);
-    void spin_simplified_internal(const SbVec2f curpos, const SbVec2f prevpos);
+    void spinInternal(const SbVec2f & pointerpos, const SbVec2f & lastpos);
+    void spinSimplifiedInternal(const SbVec2f curpos, const SbVec2f prevpos);
     bool isNavigationStyleAction(QAction* action, QActionGroup* navMenuGroup) const;
     QWidget* findView3DInventorWidget() const;
     void applyNavigationStyleChange(QAction* selectedAction);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
## Summary

Turntable orbit style should constrain vertical orientation. In FreeCAD "Turntable" orbit style does that but also limits the rotation to one axis at a time. "FreeTurntable" allows 2 axis rotation but does not constrain the vertical orientation.

I have been trying to fix "FreeTurntable" for months and finally come up with this slightly hacky solution: just do "Turntable" rotation twice through a mid point in a stair step fashion.

"FreeTurntable" has 2 more issues that are fixed:
- When the model is upside-down the rotation around vertical is inversed.
- In `getFreeTurntable()` `z..` and `x..` variables are swapped.

Before this solution I tried but failed:
- Rework `getFreeTurntable()` with varios adjustments
  - Nothing worked :D
- Multiply `inherited::getRotation()` with a compensating rotation to right up the vertical
  - Worked but produced a very jittery rotation
- Utilize `SbCylinderSheetProjector`
  - The produced rotation did not match with mouse movement. I suspect that the cursor position has to be projected with `SbCylinderSheetProjector` instead of `SbSphereSheetProjector` but I couldn't make that work.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!-- ## Issues -->
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

https://github.com/user-attachments/assets/36f75b13-54fe-4a2d-9021-ffcfde2dd651

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
