### PR TITLE
CAM: Slot - Remove duplication move to clearance height in the end

### DIFF
--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -569,11 +569,6 @@ class ObjectSlot(PathOp.ObjectOp):
             self.commandlist.clear()
             return False
 
-        # Final move to clearance height
-        self.commandlist.append(
-            Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
-        )
-
         # Hide debug visuals
         if self.showDebugObjects and FreeCAD.GuiUp:
             FreeCADGui.ActiveDocument.getObject(self.tmpGrp.Name).Visibility = False


### PR DESCRIPTION
`Slot` operation based on `Path.Op.Base.ObjectOp`, which add move to clearance height in the end
So no need to add this final move inside `Slot` operation

<img width="348" height="165" alt="Screenshot_20251201_121702_lossy" src="https://github.com/user-attachments/assets/166ca42f-9a43-4c89-80c6-26f9cef1b806" />
<br><br>

> [!Note]
> Step **3** of prepare to [ CAM: Slot improve #25090 ](https://github.com/FreeCAD/FreeCAD/pull/25090)
>
> Should be reviewed after
> - #25841 