### PR TITLE
CAM: Slot - Remove LayerMode and rename CutPattern values

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
@@ -346,35 +346,6 @@
       <property name="bottomMargin">
        <number>3</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="layerMode_label">
-        <property name="text">
-         <string>Layer mode</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="layerMode">
-        <property name="font">
-         <font>
-          <pointsize>8</pointsize>
-         </font>
-        </property>
-        <property name="toolTip">
-         <string>Complete the operation in a single pass at depth, or multiple passes to final depth</string>
-        </property>
-        <item>
-         <property name="text">
-          <string>Single-pass</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Multi-pass</string>
-         </property>
-        </item>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QLabel" name="pathOrientation_label">
         <property name="text">
@@ -441,7 +412,6 @@
   <tabstop>geo2Reference</tabstop>
   <tabstop>geo1Extension</tabstop>
   <tabstop>geo2Extension</tabstop>
-  <tabstop>layerMode</tabstop>
   <tabstop>pathOrientation</tabstop>
   <tabstop>reverseDirection</tabstop>
  </tabstops>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpSlotEdit.ui
@@ -347,30 +347,25 @@
        <number>3</number>
       </property>
       <item row="0" column="0">
-       <widget class="QLabel" name="layerMode_label">
+       <widget class="QLabel" name="cutPatter_label">
         <property name="text">
          <string>Layer mode</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QComboBox" name="layerMode">
-        <property name="font">
-         <font>
-          <pointsize>8</pointsize>
-         </font>
-        </property>
+       <widget class="QComboBox" name="cutPattern">
         <property name="toolTip">
-         <string>Complete the operation in a single pass at depth, or multiple passes to final depth</string>
+         <string>Set the cut pattern for the operation</string>
         </property>
         <item>
          <property name="text">
-          <string>Single-pass</string>
+          <string>Directional</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Multi-pass</string>
+          <string>Bidirectional</string>
          </property>
         </item>
        </widget>
@@ -441,7 +436,7 @@
   <tabstop>geo2Reference</tabstop>
   <tabstop>geo1Extension</tabstop>
   <tabstop>geo2Extension</tabstop>
-  <tabstop>layerMode</tabstop>
+  <tabstop>cutPattern</tabstop>
   <tabstop>pathOrientation</tabstop>
   <tabstop>reverseDirection</tabstop>
  </tabstops>

--- a/src/Mod/CAM/Path/Op/Gui/Slot.py
+++ b/src/Mod/CAM/Path/Op/Gui/Slot.py
@@ -99,7 +99,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             idx = enums.index(obj.Reference2)
         self.form.geo2Reference.setCurrentIndex(idx)
 
-        self.selectInComboBox(obj.LayerMode, self.form.layerMode)
         self.selectInComboBox(obj.PathOrientation, self.form.pathOrientation)
 
         if obj.ReverseDirection:
@@ -125,9 +124,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         obj.Reference2 = val
         self.geo2Extension.updateProperty()
 
-        val = self.propEnums["LayerMode"][self.form.layerMode.currentIndex()][1]
-        obj.LayerMode = val
-
         val = self.propEnums["PathOrientation"][self.form.pathOrientation.currentIndex()][1]
         obj.PathOrientation = val
 
@@ -143,7 +139,6 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.geo1Reference.currentIndexChanged)
         signals.append(self.form.geo2Extension.editingFinished)
         signals.append(self.form.geo2Reference.currentIndexChanged)
-        signals.append(self.form.layerMode.currentIndexChanged)
         signals.append(self.form.pathOrientation.currentIndexChanged)
         if hasattr(self.form.reverseDirection, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.reverseDirection.checkStateChanged)

--- a/src/Mod/CAM/Path/Op/Gui/Slot.py
+++ b/src/Mod/CAM/Path/Op/Gui/Slot.py
@@ -99,7 +99,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             idx = enums.index(obj.Reference2)
         self.form.geo2Reference.setCurrentIndex(idx)
 
-        self.selectInComboBox(obj.LayerMode, self.form.layerMode)
+        self.selectInComboBox(obj.CutPattern, self.form.cutPattern)
         self.selectInComboBox(obj.PathOrientation, self.form.pathOrientation)
 
         if obj.ReverseDirection:
@@ -125,8 +125,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         obj.Reference2 = val
         self.geo2Extension.updateProperty()
 
-        val = self.propEnums["LayerMode"][self.form.layerMode.currentIndex()][1]
-        obj.LayerMode = val
+        val = self.propEnums["CutPattern"][self.form.cutPattern.currentIndex()][1]
+        obj.CutPattern = val
 
         val = self.propEnums["PathOrientation"][self.form.pathOrientation.currentIndex()][1]
         obj.PathOrientation = val
@@ -143,7 +143,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.geo1Reference.currentIndexChanged)
         signals.append(self.form.geo2Extension.editingFinished)
         signals.append(self.form.geo2Reference.currentIndexChanged)
-        signals.append(self.form.layerMode.currentIndexChanged)
+        signals.append(self.form.cutPattern.currentIndexChanged)
         signals.append(self.form.pathOrientation.currentIndexChanged)
         if hasattr(self.form.reverseDirection, "checkStateChanged"):  # Qt version >= 6.7.0
             signals.append(self.form.reverseDirection.checkStateChanged)

--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -569,11 +569,6 @@ class ObjectSlot(PathOp.ObjectOp):
             self.commandlist.clear()
             return False
 
