### PR TITLE
Part: Preserve child visibility when deleting compound copies

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -104,7 +104,7 @@ bool ViewProviderCompound::onDelete(const std::vector<std::string>& subNames)
                 if (parent && parent != pComp && parent->isDerivedFrom<Part::Compound>()) {
                     auto otherCompound = static_cast<Part::Compound*>(parent);
                     auto otherLinks = otherCompound->Links.getValues();
-                    if (std::find(otherLinks.begin(), otherLinks.end(), pLink) != otherLinks.end()) {
+                    if (std::ranges::find(otherLinks, pLink) != otherLinks.end()) {
                         hasOtherParent = true;
                         break;
                     }


### PR DESCRIPTION
Currently, if we have a FC document two compounds, when one of them is a copy of the other containing same children and we delete the copy compound to keep the children, their visibility state changes.

The cause of that was a part of code in `onDelete()` method, which was unconditionally calling `showViewProvider()` on every child object, without checking if other compounds still claim those children or what the current visibility should be.

So this patch adds parent-checking logic before changing visibility. The visibility is only updated if the child is truly orphaned. So in the scenario where we have the children referenced STILL by some compounds, the visibility remains unchanged. It only changes when child has truly no parents.

Note: @semhustej can you check on the demo if that is something that you expected from this behavior? I'm still not sure if the visibility should be updated upon orphaning the compound, but at least now it is not updated if the children are still referenced by some other compound, essentially resolving your problem.

Demo:

https://github.com/user-attachments/assets/c0784e4d-622a-4222-8cba-bdfbf975d053

Resolves: https://github.com/FreeCAD/FreeCAD/issues/25977