### PR TITLE
Build: Bump minor version of main branch from 1.1 to 1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 project(FreeCAD)
 
 set(PACKAGE_VERSION_MAJOR "1")
-set(PACKAGE_VERSION_MINOR "1")
+set(PACKAGE_VERSION_MINOR "2")
 set(PACKAGE_VERSION_PATCH "0") # number of patch release (e.g. "4" for the 0.18.4 release)
 set(PACKAGE_VERSION_SUFFIX "dev") # either "dev" for development snapshot or "" (empty string)
 set(PACKAGE_BUILD_VERSION "0") # used when the same FreeCAD version will be re-released (for example using an updated LibPack)


### PR DESCRIPTION
The 1.1 branch has been created -- any subsequent work on main is part of the next release, tentatively called "1.2" at this time (though note that we've had some discussion about switching to a CalVer system so that version number is not written in stone).