### PR TITLE
Add an icon to "Clear Recent Files List" action

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -858,6 +858,7 @@ RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent)
 
     //: Empties the list of recent files
     clearRecentFilesListAction.setText(tr("Clear Recent Files"));
+    clearRecentFilesListAction.setIcon(QIcon(QStringLiteral(":/icons/edit-delete.svg")));
     clearRecentFilesListAction.setToolTip({});
     this->groupAction()->addAction(&clearRecentFilesListAction);
 


### PR DESCRIPTION
This commit greatly improves the visual representation by addition of an eye-catching icon of trash bin to the action. Continuation of #22638. Screenshot: https://github.com/FreeCAD/FreeCAD/pull/25948#issuecomment-3830640913
