### PR TITLE
[TD]Correct handling of custom page sizes

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -331,12 +331,12 @@ void MDIViewPage::print()
 
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-    if (pageAttr.pageSize() == QPageSize::Custom) {
+    if (pageAttr.pageSizeId() == QPageSize::Custom) {
         printer.setPageSize(
             QPageSize(QSizeF(pageAttr.pageWidth(), pageAttr.pageHeight()), QPageSize::Millimeter));
     }
     else {
-        printer.setPageSize(QPageSize(pageAttr.pageSize()));
+        printer.setPageSize(QPageSize(pageAttr.pageSizeId()));
     }
     printer.setPageOrientation(pageAttr.orientation());
 
@@ -352,12 +352,12 @@ void MDIViewPage::printPreview()
 
     QPrinter printer(QPrinter::HighResolution);
     printer.setFullPage(true);
-    if (pageAttr.pageSize() == QPageSize::Custom) {
+    if (pageAttr.pageSizeId() == QPageSize::Custom) {
         printer.setPageSize(
             QPageSize(QSizeF(pageAttr.pageWidth(), pageAttr.pageHeight()), QPageSize::Millimeter));
     }
     else {
-        printer.setPageSize(QPageSize(pageAttr.pageSize()));
+        printer.setPageSize(QPageSize(pageAttr.pageSizeId()));
     }
     printer.setPageOrientation(pageAttr.orientation());
 
@@ -402,7 +402,7 @@ void MDIViewPage::print(QPrinter* printer)
                 return;
             }
         }
-        if (doPrint && psPrtSetting != pageAttr.pageSize()) {
+        if (doPrint && psPrtSetting != pageAttr.pageSizeId()) {
             int ret = QMessageBox::warning(
                 this, tr("Different paper size"),
                 tr("The printer uses a different paper size than the drawing.\n"

--- a/src/Mod/TechDraw/Gui/PagePrinter.h
+++ b/src/Mod/TechDraw/Gui/PagePrinter.h
@@ -52,11 +52,11 @@ class TechDrawGuiExport PaperAttributes
 public:
     PaperAttributes();
     PaperAttributes(QPageLayout::Orientation orientation,
-                    QPageSize::PageSizeId paperSize,
+                    QPageSize::PageSizeId paperSizeId,
                     double pageWidth,
                     double pageHeight)
         : m_orientation(orientation)
-        , m_paperSize(paperSize)
+        , m_paperSizeId(paperSizeId)
         , m_pagewidth(pageWidth)
         , m_pageheight(pageHeight)
     {}
@@ -65,9 +65,9 @@ public:
     {
         return m_orientation;
     }
-    QPageSize::PageSizeId pageSize() const
+    QPageSize::PageSizeId pageSizeId() const
     {
-        return m_paperSize;
+        return m_paperSizeId;
     }
     double pageWidth() const
     {
@@ -80,7 +80,7 @@ public:
 
 private:
     QPageLayout::Orientation m_orientation;
-    QPageSize::PageSizeId m_paperSize;
+    QPageSize::PageSizeId m_paperSizeId;
     double m_pagewidth;
     double m_pageheight;
 };


### PR DESCRIPTION
This PR implements a fix for issue #26027.  The change corrects the handling of QPageSize::Custom in PagePrinter by creating a QPageSize object based on the provided page width, height and orientation. 

Standard page sizes continue to use the QPageSize objects provided by Qt.
<img width="1581" height="910" alt="NonStandardPageSize" src="https://github.com/user-attachments/assets/1b98cc61-737c-461d-87e2-a171529e7a1e" />
[NonStandardPageSize_Page__.pdf](https://github.com/user-attachments/files/24138791/NonStandardPageSize_Page__.pdf)
![200Wx100HCustomTemplate](https://github.com/user-attachments/assets/e9cd5016-29c8-4c18-b5db-9a5dae54f6f4)
[NonStandardPageSize.FCStd.not.zip](https://github.com/user-attachments/files/24138797/NonStandardPageSize.FCStd.not.zip)
