### PR TITLE
Assembly: Fix crash in ViewProviderAssembly::findDragMode

### DIFF
--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -839,24 +839,27 @@ ViewProviderAssembly::DragMode ViewProviderAssembly::findDragMode()
 {
     auto addPartsToMove = [&](const std::vector<Assembly::ObjRef>& refs) {
         for (auto& partRef : refs) {
-            if (!partRef.obj) {
+            auto obj = partRef.obj;
+            auto ref = partRef.ref;
+            if (!obj || !ref) {
                 continue;
             }
-            auto* pPlc = dynamic_cast<App::PropertyPlacement*>(
-                partRef.obj->getPropertyByName("Placement")
-            );
-            if (pPlc) {
-                App::DocumentObject* selRoot = partRef.ref->getValue();
-                if (!selRoot) {
-                    continue;
-                }
-                std::vector<std::string> subs = partRef.ref->getSubValues();
-                if (subs.empty()) {
-                    continue;
-                }
 
-                docsToMove.emplace_back(partRef.obj, pPlc->getValue(), selRoot, subs[0]);
+            auto pPlc = dynamic_cast<App::PropertyPlacement*>(obj->getPropertyByName("Placement"));
+            if (!pPlc) {
+                continue;
             }
+
+            App::DocumentObject* selRoot = ref->getValue();
+            if (!selRoot) {
+                continue;
+            }
+            std::vector<std::string> subs = ref->getSubValues();
+            if (subs.empty()) {
+                continue;
+            }
+
+            docsToMove.emplace_back(obj, pPlc->getValue(), selRoot, subs[0]);
         }
     };
 


### PR DESCRIPTION
This is a fix from @wwmayer's branch https://github.com/FreeCAD/FreeCAD/commit/a7882c6cbb050e23e54dfd53a1dee7f7c7505aff

The fix is actually not needed as it was fixed in upstream. But Werner's code is a cleaner refactor. So I'm PR this little refactor as it will help Werner's branch to stay closer to upstream.

Following up on https://github.com/FreeCAD/FreeCAD/issues/20001#issuecomment-3575765940 @3x380V 