### PR TITLE
[Gui] Fix AxisLetterColor on opening Preferences and correct…

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
@@ -220,7 +220,7 @@ void DlgSettingsLightSources::configureViewer()
 {
     const SbVec3f defaultViewDirection {0.0f, 1.0f, 0.3f};
 
-    View3DSettings(hGrp, view).applySettings();
+    View3DSettings(hGrpView, view).applySettings();
 
     view->setRedirectToSceneGraph(true);
     view->setViewing(true);

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.h
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.h
@@ -82,6 +82,9 @@ private:
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View/LightSources"
     );
+    ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View"
+    );
 
     float zoomStep = 3.0f;
 };

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -95,6 +95,15 @@ void View3DSettings::applySettings()
     OnChange(*hGrp, "UseVBO");
     OnChange(*hGrp, "RenderCache");
     OnChange(*hGrp, "Orthographic");
+    OnChange(*hGrp, "NavigationStyle");
+    OnChange(*hGrp, "OrbitStyle");
+    OnChange(*hGrp, "Sensitivity");
+    OnChange(*hGrp, "ResetCursorPosition");
+    OnChange(*hGrp, "DimensionsVisible");
+    OnChange(*hGrp, "Dimensions3dVisible");
+    OnChange(*hGrp, "DimensionsDeltaVisible");
+    OnChange(*hGrp, "PickRadius");
+    OnChange(*hGrp, "TransparentObjectRenderType");
 
     auto lightSourcesGrp = hGrp->GetGroup("LightSources");
     OnChange(*lightSourcesGrp, "EnableHeadlight");
@@ -111,39 +120,6 @@ void View3DSettings::applySettings()
     OnChange(*lightSourcesGrp, "FillLightIntensity");
     OnChange(*lightSourcesGrp, "AmbientLightColor");
     OnChange(*lightSourcesGrp, "AmbientLightIntensity");
-
-    // Workaround
-    // Clear old settings that was used for a while in 1.1dev
-    // By clearing these settings, 1.0 will be able to run with same config file again
-    // For more info: https://github.com/FreeCAD/FreeCAD/issues/19880
-    // TODO: Remove when 1.1.0 is about to be released
-    if (hGrp->GetASCII("FillLightDirection").empty()) {
-        hGrp->RemoveBool("EnableHeadlight");
-        hGrp->RemoveUnsigned("HeadlightColor");
-        hGrp->RemoveASCII("HeadlightDirection");
-        hGrp->RemoveInt("HeadlightIntensity");
-        hGrp->RemoveBool("EnableBacklight");
-        hGrp->RemoveUnsigned("BacklightColor");
-        hGrp->RemoveASCII("BacklightDirection");
-        hGrp->RemoveInt("BacklightIntensity");
-        hGrp->RemoveBool("EnableFillLight");
-        hGrp->RemoveUnsigned("FillLightColor");
-        hGrp->RemoveASCII("FillLightDirection");
-        hGrp->RemoveInt("FillLightIntensity");
-        hGrp->RemoveUnsigned("AmbientLightColor");
-        hGrp->RemoveInt("AmbientLightIntensity");
-    }
-    // End of workaround
-
-    OnChange(*hGrp, "NavigationStyle");
-    OnChange(*hGrp, "OrbitStyle");
-    OnChange(*hGrp, "Sensitivity");
-    OnChange(*hGrp, "ResetCursorPosition");
-    OnChange(*hGrp, "DimensionsVisible");
-    OnChange(*hGrp, "Dimensions3dVisible");
-    OnChange(*hGrp, "DimensionsDeltaVisible");
-    OnChange(*hGrp, "PickRadius");
-    OnChange(*hGrp, "TransparentObjectRenderType");
 }
 
 void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason)


### PR DESCRIPTION
…LightSources target parameter group

Also remove workaround as stated in the _src/Gui/View3DSettings.cpp_ comments just before 1.1.0 Release.

Fixes #25672 

## Before

<img width="1010" height="899" alt="Before_PR" src="https://github.com/user-attachments/assets/c255e40f-8151-45e3-9ec6-f54d250aa550" />

## After

<img width="1021" height="887" alt="After_PR" src="https://github.com/user-attachments/assets/bd694ec0-fec4-4cba-89b7-c34f244a54aa" />
