### PR TITLE
cmake: update configure checks for swig / pivy compatibility

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupSwig.cmake
+++ b/cMake/FreeCAD_Helpers/SetupSwig.cmake
@@ -1,12 +1,160 @@
 macro(SetupSwig)
-# -------------------------------- Swig ----------------------------------
 
-    find_package(SWIG)
+#-------------------------------- Swig ----------------------------------
 
-    if (NOT SWIG_FOUND)
-        message("=====================================================\n"
-                "SWIG not found, will not build SWIG binding for pivy.\n"
-                "=====================================================\n")
-    endif(NOT SWIG_FOUND)
+# force cmake to re-search for SWIG when CMAKE_PREFIX_PATH changes
+unset(SWIG_EXECUTABLE CACHE)
+unset(SWIG_DIR CACHE)
+unset(SWIG_VERSION CACHE)
+unset(SWIG_FOUND CACHE)
 
-endmacro(SetupSwig)
+if(BUILD_SKETCHER)
+    # SWIG is required for sketcher WB (use QUIET to provide custom error message)
+    find_package(SWIG QUIET)
+
+    if(NOT SWIG_FOUND)
+        message(FATAL_ERROR
+                "-----------------------------------------------------\n"
+                "SWIG not found, swig & pivy required for sketcher WB.\n"
+                "-----------------------------------------------------\n")
+        # do not continue with check if swig not found
+        return()
+    endif()
+
+    # check swig/pivy runtime compatibility
+    message(STATUS "checking SWIG/Pivy runtime compatibility...")
+
+    # get SWIG's runtime version using -external-runtime flag
+    execute_process(
+        COMMAND ${SWIG_EXECUTABLE} -python -external-runtime "${CMAKE_BINARY_DIR}/swig_runtime_check.h"
+        RESULT_VARIABLE SWIG_EXTERNAL_RUNTIME_RESULT
+        ERROR_VARIABLE SWIG_EXTERNAL_RUNTIME_ERROR
+        ERROR_QUIET
+    )
+    # NOTE: only print the below output if using `cmake --log-level=DEBUG`
+    message(DEBUG "SWIG external-runtime result: ${SWIG_EXTERNAL_RUNTIME_RESULT}")
+    message(DEBUG "SWIG external-runtime error: ${SWIG_EXTERNAL_RUNTIME_ERROR}")
+
+    message(STATUS "Looking for: ${CMAKE_BINARY_DIR}/swig_runtime_check.h")
+    if(EXISTS "${CMAKE_BINARY_DIR}/swig_runtime_check.h")
+        message(STATUS "File exists: YES")
+    else()
+        message(STATUS "File exists: NO")
+    endif()
+
+    if(EXISTS "${CMAKE_BINARY_DIR}/swig_runtime_check.h")
+        file(STRINGS "${CMAKE_BINARY_DIR}/swig_runtime_check.h"
+            SWIG_RUNTIME_VERSION_LINE
+            REGEX "^#define SWIG_RUNTIME_VERSION")
+
+        message(STATUS "SWIG_RUNTIME_VERSION_LINE: ${SWIG_RUNTIME_VERSION_LINE}")
+
+        if(SWIG_RUNTIME_VERSION_LINE)
+            # extract the version number (it's in quotes: "5")
+            string(REGEX MATCH "\"([0-9]+)\"" _ "${SWIG_RUNTIME_VERSION_LINE}")
+            set(SWIG_RUNTIME_VERSION "${CMAKE_MATCH_1}")
+            message(STATUS "Extracted SWIG_RUNTIME_VERSION: ${SWIG_RUNTIME_VERSION}")
+        endif()
+
+        file(REMOVE "${CMAKE_BINARY_DIR}/swig_runtime_check.h")
+    else()
+        message(STATUS "swig_runtime_check.h not found!")
+    endif()
+
+    # extract pivy's SWIG runtime version from the compiled module
+    # NOTE: python code can not be indented
+    set(PYTHON_CHECK_PIVY_RUNTIME [=[
+import sys
+import os
+import re
+
+try:
+    import pivy
+    pivy_dir = os.path.dirname(pivy.__file__)
+    print(f'DEBUG:pivy_dir={pivy_dir}', file=sys.stderr)
+    print(f'DEBUG:files={os.listdir(pivy_dir)}', file=sys.stderr)
+
+    pivy_path = None
+
+    # Look for _coin module with any extension (.so on Unix, .pyd on Windows)
+    for f in os.listdir(pivy_dir):
+        print(f'DEBUG:checking={f}', file=sys.stderr)
+        if f.startswith('_coin') and (f.endswith('.so') or f.endswith('.pyd')):
+            pivy_path = os.path.join(pivy_dir, f)
+            break
+
+    print(f'DEBUG:pivy_path={pivy_path}', file=sys.stderr)
+
+    if pivy_path and os.path.exists(pivy_path):
+        with open(pivy_path, 'rb') as f:
+            content = f.read().decode('latin-1', errors='ignore')
+
+        print(f'DEBUG:content_len={len(content)}', file=sys.stderr)
+
+        # Use regex to find swig_runtime_data followed by a number
+        match = re.search(r'swig_runtime_data(\d+)', content)
+        print(f'DEBUG:match={match}', file=sys.stderr)
+        if match:
+            print(match.group(1))
+
+except ImportError as e:
+    print(f'DEBUG:import_error={e}', file=sys.stderr)
+    print('ERROR_IMPORT')
+except Exception as e:
+    print(f'DEBUG:exception={e}', file=sys.stderr)
+]=])
+
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} -c "${PYTHON_CHECK_PIVY_RUNTIME}"
+    OUTPUT_VARIABLE PIVY_RUNTIME_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE PIVY_DEBUG_OUTPUT
+    TIMEOUT 10
+)
+
+message(DEBUG "Pivy debug output: ${PIVY_DEBUG_OUTPUT}")
+
+    # Handle errors and compare versions
+    if(PIVY_RUNTIME_VERSION STREQUAL "ERROR_IMPORT")
+        message(WARNING
+            "Could not import pivy to check SWIG compatibility.\n"
+            "Proceeding without SWIG version check."
+        )
+    elseif(SWIG_RUNTIME_VERSION AND PIVY_RUNTIME_VERSION)
+        if(NOT SWIG_RUNTIME_VERSION STREQUAL PIVY_RUNTIME_VERSION)
+            message(FATAL_ERROR
+" --------------------------------------------------------
+ 
+ SWIG / PIVY RUNTIME VERSION MISMATCH DETECTED!
+ 
+ SWIG runtime API version: ${SWIG_RUNTIME_VERSION}
+ Pivy runtime API version: ${PIVY_RUNTIME_VERSION}
+  
+ These must match for compatibility.
+ This will cause runtime errors: 'No SWIG wrapped library loaded'
+  
+ swig v4.4.x is not compatible with pivy built with swig <=4.3.x
+  
+ FIX: Install a SWIG version that uses runtime ${PIVY_RUNTIME_VERSION}
+ or rebuild Pivy with your current SWIG ${SWIG_VERSION}.
+ 
+--------------------------------------------------------"
+            )
+        else()
+            message(STATUS "SWIG/Pivy runtime compatibility: PASSED")
+            message(STATUS "swig runtime API version: ${SWIG_RUNTIME_VERSION}")
+            message(STATUS "pivy runtime API version: ${PIVY_RUNTIME_VERSION}")
+            message(STATUS "swig binary version building freecad: ${SWIG_VERSION}")
+        endif()
+    else()
+        if(NOT SWIG_RUNTIME_VERSION)
+            message(WARNING "Could not determine SWIG runtime version")
+        endif()
+        if(NOT PIVY_RUNTIME_VERSION)
+            message(WARNING "Could not determine Pivy runtime version")
+        endif()
+        message(WARNING "Proceeding without SWIG/Pivy compatibility check.")
+    endif()
+endif()
+
+endmacro()


