### PR TITLE
Sketcher: ConstraintList: prevent N transaction on box selection

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1818,4 +1818,3 @@ void TaskSketcherConstraints::onFilterListItemChanged(QListWidgetItem* item)
 
 #include "moc_TaskSketcherConstraints.cpp"
 // clang-format on
-

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -224,4 +224,3 @@ private:
 }  // namespace SketcherGui
 
 #endif  // GUI_TASKVIEW_TASKAPPERANCE_H
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/25249

by calling updateList only once when doing a multiple selection.

Also refactor a little bit the onSelectionChanged by doing early returns to improve readability