### PR TITLE
partdesign: fix issue #25811 while not breaking #14720 topo naming

### DIFF
--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -1194,7 +1194,11 @@ void ElementMap::addChildElements(long masterTag, const std::vector<MappedChildE
 
         // do child mapping only if the child element count >= 5
         const int threshold {5};
-        if ((child.count >= threshold && masterTag != 0) || !child.elementMap) {
+
+        // skip encoding only when masterTag=0, child.tag=0, and count is exactly at threshold
+        bool skipEncoding = (masterTag == 0 && child.tag == 0 && child.count == threshold && child.elementMap);
+
+        if ((child.count >= threshold && !skipEncoding) || !child.elementMap) {
             encodeElementName(child.indexedName[0],
                               tmp,
                               ss,


### PR DESCRIPTION
## Issues

this PR should fix the issue described in #25811 ie. fixes #25811 and not break / revert changes so that issue #14720 should stay resolved as pr #23367 introduced the regression described in issue #25811

so this PR aims to keep both of those issues resolved ie. #25811 and #14720

this is a topo naming issue. i tested both cases with this PR locally on my local testing box did not experience either issue.

the original code had the below,

```cpp
if (child.count >= threshold || !child.elementMap)
```

that encodes element names whenever count >=5 this worked for #25811 but broke with #14720

pr #23367 introduced

```cpp
if ((child.count >= threshold && child.tag != 0) || !child.elementMap)
```

which skips encoding when `child.tag == 0` this fixes #14720 but creates issue #25811 has many legitimate cases where `child.tag == 0` that need to be encoded.

the fix introduced in this PR

```cpp
 // skip encoding only when masterTag=0, child.tag=0, and count is exactly at threshold
        bool skipEncoding = (masterTag == 0 && child.tag == 0 && child.count == threshold && child.elementMap);

        if ((child.count >= threshold && !skipEncoding) || !child.elementMap) {
```

the problem for issue #14720 happens when adding a hole then fillet to a simple rectangular sketch ie.

```
masterTag=0, child.tag=0, count=5
```

> This is exactly at the threshold with both tags at zero. When encoded, it adds redundant h,e info to the element name that causes the toponaming lookup to fail. By skipping this specific case, the element names stay stable

why the above fix works for #25811

> The model in #25811 has many masterTag=0, child.tag=0 cases, **but** they all have count > 5 (i saw counts of 8, 12, 13, 14, 18, 22, etc. in the logs). Because child.count > threshold, the condition child.count > threshold is true, so encoding happens normally and edge links remain stable.

> The key insight from debugging was that #14720 only occurs when count is exactly at the threshold (5), while #25811's cases all have counts above the threshold. By adding child.count > threshold as an escape hatch, this allow encoding for larger counts while still blocking the problematic exact-threshold case that causes the #14720 issue.

## Before and After Images

see #14720 and #25811 for step to reproduce issues and to see visual results from such issues.

