### PR TITLE
TopoNaming: Fix bug with adding tags for disambiguity

### DIFF
--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -1192,7 +1192,7 @@ void ElementMap::addChildElements(long masterTag, const std::vector<MappedChildE
 
         // do child mapping only if the child element count >= 5
         const int threshold {5};
-        if ((child.count >= threshold && child.tag != 0) || !child.elementMap) {
+        if ((child.count >= threshold && masterTag != 0) || !child.elementMap) {
             encodeElementName(child.indexedName[0],
                               tmp,
                               ss,


### PR DESCRIPTION
fixes: https://github.com/FreeCAD/FreeCAD/issues/25361

This pull request changes my https://github.com/FreeCAD/FreeCAD/commit/9f2d212b120880bb4db0b02ab3020cbe6e77802b commit to fix a bug I made while writing the check. I needed to use `masterTag` instead of `child.Tag`