-        # Final move to clearance height
-        self.commandlist.append(
-            Path.Command("G0", {"Z": obj.ClearanceHeight.Value, "F": self.vertRapid})
-        )
-
         # Hide debug visuals
         if self.showDebugObjects and FreeCAD.GuiUp:
             FreeCADGui.ActiveDocument.getObject(self.tmpGrp.Name).Visibility = False

--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -303,16 +303,16 @@ class ObjectSlot(PathOp.ObjectOp):
         """opPropertyDefaults(obj, job) ... returns a dictionary of default values
         for the operation's properties."""
         defaults = {
-            "CustomPoint1": FreeCAD.Vector(0.0, 0.0, 0.0),
-            "ExtendPathStart": 0.0,
+            "CustomPoint1": FreeCAD.Vector(0, 0, 0),
+            "ExtendPathStart": 0,
             "Reference1": "Center of Mass",
-            "CustomPoint2": FreeCAD.Vector(0.0, 0.0, 0.0),
-            "ExtendPathEnd": 0.0,
+            "CustomPoint2": FreeCAD.Vector(0, 0, 0),
+            "ExtendPathEnd": 0,
             "Reference2": "Center of Mass",
             "LayerMode": "Multi-pass",
             "CutPattern": "ZigZag",
             "PathOrientation": "Start to End",
-            "ExtendRadius": 0.0,
+            "ExtendRadius": 0,
             "ReverseDirection": False,
             # For debugging
             "ShowTempObjects": False,
@@ -502,8 +502,8 @@ class ObjectSlot(PathOp.ObjectOp):
         self.isArc = 0
         self.arcCenter = None
         self.arcMidPnt = None
-        self.arcRadius = 0.0
-        self.newRadius = 0.0
+        self.arcRadius = 0
+        self.newRadius = 0
         self.featureDetails = ["", ""]
         self.commandlist = []
         self.stockZMin = self.job.Stock.Shape.BoundBox.ZMin
@@ -556,7 +556,7 @@ class ObjectSlot(PathOp.ObjectOp):
             obj.SafeHeight.Value,
             obj.StartDepth.Value,
             obj.StepDown.Value,
-            0.0,
+            0,
             obj.FinalDepth.Value,
         )
 
@@ -762,7 +762,7 @@ class ObjectSlot(PathOp.ObjectOp):
             elif obj.CutPattern == "ZigZag":
                 i = 0
                 for depth in self.depthParams:
-                    if i % 2.0 == 0:  # even
+                    if i % 2 == 0:  # even
                         CMDS.extend(arcPass(PATHS[path_index], depth))
                     else:  # odd
                         CMDS.extend(arcPass(PATHS[not path_index], depth))
@@ -805,7 +805,7 @@ class ObjectSlot(PathOp.ObjectOp):
                     edg1_len = self.shape1.Length
                     edg2_len = self.shape2.Length
                     set_length = max(edg1_len, edg2_len)
-                    pnts = self._makePerpendicular(p1, p2, 10.0 + set_length)  # 10.0 offset below
+                    pnts = self._makePerpendicular(p1, p2, 10 + set_length)  # 10.0 offset below
                     if edg1_len != edg2_len:
                         msg = obj.Label + " "
                         msg += translate("CAM_Slot", "Verify slot path start and end points.")
@@ -824,8 +824,8 @@ class ObjectSlot(PathOp.ObjectOp):
         endExt = obj.ExtendPathEnd.Value
         if perpZero:
             # Offsets for 10.0 value above in _makePerpendicular()
-            begExt -= 5.0
-            endExt -= 5.0
+            begExt -= 5
+            endExt -= 5
         pnts = self._extendLineSlot(p1, p2, begExt, endExt)
 
         if not pnts:
@@ -878,7 +878,7 @@ class ObjectSlot(PathOp.ObjectOp):
                 CMDS.append(Path.Command("G0", {"X": p1.x, "Y": p1.y, "F": self.horizRapid}))
                 i = 0
                 for dep in self.depthParams:
-                    if i % 2.0 == 0:  # even
+                    if i % 2 == 0:  # even
                         CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
                         CMDS.append(Path.Command("G1", {"X": p2.x, "Y": p2.y, "F": self.horizFeed}))
                     else:  # odd
@@ -898,7 +898,7 @@ class ObjectSlot(PathOp.ObjectOp):
 
         if cat1 == "Face":
             pnts = False
-            norm = shape_1.normalAt(0.0, 0.0)
+            norm = shape_1.normalAt(0, 0)
             Path.Log.debug("{}.normalAt(): {}".format(sub1, norm))
 
             if Path.Geom.isRoughly(shape_1.BoundBox.ZMax, shape_1.BoundBox.ZMin):
@@ -959,8 +959,8 @@ class ObjectSlot(PathOp.ObjectOp):
             norm = self._normalizeVector(vect)
             rads = self._getVectorAngle(norm)
             deg = math.degrees(rads)
-            if deg >= 180.0:
-                deg -= 180.0
+            if deg >= 180:
+                deg -= 180
             return deg
 
         # Reject incorrect faces
@@ -1086,7 +1086,7 @@ class ObjectSlot(PathOp.ObjectOp):
         temp = FreeCAD.Vector(dX, dY, dZ)
         slope = self._normalizeVector(temp)
         perpVect = FreeCAD.Vector(-1 * slope.y, slope.x, slope.z)
