### PR TITLE
Sketcher: Tooltip when hovering expression driven constraint

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -2378,7 +2378,7 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
 bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
 {
     assert(isInEditMode());
-    
+
     // Event filter to intercept the delayed tooltip event from Qt
     class ToolTipFilter : public QObject {
     public:
@@ -2410,7 +2410,7 @@ bool ViewProviderSketch::detectAndShowPreselection(SoPickedPoint* Point)
             widget->removeEventFilter(&filter);
             widget->setToolTip(QString());
         } else {
-            // 1. Set the tooltip text on the widget. 
+            // 1. Set the tooltip text on the widget.
             // This arm's Qt's internal timer to fire QEvent::ToolTip after the standard delay.
             widget->setToolTip(text);
 


### PR DESCRIPTION
Fix https://github.com/AstoCAD/FreeCAD/issues/113

When you hover a expression driven constraint, show the expression in a tooltip.

https://github.com/user-attachments/assets/71be6ab6-a146-4b1c-8464-9a96f84b2f70

