### PR TITLE
Issue #26343: CAM Tasks panel ignores selected Stock

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -722,7 +722,7 @@ class StockFromExistingEdit(StockEdit):
                 # => ridgid string comparison fails
                 # Instead of ridgid string comparsion use partial (needle in haystack)
                 # string comparison
-                #if label == stockName: # ridgid string comparison
+                # if label == stockName: # ridgid string comparison
                 if label in stockName:  # partial string comparison
                     index = i
 


### PR DESCRIPTION
This is in reference to issue:
CAM: Relation to stock "from existing solid" gets lost #26343

The current code in \src\Mod\CAM\Path\Main\Gui\Job.py (line 719) ignores a specific stock selection within the Tasks panel Stock combobox. If for example a cloned stock object, e.g. a solid body, is selected, the selection defaults to the first item in the combolist, showing a wrong stock selection when leaving and reentering the Job -> Tasks -> Setup panel (Layout -> Stock).

<img width="831" height="500" alt="2025-12-23 Issue #26343 - MTronic" src="https://github.com/user-attachments/assets/4476e62c-ff4c-45e8-899f-f7fab20e69d9" />

The cause lies in comparing different strings to find a label match, one string object is generic (short name) while the other one has a suffix created during the clone process. See picture above, showing the combobox list item "RawMaterial" and the related "Stock-RawMaterial001" tree item. The strings never match, due to the suffix "...001", and the ridgid string comparison fails. I recommend using a partial (needle in haystack) string comparison.