### PR TITLE
RTGroup 3: App: support color override in ViewProviderPart

### DIFF
--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -219,13 +219,13 @@ GeoFeatureGroupExtension::removeObjects(std::vector<App::DocumentObject*> object
 
 void GeoFeatureGroupExtension::extensionOnChanged(const Property* p)
 {
+    auto owner = getExtendedObject();
 
     // objects are only allowed in a single GeoFeatureGroup
     if (p == &Group && !Group.testStatus(Property::User3)) {
 
-        if ((!getExtendedObject()->isRestoring()
-             || getExtendedObject()->getDocument()->testStatus(Document::Importing))
-            && !getExtendedObject()->getDocument()->isPerformingTransaction()) {
+        if ((!owner->isRestoring() || owner->getDocument()->testStatus(Document::Importing))
+            && !owner->getDocument()->isPerformingTransaction()) {
 
             bool error = false;
             auto corrected = Group.getValues();
@@ -236,7 +236,7 @@ void GeoFeatureGroupExtension::extensionOnChanged(const Property* p)
                 // an error. We need a custom check
                 auto list = obj->getInList();
                 for (auto in : list) {
-                    if (in == getExtendedObject()) {
+                    if (in == owner) {
                         continue;
                     }
                     auto parent = in->getExtensionByType<GeoFeatureGroupExtension>(true);
@@ -255,6 +255,14 @@ void GeoFeatureGroupExtension::extensionOnChanged(const Property* p)
                 throw Base::RuntimeError("Object can only be in a single GeoFeatureGroup");
             }
         }
+
+        // Skip handling in parent class GroupExtension
+        return;
+    }
+
+    if (p == &owner->Visibility) {
+        // Skip visibility handling in parent class GroupExtension
+        return;
     }
 
     App::GroupExtension::extensionOnChanged(p);

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -353,14 +353,11 @@ PyObject* GroupExtension::getExtensionPyObject()
 
 void GroupExtension::extensionOnChanged(const Property* p)
 {
+    auto owner = getExtendedObject();
 
-    // objects are only allowed in a single group. Note that this check must only be done for normal
-    // groups, not any derived classes
-    if ((this->getExtensionTypeId() == GroupExtension::getExtensionClassTypeId()) && p == &Group
-        && !Group.testStatus(Property::User3)) {
-        if (!getExtendedObject()->isRestoring()
-            && !getExtendedObject()->getDocument()->isPerformingTransaction()) {
-
+    // objects are only allowed in a single group.
+    if (p == &Group && !Group.testStatus(Property::User3)) {
+        if (!owner->isRestoring() && !owner->getDocument()->isPerformingTransaction()) {
             bool error = false;
             auto corrected = Group.getValues();
             for (auto obj : Group.getValues()) {
@@ -402,13 +399,37 @@ void GroupExtension::extensionOnChanged(const Property* p)
             }
         }
     }
+    else if (p == &owner->Visibility) {
+        if (!_togglingVisibility && !owner->isRestoring()
+            && !owner->getDocument()->isPerformingTransaction()) {
+            bool touched = false;
+            bool vis = owner->Visibility.getValue();
+            Base::FlagToggler<> guard(_togglingVisibility);
+            for (auto obj : Group.getValues()) {
+                if (obj && obj->getNameInDocument() && obj->Visibility.getValue() != vis) {
+                    touched = true;
+                    obj->Visibility.setValue(vis);
+                }
+            }
+            if (touched) {
+                Base::ObjectStatusLocker<Property::Status, Property> guard(
+                    Property::Output,
+                    &_GroupTouched
+                );
+                // Temporary set the Property::Output on _GroupTouched, so that
+                // it does not touch the owner object, but still signal
+                // Part::Feature shape cache update.
+                _GroupTouched.touch();
+            }
+        }
+    }
 
     App::Extension::extensionOnChanged(p);
 }
 
 void GroupExtension::slotChildChanged(const DocumentObject& obj, const Property& prop)
 {
-    if (&prop == &obj.Visibility) {
+    if (&prop == &obj.Visibility && !_togglingVisibility) {
         _GroupTouched.touch();
     }
 }
@@ -490,3 +511,4 @@ void GroupExtension::getAllChildren(std::vector<App::DocumentObject*>& res,
         }
     }
 }
+

--- a/src/App/GroupExtension.h
+++ b/src/App/GroupExtension.h
@@ -154,6 +154,7 @@ private:
     // for tracking children visibility
     void slotChildChanged(const App::DocumentObject&, const App::Property&);
     std::unordered_map<const App::DocumentObject*, fastsignals::scoped_connection> _Conns;
+    bool _togglingVisibility {false};
 };
 
 

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -99,7 +99,7 @@ void StdCmdRandomColor::activated(int iMsg)
             if (!vpLink->OverrideMaterial.getValue()) {
                 vpLink->OverrideMaterial.setValue(true);
             }
-            vpLink->ShapeMaterial.setDiffuseColor(objColor);
+            vpLink->ShapeAppearance.setDiffuseColor(objColor);
         }
         else if (view) {
             // clang-format off

--- a/src/Gui/TaskElementColors.cpp
+++ b/src/Gui/TaskElementColors.cpp
@@ -507,9 +507,17 @@ void ElementColors::onAddSelectionClicked()
                 break;
             }
             for (auto& sub : subs) {
-                if (boost::starts_with(sub, d->editSub)) {
-                    d->addItem(-1, sub.c_str() + d->editSub.size(), true);
+                if (!boost::starts_with(sub, d->editSub)) {
+                    continue;
                 }
+                std::string s(sub.c_str() + d->editSub.size());
+                // When no specific element is selected (empty) or a child object
+                // is selected (ends with '.'), default to overriding all faces.
+                constexpr const char* allFacesWildcard = "Face";
+                if (s.empty() || s.back() == '.') {
+                    s += allFacesWildcard;
+                }
+                d->addItem(-1, s.c_str(), true);
             }
             break;
         }

--- a/src/Gui/ViewProviderGroupExtension.cpp
+++ b/src/Gui/ViewProviderGroupExtension.cpp
@@ -183,59 +183,6 @@ std::vector<App::DocumentObject*> ViewProviderGroupExtension::extensionClaimChil
     return group->Group.getValues();
 }
 
-void ViewProviderGroupExtension::extensionShow()
-{
-
-    // avoid possible infinite recursion
-    if (guard) {
-        return;
-    }
-    Base::StateLocker lock(guard);
-
-    // when reading the Visibility property from file then do not hide the
-    // objects of this group because they have stored their visibility status, too
-    //
-    // Property::User1 is used by ViewProviderDocumentObject to mark for
-    // temporary visibility changes. Do not propagate the change to children.
-    if (!getExtendedViewProvider()->isRestoring()
-        && !getExtendedViewProvider()->Visibility.testStatus(App::Property::User1)) {
-        auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GroupExtension>();
-        for (auto obj : group->Group.getValues()) {
-            if (obj && !obj->Visibility.getValue()) {
-                obj->Visibility.setValue(true);
-            }
-        }
-    }
-
-    ViewProviderExtension::extensionShow();
-}
-
-void ViewProviderGroupExtension::extensionHide()
-{
-
-    // avoid possible infinite recursion
-    if (guard) {
-        return;
-    }
-    Base::StateLocker lock(guard);
-
-    // when reading the Visibility property from file then do not hide the
-    // objects of this group because they have stored their visibility status, too
-    //
-    // Property::User1 is used by ViewProviderDocumentObject to mark for
-    // temporary visibility changes. Do not propagate the change to children.
-    if (!getExtendedViewProvider()->isRestoring()
-        && !getExtendedViewProvider()->Visibility.testStatus(App::Property::User1)) {
-        auto* group = getExtendedViewProvider()->getObject()->getExtensionByType<App::GroupExtension>();
-        for (auto obj : group->Group.getValues()) {
-            if (obj && obj->Visibility.getValue()) {
-                obj->Visibility.setValue(false);
-            }
-        }
-    }
-    ViewProviderExtension::extensionHide();
-}
-
 bool ViewProviderGroupExtension::extensionOnDelete(const std::vector<std::string>&)
 {
 

--- a/src/Gui/ViewProviderGroupExtension.h
+++ b/src/Gui/ViewProviderGroupExtension.h
@@ -45,13 +45,9 @@ public:
     bool extensionCanDropObject(App::DocumentObject*) const override;
     void extensionDropObject(App::DocumentObject*) override;
 
-    void extensionHide() override;
-    void extensionShow() override;
-
     bool extensionOnDelete(const std::vector<std::string>&) override;
 
 private:
-    bool guard {false};
     std::vector<ViewProvider*> nodes;
 };
 

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1937,8 +1937,8 @@ ViewProviderLink::ViewProviderLink()
 
     App::Material mat(App::Material::DEFAULT);
     mat.diffuseColor.setPackedValue(ViewParams::instance()->getDefaultLinkColor());
-    ADD_PROPERTY_TYPE(ShapeMaterial, (mat), " Link", App::Prop_None, 0);
-    ShapeMaterial.setStatus(App::Property::MaterialEdit, true);
+    ADD_PROPERTY_TYPE(ShapeAppearance, (mat), " Link", App::Prop_None, 0);
+    ShapeAppearance.setStatus(App::Property::MaterialEdit, true);
 
     ADD_PROPERTY_TYPE(DrawStyle, ((long int)0), " Link", App::Prop_None, "");
     static const char* DrawStyleEnums[] = {"None", "Solid", "Dashed", "Dotted", "Dashdot", nullptr};
@@ -2088,7 +2088,7 @@ void ViewProviderLink::onChanged(const App::Property* prop)
         }
     }
     else if (!isRestoring()) {
-        if (prop == &OverrideMaterial || prop == &ShapeMaterial || prop == &MaterialList
+        if (prop == &OverrideMaterial || prop == &ShapeAppearance || prop == &MaterialList
             || prop == &OverrideMaterialList) {
             applyMaterial();
         }
@@ -2106,6 +2106,26 @@ void ViewProviderLink::onChanged(const App::Property* prop)
     }
 
     inherited::onChanged(prop);
+}
+
+void ViewProviderLink::handleChangedPropertyName(
+    Base::XMLReader& reader,
+    const char* TypeName,
+    const char* PropName
+)
+{
+    // Migration: ShapeMaterial (App::PropertyMaterial) -> ShapeAppearance (App::PropertyMaterialList)
+    if (strcmp(PropName, "ShapeMaterial") == 0
+        && strcmp(TypeName, App::PropertyMaterial::getClassTypeId().getName()) == 0) {
+        App::PropertyMaterial prop;
+        prop.Restore(reader);
+        // Set the whole material object into the list (it will default to index 0)
+        ShapeAppearance.setValue(prop.getValue());
+        return;
+    }
+
+    // Delegate to parent class for standard handling
+    ViewProviderDocumentObject::handleChangedPropertyName(reader, TypeName, PropName);
 }
 
 bool ViewProviderLink::setLinkType(App::LinkBaseExtension* ext)
