### PR TITLE
Sketcher: Fix symmetry of slot redundancy false positive

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -4401,7 +4401,6 @@ int SketchObject::addSymmetric(const std::vector<int>& geoIdList, int refGeoId,
                 double start, end;
                 arc->getRange(start, end, true);
                 arc->setRange(start + Precision::Angular(), end, true);
-
             }
         }
     }


### PR DESCRIPTION
Perturb symmetric geometries when using the 'create symmetric constraints' option to avoid numerical singularities in the solver (Jacobian Rank). If geometry is "perfect", the solver cannot distinguish between the derivative of a Symmetry constraint and an Equal constraint, flagging one as redundant.

Fix https://github.com/FreeCAD/FreeCAD/issues/13551

See [this comment](https://github.com/FreeCAD/FreeCAD/issues/13551#issuecomment-3705421604) explaining why the bug was happening.

To fix the issue, I propose that we introduce a small perturbation to the arcs angle when the option 'create symmetric constraints' is enabled.
With this the solver correctly solves and does not report the false positive redundancy.

Please squash