### PR TITLE
Gui: Reorder Add Property dialog fields to Name-Value-Group-Type

### DIFF
--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -537,11 +537,12 @@ void DlgAddProperty::initializeWidgets(ViewProviderVarSet* viewProvider)
     addButton->setText(tr("Add"));
     setAddEnabled(false);
 
-    ui->lineEditName->setFocus();
+    comboBoxGroup.setFocus();
 
-    QWidget::setTabOrder(ui->lineEditName, ui->lineEditToolTip);
-    QWidget::setTabOrder(ui->lineEditToolTip, &comboBoxGroup);
     QWidget::setTabOrder(&comboBoxGroup, ui->comboBoxType);
+    QWidget::setTabOrder(ui->comboBoxType, ui->lineEditName);
+    QWidget::setTabOrder(ui->lineEditName, editor.get());
+    QWidget::setTabOrder(editor.get(), ui->lineEditToolTip);
 
     adjustSize();
 }

--- a/src/Gui/Dialogs/DlgAddProperty.ui
+++ b/src/Gui/Dialogs/DlgAddProperty.ui
@@ -15,52 +15,52 @@
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="labelName">
-     <property name="text">
-      <string>Name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="lineEditName"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="labelValue">
-     <property name="text">
-      <string>Value</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="labelToolTip">
-     <property name="text">
-      <string>Tooltip</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="lineEditToolTip"/>
-   </item>
-   <item row="3" column="0">
     <widget class="QLabel" name="labelGroup">
      <property name="text">
       <string>Group</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="1" column="0">
     <widget class="QLabel" name="labelType">
      <property name="text">
       <string>Type</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="1" column="1">
     <widget class="QComboBox" name="comboBoxType">
      <property name="editable">
       <bool>true</bool>
      </property>
     </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="labelName">
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="lineEditName"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="labelValue">
+     <property name="text">
+      <string>Value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="labelToolTip">
+     <property name="text">
+      <string>Tooltip</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QLineEdit" name="lineEditToolTip"/>
    </item>
    <item row="5" column="0" colspan="2">
     <widget class="QLabel" name="labelError">


### PR DESCRIPTION
## Description
Currently, the "Add Property" dialog (commonly used for VarSets) orders fields as Name -> Group -> Type -> Value. This often leads to usability friction where users accidentally overwrite the "Group" field (defaulting to "Base") when they intend to tab quickly from "Name" to "Value".

This PR reorders the dialog fields to Name -> Value -> Group -> Type and updates the tab order logic in the C++ code to match. This allows for a smoother workflow:
1. Type Name
2. Press Tab (Focus moves to Value)
3. Type Value
4. Press Enter
## Issues
fixes #26094

## After Images
<img width="1716" height="726" alt="image" src="https://github.com/user-attachments/assets/1c2c0a47-6cae-4f61-9122-32e671355f8f" />

