### PR TITLE
PartDesign: Fix refine not working with Boolean operations

### DIFF
--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -153,8 +153,6 @@ App::DocumentObjectExecReturn* Boolean::execute()
         }
     }
 
-    result.bakeInTransform();
-
     result = refineShapeIfActive(result);
 
     if (!isSingleSolidRuleSatisfied(result.getShape())) {


### PR DESCRIPTION
This reverts commit https://github.com/FreeCAD/FreeCAD/commit/527b2de560a1cf86b1f25416c3b82919e4cae452.

The `bakeInTransform()` call uses `transformGeometry()` which converts planar faces to BSplineSurfaces. This prevents the refine algorithm (BRepBuilderAPI_RefineModel) from detecting and merging coplanar faces, breaking the Refine option for Boolean operations.

This matches Part WB's Boolean behavior which does not use `bakeInTransform()` and has working refine functionality.

Before:
<img width="1897" height="986" alt="image" src="https://github.com/user-attachments/assets/085a0e39-b5b6-40d2-9aeb-c6b1a207c7f9" />

After:
<img width="1897" height="986" alt="image" src="https://github.com/user-attachments/assets/6c9908f5-f5c9-4dc8-bf4c-0bbc35bd78e2" />


Resolves: https://github.com/FreeCAD/FreeCAD/issues/26740