### PR TITLE
CAM: Slot - Add move to safe height in the begin

### DIFF
--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -771,6 +771,8 @@ class ObjectSlot(PathOp.ObjectOp):
         if self.isDebug:
             Path.Log.debug("G-code arc command is: {}".format(PATHS[path_index][2]))
 
+        CMDS.insert(1, Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
+
         return CMDS
 
     def _finishLine(self, obj, pnts, featureCnt):
@@ -881,6 +883,8 @@ class ObjectSlot(PathOp.ObjectOp):
                     else:  # odd
                         CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
                         CMDS.append(Path.Command("G1", {"X": p1.x, "Y": p1.y, "F": self.horizFeed}))
+
+        CMDS.insert(1, Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
 
         return CMDS
 


### PR DESCRIPTION
> [!CAUTION]
> Step **5** of prepare to [ CAM: Slot improve #25090 ](https://github.com/FreeCAD/FreeCAD/pull/25090)

---

Adds rapid move from `ClearanceHeight` to `SafeHeight` in the begin

<img width="814" height="161" alt="1_hor" src="https://github.com/user-attachments/assets/28e9cc0e-71f2-4e1c-b496-834e3c61d650" />