### PR TITLE
Include sys/sysctl.h on FreeBSD when using sysctl()

### DIFF
--- a/src/App/ApplicationDirectories.cpp
+++ b/src/App/ApplicationDirectories.cpp
@@ -630,6 +630,9 @@ fs::path ApplicationDirectories::findHomePath(const char* sCall)
 #include <cstdio>
 #include <cstdlib>
 #include <sys/param.h>
+#if defined(__FreeBSD__)
+#include <sys/sysctl.h>
+#endif
 
 fs::path ApplicationDirectories::findHomePath(const char* sCall)
 {


### PR DESCRIPTION
The ApplicationDirectories::findHomePath() on BSD uses sysctl() to find the path to the running executable. On FreeBSD, we need to include sys/sysctl.h for that - and as it is not included anywhere else, add it to the includes directly in front of this function, with a suitable ifdef.