### PR TITLE
Sketcher: Restore ExprBasedConstrDimColor

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2949,4 +2949,3 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
     ps->style.setValue(SoPickStyle::SHAPE);
     editModeScenegraphNodes.EditRoot->addChild(ps);
 }
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/pull/24534#issuecomment-3478495302

by restoring the 'reference driven' constraint color that I removed in https://github.com/FreeCAD/FreeCAD/pull/24534

Btw I had not removed in that PR the preference from the preference page, so it looked broken indeed.

@FreeCAD/design-working-group will have to decide later what to do with that color. I think it should be removed completely, from the preferences. But an alternative is to keep the preference and set the default color to the same as normal constraints.