### PR TITLE
Fix : added empty link check to prevent null entry in document link map

### DIFF
--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -4550,7 +4550,7 @@ PropertyXLink::getDocumentInList(App::Document* doc)
 {
     std::map<App::Document*, std::set<App::Document*>> ret;
     for (auto& v : _DocInfoMap) {
-        if (!v.second->pcDoc || (doc && doc != v.second->pcDoc)) {
+        if (!v.second->pcDoc || (doc && doc != v.second->pcDoc) || v.second->links.empty()) {
             continue;
         }
         auto& docs = ret[v.second->pcDoc];


### PR DESCRIPTION
Issue: #25846

**FIX**

https://github.com/user-attachments/assets/e53430c1-3108-4686-8154-77ea41e35a4c

