### PR TITLE
BIM: provide better user information when a face horizontality or verticality cannot be determined

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1438,7 +1438,7 @@ class AreaCalculator:
         verticalArea = 0
         horizontalAreaFaces = []
 
-        # Compute vertical area and collect horizontal faces
+        # Compute vertical area and collect faces to be projected for the horizontal area
         for i, face in enumerate(self.obj.Shape.Faces, start=1):
             if self.isFaceVertical(face, face_index=i):
                 verticalArea += face.Area


### PR DESCRIPTION
If the operation to determine whether a face is vertical or horizontal fails, provide information about which exact face failed. The test file from https://github.com/FreeCAD/FreeCAD/issues/26232 can be used for testing, as it produces such errors.


<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

