### PR TITLE
CAM - Experimental Waterline Minor Fix

### DIFF
--- a/src/Mod/CAM/Path/Op/Waterline.py
+++ b/src/Mod/CAM/Path/Op/Waterline.py
@@ -2014,10 +2014,12 @@ class ObjectWaterline(PathOp.ObjectOp):
                 startVect = FreeCAD.Vector(V[0].X, V[0].Y, V[0].Z)
 
             commands.append(Path.Command("N (Wire {}.)".format(w)))
-            
+
             # This ensures the tool is directly above the entry point before plunging,
             # preventing diagonal moves through the material.
-            commands.append(Path.Command("G0", {"X": startVect.x, "Y": startVect.y, "F": self.horizRapid}))            
+            commands.append(
+                Path.Command("G0", {"X": startVect.x, "Y": startVect.y, "F": self.horizRapid})
+            )
             (cmds, endVect) = self._wireToPath(obj, wire, startVect)
             commands.extend(cmds)
             commands.append(Path.Command("G0", {"Z": obj.SafeHeight.Value, "F": self.vertRapid}))


### PR DESCRIPTION
Experimental Algorithm has a lot of issues, tool offsetting is missing for example, but at least let's fix some very basic ones.

BEFORE

When using Offset or None cut patterns, the following error occurs:

`  File "/home/freecad-source/build/Mod/CAM/Path/Op/Waterline.py", line 1900, in _experimentalWaterlineOp
    ofstSolidFacesList = self._getSolidAreasFromPlanarFaces(ofstArea)
  File "/home/freecad-source/build/Mod/CAM/Path/Op/Waterline.py", line 2183, in _getSolidAreasFromPlanarFaces
    lenCsF = len(csFaces)
<class 'TypeError'>: object of type 'Part.Compound' has no len()
01:38:20  Waterline: object of type 'Part.Compound' has no len()`

ofstArea -> should be ofstArea.Faces below

https://github.com/FreeCAD/FreeCAD/blob/c8106982de865075e44dd9a7e8a58713755ae4f0/src/Mod/CAM/Path/Op/Waterline.py#L1900

During transitions between features, the tool is crossing through the shape.

<img width="856" height="632" alt="Screenshot From 2026-01-05 02-20-01" src="https://github.com/user-attachments/assets/89f24e88-00fe-4876-9ec4-ce6459cb53e8" />

Between transitions some times the tool retracts to ClearanceHeight instead of SafeHeight

<img width="1254" height="715" alt="Screenshot From 2026-01-05 02-18-19" src="https://github.com/user-attachments/assets/25e3e594-d2a9-4cb1-ab64-36ad2bae5fe2" />


AFTER

<img width="1187" height="356" alt="Screenshot From 2026-01-05 02-09-43" src="https://github.com/user-attachments/assets/358f92c6-399c-4f86-9454-be787edf7a0b" />

<img width="1128" height="711" alt="Screenshot From 2026-01-05 02-10-30" src="https://github.com/user-attachments/assets/1dd4ff6b-b536-4d16-88d1-746ad290924c" />






