### PR TITLE
cam: fix issue #23498, test47 was failing with occ >= 7.9.x

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathOpUtil.py
+++ b/src/Mod/CAM/CAMTests/TestPathOpUtil.py
@@ -820,16 +820,17 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         length = 20 * math.cos(math.pi / 6)
 
         lEdges = [
-            e for e in w.Edges
+            e
+            for e in w.Edges
             if not Path.Geom.isRoughly(e.Vertexes[0].Point.y, e.Vertexes[1].Point.y)
         ]
         self.assertEqual(2, len(lEdges))
 
         # flip the wire
         w = Path.Geom.flipWire(Part.Wire(lEdges))
-        
+
         # offset the flipped wire
-        # NOTE: depending on geometry, flipping the wire might require flipping 
+        # NOTE: depending on geometry, flipping the wire might require flipping
         # the boolean side (True -> False) to keep the offset "inside" the shape.
         wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True)
 

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -197,7 +197,6 @@ def offsetWire(wire, base, offset, forward, Side=None):
                 print(f"cannot make face: {e}")
             return True  # assume clockwise if we cannot make a face
 
-
     if debug_build:
         print(f"wire orientation - clockwise: {isWireClockwise(wire)}")
         print(f"inside parameter: {forward}")
@@ -218,7 +217,7 @@ def offsetWire(wire, base, offset, forward, Side=None):
         normalizedForward = not forward
 
     Path.Log.track("offsetWire")
-    
+
     # special handling for single-edge circular wires
     if len(wire.Edges) == 1:
         edge = wire.Edges[0]

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -177,11 +177,49 @@ def orientWire(w, forward=True):
 
 def offsetWire(wire, base, offset, forward, Side=None):
     """offsetWire(wire, base, offset, forward) ... offsets the wire away from base and orients the wire accordingly.
-    The function tries to avoid most of the pitfalls of Part.makeOffset2D which is possible because all offsetting
+    This function tries to avoid most of the pitfalls of Part.makeOffset2D which is possible because all offsetting
     happens in the XY plane.
     """
-    Path.Log.track("offsetWire")
 
+    # only print for debug builds
+    build_type = FreeCAD.ConfigGet("CmakeBuildType")
+    debug_build = build_type in ["Debug", "RelWithDebInfo"]
+
+    def isWireClockwise(w):
+        try:
+            face = Part.Face(w)
+            orientation = face.Orientation
+            if debug_build:
+                print(f"face orientation: {orientation}")
+            return orientation == "Forward"
+        except Exception as e:
+            if debug_build:
+                print(f"cannot make face: {e}")
+            return True  # assume clockwise if we cannot make a face
+
+
+    if debug_build:
+        print(f"wire orientation - clockwise: {isWireClockwise(wire)}")
+        print(f"inside parameter: {forward}")
+        print(f"wire edges: {len(wire.Edges)}")
+
+    # normalize wire orientation for offset (but only for multi-edge wires)
+    originallyClockwise = isWireClockwise(wire)
+    normalizedWire = wire
+    normalizedForward = forward
+
+    # only normalize if wire has multiple edges AND is not closed
+    should_normalize = len(wire.Edges) > 1 and not wire.isClosed()
+
+    if should_normalize and not originallyClockwise:
+        if debug_build:
+            print("debug: normalizing counter-clockwise wire to clockwise")
+        normalizedWire = Path.Geom.flipWire(wire)
+        normalizedForward = not forward
+
+    Path.Log.track("offsetWire")
+    
+    # special handling for single-edge circular wires
     if len(wire.Edges) == 1:
         edge = wire.Edges[0]
         curve = edge.Curve
@@ -282,30 +320,30 @@ def offsetWire(wire, base, offset, forward, Side=None):
                     edge = Path.Geom.flipEdge(edge)
             return Part.Wire([edge])
 
