### PR TITLE
CI: Limit backports to pixi only

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -26,14 +26,21 @@
 
 name: FreeCAD master CI
 
-on: [workflow_dispatch, push, pull_request, merge_group]
+on:
+  workflow_dispatch: ~
+  push:
+    branches:
+      - main
+      - releases/**
+  pull_request: ~
+  merge_group: ~
+
 
 concurrency:
   group: FC-CI-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-
   Prepare:
     uses: ./.github/workflows/sub_prepare.yml
     with:
@@ -47,18 +54,21 @@ jobs:
 
   Ubuntu:
     needs: [Prepare]
+    if: "!startsWith(github.ref, 'refs/heads/backport-')"
     uses: ./.github/workflows/sub_buildUbuntu.yml
     with:
       artifactBasename: Ubuntu-${{ github.run_id }}
 
   Windows:
     needs: [Prepare]
+    if: "!startsWith(github.ref, 'refs/heads/backport-')"
     uses: ./.github/workflows/sub_buildWindows.yml
     with:
       artifactBasename: Windows-${{ github.run_id }}
 
   Lint:
     needs: [Prepare]
+    if: "!startsWith(github.ref, 'refs/heads/backport-')"
     uses: ./.github/workflows/sub_lint.yml
     with:
       artifactBasename: Lint-${{ github.run_id }}


### PR DESCRIPTION
Due to backports being created as branches on our own repository they run twice: once from push event and once from pull request event. 

This PR limits the push event to only main and release branches and skips Windows and Ubuntu builds on the release branch to preserve resources. 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
