### PR TITLE
add pybind11 include path in MeshPart CMakeLists

### DIFF
--- a/src/Mod/MeshPart/App/CMakeLists.txt
+++ b/src/Mod/MeshPart/App/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(
     PRIVATE
     ${CMAKE_BINARY_DIR}
     ${CMAKE_SOURCE_DIR}/src
+    ${pybind11_INCLUDE_DIR}
 )
 
 target_include_directories(
@@ -123,6 +124,7 @@ if (BUILD_FLAT_MESH)
 
     add_library(flatmesh SHARED ${FLATMESH_SRCS})
     SET_PYTHON_PREFIX_SUFFIX(flatmesh)
+    target_include_directories(flatmesh PRIVATE ${pybind11_INCLUDE_DIR})
     target_link_libraries(flatmesh ${Python3_LIBRARIES} ${MeshPart_LIBS})
 
     SET_BIN_DIR(flatmesh flatmesh /Mod/MeshPart)


### PR DESCRIPTION
This could be a return of parts of commit d4feb5140240f730067d7b5b4fafcb102781f486
Without these, the rc1 build fails on FreeBSD with "pybind11/eigen.h not found" - the layout of the pybind11 directories on the BSDs may differ somewhat from your typical Linux distribution. But then, on Linux, this additional include path will just point to an already-known location.