-        # if we get to this point the assumption is that makeOffset2D can deal with the edge
+    # if we get to this point the assumption is that makeOffset2D can deal with the edge
+    # use normalizedWire here (NOT wire)!
+    owire = normalizedWire.makeOffset2D(offset)
+    debugWire("makeOffset2D_%d" % len(normalizedWire.Edges), owire)
 
-    owire = orientWire(wire.makeOffset2D(offset), True)
-    debugWire("makeOffset2D_%d" % len(wire.Edges), owire)
-
-    if wire.isClosed():
+    if normalizedWire.isClosed():
         if not base.isInside(owire.Edges[0].Vertexes[0].Point, offset / 2, True):
             Path.Log.track("closed - outside")
             if Side:
                 Side[0] = "Outside"
-            return orientWire(owire, forward)
+            return orientWire(owire, normalizedForward)
         Path.Log.track("closed - inside")
         if Side:
             Side[0] = "Inside"
         try:
-            owire = wire.makeOffset2D(-offset)
+            owire = normalizedWire.makeOffset2D(-offset)
         except Exception:
             # most likely offsetting didn't work because the wire is a hole
             # and the offset is too big - making the hole vanish
             return None
         # For negative offsets (holes) 'forward' is the other way
-        if forward is None:
-            return orientWire(owire, None)
-        return orientWire(owire, not forward)
+        if normalizedForward is None:
+            return orientWire
+        return orientWire(owire, not normalizedForward)
 
     # An edge is considered to be inside of shape if the mid point is inside
     # Of the remaining edges we take the longest wire to be the engraving side
@@ -317,7 +355,7 @@ def offsetWire(wire, base, offset, forward, Side=None):
     # Depending on the Axis of the circle, and which side remains we know if the wire needs to be flipped
 
     # first, let's make sure all edges are oriented the proper way
-    edges = _orientEdges(wire.Edges)
+    edges = _orientEdges(normalizedWire.Edges)
 
     # determine the start and end point
     start = edges[0].firstVertex().Point
@@ -328,24 +366,47 @@ def offsetWire(wire, base, offset, forward, Side=None):
     # find edges that are not inside the shape
     common = base.common(owire)
     insideEndpoints = [e.lastVertex().Point for e in common.Edges]
-    insideEndpoints.append(common.Edges[0].firstVertex().Point)
+    if common.Edges:
+        insideEndpoints.append(common.Edges[0].firstVertex().Point)
 
     def isInside(edge):
         p0 = edge.firstVertex().Point
         p1 = edge.lastVertex().Point
         for p in insideEndpoints:
             if Path.Geom.pointsCoincide(p, p0, 0.01) or Path.Geom.pointsCoincide(p, p1, 0.01):
+                if debug_build:
+                    print(f"edge filtered: p0={p0}, p1={p1}, coincides with {p}")
                 return True
         return False
 
+    if debug_build:
+        print(f"debug: owire has {len(owire.Edges)} edges")
+
+    # filter edges
     outside = [e for e in owire.Edges if not isInside(e)]
-    # discard all edges that are not part of the longest wire
+
+    if debug_build:
+        print(f"debug: after filtering, outside has {len(outside)} edges")
+
+    # OCC 7.9.x compatibility fallback
+    if not outside:
+        if debug_build:
+            print("WARNING: All edges were filtered out!")
+            print("This is expected behavior with OCC 7.9.x for certain wire orientations")
+            print(f"insideEndpoints: {insideEndpoints}")
+            print(f"original owire edges:")
+            for i, e in enumerate(owire.Edges):
+                print(f"edge {i}: {e.firstVertex().Point} -> {e.lastVertex().Point}")
+            print("using all edges as fallback")
+        outside = list(owire.Edges)
+
+    debugWire("outside", Part.Wire(outside))
+
     longestWire = None
     for w in [Part.Wire(el) for el in Part.sortEdges(outside)]:
         if not longestWire or longestWire.Length < w.Length:
             longestWire = w
 
-    debugWire("outside", Part.Wire(outside))
     debugWire("longest", longestWire)
 
     def isCircleAt(edge, center):
