### PR TITLE
CAM: Job object - Showing combined path from all operations

### DIFF
--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -23,6 +23,7 @@
 
 from Path.Op.Util import getCycleTimeEstimate
 from Path.Post.Processor import PostProcessorFactory  # PostProcessor,
+from PathScripts import PathUtils as PathUtils
 from PySide import QtCore
 from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD
@@ -232,6 +233,12 @@ class ObjectJob:
             ),
         )
         obj.PostProcessorPropertyOverrides = "{}"
+        obj.addProperty(
+            "App::PropertyBool",
+            "ShowCombinedPath",
+            "Path",
+            QT_TRANSLATE_NOOP("App::Property", "Show combined path from all operations"),
+        )
 
         obj.Fixtures = ["G54"]
 
@@ -599,6 +606,14 @@ class ObjectJob:
             )
             obj.PostProcessorPropertyOverrides = "{}"
 
+        if not hasattr(obj, "ShowCombinedPath"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "ShowCombinedPath",
+                "Path",
+                QT_TRANSLATE_NOOP("App::Property", "Show combined path from all operations"),
+            )
+
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
 
@@ -740,8 +755,12 @@ class ObjectJob:
         if not obj.GeometryTolerance:
             obj.GeometryTolerance = Path.Preferences.defaultGeometryTolerance()
 
+        obj.Path = Path.Path()
         if getattr(obj, "Operations", None):
-            # obj.Path = obj.Operations.Path
+            if obj.ShowCombinedPath:
+                for op in obj.Operations.Group:
+                    op.Visibility = False
+                    obj.Path.addCommands(PathUtils.getPathWithPlacement(op).Commands)
             self.getCycleTime()
             if hasattr(obj, "PathChanged"):
                 obj.PathChanged = True

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -23,6 +23,7 @@
 
 from Path.Op.Util import getCycleTimeEstimate
 from Path.Post.Processor import PostProcessorFactory  # PostProcessor,
+from PathScripts import PathUtils as PathUtils
 from PySide import QtCore
 from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD
@@ -232,6 +233,12 @@ class ObjectJob:
             ),
         )
         obj.PostProcessorPropertyOverrides = "{}"
+        obj.addProperty(
+            "App::PropertyBool",
+            "ShowCombinedPath",
+            "Path",
+            QT_TRANSLATE_NOOP("App::Property", "Show combined path from all operations"),
+        )
 
         obj.Fixtures = ["G54"]
 
@@ -601,6 +608,14 @@ class ObjectJob:
             )
             obj.PostProcessorPropertyOverrides = "{}"
 
+        if not hasattr(obj, "ShowCombinedPath"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "ShowCombinedPath",
+                "Path",
+                QT_TRANSLATE_NOOP("App::Property", "Show combined path from all operations"),
+            )
+
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])
 
@@ -759,8 +774,12 @@ class ObjectJob:
         if not obj.GeometryTolerance:
             obj.GeometryTolerance = Path.Preferences.defaultGeometryTolerance()
 
+        obj.Path = Path.Path()
         if getattr(obj, "Operations", None):
-            # obj.Path = obj.Operations.Path
+            if obj.ShowCombinedPath:
+                for op in obj.Operations.Group:
+                    op.Visibility = False
+                    obj.Path.addCommands(PathUtils.getPathWithPlacement(op).Commands)
             self.getCycleTime()
             if hasattr(obj, "PathChanged"):
                 obj.PathChanged = True


### PR DESCRIPTION
Experimental solution to showing combined path from all operations
`Job` is `<Path::FeaturePython object>` , so we can use this as a container for path

Inspired by #25440

<img width="838" height="385" alt="Screenshot_20251122_160630_lossy" src="https://github.com/user-attachments/assets/5893dc9a-a123-43d1-9f64-68f96e96b516" />

<img width="1485" height="330" alt="Screenshot_20251122_212744_hor" src="https://github.com/user-attachments/assets/b002c5d9-d581-4dff-8e2b-0020130ef43b" />
