### PR TITLE
Gui: Improve transform UI responsivness

### DIFF
--- a/src/App/Services.cpp
+++ b/src/App/Services.cpp
@@ -28,3 +28,8 @@ App::NullCenterOfMass::ofDocumentObject([[maybe_unused]] DocumentObject* object)
 {
     return std::nullopt;
 }
+
+bool App::NullCenterOfMass::supports(DocumentObject* object) const
+{
+    return false;
+}

--- a/src/App/Services.h
+++ b/src/App/Services.h
@@ -55,6 +55,7 @@ class CenterOfMassProvider
 public:
     virtual ~CenterOfMassProvider() = default;
 
+    virtual bool supports(DocumentObject* object) const = 0;
     virtual std::optional<Base::Vector3d> ofDocumentObject(DocumentObject* object) const = 0;
 };
 
@@ -66,6 +67,7 @@ class NullCenterOfMass final : public CenterOfMassProvider
 {
 public:
     std::optional<Base::Vector3d> ofDocumentObject(DocumentObject* object) const override;
+    bool supports(DocumentObject* object) const override;
 };
 
 }

--- a/src/Gui/TaskTransform.cpp
+++ b/src/Gui/TaskTransform.cpp
@@ -173,7 +173,7 @@ void TaskTransform::loadPlacementModeItems() const
         QVariant::fromValue(PlacementMode::ObjectOrigin)
     );
 
-    if (centerOfMassProvider->ofDocumentObject(vp->getObject()).has_value()) {
+    if (centerOfMassProvider->supports(vp->getObject())) {
         ui->placementComboBox->addItem(
             tr("Center of mass / centroid"),
             QVariant::fromValue(PlacementMode::Centroid)

--- a/src/Mod/Part/App/Services.cpp
+++ b/src/Mod/Part/App/Services.cpp
@@ -45,7 +45,7 @@ Base::Placement AttacherSubObjectPlacement::calculate(
 
 std::optional<Base::Vector3d> PartCenterOfMass::ofDocumentObject(App::DocumentObject* object) const
 {
-    if (const auto feature = dynamic_cast<Part::Feature*>(object)) {
+    if (const auto* feature = freecad_cast<Part::Feature*>(object)) {
         const auto shape = feature->Shape.getShape();
 
         if (const auto cog = shape.centerOfGravity()) {
@@ -56,4 +56,9 @@ std::optional<Base::Vector3d> PartCenterOfMass::ofDocumentObject(App::DocumentOb
     }
 
     return {};
+}
+
+bool PartCenterOfMass::supports(App::DocumentObject* object) const
+{
+    return object->isDerivedFrom<Part::Feature>();
 }

--- a/src/Mod/Part/App/Services.h
+++ b/src/Mod/Part/App/Services.h
@@ -42,6 +42,7 @@ class PartCenterOfMass final: public App::CenterOfMassProvider
 {
 public:
     std::optional<Base::Vector3d> ofDocumentObject(App::DocumentObject* object) const override;
+    bool supports(App::DocumentObject* object) const override;
 };
 
 #endif  // PART_SERVICES_H


### PR DESCRIPTION
This introduces much faster CenterOfMassProvider#supports method that can be used as cheap pre-check to see if the object supplied could have the center of mass and so delay the computation to a moment where it is actually needed.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
- Fixes https://forum.freecad.org/viewtopic.php?t=101694
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