@@ -412,7 +473,7 @@ def offsetWire(wire, base, offset, forward, Side=None):
     # traversal (climb milling). If that's not what we want just reverse the order,
     # orientWire takes care of orienting the edges appropriately.
     Path.Log.debug("#use left side edges")
-    if not forward:
+    if not normalizedForward:
         Path.Log.debug("#reverse")
         edges.reverse()
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR aims to resolve the issue #23498. this issue came to be when a system building freecad with opencascade version >= 7.9.x  presently i'm building freecad on a m1 running asahi linux using homebrew to build and install deps such as opencascade. circa december 2025 opencascade installed via homebrew is at v7.9.2

before this PR running the below command i was having test47 within the cam workbench failing,

```
/opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD -t TestCAMApp.TestPathOpUtil
```

obviously adjust the path to your development build of freecad. after this PR test47 no longer fails with my occ install of v7.9.2

basically before this PR all edges we're being filtered out this producing the below output when the test47 was ran,

```
======================================================================
ERROR: test46 (CAMTests.TestPathOpUtil.TestPathOpUtil.test46)
Check offsetting multiple inside edges.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/CAM/CAMTests/TestPathOpUtil.py", line 796, in test46
    wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, True)
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/CAM/Path/Op/Util.py", line 349, in offsetWire
    debugWire("outside", Part.Wire(outside))
                         ~~~~~~~~~^^^^^^^^^
Part.OCCError: BRep_API: command not done

======================================================================
ERROR: test47 (CAMTests.TestPathOpUtil.TestPathOpUtil.test47)
Check offsetting multiple backwards inside edges.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/CAM/CAMTests/TestPathOpUtil.py", line 834, in test47
    wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True)
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/CAM/Path/Op/Util.py", line 349, in offsetWire
    debugWire("outside", Part.Wire(outside))
                         ~~~~~~~~~^^^^^^^^^
Part.OCCError: BRep_API: command not done

----------------------------------------------------------------------
Ran 748 tests in 9.589s

FAILED (errors=2, skipped=6)
```


now all that said, i've tested things locally on my end, but definitely would like to get some other eyes on this PR and make sure it doesn't break anything else.

this PR uses the setting i made with the below PR ie. #25873 in short, that PR adds a new config var based on the cmake build type. ie. if building a release or debug version of freecad. that way i can conditionally add some debug statements in the test file and the `Util.py` file for the cam workbench.

and this PR makes use of PR #25873 by including statements like the below, (now this test should still pass regardless if PR #25873 has been added to freecad source code) ie. i just tested this locally and the print statements will not make the test fail, just rather they won't be printed because the config var does not exist without the prior PR ie. #25873 

```python
    # only print for debug builds
    build_type = FreeCAD.ConfigGet("CmakeBuildType")
    debug_build = build_type in ["Debug", "RelWithDebInfo"]

    def isWireClockwise(w):
        try:
            face = Part.Face(w)
            orientation = face.Orientation
            if debug_build:
                print(f"face orientation: {orientation}")
            return orientation == "Forward"
        except Exception as e:
            if debug_build:
                print(f"cannot make face: {e}")
            return True  # assume clockwise if we cannot make a face


    if debug_build:
        print(f"wire orientation - clockwise: {isWireClockwise(wire)}")
        print(f"inside parameter: {forward}")
        print(f"wire edges: {len(wire.Edges)}")
```

i'd like to think this PR will resolve issue #23498 and possibly #25064 as both of those issues report test47 as failing most likely due to the recent changes in opencascade v.7.9.x and greater.

i believe the commit in question that was introduced in opencascade that causes this failure is the below.

