### PR TITLE
CAM: Add open-route optimizations to point-based TSP solver

### DIFF
--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -29,7 +29,7 @@ Source0:        freecad-sources.tar.gz
 
 # Maintainers:  keep this list of plugins up to date
 # List plugins in %%{_libdir}/%%{name}/lib, less '.so' and 'Gui.so', here
-%global plugins AssemblyApp AssemblyGui CAMSimulator DraftUtils Fem FreeCAD Import Inspection MatGui Materials Measure Mesh MeshPart Part PartDesignGui Path PathApp PathSimulator Points QtUnitGui ReverseEngineering Robot Sketcher Spreadsheet Start Surface TechDraw Web _PartDesign area flatmesh libDriver libDriverDAT libDriverSTL libDriverUNV libE57Format libMEFISTO2 libSMDS libSMESH libSMESHDS libStdMeshers libarea-native
+%global plugins AssemblyApp AssemblyGui CAMSimulator DraftUtils Fem FreeCAD Import Inspection MatGui Materials Measure Mesh MeshPart Part PartDesignGui Path PathApp PathSimulator Points QtUnitGui ReverseEngineering Robot Sketcher Spreadsheet Start Surface TechDraw Web _PartDesign area flatmesh libDriver libDriverDAT libDriverSTL libDriverUNV libE57Format libMEFISTO2 libSMDS libSMESH libSMESHDS libStdMeshers libarea-native tsp_solver
 
 %global exported_libs libOndselSolver
 

--- a/src/Mod/CAM/App/CMakeLists.txt
+++ b/src/Mod/CAM/App/CMakeLists.txt
@@ -139,14 +139,14 @@ SET_PYTHON_PREFIX_SUFFIX(Path)
 
 INSTALL(TARGETS Path DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-# --- TSP Solver Python module (pybind11) ---
-find_package(pybind11 REQUIRED)
-
-pybind11_add_module(tsp_solver MODULE tsp_solver_pybind.cpp tsp_solver.cpp)
-target_include_directories(tsp_solver PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+add_library(tsp_solver SHARED tsp_solver_pybind.cpp tsp_solver.cpp)
+target_include_directories(tsp_solver PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${pybind11_INCLUDE_DIR})
+target_link_libraries(tsp_solver PRIVATE pybind11::module Python3::Python)
+if (FREECAD_WARN_ERROR)
+    target_compile_warn_error(tsp_solver)
+endif()
 
 SET_BIN_DIR(tsp_solver tsp_solver /Mod/CAM)
 SET_PYTHON_PREFIX_SUFFIX(tsp_solver)
 
 INSTALL(TARGETS tsp_solver DESTINATION ${CMAKE_INSTALL_LIBDIR})
-# -------------------------------------------

--- a/src/Mod/CAM/CAMTests/TestTSPSolver.py
+++ b/src/Mod/CAM/CAMTests/TestTSPSolver.py
@@ -31,6 +31,8 @@ from CAMTests.PathTestUtils import PathTestBase
 class TestTSPSolver(PathTestBase):
     """Test class for the TSP (Traveling Salesman Problem) solver."""
 
+    DEBUG = False  # Global debug flag for print_tunnels
+
     def setUp(self):
         """Set up test environment."""
         # Create test points arranged in a simple pattern
@@ -54,6 +56,8 @@ class TestTSPSolver(PathTestBase):
 
     def print_tunnels(self, tunnels, title):
         """Helper function to print tunnel information."""
+        if not self.DEBUG:
+            return
         print(f"\n{title}:")
         for i, tunnel in enumerate(tunnels):
             orig_idx = tunnel.get("index", "N/A")


### PR DESCRIPTION
Improves the point-based TSP solver to match tunnel solver behavior for open routes (no endpoint constraint). Now applies 2-opt and relocation optimizations that allow reversing or relocating segments to the end of the route, resulting in better path optimization when the ending point is flexible.

src/Mod/CAM/App/tsp_solver.cpp:
- Add optimization limit variables for controlled iteration
- Add 2-opt optimization for reversing segments to route end when open
- Add relocation optimization for moving last point when no endpoint
- Use Base::Precision::Confusion() for epsilon values
- Track last improvement step for efficient loop control