### PR TITLE
BIM/Draft: Fix path for ContinueMode parameter retrieval

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -434,7 +434,7 @@ class DraftToolBar:
             FreeCAD.activeDraftCommand, "featureName", None
         ):
             self.continueMode = params.get_param(
-                FreeCAD.activeDraftCommand.featureName, "Mod/ContinueMode", silent=True
+                FreeCAD.activeDraftCommand.featureName, "Mod/Draft/ContinueMode", silent=True
             )
 
         self.chainedMode = params.get_param("ChainedMode")


### PR DESCRIPTION
Fixes #24991.

