### PR TITLE
Improve UX for Rename Property Group with tooltip

### DIFF
--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -955,6 +955,7 @@ void PropertyEditor::removeProperties(const std::unordered_set<App::Property*>& 
 void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
 {
     QMenu menu;
+    menu.setToolTipsVisible(true);
     auto contextIndex = currentIndex();
 
     std::unordered_set<App::Property*> props = acquireSelectedProperties();
@@ -976,10 +977,21 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
 
     // rename property group
     if (!props.empty() && std::all_of(props.begin(), props.end(), [](auto prop) {
-            return prop->testStatus(App::Property::PropDynamic)
-                && !boost::starts_with(prop->getName(), prop->getGroup());
+            return prop->testStatus(App::Property::PropDynamic);
         })) {
-        menu.addAction(tr("Rename Property Group"))->setData(QVariant(MA_EditPropGroup));
+        QAction* renameGroupAction = menu.addAction(tr("Rename Property Group"));
+        renameGroupAction->setData(QVariant(MA_EditPropGroup));
+
+        // Check if any property name starts with its group name
+        bool hasGroupPrefix = std::any_of(props.begin(), props.end(), [](auto prop) {
+            return boost::starts_with(prop->getName(), prop->getGroup());
+        });
+
+        if (hasGroupPrefix) {
+            renameGroupAction->setEnabled(false);
+            renameGroupAction
+                ->setToolTip(tr("Cannot rename group: one or more properties have names that start with the group name"));
+        }
     }
 
     // rename property


### PR DESCRIPTION
## Problem
This PR resolve the issue of FreeCAD's Property Editor, the "Rename Property Group" context menu option would completely disappear when selecting dynamic properties whose names start with their group name (e.g., a property named "FooBar" in group "Foo"). This behavior was by design to prevent renaming groups for properties considered "tied" to specific groups, but it created a poor user experience users were confused about why the option was missing, often thinking it was a bug or missing feature.

## Issue
Fixes #25951

## Solution
Modified the Property Editor to always display the "Rename Property Group" menu item for dynamic properties, but disable it with a clear tooltip when the restriction applies. This makes the limitation transparent and educational, improving overall usability without breaking existing design constraints.

## After changes video
https://github.com/user-attachments/assets/4feee8ef-43ac-4f7a-b95b-ed91c64d174a

