### PR TITLE
CAM: Get Fanuc post processor working and implement several improvements (1.1 backport)

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -348,7 +348,6 @@ def export(objectslist, filename, argstring):
         gcode += "(BEGIN POSTAMBLE)\n"
     for line in POSTAMBLE.splitlines():
         gcode += linenumber() + line + "\n"
-    gcode += "%\n"
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()


### PR DESCRIPTION
As requested in https://github.com/FreeCAD/FreeCAD/pull/25850 here is a backport of the changes in this pull request.  The Fanuc post self test code was dropped as it require code in src/Mod/CAM/CAMTests/PostTestMocks.py not available in the 1.1 branch.

CAM: Adjusted Fanuc post processor to move Z to tool change position before M6 (without test)
CAM: Made Fanuc post processor compatible with FreeCAD 1.0.
CAM: Switched Fanuc post processor to end program with M30, not M2.
CAM: Adjusted Fanuc post processor to use M05 consistently everywhere.
CAM: Provide correct and more relevant header from Fanuc post processor
CAM: Avoid Z overtravel error on Fanuc tool changes
CAM: Avoid adding trailing space to all M6 lines.
CAM: Corrected Fanuc post processor M3 handling
CAM: Made empty spindle at the end optional in Fanuc CAM post processing script
CAM: Adjusted Fanuc post processing script to always start with a percent
CAM: Adjusted Fanuc post processing script to not inherit behaviour between calls
CAM: Print "Show editor" status boolean as string, not integer

## Issues

Fixes https://github.com/FreeCAD/FreeCAD/issues/14016
Fixes https://github.com/FreeCAD/FreeCAD/issues/25723
Fixes https://github.com/FreeCAD/FreeCAD/issues/25677
