### PR TITLE
core: add new config var, CmakeBuildType to Application.cpp

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2582,6 +2582,12 @@ void Application::initConfig(int argc, char ** argv)
     mConfig["Debug"] = "0";
 #   endif
 
+#ifdef FREECAD_BUILD_TYPE
+    mConfig["CmakeBuildType"] = FREECAD_BUILD_TYPE;
+#else
+    mConfig["CmakeBuildType"] = "";
+#endif
+
     if (!Py_IsInitialized()) {
         // init python
         PyImport_AppendInittab ("FreeCAD", init_freecad_module);

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -34,23 +34,26 @@ ENDIF(DOCDIR)
 set(_vars "const char CMakeVariables[] =\"cmake = [")
 set(_delim "")
 get_cmake_property(_variableNames VARIABLES)
-foreach (_variableName ${_variableNames})
-    if (${_variableName})
-        STRING(REGEX MATCH "^[_]?[^_]*" _prefix "${_variableName}_")
+foreach(_variableName ${_variableNames})
+    if(${_variableName})
+        string(REGEX MATCH "^[_]?[^_]*" _prefix "${_variableName}_")
         if(${_prefix} STREQUAL "BUILD")
-            STRING(REPLACE "\\" "\\\\" _name ${_variableName})
+            string(REPLACE "\\" "\\\\" _name ${_variableName})
             set(_vars "${_vars}${_delim}\\n\"\n\"\\\"${_name}\\\"")
             set(_delim ",")
         endif()
-    endif ()
+    endif()
 endforeach()
 set(_vars "${_vars}]\\n\" \n;")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CMakeScript.hh "${_vars}" )
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/CMakeScript.hh "${_vars}")
 
 fc_copy_file_if_different(
     "${CMAKE_CURRENT_BINARY_DIR}/CMakeScript.hh"
     "${CMAKE_CURRENT_BINARY_DIR}/CMakeScript.h"
 )
+
+# Export CMAKE_BUILD_TYPE as a preprocessor definition
+add_definitions(-DFREECAD_BUILD_TYPE="${CMAKE_BUILD_TYPE}")
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

when working with the cam workbench related to unit testing, i've been troubleshooting certain tests. specifically at the moment test46 inside of the `TestOpUtil.py` which is failing due to newer occ versions. ie. >= v7.9.x

i've wanted to add some logging to this test, but didn't want to polute the test files with erronous print statements unless i'm doing a debug build. i couldn't really find a good way to check if the cmake build type is ie. `RelWithDebInfo` or `DEBUG` from within python test file. ie. like the one above ie. `TestOpUtil.py` but setting up this config var should make that a little easier, and only affect **non** `Release` builds of freecad.

below is some output from the py console inside of freecad with this PR built into the source code.

```
>>> import pprint
>>> pprint.pprint(FreeCAD.ConfigDump())
{'AboutImage': 'freecadaboutdev',
 'AppDataSkipVendor': 'true',
 'AppHomePath': '/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/',
 'AppIcon': 'freecad',
 'AppTempPath': '/tmp/',
 'BOOST_VERSION': '1_89',
 'BinPath': '/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/bin/',
 'BuildRepositoryURL': 'git://github.com/ipatch/freecad.git',
 'BuildRevision': '44492 (Git)',
 'BuildRevisionBranch': 'ipatch.add.new.config.value.CmakeBuildType',
 'BuildRevisionDate': '2025/11/28 18:08:10',
 'BuildRevisionHash': 'f18842114fb784db8224a80ce1f2e709d92aa20c',
 'BuildVersionMajor': '1',
 'BuildVersionMinor': '2',
 'BuildVersionPoint': '0',
 'BuildVersionSuffix': 'dev',
 'COIN_VERSION': '4.0.6',
 'CmakeBuildType': 'RelWithDebInfo',
 'Console': '0',
 'CopyrightInfo': '(C) 2001-2025 FreeCAD contributors\n'
                  'FreeCAD is free and open-source software licensed under the '
                  'terms of LGPL2+ license.\n'
                  '\n',
 'Debug': '0',
 'DesktopFileName': 'org.freecad.FreeCAD',
 'DocPath': '/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/doc/',
 'EIGEN_VERSION': '5.0.1',
 'ExeName': 'FreeCAD',
 'ExeVendor': 'FreeCAD',
 'ExeVersion': '1.2.0',
 'LoggingConsole': '1',
 'LoggingFile': '',
 'MaintainerUrl': 'https://freecad.org',
 'OCC_VERSION': '7.9.2',
 'OpenFileCount': '',
 'PATH': '/home/capin/homebrew/bin:/home/capin/homebrew/sbin:/opt/local/sbin:/opt/local/bin:/home/capin/.local/share/nvim/mason/bin:/home/capin/.local/share/gem/ruby/3.4.0/bin:/home/capin/.rbenv/shims:/home/capin/.rbenv/bin:/home/capin/.local/bin:/opt/cross/apl/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin',
 'PYSIDE_VERSION': '6.9.3',
 'PYTHONPATH': '',
 'PYTHON_VERSION': '3.13.9',
 'PythonSearchPath': '/home/capin/homebrew/Cellar/python@3.13/3.13.9_1/lib/python313.zip:/home/capin/homebrew/Cellar/python@3.13/3.13.9_1/lib/python3.13:/home/capin/homebrew/Cellar/python@3.13/3.13.9_1/lib/python3.13/lib-dynload:/home/capin/.local/lib/python3.13/site-packages:/home/capin/homebrew/Cellar/python@3.13/3.13.9_1/lib/python3.13/site-packages:/home/capin/homebrew/lib/python3.13/site-packages',
 'QT_VERSION': '6.9.3',
 'RunMode': 'Gui',
 'SMESH_VERSION': '7.7.1.0',
 'SplashAlignment': 'Bottom|Left',
 'SplashInfoColor': '#000000',
 'SplashInfoPosition': '6,75',
 'SplashScreen': 'freecadsplash',
 'SplashTextColor': '#418FDE',
 'SplashWarningColor': '#CA333B',
 'StartWorkbench': 'PartDesignWorkbench',
 'SystemParameter': '/home/capin/.config/FreeCAD/v1-2/system.cfg',
 'UserAppData': '/home/capin/.local/share/FreeCAD/v1-2/',
 'UserCachePath': '/home/capin/.cache/FreeCAD/Cache/',
 'UserConfigPath': '/home/capin/.config/FreeCAD/v1-2/',
 'UserHomePath': '/home/capin',
 'UserMacroPath': '/home/capin/.local/share/FreeCAD/v1-2/Macro/',
 'UserParameter': '/home/capin/.config/FreeCAD/v1-2/user.cfg',
 'Verbose': '',
 'XERCESC_VERSION': '3.3.0'}
```

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
