### PR TITLE
CAM: Fix job assignment and model/stock initialization in ObjectOp

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -336,7 +336,10 @@ class ObjectOp(object):
 
         if not hasattr(obj, "DoNotSetDefaultValues") or not obj.DoNotSetDefaultValues:
             if parentJob:
-                self.job = PathUtils.addToJob(obj, jobname=parentJob.Name)
+                self.job = parentJob
+                self.model = parentJob.Model.Group if parentJob.Model else []
+                self.stock = parentJob.Stock if hasattr(parentJob, "Stock") else None
+                PathUtils.addToJob(obj, jobname=parentJob.Name)
             job = self.setDefaultValues(obj)
             if job:
                 job.SetupSheet.Proxy.setOperationProperties(obj, name)


### PR DESCRIPTION
This PR fixes a bug introduced with PR #25800

It updates the ObjectOp class to correctly assign the job, model, and stock properties from the parentJob object. Previously, only PathUtils.addToJob was called, which did not set these attributes directly.

This change ensures that when creating a new operation, the job, model, and stock fields are properly initialized from the parent job. This fixes issues where operations did not inherit the correct job context, leading to missing or incorrect references to the model and stock, and potential errors in downstream processing.