### PR TITLE
Gui: Fix F2 for TreeView rename on MacOS

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -697,10 +697,9 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     connect(this->createGroupAction, &QAction::triggered, this, &TreeWidget::onCreateGroup);
 
     this->relabelObjectAction = new QAction(this);
-#ifndef Q_OS_MAC
     this->relabelObjectAction->setShortcut(Qt::Key_F2);
-#endif
     connect(this->relabelObjectAction, &QAction::triggered, this, &TreeWidget::onRelabelObject);
+    this->addAction(this->relabelObjectAction);  // For shortcut to work reliably (i.e. even on macos)
 
     this->finishEditingAction = new QAction(this);
     connect(this->finishEditingAction, &QAction::triggered, this, &TreeWidget::onFinishEditing);
@@ -1379,10 +1378,15 @@ void TreeWidget::onCreateGroup()
 
 void TreeWidget::onRelabelObject()
 {
-    QTreeWidgetItem* item = currentItem();
-    if (item) {
-        editItem(item);
+    QList<QTreeWidgetItem*> items = this->selectedItems();
+    if (items.empty()) {
+        return;
     }
+    if (items.size() != 1) {
+        QMessageBox::warning(this, tr("Error"), tr("Cannot rename multiple items. Please choose one."));
+        return;
+    }
+    editItem(items.front());
 }
 
 void TreeWidget::onStartEditing()


### PR DESCRIPTION
- In online tutorials, people often say 'press F2 to rename'. This is confusing for me as I'm on MacOS and I'm not sure if I'm being gaslit.
- The code has this commented out, saying that it 'doesn't work'. On further debugging, it appears that this is because we only add it as an action when the context menu is pressed, which means the shortcut never gets routed.
- It's not clear to me why this behaviour is MacOS specific, and nothing online explains this.
- I've done my best to check regressions (on MacOS) and as far as I can tell there are no observable differences but the F2 key no works. I'll need others help to see if it causes issues on other platforms.
- If this is approved, I'll look to make the changes to the few other places where F2 is disabled on macos.

<!-- Include a brief summary of the changes. -->

Simple change to register the existing action under the actual tree view widget. This gets it working on MacOS with (AFAICT) no other undesirable changes. Would need help from other users/devs to test on other platforms.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #26145

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
