### PR TITLE
TechDraw: fix angle dim in detail view

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -1238,7 +1238,6 @@ anglePoints DrawViewDimension::getAnglePointsTwoEdges(ReferenceVector references
             farPoint0 = generic0->getStartPoint();
         }
 
-
         // pick the end of generic1 farthest from the apex
         Base::Vector3d farPoint1{generic1->getEndPoint()};
         if ((generic1->getStartPoint() - apex).Length()
@@ -1246,22 +1245,9 @@ anglePoints DrawViewDimension::getAnglePointsTwoEdges(ReferenceVector references
             farPoint1 = (generic1->getStartPoint());
         }
 
-        Base::Vector3d leg0Dir = (farPoint0 - apex).Normalize();
-        Base::Vector3d leg1Dir = (farPoint1 - apex).Normalize();
-        Base::Vector3d extenPoint0 = farPoint0;  // extension line points
-        Base::Vector3d extenPoint1 = farPoint1;
-
-
-        double extenRadius = std::min(extenPoint0.Length(),
-                                      extenPoint1.Length());
-        if (extenRadius == 0) {
-            // one of the legs has 0 length??
-            throw Base::RuntimeError("No extension point radius!!");
-        }
-
         anglePoints pts;
-        pts.first(apex + leg0Dir * extenRadius);
-        pts.second(apex + leg1Dir * extenRadius);
+        pts.first(farPoint0);
+        pts.second(farPoint1);
         pts.vertex(apex);
         return pts;
     }

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -2043,11 +2043,11 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
     anglePoints anglePoints = dimension->getAnglePoints();
 
     Base::Vector2d angleVertex = fromQtApp(anglePoints.vertex());
-    Base::Vector2d startPoint = fromQtApp(anglePoints.first());
-    Base::Vector2d endPoint = fromQtApp(anglePoints.second());
+    Base::Vector2d firstDimPoint = fromQtApp(anglePoints.first());
+    Base::Vector2d secondDimPoint = fromQtApp(anglePoints.second());
 
-    double endAngle = (endPoint - angleVertex).Angle();
-    double startAngle = (startPoint - angleVertex).Angle();
+    double endAngle = (secondDimPoint - angleVertex).Angle();
+    double startAngle = (firstDimPoint - angleVertex).Angle();
     double arcRadius {};
 
     int standardStyle = viewProvider->StandardAndStyle.getValue();
@@ -2202,14 +2202,14 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
 
         Base::Vector2d extensionOrigin;
         Base::Vector2d extensionTarget(computeExtensionLinePoints(
-            endPoint, angleVertex + Base::Vector2d::FromPolar(arcRadius, endAngle), endAngle,
+            secondDimPoint, angleVertex + Base::Vector2d::FromPolar(arcRadius, endAngle), endAngle,
             getDefaultExtensionLineOverhang(), gapSize, extensionOrigin));
         anglePath.moveTo(toQtGui(extensionOrigin));
         anglePath.lineTo(toQtGui(extensionTarget));
 
         if (arrowCount > 1) {
             extensionTarget = computeExtensionLinePoints(
-                startPoint, angleVertex + Base::Vector2d::FromPolar(arcRadius, startAngle),
+                firstDimPoint, angleVertex + Base::Vector2d::FromPolar(arcRadius, startAngle),
                 startAngle, getDefaultExtensionLineOverhang(), gapSize, extensionOrigin);
             anglePath.moveTo(toQtGui(extensionOrigin));
             anglePath.lineTo(toQtGui(extensionTarget));


### PR DESCRIPTION
This PR implements a fix for issue #23848.  It replaces PR #24519 which should be closed as it is
not the correct fix.

<img width="926" height="725" alt="AngleDimInDetailFix" src="https://github.com/user-attachments/assets/e91dda81-d1da-4f38-9bc6-50e4d020bde2" />
