### PR TITLE
ci: allow libpack builds to be triggered via githubs workflow_dispatch

### DIFF
--- a/.github/workflows/sub_buildWindows.yml
+++ b/.github/workflows/sub_buildWindows.yml
@@ -25,15 +25,26 @@
 name: Build Windows
 on:
   workflow_dispatch:
+    inputs:
+      artifactBasename:
+        description: "Base name for artifact"
+        required: false
+        type: string
+        default: "FreeCAD"
+      allowedToFail:
+        description: "whether a failed build is allowed"
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       artifactBasename:
-        type: string
         required: true
+        type: string
       allowedToFail:
+        required: false
         default: false
         type: boolean
-        required: false
     outputs:
       reportFile:
         value: ${{ jobs.Build.outputs.reportFile }}
@@ -41,7 +52,7 @@ on:
 jobs:
   Build:
     runs-on: windows-latest
-    continue-on-error: ${{ inputs.allowedToFail || false }}
+    continue-on-error: ${{ inputs.allowedToFail }}
     env:
       CCACHE_COMPILERCHECK: "%compiler%" # default:mtime
       CCACHE_COMPRESS: true


### PR DESCRIPTION
i don't have access to a windows computer to test libpack builds of freecad so i updated .yml file for the github libpack build to have a `workflow_dispatch` so i can trigger a build from my fork of freecad using github's web ui to test arbitrary code changes using github's provided ci.

## Issues

no linked issues that i'm aware of, but the issue is that i can not trigger / tshoot a libpack build of freecad using my local fork of freecad using github's provided ci.