-        perpVect.multiply(self.tool.Diameter / 2.0)
+        perpVect.multiply(self.tool.Diameter / 2)
 
         # Create offset endpoints for raw slot path
         a1 = v0.add(perpVect)
@@ -1123,7 +1123,7 @@ class ObjectSlot(PathOp.ObjectOp):
             v2 = P3 - P2
             v3 = P1 - P3
             L = v1.cross(v2).Length
-            if round(L, 8) == 0.0:
+            if round(L, 8) == 0:
                 Path.Log.error("Three points are colinear. Arc is straight.")
                 return False
             twoL2 = 2 * L * L
@@ -1134,8 +1134,8 @@ class ObjectSlot(PathOp.ObjectOp):
 
         verts = edge.Vertexes
         V1 = verts[0]
-        p1 = FreeCAD.Vector(V1.X, V1.Y, 0.0)
-        p2 = p1 if len(verts) == 1 else FreeCAD.Vector(verts[1].X, verts[1].Y, 0.0)
+        p1 = FreeCAD.Vector(V1.X, V1.Y, 0)
+        p2 = p1 if len(verts) == 1 else FreeCAD.Vector(verts[1].X, verts[1].Y, 0)
 
         curveType = edge.Curve.TypeId
         if curveType in lineTypes:
@@ -1154,28 +1154,28 @@ class ObjectSlot(PathOp.ObjectOp):
                     return False
 
                 center = edge.BoundBox.Center
-                self.arcCenter = FreeCAD.Vector(center.x, center.y, 0.0)
-                mid = edge.valueAt(edge.getParameterByLength(edge.Length / 2.0))
-                self.arcMidPnt = FreeCAD.Vector(mid.x, mid.y, 0.0)
-                self.arcRadius = edge.BoundBox.XLength / 2.0
+                self.arcCenter = FreeCAD.Vector(center.x, center.y, 0)
+                mid = edge.valueAt(edge.getParameterByLength(edge.Length / 2))
+                self.arcMidPnt = FreeCAD.Vector(mid.x, mid.y, 0)
+                self.arcRadius = edge.BoundBox.XLength / 2
             else:
                 # Arc segment
                 Path.Log.debug("Arc with multiple vertices.")
                 V2 = verts[1]
-                mid = edge.valueAt(edge.getParameterByLength(edge.Length / 2.0))
+                mid = edge.valueAt(edge.getParameterByLength(edge.Length / 2))
                 if not isHorizontal(V1.Z, V2.Z, mid.z):
                     return False
-                mid.z = 0.0
-                center = circumCircleFrom3Points(p1, p2, FreeCAD.Vector(mid.x, mid.y, 0.0))
+                mid.z = 0
+                center = circumCircleFrom3Points(p1, p2, FreeCAD.Vector(mid.x, mid.y, 0))
                 if not center:
                     return False
 
                 self.isArc = 2
-                self.arcMidPnt = FreeCAD.Vector(mid.x, mid.y, 0.0)
+                self.arcMidPnt = FreeCAD.Vector(mid.x, mid.y, 0)
                 self.arcCenter = center
                 self.arcRadius = (p1 - center).Length
 
-                if oversizedTool(self.arcRadius * 2.0):
+                if oversizedTool(self.arcRadius * 2):
                     return False
 
             return (p1, p2)
@@ -1249,9 +1249,9 @@ class ObjectSlot(PathOp.ObjectOp):
 
         def snap(val):
             if abs(val) < tol:
-                return 0.0
-            if abs(1.0 - abs(val)) < tol:
-                return 1.0 if val > 0 else -1.0
+                return 0
+            if abs(1 - abs(val)) < tol:
+                return 1 if val > 0 else -1
             return val
 
         return FreeCAD.Vector(snap(V.x), snap(V.y), snap(V.z))
@@ -1292,11 +1292,11 @@ class ObjectSlot(PathOp.ObjectOp):
             # Get slope from first vertex to center of mass
             V0 = shape.Vertexes[0]
             v1 = shape.CenterOfMass
-            temp = FreeCAD.Vector(v1.x - V0.X, v1.y - V0.Y, 0.0)
+            temp = FreeCAD.Vector(v1.x - V0.X, v1.y - V0.Y, 0)
             dYdX = self._normalizeVector(temp) if temp.Length != 0 else FreeCAD.Vector(0, 0, 0)
 
             # Face normal must be vertical
-            norm = shape.normalAt(0.0, 0.0)
+            norm = shape.normalAt(0, 0)
             if norm.z != 0:
                 msg = translate("CAM_Slot", "The selected face is not oriented vertically:")
                 FreeCAD.Console.PrintError(f"{msg} {sub}.\n")
@@ -1305,10 +1305,10 @@ class ObjectSlot(PathOp.ObjectOp):
             # Choose working point
             if Ref == "Center of Mass":
                 com = shape.CenterOfMass
-                p = FreeCAD.Vector(com.x, com.y, 0.0)
+                p = FreeCAD.Vector(com.x, com.y, 0)
             elif Ref == "Center of BoundBox":
                 bbox = shape.BoundBox.Center
-                p = FreeCAD.Vector(bbox.x, bbox.y, 0.0)
+                p = FreeCAD.Vector(bbox.x, bbox.y, 0)
             elif Ref == "Lowest Point":
                 p = self._getLowestPoint(shape)
             elif Ref == "Highest Point":
@@ -1323,15 +1323,15 @@ class ObjectSlot(PathOp.ObjectOp):
             edge = shape.Edges[0] if hasattr(shape, "Edges") else shape
             v0 = edge.Vertexes[0]
             v1 = edge.Vertexes[1]
