### PR TITLE
CI: Silence expected error message for shallow repo

### DIFF
--- a/src/Tools/SubWCRev.py
+++ b/src/Tools/SubWCRev.py
@@ -303,7 +303,8 @@ class GitControl(VersionControl):
         referencerevision = 14555
 
         result = None
-        countallfh = os.popen("git rev-list --count %s..HEAD" % referencecommit)
+        null_device = "nul" if os.name == "nt" else "/dev/null"
+        countallfh = os.popen(f"git rev-list --count {referencecommit}..HEAD 2>{null_device}")
         countallstr = countallfh.read().strip()
         if countallfh.close() is not None:  # reference commit not present, use the date
             date_object = datetime.datetime.strptime(self.date, "%Y/%m/%d %H:%M:%S")


### PR DESCRIPTION
We use a shallow checkout, so the reference commit is never present when building the Weeklies. The error message in the logs, 
```
fatal: Invalid revision range 7d8e53aaab17961d85c5009de34f69f2af084e8b..HEAD
```
is misleading when looking for failure causes. This commit redirects stderr to `/dev/null` (POSIX) or `nul` (Windows) for that call to `git rev-list`. The lack of a reference commit is handled immediately below.