### PR TITLE
Sketcher: Fix error when first constraint is DistanceX/DistanceY to vertex

### DIFF
--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -636,7 +636,8 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos == Sketcher::PointPos::none && constr->Second == GeoEnum::GeoUndef) {
+                 if (constr->FirstPos == Sketcher::PointPos::none
+                     && constr->Second == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceX', %s, %f") % geoId1
                          % constr->getValue()
@@ -661,7 +662,8 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos == Sketcher::PointPos::none && constr->Second == GeoEnum::GeoUndef) {
+                 if (constr->FirstPos == Sketcher::PointPos::none
+                     && constr->Second == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceY', %s, %f") % geoId1
                          % constr->getValue()


### PR DESCRIPTION
This PR fixes the error described in Issue #25779.

### Details

The auto‑scaling code path uses SketchObjectPy::addConstraint(), and the parameters are constructed by PythonConverter, the constraint’s First is included, but its FirstPos is omitted during PythonConverter’s processing. As a result, DistanceX/DistanceY constraints cannot be applied to single vertices like endpoints (PointPos = 1 or 2) or center points (PointPos = 3).

From the second time onward, auto‑scaling is not applied and the conventional SketchObjectPy::setDatum() path is used, which correctly preserves the FirstPos in the constraint. Consequently, this issue affected only the initial constraint in a sketch.

This PR fixes the two behaviors described in #25779 by including FirstPos in the parameters whenever it is valid.

### Notes

- I believe, ideally, the branching code below would not be necessary. 
```
if (constr->FirstPos == Sketcher::PointPos::none && constr->Second == GeoEnum::GeoUndef) {
    return boost::str(
        boost::format("Sketcher.Constraint('DistanceX', %s, %f") % geoId1
        % constr->getValue()
    );
}
else if (constr->SecondPos == Sketcher::PointPos::none) {
    return boost::str(
        boost::format("Sketcher.Constraint('DistanceX', %s, %i, %f") % geoId1
        % static_cast<int>(constr->FirstPos) % constr->getValue()
    );
}
else {
    return boost::str(
        boost::format("Sketcher.Constraint('DistanceX', %s, %i, %s, %i, %f")
        % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
        % static_cast<int>(constr->SecondPos) % constr->getValue()
    );
}
```
- instead, it seems it would be best to always send the full First/Second information to SketchObjectPy::addConstraint() and delegate the handling there, e.g.:
```
return boost::str(
    boost::format("Sketcher.Constraint('DistanceX', %s, %i, %s, %i, %f")
    % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
    % static_cast<int>(constr->SecondPos) % constr->getValue()
);
```
- however, to avoid unexpected regressions, this PR applies the minimal change needed to fix Issue #25779.

## Issues
Fixes: #25779