### PR TITLE
CAM: Path/Op/Area.py - Split areaParams in _buildPathArea()

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -242,13 +242,6 @@ The latter can be used to face of the entire stock area to ensure uniform height
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="minTravel">
-        <property name="text">
-         <string>Min travel</string>
-        </property>
-       </widget>
-      </item>
       <item row="3" column="0">
        <widget class="QCheckBox" name="useRestMachining">
         <property name="toolTip">

--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -27,7 +27,7 @@ import Path
 import Path.Op.Base as PathOp
 import Path.Op.Util as PathOpUtil
 import PathScripts.PathUtils as PathUtils
-
+from Path.Base.Generator.ramp_entry_helix import HelixRamp
 from Path.Geom import isRoughly
 
 # lazily loaded modules
@@ -148,7 +148,7 @@ class ObjectOp(PathOp.ObjectOp):
 
     def opOnDocumentRestored(self, obj):
         Path.Log.track()
-        for prop in ["AreaParams", "PathParams", "removalshape"]:
+        for prop in ("AreaParams", "PathParams", "removalshape"):
             if hasattr(obj, prop):
                 obj.setEditorMode(prop, 2)
         if not hasattr(obj, "SplitArcs"):
@@ -265,99 +265,247 @@ class ObjectOp(PathOp.ObjectOp):
 
         return candidate.discretize(3)[1]
 
-    def _buildPathArea(self, obj, baseobject, isHole, start, getsim):
-        """_buildPathArea(obj, baseobject, isHole, start, getsim) ... internal function."""
+    def getStartIndex(self, cmds1, cmds2, threshold):
+        # get index of command from which continue path to skip retract
+        index = None
+        lastPoint = lastX = lastY = None
+        nextPoint = nextX = nextY = None
+        # determine last point in previous path
+        for cmd in reversed(cmds1):
+            if cmd.Name in Path.Geom.CmdMoveMill:
+                lastX = cmd.x if cmd.x is not None and lastX is None else lastX
+                lastY = cmd.y if cmd.y is not None and lastY is None else lastY
+                if lastX is not None and lastY is not None:
+                    lastPoint = FreeCAD.Vector(lastX, lastY, 0)
+                    break
+        # determine first point in new path
+        for i, cmd in enumerate(cmds2):
+            if cmd.Name in Path.Geom.CmdMoveStraight:
+                nextX = cmd.Parameters.get("X", nextX)
+                nextY = cmd.Parameters.get("Y", nextY)
+                if nextX is not None and nextY is not None:
+                    index = i
+                    nextPoint = FreeCAD.Vector(nextX, nextY, 0)
+                    break
+        if (
+            index is not None
+            and lastPoint is not None
+            and nextPoint is not None
+            and lastPoint.distanceToPoint(nextPoint) <= threshold
+        ):
+            return index
+        else:
+            return 0
+
+    def getEndVector(self, cmds):
+        # get index of command from which continue path to skip retract
+        endVector = FreeCAD.Vector()
+        lastX = lastY = lastZ = None
+        for cmd in reversed(cmds):
+            if cmd.Name in Path.Geom.CmdMoveMill:
+                lastX = cmd.x if cmd.x is not None and lastX is None else lastX
+                lastY = cmd.y if cmd.y is not None and lastY is None else lastY
+                lastZ = cmd.z if cmd.z is not None and lastZ is None else lastZ
+                if lastX is not None and lastY is not None and lastZ is not None:
+                    endVector = FreeCAD.Vector(lastX, lastY, lastZ)
+
+        return endVector
+
+    def getCenterPoint(self, shape):
+        center = shape.CenterOfGravity
+        candidate = shape.Vertexes[0].Point
+        minDist = candidate.distanceToPoint(center)
+        for v in shape.Vertexes:
+            dist = center.distanceToPoint(v.Point)
+            if dist < minDist:
+                minDist = dist
+                candidate = v.Point
+
+        return candidate
+
+    def _buildPathArea(self, obj, baseobject, isHole, start):
+        """_buildPathArea(obj, baseobject, isHole, start) ... internal function."""
         Path.Log.track()
-        area = Path.Area()
-        area.setPlane(PathUtils.makeWorkplane(baseobject))
-        area.add(baseobject)
 
-        areaParams = self.areaOpAreaParams(obj, isHole)
-        areaParams["SectionTolerance"] = FreeCAD.Base.Precision.confusion() * 10  # basically 1e-06
+        areaParamsList = []
+        if "Path.Op.Pocket" in obj.Proxy.__module__:
+            # Pocket operation: split area and get order Clearing path -> Finishing pass
+            if obj.ClearingPattern != "No clearing":
+                areaParamsList.append(self.areaOpAreaParams(obj, isHole))  # Clearing path
+            for i in range(getattr(obj, "FinishingPasses", 0)):
+                areaParamsList.append(self.areaOpAreaParamsFinishing(obj, isHole))  # Finishing pass
+        elif obj.Proxy.__module__ == "Path.Op.Profile":
+            # Profile operation: create independent area for each offset
+            areaParams = self.areaOpAreaParams(obj, isHole)
+            offsets = areaParams["Offset"]
+            for offset in offsets:
+                areaParams["Offset"] = offset
+                areaParamsList.append(areaParams.copy())
+        else:
+            areaParamsList.append(self.areaOpAreaParams(obj, isHole))
 
-        heights = [i for i in self.depthparams]
-        Path.Log.debug("depths: {}".format(heights))
-        area.setParams(**areaParams)
-        obj.AreaParams = str(area.getParams())
+        cmds = []
+        for index, areaParams in enumerate(areaParamsList):
+            """
+            Notes:
+            Finishing pass mill last, no metter value 'StartAt'
+            For helix ramp need to skip step down and use only bottom shapes
+            For 'StartAt' 'Center' in Pocket op need to set sort_mode = 0
+            or forcing StartPoint in the center of area to get correct order
+            """
 
-        Path.Log.debug("Area with params: {}".format(area.getParams()))
+            oneStepDown = False
+            helixRamp = False
+            middleEdge = False
+            if obj.Proxy.__module__ == "Path.Op.Profile":
+                if (
+                    getattr(obj, "FinishingPasses", 0)
+                    and getattr(obj, "FinishingOneStepDown", False)
+                    and index >= len(areaParamsList) - obj.FinishingPasses
+                ):
+                    oneStepDown = True
+                elif getattr(obj, "HelixRamp", False):
+                    helixRamp = True
+                if (
+                    not obj.UseStartPoint
+                    and getattr(obj, "HandleMultipleFeatures", None) == "Individually"
+                    and getattr(obj, "UseLongestEdge", False)
+                ):
+                    middleEdge = True
 
