### PR TITLE
Core: Introduce Command Palette to interact with commands faster

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -538,6 +538,7 @@ SET(Command_CPP_SRCS
     CommandPyImp.cpp
     ShortcutManager.cpp
     CommandCompleter.cpp
+    CommandPalette.cpp
     CommandActionPy.cpp
 )
 SET(Command_SRCS
@@ -548,6 +549,7 @@ SET(Command_SRCS
     CommandT.h
     ShortcutManager.h
     CommandCompleter.h
+    CommandPalette.h
     CommandActionPy.h
 )
 SOURCE_GROUP("Command" FILES ${Command_SRCS})

--- a/src/Gui/CommandCompleter.cpp
+++ b/src/Gui/CommandCompleter.cpp
@@ -20,10 +20,12 @@
  *                                                                          *
  ****************************************************************************/
 
+#include <algorithm>
 #include <QApplication>
 #include <QKeyEvent>
 #include <QLineEdit>
 #include <QAbstractItemView>
+#include <QSortFilterProxyModel>
 
 #include "Application.h"
 #include "ShortcutManager.h"
@@ -51,6 +53,7 @@ bool _ShortcutSignalConnected = false;
 class CommandModel: public QAbstractItemModel
 {
     int revision = 0;
+    bool filterInactive = false;
 
 public:
     explicit CommandModel(QObject* parent)
@@ -62,6 +65,18 @@ public:
             QObject::connect(ShortcutManager::instance(), &ShortcutManager::shortcutChanged, [] {
                 _CommandRevision = 0;
             });
+        }
+    }
+
+    void setFilterInactive(bool filter)
+    {
+        if (filterInactive != filter) {
+            filterInactive = filter;
+            // notify views that all data has changed (for greying out)
+            if (!_Commands.empty()) {
+                QAbstractItemModel::dataChanged(createIndex(0, 0), 
+                                               createIndex(_Commands.size() - 1, 0));
+            }
         }
     }
 
@@ -98,6 +113,18 @@ public:
         }
 
         auto& info = _Commands[index.row()];
+        
+        // check if command is active to grey out if not
+        bool isActive = true;
+        if (filterInactive) {
+            if (info.cmd->getAction() && info.cmd->getAction()->action()) {
+                isActive = info.cmd->getAction()->action()->isEnabled();
+            }
+            else {
+                // no action exists so assume inactive
+                isActive = false;
+            }
+        }
 
         switch (role) {
             case Qt::DisplayRole:
@@ -123,6 +150,13 @@ public:
                     }
                 }
                 return info.icon;
+            
+            case Qt::ForegroundRole:
+                // grey out inactive commands
+                if (!isActive) {
+                    return QColor(Qt::gray);
+                }
+                break;
 
             case CommandNameRole:
                 return QByteArray(info.cmd->getName());
@@ -147,6 +181,67 @@ public:
     {
         return 1;
     }
+
+    Qt::ItemFlags flags(const QModelIndex& index) const override
+    {
+        if (!index.isValid()) {
+            return Qt::NoItemFlags;
+        }
+
+        const auto& info = _Commands[index.row()];
+
+        bool isActive = true;
+        if (filterInactive) {
+            if (info.cmd->getAction() && info.cmd->getAction()->action()) {
+                isActive = info.cmd->getAction()->action()->isEnabled();
+            }
+            else {
+                // no action exists, so assume inactive
+                isActive = false;
+            }
+        }
+
+        // so if item is visible but not active, keep it, but don't add `ItemIsEnabled` so
+        // it won't be possible to select it
+        if (!isActive) {
+            return Qt::ItemIsSelectable;
+        }
+
+        return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    }
+};
+
+// proxy sort model to prioritize active commands before inactive ones
+class CommandSortFilterProxyModel : public QSortFilterProxyModel
+{
+public:
+    explicit CommandSortFilterProxyModel(QObject* parent = nullptr)
+        : QSortFilterProxyModel(parent)
+    {
+        setFilterCaseSensitivity(Qt::CaseInsensitive);
+        setSortRole(Qt::DisplayRole);
+    }
+
+protected:
+    bool lessThan(const QModelIndex& left, const QModelIndex& right) const override
+    {
+        auto sourceModel = static_cast<CommandModel*>(this->sourceModel());
+        if (!sourceModel) {
+            return QSortFilterProxyModel::lessThan(left, right);
+        }
+
+        // check if commands are active or not
+        bool leftActive = (sourceModel->flags(left) & Qt::ItemIsEnabled) != 0;
+        bool rightActive = (sourceModel->flags(right) & Qt::ItemIsEnabled) != 0;
+
+        // if one of the commands is active but other is not, just
+        // prioritize active one - otherwise, sort alphabetically
+        if (leftActive != rightActive) {
+            return leftActive > rightActive;
+        }
+
+        return QSortFilterProxyModel::lessThan(left, right);
+    }
 };
 
 }  // anonymous namespace
