### PR TITLE
ipatch: issue #24921 this PR aims to resolve the issue with sketcher appearance colors resetting to the classic theme

### DIFF
--- a/src/Gui/PreferencePages/DlgSettings3DViewImp.h
+++ b/src/Gui/PreferencePages/DlgSettings3DViewImp.h
@@ -46,6 +46,8 @@ public:
     explicit DlgSettings3DViewImp(QWidget* parent = nullptr);
     ~DlgSettings3DViewImp() override;
 
+    static void loadThemeDefaults();
+
     void saveSettings() override;
     void loadSettings() override;
     void resetSettingsToDefaults() override;

--- a/src/Gui/PreferencePages/DlgSettingsEditor.h
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.h
@@ -48,6 +48,8 @@ public:
     explicit DlgSettingsEditor( QWidget* parent = nullptr );
     ~DlgSettingsEditor() override;
 
+    static void loadThemeDefaults();
+
 public:
     void saveSettings() override;
     void loadSettings() override;

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.h
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.h
@@ -55,6 +55,8 @@ public:
     explicit DlgSettingsLightSources(QWidget* parent = nullptr);
     ~DlgSettingsLightSources() override = default;
 
+    static void loadThemeDefaults();
+
     void saveSettings() override;
     void loadSettings() override;
     void resetSettingsToDefaults() override;
@@ -77,7 +79,8 @@ private:
     QPointer <View3DInventorViewer> view;
     SoOrthographicCamera *camera = nullptr;
 
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View/LightSources");
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/View/LightSources");
 
     float zoomStep = 3.0f;
 };

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.h
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.h
@@ -47,6 +47,8 @@ public:
     explicit DlgSettingsNavigation(QWidget* parent = nullptr);
     ~DlgSettingsNavigation() override;
 
+    static void loadThemeDefaults();
+
     void saveSettings() override;
     void loadSettings() override;
     void resetSettingsToDefaults() override;
@@ -62,6 +64,7 @@ protected:
     void translateOrientations();
 
 private:
+
     std::unique_ptr<Ui_DlgSettingsNavigation> ui;
     double q0, q1, q2, q3;
 };

--- a/src/Gui/PreferencePages/DlgSettingsUI.h
+++ b/src/Gui/PreferencePages/DlgSettingsUI.h
@@ -46,6 +46,8 @@ public:
   explicit DlgSettingsUI(QWidget* parent = nullptr);
   ~DlgSettingsUI() override;
 
+  static void loadThemeDefaults();
+
   void saveSettings() override;
   void loadSettings() override;
 
@@ -62,6 +64,7 @@ protected:
 
   void openThemeEditor();
 private:
+  void resetSettingsToDefaults() override;
   std::unique_ptr<Ui_DlgSettingsUI> ui;
 };
 

--- a/src/Gui/PreferencePages/DlgSettingsViewColor.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsViewColor.cpp
@@ -20,8 +20,13 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <filesystem>
+#include <vector>
+
 #include <QPushButton>
 
+#include <App/Application.h>
+#include <Base/Console.h>
 
 #include "DlgSettingsViewColor.h"
 #include "ui_DlgSettingsViewColor.h"
@@ -103,6 +108,119 @@ void DlgSettingsViewColor::loadSettings()
     else {
         onRadioButtonRadialGradientToggled(true);
     }
