### PR TITLE
Sketcher: Offset: Fix failure if 2+ closed wires with different orientations

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -1314,4 +1314,3 @@ void DSHOffsetController::computeNextDrawSketchHandlerMode()
 
 
 #endif  // SKETCHERGUI_DrawSketchHandlerOffset_H
-


### PR DESCRIPTION
Fix the offset problem described in https://github.com/FreeCAD/FreeCAD/issues/24253

Not linking the issue since it's not exactly on this.

<img width="1011" height="758" alt="image" src="https://github.com/user-attachments/assets/36b69fa1-4d23-405b-a66d-2441abc55218" />