@@ -156,7 +251,12 @@ public:
 CommandCompleter::CommandCompleter(QLineEdit* lineedit, QObject* parent)
     : QCompleter(parent)
 {
-    this->setModel(new CommandModel(this));
+    auto sourceModel = new CommandModel(this);
+    auto proxyModel = new CommandSortFilterProxyModel(this);
+    proxyModel->setSourceModel(sourceModel);
+    proxyModel->sort(0);
+    
+    this->setModel(proxyModel);
     this->setFilterMode(Qt::MatchContains);
     this->setCaseSensitivity(Qt::CaseInsensitive);
     this->setCompletionMode(QCompleter::PopupCompletion);
@@ -169,6 +269,23 @@ CommandCompleter::CommandCompleter(QLineEdit* lineedit, QObject* parent)
         &CommandCompleter::onCommandActivated
     );
     connect(this, qOverload<const QString&>(&CommandCompleter::highlighted), lineedit, &QLineEdit::setText);
+}
+
+void CommandCompleter::setFilterInactive(bool filter)
+{
+    auto proxyModel = static_cast<CommandSortFilterProxyModel*>(this->model());
+    if (!proxyModel) {
+        return;
+    }
+
+    // get source model and set filter flag
+    // also re-sort after changing the filter state just to be sure
+    // we get most fresh data
+    if (auto sourceModel = static_cast<CommandModel*>(proxyModel->sourceModel())) {
+        sourceModel->setFilterInactive(filter);
+        proxyModel->invalidate();
+        proxyModel->sort(0);
+    }
 }
 
 bool CommandCompleter::eventFilter(QObject* o, QEvent* ev)
@@ -234,12 +351,19 @@ void CommandCompleter::onCommandActivated(const QModelIndex& index)
 void CommandCompleter::onTextChanged(const QString& txt)
 {
     // Do not activate completer if less than 3 characters for better
-    // performance.
-    if (txt.size() < 3 || !widget()) {
+    // performance, unless called explicitly via complete()
+    if (txt.size() < 3 && txt.size() > 0) {
         return;
     }
 
-    static_cast<CommandModel*>(this->model())->update();
+    // get the source model through the proxy model
+    auto proxyModel = static_cast<CommandSortFilterProxyModel*>(this->model());
+    if (proxyModel) {
+        auto sourceModel = static_cast<CommandModel*>(proxyModel->sourceModel());
+        if (sourceModel) {
+            sourceModel->update();
+        }
+    }
 
     this->setCompletionPrefix(txt);
     QRect rect = widget()->rect();

--- a/src/Gui/CommandCompleter.cpp
+++ b/src/Gui/CommandCompleter.cpp
@@ -77,8 +77,7 @@ public:
             filterInactive = filter;
             // notify views that all data has changed (for greying out)
             if (!_Commands.empty()) {
-                QAbstractItemModel::dataChanged(createIndex(0, 0), 
-                                               createIndex(_Commands.size() - 1, 0));
+                QAbstractItemModel::dataChanged(createIndex(0, 0), createIndex(_Commands.size() - 1, 0));
             }
         }
     }
@@ -116,7 +115,7 @@ public:
         }
 
         auto& info = _Commands[index.row()];
-        
+
         // check if command is active to grey out if not
         bool isActive = true;
         if (filterInactive) {
@@ -155,7 +154,7 @@ public:
                     }
                 }
                 return info.icon;
-            
+
             case Qt::ForegroundRole:
                 // grey out inactive commands
                 if (!isActive) {
@@ -231,7 +230,7 @@ public:
 };
 
 // proxy sort model to prioritize active commands before inactive ones
-class CommandSortFilterProxyModel : public QSortFilterProxyModel
+class CommandSortFilterProxyModel: public QSortFilterProxyModel
 {
 public:
     explicit CommandSortFilterProxyModel(QObject* parent = nullptr)
@@ -296,7 +295,7 @@ CommandCompleter::CommandCompleter(QLineEdit* lineedit, QObject* parent)
     auto proxyModel = new CommandSortFilterProxyModel(this);
     proxyModel->setSourceModel(sourceModel);
     proxyModel->sort(0);
-    
+
     this->setModel(proxyModel);
     this->setFilterMode(Qt::MatchContains);
     this->setCaseSensitivity(Qt::CaseInsensitive);

--- a/src/Gui/CommandCompleter.cpp
+++ b/src/Gui/CommandCompleter.cpp
@@ -141,7 +141,9 @@ public:
                 return title;
             }
             case Qt::ToolTipRole:
