### PR TITLE
CAM: LeadInOut - Fix positive overtravel for open profile

### DIFF
--- a/src/Mod/CAM/Path/Base/Language.py
+++ b/src/Mod/CAM/Path/Base/Language.py
@@ -53,6 +53,11 @@ class Instruction(object):
     def setPositionBegin(self, begin):
         self.begin = begin
 
+    def setPositionEnd(self, end):
+        self.param["X"] = end.x
+        self.param["Y"] = end.y
+        self.param["Z"] = end.z
+
     def positionBegin(self):
         """positionBegin() ... returns a Vector of the begin position"""
         return self.begin

--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -1015,6 +1015,7 @@ class ObjectDressup:
             instr = self.source[start]
             newLength = length + instr.pathLength()
             newInstr = self.cutInstrBegin(obj, instr, newLength)
+            newInstr.setPositionEnd(instr.positionBegin())
             return [newInstr]
 
         return None
@@ -1051,6 +1052,7 @@ class ObjectDressup:
             instr = self.source[end]
             newLength = length + instr.pathLength()
             newInstr = self.cutInstrEnd(obj, instr, newLength)
+            newInstr = self.cutInstrBegin(obj, newInstr, length)
             return [newInstr]
 
         return None
@@ -1271,7 +1273,7 @@ class ObjectDressup:
                         commands = self.cutTravelEnd(obj, commands, abs(obj.OffsetOut.Value))
 
                     # Process positive Offset Lead-Out (overtravel)
-                    if obj.OffsetOut.Value > 0 and obj.StyleOut != "No Retract":
+                    elif obj.OffsetOut.Value > 0 and obj.StyleOut != "No Retract":
                         overtravelOut = self.extendTravelOut(obj, obj.OffsetOut.Value)
                         if overtravelOut:
                             commands.extend(overtravelOut)


### PR DESCRIPTION
Problem can be found with open profile and arc commands (G2 and G3)
There is no tools which can create such path at this moment, so let it be for 1.2

It also happening with G1 commands, but it is not visible and probably do not ruin the path

<img width="870" height="358" alt="Screenshot_20251120_120806_hor" src="https://github.com/user-attachments/assets/6a334ca7-f7e6-4d20-a157-98bf4d496822" />
<br>

**Issue_5**
[LeadInOut_Overtravel_5.zip](https://github.com/user-attachments/files/23651174/LeadInOut_Overtravel_5.zip)
<br>

> [!Note]
> Should be reviewed after:
> - #24849

