### PR TITLE
Gui: Add translation to 'No style sheet'

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsUI.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsUI.cpp
@@ -120,7 +120,9 @@ void DlgSettingsUI::loadSettings()
 
 void DlgSettingsUI::loadStyleSheet()
 {
-    populateStylesheets("StyleSheet", "qss", ui->StyleSheets, "No style sheet");
+    static std::string translatedString;  // Make sure the memory doesn't disappear on us
+    translatedString = tr("No style sheet").toStdString();
+    populateStylesheets("StyleSheet", "qss", ui->StyleSheets, translatedString.c_str());
     populateStylesheets("OverlayActiveStyleSheet", "overlay", ui->OverlayStyleSheets, "Auto");
 }
 


### PR DESCRIPTION
This string is not currently marked for translation. It's complicated by needing access to a `char *` version of the translated string. Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/350