-        sections = area.makeSections(mode=0, project=self.areaOpUseProjection(obj), heights=heights)
-        Path.Log.debug("sections = %s" % sections)
+            isPocketFinishingPass = False
+            pocketCenter = False
+            if "Path.Op.Pocket" in obj.Proxy.__module__:
+                if "JoinType" in areaParams:  # Pocket finishing pass
+                    isPocketFinishingPass = True
+                    if getattr(obj, "FinishingOneStepDown", False):
+                        oneStepDown = True
+                    elif getattr(obj, "FinishingRampHelix", False):
+                        helixRamp = True
+                elif getattr(obj, "ClearingPattern", None) in ("Offset", "Helix"):
+                    # Pocket clearing path
+                    if getattr(obj, "StartAt", None) == "Center":
+                        pocketCenter = True
+                    if getattr(obj, "ClearingPattern", None) == "Helix":
+                        oneStepDown = True
+                        helixRamp = True
 
-        # Rest machining
-        if hasattr(obj, "UseRestMachining") and obj.UseRestMachining:
-            restSections = []
-            for section in sections:
-                bbox = section.getShape().BoundBox
-                sectionClearedAreas = PathOpUtil.getClearedAreas(obj, bbox)
-                restSection = section.getRestArea(
-                    sectionClearedAreas, self.tool.Diameter.getValueAs("mm")
-                )
-                if restSection is not None:
-                    restSections.append(restSection)
-            sections = restSections
+            area = Path.Area()
+            area.setPlane(PathUtils.makeWorkplane(baseobject))
+            area.add(baseobject)
+            areaParams["SectionTolerance"] = FreeCAD.Base.Precision.confusion() * 10
 
-        shapelist = [sec.getShape() for sec in sections]
-        Path.Log.debug("shapelist = %s" % shapelist)
-
-        pathParams = self.areaOpPathParams(obj, isHole)
-        pathParams["shapes"] = shapelist
-        pathParams["feedrate"] = self.horizFeed
-        pathParams["feedrate_v"] = self.vertFeed
-        pathParams["verbose"] = True
-        pathParams["resume_height"] = obj.SafeHeight.Value
-        pathParams["retraction"] = obj.ClearanceHeight.Value
-        pathParams["return_end"] = True
-        # Note that emitting preambles between moves breaks some dressups and prevents path optimization on some controllers
-        pathParams["preamble"] = False
-
-        # disable path sorting for offset and zigzag-offset paths
-        if (
-            hasattr(obj, "ClearingPattern")
-            and obj.ClearingPattern in ["ZigZagOffset", "Offset"]
-            and hasattr(obj, "MinTravel")
-            and not obj.MinTravel
-        ):
-            pathParams["sort_mode"] = 0
-
-        if hasattr(obj, "RetractThreshold"):
-            pathParams["threshold"] = obj.RetractThreshold.Value
-
-        if (
-            not obj.UseStartPoint
-            and getattr(obj, "HandleMultipleFeatures", None) == "Individually"
-            and getattr(obj, "UseLongestEdge", False)
-        ):
-            pathParams["start"] = self.getMiddlePointLongestEdge(shapelist[0])
-        elif self.endVector is not None:
-            if self.endVector[:2] != (0, 0):
-                pathParams["start"] = self.endVector
-        elif PathOp.FeatureStartPoint & self.opFeatures(obj) and obj.UseStartPoint:
-            pathParams["start"] = obj.StartPoint
-
-        obj.PathParams = str({key: value for key, value in pathParams.items() if key != "shapes"})
-        Path.Log.debug("Path with params: {}".format(obj.PathParams))
-
-        pp, end_vector = Path.fromShapes(**pathParams)
-        Path.Log.debug("pp: {}, end vector: {}".format(pp, end_vector))
-
-        # Keep track of this segment's end only if it has movement (otherwise end_vector is 0,0,0 and the next segment will unnecessarily start there)
-        if pp.Size > 0:
-            self.endVector = end_vector
-
-        simobj = None
-        if getsim:
-            areaParams["Thicken"] = True
-            areaParams["ToolRadius"] = self.radius - self.radius * 0.005
+            heights = [i for i in self.depthparams]
+            Path.Log.debug("depths: {}".format(heights))
             area.setParams(**areaParams)
-            sec = area.makeSections(mode=0, project=False, heights=heights)[-1].getShape()
-            simobj = sec.extrude(FreeCAD.Vector(0, 0, baseobject.BoundBox.ZMax))
+            obj.AreaParams = str(area.getParams())
 
-        return pp, simobj
+            Path.Log.debug("Area with params: {}".format(area.getParams()))
 
