### PR TITLE
Define DlgScale task panel's tab order

### DIFF
--- a/src/Mod/Part/Gui/DlgScale.ui
+++ b/src/Mod/Part/Gui/DlgScale.ui
@@ -238,4 +238,3 @@
  <resources/>
  <connections/>
 </ui>
-


### PR DESCRIPTION
To improve keyboard navigation.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/23772

Note: when landing on a radio button after hitting Tab, use the arrow keys to switch to the next related radio button. Clicking Tab again will switch to the next widget (not the next radio button).

I'm still building this, so I've not tested it. But the change seems trivial enough and works in Qt Designer's form preview (for the enabled widgets only).

## Before (tab order)

<img width="380" height="410" alt="Image" src="https://github.com/user-attachments/assets/b2dc469e-2d56-4499-9ee5-fc044d0e3299" />

## After (tab order)

<img width="380" height="410" alt="image" src="https://github.com/user-attachments/assets/d5c3d7d1-efeb-4d4f-bda3-5024b30bcfab" />