-            temp = FreeCAD.Vector(v1.X - v0.X, v1.Y - v0.Y, 0.0)
+            temp = FreeCAD.Vector(v1.X - v0.X, v1.Y - v0.Y, 0)
             dYdX = self._normalizeVector(temp) if temp.Length != 0 else FreeCAD.Vector(0, 0, 0)
 
             if Ref == "Center of Mass":
                 com = shape.CenterOfMass
-                p = FreeCAD.Vector(com.x, com.y, 0.0)
+                p = FreeCAD.Vector(com.x, com.y, 0)
             elif Ref == "Center of BoundBox":
                 bbox = shape.BoundBox.Center
-                p = FreeCAD.Vector(bbox.x, bbox.y, 0.0)
+                p = FreeCAD.Vector(bbox.x, bbox.y, 0)
             elif Ref == "Lowest Point":
                 p = self._findLowestPointOnEdge(shape)
             elif Ref == "Highest Point":
@@ -1340,7 +1340,7 @@ class ObjectSlot(PathOp.ObjectOp):
         elif sub.startswith("Vert"):
             cat = "Vert"
             V = shape.Vertexes[0]
-            p = FreeCAD.Vector(V.X, V.Y, 0.0)
+            p = FreeCAD.Vector(V.X, V.Y, 0)
 
         else:
             Path.Log.warning(f"Unrecognized subfeature type: {sub}")
@@ -1422,8 +1422,8 @@ class ObjectSlot(PathOp.ObjectOp):
         Find mid-points between ends of equal, oppossing edges passed in tuple (edge1, edge2)."""
         com1 = same[0].CenterOfMass
         com2 = same[1].CenterOfMass
-        p1 = FreeCAD.Vector(com1.x, com1.y, 0.0)
-        p2 = FreeCAD.Vector(com2.x, com2.y, 0.0)
+        p1 = FreeCAD.Vector(com1.x, com1.y, 0)
+        p2 = FreeCAD.Vector(com2.x, com2.y, 0)
         return (p1, p2)
 
     def _isParallel(self, dYdX1, dYdX2):
@@ -1435,23 +1435,23 @@ class ObjectSlot(PathOp.ObjectOp):
         centered at the midpoint of the line, with given length."""
 
         midPnt = (p1.add(p2)).multiply(0.5)
-        halfDist = length / 2.0
+        halfDist = length / 2
 
         if getattr(self, "dYdX1", None):
-            half = FreeCAD.Vector(self.dYdX1.x, self.dYdX1.y, 0.0).multiply(halfDist)
+            half = FreeCAD.Vector(self.dYdX1.x, self.dYdX1.y, 0).multiply(halfDist)
             n1 = midPnt.add(half)
             n2 = midPnt.sub(half)
             return (n1, n2)
 
         elif getattr(self, "dYdX2", None):
-            half = FreeCAD.Vector(self.dYdX2.x, self.dYdX2.y, 0.0).multiply(halfDist)
+            half = FreeCAD.Vector(self.dYdX2.x, self.dYdX2.y, 0).multiply(halfDist)
             n1 = midPnt.add(half)
             n2 = midPnt.sub(half)
             return (n1, n2)
 
         else:
             toEnd = p2.sub(p1)
-            perp = FreeCAD.Vector(-toEnd.y, toEnd.x, 0.0)
+            perp = FreeCAD.Vector(-toEnd.y, toEnd.x, 0)
             perp = perp.normalize()  # normalize() returns the vector normalized
             perp = perp.multiply(halfDist)
             n1 = midPnt.add(perp)
@@ -1468,7 +1468,7 @@ class ObjectSlot(PathOp.ObjectOp):
                 return FreeCAD.Vector(v.X, v.Y, v.Z)
 
         # Try midpoint
-        mid = E.valueAt(E.getParameterByLength(E.Length / 2.0))
+        mid = E.valueAt(E.getParameterByLength(E.Length / 2))
         if abs(mid.z - zMin) < tol or E.BoundBox.ZLength < 1e-9:
             return mid
 
@@ -1477,7 +1477,7 @@ class ObjectSlot(PathOp.ObjectOp):
 
     def _findLowestEdgePoint(self, E):
         zMin = E.BoundBox.ZMin
-        L0, L1 = 0.0, E.Length
+        L0, L1 = 0, E.Length
         tol = 1e-5
         max_iter = 2000
         cnt = 0
@@ -1500,7 +1500,7 @@ class ObjectSlot(PathOp.ObjectOp):
                 L1 -= adj
             cnt += 1
 
-        midLen = (L0 + L1) / 2.0
+        midLen = (L0 + L1) / 2
         return E.valueAt(E.getParameterByLength(midLen))
 
     def _findHighestPointOnEdge(self, E):
@@ -1518,7 +1518,7 @@ class ObjectSlot(PathOp.ObjectOp):
             return FreeCAD.Vector(v.X, v.Y, v.Z)
 
         # Check midpoint on edge
-        midLen = E.Length / 2.0
+        midLen = E.Length / 2
         midPnt = E.valueAt(E.getParameterByLength(midLen))
         if abs(zMax - midPnt.z) < tol or E.BoundBox.ZLength < 1e-9:
             return midPnt
@@ -1528,7 +1528,7 @@ class ObjectSlot(PathOp.ObjectOp):
     def _findHighestEdgePoint(self, E):
         zMax = E.BoundBox.ZMax
         eLen = E.Length
