### PR TITLE
part workbench: resolve issue #22827 spliting of a split that is a container  / group

### DIFF
--- a/src/Mod/Part/BOPTools/SplitFeatures.py
+++ b/src/Mod/Part/BOPTools/SplitFeatures.py
@@ -303,12 +303,12 @@ class FeatureSlice:
         # helper function to get the shape from object or group
         def get_shape(obj):
             """get shape from a part object or compound from a group."""
-            if hasattr(obj, 'Shape'):
+            if hasattr(obj, "Shape"):
                 return obj.Shape
-            elif hasattr(obj, 'Group'): # it's a group/container from ie. slice apart
+            elif hasattr(obj, "Group"):  # it's a group/container from ie. slice apart
                 shapes = []
                 for child in obj.Group:
-                    if hasattr(child, 'Shape'):
+                    if hasattr(child, "Shape"):
                         shapes.append(child.Shape)
                 if shapes:
                     return Part.makeCompound(shapes)
@@ -317,7 +317,7 @@ class FeatureSlice:
         # get base shape
         base_shape = get_shape(selfobj.Base)
         if base_shape is None or base_shape.isNull():
-                raise ValueError("Base object has no valid shape!")
+            raise ValueError("Base object has no valid shape!")
 
         # get tool shapes
         tool_shapes = []


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR aims at fixing freecad issue #22827 after further discussion @mnesarco is able to produce reproducable steps to recreate the issue as opposed to the originally uploaded file when the issue was originally creates.

steps to reproduce,

https://github.com/FreeCAD/FreeCAD/issues/22827#issuecomment-3514809902

i followed up with a comment stating that i could reproduce the steps from the original issue,

https://github.com/FreeCAD/FreeCAD/issues/22827#issuecomment-3530163431

so basically the `splitfeatures.py` was not setup to handle "groups" because they did not have a `.Shape` attribute so this PR adds conditions to where it checks if a "group" is the object in question and allows splitting of "groups".

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
