### PR TITLE
Core: Fine grained recomputes

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -825,6 +825,15 @@ bool Application::isAsyncRecomputeEnabled()
     return enableAsyncRecompute;
 }
 
+bool Application::isFineGrainedRecomputeEnabled()
+{
+    static const ParameterGrp::handle hGrp = GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/General"
+    );
+    bool enableAsyncRecompute = hGrp->GetBool("FineGrainedRecompute");
+    return enableAsyncRecompute;
+}
+
 bool Application::canRecomputeRequestOnWorker(const RecomputeRequest& req) const
 {
     if (DocumentObject* documentObject = req.resolveDocumentObject()) {

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -830,8 +830,8 @@ bool Application::isFineGrainedRecomputeEnabled()
     static const ParameterGrp::handle hGrp = GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/General"
     );
-    bool enableAsyncRecompute = hGrp->GetBool("FineGrainedRecompute");
-    return enableAsyncRecompute;
+    bool enableFineGrainedRecompute = hGrp->GetBool("FineGrainedRecompute");
+    return enableFineGrainedRecompute;
 }
 
 bool Application::canRecomputeRequestOnWorker(const RecomputeRequest& req) const

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -393,6 +393,7 @@ public:
 
     // Returns if document and object recomputes should be done async.
     bool isAsyncRecomputeEnabled();
+    bool isFineGrainedRecomputeEnabled();
     bool canRecomputeRequestOnWorker(const RecomputeRequest& req) const;
 
     // Adds a recompute request to the processing queue.
@@ -893,6 +894,7 @@ public:
     /// Check if there is any link to the given object
     bool hasLinksTo(const DocumentObject *obj) const;
     /// @}
+
 
     friend class App::Document;
 

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -93,6 +93,7 @@ list(APPEND FreeCADApp_LIBS
 )
 
 generate_from_py(ApplicationDirectories)
+generate_from_py(DepEdge)
 generate_from_py(Document)
 generate_from_py(DocumentObject)
 generate_from_py(Extension)
