### PR TITLE
CAM: Fix crash when Path panel widgets are deleted

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -602,15 +602,23 @@ class TaskPanelBaseGeometryPage(TaskPanelPage):
         # Load available operations into combobox
         if len(availableOps) > 0:
             # Populate the operations list
-            panel.geometryImportList.blockSignals(True)
-            panel.geometryImportList.clear()
-            availableOps.sort()
-            for opLbl in availableOps:
-                panel.geometryImportList.addItem(opLbl)
-            panel.geometryImportList.blockSignals(False)
+            try:
+                panel.geometryImportList.blockSignals(True)
+                panel.geometryImportList.clear()
+                availableOps.sort()
+                for opLbl in availableOps:
+                    panel.geometryImportList.addItem(opLbl)
+                panel.geometryImportList.blockSignals(False)
+            except (AttributeError, RuntimeError):
+                # Widget doesn't exist in UI or C++ object already deleted
+                pass
         else:
-            panel.geometryImportList.hide()
-            panel.geometryImportButton.hide()
+            try:
+                panel.geometryImportList.hide()
+                panel.geometryImportButton.hide()
+            except (AttributeError, RuntimeError):
+                # Widget doesn't exist in UI or C++ object already deleted
+                pass
 
     def getTitle(self, obj):
         return translate("PathOp", "Base Geometry")


### PR DESCRIPTION
Prevent RuntimeError by safely handling missing or deleted geometry import widgets in Path operation panels. This ensures the UI update code does not fail if the underlying C++ objects are destroyed, improving stability when panels are closed or the UI changes.

src/Mod/CAM/Path/Op/Base.py:
- Wrap geometry import widget access in try/except to avoid crashes
- Add error handling for panel widget deletion scenarios

Fixes: #25345