### PR TITLE
Add status bar hints for modifier keys in Std_Measure

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -417,12 +417,14 @@ void TaskMeasure::invoke()
     bool greedy = Gui::Selection().getSelectionStyle() == SelectionStyle::GreedySelection;
     std::list<Gui::InputHint> hints;
     if (greedy) {
-        hints = std::list<Gui::InputHint>{
+        hints = std::list<Gui::InputHint> {
             {tr("%1 start new measurement, %2 toggle auto-save"), {{ModifierCtrl}, {ModifierShift}}}
         };
     }
     else {
-        hints = std::list<Gui::InputHint>{{tr("%1 add to measurement, %2 toggle auto-save"), {{ModifierCtrl}, {ModifierShift}}}};
+        hints = std::list<Gui::InputHint> {
+            {tr("%1 add to measurement, %2 toggle auto-save"), {{ModifierCtrl}, {ModifierShift}}}
+        };
     }
     Gui::getMainWindow()->showHints(hints);
 }
@@ -612,10 +614,14 @@ void TaskMeasure::newMeasurementBehaviourChanged(bool checked)
 
     std::list<Gui::InputHint> hints;
     if (checked) {
-        hints = std::list<Gui::InputHint>{{tr("%1 new measurement, %2 toggle auto-save"), {{ModifierCtrl}, {ModifierShift}}}};
+        hints = std::list<Gui::InputHint> {
+            {tr("%1 new measurement, %2 toggle auto-save"), {{ModifierCtrl}, {ModifierShift}}}
+        };
     }
     else {
-        hints = std::list<Gui::InputHint>{{tr("%1 add to measurement, %2 toggle auto-save"), {{ModifierCtrl}, {ModifierShift}}}};
+        hints = std::list<Gui::InputHint> {
+            {tr("%1 add to measurement, %2 toggle auto-save"), {{ModifierCtrl}, {ModifierShift}}}
+        };
     }
     Gui::getMainWindow()->showHints(hints);
 }


### PR DESCRIPTION
## Problem
The Std_Measure tool supports Ctrl (to add to/start new measurement) and Shift (to invert auto-save behavior) modifiers, but these features were not discoverable via the UI, forcing users to rely on external documentation or experimentation.

## Issues
fixes #26042

## Solution
This PR adds status bar messages to the `TaskMeasure`  dialog to guide the user.
**On Invoke**: Displays a message explaining the modifiers based on the current selection style.
- Normal Mode: "Select objects. Ctrl to add to measurement. Shift to invert auto-save."
- Additive Mode: "Select objects. Ctrl to start new measurement. Shift to invert auto-save."

**On Setting Change**: The message updates immediately if the user toggles "Additive Selection" in the tool's settings menu.

**On Close**: The status bar message is cleared when the dialog is closed.

