### PR TITLE
PartDesign: move AllowCompound to Base property group 

### DIFF
--- a/src/Mod/PartDesign/App/Body.cpp
+++ b/src/Mod/PartDesign/App/Body.cpp
@@ -41,13 +41,7 @@ PROPERTY_SOURCE(PartDesign::Body, Part::BodyBase)
 
 Body::Body()
 {
-    ADD_PROPERTY_TYPE(
-        AllowCompound,
-        (true),
-        "Base",
-        App::Prop_None,
-        "Allow multiple solids in Body"
-    );
+    ADD_PROPERTY_TYPE(AllowCompound, (true), "Base", App::Prop_None, "Allow multiple solids in Body");
 
     _GroupTouched.setStatus(App::Property::Output, true);
 }


### PR DESCRIPTION
 This PR moves the `AllowCompound` property of `PartDesign::Body` from the **Experimental** group to the **Base** group in the Properties pane. The feature is no longer experimental as of FreeCAD 1.1, and this change aligns the property with other core Body properties without modifying behavior.

Tested locally using pixi.


## Issues
Fixes #26140

## Before and After Images :

**Before**
- `AllowCompound` appears under the *Experimental* group in the Properties pane.
<img width="731" height="341" alt="image" src="https://github.com/user-attachments/assets/9278af08-c305-4b4d-a500-1bec8397bbc3" />

**After**
- `AllowCompound` appears under the *Base* group alongside other core Body properties.
<img width="493" height="601" alt="Screenshot from 2025-12-15 17-59-16" src="https://github.com/user-attachments/assets/a64ebe20-16d8-41c9-8532-63bb06eec896" />