### PR TITLE
[Gui] improve Draft default settings for FreeCAD Dark

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -50,10 +50,17 @@
             <FCUInt Name="DefaultRapidPathColor" Value="4199699199"/>
           </FCParamGroup>
           <FCParamGroup Name="Draft">
+            <FCFloat Name="arrowsizestart" Value="7.000000000000"/>
+            <FCFloat Name="arrowsizeend" Value="7.000000000000"/>
             <FCInt Name="gridTransparency" Value="0"/>
             <FCUInt Name="constructioncolor" Value="746455039"/>
+            <FCUInt Name="DefaultAnnoLineColor" Value="2593756927"/>
+            <FCUInt Name="DefaultTextColor" Value="2593756927"/>
+            <FCInt Name="dimsymbolstart" Value="2"/>
+            <FCInt Name="dimsymbolend" Value="2"/>
             <FCUInt Name="gridColor" Value="1230002175"/>
             <FCUInt Name="snapcolor" Value="4289331455"/>
+            <FCFloat Name="textheight" Value="20.000000000000"/>
           </FCParamGroup>
           <FCParamGroup Name="Measure">
             <FCParamGroup Name="Appearance">
@@ -128,6 +135,8 @@
           <FCUInt Name="CursorTextColor" Value="2914369023"/>
           <FCUInt Name="DeactivatedConstrDimColor" Value="2257491711"/>
           <FCUInt Name="DefaultShapeColor" Value="1920565503"/>
+          <FCUInt Name="DefaultShapeLineColor" Value="1583113471"/>
+          <FCUInt Name="DefaultShapeVertexColor" Value="1583113471"/>
           <FCUInt Name="EditedEdgeColor" Value="4059297279"/>
           <FCUInt Name="EditedVertexColor" Value="4199699199"/>
           <FCUInt Name="ExprBasedConstrDimColor" Value="4252898559"/>


### PR DESCRIPTION
Feedback from forum user https://forum.freecad.org/viewtopic.php?p=862152#p862152

## Before
(yes there is a rectangle with a dimension :smile: )

<img width="1266" height="658" alt="Screenshot from 2025-12-15 11-44-48" src="https://github.com/user-attachments/assets/88fdac1d-984d-4483-85be-111f4ad6d706" />


## After
<img width="1441" height="740" alt="Screenshot from 2025-12-15 11-55-53" src="https://github.com/user-attachments/assets/e0bff992-c4bd-4e81-9fc7-f9e0ecec3f2b" />
