### PR TITLE
Update stale issue and PR settings in workflow

### DIFF
--- a/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
+++ b/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
@@ -30,14 +30,14 @@ jobs:
         uses: actions/stale@5f858e3efba33a5ca4407a664cc011ad407f2008 # v10.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-issue-stale: 60
+          days-before-issue-stale: 90
           days-before-issue-close: 14
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          operations-per-run: 100  # max num of ops per run
+          operations-per-run: 200  # max num of ops per run
           stale-issue-label: 'Status: Stale'
           close-issue-label: 'Status: Auto-closing'
-          exempt-issue-labels: 'Status: Confirmed,Priority: High,Priority: Critical,Blocker,Type: Feature,no-auto-close'
+          exempt-issue-labels: 'Status: Confirmed,Priority: High,Priority: Critical,Blocker,Type: Feature,no-auto-close,3rd party: OCC'
           remove-stale-when-updated: true
           ascending: true
           stale-issue-message: |
@@ -87,10 +87,10 @@ jobs:
           days-before-issue-close: 60
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          operations-per-run: 50  # max num of ops per run
+          operations-per-run: 100  # max num of ops per run
           stale-issue-label: 'Status: Stale'
           close-issue-label: 'Status: Auto-closing'
-          exempt-issue-labels: 'Priority: High,Priority: Critical,Blocker,Type: Feature,no-auto-close'
+          exempt-issue-labels: 'Priority: High,Priority: Critical,Blocker,Type: Feature,no-auto-close,3rd party: OCC'
           remove-stale-when-updated: true
           ascending: true
           stale-issue-message: |


### PR DESCRIPTION
@Roy-043 @pieterhijma FYI

Changes stale action to:
- tag **unconfirmed** bugs stale after 90 (currently 60) days; closing after another 2 weeks without an answer.
- no auto-close for **OCC** issues.

Not changes but still active:
- tag issues where we **requested feedback but none was provided** after 20 days; closing after another 2 weeks without an answer.
- follow up on **all bugs** (no feature requests) after 6 months; closing after another 2 months if there is no response.
- tag **PRs** stale after 4 months without activity; closing after another 2 months if there is no activity.

In the past a lot of issues were not reproducible when the stale action requested feedback from the author. Sometimes no one replied. If the issue is critical and a lot of users are affected, there will be enough activity on the issue. This way we can focus on the issues which more users experience. Every closed issue can be reopened anytime.
Plus with the new issue template, we should enforce stricter rules and close issues right away, if users do not provide info but expect fixes from the devs.