### PR TITLE
part design: reimp feature to move datum objects using modal / dialogue box from right click menu in model tab, fixes #23799

### DIFF
--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -26,7 +26,7 @@
 #include <QMessageBox>
 #include <TopExp_Explorer.hxx>
 
-
+#include <App/Datums.h>
 #include <App/Document.h>
 #include <App/GeoFeatureGroupExtension.h>
 #include <App/Origin.h>
@@ -218,7 +218,6 @@ void CmdPartDesignBody::activated(int iMsg)
             return;
         }
     }
-
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Add a Body"));
 
@@ -1028,6 +1027,13 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
     std::vector<App::DocumentObject*> features = getSelection().getObjectsOfType(
         Part::Feature::getClassTypeId()
     );
+
+    // also check and include datum objects, ie. plane, line, and point
+    std::vector<App::DocumentObject*> datums = getSelection().getObjectsOfType(
+        App::DatumElement::getClassTypeId()
+    );
+    features.insert(features.end(), datums.begin(), datums.end());
+
     if (features.empty()) {
         return;
     }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

with recent dev builds of freecad the ability to move datum objects ie. plane, point, and line has been removed in favor of manually moving the objects in the "object tree" via the "model tab". this pr aims to restore the feature of the part design workbench to allow users to right click on a datum object in the model and use the "move feature after" modal / dialogue box to place the datum object in the "object tree" as opposed to manually dragging and dropping the object. this issue was brought up in the below github issue (link below).

https://github.com/FreeCAD/FreeCAD/issues/23799

@leoheck @PaddleStroke

do you guys mind testing PR on y'alls boxes? i tested locally with a datum plane with simple file i created and everything seems work as it should

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