@@ -2310,8 +2330,8 @@ void ViewProviderLink::updateDataPrivate(App::LinkBaseExtension* ext, const App:
                     }
                     overrideMaterial = overrideMaterial || vp->OverrideMaterial.getValue();
                     hasMaterial = overrideMaterial || hasMaterial
-                        || vp->ShapeMaterial.getValue() != ShapeMaterial.getValue();
-                    materials.push_back(vp->ShapeMaterial.getValue());
+                        || vp->ShapeAppearance[0] != ShapeAppearance[0];
+                    materials.push_back(vp->ShapeAppearance[0]);
                     overrideMaterials[i] = vp->OverrideMaterial.getValue();
                 }
                 if (!overrideMaterial) {
@@ -2409,7 +2429,7 @@ void ViewProviderLink::updateElementList(App::LinkBaseExtension* ext)
                 vp->OverrideMaterial.setValue(OverrideMaterialList[i]);
             }
             if (MaterialList.getSize() > i) {
-                vp->ShapeMaterial.setValue(MaterialList[i]);
+                vp->ShapeAppearance.setValue(MaterialList[i]);
             }
         }
         OverrideMaterialList.setSize(0);
@@ -2459,7 +2479,7 @@ void ViewProviderLink::applyMaterial()
         // This is decoupled and respects the core/module architecture.
 
         // 1. Get the material from our property.
