### PR TITLE
CAM: Job - Fix setCenterOfRotation()

### DIFF
--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -743,7 +743,6 @@ class ObjectJob:
     def setCenterOfRotation(self, center):
         if center != self.obj.Path.Center:
             self.obj.Path.Center = center
-            self.obj.Operations.Path.Center = center
             for op in self.allOperations():
                 op.Path.Center = center
 


### PR DESCRIPTION
Fix error, which get while changing property `Radius` in `DressupAxisMap`:

```
pyException: Traceback (most recent call last):
  File "/tmp/.mount_FreeCACOhkgo/usr/Mod/CAM/Path/Dressup/Gui/AxisMap.py", line 153, in onChanged
    job.Proxy.setCenterOfRotation(self.center(obj))
  File "/tmp/.mount_FreeCACOhkgo/usr/Mod/CAM/Path/Main/Job.py", line 746, in setCenterOfRotation
    self.obj.Operations.Path.Center = center
    ^^^^^^^^^^^^^^^^^^^^^^^^
<class 'AttributeError'>: 'App.DocumentObjectGroup' object has no attribute 'Path'
```