### PR TITLE
Gui: Add hidden anchor object to root for transparency

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -552,13 +552,17 @@ void View3DInventorViewer::init()
     // in empty scenes - OpenInventor's two-pass transparency rendering requires at least
     // one opaque object to properly initialize the depth buffer. so this fixes transparency
     // issues for image planes, planes, and other transparent geometry.
+    // wrap in SoSkipBoundingGroup to exclude from bounding box calculations
     // check #15192 #24003
-    auto hiddenAnchor = new SoSeparator();
+    auto hiddenAnchor = new SoSkipBoundingGroup();
+    hiddenAnchor->mode = SoSkipBoundingGroup::EXCLUDE_BBOX;
+    auto hiddenSep = new SoSeparator();
     auto hiddenScale = new SoScale();
     hiddenScale->scaleFactor = SbVec3f(0, 0, 0);
     auto hiddenCube = new SoCube();
-    hiddenAnchor->addChild(hiddenScale);
-    hiddenAnchor->addChild(hiddenCube);
+    hiddenSep->addChild(hiddenScale);
+    hiddenSep->addChild(hiddenCube);
+    hiddenAnchor->addChild(hiddenSep);
     pcViewProviderRoot->addChild(hiddenAnchor);
 
     // increase refcount before passing it to setScenegraph(), to avoid


### PR DESCRIPTION
Image planes with transparency failed to render correctly in empty scenes because OpenInventor's two-pass transparency rendering requires at least one opaque object to properly initialize the depth buffer.

The fix adds a zero-scaled cube with no material node (making it use OpenGL's default opaque material) to each image plane's scene graph. This hidden object:
- Acts as a depth buffer anchor for transparent rendering
- Is invisible (scaled to 0,0,0)
- Has negligible performance impact

This matches the workaround already used in the rotation center indicator and resolves the issue where image transparency only worked when the rotation center, grid, or other opaque objects were visible.

Demo:

Before:

https://github.com/user-attachments/assets/a7c703b8-e2d0-4d7a-a8fe-6fa997e57ca5

After:

https://github.com/user-attachments/assets/9c113eee-d0bd-483d-8023-253c180f856d

Resolves: https://github.com/FreeCAD/FreeCAD/issues/24003
Resolves: https://github.com/FreeCAD/FreeCAD/issues/15192
Resolves: https://github.com/FreeCAD/FreeCAD/issues/24309