### PR TITLE
BIM: BIM_Material: only assign material object to component

### DIFF
--- a/src/Mod/BIM/bimcommands/BimMaterial.py
+++ b/src/Mod/BIM/bimcommands/BimMaterial.py
@@ -545,8 +545,7 @@ class Arch_Material:
         FreeCADGui.Control.closeDialog()
         FreeCADGui.doCommand("mat = Arch.makeMaterial()")
         for obj in sel:
-            if hasattr(obj, "Material") \
-                    and hasattr(obj, "MoveWithHost"):  # 'isComponent' check
+            if hasattr(obj, "Material") and hasattr(obj, "MoveWithHost"):  # 'isComponent' check
                 FreeCADGui.doCommand(
                     'FreeCAD.ActiveDocument.getObject("' + obj.Name + '").Material = mat'
                 )


### PR DESCRIPTION
Fixes #25819 

BIM_Material could assign a material object to the Material property of another material object.

Using an additional check for the "MoveWithHost" property to verify the object is a component.

Alternative component check (rejected because it requires an import):
```python
import ArchComponent
ArchComponent.Component in obj.Proxy.__class__.__bases__
```