### PR TITLE
BIM: ArchReference: handle transparency-alpha switch

### DIFF
--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -511,6 +511,7 @@ class ArchReference:
 
         if writemode2:
             # Old DiffuseColor support:
+            alpha_to_transparency = False
             for i in range(1, int(len(buf) / 4)):
                 # ShapeAppearance material with default v0.21 properties:
                 material = FreeCAD.Material()
@@ -518,6 +519,13 @@ class ArchReference:
                 material.DiffuseColor = color[:3] + (255,)
                 material.Transparency = color[3] / 255.0
                 colors.append(material)
+                if material.Transparency == 1.0:
+                    # Assumption: a face with 100% transparency indicates
+                    # we are actually dealing with alpha values.
+                    alpha_to_transparency = True
+            if alpha_to_transparency:
+                for material in colors:
+                    material.Transparency = 1.0 - material.Transparency
 
         if writemode3:
             # File format ShapeAppearance files in FCStd file:


### PR DESCRIPTION
The 'old' DiffuseColor comes in 2 flavors. In v0.21.2 it stores transparency values. In v1.0.2 and v1.1 it stores alpha values. The ArchReference code should handle both. DiffuseColor is still used by BuildingParts in v1.0.2 and v1.1.

The solution is a bit hacky: if 100% transparency occurs we assume we are actually dealing with alpha values.