### PR TITLE
CAM: DressupBoundary - Fix init clearance height move

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Boundary.py
@@ -231,8 +231,8 @@ class PathBoundary:
 
         cmd = path.Commands[0]
         pos = cmd.Placement.Base  # bogus m/c position to create first edge
-        bogusX = True
-        bogusY = True
+        bogusX = True  # true for start moves, than position X not defined
+        bogusY = True  # true for start moves, than position Y not defined
         commands = [cmd]
         lastExit = None
         for cmd in path.Commands[1:]:
@@ -241,28 +241,33 @@ class PathBoundary:
                     bogusX = "X" not in cmd.Parameters
                 if bogusY:
                     bogusY = "Y" not in cmd.Parameters
+
+                if cmd.z is not None and Path.Geom.isRoughly(cmd.z, self.clearanceHeight):
+                    # append move to clearance height
+                    commands.append(cmd)
+                    pos = Path.Geom.commandEndPoint(cmd, pos)
+                    lastExit = None
+                    continue
+
                 edge = Path.Geom.edgeForCmd(cmd, pos)
                 if edge and cmd.Name in Path.Geom.CmdMoveDrill:
                     inside = edge.common(self.boundary).Edges
                     outside = edge.cut(self.boundary).Edges
                     if 1 == len(inside) and 0 == len(outside):
                         commands.append(cmd)
-                if edge and not cmd.Name in Path.Geom.CmdMoveDrill:
+                if edge and cmd.Name not in Path.Geom.CmdMoveDrill:
                     inside = edge.common(self.boundary).Edges
                     outside = edge.cut(self.boundary).Edges
                     if not self.inside:  # UI "inside boundary" param
-                        tmp = inside
-                        inside = outside
-                        outside = tmp
+                        inside, outside = outside, inside
                     # it's really a shame that one cannot trust the sequence and/or
                     # orientation of edges
                     if 1 == len(inside) and 0 == len(outside):
                         Path.Log.track(_vstr(pos), _vstr(lastExit), " + ", cmd)
                         # cmd fully included by boundary
                         if lastExit:
-                            if not (
-                                bogusX or bogusY
-                            ):  # don't insert false paths based on bogus m/c position
+                            if not (bogusX or bogusY):
+                                # don't insert false paths based on bogus m/c position
                                 commands.extend(
                                     self.boundaryCommands(lastExit, pos, tc.VertFeed.Value)
                                 )
@@ -306,9 +311,9 @@ class PathBoundary:
                                     commands.extend(
                                         Path.Geom.cmdsForEdge(
                                             e,
-                                            flip,
-                                            tc.HorizFeed.Value,
-                                            tc.VertFeed.Value,
+                                            flip=flip,
+                                            hSpeed=tc.HorizFeed.Value,
+                                            vSpeed=tc.VertFeed.Value,
                                         )
                                     )
                                     # restore G0 movement


### PR DESCRIPTION
In some cases initial move to clearance height can be skipped, which will create dangerous situation

[boundary_clearance.zip](https://github.com/user-attachments/files/23905963/boundary_clearance.zip)

<img width="1244" height="369" alt="521879567-9b15b14f-0547-4f12-9448-825cdfc0c2b1_lossy" src="https://github.com/user-attachments/assets/9c8bd46a-3560-457a-90aa-8647cc145a3c" />

