### PR TITLE
Part: revert changes to ViewProviderExt::getDetails

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -1538,4 +1538,3 @@ void ViewProviderPartExt::handleChangedPropertyName(
         Gui::ViewProviderGeometryObject::handleChangedPropertyName(reader, TypeName, PropName);
     }
 }
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/25894

by reverting https://github.com/FreeCAD/FreeCAD/pull/25702 entirely

@kadet1090 @chennes this can be merged asap as the bug it introduced is quite severe.

I am working on another fix for the issue it was fixing