### PR TITLE
Pylint: increase max line length limit to 120 characters

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -398,7 +398,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000


### PR DESCRIPTION
This is a commit to suggest switching to a 120 character line limit in pylint linter configuration.

120 is becoming a standard in Python modern development environments as most of us outgrew 640x480 CRT monitors or code development using tty terminals over phone lines.

I know this PR will probably start a heated discussion with people citing PEP8 right and left. Remember that leaded gasoline used to be a standard too. You may also refer to  something else than random dude on GitHub if you want:

https://gds-way.digital.cabinet-office.gov.uk/manuals/programming-languages/python/python.html#python-style-guide


I know commit hooks still auto-format code with 100 line limit using `black` but at least linter will give us some slack when it comes to strings and comments. With the current state of Python code and stuff reported by linter - line limit is the least of our problems.