-                return Action::commandToolTip(info.cmd);
+                // return just the tooltip text without formatting for the description line
+                // (richFormat = false)
+                return Action::commandToolTip(info.cmd, false);
 
             case Qt::DecorationRole:
                 if (!info.iconChecked) {

--- a/src/Gui/CommandCompleter.cpp
+++ b/src/Gui/CommandCompleter.cpp
@@ -49,6 +49,8 @@ struct CmdInfo
 std::vector<CmdInfo> _Commands;
 int _CommandRevision;
 const int CommandNameRole = Qt::UserRole;
+const int CommandMenuTextRole = Qt::UserRole + 1;  // menu text only (for palette)
+const int CommandGroupRole = Qt::UserRole + 2;     // group/workbench name
 bool _ShortcutSignalConnected = false;
 
 class CommandModel: public QAbstractItemModel
@@ -136,7 +138,7 @@ public:
                 );
                 QString shortcut = info.cmd->getShortcut();
                 if (!shortcut.isEmpty()) {
-                    title += QStringLiteral(" (%1)").arg(shortcut);
+                    title += QStringLiteral(" [%1]").arg(shortcut);
                 }
                 return title;
             }
@@ -163,6 +165,20 @@ public:
 
             case CommandNameRole:
                 return QByteArray(info.cmd->getName());
+
+            // custom role for menu text only (without internal name)
+            case CommandMenuTextRole: {
+                QString title = Action::commandMenuText(info.cmd);
+                QString shortcut = info.cmd->getShortcut();
+                if (!shortcut.isEmpty()) {
+                    title += QStringLiteral(" [%1]").arg(shortcut);
+                }
+                return title;
+            }
+
+            // custom role for workbench/group name
+            case CommandGroupRole:
+                return QString::fromUtf8(info.cmd->getGroupName());
 
             default:
                 break;

--- a/src/Gui/CommandCompleter.cpp
+++ b/src/Gui/CommandCompleter.cpp
@@ -48,9 +48,6 @@ struct CmdInfo
 };
 std::vector<CmdInfo> _Commands;
 int _CommandRevision;
-const int CommandNameRole = Qt::UserRole;
-const int CommandMenuTextRole = Qt::UserRole + 1;  // menu text only (for palette)
-const int CommandGroupRole = Qt::UserRole + 2;     // group/workbench name
 bool _ShortcutSignalConnected = false;
 
 class CommandModel: public QAbstractItemModel
@@ -165,7 +162,6 @@ public:
             case CommandNameRole:
                 return QByteArray(info.cmd->getName());
 
-            // custom role for menu text only (without internal name)
             case CommandMenuTextRole: {
                 QString title = Action::commandMenuText(info.cmd);
                 QString shortcut = info.cmd->getShortcut();
@@ -175,7 +171,6 @@ public:
                 return title;
             }
 
-            // custom role for workbench/group name
             case CommandGroupRole:
                 return QString::fromUtf8(info.cmd->getGroupName());
 

--- a/src/Gui/CommandCompleter.h
+++ b/src/Gui/CommandCompleter.h
@@ -43,6 +43,9 @@ class GuiExport CommandCompleter: public QCompleter
 public:
     explicit CommandCompleter(QLineEdit* edit, QObject* parent = nullptr);
 
+    /// Enable or disable filtering of inactive commands
+    void setFilterInactive(bool filter);
+
 Q_SIGNALS:
     /// Triggered when a command is selected in the completer
     void commandActivated(const QByteArray& name);

