### PR TITLE
CAM: Simulator — fix model centering when HiDPI scaling is active

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -238,10 +238,10 @@ void DlgCAMSimulator::startSimulation(const Part::TopoShape& stock, float qualit
 
 void DlgCAMSimulator::initialize()
 {
-    mMillSimulator->InitSimulation(mQuality);
-
     const qreal retinaScale = devicePixelRatio();
-    glViewport(0, 0, width() * retinaScale, height() * retinaScale);
+    mMillSimulator->InitSimulation(mQuality, retinaScale);
+
+    glViewport(0, 0, (int)(width() * retinaScale), (int)(height() * retinaScale));
 }
 
 void DlgCAMSimulator::checkInitialization()

--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.cpp
@@ -89,7 +89,7 @@ void MillSimulation::SimNext()
     }
 }
 
-void MillSimulation::InitSimulation(float quality)
+void MillSimulation::InitSimulation(float quality, qreal devicePixelRatio)
 {
     ClearMillPathSegments();
     millPathLine.Clear();
@@ -121,7 +121,7 @@ void MillSimulation::InitSimulation(float quality)
     }
     mNPathSteps = (int)MillPathSegments.size();
     millPathLine.GenerateModel();
-    InitDisplay(quality);
+    InitDisplay(quality, devicePixelRatio);
 }
 
 EndMill* MillSimulation::GetTool(int toolId)
@@ -529,7 +529,7 @@ void MillSimulation::HandleGuiAction(eGuiItems actionItem, bool checked)
 }
 
 
-void MillSimulation::InitDisplay(float quality)
+void MillSimulation::InitDisplay(float quality, qreal devicePixelRatio)
 {
     // generate tools
     for (unsigned int i = 0; i < mToolTable.size(); i++) {
@@ -537,7 +537,7 @@ void MillSimulation::InitDisplay(float quality)
     }
 
     // init 3d display
-    simDisplay.InitGL();
+    simDisplay.InitGL(devicePixelRatio);
 
     // init gui elements
     guiDisplay.InitGui();

--- a/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/MillSimulation.h
@@ -54,7 +54,7 @@ public:
     void ClearMillPathSegments();
     void Clear();
     void SimNext();
-    void InitSimulation(float quality);
+    void InitSimulation(float quality, qreal devicePixelRatio);
     void AddTool(EndMill* tool);
     void AddTool(const std::vector<float>& toolProfile, int toolid, float diameter);
     bool ToolExists(int toolid)
@@ -85,7 +85,7 @@ public:
 
 
 protected:
-    void InitDisplay(float quality);
+    void InitDisplay(float quality, qreal devicePixelRatio);
     void GlsimStart();
     void GlsimToolStep1(void);
     void GlsimToolStep2(void);

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.cpp
@@ -240,7 +240,7 @@ SimDisplay::~SimDisplay()
     CleanGL();
 }
 
-void SimDisplay::InitGL()
+void SimDisplay::InitGL(qreal devicePixelRatio)
 {
     if (displayInitiated) {
         return;
@@ -249,8 +249,9 @@ void SimDisplay::InitGL()
     // setup light object
     mlightObject.GenerateBoxStock(-0.5f, -0.5f, -0.5f, 1, 1, 1);
 
-    mWidth = gWindowSizeW;
-    mHeight = gWindowSizeH;
+    mDevicePixelRatio = devicePixelRatio;
+    mWidth = (int)(gWindowSizeW * mDevicePixelRatio);
+    mHeight = (int)(gWindowSizeH * mDevicePixelRatio);
     InitShaders();
     CreateDisplayFbos();
     CreateSsaoFbos();
@@ -550,8 +551,8 @@ void SimDisplay::UpdateEyeFactor(float factor)
 
 void SimDisplay::UpdateWindowScale()
 {
-    mWidth = gWindowSizeW;
-    mHeight = gWindowSizeH;
+    mWidth = (int)(gWindowSizeW * mDevicePixelRatio);
+    mHeight = (int)(gWindowSizeH * mDevicePixelRatio);
     glBindFramebuffer(GL_FRAMEBUFFER, mFbo);
     CleanFbos();
     CreateDisplayFbos();

--- a/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.h
+++ b/src/Mod/CAM/PathSimulator/AppGL/SimDisplay.h
@@ -47,7 +47,7 @@ class SimDisplay
 {
 public:
     ~SimDisplay();
-    void InitGL();
+    void InitGL(qreal devicePixelRatio);
     void CleanGL();
     void CleanFbos();
     void PrepareDisplay(vec3 objCenter);
@@ -108,6 +108,7 @@ protected:
     mat4x4 mMatLookAt;
     StockObject mlightObject;
 
+    qreal mDevicePixelRatio;
     int mWidth;
     int mHeight;
 


### PR DESCRIPTION
When the CAM Simulator is shown on a screen with the HiDPI scale factor set to something other than 100%, the simulated object will not be in the center because the `SimDisplay` class responsible for rendering it is not aware of the scaling.

This PR fixes it by passing the scale factor to this class so both the initialization and the window resize handler can take it into account.

## Issues
fixes #25041 (which seems to be a duplicate of #18137)

## Before and After Images

Tested on Arch Linux and KDE Plasma 6

|Before (1.0.2)|After|
|---|---|
|<img width="1868" height="1524" alt="hidpi-1 0 2" src="https://github.com/user-attachments/assets/b3f60f17-1de8-45e1-8bd1-448229e47e98" />|<img width="1868" height="1524" alt="hidpi-fixed" src="https://github.com/user-attachments/assets/39717684-9eb3-49f6-8e94-93e7626cea14" />|





