### PR TITLE
CI: Update GitHub Actions for Crowdin translation sync

### DIFF
--- a/.github/workflows/fetch_crowdin_translations.yml
+++ b/.github/workflows/fetch_crowdin_translations.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN_FOR_CROWDIN_SYNC }}
 
       - name: Install Qt ≥ 6.8
         uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005
@@ -45,8 +46,8 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
+          git config --global user.name "freecad-gh-actions-translation-bot"
+          git config --global user.email "freecad-gh-actions-translation-bot@github.com"
           git add src
           git commit -m "Update translations from Crowdin" || echo "No changes to commit"
 


### PR DESCRIPTION
Ensure the clone is also using the freecad-gh-actions-translation-bot account so that if it force-pushes to an existing PR, the CI will run.