### PR TITLE
WindowsInstaller: more robust automatic version info from freecadcmd

### DIFF
--- a/package/WindowsInstaller/Settings.nsh
+++ b/package/WindowsInstaller/Settings.nsh
@@ -34,11 +34,7 @@ These typically need to be modified for each FreeCAD release
 
 #--------------------------------
 # get version info from freecadcmd
-!system "${FILES_FREECAD}\bin\freecadcmd.exe --safe-mode -c $\"import datetime; print(f'!define COPYRIGHT_YEAR {datetime.date.today().year}')$\">${__FILEDIR__}\version.nsh" = 0
-!system "${FILES_FREECAD}\bin\freecadcmd.exe --safe-mode -c $\"print(f'!define APP_VERSION_MAJOR \$\"{App.Version()[0]}\$\"')$\">>${__FILEDIR__}\version.nsh" = 0
-!system "${FILES_FREECAD}\bin\freecadcmd.exe --safe-mode -c $\"print(f'!define APP_VERSION_MINOR \$\"{App.Version()[1]}\$\"')$\">>${__FILEDIR__}\version.nsh" = 0
-!system "${FILES_FREECAD}\bin\freecadcmd.exe --safe-mode -c $\"print(f'!define APP_VERSION_PATCH \$\"{App.Version()[2]}\$\"')$\">>${__FILEDIR__}\version.nsh" = 0
-!system "${FILES_FREECAD}\bin\freecadcmd.exe --safe-mode -c $\"print(f'!define APP_VERSION_REVISION \$\"{App.Version()[3].split()[0]}\$\"')$\">>${__FILEDIR__}\version.nsh" = 0
+!system "${FILES_FREECAD}\bin\freecadcmd.exe --safe-mode $\"${__FILEDIR__}\write_version_nsh.py$\"" = 0
 !include "${__FILEDIR__}\version.nsh"
 !delfile "${__FILEDIR__}\version.nsh"
 

--- a/package/WindowsInstaller/write_version_nsh.py
+++ b/package/WindowsInstaller/write_version_nsh.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# this script is meant to be called by nsis installer scripts, it gets version information
+# from freecad and writes version.nsh file in the directory the script is located at
+import FreeCAD
+import datetime
+import os
+
+filepath=os.path.join(os.path.dirname(os.path.abspath(__file__)),"version.nsh")
+v=FreeCAD.Version()
+content=f'''\
+!define COPYRIGHT_YEAR {datetime.date.today().year}
+!define APP_VERSION_MAJOR "{v[0]}"
+!define APP_VERSION_MINOR "{v[1]}"
+!define APP_VERSION_PATCH "{v[2]}"
+!define APP_VERSION_REVISION "{v[3].split()[0]}"
+'''
+
+with open(filepath, "w", encoding="utf-8") as file:
+    file.writelines(content)


### PR DESCRIPTION
otherwise it broke if freecad had other unrelated output