### PR TITLE
Revert "ui: allow selecting of all objects ie. resolve issue #15527"

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -6539,37 +6539,20 @@ int DocumentObjectItem::getSubName(std::ostringstream& str, App::DocumentObject*
         int group = parent->isGroup();
         if (group == NotGroup) {
             if (ret != PartGroup) {
-                // check if the parent explicitly claims this child,
-                // if so, we should include the parent in the subname path
-                auto children = parent->object()->claimChildren();
-                bool parentClaimsThis = false;
-                for (auto child : children) {
-                    if (child == object()->getObject()) {
-                        parentClaimsThis = true;
-                        break;
-                    }
-                }
-
-                if (!parentClaimsThis) {
-                    // Handle this situation,
-                    //
-                    // LinkGroup
-                    //    |--PartExtrude
-                    //           |--Sketch
-                    //
-                    // This function traverse from top down, so, when seeing a
-                    // non-group object 'PartExtrude', its following children should
-                    // not be grouped, so must reset any previous parents here.
-                    topParent = nullptr;
-                    str.str("");  // reset the current subname
-                    return NotGroup;
-                }
-                // if parent claims this child, treat it like a PartGroup
-                group = PartGroup;
+                // Handle this situation,
+                //
+                // LinkGroup
+                //    |--PartExtrude
+                //           |--Sketch
+                //
+                // This function traverse from top down, so, when seeing a
+                // non-group object 'PartExtrude', its following children should
+                // not be grouped, so must reset any previous parents here.
+                topParent = nullptr;
+                str.str("");  // reset the current subname
+                return NotGroup;
             }
-            else {
-                group = PartGroup;
-            }
+            group = PartGroup;
         }
         ret = group;
     }


### PR DESCRIPTION
Reverts FreeCAD/FreeCAD#25503 due to #25788 -- on the main branch we could consider adding a follow-on fix if one is forthcoming, rather than merging this reversion, if that's preferred. For the 1.1 release branch we should probably go ahead and revert.