### PR TITLE
OCC usage: fix deprecated `Handle_*`

### DIFF
--- a/src/Mod/CAM/App/Area.cpp
+++ b/src/Mod/CAM/App/Area.cpp
@@ -1149,7 +1149,7 @@ struct WireJoiner
             }
 
             Standard_Real first, last;
-            Handle_Geom_Curve curve = BRep_Tool::Curve(it->edge, first, last);
+            Handle(Geom_Curve) curve = BRep_Tool::Curve(it->edge, first, last);
             bool reversed =
                 pstart.SquareDistance(curve->Value(last)) <= Precision::SquareConfusion();
 
@@ -1631,7 +1631,7 @@ int Area::project(TopoDS_Shape& shape_out,
                   const TopoDS_Shape* work_plane)
 {
     FC_TIME_INIT2(t, t1);
-    Handle_HLRBRep_Algo brep_hlr;
+    Handle(HLRBRep_Algo) brep_hlr;
     gp_Dir dir(0, 0, 1);
     try {
         brep_hlr = new HLRBRep_Algo();
@@ -3161,7 +3161,7 @@ struct ShapeInfo
                 // PointProjectionFailed. Why??
 
                 Standard_Real first, last;
-                Handle_Geom_Curve curve = BRep_Tool::Curve(edge, first, last);
+                Handle(Geom_Curve) curve = BRep_Tool::Curve(edge, first, last);
                 pt = curve->Value(last);
                 bool reversed;
                 if (pprev.SquareDistance(pt) <= Precision::SquareConfusion()) {

--- a/src/Mod/Part/App/WireJoiner.cpp
+++ b/src/Mod/Part/App/WireJoiner.cpp
@@ -212,7 +212,7 @@ public:
         std::unique_ptr<Geometry> geo {};
         Standard_Real firstParam {};
         Standard_Real lastParam {};
-        Handle_Geom_Curve curve;
+        Handle(Geom_Curve) curve;
         GeomAbs_CurveType type {};
         bool isLinear;
 
@@ -2650,7 +2650,7 @@ public:
 
     // This method was originally part of WireJoinerP::makeCleanWire(), split to reduce cognitive
     // complexity
-    void printHistoryInit(const Handle_BRepTools_History& newHistory,
+    void printHistoryInit(const Handle(BRepTools_History)& newHistory,
                           const std::vector<TopoShape>& inputEdges)
     {
         FC_MSG("init:");


### PR DESCRIPTION
`Handle_Something` typedef are marked deprecated and will be removed after OCC 7.9.
Use the `Handle(Something)` macro instead.