### PR TITLE
CI: Update macOS Intel target version in workflow

### DIFF
--- a/.github/workflows/sub_weeklyBuild.yml
+++ b/.github/workflows/sub_weeklyBuild.yml
@@ -63,7 +63,7 @@ jobs:
         include:
           - { target: linux-64, os: ubuntu-22.04 }
           - { target: linux-arm64, os: ubuntu-22.04-arm }
-          - { target: osx-64, os: macos-13 }
+          - { target: osx-64, os: macos-15-intel }
           - { target: osx-arm64, os: macos-latest }
           - { target: win-64, os: windows-latest }
       fail-fast: false


### PR DESCRIPTION
GitHub is deprecating macOS 13 runners -- the only remaining Intel runner is now macOS 15, and it is scheduled for retirement in 2027, at which point we will no longer be able to provide Intel weeklies.
