### PR TITLE
CAM: Refactor stock used as boundary to be distinct from regular stock

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Boundary.py
@@ -46,6 +46,16 @@ def _vstr(v):
 
 
 class DressupPathBoundary(object):
+    def promoteStockToBoundary(self, stock):
+        """Ensure stock object has boundary properties set."""
+        if stock:
+            if not hasattr(stock, "IsBoundary"):
+                stock.addProperty("App::PropertyBool", "IsBoundary", "Base")
+            stock.IsBoundary = True
+            if hasattr(stock, "setEditorMode"):
+                stock.setEditorMode("IsBoundary", 3)
+            stock.Label = "Boundary"
+
     def __init__(self, obj, base, job):
         obj.addProperty(
             "App::PropertyLink",
@@ -64,6 +74,7 @@ class DressupPathBoundary(object):
             ),
         )
         obj.Stock = PathStock.CreateFromBase(job)
+        self.promoteStockToBoundary(obj.Stock)
         obj.addProperty(
             "App::PropertyBool",
             "Inside",
@@ -99,8 +110,14 @@ class DressupPathBoundary(object):
         if prop == "Path" and obj.ViewObject:
             obj.ViewObject.signalChangeIcon()
 
+        # If Stock is changed, ensure boundary stock properties are set
+        if prop == "Stock" and obj.Stock:
+            self.promoteStockToBoundary(obj.Stock)
+
     def onDocumentRestored(self, obj):
         self.obj = obj
+        # Ensure Stock property exists and is flagged as boundary stock
+        self.promoteStockToBoundary(obj.Stock)
         if not hasattr(obj, "KeepToolDown"):
             obj.addProperty(
                 "App::PropertyBool",
@@ -120,12 +137,20 @@ class DressupPathBoundary(object):
             if obj.Base.ViewObject:
                 obj.Base.ViewObject.Visibility = True
             obj.Base = None
-        if obj.Stock:
+        if hasattr(obj, "Stock") and obj.Stock:
             obj.Document.removeObject(obj.Stock.Name)
             obj.Stock = None
         return True
 
     def execute(self, obj):
+        if not hasattr(obj, "Stock") or obj.Stock is None:
+            Path.Log.error("BoundaryStock (Stock) missing; cannot execute dressup.")
+            obj.Path = Path.Path([])
+            return
+        if not hasattr(obj.Stock, "Shape") or obj.Stock.Shape is None:
+            Path.Log.error("Boundary stock has no Shape; cannot execute dressup.")
+            obj.Path = Path.Path([])
+            return
         pb = PathBoundary(obj.Base, obj.Stock.Shape, obj.Inside, obj.KeepToolDown)
         obj.Path = pb.execute()
 

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -261,6 +261,9 @@ class ViewProvider:
 
     def editObject(self, obj):
         if obj:
+            # Block editing for Boundary objects
+            if hasattr(obj, "IsBoundary") and getattr(obj, "IsBoundary", False):
+                return False
             if obj in self.obj.Model.Group:
                 return self.openTaskPanel("Model")
             if obj == self.obj.Stock:


### PR DESCRIPTION
This commit makes boundary stock objects distinct from regular stock by setting a boundary flag and label, and prevents editing of boundary objects in the job view provider.

src/Mod/CAM/Path/Dressup/Boundary.py:
- Add promoteStockToBoundary method, set boundary properties, handle missing stock/shape

src/Mod/CAM/Path/Main/Gui/Job.py:
- Block editing for objects flagged as boundary stock

Before/After
<img width="630" height="138" alt="boundary-before-after" src="https://github.com/user-attachments/assets/f705f195-3795-4842-9cd8-84e17b4a5ef2" />

New property (Normally Hidden)
<img width="341" height="333" alt="Screenshot from 2025-12-06 12-33-42" src="https://github.com/user-attachments/assets/e32b3b9f-708b-4972-8b19-94a552190ead" />
