### PR TITLE
RTGroup 1: App: fix PropertyLinkBase::getLinkedObjects()

### DIFF
--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -288,7 +288,7 @@ public:
 
     /// Helper function to return linked objects using an std::inserter
     template<class T>
-    void getLinkedObjects(T& inserter, bool all = false) const
+    void getLinkedObjects(T inserter, bool all = false) const
     {
         std::vector<App::DocumentObject*> ret;
         getLinks(ret, all);


### PR DESCRIPTION
Cherry pick from https://github.com/FreeCAD/FreeCAD/pull/2759/commits/5130baba6480599330a05c36cedc83cc6d71b8c3