### PR TITLE
Part Design: Enforce recompute after UI is fully-initialized

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -116,6 +116,10 @@ void TaskExtrudeParameters::setupDialog()
     updateUI(Side::First);
 
     setupGizmos();
+
+    // trigger recompute to ensure external geometry references update correctly.
+    // see freecad issue #25794
+    tryRecomputeFeature();
 }
 
 void TaskExtrudeParameters::setupSideDialog(SideController& side)


### PR DESCRIPTION
this PR aims at fixing the issue ie. fixes #25794 the issue mentions shapebinder, but the issue is still present ie. can be reproduced without a shapebinder as both I and connor confirmed. the commit that introduced this issue was 92e96839c9 which implemented some optimizations when recomputing objects, however with these optimizations this bug was introduced.

basically commit 92e968 reordered `setChecked()` to be called before `connectSlots()` in the `TaskExtrudeParameters.cpp` this prevented the `onAllFacesToggled()` signal handler from firing during the dialog setup, which basically means `tryRecomputeFeature()` was not being called.

> The Problem:
Without that recompute during Pad dialog setup, sketches with external geometry references to the Pad weren't getting their element references updated correctly. This caused the "missing element reference" errors and broken geometry updates.

i added a explicit `tryRecomputeFeature()` call at the end of the `setupDialog()` to ensure a recompute happens after the ui is fully initialized.

