### PR TITLE
Draft: make Draft_SetStyle work for sketches

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_setstyle.py
+++ b/src/Mod/Draft/draftguitools/gui_setstyle.py
@@ -422,6 +422,9 @@ class Draft_SetStyle_TaskPanel:
 
         properties = vobj.PropertiesList
         if "FontName" not in properties:  # Shapes
+            if "AutoColor" in properties:
+                # For sketches.
+                vobj.AutoColor = False
             if "ShapeAppearance" in properties:
                 material = App.Material()
                 material.DiffuseColor = self.form.ShapeColor.property("color").getRgbF()[


### PR DESCRIPTION
The AutoColor property of sketches has to be set to False before applying colors, otherwise the default colors from the Sketcher preferences will be re-applied.