### PR TITLE
Gui: Add dynamic property count to VarSet tree labels

### DIFF
--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -350,6 +350,13 @@ QIcon ViewProvider::getIcon() const
     return mergeGreyableOverlayIcons(Gui::BitmapFactory().pixmap(sPixmap));
 }
 
+std::string ViewProvider::getTreeLabel() const
+{
+    // Default implementation returns empty string
+    // ViewProviderDocumentObject overrides this to return the Label property
+    return {};
+}
+
 QIcon ViewProvider::mergeGreyableOverlayIcons(const QIcon& orig) const
 {
     auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -294,6 +294,8 @@ public:
     //@{
     /// deliver the icon shown in the tree view
     virtual QIcon getIcon() const;
+    /// deliver the label text shown in the tree view
+    virtual std::string getTreeLabel() const;
 
     /**
      * @brief Whether the viewprovider should allow to toggle the visibility.
@@ -450,6 +452,8 @@ public:
     //@{
     /// signal on icon change
     boost::signals2::signal<void()> signalChangeIcon;
+    /// signal on tree label change
+    boost::signals2::signal<void()> signalChangeTreeLabel;
     /// signal on tooltip change
     boost::signals2::signal<void(const QString&)> signalChangeToolTip;
     /// signal on status tip change

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -652,6 +652,14 @@ bool ViewProviderDocumentObject::showInTree() const
     return ShowInTree.getValue();
 }
 
+std::string ViewProviderDocumentObject::getTreeLabel() const
+{
+    if (pcObject && pcObject->isAttachedToDocument()) {
+        return pcObject->Label.getValue();
+    }
+    return {};
+}
+
 bool ViewProviderDocumentObject::getElementPicked(const SoPickedPoint* pp, std::string& subname) const
 {
     auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -93,6 +93,9 @@ public:
     /// Get a list of TaskBoxes associated with this object
     void getTaskViewContent(std::vector<Gui::TaskView::TaskContent*>&) const override;
 
+    /// deliver the label text shown in the tree view
+    std::string getTreeLabel() const override;
+
     /// Run a redraw
     void updateView();
     /// Get the object of this ViewProvider object

--- a/src/Gui/ViewProviderVarSet.cpp
+++ b/src/Gui/ViewProviderVarSet.cpp
@@ -45,28 +45,28 @@ ViewProviderVarSet::ViewProviderVarSet()
 std::string ViewProviderVarSet::getTreeLabel() const
 {
     std::string baseLabel = ViewProviderDocumentObject::getTreeLabel();
-    
+
     auto* obj = getObject();
     if (!obj || !obj->isAttachedToDocument()) {
         return baseLabel;
     }
-    
+
     // Count dynamic properties (exclude built-in properties)
     auto dynamicNames = obj->getDynamicPropertyNames();
     int count = static_cast<int>(dynamicNames.size());
-    
+
     // Append count if there are dynamic properties
     if (count > 0) {
         return baseLabel + " (" + std::to_string(count) + ")";
     }
-    
+
     return baseLabel;
 }
 
 void ViewProviderVarSet::attach(App::DocumentObject* pcObject)
 {
     ViewProviderDocumentObject::attach(pcObject);
-    
+
     // Connect to application-level signals for dynamic property changes
     connPropertyAdded = App::GetApplication().signalAppendDynamicProperty.connect(
         [this](const App::Property& prop) { onDynamicPropertyAdded(prop); }
@@ -89,9 +89,7 @@ void ViewProviderVarSet::onDynamicPropertyRemoved(const App::Property& prop)
     // Only update if the property belongs to our object
     // Use deferred update because this signal fires BEFORE the property is removed
     if (prop.getContainer() == getObject()) {
-        QTimer::singleShot(0, [this]() {
-            signalChangeTreeLabel();
-        });
+        QTimer::singleShot(0, [this]() { signalChangeTreeLabel(); });
     }
 }
 

--- a/src/Gui/ViewProviderVarSet.h
+++ b/src/Gui/ViewProviderVarSet.h
@@ -57,7 +57,7 @@ private:
     void onDynamicPropertyRemoved(const App::Property& prop);
 
     std::unique_ptr<Dialog::DlgAddProperty> dialog;
-    
+
     using Connection = boost::signals2::scoped_connection;
     Connection connPropertyAdded;
     Connection connPropertyRemoved;

--- a/src/Gui/ViewProviderVarSet.h
+++ b/src/Gui/ViewProviderVarSet.h
@@ -44,12 +44,23 @@ public:
         return true;
     }
 
+    std::string getTreeLabel() const override;
+
+    void attach(App::DocumentObject* pcObject) override;
+
     bool doubleClicked() override;
 
     void onFinished(int);
 
 private:
+    void onDynamicPropertyAdded(const App::Property& prop);
+    void onDynamicPropertyRemoved(const App::Property& prop);
+
     std::unique_ptr<Dialog::DlgAddProperty> dialog;
+    
+    using Connection = boost::signals2::scoped_connection;
+    Connection connPropertyAdded;
+    Connection connPropertyRemoved;
 };
 
 }  // namespace Gui


### PR DESCRIPTION
## Description
This PR implements to show the number of dynamic properties in Varset items in the Tree view

## Issues
Fixes #26572

## Changes
- **Core**: Added `getTreeLabel()` virtual method to `ViewProvider` base class, allowing ViewProviders to customize their tree label text
- Added `signalChangeTreeLabel` to notify the tree when labels need updating
- Modified `Tree.cpp` to use the new method and connect to the signal
- Overrode `getTreeLabel()` in `ViewProviderVarSet` to append property count (e.g., "VarSet (5)")