### PR TITLE
PartDesign: add result quality requirement

### DIFF
--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 
+#include <BRepAlgo.hxx>
 #include <BRep_Tool.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepCheck_Solid.hxx>
@@ -100,7 +101,13 @@ App::DocumentObjectExecReturn* Feature::recompute()
     }
 
     SuppressedShape.setValue(TopoShape());
-    return Part::Feature::recompute();
+    auto ret = Part::Feature::recompute();
+    if (!ret && !BRepAlgo::IsValid(Shape.getValue())) {
+        return new App::DocumentObjectExecReturn(
+            QT_TRANSLATE_NOOP("Exception", "Result shape is not valid")
+        );
+    }
+    return ret;
 }
 
 App::DocumentObjectExecReturn* Feature::recomputePreview()


### PR DESCRIPTION
Add a check in PartDesign feature so the error is reported by the failing feature and not by the next which fail to use the erroneous shape.

Before: No error
<img width="635" height="370" alt="image" src="https://github.com/user-attachments/assets/75094cb9-c5d0-4b19-8d5f-699efb39123c" />

After: **Result shape is not valid**
<img width="672" height="313" alt="image" src="https://github.com/user-attachments/assets/144e9627-b50b-41a0-b1bb-1350ac09c008" />
