### PR TITLE
Gui: Unify Python exception reporting in command handlers

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1444,12 +1444,8 @@ void PythonCommand::activated(int iMsg)
             }
         }
         catch (const Base::PyException& e) {
-            Base::Console().error(
-                "Running the Python command '%s' failed:\n%s\n%s",
-                sName,
-                e.getStackTrace().c_str(),
-                e.what()
-            );
+            Base::Console().error("Running the Python command '%s' failed:", sName);
+            e.reportException();
         }
         catch (const Base::Exception&) {
             Base::Console().error("Running the Python command '%s' failed, try to resume", sName);
@@ -1697,12 +1693,8 @@ void PythonGroupCommand::activated(int iMsg)
     catch (Py::Exception&) {
         Base::PyGILStateLocker lock;
         Base::PyException e;
-        Base::Console().error(
-            "Running the Python command '%s' failed:\n%s\n%s",
-            sName,
-            e.getStackTrace().c_str(),
-            e.what()
-        );
+        Base::Console().error("Running the Python command '%s' failed:", sName);
+        e.reportException();
     }
 }
 
@@ -1794,12 +1786,8 @@ Action* PythonGroupCommand::createAction()
     catch (Py::Exception&) {
         Base::PyGILStateLocker lock;
         Base::PyException e;
-        Base::Console().error(
-            "createAction() of the Python command '%s' failed:\n%s\n%s",
-            sName,
-            e.getStackTrace().c_str(),
-            e.what()
-        );
+        Base::Console().error("createAction() of the Python command '%s' failed:", sName);
+        e.reportException();
     }
 
     _pcAction = pcAction;


### PR DESCRIPTION
Replace custom exception formatting with `PyException::reportException()` for consistent output that includes previously missing exception types.

First observed on this comment, where the printed exception is missing the exception type: https://github.com/FreeCAD/FreeCAD/issues/17047#issuecomment-2395614250

---

I've left these two instances of custom exception printing untouched:

https://github.com/FreeCAD/FreeCAD/blob/da717d4ca0e9c48bae999abdfc99ff4fae0f9956/src/Gui/propertyeditor/PropertyItem.cpp#L638-L650

I believe the stack trace is being printed twice for the Python exception, so the line that prints "Stack Trace:" on the console should probably be removed.

https://github.com/FreeCAD/FreeCAD/blob/da717d4ca0e9c48bae999abdfc99ff4fae0f9956/src/Gui/Application.cpp#L1833-L1851

Here the code seemed less trivial and I preferred not to change it.

