### PR TITLE
PartDesign: Fix upToFace not working with non-ASCII filenames

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -1464,4 +1464,3 @@ bool TaskDlgExtrudeParameters::reject()
 }
 
 #include "moc_TaskExtrudeParameters.cpp"
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/26476