### PR TITLE
BIM: Fix tooltip string in dialogLibrary.ui

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogLibrary.ui
+++ b/src/Mod/BIM/Resources/ui/dialogLibrary.ui
@@ -226,7 +226,7 @@
          <bool>true</bool>
         </property>
         <property name="toolTip">
-         <string>Show available alternative file formats for library items (STEP, IFC, etc...)</string>
+         <string>Show available alternative file formats for library items (STEP, IFC, etc.)</string>
         </property>
         <property name="text">
          <string>Display alternative formats</string>


### PR DESCRIPTION
Removes ellipsis from tooltip.  
Not eligible for backport.

Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/344