### PR TITLE
PartDesign: fix the interactive controls for revolution/groove

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -588,9 +588,7 @@ void TaskRevolutionParameters::onAxisChanged(int num)
 
         recomputeFeature();
 
-        if (gizmoContainer) {
-            setGizmoPositions();
-        }
+        setGizmoPositions();
     }
     catch (const Base::Exception& e) {
         e.reportException();
@@ -615,9 +613,7 @@ void TaskRevolutionParameters::onReversed(bool on)
         propReversed->setValue(on);
         recomputeFeature();
 
-        if (gizmoContainer) {
-            reverseGizmoDir();
-        }
+        setGizmoPositions();
     }
 }
 
@@ -749,9 +745,6 @@ void TaskRevolutionParameters::setupGizmos(ViewProvider* vp)
     rotationGizmo2->flipArrow();
 
     setGizmoPositions();
-    if (getReversed()) {
-        reverseGizmoDir();
-    }
     setGizmoVisibility();
 }
 
@@ -764,52 +757,48 @@ void TaskRevolutionParameters::setGizmoPositions()
     Base::Vector3d profileCog;
     Base::Vector3d basePos;
     Base::Vector3d axisDir;
+    bool reversed = false;
 
-    if (isGroove) {
-        auto groove = getObject<PartDesign::Groove>();
-        if (!groove || groove->isError()) {
-            gizmoContainer->visible = false;
-            return;
+    auto getFeatureProps = [&profileCog, &basePos, &axisDir, &reversed](auto* feature) {
+        if (!feature || feature->isError()) {
+            return false;
         }
-        Part::TopoShape profile = groove->getProfileShape();
+        Part::TopoShape profile = feature->getProfileShape();
 
         profile.getCenterOfGravity(profileCog);
-        basePos = groove->Base.getValue();
-        axisDir = groove->Axis.getValue();
+        basePos = feature->Base.getValue();
+        axisDir = feature->Axis.getValue();
+        reversed = feature->Reversed.getValue();
+        return true;
+    };
+
+    bool ret;
+    if (isGroove) {
+        ret = getFeatureProps(getObject<PartDesign::Groove>());
     }
     else {
-        auto revolution = getObject<PartDesign::Revolution>();
-        if (!revolution || revolution->isError()) {
-            gizmoContainer->visible = false;
-            return;
-        }
-        Part::TopoShape profile = revolution->getProfileShape();
-
-        profile.getCenterOfGravity(profileCog);
-        basePos = revolution->Base.getValue();
-        axisDir = revolution->Axis.getValue();
+        ret = getFeatureProps(getObject<PartDesign::Revolution>());
     }
-    gizmoContainer->visible = true;
+
+    gizmoContainer->visible = ret;
+    if (!ret) {
+        return;
+    }
 
     auto diff = profileCog - basePos;
     axisDir.Normalize();
     auto axisComp = axisDir * diff.Dot(axisDir);
     auto normalComp = diff - axisComp;
 
+    if (reversed) {
+        axisDir = -axisDir;
+    }
+
     rotationGizmo->Gizmo::setDraggerPlacement(basePos + axisComp, normalComp);
     rotationGizmo->getDraggerContainer()->setArcNormalDirection(Base::convertTo<SbVec3f>(axisDir));
 
     rotationGizmo2->Gizmo::setDraggerPlacement(basePos + axisComp, normalComp);
     rotationGizmo2->getDraggerContainer()->setArcNormalDirection(Base::convertTo<SbVec3f>(-axisDir));
-}
-
-void TaskRevolutionParameters::reverseGizmoDir()
-{
-    rotationGizmo->setMultFactor(-rotationGizmo->getMultFactor());
-    rotationGizmo->flipArrow();
-
-    rotationGizmo2->setMultFactor(-rotationGizmo2->getMultFactor());
-    rotationGizmo2->flipArrow();
 }
 
 void TaskRevolutionParameters::setGizmoVisibility()

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.h
@@ -137,7 +137,6 @@ private:
     Gui::RadialGizmo* rotationGizmo2 = nullptr;
     void setupGizmos(ViewProvider* vp);
     void setGizmoPositions();
-    void reverseGizmoDir();
     void setGizmoVisibility();
 };
 


### PR DESCRIPTION
For the revolution/groove operation in FreeCAD there is a possibility that the reversed option gets toggled based on the reference axis. This PR updates the draggers to handle that.