### PR TITLE
[GUI] Rename Cancel ‘Close’ in Add Property dialog

### DIFF
--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -512,8 +512,8 @@ void DlgAddProperty::setTitle()
 void DlgAddProperty::setAddEnabled(bool enabled)
 {
     QPushButton* addButton = ui->buttonBox->button(QDialogButtonBox::Ok);
-    QPushButton* cancelButton = ui->buttonBox->button(QDialogButtonBox::Cancel);
-    cancelButton->setDefault(!enabled);
+    QPushButton* closeButton = ui->buttonBox->button(QDialogButtonBox::Close);
+    closeButton->setDefault(!enabled);
     addButton->setDefault(enabled);
     addButton->setEnabled(enabled);
 }

--- a/src/Gui/Dialogs/DlgAddProperty.ui
+++ b/src/Gui/Dialogs/DlgAddProperty.ui
@@ -75,7 +75,7 @@
       <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Close|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This pull request renames the Cancel button. Perhaps, closes #24184 and connected to #25256.