### PR TITLE
TechDraw: improve draw performance

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewPart.h
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.h
@@ -115,6 +115,7 @@ public:
                                      double x, double y,
                                      double curx, double cury);
 
+    void addToGroupWithoutUpdate(QGraphicsItem* item);
     bool getGroupSelection() override;
     void setGroupSelection(bool isSelected) override;
     void setGroupSelection(bool isSelected, const std::vector<std::string> &subNames) override;


### PR DESCRIPTION

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Closes #24191

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

TechDraw is slow when scaling to a few hundred items. A benchmark tells us that FreeCAD spends a lot of time in the `boundingRect` method of `QGIView`.

<img width="1544" height="1131" alt="draw" src="https://github.com/user-attachments/assets/e2211ff3-623d-4c6f-8a90-84043514d636" />

When an item is added to the view, `addToGroup` calls the bounding box computation routine, and loops over all existing child items, effectively making the `paint` routine O(N^2), for N:=#elements. This PR makes it O(N) by delaying the update and computation of bounding box until all items are added, using a custom `addToGroupWithoutUpdate` function inspired by the [qt implementation](https://codebrowser.dev/qt5/qtbase/src/widgets/graphicsview/qgraphicsitem.cpp.html#_ZN18QGraphicsItemGroup10addToGroupEP13QGraphicsItem). This reduces the load time for the dataset provided in #24191 to a few instants.

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
