### PR TITLE
Gui: Use C99 `_Exit` instead of not as portable POSIX `_exit`.

### DIFF
--- a/src/Gui/Dialogs/DlgVersionMigrator.cpp
+++ b/src/Gui/Dialogs/DlgVersionMigrator.cpp
@@ -37,6 +37,7 @@
 #include <set>
 #include <string>
 #include <ranges>
+#include <cstdlib>
 
 #include "DlgVersionMigrator.h"
 #include "ui_DlgVersionMigrator.h"
@@ -363,7 +364,7 @@ void DlgVersionMigrator::restart(const QString &message)
         }
     });
     QCoreApplication::exit(0);
-    _exit(0); // No really. Die.
+    _Exit(0); // No really. Die.
 }
 
 


### PR DESCRIPTION
The actual fix here is for a compile error which started appearing as an error due to `unistd.h` include being included implicitly from `boost::signals`, which is not the case on https://github.com/FreeCAD/FreeCAD/pull/19132 anymore.

But might as well use the portable version.

```
Error:
/Users/runner/work/FreeCAD/FreeCAD/src/Gui/Dialogs/DlgVersionMigrator.cpp:366:5:
error: use of undeclared identifier '_exit'
```
