### PR TITLE
Sketcher: Harden against flip with signed constraints

### DIFF
--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -42,6 +42,7 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/thread.hpp>
 #include "Constraint.h"
+
 #include "ConstraintPy.h"
 
 
@@ -82,6 +83,7 @@ Constraint* Constraint::copy() const
     temp->Value = this->Value;
     temp->Type = this->Type;
     temp->AlignmentType = this->AlignmentType;
+    temp->Orientation = this->Orientation;
     temp->Name = this->Name;
     temp->LabelDistance = this->LabelDistance;
     temp->LabelPosition = this->LabelPosition;
@@ -161,6 +163,7 @@ void Constraint::Save(Writer& writer) const
         writer.Stream() << "InternalAlignmentType=\"" << (int)AlignmentType << "\" "
                         << "InternalAlignmentIndex=\"" << InternalAlignmentIndex << "\" ";
     }
+    writer.Stream() << "Orientation=\"" << Orientation.toUnderlyingType() << "\" ";
     writer.Stream() << "Value=\"" << Value << "\" "
                     << "LabelDistance=\"" << LabelDistance << "\" "
                     << "LabelPosition=\"" << LabelPosition << "\" "
@@ -213,6 +216,12 @@ void Constraint::Restore(XMLReader& reader)
     }
     else {
         AlignmentType = Undef;
+    }
+    if (reader.hasAttribute("Orientation")) {
+        Orientation = reader.getAttribute<ConstraintOrientations>("Orientation");
+    }
+    else {
+        Orientation = ConstraintOrientations::None;
     }
 
     // Read the distance a constraint label has been moved

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -28,6 +28,8 @@
 
 #include <Base/Persistence.h>
 #include <Base/Quantity.h>
+#include <Base/Bitmask.h>
+
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 
@@ -90,6 +92,15 @@ enum InternalAlignmentType
     ParabolaFocalAxis = 11,
     NumInternalAlignmentType  // must be the last item!
 };
+enum class ConstraintOrientations
+{
+    None = 0,
+    CounterClockwise = 1,
+    Clockwise = 2,
+    Internal = 4,
+    External = 8
+};
+using ConstraintOrientation = Base::Flags<ConstraintOrientations>;
 
 class SketcherExport Constraint: public Base::Persistence
 {
@@ -215,6 +226,8 @@ private:
 public:
     ConstraintType Type {None};
     InternalAlignmentType AlignmentType {Undef};
+    ConstraintOrientation Orientation {ConstraintOrientations::None};
+
     std::string Name;
     std::string MetaData;
     float LabelDistance {10.F};
@@ -271,3 +284,5 @@ protected:
 };
 
 }  // namespace Sketcher
+
+ENABLE_BITMASK_OPERATORS(Sketcher::ConstraintOrientations);

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -2266,7 +2266,13 @@ int Sketch::addConstraint(const Constraint* constraint)
                     Parameters.push_back(c.value);
                     DrivenParameters.push_back(c.value);
                 }
-                rtn = addDistanceConstraint(constraint->First, constraint->Second, c.value, c.driving);
+                rtn = addDistanceConstraint(
+                    constraint->First,
+                    constraint->Second,
+                    c.value,
+                    constraint->Orientation,
+                    c.driving
+                );
             }
             else if (constraint->Second != GeoEnum::GeoUndef) {
                 if (constraint->FirstPos != PointPos::none) {  // point to line distance
@@ -2283,6 +2289,7 @@ int Sketch::addConstraint(const Constraint* constraint)
                         constraint->FirstPos,
                         constraint->Second,
                         c.value,
+                        constraint->Orientation,
                         c.driving
                     );
                 }
@@ -3541,7 +3548,14 @@ int Sketch::addDistanceConstraint(int geoId, double* value, bool driving)
 }
 
 // point to line or circular distance constraint
