### PR TITLE
CAM: CircularHoleBase - Manual selection

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelix.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelix.py
@@ -55,6 +55,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
         """Verify Helix does not throw an exception."""
 
         op = PathHelix.Create("Helix")
+        op.Proxy.findAllHoles(op)
         op.Proxy.execute(op)
 
     def testCreateWithPrototype(self):
@@ -67,6 +68,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
         """Verify Helix generates proper holes from model"""
 
         op = PathHelix.Create("Helix")
+        op.Proxy.findAllHoles(op)
         proxy = op.Proxy
         for base in op.Base:
             model = base[0]
@@ -78,6 +80,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
         """Verify Helix generates proper holes for rotated model"""
 
         op = PathHelix.Create("Helix")
+        op.Proxy.findAllHoles(op)
         proxy = op.Proxy
         model = self.job.Model.Group[0]
 
@@ -104,6 +107,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
             self.job.Tools.Group[0].Tool.Diameter = 0.5
 
             op = PathHelix.Create("Helix")
+            op.Proxy.findAllHoles(op)
             proxy = op.Proxy
             model = self.job.Model.Group[0]
 
@@ -128,6 +132,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
             self.job.Tools.Group[0].Tool.Diameter = 0.5
 
             op = PathHelix.Create("Helix")
+            op.Proxy.findAllHoles(op)
             proxy = op.Proxy
             model = self.job.Model.Group[0]
 
@@ -143,6 +148,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
     def testPathDirection(self):
         """Verify that the generated paths obeys the given parameters"""
         helix = PathHelix.Create("Helix")
+        helix.Proxy.findAllHoles(helix)
 
         def check(start_side, cut_mode, expected_direction):
             with self.subTest(f"({start_side}, {cut_mode}) => {expected_direction}"):
