### PR TITLE
CAM: Slot - Clear path if can not create slot

### DIFF
--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -564,6 +564,10 @@ class ObjectSlot(PathOp.ObjectOp):
         cmds = self._makeOperation(obj)
         if cmds:
             self.commandlist.extend(cmds)
+        else:
+            # clear Path if can not create slot
+            self.commandlist.clear()
+            return False
 
         # Final move to clearance height
         self.commandlist.append(


### PR DESCRIPTION
At this moment if `Slot` operation can not process shape, useless movements will be added
Better clear path completely

<img width="547" height="292" alt="Screenshot_20251201_120339_lossy" src="https://github.com/user-attachments/assets/ceaf584e-3eff-47df-b4f1-a89306d878af" />
 <br><br>

> [!Note]
> Step **2** of prepare to [ CAM: Slot improve #25090 ](https://github.com/FreeCAD/FreeCAD/pull/25090)
>
> Should be reviewed after
> - #25839 