### PR TITLE
CAM: Engrave - Fix #9114 - Unable to engrave an arc

### DIFF
--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -133,11 +133,14 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
                 elif hasattr(base, "ArrayType"):
                     jobshapes.append(base.Shape)
 
-        if len(jobshapes) > 0:
+        if jobshapes:
             Path.Log.debug("processing {} jobshapes".format(len(jobshapes)))
             wires = []
             for shape in jobshapes:
-                shapeWires = shape.Wires
+                if isinstance(shape, Part.Edge):
+                    shapeWires = [Part.Wire(shape)]
+                else:
+                    shapeWires = shape.Wires
                 Path.Log.debug("jobshape has {} edges".format(len(shape.Edges)))
                 self.commandlist.append(
                     Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})


### PR DESCRIPTION
Fix #9114 - Unable to engrave an arc

We should send `list(Part.Wires)` to `buildpathocc()`
not a `Part.Edge`