### PR TITLE
Backport item deletion fixes to 1.0 branch.

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5289,6 +5289,11 @@ enum Status {
 
 void DocumentObjectItem::testStatus(bool resetStatus, QIcon& icon1, QIcon& icon2)
 {
+    // guard against calling this during destruction when tree widget may be nullptr
+    if (!treeWidget()) {
+        return;
+    }
+
     App::DocumentObject* pObject = object()->getObject();
 
     int visible = -1;


### PR DESCRIPTION
Backport of #21965 to 1.0 branch.

Ran into this when working with kicadStepUp workbench when running stable version: https://github.com/easyw/kicadStepUpMod/issues/266