### PR TITLE
Gui: Introduce search bar to Report View 

### DIFF
--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -959,7 +959,7 @@ void ReportOutput::keyPressEvent(QKeyEvent* event)
     QTextEdit::keyPressEvent(event);
 }
 
-void ReportOutput::showSearchBar() const
+void ReportOutput::showSearchBar()
 {
     if (!searchBar) {
         return;
@@ -972,6 +972,9 @@ void ReportOutput::showSearchBar() const
     QRect rect = this->rect();
     int height = searchBar->sizeHint().height();
     searchBar->setGeometry(0, rect.height() - height, rect.width(), height);
+
+    // adjust viewport margins to prevent text from being hidden under search bar
+    setViewportMargins(0, 0, 0, height);
 }
 
 void ReportOutput::hideSearchBar()
@@ -982,6 +985,9 @@ void ReportOutput::hideSearchBar()
 
     searchBar->hide();
     setFocus();
+
+    // reset viewport margins
+    setViewportMargins(0, 0, 0, 0);
 }
 
 void ReportOutput::performSearch(SearchDirection direction)

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -940,7 +940,12 @@ void ReportOutput::OnChange(Base::Subject<const char*> &rCaller, const char * sR
 void ReportOutput::keyPressEvent(QKeyEvent* event)
 {
     if (event->matches(QKeySequence::Find)) {
-        showSearchBar();
+        if (searchBar && searchBar->isVisible()) {
+            hideSearchBar();
+        }
+        else {
+            showSearchBar();
+        }
         event->accept();
         return;
     }

--- a/src/Gui/ReportView.h
+++ b/src/Gui/ReportView.h
@@ -25,6 +25,7 @@
 
 #include <QPointer>
 #include <QTextEdit>
+#include <QLineEdit>
 #include <QSyntaxHighlighter>
 
 #include "Window.h"
@@ -170,6 +171,10 @@ protected:
     void contextMenuEvent ( QContextMenuEvent* e ) override;
     /** Handle shortcut override events */
     bool event(QEvent* event) override;
+    /** Handle key press events */
+    void keyPressEvent(QKeyEvent* event) override;
+    /** Handle resize events */
+    void resizeEvent(QResizeEvent* event) override;
 
 public Q_SLOTS:
     /** Save the report messages into a file. */
@@ -200,6 +205,14 @@ public Q_SLOTS:
     void onToggleRedirectPythonStderr();
     /** Toggles the report to go to the end if new messages appear. */
     void onToggleGoToEnd();
+    /** Shows the search bar. */
+    void showSearchBar() const;
+    /** Hides the search bar. */
+    void hideSearchBar();
+    /** Finds the next occurrence of the search text. */
+    void findNext();
+    /** Finds the previous occurrence of the search text. */
+    void findPrevious();
 
 private:
     class Data;
@@ -209,6 +222,11 @@ private:
     ReportHighlighter* reportHl; /**< Syntax highlighter */
     int messageSize;
     ParameterGrp::handle _prefs;
+    QWidget* searchBar;
+    QLineEdit* searchLineEdit;
+    QPushButton* findNextButton;
+    QPushButton* findPreviousButton;
+    QPushButton* closeSearchButton;
 };
 
 /**

--- a/src/Gui/ReportView.h
+++ b/src/Gui/ReportView.h
@@ -209,12 +209,14 @@ public Q_SLOTS:
     void showSearchBar() const;
     /** Hides the search bar. */
     void hideSearchBar();
-    /** Finds the next occurrence of the search text. */
-    void findNext();
-    /** Finds the previous occurrence of the search text. */
-    void findPrevious();
 
 private:
+    enum class SearchDirection {
+        Forward,
+        Backward
+    };
+    /** Perform text search with given direction. */
+    void performSearch(SearchDirection direction);
     class Data;
     Data* d;
     bool gotoEnd;

--- a/src/Gui/ReportView.h
+++ b/src/Gui/ReportView.h
@@ -206,7 +206,7 @@ public Q_SLOTS:
     /** Toggles the report to go to the end if new messages appear. */
     void onToggleGoToEnd();
     /** Shows the search bar. */
-    void showSearchBar() const;
+    void showSearchBar();
     /** Hides the search bar. */
     void hideSearchBar();
 


### PR DESCRIPTION
Currently there's no option to search in Report View, which makes it problematic to find if either someone logs something or tries to find something among logs that are printed from the features.

So, this adds this feature. Users are able to toggle it by pressing CTRL+F while having focus on report view. Additionally:
- ESC closes it
- There are also buttons to navigate, but pressing ENTER goes to next position
- Pressing CTRL+F again while it's open hides it

Demo:

https://github.com/user-attachments/assets/b2af36e4-cf6a-4e7d-9108-131b4b9522a8

