### PR TITLE
BIM: Initialize SketchArch variable before use

### DIFF
--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -179,6 +179,8 @@ class Arch_Window:
         from draftutils.messages import _wrn
         from ArchWindowPresets import WindowPresets
 
+        SketchArch = False
+
         FreeCAD.activeDraftCommand = None
         FreeCADGui.Snapper.off()
         self.tracker.off()


### PR DESCRIPTION
Fixes an error whereby the `SketchArch` variable was being used before being initialized.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/26335

I'm puzzled about a couple of things:

1. Why wasn't a Python traceback shown when the error happened? [*]
2. Why did CodeQL not highlight this? Probably changes to the `BimWindow.py` file predate the use of CodeQL in CI.

[*] I stumbled upon the root cause by chance only, when one of the windows I was testing on my local build output the following:

```python-traceback
  <class 'UnboundLocalError'>
Traceback (most recent call last):
  File "~/dev/FreeCAD/build/release/Mod/Draft/draftguitools/gui_snapper.py", line 1468, in click
    accept()
  File "~/dev/FreeCAD/build/release/Mod/Draft/draftguitools/gui_snapper.py", line 1495, in accept
    callback(self.pt, obj)
  File "~/dev/FreeCAD/build/release/Mod/BIM/bimcommands/BimWindow.py", line 341, in getPoint
   if SketchArch:
UnboundLocalError: local variable 'SketchArch' referenced before assignment
```

Notes:
- A traceback was produced, but in addition to the `<class 'UnboundLocalError'>` warning message. That orphaned warning was still produced
- Frustratingly, I don't seem to be able to reproduce the traceback output again. In any case that pointed to the bug, and the fix works.