### PR TITLE
Part: added floating point fallback in PropertyLinks::_updateElementR…

### DIFF
--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -472,7 +472,11 @@ bool PropertyLinkBase::_updateElementReference(DocumentObject* feature,
         // to version change, i.e. 'reverse', try search by geometry first
         const char* oldElement = Data::findElementName(shadow.oldName.c_str());
         if (!Data::hasMissingElement(oldElement)) {
-            const auto& names = geo->searchElementCache(oldElement);
+            auto names = geo->searchElementCache(oldElement);
+            if (names.empty()) {
+                // try floating point tolerance
+                names = geo->searchElementCache(oldElement, Data::SearchOptions());
+            }
             if (names.size()) {
                 missing = false;
                 std::string newsub(subname, strlen(subname) - strlen(element));

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -1578,9 +1578,11 @@ const std::vector<std::string>& Feature::searchElementCache(
                 break;
             }
         }
-        it->second.searched = true;
         propShape->getShape()
             .findSubShapesWithSharedVertex(it->second.shape, &it->second.names, options, tol, atol);
+        if (!it->second.names.empty()) {
+            it->second.searched = true;
+        }
         if (prefix) {
             for (auto& name : it->second.names) {
                 if (auto dot = strrchr(name.c_str(), '.')) {


### PR DESCRIPTION
…eference


Issue : #26198

core issue
So while debugging with the test file provided in the mentioned issue i found that there is floating point error and at first we doing searchElementCache(oldElement) which returns empty and marks the searched as true in _cacheElements while name is empty.
 

changes are 
***PropertyLinkBase::_updateElementReference***
```
if (!Data::hasMissingElement(oldElement)) {
            auto names = geo->searchElementCache(oldElement);
            if (names.empty()) {
                // try floating point tolerance
                names = geo->searchElementCache(oldElement, Data::SearchOptions());
            }
            if (names.size()) {
```

***Feature::searchElementCache***
```
propShape->getShape()
            .findSubShapesWithSharedVertex(it->second.shape, &it->second.names, options, tol, atol);
        if (!it->second.names.empty()) {
            it->second.searched = true;
        }
```