+}
+
+void DlgSettingsViewColor::loadThemeDefaults()
+{
+    // get current theme name
+    ParameterGrp::handle hMainWindow = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/MainWindow");
+    std::string themeName = hMainWindow->GetASCII("Theme", "");
+
+    if (themeName.empty()) {
+#ifdef FC_DEBUG
+        Base::Console().message("No theme set, skipping theme color defaults\n");
+#endif
+        return;  // no theme active, use current colors
+    }
+
+#ifdef FC_DEBUG
+    Base::Console().message("Loading View Colors defaults for theme: %s\n", themeName.c_str());
+#endif
+
+    // construct path to the theme's config file
+    std::string appPath = App::Application::getResourceDir();
+    std::filesystem::path configFile = std::filesystem::path(appPath) / "Gui" / "PreferencePacks"
+        / themeName / (themeName + ".cfg");
+
+    if (!std::filesystem::exists(configFile)) {
+#ifdef FC_DEBUG
+        Base::Console().warning("Config file not found for theme '%s'\n", themeName.c_str());
+#endif
+        return;
+    }
+
+    // load theme config into temporary parameters
+    auto themeParams = ParameterManager::Create();
+    themeParams->LoadDocument(Base::FileInfo::pathToString(configFile).c_str());
+
+    // get the view group from the theme config
+    auto themeViewGroup =
+        themeParams->GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("View");
+
+    // get the current user's View group
+    auto userViewGroup =
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+
+    // list of View color parameters to copy from theme
+    std::vector<std::string> viewColors = {"BackgroundColor",
+                                           "BackgroundColor2",
+                                           "BackgroundColor3",
+                                           "BackgroundColor4",
+                                           "CbLabelColor"};
+
+    // copy only the view colors from theme to user config
+    for (const auto& colorName : viewColors) {
+        unsigned long colorValue = themeViewGroup->GetUnsigned(colorName.c_str(), UINT_MAX);
+        if (colorValue != UINT_MAX) {
+            userViewGroup->SetUnsigned(colorName.c_str(), colorValue);
+        }
+    }
+
+    // get the TreeView group from the theme config
+    auto themeTreeViewGroup =
+        themeParams->GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("TreeView");
+
+    // get the current user's TreeView group
+    auto userTreeViewGroup =
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/TreeView");
+
+    // list of TreeView color parameters to copy from theme
+    std::vector<std::string> treeViewColors = {"TreeEditColor", "TreeActiveColor"};
+
+    // copy only the tree view colors from theme to user config
+    for (const auto& colorName : treeViewColors) {
+        unsigned long colorValue = themeTreeViewGroup->GetUnsigned(colorName.c_str(), UINT_MAX);
+        if (colorValue != UINT_MAX) {
+            userTreeViewGroup->SetUnsigned(colorName.c_str(), colorValue);
+        }
+    }
+}
+
+void DlgSettingsViewColor::resetSettingsToDefaults()
+{
+    // get parameter groups
+    ParameterGrp::handle hView =
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    ParameterGrp::handle hTreeView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/TreeView");
+
+    // remove all View color parameters so theme defaults can be applied fresh
+    std::vector<std::string> viewColors = {"BackgroundColor",
+                                           "BackgroundColor2",
+                                           "BackgroundColor3",
+                                           "BackgroundColor4",
+                                           "CbLabelColor"};
+
+    for (const auto& colorName : viewColors) {
+        hView->RemoveUnsigned(colorName.c_str());
+    }
+
+    // remove all TreeView color parameters
+    std::vector<std::string> treeViewColors = {"TreeEditColor", "TreeActiveColor"};
+
+    for (const auto& colorName : treeViewColors) {
+        hTreeView->RemoveUnsigned(colorName.c_str());
+    }
+
+    // reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
+
+    // apply theme default colors
+    loadThemeDefaults();
+
+    // reload the settings to update the GUI
+    loadSettings();
 }
 
 /**

--- a/src/Gui/PreferencePages/DlgSettingsViewColor.h
+++ b/src/Gui/PreferencePages/DlgSettingsViewColor.h
@@ -44,8 +44,11 @@ public:
   explicit DlgSettingsViewColor(QWidget* parent = nullptr);
   ~DlgSettingsViewColor() override;
 
+  static void loadThemeDefaults();
+
   void saveSettings() override;
   void loadSettings() override;
+  void resetSettingsToDefaults() override;
 
 protected:
   void changeEvent(QEvent *e) override;

--- a/src/Mod/Measure/Gui/DlgPrefsMeasureAppearanceImp.cpp
+++ b/src/Mod/Measure/Gui/DlgPrefsMeasureAppearanceImp.cpp
@@ -19,6 +19,10 @@
  *                                                                         *
  **************************************************************************/
 
+#include <filesystem>
+#include <vector>
+#include <App/Application.h>
+#include <Base/Console.h>
 
 #include "DlgPrefsMeasureAppearanceImp.h"
 #include "ui_DlgPrefsMeasureAppearanceImp.h"
@@ -64,6 +68,99 @@ void DlgPrefsMeasureAppearanceImp::changeEvent(QEvent* e)
     else {
         QWidget::changeEvent(e);
     }
