### PR TITLE
Materials: Assigning material without appearance

### DIFF
--- a/src/App/Material.h
+++ b/src/App/Material.h
@@ -140,16 +140,17 @@ public:
     bool operator==(const Material& m) const
     {
         // clang-format off
-        return _matType == m._matType
-            && shininess == m.shininess
+        if (!uuid.empty() && uuid == m.uuid) {
+            return true;
+        }
+        return shininess == m.shininess
             && transparency == m.transparency
             && ambientColor == m.ambientColor
             && diffuseColor == m.diffuseColor
             && specularColor == m.specularColor
             && emissiveColor == m.emissiveColor
             && image == m.image
-            && image == m.imagePath
-            && uuid == m.uuid;
+            && imagePath == m.imagePath;
         // clang-format on
     }
     bool operator!=(const Material& m) const

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -192,8 +192,10 @@ void ViewProviderGeometryObject::updateData(const App::Property* prop)
              */
             App::Material defaultMaterial;
             auto material = geometry->getMaterialAppearance();
-            if ((materialAppearance == defaultMaterial)
-                || (ShapeAppearance.getSize() == 1 && ShapeAppearance[0] == materialAppearance)) {
+            if ((ShapeAppearance.getSize() == 1)
+                && (ShapeAppearance[0] == defaultMaterial
+                    || ShapeAppearance[0] == materialAppearance)
+                && (material != defaultMaterial)) {
                 ShapeAppearance.setValue(material);
             }
             materialAppearance = material;


### PR DESCRIPTION
Assigning a material without an appearance reset the appearance to the default appearance.

There were two main problems. One was the comparison function for App::Material objects. It would return false when the UUID or MatType values were different although there are many circumstances where this could be true and the appearance be the same. It also incorrectly compared the imagePath.

The second problem was the logic for detecting if an object has already been assigned an appearance by assigning a material or manually setting the appearance. If assigned a material, the appearance should update but not if it has been set manually. This logic has been corrected.

## Issues
Fixes #18262 

## Before and After Images
N/A