### PR TITLE
Gui: fix skip grabMouse on Wayland

### DIFF
--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -2013,7 +2013,10 @@ bool OverlayManager::eventFilter(QObject* o, QEvent* ev)
                 hitWidget->setFocus();
                 d->_trackingWidget = hitWidget;
                 d->_trackingOverlay = activeTabWidget;
-                d->_trackingOverlay->grabMouse();
+                // Wayland doesn't allow mouse grab
+                if (QGuiApplication::platformName() != QLatin1String("wayland")) {
+                    d->_trackingOverlay->grabMouse();
+                }
             }
             return true;
         }
@@ -2038,7 +2041,10 @@ public:
     ~MouseGrabberGuard()
     {
         if (_grabber) {
-            _grabber->grabMouse();
+            // Wayland doesn't allow mouse grab
+            if (QGuiApplication::platformName() != QLatin1String("wayland")) {
+                _grabber->grabMouse();
+            }
         }
     }
 


### PR DESCRIPTION
this fixes some instances of the warning message of `This plugin supports grabbing the mouse only for popup windows` 

it seems one instance of this warning remains in the treeview splitter/dragger but i cannot find what causes that one