### PR DESCRIPTION
**updated jan 07 2026**

this pr updates the `setupswig.cmake` file to check and make sure that the swig version found is the same version that was used to build pivy, ie. swig and pivy need to use the same swig API versions with the recent update to swig v4.4.x from v4.3.x the internal swig API has changed from version 4 to version 5, ie.

- swig v4.4.x uses a runtime api of v5
- swig v4.3.x and lower use a api of v4

as described in the below github issue, when creating a new sketch using the sketcher workbench warnings will begin to arise in the report view stating that the swig python bindings do not match the ones used by pivy, ie.

```
13:22:50  Show.ShowUtils.is3DObject error: No SWIG wrapped library loaded
13:22:50  Show.ShowUtils.is3DObject error: No SWIG wrapped library loaded
```

basically versions of pivy built with swig <= v4.3.1 will show the below, use the below command linux or mac

```
strings /home/capin/homebrew/lib/python3.13/site-packages/pivy/_coin.so | grep -E '^(swig_runtime_data[0-9]+\.)?(SwigPy|swigvar|SwigVar)'
```

~~**note** i dont know if windows supports the `strings` command thus this PR uses a pure python version of basically the same check to verify which swig was used at build time for pivy~~

ie.

SwigPyObject, 
SwigPyPacked, 
swigvarlink


<details>

<summary>if pivy was built with swig >= v4.4.0 one would see something like the below using the above strings command,</summary>


