### PR TITLE
TechDraw: Implemented View Frame Mode preference

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneral.ui
@@ -189,10 +189,10 @@ for ProjectionGroups</string>
         <item row="0" column="1">
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeType">
-           <enum>QSizePolicy::Preferred</enum>
+           <enum>QSizePolicy::Policy::Preferred</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -220,7 +220,7 @@ for ProjectionGroups</string>
            <string>Font for labels</string>
           </property>
           <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
+           <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
           </property>
           <property name="currentFont">
            <font/>
@@ -243,7 +243,7 @@ for ProjectionGroups</string>
         <item row="1" column="1">
          <spacer name="horizontalSpacer_6">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -303,7 +303,7 @@ for ProjectionGroups</string>
         <item row="0" column="1">
          <spacer name="horizontalSpacer_3">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -332,7 +332,7 @@ for ProjectionGroups</string>
            <string>Use first or third-angle multiview projection convention</string>
           </property>
           <property name="sizeAdjustPolicy">
-           <enum>QComboBox::AdjustToContents</enum>
+           <enum>QComboBox::SizeAdjustPolicy::AdjustToContents</enum>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>ProjectionAngle</cstring>
@@ -423,7 +423,7 @@ for ProjectionGroups</string>
         <item row="1" column="1" rowspan="2">
          <spacer name="horizontalSpacer_7">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -643,7 +643,7 @@ for ProjectionGroups</string>
            <string>Diamond</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>NamePattern</cstring>
@@ -693,7 +693,7 @@ for ProjectionGroups</string>
         <item row="1" column="1">
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -815,8 +815,8 @@ for ProjectionGroups</string>
      <property name="title">
       <string>View Defaults</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_8">
-      <item>
+     <layout class="QGridLayout" name="gridLayout_9">
+      <item row="1" column="0">
        <layout class="QVBoxLayout" name="verticalLayout_7">
         <item>
          <widget class="Gui::PrefCheckBox" name="cb_useCameraDirection">
@@ -868,6 +868,41 @@ for ProjectionGroups</string>
         </item>
        </layout>
       </item>
+      <item row="0" column="1">
+       <widget class="Gui::PrefComboBox" name="cb_viewFramesVisibility">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Control when the view boundary frames and labels are displayed.&lt;/p&gt;&lt;p&gt;Auto: Show on hover, On: Always show, Off: Never show.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>ViewFrameMode</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/TechDraw/View</cstring>
+        </property>
+        <item>
+         <property name="text">
+          <string>Auto</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>On</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Off</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_15">
+        <property name="text">
+         <string>View frames mode</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -884,7 +919,7 @@ for ProjectionGroups</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_9">
       <item>
-       <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,0,2,0">
+       <layout class="QGridLayout" name="gridLayout_8" columnstretch="1,0,2">
         <item row="0" column="0">
          <widget class="Gui::PrefCheckBox" name="cb_SnapViews">
           <property name="toolTip">
@@ -929,7 +964,7 @@ for ProjectionGroups</string>
            <string>When dragging a view, if it is within this fraction of view size of the correct alignment, it will snap into alignment.</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
           <property name="value">
            <double>0.050000000000000</double>
@@ -945,7 +980,7 @@ for ProjectionGroups</string>
         <item row="1" column="1">
          <spacer name="horizontalSpacer_4">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -975,7 +1010,7 @@ for ProjectionGroups</string>
            <string>Controls the snap radius for highlights. Vertex must be within this factor times the highlight size to be a snap target.</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
           <property name="value">
            <double>0.600000000000000</double>
@@ -986,7 +1021,6 @@ for ProjectionGroups</string>
           <property name="prefPath" stdset="0">
            <cstring>/Mod/TechDraw/General</cstring>
           </property>
-
          </widget>
         </item>
        </layout>

--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawGeneralImp.cpp
@@ -80,6 +80,7 @@ void DlgPrefsTechDrawGeneralImp::saveSettings()
 
     ui->cbMultiSelection->onSave();
 
+    ui->cb_viewFramesVisibility->onSave();
     ui->cb_useCameraDirection->onSave();
     ui->cb_alwaysShowLabel->onSave();
     ui->cb_SnapViews->onSave();
