### PR TITLE
Gui: Force Expression Completer to show drop-down upon clicking on item

### DIFF
--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -1158,6 +1158,12 @@ void ExpressionTextEdit::slotCompleteText(const QString& completionPrefix)
     Base::FlagToggler<bool> flag(block, false);
     cursor.insertText(completionPrefix);
     completer->updatePrefixEnd(cursor.positionInBlock());
+
+    std::string textToComplete = completionPrefix.toUtf8().constData();
+    if (textToComplete.size()
+        && (*textToComplete.crbegin() == '.' || *textToComplete.crbegin() == '#')) {
+        completer->slotUpdate(cursor.block().text(), cursor.positionInBlock());
+    }
 }
 
 void ExpressionTextEdit::keyPressEvent(QKeyEvent* e)


### PR DESCRIPTION
As the title says - currently if user clicks "Box" from the autocomplete dropdown, it adds "Box.", but the property drop-down is never resolved further, so user has to delete the separator and write it by hand.

When a completion ends with '.' or '#' and is being selected by clicking, code sets `block=true` and calls `slotTextChanged()` which prevents the `textChanged2` signal from being emitted. This results in completer being blocked from updating next level of properties.

So, this patch adds a direct call to `completer->slotUpdate()`, which triggers completer to parse the expression and show the drop-down.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/24945