-int Sketch::addDistanceConstraint(int geoId1, PointPos pos1, int geoId2, double* value, bool driving)
+int Sketch::addDistanceConstraint(
+    int geoId1,
+    PointPos pos1,
+    int geoId2,
+    double* value,
+    ConstraintOrientation orientation,
+    bool driving
+)
 {
     geoId1 = checkGeoId(geoId1);
     geoId2 = checkGeoId(geoId2);
@@ -3556,7 +3570,14 @@ int Sketch::addDistanceConstraint(int geoId1, PointPos pos1, int geoId2, double*
         GCS::Line& l2 = Lines[Geoms[geoId2].index];
 
         int tag = ++ConstraintsCounter;
-        GCSsys.addConstraintP2LDistance(p1, l2, value, tag, driving);
+        GCSsys.addConstraintP2LDistance(
+            p1,
+            l2,
+            value,
+            orientation.testFlag(ConstraintOrientations::CounterClockwise),
+            tag,
+            driving
+        );
         return ConstraintsCounter;
     }
     else {
@@ -3605,7 +3626,13 @@ int Sketch::addDistanceConstraint(
 }
 
 // circular-(circular or line) distance constraint
-int Sketch::addDistanceConstraint(int geoId1, int geoId2, double* value, bool driving)
+int Sketch::addDistanceConstraint(
+    int geoId1,
+    int geoId2,
+    double* value,
+    ConstraintOrientation orientation,
+    bool driving
+)
 {
     geoId1 = checkGeoId(geoId1);
     geoId2 = checkGeoId(geoId2);
@@ -3624,7 +3651,15 @@ int Sketch::addDistanceConstraint(int geoId1, int geoId2, double* value, bool dr
 
         GCS::Line* l = &Lines[Geoms[geoId2].index];
         int tag = ++ConstraintsCounter;
-        GCSsys.addConstraintC2LDistance(*c1, *l, value, tag, driving);
+        GCSsys.addConstraintC2LDistance(
+            *c1,
+            *l,
+            value,
+            orientation.testFlag(ConstraintOrientations::CounterClockwise),
+            orientation.testFlag(ConstraintOrientations::Internal),
+            tag,
+            driving
+        );
         return ConstraintsCounter;
     }
     else {
@@ -3646,7 +3681,16 @@ int Sketch::addDistanceConstraint(int geoId1, int geoId2, double* value, bool dr
         }
 
         int tag = ++ConstraintsCounter;
-        GCSsys.addConstraintC2CDistance(*c1, *c2, value, tag, driving);
+
+        std::optional<bool> c1Bigger = std::nullopt;
+        if (orientation.testFlag(ConstraintOrientations::Internal)) {
+            c1Bigger = false;
+        }
+        else if (orientation.testFlag(ConstraintOrientations::External)) {
+            c1Bigger = true;
+        }
+
+        GCSsys.addConstraintC2CDistance(*c1, *c2, value, c1Bigger, tag, driving);
         return ConstraintsCounter;
     }
 }

--- a/src/Mod/Sketcher/App/Sketch.h
+++ b/src/Mod/Sketcher/App/Sketch.h
@@ -341,7 +341,14 @@ public:
      *   constraint value and already inserted into either the FixParameters or
      *   Parameters array, as the case may be.
      */
-    int addDistanceConstraint(int geoId1, PointPos pos1, int geoId2, double* value, bool driving = true);
+    int addDistanceConstraint(
+        int geoId1,
+        PointPos pos1,
+        int geoId2,
+        double* value,
+        ConstraintOrientation orientation,
+        bool driving = true
+    );
     /**
      *   add a length or distance constraint
      *
@@ -364,7 +371,13 @@ public:
      *   constraint value and already inserted into either the FixParameters or
      *   Parameters array, as the case may be.
      */
-    int addDistanceConstraint(int geoId1, int geoId2, double* value, bool driving = true);
+    int addDistanceConstraint(
+        int geoId1,
+        int geoId2,
+        double* value,
+        ConstraintOrientation orientation,
+        bool driving = true
+    );
 
     /// add a parallel constraint between two lines
     int addParallelConstraint(int geoId1, int geoId2);

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -56,6 +56,7 @@
 
 #include "GeoEnum.h"
 #include "SketchObject.h"
+#include "Constraint.h"
 #include "SketchObjectPy.h"
 #include "ExternalGeometryFacade.h"
 
@@ -1442,6 +1443,16 @@ void SketchObject::migrateSketch()
 
             g->deleteExtension(Part::GeometryMigrationExtension::getClassTypeId());
         }
+    }
+
+    {
+        // Migrate point-line, circle-circle and circle-line distance from abs to signed
+        auto constraints = Constraints.getValues();
+        for (auto& constr : constraints) {
+            setOrientation(constr, false);
+        }
+
+        Constraints.setValues(std::move(constraints));
     }
 
     /* parabola axis as internal geometry */

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1136,6 +1136,13 @@ protected:
         Sketcher::PointPos thirdPos = Sketcher::PointPos::none
     );
 
+    // sets the constraint's orientation flag
+    // if applicable using the geometric state
+    // if reset is set to false, the function
+    // will return early when the constraint
+    // already has an orientation
+    void setOrientation(Constraint* constr, bool reset);
+
 public:
     // FIXME: These may not need to be public. Decide before merging.
     std::unique_ptr<Constraint> getConstraintAfterDeletingGeo(

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -244,6 +244,7 @@ int SketchObject::setDriving(int ConstrId, bool isdriving)
     std::vector<Constraint*> newVals(vals);
     newVals[ConstrId] = newVals[ConstrId]->clone();
     newVals[ConstrId]->isDriving = isdriving;
+    setOrientation(newVals[ConstrId], newVals[ConstrId]->isDriving);
 
     this->Constraints.setValues(std::move(newVals));
 
@@ -306,6 +307,8 @@ int SketchObject::setActive(int ConstrId, bool isactive)
     // clone the changed Constraint
     Constraint* constNew = vals[ConstrId]->clone();
     constNew->isActive = isactive;
+    setOrientation(constNew, constNew->isActive);
+
     newVals[ConstrId] = constNew;
     this->Constraints.setValues(std::move(newVals));
 
@@ -363,6 +366,8 @@ int SketchObject::toggleActive(int ConstrId)
     // clone the changed Constraint
     Constraint* constNew = vals[ConstrId]->clone();
     constNew->isActive = !constNew->isActive;
+    setOrientation(constNew, constNew->isActive);
+
     newVals[ConstrId] = constNew;
     this->Constraints.setValues(std::move(newVals));
 
@@ -868,6 +873,8 @@ int SketchObject::addConstraints(const std::vector<Constraint*>& ConstraintList)
             AutoLockTangencyAndPerpty(cnew);
         }
 
