### PR TITLE
Sketcher: Use constraint index instead of geoId as key in expr storage

### DIFF
--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
@@ -54,10 +54,11 @@ void SketcherTransformationExpressionHelper::storeOriginalExpressions(
                     = sketchObject->getExpression(spath);
 
                 if (expr_info.expression) {
-                    // map expression to geoid as a key
-                    originalExpressions[geoId] = std::shared_ptr<App::Expression>(
-                        expr_info.expression->copy()
-                    );
+                    // map expression to constraint index as a key, storing both expression and geoId
+                    ConstraintExpressionInfo info;
+                    info.expression = std::shared_ptr<App::Expression>(expr_info.expression->copy());
+                    info.geoId = geoId;
+                    originalExpressions[static_cast<int>(i)] = info;
                 }
             }
         }
@@ -91,7 +92,7 @@ void SketcherTransformationExpressionHelper::copyExpressionsToNewConstraints(
         // try to find and apply a matching expression for this constraint
         bool expressionApplied = false;
         for (const auto& exprPair : originalExpressions) {
-            int originalGeoId = exprPair.first;
+            int originalGeoId = exprPair.second.geoId;
             int originalIndex = indexOfGeoId(listOfGeoIds, originalGeoId);
 
             if (originalIndex >= 0) {
@@ -101,7 +102,7 @@ void SketcherTransformationExpressionHelper::copyExpressionsToNewConstraints(
                     originalIndex,
                     params,
                     secondNumberOfCopies,
-                    exprPair.second,
+                    exprPair.second.expression,
                     sketchObj
                 );
 

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.h
@@ -84,6 +84,12 @@ private:
         int numberOfCopiesToMake;
     };
 
+    struct ConstraintExpressionInfo
+    {
+        std::shared_ptr<App::Expression> expression;
+        int geoId;  // the geoId from listOfGeoIds that this constraint references
+    };
+
     /// calculate parameters needed for copy operations
     CopyCalculationParams calculateCopyParams(
         Sketcher::SketchObject* sketchObject,
@@ -106,8 +112,8 @@ private:
     /// check if a constraint references the specified geometry ID
     bool constraintReferencesGeometry(const Sketcher::Constraint* cstr, int geoId) const;
 
-    // original geo id to expression mapping
-    std::map<int, std::shared_ptr<App::Expression>> originalExpressions;
+    // original constraint index to expression and geoId mapping
+    std::map<int, ConstraintExpressionInfo> originalExpressions;
 };
 
 }  // namespace SketcherGui


### PR DESCRIPTION
`SketcherTransformationExpressionHelper` was using `geoId` as the map key for storing expressions during geometry transformations. This is incorrect since single geometry may have multiple constraints with different expressions.

So, using `geoId` as the key causes `std::map` overwrites, resulting in only the last expression being preserved per geometry.

So this patch changes key to be a constraint index, and adds `ConstraintExpressionInfo` struct to store both expression and `geoId`.

Sorry for the delay and thanks @PaddleStroke for the investigation, once again.

Before:

https://github.com/user-attachments/assets/446ea82b-dbc4-47c1-ab08-a3db18da44c1

After:

https://github.com/user-attachments/assets/b21366a4-725e-4d73-b202-e635d6a2a6c9

Resolves: https://github.com/FreeCAD/FreeCAD/issues/24946