-    def _buildProfileOpenEdges(self, obj, openWire, start, getsim):
-        """_buildPathArea(obj, openWire, start, getsim) ... internal function."""
+            sections = area.makeSections(
+                mode=0, project=self.areaOpUseProjection(obj), heights=heights
+            )
+            Path.Log.debug("sections = %s" % sections)
+
+            # Rest machining
+            if getattr(obj, "UseRestMachining", False):
+                restSections = []
+                for section in sections:
+                    bbox = section.getShape().BoundBox
+                    sectionClearedAreas = PathOpUtil.getClearedAreas(obj, bbox)
+                    restSection = section.getRestArea(
+                        sectionClearedAreas, self.tool.Diameter.getValueAs("mm")
+                    )
+                    if restSection is not None:
+                        restSections.append(restSection)
+                sections = restSections
+
+            shapelist = []
+            for sec in sections:
+                shape = sec.getShape()
+                if shape.Wires:
+                    # skip empty shape
+                    shapelist.append(shape)
+
+            if not shapelist:
+                continue
+
+            Path.Log.debug("shapelist = %s" % shapelist)
+
+            pathParams = self.areaOpPathParams(obj, isHole)
+
+            if isPocketFinishingPass:
+                # invert orientation for finishing Offset pass in Pocket operation
+                pathParams["orientation"] = not pathParams["orientation"]
+
+            pathParams["shapes"] = shapelist[-1] if oneStepDown else shapelist
+            pathParams["feedrate"] = self.horizFeed
+            pathParams["feedrate_v"] = self.vertFeed
+            pathParams["verbose"] = True
+            pathParams["resume_height"] = obj.SafeHeight.Value
+            pathParams["retraction"] = obj.ClearanceHeight.Value
+            pathParams["return_end"] = True
+            # Note that emitting preambles between moves breaks some dressups
+            # and prevents path optimization on some controllers
+            pathParams["preamble"] = False
+
+            pathParams["sort_mode"] = 1  # 2D5 sorting mode
+            if isPocketFinishingPass or pocketCenter:
+                if obj.RetractThreshold:
+                    pathParams["sort_mode"] = 3  # Greedy sorting mode
+
+            if hasattr(obj, "SortMode"):
+                # user can forcing sort_mode if add int property 'SortMode'
+                pathParams["sort_mode"] = obj.SortMode
+
+            if hasattr(obj, "RetractThreshold"):
+                pathParams["threshold"] = obj.RetractThreshold.Value
+
+            if middleEdge:
+                pathParams["start"] = self.getMiddlePointLongestEdge(shapelist[0])
+            elif pocketCenter:
+                pathParams["start"] = self.getCenterPoint(shapelist[0])
+            elif self.endVector is not None:
+                if self.endVector[:2] != (0, 0):
+                    pathParams["start"] = self.endVector
+            elif PathOp.FeatureStartPoint & self.opFeatures(obj) and obj.UseStartPoint:
+                pathParams["start"] = obj.StartPoint
+
+            obj.PathParams = str(
+                {key: value for key, value in pathParams.items() if key != "shapes"}
+            )
+            Path.Log.debug("Path with params: {}".format(obj.PathParams))
+
+            pp, end_vector = Path.fromShapes(**pathParams)
+            Path.Log.debug("pp: {}, end vector: {}".format(pp, end_vector))
+
+            # Keep track of this segment's end only if it has movement (otherwise end_vector is 0,0,0 and the next segment will unnecessarily start there)
+            if pp.Size:
+                self.endVector = end_vector
+                if end_vector[:2] == (0, 0):
+                    # need for finishing pass after pocket offset pattern
+                    self.endVector = self.getEndVector(pp.Commands)
+
+            commands = pp.Commands
+            if helixRamp:
+                commands = HelixRamp(
+                    commands,
+                    maxStepDown=obj.StepDown.Value,
+                    tc=obj.ToolController,
+                    ignoreAbove=obj.StartDepth.Value,
+                ).generate()
+
+            # remove retract between "main" area and Offset
+            if obj.RetractThreshold and cmds and commands and (not helixRamp or oneStepDown):
+                startIndex = self.getStartIndex(cmds, commands, obj.RetractThreshold.Value)
+                cmds.extend(commands[startIndex:])
+            else:
+                cmds.extend(commands)
+
+        return Path.Path(cmds)
+
+    def _buildProfileOpenEdges(self, obj, openWire, start):
+        """_buildPathArea(obj, openWire, start) ... internal function."""
         Path.Log.track()
 
         paths = []
@@ -407,12 +555,11 @@ class ObjectOp(PathOp.ObjectOp):
             Path.Log.debug("pp: {}, end vector: {}".format(pp, end_vector))
 
         self.endVector = end_vector
-        simobj = None
 
-        return paths, simobj
+        return paths
 
-    def opExecute(self, obj, getsim=False):
-        """opExecute(obj, getsim=False) ... implementation of Path.Area ops.
+    def opExecute(self, obj):
+        """opExecute(obj) ... implementation of Path.Area ops.
         determines the parameters for _buildPathArea().
         Do not overwrite, implement
             areaOpAreaParams(obj, isHole) ... op specific area param dictionary
@@ -479,7 +626,6 @@ class ObjectOp(PathOp.ObjectOp):
 
             shapes = collectively
 
-        sims = []
         for shape, isHole, sub in shapes:
             profileEdgesIsOpen = False
 
@@ -493,9 +639,9 @@ class ObjectOp(PathOp.ObjectOp):
 
             try:
                 if profileEdgesIsOpen:
-                    pp, sim = self._buildProfileOpenEdges(obj, shape, start, getsim)
+                    pp = self._buildProfileOpenEdges(obj, shape, start)
                 else:
-                    pp, sim = self._buildPathArea(obj, shape, isHole, start, getsim)
+                    pp = self._buildPathArea(obj, shape, isHole, start)
             except Exception as e:
                 FreeCAD.Console.PrintError(e)
                 FreeCAD.Console.PrintError(
@@ -506,16 +652,13 @@ class ObjectOp(PathOp.ObjectOp):
                 ppCmds = pp if profileEdgesIsOpen else pp.Commands
 
                 self.commandlist.extend(ppCmds)
-                sims.append(sim)
 
             if self.endVector is not None and len(self.commandlist) > 1:
-                self.endVector[2] = obj.ClearanceHeight.Value
-                self.commandlist.append(
-                    Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
-                )
+                z = getattr(obj, "ClearanceHeightOut", obj.ClearanceHeight).Value
+                self.endVector[2] = z
+                self.commandlist.append(Path.Command("G0", {"Z": z, "F": self.vertRapid}))
 
         Path.Log.debug("obj.Name: " + str(obj.Name) + "\n\n")
-        return sims
 
     def areaOpAreaParams(self, obj, isHole):
         """areaOpAreaParams(obj, isHole) ... return operation specific area parameters in a dictionary.

--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -29,6 +29,7 @@ import Path.Op.Util as PathOpUtil
 import PathScripts.PathUtils as PathUtils
 from Path.Base.Generator.ramp_entry_helix import HelixRamp
 from Path.Geom import isRoughly
+import Constants
 
 # lazily loaded modules
 from lazy_loader.lazy_loader import LazyLoader
@@ -270,17 +271,15 @@ class ObjectOp(PathOp.ObjectOp):
         index = None
         lastPoint = lastX = lastY = None
         nextPoint = nextX = nextY = None
-        # determine last point in previous path
-        for cmd in reversed(cmds1):
-            if cmd.Name in Path.Geom.CmdMoveMill:
+        for cmd in reversed(cmds1):  # define previous path last point
+            if cmd.Name in Constants.GCODE_MOVE_MILL:
                 lastX = cmd.x if cmd.x is not None and lastX is None else lastX
                 lastY = cmd.y if cmd.y is not None and lastY is None else lastY
                 if lastX is not None and lastY is not None:
                     lastPoint = FreeCAD.Vector(lastX, lastY, 0)
                     break
-        # determine first point in new path
-        for i, cmd in enumerate(cmds2):
-            if cmd.Name in Path.Geom.CmdMoveStraight:
+        for i, cmd in enumerate(cmds2):  # define next path first point
+            if cmd.Name in Constants.GCODE_MOVE_STRAIGHT:
                 nextX = cmd.Parameters.get("X", nextX)
                 nextY = cmd.Parameters.get("Y", nextY)
                 if nextX is not None and nextY is not None:
@@ -296,20 +295,6 @@ class ObjectOp(PathOp.ObjectOp):
             return index
         else:
             return 0
-
-    def getEndVector(self, cmds):
-        # get index of command from which continue path to skip retract
-        endVector = FreeCAD.Vector()
-        lastX = lastY = lastZ = None
-        for cmd in reversed(cmds):
-            if cmd.Name in Path.Geom.CmdMoveMill:
-                lastX = cmd.x if cmd.x is not None and lastX is None else lastX
-                lastY = cmd.y if cmd.y is not None and lastY is None else lastY
-                lastZ = cmd.z if cmd.z is not None and lastZ is None else lastZ
-                if lastX is not None and lastY is not None and lastZ is not None:
-                    endVector = FreeCAD.Vector(lastX, lastY, lastZ)
-
-        return endVector
 
     def getCenterPoint(self, shape):
         center = shape.CenterOfGravity
@@ -332,7 +317,7 @@ class ObjectOp(PathOp.ObjectOp):
             # Pocket operation: split area and get order Clearing path -> Finishing pass
             if obj.ClearingPattern != "No clearing":
                 areaParamsList.append(self.areaOpAreaParams(obj, isHole))  # Clearing path
-            for i in range(getattr(obj, "FinishingPasses", 0)):
+            for i in range(obj.FinishingPasses):
                 areaParamsList.append(self.areaOpAreaParamsFinishing(obj, isHole))  # Finishing pass
         elif obj.Proxy.__module__ == "Path.Op.Profile":
             # Profile operation: create independent area for each offset
@@ -345,48 +330,43 @@ class ObjectOp(PathOp.ObjectOp):
             areaParamsList.append(self.areaOpAreaParams(obj, isHole))
 
         cmds = []
-        for index, areaParams in enumerate(areaParamsList):
+        for indexArea, areaParams in enumerate(areaParamsList):
             """
             Notes:
-            Finishing pass mill last, no metter value 'StartAt'
-            For helix ramp need to skip step down and use only bottom shapes
-            For 'StartAt' 'Center' in Pocket op need to set sort_mode = 0
-            or forcing StartPoint in the center of area to get correct order
+            - Finishing pass should be the last in order, no matter value 'StartAt'.
+            - For helix ramp need to skip step down and use only bottom shapes.
+            - For 'StartAt' at 'Center' in Pocket op StartPoint should be in the center.
             """
 
             oneStepDown = False
             helixRamp = False
             middleEdge = False
-            if obj.Proxy.__module__ == "Path.Op.Profile":
-                if (
-                    getattr(obj, "FinishingPasses", 0)
-                    and getattr(obj, "FinishingOneStepDown", False)
-                    and index >= len(areaParamsList) - obj.FinishingPasses
-                ):
-                    oneStepDown = True
-                elif getattr(obj, "HelixRamp", False):
+            isPocketFinishingPass = False
+            pocketCenter = False
+            if "Path.Op.Profile" in obj.Proxy.__module__:
+                if indexArea >= len(areaParamsList) - obj.FinishingPasses:  # Profile finishing pass
+                    if obj.FinishingOneStepDown:
+                        oneStepDown = True
+                elif obj.HelixRamp:
                     helixRamp = True
                 if (
-                    not obj.UseStartPoint
-                    and getattr(obj, "HandleMultipleFeatures", None) == "Individually"
-                    and getattr(obj, "UseLongestEdge", False)
+                    obj.UseLongestEdge
+                    and not obj.UseStartPoint
+                    and obj.HandleMultipleFeatures == "Individually"
                 ):
                     middleEdge = True
 
-            isPocketFinishingPass = False
-            pocketCenter = False
-            if "Path.Op.Pocket" in obj.Proxy.__module__:
-                if "JoinType" in areaParams:  # Pocket finishing pass
+            elif "Path.Op.Pocket" in obj.Proxy.__module__:
+                if indexArea >= len(areaParamsList) - obj.FinishingPasses:  # Pocket finishing pass
                     isPocketFinishingPass = True
-                    if getattr(obj, "FinishingOneStepDown", False):
+                    if obj.FinishingOneStepDown:
                         oneStepDown = True
-                    elif getattr(obj, "FinishingRampHelix", False):
+                    elif obj.FinishingRampHelix:
                         helixRamp = True
-                elif getattr(obj, "ClearingPattern", None) in ("Offset", "Helix"):
-                    # Pocket clearing path
-                    if getattr(obj, "StartAt", None) == "Center":
+                elif obj.ClearingPattern in ("Offset", "Helix"):  # Pocket clearing path
+                    if obj.StartAt == "Center":
                         pocketCenter = True
-                    if getattr(obj, "ClearingPattern", None) == "Helix":
+                    if obj.ClearingPattern == "Helix":
                         oneStepDown = True
                         helixRamp = True
 
@@ -423,8 +403,7 @@ class ObjectOp(PathOp.ObjectOp):
             shapelist = []
             for sec in sections:
                 shape = sec.getShape()
-                if shape.Wires:
-                    # skip empty shape
+                if shape.Wires:  # skip empty shape
                     shapelist.append(shape)
 
             if not shapelist:
@@ -433,9 +412,8 @@ class ObjectOp(PathOp.ObjectOp):
             Path.Log.debug("shapelist = %s" % shapelist)
 
             pathParams = self.areaOpPathParams(obj, isHole)
-
             if isPocketFinishingPass:
-                # invert orientation for finishing Offset pass in Pocket operation
+                # invert orientation for finishing pass in Pocket operation
                 pathParams["orientation"] = not pathParams["orientation"]
 
             pathParams["shapes"] = shapelist[-1] if oneStepDown else shapelist
@@ -454,7 +432,7 @@ class ObjectOp(PathOp.ObjectOp):
                 if obj.RetractThreshold:
                     pathParams["sort_mode"] = 3  # Greedy sorting mode
 
-            if hasattr(obj, "SortMode"):
+            if getattr(obj, "SortMode", -1) != -1:
                 # user can forcing sort_mode if add int property 'SortMode'
                 pathParams["sort_mode"] = obj.SortMode
 
@@ -479,28 +457,24 @@ class ObjectOp(PathOp.ObjectOp):
             pp, end_vector = Path.fromShapes(**pathParams)
             Path.Log.debug("pp: {}, end vector: {}".format(pp, end_vector))
 
-            # Keep track of this segment's end only if it has movement (otherwise end_vector is 0,0,0 and the next segment will unnecessarily start there)
             if pp.Size:
                 self.endVector = end_vector
-                if end_vector[:2] == (0, 0):
-                    # need for finishing pass after pocket offset pattern
-                    self.endVector = self.getEndVector(pp.Commands)
+                commands = pp.Commands
 
-            commands = pp.Commands
-            if helixRamp:
-                commands = HelixRamp(
-                    commands,
-                    maxStepDown=obj.StepDown.Value,
-                    tc=obj.ToolController,
-                    ignoreAbove=obj.StartDepth.Value,
-                ).generate()
+                if helixRamp:  # create helix ramp entry
+                    commands = HelixRamp(
+                        commands,
+                        maxStepDown=obj.StepDown.Value,
+                        tc=obj.ToolController,
+                        ignoreAbove=obj.StartDepth.Value,
+                    ).generate()
 
-            # remove retract between "main" area and Offset
-            if obj.RetractThreshold and cmds and commands and (not helixRamp or oneStepDown):
-                startIndex = self.getStartIndex(cmds, commands, obj.RetractThreshold.Value)
-                cmds.extend(commands[startIndex:])
-            else:
-                cmds.extend(commands)
+                # remove retract between previous and next path
+                if obj.RetractThreshold and cmds and (not helixRamp or oneStepDown):
+                    startIndex = self.getStartIndex(cmds, commands, obj.RetractThreshold.Value)
+                    cmds.extend(commands[startIndex:])
+                else:
+                    cmds.extend(commands)
 
         return Path.Path(cmds)
 
@@ -539,9 +513,9 @@ class ObjectOp(PathOp.ObjectOp):
             x = verts[idx].X
             y = verts[idx].Y
             # Zero start value adjustments for Path.fromShapes() bug
-            if Path.Geom.isRoughly(x, 0.0):
+            if isRoughly(x, 0.0):
                 x = 0.00001
-            if Path.Geom.isRoughly(y, 0.0):
+            if isRoughly(y, 0.0):
                 y = 0.00001
             pathParams["start"] = FreeCAD.Vector(x, y, verts[0].Z)
 
@@ -650,6 +624,7 @@ class ObjectOp(PathOp.ObjectOp):
                 raise e
             else:
                 ppCmds = pp if profileEdgesIsOpen else pp.Commands
+                # ppCmds = Path.Geom.filterArcs(ppCmds, self.job.GeometryTolerance.Value)
 
                 self.commandlist.extend(ppCmds)
 

--- a/src/Mod/CAM/Path/Op/Gui/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/PocketBase.py
@@ -96,10 +96,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
 
         return form
 
-    def updateMinTravel(self, obj, setModel=True):
-        if setModel and obj.MinTravel != self.form.minTravel.isChecked():
-            obj.MinTravel = self.form.minTravel.isChecked()
-
     def updateAngle(self, obj, setModel=True):
         if obj.ClearingPattern == "Offset":
             self.form.angle.setEnabled(False)
@@ -133,8 +129,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             if obj.UseOutline != self.form.useOutline.isChecked():
                 obj.UseOutline = self.form.useOutline.isChecked()
 
-        self.updateMinTravel(obj)
-
         if FeatureFacing & self.pocketFeatures():
             print(obj.BoundaryShape)
             print(self.form.boundaryShape.currentText())
@@ -158,9 +152,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         self.form.angle.setText(FreeCAD.Units.Quantity(obj.Angle, FreeCAD.Units.Angle).UserString)
         self.updateAngle(obj, False)
 
-        self.form.minTravel.setChecked(obj.MinTravel)
-        self.updateMinTravel(obj, False)
-
         self.selectInComboBox(obj.ClearingPattern, self.form.clearingPattern)
         self.selectInComboBox(obj.CutMode, self.form.cutMode)
         self.setupToolController(obj, self.form.toolController)
@@ -183,7 +174,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.useStartPoint.clicked)
         signals.append(self.form.useRestMachining.clicked)
         signals.append(self.form.useOutline.clicked)
-        signals.append(self.form.minTravel.clicked)
         signals.append(self.form.coolantController.currentIndexChanged)
 
         if FeatureFacing & self.pocketFeatures():

--- a/src/Mod/CAM/Path/Op/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/PocketBase.py
@@ -69,9 +69,10 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             "ClearingPattern": [
                 (translate("CAM_Pocket", "ZigZag"), "ZigZag"),
                 (translate("CAM_Pocket", "Offset"), "Offset"),
-                (translate("CAM_Pocket", "ZigZagOffset"), "ZigZagOffset"),
+                (translate("CAM_Pocket", "Helix"), "Helix"),
                 (translate("CAM_Pocket", "Line"), "Line"),
                 (translate("CAM_Pocket", "Grid"), "Grid"),
+                (translate("CAM_Pocket", "No clearing"), "No clearing"),
             ],  # Fill Pattern
             "SortingMode": [
                 (translate("CAM_Pocket", "Automatic"), "Automatic"),
@@ -111,9 +112,25 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         super().opExecute(obj)
 
     def areaOpOnChanged(self, obj, prop):
-        if prop == "ClearingPattern":
-            angleMode = 0 if obj.ClearingPattern != "Offset" else 2
-            obj.setEditorMode("Angle", angleMode)
+        if not obj.Document.Restoring:
+            finishingPassMode = 0 if obj.FinishingPasses else 2
+            if hasattr(obj, "FinishingOffset"):
+                obj.setEditorMode("FinishingOffset", finishingPassMode)
+            if hasattr(obj, "FinishingOneStepDown"):
+                obj.setEditorMode("FinishingOneStepDown", finishingPassMode)
+            if hasattr(obj, "FinishingRampHelix"):
+                obj.setEditorMode("FinishingRampHelix", finishingPassMode)
+
+            if prop == "ClearingPattern":
+                startAtMode = 0 if obj.ClearingPattern in ("Offset", "Helix") else 2
+                obj.setEditorMode("StartAt", startAtMode)
+                patternsNoAngle = ("Offset", "Helix", "No clearing")
+                angleMode = 0 if obj.ClearingPattern not in patternsNoAngle else 2
+                obj.setEditorMode("Angle", angleMode)
+
+            if getattr(self, "job", None) and obj in self.job.Operations.Group:
+                useRestMode = 0 if self.job.Operations.Group.index(obj) else 2
+                obj.setEditorMode("UseRestMachining", useRestMode)
 
     def pocketInvertExtraOffset(self):
         """pocketInvertExtraOffset() ... return True if ExtraOffset's direction is inward.
@@ -171,12 +188,6 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             QT_TRANSLATE_NOOP("App::Property", "Clearing pattern to use"),
         )
         obj.addProperty(
-            "App::PropertyBool",
-            "MinTravel",
-            "Pocket",
-            QT_TRANSLATE_NOOP("App::Property", "Use 3D Sorting of Path"),
-        )
-        obj.addProperty(
             "App::PropertyLength",
             "RetractThreshold",
             "Pocket",
@@ -214,6 +225,43 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 "Force maximum stepover even if not all area is cleared. Without this flag set, the stepover may be reduced (for large stepover, >50%) to ensure full area coverage.",
             ),
         )