--- a/src/Gui/CommandCompleter.h
+++ b/src/Gui/CommandCompleter.h
@@ -30,6 +30,13 @@ class QLineEdit;
 namespace Gui
 {
 
+enum CommandModelRole
+{
+    CommandNameRole = Qt::UserRole,
+    CommandMenuTextRole = Qt::UserRole + 1,
+    CommandGroupRole = Qt::UserRole + 2,
+};
+
 /**
  * Command name auto completer.
  *

--- a/src/Gui/CommandPalette.cpp
+++ b/src/Gui/CommandPalette.cpp
@@ -23,14 +23,14 @@
 
 #include "PreCompiled.h"
 #ifndef _PreComp_
-#include <QApplication>
-#include <QGuiApplication>
-#include <QKeyEvent>
-#include <QPainter>
-#include <QTextDocument>
-#include <QTimer>
-#include <QVBoxLayout>
-#include <QWindow>
+# include <QApplication>
+# include <QGuiApplication>
+# include <QKeyEvent>
+# include <QPainter>
+# include <QTextDocument>
+# include <QTimer>
+# include <QVBoxLayout>
+# include <QWindow>
 #endif
 
 #include "CommandPalette.h"
@@ -320,7 +320,7 @@ bool CommandPalette::eventFilter(QObject* obj, QEvent* event)
             QPoint globalPos = mouseEvent->globalPosition().toPoint();
             if (isClickOutside(globalPos)) {
                 close();
-                return false; // propagate further to target widget
+                return false;  // propagate further to target widget
             }
         }
     }

--- a/src/Gui/CommandPalette.cpp
+++ b/src/Gui/CommandPalette.cpp
@@ -1,0 +1,296 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 The FreeCAD Project Association AISBL               *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+#include <QApplication>
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <QWindow>
+#endif
+
+#include "CommandPalette.h"
+#include "CommandCompleter.h"
+#include "Application.h"
+#include "Command.h"
+#include "Action.h"
+#include "MainWindow.h"
+
+using namespace Gui;
+
+CommandPalette::CommandPalette(QWidget* parent)
+    : QDialog(parent)
+{
+    setupUi();
+
+    setModal(false);
+    setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+    setAttribute(Qt::WA_TranslucentBackground, false);
+
+    // WA_DeleteOnClose because for the love of god i couldn't make it
+    // clear the state of completer upon closing and it remembered full
+    // previous state
+    setAttribute(Qt::WA_DeleteOnClose, true);
+
+    searchLineEdit->installEventFilter(this);
+}
+
+void CommandPalette::setupUi()
+{
+    mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(10, 10, 10, 10);
+    mainLayout->setSpacing(5);
+    searchLineEdit = new QLineEdit(this);
+    searchLineEdit->setPlaceholderText(tr("Type a command name..."));
+    searchLineEdit->setClearButtonEnabled(true);
+    searchLineEdit->setMinimumWidth(500);
+    searchLineEdit->setMinimumHeight(30);
+
+    completer = new CommandCompleter(searchLineEdit, this);
+
+    // remove widget association to prevent completer's popup as we just embed the logic inside
+    // our own qlistwidget
+    completer->setWidget(nullptr);
+
+    // disconnect completer's signals as we don't use them, we need the base model only
+    disconnect(searchLineEdit, nullptr, completer, nullptr);
+
+    // Create a list view to show commands directly in the dialog
+    commandListView = new QListView(this);
+
+    // use completion model from CommandCompleter
+    commandListView->setModel(completer->completionModel());
+    commandListView->setMinimumHeight(400);
+    commandListView->setMaximumHeight(600);
+    commandListView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    commandListView->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    mainLayout->addWidget(searchLineEdit);
+    mainLayout->addWidget(commandListView);
+
+    connect(searchLineEdit, &QLineEdit::textChanged, this, &CommandPalette::onTextChanged);
+    connect(commandListView, &QListView::activated, this, &CommandPalette::onListItemActivated);
+    connect(completer, &CommandCompleter::commandActivated, this, &CommandPalette::onCommandActivated);
+
+    setMinimumWidth(520);
+    setMaximumWidth(800);
+    setMinimumHeight(450);
+
+    setStyleSheet(QStringLiteral(
+        "QDialog {"
+        "    background-color: palette(window);"
+        "    border: 1px solid palette(dark);"
+        "    border-radius: 5px;"
+        "}"
+        "QLineEdit {"
+        "    padding: 5px;"
+        "    font-size: 14px;"
+        "    border: 1px solid palette(mid);"
+        "    border-radius: 3px;"
+        "}"
+        "QLineEdit:focus {"
+        "    border: 2px solid palette(highlight);"
+        "}"
+        "QListView {"
+        "    border: 1px solid palette(mid);"
+        "    border-radius: 3px;"
+        "}"
+    ));
+}
+
+void CommandPalette::showPalette()
+{
+    searchLineEdit->clear();
+    completer->setFilterInactive(true);
+
+    // set empty prefix to show all cmds by default
+    completer->setCompletionPrefix(QString());
+
+    centerOnMainWindow();
+
+    show();
+    raise();
+    activateWindow();
+
+    searchLineEdit->setFocus();
+
+    if (commandListView->model()->rowCount() > 0) {
+        commandListView->setCurrentIndex(commandListView->model()->index(0, 0));
+    }
+}
+
+void CommandPalette::centerOnMainWindow()
+{
+    QWidget* mainWindow = getMainWindow();
+    if (!mainWindow) {
+        return;
+    }
+
+    QRect mainWindowRect = mainWindow->geometry();
+
+    int x = mainWindowRect.x() + ((mainWindowRect.width() - width()) / 2);
+    int y = mainWindowRect.y() + (mainWindowRect.height() / 4);
+
+    move(x, y);
+}
+
+bool CommandPalette::eventFilter(QObject* obj, QEvent* event)
+{
+    if (event->type() == QEvent::MouseButtonPress) {
+        QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
+
+        if (mouseEvent->button() == Qt::LeftButton) {
+            QWidget* widget = qobject_cast<QWidget*>(obj);
+            if (widget) {
+                if (widget == this || widget->isAncestorOf(this) || isAncestorOf(widget)) {
+                    return QDialog::eventFilter(obj, event);
+                }
+            }
+
+            // check if click is outside the dialog and close if yes
+            QPoint globalPos = mouseEvent->globalPosition().toPoint();
+            if (isClickOutside(globalPos)) {
+                close();
+                return false; // propagate further to target widget
+            }
+        }
+    }
+
+    if (obj == searchLineEdit && event->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+
+        // esc closes the palette
+        if (keyEvent->key() == Qt::Key_Escape) {
+            if (searchLineEdit->text().isEmpty()) {
+                close();
+                return true;
+            }
+        }
+
+        // forward events to list, but basically they are used for going up/down
+        if (keyEvent->key() == Qt::Key_Down || keyEvent->key() == Qt::Key_Up
+            || keyEvent->key() == Qt::Key_PageDown || keyEvent->key() == Qt::Key_PageUp) {
+            QApplication::sendEvent(commandListView, event);
+            return true;
+        }
+
+        if (keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter) {
+            QModelIndex currentIndex = commandListView->currentIndex();
+            if (currentIndex.isValid()) {
+                onListItemActivated(currentIndex);
+                return true;
+            }
+        }
+    }
+
+    return QDialog::eventFilter(obj, event);
+}
+
+void CommandPalette::closeEvent(QCloseEvent* event)
+{
+    QDialog::closeEvent(event);
+}
+
+void CommandPalette::showEvent(QShowEvent* event)
+{
+    QDialog::showEvent(event);
+
+    // install application-wide event filter to catch clicks outside
+    qApp->installEventFilter(this);
+}
+
+void CommandPalette::hideEvent(QHideEvent* event)
+{
+    QDialog::hideEvent(event);
+
+    // remove application-wide event filter when hidden
+    qApp->removeEventFilter(this);
+}
+
+bool CommandPalette::isClickOutside(const QPoint& globalPos) const
+{
+    QRect dialogRect = QRect(mapToGlobal(QPoint(0, 0)), size());
+    return !dialogRect.contains(globalPos);
+}
+
+void CommandPalette::onCommandActivated(const QByteArray& commandName)
+{
+    // Get the command
+    Command* cmd = Application::Instance->commandManager().getCommandByName(commandName.constData());
+    if (!cmd) {
+        // not sure how would it be possible to get here, but just as a sanity check
+        Base::Console().warning("CMD Palette:: Command '%s' not found\n", commandName.constData());
+        close();
+        return;
+    }
+
+    close();
+
+    // run cmd
+    try {
+        Application::Instance->commandManager().runCommandByName(commandName.constData());
+    }
+    catch (const Base::Exception& e) {
+        Base::Console().error(
+            "CMD Palette:: Error executing command '%s': %s\n",
+            commandName.constData(),
+            e.what()
+        );
+    }
+    catch (...) {
+        Base::Console().error(
+            "CMD Palette:: Unknown error executing command '%s'\n",
+            commandName.constData()
+        );
+    }
+}
+
+void CommandPalette::onTextChanged(const QString& text)
+{
+    // update completer filter to match the text
+    completer->setCompletionPrefix(text);
+
+    // select first matched item
+    if (commandListView->model()->rowCount() > 0) {
+        commandListView->setCurrentIndex(commandListView->model()->index(0, 0));
+    }
+}
+
+void CommandPalette::onListItemActivated(const QModelIndex& index)
+{
+    if (!index.isValid()) {
+        return;
+    }
+
+    // get the command name from the model
+    const int CommandNameRole = Qt::UserRole;
+    QByteArray commandName = commandListView->model()->data(index, CommandNameRole).toByteArray();
+
+    if (!commandName.isEmpty()) {
+        onCommandActivated(commandName);
+    }
+}
+
+#include "moc_CommandPalette.cpp"

--- a/src/Gui/CommandPalette.cpp
+++ b/src/Gui/CommandPalette.cpp
@@ -65,8 +65,13 @@ void CommandItemDelegate::paint(
     initStyleOption(&opt, index);
     option.widget->style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter, option.widget);
 
-    QString title = index.data(Qt::DisplayRole).toString();
+    // use custom roles
+    const int CommandMenuTextRole = Qt::UserRole + 1;
+    const int CommandGroupRole = Qt::UserRole + 2;
+
+    QString title = index.data(CommandMenuTextRole).toString();
     QString tooltip = index.data(Qt::ToolTipRole).toString();
+    QString groupName = index.data(CommandGroupRole).toString();
     QIcon icon = index.data(Qt::DecorationRole).value<QIcon>();
 
     QRect rect = option.rect;
@@ -107,6 +112,33 @@ void CommandItemDelegate::paint(
     QRect titleRect = textRect;
     if (!tooltip.isEmpty()) {
         titleRect.setHeight(textRect.height() / 2);
+    }
+
+    // draw group name on the right if available
+    if (!groupName.isEmpty()) {
+        QFont groupFont = titleFont;
+        groupFont.setPointSize(qMax(groupFont.pointSize() - 1, 8));
+        painter->setFont(groupFont);
+
+        QColor groupColor = textColor;
+        // make group name transparent
+        groupColor.setAlpha(150);
+        painter->setPen(groupColor);
+
+        QFontMetrics groupFm(groupFont);
+        int groupWidth = groupFm.horizontalAdvance(groupName);
+
+        QRect groupRect = titleRect;
+        groupRect.setLeft(titleRect.right() - groupWidth);
+
+        painter->drawText(groupRect, Qt::AlignRight | Qt::AlignVCenter, groupName);
+
+        // adjust title rect to not overlap with group name
+        titleRect.setRight(groupRect.left() - 10);
+
+        // reset font and color for title
+        painter->setFont(titleFont);
+        painter->setPen(textColor);
     }
 
     painter->drawText(titleRect, Qt::AlignLeft | Qt::AlignVCenter, title);

--- a/src/Gui/CommandPalette.cpp
+++ b/src/Gui/CommandPalette.cpp
@@ -240,27 +240,6 @@ void CommandPalette::setupUi()
     setMinimumWidth(520);
     setMaximumWidth(800);
     setMinimumHeight(450);
-
-    setStyleSheet(QStringLiteral(
-        "QDialog {"
-        "    background-color: palette(window);"
-        "    border: 1px solid palette(dark);"
-        "    border-radius: 5px;"
-        "}"
-        "QLineEdit {"
-        "    padding: 5px;"
-        "    font-size: 14px;"
-        "    border: 1px solid palette(mid);"
-        "    border-radius: 3px;"
-        "}"
-        "QLineEdit:focus {"
-        "    border: 2px solid palette(highlight);"
-        "}"
-        "QListView {"
-        "    border: 1px solid palette(mid);"
-        "    border-radius: 3px;"
-        "}"
-    ));
 }
 
 void CommandPalette::showPalette()

--- a/src/Gui/CommandPalette.cpp
+++ b/src/Gui/CommandPalette.cpp
@@ -186,7 +186,7 @@ CommandPalette::CommandPalette(QWidget* parent)
     setupUi();
 
     setModal(false);
-    setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+    setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint | Qt::BypassWindowManagerHint);
     setAttribute(Qt::WA_TranslucentBackground, false);
 
     // WA_DeleteOnClose because for the love of god i couldn't make it

--- a/src/Gui/CommandPalette.cpp
+++ b/src/Gui/CommandPalette.cpp
@@ -199,35 +199,39 @@ CommandPalette::CommandPalette(QWidget* parent)
 
 void CommandPalette::setupUi()
 {
+    constexpr int layoutMargin = 10;
+    constexpr int layoutSpacing = 5;
+    constexpr int searchMinWidth = 500;
+    constexpr int searchMinHeight = 30;
+    constexpr int listMinHeight = 400;
+    constexpr int listMaxHeight = 600;
+    constexpr int paletteMinWidth = 520;
+    constexpr int paletteMaxWidth = 800;
+    constexpr int paletteMinHeight = 450;
+
     mainLayout = new QVBoxLayout(this);
-    mainLayout->setContentsMargins(10, 10, 10, 10);
-    mainLayout->setSpacing(5);
+    mainLayout->setContentsMargins(layoutMargin, layoutMargin, layoutMargin, layoutMargin);
+    mainLayout->setSpacing(layoutSpacing);
+
     searchLineEdit = new QLineEdit(this);
     searchLineEdit->setPlaceholderText(tr("Type a command name..."));
     searchLineEdit->setClearButtonEnabled(true);
-    searchLineEdit->setMinimumWidth(500);
-    searchLineEdit->setMinimumHeight(30);
+    searchLineEdit->setMinimumWidth(searchMinWidth);
+    searchLineEdit->setMinimumHeight(searchMinHeight);
 
     completer = new CommandCompleter(searchLineEdit, this);
 
-    // remove widget association to prevent completer's popup as we just embed the logic inside
-    // our own qlistwidget
+    // Remove widget association to prevent completer's popup; we embed the
+    // completion model inside our own QListView instead.
     completer->setWidget(nullptr);
-
-    // disconnect completer's signals as we don't use them, we need the base model only
     disconnect(searchLineEdit, nullptr, completer, nullptr);
 
-    // Create a list view to show commands directly in the dialog
     commandListView = new QListView(this);
-
-    // use completion model from CommandCompleter
     commandListView->setModel(completer->completionModel());
-    commandListView->setMinimumHeight(400);
-    commandListView->setMaximumHeight(600);
+    commandListView->setMinimumHeight(listMinHeight);
+    commandListView->setMaximumHeight(listMaxHeight);
     commandListView->setEditTriggers(QAbstractItemView::NoEditTriggers);
     commandListView->setSelectionMode(QAbstractItemView::SingleSelection);
-
-    // set custom delegate to show command name and description
     commandListView->setItemDelegate(new CommandItemDelegate(this));
 
     mainLayout->addWidget(searchLineEdit);
@@ -237,9 +241,9 @@ void CommandPalette::setupUi()
     connect(commandListView, &QListView::activated, this, &CommandPalette::onListItemActivated);
     connect(completer, &CommandCompleter::commandActivated, this, &CommandPalette::onCommandActivated);
 
-    setMinimumWidth(520);
-    setMaximumWidth(800);
-    setMinimumHeight(450);
+    setMinimumWidth(paletteMinWidth);
+    setMaximumWidth(paletteMaxWidth);
+    setMinimumHeight(paletteMinHeight);
 }
 
 void CommandPalette::showPalette()

--- a/src/Gui/CommandPalette.cpp
+++ b/src/Gui/CommandPalette.cpp
@@ -189,11 +189,6 @@ CommandPalette::CommandPalette(QWidget* parent)
     setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint | Qt::BypassWindowManagerHint);
     setAttribute(Qt::WA_TranslucentBackground, false);
 
-    // WA_DeleteOnClose because for the love of god i couldn't make it
-    // clear the state of completer upon closing and it remembered full
-    // previous state
-    setAttribute(Qt::WA_DeleteOnClose, true);
-
     searchLineEdit->installEventFilter(this);
 }
 

--- a/src/Gui/CommandPalette.cpp
+++ b/src/Gui/CommandPalette.cpp
@@ -65,10 +65,6 @@ void CommandItemDelegate::paint(
     initStyleOption(&opt, index);
     option.widget->style()->drawPrimitive(QStyle::PE_PanelItemViewItem, &opt, painter, option.widget);
 
-    // use custom roles
-    const int CommandMenuTextRole = Qt::UserRole + 1;
-    const int CommandGroupRole = Qt::UserRole + 2;
-
     QString title = index.data(CommandMenuTextRole).toString();
     QString tooltip = index.data(Qt::ToolTipRole).toString();
     QString groupName = index.data(CommandGroupRole).toString();
@@ -431,8 +427,6 @@ void CommandPalette::onListItemActivated(const QModelIndex& index)
         return;
     }
 
-    // get the command name from the model
-    const int CommandNameRole = Qt::UserRole;
     QByteArray commandName = commandListView->model()->data(index, CommandNameRole).toByteArray();
 
     if (!commandName.isEmpty()) {

--- a/src/Gui/CommandPalette.h
+++ b/src/Gui/CommandPalette.h
@@ -26,14 +26,31 @@
 
 #include <FCGlobal.h>
 #include <QDialog>
-#include <QLineEdit>
 #include <QListView>
+#include <QStyledItemDelegate>
 #include <QVBoxLayout>
 
 namespace Gui
 {
 
 class CommandCompleter;
+
+/**
+ * CommandItemDelegate - Custom delegate to display command name and tooltip
+ */
+class CommandItemDelegate: public QStyledItemDelegate
+{
+    Q_OBJECT
+
+public:
+    explicit CommandItemDelegate(QObject* parent = nullptr);
+
+    void paint(QPainter* painter,
+               const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override;
+
+    QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
+};
 
 /**
  * CommandPalette - A quick command search and execution dialog

--- a/src/Gui/CommandPalette.h
+++ b/src/Gui/CommandPalette.h
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 The FreeCAD Project Association AISBL               *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#ifndef GUI_COMMAND_PALETTE_H
+#define GUI_COMMAND_PALETTE_H
+
+#include <FCGlobal.h>
+#include <QDialog>
+#include <QLineEdit>
+#include <QListView>
+#include <QVBoxLayout>
+
+namespace Gui
+{
+
+class CommandCompleter;
+
+/**
+ * CommandPalette - A quick command search and execution dialog
+ *
+ * This dialog provides a VS Code style command palette that allows users to:
+ * - Quickly search for commands by typing
+ * - Navigate through results using keyboard arrows or mouse
+ * - Execute commands by pressing Enter or double-clicking
+ * - Close the palette with Escape
+ *
+ * The palette is triggered by a keyboard shortcut (default: Ctrl+Shift+P)
+ */
+class GuiExport CommandPalette: public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit CommandPalette(QWidget* parent = nullptr);
+    ~CommandPalette() override = default;
+    void showPalette();
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
+
+private Q_SLOTS:
+    void onCommandActivated(const QByteArray& commandName);
+    void onTextChanged(const QString& text);
+    void onListItemActivated(const QModelIndex& index);
+
+private:
+    void setupUi();
+    void centerOnMainWindow();
+    bool isClickOutside(const QPoint& globalPos) const;
+
+    QLineEdit* searchLineEdit;
+    QListView* commandListView;
+    CommandCompleter* completer;
+    QVBoxLayout* mainLayout;
+};
+
+}  // namespace Gui
+
+#endif  // GUI_COMMAND_PALETTE_H

