### PR TITLE
3rdParty: Suppress "error" message when navlib isn't present on macOS.

### DIFF
--- a/src/3rdParty/3Dconnexion/src/navlib_stub.c
+++ b/src/3rdParty/3Dconnexion/src/navlib_stub.c
@@ -101,7 +101,7 @@ long NlLoadLibrary() {
   void *libHandle = dlopen(TheLibrary, RTLD_LAZY | RTLD_LOCAL);
   if (NULL == libHandle) {
     error = -1; // whatever error it's an error dlopen() does not set errno
-    fprintf(stderr, "Error: Failed to open library \"%s\"! Error: %s!\n", TheLibrary, dlerror());
+    //fprintf(stderr, "Error: Failed to open library \"%s\"! Error: %s!\n", TheLibrary, dlerror());
   }
   else {
     /* load up the function pointer table */


### PR DESCRIPTION
This simply comments out the "error" message that appeared every single time I launched FreeCAD from the command line.

Since 99% of users probably don't have a 3D mouse, this is not worth reporting.