+        obj.addProperty(
+            "App::PropertyLength",
+            "FinishingOffset",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Distance between roughing and finishing passes",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyIntegerConstraint",
+            "FinishingPasses",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Adds an additional finishing pass "
+                "that clears the stock left over from tool deflection",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "FinishingOneStepDown",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Finishing pass will processing with one step down at final depth",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyBool",
+            "FinishingRampHelix",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Create helix ramp for finishing pass",
+            ),
+        )
 
         for n in self.pocketPropertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -236,8 +284,10 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         params["FromCenter"] = obj.StartAt == "Center"
         params["PocketStepover"] = (self.radius * 2) * (float(obj.StepOver) / 100)
         extraOffset = obj.ExtraOffset.Value
+        if obj.FinishingPasses:
+            extraOffset += obj.FinishingOffset.Value
         if self.pocketInvertExtraOffset():
-            extraOffset = 0 - extraOffset
+            extraOffset = -extraOffset
         params["PocketExtraOffset"] = extraOffset
         params["ToolRadius"] = self.radius
         params["ForceMaxStepover"] = obj.ForceMaxStepOver
@@ -245,9 +295,12 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         Pattern = {
             "ZigZag": 1,
             "Offset": 2,
-            "ZigZagOffset": 4,
+            "Spiral": 3,
+            "ZigZagOffset": 1,  # 4,
             "Line": 5,
             "Grid": 6,
+            "Triangle": 7,
+            "Helix": 2,
         }
 
         params["PocketMode"] = Pattern.get(obj.ClearingPattern, 1)