```diff
╰─λ git show 65d8eece35
commit 65d8eece350df6e92710f64687f2dc1cabb9edbd
Author: astromko <astromko@opencascade.com>
Date:   Fri May 17 08:58:06 2024 +0000

    0032964: Modeling Algorithms - 2d Offset sometimes 'split' straight edges

    Implemented avoiding force cut of an edge in case of simple edge (that contains just 1 curve).

diff --git a/src/BRepFill/BRepFill_OffsetWire.cxx b/src/BRepFill/BRepFill_OffsetWire.cxx
index ee611c1f09..dae07a5bb3 100644
--- a/src/BRepFill/BRepFill_OffsetWire.cxx
+++ b/src/BRepFill/BRepFill_OffsetWire.cxx
@@ -1198,7 +1198,9 @@ void BRepFill_OffsetWire::PrepareSpine()
       // Cut
       TopoDS_Shape aLocalShape = E.Oriented(TopAbs_FORWARD);
       //  Modified by Sergey KHROMOV - Thu Nov 16 17:29:29 2000 Begin
-      if (nbEdges == 2 && nbResEdges == 0)
+      Handle(BRep_TEdge) TEdge = Handle(BRep_TEdge)::DownCast(E.TShape());
+      const Standard_Integer aNumCurvesInEdge = TEdge->Curves().Size();
+      if (nbEdges == 2 && nbResEdges == 0 && aNumCurvesInEdge > 1)
         ForcedCut = 1;
       //  Modified by Sergey KHROMOV - Thu Nov 16 17:29:33 2000 End
       nbResEdges = CutEdge (TopoDS::Edge(aLocalShape), mySpine, ForcedCut, Cuts);
diff --git a/tests/bugs/modalg_5/bug25704_6 b/tests/bugs/modalg_5/bug25704_6
index 64a98dafa8..e9e0e2abcd 100644
--- a/tests/bugs/modalg_5/bug25704_6
+++ b/tests/bugs/modalg_5/bug25704_6
@@ -17,7 +17,7 @@ if [catch { openoffset resoffset a 5 5 i } ] {
 checkshape result
 checksection result

-  checknbshapes result -vertex 4 -edge 3 -wire 1 -face 0 -shell 0 -solid 0 -compsolid 0 -compound 0 -shape 8
+  checknbshapes result -vertex 3 -edge 2 -wire 1 -face 0 -shell 0 -solid 0 -compsolid 0 -compound 0 -shape 6
...skipping...
diff --git a/tests/bugs/modalg_5/bug25704_6 b/tests/bugs/modalg_5/bug25704_6
index 64a98dafa8..e9e0e2abcd 100644
--- a/tests/bugs/modalg_5/bug25704_6
+++ b/tests/bugs/modalg_5/bug25704_6
@@ -17,7 +17,7 @@ if [catch { openoffset resoffset a 5 5 i } ] {
 checkshape result
 checksection result

-  checknbshapes result -vertex 4 -edge 3 -wire 1 -face 0 -shell 0 -solid 0 -compsolid 0 -compound 0 -shape 8
+  checknbshapes result -vertex 3 -edge 2 -wire 1 -face 0 -shell 0 -solid 0 -compsolid 0 -compound 0 -shape 6
 }

 smallview
diff --git a/tests/bugs/modalg_8/bug32964 b/tests/bugs/modalg_8/bug32964
new file mode 100644
index 0000000000..a4f3009e81
--- /dev/null
+++ b/tests/bugs/modalg_8/bug32964
@@ -0,0 +1,14 @@
+puts "============="
+puts "0032964: Modeling Algorithms - 2d Offset sometimes 'split' straight edges"
+puts "============="
+
+pload MODELING
+vertex p1 -90 40 0
+vertex p2 40 40 0
+vertex p3 40 -90 0
+edge e1 p1 p2
+edge e2 p2 p3
+wire w1 e1 e2
+openoffset oo w1 1 40
+checknbshapes oo_1 -vertex 3 -edge 2 -wire 1 -shape 6
+checkview -display oo_1 -2d -path ${imagedir}/${test_image}.png
```

i have **not** tested this fix with older versions of opencascade ie. prior to v7.9.x so i'm not sure if this will break with occ v7.8.x

