### PR TITLE
Gui: Fix XHTML and X3D export validation and rendering issues

### DIFF
--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -42,6 +42,7 @@
 
 
 #include <Base/FileInfo.h>
+#include <Base/Persistence.h>
 #include <Base/Stream.h>
 #include <Base/Tools.h>
 #include <zipios++/gzipoutputstream.h>
@@ -497,42 +498,6 @@ bool Gui::SoFCDB::writeToX3D(SoNode* node, bool exportViewpoints, std::string& b
     return true;
 }
 
-namespace
-{
-std::string escapeXmlAttribute(const char* str)
-{
-    if (!str) {
-        return std::string();
-    }
-
-    std::string result;
-    result.reserve(strlen(str));
-
-    for (const char* p = str; *p; ++p) {
-        switch (*p) {
-            case '"':
-                result.append("&quot;");
-                break;
-            case '&':
-                result.append("&amp;");
-                break;
-            case '<':
-                result.append("&lt;");
-                break;
-            case '>':
-                result.append("&gt;");
-                break;
-            case '\'':
-                result.append("&apos;");
-                break;
-            default:
-                result.push_back(*p);
-                break;
-        }
-    }
-    return result;
-}
-}  // namespace
 
 void Gui::SoFCDB::writeX3DFields(
     SoNode* node,
@@ -559,7 +524,7 @@ void Gui::SoFCDB::writeX3DFields(
         }
 
         nodeMap[node] = str.str();
-        std::string escapedName = escapeXmlAttribute(str.str().c_str());
+        std::string escapedName = Base::Persistence::encodeAttribute(str.str());
         out << " DEF=\"" << escapedName << "\"";
     }
 
@@ -584,7 +549,9 @@ void Gui::SoFCDB::writeX3DFields(
                     }
 
                     // escape XML special characters in attribute value
-                    std::string escapedValue = escapeXmlAttribute(ba.data());
+                    std::string escapedValue = Base::Persistence::encodeAttribute(
+                        std::string(ba.data())
+                    );
 
                     out << '\n'
                         << Base::blanks(spaces + 2) << fielddata->getFieldName(i).getString()
@@ -647,7 +614,7 @@ void Gui::SoFCDB::writeX3DChild(
         // remove the VRML prefix from the type name
         std::string sftype(node->getTypeId().getName().getString());
         sftype = sftype.substr(4);
-        std::string escapedRef = escapeXmlAttribute(mapIt->second.c_str());
+        std::string escapedRef = Base::Persistence::encodeAttribute(mapIt->second);
         out << Base::blanks(spaces) << "<" << sftype << " USE=\"" << escapedRef << "\" />\n";
     }
 }


### PR DESCRIPTION
Those patches fix multiple validation errors and rendering issues in XHTML and X3D file exports.
Fixed doc structure for XHTML:
- Add missing <title> element in <head> (required by XHTML Strict)
- Add <body> wrapper around content (required by XHTML)
- Add Content-Type meta tag for proper character encoding
- Fix indentation of content elements

Escaped XML special chars in attributes (this is the initial problem in the reported issue that prevented rendering the file):
- added helper function that escapes all of the chars properly

Fixed X3D doctype and XHTML structure
For X3D:
- changed xhtml doctype to proper x3d 3.3 doctype
- removed namespace declarations
- removed invalid width and height attribs

For XHTML
- wrapped navigation buttons in `<div>` as it seems to be requirted by XHTML strict
- kept X3D elements unprefixed

Before (for the sample file attached in the issue):

<img width="1899" height="301" alt="image" src="https://github.com/user-attachments/assets/84245986-531b-45f2-a570-ec2aa9864241" />

After:

<img width="1831" height="897" alt="image" src="https://github.com/user-attachments/assets/9f130700-b2dc-4701-9060-0c902967403b" />

Note: I couldn't fix all W3D validation errors, it's because we use X3DOM. From what I've checked, W3C uses and validates against XHTML 1.0 Strict DTD, which has predefined set of elements (it doesn't define X3D element) and for every single one of those that X3DOM allows to write, it reports an error. So I just treated those as false-positives, rather than actual error. However, 4th commit has additional changes made after running on https://validator.w3.org/nu/#file.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/26441