### PR TITLE
Gui: Default load/save img to working directory (#26182)

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2238,6 +2238,7 @@ void StdViewLoadImage::activated(int iMsg)
     // Reading an image
     QFileDialog dialog(Gui::getMainWindow());
     dialog.setWindowTitle(QObject::tr("Choose an Image File to Open"));
+    dialog.setDirectory(FileDialog::getWorkingDirectory());
     dialog.setMimeTypeFilters(mimeTypeFilters);
     dialog.selectMimeTypeFilter(QStringLiteral("image/png"));
     dialog.setDefaultSuffix(QStringLiteral("png"));

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -516,6 +516,7 @@ FileOptionsDialog::FileOptionsDialog(QWidget* parent, Qt::WindowFlags fl)
     extensionButton->setText(tr("Extended"));
 
     setOption(QFileDialog::DontUseNativeDialog);
+    setDirectory(FileDialog::getWorkingDirectory());
 
     // search for the grid layout and add the new button
     auto grid = this->findChild<QGridLayout*>();


### PR DESCRIPTION
- FileOptionsDialog is only used in the 'save screenshot / save image' codepath, and currently it doesn't set a directory to it defaults to process CWD, which is surely not what the user wants.
- The load image codepath uses a custom QFileDialog instead of the helper code in FileDialog, there doesn't seem to be a great reason for this, although the helper doesn't have support for mime types it seems.
- I haven't changed the dialogs to 'set/store' the working directory. I'm not sure this is desired as this isn't a 'normal' save/load operation.
- It would be ideal to remove the FileOptionsDialog in future. The extended functionality could be turned into a separate dialog which opens before or after the file chooser. This would allow native dialogs to be used and would unify the code paths for file selection.
- Further, it would be nice to just merge at least the load image into the existing import/open option, and to put 'save image' next to 'export', but those changes may be much more time consuming.

For now I've kept it simple. Let's see what others think.

<!-- Include a brief summary of the changes. -->
Trivial changes to set the working directory on the file dialog(s). Would like to make more extensive changes if/when there's more consensus.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #26182 

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Will put them on the issue, as the user may be interested too


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
