### PR TITLE
CI: Update CrowdIn action to use 1.1 release branch

### DIFF
--- a/.github/workflows/push_crowdin_translations.yml
+++ b/.github/workflows/push_crowdin_translations.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          ref: releases/FreeCAD-1-1
 
       - name: Install Qt ≥ 6.8
         uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005


### PR DESCRIPTION
To make sure that until the release of 1.1 all CrowdIn actions happen on 1.1 strings, temporarily update the CrowdIn sync to use that branch.