### PR TITLE
sketcher: fix issue #13852 resolve issue with state not updating constraint text

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3366,6 +3366,9 @@ bool ViewProviderSketch::setEdit(int ModNum)
     addNodeToRoot(gridnode);
     setGridEnabled(true);
 
+    // update the documents stored transform
+    getDocument()->setEditingTransform(plm.toMatrix());
+
     // create the container for the additional edit data
     assert(!isInEditMode());
     preselection.reset();


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR aims to resolve the issue described in the below link,

https://github.com/FreeCAD/FreeCAD/issues/13852

basically the state for a sketch's transform was not updating. this simple change should properly render the text for the constraints in the sketcher workbench.

basically there was an edge case where one could select a sketch, then click back to the "model" tab and open another sketch, and so on, and so on (do not use the close button the task panel when a sketch is open, just open another sketch). and after opening several sketches this way the text rendered in the sketcher workbench for the constraints would appear "flipped" due to the logic not updating the `plm` varible, or rather having a "out of sync" `plm` variable in the `ViewProviderSketch.cpp`

i tested this code with the provided file shared in the issue ie. #13852

the file: 

https://github.com/FreeCAD/FreeCAD/files/15235853/krushia-clampstrip-mkJ-22dev.zip

i opened that file in my dev build, opened several sketches in the file using the method above, and never saw the text rendered "flipped" / "backwards".

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