-        const auto& material = ShapeMaterial.getValue();
+        const auto& material = ShapeAppearance[0];
 
         // 2. Prepare the color for the rendering action. The action's ultimate
         // consumer (SoBrepFaceSet) expects a Base::Color where .a is transparency,
@@ -3510,6 +3530,39 @@ PyObject* ViewProviderLink::getPyLinkView()
 
 std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char* subname) const
 {
+    std::map<std::string, Base::Color> colors;
+    auto ext = getLinkExtension();
+    if (!ext || !ext->getColoredElementsProperty()) {
+        return colors;
+    }
+
+    const auto& mat = ShapeAppearance[0];
+    return getElementColorsFrom(
+        this,
+        subname,
+        *ext->getColoredElementsProperty(),
+        OverrideColorList,
+        OverrideMaterial.getValue(),
+        &mat,
+        ext->getElementCountValue()
+    );
+}
+
+std::map<std::string, Base::Color> ViewProviderLink::getElementColorsFrom(
+    const ViewProviderDocumentObject* vp,
+    const char* subname,
+    const App::PropertyLinkSub& coloredElements,
+    const App::PropertyColorList& colorList,
+    bool overrideMaterial,
+    const App::Material* shapeMaterial,
+    int element_count
+)
+{
+    std::map<std::string, Base::Color> colors;
+    if (!vp) {
+        return colors;
+    }
+
     bool isPrefix = true;
     if (!subname) {
         subname = "";
@@ -3518,19 +3571,20 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
         auto len = strlen(subname);
         isPrefix = !len || subname[len - 1] == '.';
     }
-    std::map<std::string, Base::Color> colors;
-    auto ext = getLinkExtension();
-    if (!ext || !ext->getColoredElementsProperty()) {
-        return colors;
-    }
-    const auto& subs = ext->getColoredElementsProperty()->getShadowSubs();
-    int size = OverrideColorList.getSize();
 
+    if (!shapeMaterial) {
+        overrideMaterial = false;
+    }
+
+    const auto& subs = coloredElements.getShadowSubs();
+    int size = colorList.getSize();
+
+    std::string _subname;
     std::string wildcard(subname);
     if (wildcard == "Face" || wildcard == "Face*" || wildcard.empty()) {
-        if (wildcard.size() == 4 || OverrideMaterial.getValue()) {
-            Base::Color c = ShapeMaterial.getValue().diffuseColor;
-            c.setTransparency(ShapeMaterial.getValue().transparency);
+        if (wildcard.size() == 4 || overrideMaterial) {
+            Base::Color c = shapeMaterial->diffuseColor;
+            c.setTransparency(shapeMaterial->transparency);
             colors["Face"] = c;
             if (wildcard.size() == 4) {
                 return colors;
@@ -3548,6 +3602,13 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
     }
     else if (wildcard == ViewProvider::hiddenMarker() + "*") {
         wildcard.resize(ViewProvider::hiddenMarker().size());
+    }
+    else if (wildcard.back() == '*') {
+        _subname = std::move(wildcard);
+        _subname.resize(_subname.size() - 1);
+        subname = _subname.c_str();
+        isPrefix = true;
+        wildcard.clear();
     }
     else {
         wildcard.clear();
@@ -3568,22 +3629,26 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
             }
             const char* element = sub.oldName.c_str() + pos;
             if (boost::starts_with(element, wildcard)) {
-                colors[sub.oldName] = OverrideColorList[i];
+                colors[sub.oldName] = colorList[i];
             }
             else if (!element[0] && wildcard == "Face") {
-                colors[sub.oldName.substr(0, element - sub.oldName.c_str()) + wildcard]
-                    = OverrideColorList[i];
+                colors[sub.oldName.substr(0, element - sub.oldName.c_str()) + wildcard] = colorList[i];
             }
+        }
+
+        bool overridden = false;
+        if (wildcard != ViewProvider::hiddenMarker() && overrideMaterial) {
+            auto color = shapeMaterial->diffuseColor;
+            color.setTransparency(shapeMaterial->transparency);
+            colors.emplace(wildcard, color);
+            overridden = true;
         }
 
         // In case of multi-level linking, we recursively call into each level,
         // and merge the colors
-        auto vp = this;
         while (true) {
-            if (wildcard != ViewProvider::hiddenMarker() && vp->OverrideMaterial.getValue()) {
-                auto color = ShapeMaterial.getValue().diffuseColor;
-                color.setTransparency(ShapeMaterial.getValue().transparency);
-                colors.emplace(wildcard, color);
+            if (!vp->getObject()) {
+                break;
             }
             auto link = vp->getObject()->getLinkedObject(false);
             if (!link || link == vp->getObject()) {
@@ -3593,18 +3658,30 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
             if (!next) {
                 break;
             }
+            if (!overridden && wildcard != ViewProvider::hiddenMarker()
+                && next->OverrideMaterial.getValue()) {
+                auto color = next->ShapeAppearance[0].diffuseColor;
+                color.setTransparency(next->ShapeAppearance[0].transparency);
+                colors.emplace(wildcard, color);
+                overridden = true;
+            }
             for (const auto& v : next->getElementColors(subname)) {
                 colors.insert(v);
             }
             vp = next;
         }
+
         if (wildcard != ViewProvider::hiddenMarker()) {
             // Get collapsed array color override.
-            auto ext = vp->getLinkExtension();
-            if (ext->_getElementCountValue() && !ext->_getShowElementValue()) {
-                const auto& overrides = vp->OverrideMaterialList.getValues();
+            const App::LinkBaseExtension* ext = nullptr;
+            auto vpLink = freecad_cast<ViewProviderLink*>(vp);
+            if (vpLink) {
+                ext = vpLink->getLinkExtension();
+            }
+            if (ext && ext->_getElementCountValue() && !ext->_getShowElementValue()) {
+                const auto& overrides = vpLink->OverrideMaterialList.getValues();
                 int i = -1;
-                for (const auto& mat : vp->MaterialList.getValues()) {
+                for (const auto& mat : vpLink->MaterialList.getValues()) {
                     if (++i >= (int)overrides.size()) {
                         break;
                     }
@@ -3620,8 +3697,6 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
         return colors;
     }
 
-    int element_count = ext->getElementCountValue();
-
     for (const auto& sub : subs) {
         if (++i >= size) {
             break;
@@ -3629,16 +3704,16 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
 
         int offset = 0;
 
-        if (!sub.oldName.empty() && element_count && !std::isdigit(sub.oldName[0])) {
+        if (!sub.oldName.empty() && element_count > 0 && !std::isdigit(sub.oldName[0])) {
             // For checking and expanding color override of array base
             if (!subname[0]) {
                 std::ostringstream ss;
                 ss << "0." << sub.oldName;
-                if (getObject()->getSubObject(ss.str().c_str())) {
+                if (vp->getObject()->getSubObject(ss.str().c_str())) {
                     for (int j = 0; j < element_count; ++j) {
                         ss.str("");
                         ss << j << '.' << sub.oldName;
-                        colors.emplace(ss.str(), OverrideColorList[i]);
+                        colors.emplace(ss.str(), colorList[i]);
                     }
                     continue;
                 }
@@ -3662,10 +3737,10 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
         }
 
         if (offset) {
-            colors.emplace(std::string(subname, offset) + sub.oldName, OverrideColorList[i]);
+            colors.emplace(std::string(subname, offset) + sub.oldName, colorList[i]);
         }
         else {
-            colors[sub.oldName] = OverrideColorList[i];
+            colors[sub.oldName] = colorList[i];
         }
     }
 
@@ -3681,19 +3756,21 @@ std::map<std::string, Base::Color> ViewProviderLink::getElementColors(const char
     std::map<std::string, Base::Color> ret;
     for (const auto& v : colors) {
         const char* pos = nullptr;
-        auto sobj = getObject()->resolve(v.first.c_str(), nullptr, nullptr, &pos);
+        auto sobj = vp->getObject()->resolve(v.first.c_str(), nullptr, nullptr, &pos);
         if (!sobj || !pos) {
             continue;
         }
         auto link = sobj->getLinkedObject(true);
-        if (!link || link == getObject()) {
+        if (!link || link == vp->getObject()) {
             continue;
         }
-        auto vp = Application::Instance->getViewProvider(sobj->getLinkedObject(true));
-        if (!vp) {
+        auto vplo = Application::Instance->getViewProvider(sobj->getLinkedObject(true));
+        if (!vplo) {
             continue;
         }
-        for (const auto& v2 : vp->getElementColors(!pos[0] ? "Face" : pos)) {
+        // In case the topo name is gone, query the shape owner so it can
+        // return some suggested elements
+        for (const auto& v2 : vplo->getElementColors(!pos[0] ? "Face" : pos)) {
             std::string name;
             if (pos[0]) {
                 name = v.first.substr(0, pos - v.first.c_str()) + v2.first;
@@ -3713,10 +3790,33 @@ void ViewProviderLink::setElementColors(const std::map<std::string, Base::Color>
     if (!ext || !ext->getColoredElementsProperty()) {
         return;
     }
+    setElementColorsTo(
+        this,
+        colorMap,
+        *ext->getColoredElementsProperty(),
+        OverrideColorList,
+        &OverrideMaterial,
+        &ShapeAppearance,
+        ext->getElementCountValue()
+    );
+}
+
+void ViewProviderLink::setElementColorsTo(
+    ViewProviderDocumentObject* vp,
+    const std::map<std::string, Base::Color>& colorMap,
+    App::PropertyLinkSub& coloredElements,
+    App::PropertyColorList& colorList,
+    App::PropertyBool* overrideMaterial,
+    App::PropertyMaterialList* shapeAppearance,
+    int element_count
+)
+{
+    if (!vp || !vp->getObject()) {
+        return;
+    }
 
     // For checking and collapsing array element color
     std::map<std::string, std::map<int, Base::Color>> subMap;
-    int element_count = ext->getElementCountValue();
 
     std::vector<std::string> subs;
     std::vector<Base::Color> colors;
@@ -3729,7 +3829,7 @@ void ViewProviderLink::setElementColors(const std::map<std::string, Base::Color>
             continue;
         }
 
-        if (element_count && !v.first.empty() && std::isdigit(v.first[0])) {
+        if (element_count > 0 && !v.first.empty() && std::isdigit(v.first[0])) {
             // In case of array, check if there are override of the same
             // sub-element for every array element. And collapse those overrides
             // into one without the index.
@@ -3765,22 +3865,23 @@ void ViewProviderLink::setElementColors(const std::map<std::string, Base::Color>
         }
     }
 
-    auto prop = ext->getColoredElementsProperty();
-    if (subs != prop->getSubValues() || colors != OverrideColorList.getValues()) {
-        prop->setStatus(App::Property::User3, true);
-        prop->setValue(getObject(), subs);
-        prop->setStatus(App::Property::User3, false);
-        OverrideColorList.setValues(colors);
+    if (subs != coloredElements.getSubValues() || colors != colorList.getValues()) {
+        coloredElements.setStatus(App::Property::User3, true);
+        coloredElements.setValue(vp->getObject(), subs);
+        coloredElements.setStatus(App::Property::User3, false);
+        colorList.setValues(colors);
     }
-    if (hasFaceColor) {
-        auto mat = ShapeMaterial.getValue();
+    if (hasFaceColor && shapeAppearance && shapeAppearance->getSize() > 0) {
+        auto mat = shapeAppearance->getValue().front();
         mat.diffuseColor = faceColor;
         mat.transparency = faceColor.transparency();
-        ShapeMaterial.setStatus(App::Property::User3, true);
-        ShapeMaterial.setValue(mat);
-        ShapeMaterial.setStatus(App::Property::User3, false);
+        shapeAppearance->setStatus(App::Property::User3, true);
+        shapeAppearance->setValue(mat);
+        shapeAppearance->setStatus(App::Property::User3, false);
     }
-    OverrideMaterial.setValue(hasFaceColor);
+    if (overrideMaterial) {
+        overrideMaterial->setValue(hasFaceColor);
+    }
 }
 
 void ViewProviderLink::applyColors()
@@ -3790,18 +3891,36 @@ void ViewProviderLink::applyColors()
         return;
     }
 
+    prevColorOverride = applyColorsTo(this, prevColorOverride);
+}
+
+bool ViewProviderLink::applyColorsTo(ViewProviderDocumentObject* vp, bool prevOverride)
+{
+    if (!vp) {
+        return prevOverride;
+    }
+    auto obj = vp->getObject();
+    if (!obj || !obj->getDocument() || obj->getDocument()->testStatus(App::Document::Restoring)) {
+        return prevOverride;
+    }
+
+    auto node = vp->getModeSwitch();
+    if (!node) {
+        return prevOverride;
+    }
+
     SoSelectionElementAction action(SoSelectionElementAction::Color, true);
     // reset color and visibility first
-    action.apply(linkView->getLinkRoot());
+    action.apply(node);
 
     std::map<std::string, std::map<std::string, Base::Color>> colorMap;
     std::set<std::string> hideList;
-    auto colors = getElementColors();
+    auto colors = vp->getElementColors();
     colors.erase("Face");
     for (const auto& v : colors) {
         const char* subname = v.first.c_str();
         const char* element = nullptr;
-        auto sobj = getObject()->resolve(subname, nullptr, nullptr, &element);
+        auto sobj = obj->resolve(subname, nullptr, nullptr, &element);
         if (!sobj || !element) {
             continue;
         }
@@ -3818,12 +3937,14 @@ void ViewProviderLink::applyColors()
     for (auto& v : colorMap) {
         action.swapColors(v.second);
         if (v.first.empty()) {
-            action.apply(linkView->getLinkRoot());
+            prevOverride = true;
+            action.apply(node);
             continue;
         }
         SoDetail* det = nullptr;
         path.truncate(0);
-        if (getDetailPath(v.first.c_str(), &path, false, det)) {
+        if (vp->getDetailPath(v.first.c_str(), &path, false, det)) {
+            prevOverride = true;
             action.apply(&path);
         }
         delete det;
@@ -3833,12 +3954,14 @@ void ViewProviderLink::applyColors()
     for (const auto& sub : hideList) {
         SoDetail* det = nullptr;
         path.truncate(0);
-        if (!sub.empty() && getDetailPath(sub.c_str(), &path, false, det)) {
+        if (!sub.empty() && vp->getDetailPath(sub.c_str(), &path, false, det)) {
+            prevOverride = true;
             action.apply(&path);
         }
         delete det;
     }
     path.unrefNoDelete();
+    return prevOverride;
 }
 
 void ViewProviderLink::setOverrideMode(const std::string& mode)

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2116,7 +2116,7 @@ void ViewProviderLink::handleChangedPropertyName(
 {
     // Migration: ShapeMaterial (App::PropertyMaterial) -> ShapeAppearance (App::PropertyMaterialList)
     if (strcmp(PropName, "ShapeMaterial") == 0
-        && TypeName == App::PropertyColor::getClassTypeId().getName()) {
+        && TypeName == App::PropertyMaterial::getClassTypeId().getName()) {
         App::PropertyMaterial prop;
         prop.Restore(reader);
         // Set the whole material object into the list (it will default to index 0)

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2116,7 +2116,7 @@ void ViewProviderLink::handleChangedPropertyName(
 {
     // Migration: ShapeMaterial (App::PropertyMaterial) -> ShapeAppearance (App::PropertyMaterialList)
     if (strcmp(PropName, "ShapeMaterial") == 0
-        && TypeName == PropertyColor::getClassTypeId().getName()) {
+        && TypeName == App::PropertyColor::getClassTypeId().getName()) {
         App::PropertyMaterial prop;
         prop.Restore(reader);
         // Set the whole material object into the list (it will default to index 0)

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2116,7 +2116,7 @@ void ViewProviderLink::handleChangedPropertyName(
 {
     // Migration: ShapeMaterial (App::PropertyMaterial) -> ShapeAppearance (App::PropertyMaterialList)
     if (strcmp(PropName, "ShapeMaterial") == 0
-        && strcmp(TypeName, App::PropertyMaterial::getClassTypeId().getName()) == 0) {
+        && TypeName == PropertyColor::getClassTypeId().getName()) {
         App::PropertyMaterial prop;
         prop.Restore(reader);
         // Set the whole material object into the list (it will default to index 0)

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -225,7 +225,7 @@ class GuiExport ViewProviderLink: public ViewProviderDragger
 
 public:
     App::PropertyBool OverrideMaterial;
-    App::PropertyMaterial ShapeMaterial;
+    App::PropertyMaterialList ShapeAppearance;
     App::PropertyEnumeration DrawStyle;
     App::PropertyFloatConstraint LineWidth;
     App::PropertyFloatConstraint PointSize;
@@ -296,6 +296,28 @@ public:
     std::map<std::string, Base::Color> getElementColors(const char* subname = nullptr) const override;
     void setElementColors(const std::map<std::string, Base::Color>& colors) override;
 
+    static std::map<std::string, Base::Color> getElementColorsFrom(
+        const ViewProviderDocumentObject* vp,
+        const char* subname,
+        const App::PropertyLinkSub& coloredElements,
+        const App::PropertyColorList& colorList,
+        bool overrideMaterial,
+        const App::Material* shapeMaterial,
+        int elementCount = 0
+    );
+
+    static void setElementColorsTo(
+        ViewProviderDocumentObject* vp,
+        const std::map<std::string, Base::Color>& colors,
+        App::PropertyLinkSub& coloredElements,
+        App::PropertyColorList& colorList,
+        App::PropertyBool* overrideMaterial,
+        App::PropertyMaterialList* shapeMaterial,
+        int elementCount = 0
+    );
+
+    static bool applyColorsTo(ViewProviderDocumentObject* vp, bool prevOverride);
+
     void setOverrideMode(const std::string& mode) override;
 
     void onBeforeChange(const App::Property*) override;
@@ -360,6 +382,12 @@ protected:
     bool initDraggingPlacement();
     bool callDraggerProxy(const char* fname);
 
+    void handleChangedPropertyName(
+        Base::XMLReader& reader,
+        const char* TypeName,
+        const char* PropName
+    ) override;
+
 private:
     static void dragStartCallback(void* data, SoDragger* d);
     static void dragFinishCallback(void* data, SoDragger* d);
@@ -370,6 +398,7 @@ protected:
     LinkType linkType;
     bool hasSubName;
     bool hasSubElement;
+    bool prevColorOverride {false};
 
     struct DraggerContext
     {

--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -23,7 +23,6 @@
 
 #include <QMenu>
 
-
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/Part.h>
@@ -35,6 +34,10 @@
 #include "Command.h"
 #include "MDIView.h"
 
+#include "ViewParams.h"
+#include "TaskElementColors.h"
+#include "Control.h"
+#include "ViewProviderLink.h"
 
 using namespace Gui;
 
@@ -49,6 +52,10 @@ ViewProviderPart::ViewProviderPart()
 {
     initExtension(this);
 
+    ADD_PROPERTY_TYPE(OverrideMaterial, (false), 0, App::Prop_None, "Override part material");
+
+    ADD_PROPERTY(OverrideColorList, ());
+
     sPixmap = "Geofeaturegroup.svg";
     aPixmap = "Geoassembly.svg";
 }
@@ -62,7 +69,25 @@ ViewProviderPart::~ViewProviderPart() = default;
  */
 void ViewProviderPart::onChanged(const App::Property* prop)
 {
-    ViewProviderGeometryObject::onChanged(prop);
+    if (prop == &OverrideMaterial) {
+        pcShapeMaterial->setOverride(OverrideMaterial.getValue());
+    }
+    else if (!isRestoring()) {
+        if (prop == &OverrideColorList) {
+            applyColors();
+        }
+    }
+    inherited::onChanged(prop);
+}
+
+void ViewProviderPart::updateData(const App::Property* prop)
+{
+    if (prop && !isRestoring() && !pcObject->isRestoring()) {
+        if (prop == getColoredElementsProperty()) {
+            applyColors();
+        }
+    }
+    inherited::updateData(prop);
 }
 
 void ViewProviderPart::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
@@ -74,7 +99,12 @@ void ViewProviderPart::setupContextMenu(QMenu* menu, QObject* receiver, const ch
     act->setChecked(isActivePart());
     func->trigger(act, [this]() { this->toggleActivePart(); });
 
-    ViewProviderGeometryObject::setupContextMenu(menu, receiver, member);
+    if (getColoredElementsProperty()) {
+        act = menu->addAction(QObject::tr("Override colors..."), receiver, member);
+        act->setData(QVariant((int)ViewProvider::Color));
+    }
+
+    inherited::setupContextMenu(menu, receiver, member);
 }
 
 bool ViewProviderPart::isActivePart(const char* key)
@@ -143,6 +173,92 @@ QIcon ViewProviderPart::getIcon() const
     return mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(pixmap));
 }
 
+App::PropertyLinkSub* ViewProviderPart::getColoredElementsProperty() const
+{
+    if (!getObject()) {
+        return nullptr;
+    }
+    return freecad_cast<App::PropertyLinkSub*>(getObject()->getPropertyByName("ColoredElements"));
+}
+
+bool ViewProviderPart::setEdit(int ModNum)
+{
+    if (ModNum == ViewProvider::Color) {
+        TaskView::TaskDialog* dlg = Control().activeDialog();
+        if (dlg) {
+            Control().showDialog(dlg);
+            return false;
+        }
+        Selection().clearSelection();
+        return true;
+    }
+    return inherited::setEdit(ModNum);
+}
+
+void ViewProviderPart::setEditViewer(Gui::View3DInventorViewer* viewer, int ModNum)
+{
+    if (ModNum == ViewProvider::Color) {
+        Gui::Control().showDialog(new TaskElementColors(this));
+        return;
+    }
+    return inherited::setEditViewer(viewer, ModNum);
+}
+
+std::map<std::string, Base::Color> ViewProviderPart::getElementColors(const char* subname) const
+{
+    std::map<std::string, Base::Color> res;
+    if (!getObject()) {
+        return res;
+    }
+    auto prop = getColoredElementsProperty();
+    if (!prop) {
+        return res;
+    }
+    const auto& mats = ShapeAppearance.getValue();
+    if (mats.empty()) {
+        return res;
+    }
+    const auto& mat = mats.front();
+
+    return ViewProviderLink::getElementColorsFrom(
+        this,
+        subname,
+        *prop,
+        OverrideColorList,
+        OverrideMaterial.getValue(),
+        &mat
+    );
+}
+
+void ViewProviderPart::setElementColors(const std::map<std::string, Base::Color>& colorMap)
+{
+    if (!getObject()) {
+        return;
+    }
+    auto prop = getColoredElementsProperty();
+    if (!prop) {
+        return;
+    }
+    ViewProviderLink::setElementColorsTo(
+        this,
+        colorMap,
+        *prop,
+        OverrideColorList,
+        &OverrideMaterial,
+        &ShapeAppearance
+    );
+}
+
+void ViewProviderPart::applyColors()
+{
+    prevColorOverride = ViewProviderLink::applyColorsTo(this, prevColorOverride);
+}
+
+void ViewProviderPart::finishRestoring()
+{
+    inherited::finishRestoring();
+    applyColors();
+}
 
 // Python feature -----------------------------------------------------------------------
 

--- a/src/Gui/ViewProviderPart.cpp
+++ b/src/Gui/ViewProviderPart.cpp
@@ -23,6 +23,8 @@
 
 #include <QMenu>
 
+#include <Inventor/nodes/SoMaterial.h>
+
 #include <App/Document.h>
 #include <App/DocumentObject.h>
 #include <App/Part.h>

--- a/src/Gui/ViewProviderPart.h
+++ b/src/Gui/ViewProviderPart.h
@@ -35,6 +35,7 @@ class GuiExport ViewProviderPart: public ViewProviderGeometryObject,
                                   public ViewProviderOriginGroupExtension
 {
     PROPERTY_HEADER_WITH_EXTENSIONS(Gui::ViewProviderPart);
+    typedef ViewProviderGeometryObject inherited;
 
 public:
     /// constructor.
@@ -57,11 +58,31 @@ public:
         return true;
     };
 
+    std::map<std::string, Base::Color> getElementColors(const char* subname = 0) const override;
+    void setElementColors(const std::map<std::string, Base::Color>& colors) override;
+
+    void finishRestoring() override;
+
+    App::PropertyColorList OverrideColorList;
+    App::PropertyBool OverrideMaterial;
+
 protected:
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop) override;
+
+    App::PropertyLinkSub* getColoredElementsProperty() const;
+    void applyColors();
+
+    void updateData(const App::Property*) override;
+
+    bool setEdit(int ModNum) override;
+    void setEditViewer(View3DInventorViewer*, int ModNum) override;
+
     /// a second icon for the Assembly type
     const char* aPixmap;
+
+private:
+    bool prevColorOverride {false};
 };
 
 using ViewProviderPartPython = ViewProviderFeaturePythonT<ViewProviderPart>;

--- a/src/Mod/BIM/importers/importWebGL.py
+++ b/src/Mod/BIM/importers/importWebGL.py
@@ -226,7 +226,7 @@ def export(
                 if obj.isDerivedFrom("App::Link"):
                     if obj.ViewObject.OverrideMaterial:
                         color = Draft.getrgb(
-                            obj.ViewObject.ShapeMaterial.DiffuseColor, testbw=False
+                            obj.ViewObject.ShapeAppearance[0].DiffuseColor, testbw=False
                         )
                     obj = obj.LinkedObject
                     if hasattr(obj, "__len__"):

--- a/src/Mod/Import/Gui/ImportOCAFGui.cpp
+++ b/src/Mod/Import/Gui/ImportOCAFGui.cpp
@@ -88,7 +88,7 @@ void ImportOCAFGui::applyLinkColor(App::DocumentObject* obj, int index, Base::Co
     }
     if (index < 0) {
         vp->OverrideMaterial.setValue(true);
-        vp->ShapeMaterial.setDiffuseColor(color);
+        vp->ShapeAppearance.setDiffuseColor(color);
         return;
     }
     if (vp->OverrideMaterialList.getSize() <= index) {


### PR DESCRIPTION
Cherry pick 
[App: support color override in ViewProviderPart](https://github.com/FreeCAD/FreeCAD/pull/2759/commits/cace970a0d876e91dcdb59dd1cfec6acc7a734af)
[Import: support step import with Link using App::Part](https://github.com/FreeCAD/FreeCAD/pull/2759/commits/2fb7a8509b0dc763f32eaae48a32364f7225209a) (only the changes to ViewProviderPart and squashed to first, as I wanted to keep all the changes to import mod together in the end)
[Gui: improve ViewProviderLink::getElementColors](https://github.com/FreeCAD/FreeCAD/pull/2759/commits/b7add18b0ea0a2bcd9b3c9a4983a669f976e1256) (squashed to first)
[App/Gui: move GroupExtension child visibility handling to App](https://github.com/FreeCAD/FreeCAD/pull/2759/commits/ec44beba0fc464b85f33fe994d55ff0bd4442e4f)

From https://github.com/FreeCAD/FreeCAD/pull/2759, a realthunder's PR that got lost.

Why? Well my goal is to fix issue https://github.com/FreeCAD/FreeCAD/issues/25335, which is fixed by #2759, but that PR is massive and does a lot of things. So I started to cherry pick things. And want to split things since it's just too big and difficult to handle.

This PR is also migrating ViewProviderLink from ShapeMaterial to ShapeAppearance. This change was done before to the ViewProviderGeometricObject, but link were not changed. So I do this for consistency. And also because ViewProviderPart and Link are using the same static helpers that needs the property object. So having one with a PropertyMaterial and the other PropertyMaterialList was not good.


Note that the first commit I cherry-picked, is supposed to enable overriding the color of the content of a App::Part. But it does not work. However it is also broken in the latest build of Linkstage that I tested. So it's not my cherry-pick which broke this feature. But I still think it's best if we have the framework in place, so then fixing it will be easy.