### PR TITLE
CAM: DressupArray - Fix python import

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/Array.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Array.py
@@ -1,20 +1,14 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-from PySide.QtCore import QT_TRANSLATE_NOOP
-import FreeCAD
-import Path
-import Path.Base.Util as PathUtil
-import Path.Dressup.Array as DressupArray
-import Path.Dressup.Utils as PathDressup
-import Path.Main.Stock as PathStock
-import PathScripts.PathUtils as PathUtils
-
-from PySide import QtGui
-from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD
 import FreeCADGui
 import Path
-import PathGui
+import Path.Dressup.Array as DressupArray
+import Path.Dressup.Utils as PathDressup
+
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+translate = FreeCAD.Qt.translate
 
 
 class DressupArrayViewProvider(object):


### PR DESCRIPTION
Fix #25097

translate function is not defined in `Mod/CAM/Path/Dressup/Gui/Array.py`

```
Running the Python command 'CAM_DressupArray' failed:
Traceback (most recent call last):
  File "/home/roy/Downloads/squashfs-root/usr/Mod/CAM/Path/Dressup/Gui/Array.py", line 75, in Activated
    Path.Log.error(translate("CAM_DressupArray", "Select one toolpath object") + "\n")
                   ^^^^^^^^^

name 'translate' is not defined
```