### PR TITLE
Sketcher: Fix selection & zoom lag in large sketches

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2503,10 +2503,7 @@ void EditModeConstraintCoinManager::combineConstraintIcons(IconQueue iconQueue)
 
     // Grid size needs to be slightly larger than the max merge distance to ensure
     // we catch neighbors.
-    float gridSize = std::abs(scale) * 1.1f;
-    if (gridSize < 1.0f) {
-        gridSize = 1.0f;
-    }
+    float gridSize = std::max(1.0f, std::abs(scale) * 1.1f);
 
     // 2. FILTERING & PREPARATION
     // We create a list of valid indices.


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/26607
Fix https://github.com/FreeCAD/FreeCAD/issues/26608

test file : 
[box.zip](https://github.com/user-attachments/files/24434732/box.zip)

Video : 

https://github.com/user-attachments/assets/ab4dcd98-9237-4e09-ac48-3747edc651e4

The original `EditModeConstraintCoinManager::combineConstraintIcons` was doing a O(N²) brute force algorithm.
The proposed algorithm is a grid based approach O(N).

In my test the grouping is identical as before. But the lag is gone.