### PR TITLE
CAM: PathCommands - Remove pop message about loop error

### DIFF
--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -39,9 +39,8 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore
-    from PySide import QtGui
 
-# translate = FreeCAD.Qt.translate
+translate = FreeCAD.Qt.translate
 
 __title__ = "FreeCAD Path Commands"
 __author__ = "sliptonic"
@@ -143,13 +142,7 @@ class _CommandSelectLoop:
                         FreeCADGui.Selection.addSelection(obj, f"Edge{objEdges.index(eo) + 1}")
             return
 
-        # Final fallback
-        if FreeCAD.GuiUp:
-            QtGui.QMessageBox.information(
-                None,
-                QT_TRANSLATE_NOOP("CAM_SelectLoop", "Feature Completion"),
-                QT_TRANSLATE_NOOP("CAM_SelectLoop", "Closed loop detection failed."),
-            )
+        Path.Log.warning(translate("CAM_SelectLoop", "Closed loop detection failed."))
 
     def formsPartOfALoop(self, obj, sub, names):
         try:


### PR DESCRIPTION
Does we really need this popup message?

<img width="249" height="101" alt="Screenshot_20251130_201100_lossy" src="https://github.com/user-attachments/assets/7ea5bf51-f110-43c3-9643-731f5c65d936" />

Must be very important reason to change focus from 3d view and showing new window
Probably message in `Report` view is enough in this case