### PR TITLE
CAM: Clearance height out (experimental, do not merge)

### DIFF
--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -469,7 +469,7 @@ class ObjectOp(PathOp.ObjectOp):
             ):
                 self.endVector[2] = obj.ClearanceHeight.Value
                 self.commandlist.append(
-                    Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
+                    Path.Command("G0", {"Z": obj.ClearanceHeightOut.Value, "F": self.vertRapid})
                 )
 
         Path.Log.debug("obj.Name: " + str(obj.Name) + "\n\n")

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -280,6 +280,15 @@ class ObjectOp(object):
             )
             obj.addProperty(
                 "App::PropertyDistance",
+                "ClearanceHeightOut",
+                "Depth",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Move to this height at the end of the operation",
+                ),
+            )
+            obj.addProperty(
+                "App::PropertyDistance",
                 "SafeHeight",
                 "Depth",
                 QT_TRANSLATE_NOOP("App::Property", "Rapid Safety Height between locations."),
@@ -450,6 +459,18 @@ class ObjectOp(object):
             )
             obj.StepDown = 0
 
+        if FeatureDepths & features and not hasattr(obj, "ClearanceHeightOut"):
+            obj.addProperty(
+                "App::PropertyDistance",
+                "ClearanceHeightOut",
+                "Depth",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Move to this height at the end of the operation",
+                ),
+            )
+            self.applyExpression(obj, "ClearanceHeightOut", "ClearanceHeight")
+
         self.setEditorModes(obj, features)
         self.opOnDocumentRestored(obj)
 
@@ -596,6 +617,7 @@ class ObjectOp(object):
                     obj, "ClearanceHeight", job.SetupSheet.ClearanceHeightExpression
                 ):
                     obj.ClearanceHeight = "5 mm"
+                self.applyExpression(obj, "ClearanceHeightOut", "ClearanceHeight")
 
         if FeatureDiameters & features:
             obj.MinDiameter = "0 mm"
@@ -795,7 +817,7 @@ class ObjectOp(object):
 
         if self.commandlist and (FeatureHeights & self.opFeatures(obj)):
             # Let's finish by rapid to clearance...just for safety
-            self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
+            self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeightOut.Value}))
 
         path = Path.Path(self.commandlist)
         obj.Path = path


### PR DESCRIPTION
> [!Caution]
Experimental pull request not intended for main branch
Just want to play with this and get opinion from other users

We can use different `ClearanceHeight` for each operation
Using different height for safety move to start and height in the end of an operation will allow operations to be coordinated with each other without useless vertical movements
Also this is another way to exclude retract in the end if needed
 
<img width="1468" height="441" alt="Screenshot_20251123_183658_hor" src="https://github.com/user-attachments/assets/d411597c-76bf-481f-a01e-638bb5523736" />
<img width="870" height="468" alt="Screenshot_20251123_182508_hor" src="https://github.com/user-attachments/assets/abd16323-4762-44b6-9a55-468767f92295" />