### PR TITLE
CAM: RampEntryDressup - Fix findMinZ()

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
@@ -543,7 +543,7 @@ class ObjectDressup:
     def findMinZ(self, edges):
         minZ = 99999999999
         for edge in edges:
-            if edge.end_point[2] < minZ:
+            if edge.command.Name in Path.Geom.CmdMoveAll and edge.end_point[2] < minZ:
                 minZ = edge.end_point[2]
         return minZ
 


### PR DESCRIPTION
[rampentry_zmin.zip](https://github.com/user-attachments/files/24448576/rampentry_zmin.zip)

Example of base gcode:
```
(Profile005)
(Compensated Tool Path. Diameter: 10.0)
G0 Z35.000000
G0 X160.908669 Y230.978285
...
```

First commented lines do not contain moves,
but `AnnotatedGCode` set `end_point = (0, 0, 0)`
So `findMinZ()` can not correctly determine min Z value above 0

https://github.com/FreeCAD/FreeCAD/blob/ede7013f55872bd631d268ded826518b19d616de/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py#L543-L548

If base operation have `FinalDepth` > 0,
get path without moves at final depth

This changes allow to check z only from move commands

<img width="876" height="427" alt="Screenshot_20260106_102027_hor" src="https://github.com/user-attachments/assets/4d1a7acc-cd38-41a1-894b-4b4fa7b384eb" />
