### PR TITLE
UI: Fix select all instances of an object in the tree

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5451,7 +5451,7 @@ void DocumentItem::updateItemSelection(DocumentObjectItem* item)
         item->setCheckState(false);
     }
 
-    if ((selected && item->selected > 0) || (!selected && !item->selected)) {
+    if (!selected && !item->selected) {
         return;
     }
     if (item->selected != -1) {
@@ -5484,7 +5484,38 @@ void DocumentItem::updateItemSelection(DocumentObjectItem* item)
 #endif
 
     if (!selected) {
-        Gui::Selection().rmvSelection(docname, objname, subname.c_str());
+        // Handles deselection for same name object and subname
+        bool keep = false;
+        auto items = getTree()->selectedItems();
+        for (auto it : items) {
+            if (it->type() == TreeWidget::ObjectType) {
+                auto docitem = static_cast<DocumentObjectItem*>(it);
+                auto obj2 = docitem->object()->getObject();
+                if (!obj2 || !obj2->isAttachedToDocument()) {
+                    continue;
+                }
+
+                std::ostringstream str2;
+                App::DocumentObject* topParent2 = nullptr;
+                docitem->getSubName(str2, topParent2);
+
+                if (topParent2) {
+                    if (!obj2->redirectSubName(str2, topParent2, nullptr)) {
+                        str2 << obj2->getNameInDocument() << '.';
+                    }
+                    obj2 = topParent2;
+                }
+
+                if (obj2 == obj && str2.str() == subname) {
+                    keep = true;
+                    break;
+                }
+            }
+        }
+
+        if (!keep) {
+            Gui::Selection().rmvSelection(docname, objname, subname.c_str());
+        }
         return;
     }
 
@@ -5492,14 +5523,16 @@ void DocumentItem::updateItemSelection(DocumentObjectItem* item)
     selected = false;
     if (!item->mySubs.empty()) {
         for (auto& sub : item->mySubs) {
-            if (Gui::Selection().addSelection(docname, objname, (subname + sub).c_str())) {
+            if (Gui::Selection().isSelected(docname, objname, (subname + sub).c_str())
+                || Gui::Selection().addSelection(docname, objname, (subname + sub).c_str())) {
                 selected = true;
             }
         }
     }
     if (!selected) {
         item->mySubs.clear();
-        if (!Gui::Selection().addSelection(docname, objname, subname.c_str())) {
+        if (!Gui::Selection().isSelected(docname, objname, subname.c_str())
+            && !Gui::Selection().addSelection(docname, objname, subname.c_str())) {
             // Safely re-access the item
             DocumentObjectItem* item2 = findItem(vobj->getObject(), subname);
             if (item2) {


### PR DESCRIPTION
Issue: #15527

add this check  "!Gui::Selection().isSelected(docname, objname, subname.c_str()"  to for selecting same obj as "Gui::Selection().addSelection(docname, objname, subname.c_str())" returns false for duplicate also.

**Fixed**

https://github.com/user-attachments/assets/87b7112c-2dc7-42ae-8e26-2afff5a60f3d


**Tested Issue :#25759**

https://github.com/user-attachments/assets/bbd75ac0-fd07-4628-8ba2-0abc5e2501bd

