### PR TITLE
TechDraw: DrawViewSpreadsheet do not create cyclic dependency

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSpreadsheet.cpp
@@ -143,7 +143,6 @@ std::string DrawViewSpreadsheet::getSVGTail()
 std::string DrawViewSpreadsheet::getSheetImage()
 {
     App::DocumentObject* link = Source.getValue();
-    link->recomputeFeature();   //make sure s/s is up to date
 
     std::string scellstart = CellStart.getValue();
     std::string scellend = CellEnd.getValue();
@@ -411,3 +410,4 @@ template<> const char* TechDraw::DrawViewSpreadsheetPython::getViewProviderName(
 // explicit template instantiation
 template class TechDrawExport FeaturePythonT<TechDraw::DrawViewSpreadsheet>;
 }
+


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/25568 by reversing https://github.com/FreeCAD/FreeCAD/pull/2010
@WandererFan the fixof 2010 is not a good solution because it generate cyclic dependency between the sheet and the view.

I cannot replicate[ the bug ](https://tracker.freecad.org/view.php?id=3891) that #2010 was supposed to be fixing. But the reproduction steps are not clear so I'm not sure.