### PR TITLE
CAM: Slot - Remove useless move to Safe height in the end

### DIFF
--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -758,16 +758,15 @@ class ObjectSlot(PathOp.ObjectOp):
                     CMDS.append(
                         Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
                     )
+                CMDS.pop()  # remove move to safe height after last step down
             elif obj.CutPattern == "ZigZag":
-                i = 0
-                for depth in self.depthParams:
-                    if i % 2 == 0:  # even
+                for i, depth in enumerate(self.depthParams):
+                    if i == 0:  # first
                         CMDS.extend(arcPass(PATHS[path_index], depth))
+                    elif i % 2 == 0:  # even
+                        CMDS.extend(arcPass(PATHS[path_index], depth)[1:])
                     else:  # odd
-                        CMDS.extend(arcPass(PATHS[not path_index], depth))
-                    i += 1
-        # Raise to SafeHeight when finished
-        CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
+                        CMDS.extend(arcPass(PATHS[not path_index], depth)[1:])
 
         if self.isDebug:
             Path.Log.debug("G-code arc command is: {}".format(PATHS[path_index][2]))
@@ -865,7 +864,6 @@ class ObjectSlot(PathOp.ObjectOp):
         # CMDS.append(Path.Command('N (Tool type: {})'.format(toolType), {}))
         if obj.LayerMode == "Single-pass":
             CMDS.extend(linePass(p1, p2, obj.FinalDepth.Value))
-            CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
         else:
             if obj.CutPattern == "Line":
                 for dep in self.depthParams:
@@ -873,18 +871,16 @@ class ObjectSlot(PathOp.ObjectOp):
                     CMDS.append(
                         Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
                     )
+                CMDS.pop()  # remove move to safe height after last step down
             elif obj.CutPattern == "ZigZag":
                 CMDS.append(Path.Command("G0", {"X": p1.x, "Y": p1.y, "F": self.horizRapid}))
-                i = 0
-                for dep in self.depthParams:
+                for i, dep in enumerate(self.depthParams):
                     if i % 2 == 0:  # even
                         CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
                         CMDS.append(Path.Command("G1", {"X": p2.x, "Y": p2.y, "F": self.horizFeed}))
                     else:  # odd
                         CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
                         CMDS.append(Path.Command("G1", {"X": p1.x, "Y": p1.y, "F": self.horizFeed}))
-                    i += 1
-            CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
 
         return CMDS
 


### PR DESCRIPTION
No need move to safe height in the end
Move to clearance height is enough

<img width="385" height="171" alt="Screenshot_20251201_125611_lossy" src="https://github.com/user-attachments/assets/39fb3844-b954-4f6c-90b0-5bf3aa052095" />
<br><br>

> [!Note]
> Step **4** of prepare to [ CAM: Slot improve #25090 ](https://github.com/FreeCAD/FreeCAD/pull/25090)