### PR TITLE
CI: Add GitHub token for Crowdin sync

### DIFF
--- a/.github/workflows/fetch_crowdin_translations.yml
+++ b/.github/workflows/fetch_crowdin_translations.yml
@@ -62,6 +62,7 @@ jobs:
           title: "Update translations from Crowdin"
           body: "Automatic Crowdin update."
           labels: "translations, automated"
+          token: ${{ secrets.GH_TOKEN_FOR_CROWDIN_SYNC }}
           delete-branch: true
           add-paths: |
             src


### PR DESCRIPTION
Right now our CrowdIn sync action can create PRs, but those PRs cannot run further workflows (such as our CI). Since merging those PRs requires CI to run, they are effectively blocked. A new GitHub account has been created specifically to create these PRs, and a PAT added for it.