+}
+
+void DlgPrefsMeasureAppearanceImp::loadThemeDefaults()
+{
+    // get current theme name
+    ParameterGrp::handle hMainWindow = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/MainWindow");
+    std::string themeName = hMainWindow->GetASCII("Theme", "");
+
+    if (themeName.empty()) {
+#ifdef FC_DEBUG
+        Base::Console().message("No theme set, skipping theme color defaults\n");
+#endif
+        return;
+    }
+
+#ifdef FC_DEBUG
+    Base::Console().message("Loading Measure color defaults for theme: %s\n", themeName.c_str());
+#endif
+
+    // construct path to the theme's config file
+    std::string appPath = App::Application::getResourceDir();
+    std::filesystem::path configFile = std::filesystem::path(appPath) / "Gui" / "PreferencePacks"
+        / themeName / (themeName + ".cfg");
+
+    if (!std::filesystem::exists(configFile)) {
+#ifdef FC_DEBUG
+        Base::Console().warning("Config file not found for theme '%s'\n", themeName.c_str());
+#endif
+        return;
+    }
+
+    // load theme config into temporary parameters
+    auto themeParams = ParameterManager::Create();
+    themeParams->LoadDocument(Base::FileInfo::pathToString(configFile).c_str());
+
+    // try to get the Measure/Appearance group from the theme config
+    // Note: Not all themes may have Measure colors defined
+    try {
+        auto themeMeasureGroup = themeParams->GetGroup("BaseApp")
+                                     ->GetGroup("Preferences")
+                                     ->GetGroup("Mod")
+                                     ->GetGroup("Measure")
+                                     ->GetGroup("Appearance");
+
+        // get the current user's Measure/Appearance group
+        auto userMeasureGroup = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Mod/Measure/Appearance");
+
+        // list of Measure color parameters to copy from theme
+        std::vector<std::string> measureColors = {"DefaultTextColor",
+                                                  "DefaultLineColor",
+                                                  "DefaultTextBackgroundColor"};
+
+        // copy only the Measure colors from theme to user config
+        for (const auto& colorName : measureColors) {
+            unsigned long colorValue = themeMeasureGroup->GetUnsigned(colorName.c_str(), UINT_MAX);
+            if (colorValue != UINT_MAX) {
+                userMeasureGroup->SetUnsigned(colorName.c_str(), colorValue);
+            }
+        }
+    }
+    catch (...) {
+#ifdef FC_DEBUG
+        Base::Console().message("Theme '%s' does not define Measure colors, using defaults\n",
+                                themeName.c_str());
+#endif
+    }
+}
+
+void DlgPrefsMeasureAppearanceImp::resetSettingsToDefaults()
+{
+    // get parameter group
+    ParameterGrp::handle hMeasureAppearance = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Measure/Appearance");
+
+    // remove all color parameters so theme defaults can be applied fresh
+    std::vector<std::string> measureColors = {"DefaultTextColor",
+                                              "DefaultLineColor",
+                                              "DefaultTextBackgroundColor"};
+
+    for (const auto& colorName : measureColors) {
+        hMeasureAppearance->RemoveUnsigned(colorName.c_str());
+    }
+
+    // remove non-color parameters
+    hMeasureAppearance->RemoveInt("DefaultFontSize");
+
+    // apply theme specific color defaults
+    loadThemeDefaults();
+
+    // reload the settings from parameter storage to update gui
+    loadSettings();
 }
 
 #include <Mod/Measure/Gui/moc_DlgPrefsMeasureAppearanceImp.cpp>

--- a/src/Mod/Measure/Gui/DlgPrefsMeasureAppearanceImp.h
+++ b/src/Mod/Measure/Gui/DlgPrefsMeasureAppearanceImp.h
@@ -40,6 +40,7 @@ class DlgPrefsMeasureAppearanceImp: public Gui::Dialog::PreferencePage
 public:
     explicit DlgPrefsMeasureAppearanceImp(QWidget* parent = nullptr);
     ~DlgPrefsMeasureAppearanceImp() override;
+    static void loadThemeDefaults();
 
 protected:
     void saveSettings() override;
@@ -47,6 +48,7 @@ protected:
     void changeEvent(QEvent* e) override;
 
 private:
+    void resetSettingsToDefaults() override;
     std::unique_ptr<Ui_DlgPrefsMeasureAppearanceImp> ui;
 };
 

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.cpp
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.cpp
@@ -20,6 +20,11 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <map>
+#include <filesystem>
+
+#include <App/Application.h>
+#include <Base/Console.h>
 
 #include "DlgSettingsObjectColor.h"
 #include "ui_DlgSettingsObjectColor.h"
@@ -99,6 +104,110 @@ void DlgSettingsObjectColor::changeEvent(QEvent *e)
     else {
         QWidget::changeEvent(e);
     }
