### PR TITLE
Fix: Update PartDesign Boolean dropdown immediately before recomputation

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp
@@ -23,6 +23,7 @@
 
 
 #include <QAction>
+#include <QApplication>
 #include <QMessageBox>
 
 
@@ -258,6 +259,9 @@ void TaskBooleanParameters::onTypeChanged(int index)
         default:
             pcBoolean->Type.setValue("Fuse");
     }
+
+    // Force UI update before starting heavy computation to show user's selection immediately
+    QApplication::processEvents();
 
     pcBoolean->getDocument()->recomputeFeature(pcBoolean);
 }


### PR DESCRIPTION
## Problem
When changing the boolean operation type (Fuse/Cut/Common) in the PartDesign Boolean dialog, the dropdown list would not update visually until **after** the recomputation finished. This created a poor user experience where:

- User selects "Cut" from dropdown
- FreeCAD freezes and starts computing
- Dropdown still shows "Fuse" during computation
- User thinks they selected the wrong operation or FreeCAD is computing the wrong thing
- Only after computation completes does the dropdown finally change to "Cut"

For complex models, this computation can take a very long time, causing significant user confusion.

## Issues
Fixes #26087

## Root Cause
The `onTypeChanged()` slot handler in `TaskBooleanParameters.cpp` was calling `recomputeFeature()` immediately after setting the property value, blocking the Qt event loop before the combo box widget could process its visual update events.

## Solution
Added `QApplication::processEvents()` before the recomputation call to force Qt to process all pending UI events (including the combo box visual update) before starting the potentially long-running computation.

## Changes
- **File modified:** `src/Mod/PartDesign/Gui/TaskBooleanParameters.cpp`
  - Added `#include <QApplication>` 
  - Added `QApplication::processEvents()` in `onTypeChanged()` method before `recomputeFeature()` call