### PR TITLE
BIM: fix handling of BIM_Sketch view properties

### DIFF
--- a/src/Mod/BIM/bimcommands/BimSketch.py
+++ b/src/Mod/BIM/bimcommands/BimSketch.py
@@ -44,7 +44,7 @@ class BIM_Sketch:
     def IsActive(self):
         v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
         return v
-        
+
     def Activated(self):
         import WorkingPlane
         from draftutils import params


### PR DESCRIPTION
The handling of the sketch view properties was not correct:
* AutoColor was not set to `False`.
* PointSize was missing.
* PointColor was not set to the DefaultShapeVertexColor preference.
* Grid values were never applied. Sketches do not have a GridSnap property and gridSize is not the correct Draft preference.
* Sketch grid snap is a global setting that affects all sketches, the code should not change that setting IMO.

Related to #25190.