### PR TITLE
Sketcher: Remove transaction from TaskSketcherConstraints::doSetVisible

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1792,4 +1792,3 @@ void TaskSketcherConstraints::onFilterListItemChanged(QListWidgetItem* item)
 
 #include "moc_TaskSketcherConstraints.cpp"
 // clang-format on
-


### PR DESCRIPTION
Completely remove the transaction from TaskSketcherConstraints::doSetVisible because : 
- It would create a transaction on every selection if you have 'associated constraint' filter activated. Bloating the history.
- It would undo the visibility of constraint, WITHOUT reverting the changes to the filter. Resulting in constraint visibility not corresponding to the filter state.
- It does not seem really useful.