### PR TITLE
Match the string that gets sent to setCommand

### DIFF
--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -731,4 +731,3 @@ void addSketcherWorkbenchVisual(Gui::ToolBarItem& visual)
 }
 
 } /* namespace SketcherGui */
-


### PR DESCRIPTION
Correction of a not matching string (one word in line 45) that gets sent to setCommand. This results in a not translated menu item in the Sketcher menu.

## Issues

None. Short conversation with chennes on crowdin. See [here](https://crowdin.com/editor/freecad/569/en-de?view=comfortable&filter=basic&value=0#6680452)