--- a/src/Gui/CommandPalette.h
+++ b/src/Gui/CommandPalette.h
@@ -45,9 +45,11 @@ class CommandItemDelegate: public QStyledItemDelegate
 public:
     explicit CommandItemDelegate(QObject* parent = nullptr);
 
-    void paint(QPainter* painter,
-               const QStyleOptionViewItem& option,
-               const QModelIndex& index) const override;
+    void paint(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index
+    ) const override;
 
     QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 };

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -41,6 +41,7 @@
 #include "Action.h"
 #include "BitmapFactory.h"
 #include "Command.h"
+#include "CommandPalette.h"
 #include "Dialogs/DlgAbout.h"
 #include "Dialogs/DlgCustomizeImp.h"
 #include "Dialogs/DlgParameterImp.h"
@@ -1044,6 +1045,40 @@ void StdCmdAnnotationLabel::activated(int)
     commitCommand();
 }
 
+//===========================================================================
+// Std_CommandPalette
+//===========================================================================
+DEF_STD_CMD_A(StdCmdCommandPalette)
+
+StdCmdCommandPalette::StdCmdCommandPalette()
+    : Command("Std_CommandPalette")
+{
+    sGroup = "Tools";
+    sMenuText = QT_TR_NOOP("Command &Palette...");
+    sToolTipText = QT_TR_NOOP("Open the command palette to search and execute commands");
+    sWhatsThis = "Std_CommandPalette";
+    sStatusTip = sToolTipText;
+    sAccel = "Ctrl+Shift+P";
+    sPixmap = "accessories-text-editor";
+    eType = 0;
+}
+
+void StdCmdCommandPalette::activated(int)
+{
+    static QPointer<CommandPalette> palette;
+
+    if (!palette) {
+        palette = new CommandPalette(getMainWindow());
+    }
+
+    palette->showPalette();
+}
+
+bool StdCmdCommandPalette::isActive()
+{
+    return true;
+}
+
 namespace Gui
 {
 
@@ -1075,6 +1110,7 @@ void CreateStdCommands()
     rcCmdMgr.addCommand(new StdCmdUnitsCalculator());
     rcCmdMgr.addCommand(new StdCmdUserEditMode());
     rcCmdMgr.addCommand(new StdCmdReloadStyleSheet());
+    rcCmdMgr.addCommand(new StdCmdCommandPalette());
     rcCmdMgr.addCommand(new StdCmdDevHandbook());
     // rcCmdMgr.addCommand(new StdCmdDownloadOnlineHelp());
     // rcCmdMgr.addCommand(new StdCmdDescription());

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -494,6 +494,14 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     // accept drops on the window, get handled in dropEvent, dragEnterEvent
     setAcceptDrops(true);
 
+    // initialize the Command Palette action to register its global shortcut
+    if (auto cmd = Application::Instance->commandManager().getCommandByName("Std_CommandPalette")) {
+        cmd->initAction();
+        if (auto action = cmd->getAction()) {
+            addAction(action->action());
+        }
+    }
+
     statusBar()->showMessage(tr("Ready"), 2001);
 }
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -494,10 +494,12 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     // accept drops on the window, get handled in dropEvent, dragEnterEvent
     setAcceptDrops(true);
 
