### PR TITLE
Core: add setting to make button toggle visibility of consoles

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsNotificationArea.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNotificationArea.cpp
@@ -74,6 +74,7 @@ void DlgSettingsNotificationArea::saveSettings()
     ui->preventNonIntrusiveNotificationsWhenWindowNotActive->onSave();
     ui->developerErrorSubscriptionEnabled->onSave();
     ui->developerWarningSubscriptionEnabled->onSave();
+    ui->buttonTogglesConsoleViews->onSave();
 }
 
 void DlgSettingsNotificationArea::loadSettings()
@@ -98,6 +99,7 @@ void DlgSettingsNotificationArea::loadSettings()
     ui->preventNonIntrusiveNotificationsWhenWindowNotActive->onRestore();
     ui->developerErrorSubscriptionEnabled->onRestore();
     ui->developerWarningSubscriptionEnabled->onRestore();
+    ui->buttonTogglesConsoleViews->onRestore();
 }
 
 void DlgSettingsNotificationArea::changeEvent(QEvent* e)

--- a/src/Gui/PreferencePages/DlgSettingsNotificationArea.ui
+++ b/src/Gui/PreferencePages/DlgSettingsNotificationArea.ui
@@ -313,6 +313,25 @@ Additionally, pop-up notifications can be disabled. In this case the user can st
      </layout>
     </widget>
    </item>
+   <item row="1" column="0">
+    <widget class="Gui::PrefCheckBox" name="buttonTogglesConsoleViews">
+     <property name="toolTip">
+      <string>Instead of showing the notification area widget, clicking the status bar button will toggle the visibility of the report view and of the python console.</string>
+     </property>
+     <property name="text">
+      <string>Button toggles the visibility of the console views</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <property name="prefEntry" stdset="0">
+      <cstring>ButtonTogglesConsoleViews</cstring>
+     </property>
+     <property name="prefPath" stdset="0">
+      <cstring>NotificationArea</cstring>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">


### PR DESCRIPTION
Add a setting that change the behavior of the 'notification' button.

If this setting is enabled: 
Instead of opening the 'notification area widget'
Clicking toggles the visibility of Report view and python console.

By default the behavior is not changed.