### PR TITLE
GUI: no minimum width for status bar buttons

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD.qss
+++ b/src/Gui/Stylesheets/FreeCAD.qss
@@ -236,6 +236,7 @@ QStatusBar QLabel {
 }
 
 QStatusBar QPushButton {
+    min-width: 0;
     padding-left: 8px;
     padding-right: 8px;
 }


### PR DESCRIPTION
The change was done before but something broke it.

Before:
<img width="826" height="232" alt="grafik" src="https://github.com/user-attachments/assets/bd47762c-a6a4-43e2-b5a5-5a10d55cf2e4" />

After:
<img width="852" height="286" alt="grafik" src="https://github.com/user-attachments/assets/dd96820e-f4cb-477f-b061-91e75e63f619" />