+}
+
+void DlgSettingsObjectColor::loadThemeDefaults()
+{
+    // get current theme name
+    ParameterGrp::handle hMainWindow = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/MainWindow");
+    std::string themeName = hMainWindow->GetASCII("Theme", "");
+
+    if (themeName.empty()) {
+#ifdef FC_DEBUG
+        Base::Console().message("No theme set, skipping theme color defaults\n");
+#endif
+        return;  // no theme active, use current colors
+    }
+
+#ifdef FC_DEBUG
+    Base::Console().message("Loading Part color defaults for theme: %s\n", themeName.c_str());
+#endif
+
+    // construct path to the theme's config file
+    std::string appPath = App::Application::getResourceDir();
+    std::filesystem::path configFile = std::filesystem::path(appPath) / "Gui" / "PreferencePacks" 
+        / themeName / (themeName + ".cfg");
+
+    if (!std::filesystem::exists(configFile)) {
+#ifdef FC_DEBUG
+        Base::Console().warning("Config file not found for theme '%s'\n", themeName.c_str());
+#endif
+        return;
+    }
+
+    // load theme config into temporary parameters
+    auto themeParams = ParameterManager::Create();
+    themeParams->LoadDocument(Base::FileInfo::pathToString(configFile).c_str());
+
+    // get the view group from the theme config
+    auto themeViewGroup = themeParams->GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("View");
+
+    // get the current user's View group
+    auto userViewGroup = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View");
+
+    // list of Part/PartDesign color parameters to copy from theme
+    std::vector<std::string> partColors = {
+        "DefaultShapeColor",
+        "DefaultAmbientColor",
+        "DefaultEmissiveColor",
+        "DefaultSpecularColor",
+        "DefaultShapeLineColor",
+        "DefaultShapeVertexColor",
+        "BoundingBoxColor",
+        "AnnotationTextColor"
+    };
+
+    // copy only the Part colors from theme to user config
+    for (const auto& colorName : partColors) {
+        unsigned long colorValue = themeViewGroup->GetUnsigned(colorName.c_str(), UINT_MAX);
+        if (colorValue != UINT_MAX) {
+            userViewGroup->SetUnsigned(colorName.c_str(), colorValue);
+        }
+    }
+}
+
+void DlgSettingsObjectColor::resetSettingsToDefaults()
+{
+    // get parameter groups
+    ParameterGrp::handle hView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View");
+    ParameterGrp::handle hModPart = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Part");
+
+    // remove all color parameters so theme defaults can be applied fresh
+    std::vector<std::string> partColors = {
+        "DefaultShapeColor",
+        "DefaultAmbientColor",
+        "DefaultEmissiveColor",
+        "DefaultSpecularColor",
+        "DefaultShapeLineColor",
+        "DefaultShapeVertexColor",
+        "BoundingBoxColor",
+        "AnnotationTextColor"
+    };
+
+    for (const auto& colorName : partColors) {
+        hView->RemoveUnsigned(colorName.c_str());
+    }
+
+    // remove non-color parameters from View group
+    hView->RemoveBool("RandomColor");
+    hView->RemoveInt("DefaultShapeTransparency");
+    hView->RemoveInt("DefaultShapeShininess");
+    hView->RemoveInt("DefaultShapeLineWidth");
+    hView->RemoveInt("DefaultShapePointSize");
+    hView->RemoveFloat("BoundingBoxFontSize");
+
+    // remove Mod/Part parameters
+    hModPart->RemoveBool("TwoSideRendering");
+
+    // apply theme specific color defaults
+    loadThemeDefaults();
+
+    // reload the settings from parameter storage to update gui
+    loadSettings();
 }
 
 #include "moc_DlgSettingsObjectColor.cpp"

--- a/src/Mod/Part/Gui/DlgSettingsObjectColor.h
+++ b/src/Mod/Part/Gui/DlgSettingsObjectColor.h
@@ -46,10 +46,13 @@ public:
   void saveSettings() override;
   void loadSettings() override;
 
+  static void loadThemeDefaults();
+
 protected:
   void changeEvent(QEvent *e) override;
 
 private:
