### PR TITLE
Gui: Correct UTF-8 support for property names

### DIFF
--- a/src/Gui/propertyeditor/PropertyModel.cpp
+++ b/src/Gui/propertyeditor/PropertyModel.cpp
@@ -240,7 +240,7 @@ QModelIndex PropertyModel::propertyIndexFromPath(const QStringList& path) const
 
 static void setPropertyItemName(PropertyItem* item, const char* propName, QString groupName)
 {
-    QString name = QString::fromLatin1(propName);
+    QString name = QString::fromUtf8(propName);
     QString realName = name;
     if (name.size() > groupName.size() + 1 && name.startsWith(groupName + QLatin1Char('_'))) {
         name = name.right(name.size() - groupName.size() - 1);


### PR DESCRIPTION
Fix bug reported here: https://forum.freecad.org/viewtopic.php?p=861899#p861899

As I've mentioned before, it's likely that nearly all of our uses of explicit Latin-1 encoding are wrong. For the time being I'm fixing them one at a time so it's easy to bisect to the commit that broke things if there are some that are correct.