### PR TITLE
PD: Fix missing silent mode check in GetTopoShapeVerifiedFace

### DIFF
--- a/src/Mod/PartDesign/App/FeatureSketchBased.cpp
+++ b/src/Mod/PartDesign/App/FeatureSketchBased.cpp
@@ -235,6 +235,9 @@ TopoShape ProfileBased::getTopoShapeVerifiedFace(
 
 
                     if (subshape.isNull()) {
+                        if (silent) {
+                            return {};
+                        }
                         FC_THROWM(
                             Base::CADKernelError,
                             "Sub shape not found: " << obj->getFullName() << "." << sub
@@ -622,7 +625,7 @@ TopoShape ProfileBased::getTopoShapeSupportFace() const
     TopoShape shape;
     const Part::Part2DObject* sketch = getVerifiedSketch(true);
     if (!sketch) {
-        shape = getTopoShapeVerifiedFace();
+        shape = getTopoShapeVerifiedFace(true);
     }
     else if (sketch->MapMode.getValue() == Attacher::mmFlatFace
              && sketch->AttachmentSupport.getValue()) {
@@ -1373,6 +1376,10 @@ Base::Vector3d ProfileBased::getProfileNormal() const
     // some reason.
     TopoShape shape = getTopoShapeVerifiedFace(true, true, true);  //, _ProfileBasedVersion.getValue()
                                                                    //<= 0);
+
+    if (shape.isNull()) {
+        return SketchVector;
+    }
 
     gp_Pln pln;
     if (shape.findPlane(pln)) {


### PR DESCRIPTION
Fixes #21210. `GetTopoShapeVerifiedFace` has a parameter that is supposed to control whether it throws exceptions on error or just silently returns a null shape. In one path, that parameter was being ignored and an exception thrown. This PR also ensures that all calls to this method actually verify the result when they are using `silent=true`.
