### PR TITLE
TechDraw: fix load failure with Building US unit schema

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -273,13 +273,13 @@ void QGIViewDimension::updateDim()
         return;
     }
 
-    QString labelText =
-        // what about fromStdString?
-        QString::fromUtf8(dim->getFormattedDimensionValue(Format::FORMATTED).c_str());// pre value [unit] post
+    Format fmt = Format::FORMATTED;
     if (dim->isMultiValueSchema()) {
-        labelText =
-            QString::fromUtf8(dim->getFormattedDimensionValue(Format::UNALTERED).c_str());//don't format multis
+        fmt = Format::UNALTERED;
     }
+
+    std::string formattedValue = dim->getFormattedDimensionValue(fmt);
+    QString labelText = QString::fromStdString(formattedValue);         // <<<< here
 
     QFont font = datumLabel->getFont();
     font.setFamily(QString::fromUtf8(vp->Font.getValue()));


### PR DESCRIPTION
This PR implements a fix for issue #25776.  It avoids a problem due to changes to the unit subsystem that cause an unexpected return from UnitSchema::getUnitText(). 

Previous to commit 1155f0d, getUnitText returned unit strings such as "in", "ft" or "mm".  Now getUnitText may returns the strings "toFractional" or "toDMS" which can not be parsed.

Note that this PR does not address getUnitText's return value, but merely avoids using it with the Building US schema.