### PR TITLE
Linux: use exec command in AppRun

### DIFF
--- a/package/rattler-build/linux/AppDir/AppRun
+++ b/package/rattler-build/linux/AppDir/AppRun
@@ -31,4 +31,4 @@ else
     MAIN="$HERE/usr/bin/freecad"
 fi
 
-"${MAIN}" "$@"
+exec "${MAIN}" "$@"


### PR DESCRIPTION
In most of programs with AppImage, `AppRun` will use `exec` to avoid unnecessary shell process.