### PR TITLE
Refactor problem report template for improved previews

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-FUNCTIONAL_PROBLEM_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/1-FUNCTIONAL_PROBLEM_REPORT.yml
@@ -7,6 +7,15 @@ body:
       value: |
         Thanks for taking the time to fill out this problem report! Please [search](https://github.com/FreeCAD/FreeCAD/issues) if a similar issue already exists and check out [how to report issues](https://github.com/FreeCAD/FreeCAD?tab=readme-ov-file#reporting-issues). By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/FreeCAD/FreeCAD/blob/main/CODE_OF_CONDUCT.md).
 
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: Describe the problem and how it impacts user experience, workflow, maintainability or performance. You can attach images or log files by clicking this area to highlight it and then dragging files in. To attach a FCStd file, ZIP it first.
+      placeholder: Describe your problem briefly.
+    validations:
+      required: true
+
   - type: dropdown
     id: wb
     attributes:
@@ -27,15 +36,6 @@ body:
         - Spreadsheet
         - TechDraw
         - Other (specify in description)
-
-  - type: textarea
-    id: description
-    attributes:
-      label: Problem description
-      description: Describe the problem and how it impacts user experience, workflow, maintainability or performance. You can attach images or log files by clicking this area to highlight it and then dragging files in. To attach a FCStd file, ZIP it first.
-      placeholder: Describe your problem briefly.
-    validations:
-      required: true
 
   - type: textarea
     id: steps_to_reproduce


### PR DESCRIPTION
Reorder fields so that the problem description will be rendered first in previews.

## Issues

Fixes: https://github.com/FreeCAD/FreeCAD/issues/26234

## Before

<img width="658" height="425" alt="image" src="https://github.com/user-attachments/assets/22f2b817-d1aa-4bb9-b654-29fc68834eb6" />

## After

<img width="658" height="425" alt="image" src="https://github.com/user-attachments/assets/616679cd-5342-47ff-90e8-99956bb04d73" />

