### PR TITLE
Draft: Add recursive deletion support for Draft Layers

### DIFF
--- a/src/Gui/ViewProvider.pyi
+++ b/src/Gui/ViewProvider.pyi
@@ -169,6 +169,23 @@ class ViewProvider(ExtensionContainer):
         """
         ...
 
+    def onDelete(self, subNames: List[str], /) -> bool:
+        """
+        Called when the object is about to be deleted.
+
+        This allows the view provider to perform cleanup, show confirmation dialogs,
+        or prevent deletion by returning False.
+
+        subNames : List[str]
+            List of selected subelements
+
+        Returns
+        -------
+        bool
+            True if deletion should proceed, False to prevent deletion
+        """
+        ...
+
     def addDisplayMode(self, obj: Any, mode: str, /) -> None:
         """
         Add a new display mode to the view provider.

--- a/src/Gui/ViewProviderPyImp.cpp
+++ b/src/Gui/ViewProviderPyImp.cpp
@@ -701,6 +701,33 @@ PyObject* ViewProviderPy::doubleClicked(PyObject* args)
     PY_CATCH;
 }
 
+PyObject* ViewProviderPy::onDelete(PyObject* args)
+{
+    PyObject* subNames;
+    if (!PyArg_ParseTuple(args, "O!", &PyList_Type, &subNames)) {
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        std::vector<std::string> sub;
+        Py::List list(subNames);
+        for (Py::List::size_type i = 0; i < list.size(); ++i) {
+            Py::Object item = list.getItem(i);
+            if (item.isString()) {
+                sub.push_back(Py::String(item));
+            }
+            else {
+                throw Py::TypeError("subNames must be a list of strings");
+            }
+        }
+
+        bool ret = getViewProviderPtr()->onDelete(sub);
+        return Py::new_reference_to(Py::Boolean(ret));
+    }
+    PY_CATCH;
+}
+
 PyObject* ViewProviderPy::getCustomAttributes(const char* attr) const
 {
     // search for dynamic property

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -593,20 +593,16 @@ class ViewProviderLayer:
             except (AttributeError, ReferenceError):
                 continue
 
-            # give the child's view provider a chance to handle deletion
             child_vobj = getattr(child, "ViewObject", None)
             if child_vobj:
-                if hasattr(child_vobj, "Proxy") and hasattr(child_vobj.Proxy, "onDelete"):
-                    try:
-                        should_delete = child_vobj.Proxy.onDelete(
-                            child_vobj, ["group_recursive_deletion"]
-                        )
-                        if not should_delete:
-                            continue
-                    except Exception as e:
-                        App.Console.PrintWarning(
-                            "Error calling onDelete for {}: {}\n".format(child.Label, str(e))
-                        )
+                try:
+                    should_delete = child_vobj.onDelete(["group_recursive_deletion"])
+                    if not should_delete:
+                        continue
+                except Exception as e:
+                    App.Console.PrintWarning(
+                        "Error calling onDelete for {}: {}\n".format(child.Label, str(e))
+                    )
 
             # delete the object if it still exists
             try:

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -553,7 +553,7 @@ class ViewProviderLayer:
 
         choice = QtGui.QMessageBox.question(
             Gui.getMainWindow(),
-            translate("draft", "Delete layer contents recursively?"),
+            translate("draft", "Delete Layer Contents Recursively?"),
             message,
             QtGui.QMessageBox.Yes | QtGui.QMessageBox.No | QtGui.QMessageBox.Cancel,
             QtGui.QMessageBox.No,


### PR DESCRIPTION
As the title says - this patch implements `onDelete()` method in `ViewProviderLayer` to handle deletion of layer contents. Draft Layers use PropertyLinkListHidden instead of `GroupExtension` so they need to have custom deletion logic.

It adds:
-confirmation dialog for non-empty layers,
-handles `group_recursive_deletion` marker to avoid duplicate dialog logic
-recursively deletes nested layers/groups
-propagates deletion event further to child's `onDelete()` methods

Demo:

https://github.com/user-attachments/assets/06f5c246-04f5-4f33-9779-55d0766b35dd

Note: I didn't intend to change Draft Layers to use `GroupExtension` since it looks like it enforces objects to be only in one group at a time. This kinda feels like breaking purpose of layers, so I've added this custom handling.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/26417