### PR TITLE
CAM: Profile - Split multiple passes

### DIFF
--- a/src/Mod/CAM/Path/Op/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/PocketBase.py
@@ -102,7 +102,22 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         Can safely be overwritten by subclass."""
         pass
 
+    def areaOpOnChanged(self, obj, prop):
+        print("areaOpOnChanged PocketBase", prop)
+
+        if hasattr(obj, "ExtraOffsetZigZag"):
+            extraOffsetZigZagMode = 0 if obj.ClearingPattern == "ZigZagOffset" else 2
+            obj.setEditorMode("ExtraOffsetZigZag", extraOffsetZigZagMode)
+
+        if hasattr(obj, "StartAt") and hasattr(obj, "OffsetOneStepDown"):
+            offsetOneStepDownMode = (
+                0 if obj.ClearingPattern == "ZigZagOffset" and obj.StartAt == "Center" else 2
+            )
+            obj.setEditorMode("OffsetOneStepDown", offsetOneStepDownMode)
+
     def opExecute(self, obj):
+        print("opExecute PocketBase")
+
         if len(obj.Base) == 0:
             return
         super().opExecute(obj)
@@ -140,6 +155,15 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             ),
         )
         obj.addProperty(
+            "App::PropertyDistance",
+            "ExtraOffsetZigZag",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Extra offset to apply to the ZigZag path with pattern ZigZagOffset.",
+            ),
+        )
+        obj.addProperty(
             "App::PropertyEnumeration",
             "StartAt",
             "Pocket",
@@ -172,10 +196,13 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             QT_TRANSLATE_NOOP("App::Property", "Use 3D Sorting of Path"),
         )
         obj.addProperty(
-            "App::PropertyBool",
-            "KeepToolDown",
+            "App::PropertyLength",
+            "RetractThreshold",
             "Pocket",
-            QT_TRANSLATE_NOOP("App::Property", "Attempts to avoid unnecessary retractions."),
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Set distance which will attempts to avoid unnecessary retractions.",
+            ),
         )
         obj.addProperty(
             "App::PropertyPercent",
@@ -195,15 +222,21 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 "Skips machining regions that have already been cleared by previous operations.",
             ),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "OffsetOneStepDown",
+            "Pocket",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "With clearing pattern ZigZagOffset and start at center,"
+                "\nOffset path will processing with one step down at final depth.",
+            ),
+        )
 
         for n in self.pocketPropertyEnumerations():
             setattr(obj, n[0], n[1])
 
         self.initPocketOp(obj)
-
-    def areaOpRetractTool(self, obj):
-        Path.Log.debug("retracting tool: %d" % (not obj.KeepToolDown))
-        return not obj.KeepToolDown
 
     def areaOpUseProjection(self, obj):
         """areaOpUseProjection(obj) ... return False"""
@@ -222,8 +255,11 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         params["PocketStepover"] = (self.radius * 2) * (float(obj.StepOver) / 100)
         extraOffset = obj.ExtraOffset.Value
         if self.pocketInvertExtraOffset():
-            extraOffset = 0 - extraOffset
-        params["PocketExtraOffset"] = extraOffset
+            extraOffset = -extraOffset
+        if obj.ClearingPattern == "ZigZagOffset":
+            params["PocketExtraOffset"] = extraOffset + obj.ExtraOffsetZigZag.Value
+        else:
+            params["PocketExtraOffset"] = extraOffset
         params["ToolRadius"] = self.radius
         params["PocketLastStepover"] = obj.PocketLastStepOver
 
@@ -240,6 +276,21 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         if obj.SplitArcs:
             params["Explode"] = True
             params["FitArcs"] = False
+
+        return params
+
+    def areaOpAreaParamsOffset(self, obj, isHole):
+        """areaOpAreaParamsOffset(obj, isHole) ... return dictionary with area parameters
+        for pattern ZigZagOffset
+        This AreaParams using for Offset after Pocket ZigZag"""
+        params = {}
+        params["Fill"] = 0
+        params["Coplanar"] = 0
+        params["SectionCount"] = -1
+        params["Offset"] = -(self.radius + obj.ExtraOffset.Value)
+        params["ExtraPass"] = 0
+        params["Stepover"] = 0
+        params["JoinType"] = 0
 
         return params
 
@@ -267,7 +318,39 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                     "Skips machining regions that have already been cleared by previous operations.",
                 ),
             )
-
+        if not hasattr(obj, "RetractThreshold"):
+            obj.addProperty(
+                "App::PropertyLength",
+                "RetractThreshold",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Set distance which will attempts to avoid unnecessary retractions.",
+                ),
+            )
+        if not hasattr(obj, "ExtraOffsetZigZag"):
+            obj.addProperty(
+                "App::PropertyDistance",
+                "ExtraOffsetZigZag",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Extra offset to apply to the ZigZag path with pattern ZigZagOffset.",
+                ),
+            )
+            expr = f"{obj.Name}.ToolController.Tool.Diameter.Value * 0.25"
+            obj.setExpression("ExtraOffsetZigZag", expr)
+        if not hasattr(obj, "OffsetOneStepDown"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "OffsetOneStepDown",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "With clearing pattern ZigZagOffset and start at center,"
+                    "\nOffset path will processing with one step down at final depth.",
+                ),
+            )
         if hasattr(obj, "OffsetPattern"):
             obj.setGroupOfProperty("OffsetPattern", "Pocket")
             obj.renameProperty("OffsetPattern", "ClearingPattern")
@@ -275,6 +358,11 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             obj.removeProperty("RestMachiningRegions")
         if hasattr(obj, "RestMachiningRegionsNeedRecompute"):
             obj.removeProperty("RestMachiningRegionsNeedRecompute")
+        if hasattr(obj, "KeepToolDown"):
+            if obj.KeepToolDown:
+                expr = f"{obj.Name}.ToolController.Tool.Diameter.Value"
+                obj.setExpression("RetractThreshold", expr)
+            obj.removeProperty("KeepToolDown")
 
         Path.Log.track()
 
@@ -296,7 +384,6 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         #
         if obj.MinTravel and obj.UseStartPoint and obj.StartPoint is not None:
             params["sort_mode"] = 3
-            params["threshold"] = self.radius * 2
         return params
 
 
@@ -309,5 +396,4 @@ def SetupProperties():
     setup.append("ClearingPattern")
     setup.append("StartAt")
     setup.append("MinTravel")
-    setup.append("KeepToolDown")
     return setup

--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -180,6 +180,8 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         obj.StepOver = 50
         obj.ZigZagAngle = 45
         obj.UseOutline = False
+        expr = f"{obj.Name}.ToolController.Tool.Diameter.Value * 0.25"
+        obj.setExpression("ExtraOffsetZigZag", expr)
         FeatureExtensions.set_default_property_values(obj, job)
 
     def areaOpShapes(self, obj):

--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -180,9 +180,9 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         obj.StepOver = 50
         obj.ZigZagAngle = 45
         obj.UseOutline = False
-        expr = f"{obj.Name}.ToolController.Tool.Diameter.Value * 0.25"
-        obj.setExpression("ExtraOffsetZigZag", expr)
+        obj.setExpression("ExtraFinishOffset", "OpToolDiameter * 0.25")
         FeatureExtensions.set_default_property_values(obj, job)
+        obj.setExpression("RetractThreshold", "0 * OpToolDiameter")
 
     def areaOpShapes(self, obj):
         """areaOpShapes(obj) ... return shapes representing the solids to be removed."""


### PR DESCRIPTION
> [!CAUTION]
> This PR will be combined with
> - #25313

Fix:
- #25684

Create `area` for each offset independently
So we get correct order without `sort_mode = 0` and can set `StartPoint`
Also added property `StartAt`

<img width="907" height="356" alt="Screenshot_20251126_153416_lossy" src="https://github.com/user-attachments/assets/c0c18179-67f1-42a6-bdb0-674a9c069bd8" />
<br>
<br>

Probably need to find more universal names of parameters for `StartAt`, 
which can be used for `Pocket` and `Profile` operations
Something like `Inside` and `Outside`