### PR TITLE
CAM: Slot - Reject incorrect faces selection

### DIFF
--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -963,9 +963,9 @@ class ObjectSlot(PathOp.ObjectOp):
                 deg -= 180.0
             return deg
 
-        # Reject triangular faces
-        if len(shape.Edges) < 4:
-            msg = translate("CAM_Slot", "A single selected face must have four edges minimum.")
+        # Reject incorrect faces
+        if len(shape.Edges) != 4:
+            msg = translate("CAM_Slot", "A single selected face must have four edges.")
             FreeCAD.Console.PrintError(msg + "\n")
             return False
 
@@ -984,12 +984,9 @@ class ObjectSlot(PathOp.ObjectOp):
         parallel_pairs = []
         parallel_flags = [0] * len(shape.Edges)
         current_flag = 1
-        last_edge_index = len(shape.Edges) - 1
+        last_edge_index = min(len(shape.Edges), len(edge_info_list)) - 1
 
-        for i in range(len(shape.Edges)):
-            if i >= last_edge_index:
-                continue
-
+        for i in range(last_edge_index):
             next_i = i + 1
             edge_a_info = edge_info_list[i]
             edge_b_info = edge_info_list[next_i]


### PR DESCRIPTION
Fixed checks to get normal warning message instead of Python error, if selected horizontal face with amount of edges less or more than 4

### Before

```
22:27:45  pyException: Traceback (most recent call last):
  File "/home/user/projects/FreeCAD_build/Mod/CAM/PathScripts/PathUtils.py", line 73, in new_function
    res = function(*args, **kwargs)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Base.py", line 821, in execute
    result = self.opExecute(obj)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Slot.py", line 564, in opExecute
    cmds = self._makeOperation(obj)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Slot.py", line 630, in _makeOperation
    pnts = self._processSingle(obj, shape_1, sub1)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Slot.py", line 907, in _processSingle
    pnts = self._processSingleHorizFace(obj, shape_1)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Slot.py", line 995, in _processSingleHorizFace
    edge_b_info = edge_info_list[next_i]
<class 'IndexError'>: list index out of range
22:27:45  Slot: list index out of range
```

</br>

### After

```
22:41:04  A single selected face must have four edges.
22:41:04  The selected face is inaccessible.
```