### PR TITLE
CAM: Turn off debugging in CAM Preferences

### DIFF
--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -30,7 +30,7 @@ from collections import defaultdict
 from typing import Optional
 
 
-if True:
+if False:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
     Path.Log.trackModule(Path.Log.thisModule())
 else:
@@ -154,7 +154,7 @@ def getAssetPath() -> pathlib.Path:
 
 
 def setAssetPath(path: pathlib.Path):
-    Path.Log.info(f"Setting asset path to {path}")
+    Path.Log.debug(f"Setting asset path to {path}")
     assert path.is_dir(), f"Cannot put a non-initialized asset directory into preferences: {path}"
     pref = tool_preferences()
     current_path = pref.GetString(ToolPath, "")


### PR DESCRIPTION
Debugging was left on by mistake. Also 'Setting asset path' log message was at info level. Changed to debug level.

Backport to 1.1.0 Please

Fixes: #25734