### PR TITLE
Enable Reverse Engineering WB.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,10 +71,6 @@
             "type": "BOOL",
             "value": "ON"
           },
-          "BUILD_REVERSEENGINEERING": {
-            "type": "BOOL",
-            "value": "OFF"
-          },
           "ENABLE_DEVELOPER_TESTS": {
             "type": "BOOL",
             "value": "ON"


### PR DESCRIPTION
The Reverse Engineering WB was temporarily disabled as it didn't support Qt6.As it now supports Qt6, it is time to re-enable the WB.

## Issues

* #24918
* #25473

## Before and After Images

N/A