### PR TITLE
App: cherry-pick - Implement Save() & Restore() for int/float constraint properties

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -790,22 +790,22 @@ void PropertyIntegerConstraint::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Integer");
     // get the value of my Attribute
-    setValue(reader.getAttributeAsInteger("value"));
+    setValue(reader.getAttribute<long>("value"));
 
     bool createConstraint = false;
     long minimum = std::numeric_limits<int>::lowest();
     long maximum = std::numeric_limits<int>::max();
     long stepsize = 1.0;
     if (reader.hasAttribute("min")) {
-        minimum = reader.getAttributeAsInteger("min");
+        minimum = reader.getAttribute<long>("min");
         createConstraint = true;
     }
     if (reader.hasAttribute("max")) {
-        maximum = reader.getAttributeAsInteger("max");
+        maximum = reader.getAttribute<long>("max");
         createConstraint = true;
     }
     if (reader.hasAttribute("step")) {
-        stepsize = reader.getAttributeAsInteger("step");
+        stepsize = reader.getAttribute<long>("step");
     }
 
     if (createConstraint) {
@@ -1340,22 +1340,22 @@ void PropertyFloatConstraint::Restore(Base::XMLReader& reader)
     // read my Element
     reader.readElement("Float");
     // get the value of my Attribute
-    setValue(reader.getAttributeAsFloat("value"));
+    setValue(reader.getAttribute<double>("value"));
 
     bool createConstraint = false;
     double minimum = std::numeric_limits<double>::lowest();
     double maximum = std::numeric_limits<double>::max();
     double stepsize = 1.0;
     if (reader.hasAttribute("min")) {
-        minimum = reader.getAttributeAsFloat("min");
+        minimum = reader.getAttribute<double>("min");
         createConstraint = true;
     }
     if (reader.hasAttribute("max")) {
-        maximum = reader.getAttributeAsFloat("max");
+        maximum = reader.getAttribute<double>("max");
         createConstraint = true;
     }
     if (reader.hasAttribute("step")) {
-        stepsize = reader.getAttributeAsFloat("step");
+        stepsize = reader.getAttribute<double>("step");
     }
 
     if (createConstraint) {

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -770,6 +770,54 @@ void PropertyIntegerConstraint::setPyObject(PyObject* value)
     }
 }
 
+void PropertyIntegerConstraint::Save(Base::Writer& writer) const
+{
+    writer.Stream() << writer.ind()
+                    << "<Integer value=\"" << _lValue << "\"";
+    if (_ConstStruct && _ConstStruct->isDeletable()) {
+        long minimum = _ConstStruct->LowerBound;
+        long maximum = _ConstStruct->UpperBound;
+        long stepsize = _ConstStruct->StepSize;
+        writer.Stream() << " min=\"" << minimum << "\""
+                        << " max=\"" << maximum << "\""
+                        << " step=\"" << stepsize << "\"";
+    }
+    writer.Stream() << "/>\n";
+}
+
+void PropertyIntegerConstraint::Restore(Base::XMLReader& reader)
+{
+    // read my Element
+    reader.readElement("Integer");
+    // get the value of my Attribute
+    setValue(reader.getAttributeAsInteger("value"));
+
+    bool createConstraint = false;
+    long minimum = std::numeric_limits<int>::lowest();
+    long maximum = std::numeric_limits<int>::max();
+    long stepsize = 1.0;
+    if (reader.hasAttribute("min")) {
+        minimum = reader.getAttributeAsInteger("min");
+        createConstraint = true;
+    }
+    if (reader.hasAttribute("max")) {
+        maximum = reader.getAttributeAsInteger("max");
+        createConstraint = true;
+    }
+    if (reader.hasAttribute("step")) {
+        stepsize = reader.getAttributeAsInteger("step");
+    }
+
+    if (createConstraint) {
+        Constraints* c = new Constraints();
+        c->setDeletable(true);
+        c->LowerBound = minimum;
+        c->UpperBound = maximum;
+        c->StepSize = stepsize;
+        setConstraints(c);
+    }
+}
+
 //**************************************************************************
 //**************************************************************************
 // PropertyPercent
@@ -1269,6 +1317,54 @@ void PropertyFloatConstraint::setPyObject(PyObject* value)
         aboutToSetValue();
         _dValue = valConstr[0];
         hasSetValue();
