### PR TITLE
CAM: Engrave - Remove useless property BaseObject

### DIFF
--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -70,14 +70,6 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
                 QT_TRANSLATE_NOOP("App::Property", "Additional base objects to be engraved"),
             )
         obj.setEditorMode("BaseShapes", 2)  # hide
-        if not hasattr(obj, "BaseObject"):
-            obj.addProperty(
-                "App::PropertyLink",
-                "BaseObject",
-                "Path",
-                QT_TRANSLATE_NOOP("App::Property", "Additional base objects to be engraved"),
-            )
-        obj.setEditorMode("BaseObject", 2)  # hide
 
     def initOperation(self, obj):
         """initOperation(obj) ... create engraving specific properties."""


### PR DESCRIPTION
Property `BaseObject` not uses in Engrave operation