### PR TITLE
CAM: Clearance height out

### DIFF
--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -454,11 +454,10 @@ class ObjectOp(PathOp.ObjectOp):
                 self.commandlist.extend(ppCmds)
                 sims.append(sim)
 
-            if self.endVector is not None and len(self.commandlist) > 1:
-                self.endVector[2] = obj.ClearanceHeight.Value
-                self.commandlist.append(
-                    Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
-                )
+            if self.endVector is not None and len(ppCmds) > 1:
+                z = obj.ClearanceHeightOut.Value
+                self.endVector[2] = z
+                self.commandlist.append(Path.Command("G0", {"Z": z, "F": self.vertRapid}))
 
         Path.Log.debug("obj.Name: " + str(obj.Name) + "\n\n")
         return sims

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -400,6 +400,15 @@ class ObjectOp(object):
             )
             obj.addProperty(
                 "App::PropertyDistance",
+                "ClearanceHeightOut",
+                "Depth",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Move to this height at the end of the operation",
+                ),
+            )
+            obj.addProperty(
+                "App::PropertyDistance",
                 "SafeHeight",
                 "Depth",
                 QT_TRANSLATE_NOOP("App::Property", "Rapid Safety Height between locations."),
@@ -606,6 +615,18 @@ class ObjectOp(object):
                 ),
             )
             obj.Workplane = FreeCAD.Vector(0, 0, 1)
+
+        if FeatureHeights & features and not hasattr(obj, "ClearanceHeightOut"):
+            obj.addProperty(
+                "App::PropertyDistance",
+                "ClearanceHeightOut",
+                "Depth",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Move to this height at the end of the operation",
+                ),
+            )
+            self.applyExpression(obj, "ClearanceHeightOut", "ClearanceHeight")
 
         self.setEditorModes(obj, features)
         self.opOnDocumentRestored(obj)
@@ -818,6 +839,7 @@ class ObjectOp(object):
                     obj, "ClearanceHeight", job.SetupSheet.ClearanceHeightExpression
                 ):
                     obj.ClearanceHeight = "5 mm"
+                self.applyExpression(obj, "ClearanceHeightOut", "ClearanceHeight")
 
         if FeatureDiameters & features:
             obj.MinDiameter = "0 mm"
@@ -1231,7 +1253,7 @@ class ObjectOp(object):
 
         if self.commandlist and (FeatureHeights & self.opFeatures(obj)):
             # Let's finish by rapid to clearance...just for safety
-            self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
+            self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeightOut.Value}))
 
         path = Path.Path(self.commandlist)
 


### PR DESCRIPTION
`ClearanceHeight` is not a common property for whole `Job`
User can set different values for each operation

Added property `ClearanceHeightOut`, which allows operations to be coordinated with each other without useless vertical movements
Also this is way to exclude retract in the end of operation if needed
 
<img width="1890" height="390" alt="1_hor_lossy" src="https://github.com/user-attachments/assets/3bff0b38-1007-4d06-868e-f67bad83a191" />

<img width="870" height="468" alt="Screenshot_20251123_182508_hor" src="https://github.com/user-attachments/assets/abd16323-4762-44b6-9a55-468767f92295" />