### PR TITLE
Assembly: Explode radially: prevent click on item

### DIFF
--- a/src/Mod/Assembly/CommandCreateView.py
+++ b/src/Mod/Assembly/CommandCreateView.py
@@ -644,6 +644,7 @@ class TaskAssemblyCreateView(QtCore.QObject):
         self.blockSetDragger = False
         self.blockDraggerMove = True
         self.currentStep = None
+        self.radialExplosion = False
 
     def accept(self):
         self.deactivate()
@@ -779,7 +780,7 @@ class TaskAssemblyCreateView(QtCore.QObject):
         self.blockSetDragger = False
         self.setDragger()
 
-        self.createExplodedStepObject(1)  # 1 = type_index of "Radial"
+        self.radialExplosion = True
 
     def onAlignTo(self):
         self.alignMode = "Custom"
@@ -838,7 +839,12 @@ class TaskAssemblyCreateView(QtCore.QObject):
         self.viewObj = Gui.doCommandEval("viewObj")
         Gui.doCommandGui("CommandCreateView.ViewProviderExplodedView(viewObj.ViewObject)")
 
-    def createExplodedStepObject(self, moveType_index=0):
+    def createExplodedStepObject(self):
+        moveType_index = 0
+        if self.radialExplosion:
+            self.radialExplosion = False
+            moveType_index = 1  # 1 = type_index of "Radial"
+
         commands = (
             f'assembly = App.ActiveDocument.getObject("{self.assembly.Name}")\n'
             'currentStep = assembly.newObject("App::FeaturePython", "Move")\n'


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/26597

Before this PR, the move object was being created as soon as you click on 'Explode radially'. And so the user could then click on the 'Move' item in the listview. Which cleared the selection, which deleted the object, which deleted the list item. And so onItemClicked would say the item has been deleted.

Instead we create the Move object only when the user start dragging. Which is the behavior of the normal explosion. So it's also more consistent. And so the user cannot click on the list item. So the bug is fixed