+        setOrientation(cnew, false);
+
         addGeometryState(cnew);
 
         signalConstraintAdded(cnew);
@@ -939,9 +946,11 @@ int SketchObject::addConstraint(std::unique_ptr<Constraint> constraint)
 
     Constraint* constNew = constraint.release();
 
-    if (constNew->Type == Tangent || constNew->Type == Perpendicular)
+    if (constNew->Type == Tangent || constNew->Type == Perpendicular) {
         AutoLockTangencyAndPerpty(constNew);
-
+    }
+    setOrientation(constNew, false);
+    
     addGeometryState(constNew);
 
     signalConstraintAdded(constNew);
@@ -1400,7 +1409,63 @@ void SketchObject::addConstraint(Sketcher::ConstraintType constrType, int firstG
 
     this->addConstraint(std::move(newConstr));
 }
+void SketchObject::setOrientation(Constraint* constr, bool reset)
+{
+    // Returns true if the points A-B-C truncated to 2d (x, y) are in a ccw order
+    auto ccw2d = [](const Base::Vector3d& A, const Base::Vector3d& B, const Base::Vector3d& C) -> ConstraintOrientations
+    {
+        double signedArea = B.x * C.y - B.y * C.x - A.x * C.y + A.y * C.x + A.x * B.y - A.y * B.x;
+        return signedArea > 0.0 ? ConstraintOrientations::CounterClockwise : ConstraintOrientations::Clockwise;
+    };
 
+    if (constr->Type != Distance || (!reset && !constr->Orientation.testFlag(ConstraintOrientations::None))) {
+        return;
+    }
+
+    // Try to find the orientation of point-line distance
+    if (constr->FirstPos != PointPos::none && constr->Second != GeoEnum::GeoUndef) {
+        auto* geo1AsLine = freecad_cast<const Part::GeomLineSegment*>(getGeometry(constr->Second));
+        if (geo1AsLine) {
+            constr->Orientation = ccw2d(geo1AsLine->getStartPoint(), geo1AsLine->getEndPoint(), getPoint(constr->First, constr->FirstPos));
+        }
+        return;
+    }
+
+    // Try to find the orientation of circle-circle distance or circle-line
+    if (constr->FirstPos == PointPos::none && constr->SecondPos == PointPos::none && constr->Second != GeoEnum::GeoUndef) {
+        const Part::Geometry* firGeo = getGeometry(constr->First);
+        const Part::Geometry* secGeo = getGeometry(constr->Second);
+        auto* geo1AsCirc = freecad_cast<const Part::GeomCircle*>(firGeo);
+        auto* geo2AsCirc = freecad_cast<const Part::GeomCircle*>(secGeo);
+
+        if (geo1AsCirc && geo2AsCirc) { // circle-circle distance
+
+            // If one of the circle is completly within the other, we will say that
+            // it is internal, if they are not within each other or intersect we won't
+            // make a call
+
+            double centerDistance = Base::Distance(geo1AsCirc->getLocation(), geo2AsCirc->getLocation());
+
+            auto circ1Radius = geo1AsCirc->getRadius();
+            auto circ2Radius = geo2AsCirc->getRadius();
+            if (centerDistance + circ1Radius < circ2Radius) {
+                constr->Orientation = ConstraintOrientations::Internal; // Circ1 is within circ2
+            } else if (centerDistance + circ2Radius < circ1Radius) {
+                constr->Orientation = ConstraintOrientations::External; // Circ2 is within circ1
+            }
+            return;
+        }
+
+        auto* geo2AsLine = freecad_cast<const Part::GeomLineSegment*>(secGeo);
+        if (geo1AsCirc && geo2AsLine) { // circle-line distance
+            bool internal = geo1AsCirc->getLocation().DistanceToLine(geo2AsLine->getStartPoint(), geo2AsLine->getEndPoint()-geo2AsLine->getStartPoint()) < geo1AsCirc->getRadius();
+            auto ccw = ccw2d(geo2AsLine->getStartPoint(), geo2AsLine->getEndPoint(), geo1AsCirc->getLocation());
+
+            constr->Orientation = ccw | (internal ? ConstraintOrientations::Internal : ConstraintOrientations::External);
+        }
+    }
+
+}
 std::unique_ptr<Constraint>
 SketchObject::getConstraintAfterDeletingGeo(const Constraint* constr,
                                             const int deletedGeoId) const

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -950,7 +950,7 @@ int SketchObject::addConstraint(std::unique_ptr<Constraint> constraint)
         AutoLockTangencyAndPerpty(constNew);
     }
     setOrientation(constNew, false);
