### PR TITLE
CAM: PathCommands - Remove unused import QtCore

### DIFF
--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -38,7 +38,6 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 if FreeCAD.GuiUp:
     import FreeCADGui
-    from PySide import QtCore
 
 translate = FreeCAD.Qt.translate
 


### PR DESCRIPTION
Remove unused import `QtCore`