### PR TITLE
CAM: Fix typo in tooltip for ToolBitLibraryEdit.ui

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/ToolBitLibraryEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/ToolBitLibraryEdit.ui
@@ -200,7 +200,7 @@
         <bool>true</bool>
        </property>
        <property name="toolTip">
-        <string>Table of tool bits of the library</string>
+        <string>Table of toolbits of the library</string>
        </property>
        <property name="frameShape">
         <enum>QFrame::Box</enum>


### PR DESCRIPTION
Modifies 'tool bit' to 'toolbit'.  
Not eligible for backport to 1.1

Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/339