-    
+
     addGeometryState(constNew);
 
     signalConstraintAdded(constNew);

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -1440,8 +1440,8 @@ void SketchObject::setOrientation(Constraint* constr, bool reset)
 
         if (geo1AsCirc && geo2AsCirc) { // circle-circle distance
 
-            // If one of the circle is completly within the other, we will say that
-            // it is internal, if they are not within each other or intersect we won't
+            // If one of the circles is completely within the other, we will say that
+            // it is internal, if they are not within each other orcompletly intersect we won't
             // make a call
 
             double centerDistance = Base::Distance(geo1AsCirc->getLocation(), geo2AsCirc->getLocation());

--- a/src/Mod/Sketcher/App/planegcs/Constraints.cpp
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.cpp
@@ -860,7 +860,8 @@ void ConstraintP2PAngle::evaluate()
 
 // --------------------------------------------------------
 // P2LDistance
-ConstraintP2LDistance::ConstraintP2LDistance(Point& p, Line& l, double* d)
+ConstraintP2LDistance::ConstraintP2LDistance(Point& p, Line& l, double* d, bool ccw)
+    : ccw(ccw)
 {
     pvec.push_back(p.x);
     pvec.push_back(p.y);
@@ -880,18 +881,23 @@ ConstraintType ConstraintP2LDistance::getTypeId()
 
 double ConstraintP2LDistance::value()
 {
+    return std::abs(signed_value());
+}
+double ConstraintP2LDistance::signed_value()
+{
     double x0 = *p0x(), x1 = *p1x(), x2 = *p2x();
     double y0 = *p0y(), y1 = *p1y(), y2 = *p2y();
     double dx = x2 - x1;
     double dy = y2 - y1;
     double d = sqrt(dx * dx + dy * dy);  // line length
     double area = -x0 * dy + y0 * dx + x1 * y2 - x2 * y1;
-    return std::abs(area / d);
+    return area / d;
 }
 double ConstraintP2LDistance::error()
 {
-    double dist = *distance();
-    return scale * (value() - dist);
+    double dist = ccw ? *distance() : -*distance();
+
+    return scale * (signed_value() - dist);
 }
 
 double ConstraintP2LDistance::grad(double* param)
@@ -907,6 +913,7 @@ double ConstraintP2LDistance::grad(double* param)
         double d2 = dx * dx + dy * dy;
         double d = sqrt(d2);
         double area = -x0 * dy + y0 * dx + x1 * y2 - x2 * y1;
+
         if (param == p0x()) {
             deriv += (y1 - y2) / d;
         }
@@ -925,12 +932,6 @@ double ConstraintP2LDistance::grad(double* param)
         if (param == p2y()) {
             deriv += ((x1 - x0) * d - (dy / d) * area) / d2;
         }
-        if (area < 0) {
-            deriv *= -1;
-        }
-    }
-    if (param == distance()) {
-        deriv += -1;
     }
 
     return scale * deriv;
@@ -2885,9 +2886,10 @@ void ConstraintEqualLineLength::errorgrad(double* err, double* grad, double* par
 
 // --------------------------------------------------------
 // ConstraintC2CDistance
-ConstraintC2CDistance::ConstraintC2CDistance(Circle& c1, Circle& c2, double* d)
+ConstraintC2CDistance::ConstraintC2CDistance(Circle& c1, Circle& c2, double* d, std::optional<bool> c1Bigger)
     : c1(c1)
     , c2(c2)
+    , c1Bigger(c1Bigger)
 {
     pvec.push_back(d);
     this->c1.PushOwnParams(pvec);
@@ -2928,13 +2930,26 @@ void ConstraintC2CDistance::errorgrad(double* err, double* grad, double* param)
             *err = length_ct12 - (*c2.rad + *c1.rad + *distance());
         }
         else if (grad) {
-            double drad = (param == c2.rad || param == c1.rad || param == distance()) ? -1.0 : 0.0;
+            double drad = (param == c2.rad || param == c1.rad) ? -1.0 : 0.0;
             *grad = dlength_ct12 + drad;
         }
     }
     else {
-        double* bigradius = (*c1.rad >= *c2.rad) ? c1.rad : c2.rad;
-        double* smallradius = (*c1.rad >= *c2.rad) ? c2.rad : c1.rad;
+        double* bigradius = nullptr;
+        double* smallradius = nullptr;
+
+        if (!c1Bigger.has_value()) {
+            bigradius = (*c1.rad >= *c2.rad) ? c1.rad : c2.rad;
+            smallradius = (*c1.rad >= *c2.rad) ? c2.rad : c1.rad;
+        }
+        else if (*c1Bigger) {
+            bigradius = c1.rad;
+            smallradius = c2.rad;
+        }
+        else {  // c2Bigger
+            bigradius = c2.rad;
+            smallradius = c1.rad;
+        }
 
         double smallspan = *smallradius + length_ct12 + *distance();
 
@@ -2980,9 +2995,11 @@ void ConstraintC2CDistance::evaluate()
 
 // --------------------------------------------------------
 // ConstraintC2LDistance
-ConstraintC2LDistance::ConstraintC2LDistance(Circle& c, Line& l, double* d)
+ConstraintC2LDistance::ConstraintC2LDistance(Circle& c, Line& l, double* d, bool ccw, bool internal)
     : circle(c)
     , line(l)
+    , ccw(ccw)
+    , internal(internal)
 {
     pvec.push_back(d);
     this->circle.PushOwnParams(pvec);
@@ -3006,7 +3023,7 @@ void ConstraintC2LDistance::reconstructGeomPointers()
     line.ReconstructOnNewPvec(pvec, i);
 }
 
-double ConstraintC2LDistance::value(double& deriValue, double* param)
+double ConstraintC2LDistance::signed_value(double& deriValue, double* param)
 {
     DeriVector2 ct(circle.center, param);
     DeriVector2 p1(line.p1, param);
@@ -3027,13 +3044,9 @@ double ConstraintC2LDistance::value(double& deriValue, double* param)
     // the base, which is the distance from the center of the circle to the line.
     //
     // However, the vector (which points in z direction), can be positive or negative.
-    // the area is the absolute value
-    double h = std::abs(area) / length;
-
-    // darea is the magnitude of a vector in the z direction, which makes the area vector
-    // increase or decrease. If area vector is negative a negative value makes the area increase
-    // and a positive value makes it decrease.
-    darea = std::signbit(area) ? -darea : darea;
+    // here our area is signed which does not make geometric sense, but allows
+    // us to solve for a signed distance
+    double h = area / length;
 
     deriValue = (darea - h * dlength) / length;
 
@@ -3042,24 +3055,22 @@ double ConstraintC2LDistance::value(double& deriValue, double* param)
 void ConstraintC2LDistance::errorgrad(double* err, double* grad, double* param)
 {
     double h, dh;
-    h = value(dh, param);
+    h = signed_value(dh, param);
 
     if (err) {
-        if (h < *circle.rad) {
-            *err = *circle.rad - std::abs(*distance()) - h;
+        double target;
+        if (internal) {
+            target = *circle.rad - std::abs(*distance());
         }
         else {
-            *err = *circle.rad + std::abs(*distance()) - h;
+            target = *circle.rad + std::abs(*distance());
         }
+        target = ccw ? target : -target;  // Solve for one side of the line or the other
+        *err = target - h;
     }
     else if (grad) {
-        if (param == distance() || param == circle.rad) {
-            if (h < *circle.rad) {
-                *grad = -1.0;
-            }
-            else {
-                *grad = 1.0;
-            }
+        if (param == circle.rad) {
+            *grad = ccw ? 1.0 : -1.0;
         }
         else {
             *grad = -dh;
@@ -3069,7 +3080,7 @@ void ConstraintC2LDistance::errorgrad(double* err, double* grad, double* param)
 void ConstraintC2LDistance::evaluate()
 {
     double h, dh;
-    h = value(dh, nullptr);
+    h = std::abs(signed_value(dh, nullptr));
 
     if (h < *circle.rad) {
         *distance() = *circle.rad - h;

--- a/src/Mod/Sketcher/App/planegcs/Constraints.h
+++ b/src/Mod/Sketcher/App/planegcs/Constraints.h
@@ -26,6 +26,7 @@
 
 #include "../../SketcherGlobal.h"
 #include "Geo.h"
+#include <optional>
 
 // This enables debugging code intended to extract information to file bug reports against Eigen,
 // not for production code
@@ -503,6 +504,8 @@ public:
 class ConstraintP2LDistance: public Constraint
 {
 private:
+    bool ccw;
+
     double* p0x()
     {
         return pvec[0];
@@ -532,9 +535,10 @@ private:
         return pvec[6];
     }
     double value();
+    double signed_value();
 
 public:
-    ConstraintP2LDistance(Point& p, Line& l, double* d);
+    ConstraintP2LDistance(Point& p, Line& l, double* d, bool ccw);
 #ifdef _GCS_EXTRACT_SOLVER_SUBSYSTEM_
     ConstraintP2LDistance()
     {}
@@ -1309,9 +1313,12 @@ public:
 
 class ConstraintC2CDistance: public Constraint
 {
+public:
 private:
     Circle c1;
     Circle c2;
+    std::optional<bool> c1Bigger;
+
     double* distance()
     {
         return pvec[0];
@@ -1322,7 +1329,7 @@ private:
     void evaluate() override;
 
 public:
-    ConstraintC2CDistance(Circle& c1, Circle& c2, double* d);
+    ConstraintC2CDistance(Circle& c1, Circle& c2, double* d, std::optional<bool> c1Bigger);
     ConstraintType getTypeId() override;
 };
 
@@ -1332,6 +1339,9 @@ class ConstraintC2LDistance: public Constraint
 private:
     Circle circle;
     Line line;
+    bool ccw;
+    bool internal;
+
     double* distance()
     {
         return pvec[0];
@@ -1339,12 +1349,12 @@ private:
     // writes pointers in pvec to the parameters of c, l
     void reconstructGeomPointers() override;
 
-    double value(double& deriValue, double* param);
+    double signed_value(double& deriValue, double* param);
     void errorgrad(double* err, double* grad, double* param) override;
     void evaluate() override;
 
 public:
-    ConstraintC2LDistance(Circle& c, Line& l, double* d);
+    ConstraintC2LDistance(Circle& c, Line& l, double* d, bool ccw, bool internal);
     ConstraintType getTypeId() override;
 };
 

--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -655,9 +655,9 @@ int System::addConstraintP2PAngle(Point& p1, Point& p2, double* angle, int /*tag
     return addConstraintP2PAngle(p1, p2, angle, 0., 0, driving);
 }
 
-int System::addConstraintP2LDistance(Point& p, Line& l, double* distance, int tagId, bool driving)
+int System::addConstraintP2LDistance(Point& p, Line& l, double* distance, bool ccw, int tagId, bool driving)
 {
-    Constraint* constr = new ConstraintP2LDistance(p, l, distance);
+    Constraint* constr = new ConstraintP2LDistance(p, l, distance, ccw);
     constr->setTag(tagId);
     constr->setDriving(driving);
     return addConstraint(constr);
@@ -869,17 +869,32 @@ int System::addConstraintTangentAtBSplineKnot(
     return addConstraint(constr);
 }
 
-int System::addConstraintC2CDistance(Circle& c1, Circle& c2, double* dist, int tagId, bool driving)
+int System::addConstraintC2CDistance(
+    Circle& c1,
+    Circle& c2,
+    double* dist,
+    std::optional<bool> c1bigger,
+    int tagId,
+    bool driving
+)
 {
-    Constraint* constr = new ConstraintC2CDistance(c1, c2, dist);
+    Constraint* constr = new ConstraintC2CDistance(c1, c2, dist, c1bigger);
     constr->setTag(tagId);
     constr->setDriving(driving);
     return addConstraint(constr);
 }
 
-int System::addConstraintC2LDistance(Circle& c, Line& l, double* dist, int tagId, bool driving)
+int System::addConstraintC2LDistance(
+    Circle& c,
+    Line& l,
+    double* dist,
+    bool ccw,
+    bool internal,
+    int tagId,
+    bool driving
+)
 {
-    Constraint* constr = new ConstraintC2LDistance(c, l, dist);
+    Constraint* constr = new ConstraintC2LDistance(c, l, dist, ccw, internal);
     constr->setTag(tagId);
     constr->setDriving(driving);
     return addConstraint(constr);

--- a/src/Mod/Sketcher/App/planegcs/GCS.h
+++ b/src/Mod/Sketcher/App/planegcs/GCS.h
@@ -300,7 +300,14 @@ public:
         bool driving = true
     );
     int addConstraintP2PAngle(Point& p1, Point& p2, double* angle, int tagId = 0, bool driving = true);
-    int addConstraintP2LDistance(Point& p, Line& l, double* distance, int tagId = 0, bool driving = true);
+    int addConstraintP2LDistance(
+        Point& p,
+        Line& l,
+        double* distance,
+        bool ccw,
+        int tagId = 0,
+        bool driving = true
+    );
     int addConstraintPointOnLine(Point& p, Line& l, int tagId = 0, bool driving = true);
     int addConstraintPointOnLine(Point& p, Point& lp1, Point& lp2, int tagId = 0, bool driving = true);
     int addConstraintPointOnPerpBisector(Point& p, Line& l, int tagId = 0, bool driving = true);
@@ -476,8 +483,23 @@ public:
         bool driving = true
     );
 
-    int addConstraintC2CDistance(Circle& c1, Circle& c2, double* dist, int tagId, bool driving = true);
-    int addConstraintC2LDistance(Circle& c, Line& l, double* dist, int tagId, bool driving = true);
+    int addConstraintC2CDistance(
+        Circle& c1,
+        Circle& c2,
+        double* dist,
+        std::optional<bool> c1bigger,
+        int tagId,
+        bool driving = true
+    );
+    int addConstraintC2LDistance(
+        Circle& c,
+        Line& l,
+        double* dist,
+        bool ccw,
+        bool internal,
+        int tagId,
+        bool driving = true
+    );
     int addConstraintP2CDistance(Point& p, Circle& c, double* distance, int tagId = 0, bool driving = true);
     int addConstraintArcLength(Arc& a, double* dist, int tagId, bool driving = true);
 

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherSolver.py
@@ -483,6 +483,7 @@ class TestSketcherSolver(unittest.TestCase):
         )
 
     def testCircleToLineDistance_Legacy_Negative(self):
+        # TestSketcherApp.TestSketcherSolver.testCircleToLineDistance_Legacy_Negative
         # compare a driving negative distance to an expected positive reference one
         sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
         radius = 20
@@ -509,6 +510,181 @@ class TestSketcherSolver(unittest.TestCase):
             delta=Precision.confusion(),
             msg="Negative length constraint did not return the expected distance.",
         )
+
+    def testCircleToLineDistanceOriented(self):
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        radius = 20
+
+        c_idx = sketch.addGeometry(Part.Circle(vec(0, 0), xy_normal, radius))
+        l_left_ext = sketch.addGeometry(
+            Part.LineSegment(vec(-2 * radius, -20), vec(-2 * radius, 20))
+        )
+        l_left_int = sketch.addGeometry(
+            Part.LineSegment(vec(-0.5 * radius, -20), vec(-0.5 * radius, 20))
+        )
+        l_right_ext = sketch.addGeometry(
+            Part.LineSegment(vec(2 * radius, -20), vec(2 * radius, 20))
+        )
+        l_right_int = sketch.addGeometry(
+            Part.LineSegment(vec(0.5 * radius, -20), vec(0.5 * radius, 20))
+        )
+
+        radius_idx = sketch.addConstraint(
+            [
+                Sketcher.Constraint("Coincident", c_idx, 3, -1, 1),  # constrain circle to origin
+                Sketcher.Constraint("Vertical", l_left_ext),
+                Sketcher.Constraint("Vertical", l_left_int),
+                Sketcher.Constraint("Vertical", l_right_ext),
+                Sketcher.Constraint("Vertical", l_right_int),
+                Sketcher.Constraint("Distance", c_idx, l_left_ext, 0.25 * radius),
+                Sketcher.Constraint("Distance", c_idx, l_left_int, 0.25 * radius),
+                Sketcher.Constraint("Distance", c_idx, l_right_ext, 0.25 * radius),
+                Sketcher.Constraint("Distance", c_idx, l_right_int, 0.25 * radius),
+                Sketcher.Constraint("Radius", c_idx, radius),
+            ]
+        )[-1]
+
+        self.assertSuccessfulSolve(sketch)
+
+        self.assertLess(sketch.Geometry[l_left_ext].StartPoint.x, -radius)
+        self.assertLess(sketch.Geometry[l_left_int].StartPoint.x, 0)
+        self.assertGreater(sketch.Geometry[l_left_int].StartPoint.x, -radius)
+
+        self.assertGreater(sketch.Geometry[l_right_ext].StartPoint.x, radius)
+        self.assertGreater(sketch.Geometry[l_right_int].StartPoint.x, 0)
+        self.assertLess(sketch.Geometry[l_right_int].StartPoint.x, radius)
+
+        # Try to flip the sketch
+        radius = 200.0
+        sketch.setDatum(radius_idx, App.Units.Quantity("{} mm".format(radius)))
+
+        self.assertSuccessfulSolve(sketch)
+
+        self.assertLess(sketch.Geometry[l_left_ext].StartPoint.x, -radius)
+        self.assertLess(sketch.Geometry[l_left_int].StartPoint.x, 0)
+        self.assertGreater(sketch.Geometry[l_left_int].StartPoint.x, -radius)
+
+        self.assertGreater(sketch.Geometry[l_right_ext].StartPoint.x, radius)
+        self.assertGreater(sketch.Geometry[l_right_int].StartPoint.x, 0)
+        self.assertLess(sketch.Geometry[l_right_int].StartPoint.x, radius)
+
+    def testPointToLineDistanceSigned(self):
+        # Test the signed p2l constraint by trying to flip the sketch
+        # with a big constraint datum change
+
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+
+        lv_idx = sketch.addGeometry(Part.LineSegment(vec(0, -25), vec(0, 0)))
+        lh_idx = sketch.addGeometry(Part.LineSegment(vec(0, 0), vec(25, 0)))
+        ln_idx = sketch.addGeometry(Part.LineSegment(vec(0, -25), vec(25, 0)))
+        pt_idx = sketch.addGeometry(Part.Point(vec(20, -20)))
+
+        linepose_idx = sketch.addConstraint(
+            [
+                Sketcher.Constraint("PointOnObject", lv_idx, 1, -2),
+                Sketcher.Constraint("Coincident", lv_idx, 2, -1, 1),
+                Sketcher.Constraint("Coincident", lh_idx, 1, lv_idx, 2),
+                Sketcher.Constraint("PointOnObject", lh_idx, 2, -1),
+                Sketcher.Constraint("Coincident", ln_idx, 1, lv_idx, 1),
+                Sketcher.Constraint("Coincident", ln_idx, 2, lh_idx, 2),
+                Sketcher.Constraint("Equal", lv_idx, lh_idx),
+                Sketcher.Constraint("DistanceX", lh_idx, 1, lh_idx, 2, 25.0),
+                Sketcher.Constraint("Distance", pt_idx, 1, ln_idx, 5.0),
+            ]
+        )[7]
+
+        self.assertSuccessfulSolve(sketch)
+
+        sketch.setDatum(linepose_idx, App.Units.Quantity("100.000000 mm"))
+
+        self.assertSuccessfulSolve(sketch)
+
+        A = sketch.Geometry[pt_idx]
+        ln = sketch.Geometry[ln_idx]
+        B = ln.StartPoint
+        C = ln.EndPoint
+
+        ccw = B.x * C.y - B.y * C.x - A.X * C.y + A.Y * C.x + A.X * B.y - A.Y * B.x > 0.0
+
+        self.assertEqual(ccw, False)
+
+    def testCircleToCircleDistanceOriented(self):
+        # Make a set of two circles a small and a big
+        # the small is fully contained in the big
+        # add a distance between the small and the big
+        # then set the small's diameter to a big value
+        # it should remain smaller
+        # tests concentric and non concentric and both distance orders (small-big, big-small)
+
+        sketch = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+
+        sm1_idx = sketch.addGeometry(
+            Part.Circle(App.Vector(-27.105705, 20.597332, 0.000000), xy_normal, 9.964653)
+        )
+        bg1_idx = sketch.addGeometry(
+            Part.Circle(App.Vector(-27.105705, 20.597332, 0.000000), xy_normal, 19.924598)
+        )
+
+        sm2_idx = sketch.addGeometry(
+            Part.Circle(App.Vector(-21.745829, -21.056572, 0.000000), xy_normal, 9.019634)
+        )
+        bg2_idx = sketch.addGeometry(
+            Part.Circle(App.Vector(-27.871407, -22.434828, 0.000000), xy_normal, 18.524801)
+        )
+
+        sm3_idx = sketch.addGeometry(
+            Part.Circle(App.Vector(27.565046, 20.750475, 0.000000), xy_normal, 12.809815)
+        )
+        bg3_idx = sketch.addGeometry(
+            Part.Circle(App.Vector(27.565046, 20.750475, 0.000000), xy_normal, 22.553629)
+        )
+
+        sm4_idx = sketch.addGeometry(
+            Part.Circle(App.Vector(20.980043, -21.822269, 0.000000), xy_normal, 10.010452)
+        )
+        bg4_idx = sketch.addGeometry(
+            Part.Circle(App.Vector(29.249569, -24.272499, 0.000000), xy_normal, 22.875263)
+        )
+
+        sm_diam = sketch.addConstraint(
+            [
+                Sketcher.Constraint("Coincident", bg1_idx, 3, sm1_idx, 3),
+                Sketcher.Constraint("Coincident", sm3_idx, 3, bg3_idx, 3),
+                Sketcher.Constraint("Equal", sm1_idx, sm2_idx),
+                Sketcher.Constraint("Equal", sm2_idx, sm3_idx),
+                Sketcher.Constraint("Equal", sm3_idx, sm4_idx),
+                Sketcher.Constraint("Diameter", sm1_idx, 20.0),
+                Sketcher.Constraint("Distance", sm2_idx, bg2_idx, 3.0),
+                Sketcher.Constraint("Distance", sm4_idx, bg4_idx, 4.0),
+                Sketcher.Constraint("Distance", bg3_idx, sm3_idx, 5.0),
+                Sketcher.Constraint("Distance", bg1_idx, sm1_idx, 6.0),
+            ]
+        )[5]
+
+        self.assertSuccessfulSolve(sketch)
+
+        # Change the small radiuses by a big amount
+
+        sketch.setDatum(sm_diam, App.Units.Quantity("100.00 mm"))
+
+        self.assertSuccessfulSolve(sketch)
+
+        sm1 = sketch.Geometry[sm1_idx]
+        bg1 = sketch.Geometry[bg1_idx]
+
+        sm2 = sketch.Geometry[sm2_idx]
+        bg2 = sketch.Geometry[bg2_idx]
+
+        sm3 = sketch.Geometry[sm3_idx]
+        bg3 = sketch.Geometry[bg3_idx]
+
+        sm4 = sketch.Geometry[sm4_idx]
+        bg4 = sketch.Geometry[bg4_idx]
+
+        self.assertGreater(bg1.Radius, sm1.Radius)
+        self.assertGreater(bg2.Radius, sm2.Radius)
+        self.assertGreater(bg3.Radius, sm3.Radius)
+        self.assertGreater(bg4.Radius, sm4.Radius)
 
     def testRemovedExternalGeometryReference(self):
         if "BUILD_PARTDESIGN" in FreeCAD.__cmake__:


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This PR adds a concept of orientation to 
* point-line distance
* circle-circle distance
* circle-line distance

to make sketches harder to flip

The orientation is saved to file and handled by the App::Constraint rather than the planegcs::Constraint to better capture design intent (it allows to react to external geometry movement, which the solver is blind to)

The orientation is computed on sketch restore so older files are upgraded seamlessly

The constraints can still be made driven or deactivated and their orientation is recomputed when made driving/reactivated so the user can manually flip them

### Point-Line distance

This PR makes point-line constraints signed which prevents flips when constraints values change drastically or a reference geometry moves around


Before:

https://github.com/user-attachments/assets/067c3eaa-dccc-41c4-bf05-593ff31fcc67


After:

https://github.com/user-attachments/assets/dc51966d-09bd-4e82-951d-146add91a0b1


### Circle-Circle distance

This PR adds a concept of relative size for circle-circle distance which allows to keep an inner circle and an outer circle when one of the circles is completely within the other 

Before:

https://github.com/user-attachments/assets/4a22a54f-5805-477d-b9ba-50ac31c54c6a

After:

https://github.com/user-attachments/assets/3f9d76b8-781e-4a32-bbca-a41cc3573e59

### Circle-Line distance

This PR adds an orientation concept to circle-line distances. 4 possible orientations are established with 2 flags: ccw and internal. 

A ccw orientation means that the sequence [line.pt1, line.pt2, circle.center] is and should remain ccw, this is the same as the point-line distance orientation from https://github.com/FreeCAD/FreeCAD/pull/26228/changes

An internal orientation means that the line is and should remain closer to the center then the radius of the circle

Before:


https://github.com/user-attachments/assets/c0e889eb-0232-4efc-a7fd-a041266ee6bf


After:

https://github.com/user-attachments/assets/8d47a307-3f2c-4805-aff1-fef320a8738c




<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Issues
Fix: https://github.com/FreeCAD/FreeCAD/issues/26634
Fix https://github.com/FreeCAD/FreeCAD/issues/17579


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
