### PR TITLE
CAM: fixing drill handling, as KinetiNC does not implement G81 etc. correctly

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_post.py
@@ -402,8 +402,12 @@ def parse(pathobj):
                                 param + format(float(pos.getValueAs(UNIT_FORMAT)), precision_string)
                             )
 
-            if command in ["G0"] and "Z" not in c.Parameters \
-               and pathobj.Label == "Drilling" and "R" in currLocation.keys():
+            if (
+                command in ["G0"]
+                and "Z" not in c.Parameters
+                and pathobj.Label == "Drilling"
+                and "R" in currLocation.keys()
+            ):
                 if not OUTPUT_DOUBLES:
                     continue
                 else:


### PR DESCRIPTION
The KinecticNC does not handle the drilling commands (G81 etc.) correctly and does not support G98/G99. As a result the drill moves down, up again and then moves in a diagonal path to the next drilling location. However, it should first move to the new location and then move down. This breaks your drill or at least messes with your work product.

The solution is to remove the G98/G99 commands and introduce the Z-value to the already used G0 command. Now the drill moves first to the side and then down. Also G85 is not supported and will therefore, completly ignored.


## Issues
This has not beed addressed in an issue yet.

## Before and After Images
If you remove the unspported commands G98/G99, KineticNC will interprete the G-code as follows:
<img width="506" height="248" alt="KinetiC-NC_paZgWSMnfY" src="https://github.com/user-attachments/assets/6bddb91b-45be-446b-8f25-9af3d45fb044" />

G0 X20.000 Y20.000
G81 X20.000 Y20.000 Z-5.200 F230.000 R20.000
G0 X20.000 Y60.000
G81 X20.000 Y60.000 Z-5.200 F230.000 R20.000
G0 X20.000 Y100.000


Here is how it should look like (and do with the PR):
<img width="433" height="192" alt="KinetiC-NC_EVgXOy7ijB" src="https://github.com/user-attachments/assets/fc1f02e9-d1ad-40eb-b01e-a7a10510e849" />

G0 X20.000 Y20.000
G81 X20.000 Y20.000 Z-5.200 F230.000 R20.000
G0 X20.000 Y60.000 Z20.000 <- here R-value is used as target Z-value
G81 X20.000 Y60.000 Z-5.200 F230.000 R20.000
G0 X20.000 Y100.000 Z20.000 <- here R-value is used as target Z-value