+    }
+}
+
+void PropertyFloatConstraint::Save(Base::Writer& writer) const
+{
+    writer.Stream() << writer.ind()
+                    << "<Float value=\"" << _dValue << "\"";
+    if (_ConstStruct && _ConstStruct->isDeletable()) {
+        double minimum = _ConstStruct->LowerBound;
+        double maximum = _ConstStruct->UpperBound;
+        double stepsize = _ConstStruct->StepSize;
+        writer.Stream() << " min=\"" << minimum << "\""
+                        << " max=\"" << maximum << "\""
+                        << " step=\"" << stepsize << "\"";
+    }
+    writer.Stream() << "/>\n";
+}
+
+void PropertyFloatConstraint::Restore(Base::XMLReader& reader)
+{
+    // read my Element
+    reader.readElement("Float");
+    // get the value of my Attribute
+    setValue(reader.getAttributeAsFloat("value"));
+
+    bool createConstraint = false;
+    double minimum = std::numeric_limits<double>::lowest();
+    double maximum = std::numeric_limits<double>::max();
+    double stepsize = 1.0;
+    if (reader.hasAttribute("min")) {
+        minimum = reader.getAttributeAsFloat("min");
+        createConstraint = true;
+    }
+    if (reader.hasAttribute("max")) {
+        maximum = reader.getAttributeAsFloat("max");
+        createConstraint = true;
+    }
+    if (reader.hasAttribute("step")) {
+        stepsize = reader.getAttributeAsFloat("step");
+    }
+
+    if (createConstraint) {
+        Constraints* c = new Constraints();
+        c->setDeletable(true);
+        c->LowerBound = minimum;
+        c->UpperBound = maximum;
+        c->StepSize = stepsize;
+        setConstraints(c);
     }
 }
 

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -339,6 +339,9 @@ public:
     }
     void setPyObject(PyObject* py) override;
 
+    void Save(Base::Writer& writer) const override;
+    void Restore(Base::XMLReader& reader) override;
+
 protected:
     const Constraints* _ConstStruct {nullptr};
 };
@@ -672,6 +675,9 @@ public:
     }
 
     void setPyObject(PyObject* py) override;
+
+    void Save(Base::Writer& writer) const override;
+    void Restore(Base::XMLReader& reader) override;
 
 protected:
     const Constraints* _ConstStruct {nullptr};

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -75,6 +75,23 @@ class DocumentBasicCases(unittest.TestCase):
         FreeCAD.closeDocument(doc.Name)
         self.Doc = FreeCAD.newDocument("CreateTest")
 
+    def testIssue24571(self):
+        obj = self.Doc.addObject("App::FeatureTest", "Object")
+        obj.ConstraintInt = (50, 0, 100, 1)
+        obj.ConstraintFloat = (50.0, 0.0, 100.0, 1.0)
+        self.Doc = self.saveAndRestore()
+        obj = self.Doc.getObject("Object")
+        # int
+        obj.ConstraintInt = -1
+        self.assertEqual(obj.ConstraintInt, 0)
+        obj.ConstraintInt = 101
+        self.assertEqual(obj.ConstraintInt, 100)
+        # float
+        obj.ConstraintFloat = -1.0
+        self.assertEqual(obj.ConstraintFloat, 0.0)
+        obj.ConstraintFloat = 101.0
+        self.assertEqual(obj.ConstraintFloat, 100.0)
+
     def testAccessByNameOrID(self):
         obj = self.Doc.addObject("App::DocumentObject", "MyName")
 


### PR DESCRIPTION
Cherry-picked commits from https://codeberg.org/xCAD/FreeCAD11/pulls/55

The sole credit for the implementation goes to @wwmayer (thanks!), and authorship metadata has been kept in the original commits. Please let me know if there is any additional step to ensure the attribution is done correctly.

The [original author's description](https://codeberg.org/xCAD/FreeCAD11/pulls/55) reads:

> Implement the methods Save() and Restore() for PropertyIntegerConstraint and PropertyFloatConstraint.
> Handle also the case of a user-defined ranges.
>
>This fixes https://github.com/FreeCAD/FreeCAD/issues/24571.
>
> Hint: For PropertyQuantityConstraint this is not doable because it doesn't support user-defined ranges

Fixes: #24571 

 