### PR TITLE
Part: Fix addSelection failing for links to body.

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -1570,4 +1570,3 @@ void ViewProviderPartExt::handleChangedPropertyName(
         Gui::ViewProviderGeometryObject::handleChangedPropertyName(reader, TypeName, PropName);
     }
 }
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/25688
ViewProviderPartExt was failing to resolve TNP hash in subnames.