### PR TITLE
sketcher: fixes issue #26167 no polygon distort when repositioning / constraining

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchControllableHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchControllableHandler.h
@@ -91,7 +91,12 @@ public:
 
     bool pressButton(Base::Vector2d onSketchPos) override
     {
+        // ensure controller state is initialized even if no mouseMove occurred
+        // ie. when a modal dialog blocks input before the first click
+        toolWidgetManager.mouseMoved(onSketchPos);
         toolWidgetManager.enforceControlParameters(onSketchPos);
+        updateDataAndDrawToPosition(onSketchPos);
+        toolWidgetManager.adaptParameters(onSketchPos);
 
         onButtonPressed(onSketchPos);
         return true;


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR resolves issue #26167

basically when creating a sketch using the polygon tool in the sketcher workbench a modal / dialog appears before allowing the user to create such shape. the user inputs the number of sides for the polygon and then clicks in 3d viewport to place such polygon within the sketch. however doing this does not fully initialize the state leaving the controller in an uninitialized state. this PR resolves that issue with sketcher tools that use a modal / dialog.

one way to avoid this bug was to wiggle the mouse around before creating such polygon. the mouse movement initialized the state.

## Issues

fixes issue #26167

## Before and After Images

see original issue for images and video of bug

