### PR TITLE
Tools: Add Measure to translation download

### DIFF
--- a/src/Tools/updatecrowdin.py
+++ b/src/Tools/updatecrowdin.py
@@ -141,6 +141,11 @@ locations = [
         "../Mod/Material/Gui/Resources/Material.qrc",
     ],
     [
+        "Measure",
+        "../Mod/Measure/Gui/Resources/translations",
+        "../Mod/Measure/Gui/Resources/Measure.qrc",
+    ],
+    [
         "Mesh",
         "../Mod/Mesh/Gui/Resources/translations",
         "../Mod/Mesh/Gui/Resources/Mesh.qrc",


### PR DESCRIPTION
We added Measure to the translation extraction, but not to the translation download.