### PR TITLE
CAM: revert accidental icon name change from #25440

### DIFF
--- a/src/Mod/CAM/Gui/ViewProviderPath.cpp
+++ b/src/Mod/CAM/Gui/ViewProviderPath.cpp
@@ -879,7 +879,7 @@ long ViewProviderPath::findFirstFeedMoveIndex(const Path::Toolpath& path) const
 
 QIcon ViewProviderPath::getIcon() const
 {
-    return Gui::BitmapFactory().pixmap("Path-ToolPath");
+    return Gui::BitmapFactory().pixmap("CAM_Toolpath");
 }
 
 // Python object -----------------------------------------------------------------------


### PR DESCRIPTION
#25440 changed the icon name in ViewProviderPath.cpp from "CAM_Toolpath" to "Path-ToolPath". According to @sliptonic this was by accident. This causes "Cannot find icon: Path-ToolPath" warnings and question mark icons to be displayed instead of the tool path icons:

<img width="375" height="206" alt="grafik" src="https://github.com/user-attachments/assets/eda9185d-421a-441e-b729-b77c3af75caf" />