### PR TITLE
Gui: Restore 'Exit' menu text for Linux/Windows

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -986,7 +986,7 @@ StdCmdQuit::StdCmdQuit()
   :Command("Std_Quit")
 {
   sGroup        = "File";
-  // sMenuText     = No menu text here, Qt sets it based on QAction::QuitRole
+  sMenuText     = QT_TR_NOOP("E&xit");
   sToolTipText  = QT_TR_NOOP("Quits the application");
   sWhatsThis    = "Std_Quit";
   sStatusTip    = sToolTipText;


### PR DESCRIPTION
Only macOS appears to set the text based on the menu item's role, and it does so regardless of the text we set here.