### PR TITLE
Fix sketch redundancy warning

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -596,7 +596,7 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
     }
 
     if (lastHasPartialRedundancies) {
-        QString uniqueName = QString::fromLatin1(this->getNameInDocument());   
+        QString uniqueName = QString::fromLatin1(this->getNameInDocument());
         QString userLabel = QString::fromUtf8(Label.getValue());
 
         QString ref;


### PR DESCRIPTION
This PR improves the warning message when a sketch has partially redundant constraints to be more concise and user-friendly.

**Changes:**
- Show sketch name with label only when they differ (avoiding redundancy in 90% of cases)
- Use concise format: "Name" or "Name (Label)"
- Keep message short and direct for better readability
- Consistent with other FreeCAD notification messages

**Examples:**
- When name equals label: `"Sketch001" has partially redundant constraint(s).`
- When different: `"Sketch001 (MasterSketch)" has partially redundant constraint(s).`

## Issues
Fixes #26045

## Before and After Images
**Before:**
```
The Sketch has partially redundant constraints!
```
(Generic message with no identification of which sketch)
<img width="1383" height="62" alt="image" src="https://github.com/user-attachments/assets/2045d5d0-e305-46ea-bdaa-8633c61ca5bb" />


**After:**
```
"Sketch001" has partially redundant constraint(s).
```
or
```
"Sketch001 (MasterSketch)" has partially redundant constraint(s).
```
<img width="2497" height="1168" alt="image" src="https://github.com/user-attachments/assets/fb9310b2-f4c0-4d6d-86d8-30408c0b0059" />