-        L0 = 0.0
+        L0 = 0
         L1 = eLen
         cnt = 0
         while L1 - L0 > 1e-5 and cnt < 2000:
@@ -1552,7 +1552,7 @@ class ObjectSlot(PathOp.ObjectOp):
 
             cnt += 1
 
-        midLen = (L0 + L1) / 2.0
+        midLen = (L0 + L1) / 2
         return E.valueAt(E.getParameterByLength(midLen))
 
     def _getVectorAngle(self, v):
@@ -1564,14 +1564,14 @@ class ObjectSlot(PathOp.ObjectOp):
         ea3 = Part.makeLine(a2, v1)
         ea4 = Part.makeLine(v1, v0)
         boxA = Part.Face(Part.Wire([ea1, ea2, ea3, ea4]))
-        cubeA = boxA.extrude(FreeCAD.Vector(0.0, 0.0, 1.0))
+        cubeA = boxA.extrude(FreeCAD.Vector(0, 0, 1))
         cmnA = self.base.Shape.common(cubeA)
         eb1 = Part.makeLine(v0, b1)
         eb2 = Part.makeLine(b1, b2)
         eb3 = Part.makeLine(b2, v1)
         eb4 = Part.makeLine(v1, v0)
         boxB = Part.Face(Part.Wire([eb1, eb2, eb3, eb4]))
-        cubeB = boxB.extrude(FreeCAD.Vector(0.0, 0.0, 1.0))
+        cubeB = boxB.extrude(FreeCAD.Vector(0, 0, 1))
         cmnB = self.base.Shape.common(cubeB)
         if cmnA.Volume > cmnB.Volume:
             return (b1, b2)
@@ -1601,7 +1601,7 @@ class ObjectSlot(PathOp.ObjectOp):
         extruded = shape.extrude(extrude_vec)
 
         # Slice halfway up the extrusion
-        slice_z = shape.BoundBox.ZMin + extrude_vec.z / 2.0
+        slice_z = shape.BoundBox.ZMin + extrude_vec.z / 2
         slices = extruded.slice(FreeCAD.Vector(0, 0, 1), slice_z)
 
         if not slices:
@@ -1640,8 +1640,8 @@ class ObjectSlot(PathOp.ObjectOp):
 
     def _lineCollisionCheck(self, obj, p1, p2):
         """Model the swept volume of a linear tool move and check for collision with the model."""
-        rad = getattr(self.tool.Diameter, "Value", self.tool.Diameter) / 2.0
-        extVect = FreeCAD.Vector(0.0, 0.0, obj.StartDepth.Value - obj.FinalDepth.Value)
+        rad = getattr(self.tool.Diameter, "Value", self.tool.Diameter) / 2
+        extVect = FreeCAD.Vector(0, 0, obj.StartDepth.Value - obj.FinalDepth.Value)
 
         def make_cylinder(point):
             circle = Part.makeCircle(rad, point)
@@ -1653,7 +1653,7 @@ class ObjectSlot(PathOp.ObjectOp):
             toEnd = p2.sub(p1)
             if toEnd.Length == 0:
                 return None
-            perp = FreeCAD.Vector(-toEnd.y, toEnd.x, 0.0)
+            perp = FreeCAD.Vector(-toEnd.y, toEnd.x, 0)
             if perp.Length == 0:
                 return None
             perp.normalize()
@@ -1709,10 +1709,10 @@ class ObjectSlot(PathOp.ObjectOp):
             (pC, pD) = self._makeOffsetArc(p1, p2, center, outer_radius)
             arc_outside = Arcs.arcFrom2Pts(pC, pD, center)
 
-            pa = FreeCAD.Vector(*arc_inside.Vertexes[0].Point[:2], 0.0)
-            pb = FreeCAD.Vector(*arc_inside.Vertexes[1].Point[:2], 0.0)
-            pc = FreeCAD.Vector(*arc_outside.Vertexes[1].Point[:2], 0.0)
-            pd = FreeCAD.Vector(*arc_outside.Vertexes[0].Point[:2], 0.0)
+            pa = FreeCAD.Vector(*arc_inside.Vertexes[0].Point[:2], 0)
+            pb = FreeCAD.Vector(*arc_inside.Vertexes[1].Point[:2], 0)
+            pc = FreeCAD.Vector(*arc_outside.Vertexes[1].Point[:2], 0)
+            pd = FreeCAD.Vector(*arc_outside.Vertexes[0].Point[:2], 0)
 
             e1 = Part.makeLine(pb, pc)
             e2 = Part.makeLine(pd, pa)
@@ -1720,7 +1720,7 @@ class ObjectSlot(PathOp.ObjectOp):
             return Part.Face(Part.Wire(edges))
 
         # Radius and extrusion direction
-        rad = getattr(self.tool.Diameter, "Value", self.tool.Diameter) / 2.0
+        rad = getattr(self.tool.Diameter, "Value", self.tool.Diameter) / 2
         extVect = FreeCAD.Vector(0, 0, obj.StartDepth.Value - obj.FinalDepth.Value)
 
         if self.isArc == 1:

--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -564,6 +564,10 @@ class ObjectSlot(PathOp.ObjectOp):
         cmds = self._makeOperation(obj)
         if cmds:
             self.commandlist.extend(cmds)
