### PR TITLE
BIM: BIM_Sketch: do not override sketch colors and line width

### DIFF
--- a/src/Mod/BIM/bimcommands/BimSketch.py
+++ b/src/Mod/BIM/bimcommands/BimSketch.py
@@ -64,9 +64,6 @@ class BIM_Sketch:
             sk.ViewObject.GridSize = s
             sk.ViewObject.GridSnap = True
         sk.MapMode = "Deactivated"
-        sk.ViewObject.LineColor = params.get_param_view("DefaultShapeLineColor")
-        sk.ViewObject.PointColor = params.get_param_view("DefaultShapeLineColor")
-        sk.ViewObject.LineWidth = params.get_param_view("DefaultShapeLineWidth")
         sk.Placement = WorkingPlane.get_working_plane().get_placement()
         FreeCADGui.ActiveDocument.setEdit(sk.Name)
         FreeCADGui.activateWorkbench("SketcherWorkbench")


### PR DESCRIPTION
Fixes #25187

Overriding these properties does not work well with the handling of the Auto Color property of the sketch.

It is also not a good idea to ignore the dedicated sketcher preferences for these properties. That is confusing for the user, and can conflict with the theming.