### PR TITLE
CAM: Profile - Open wire with 2 equal edges

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -1037,9 +1037,10 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         part0 = Part.Wire(Part.__sortEdges__(edgs0))
         part1 = Part.Wire(Part.__sortEdges__(edgs1))
 
-        # Determine which part is nearest original edge(s)
-        distToPart0 = self._distMidToMid(wire.Wires[0], part0.Wires[0])
-        distToPart1 = self._distMidToMid(wire.Wires[0], part1.Wires[0])
+        # Determine which part is nearest original edge(s) using middle points of wires
+        point = wire.Wires[0].discretize(3)[1]
+        distToPart0 = point.sub(part0.Wires[0].discretize(3)[1]).Length
+        distToPart1 = point.sub(part1.Wires[0].discretize(3)[1]).Length
         if distToPart0 < distToPart1:
             rtnWIRES.append(part0)
         else:
@@ -1427,28 +1428,6 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         factor = dist / toEnd.Length
         perp = FreeCAD.Vector(-1 * toEnd.y, toEnd.x, 0.0).multiply(factor)
         return p1.add(toEnd.add(perp))
-
-    def _distMidToMid(self, wireA, wireB):
-        mpA = self._findWireMidpoint(wireA)
-        mpB = self._findWireMidpoint(wireB)
-        return mpA.sub(mpB).Length
-
-    def _findWireMidpoint(self, wire):
-        midPnt = None
-        dist = 0.0
-        wL = wire.Length
-        midW = wL / 2
-
-        for E in Part.sortEdges(wire.Edges)[0]:
-            elen = E.Length
-            d_ = dist + elen
-            if dist < midW and midW <= d_:
-                dtm = midW - dist
-                midPnt = E.valueAt(E.getParameterByLength(dtm))
-                break
-            else:
-                dist += elen
-        return midPnt
 
     # Method to add temporary debug object
     def _addDebugObject(self, objName, objShape):


### PR DESCRIPTION
[Unnamed3.zip](https://github.com/user-attachments/files/24123573/Unnamed3.zip)

While attempt to process open wire with 2 equal edges get errors
```
File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Profile.py", line 1496, in _distMidToMid
    mpB = self._findWireMidpoint(wireB)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Profile.py", line 1513, in _findWireMidpoint
    midPnt = E.valueAt(E.getParameterByLength(dtm))
<class 'ValueError'>: value out of range
Profile: value out of range
```

Suggest to use more simple and faster way to define middle point of wire: `wire.discretize(3)[1]`
Removed `_findWireMidpoint()` and `_distMidToMid()` as useless

<img width="1243" height="670" alt="Screenshot_20251212_105306_lossy" src="https://github.com/user-attachments/assets/4a1e8a0f-3f2f-45c7-b20d-8d2e23897f8e" />
