### PR TITLE
PD: Add case for when scripts set Midplane=False

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -145,6 +145,11 @@ void FeatureExtrude::onChanged(const App::Property* prop)
         if (Midplane.getValue()) {
             SideType.setValue("Symmetric");
         }
+        else {
+            Base::Console()
+                .warning("Deprecated Midplane property was explicitly set to False: assuming SideType='One side'\n");
+            SideType.setValue("One side");
+        }
     }
     ProfileBased::onChanged(prop);
 }


### PR DESCRIPTION
As discussed in the PR Review Meeting a couple weeks ago, it is safer to handle the case where a script manually sets `Midplane=False` than to assume that this repetition of the default value exists in isolation (rather than after earlier setting `Midplane=True`). The consequence of this change is that if a script sets `SideType = 'Two sided'` and then also sets `Midplane=False` they will not get their expected result. We're basically assuming that if someone is still using `Midplane`, they are doing so because their script predates the existence of `SideType`. Just in case, however, I'm emitting another warning that this is what's going on.

Fixes https://github.com/FreeCAD/FreeCAD/issues/26014 (again, some more)