### PR TITLE
Core: add a check on object deletion

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3221,6 +3221,10 @@ bool Document::containsObject(const DocumentObject* pcObject) const
 void Document::removeObject(const char* sName)
 {
     auto pos = d->objectMap.find(sName);
+    if (pos == d->objectMap.end()){
+        FC_MSG("Object " << sName << " already deleted in document " << getName());
+        return;
+    }
 
     if (pos->second->testStatus(ObjectStatus::PendingRecompute)) {
         // TODO: shall we allow removal if there is active undo transaction?


### PR DESCRIPTION
It appears a crash occurs in some cases because of this `find` result is not checked for validity.

It appends to me with a Link  to a Body I couldn't deleted. With this patch I obtain
```
15:20:17  10.8753 <App> Document.cpp(3225): Object Origin013 already deleted in document MyDoc
15:20:17  10.8753 <App> Document.cpp(3225): Object Origin012 already deleted in document MyDoc
15:20:17  10.8753 <App> Document.cpp(3225): Object YZ_Plane006 already deleted in document MyDoc
15:20:17  10.8753 <App> Document.cpp(3225): Object XZ_Plane006 already deleted in document MyDoc
15:20:17  10.8753 <App> Document.cpp(3225): Object XY_Plane006 already deleted in document MyDoc
15:20:17  10.8753 <App> Document.cpp(3225): Object Z_Axis006 already deleted in document MyDoc
15:20:17  10.8753 <App> Document.cpp(3225): Object Y_Axis006 already deleted in document MyDoc
15:20:17  10.8753 <App> Document.cpp(3225): Object X_Axis006 already deleted in document MyDoc
```