### PR TITLE
TechDraw: Fix page rectangle tearing on pan

### DIFF
--- a/src/Mod/TechDraw/Gui/QGISVGTemplate.h
+++ b/src/Mod/TechDraw/Gui/QGISVGTemplate.h
@@ -55,9 +55,11 @@ public:
     int type() const override { return Type; }
 
     void draw() override;
+    void drawPageRectangle();
+
     void updateView(bool update = false) override;
 
-    TechDraw::DrawSVGTemplate* getSVGTemplate();
+    TechDraw::DrawSVGTemplate* getSVGTemplate() const;
     std::vector<TemplateTextField*> getTextFields() override;
 
 protected:
@@ -70,6 +72,8 @@ protected:
 private:
     QGraphicsSvgItem* m_svgItem;
     QSvgRenderer* m_svgRender;
+    QGraphicsRectItem* m_pageRectangle;
+
 };// class QGISVGTemplate
 
 }// namespace TechDrawGui

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -310,24 +310,6 @@ void QGVPage::drawBackground(QPainter* painter, const QRectF&)
     painter->drawRect(
         viewport()->rect().adjusted(-2, -2, 2, 2));//just bigger than viewport to prevent artifacts
 
-    // Default to A3 landscape, though this is currently relevant
-    // only for opening corrupt docs, etc.
-    float pageWidth = 420, pageHeight = 297;
-
-    if (m_vpPage->getDrawPage()->hasValidTemplate()) {
-        pageWidth = Rez::guiX(m_vpPage->getDrawPage()->getPageWidth());
-        pageHeight = Rez::guiX(m_vpPage->getDrawPage()->getPageHeight());
-    }
-
-    // Draw the white page
-    QRectF paperRect(0, -pageHeight, pageWidth, pageHeight);
-    QPolygon poly = mapFromScene(paperRect);
-
-    QBrush pageBrush(PreferencesGui::pageQColor());
-    painter->setBrush(pageBrush);
-
-    painter->drawRect(poly.boundingRect());
-
     painter->restore();
 }
 


### PR DESCRIPTION
This PR implements a fix for issue #26018.  

It replaces the painting of the Page rectangle as the QGraphicsView widget background using a QPainter with a QGraphicsRectItem in QGISVGTemplate.  This allows the scene to manage the updating of the page rectangle and prevents the tearing of the rectangle edges when panning.
