### PR TITLE
Gui: Fix 25974 freecad.gui alias regression

### DIFF
--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -385,6 +385,7 @@ def InitApplications():
 
     # Patch freecad module with gui alias of FreeCADGui
     import freecad
+
     freecad.gui = FreeCADGui
 
     Log("Init:   Searching modules\n")


### PR DESCRIPTION
`freecad.gui` is not an actual module but an alias of `FreeCADGui`, it is not loaded as other modules but by patching `freecad` module during `FreeCADGuiInit.py`, the patch line was removed by accident. This PR fixes that.

FYI: @Syres916 @chennes @tritao 