@@ -128,6 +129,7 @@ void DlgPrefsTechDrawGeneralImp::loadSettings()
     ui->cbMultiSelection->setChecked(multiSelectionDefault);
     ui->cbMultiSelection->onRestore();
 
+    ui->cb_viewFramesVisibility->onRestore();
     ui->cb_useCameraDirection->onRestore();
     ui->cb_alwaysShowLabel->onRestore();
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -114,8 +114,7 @@ QGIView::QGIView()
     m_lockHeight = (double) sizeLock.height();
 
     m_lock->hide();
-    m_border->hide();
-    m_label->hide();
+    updateFrameVisibility();
 }
 
 void QGIView::isVisible(bool state)
@@ -200,21 +199,18 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
     if (change == ItemSelectedHasChanged && scene()) {
         if (isSelected() || hasSelectedChildren(this)) {
             m_colCurrent = getSelectColor();
-            m_border->show();
-            m_label->show();
             m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
         } else {
             dragFinished();
 
             if (!m_isHovered) {
                 m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
-                m_border->hide();
-                m_label->hide();
                 m_lock->hide();
             } else {
                 m_colCurrent = getPreColor();
             }
         }
+        updateFrameVisibility();
         drawBorder();
     }
 
@@ -526,8 +522,7 @@ void QGIView::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
         m_colCurrent = getPreColor();
     }
 
-    m_border->show();
-    m_label->show();
+    updateFrameVisibility();
 
     m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
 
@@ -543,16 +538,13 @@ void QGIView::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
     if (isSelected()) {
         m_colCurrent = getSelectColor();
-        m_border->show();
-        m_label->show();
         m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
     } else {
         m_colCurrent = PreferencesGui::getAccessibleQColor(PreferencesGui::normalQColor());
-        m_border->hide();
-        m_label->hide();
         m_lock->hide();
     }
 
+    updateFrameVisibility();
     drawBorder();
 }
 
@@ -605,6 +597,7 @@ void QGIView::updateView(bool forceUpdate)
         rotateView();
     }
 
+    updateFrameVisibility();
     drawBorder();
 
     QGIView::draw();
@@ -1076,6 +1069,47 @@ void QGIView::makeMark(QPointF pos, QColor color)
     makeMark(pos.x(), pos.y(), color);
 }
 
+void QGIView::updateFrameVisibility()
+{
+    // Get the preference group
+    auto hGrp = App::GetApplication().GetUserParameter()
+        .GetGroup("BaseApp")->GetGroup("Preferences")->GetGroup("Mod/TechDraw/View");
+    
+    // 0 = Auto (Default), 1 = Always On, 2 = Always Off
+    int frameMode = hGrp->GetInt("ViewFrameMode", 0);
+
+    bool shouldShow = false;
+
+    if (isSelected()) {
+        shouldShow = true;
+    } 
+    else {
+        if (frameMode == 1) {
+            // Always On
+            shouldShow = true;
+        }
+        else if (frameMode == 2) {
+            // Always Off
+            shouldShow = false;
+        }
+        else {
+            // Auto (Default)
+            shouldShow = m_isHovered;
+        }
+    }
+
+    if (shouldShow) {
+        m_border->show();
+        m_label->show();
+        if (m_lock && getViewObject()) {
+            m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
+        }
+    } else {
+        m_border->hide();
+        m_label->hide();
+        if (m_lock) m_lock->hide();
+    }
+}
 
 //! Retrieves objects of type T with given indexes
 template <typename T>

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -190,6 +190,7 @@ protected:
     void dumpRect(const char* text, QRectF rect);
     bool m_isHovered;
 
+    void updateFrameVisibility();
 
     Base::Reference<ParameterGrp> getParmGroupCol();
 


### PR DESCRIPTION
A number of users have expressed that the recent view frames change has made page elements difficult to select. As suggested in #25405, a preference has been added with options "Auto", "On", "Off".

Auto = Show on hover
On = Always show
Off = Always hide

This change affects both frames and labels.

## Issues
Fixes #25405

## Demo Video

https://github.com/user-attachments/assets/2e9aac74-a763-4762-8643-f9286164973a


## For Reviewers
I edited the `.ui` file in QT6 Designer, so on save some namespace additions were automatically added. As i understand it, QT5 is no longer supported, so this should be fine.