@@ -154,12 +160,12 @@ class TestPathHelix(PathTestUtils.PathTestBase):
                 self.assertEqual(
                     helix.Direction,
                     expected_direction,
-                    msg=f"Direction was not correctly determined",
+                    msg="Direction was not correctly determined",
                 )
                 self.assertPathDirection(
                     helix.Path,
                     expected_direction,
-                    msg=f"Path with wrong direction generated",
+                    msg="Path with wrong direction generated",
                 )
 
         check("Inside", "Conventional", "CW")

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -199,8 +199,8 @@ class ObjectOp(PathOp.ObjectOp):
         Must be overwritten by subclasses."""
         pass
 
-    def findAllHoles(self, obj):
-        """findAllHoles(obj) ... find all holes of all base models and assign as features."""
+    def findAllHoles(self, obj, selection=None):
+        """findAllHoles(obj, selection) ... find holes and assign as features."""
         Path.Log.track()
         job = self.getJob(obj)
         if not job:
@@ -210,9 +210,38 @@ class ObjectOp(PathOp.ObjectOp):
         tooldiameter = obj.ToolController.Tool.Diameter
 
         features = []
-        for base in self.model:
-            features.extend(
-                Drillable.getDrillableTargets(base, ToolDiameter=tooldiameter, vector=matchvector)
-            )
+        if selection:
+            # get drillable holes from selection
+            for sel in selection:
+                baseObj = sel.Object
+                if not hasattr(baseObj, "Shape"):
+                    continue
+                if sel.SubElementNames:
+                    # get drillable holes from shapes selected in 3d view
+                    for subName in sel.SubElementNames:
+                        subElement = baseObj.getSubObject(subName)
+                        if Drillable.isDrillable(
+                            baseObj.Shape,
+                            candidate=subElement,
+                            tooldiameter=tooldiameter,
+                            vector=matchvector,
+                        ):
+                            features.append((baseObj, subName))
+                else:
+                    # get drillable holes from model selected in tree view
+                    features.extend(
+                        Drillable.getDrillableTargets(
+                            baseObj, ToolDiameter=tooldiameter, vector=matchvector
+                        )
+                    )
+        else:
+            # get drillable holes from all base models
+            for base in self.model:
+                features.extend(
+                    Drillable.getDrillableTargets(
+                        base, ToolDiameter=tooldiameter, vector=matchvector
+                    )
+                )
+
         obj.Base = features
         obj.Disabled = []

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -95,13 +95,13 @@ class ObjectOp(PathOp.ObjectOp):
             if shape.ShapeType == "Vertex":
                 return 0
 
-            if shape.ShapeType == "Edge" and type(shape.Curve) == Part.Circle:
+            if shape.ShapeType == "Edge" and isinstance(shape.Curve, Part.Circle):
                 return shape.Curve.Radius * 2
 
             if shape.ShapeType == "Face":
                 for i in range(len(shape.Edges)):
                     if (
-                        type(shape.Edges[i].Curve) == Part.Circle
+                        isinstance(shape.Edges[i].Curve, Part.Circle)
                         and shape.Edges[i].Curve.Radius * 2 < shape.BoundBox.XLength * 1.1
                         and shape.Edges[i].Curve.Radius * 2 > shape.BoundBox.XLength * 0.9
                     ):
@@ -136,7 +136,7 @@ class ObjectOp(PathOp.ObjectOp):
             if shape.ShapeType == "Face":
                 if hasattr(shape.Surface, "Center"):
                     return FreeCAD.Vector(shape.Surface.Center.x, shape.Surface.Center.y, 0)
-                if len(shape.Edges) == 1 and type(shape.Edges[0].Curve) == Part.Circle:
+                if len(shape.Edges) == 1 and isinstance(shape.Edges[0].Curve, Part.Circle):
                     return shape.Edges[0].Curve.Center
         except Part.OCCError as e:
             Path.Log.error(e)

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -346,7 +346,5 @@ def Create(name, obj=None, parentJob=None):
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
 
     obj.Proxy = ObjectDrilling(obj, name, parentJob)
-    if obj.Proxy:
-        obj.Proxy.findAllHoles(obj)
 
     return obj

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -1525,7 +1525,16 @@ class CommandResources:
         self.job = None
 
 
-def SetupOperation(name, objFactory, opPageClass, pixmap, menuText, toolTip, setupProperties=None):
+def SetupOperation(
+    name,
+    objFactory,
+    opPageClass,
+    pixmap,
+    menuText,
+    toolTip,
+    setupProperties=None,
+    commandClass=CommandPathOp,
+):
     """SetupOperation(name, objFactory, opPageClass, pixmap, menuText, toolTip, setupProperties=None)
     Creates an instance of CommandPathOp with the given parameters and registers the command with FreeCAD.
     When activated it creates a model with proxy (by invoking objFactory), assigns a view provider to it
@@ -1536,7 +1545,7 @@ def SetupOperation(name, objFactory, opPageClass, pixmap, menuText, toolTip, set
 
     res = CommandResources(name, objFactory, opPageClass, pixmap, menuText, None, toolTip)
 
-    command = CommandPathOp(res)
+    command = commandClass(res)
     FreeCADGui.addCommand("CAM_%s" % name.replace(" ", "_"), command)
 
     if setupProperties is not None:

--- a/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
@@ -185,3 +185,10 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def taskPanelBaseGeometryPage(self, obj, features):
         """taskPanelBaseGeometryPage(obj, features) ... Return circular hole specific page controller for Base Geometry."""
         return TaskPanelHoleGeometryPage(obj, features)
+
+
+class CircularHoleCommand(PathOpGui.CommandPathOp):
+    def Activated(self):
+        obj = super().Activated()
+        selection = FreeCADGui.Selection.getSelectionEx()
+        obj.Proxy.findAllHoles(obj, selection)

--- a/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
@@ -25,7 +25,6 @@ import FreeCAD
 import FreeCADGui
 import Path
 import Path.Op.Gui.Base as PathOpGui
-import PathGui
 
 from PySide import QtCore, QtGui
 
@@ -104,7 +103,7 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
             activatedRows = []
             for item in self.form.baseList.selectedItems():
                 row = item.row()
-                if not row in activatedRows:
+                if row not in activatedRows:
                     activatedRows.append(row)
                     obj = item.data(self.DataObject)
                     sub = str(item.data(self.DataObjectSub))

--- a/src/Mod/CAM/Path/Op/Gui/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/Drilling.py
@@ -224,6 +224,7 @@ Command = PathOpGui.SetupOperation(
         "Creates a Drilling toolpath from the features of a base object",
     ),
     PathDrilling.SetupProperties,
+    commandClass=PathCircularHoleBaseGui.CircularHoleCommand,
 )
 
 FreeCAD.Console.PrintLog("Loading PathDrillingGui... done\n")

