### PR TITLE
CAM: Ensure Chipload is restored and displayed with user-preferred units

### DIFF
--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -179,6 +179,8 @@ class ToolBit(Asset, ABC):
         # Update parameters.
         for param_name, param_value in params.items():
             tool_bit_shape.set_parameter(param_name, param_value)
+            if hasattr(toolbit.obj, param_name):
+                PathUtil.setProperty(toolbit.obj, param_name, param_value)
 
         # Update attributes; the separation between parameters and attributes
         # is currently not well defined, so for now we add them to the

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
@@ -55,6 +55,16 @@ class ToolBitPropertiesWidget(QtGui.QWidget):
         self._show_shape = icon
         self._tool_no = tool_no
 
+        # Set schema to user preference if no document is open
+        # TODO: Add a preference for toolbit unit schema.
+        # We probably want to look at making it possible to have a toolbit be metric
+        # or imperial regardless of document settings / or user preferences, but for now this is sufficient.
+        if FreeCAD.ActiveDocument is None:
+            pref_schema = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
+                "UserSchema", 0
+            )
+            FreeCAD.Units.setSchema(pref_schema)
+
         # UI Elements
         self._label_edit = QtGui.QLineEdit()
         self._id_label = QtGui.QLabel()  # Read-only ID


### PR DESCRIPTION
Fixes an issue where Chipload and similar mixin-defined properties were added to the schema but not reliably restored, because parameter restoration did not always apply them to the toolbit object. This change ensures Chipload is restored from saved data and displayed using the user's preferred unit schema, even when no document is open. This update also ensures the toolbit editor respects the user’s unit schema preference during editing, even outside an open document.

src/Mod/CAM/Path/Tool/toolbit/models/base.py:
- Restore Chipload (and other parameters) to toolbit.obj if the property exists.

src/Mod/CAM/Path/Tool/toolbit/ui/editor.py:
- Set units schema to user preference when opening the toolbit editor, so Chipload and other values display correctly.

Fixes: #25550

Should be backported to 1.1 if possible.