### PR TITLE
Fix CAM job "no attribute Proxy"

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -300,7 +300,7 @@ class ViewProvider:
         # make sure the resource view providers are setup properly
         if prop == "Model" and self.obj.Model:
             for base in self.obj.Model.Group:
-                if base.ViewObject and hasattr(base.ViewObject, 'Proxy') and base.ViewObject.Proxy:
+                if base.ViewObject and hasattr(base.ViewObject, "Proxy") and base.ViewObject.Proxy:
                     base.ViewObject.Proxy.onEdit(_OpenCloseResourceEditor)
         if (
             prop == "Stock"


### PR DESCRIPTION
I have a large `FCStd` + CAM Job that must have accumulated some broken state over time, because I started getting this error at some point, and it persists through restarting FC:

```python
09:48:04  pyException: Traceback (most recent call last):
  File "/tmp/.mount_FreeCABKpBkg/usr/Mod/CAM/Path/Main/Gui/Job.py", line 303, in updateData
    if base.ViewObject and base.ViewObject.Proxy:
                           ^^^^^^^^^^^^^^^^^^^^^
<class 'AttributeError'>: 'PartGui.ViewProviderPartExt' object has no attribute 'Proxy'
```

I've added a simple fix that resolves this error, but I imagine there's a deeper issue at play too - why is the Proxy not getting established?