### PR TITLE
CAM: Processor - Fix regression after #22764

### DIFF
--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -143,10 +143,13 @@ class PostProcessor:
             # process only selected operations
             self._job = job["job"]
             self._operations = job["operations"]
-        else:
+        elif job:
             # get all operations from 'Operations' group
             self._job = job
             self._operations = getattr(job.Operations, "Group", [])
+        else:
+            self._job = job
+            self._operations = []
 
     @classmethod
     def exists(cls, processor):


### PR DESCRIPTION
Fix regression after
- #22764

Get errors if place cursor in list of post-processors in CAM Preferences

 
<img width="869" height="518" alt="Screenshot_20260105_140942_lossy" src="https://github.com/user-attachments/assets/e8deeb0a-1c31-46ce-8928-9180c5be651f" />

```
Traceback (most recent call last):
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Post/Processor.py", line 112, in get_post_processor
    PostClass = getattr(module, class_name)
AttributeError: module 'KineticNCBeamicon2_post' has no attribute 'Kineticncbeamicon2'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Main/Gui/PreferencesJob.py", line 294, in setProcessorListTooltip
    self.setPostProcessorTooltip(self.form.postProcessorList, item.text(), "")
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Main/Gui/PreferencesJob.py", line 287, in setPostProcessorTooltip
    processor = self.getPostProcessor(name)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Main/Gui/PreferencesJob.py", line 281, in getPostProcessor
    processor = PostProcessorFactory.get_post_processor(None, name)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Post/Processor.py", line 117, in get_post_processor
    return WrapperPost(job, module_path, module_name)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Post/Processor.py", line 537, in __init__
    super().__init__(job, tooltip=None, tooltipargs=None, units=None, *args, **kwargs)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Post/Processor.py", line 149, in __init__
    self._operations = getattr(job.Operations, "Group", [])
                               ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'Operations'
```