@@ -255,6 +308,20 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         if obj.SplitArcs:
             params["Explode"] = True
             params["FitArcs"] = False
+
+        return params
+
+    def areaOpAreaParamsFinishing(self, obj, isHole):
+        """areaOpAreaParamsOffset(obj, isHole) ... return dictionary with area parameters
+        This AreaParams using for Finishing Offset passes"""
+        params = {}
+        params["Fill"] = 0
+        params["Coplanar"] = 0
+        params["SectionCount"] = -1
+        params["Offset"] = -(self.radius + obj.ExtraOffset.Value)
+        params["ExtraPass"] = 0
+        params["Stepover"] = 0
+        params["JoinType"] = 0
 
         return params
 
@@ -318,36 +385,72 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         if hasattr(obj, "PocketLastStepOver"):
             obj.removeProperty("PocketLastStepOver")
 
+        if not hasattr(obj, "FinishingOffset"):
+            obj.addProperty(
+                "App::PropertyLength",
+                "FinishingOffset",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property", "Distance between roughing and finishing passes"
+                ),
+            )
+            if obj.ClearingPattern == "ZigZagOffset":
+                obj.FinishingOffset = 0.01
+        if not hasattr(obj, "FinishingOneStepDown"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "FinishingOneStepDown",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Finishing pass will processing with one step down at final depth",
+                ),
+            )
+        if not hasattr(obj, "FinishingPasses"):
+            obj.addProperty(
+                "App::PropertyIntegerConstraint",
+                "FinishingPasses",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Adds an additional finishing pass "
+                    "that clears the stock left over from tool deflection",
+                ),
+            )
+            obj.FinishingPasses = (0, 0, 999999, 1)
+        if not hasattr(obj, "FinishingRampHelix"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "FinishingRampHelix",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Create helix ramp for finishing pass",
+                ),
+            )
+
         Path.Log.track()
 
     def areaOpPathParams(self, obj, isHole):
         """areaOpAreaParams(obj, isHole) ... return dictionary with pocket's path parameters"""
         params = {}
 
-        CutMode = ["Conventional", "Climb"]
+        CutMode = ("Conventional", "Climb")
         params["orientation"] = CutMode.index(obj.CutMode)
 
-        # if MinTravel is turned on, set path sorting to 3DSort
-        # 3DSort shouldn't be used without a valid start point. Can cause
-        # tool crash without it.
-        #
-        # ml: experimental feature, turning off for now (see https://forum.freecad.org/viewtopic.php?f=15&t=24422&start=30#p192458)
-        # realthunder: I've fixed it with a new sorting algorithm, which I
-        # tested fine, but of course need more test. Please let know if there is
-        # any problem
-        #
-        if obj.MinTravel and obj.UseStartPoint and obj.StartPoint is not None:
-            params["sort_mode"] = 3
         return params
 
 
 def SetupProperties():
     setup = PathAreaOp.SetupProperties()
-    setup.append("CutMode")
-    setup.append("ExtraOffset")
-    setup.append("StepOver")
     setup.append("Angle")
     setup.append("ClearingPattern")
+    setup.append("CutMode")
+    setup.append("ExtraOffset")
+    setup.append("FinishingPasses")
+    setup.append("FinishingOffset")
+    setup.append("FinishingOneStepDown")
     setup.append("StartAt")
-    setup.append("MinTravel")
+    setup.append("StepDown")
+    setup.append("StepOver")
     return setup

--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -184,13 +184,12 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         obj.Angle = 45
         obj.setEditorMode("Angle", 2)  # hide for default Offset pattern
         obj.UseOutline = False
+        obj.FinishingPasses = (0, 0, 999999, 1)
         FeatureExtensions.set_default_property_values(obj, job)
 
     def areaOpShapes(self, obj):
         """areaOpShapes(obj) ... return shapes representing the solids to be removed."""
         Path.Log.track()
