### PR TITLE
BIM: prevent crash when switching BIM_View Render Mode

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -769,6 +769,9 @@ def getCoinSVG(cutplane, objs, cameradata=None, linewidth=0.2, singleface=False,
     view_window = FreeCADGui.createViewer()
     view_window_name = "Temp" + str(uuid.uuid4().hex[:8])
     view_window.setName(view_window_name)
+    # disable animations to prevent a crash:
+    # https://github.com/FreeCAD/FreeCAD/issues/24929
+    view_window.setAnimationEnabled(False)
     inventor_view = view_window.getViewer()
 
     inventor_view.setBackgroundColor(1, 1, 1)


### PR DESCRIPTION
See: https://github.com/FreeCAD/FreeCAD/issues/24929#issuecomment-3693985572.

Does not fix the problem entirely, but prevents the crash on Linux.