### PR TITLE
Part: fix Part_EditAttachment nesting handling

### DIFF
--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -459,7 +459,7 @@ class AttachmentEditorTaskPanel(FrozenClass):
             if parent is not None:
                 path = [objname] + subname.split(".")
                 if parent.Name in path:
-                    path = path[path.index(parent.Name)+1:]
+                    path = path[path.index(parent.Name) + 1 :]
                     if len(path) > 1:
                         objname = path[0]
                         subname = ".".join(path[1:])


### PR DESCRIPTION
Fixes #26264.

The previous 'fix' (#25887) did not consider that the object to-be-attached may not be in the global space.

The code in this PR has been tested on the forum:
https://forum.freecad.org/viewtopic.php?p=862968#p862968