### PR TITLE
BIM: Fix duplicate vertices in Wavefront OBJ export

### DIFF
--- a/src/Mod/BIM/importers/importOBJ.py
+++ b/src/Mod/BIM/importers/importOBJ.py
@@ -150,13 +150,12 @@ def getIndices(obj, shape, offsetv, offsetvn):
                     flist.append(fi)
             else:
                 fi = ""
-                edges = f.OuterWire.OrderedEdges
+                verts = f.OuterWire.OrderedVertexes
                 # Avoid flipped normals:
                 if f.Orientation == "Reversed":
-                    edges.reverse()
-                for e in edges:
-                    v = e.Vertexes[0 if e.Orientation == "Forward" else 1]
-                    ind = findVert(v, shape.Vertexes)
+                    verts.reverse()
+                for vert in verts:
+                    ind = findVert(vert, shape.Vertexes)
                     if ind is None:
                         return None, None, None, None
                     fi += " " + str(ind + offsetv)


### PR DESCRIPTION
Fixes: #13151.

The vertices derived from a face's outerwire could contain duplicates.

Excerpt from a faulty .obj file (notice that 4 faces have duplicate vertex indices):
```
f 2 4 3 1
f 2 1 6 5
f 3 1 6 6 11 10 9 8
f 4 3 7 12
f 4 2 16 15 14 13 12 12
f 11 5 5 16
f 7 8 13 7
f 9 8 13 14
f 10 15 14 9
f 16 15 10 11
```

Fixed by switching to:
`f.OuterWire.OrderedVertexes`