+  void resetSettingsToDefaults() override;
   std::unique_ptr<Ui_DlgSettingsObjectColor> ui;
 };
 

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -103,78 +103,78 @@ SketcherSettings::~SketcherSettings()
 
 void SketcherSettings::loadThemeDefaults()
 {
-  // get current theme name
-  ParameterGrp::handle hMainWindow = App::GetApplication().GetParameterGroupByPath(
-      "User parameter:BaseApp/Preferences/MainWindow");
-  std::string themeName = hMainWindow->GetASCII("Theme", "");
+    // get current theme name
+    ParameterGrp::handle hMainWindow = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/MainWindow");
+    std::string themeName = hMainWindow->GetASCII("Theme", "");
 
-  if (themeName.empty()) {
+    if (themeName.empty()) {
 #ifdef FC_DEBUG
-    Base::Console().message("No theme set, skipping theme color defaults\n");
+        Base::Console().message("No theme set, skipping theme color defaults\n");
 #endif
-    return; // no theme active, use current colors
-  }
-
-#ifdef FC_DEBUG
-  Base::Console().message("Loading Sketcher color defaults for theme: %s\n", themeName.c_str());
-#endif
-
-  // construct path to the theme's config file
-  // preference packs are in the Gui/PreferencePacks directory
-  std::string appPath = App::Application::getResourceDir();
-  std::filesystem::path configFile = std::filesystem::path(appPath) / "Gui" / "PreferencePacks" / themeName / (themeName + ".cfg");
-
-  if (!std::filesystem::exists(configFile)) {
-#ifdef FC_DEBUG
-    Base::Console().warning("Config file not found for theme '%s'\n", themeName.c_str());
-#endif
-    return;
-  }
-
-  // load theme config into temporary parameters
-  auto themeParams = ParameterManager::Create();
-  themeParams->LoadDocument(Base::FileInfo::pathToString(configFile).c_str());
-
-  // get the view group from the theme config
-  auto themeViewGroup = themeParams->GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("View");
-
-  // get the current user's View group
-  auto userViewGroup = App::GetApplication().GetParameterGroupByPath(
-      "User parameter:BaseApp/Preferences/View");
-
-  // list of sketcher color parameters to copy from theme
-  std::vector<std::string> sketcherColors = {
-    "SketchEdgeColor",
-    "SketchVertexColor",
-    "EditedEdgeColor",
-    "EditedVertexColor",
-    "ConstructionColor",
-    "ExternalColor",
-    "ExternalDefiningColor",
-    "FullyConstrainedColor",
-    "ConstrainedColor",
-    "NonDrivingConstraintColor",
-    "InvalidSketchColor",
-    "FullyConstraintElementColor",
-    "FullyConstraintConstructionElementColor",
-    "FullyConstraintInternalAlignmentColor",
-    "FullyConstraintConstructionPointColor",
-    "InternalAlignedGeoColor",
-    "DeactivatedConstrDimColor",
-    "DatumColor",
-    "ExprBasedConstrDimColor",
-    "CursorTextColor",
-    "CursorCrosshairColor",
-    "CreateLineColor"
-  };
-
-  // copy only the sketcher colors from theme to user config
-  for (const auto& colorName : sketcherColors) {
-    unsigned long colorValue = themeViewGroup->GetUnsigned(colorName.c_str(), UINT_MAX);
-    if (colorValue != UINT_MAX) {
-      userViewGroup->SetUnsigned(colorName.c_str(), colorValue);
+        return;  // no theme active, use current colors
     }
-  }
+
+#ifdef FC_DEBUG
+    Base::Console().message("Loading Sketcher color defaults for theme: %s\n", themeName.c_str());
+#endif
+
+    // construct path to the theme's config file
+    // preference packs are in the Gui/PreferencePacks directory
+    std::string appPath = App::Application::getResourceDir();
+    std::filesystem::path configFile = std::filesystem::path(appPath) / "Gui" / "PreferencePacks"
+        / themeName / (themeName + ".cfg");
+
+    if (!std::filesystem::exists(configFile)) {
+#ifdef FC_DEBUG
+        Base::Console().warning("Config file not found for theme '%s'\n", themeName.c_str());
+#endif
+        return;
+    }
+
+    // load theme config into temporary parameters
+    auto themeParams = ParameterManager::Create();
+    themeParams->LoadDocument(Base::FileInfo::pathToString(configFile).c_str());
+
+    // get the view group from the theme config
+    auto themeViewGroup =
+        themeParams->GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("View");
+
+    // get the current user's View group
+    auto userViewGroup =
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+
+    // list of sketcher color parameters to copy from theme
+    std::vector<std::string> sketcherColors = {"SketchEdgeColor",
+                                               "SketchVertexColor",
+                                               "EditedEdgeColor",
+                                               "EditedVertexColor",
+                                               "ConstructionColor",
+                                               "ExternalColor",
+                                               "ExternalDefiningColor",
+                                               "FullyConstrainedColor",
+                                               "ConstrainedColor",
+                                               "NonDrivingConstraintColor",
+                                               "InvalidSketchColor",
+                                               "FullyConstraintElementColor",
+                                               "FullyConstraintConstructionElementColor",
+                                               "FullyConstraintInternalAlignmentColor",
+                                               "FullyConstraintConstructionPointColor",
+                                               "InternalAlignedGeoColor",
+                                               "DeactivatedConstrDimColor",
+                                               "DatumColor",
+                                               "ExprBasedConstrDimColor",
+                                               "CursorTextColor",
+                                               "CursorCrosshairColor",
+                                               "CreateLineColor"};
+
+    // copy only the sketcher colors from theme to user config
+    for (const auto& colorName : sketcherColors) {
+        unsigned long colorValue = themeViewGroup->GetUnsigned(colorName.c_str(), UINT_MAX);
+        if (colorValue != UINT_MAX) {
+            userViewGroup->SetUnsigned(colorName.c_str(), colorValue);
+        }
+    }
 }
 
 void SketcherSettings::saveSettings()
@@ -358,27 +358,27 @@ void SketcherSettings::changeEvent(QEvent* e)
 
 void SketcherSettings::resetSettingsToDefaults()
 {
-  ParameterGrp::handle hGrp;
+    ParameterGrp::handle hGrp;
 
-  hGrp = App::GetApplication().GetParameterGroupByPath(
-      "User parameter:BaseApp/Preferences/Mod/Sketcher/dimensioning");
-  // reset "Dimension tools" parameters
-  hGrp->RemoveBool("SingleDimensioningTool");
-  hGrp->RemoveBool("SeparatedDimensioningTools");
+    hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/dimensioning");
+    // reset "Dimension tools" parameters
+    hGrp->RemoveBool("SingleDimensioningTool");
+    hGrp->RemoveBool("SeparatedDimensioningTools");
 
-  // reset "radius/diameter mode for dimensioning" parameter
-  hGrp->RemoveBool("DimensioningDiameter");
-  hGrp->RemoveBool("DimensioningRadius");
+    // reset "radius/diameter mode for dimensioning" parameter
+    hGrp->RemoveBool("DimensioningDiameter");
+    hGrp->RemoveBool("DimensioningRadius");
 
-  hGrp->RemoveInt("AutoScaleMode");
+    hGrp->RemoveInt("AutoScaleMode");
 
-  hGrp = App::GetApplication().GetParameterGroupByPath(
-      "User parameter:BaseApp/Preferences/Mod/Sketcher/Tools");
-  // reset "OVP visibility" parameter
-  hGrp->RemoveInt("OnViewParameterVisibility");
+    hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/Tools");
+    // reset "OVP visibility" parameter
+    hGrp->RemoveInt("OnViewParameterVisibility");
 
-  // finally reset all the parameters associated to Gui::Pref* widgets
-  PreferencePage::resetSettingsToDefaults();
+    // finally reset all the parameters associated to Gui::Pref* widgets
+    PreferencePage::resetSettingsToDefaults();
 }
 
 /* TRANSLATOR SketcherGui::SketcherSettingsGrid */
@@ -775,58 +775,56 @@ void SketcherSettingsAppearance::loadSettings()
 
 void SketcherSettingsAppearance::resetSettingsToDefaults()
 {
-  // get parameter groups
-  ParameterGrp::handle hView = App::GetApplication().GetParameterGroupByPath(
-      "User parameter:BaseApp/Preferences/View");
-  ParameterGrp::handle hSketcherView = App::GetApplication().GetParameterGroupByPath(
-      "User parameter:BaseApp/Preferences/Mod/Sketcher/View");
+    // get parameter groups
+    ParameterGrp::handle hView =
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
+    ParameterGrp::handle hSketcherView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/View");
 
-  // remove only non-color parameters (widths and patterns)
-  hSketcherView->RemoveInt("EdgeWidth");
-  hSketcherView->RemoveInt("ConstructionWidth");
-  hSketcherView->RemoveInt("InternalWidth");
-  hSketcherView->RemoveInt("ExternalWidth");
-  hSketcherView->RemoveInt("ExternalDefiningWidth");
-  hSketcherView->RemoveInt("EdgePattern");
-  hSketcherView->RemoveInt("ConstructionPattern");
-  hSketcherView->RemoveInt("InternalPattern");
-  hSketcherView->RemoveInt("ExternalPattern");
-  hSketcherView->RemoveInt("ExternalDefiningPattern");
+    // remove only non-color parameters (widths and patterns)
+    hSketcherView->RemoveInt("EdgeWidth");
+    hSketcherView->RemoveInt("ConstructionWidth");
+    hSketcherView->RemoveInt("InternalWidth");
+    hSketcherView->RemoveInt("ExternalWidth");
+    hSketcherView->RemoveInt("ExternalDefiningWidth");
+    hSketcherView->RemoveInt("EdgePattern");
+    hSketcherView->RemoveInt("ConstructionPattern");
+    hSketcherView->RemoveInt("InternalPattern");
+    hSketcherView->RemoveInt("ExternalPattern");
+    hSketcherView->RemoveInt("ExternalDefiningPattern");
 
-  // remove all sketcher color parameters so theme defaults can be applied fresh
-  std::vector<std::string> sketcherColors = {
-    "SketchEdgeColor",
-    "SketchVertexColor",
-    "EditedEdgeColor",
-    "EditedVertexColor",
-    "ConstructionColor",
-    "ExternalColor",
-    "FullyConstrainedColor",
-    "ConstrainedColor",
-    "NonDrivingConstraintColor",
-    "InvalidSketchColor",
-    "FullyConstraintElementColor",
-    "FullyConstraintConstructionElementColor",
-    "FullyConstraintInternalAlignmentColor",
-    "FullyConstraintConstructionPointColor",
-    "InternalAlignedGeoColor",
-    "DeactivatedConstrDimColor",
-    "DatumColor",
-    "ExprBasedConstrDimColor",
-    "CursorTextColor",
-    "CursorCrosshairColor",
-    "CreateLineColor"
-  };
+    // remove all sketcher color parameters so theme defaults can be applied fresh
+    std::vector<std::string> sketcherColors = {"SketchEdgeColor",
+                                               "SketchVertexColor",
+                                               "EditedEdgeColor",
+                                               "EditedVertexColor",
+                                               "ConstructionColor",
+                                               "ExternalColor",
+                                               "FullyConstrainedColor",
+                                               "ConstrainedColor",
+                                               "NonDrivingConstraintColor",
+                                               "InvalidSketchColor",
+                                               "FullyConstraintElementColor",
+                                               "FullyConstraintConstructionElementColor",
+                                               "FullyConstraintInternalAlignmentColor",
+                                               "FullyConstraintConstructionPointColor",
+                                               "InternalAlignedGeoColor",
+                                               "DeactivatedConstrDimColor",
+                                               "DatumColor",
+                                               "ExprBasedConstrDimColor",
+                                               "CursorTextColor",
+                                               "CursorCrosshairColor",
+                                               "CreateLineColor"};
 
-  for (const auto& colorName : sketcherColors) {
-    hView->RemoveUnsigned(colorName.c_str());
-  }
+    for (const auto& colorName : sketcherColors) {
+        hView->RemoveUnsigned(colorName.c_str());
+    }
 
-  // apply theme specific color defaults
-  SketcherSettings::loadThemeDefaults();
+    // apply theme specific color defaults
+    SketcherSettings::loadThemeDefaults();
 
-  // reload the settings from parameter storage to update gui
-  loadSettings();
+    // reload the settings from parameter storage to update gui
+    loadSettings();
 }
 
 /**

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -23,12 +23,14 @@
 #include <QMessageBox>
 #include <QPainter>
 #include <QPixmap>
-
+#include <map>
+#include <filesystem>
 
 #include <App/Application.h>
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
 #include <Gui/Command.h>
+#include <Gui/PreferencePackManager.h>
 
 #include "SketcherSettings.h"
 #include "ui_SketcherSettings.h"
@@ -97,6 +99,82 @@ SketcherSettings::SketcherSettings(QWidget* parent)
 SketcherSettings::~SketcherSettings()
 {
     // no need to delete child widgets, Qt does it all for us
+}
+
+void SketcherSettings::loadThemeDefaults()
+{
+  // get current theme name
+  ParameterGrp::handle hMainWindow = App::GetApplication().GetParameterGroupByPath(
+      "User parameter:BaseApp/Preferences/MainWindow");
+  std::string themeName = hMainWindow->GetASCII("Theme", "");
+
+  if (themeName.empty()) {
+#ifdef FC_DEBUG
+    Base::Console().message("No theme set, skipping theme color defaults\n");
+#endif
+    return; // no theme active, use current colors
+  }
+
+#ifdef FC_DEBUG
+  Base::Console().message("Loading Sketcher color defaults for theme: %s\n", themeName.c_str());
+#endif
+
+  // construct path to the theme's config file
+  // preference packs are in the Gui/PreferencePacks directory
+  std::string appPath = App::Application::getResourceDir();
+  std::filesystem::path configFile = std::filesystem::path(appPath) / "Gui" / "PreferencePacks" / themeName / (themeName + ".cfg");
+
+  if (!std::filesystem::exists(configFile)) {
+#ifdef FC_DEBUG
+    Base::Console().warning("Config file not found for theme '%s'\n", themeName.c_str());
+#endif
+    return;
+  }
+
+  // load theme config into temporary parameters
+  auto themeParams = ParameterManager::Create();
+  themeParams->LoadDocument(Base::FileInfo::pathToString(configFile).c_str());
+
+  // get the view group from the theme config
+  auto themeViewGroup = themeParams->GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("View");
+
+  // get the current user's View group
+  auto userViewGroup = App::GetApplication().GetParameterGroupByPath(
+      "User parameter:BaseApp/Preferences/View");
+
+  // list of sketcher color parameters to copy from theme
+  std::vector<std::string> sketcherColors = {
+    "SketchEdgeColor",
+    "SketchVertexColor",
+    "EditedEdgeColor",
+    "EditedVertexColor",
+    "ConstructionColor",
+    "ExternalColor",
+    "ExternalDefiningColor",
+    "FullyConstrainedColor",
+    "ConstrainedColor",
+    "NonDrivingConstraintColor",
+    "InvalidSketchColor",
+    "FullyConstraintElementColor",
+    "FullyConstraintConstructionElementColor",
+    "FullyConstraintInternalAlignmentColor",
+    "FullyConstraintConstructionPointColor",
+    "InternalAlignedGeoColor",
+    "DeactivatedConstrDimColor",
+    "DatumColor",
+    "ExprBasedConstrDimColor",
+    "CursorTextColor",
+    "CursorCrosshairColor",
+    "CreateLineColor"
+  };
+
+  // copy only the sketcher colors from theme to user config
+  for (const auto& colorName : sketcherColors) {
+    unsigned long colorValue = themeViewGroup->GetUnsigned(colorName.c_str(), UINT_MAX);
+    if (colorValue != UINT_MAX) {
+      userViewGroup->SetUnsigned(colorName.c_str(), colorValue);
+    }
+  }
 }
 
 void SketcherSettings::saveSettings()
@@ -280,27 +358,27 @@ void SketcherSettings::changeEvent(QEvent* e)
 
 void SketcherSettings::resetSettingsToDefaults()
 {
-    ParameterGrp::handle hGrp;
+  ParameterGrp::handle hGrp;
 
-    hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Sketcher/dimensioning");
-    // reset "Dimension tools" parameters
-    hGrp->RemoveBool("SingleDimensioningTool");
-    hGrp->RemoveBool("SeparatedDimensioningTools");
+  hGrp = App::GetApplication().GetParameterGroupByPath(
+      "User parameter:BaseApp/Preferences/Mod/Sketcher/dimensioning");
+  // reset "Dimension tools" parameters
+  hGrp->RemoveBool("SingleDimensioningTool");
+  hGrp->RemoveBool("SeparatedDimensioningTools");
 
-    // reset "radius/diameter mode for dimensioning" parameter
-    hGrp->RemoveBool("DimensioningDiameter");
-    hGrp->RemoveBool("DimensioningRadius");
+  // reset "radius/diameter mode for dimensioning" parameter
+  hGrp->RemoveBool("DimensioningDiameter");
+  hGrp->RemoveBool("DimensioningRadius");
 
-    hGrp->RemoveInt("AutoScaleMode");
+  hGrp->RemoveInt("AutoScaleMode");
 
-    hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Sketcher/Tools");
-    // reset "OVP visibility" parameter
-    hGrp->RemoveInt("OnViewParameterVisibility");
+  hGrp = App::GetApplication().GetParameterGroupByPath(
+      "User parameter:BaseApp/Preferences/Mod/Sketcher/Tools");
+  // reset "OVP visibility" parameter
+  hGrp->RemoveInt("OnViewParameterVisibility");
 
-    // finally reset all the parameters associated to Gui::Pref* widgets
-    PreferencePage::resetSettingsToDefaults();
+  // finally reset all the parameters associated to Gui::Pref* widgets
+  PreferencePage::resetSettingsToDefaults();
 }
 
 /* TRANSLATOR SketcherGui::SketcherSettingsGrid */
@@ -693,6 +771,62 @@ void SketcherSettingsAppearance::loadSettings()
         index = 0;
     }
     ui->ExternalDefiningPattern->setCurrentIndex(index);
