### PR TITLE
Gui: Fix Gesture style context menu segfault

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2149,29 +2149,26 @@ void NavigationStyle::openPopupMenu(const SbVec2s& position)
         contextMenu->insertSeparator(posAction);
     }
 
-    QObject::connect(
-        contextMenu,
-        &QMenu::triggered,
-        contextMenu,
-        [this, navMenuGroup, pickAction](QAction* selectedAction) {
-            // handle navigation style change if user selected a navigation style option
-            if (selectedAction && isNavigationStyleAction(selectedAction, navMenuGroup)) {
-                applyNavigationStyleChange(selectedAction);
-                rightClickPosition.reset();
-                return;
-            }
+    auto navigationFunction = [this, navMenuGroup](QAction* selectedAction) {
+        // handle navigation style change if user selected a navigation style option
+        if (isNavigationStyleAction(selectedAction, navMenuGroup)) {
+            applyNavigationStyleChange(selectedAction);
+            rightClickPosition.reset();
+        }
+    };
 
-            if (pickAction && selectedAction == pickAction) {
-                // Execute the Clarify Selection command at this position
-                auto cmd = Application::Instance->commandManager().getCommandByName(
-                    "Std_ClarifySelection"
-                );
-                if (cmd && cmd->isActive()) {
-                    cmd->invoke(0);  // required placeholder value - we don't use group command
-                }
+    auto clarifyFunction = [pickAction](QAction* selectedAction) {
+        if (selectedAction == pickAction) {
+            // Execute the Clarify Selection command at this position
+            auto cmd = Application::Instance->commandManager().getCommandByName("Std_ClarifySelection");
+            if (cmd && cmd->isActive()) {
+                cmd->invoke(0);  // required placeholder value - we don't use group command
             }
         }
-    );
+    };
+
+    QObject::connect(contextMenu, &QMenu::triggered, navigationFunction);
+    QObject::connect(contextMenu, &QMenu::triggered, clarifyFunction);
 
     contextMenu->popup(QCursor::pos());
 


### PR DESCRIPTION
Fixes #24869

The change from `contextMenu->popup(QCursor::pos());` which returns immediately, to `contextMenu->exec(QCursor::pos());` that creates a local event loop (blocks until menu is closed), which is causing trouble in the Gesture Style state transition.

AI suggested to use `popup` and `QObject::connect` instead.