### PR TITLE
PartDesign: Change fuse order for revolution

### DIFF
--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -36,6 +36,8 @@
 #include "FeatureRevolution.h"
 #include "Mod/Part/App/TopoShapeOpCode.h"
 
+#include <Base/ProgramVersion.h>
+
 using namespace PartDesign;
 
 namespace PartDesign
@@ -45,6 +47,8 @@ namespace PartDesign
 
 const char* Revolution::TypeEnums[]
     = {"Angle", "UpToLast", "UpToFirst", "UpToFace", "TwoAngles", nullptr};
+
+const char* Revolution::FuseOrderEnums[] = {"BaseFirst", "FeatureFirst", nullptr};
 
 PROPERTY_SOURCE(PartDesign::Revolution, PartDesign::ProfileBased)
 
@@ -82,12 +86,21 @@ Revolution::Revolution()
         (App::Prop_None),
         "Reference axis of revolution"
     );
+
+    ADD_PROPERTY_TYPE(
+        FuseOrder,
+        (BaseFirst),
+        "Compatibility",
+        App::Prop_Hidden,
+        "Order of fuse operation to preserve compatibility with filest created using FreeCAD 1.0"
+    );
+    FuseOrder.setEnums(FuseOrderEnums);
 }
 
 short Revolution::mustExecute() const
 {
     if (Placement.isTouched() || ReferenceAxis.isTouched() || Axis.isTouched() || Base.isTouched()
-        || UpToFace.isTouched() || Angle.isTouched() || Angle2.isTouched()) {
+        || UpToFace.isTouched() || Angle.isTouched() || Angle2.isTouched() || FuseOrder.isTouched()) {
         return 1;
     }
     return ProfileBased::mustExecute();
@@ -254,7 +267,16 @@ App::DocumentObjectExecReturn* Revolution::execute()
             this->AddSubShape.setValue(result);
 
             if (!base.isNull()) {
-                result = result.makeElementFuse(base);
+                // In 1.0 there was a bug that caused the order of operations to be reversed.
+                // Changing the order may impact geometry order and the results of refine operation,
+                // hence we need to support both ways to ensure compatibility.
+                if (FuseOrder.getValue() == FeatureFirst) {
+                    result = result.makeElementFuse(base);
+                }
+                else {
+                    result = base.makeElementFuse(result);
+                }
+
                 // store shape before refinement
                 this->rawShape = result;
                 result = refineShapeIfActive(result);
@@ -294,6 +316,16 @@ App::DocumentObjectExecReturn* Revolution::execute()
     }
     catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
+    }
+}
+
+void Revolution::Restore(Base::XMLReader& reader)
+{
+    ProfileBased::Restore(reader);
+
+    // For 1.0 and 1.0 only the order was feature first due to a bug
+    if (Base::getVersion(reader.ProgramVersion) == Base::Version::v1_0) {
+        FuseOrder.setValue(FeatureFirst);
     }
 }
 

--- a/src/Mod/PartDesign/App/FeatureRevolution.h
+++ b/src/Mod/PartDesign/App/FeatureRevolution.h
@@ -30,6 +30,12 @@
 namespace PartDesign
 {
 
+enum FuseOrder : std::uint8_t
+{
+    BaseFirst,
+    FeatureFirst,
+};
+
 class PartDesignExport Revolution: public ProfileBased
 {
     PROPERTY_HEADER_WITH_OVERRIDE(PartDesign::Revolution);
@@ -48,6 +54,12 @@ public:
      */
     App::PropertyLinkSub ReferenceAxis;
 
+    /**
+     * Compatibility property that is required to preserve behavior from 1.0, that while incorrect
+     * may have an impact over user files.
+     */
+    App::PropertyEnumeration FuseOrder;
+
     /** @name methods override feature */
     //@{
     /** Recalculate the feature
@@ -65,6 +77,8 @@ public:
         return "PartDesignGui::ViewProviderRevolution";
     }
     //@}
+
+    void Restore(Base::XMLReader& reader) override;
 
     /// suggests a value for Reversed flag so that material is always added to the support
     bool suggestReversed();
@@ -132,6 +146,7 @@ protected:
 
 private:
     static const char* TypeEnums[];
+    static const char* FuseOrderEnums[];
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestTopologicalNamingProblem.py
@@ -569,7 +569,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         #  Pad -> Extrusion -> makes compounds and does booleans, thus the resulting newName element maps
         #  See if we can turn those off, or try them on the other types?
 
-    def testPartDesignElementMapRevolution(self):
+    def _testPartDesignElementMapRevolution(self, order, vertex, face):
         # App.KeepTestDoc = True    # Uncomment this if you want to keep the test document to examine
         self.Doc.UseHasher = False
         # Arrange
@@ -596,6 +596,7 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         revolution.Profile = sketch2
         revolution.Angle = 180
         revolution.Refine = True
+        revolution.FuseOrder = order
         body.addObject(revolution)
         volume = (math.pi * 3 * 3 - math.pi * 2 * 2) * 2 / 2
         padVolume = 3 * 3 * 2  # 50.26548245743668
@@ -611,8 +612,8 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         self.assertEqual(
             self.countFacesEdgesVertexes(revolution.Shape.ElementReverseMap), (9, 21, 14)
         )
-        self.assertEqual(revolution.Shape.ElementReverseMap["Vertex9"][1].count(";"), 3)
-        self.assertEqual(revolution.Shape.ElementReverseMap["Face9"].count(";"), 19)
+        self.assertEqual(revolution.Shape.ElementReverseMap[vertex][1].count(";"), 3)
+        self.assertEqual(revolution.Shape.ElementReverseMap[face].count(";"), 19)
 
         ### This test has been removed because FeatureRevolution generates improper element maps when the user select the
         #   UpToFace mode. That behavior seems to be the fault of OpenCASCADE itself, and we need to rewrite that section
@@ -641,6 +642,12 @@ class TestTopologicalNamingProblem(unittest.TestCase):
         # # output elements)
         # self.assertEqual( revolution.Shape.ElementReverseMap["Face8"].count("Face8"), 3)
         # self.assertEqual( revolution.Shape.ElementReverseMap["Face8"].count("Face10"), 3)
+
+    def testPartDesignElementMapRevolutionFuseFeatureFirst(self):
+        self._testPartDesignElementMapRevolution("FeatureFirst", "Vertex9", "Face9")
+
+    def testPartDesignElementMapRevolutionWithDefaultFuseOrder(self):
+        self._testPartDesignElementMapRevolution("BaseFirst", "Vertex8", "Face8")
 
     def testPartDesignBinderRevolution(self):
         doc = self.Doc


### PR DESCRIPTION
In older versions of FreeCAD the boolean order was base + result. After TNP mitigation the order was changed to be result + base. For the resulting shape that does not matter, but order of edges can differ if arguments are in a different order.

This can impact refine algorithm which may pick other face as the base one and result in a differnt shape after refining. This commit restores previous order. For most files it should not make any difference, but it may fix some older files.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
- Fixes https://github.com/FreeCAD/FreeCAD/issues/25821
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
