### PR TITLE
CAM: Add comprehensive tests for Command constructor annotations

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
+++ b/src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py
@@ -257,8 +257,8 @@ class TestPathCommandAnnotations(PathTestBase):
         # Note: Parameters are restored via GCode parsing
 
     def test12(self):
-        """Test save/restore with empty and complex annotations (in-memory)."""
-        # Test 1: Empty annotations (should work and use compact format)
+        """Test save/restore with empty annotations (in-memory)."""
+        # Test empty annotations (should work and use compact format)
         simple = Path.Command("G0", {"Z": 5.0})
         self.assertEqual(simple.Annotations, {})
 
@@ -269,7 +269,9 @@ class TestPathCommandAnnotations(PathTestBase):
         self.assertEqual(simple_restored.Annotations, {})
         self.assertEqual(simple_restored.Name, "G0")
 
-        # Test 2: Complex CAM annotations with edge cases
+    def test13(self):
+        """Test save/restore with complex annotations and edge cases (in-memory)."""
+        # Test complex CAM annotations with edge cases
         complex_cmd = Path.Command("G84", {"X": 25.4, "Y": 12.7, "Z": -8.0})
         complex_cmd.Annotations = {
             # Mixed types with edge cases
@@ -311,3 +313,68 @@ class TestPathCommandAnnotations(PathTestBase):
         # Check scientific notation (now only 6 decimal places)
         self.assertAlmostEqual(complex_restored.Annotations["scientific"], 1.23e-6, places=6)
         self.assertIsInstance(complex_restored.Annotations["scientific"], float)
+
+    def test14(self):
+        """Test Command constructor with positional annotations parameter."""
+        # Test constructor with string annotations (positional)
+        c1 = Path.Command("G1", {"X": 10.0, "Y": 5.0}, {"note": "Rapid move"})
+        self.assertEqual(c1.Name, "G1")
+        self.assertEqual(c1.Parameters["X"], 10.0)
+        self.assertEqual(c1.Parameters["Y"], 5.0)
+        self.assertEqual(c1.Annotations["note"], "Rapid move")
+
+    def test15(self):
+        """Test Command constructor with keyword annotations parameter."""
+        # Test constructor with annotations keyword argument
+        c1 = Path.Command("G1", {"X": 10.0, "Y": 5.0}, annotations={"note": "Rapid move"})
+        self.assertEqual(c1.Name, "G1")
+        self.assertEqual(c1.Parameters["X"], 10.0)
+        self.assertEqual(c1.Parameters["Y"], 5.0)
+        self.assertEqual(c1.Annotations["note"], "Rapid move")
+
+    def test16(self):
+        """Test Command constructor with numeric annotations."""
+        # Test constructor with numeric annotations
+        c1 = Path.Command("G2", {"X": 20.0, "Y": 15.0}, {"priority": 1})
+        self.assertEqual(c1.Name, "G2")
+        self.assertEqual(c1.Parameters["X"], 20.0)
+        self.assertEqual(c1.Parameters["Y"], 15.0)
+        self.assertEqual(c1.Annotations["priority"], 1)
+
+    def test17(self):
+        """Test Command constructor with mixed string and numeric annotations."""
+        # Test constructor with mixed annotations
+        c1 = Path.Command("G3", {"X": 30.0, "Y": 25.0}, {"note": "Arc move", "speed": 1500})
+        self.assertEqual(c1.Name, "G3")
+        self.assertEqual(c1.Parameters["X"], 30.0)
+        self.assertEqual(c1.Parameters["Y"], 25.0)
+        self.assertEqual(c1.Annotations["note"], "Arc move")
+        self.assertEqual(c1.Annotations["speed"], 1500)
+
+    def test18(self):
+        """Test Command constructor with empty annotations."""
+        # Test constructor with empty annotations dict
+        c1 = Path.Command("G0", {"X": 0.0, "Y": 0.0}, {})
+        self.assertEqual(c1.Name, "G0")
+        self.assertEqual(c1.Parameters["X"], 0.0)
+        self.assertEqual(c1.Parameters["Y"], 0.0)
+        self.assertEqual(c1.Annotations, {})
+
+    def test19(self):
+        """Test Command constructor without annotations (backward compatibility)."""
+        # Test constructor without annotations (should work as before)
+        c1 = Path.Command("G1", {"X": 10.0, "Y": 5.0})
+        self.assertEqual(c1.Name, "G1")
+        self.assertEqual(c1.Parameters["X"], 10.0)
+        self.assertEqual(c1.Parameters["Y"], 5.0)
+        self.assertEqual(c1.Annotations, {})
+
+    def test20(self):
+        """Test Command constructor with floating point annotations."""
+        # Test constructor with floating point annotations
+        c1 = Path.Command("G1", {"X": 10.0, "Y": 5.0}, {"retract": 15.5, "angle": 30.25})
+        self.assertEqual(c1.Name, "G1")
+        self.assertEqual(c1.Parameters["X"], 10.0)
+        self.assertEqual(c1.Parameters["Y"], 5.0)
+        self.assertEqual(c1.Annotations["retract"], 15.5)
+        self.assertEqual(c1.Annotations["angle"], 30.25)


### PR DESCRIPTION
Add detailed test coverage for the new Command constructor that accepts annotations parameter, including positional and keyword arguments, string and numeric annotations, empty annotations, and backward compatibility. Split existing save/restore tests for better granularity.

src/Mod/CAM/CAMTests/TestPathCommandAnnotations.py:
- Added test14-test20 for Command constructor with annotations
- Split test12 into test12 (empty annotations) and test13 (complex annotations) for focused testing
