### PR TITLE
part design: fix issue #25639 use c++ exception to prevent crash

### DIFF
--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -154,11 +154,12 @@ App::DocumentObjectExecReturn* Fillet::execute()
         return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
     catch (...) {
-        return new App::DocumentObjectExecReturn(
-                QT_TRANSLATE_NOOP("Exception", 
-                    "Fillet operation failed. The selected edges may contain geometry that cannot be filleted together. "
-                    "Try filleting edges individually or with a smaller radius.")
-                );
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+            "Exception",
+            "Fillet operation failed. The selected edges may contain geometry that cannot be "
+            "filleted together. "
+            "Try filleting edges individually or with a smaller radius."
+        ));
     }
 }
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR aims to resolve crash described in issue #25639

fixes #25639

though this does prevent the crash i believe the upstream opencascade code could be improved as the stacktrace / backtrace the error is caused by an internal occ algo.

The crash happens in Geom2dAdaptor_Curve::D0 which is called from ChFi3d_FilBuilder::PerformTwoCorner

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images

<img width="3363" height="2089" alt="image" src="https://github.com/user-attachments/assets/ad051ca9-1584-4c30-a57c-3e953a1523df" />


<img width="3458" height="2080" alt="image" src="https://github.com/user-attachments/assets/48e92756-b059-48de-a45d-145dc36e8ea9" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
