### PR TITLE
Sketcher: Fix large sketch being laggy

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2950,4 +2950,3 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
     ps->style.setValue(SoPickStyle::SHAPE);
     editModeScenegraphNodes.EditRoot->addChild(ps);
 }
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/11498

by removing the whole logic based on ray picking to position constraints.

As found by @flaviut in the issue, `seekConstraintPosition` was taking the lion share of sketcher solve time in large sketches. So much so that it made the software very laggy when you have 500+ constraints.

The cherry on the cake is that this colision detection in seekConstraintPosition is apparantly useless because there are actually two different systems fighting to prevent icon overlap. And the second one is the one that is actually doing the work (combineConstraintIcons & drawMergedConstraintIcons).

The first one is actually not doing anything anymore (at least I cannot detect any effects). Asides from making the workbench slow.

See the below video where I compare with and without this PR. 

https://github.com/user-attachments/assets/f5f824aa-3d46-4473-a28d-421bf7cc5b07

