### PR TITLE
CAM: Fix duplicate label issues with toolbits

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -1149,7 +1149,9 @@ class TaskPanel:
         toolbit = selector.get_selected_tool()
         toolbit.attach_to_doc(FreeCAD.ActiveDocument)
         toolNum = self.obj.Proxy.nextToolNumber()
-        tc = PathToolControllerGui.Create(name=toolbit.label, tool=toolbit.obj, toolNumber=toolNum)
+        tc = PathToolControllerGui.Create(
+            name=f"TC: {toolbit.label}", tool=toolbit.obj, toolNumber=toolNum
+        )
         self.obj.Proxy.addToolController(tc)
 
         FreeCAD.ActiveDocument.recompute()

--- a/src/Mod/CAM/Path/Tool/shape/models/base.py
+++ b/src/Mod/CAM/Path/Tool/shape/models/base.py
@@ -718,8 +718,23 @@ class ToolBitShape(Asset):
             # Recompute the document to apply property changes
             tmp_doc.recompute()
 
-            # Copy the body to the given document without immediate compute.
-            return doc.copyObject(shape, True)
+            # Temporarily disable duplicate labels to let FreeCAD automatically
+            # make labels unique during the copy operation
+
+            param = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Document")
+            original_setting = param.GetBool("DuplicateLabels", False)
+
+            try:
+                # Disable duplicate labels temporarily
+                param.SetBool("DuplicateLabels", False)
+
+                # Copy the body - FreeCAD will now automatically make labels unique
+                copied_shape = doc.copyObject(shape, True)
+
+                return copied_shape
+            finally:
+                # Restore the original setting
+                param.SetBool("DuplicateLabels", original_setting)
 
         """
         Retrieves the thumbnail data for the tool bit shape in PNG format.


### PR DESCRIPTION
Addresses problems caused by the "Allow duplicate object labels in one document" option. Toolbit sub-objects now always get unique labels by temporarily disabling this option during copy, preventing expression and property binding errors. Also ensures tool controllers always use the "TC: " prefix for consistency.

src/Mod/CAM/Path/Tool/shape/models/base.py:
- Temporarily disable DuplicateLabels during shape copy to enforce unique labels

src/Mod/CAM/Path/Main/Gui/Job.py:
- Add "TC: " prefix to tool controller names when adding from the Job panel

Fixes #26625

@maxwxyz  Should be backported to 1.1