### PR TITLE
Gui: fix linear dragger increments when the multFactor is set

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -179,7 +179,9 @@ void LinearGizmo::setDragLength(double dragLength)
 void LinearGizmo::setGeometryScale(float scale)
 {
     dragger->geometryScale = SbVec3f(scale, scale, scale);
-    dragger->translationIncrement = std::pow(10.0f, std::floor(std::log10(scale)));
+    // Scales the dragger increment in exponents of 10 based on the zoom level (scale)
+    constexpr float base = 10.0F;
+    dragger->translationIncrement = multFactor * std::pow(base, std::floor(std::log10(scale)));
 }
 
 SoLinearDraggerContainer* LinearGizmo::getDraggerContainer()


### PR DESCRIPTION
After this change the task dialog values change in the multiples of 10^x (where x is dependent of the zoom level) instead of having weird values while filleting two non orthogonal faces or padding in a custom direction.
This PR is intended for 1.1.