### PR TITLE
FEM: sanitize NAN format on frd import

### DIFF
--- a/src/Mod/Fem/feminout/importCcxFrdResults.py
+++ b/src/Mod/Fem/feminout/importCcxFrdResults.py
@@ -383,6 +383,9 @@ def read_frd_result(frd_input):
 
     for line in frd_file:
 
+        # depending on c runtime lib and possibly locale calculix may format NAN differently so we
+        # need to sanitize the file
+        line = line.replace("NAN(IND)", "NAN")
         # Check if we found nodes section
         if line[4:6] == "2C":
             nodes_found = True


### PR DESCRIPTION
depending on c runtime lib and possibly locale calculix may format NAN differently so we need to sanitize when importing the results

this is part of the fix for #18368