### PR TITLE
Sketcher: prevent undo/redo crash when selected geometry goes away.

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -359,6 +359,9 @@ bool isCommandNeedingBSplineKnotActive(Gui::Document* doc)
         }
 
         auto* Obj = static_cast<Sketcher::SketchObject*>(sel[0].getObject());
+        if (!Obj) {
+            return false;
+        }
         const std::string& name = names[0];
 
         int geoId {GeoEnum::GeoUndef};

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -355,7 +355,7 @@ bool SketcherGui::isBsplineKnotOrEndPoint(
 
     const Part::Geometry* geo = Obj->getGeometry(GeoId);
     // end points of B-Splines are also knots
-    if (geo->is<Part::GeomBSplineCurve>()
+    if (geo && geo->is<Part::GeomBSplineCurve>()
         && (PosId == Sketcher::PointPos::start || PosId == Sketcher::PointPos::end)) {
         return true;
     }


### PR DESCRIPTION
Check for two null pointers when walking selection geometry to update the UI after an undo/redo.

## Issues
Fixes #25497

This should be backported to the 1.1.0 release branch.