### PR TITLE
Gui: prevent native macOS color picker crash.

### DIFF
--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -749,7 +749,13 @@ void ColorButton::showModal()
             setColor(currentColor);
             Q_EMIT changed();
         }
+        setProperty("modal_dialog_active", false);
     });
+
+    /* A FocusOut event is sent when a native macOS color picker is opened, which
+     * closes the editor and destroys this object. Set a property to ignore this event.
+     */
+    setProperty("modal_dialog_active", true);
 
     dlg->exec();
 }

--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -195,6 +195,12 @@ bool PropertyItemDelegate::eventFilter(QObject *o, QEvent *ev)
         }
     }
     else if (ev->type() == QEvent::FocusOut) {
+        if (auto button = qobject_cast<Gui::ColorButton*>(o)) {
+            // Ignore the event if the ColorButton's modal dialog is active.
+            if (button->property("modal_dialog_active").toBool()) {
+                return true;
+            }
+        }
         auto parentEditor = qobject_cast<PropertyEditor*>(this->parent());
         if (auto* comboBox = qobject_cast<QComboBox*>(o)) {
             if (parentEditor && parentEditor->activeEditor == comboBox) {


### PR DESCRIPTION
When using the macOS native color picker (and apparently in no other case), `PropertyItemDelegate::eventFilter` receives a `FocusOut` event with an `ActiveWindowFocusReason`.  That eventually makes its way to `PropertyEditor::closeEditor` which initiates deletion of the `ColorButton` that's showing the modal.

All that happens while the dialog is open, so that when the dialog closes, the `ColorButton` object has been destroyed, and it crashes.

This patch sets a flag in the ColorButton that allows the event filter to ignore FocusOut events when the modal is active.

## Issues
Fixes #25153