### PR TITLE
CAM: Fix pyi signature to match c++

### DIFF
--- a/src/Mod/CAM/App/Command.pyi
+++ b/src/Mod/CAM/App/Command.pyi
@@ -32,7 +32,7 @@ class Command(Persistence):
         """returns a copy of this command transformed by the given placement"""
         ...
 
-    def addAnnotations(self, annotations) -> "Command":
+    def addAnnotations(self, annotations, /) -> "Command":
         """addAnnotations(annotations): adds annotations from dictionary or string and returns self for chaining"""
         ...
     Name: str


### PR DESCRIPTION
CAM: Fix pyi signature to match c++ (No keywords support in the c++ impl)