### PR TITLE
core: preserve body name in step file when exporting part that contains body with feature, fixes #24962

### DIFF
--- a/src/Mod/Import/App/ExportOCAF2.cpp
+++ b/src/Mod/Import/App/ExportOCAF2.cpp
@@ -426,10 +426,7 @@ TDF_Label ExportOCAF2::exportObject(
         App::DocumentObject* tip = body->Tip.getValue();
         if (tip) {
             // reget shape from tip to ensure latest feature is included
-            auto tipShape = Part::Feature::getTopoShape(
-                    tip,
-                    Part::ShapeOption::Transform
-                    );
+            auto tipShape = Part::Feature::getTopoShape(tip, Part::ShapeOption::Transform);
             if (!tipShape.isNull()) {
                 shape = tipShape;
             }
@@ -515,9 +512,8 @@ TDF_Label ExportOCAF2::exportObject(
     // 1. no subobjects (subs.empty())
     // 2. is a partdesign feature ie. pad, pocket, boolean
     // 3. is a partdesign body, should export as single shape via its tip, not as assembly
-    if (subs.empty()
-            || obj->isDerivedFrom(PartDesign::Feature::getClassTypeId())
-            || obj->isDerivedFrom(PartDesign::Body::getClassTypeId())) {
+    if (subs.empty() || obj->isDerivedFrom(PartDesign::Feature::getClassTypeId())
+        || obj->isDerivedFrom(PartDesign::Body::getClassTypeId())) {
 
         if (!parent.IsNull()) {
             // Search for non-located shape to see if we've stored the original shape before


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR aims to fix the edge case mentioned in freecad issue #24962

basically if a freecad document contains a part -> body -> feature (fillet) and one has the part selected and uses file -> export -> step file. the exported step file will contain / show a "part" that will match with the name in the original freecad document. however the object inside the part will use the name of the "tip" feature ie. a fillet.

so this PR fixes that, so when a user exports a part as mentioned above the exported step file will use the name of the body.

i will attach a document in a second that can be used for testing.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
