### PR TITLE
PD: Add deprecation warning if Midplane is set

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -129,6 +129,23 @@ bool FeatureExtrude::hasTaperedAngle() const
         || fabs(TaperAngle2.getValue()) > Base::toRadians(Precision::Angular());
 }
 
+void FeatureExtrude::onChanged(const App::Property* prop)
+{
+    if (prop == &Midplane) {
+        // Deprecation notice: Midplane property is deprecated and has been replaced by SideType in
+        // FreeCAD 1.1 when FeatureExtrude was refactored.
+        Base::Console().warning(
+            "The 'Midplane' property is deprecated and has been replaced by the 'SideType' "
+            "property in FeatureExtrude. Please update your script, this property will be "
+            "removed in a future version.\n"
+        );
+        if (Midplane.getValue()) {
+            SideType.setValue("Symmetric");
+        }
+    }
+    ProfileBased::onChanged(prop);
+}
+
 TopoShape FeatureExtrude::makeShellFromUpToShape(TopoShape shape, TopoShape sketchshape, gp_Dir dir)
 {
 
@@ -932,6 +949,7 @@ void FeatureExtrude::onDocumentRestored()
         SideType.setValue("Two sides");
     }
     else if (Midplane.getValue()) {
+        // This code is probably now dead, replaced by the onChanged watcher for the Midplane value
         Midplane.setValue(false);
         SideType.setValue("Symmetric");
     }

--- a/src/Mod/PartDesign/App/FeatureExtrude.h
+++ b/src/Mod/PartDesign/App/FeatureExtrude.h
@@ -77,6 +77,7 @@ protected:
     void onDocumentRestored() override;
     Base::Vector3d computeDirection(const Base::Vector3d& sketchVector, bool inverse);
     bool hasTaperedAngle() const;
+    void onChanged(const App::Property* prop) override;
 
 
     /// Options for buildExtrusion()


### PR DESCRIPTION
Intended to fix #26014 (but see that bug for the testing challenge I'm facing -- I'm creating this PR first to get the CI suite to run on it). Anyone who has scripts that use Midplane, testing would be very welcome. Note that unlike the document reading code, this does NOT also set Midplane to false, to avoid the circularity that would create. We could work around that, but it seemed unnecessary.