### PR TITLE
CAM: Profile - clean areaOpOnDocumentRestored()

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -312,29 +312,6 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
     def areaOpOnDocumentRestored(self, obj):
         self.propertiesReady = False
-
-        if not hasattr(obj, "NumPasses"):
-            obj.addProperty(
-                "App::PropertyInteger",
-                "NumPasses",
-                "Profile",
-                QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "The number of passes to do. Requires a non-zero value for Stepover",
-                ),
-            )
-
-        if not hasattr(obj, "Stepover"):
-            obj.addProperty(
-                "App::PropertyDistance",
-                "Stepover",
-                "Profile",
-                QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "If doing multiple passes, the extra offset of each additional pass",
-                ),
-            )
-
         self.initAreaOpProperties(obj, warn=True)
         self.areaOpSetDefaultValues(obj, PathUtils.findParentJob(obj))
         self.setOpEditorProperties(obj)


### PR DESCRIPTION
Removed code do nothing
All properties restored above by `initAreaOpProperties()`

https://github.com/FreeCAD/FreeCAD/blob/bb37dfda0e6e689d497f038656f3c2430a089eee/src/Mod/CAM/Path/Op/Profile.py#L313-L316