-        self.removalshapes = []
-
         # self.isDebug = True if Path.Log.getLevel(Path.Log.thisModule()) == 4 else False
         self.removalshapes = []
         avoidFeatures = list()
@@ -206,9 +205,10 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             self.horiz = []
             self.vert = []
             self.edges = []
+            virtFeatures = []
             for base, subList in obj.Base:
                 for sub in subList:
-                    if sub in avoidFeatures:
+                    if sub in avoidFeatures:  # TODO looks like do nothing
                         # skip this sub shape
                         continue
                     if "Edge" in sub and self.classifySubEdge(base, sub):
@@ -225,6 +225,14 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                 if wire.isClosed():
                     face = Part.Face(wire)
                     self.horiz.append((face, base))
+                else:
+                    p0 = wire.OrderedVertexes[0].Point
+                    p1 = wire.OrderedVertexes[-1].Point
+                    e = Part.makeLine(p0, p1)
+                    wire = Part.Wire(sortEdges + [e])
+                    face = Part.Face(wire)
+                    self.horiz.append((face, base))
+                    virtFeatures.append([None, face, e])
 
             # Convert horizontal faces to use outline only if requested
             Path.Log.debug("UseOutline: {}".format(obj.UseOutline))
@@ -238,22 +246,37 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
 
             # Check if selected vertical faces form a loop
             if len(self.vert) > 0:
-                self.vertical = Path.Geom.combineConnectedShapes(self.vert)
-                self.vWires = [
-                    TechDraw.findShapeOutline(shape, 1, FreeCAD.Vector(0, 0, 1))
-                    for shape in self.vertical
+                zMin = min(e.BoundBox.ZMin for f in self.vert for e in f.Edges)
+                bEdges = [
+                    e
+                    for f in self.vert
+                    for e in f.Edges
+                    if Path.Geom.isRoughly(e.BoundBox.ZMax, zMin)
                 ]
-                for wire in self.vWires:
-                    w = Path.Geom.removeDuplicateEdges(wire)
-                    face = Part.Face(w)
-                    # face.tessellate(0.1)
-                    if Path.Geom.isRoughly(face.Area, 0):
-                        Path.Log.error("Vertical faces do not form a loop - ignoring")
-                    else:
+                for se in Part.sortEdges(bEdges):
+                    wire = Part.Wire(se)
+                    if wire.isClosed():
+                        face = Part.Face(wire)
                         self.horiz.append(face)
+                    else:
+                        p0 = wire.OrderedVertexes[0].Point
+                        p1 = wire.OrderedVertexes[-1].Point
+                        e = Part.makeLine(p0, p1)
+                        wire = Part.Wire(wire.Edges + [e])
+                        face = Part.Face(wire)
+                        self.horiz.append(face)
+                        virtFeatures.append([None, face, e])
+
+            # Add base to virtaul features
+            for i in range(len(virtFeatures)):
+                for base, _ in obj.Base:
+                    if base.Shape.BoundBox.intersect(virtFeatures[i][1].BoundBox):
+                        virtFeatures[i][0] = base
+                        break
 
             # Add faces for extensions
             # Note: Extension faces don't have a parent base object, so we append them directly
+            extensions.extend(FeatureExtensions.getExtensions(obj, virtFeatures))
             self.exts = []
             for ext in extensions:
                 if not ext.avoid:
@@ -268,22 +291,13 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             keepOrder = getattr(obj, "SortingMode", None) == "Manual"
             self.horizontal = Path.Geom.combineHorizontalFaces(self.horiz, keepOrder=keepOrder)
 
-            # Move all faces to final depth less buffer before extrusion
-            # Small negative buffer is applied to compensate for internal significant digits/rounding issue
-            if self.job.GeometryTolerance.Value == 0.0:
-                buffer = 0.000001
-            else:
-                buffer = self.job.GeometryTolerance.Value / 10.0
+            # removalshapes should be lower than FinalDepth and higher than StartDepth
             for h in self.horizontal:
-                h.translate(
-                    FreeCAD.Vector(0.0, 0.0, obj.FinalDepth.Value - h.BoundBox.ZMin - buffer)
-                )
-
-            # extrude all faces up to StartDepth plus buffer and those are the removal shapes
-            extent = FreeCAD.Vector(0, 0, obj.StartDepth.Value - obj.FinalDepth.Value + buffer)
-            self.removalshapes = [
-                (face.removeSplitter().extrude(extent), False) for face in self.horizontal
-            ]
+                # move each face on height below 1 mm of FinalDepth
+                h.translate(FreeCAD.Vector(0, 0, obj.FinalDepth.Value - h.BoundBox.ZMin - 1))
+                # extrude each face to height 1 mm above StartDepth
+                v = FreeCAD.Vector(0, 0, obj.StartDepth.Value - obj.FinalDepth.Value + 2)
+                self.removalshapes.append((h.removeSplitter().extrude(v), False))
 
         else:  # process the job base object as a whole
             Path.Log.debug("processing the whole job base object")

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -57,7 +57,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
     def areaOpFeatures(self, obj):
         """areaOpFeatures(obj) ... returns operation-specific features"""
-        return PathOp.FeatureBaseFaces | PathOp.FeatureBaseEdges
+        return PathOp.FeatureBaseFaces | PathOp.FeatureBaseEdges | PathOp.FeatureBaseModels
 
     def initAreaOp(self, obj):
         """initAreaOp(obj) ... creates all profile specific properties."""
@@ -220,6 +220,52 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     "\nManual: uses order of shapes selection",
                 ),
             ),
+            (
+                "App::PropertyLength",
+                "FinishingOffset",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "If doing multiple passes, the extra offset of each additional pass",
+                ),
+            ),
+            (
+                "App::PropertyBool",
+                "FinishingOneStepDown",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Finish pass will processing with one step down at final depth",
+                ),
+            ),
+            (
+                "App::PropertyEnumeration",
+                "StartAt",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Start multiple profile from edge or out of edge",
+                ),
+            ),
+            (
+                "App::PropertyBool",
+                "HelixRamp",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Create helix ramp for closed path\nHelix pitch limits by 'Step Down'",
+                ),
+            ),
+            (
+                "App::PropertyIntegerConstraint",
+                "FinishingPasses",
+                "Profile",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Adds an additional finishing pass "
+                    "that clears the stock left over from tool deflection",
+                ),
+            ),
         ]
 
     @classmethod
@@ -256,6 +302,10 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                 (translate("PathProfile", "Automatic"), "Automatic"),
                 (translate("PathProfile", "Manual"), "Manual"),
             ],
