### PR TITLE
Core: workaround for Building US unit system bug

### DIFF
--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -825,4 +825,3 @@ QValidator::State InputValidator::validate(QString& input, int& pos) const
 
 
 #include "moc_InputField.cpp"
-


### PR DESCRIPTION
Fixes #11345

See:
https://github.com/FreeCAD/FreeCAD/issues/11345#issuecomment-3515242591

This workaround should hopefully fix the Building US unit system bug at the level of the InputField code. This is currently the most feasible solution given that we are close to the v1.1 release. The InputField code is only used in the Draft and BIM workbenches.

I use the word "hopefully" because I have not compiled and tested the code. But replacing `+` with `--` works in Python examples.

If testing in v1.2 confirms that the workaround is effective, this PR should be backported to v1.1.