### PR TITLE
Sketcher: Fix crash when applying constraints during selection batching

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1708,6 +1708,7 @@ void TaskSketcherConstraints::slotConstraintsChanged()
     assert(sketchView);
 
     constraintMap.clear();
+    selectionBuffer.clear();
 
     // Build up ListView with the constraints
     const Sketcher::SketchObject* sketch = sketchView->getSketchObject();

--- a/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherElements.cpp
@@ -1875,6 +1875,7 @@ void TaskSketcherElements::slotElementsChanged()
 
     ui->listWidgetElements->clear();
     elementMap.clear();
+    selectionBuffer.clear();
 
     using GeometryState = ElementItem::GeometryState;
 


### PR DESCRIPTION
Currently, the selection batching optimization introduced in #26663 stores ElementItem/ConstraintItem pointers in a buffer to be processed on the next event loop cycle via `QTimer::singleShot`.

When a constraint is applied, `slotElementsChanged()/slotConstraintsChanged()`
rebuilds the list widget, destroying all items. However, the selection buffer was not cleared, leaving dangling pointers. When `processSelectionBuffer()` executed, it attempted to call `QListWidget::row()` on deleted items, causing a segmentation fault.

So, this patch fixes it by clearing `selectionBuffer` when the list is rebuilt, since the buffered pointers are invalidated anyway.

Would you be able to check @PaddleStroke?

Demo: nothing to show, was crashing, doesn't crash now. At least on my Debian machine.

Resolves: https://github.com/FreeCAD/FreeCAD/issues/26734