@@ -126,6 +127,7 @@ SET(FreeCADApp_Pyi_SRCS
     GroupExtension.pyi
     LinkBaseExtension.pyi
     Metadata.pyi
+    DepEdge.pyi
     DocumentObjectGroup.pyi
     DocumentObject.pyi
     GeoFeature.pyi
@@ -150,6 +152,7 @@ SET(Document_CPP_SRCS
     Document.cpp
     RecoverySnapshot.cpp
     DocumentObject.cpp
+    DepEdgePyImp.cpp
     Extension.cpp
     ExtensionPyImp.cpp
     DocumentObjectExtension.cpp
@@ -205,6 +208,7 @@ SET(Document_HPP_SRCS
     BackupPolicy.h
     Document.h
     RecoverySnapshot.h
+    DepEdge.h
     DocumentObject.h
     Extension.h
     ExtensionContainer.h

--- a/src/App/DepEdge.h
+++ b/src/App/DepEdge.h
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                 *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <FCGlobal.h>
+#include <string>
+
+namespace App
+{
+
+class DocumentObject;
+
+/**
+ * @brief Represents a dependency edge between two objects/properties.
+ *
+ * This class is used for fine-grained recompute and represents a dependency
+ * edge from a property in one document object to another property in a
+ * document object.  The dependency may also be on the object as a whole.  In
+ * that case, @p fromProp or @p toProp are an empty string that represents
+ * @c fromObj.HEAD or @c toObj.HEAD respectively.
+ */
+class AppExport DepEdge
+{
+public:
+    /**
+     * @brief Constructs a dependency edge.
+     *
+     * @param fromObj The source DocumentObject.
+     * @param fromProp Name of the source property.  If empty, indicates the
+     * dependency is on the object as a whole.
+     * @param toObj The target DocumentObject.
+     * @param toProp Name of the target property.  If empty, indicates the
+     * dependency is on the object as a whole.
+     */
+    DepEdge(DocumentObject* fromObj,
+            std::string fromProp,
+            DocumentObject* toObj,
+            std::string toProp)
+        : fromObj(fromObj)
+        , fromProp(std::move(fromProp))
+        , toObj(toObj)
+        , toProp(std::move(toProp))
+    {}
+
+    DepEdge(const DepEdge&) = default;
+    DepEdge(DepEdge&&) noexcept = default;
+    DepEdge& operator=(const DepEdge&) = default;
+    DepEdge& operator=(DepEdge&&) noexcept = default;
+    ~DepEdge() = default;
+
+    /**
+     * @brief Less-than operator for comparing two DepEdge objects.
+     *
+     * This operator allows for ordering DepEdge objects based on their
+     * fromObj, fromProp, toObj, and toProp members.  The ordering is based on
+     * what the ordering would be if DepEdge were a tuple.
+     *
+     * @param other The other DepEdge object to compare against.
+     *
+     * @return true if this DepEdge is less than the other, false otherwise.
+     */
+    bool operator<(const DepEdge& other) const noexcept
+    {
+        return std::tie(fromObj, fromProp, toObj, toProp) <
+               std::tie(other.fromObj, other.fromProp, other.toObj, other.toProp);
+    }
+
+    /// Check if two DepEdge objects are equal.
+    bool operator==(const DepEdge& other) const noexcept
+    {
+        return fromObj == other.fromObj
+            && fromProp == other.fromProp
+            && toObj   == other.toObj
+            && toProp  == other.toProp;
+    }
+
+    /// The source DocumentObject.
+    DocumentObject* fromObj;
+    /// Name of the source property.
+    std::string fromProp;
+    /// The target DocumentObject.
+    DocumentObject* toObj;
+    /// Name of the target property.
+    std::string toProp;
+};
+
+// Tuple-like accessors for DepEdge
+template <std::size_t I>
+decltype(auto) get(DepEdge& e) {
+    if constexpr (I == 0) {return (e.fromObj);}
+    else if constexpr (I == 1) {return (e.fromProp);}
+    else if constexpr (I == 2) {return (e.toObj);}
+    else /* I == 3 */ {return (e.toProp);}
+}
+
+template <std::size_t I>
+decltype(auto) get(DepEdge const& e) {
+    if constexpr (I == 0) {return (e.fromObj);}
+    else if constexpr (I == 1) {return (e.fromProp);}
+    else if constexpr (I == 2) {return (e.toObj);}
+    else /* I == 3 */ {return (e.toProp);}
+}
+
+template <std::size_t I>
+decltype(auto) get(DepEdge&& e) {
+    if constexpr (I == 0) {return std::move(e.fromObj);}
+    else if constexpr (I == 1) {return std::move(e.fromProp);}
+    else if constexpr (I == 2) {return std::move(e.toObj);}
+    else /* I == 3 */ {return std::move(e.toProp);}
+}
+
+}  // namespace App
+
+namespace std
+{
+// Specializations of tuple_size and tuple_element for App::DepEdge for tuple-like access.
+template<> struct tuple_size<App::DepEdge> : integral_constant<std::size_t, 4> {};
+
+template<> struct tuple_element<0, App::DepEdge> { using type = App::DocumentObject*; };
+template<> struct tuple_element<1, App::DepEdge> { using type = std::string; };
+template<> struct tuple_element<2, App::DepEdge> { using type = App::DocumentObject*; };
+template<> struct tuple_element<3, App::DepEdge> { using type = std::string; };
+}

--- a/src/App/DepEdge.pyi
+++ b/src/App/DepEdge.pyi
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from PyObjectBase import PyObjectBase
+
+from Base.Metadata import export
+from DocumentObject import DocumentObject
+from typing import Final
+
+@export(
+    Father="PyObjectBase",
+    FatherInclude="Base/PyObjectBase.h",
+    FatherNamespace="Base",
+    Delete=True,
+)
+class DepEdge(PyObjectBase):
+    FromObj: Final[DocumentObject] = None
+    FromProp: Final[str] = ""
+    ToObj: Final[DocumentObject] = None
+    ToProp: Final[str] = ""

--- a/src/App/DepEdgePyImp.cpp
+++ b/src/App/DepEdgePyImp.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                 *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <App/DepEdge.h>
+#include <App/DocumentObject.h>
+
+#include <App/DepEdgePy.h>
+#include <App/DepEdgePy.cpp>
+
+using namespace App;
+
+std::string DepEdgePy::representation() const
+{
+    std::stringstream str;
+    auto& [fromObj, fromProp, toObj, toProp] = *getDepEdgePtr();
+
+    str << fromObj->getFullName() << "." << (fromProp.empty() ? "HEAD" : fromProp)
+        << " --> "
+        << toObj->getFullName() << "." << (toProp.empty() ? "HEAD" : toProp);
+    return {str.str()};
+}
+
+Py::Object DepEdgePy::getFromObj() const
+{
+    return Py::Object(getDepEdgePtr()->fromObj->getPyObject(), true);
+}
+
+Py::String DepEdgePy::getFromProp() const
+{
+    return Py::String(getDepEdgePtr()->fromProp);
+}
+
+Py::Object DepEdgePy::getToObj() const
+{
+    return Py::Object(getDepEdgePtr()->toObj->getPyObject(), true);
+}
+
+Py::String DepEdgePy::getToProp() const
+{
+    return Py::String(getDepEdgePtr()->toProp);
+}
+
+PyObject* DepEdgePy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int DepEdgePy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2586,6 +2586,31 @@ static void buildDependencyList(const std::vector<DocumentObject*>& objectArray,
         depList->clear();
     }
 
+    auto getOutListFineGrained = [](DocumentObject* obj, int op) {
+        // Convert an OutListProp to a regular outlist with only DocumentObject*
+        std::vector<DocumentObject*> outList;
+        std::unordered_set<DocumentObject*> outListSet; // For O(1) avg lookup
+
+        std::vector<DepEdge> outListProp = obj->getOutListProp(op);
+        for (const auto& [objFrom, propFrom, objTo, propNameTo] : outListProp) {
+            // Add dependencies on HEAD
+            if (propNameTo.empty()) {
+                if (outListSet.insert(objTo).second) {
+                    outList.push_back(objTo);
+                }
+                continue;
+            }
+            // Add additional dependencies on specific properties unless it is
+            // an input property.  This to avoid over dependencies.
+            if (!outListSet.contains(objTo) && !objTo->isInputProperty(propNameTo)) {
+                outListSet.insert(objTo);
+                outList.push_back(objTo);
+            }
+        }
+
+        return outList;
+    };
+
     const int op = ((options & Document::DepNoXLinked) != 0) ? DocumentObject::OutListNoXLinked : 0;
     for (auto obj : objectArray) {
         objs.push_back(obj);
@@ -2616,7 +2641,12 @@ static void buildDependencyList(const std::vector<DocumentObject*>& objectArray,
             }
 
             auto& outList = outLists[objF];
-            outList = objF->getOutList(op);
+            if (GetApplication().isFineGrainedRecomputeEnabled()) {
+                outList = getOutListFineGrained(objF, op);
+            }
+            else {
+                outList = objF->getOutList(op);
+            }
             objs.insert(objs.end(), outList.begin(), outList.end());
         }
     }
@@ -2868,6 +2898,8 @@ int Document::recompute(const std::vector<DocumentObject*>& objs,
 
     signalBeforeRecompute(*this);
 
+    bool fineGrained = GetApplication().isFineGrainedRecomputeEnabled();
+
     //////////////////////////////////////////////////////////////////////////
     // FIXME Comment by Realthunder:
     // the topologicalSrot() below cannot handle partial recompute, haven't got
@@ -2940,10 +2972,22 @@ int Document::recompute(const std::vector<DocumentObject*>& objs,
                 }
                 if (obj->isTouched() || doRecompute) {
                     signalRecomputedObject(*obj);
-                    obj->purgeTouched();
-                    // set all dependent object touched to force recompute
-                    for (auto inObjIt : obj->getInList()) {
-                        inObjIt->enforceRecompute();
+                    if (fineGrained) {
+                        // set all dependent objects touched based on properties
+                        std::vector<DepEdge> inList = obj->getInListProp();
+                        for (auto& [objFrom, propFrom, objTo, propTo] : inList) {
+                            if (obj->touchedProps.contains(propTo) || propTo.empty()) {
+                                objFrom->enforceRecompute(propFrom);
+                            }
+                        }
+                        obj->purgeTouched();
+                    }
+                    else {
+                        obj->purgeTouched();
+                        // set all dependent objects touched to force recompute
+                        for (auto inObjIt : obj->getInList()) {
+                            inObjIt->enforceRecompute();
+                        }
                     }
                 }
                 if (seq) {

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -398,6 +398,19 @@ public:
     void exportGraphviz(std::ostream& out) const;
 
     /**
+     * @brief Write the dependency graph of this document on the property
+     * level.
+     *
+     * The Graphviz output represents dependencies between properties
+     * (fine-grained recompute) instead of document objects.
+     *
+     * The output is in the DOT format of Graphviz.
+     *
+     * @param[in, out] out: The output stream to write to.
+     */
+    void exportGraphvizProp(std::ostream& out) const;
+
+    /**
      * @brief Import objects from a stream.
      *
      * @param[in, out] reader: The XML reader to read from.

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -392,6 +392,72 @@ const char* DocumentObject::detachFromDocument()
     return name ? name->c_str() : nullptr;
 }
 
+// Fully mimics getOutList()
+const std::vector<DepEdge>& DocumentObject::getOutListProp()
+{
+    if (!_outListCachedProp) {
+        _outListProp.clear();
+        getOutListProp(0, _outListProp);
+        _outListCachedProp = true;
+    }
+    return _outListProp;
+}
+
+// Fully mimics getOutList(int options)
+std::vector<DepEdge>
+DocumentObject::getOutListProp(int options)
+{
+    std::vector<DepEdge> res;
+    getOutListProp(options, res);
+    return res;
+}
+
+// Mimics getOutList(int options, std::vector<DocumentObject*>& res) except for
+// an extra filter for ExpressionEngine that is handled in a later case.
+void DocumentObject::getOutListProp(int options, std::vector<DepEdge>& res)
+{
+    if (_outListCachedProp && !options) {
+        res.insert(res.end(), _outListProp.begin(), _outListProp.end());
+        return;
+    }
+    std::vector<Property*> props;
+    getPropertyList(props);
+    bool noHidden = !!(options & OutListNoHidden);
+    std::size_t size = res.size();
+    for (auto prop : props) {
+        std::vector<DocumentObject*> objs;
+        auto* linkProp = freecad_cast<PropertyLinkBase*>(prop);
+        // Filter for ExpressionEngine, because it is handled in the next if
+        // outside of this for loop.
+        if (linkProp && linkProp != &ExpressionEngine) {
+            linkProp->getLinks(objs, noHidden);
+        }
+        for (auto* obj : objs) {
+            res.emplace_back(this, prop->getName(), obj, "");
+        }
+    }
+
+    if (!(options & OutListNoExpression)) {
+        std::vector<std::pair<std::string, DocumentObject*>> linksProp;
+        ExpressionEngine.getLinksProp(linksProp);
+        for (auto& [propObj, obj] : linksProp) {
+            res.emplace_back(this, "ExpressionEngine", obj, propObj);
+        }
+    }
+
+    if (options & OutListNoXLinked) {
+        for (auto it = res.begin() + size; it != res.end();) {
+            auto& [objFrom, propFrom, objTo, propTo] = *it;
+            if (objTo && objTo->getDocument() != getDocument()) {
+                it = res.erase(it);
+            }
+            else {
+                ++it;
+            }
+        }
+    }
+}
+
 const std::vector<DocumentObject*>& DocumentObject::getOutList() const
 {
     if (!_outListCached) {
@@ -461,6 +527,12 @@ const std::vector<App::DocumentObject*>& DocumentObject::getInList() const
     return _inList;
 }
 
+// Fully mimics getInList()
+const std::vector<DepEdge>& DocumentObject::getInListProp() const
+{
+    return _inListProp;
+}
+
 // The original algorithm is highly inefficient in some special case.
 // Considering an object is linked by every other objects. After excluding this
 // object, there is another object linked by every other of the remaining
@@ -509,12 +581,48 @@ void DocumentObject::getInListEx(std::set<App::DocumentObject*>& inSet,
     }
 }
 
+// Fully mimics getInListExProp(std::set<App::DocumentObject*>& inSet, bool
+// recursive, std::vector<App::DocumentObject*>*) except for the extra vector
+// parameter that is not needed here.
+void DocumentObject::getInListExProp(
+    std::set<DepEdge>& inSet,
+    bool recursive) const
+{
+    if (!recursive) {
+        inSet.insert(_inListProp.begin(), _inListProp.end());
+        return;
+    }
+
+    std::stack<DocumentObject*> pendings;
+    pendings.push(const_cast<DocumentObject*>(this));
+    while (!pendings.empty()) {
+        auto obj = pendings.top();
+        pendings.pop();
+        for (const auto& edge : obj->getInListProp()) {
+            if (edge.fromObj && edge.fromObj->isAttachedToDocument()
+                && inSet.insert(edge).second) {
+                pendings.push(edge.fromObj);
+            }
+        }
+    }
+}
+
 std::set<App::DocumentObject*> DocumentObject::getInListEx(bool recursive) const
 {
     std::set<App::DocumentObject*> ret;
     getInListEx(ret, recursive);
     return ret;
 }
+
+// Fully mimics getInListEx(bool recursive)
+std::set<DepEdge>
+DocumentObject::getInListExProp(bool recursive) const
+{
+    std::set<DepEdge> ret;
+    getInListExProp(ret, recursive);
+    return ret;
+}
+
 
 void _getOutListRecursive(std::set<DocumentObject*>& objSet,
                           const DocumentObject* obj,
@@ -953,6 +1061,9 @@ void DocumentObject::clearOutListCache() const
     _outList.clear();
     _outListMap.clear();
     _outListCached = false;
+
+    _outListProp.clear();
+    _outListCachedProp = false;
 }
 
 PyObject* DocumentObject::getPyObject()
@@ -1310,6 +1421,22 @@ void App::DocumentObject::_addBackLink(DocumentObject* newObj)
     // only once this removal would clear the object from the inlist, even though there may be other
     // link properties from this object that link to us.
     _inList.push_back(newObj);
+}
+
+// Fully mimics _removeBackLink()
+void App::DocumentObject::_removeBackLinkProp(const char* objProp, DocumentObject* obj, const char* myProp)
+{
+    DepEdge key(obj, objProp, this, myProp ? myProp : "");
+    auto it = std::ranges::find(_inListProp, key);
+    if (it != _inListProp.end()) {
+        _inListProp.erase(it);
+    }
+}
+
+// Fully mimics _addBackLink()
+void App::DocumentObject::_addBackLinkProp(const char* objProp, DocumentObject* obj, const char* myProp)
+{
+    _inListProp.emplace_back(obj, objProp, this, myProp ? myProp : "");
 }
 
 int DocumentObject::setElementVisible(const char* element, bool visible)

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -657,6 +657,34 @@ bool DocumentObject::testIfLinkDAGCompatible(PropertyLinkSub& linkTo) const
     return this->testIfLinkDAGCompatible(linkTo_in_vector);
 }
 
+bool DocumentObject::isInputProperty(const std::string& propName) const
+{
+    Property* prop = getPropertyByName(propName.c_str());
+    if (!prop) {
+        return false;
+    }
+    return isInputProperty(prop);
+}
+
+bool DocumentObject::isInputProperty(const Property* prop) const
+{
+    return (prop->getType() & Prop_Input) || prop->testStatus(Property::Input);
+}
+
+bool DocumentObject::isOutputProperty(const std::string& propName) const
+{
+    Property* prop = getPropertyByName(propName.c_str());
+    if (!prop) {
+        return false;
+    }
+    return isOutputProperty(prop);
+}
+
+bool DocumentObject::isOutputProperty(const Property* prop) const
+{
+    return (prop->getType() & Prop_Output) || prop->testStatus(Property::Output);
+}
+
 void DocumentObject::onLostLinkToObject(DocumentObject*)
 {}
 

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -204,6 +204,15 @@ bool DocumentObject::recomputeFeature(bool recursive)
     return isValid();
 }
 
+void DocumentObject::setTouched(const char* name)
+{
+    // This function is not a replacement for touch(), it is only
+    // used internally for fine-grained document recompute and replaces
+    // the coarse grained equivalent of StatusBits.set(ObjectStatus::Touch);
+    touchedProps.insert(name);
+    StatusBits.set(ObjectStatus::Touch);
+}
+
 void DocumentObject::touch(bool noRecompute)
 {
     if (!noRecompute) {
@@ -257,6 +266,12 @@ void DocumentObject::unfreeze(bool noRecompute)
 bool DocumentObject::isTouched() const
 {
     return ExpressionEngine.isTouched() || StatusBits.test(ObjectStatus::Touch);
+}
+
+void DocumentObject::enforceRecompute(const std::string& propName)
+{
+    touch(false);
+    touchedProps.insert(propName);
 }
 
 void DocumentObject::enforceRecompute()
@@ -1032,16 +1047,40 @@ void DocumentObject::onChanged(const Property* prop)
         _pDoc->signalRelabelObject(*this);
     }
 
-    // set object touched if it is an input property
-    if (!testStatus(ObjectStatus::NoTouch) && !(prop->getType() & Prop_Output)
-        && !prop->testStatus(Property::Output)) {
-        if (!StatusBits.test(ObjectStatus::Touch)) {
-            FC_TRACE("touch '" << getFullName() << "' on change of '" << prop->getName() << "'");
-            StatusBits.set(ObjectStatus::Touch);
+    bool fineGrained = GetApplication().isFineGrainedRecomputeEnabled();
+
+    auto outputHasDeps = [this](const Property* prop) {
+        return std::ranges::any_of(getInListProp(), [this, prop](const DepEdge& edge) {
+            return edge.toObj == this && edge.toProp == prop->getName();
+        });
+    };
+
+    if (fineGrained) {
+        // set object touched if it is not an output property unless it has dependencies
+        if (!testStatus(ObjectStatus::NoTouch)
+            && ((isOutputProperty(prop) && outputHasDeps(prop)) ||
+                !isOutputProperty(prop))) {
+            FC_TRACE("touch '" << getFullName() << "' on change of '" << prop->getName()
+                     << "'");
+            setTouched(prop->getName());
+            // must execute on document recompute
+            if (!(prop->getType() & Prop_NoRecompute)) {
+                StatusBits.set(ObjectStatus::Enforce);
+            }
         }
-        // must execute on document recompute
-        if (!(prop->getType() & Prop_NoRecompute)) {
-            StatusBits.set(ObjectStatus::Enforce);
+    }
+    else {
+        // set object touched if it is not an output property
+        if (!testStatus(ObjectStatus::NoTouch) && !(prop->getType() & Prop_Output)
+            && !prop->testStatus(Property::Output)) {
+            if (!StatusBits.test(ObjectStatus::Touch)) {
+                FC_TRACE("touch '" << getFullName() << "' on change of '" << prop->getName() << "'");
+                StatusBits.set(ObjectStatus::Touch);
+            }
+            // must execute on document recompute
+            if (!(prop->getType() & Prop_NoRecompute)) {
+                StatusBits.set(ObjectStatus::Enforce);
+            }
         }
     }
 

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <App/DepEdge.h>
 #include <App/TransactionalObject.h>
 #include <App/PropertyExpressionEngine.h>
 #include <App/PropertyGeo.h>
@@ -479,6 +480,43 @@ public:
         OutListNoXLinked = 4, ///< Do not include links from PropertyXLink properties.
     };
 
+    /**
+     * @brief Get a list of dependency edges this object links to.
+     *
+     * The dependency edge registers both the object and the property (if
+     * applicable) this object links to.
+     *
+     * @return the vector of dependency edges.
+     */
+    const std::vector<DepEdge>& getOutListProp();
+
+    /**
+     * @brief Get a list of dependency edges this object links to.
+     *
+     * The dependency edge registers both the object and the property (if
+     * applicable) this object links to.
+     *
+     * @param[in] option Options for computing the OutList.
+     *
+     * @return the vector of dependency edges.
+     *
+     * @see OutListOption for available options.
+     */
+    std::vector<DepEdge> getOutListProp(int options);
+
+    /**
+     * @brief Get a list of dependency edges this object links to.
+     *
+     * The dependency edge registers both the object and the property (if
+     * applicable) this object links to.
+     *
+     * @param[in] option Options for computing the OutList.
+     * @param[in,out] res The vector to fill with the objects this object depends on.
+     *
+     * @see OutListOption for available options.
+     */
+    void getOutListProp(int options, std::vector<DepEdge>& res);
+
     /// Get a list of objects this object links to.
     const std::vector<App::DocumentObject*>& getOutList() const;
 
@@ -549,6 +587,15 @@ public:
     const std::vector<App::DocumentObject*>& getInList() const;
 
     /**
+     * @brief Get a list of dependency edges that link to this object.
+     *
+     * Dependency edges register both the object and the property (if applicable).
+     *
+     * @returns The list of dependency edges.
+     */
+    const std::vector<DepEdge>& getInListProp() const;
+
+    /**
      * @brief Get a list of objects that link to this object, recursively.
      *
      * This function returns all objects that link to this object directly and
@@ -583,6 +630,31 @@ public:
      * @return A set containing all objects linking to this object.
      */
     std::set<App::DocumentObject*> getInListEx(bool recursive) const;
+
+    /** @brief Get a set of all dependency edges linking to this object.
+     *
+     * This function returns a set of all dependency edges that link to this
+     * object, including possible external parent objects.  Dependency edges
+     * record both the object and the property.
+     *
+     * @param[in,out] inSet A set containing all dependency edges linking to
+     * this object.
+     * @param[in] recursive Whether to obtain the InList recursively.
+     */
+    void getInListExProp(std::set<DepEdge>& inSet, bool recursive) const;
+
+    /**
+     * @brief Get a set of all dependency edges linking to this object.
+     *
+     * This function returns a set of all dependency edges that link to this
+     * object, including possible external parent objects.  Dependency edges
+     * record both the object and the property.
+     *
+     * @param[in] recursive Whether to obtain the InList recursively.
+     *
+     * @return A set containing all dependency edges linking to this object.
+     */
+    std::set<DepEdge> getInListExProp(bool recursive) const;
 
     /**
      * @brief Get the group this object belongs to.
@@ -663,6 +735,11 @@ public:
      * @param[in] obj The object to remove from the InList.
      */
     void _addBackLink(DocumentObject*);
+
+    /// internal, used by PropertyLink to maintain DAG back links
+    void _removeBackLinkProp(const char* objProp, DocumentObject* obj, const char* myProp = nullptr);
+    /// internal, used by PropertyLink to maintain DAG back links
+    void _addBackLinkProp(const char* objProp, DocumentObject* obj, const char* myProp = nullptr);
 
     /**
      * @brief Test an about to created link for circular references.
@@ -1407,10 +1484,13 @@ private:
     // Back pointer to all the fathers in a DAG of the document
     // this is used by the document (via friend) to have a effective DAG handling
     std::vector<App::DocumentObject*> _inList;
+    std::vector<DepEdge> _inListProp;
     mutable std::vector<App::DocumentObject*> _outList;
+    mutable std::vector<DepEdge> _outListProp;
     mutable std::unordered_map<const char*, App::DocumentObject*, CStringHasher, CStringHasher>
         _outListMap;
     mutable bool _outListCached = false;
+    mutable bool _outListCachedProp = false;
 };
 
 }  // namespace App

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -41,6 +41,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace Base
@@ -324,6 +325,18 @@ public:
     void enforceRecompute();
 
     /**
+     * @brief Enforce this document object to be recomputed.
+     *
+     * The given property is a property that is marked as a dependency by a
+     * property from a different document object that is touched.  As such, the
+     * given property needs to be touched as well.
+     *
+     * @param[in] propName The name of the property that needs to be marked as
+     * touched.
+     */
+    void enforceRecompute(const std::string& propName);
+
+    /**
      * @brief Check whether the document object must be recomputed.
      *
      * This means that the 'Enforce' flag is set or that \ref mustExecute()
@@ -339,6 +352,7 @@ public:
         StatusBits.reset(ObjectStatus::Touch);
         StatusBits.reset(ObjectStatus::Enforce);
         setPropertyStatus(0, false);
+        touchedProps.clear();
     }
 
     /// Check whether this document object is in an error state.
@@ -1458,6 +1472,7 @@ protected:
 
 private:
     void printInvalidLinks() const;
+    void setTouched(const char* propName);
 
 protected:  // attributes
 
@@ -1479,6 +1494,9 @@ private:
 
     // unique identifier (among a document) of this object.
     long _Id {0};
+
+private:
+    std::unordered_set<std::string> touchedProps;
 
 private:
     // Back pointer to all the fathers in a DAG of the document

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -692,6 +692,18 @@ public:
 
     /// @copydoc testIfLinkDAGCompatible(DocumentObject*) const
     bool testIfLinkDAGCompatible(App::PropertyLinkSub& linkTo) const;
+
+    /// Check if the property is an input property
+    bool isInputProperty(const std::string& propName) const;
+
+    /// Check if the property is an input property
+    bool isInputProperty(const Property* prop) const;
+
+    /// Check if the property is an output property
+    bool isOutputProperty(const std::string& propName) const;
+
+    /// Check if the property is an output property
+    bool isOutputProperty(const Property* prop) const;
     ///@}
 
     /**

--- a/src/App/DocumentObject.pyi
+++ b/src/App/DocumentObject.pyi
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from Base.Metadata import constmethod
 from Base.Matrix import Matrix
+from DepEdge import DepEdge
 from Document import Document
 from DocumentObjectGroup import DocumentObjectGroup
 from ExtensionContainer import ExtensionContainer
@@ -21,6 +22,9 @@ class DocumentObject(ExtensionContainer):
         Label: str = ...
         Label2: str = ...
 
+    OutListProp: Final[List[DepEdge]] = []
+    """A list of all objects which link to this object with properties."""
+
     OutList: Final[List["DocumentObject"]] = []
     """A list of all objects this object links to."""
 
@@ -29,6 +33,9 @@ class DocumentObject(ExtensionContainer):
 
     InList: Final[List["DocumentObject"]] = []
     """A list of all objects which link to this object."""
+
+    InListProp: Final[List[DepEdge]] = []
+    """A list of all objects which link to this object with properties."""
 
     InListRecursive: Final[List["DocumentObject"]] = []
     """A list of all objects which link to this object recursively."""

--- a/src/App/DocumentObjectPyImp.cpp
+++ b/src/App/DocumentObjectPyImp.cpp
@@ -30,6 +30,8 @@
 #include <Base/PyWrapParseTupleAndKeywords.h>
 #include <Base/ServiceProvider.h>
 
+#include "DepEdge.h"
+#include "DepEdgePy.h"
 #include "DocumentObject.h"
 #include "Document.h"
 #include "ExpressionParser.h"
@@ -345,6 +347,21 @@ Py::List DocumentObjectPy::getInListRecursive() const
     return ret;
 }
 
+Py::List DocumentObjectPy::getInListProp() const
+{
+    Py::List ret;
+    std::vector<DepEdge> list = getDocumentObjectPtr()->getInListProp();
+
+    for (const auto& edge : list) {
+        // copy will be deleted by DepEdgePy
+        auto* copy = new DepEdge(edge);
+        auto* depEdgePy = new DepEdgePy(copy);
+        ret.append(Py::Object(depEdgePy, true));
+    }
+
+    return ret;
+}
+
 Py::List DocumentObjectPy::getOutList() const
 {
     Py::List ret;
@@ -370,6 +387,21 @@ Py::List DocumentObjectPy::getOutListRecursive() const
     }
     catch (const Base::Exception& e) {
         throw Py::IndexError(e.what());
+    }
+
+    return ret;
+}
+
+Py::List DocumentObjectPy::getOutListProp() const
+{
+    Py::List ret;
+    std::vector<DepEdge> list = getDocumentObjectPtr()->getOutListProp();
+
+    for (const auto& edge : list) {
+        // copy will be deleted by DepEdgePy
+        auto* copy = new DepEdge(edge);
+        auto* depEdgePy = new DepEdgePy(copy);
+        ret.append(Py::Object(depEdgePy, true));
     }
 
     return ret;

--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -909,14 +909,15 @@ ExpressionDeps Expression::getDeps(int option)  const {
     return deps;
 }
 
-void Expression::getDepObjects(
-        std::map<App::DocumentObject*,bool> &deps, std::vector<std::string> *labels) const
+void Expression::getDepObjects(std::map<App::DocumentObject*, bool>& deps,
+                               std::vector<std::string>* labels,
+                               std::map<std::pair<std::string, App::DocumentObject*>, bool>* propDeps) const
 {
     for(auto &v : getIdentifiers()) {
         bool hidden = v.second;
         const ObjectIdentifier &var = v.first;
         std::vector<std::string> strings;
-        for(auto &dep : var.getDep(false, &strings)) {
+        for(auto &dep : var.getDep(propDeps != nullptr, &strings)) {
             DocumentObject *obj = dep.first;
             if (!obj->testStatus(ObjectStatus::Remove)) {
                 if (labels) {
@@ -926,6 +927,11 @@ void Expression::getDepObjects(
                 auto res = deps.insert(std::make_pair(obj, hidden));
                 if (!hidden || res.second)
                     res.first->second = hidden;
+                if (propDeps) {
+                    for (auto &propName : dep.second) {
+                        (*propDeps)[std::make_pair(propName, obj)] = hidden;
+                    }
+                }
             }
 
             strings.clear();

--- a/src/App/Expression.h
+++ b/src/App/Expression.h
@@ -433,8 +433,14 @@ public:
      * @param[in,out] deps The map to fill with dependent document objects to a
      * boolean indicating whether they are hidden (`href` references).
      * @param[in,out] labels Optional vector to fill with labels of dependent objects.
+     * @param[in,out] propDeps Optional mapping with property names. The boolean
+     * indicates whether this is a hidden reference.
      */
-    void getDepObjects(std::map<App::DocumentObject*,bool>& deps, std::vector<std::string> *labels=nullptr) const;
+    void getDepObjects(
+        std::map<App::DocumentObject*, bool>& deps,
+        std::vector<std::string>* labels = nullptr,
+        std::map<std::pair<std::string, DocumentObject*>, bool>* propDeps = nullptr
+    ) const;
 
     /**
      * @brief Import sub-names in the expression after importing external objects.

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -677,6 +677,7 @@ class PropertyType(IntEnum):
     Prop_Output = 8
     Prop_NoRecompute = 16
     Prop_NoPersist = 32
+    Prop_Input = 64
 
 App.PropertyType = PropertyType
 

--- a/src/App/Graphviz.cpp
+++ b/src/App/Graphviz.cpp
@@ -23,8 +23,10 @@
  ***************************************************************************/
 
 
+#include <algorithm>
 #include <boost/graph/graphviz.hpp>
 #include <random>
+#include <App/Application.h>
 
 #include "Application.h"
 #include "Document.h"
@@ -73,8 +75,128 @@ void Document::writeDependencyGraphViz(std::ostream& out)
     out << "}" << std::endl;
 }
 
+enum class PropType
+{
+    PROP_REGULAR,
+    PROP_INPUT,
+    PROP_OUTPUT
+};
+
+static PropType getPropType(DocumentObject* obj, const std::string& propName)
+{
+    if (obj->isInputProperty(propName)) {
+        return PropType::PROP_INPUT;
+    }
+    else if (obj->isOutputProperty(propName)) {
+        return PropType::PROP_OUTPUT;
+    }
+    return PropType::PROP_REGULAR;
+}
+
+static void exportProp(const char* objName, const char* propName, PropType propType, std::ostream& out)
+{
+    const char* color = propType == PropType::PROP_INPUT ? ", color=blue, fontcolor=blue" : "";
+    out << "    " << objName << "_" << propName <<
+        " [label=\"" << propName << "\"" << color << "];\n";
+}
+
+static std::map<std::string, PropType> getSubGraphNodes(DocumentObject* obj)
+{
+    std::map<std::string, PropType> nodes;
+    nodes["HEAD"] = PropType::PROP_REGULAR;
+
+    for (const auto& [objFrom, propFrom, objTo, propTo] : obj->getOutListProp()) {
+        if (!nodes.contains(propFrom)) {
+            nodes[propFrom] = getPropType(objFrom, propFrom);
+        }
+    }
+
+    for (const auto& [objFrom, propFrom, objTo, propTo] : obj->getInListProp()) {
+        if (!propTo.empty() && !nodes.contains(propTo)) {
+            nodes[propTo] = getPropType(objTo, propTo);
+        }
+    }
+
+    return nodes;
+}
+
+static void exportSubGraphNodes(DocumentObject* obj, std::ostream& out)
+{
+    const char* name = obj->getNameInDocument();
+    std::map<std::string, PropType> nodes = getSubGraphNodes(obj);
+    for (const auto& [propName, propType] : nodes) {
+        exportProp(name, propName.c_str(), propType, out);
+    }
+}
+
+static void exportSubGraph(DocumentObject* obj, std::ostream& out)
+{
+    const char* name = obj->getNameInDocument();
+    out << "  subgraph cluster_" << name << " {\n";
+    out << "    label = \"" << name << " (" << obj->Label.getValue() << ")\";\n";
+    out << "    style=dashed;\n\n";
+
+    exportSubGraphNodes(obj, out);
+    out << "  }\n\n";
+}
+
+static void exportEdge(std::string& from, std::string& to, std::ostream& out)
+{
+    out << "  " << from << " -> " << to << ";\n";
+}
+
+static void exportEdges(DocumentObject* objTo, std::ostream& out)
+{
+    const char* nameObjTo = objTo->getNameInDocument();
+
+    std::map<std::string, PropType> subgraphNodes = getSubGraphNodes(objTo);
+    // create edges from the first node (HEAD) to all other nodes in the subgraph
+    std::string from = nameObjTo + std::string("_HEAD");
+    for (const auto& [propName, propType] : subgraphNodes) {
+        if (propName != "HEAD") {
+            std::string to = nameObjTo + ("_" + propName);
+            if (propType == PropType::PROP_OUTPUT) {
+                exportEdge(to, from, out);
+            }
+            else {
+                exportEdge(from, to, out);
+            }
+        }
+    }
+
+    for (const auto& [objFrom, propFrom, objTo, propTo] : objTo->getInListProp()) {
+        const char* nameObjFrom = objFrom->getNameInDocument();
+        std::string from = nameObjFrom + ("_" + propFrom);
+        std::string to = nameObjTo + ("_" + (propTo == "" ? "HEAD" : propTo));
+        exportEdge(from,to, out);
+    }
+    out << "\n";
+}
+
+void Document::exportGraphvizProp(std::ostream& out) const
+{
+    out << "digraph G {\n";
+    out << "  rankdir=TB;\n";
+    out << "  node [shape=ellipse, color=black];\n\n";
+
+    for (auto* obj : getDependingObjects()) {
+        exportSubGraph(obj, out);
+    }
+
+    for (auto* obj : getDependingObjects()) {
+        exportEdges(obj, out);
+    }
+
+    out << "}\n";
+}
+
 void Document::exportGraphviz(std::ostream& out) const
 {
+    if (GetApplication().isFineGrainedRecomputeEnabled()) {
+        exportGraphvizProp(out);
+        return;
+    }
+
     /* Type defs for a graph with graphviz attributes */
     using GraphvizAttributes = std::map<std::string, std::string>;
     using Graph = boost::subgraph<adjacency_list<

--- a/src/App/Property.cpp
+++ b/src/App/Property.cpp
@@ -120,6 +120,7 @@ std::string Property::getFileName(const char* postfix, const char* prefix) const
 static constexpr auto mapProps = std::to_array<std::tuple<Property::Status, PropertyType>>({
     {App::Property::PropReadOnly,    Prop_ReadOnly},
     {App::Property::PropHidden,      Prop_Hidden},
+    {App::Property::PropInput,       Prop_Input},
     {App::Property::PropOutput,      Prop_Output},
     {App::Property::PropTransient,   Prop_Transient},
     {App::Property::PropNoRecompute, Prop_NoRecompute},

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -95,8 +95,8 @@ public:
         PartialTrigger = 10,
         /// Whether to prevent to touch the owner for a recompute on property change.
         NoRecompute = 11,
-        /// Whether a floating point number should be saved as single precision.
-        Single = 12,
+        /// Whether a property is an input property.
+        Input = 12,
         /// For PropertyLists, whether the order of the elements is
         /// relevant for the container using it.
         Ordered = 13,
@@ -133,17 +133,19 @@ public:
         PropHidden = 26,
         /// Corresponds to Prop_Output.
         PropOutput = 27,
+        /// Corresponds to Prop_Input.
+        PropInput = 28,
         /// Mark the end of enum PropertyType bits.
-        PropStaticEnd = 28,
+        PropStaticEnd = 29,
 
         /// User defined status bit.
-        User1 = 28,
+        User1 = 29,
         /// User defined status bit.
-        User2 = 29,
+        User2 = 30,
         /// User defined status bit.
-        User3 = 30,
+        User3 = 31,
         /// User defined status bit.
-        User4 = 31
+        User4 = 32
     };
 
     /// Construct a property.

--- a/src/App/Property.h
+++ b/src/App/Property.h
@@ -446,24 +446,25 @@ public:
     /**
      * @brief Set the precision of floating point properties.
      *
-     * This sets the precision of properties using floating point
-     * numbers to single precision. The default is double precision.
+     * Deprecated.  All floating proint properties are double precision.
      *
-     * @param[in] single True to set single precision, false for double precision.
+     * @param[in] single Unused.
      */
-    void setSinglePrecision(bool single)
+    void setSinglePrecision(bool /*single*/)
     {
-        setStatus(App::Property::Single, single);
     }
 
     /**
      * @brief Gets precision of floating point properties.
      *
-     * @return True if single precision is set, false for double precision.
+     * This function is deprecated.  All floating point properties are
+     * double precision.
+     *
+     * @return False always.
      */
     inline bool isSinglePrecision() const
     {
-        return testStatus(App::Property::Single);
+        return false;
     }
     /// @}
 

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -70,6 +70,8 @@ enum PropertyType
     Prop_NoRecompute = 16,
     /// The property won't be saved to file at all.
     Prop_NoPersist   = 32,
+    /// The property is a true input property.
+    Prop_Input   = 64,
 };
 // clang-format on
 

--- a/src/App/PropertyContainer.pyi
+++ b/src/App/PropertyContainer.pyi
@@ -42,7 +42,7 @@ class PropertyContainer(Persistence):
     def getTypeOfProperty(self, name: str, /) -> list:
         """
         Returns the type of a named property. This can be a list conformed by elements in
-        (Hidden, NoRecompute, NoPersist, Output, ReadOnly, Transient).
+        (Hidden, NoRecompute, NoPersist, Output, ReadOnly, Transient, Input).
 
         name : str
             Property name.

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -130,6 +130,9 @@ PyObject* PropertyContainerPy::getTypeOfProperty(PyObject* args)
     if (Type & Prop_Output) {
         ret.append(Py::String("Output"));
     }
+    if (Type & Prop_Input) {
+        ret.append(Py::String("Input"));
+    }
     if (Type & Prop_NoRecompute) {
         ret.append(Py::String("NoRecompute"));
     }
@@ -222,6 +225,7 @@ static const std::map<std::string, int>& getStatusMap()
         statusMap["MaterialEdit"] = Property::MaterialEdit;
         statusMap["NoMaterialListEdit"] = Property::NoMaterialListEdit;
         statusMap["Output"] = Property::Output;
+        statusMap["Input"] = Property::Input;
         statusMap["LockDynamic"] = Property::LockDynamic;
         statusMap["NoModify"] = Property::NoModify;
         statusMap["PartialTrigger"] = Property::PartialTrigger;

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -22,6 +22,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
 #include <boost/graph/topological_sort.hpp>
 #include <boost/unordered/unordered_map.hpp>
 #include <boost_graph_adjacency_list.hpp>
@@ -255,7 +256,7 @@ Property* PropertyExpressionEngine::Copy() const
 
 void PropertyExpressionEngine::hasSetValue()
 {
-    App::DocumentObject* owner = dynamic_cast<App::DocumentObject*>(getContainer());
+    auto* owner = freecad_cast<App::DocumentObject*>(getContainer());
     if (!owner || !owner->isAttachedToDocument() || owner->isRestoring()
         || testFlag(LinkDetached)) {
         PropertyExpressionContainer::hasSetValue();
@@ -263,13 +264,14 @@ void PropertyExpressionEngine::hasSetValue()
     }
 
     std::map<App::DocumentObject*, bool> deps;
+    std::map<std::pair<std::string, App::DocumentObject*>, bool> propDeps;
     std::vector<std::string> labels;
     unregisterElementReference();
     UpdateElementReferenceExpressionVisitor<PropertyExpressionEngine> v(*this);
     for (auto& e : expressions) {
         auto expr = e.second.expression;
         if (expr) {
-            expr->getDepObjects(deps, &labels);
+            expr->getDepObjects(deps, &labels, &propDeps);
             if (!restoring) {
                 expr->visit(v);
             }
@@ -277,7 +279,7 @@ void PropertyExpressionEngine::hasSetValue()
     }
     registerLabelReferences(std::move(labels));
 
-    updateDeps(std::move(deps));
+    updateDeps(std::move(deps), &propDeps);
 
     if (pimpl) {
         pimpl->conns.clear();
@@ -819,15 +821,36 @@ PropertyExpressionEngine::validateExpression(const ObjectIdentifier& path,
     DocumentObject* pathDocObj = usePath.getDocumentObject();
     assert(pathDocObj);
 
-    auto inList = pathDocObj->getInListEx(true);
-    for (auto& v : expr->getDepObjects()) {
-        auto docObj = v.first;
-        if (!v.second && inList.contains(docObj)) {
-            std::stringstream ss;
-            ss << "cyclic reference to " << docObj->getFullName();
-            return ss.str();
+    if (GetApplication().isFineGrainedRecomputeEnabled()) {
+        // Fully mimics the else part except for taking into account input properties.
+        auto inList = pathDocObj->getInListEx(true);
+
+        std::map<DocumentObject*, bool> depObjects;
+        std::map<std::pair<std::string, DocumentObject*>, bool> propDeps;
+        expr->getDepObjects(depObjects, nullptr, &propDeps);
+
+        for (const auto& [pair, hidden] : propDeps) {
+            auto* docObj = pair.second;
+            auto& propName = pair.first;
+            if (!hidden && inList.contains(docObj) && !docObj->isInputProperty(propName)) {
+                std::stringstream ss;
+                ss << "cyclic reference to " << docObj->getFullName() << "." << propName;
+                return ss.str();
+            }
         }
     }
+    else {
+        auto inList = pathDocObj->getInListEx(true);
+        for (auto& v : expr->getDepObjects()) {
+            auto docObj = v.first;
+            if (!v.second && inList.contains(docObj)) {
+                std::stringstream ss;
+                ss << "cyclic reference to " << docObj->getFullName();
+                return ss.str();
+            }
+        }
+    }
+
 
     // Check for internal document object dependencies
 

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -22,6 +22,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
+
 #include <QDir>
 #include <QFileInfo>
 #include <boost/algorithm/string/predicate.hpp>
@@ -724,6 +726,7 @@ void PropertyLink::resetLink()
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             if (_pcLink) {
                 _pcLink->_removeBackLink(parent);
+                _pcLink->_removeBackLinkProp(getName(), parent);
             }
         }
     }
@@ -747,9 +750,11 @@ void PropertyLink::setValue(App::DocumentObject* lValue)
         if (!parent->testStatus(ObjectStatus::Destroy)) {
             if (_pcLink) {
                 _pcLink->_removeBackLink(parent);
+                _pcLink->_removeBackLinkProp(getName(), parent);
             }
             if (lValue) {
                 lValue->_addBackLink(parent);
+                lValue->_addBackLinkProp(getName(), parent);
             }
         }
     }
@@ -929,6 +934,7 @@ PropertyLinkList::~PropertyLinkList()
             for (auto* obj : _lValueList) {
                 if (obj) {
                     obj->_removeBackLink(parent);
+                    obj->_removeBackLinkProp(getName(), parent);
                 }
             }
         }
@@ -946,6 +952,7 @@ void PropertyLinkList::setSize(int newSize)
 
         if (_pcScope != LinkScope::Hidden) {
             obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+            obj->_removeBackLinkProp(getName(), static_cast<DocumentObject*>(getContainer()));
         }
     }
     _lValueList.resize(newSize);
@@ -983,9 +990,11 @@ void PropertyLinkList::set1Value(int idx, DocumentObject* const& value)
         if (!parent->testStatus(ObjectStatus::Destroy) && _pcScope != LinkScope::Hidden) {
             if (obj) {
                 obj->_removeBackLink(static_cast<DocumentObject*>(getContainer()));
+                obj->_removeBackLinkProp(getName(), static_cast<DocumentObject*>(getContainer()));
             }
             if (value) {
                 value->_addBackLink(static_cast<DocumentObject*>(getContainer()));
+                value->_addBackLinkProp(getName(), static_cast<DocumentObject*>(getContainer()));
             }
         }
     }
@@ -1020,11 +1029,13 @@ void PropertyLinkList::setValues(const std::vector<DocumentObject*>& value)
             for (auto* obj : _lValueList) {
                 if (obj) {
                     obj->_removeBackLink(parent);
+                    obj->_removeBackLinkProp(getName(), parent);
                 }
             }
             for (auto* obj : value) {
                 if (obj) {
                     obj->_addBackLink(parent);
+                    obj->_addBackLinkProp(getName(), parent);
                 }
             }
         }
@@ -1325,6 +1336,7 @@ PropertyLinkSub::~PropertyLinkSub()
         if (!parent->testStatus(ObjectStatus::Destroy) && _pcScope != LinkScope::Hidden) {
             if (_pcLinkSub) {
                 _pcLinkSub->_removeBackLink(parent);
+                _pcLinkSub->_removeBackLinkProp(getName(), parent);
             }
         }
     }
@@ -1364,9 +1376,11 @@ void PropertyLinkSub::setValue(App::DocumentObject* lValue,
         if (!parent->testStatus(ObjectStatus::Destroy) && _pcScope != LinkScope::Hidden) {
             if (_pcLinkSub) {
                 _pcLinkSub->_removeBackLink(parent);
+                _pcLinkSub->_removeBackLinkProp(getName(), parent);
             }
             if (lValue) {
                 lValue->_addBackLink(parent);
+                lValue->_addBackLinkProp(getName(), parent);
             }
         }
     }
@@ -2208,6 +2222,7 @@ PropertyLinkSubList::~PropertyLinkSubList()
             for (auto* obj : _lValueList) {
                 if (obj) {
                     obj->_removeBackLink(parent);
+                    obj->_removeBackLinkProp(getName(), parent);
                 }
             }
         }
@@ -2256,10 +2271,12 @@ void PropertyLinkSubList::setValue(DocumentObject* lValue, const char* SubName)
             for (auto* obj : _lValueList) {
                 if (obj) {
                     obj->_removeBackLink(parent);
+                    obj->_removeBackLinkProp(getName(), parent);
                 }
             }
             if (lValue) {
                 lValue->_addBackLink(parent);
+                lValue->_addBackLinkProp(getName(), parent);
             }
         }
     }
@@ -2304,6 +2321,7 @@ void PropertyLinkSubList::setValues(const std::vector<DocumentObject*>& lValue,
             for (auto* obj : _lValueList) {
                 if (obj) {
                     obj->_removeBackLink(parent);
+                    obj->_removeBackLinkProp(getName(), parent);
                 }
             }
 
@@ -2312,6 +2330,7 @@ void PropertyLinkSubList::setValues(const std::vector<DocumentObject*>& lValue,
             for (auto* obj : lValue) {
                 if (obj) {
                     obj->_addBackLink(parent);
+                    obj->_addBackLinkProp(getName(), parent);
                 }
             }
         }
@@ -2364,6 +2383,7 @@ void PropertyLinkSubList::setValues(std::vector<DocumentObject*>&& lValue,
             for (auto* obj : _lValueList) {
                 if (obj) {
                     obj->_removeBackLink(parent);
+                    obj->_removeBackLinkProp(getName(), parent);
                 }
             }
 
@@ -2372,6 +2392,7 @@ void PropertyLinkSubList::setValues(std::vector<DocumentObject*>&& lValue,
             for (auto* obj : lValue) {
                 if (obj) {
                     obj->_addBackLink(parent);
+                    obj->_addBackLinkProp(getName(), parent);
                 }
             }
         }
@@ -2406,6 +2427,7 @@ void PropertyLinkSubList::setValue(DocumentObject* lValue, const std::vector<std
             for (auto* obj : _lValueList) {
                 if (obj) {
                     obj->_removeBackLink(parent);
+                    obj->_removeBackLinkProp(getName(), parent);
                 }
             }
 
@@ -2413,6 +2435,7 @@ void PropertyLinkSubList::setValue(DocumentObject* lValue, const std::vector<std
             // document object to ensure that the backlink is only added once
             if (lValue) {
                 lValue->_addBackLink(parent);
+                lValue->_addBackLinkProp(getName(), parent);
             }
         }
     }
@@ -2454,6 +2477,7 @@ void PropertyLinkSubList::addValue(App::DocumentObject* obj,
                 for (auto* value : _lValueList) {
                     if (value && value == obj) {
                         value->_removeBackLink(parent);
+                        value->_removeBackLinkProp(getName(), parent);
                     }
                 }
             }
@@ -2462,6 +2486,7 @@ void PropertyLinkSubList::addValue(App::DocumentObject* obj,
             // document object to ensure that the backlink is only added once
             if (obj) {
                 obj->_addBackLink(parent);
+                obj->_addBackLinkProp(getName(), parent);
             }
         }
     }
@@ -3872,6 +3897,7 @@ void PropertyXLink::restoreLink(App::DocumentObject* lValue)
 
     if (!owner->testStatus(ObjectStatus::Destroy) && _pcScope != LinkScope::Hidden) {
         lValue->_addBackLink(owner);
+        lValue->_addBackLinkProp(getName(), owner);
     }
 
     _pcLink = lValue;
@@ -3933,9 +3959,11 @@ void PropertyXLink::setValue(App::DocumentObject* lValue,
     if (!owner->testStatus(ObjectStatus::Destroy) && _pcScope != LinkScope::Hidden) {
         if (_pcLink) {
             _pcLink->_removeBackLink(owner);
+            _pcLink->_removeBackLinkProp(getName(), owner);
         }
         if (lValue) {
             lValue->_addBackLink(owner);
+            lValue->_addBackLinkProp(getName(), owner);
         }
     }
 
@@ -3991,6 +4019,7 @@ void PropertyXLink::setValue(std::string&& filename,
 
     if (_pcLink && !owner->testStatus(ObjectStatus::Destroy) && _pcScope != LinkScope::Hidden) {
         _pcLink->_removeBackLink(owner);
+        _pcLink->_removeBackLinkProp(getName(), owner);
     }
 
     _pcLink = nullptr;
@@ -5737,6 +5766,7 @@ void PropertyXLinkContainer::breakLink(App::DocumentObject* obj, bool clear)
         }
         else if (!it->second) {
             obj->_removeBackLink(owner);
+            obj->_removeBackLinkProp(getName(), owner);
         }
         _Deps.erase(it);
         onRemoveDep(obj);
@@ -5920,8 +5950,67 @@ bool PropertyXLinkContainer::isLinkedToDocument(const App::Document& doc) const
     return false;
 }
 
-void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*, bool>&& newDeps)
+// Mimics updateDeps() but for fine-grained property dependencies.  It does not
+// handle the XLink logic that is left to updateDeps().
+void PropertyXLinkContainer::updateDepsProp(
+    std::map<std::pair<std::string, DocumentObject*>, bool>& propDeps)
 {
+    auto owner = freecad_cast<DocumentObject*>(getContainer());
+    if (!owner || !owner->isAttachedToDocument()) {
+        return;
+    }
+
+    // delete all entries in propDeps of owner:
+    std::erase_if(propDeps, [owner](auto const& kv) {
+        return kv.first.second == owner;
+    });
+
+    for (auto& [pair, hidden] : propDeps) {
+        std::string const& propName = pair.first;
+        DocumentObject* obj = pair.second;
+        if (obj && obj->isAttachedToDocument()) {
+            auto it = _PropDeps.find(pair);
+            if (it != _PropDeps.end()) {
+                if (hidden != it->second) {
+                    if (hidden) {
+                        obj->_removeBackLinkProp(getName(), owner, propName.c_str());
+                    }
+                    else {
+                        obj->_addBackLinkProp(getName(), owner, propName.c_str());
+                    }
+                }
+                _PropDeps.erase(it);
+                continue;
+            }
+            if (!hidden) {
+                obj->_addBackLinkProp(getName(), owner, propName.c_str());
+            }
+        }
+    }
+
+    for (auto& [pair, hidden] : _PropDeps) {
+        std::string const& propName = pair.first;
+        DocumentObject* obj = pair.second;
+        if (!obj || !obj->isAttachedToDocument()) {
+            continue;
+        }
+        if (!hidden) {
+            obj->_removeBackLinkProp(getName(), owner, propName.c_str());
+        }
+    }
+
+    _PropDeps = std::move(propDeps);
+}
+
+void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*, bool>&& newDeps,
+                                        std::map<std::pair<std::string, DocumentObject*>, bool>* propDeps)
+{
+    // We want dependencies in terms of the to- and fromProperty if true.
+    // Otherwise we only want the dependencies in terms of HEAD.
+    bool fineGrainedProps = propDeps != nullptr;
+    if (fineGrainedProps) {
+        updateDepsProp(*propDeps);
+    }
     auto owner = freecad_cast<App::DocumentObject*>(getContainer());
     if (!owner || !owner->isAttachedToDocument()) {
         return;
@@ -5936,9 +6025,15 @@ void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*, bool>&& newDep
                 if (v.second != it->second) {
                     if (v.second) {
                         obj->_removeBackLink(owner);
+                        if (!fineGrainedProps) {
+                            obj->_removeBackLinkProp(getName(), owner);
+                        }
                     }
                     else {
                         obj->_addBackLink(owner);
+                        if (!fineGrainedProps) {
+                            obj->_addBackLinkProp(getName(), owner);
+                        }
                     }
                 }
                 _Deps.erase(it);
@@ -5954,6 +6049,9 @@ void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*, bool>&& newDep
             }
             else if (!v.second) {
                 obj->_addBackLink(owner);
+                if (!fineGrainedProps) {
+                    obj->_addBackLinkProp(getName(), owner);
+                }
             }
 
             onAddDep(obj);
@@ -5967,6 +6065,9 @@ void PropertyXLinkContainer::updateDeps(std::map<DocumentObject*, bool>&& newDep
         if (obj->getDocument() == owner->getDocument()) {
             if (!v.second) {
                 obj->_removeBackLink(owner);
+                if (!fineGrainedProps) {
+                    obj->_removeBackLinkProp(getName(), owner);
+                }
             }
         }
         else {
@@ -6001,6 +6102,7 @@ void PropertyXLinkContainer::clearDeps()
             if (!v.second && obj && obj->isAttachedToDocument()
                 && obj->getDocument() == owner->getDocument()) {
                 obj->_removeBackLink(owner);
+                obj->_removeBackLinkProp(getName(), owner);
             }
         }
     }
@@ -6018,6 +6120,16 @@ void PropertyXLinkContainer::getLinks(std::vector<App::DocumentObject*>& objs,
     for (auto& v : _Deps) {
         if (all || !v.second) {
             objs.push_back(v.first);
+        }
+    }
+}
+
+void PropertyXLinkContainer::getLinksProp(std::vector<std::pair<std::string, App::DocumentObject*>>& links,
+                                          bool all) const
+{
+    for (auto& [pair, hidden] : _PropDeps) {
+        if (all || !hidden) {
+            links.push_back(pair);
         }
     }
 }

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -1622,6 +1622,8 @@ public:
                   bool all = false,
                   std::vector<std::string>* subs = nullptr,
                   bool newStyle = true) const override;
+    void getLinksProp(std::vector<std::pair<std::string, App::DocumentObject*>>& links,
+                      bool all = false) const;
 
     bool isLinkedToDocument(const App::Document& doc) const;
 
@@ -1633,13 +1635,16 @@ protected:
     {}
     virtual void onRemoveDep(App::DocumentObject*)
     {}
-    void updateDeps(std::map<DocumentObject*, bool>&& newDeps);
+    void updateDepsProp(std::map<std::pair<std::string, DocumentObject*>, bool>& newPropDeps);
+    void updateDeps(std::map<DocumentObject*, bool>&& newDeps,
+                    std::map<std::pair<std::string, DocumentObject*>, bool>* propDeps = nullptr);
     void clearDeps();
 
     void _onBreakLink(App::DocumentObject* obj);
 
 protected:
     std::map<App::DocumentObject*, bool> _Deps;
+    std::map<std::pair<std::string, App::DocumentObject*>, bool> _PropDeps;
     std::map<std::string, std::unique_ptr<PropertyXLink>> _XLinks;
     std::map<std::string, std::string> _DocMap;
     bool _LinkRestored;

--- a/src/App/Transactions.cpp
+++ b/src/App/Transactions.cpp
@@ -493,9 +493,18 @@ void TransactionDocumentObject::applyDel(Document& Doc, TransactionalObject* pcO
         // Make sure the backlinks of all linked objects are updated. As the links of the removed
         // object are never set to [] they also do not remove the backlink. But as they are
         // not in the document anymore we need to remove them anyway to ensure a correct graph
-        auto list = obj->getOutList();
-        for (auto link : list) {
-            link->_removeBackLink(obj);
+        {
+            auto list = obj->getOutList();
+            for (auto link : list) {
+                link->_removeBackLink(obj);
+            }
+        }
+
+        {
+            auto list = obj->getOutListProp();
+            for (const auto& [fromObj, fromProp, toObj, toProp] : list) {
+                toObj->_removeBackLinkProp(fromProp.c_str(), fromObj, toProp.c_str());
+            }
         }
 
         // simply filling in the saved object
@@ -510,9 +519,18 @@ void TransactionDocumentObject::applyNew(Document& Doc, TransactionalObject* pcO
         Doc._addObject(obj, _NameInDocument.c_str());
 
         // make sure the backlinks of all linked objects are updated
-        auto list = obj->getOutList();
-        for (auto link : list) {
-            link->_addBackLink(obj);
+        {
+            auto list = obj->getOutList();
+            for (auto link : list) {
+                link->_addBackLink(obj);
+            }
+        }
+
+        {
+            auto list = obj->getOutListProp();
+            for (const auto& [fromObj, fromProp, toObj, toProp] : list) {
+                toObj->_addBackLinkProp(fromProp.c_str(), fromObj, toProp.c_str());
+            }
         }
     }
 }

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -299,8 +299,10 @@ void GraphvizView::updateSvgItem(const App::Document& doc)
     QStringList args, flatArgs;
     // TODO: Make -Granksep flag value variable depending on number of edges,
     // the downside is that the value affects all subgraphs
-    args << QLatin1String("-Granksep=2") << QLatin1String("-Goutputorder=edgesfirst")
-         << QLatin1String("-Gsplines=ortho") << QLatin1String("-Tsvg");
+    args << QLatin1String("-Granksep=2") << QLatin1String("-Tsvg");
+    if (!App::GetApplication().isFineGrainedRecomputeEnabled()) {
+        args << QLatin1String("-Gsplines=ortho") << QLatin1String("-Goutputorder=edgesfirst");
+    }
     flatArgs << QLatin1String("-c2 -l2");
     auto dot = QStringLiteral("dot");
     auto unflatten = QStringLiteral("unflatten");

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -252,6 +252,7 @@ void DlgSettingsGeneral::saveSettings()
     if (property("ActivateOverlay").toBool() != ui->ActivateOverlay->isChecked()) {
         requireRestart();
     }
+    ui->FineGrainedRecompute->onSave();
 
     setRecentFileSize();
     bool force = setLanguage();
@@ -305,6 +306,7 @@ void DlgSettingsGeneral::loadSettings()
     ui->SplashScreen->onRestore();
     ui->ActivateOverlay->onRestore();
     setProperty("ActivateOverlay", ui->ActivateOverlay->isChecked());
+    ui->FineGrainedRecompute->onRestore();
 
     // search for the language files
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.ui
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.ui
@@ -357,6 +357,25 @@ display the splash screen.</string>
          </property>
         </widget>
        </item>
+       <item row="7" column="0">
+        <widget class="Gui::PrefCheckBox" name="FineGrainedRecompute">
+         <property name="toolTip">
+          <string>Activate fine-grained recomputation of documents</string>
+         </property>
+         <property name="text">
+          <string>Fine-grained recompute (experimental)</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="prefEntry" stdset="0">
+          <cstring>FineGrainedRecompute</cstring>
+         </property>
+         <property name="prefPath" stdset="0">
+          <cstring>General</cstring>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </item>

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -810,6 +810,7 @@ enum MenuAction
     MA_ShowPropUses,
     MA_Transient,
     MA_Output,
+    MA_Input,
     MA_NoRecompute,
     MA_ReadOnly,
     MA_Hidden,
@@ -1200,6 +1201,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
 
         ACTION_SETUP(Hidden);
         ACTION_SETUP(Output);
+        ACTION_SETUP(Input);
         ACTION_SETUP(NoRecompute);
         ACTION_SETUP(ReadOnly);
         ACTION_SETUP(Transient);
@@ -1258,6 +1260,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
             ACTION_CHECK(Transient);
             ACTION_CHECK(ReadOnly);
             ACTION_CHECK(Output);
+            ACTION_CHECK(Input);
             ACTION_CHECK(Hidden);
             ACTION_CHECK(EvalOnRestore);
             ACTION_CHECK(CopyOnChange);

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -795,7 +795,7 @@ bool importExternalElements(App::PropertyLinkSub& prop, std::vector<App::SubObje
         if (App::GetApplication().isFineGrainedRecomputeEnabled()) {
             // Fully mimics the else block except for taking into account input properties.
             for (const auto& [fromObj, fromProp, toObj, toProp] : inListProp) {
-                if (fromObj == sobj && !editObj->isInputProperty(toProp)) {
+                if (fromObj == sobj && !toObj->isInputProperty(toProp)) {
                     FC_THROWM(
                         Base::RuntimeError,
                         "Cyclic dependency on object " << sobjT.getSubObjectFullName(docName)

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -783,6 +783,7 @@ bool importExternalElements(App::PropertyLinkSub& prop, std::vector<App::SubObje
     std::vector<App::SubObjectT> sobjs;
     auto docName = editObj->getDocument()->getName();
     auto inList = editObj->getInListEx(true);
+    auto inListProp = editObj->getInListExProp(true);
     for (auto sobjT : _sobjs) {
         auto sobj = sobjT.getSubObject();
         if (sobj == editObj) {
@@ -791,11 +792,24 @@ bool importExternalElements(App::PropertyLinkSub& prop, std::vector<App::SubObje
         if (!sobj) {
             FC_THROWM(Base::RuntimeError, "Object not found: " << sobjT.getSubObjectFullName(docName));
         }
-        if (inList.count(sobj)) {
-            FC_THROWM(
-                Base::RuntimeError,
-                "Cyclic dependency on object " << sobjT.getSubObjectFullName(docName)
-            );
+        if (App::GetApplication().isFineGrainedRecomputeEnabled()) {
+            // Fully mimics the else block except for taking into account input properties.
+            for (const auto& [fromObj, fromProp, toObj, toProp] : inListProp) {
+                if (fromObj == sobj && !editObj->isInputProperty(toProp)) {
+                    FC_THROWM(
+                        Base::RuntimeError,
+                        "Cyclic dependency on object " << sobjT.getSubObjectFullName(docName)
+                    );
+                }
+            }
+        }
+        else {
+            if (inList.count(sobj)) {
+                FC_THROWM(
+                    Base::RuntimeError,
+                    "Cyclic dependency on object " << sobjT.getSubObjectFullName(docName)
+                );
+            }
         }
         sobjT.normalized();
         // Make sure that if a subelement is chosen for some object,

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -13,6 +13,8 @@ SET(Test_SRCS
     Metadata.py
     StringHasher.py
     Menu.py
+    Recompute.py
+    GuiRecompute.py
     TestApp.py
     TestGui.py
     UnicodeTests.py

--- a/src/Mod/Test/GuiRecompute.py
+++ b/src/Mod/Test/GuiRecompute.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ****************************************************************************
+# *                                                                          *
+# *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                 *
+# *                                                                          *
+# *   This file is part of FreeCAD.                                          *
+# *                                                                          *
+# *   FreeCAD is free software: you can redistribute it and/or modify it     *
+# *   under the terms of the GNU Lesser General Public License as            *
+# *   published by the Free Software Foundation, either version 2.1 of the   *
+# *   License, or (at your option) any later version.                        *
+# *                                                                          *
+# *   FreeCAD is distributed in the hope that it will be useful, but         *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+# *   Lesser General Public License for more details.                        *
+# *                                                                          *
+# *   You should have received a copy of the GNU Lesser General Public       *
+# *   License along with FreeCAD. If not, see                                *
+# *   <https://www.gnu.org/licenses/>.                                       *
+# *                                                                          *
+# ***************************************************************************/
+
+import unittest
+
+import FreeCAD
+import FreeCADGui as Gui
+
+
+from Recompute import createPartDesignSketch
+
+
+class FineGrainedRecomputeCasesGui(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument(f"RecomputeTestsGui_{self._testMethodName}")
+        self.ParamGroup = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General")
+        self.fineGrainedPref = self.ParamGroup.GetBool("FineGrainedRecompute", False)
+        self.ParamGroup.SetBool("FineGrainedRecompute", True)
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+        self.ParamGroup.SetBool("FineGrainedRecompute", self.fineGrainedPref)
+
+    def testSketchWithInputPropertyAndPad(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode.
+        if not FreeCAD.GuiUp:
+            self.skipTest("This test requires the GUI")
+
+        if not FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General").GetBool(
+            "FineGrainedRecompute"
+        ):
+            self.skipTest("This test requires fine-grained recompute")
+
+        createPartDesignSketch(self)
+
+        body = self.Doc.Body
+        body.addProperty("App::PropertyLength", "Length", "Params")
+        body.Length = "20 mm"
+        body.setPropertyStatus("Length", ["Input"])
+
+        sketch = self.Doc.Sketch
+        sketch.setExpression("Constraints[10]", "Body.Length")
+        self.Doc.recompute()
+
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(self.Doc.Name, body.Name, sketch.Name + ".")
+        Gui.runCommand("PartDesign_Pad")
+
+        taskDialog = Gui.Control.activeTaskDialog()
+        if taskDialog:
+            taskDialog.accept()
+
+        self.Doc.recompute()
+
+        self.assertEqual(body.Shape.BoundBox.XLength, 20.0)
+        self.assertEqual(body.Shape.BoundBox.ZLength, 10.0)

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -29,6 +29,7 @@ FreeCAD.__unit_test__ += [
     "UnitTests",
     "Document",
     "Metadata",
+    "Recompute",
     "StringHasher",
     "UnicodeTests",
     "TestPythonSyntax",

--- a/src/Mod/Test/Recompute.py
+++ b/src/Mod/Test/Recompute.py
@@ -1,0 +1,722 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# ****************************************************************************
+# *                                                                          *
+# *   Copyright (c) 2025 Pieter Hijma <info@pieterhijma.net>                 *
+# *                                                                          *
+# *   This file is part of FreeCAD.                                          *
+# *                                                                          *
+# *   FreeCAD is free software: you can redistribute it and/or modify it     *
+# *   under the terms of the GNU Lesser General Public License as            *
+# *   published by the Free Software Foundation, either version 2.1 of the   *
+# *   License, or (at your option) any later version.                        *
+# *                                                                          *
+# *   FreeCAD is distributed in the hope that it will be useful, but         *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+# *   Lesser General Public License for more details.                        *
+# *                                                                          *
+# *   You should have received a copy of the GNU Lesser General Public       *
+# *   License along with FreeCAD. If not, see                                *
+# *   <https://www.gnu.org/licenses/>.                                       *
+# *                                                                          *
+# ***************************************************************************/
+
+import unittest
+import functools
+
+import FreeCAD
+import Part
+import Sketcher
+
+
+def finegrained(variants):
+    """Method decorator: mark a test to be duplicated for each variant.
+
+    Accepts either a single bool or an iterable of bools, for example:
+      @finegrained((True, False))
+      @finegrained(True)
+    """
+
+    # Normalize to a tuple of booleans
+    if isinstance(variants, bool):
+        variants = (variants,)
+    else:
+        variants = tuple(variants)
+
+    def decorate(func):
+        setattr(func, "_fg_variants", variants)
+        return func
+
+    return decorate
+
+
+def parameterize():
+    """Class decorator: create wrapper test methods for each @finegrained variant.
+
+    For every test method named test* that has a _fg_variants attribute, this
+    will create additional methods:
+      <orig>_fineGrained_on   (for True)
+      <orig>_fineGrained_off  (for False)
+    """
+
+    def decorate(cls):
+        def make_wrapper(func, fg):
+            """Capture func and fg at creation time."""
+
+            @functools.wraps(func)
+            def wrapper(self, *args, **kwargs):
+                return func(self, *args, **kwargs)
+
+            wrapper._fineGrained = fg
+            wrapper._generated = True
+            return wrapper
+
+        for name, func in list(cls.__dict__.items()):
+            if not name.startswith("test"):
+                continue
+
+            if getattr(func, "_generated", False):
+                continue
+
+            variants = getattr(func, "_fg_variants", None)
+            if variants is None:
+                continue
+
+            for fg in variants:
+                suffix = "on" if fg else "off"
+                new_name = f"{name}_fineGrained_{suffix}"
+                if hasattr(cls, new_name):
+                    continue
+
+                wrapper = make_wrapper(func, fg)
+                wrapper.__name__ = new_name
+                setattr(cls, new_name, wrapper)
+
+            try:
+                # Remove the original test function.
+                delattr(cls, name)
+            except AttributeError:
+                # The attribute may have been removed.  Not a problem.
+                pass
+        return cls
+
+    return decorate
+
+
+def createPartDesignSketch(testClass):
+    body = testClass.Doc.addObject("PartDesign::Body", "Body")
+    sketch = body.newObject("Sketcher::SketchObject", "Sketch")
+    sketch.AttachmentSupport = (testClass.Doc.Origin, ["XY_Plane"])
+    sketch.MapMode = "FlatFace"
+
+    def lsegment(x1, y1, x2, y2):
+        return Part.LineSegment(FreeCAD.Vector(x1, y1, 0), FreeCAD.Vector(x2, y2, 0))
+
+    geoList = []
+    geoList.append(lsegment(-16, 16, -16, -16))
+    geoList.append(lsegment(-16, -16, 16, -16))
+    geoList.append(lsegment(16, -16, 16, 16))
+    geoList.append(lsegment(16, 16, -16, 16))
+    sketch.addGeometry(geoList, False)
+    del geoList
+
+    constraintList = []
+    constraintList.append(Sketcher.Constraint("Coincident", 0, 2, 1, 1))
+    constraintList.append(Sketcher.Constraint("Coincident", 1, 2, 2, 1))
+    constraintList.append(Sketcher.Constraint("Coincident", 2, 2, 3, 1))
+    constraintList.append(Sketcher.Constraint("Coincident", 3, 2, 0, 1))
+    constraintList.append(Sketcher.Constraint("Vertical", 0))
+    constraintList.append(Sketcher.Constraint("Vertical", 2))
+    constraintList.append(Sketcher.Constraint("Horizontal", 1))
+    constraintList.append(Sketcher.Constraint("Horizontal", 3))
+    constraintList.append(Sketcher.Constraint("Symmetric", 2, 2, 0, 2, -1, 1))
+    constraintList.append(Sketcher.Constraint("Equal", 3, 2))
+    constraintList.append(Sketcher.Constraint("Distance", 3, 1, 3, 2, 32.0))
+    sketch.addConstraint(constraintList)
+    del constraintList
+
+    sketch.setGeometryIds([(0, 1), (1, 2), (2, 3), (3, 4)])
+    sketch.setDatum(10, FreeCAD.Units.Quantity("32.0 mm"))
+
+    testClass.Doc.recompute()
+
+
+def createPartDesignObject(testClass):
+    createPartDesignSketch(testClass)
+
+    body = testClass.Doc.Body
+    sketch = testClass.Doc.Sketch
+
+    pad = body.newObject("PartDesign::Pad", "Pad")
+    pad.Profile = sketch
+    pad.Length = "10 mm"
+    pad.ReferenceAxis = (sketch, "N_Axis")
+
+
+class DoubleLengthCube:
+    # A cube that has an input length and an output double length.
+    def __init__(self, obj):
+        self.Object = obj
+        obj.Proxy = self
+        obj.addProperty("App::PropertyLength", "Length", "Cube")
+        obj.addProperty("App::PropertyLength", "DoubleLength", "Output")
+        obj.setPropertyStatus("DoubleLength", "Output")
+        obj.Length = "10 mm"
+
+    def execute(self, obj):
+        length = float(obj.Length)
+        obj.Shape = Part.makeBox(length, length, length)
+        obj.DoubleLength = f"{length * 2} mm"
+
+    def onChanged(self, obj, prop):
+        if prop == "Length":
+            self.execute(obj)
+
+
+@parameterize()
+class FineGrainedRecomputeCases(unittest.TestCase):
+    # Most tests work both with fine-grained recompute on and off.  Some tests
+    # only work with either fine-grained on or off and those tests have an
+    # explicit comment that explains why fine-grained recompute needs to be on
+    # or off.
+
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument(f"RecomputeTests_{self._testMethodName}")
+
+        method = getattr(self, self._testMethodName)
+        self.fineGrained = getattr(method, "_fineGrained", None)
+        self.ParamGroup = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General")
+        self.fineGrainedPref = self.ParamGroup.GetBool("FineGrainedRecompute", False)
+        self.ParamGroup.SetBool("FineGrainedRecompute", self.fineGrained)
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+        self.ParamGroup.SetBool("FineGrainedRecompute", self.fineGrainedPref)
+
+    def assertDep(self, depEdges, depEdgeTuples):
+        """Helper to assert that a list of dependency edges matches expected.
+        depEdges: list of DepEdge
+        depEdgeTuples: list of tuples (fromObj, fromProp, toObj, toProp)
+        """
+        actual = {str(de) for de in depEdges}
+        expected = {
+            f"{fromObj.FullName}.{fromProp} --> {toObj.FullName}.{toProp}"
+            for fromObj, fromProp, toObj, toProp in depEdgeTuples
+        }
+        for actualDepEdge in actual:
+            self.assertIn(
+                actualDepEdge, expected, f"{actualDepEdge} not in the expected dependency edges"
+            )
+        for expectedDepEdge in expected:
+            self.assertIn(
+                expectedDepEdge, actual, f"{expectedDepEdge} not in the actual dependency edges"
+            )
+
+    @finegrained((True, False))
+    def testSimple(self):
+        # arrange
+        varSet = self.Doc.addObject("App::VarSet", "VarSet")
+        varSet.addProperty("App::PropertyLength", "Length", "Params")
+        varSet.Length = "10.0 mm"
+
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        cube.setExpression("Length", "VarSet.Length")
+        self.Doc.recompute()
+
+        # activate
+        varSet.Length = "20.0 mm"
+        self.Doc.recompute([varSet])
+
+        # assert
+        self.assertIn("Touched", cube.State)
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(varSet.Name)
+
+    @finegrained((True,))
+    def testIndependent(self):
+        # This is the crucial test that will fail if fine-grained recompute is
+        # disabled because without fine-grained recomputation, both cube1 and
+        # cube2 will be touched.
+
+        # arrange
+        varSet = self.Doc.addObject("App::VarSet", "VarSet")
+
+        varSet.addProperty("App::PropertyLength", "Length1", "Params")
+        varSet.Length1 = "10.0 mm"
+
+        varSet.addProperty("App::PropertyLength", "Length2", "Params")
+        varSet.Length2 = "10.0 mm"
+
+        cube1 = self.Doc.addObject("Part::Box", "Cube1")
+        cube1.setExpression("Length", "VarSet.Length1")
+
+        cube2 = self.Doc.addObject("Part::Box", "Cube2")
+        cube2.setExpression("Length", "VarSet.Length2")
+        self.Doc.recompute()
+
+        # activate
+        varSet.Length1 = "20.0 mm"
+        self.Doc.recompute([varSet])
+
+        # assert
+        self.assertIn("Touched", cube1.State)
+        self.assertNotIn("Touched", cube2.State)
+
+        # teardown
+        self.Doc.removeObject(cube1.Name)
+        self.Doc.removeObject(cube2.Name)
+        self.Doc.removeObject(varSet.Name)
+
+    @finegrained((True, False))
+    def testChaining(self):
+        # arrange
+        varSet1 = self.Doc.addObject("App::VarSet", "VarSet1")
+        varSet1.addProperty("App::PropertyLength", "Length", "Params")
+        varSet1.Length = "10.0 mm"
+
+        varSet2 = self.Doc.addObject("App::VarSet", "VarSet2")
+        varSet2.addProperty("App::PropertyLength", "Length", "Params")
+        varSet2.setExpression("Length", "VarSet1.Length")
+
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        cube.setExpression("Length", "VarSet2.Length")
+        self.Doc.recompute()
+
+        # activate
+        varSet1.Length = "20.0 mm"
+        self.Doc.recompute([varSet1, varSet2])
+
+        # assert
+        self.assertIn("Touched", cube.State)
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(varSet2.Name)
+        self.Doc.removeObject(varSet1.Name)
+
+    @finegrained((True, False))
+    def testOutputThroughExpression(self):
+        # arrange
+        varSet = self.Doc.addObject("App::VarSet", "VarSet")
+
+        varSet.addProperty("App::PropertyLength", "Length", "Params")
+        varSet.Length = "10.0 mm"
+
+        cube1 = self.Doc.addObject("Part::Box", "Cube1")
+        cube1.addProperty("App::PropertyLength", "OutputLength", "Output")
+        cube1.setPropertyStatus("OutputLength", "Output")
+        cube1.setExpression("Length", "VarSet.Length")
+        cube1.setExpression("OutputLength", "Length + Width")
+
+        cube2 = self.Doc.addObject("Part::Box", "Cube2")
+        cube2.setExpression("Length", "Cube1.OutputLength")
+        self.Doc.recompute()
+
+        # activate
+        varSet.Length = "20.0 mm"
+        self.Doc.recompute([varSet, cube1])
+
+        # assert
+        self.assertIn("Touched", cube2.State)
+
+        # teardown
+        self.Doc.removeObject(cube2.Name)
+        self.Doc.removeObject(cube1.Name)
+        self.Doc.removeObject(varSet.Name)
+
+    @finegrained((True, False))
+    def testOutputInternal(self):
+        # arrange
+        cube1 = self.Doc.addObject("Part::FeaturePython", "Cube1")
+        DoubleLengthCube(cube1)
+
+        cube2 = self.Doc.addObject("Part::Box", "Cube2")
+        cube2.setExpression("Length", "Cube1.DoubleLength")
+        self.Doc.recompute()
+
+        # activate
+        cube1.Length = "20.0 mm"
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(cube1.DoubleLength.Value, 40.0)
+        self.assertEqual(cube1.DoubleLength.Unit, FreeCAD.Units.Length)
+        self.assertEqual(cube2.Length.Value, 40.0)
+        self.assertEqual(cube2.Length.Unit, FreeCAD.Units.Length)
+
+        # teardown
+        self.Doc.removeObject(cube2.Name)
+        self.Doc.removeObject(cube1.Name)
+
+    @finegrained((True, False))
+    def testRelabel(self):
+        # arrange
+        varSet = self.Doc.addObject("App::VarSet", "VarSet")
+        varSet.addProperty("App::PropertyLength", "Length", "Params")
+        varSet.Length = "10.0 mm"
+
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        cube.setExpression("Length", "VarSet.Length")
+        self.Doc.recompute()
+
+        # activate
+        varSet.Label = "Params"
+
+        # assert
+        self.assertNotIn("Touched", varSet.State)
+        self.assertNotIn("Touched", cube.State)
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(varSet.Name)
+
+    @finegrained((True, False))
+    def testChangeVisibility(self):
+        # arrange
+        cube1 = self.Doc.addObject("Part::Box", "Cube1")
+        cube2 = self.Doc.addObject("Part::Box", "Cube2")
+        cube2.setExpression("Length", "Cube1.Length")
+        self.Doc.recompute()
+
+        # activate
+        cube1.Visibility = False
+
+        # assert
+        self.assertNotIn("Touched", cube1.State)
+        self.assertNotIn("Touched", cube2.State)
+
+        # teardown
+        self.Doc.removeObject(cube2.Name)
+        self.Doc.removeObject(cube1.Name)
+
+    @finegrained((True, False))
+    def testExpression(self):
+        # arrange
+        cube1 = self.Doc.addObject("Part::Box", "Cube1")
+        cube2 = self.Doc.addObject("Part::Box", "Cube2")
+        cube2.setExpression("Length", "Cube1.Length")
+
+        # activate
+        self.Doc.recompute()
+
+        # assert
+        depEdges = [(cube2, "ExpressionEngine", cube1, "Length")]
+        self.assertDep(cube1.OutListProp, [])
+        self.assertDep(cube2.OutListProp, depEdges)
+        self.assertDep(cube1.InListProp, depEdges)
+        self.assertDep(cube2.InListProp, [])
+
+        # teardown
+        self.Doc.removeObject(cube2.Name)
+        self.Doc.removeObject(cube1.Name)
+
+    @finegrained((True, False))
+    def testRemoveExpression(self):
+        # arrange
+        cube1 = self.Doc.addObject("Part::Box", "Cube1")
+        cube2 = self.Doc.addObject("Part::Box", "Cube2")
+        cube2.setExpression("Length", "Cube1.Length")
+
+        # activate
+        self.Doc.recompute()
+
+        # assert
+        depEdges = [(cube2, "ExpressionEngine", cube1, "Length")]
+        self.assertDep(cube1.OutListProp, [])
+        self.assertDep(cube2.OutListProp, depEdges)
+        self.assertDep(cube1.InListProp, depEdges)
+        self.assertDep(cube2.InListProp, [])
+
+        # activate
+        cube2.setExpression("Length", None)
+        self.Doc.recompute()
+
+        # assert
+        self.assertDep(cube1.OutListProp, [])
+        self.assertDep(cube2.OutListProp, [])
+        self.assertDep(cube1.InListProp, [])
+        self.assertDep(cube2.InListProp, [])
+
+        # teardown
+        self.Doc.removeObject(cube2.Name)
+        self.Doc.removeObject(cube1.Name)
+
+    @finegrained((True,))
+    def testInputProperty(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode.
+
+        # arrange
+        part = self.Doc.addObject("App::Part", "Part")
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        part.addObject(cube)
+        part.addProperty("App::PropertyLength", "Length", "Params")
+        part.Length = "10 mm"
+        part.setPropertyStatus("Length", ["Input"])
+        cube.setExpression("Length", "Part.Length")
+        self.Doc.recompute()
+
+        # activate
+        part.Length = "20 mm"
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(cube.Length.Value, 20.0)
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(part.Name)
+
+    @finegrained((True,))
+    def testInputPropertyDeps(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode.
+
+        # arrange
+        part = self.Doc.addObject("App::Part", "Part")
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        part.addObject(cube)
+        part.addProperty("App::PropertyLength", "Length", "Params")
+        part.Length = "10 mm"
+        part.setPropertyStatus("Length", ["Input"])
+        self.Doc.recompute()
+
+        # activate
+        cube.setExpression("Length", "Part.Length")
+
+        # assert
+        origin = self.Doc.Origin
+        inListPart = [(cube, "ExpressionEngine", part, "Length")]
+        inListCube = [(part, "Group", cube, "HEAD")]
+        outListPart = [(part, "Origin", origin, "HEAD")] + inListCube
+        outListCube = inListPart
+
+        self.assertDep(part.OutListProp, outListPart)
+        self.assertDep(part.InListProp, inListPart)
+        self.assertDep(cube.OutListProp, outListCube)
+        self.assertDep(cube.InListProp, inListCube)
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(part.Name)
+
+    @finegrained((False,))
+    def testInputPropertyCoarse(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode, so should raise an error here.
+
+        # arrange
+        part = self.Doc.addObject("App::Part", "Part")
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        part.addObject(cube)
+        part.addProperty("App::PropertyLength", "Length", "Params")
+        part.Length = "10 mm"
+        part.setPropertyStatus("Length", ["Input"])
+
+        # activate / assert
+        with self.assertRaises(RuntimeError):
+            cube.setExpression("Length", "Part.Length")
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(part.Name)
+
+    @finegrained((True, False))
+    def testCyclicDependency(self):
+        # arrange
+        part = self.Doc.addObject("App::Part", "Part")
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        part.addObject(cube)
+        part.addProperty("App::PropertyLength", "Length", "Params")
+        part.Length = "10 mm"
+
+        # activate/assert
+        with self.assertRaises(RuntimeError):
+            cube.setExpression("Length", "Part.Length")
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(part.Name)
+
+    @finegrained((True,))
+    def testInputPropertyChain(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode.
+
+        # arrange
+        varSet = self.Doc.addObject("App::VarSet", "VarSet")
+        part = self.Doc.addObject("App::Part", "Part")
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        part.addObject(cube)
+
+        varSet.addProperty("App::PropertyLength", "Length", "Params")
+        varSet.Length = "10 mm"
+        part.addProperty("App::PropertyLength", "Length", "Params")
+        part.Length = "10 mm"
+        part.setPropertyStatus("Length", ["Input"])
+        part.setExpression("Length", "VarSet.Length")
+        cube.setExpression("Length", "Part.Length")
+        self.Doc.recompute()
+
+        # activate
+        varSet.Length = "20 mm"
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(cube.Length.Value, 20.0)
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(part.Name)
+        self.Doc.removeObject(varSet.Name)
+
+    @finegrained((True,))
+    def testInputLink(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode.
+
+        # arrange
+        varSet1 = self.Doc.addObject("App::VarSet", "VarSet")
+        varSet2 = self.Doc.addObject("App::VarSet", "VarSet")
+        part = self.Doc.addObject("App::Part", "Part")
+        cube = self.Doc.addObject("Part::Box", "Cube")
+        part.addObject(cube)
+
+        varSet1.addProperty("App::PropertyLength", "Length", "Params")
+        varSet1.Length = "10 mm"
+
+        varSet2.addProperty("App::PropertyLength", "Length", "Params")
+        varSet2.Length = "20 mm"
+
+        part.addProperty("App::PropertyLink", "Params", "Params")
+        part.setPropertyStatus("Params", ["Input"])
+        part.Params = varSet1
+
+        cube.setExpression("Length", "Part.Params.Length")
+        self.Doc.recompute()
+
+        # activate
+        varSet1.Length = "15 mm"
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(cube.Length.Value, 15.0)
+
+        # activate
+        part.Params = varSet2
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(cube.Length.Value, 20.0)
+
+        # teardown
+        self.Doc.removeObject(cube.Name)
+        self.Doc.removeObject(part.Name)
+        self.Doc.removeObject(varSet2.Name)
+        self.Doc.removeObject(varSet1.Name)
+
+    @finegrained((True,))
+    def testPadWithInputProperty(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode.
+        createPartDesignObject(self)
+
+        body = self.Doc.Body
+        body.addProperty("App::PropertyLength", "Height", "Params")
+        body.Height = "20 mm"
+        body.setPropertyStatus("Height", ["Input"])
+
+        pad = self.Doc.Pad
+        pad.setExpression("Length", "Body.Height")
+
+        # activate
+        body.Height = "30 mm"
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(pad.Length.Value, 30.0)
+
+    @finegrained((True,))
+    def testSketchWithInputProperty(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode.
+        createPartDesignObject(self)
+
+        body = self.Doc.Body
+        body.addProperty("App::PropertyLength", "Length", "Params")
+        body.Length = "20 mm"
+        body.setPropertyStatus("Length", ["Input"])
+
+        sketch = self.Doc.Sketch
+        sketch.setExpression("Constraints[10]", "Body.Length")
+
+        # activate
+        body.Length = "30 mm"
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(body.Shape.BoundBox.XLength, 30.0)
+
+    @finegrained((True, False))
+    def testSketchWithHiddenRef(self):
+        # References to input properties of dependent objects only works in
+        # fine-grained mode.
+        createPartDesignObject(self)
+
+        body = self.Doc.Body
+        body.addProperty("App::PropertyLength", "Length", "Params")
+        body.Length = "20 mm"
+
+        sketch = self.Doc.Sketch
+        sketch.setExpression("Constraints[10]", "hiddenref(Body.Length)")
+
+        # activate
+        body.Length = "30 mm"
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(body.Shape.BoundBox.XLength, 30.0)
+        self.assertEqual(body.InList, [])
+        self.assertEqual(body.InListProp, [])
+
+    @finegrained((True, False))
+    def testHiddenRefChanges(self):
+        # arrange
+        varSet = self.Doc.addObject("App::VarSet", "VarSet")
+        cube = self.Doc.addObject("Part::Box", "Cube")
+
+        varSet.addProperty("App::PropertyLength", "Length", "Params")
+        varSet.Length = "10 mm"
+
+        # activate
+        cube.setExpression("Length", "VarSet.Length")
+        self.Doc.recompute()
+
+        # assert
+        depEdges = [(cube, "ExpressionEngine", varSet, "Length")]
+        self.assertDep(cube.OutListProp, depEdges)
+        self.assertEqual(cube.OutList, [varSet, varSet])
+        self.assertDep(varSet.InListProp, depEdges)
+        self.assertEqual(varSet.InList, [cube])
+
+        # activate
+        cube.setExpression("Length", "hiddenref(VarSet.Length)")
+        self.Doc.recompute()
+
+        # assert
+        self.assertEqual(cube.OutListProp, [])
+        self.assertEqual(cube.OutList, [])
+        self.assertEqual(varSet.InListProp, [])
+        self.assertEqual(varSet.InList, [])
+
+        # activate
+        cube.setExpression("Length", "VarSet.Length")
+        self.Doc.recompute()
+
+        # assert
+        self.assertDep(cube.OutListProp, depEdges)
+        self.assertEqual(cube.OutList, [varSet, varSet])
+        self.assertDep(varSet.InListProp, depEdges)
+        self.assertEqual(varSet.InList, [cube])


### PR DESCRIPTION
This PR introduces fine-grained recomputes in FreeCAD. These are recomputes based on dependencies between *properties* instead of based on *objects* as is the case in FreeCAD currently. This is essentially the [implementation of phase 1](https://github.com/pieterhijma/FreeCAD-Enhancement-Proposals/blob/variant-parts/FEPs/FEP-0010-variant-parts/README.md#phase-1-fine-grained-recomputation) of [FEP-0010](https://github.com/pieterhijma/FreeCAD-Enhancement-Proposals/blob/variant-parts/FEPs/FEP-0010-variant-parts/README.md).

Important design decisions:
- I chose to deprecate `Property::Status::Single`, a non-used flag that indicates that floating points in some properties need to be single precision instead of double precision. As far as I can tell, this is not actively used in FreeCAD. Removing this flag paves the way for introducing an `Property::Status::Input` flag that allows us to mark properties as "true" input properties.
- It introduces a simple dependency edge tuple with a "from object", "from property", "to object", "to property". This is used to define the fine-grained relations in the dependency graph.
- Besides the regular InList and OutList, FreeCAD now computes InListProp and OutListProp, the same datastructure but with more fine-grained information.
- There is a preference in the Gui that allows users to turn on or off fine-grained recomputes. From the console or Python use `FreeCAD.ParamGet("User parameter:BaseApp/Preferences/General").SetBool("FineGrainedRecompute", True)`.
- If fine-grained recomputes is on Tools->Dependency Graph will show the dependencies based on properties.
- Cyclic dependency checks are aware of input properties.
- The logic for fine-grained recomputes mimics the original logic as much as possible, to make minimal changes to the existing logic. This ensured that when the topological order is computed, we can still do that on the dependency graph based on objects.
- To make very clear where the logic has changed compared to coarse-grained recomputes, some dependency check codes has an extra level of indentation because of the condition if we are doing fine grained or coarse-grained recomputes. I think this benefits the review process where all new logic can be compared easily to the old logic. However, in terms of code-quality, I would prefer to refactor the code to get rid of this extra level of indentation.
- There is a test-suite that is explicit in whether a test should be run in either fine-grained, coarse-grained or both modes.
- In my humble opinion marking properties as "output" is misused in FreeCAD code to mean that a property change should not cause a recompute. For example `Label` and `Visibility` are marked as output properties. Although I would prefer those properties to change the flag to `NoRecompute`, it turns out that FreeCAD has semantics solidified in tests that prevent me to make this change. So, this PR is compatible with the semantics that output properties should not cause recomputes.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Part of https://github.com/FreeCAD/FreeCAD/issues/12120
Closes #5948

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
