### PR TITLE
CAM: Avoid adding trailing space to all M6 lines in Fanuc processor

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -590,8 +590,7 @@ def parse(pathobj):
                     outstring.insert(0, (linenumber()))
 
                 # append the line to the final output
-                for w in outstring:
-                    out += w.upper() + COMMAND_SPACE
+                out += COMMAND_SPACE.join(outstring).upper()
                 out = out.strip() + "\n"
 
         return out


### PR DESCRIPTION
The Fanuc post processor add a trailing space to all M6 lines. This make it problematic to write test for the generated output, when compiled with the automatic policy enforcer on github removing trialing space from the expected output.  Avoid the problem by removing the trailing space from the generated output.