### PR TITLE
Sketcher: Add symmetric constraint option (an element + a symmetry line)

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -9854,7 +9854,7 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
 
             if (GeoId1 == GeoId2
                 && (isEdge(GeoId2, PosId2)
-                    || (isVertex(GeoId2, PosId2) 
+                    || (isVertex(GeoId2, PosId2)
                         && (PosId2 == Sketcher::PointPos::start || PosId2 == Sketcher::PointPos::end)) )) {
                 Gui::TranslatedUserWarning(
                     Obj,


### PR DESCRIPTION
This PR relates to issue #25428.

### Description:
Currently, the symmetric constraint can be specified in three ways:

1. two points and a symmetry line  
2. two points and a symmetry point  
3. a line and a symmetry point  

This PR adds a fourth option:

4. an element (line, arc, or open B-spline) and a symmetry line  

This makes it easier to apply symmetry in sketches.

This PR is conceptually different from option (3) with a midpoint constraint. 
While option (3) focuses on creating a midpoint, the new option reduces the amount of user interaction when creating a symmetric element orthogonal to a symmetry line. Normally, this requires option (1), selecting two endpoints and the symmetry line. However, selecting endpoints with the mouse requires precise handling. 
It is much simpler and more user‑friendly to select the entire edge element directly instead of its individual endpoints.

This also fixes #25522.

### Video demonstration:
This video shows a line and an arc being constrained symmetrically with respect to the H axis. In each case, the symmetric constraint is created with only two operations: clicking the element and clicking the HAxis.

https://github.com/user-attachments/assets/072a37b1-4988-42fc-ac6a-5d65129a8588

### Note:
There are two separate implementations depending on ContinuousConstraintMode (`activated()` and `applyConstraint()`), which results in some redundancy. Refactoring is outside the scope of this PR.