### PR TITLE
Gui: Keep workbench selector visible

### DIFF
--- a/src/Gui/WorkbenchSelector.cpp
+++ b/src/Gui/WorkbenchSelector.cpp
@@ -440,4 +440,22 @@ void WorkbenchTabWidget::adjustSize()
     parentWidget()->adjustSize();
 }
 
+void WorkbenchComboBox::setVisible(bool visible)
+{
+    if (!visible && parentWidget() && parentWidget()->isVisible()) {
+        // ignore attempts to hide while parent is visible
+        // this works around a layout bug when toolbar grip is attached
+        // in the menu bar area
+        QTimer::singleShot(0, this, [this]() {
+            if (auto toolbar = parentWidget()) {
+                if (auto areaWidget = toolbar->parentWidget()) {
+                    areaWidget->adjustSize();
+                }
+            }
+        });
+        return;
+    }
+    QComboBox::setVisible(visible);
+}
+
 #include "moc_WorkbenchSelector.cpp"

--- a/src/Gui/WorkbenchSelector.h
+++ b/src/Gui/WorkbenchSelector.h
@@ -53,6 +53,7 @@ Q_OBJECT  // NOLINT
     ~WorkbenchComboBox() override = default;
     WorkbenchComboBox(WorkbenchComboBox&& rhs) = delete;
     void showPopup() override;
+    void setVisible(bool visible) override;
 
     WorkbenchComboBox operator=(WorkbenchComboBox&& rhs) = delete;
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

basically when a user had the workbench selector "docked" to the menubar ie. where the `file` `edit` `view` ... labels are in the interface the workbench selector would "dissappear" ie. enter a state where workbenches could not become selected.

the steps to reproduce are quite simple. 

1. mount the workbench selector in the menubar 
2. switch to a different workbench, (should not matter which one).
3. lock the toolbars
4. switch to a random workbench again
5. unlock the toolbars
6. switch to a different workbench again
7. note how the workbench selector "disappears"

this bug appears to be present in the latest dev builds along with the v1.0.2 release

this PR prevents the workbench selector from disappearing.

what didn't work, calling layout updates directly triggers the hide again. 👎️
calling `adjustSize()` on the toolbar itself triggers the hide again

by deferring the layout update to after the current event loop iteration completes, this avoids re-triggering the bad code path.

basically don't let qt hide this widget when it shouldn't be hidden

## Issues

fixes issue #26048

## Before and After Images

see the below issue link for before images and videos of ui bug

https://github.com/FreeCAD/FreeCAD/issues/26048

