### PR TITLE
CAM: DressupBoundary - Fix for drill outside

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Boundary.py
@@ -253,7 +253,9 @@ class PathBoundary:
                 if edge and cmd.Name in Path.Geom.CmdMoveDrill:
                     inside = edge.common(self.boundary).Edges
                     outside = edge.cut(self.boundary).Edges
-                    if 1 == len(inside) and 0 == len(outside):
+                    if not self.inside:
+                        inside, outside = outside, inside
+                    if inside and not outside:
                         commands.append(cmd)
                 if edge and cmd.Name not in Path.Geom.CmdMoveDrill:
                     inside = edge.common(self.boundary).Edges


### PR DESCRIPTION
At this moment for drill commands side of boundary not taken into account
Fix this

In example below hole inside boundary should be excluded 

<img width="822" height="377" alt="Screenshot_20260321_095211_hor_lossy" src="https://github.com/user-attachments/assets/f3d4c218-2df9-4b81-82de-a54321e71e96" />
