### PR TITLE
CAM: Dogbone Dressup - Limit max length of adaptive incision

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathDressupDogboneII.py
+++ b/src/Mod/CAM/CAMTests/TestPathDressupDogboneII.py
@@ -85,7 +85,7 @@ class MockFeaturePython(object):
         if typ is None and val is None:
             raise AttributeError
         if typ == "App::PropertyLength":
-            if type(val) == float or type(val) == int:
+            if isinstance(val, (float, int)):
                 return FreeCAD.Units.Quantity(val, FreeCAD.Units.Length)
             return FreeCAD.Units.Quantity(val)
         return val
@@ -134,7 +134,7 @@ class TestDressupDogboneII(PathTestUtils.PathTestBase):
         """Verify adaptive length"""
 
         def adaptive(k, a, n):
-            return Path.Dressup.DogboneII.calc_length_adaptive(k, a, n, n)
+            return Path.Dressup.DogboneII.calc_length_adaptive(k, a, n, 0)
 
         if True:
             # horizontal bones

--- a/src/Mod/CAM/Path/Dressup/DogboneII.py
+++ b/src/Mod/CAM/Path/Dressup/DogboneII.py
@@ -91,7 +91,7 @@ def calc_length_adaptive(kink, angle, nominal_length, custom_length):
             f"{kink}: angle={180*angle/PI}, dist={dist:.4f}, da={180*da/PI}, depth={depth:.4f}"
         )
 
-    return depth
+    return custom_length if custom_length and depth > custom_length else depth
 
 
 def calc_length_nominal(kink, angle, nominal_length, custom_length):
@@ -235,7 +235,13 @@ class Proxy(object):
             "App::PropertyEnumeration",
             "Incision",
             "Dressup",
-            QT_TRANSLATE_NOOP("App::Property", "The algorithm to determine the bone length"),
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "The algorithm to determine the bone length\n\n"
+                "Adaptive: length depend from shape\n"
+                "Fixed: length equal tool radius\n"
+                "Custom: length from Custom property",
+            ),
         )
         obj.Incision = Incision.All
         obj.Incision = Incision.Adaptive
@@ -244,7 +250,11 @@ class Proxy(object):
             "App::PropertyLength",
             "Custom",
             "Dressup",
-            QT_TRANSLATE_NOOP("App::Property", "Dressup length if incision is set to 'custom'"),
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Dressup length if incision is set to 'custom'"
+                "\nAlso non zero value limit max 'adaptive' length",
+            ),
         )
         obj.Custom = 0.0
 


### PR DESCRIPTION
### Changes:
- Refactoring
- Added comments
- Added description of `Incision` types
- Added ability to limit max length of adaptive incision
Sharp corners will create very long incision, which can be not good
This changes will limit length of incision by value in property `Custom` (only if `Custom` non zero)

<img width="721" height="543" alt="Screenshot_20251221_223426_lossy" src="https://github.com/user-attachments/assets/b6456267-57be-4463-a8b6-00d89b71dcee" />
