### PR TITLE
PartDesign: fix hole clearance not appearing in the taskpanel

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHoleParameters.cpp
@@ -290,6 +290,9 @@ void TaskHoleParameters::holeTypeChanged(int index)
     pcHole->Threaded.setValue(isThreaded);
     pcHole->ModelThread.setValue(isModeled);
 
+    ui->ThreadFit->setHidden(isThreaded);
+    ui->labelThreadClearance->setHidden(isThreaded);
+
     ui->ThreadGroupBox->setVisible(isThreaded);
     // update view not active if modeling threads
     // this will also ensure that the feature is recomputed.


### PR DESCRIPTION
Steps to reproduce:
1. Create a Pad
2. Create a Hole with standard as Metric and select tap-drill or modeled
3. Accept to create the Hole Feature
4. Edit the Hole type in the taskpanel to clearance/passthrough
5. Notice the missing Clearance dropdown where you would select the fit values

needs backport to 1.1

Edit i'll attach a quick model where you just need to edit the Hole and change the `Hole Type` to clearance

[Extract test2.zip to get the fcstd file](https://github.com/user-attachments/files/24256706/test2.zip)

