### PR TITLE
Datums: Prevent 'doesn't contain feature with role' error on load

### DIFF
--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -179,10 +179,15 @@ App::DatumElement* LocalCoordinateSystem::getDatumElement(const char* role) cons
     if (featIt != features.end()) {
         return static_cast<App::DatumElement*>(*featIt);
     }
-    std::stringstream err;
-    err << "LocalCoordinateSystem \"" << getFullName() << "\" doesn't contain feature with role \""
-        << role << '"';
-    throw Base::RuntimeError(err.str().c_str());
+    // During restore, if role lookup fails (e.g. timing issues or fallback to internal name),
+    // we suppress the error. The default getSubObject will try to resolve it by Internal Name next.
+    if (!getDocument()->testStatus(App::Document::Restoring)) {
+        std::stringstream err;
+        err << "LocalCoordinateSystem \"" << getFullName()
+            << "\" doesn't contain feature with role \"" << role << '"';
+        throw Base::RuntimeError(err.str().c_str());
+    }
+    return nullptr;
 }
 
 App::Line* LocalCoordinateSystem::getAxis(const char* role) const


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/20465#issuecomment-3568434336
Fix https://github.com/FreeCAD/FreeCAD/issues/18440

So as a summary : 
A - SketchWorkflow (new sketch tool) creates manually an attachment like `Origin [XY_Plane]`. This is actually not correct. Because subnames should end with a trailing white space if there is no element.
B - If you use attacher task, the link will correctly be `Origin [XY_Plane.]` ie including the trailing dot.

Now the bug described in 20465 is that a warning prints during load, but ONLY in case B (which is supposed to be the correct case).

Why this warning? Because `extensionGetSubObject `is overriden in LCS class. And in this override we are doing `getDatumElement`. But it fails because the document is not restored yet. After failing the standard `getSubObject` triggers and works correctly (document loads OK).

Why no warning in case A? Not sure, perhaps the missing dot abort the getSubObject call. Or perhaps resolve the object without having to call `extensionGetSubObject`.

It seems to me that this `extensionGetSubObject` override is not necessary. Removing it entirely does not seem to have any problem. But this is for @wwmayer to confirm if he comes around.

In this PR I suggest just silencing the warning if it happens during load.