-    // initialize the Command Palette action to register its global shortcut
+    // Initialize the Command Palette action with an application-wide shortcut
+    // so it works regardless of which widget has focus.
     if (auto cmd = Application::Instance->commandManager().getCommandByName("Std_CommandPalette")) {
         cmd->initAction();
         if (auto action = cmd->getAction()) {
+            action->action()->setShortcutContext(Qt::ApplicationShortcut);
             addAction(action->action());
         }
     }

--- a/src/Gui/Stylesheets/defaults.qss
+++ b/src/Gui/Stylesheets/defaults.qss
@@ -18,3 +18,27 @@ Gui--SplitButton QToolButton::menu-indicator {
     image: none;
     border-image: none;
 }
+
+/* Gui::CommandPalette ------------------------------------------------------ */
+
+Gui--CommandPalette {
+    background-color: palette(window);
+    border: 1px solid palette(dark);
+    border-radius: 5px;
+}
+
+Gui--CommandPalette QLineEdit {
+    padding: 5px;
+    font-size: 14px;
+    border: 1px solid palette(mid);
+    border-radius: 3px;
+}
+
+Gui--CommandPalette QLineEdit:focus {
+    border: 2px solid palette(highlight);
+}
+
+Gui--CommandPalette QListView {
+    border: 1px solid palette(mid);
+    border-radius: 3px;
+}

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -769,7 +769,8 @@ MenuItem* StdWorkbench::setupMenuBar() const
               << "Separator";
     }
 #endif
-    *tool << "Std_Measure"
+    *tool << "Std_CommandPalette"
+          << "Std_Measure"
           << "Std_AnnotationLabel"
           << "Std_UnitsCalculator"
           << "Std_ClarifySelection"


### PR DESCRIPTION
As the title says. This patch introduces Command Palette/Command Window, which is allowing for fast interactions with commands throughout FreeCAD.

This reuses Command Completer logic, by adding a `QListWidget` inside a separate dialog window. Command Palette also filters out inactive commands by making them gray and allows those interactions:
- double mouse click runs the command
- scrolling with keyboard is possible
- pressing enter executes command
- ESC closes the window
- clicking outside of the window closes it as well


Demo:

https://github.com/user-attachments/assets/90fc083f-1b53-4eb4-8db6-684161540b82

Resolves: https://github.com/FreeCAD/FreeCAD/issues/8290