### PR TITLE
MacOS: Block shortcuts from overriding text input (#14869)

### DIFF
--- a/src/Gui/ShortcutManager.cpp
+++ b/src/Gui/ShortcutManager.cpp
@@ -305,6 +305,26 @@ bool ShortcutManager::eventFilter(QObject* o, QEvent* ev)
         case QEvent::KeyPress:
             lastFocus = nullptr;
             break;
+        case QEvent::ShortcutOverride: {
+            auto kev = static_cast<QKeyEvent*>(ev);
+            if (!kev) {
+                break;
+            }
+            // don't process application shortcuts if we are editing a text widget
+            if (auto* focus = QApplication::focusWidget()) {
+                auto* maybeProxy = focus->focusProxy();
+                auto* focusOrProxy = maybeProxy ? maybeProxy : focus;
+
+                bool isFocusedWidgetTextInput = focusOrProxy->inherits("QLineEdit")
+                    || focusOrProxy->inherits("QTextEdit")
+                    || focusOrProxy->inherits("QPlainTextEdit");
+                if (isFocusedWidgetTextInput) {
+                    ev->accept();
+                    return true;
+                }
+            }
+            break;
+        }
         case QEvent::Shortcut:
             if (timeout > 0) {
                 auto sev = static_cast<QShortcutEvent*>(ev);


### PR DESCRIPTION
- It seems that on MacOS (vs other platforms), shortcuts for items in the application menu are given 'ultimate' priority, and will even take precedence over text inputs
- There is a mechanism in QT (I believe designed with mac in mind) to try to 'block' these shortcuts and send it to the focus instead. It's 'Shortcut Override': https://wiki.qt.io/ShortcutOverride
- Initially I was going to only apply this check when it's a Command that overrides a known line-editing shortcut, but I figure it's simpler to just always apply it when editing text. I can't really imagine a user wanting to use an application shortcut while editing text, but if there's some compelling use-case for this then let me know and I'll add a further filter.

I'm quite optimistic that this won't have any ill-effects on other platforms, but I'll need help from others to test this.

<!-- Include a brief summary of the changes. -->
Add a ShortcutOverride branch in ShortcutManager that checks (with heuristics) if the currently focused window is a text edit window. If it is, ignore shortcuts (they are then passed correctly to the input box).

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #14869 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/af618c96-abac-45fa-8d3c-80bb136a65bf


https://github.com/user-attachments/assets/d45d5089-3b83-4928-820f-816b3ae7541c



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