+            "StartAt": [
+                (translate("PathProfile", "OutOfEdge"), "OutOfEdge"),
+                (translate("PathProfile", "Edge"), "Edge"),
+            ],
         }
 
         if dataType == "raw":
@@ -288,7 +338,8 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             "processHoles": False,
             "processPerimeter": True,
             "Stepover": 0,
-            "NumPasses": (1, 1, 99999, 1),
+            "NumPasses": (1, 1, 999999, 1),
+            "FinishingPasses": (0, 0, 999999, 1),
         }
 
     def areaOpApplyPropertyDefaults(self, obj, job, propList):
@@ -332,6 +383,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         )
         sortingMode = 0 if obj.HandleMultipleFeatures == "Individually" else 2
         multiPassMode = 0 if obj.NumPasses > 1 else 2
+        finishingMode = 0 if obj.FinishingPasses else 2
 
         obj.setEditorMode("Stepover", multiPassMode)
         obj.setEditorMode("JoinType", 2)
@@ -343,6 +395,10 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         obj.setEditorMode("processPerimeter", fc)
         obj.setEditorMode("UseLongestEdge", useLongestEdgeMode)
         obj.setEditorMode("SortingMode", sortingMode)
+        obj.setEditorMode("RetractThreshold", multiPassMode)
+        obj.setEditorMode("StartAt", multiPassMode)
+        obj.setEditorMode("FinishingOffset", finishingMode)
+        obj.setEditorMode("FinishingOneStepDown", finishingMode)
 
     def _getOperationType(self, obj):
         if len(obj.Base) == 0:
@@ -371,33 +427,33 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         params["Coplanar"] = 0
         params["SectionCount"] = -1
 
-        offset = obj.OffsetExtra.Value  # 0.0
-        num_passes = max(1, obj.NumPasses)
+        num_passes_rough = max(1, obj.NumPasses)
+        num_passes_finish = obj.FinishingPasses
         stepover = obj.Stepover.Value
-        if num_passes > 1 and stepover == 0:
-            # This check is important because C++ code has a default value for stepover
-            # if it's 0 and extra passes are requested
-            num_passes = 1
-            Path.Log.warning(
-                "Multipass profile requires a non-zero stepover. Reducing to a single pass."
-            )
-
+        offset_rough = obj.OffsetExtra.Value
+        offset_finish = obj.FinishingOffset.Value
+        if num_passes_finish:
+            offset_rough += offset_finish
         if obj.UseComp:
-            offset = self.radius + obj.OffsetExtra.Value
+            offset_rough += self.radius
         if obj.Side == "Inside":
-            offset = 0 - offset
+            offset_rough = -offset_rough
             stepover = -stepover
+            offset_finish = -offset_finish
         if isHole:
-            offset = 0 - offset
+            offset_rough = -offset_rough
             stepover = -stepover
+            offset_finish = -offset_finish
 
-        # Modify offset and stepover to do passes from most-offset to least
-        offset += stepover * (num_passes - 1)
-        stepover = -stepover
+        # Create list of offsets for multiple passes
+        offsets = [offset_rough + i * stepover for i in range(num_passes_rough)]
+        if obj.StartAt != "Edge":
+            offsets.reverse()
+        offsets.extend([offset_rough - offset_finish] * num_passes_finish)
 
-        params["Offset"] = offset
-        params["ExtraPass"] = num_passes - 1
-        params["Stepover"] = stepover
+        params["Offset"] = offsets
+        params["ExtraPass"] = 0
+        params["Stepover"] = 0
 
         # Map JoinType string to AreaParams enum value
         jointype_map = {
@@ -440,10 +496,6 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                 params["orientation"] = 1
             else:
                 params["orientation"] = 0
-
-        if obj.NumPasses > 1:
-            # Disable path sorting to ensure that offsets appear in order, from farthest offset to closest, on all layers
-            params["sort_mode"] = 0
 
         return params
 
@@ -663,12 +715,8 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     flatWire.translate(FreeCAD.Vector(0, 0, diffDepth))
                     self._addDebugObject("FlatWire", flatWire)
 
-                    params = self.areaOpAreaParams(obj, False)
-                    passOffsets = [
-                        self.ofstRadius + i * abs(params["Stepover"])
-                        for i in range(params["ExtraPass"] + 1)
-                    ][::-1]
                     openWires = []
+                    passOffsets = self.areaOpAreaParams(obj, False)["Offset"]
                     for po in passOffsets:
                         cutWireObjs = False
                         self.ofstRadius = po


### PR DESCRIPTION
> [!CAUTION] 
> Will be superseded by
> - #30402

---

Fixes #25684
Fixes #27878
Fixes #24022
Fixes #29448

Another implementation of #21605 but only in Python files, without changes in C++ libarea
In this case get much more flexibility

### Profile operation:

- For each offset creates independent `Path.Area`
- Independent `Path.Area` allows to control order of each offset, which fixes issue `StartPoint` with multipass
- Added property `StartAt` to change order
- Added repeatable finishing passes with adjustable distance
- Finishing passes with several or one step down
- Roughing passes can be with zero step over 

---

### Pocket_Shape operation:

- Creates independent `Path.Area` for clearing pass and finishing pass
- Added repeatable finishing passes with adjustable distance, which can be added to any clearing pattern
   <img width="2065" height="663" alt="Screenshot_20260502_000022_hor" src="https://github.com/user-attachments/assets/a51c8dbb-d0f2-4a0b-a8df-b6f451140f2f" />


- Finishing passes with several or one step down
![Screenshot_20260126_214352](https://github.com/user-attachments/assets/796458ad-2436-4c01-b507-f0874c02e981)

- Removed pattern `ZigZagOffset` as useless now
To get old behavior select pattern `ZigZag` and set non zero value for `FinishingPasses` 

- Fixed `StartAt = Center`
Before order was incorrect with some parameters

- Removed `MinTravel` as useless now

- Added pattern `No clearing` to exclude milling in area
Give ability to apply `Extensions` to "Profile like" path <img width="1005" height="458" alt="Screenshot_20260126_135414_lossy" src="https://github.com/user-attachments/assets/92549a86-4b2b-4fc7-a75e-68347615d37d" />

- Added pattern `Helix`, which can transformed to "Adaptive like" by `RetractThreshold`
   <img width="1738" height="498" alt="Screenshot_20260219_125759_hor" src="https://github.com/user-attachments/assets/bce9ba7c-60c3-47c1-8dc0-596f7c3c3439" />