### PR TITLE
CAM: EngraveBase - OpFinalDepth

### DIFF
--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -174,9 +174,13 @@ class ObjectOp(PathOp.ObjectOp):
     def opSetDefaultValues(self, obj, job):
         """opSetDefaultValues(obj) ... set depths for engraving"""
         if PathOp.FeatureDepths & self.opFeatures(obj):
-            if job and len(job.Model.Group) > 0:
-                bb = job.Proxy.modelBoundBox(job)
-                obj.OpStartDepth = bb.ZMax
-                obj.OpFinalDepth = bb.ZMax - max(obj.StepDown.Value, 0.1)
-            else:
-                obj.OpFinalDepth = -0.1
+            if job and job.Stock:
+                obj.OpStartDepth = job.Stock.Shape.BoundBox.ZMax
+                obj.OpFinalDepth = job.Stock.Shape.BoundBox.ZMax
+
+            if obj.Base:
+                obj.OpFinalDepth = obj.Base[0][0].Shape.BoundBox.ZMax
+            elif obj.BaseShapes:
+                obj.OpFinalDepth = obj.BaseShapes[0].Shape.BoundBox.ZMax
+
+            obj.OpStartDepth = max(obj.OpStartDepth, obj.OpFinalDepth)


### PR DESCRIPTION
Fixes #26542 
- #26542 

**Before:**
`OpFinalDepth` depends from `StepDown`

**After:**
`OpFinalDepth` depends from stock and engraving shape

<img width="866" height="622" alt="Screenshot_20260222_170507_hor_lossy" src="https://github.com/user-attachments/assets/25c4b288-9a1d-4eea-9e17-c7980281390e" />
