### PR TITLE
[Gui] increase contrast of menu separators and down arrows in comboboxes

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD.qss
+++ b/src/Gui/Stylesheets/FreeCAD.qss
@@ -508,7 +508,7 @@ QMenu::item:disabled {
 }
 
 QMenu::separator {
-  height: 2px;
+  height: 1px;
   background-color: @GroupboxBorderColor;
 }
 


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/23608
Fixes https://github.com/FreeCAD/FreeCAD/issues/25065

## Before
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

<img width="483" height="341" alt="Light_Before" src="https://github.com/user-attachments/assets/8c7be84d-e251-47fc-aa38-33de4b018cf0" />
<img width="500" height="338" alt="Dark_Before" src="https://github.com/user-attachments/assets/50430944-078d-4351-a43e-c32cb4929ffa" />



## After

<img width="501" height="335" alt="Light_After" src="https://github.com/user-attachments/assets/f8a519a2-5354-448e-895f-9503bfdd8775" />
<img width="490" height="334" alt="Dark_After" src="https://github.com/user-attachments/assets/b400486c-6e7e-4252-8365-3b645e6f218b" />



FYI @furgo16 @FEA-eng @kadet1090 