### PR TITLE
Build: Update pylint minimum python version to 3.10

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -87,10 +87,6 @@ py-version=3.10
 # Discover python modules and packages in the file system subtree.
 recursive=no
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages.
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no


### PR DESCRIPTION
Minimum supported python version is 3.10 but .pylintrc is outdated setting it to 3.8 firing a lot of lint errors that are false positives.