### PR TITLE
CAM: Add migration for Toolbit Units property

### DIFF
--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -793,7 +793,7 @@ class ToolBit(Asset, ABC):
 
         # 3. Ensure Units property exists and is set
         if not hasattr(self.obj, "Units"):
-            print("Adding Units property")
+            Path.Log.debug("Adding Units property")
             self.obj.addProperty(
                 "App::PropertyEnumeration",
                 "Units",


### PR DESCRIPTION
This PR adds migration for toolbit units by automatically infering the Units (Metric/Imperial) from toolbit parameter strings and sets the Units property if missing. It adds a utility function to detect units from JSON. This is done at the JSON level during migration to ensure that all toolbits have the correct Units property set.

src/Mod/CAM/Path/Tool/toolbit/migration.py:
- Infer Units from parameter strings if not set during migration
- Set Units property and log inference
- Refactor migration logic for clarity and reliability

src/Mod/CAM/Path/Tool/toolbit/models/base.py:
- Use Path.Log.debug instead of print when adding Units property

src/Mod/CAM/Path/Tool/toolbit/util.py:
- Add units_from_json() to infer Metric/Imperial from parameter strings