+}
+
+void SketcherSettingsAppearance::resetSettingsToDefaults()
+{
+  // get parameter groups
+  ParameterGrp::handle hView = App::GetApplication().GetParameterGroupByPath(
+      "User parameter:BaseApp/Preferences/View");
+  ParameterGrp::handle hSketcherView = App::GetApplication().GetParameterGroupByPath(
+      "User parameter:BaseApp/Preferences/Mod/Sketcher/View");
+
+  // remove only non-color parameters (widths and patterns)
+  hSketcherView->RemoveInt("EdgeWidth");
+  hSketcherView->RemoveInt("ConstructionWidth");
+  hSketcherView->RemoveInt("InternalWidth");
+  hSketcherView->RemoveInt("ExternalWidth");
+  hSketcherView->RemoveInt("ExternalDefiningWidth");
+  hSketcherView->RemoveInt("EdgePattern");
+  hSketcherView->RemoveInt("ConstructionPattern");
+  hSketcherView->RemoveInt("InternalPattern");
+  hSketcherView->RemoveInt("ExternalPattern");
+  hSketcherView->RemoveInt("ExternalDefiningPattern");
+
+  // remove all sketcher color parameters so theme defaults can be applied fresh
+  std::vector<std::string> sketcherColors = {
+    "SketchEdgeColor",
+    "SketchVertexColor",
+    "EditedEdgeColor",
+    "EditedVertexColor",
+    "ConstructionColor",
+    "ExternalColor",
+    "FullyConstrainedColor",
+    "ConstrainedColor",
+    "NonDrivingConstraintColor",
+    "InvalidSketchColor",
+    "FullyConstraintElementColor",
+    "FullyConstraintConstructionElementColor",
+    "FullyConstraintInternalAlignmentColor",
+    "FullyConstraintConstructionPointColor",
+    "InternalAlignedGeoColor",
+    "DeactivatedConstrDimColor",
+    "DatumColor",
+    "ExprBasedConstrDimColor",
+    "CursorTextColor",
+    "CursorCrosshairColor",
+    "CreateLineColor"
+  };
+
+  for (const auto& colorName : sketcherColors) {
+    hView->RemoveUnsigned(colorName.c_str());
+  }
+
+  // apply theme specific color defaults
+  SketcherSettings::loadThemeDefaults();
+
+  // reload the settings from parameter storage to update gui
+  loadSettings();
 }
 
 /**

--- a/src/Mod/Sketcher/Gui/SketcherSettings.h
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.h
@@ -49,7 +49,8 @@ public:
     void saveSettings() override;
     void loadSettings() override;
 
-    void resetSettingsToDefaults() override;
+
+    static void loadThemeDefaults();
 
 protected:
     void changeEvent(QEvent* e) override;
@@ -57,6 +58,8 @@ protected:
     void checkForRestart();
 
 private:
+    void resetSettingsToDefaults() override;
+
     std::unique_ptr<Ui_SketcherSettings> ui;
 };
 
@@ -125,6 +128,7 @@ protected:
     void changeEvent(QEvent* e) override;
 
 private:
+    void resetSettingsToDefaults() override;
     std::unique_ptr<Ui_SketcherSettingsAppearance> ui;
 };
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

basically as stated in issue #24921 a user changes some colors in the preferences under sketcher preferences and then uses the menu, ie.

edit -> preferences -> sketcher -> appearance 

and in the lower left of the preferences window the user clicks, reset -> 'reset page appearance'

after this action is taken no matter what theme the current user is using the colors will reset to the classic theme thus ignoring the default colors setup in the dark and light themes.

this PR should **only** reset the colors defined in the sketcher preferences page and **NOT** affect any of the other colors defined in other settings ie. part design -> shape appearance -> shape color

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

#24921 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

i'll upload a video in a second.

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
