### PR TITLE
Core: fix "Save Image" giving dark area as compare to viewport

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1776,6 +1776,8 @@ void View3DInventorViewer::savePicture(int width, int height, int sample, const 
     }
 
     root->addChild(getHeadlight());
+    root->addChild(getBacklight());
+    root->addChild(getFillLight());
     root->addChild(camera);
     auto gl = new SoCallback;
     gl->setCallback(setGLWidgetCB, this->getGLWidget());


### PR DESCRIPTION
Issue: #25605
**Screenshot**
<img width="1920" height="1080" alt="Screenshot from 2025-12-08 21-27-22" src="https://github.com/user-attachments/assets/1c938f71-598b-4d29-99b6-ff09051a330e" />

**Before**
<img width="1424" height="629" alt="before_n" src="https://github.com/user-attachments/assets/3486f81e-9675-40f3-8cb9-ea207a8ce5c7" />

**After**
<img width="1424" height="629" alt="after_n" src="https://github.com/user-attachments/assets/b8a720dd-35d9-4f8d-bcf1-68244e2e9b34" />
