### PR TITLE
BIM: Fix typo in ArchComponent.py documentation

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -273,7 +273,7 @@ class Component(ArchIFC.IfcProduct):
                 "Component",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "An optional standard (OmniClass, etc…) code for this component",
+                    "An optional standard (OmniClass, etc.) code for this component",
                 ),
                 locked=True,
             )


### PR DESCRIPTION
Removes ellipsis to avoid confusion for translators.  
Not eligible for backporting to 1.1

Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/341
