### PR TITLE
Avoid using non-Standard `std::locale::empty()` for MSVC

### DIFF
--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -65,11 +65,7 @@ using namespace std;
 Base::XMLReader::XMLReader(const char* FileName, std::istream& str)
     : _File(FileName)
 {
-#ifdef _MSC_VER
-    str.imbue(std::locale::empty());
-#else
     str.imbue(std::locale::classic());
-#endif
 
     // create the parser
     parser = XMLReaderFactory::createXMLReader();  // NOLINT

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -318,11 +318,7 @@ void Writer::putNextEntry(const char* file, const char* obj)
 ZipWriter::ZipWriter(const char* FileName)
     : ZipStream(FileName)
 {
-#ifdef _MSC_VER
-    ZipStream.imbue(std::locale::empty());
-#else
     ZipStream.imbue(std::locale::classic());
-#endif
     ZipStream.precision(std::numeric_limits<double>::digits10 + 1);
     ZipStream.setf(std::ios::fixed, std::ios::floatfield);
 }
@@ -330,11 +326,7 @@ ZipWriter::ZipWriter(const char* FileName)
 ZipWriter::ZipWriter(std::ostream& os)
     : ZipStream(os)
 {
-#ifdef _MSC_VER
-    ZipStream.imbue(std::locale::empty());
-#else
     ZipStream.imbue(std::locale::classic());
-#endif
     ZipStream.precision(std::numeric_limits<double>::digits10 + 1);
     ZipStream.setf(std::ios::fixed, std::ios::floatfield);
 }


### PR DESCRIPTION
I'm the primary maintainer of MSVC's C++ Standard Library. We regularly build popular open-source projects, including FreeCAD, with development versions of the compiler toolset in order to find and fix regressions before they're released and cause trouble for you. This also allows us to provide advance notice of breaking changes, which is the case here.

MSVC historically provided a non-Standard `std::locale::empty()`. We deprecated it in the MSVC Build Tools 14.44 (VS 2022 17.14) in May 2025, and have removed it in the MSVC Build Tools 14.51 which will ship in a future update of VS 2026 18.x. (See https://github.com/microsoft/STL/pull/5834 .)

It appears that FreeCAD was suppressing all MSVC deprecation warnings (they're [warning C4996][]), at least in certain files, which is why you might not have seen this warning before.

Fortunately, FreeCAD already has a Standard codepath, used for other compilers, that uses Standard `std::locale::classic()`. This should just be used unconditionally.

If for some reason you need to keep using non-Standard `std::locale::empty()` for ancient versions of MSVC, then I'd recommend guarding it with `_MSC_VER < 1944`. That way, you'll use the Standard codepath for the MSVC Compiler 19.44 / MSVC Build Tools 14.44 / VS 2022 17.14 and later, including all versions of VS 2026.

[warning C4996]: https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4996?view=msvc-170