### PR TITLE
PD: Correct is-datum-in-body check

### DIFF
--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -436,7 +436,7 @@ public:
                 }
                 else {
                     if ((geoGroup && geoGroup->hasObject(plane, true))
-                        || !App::GeoFeatureGroupExtension::getGroupOfObject(plane)) {
+                        || App::GeoFeatureGroupExtension::getGroupOfObject(plane)) {
                         status.push_back(PartDesignGui::TaskFeaturePick::otherPart);
                     }
                     else {


### PR DESCRIPTION
Intended to fix #25831 -- but seems to either be flawed, or to expose another underlying bug. This does fix the segfault, and the incorrect reporting of the datum plane as being part of another body (when it is in fact not in any body), but actually attaching a sketch to the datum plane does not work. @PaddleStroke or @kadet1090?