### PR TITLE
App: Clear OCC cache for FaceMaker

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -24,6 +24,7 @@
 
 #include <Bnd_Box.hxx>
 #include <BRep_Tool.hxx>
+#include <BRepTools.hxx>
 #include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepExtrema_DistShapeShape.hxx>
@@ -1094,6 +1095,13 @@ void ViewProviderPartExt::setupCoinGeometry(
     meshParams.Angle = AngDeflectionRads;
     meshParams.InParallel = Standard_True;
     meshParams.AllowQualityDecrease = Standard_True;
+
+    // Clear triangulation and PCurves from geometry which can slow down the process
+#if OCC_VERSION_HEX < 0x070600
+    BRepTools::Clean(shape);
+#else
+    BRepTools::Clean(shape, Standard_True);
+#endif
 
     BRepMesh_IncrementalMesh(shape, meshParams);
 


### PR DESCRIPTION
This adds clearing OCC caches that seem to slow down over time in FaceMaker. Huge thanks to @Lgt2x who found the `BRepTools::Clean(...)` method. 

Clearnig caches like that should not be needed and if needed should probably be done on some higher level of code so the clearing of cache is not required in every feature. For now however it fixes issue with `getTopoVerifiedFace()` which is used by many features so should be reasonably good to push forward even non-perfect fix.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
- Fixes https://github.com/FreeCAD/FreeCAD/issues/19128
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images

Performance before:
```
0 : 1.6318765750620514
1 : 1.9971186049515381
2 : 2.5401777470251545
3 : 2.9849944479065016
4 : 3.4064703199546784
5 : 4.142990636988543
6 : 4.943178449990228
7 : 5.605076595908031
```

Performance after:
```
0 : 0.579755149083212
1 : 0.6094227830180898
2 : 0.6430805550189689
3 : 0.6694467189954594
4 : 0.6931216750526801
5 : 0.7496457860106602
6 : 0.7781474189832807
7 : 0.8183370280312374
```

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
