### PR TITLE
CAM: Engrave - Allow flat Part::Feature object in Task panel

### DIFF
--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -99,15 +99,12 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
                 wires = []
                 for feature in subs:
                     sub = base.Shape.getElement(feature)
-                    if isinstance(sub, Part.Edge):
-                        edges.append(sub)
-                    elif sub.Wires:
+                    if sub.Wires:
                         wires.extend(sub.Wires)
                     else:
-                        wires.append(Part.Wire(sub.Edges))
+                        edges.extend(sub.Edges)
 
-                for sortedEdges in Part.sortEdges(edges):
-                    wires.append(Part.Wire(sortedEdges))
+                wires.extend([Part.Wire(se) for se in Part.sortEdges(edges)])
 
                 jobshapes.append(Part.makeCompound(wires))
 
@@ -119,11 +116,7 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
             Path.Log.track(self.model)
             for base in self.model:
                 Path.Log.track(base.Label)
-                if base.isDerivedFrom("Part::Part2DObject"):
-                    jobshapes.append(base.Shape)
-                elif base.isDerivedFrom("Sketcher::SketchObject"):
-                    jobshapes.append(base.Shape)
-                elif hasattr(base, "ArrayType"):
+                if base.isDerivedFrom("Part::Feature") and base.Shape.Volume == 0:
                     jobshapes.append(base.Shape)
 
         if jobshapes:

--- a/src/Mod/CAM/Path/Op/Gui/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Gui/Engrave.py
@@ -55,7 +55,11 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
 
     def selectionSupportedAsBaseGeometry(self, sel, ignoreErrors):
         # allow selection of an entire 2D object, which is generally not the case
-        if not sel.HasSubObjects and sel.Object.isDerivedFrom("Part::Part2DObject"):
+        if (
+            not sel.HasSubObjects
+            and sel.Object.isDerivedFrom("Part::Feature")
+            and sel.Object.Shape.Volume == 0
+        ):
             return True
 
         # Let general logic handle all other cases.
@@ -79,7 +83,7 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                     % (sel.Object.Label)
                 )
                 continue
-            if base.isDerivedFrom("Part::Part2DObject"):
+            if base.isDerivedFrom("Part::Feature") and base.Shape.Volume == 0:
                 if sel.HasSubObjects:
                     # selectively add some elements of the drawing to the Base
                     for sub in sel.SubElementNames:
@@ -93,12 +97,15 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                     shapes.append(base)
                     self.obj.BaseShapes = shapes
                 added = True
-            else:
+            elif self.super().addBaseGeometry(selection):
                 # user wants us to engrave an edge of face of a base model
-                base = self.super().addBaseGeometry(selection)
-                added = added or base
+                added = True
 
         return added
+
+    def clearBase(self):
+        self.obj.BaseShapes = []
+        self.super().clearBase()
 
     def setFields(self, obj):
         self.super().setFields(obj)


### PR DESCRIPTION
At this moment only `Part::Part2DObject` allowed for selection in `Task panel` for `Engrave` operation

`Part::Part2DObject` is a special case of `Part::Feature` with shape strictly flat
[freecad wiki](https://wiki.freecad.org/index.php?title=Part_Part2DObject)

Suggest to replace `Part::Part2DObject` by `Part::Feature` with `Shape.Volume == 0`, as more universal solution
This allows to add imported **svg** geometry object in `Task panel`
So no need to select hundreds edges in 3d view, just select whole object

<img width="1646" height="448" alt="Screenshot_20251231_102854_hor" src="https://github.com/user-attachments/assets/097fcffd-9801-45a3-962c-7b66592d523d" />

---

Example:
[engrave_partfeature.zip](https://github.com/user-attachments/files/24305586/engrave_partfeature.zip)

https://github.com/user-attachments/assets/3e063896-50ea-4f4f-8ab2-ecff87f4f914

---

Also button `Clear` uses to clear only list `Base`,
but in `Engrave` operation contains `Base` and `BaseShape`
So added code to clear also `BaseShape`