### PR TITLE
CAM: Path.Geom.cmdsForEdge() - remove useless 'segm'

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Boundary.py
@@ -284,7 +284,6 @@ class PathBoundary:
                                             e,
                                             flip,
                                             False,
-                                            50,
                                             tc.HorizFeed.Value,
                                             tc.VertFeed.Value,
                                         )

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -272,10 +272,9 @@ class Tag:
 
 
 class MapWireToTag:
-    def __init__(self, edge, tag, i, segm, maxZ, hSpeed, vSpeed):
+    def __init__(self, edge, tag, i, maxZ, hSpeed, vSpeed):
         debugEdge(edge, "MapWireToTag(%.2f, %.2f, %.2f)" % (i.x, i.y, i.z))
         self.tag = tag
-        self.segm = segm
         self.maxZ = maxZ
         self.hSpeed = hSpeed
         self.vSpeed = vSpeed
@@ -285,16 +284,12 @@ class MapWireToTag:
             debugEdge(tail, ".........=")
         elif Path.Geom.pointsCoincide(edge.valueAt(edge.LastParameter), i):
             debugEdge(edge, "++++++++ .")
-            self.commands = Path.Geom.cmdsForEdge(
-                edge, segm=segm, hSpeed=self.hSpeed, vSpeed=self.vSpeed
-            )
+            self.commands = Path.Geom.cmdsForEdge(edge, hSpeed=self.hSpeed, vSpeed=self.vSpeed)
             tail = None
         else:
             e, tail = Path.Geom.splitEdgeAt(edge, i)
             debugEdge(e, "++++++++ .")
-            self.commands = Path.Geom.cmdsForEdge(
-                e, segm=segm, hSpeed=self.hSpeed, vSpeed=self.vSpeed
-            )
+            self.commands = Path.Geom.cmdsForEdge(e, hSpeed=self.hSpeed, vSpeed=self.vSpeed)
             debugEdge(tail, ".........-")
             self.initialEdge = edge
         self.tail = tail
@@ -562,7 +557,6 @@ class MapWireToTag:
                                 e,
                                 False,
                                 False,
-                                self.segm,
                                 hSpeed=self.hSpeed,
                                 vSpeed=self.vSpeed,
                             )
@@ -940,15 +934,6 @@ class ObjectTagDressup:
             "Tag",
             QT_TRANSLATE_NOOP("App::Property", "IDs of disabled holding tags"),
         )
-        obj.addProperty(
-            "App::PropertyInteger",
-            "SegmentationFactor",
-            "Tag",
-            QT_TRANSLATE_NOOP(
-                "App::Property",
-                "Factor determining the # of segments used to approximate rounded tags.",
-            ),
-        )
 
         self.obj = obj
         self.solids = []
@@ -1014,7 +999,6 @@ class ObjectTagDressup:
         obj.Height = fromObj.Height
         obj.Angle = fromObj.Angle
         obj.Radius = fromObj.Radius
-        obj.SegmentationFactor = fromObj.SegmentationFactor
 
         self.tags = self.pathData.copyTags(
             obj, fromObj, obj.Width.Value, obj.Height.Value, obj.Angle, obj.Radius.Value
@@ -1041,13 +1025,6 @@ class ObjectTagDressup:
         lastTag = 0
         t = 0
         edge = None
-
-        segm = 50
-        if hasattr(obj, "SegmentationFactor"):
-            segm = obj.SegmentationFactor
-            if segm <= 0:
-                segm = 50
-                obj.SegmentationFactor = 50
 
         self.mappers = []
         mapper = None
@@ -1083,7 +1060,6 @@ class ObjectTagDressup:
                         edge,
                         tags[tIndex],
                         i,
-                        segm,
                         pathData.maxZ,
                         hSpeed=horizFeed,
                         vSpeed=vertFeed,
@@ -1111,9 +1087,7 @@ class ObjectTagDressup:
                             )
                     else:
                         commands.extend(
-                            Path.Geom.cmdsForEdge(
-                                edge, segm=segm, hSpeed=horizFeed, vSpeed=vertFeed
-                            )
+                            Path.Geom.cmdsForEdge(edge, hSpeed=horizFeed, vSpeed=vertFeed)
                         )
                 edge = None
                 t = 0

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -279,15 +279,13 @@ def speedBetweenPoints(p0, p1, hSpeed, vSpeed):
     return speed
 
 
-def cmdsForEdge(edge, flip=False, useHelixForBSpline=True, segm=50, hSpeed=0, vSpeed=0):
-    """cmdsForEdge(edge, flip=False, useHelixForBSpline=True, segm=50) -> List(Path.Command)
+def cmdsForEdge(edge, flip=False, useHelixForBSpline=True, hSpeed=0, vSpeed=0):
+    """cmdsForEdge(edge, flip=False, useHelixForBSpline=True) -> List(Path.Command)
     Returns a list of Path.Command representing the given edge.
     If flip is True the edge is considered to be backwards.
     If useHelixForBSpline is True an Edge based on a BSplineCurve is considered
     to represent a helix and results in G2 or G3 command. Otherwise edge has
-    no direct Path.Command mapping and will be approximated by straight segments.
-    segm is a factor for the segmentation of arbitrary curves not mapped to G1/2/3
-    commands. The higher the value the more segments will be used."""
+    no direct Path.Command mapping and will be approximated by straight segments."""
     pt = edge.valueAt(edge.LastParameter) if not flip else edge.valueAt(edge.FirstParameter)
     params = {"X": pt.x, "Y": pt.y, "Z": pt.z}
     if type(edge.Curve) == Part.Line or type(edge.Curve) == Part.LineSegment:


### PR DESCRIPTION
Argument `segm` in function `Path.Geom.cmdsForEdge()` do nothing
So remove them

Step **2** of prepare to #22080