### PR TITLE
sketcher wb: fix issue #25078, allow grid snapping while hovering mouse over axis

### DIFF
--- a/src/Mod/Sketcher/Gui/SnapManager.cpp
+++ b/src/Mod/Sketcher/Gui/SnapManager.cpp
@@ -220,7 +220,7 @@ Base::Vector2d SnapManager::snap(Base::Vector2d inputPos, SnapType mask)
     if ((static_cast<int>(mask) & static_cast<int>(SnapType::Grid)) && snapToGridRequested
         /*&& viewProvider.ShowGrid.getValue() */) {  // Snap to grid is enabled
                                                      // even if the grid is not visible.
-        
+
         // use snapPos as input (which may have one coordinate locked by axis)
         Base::Vector2d gridSnapResult = snapPos;
         if (snapToGrid(snapPos, gridSnapResult)) {


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR aims resolving the below linked github issue. basically there's an edge case where snap to grid works, but if the user is hovering the mouse along an axis line in the sketcher workbench while creating a line and grid snapping is enabled. then while hovering the mouse along the axis the 2nd point of the line will not snap to the grid. this PR uses a combination of grid snapping and axis snapping to allow both to happen while moving the mouse cursor across an axis line. i tested this locally on my m1 box running asahi. and can say it is noticeably better. i don't even think v1.0.2 works this well but maybe i am just partially bias.

https://github.com/FreeCAD/FreeCAD/issues/25078

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
