### PR TITLE
CAM: Path.Geom.combineHorizontalFaces() - Filter bad wires from face

### DIFF
--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -742,7 +742,7 @@ def combineHorizontalFaces(faces):
     if not topFace:
         return horizontal
 
-    outer = [Part.Face(w) for w in topFace.Wires[1:]]
+    outer = [Part.Face(w) for w in topFace.Wires[1:] if w.isClosed()]
 
     if outer:
         for f in outer:


### PR DESCRIPTION
Fixes #26635
- #26635

[board_back_topFace.zip](https://github.com/user-attachments/files/24420658/board_back_topFace.zip)

---

Top face after `cut` contain 'strange' short not closed wires
Probably the source of the problem is broken shape

https://github.com/FreeCAD/FreeCAD/blob/3f49f3f05958c4a8f4c5b470adfebbc1503b3f45/src/Mod/CAM/Path/Geom.py#L720

```
for w in obj.Shape.Wires: print(w.isClosed(), w.Length)

True 298.5365
True 349.78476182242264
False 2.9907512182347773e-06
False 2.99075124488013e-06
```

From this 'strange' wires can not be created faces
But we can filter them 

https://github.com/FreeCAD/FreeCAD/blob/400c0b6db787994054f8e9ffbbad13c22ce08f6a/src/Mod/CAM/Path/Geom.py#L743