### PR TITLE
Part Design: Add sketch sub element names for refs in revolutions

### DIFF
--- a/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
+++ b/src/Mod/PartDesign/Gui/ReferenceSelection.cpp
@@ -373,11 +373,13 @@ QString getRefStr(const App::DocumentObject* obj, const std::vector<std::string>
     if (PartDesign::Feature::isDatum(obj)) {
         return QString::fromLatin1(obj->getNameInDocument());
     }
-    else if (!sub.empty() && !sub.front().empty()) {
+
+    if (!sub.empty() && !sub.front().empty()) {
         return QString::fromLatin1(obj->getNameInDocument()) + QStringLiteral(":")
             + QString::fromLatin1(sub.front().c_str());
     }
-    else if (obj->isDerivedFrom<Part::Part2DObject>()) {
+
+    if (obj->isDerivedFrom<Part::Part2DObject>()) {
         // only return bare name for sketches when no subelement is specified
         return QString::fromLatin1(obj->getNameInDocument());
     }


### PR DESCRIPTION
at some point there was a regression introduced in the latest dev cycle from v1.0.2 to where reference names for partdesign revolution where not listing sub element names for sketches. this PR fixes that with additional `elese` condition in the affected code, ie. `ReferenceSelection.cpp`

purposefully added a second commit that removes the elese blocks as every if / else had a return statement. so for readability converted the else blocks to if statements. my lsp ie. clang-tidy was showing me some diagnostic warnings.

```
Do not use 'else' after 'return' (fix available)
```

## Issues

fixes #26223

## Before and After Images

see @Roy-043 original issue https://github.com/FreeCAD/FreeCAD/issues/26223 for before images

<img width="2848" height="2151" alt="image" src="https://github.com/user-attachments/assets/270ddee9-25a5-49aa-b764-c779bd329212" />





