### PR TITLE
Gui: Save previous default for overlay widgets

### DIFF
--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -801,14 +801,14 @@ void OverlayTabWidget::restore(ParameterGrp::handle handle)
         return;
     }
 
-    const char* defaultWidgets = "";
-
     // If overlay was ever used and disabled by the user it should respect that choice
-    if (handle->GetInt("Width", 0) == 0 || handle->GetInt("Height", 0) == 0) {
-        defaultWidgets = getDockArea() == Qt::RightDockWidgetArea ? "Tasks," : "";
+    if (handle->GetInt("Width", 0) != 0 || handle->GetInt("Height", 0) != 0) {
+        // save current value with old default to prevent layout change
+        handle->SetASCII("Widgets", handle->GetASCII("Widgets", ""));
     }
 
-    std::string widgets = handle->GetASCII("Widgets", defaultWidgets);
+    std::string widgets
+        = handle->GetASCII("Widgets", getDockArea() == Qt::RightDockWidgetArea ? "Tasks," : "");
 
     for (auto& name : QString::fromUtf8(widgets.c_str()).split(QLatin1Char(','))) {
         if (name.isEmpty()) {


### PR DESCRIPTION
For some reason the empty layout was not saved for users with existing config. To ensure that the change does not affect existing users and is persistent for current ones we need to save value with older default before using it. Previous solution did not work correctly as the widgets were not persisted correctly.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
