### PR TITLE
Add more details available for the user to input for Copper-Generic.FCMat

### DIFF
--- a/src/Mod/Material/Resources/Materials/Standard/Metal/Copper/Copper-Generic.FCMat
+++ b/src/Mod/Material/Resources/Materials/Standard/Metal/Copper/Copper-Generic.FCMat
@@ -31,3 +31,9 @@ Models:
     UUID: 'b2eb5f48-74b3-4193-9fbb-948674f427f3'
     ElectricalConductivity: "59.59 MS/m"
     RelativePermeability: "0.999994"
+  Hardness:
+    UUID: '3d1a6141-d032-4d82-8bb5-a8f339fff8ad'
+    HardnessUnits: "HV"
+  Costs:
+    UUID: "881df808-8726-4c2e-be38-688bb6cce466"
+    ProductURL: "https://en.wikipedia.org/wiki/List_of_copper_alloys"


### PR DESCRIPTION
This PR is looking more towards the end-user's point of view, since adding info "Now" when it's at hand is less work than adding it later, especially if you've stored the info somewhere else and time has passed.

Added Costs.
I've pre-loaded the Vendor URL with a wikipedia URL showing available copper types C1xxxx...C7xxxx and other possibly useful information (the end user can always change it to an appropriate vendor).
Costs are something more of use to end-users if they use it, and if the fields are available, they can decide to make use of, it or not.

added Hardness.
Rockwell C is not a good choice since copper is soft, so I've pre-loaded Hardness with (suggested) HV for Vickers hardness.
I've noted [some](https://www.matweb.com/search/DataSheet.aspx?MatGUID=ca486cc7cefa44d98ee67d2f5eb7d21f&ckck=1) Brinell and Rockwell B values are converted from Vickers (requires preperation, but also more accurate), however, this choice is ultimately up to the user to choose themselves.
Although Hardness is not used (yet) by FreeCAD, having this field available to store values may help with later development (if/because/when there is data collected). From an end-user point of view, if this category is available, they can enter that value "Now" when they create/copy their own card, versus having to dig-up the value later in time (generally a lot more work if time has passed and your original info is stored elsewhere).
