### PR TITLE
CAM: Fix ReferenceError when accessing deleted toolbit object

### DIFF
--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -52,8 +52,15 @@ class ToolBitRecomputeObserver:
 
     def slotRecomputedDocument(self, doc):
         """Called when document recompute is finished."""
+        # Check if the toolbit object is still valid
+        try:
+            obj_doc = self.toolbit_proxy.obj.Document
+        except ReferenceError:
+            # Object has been deleted or does not exist, nothing to do
+            return
+
         # Only process updates for the correct document
-        if doc != self.toolbit_proxy.obj.Document:
+        if doc != obj_doc:
             return
 
         # Process any queued visual updates


### PR DESCRIPTION
Prevent crash (CAMTests) in ToolBitRecomputeObserver when the toolbit object has been deleted/missing by catching ReferenceError before accessing its Document attribute. This ensures slotRecomputedDocument exits gracefully if the object is no longer valid.

src/Mod/CAM/Path/Tool/toolbit/models/base.py
- Wrapped access to self.toolbit_proxy.obj.Document in try/except to handle ReferenceError if object is deleted/missing, preventing crash during document recompute.
