### PR TITLE
BIM: remove BIM Project command from toolbar

### DIFF
--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -112,7 +112,6 @@ class BIMWorkbench(Workbench):
         ]
 
         self.bimtools = [
-            "BIM_Project",
             "Arch_Site",
             "Arch_Building",
             "Arch_Level",
@@ -233,6 +232,7 @@ class BIMWorkbench(Workbench):
             "BIM_Reextrude",
             "Arch_PanelTools",
             "Arch_StructureTools",
+            "BIM_Project",
         ]
 
         nudge = [

--- a/src/Mod/BIM/Resources/ui/dialogProjectManager.ui
+++ b/src/Mod/BIM/Resources/ui/dialogProjectManager.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>443</width>
+    <width>600</width>
     <height>840</height>
    </rect>
   </property>
@@ -117,7 +117,7 @@
                <string>Create a new document without IFC support</string>
               </property>
               <property name="checked">
-               <bool>false</bool>
+               <bool>true</bool>
               </property>
              </widget>
             </item>
@@ -130,7 +130,7 @@
                <string>Create a native IFC project in the current document</string>
               </property>
               <property name="checked">
-               <bool>true</bool>
+               <bool>false</bool>
               </property>
              </widget>
             </item>

--- a/src/Mod/BIM/bimcommands/BimProject.py
+++ b/src/Mod/BIM/bimcommands/BimProject.py
@@ -35,7 +35,7 @@ class BIM_Project:
     def GetResources(self):
         return {
             "Pixmap": "BIM_Project",
-            "MenuText": QT_TRANSLATE_NOOP("BIM_Project", "Project"),
+            "MenuText": QT_TRANSLATE_NOOP("BIM_Project", "IFC Project"),
             "ToolTip": QT_TRANSLATE_NOOP("BIM_Project", "Creates an empty NativeIFC project"),
         }
 

--- a/src/Mod/BIM/nativeifc/ifc_commands.py
+++ b/src/Mod/BIM/nativeifc/ifc_commands.py
@@ -140,7 +140,7 @@ class IFC_MakeProject:
         )
         return {
             "Pixmap": "IFC",
-            "MenuText": QT_TRANSLATE_NOOP("IFC_MakeProject", "Create IFC Project"),
+            "MenuText": QT_TRANSLATE_NOOP("IFC_MakeProject", "Convert to IFC Project"),
             "ToolTip": tt,
             "Accel": "I, P",
         }


### PR DESCRIPTION
- The `BIM_Project` command is removed from the toolbar and relocated to the Utils menu
- The default when creating a new project in `BIM_ProjectManager` has been changed to non-IFC-native
- The default width of the `BIM_ProjectManager` dialog has been adjusted from a seemingly random value that was too narrow (443px => 600px)
- The `BIM_Project` and `IFC_MakeProject` command menu texts have been reworded to remove ambiguity. "Project" => "IFC Project", "Create IFC Project" => "Convert to IFC Project"

I'm proposing to include this change for **FreeCAD 1.1**:

- The changes are minimal
- They solve a common source of confusion
- No functionality is removed, just relocated
- The UX is still not perfect, but it can be iterated upon during the 1.2 cycle

I was very tempted to include an additional change: instead of simply removing the `BIM_Project` command, replace it with `BIM_ProjectManager`, but I decided against it to keep the UX changes to a minimum. 

## Issues

Fixes: https://github.com/FreeCAD/FreeCAD/issues/24557

## Before and After Images
### Before

<img width="191" height="44" alt="Captura de pantalla de 2025-11-05 05-59-11" src="https://github.com/user-attachments/assets/fcbb45db-6916-4044-8503-ff0f21f6c180" />

---

<img width="372" height="878" alt="Captura de pantalla de 2025-11-05 05-58-43" src="https://github.com/user-attachments/assets/17851b47-1937-4821-9359-6ce75497f378" />

### After

<img width="155" height="44" alt="Captura de pantalla de 2025-11-05 05-59-23" src="https://github.com/user-attachments/assets/114db922-0351-497f-aeee-39a79b232a43" />

---

<img width="372" height="878" alt="Captura de pantalla de 2025-11-05 05-58-08" src="https://github.com/user-attachments/assets/616cac57-61bb-4abc-87db-df0d35b1db48" />