+        else:
+            # clear Path if can not create slot
+            self.commandlist.clear()
+            return False
 
         # Final move to clearance height
         self.commandlist.append(

--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -167,15 +167,6 @@ class ObjectSlot(PathOp.ObjectOp):
             ),
             (
                 "App::PropertyEnumeration",
-                "LayerMode",
-                "Slot",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Complete the operation in a single pass at depth, or multiple passes to final depth.",
-                ),
-            ),
-            (
-                "App::PropertyEnumeration",
                 "PathOrientation",
                 "Slot",
                 QtCore.QT_TRANSLATE_NOOP(
@@ -250,12 +241,8 @@ class ObjectSlot(PathOp.ObjectOp):
 
         enums = {
             "CutPattern": [
-                (translate("CAM_Slot", "Line"), "Line"),
-                (translate("CAM_Slot", "ZigZag"), "ZigZag"),
-            ],
-            "LayerMode": [
-                (translate("CAM_Slot", "Single-pass"), "Single-pass"),
-                (translate("CAM_Slot", "Multi-pass"), "Multi-pass"),
+                (translate("CAM_Slot", "Directional"), "Directional"),
+                (translate("CAM_Slot", "Bidirectional"), "Bidirectional"),
             ],
             "PathOrientation": [
                 (translate("CAM_Slot", "Start to End"), "Start to End"),
@@ -309,8 +296,7 @@ class ObjectSlot(PathOp.ObjectOp):
             "CustomPoint2": FreeCAD.Vector(0, 0, 0),
             "ExtendPathEnd": 0,
             "Reference2": "Center of Mass",
-            "LayerMode": "Multi-pass",
-            "CutPattern": "ZigZag",
+            "CutPattern": "Bidirectional",
             "PathOrientation": "Start to End",
             "ExtendRadius": 0,
             "ReverseDirection": False,
@@ -356,6 +342,7 @@ class ObjectSlot(PathOp.ObjectOp):
         ENUMS = self.getActiveEnumerations(obj)
         obj.Reference1 = ENUMS["Reference1"]
         obj.Reference2 = ENUMS["Reference2"]
+        obj.CutPattern = ENUMS["CutPattern"]
 
         # Restore pre-existing values if available with active enumerations.
         # If not, set to first element in active enumeration list.
@@ -400,6 +387,16 @@ class ObjectSlot(PathOp.ObjectOp):
             obj.ViewObject.signalChangeIcon()
 
     def opOnDocumentRestored(self, obj):
+        if obj.CutPattern == "Line":
+            self.updateEnumerations(obj)
+            obj.CutPattern = "Directional"
+        if obj.CutPattern == "ZigZag":
+            self.updateEnumerations(obj)
+            obj.CutPattern = "Bidirectional"
+
+        if hasattr(obj, "LayerMode"):
+            obj.removeProperty("LayerMode")
+
         self.propertiesReady = False
         job = PathUtils.findParentJob(obj)
 
@@ -749,24 +746,19 @@ class ObjectSlot(PathOp.ObjectOp):
             )
             return cmds
 
-        if obj.LayerMode == "Single-pass":
-            CMDS.extend(arcPass(PATHS[path_index], obj.FinalDepth.Value))
+        if obj.CutPattern == "Directional":
+            for depth in self.depthParams:
+                CMDS.extend(arcPass(PATHS[path_index], depth))
+                CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
+            CMDS.pop()  # remove last move to safe height
         else:
-            if obj.CutPattern == "Line":
-                for depth in self.depthParams:
+            i = 0
+            for depth in self.depthParams:
+                if i % 2 == 0:  # even
                     CMDS.extend(arcPass(PATHS[path_index], depth))
-                    CMDS.append(
-                        Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
-                    )
-                CMDS.pop()  # remove last move to safe height
-            elif obj.CutPattern == "ZigZag":
-                i = 0
-                for depth in self.depthParams:
-                    if i % 2 == 0:  # even
-                        CMDS.extend(arcPass(PATHS[path_index], depth))
-                    else:  # odd
-                        CMDS.extend(arcPass(PATHS[not path_index], depth))
-                    i += 1
+                else:  # odd
+                    CMDS.extend(arcPass(PATHS[not path_index], depth))
+                i += 1
 
         if self.isDebug:
             Path.Log.debug("G-code arc command is: {}".format(PATHS[path_index][2]))
@@ -863,28 +855,22 @@ class ObjectSlot(PathOp.ObjectOp):
             cmds.append(Path.Command("G1", {"X": p2.x, "Y": p2.y, "F": self.horizFeed}))
             return cmds
 
-        # CMDS.append(Path.Command('N (Tool type: {})'.format(toolType), {}))
-        if obj.LayerMode == "Single-pass":
-            CMDS.extend(linePass(p1, p2, obj.FinalDepth.Value))
+        if obj.CutPattern == "Directional":
+            for dep in self.depthParams:
+                CMDS.extend(linePass(p1, p2, dep))
+                CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
+            CMDS.pop()  # remove last move to safe height
         else:
-            if obj.CutPattern == "Line":
-                for dep in self.depthParams:
-                    CMDS.extend(linePass(p1, p2, dep))
-                    CMDS.append(
-                        Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
-                    )
-                CMDS.pop()  # remove last move to safe height
-            elif obj.CutPattern == "ZigZag":
-                CMDS.append(Path.Command("G0", {"X": p1.x, "Y": p1.y, "F": self.horizRapid}))
-                i = 0
-                for dep in self.depthParams:
-                    if i % 2 == 0:  # even
-                        CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
-                        CMDS.append(Path.Command("G1", {"X": p2.x, "Y": p2.y, "F": self.horizFeed}))
-                    else:  # odd
-                        CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
-                        CMDS.append(Path.Command("G1", {"X": p1.x, "Y": p1.y, "F": self.horizFeed}))
-                    i += 1
+            CMDS.append(Path.Command("G0", {"X": p1.x, "Y": p1.y, "F": self.horizRapid}))
+            i = 0
+            for dep in self.depthParams:
+                if i % 2 == 0:  # even
+                    CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
+                    CMDS.append(Path.Command("G1", {"X": p2.x, "Y": p2.y, "F": self.horizFeed}))
+                else:  # odd
+                    CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
+                    CMDS.append(Path.Command("G1", {"X": p1.x, "Y": p1.y, "F": self.horizFeed}))
+                i += 1
 
         CMDS.insert(1, Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
 

--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -766,8 +766,6 @@ class ObjectSlot(PathOp.ObjectOp):
                     else:  # odd
                         CMDS.extend(arcPass(PATHS[not path_index], depth))
                     i += 1
-        # Raise to SafeHeight when finished
-        CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
 
         if self.isDebug:
             Path.Log.debug("G-code arc command is: {}".format(PATHS[path_index][2]))
@@ -865,7 +863,6 @@ class ObjectSlot(PathOp.ObjectOp):
         # CMDS.append(Path.Command('N (Tool type: {})'.format(toolType), {}))
         if obj.LayerMode == "Single-pass":
             CMDS.extend(linePass(p1, p2, obj.FinalDepth.Value))
-            CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
         else:
             if obj.CutPattern == "Line":
                 for dep in self.depthParams:
@@ -884,7 +881,6 @@ class ObjectSlot(PathOp.ObjectOp):
                         CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
                         CMDS.append(Path.Command("G1", {"X": p1.x, "Y": p1.y, "F": self.horizFeed}))
                     i += 1
-            CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
 
         return CMDS
 

--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -758,6 +758,7 @@ class ObjectSlot(PathOp.ObjectOp):
                     CMDS.append(
                         Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
                     )
+                CMDS.pop()  # remove last move to safe height
             elif obj.CutPattern == "ZigZag":
                 i = 0
                 for depth in self.depthParams:
@@ -769,6 +770,8 @@ class ObjectSlot(PathOp.ObjectOp):
 
         if self.isDebug:
             Path.Log.debug("G-code arc command is: {}".format(PATHS[path_index][2]))
+
+        CMDS.insert(1, Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
 
         return CMDS
 
@@ -870,6 +873,7 @@ class ObjectSlot(PathOp.ObjectOp):
                     CMDS.append(
                         Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
                     )
+                CMDS.pop()  # remove last move to safe height
             elif obj.CutPattern == "ZigZag":
                 CMDS.append(Path.Command("G0", {"X": p1.x, "Y": p1.y, "F": self.horizRapid}))
                 i = 0
@@ -881,6 +885,8 @@ class ObjectSlot(PathOp.ObjectOp):
                         CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
                         CMDS.append(Path.Command("G1", {"X": p1.x, "Y": p1.y, "F": self.horizFeed}))
                     i += 1
+
+        CMDS.insert(1, Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
 
         return CMDS
 

--- a/src/Mod/CAM/Path/Op/Slot.py
+++ b/src/Mod/CAM/Path/Op/Slot.py
@@ -144,7 +144,7 @@ class ObjectSlot(PathOp.ObjectOp):
                 "Slot",
                 QtCore.QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "Set the geometric clearing pattern to use for the operation.",
+                    "Set the cut pattern for the operation.",
                 ),
             ),
             (
@@ -163,15 +163,6 @@ class ObjectSlot(PathOp.ObjectOp):
                 QtCore.QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Positive extends the end of the toolpath, negative shortens.",
-                ),
-            ),
-            (
-                "App::PropertyEnumeration",
-                "LayerMode",
-                "Slot",
-                QtCore.QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Complete the operation in a single pass at depth, or multiple passes to final depth.",
                 ),
             ),
             (
@@ -250,12 +241,8 @@ class ObjectSlot(PathOp.ObjectOp):
 
         enums = {
             "CutPattern": [
-                (translate("CAM_Slot", "Line"), "Line"),
-                (translate("CAM_Slot", "ZigZag"), "ZigZag"),
-            ],
-            "LayerMode": [
-                (translate("CAM_Slot", "Single-pass"), "Single-pass"),
-                (translate("CAM_Slot", "Multi-pass"), "Multi-pass"),
+                (translate("CAM_Slot", "Directional"), "Directional"),
+                (translate("CAM_Slot", "Bidirectional"), "Bidirectional"),
             ],
             "PathOrientation": [
                 (translate("CAM_Slot", "Start to End"), "Start to End"),
@@ -309,8 +296,7 @@ class ObjectSlot(PathOp.ObjectOp):
             "CustomPoint2": FreeCAD.Vector(0, 0, 0),
             "ExtendPathEnd": 0,
             "Reference2": "Center of Mass",
-            "LayerMode": "Multi-pass",
-            "CutPattern": "ZigZag",
+            "CutPattern": "Bidirectional",
             "PathOrientation": "Start to End",
             "ExtendRadius": 0,
             "ReverseDirection": False,
@@ -356,6 +342,7 @@ class ObjectSlot(PathOp.ObjectOp):
         ENUMS = self.getActiveEnumerations(obj)
         obj.Reference1 = ENUMS["Reference1"]
         obj.Reference2 = ENUMS["Reference2"]
+        obj.CutPattern = ENUMS["CutPattern"]
 
         # Restore pre-existing values if available with active enumerations.
         # If not, set to first element in active enumeration list.
@@ -400,6 +387,16 @@ class ObjectSlot(PathOp.ObjectOp):
             obj.ViewObject.signalChangeIcon()
 
     def opOnDocumentRestored(self, obj):
+        if obj.CutPattern == "Line":
+            self.updateEnumerations(obj)
+            obj.CutPattern = "Directional"
+        if obj.CutPattern == "ZigZag":
+            self.updateEnumerations(obj)
+            obj.CutPattern = "Bidirectional"
+
+        if hasattr(obj, "LayerMode"):
+            obj.removeProperty("LayerMode")
+
         self.propertiesReady = False
         job = PathUtils.findParentJob(obj)
 
@@ -749,24 +746,17 @@ class ObjectSlot(PathOp.ObjectOp):
             )
             return cmds
 
-        if obj.LayerMode == "Single-pass":
-            CMDS.extend(arcPass(PATHS[path_index], obj.FinalDepth.Value))
+        if obj.CutPattern == "Directional":
+            for depth in self.depthParams:
+                CMDS.extend(arcPass(PATHS[path_index], depth))
+                CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
+            CMDS.pop()  # remove last move to safe height
         else:
-            if obj.CutPattern == "Line":
-                for depth in self.depthParams:
+            for i, depth in enumerate(self.depthParams):
+                if i % 2 == 0:  # even
                     CMDS.extend(arcPass(PATHS[path_index], depth))
-                    CMDS.append(
-                        Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
-                    )
-                CMDS.pop()  # remove move to safe height after last step down
-            elif obj.CutPattern == "ZigZag":
-                for i, depth in enumerate(self.depthParams):
-                    if i == 0:  # first
-                        CMDS.extend(arcPass(PATHS[path_index], depth))
-                    elif i % 2 == 0:  # even
-                        CMDS.extend(arcPass(PATHS[path_index], depth)[1:])
-                    else:  # odd
-                        CMDS.extend(arcPass(PATHS[not path_index], depth)[1:])
+                else:  # odd
+                    CMDS.extend(arcPass(PATHS[not path_index], depth))
 
         if self.isDebug:
             Path.Log.debug("G-code arc command is: {}".format(PATHS[path_index][2]))
@@ -863,26 +853,20 @@ class ObjectSlot(PathOp.ObjectOp):
             cmds.append(Path.Command("G1", {"X": p2.x, "Y": p2.y, "F": self.horizFeed}))
             return cmds
 
-        # CMDS.append(Path.Command('N (Tool type: {})'.format(toolType), {}))
-        if obj.LayerMode == "Single-pass":
-            CMDS.extend(linePass(p1, p2, obj.FinalDepth.Value))
+        if obj.CutPattern == "Directional":
+            for dep in self.depthParams:
+                CMDS.extend(linePass(p1, p2, dep))
+                CMDS.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
+            CMDS.pop()  # remove last move to safe height
         else:
-            if obj.CutPattern == "Line":
-                for dep in self.depthParams:
-                    CMDS.extend(linePass(p1, p2, dep))
-                    CMDS.append(
-                        Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid})
-                    )
-                CMDS.pop()  # remove move to safe height after last step down
-            elif obj.CutPattern == "ZigZag":
-                CMDS.append(Path.Command("G0", {"X": p1.x, "Y": p1.y, "F": self.horizRapid}))
-                for i, dep in enumerate(self.depthParams):
-                    if i % 2 == 0:  # even
-                        CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
-                        CMDS.append(Path.Command("G1", {"X": p2.x, "Y": p2.y, "F": self.horizFeed}))
-                    else:  # odd
-                        CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
-                        CMDS.append(Path.Command("G1", {"X": p1.x, "Y": p1.y, "F": self.horizFeed}))
+            CMDS.append(Path.Command("G0", {"X": p1.x, "Y": p1.y, "F": self.horizRapid}))
+            for i, dep in enumerate(self.depthParams):
+                if i % 2 == 0:  # even
+                    CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
+                    CMDS.append(Path.Command("G1", {"X": p2.x, "Y": p2.y, "F": self.horizFeed}))
+                else:  # odd
+                    CMDS.append(Path.Command("G1", {"Z": dep, "F": self.vertFeed}))
+                    CMDS.append(Path.Command("G1", {"X": p1.x, "Y": p1.y, "F": self.horizFeed}))
 
         CMDS.insert(1, Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))
 


### PR DESCRIPTION
> [!NOTE]
> Step **6** of prepare to [ CAM: Slot improve #25090 ](https://github.com/FreeCAD/FreeCAD/pull/25090)

---

All other operations do not contains property to ignore `StepDown` value

### Changes:

1. Removed property `LayerMode` to get behavior of `StepDown` similar with other operations

2. Renamed options names of property `CutPattern`
from `ZigZag` and `Line` to `Bidirectional` and `Directional` (similar to `MillFacing`)

3. Added `CutPattern` to Task panel

<img width="874" height="518" alt="Screenshot_20260425_101727_hor_lossy" src="https://github.com/user-attachments/assets/a9447f5a-bc46-48a8-a23c-6c6b95bb0645" />

