### PR TITLE
CAM: Exporting G-code - Buttons text

### DIFF
--- a/src/Mod/CAM/Path/Post/Utils.py
+++ b/src/Mod/CAM/Path/Post/Utils.py
@@ -40,6 +40,7 @@ import Path
 import os
 import re
 
+translate = FreeCAD.Qt.translate
 
 debug = False
 if debug:
@@ -231,32 +232,22 @@ class GCodeEditorDialog(QtGui.QDialog):
         self.editor.setPlainText(text)
         layout.addWidget(self.editor)
 
+        buttonBox = QtGui.QDialogButtonBox
+        self.buttons = buttonBox()
+        ok_button = self.buttons.addButton(buttonBox.Ok)
+        ok_button.setText(translate("CAM", "Save With Changes"))
+        cancel_button = self.buttons.addButton(buttonBox.Cancel)
         # buttons depending on the post processor used
         if refactored:
-            self.buttons = QtGui.QDialogButtonBox(
-                QtGui.QDialogButtonBox.Ok
-                | QtGui.QDialogButtonBox.Discard
-                | QtGui.QDialogButtonBox.Cancel,
-                QtCore.Qt.Horizontal,
-                self,
-            )
             # Swap the button text as to not change the old cancel behaviour for the user
-            self.buttons.button(QtGui.QDialogButtonBox.Discard).setIcon(
-                self.buttons.button(QtGui.QDialogButtonBox.Cancel).icon()
-            )
-            self.buttons.button(QtGui.QDialogButtonBox.Discard).setText(
-                self.buttons.button(QtGui.QDialogButtonBox.Cancel).text()
-            )
-            self.buttons.button(QtGui.QDialogButtonBox.Cancel).setIcon(QtGui.QIcon())
-            self.buttons.button(QtGui.QDialogButtonBox.Cancel).setText("Abort")
+            discard_button = self.buttons.addButton(buttonBox.Discard)
+            discard_button.setIcon(QtGui.QIcon())
+            discard_button.setText(translate("CAM", "Save Without Changes"))
+            cancel_button.setText(translate("CAM", "Abort"))
         else:
-            self.buttons = QtGui.QDialogButtonBox(
-                QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel,
-                QtCore.Qt.Horizontal,
-                self,
-            )
+            cancel_button.setText(translate("CAM", "Save Without Changes"))
 
-        self.buttons.button(QtGui.QDialogButtonBox.Ok).setDisabled(True)
+        ok_button.setDisabled(True)
         layout.addWidget(self.buttons)
 
         # restore placement and size


### PR DESCRIPTION
<img width="1102" height="279" alt="1_hor" src="https://github.com/user-attachments/assets/09a29551-b480-46bb-8311-05f3bc99e0f1" />

It is not obvious behavior each of this buttons while export gcode
Also was added more confusion after
- #25273

Got several questions about this behavior in short time:
- https://forum.freecad.org/viewtopic.php?p=863458#p863458
- https://forum.freecad.org/viewtopic.php?t=102091
- https://forum.freecad.org/viewtopic.php?p=866595#p866595
- https://forum.freecad.org/viewtopic.php?p=869733#p869733

### After this commit:
<img width="1102" height="279" alt="Screenshot_20251228_173312_hor" src="https://github.com/user-attachments/assets/c4f5b4a3-82e2-44a3-88e0-7fe54f67748f" />
<br>