### PR TITLE
PartDesign: Apply pattern transform in Feature not VP

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderTransformed.cpp
@@ -104,19 +104,6 @@ void ViewProviderTransformed::updatePreview()
 
     try {
         if (auto feature = getObject<PartDesign::Transformed>()) {
-            const Part::Feature* supportFeature = feature->getBaseObject();
-            const Part::TopoShape& supportShape = supportFeature->Shape.getShape();
-
-            if (supportShape.isNull()) {
-                return;
-            }
-
-            Base::Matrix4D invertedSupportMatrix;
-            Part::TopoShape::convertToMatrix(
-                supportShape.getShape().Location().Transformation().Inverted(),
-                invertedSupportMatrix
-            );
-
             auto originals = feature->getOriginals();
             auto transforms = feature->getTransformations(originals);
 
@@ -133,7 +120,7 @@ void ViewProviderTransformed::updatePreview()
                 auto sep = new SoSeparator;
 
                 auto transformNode = new SoTransform;
-                transformNode->setMatrix(convert(transformMatrix * invertedSupportMatrix));
+                transformNode->setMatrix(convert(transformMatrix));
 
                 sep->addChild(transformNode);
                 sep->addChild(pcPreviewShape);


### PR DESCRIPTION
This is followup for https://github.com/FreeCAD/FreeCAD/pull/26563 which fixed previews for a given file but broke it for others.

This approach should be more robust as it is applied in the Feature itself and not on view provider level which should give us more precise control and per feature transform ability.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
- https://github.com/FreeCAD/FreeCAD/issues/26561
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
