### PR TITLE
CI: Remove labels from Crowdin update workflow

### DIFF
--- a/.github/workflows/fetch_crowdin_translations.yml
+++ b/.github/workflows/fetch_crowdin_translations.yml
@@ -61,7 +61,6 @@ jobs:
           branch: update-crowdin-translations
           title: "Update translations from Crowdin"
           body: "Automatic Crowdin update."
-          labels: "translations, automated"
           token: ${{ secrets.GH_TOKEN_FOR_CROWDIN_SYNC }}
           delete-branch: true
           add-paths: |


### PR DESCRIPTION
Adding labels requires admin privileges, which we don't want this account to have.