### PR TITLE
CI: upgrade pixi to prevent CI-breaking version mismatch.

### DIFF
--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -118,7 +118,7 @@ jobs:
 
     - uses: prefix-dev/setup-pixi@28eb668aafebd9dede9d97c4ba1cd9989a4d0004 # v0.9.2
       with:
-        pixi-version: v0.48.1
+        pixi-version: v0.59.0
         cache: false
 
     - name: Restore Compiler Cache

--- a/.github/workflows/sub_weeklyBuild.yml
+++ b/.github/workflows/sub_weeklyBuild.yml
@@ -106,7 +106,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@28eb668aafebd9dede9d97c4ba1cd9989a4d0004 # v0.9.2
         with:
-          pixi-version: v0.48.1
+          pixi-version: v0.59.0
           cache: false
 
       - name: Install the Apple certificate and provisioning profile


### PR DESCRIPTION
Upgrades the version of `pixi` used in the CI and weekly builds to address a defect in which newer, incompatible versions of `pixi` components may be used resulting in failure during the build.

## Issues

* None

## Before and After Images

* N/A
