### PR TITLE
CAM: Slot - Fix Task panel references enumeration

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Slot.py
+++ b/src/Mod/CAM/Path/Op/Gui/Slot.py
@@ -117,10 +117,12 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.updateToolController(obj, self.form.toolController)
         self.updateCoolant(obj, self.form.coolantController)
 
-        obj.Reference1 = str(self.form.geo1Reference.currentText())
+        val = obj.getEnumerationsOfProperty("Reference1")[self.form.geo1Reference.currentIndex()]
+        obj.Reference1 = val
         self.geo1Extension.updateProperty()
 
-        obj.Reference2 = str(self.form.geo2Reference.currentText())
+        val = obj.getEnumerationsOfProperty("Reference2")[self.form.geo2Reference.currentIndex()]
+        obj.Reference2 = val
         self.geo2Extension.updateProperty()
 
         val = self.propEnums["LayerMode"][self.form.layerMode.currentIndex()][1]


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=100852

Attempt to fir error after change something in the `Slot` task panel

```
Traceback (most recent call last):
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Gui/Base.py", line 258, in pageGetFields
    self.getFields(self.obj)
    ~~~~~~~~~~~~~~^^^^^^^^^^
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Gui/Slot.py", line 122, in getFields
    obj.Reference2 = str(self.form.geo2Reference.currentText())
    ^^^^^^^^^^^^^^
ValueError: 'Center of mass' is not part of the enumeration in slot#Slot.Reference2
```