### PR TITLE
Draft: fix relative path issue when editing existing hatch

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_hatch.py
+++ b/src/Mod/Draft/draftguitools/gui_hatch.py
@@ -124,6 +124,11 @@ class Draft_Hatch_TaskPanel:
 
     def onFileChanged(self, filename):
 
+        if filename[0] == "." and self.baseobj:
+            # File path relative to the FreeCAD file directory.
+            filename = os.path.join(os.path.dirname(self.baseobj.Document.FileName), filename)
+            filename = os.path.abspath(filename)
+
         pat = self.form.Pattern.currentText()
         self.form.Pattern.clear()
         patterns = self.getPatterns(filename)


### PR DESCRIPTION
Something that was missed in #23294.

When double-clicking a hatch in the Tree View to edit it a relative path was not resolved.