### PR TITLE
Sketcher: External Face: decide between defining and construction

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -11874,4 +11874,3 @@ template class SketcherExport FeaturePythonT<Sketcher::SketchObject>;
 }// namespace App
 
 // clang-format on
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/25373

Note: I was not able to do as OP suggested: 

> - If all the existing external geometry is construction, new geometry becomes construction.
> - If all the existing external geometry is not construction, new geometry becomes not construction.
> - If neither of the above two are true, new geometry checks for attached (e.g. via coincident) old geometry (recursive through all new geometry) and uses the old geometry flags. If no attached geometry is found, finally default to construction geometry.

Since the third thing is tricky because we are currently rebuilding the external geometries, and it seems there are potential TNP issues when the reference face changes, so we apparantly have no guarantee that one edge stay the same number after the rebuild. 

Long story short I did the next best thing : if a face's edge were all defining, then the new one is also defining. Else new are construction.