### PR TITLE
Draft: make Draft_AnnotationStyleEditor dialog wider

### DIFF
--- a/src/Mod/Draft/draftutils/params.py
+++ b/src/Mod/Draft/draftutils/params.py
@@ -466,7 +466,7 @@ def _get_param_dictionary():
     # fmt: off
     param_dict["Mod/Draft"] = {
         "AnnotationStyleEditorHeight": ("int",       450),
-        "AnnotationStyleEditorWidth":  ("int",       450),
+        "AnnotationStyleEditorWidth":  ("int",       600),
         "CenterPlaneOnView":           ("bool",      False),
         "ChainedMode":                 ("bool",      False),
         "CopyMode":                    ("bool",      False),


### PR DESCRIPTION
Increase AnnotationStyleEditorWidth (default width) from 450 to 600 to mitigate #25983.