```
swig_runtime_data5.SwigPyPacked
SwigPyPacked
swig_runtime_data5.SwigVarLink
SwigVarLink
swig_runtime_data5.SwigPyObject
SwigPyObject_disown
SwigPyObject_acquire
SwigVarLink_dealloc
SwigPyObject_long
SwigPyObject_own
SwigVarLink_str
SwigVarLink_repr
SwigPyClientData_New
SwigPyObject_next
SwigVarLink_getattr
SwigPyPacked_repr
SwigPyPacked_str
SwigPyObject_repr
SwigPyObject_repr2
SwigVarLink_setattr
SwigPyPacked_Type
SwigPyPacked_dealloc
SwigVarLink_Type
SwigPyObject_Type
SwigPyObject_richcompare
SwigPyObject_append
SwigPyObject_dealloc
```

</details>

also if the swig version used to build pivy does not match the current version found by cmake during the setup process the below output will be shown to the user when configuring freecad using cmake,

<details>
<summary>cmake output of error messages with this PR applied</summary>

```
-- checking SWIG/Pivy runtime compatibility...
-- SWIG external-runtime result: 0
-- SWIG external-runtime error:
-- Looking for: /opt/code/fcgit/builds/issue.tshooting.qt6.py313/swig_runtime_check.h
-- File exists: YES
-- SWIG_RUNTIME_VERSION_LINE: #define SWIG_RUNTIME_VERSION "4"
-- Extracted SWIG_RUNTIME_VERSION: 4
-- Pivy debug output: DEBUG:pivy_dir=/home/capin/homebrew/lib/python3.13/site-packages/pivy
DEBUG:files=['__pycache__', '__init__.py', '_coin.so', 'coin.py', 'graphics', 'gui', 'pivy_meta.py', 'qt', 'quarter', 'sogui.py', 'utils.py']
DEBUG:checking=__pycache__
DEBUG:checking=__init__.py
DEBUG:checking=_coin.so
DEBUG:pivy_path=/home/capin/homebrew/lib/python3.13/site-packages/pivy/_coin.so
DEBUG:content_len=11280744
DEBUG:match=<re.Match object; span=(5197584, 5197602), match='swig_runtime_data5'>

CMake Error at cMake/FreeCAD_Helpers/SetupSwig.cmake:123 (message):
   --------------------------------------------------------

   SWIG / PIVY RUNTIME VERSION MISMATCH DETECTED!

   SWIG runtime version: 4
   Pivy runtime version: 5

   These must match for compatibility.
   This will cause runtime errors: 'No SWIG wrapped library loaded'

   swig v4.4.x is not compatible with pivy built with swig <=4.3.x

   FIX: Install a SWIG version that uses runtime 5
   or rebuild Pivy with your current SWIG 4.2.1.


  --------------------------------------------------------
Call Stack (most recent call first):
  CMakeLists.txt:101 (SetupSwig)


-- Configuring incomplete, errors occurred!
```

</details>

originally reported issue
- https://github.com/FreeCAD/FreeCAD/issues/25048

---

<details>

<summary>

**update jan 07 2026** below is the output from a libpack build i did locally using github ci from my fork of freecad

</summary>

```
-- checking SWIG/Pivy runtime compatibility...
-- SWIG external-runtime result: 0
-- SWIG external-runtime error: 
-- Looking for: C:/FC/build/release/swig_runtime_check.h
-- File exists: YES
-- SWIG_RUNTIME_VERSION_LINE: #define SWIG_RUNTIME_VERSION "4"
-- Extracted SWIG_RUNTIME_VERSION: 4
-- Pivy debug output: DEBUG:pivy_dir=C:\FC\libpack\bin\Lib\site-packages\pivy
DEBUG:files=['coin.py', 'graphics', 'gui', 'pivy_meta.py', 'qt', 'quarter', 'sogui.py', 'utils.py', '_coin.pyd', '__init__.py', '__pycache__']
DEBUG:checking=coin.py
DEBUG:checking=graphics
DEBUG:checking=gui
DEBUG:checking=pivy_meta.py
DEBUG:checking=qt
DEBUG:checking=quarter
DEBUG:checking=sogui.py
DEBUG:checking=utils.py
DEBUG:checking=_coin.pyd
DEBUG:pivy_path=C:\FC\libpack\bin\Lib\site-packages\pivy\_coin.pyd
DEBUG:content_len=14995968
DEBUG:match=<re.Match object; span=(12899080, 12899098), match='swig_runtime_data4'>
-- SWIG/Pivy runtime compatibility: PASSED
-- swig runtime API version: 4
-- pivy runtime API version: 4
-- swig binary version building freecad: 4.4.0
```

</details>