### PR TITLE
PartDesign: Polar pattern: Accept negative angles

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -368,4 +368,3 @@ void PolarPattern::updateSpacings()
 }
 
 }  // namespace PartDesign
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/25489

And also enable the 'extent' mode to have negative angles too. No reason this should not be possible.