### PR TITLE
Toponaming: Fix recurring migration issue.

### DIFF
--- a/src/App/ComplexGeoData.h
+++ b/src/App/ComplexGeoData.h
@@ -280,7 +280,7 @@ public:
         return _elementMap->setElementName(element, name, masterTag, sid, overwrite);
     }
 
-    bool hasElementMap()
+    bool hasElementMap() const
     {
         return _elementMap != nullptr;
     }

--- a/src/App/PropertyGeo.cpp
+++ b/src/App/PropertyGeo.cpp
@@ -1302,7 +1302,7 @@ std::string PropertyComplexGeoData::getElementMapVersion(bool) const
     }
     auto owner = freecad_cast<DocumentObject*>(getContainer());
     std::ostringstream ss;
-    if (owner && owner->getDocument() && owner->getDocument()->getStringHasher() == data->Hasher) {
+    if (owner && owner->getDocument() && data->hasElementMap() && data->getElementMapSize() && owner->getDocument()->getStringHasher() == data->Hasher) {
         ss << "1.";
     }
     else {


### PR DESCRIPTION
Fixes: https://github.com/FreeCAD/FreeCAD/issues/26690

This change makes the program only mark an object's ElementMapVersion with the "1" prefix if the object has a hasher AND an element map.