### PR TITLE
BIM: fix component VerticalArea calculation

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1399,7 +1399,7 @@ class AreaCalculator:
 
     def isRightAngle(self, angle):
         """Check if the angle is close to 90 degrees."""
-        return math.isclose(angle, math.pi/2, abs_tol=0.0005)
+        return math.isclose(angle, math.pi / 2, abs_tol=0.0005)
 
     def isZeroAngle(self, angle):
         """Check if the angle is close to 0 or 180 degrees."""


### PR DESCRIPTION
Fixes #26232.

Projecting faces can result in an open wire. The code did not take that into account, it tried to create a face from such a wire.

Additionally:
* Areas of Periodic vertical faces (cylindrical columns, extruded B-splines) were not calculated. Their projection results in a face with a non-zero area. They were therefore wrongly not considered vertical.
* Also added special handling for planar faces.
* The VerticalArea property was not updated if the new value was zero.
* Tweaked the isRightAngle function.