### PR TITLE
CAM: Axismap Dressup - Invert rotary axis

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/AxisMapEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/AxisMapEdit.ui
@@ -78,6 +78,20 @@
      </item>
     </widget>
    </item>
+   <item row="2" column="0">
+     <widget class="QLabel" name="lblReverse">
+       <property name="text">
+         <string>Reverse</string>
+       </property>
+     </widget>
+   </item>
+   <item row="2" column="2" colspan="2">
+     <widget class="QComboBox" name="reverse">
+       <property name="toolTip">
+         <string>Reverse rotary axis direction</string>
+       </property>
+     </widget>
+   </item>
   <item row="3" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">

--- a/src/Mod/CAM/Path/Dressup/Gui/AxisMap.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/AxisMap.py
@@ -157,6 +157,7 @@ class TaskPanel:
         self.obj = obj
         self.form = FreeCADGui.PySideUic.loadUi(":/panels/AxisMapEdit.ui")
         self.radius = PathGuiUtil.QuantitySpinBox(self.form.radius, obj, "Radius")
+        self.reverse = PathGuiUtil.BooleanComboBox(self.form.reverse, obj, "Reverse")
         FreeCAD.ActiveDocument.openTransaction("Edit AxisMap Dress-up")
 
     def reject(self):
@@ -173,11 +174,13 @@ class TaskPanel:
 
     def getFields(self):
         self.radius.updateProperty()
+        self.reverse.updateProperty()
         self.obj.AxisMap = self.form.axisMapInput.currentText()
         self.obj.Proxy.execute(self.obj)
 
     def updateUI(self):
         self.radius.updateWidget()
+        self.reverse.updateWidget()
         self.form.axisMapInput.setCurrentText(self.obj.AxisMap)
         self.updateModel()
 
@@ -194,6 +197,7 @@ class TaskPanel:
     def setupUi(self):
         self.setFields()
         self.form.radius.valueChanged.connect(self.updateModel)
+        self.form.reverse.currentIndexChanged.connect(self.updateModel)
         self.form.axisMapInput.currentIndexChanged.connect(self.updateModel)
 
 


### PR DESCRIPTION
Attempt to fix:
- #26122

<br>

Probably this issue related to representation and direction B-axis in 3d view
Also there is no information about real B-axis direction from machine

I offer to add ability to change rotary axis direction in Dress-up, which will increase flexibility 

Contain changes:
- Refactoring
- Get tolerance from `Job` to convert arcs to lines
- Added property to reverse rotary axis direction
- Added property `Reverse` to `Task panel`

<img width="1054" height="698" alt="Screenshot_20260130_194229_hor" src="https://github.com/user-attachments/assets/c0a19632-ef6f-4cf4-83c5-756617f40af3" />

<img width="358" height="152" alt="Screenshot_20260130_094741_lossy" src="https://github.com/user-attachments/assets/4798c7f1-f491-4fb8-89b6-83495ffcdf9b" />


