### PR TITLE
Improve error message for empty transformed features

### DIFF
--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -103,7 +103,15 @@ Part::Feature* Transformed::getBaseObject(bool silent) const
         }
     }
     else {
-        err = QT_TRANSLATE_NOOP("Exception", "No originals linked to the transformed feature.");
+        if (freecad_cast<const Mirrored*>(this)) {
+            err = QT_TRANSLATE_NOOP("Exception", "No features selected to be mirrored.");
+        }
+        else if (freecad_cast<const LinearPattern*>(this) || freecad_cast<const PolarPattern*>(this)) {
+            err = QT_TRANSLATE_NOOP("Exception", "No features selected to be patterned.");
+        }
+        else {
+            err = QT_TRANSLATE_NOOP("Exception", "No features selected to be transformed.");
+        }
     }
 
     if (!silent && err) {


### PR DESCRIPTION
This PR improves the error feedback when a user creates a Mirrored, LinearPattern, or PolarPattern feature (or other Transformed features) without selecting any base features to transform.

Previously, the error message was "No originals linked to the transformed feature.", which used internal terminology ("originals", "transformed feature") confusing to end-users.

The new messages are context-aware:
- "No features selected to be mirrored."
- "No features selected to be patterned."
- "No features selected to be transformed." (Fallback)

## Issues
fixes #26138

## Impact
This change only affects the error message string displayed to the user. It does not alter the underlying logic of the feature creation.