--- a/src/Mod/CAM/Path/Op/Gui/Helix.py
+++ b/src/Mod/CAM/Path/Op/Gui/Helix.py
@@ -111,6 +111,7 @@ Command = PathOpGui.SetupOperation(
     QT_TRANSLATE_NOOP("CAM_Helix", "Helix"),
     QT_TRANSLATE_NOOP("CAM_Helix", "Creates a Helical toolpath from the features of a base object"),
     PathHelix.SetupProperties,
+    commandClass=PathCircularHoleBaseGui.CircularHoleCommand,
 )
 
 FreeCAD.Console.PrintLog("Loading PathHelixGui... done\n")

--- a/src/Mod/CAM/Path/Op/Gui/Tapping.py
+++ b/src/Mod/CAM/Path/Op/Gui/Tapping.py
@@ -183,6 +183,7 @@ Command = PathOpGui.SetupOperation(
         "Creates a Tapping toolpath from the features of a base object",
     ),
     PathTapping.SetupProperties,
+    commandClass=PathCircularHoleBaseGui.CircularHoleCommand,
 )
 
 FreeCAD.Console.PrintLog("Loading PathTappingGui... done\n")

--- a/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/Gui/ThreadMilling.py
@@ -256,6 +256,7 @@ Command = PathOpGui.SetupOperation(
         "Creates a Thread Milling toolpath from features of a base object",
     ),
     PathThreadMilling.SetupProperties,
+    commandClass=PathCircularHoleBaseGui.CircularHoleCommand,
 )
 
 FreeCAD.Console.PrintLog("Loading PathThreadMillingGui ... done\n")

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -301,6 +301,5 @@ def Create(name, obj=None, parentJob=None):
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     obj.Proxy = ObjectHelix(obj, name, parentJob)
-    if obj.Proxy:
-        obj.Proxy.findAllHoles(obj)
+
     return obj

--- a/src/Mod/CAM/Path/Op/Tapping.py
+++ b/src/Mod/CAM/Path/Op/Tapping.py
@@ -310,7 +310,5 @@ def Create(name, obj=None, parentJob=None):
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
 
     obj.Proxy = ObjectTapping(obj, name, parentJob)
-    if obj.Proxy:
-        obj.Proxy.findAllHoles(obj)
 
     return obj

--- a/src/Mod/CAM/Path/Op/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/ThreadMilling.py
@@ -535,6 +535,5 @@ def Create(name, obj=None, parentJob=None):
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     obj.Proxy = ObjectThreadMilling(obj, name, parentJob)
-    if obj.Proxy:
-        obj.Proxy.findAllHoles(obj)
+
     return obj


### PR DESCRIPTION
> [!CAUTION]
> This PR will be closed, as there is another solution for this task, which looks much more simpler and correct
> - #27494

Add ability to manual selection of shapes for `Drilling` and `Helix` operations

By default `Drillable.getDrillableTargets()` check all sub-shapes from `self.model` with `Drillable.isDrillable()`

Changed behavior with selection:
- Uses  the same method `Drillable.isDrillable()`, but only with sub-shapes selected in `3d view`
- Added possibility to select model in `Tree view`
Can be useful if needed process holes in one model, but `Job` contain several models

