### PR TITLE
FEM: Clarify Connected Sectors tooltip for cyclic symmetry

### DIFF
--- a/src/Mod/Fem/femobjects/constraint_tie.py
+++ b/src/Mod/Fem/femobjects/constraint_tie.py
@@ -102,7 +102,7 @@ class ConstraintTie(base_fempythonobject.BaseFemPythonObject):
                 type="App::PropertyInteger",
                 name="ConnectedSectors",
                 group="Geometry",
-                doc="Number of connected sectors",
+                doc="Number of connected sectors used for results display",
                 value=1,
             )
         )


### PR DESCRIPTION
Adds a short note to the tooltip mentioned in the title