### PR TITLE
Fix carriage returns in the Migrator Dialog Title.

### DIFF
--- a/src/Gui/Dialogs/DlgVersionMigrator.cpp
+++ b/src/Gui/Dialogs/DlgVersionMigrator.cpp
@@ -133,8 +133,8 @@ DlgVersionMigrator::DlgVersionMigrator(MainWindow* mw)
     // NOTE: All rich-text strings are generated programmatically so that translators don't have to
     // deal with the markup. The two strings in the middle of the dialog are set in the UI file.
 
-    auto programNameString = tr("Welcome to %1 %2.%3")
-                                 .arg(programName, QString::number(major), QString::number(minor));
+    auto programNameString
+        = tr("Welcome to %1 %2.%3").arg(programName, QString::number(major), QString::number(minor));
     auto welcomeString = QStringLiteral("<b>") + programNameString + QStringLiteral("</b>");
 
     auto calculatingSizeString = QStringLiteral("<b>") + tr("Calculating size…")


### PR DESCRIPTION
Fix the carriage returns in the Migrator Dialog Title.

<img width="669" height="392" alt="Screenshot from 2025-11-15 22-55-33" src="https://github.com/user-attachments/assets/9e57c232-2bc6-4724-82ed-c7306ff4a70d" />
