### PR TITLE
Build: Fix punctuation in Windows installer (English only)

### DIFF
--- a/package/WindowsInstaller/lang/english.nsh
+++ b/package/WindowsInstaller/lang/english.nsh
@@ -7,7 +7,7 @@ Language: English
 
 ${LangFileString} TEXT_INSTALL_CURRENTUSER "(Installed for Current User)"
 
-${LangFileString} TEXT_WELCOME "This wizard will guide you through the installation of $(^NameDA), $\r$\n\
+${LangFileString} TEXT_WELCOME "This wizard will guide you through the installation of $(^NameDA). $\r$\n\
 				$\r$\n\
 				$_CLICK"
 


### PR DESCRIPTION
Translators have already fixed this in all other languages I checked, only the English punctuation is wrong.