### PR TITLE
Utils: Don't save location of Python executable

### DIFF
--- a/src/Ext/freecad/utils.py
+++ b/src/Ext/freecad/utils.py
@@ -32,15 +32,15 @@ import FreeCAD
 
 def get_python_exe() -> str:
     """Find Python. In preference order
-    A) The value of the BaseApp/Preferences/PythonConsole/ExternalPythonExecutable user preference
+    A) The value of the BaseApp/Preferences/PythonConsole/PathToPythonExecutable user preference
     B) The executable located in the same bin directory as FreeCAD and called "python3"
     C) The executable located in the same bin directory as FreeCAD and called "python"
     D) The result of a shutil search for your system's "python3" executable
     E) The result of a shutil search for your system's "python" executable"""
     prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/PythonConsole")
-    python_exe = prefs.GetString("ExternalPythonExecutable", "Not set")
+    python_exe = prefs.GetString("PathToPythonExecutable", "")
     fc_dir = FreeCAD.getHomePath()
-    if not python_exe or python_exe == "Not set" or not os.path.exists(python_exe):
+    if not python_exe or not os.path.exists(python_exe):
         python_exe = os.path.join(fc_dir, "bin", "python3")
         if "Windows" in platform.system():
             python_exe += ".exe"
@@ -60,5 +60,4 @@ def get_python_exe() -> str:
         return ""
 
     python_exe = python_exe.replace("/", os.path.sep)
-    prefs.SetString("ExternalPythonExecutable", python_exe)
     return python_exe

--- a/src/Gui/PreferencePages/DlgSettingsPythonConsole.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsPythonConsole.cpp
@@ -44,7 +44,7 @@ void DlgSettingsPythonConsole::saveSettings()
     ui->PythonBlockCursor->onSave();
     ui->PythonSaveHistory->onSave();
     ui->ProfilerInterval->onSave();
-    ui->ExternalPythonExecutable->onSave();
+    ui->PathToPythonExecutable->onSave();
 }
 
 void DlgSettingsPythonConsole::loadSettings()
@@ -53,7 +53,7 @@ void DlgSettingsPythonConsole::loadSettings()
     ui->PythonBlockCursor->onRestore();
     ui->PythonSaveHistory->onRestore();
     ui->ProfilerInterval->onRestore();
-    ui->ExternalPythonExecutable->onRestore();
+    ui->PathToPythonExecutable->onRestore();
 }
 
 void DlgSettingsPythonConsole::changeEvent(QEvent* event)

--- a/src/Gui/PreferencePages/DlgSettingsPythonConsole.ui
+++ b/src/Gui/PreferencePages/DlgSettingsPythonConsole.ui
@@ -127,7 +127,7 @@ horizontal space in Python console</string>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="Gui::PrefFileChooser" name="ExternalPythonExecutable" native="true">
+      <widget class="Gui::PrefFileChooser" name="PathToPythonExecutable" native="true">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
@@ -144,7 +144,7 @@ horizontal space in Python console</string>
         <string>Used for package installation with pip and debugging with debugpy. Autodetected if needed and not specified.</string>
        </property>
        <property name="prefEntry" stdset="0">
-        <cstring>ExternalPythonExecutable</cstring>
+        <cstring>PathToPythonExecutable</cstring>
        </property>
        <property name="prefPath" stdset="0">
         <cstring>PythonConsole</cstring>


### PR DESCRIPTION
A couple of years ago I added code to look for the underlying Python executable. Originally this was part of the Addon Manager, which needed it to call `pip`, but it was later integrated into FreeCAD proper. Unfortunately, it has a side-effect of actually recording the found location to a preference setting. This was intended as a sort of cache, but has the unfortunate side effect of propagating old python binaries forward to new installations of FreeCAD when used for things like `pip` calls, because that cache is never invalidated. So, this change first blanket -invalidates the "cache" by using a different variable name, and never writing to it again. This variable is now _only_ set by direct user input: this overrides any automatic calculation, but only if explicitly set. If it's not set, then the code to find the local copy is simply run when needed. This is unlikely to be called often enough for that to be a meaningful runtime cost. If it turns out to be, we can use a more ephemeral cache mechanism.