### PR TITLE
BIM: remove v1.1 Sill Height code

### DIFF
--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -323,10 +323,12 @@ class _Window(ArchComponent.Component):
         #     https://github.com/FreeCAD/FreeCAD/pull/23014
         # The properties that were added are removed here. Note that we do not check
         # for "SillHeight" so that it is safe to use that property name in the future.
-        if hasattr(obj, "Sill") \
-                or hasattr(obj, "baseSill") \
-                or hasattr(obj, "basePosZ") \
-                or hasattr(obj, "atthOffZ"):
+        if (
+            hasattr(obj, "Sill")
+            or hasattr(obj, "baseSill")
+            or hasattr(obj, "basePosZ")
+            or hasattr(obj, "atthOffZ")
+        ):
             for prop in ("Sill", "SillHeight", "baseSill", "basePosZ", "atthOffZ"):
                 if hasattr(obj, prop):
                     obj.setPropertyStatus(prop, "-LockDynamic")


### PR DESCRIPTION


The v1.1 the Sill Height implementation did not work properly. At this late stage in the dev cycle the best option is to remove it.