### PR TITLE
Sketcher: Fix snap to axis not working

### DIFF
--- a/src/Mod/Sketcher/Gui/SnapManager.cpp
+++ b/src/Mod/Sketcher/Gui/SnapManager.cpp
@@ -407,4 +407,3 @@ Base::Vector2d SketcherGui::SnapManager::SnapHandle::compute(SnapType mask)
     }
     return mgr->snap(cursorPos, mask);
 }
-


### PR DESCRIPTION
When snapping to an axis, snapToObject returns false because we should also be able to snap to grid at the same time. Recent changes made the end return to be the initial unmodified position. Breaking snap to axis

Fix https://github.com/FreeCAD/FreeCAD/issues/26556

@matthiasdanner 