### PR TITLE
Spreadsheet: Remove redundant ellipses from the context menu

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -195,12 +195,12 @@ SheetTableView::SheetTableView(QWidget* parent)
         return act;
     };
 
-    actionProperties = createAction("", tr("Properties…"), &SheetTableView::cellProperties);
+    actionProperties = createAction("", tr("Properties"), &SheetTableView::cellProperties);
     contextMenu.addSeparator();
     actionRecompute =
         createAction(":/icons/view-refresh.svg", tr("Recompute"), &SheetTableView::onRecompute);
     actionBind = createAction("", tr("Bind…"), &SheetTableView::onBind);
-    actionConf = createAction("", tr("Configuration Table…"), &SheetTableView::onConfSetup);
+    actionConf = createAction("", tr("Configuration Table"), &SheetTableView::onConfSetup);
     contextMenu.addSeparator();
     actionMerge = createAction(":/icons/SpreadsheetMergeCells.svg",
                                tr("Merge Cells"),


### PR DESCRIPTION
fixes #23840 (removes ellipses from "Properties" and "Configuration Table", leaves only the one after "Bind")