### PR TITLE
Fix warning of widgets with the same name.

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
+++ b/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui
@@ -27,7 +27,7 @@
       <widget class="QComboBox" name="sidesMode"/>
      </item>
      <item row="1" column="0" colspan="2">
-      <layout class="QHBoxLayout" name="verticalLayout_22">
+      <layout class="QHBoxLayout" name="verticalLayout_220">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -262,7 +262,7 @@
       </layout>
      </item>
      <item row="8" column="0" colspan="2">
-      <layout class="QHBoxLayout" name="verticalLayout_22">
+      <layout class="QHBoxLayout" name="verticalLayout_221">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -424,7 +424,7 @@
         </item>
         <item>
          <widget class="QWidget" name="upToShapeFaces2" native="true">
-          <layout class="QVBoxLayout" name="verticalLayout_22">
+          <layout class="QVBoxLayout" name="verticalLayout_222">
            <property name="leftMargin">
             <number>0</number>
            </property>


### PR DESCRIPTION
This PR fixes the conflicting names with some widgets.

The issue is somehow solved during the compilation time (see it below), but it is better to update the widgets to avoid any future problems.

```bash
[ 96%] Building CXX object src/Mod/Assembly/Gui/CMakeFiles/AssemblyGui.dir/TaskAssemblyMessages.cpp.o
AutoUic: /home/lheck/FreeCAD/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui: Warning: The name 'verticalLayout_22' (QHBoxLayout) is already in use, defaulting to 'verticalLayout_221'.
/home/lheck/FreeCAD/src/Mod/PartDesign/Gui/TaskPadPocketParameters.ui: Warning: The name 'verticalLayout_22' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_222'.
```