### PR TITLE
BIM: use optimalBoundingBox in getCutVolume

### DIFF
--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -487,9 +487,9 @@ def getCutVolume(cutplane, shapes, clip=False, depth=None):
     if not isinstance(shapes, list):
         shapes = [shapes]
     # building boundbox
-    bb = shapes[0].BoundBox
+    bb = shapes[0].optimalBoundingBox()
     for sh in shapes[1:]:
-        bb.add(sh.BoundBox)
+        bb.add(sh.optimalBoundingBox())
     bb.enlarge(1)
     # building cutplane space
     um = vm = wm = 0


### PR DESCRIPTION
Fixes #25900.

The BoundBox of objects with curved faces can have a high tolerance. The optimalBoundingBox method calculates the exact boundbox.

```
>>> shp.BoundBox
BoundBox (-32489, -4388, -249.909, 31064, -3888, 248.535)
>>> shp.optimalBoundingBox()
BoundBox (-32490.8, -4389.82, -251.731, 31065.8, -3886.18, 250.358)
```