### PR TITLE
Refactor FileException to support translation and provide granular error types

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1983,7 +1983,7 @@ bool Document::saveToFile(const char* filename) const
     // check if file is writeable, then block the save if it is not.
     Base::FileInfo originalFileInfo(nativePath);
     if (originalFileInfo.exists() && !originalFileInfo.isWritable()) {
-        throw Base::FileException("Unable to save document because file is marked as read-only or write permission is not available.", originalFileInfo);
+        throw Base::FilePermissionException(originalFileInfo);
     }
 
     // make a tmp. file where to save the project data first and then rename to

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1983,7 +1983,7 @@ bool Document::saveToFile(const char* filename) const
     // check if file is writeable, then block the save if it is not.
     Base::FileInfo originalFileInfo(nativePath);
     if (originalFileInfo.exists() && !originalFileInfo.isWritable()) {
-        throw Base::FilePermissionException(originalFileInfo);
+        throw Base::FileWritePermissionException(originalFileInfo);
     }
 
     // make a tmp. file where to save the project data first and then rename to

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2001,7 +2001,7 @@ bool Document::saveToFile(const char* filename) const
     // check if file is writeable, then block the save if it is not.
     Base::FileInfo originalFileInfo(nativePath);
     if (originalFileInfo.exists() && !originalFileInfo.isWritable()) {
-        throw Base::FileException("Unable to save document because file is marked as read-only or write permission is not available.", originalFileInfo);
+        throw Base::FilePermissionException(originalFileInfo);
     }
 
     // make a tmp. file where to save the project data first and then rename to

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2001,7 +2001,7 @@ bool Document::saveToFile(const char* filename) const
     // check if file is writeable, then block the save if it is not.
     Base::FileInfo originalFileInfo(nativePath);
     if (originalFileInfo.exists() && !originalFileInfo.isWritable()) {
-        throw Base::FilePermissionException(originalFileInfo);
+        throw Base::FileWritePermissionException(originalFileInfo);
     }
 
     // make a tmp. file where to save the project data first and then rename to

--- a/src/Base/Exception.cpp
+++ b/src/Base/Exception.cpp
@@ -319,15 +319,15 @@ PyObject* FileException::getPyExceptionType() const
 namespace
 {
 constexpr const char* fileNotFoundMsg = QT_TRANSLATE_NOOP("Exceptions", "File not found");
-constexpr const char* fileReadPermissionMsg =
-    QT_TRANSLATE_NOOP("Exceptions", "No permission to read the file");
-constexpr const char* fileWritePermissionMsg =
-    QT_TRANSLATE_NOOP("Exceptions", "No write permission for the file or the file is read-only");
+constexpr const char* fileReadPermissionMsg
+    = QT_TRANSLATE_NOOP("Exceptions", "No permission to read the file");
+constexpr const char* fileWritePermissionMsg
+    = QT_TRANSLATE_NOOP("Exceptions", "No write permission for the file or the file is read-only");
 constexpr const char* fileFormatMsg = QT_TRANSLATE_NOOP("Exceptions", "File format not supported");
 constexpr const char* fileReadMsg = QT_TRANSLATE_NOOP("Exceptions", "Error reading from file");
 constexpr const char* fileWriteMsg = QT_TRANSLATE_NOOP("Exceptions", "Error writing to file");
-constexpr const char* directoryNotFoundMsg =
-    QT_TRANSLATE_NOOP("Exceptions", "Directory does not exist");
+constexpr const char* directoryNotFoundMsg
+    = QT_TRANSLATE_NOOP("Exceptions", "Directory does not exist");
 }  // namespace
 
 FileNotFoundException::FileNotFoundException(const std::string& fileName)

--- a/src/Base/Exception.cpp
+++ b/src/Base/Exception.cpp
@@ -29,8 +29,14 @@
 
 #include "Console.h"
 #include "PyObjectBase.h"
+#include "Translation.h"
 
 #include "Exception.h"
+
+// Base does not link against Qt; lupdate still extracts the marked strings.
+#ifndef QT_TRANSLATE_NOOP
+# define QT_TRANSLATE_NOOP(context, sourceText) sourceText
+#endif
 
 FC_LOG_LEVEL_INIT("Exception", true, true)
 
@@ -87,6 +93,15 @@ void Exception::reportException() const
 
     _FC_ERR(fileName.c_str(), lineNum, msg);
     hasBeenReported = true;
+}
+
+std::string Exception::getTranslatedMessage() const
+{
+    if (isTranslatable) {
+        return Translation::translate("Exceptions", errorMessage);
+    }
+
+    return errorMessage;
 }
 
 PyObject* Exception::getPyObject()
@@ -232,15 +247,26 @@ void FileException::setFileName(const std::string& fileName)
 {
     file.setFile(fileName);
     _sErrMsgAndFileName = getMessage();
-    if (!getFile().empty()) {
+    if (const std::string path = file.filePath(); !path.empty()) {
         _sErrMsgAndFileName += ": ";
-        _sErrMsgAndFileName += fileName;
+        _sErrMsgAndFileName += path;
     }
 }
 
 std::string FileException::getFileName() const
 {
     return file.fileName();
+}
+
+std::string FileException::getTranslatedMessage() const
+{
+    std::string message = Exception::getTranslatedMessage();
+    if (const std::string path = file.filePath(); !path.empty()) {
+        message += ": ";
+        message += path;
+    }
+
+    return message;
 }
 
 const char* FileException::what() const noexcept
@@ -286,6 +312,118 @@ void FileException::setPyObject(PyObject* pydict)
 PyObject* FileException::getPyExceptionType() const
 {
     return PyExc_IOError;
+}
+
+// ---------------------------------------------------------
+
+namespace
+{
+constexpr const char* fileNotFoundMsg = QT_TRANSLATE_NOOP("Exceptions", "File not found");
+constexpr const char* fileReadPermissionMsg =
+    QT_TRANSLATE_NOOP("Exceptions", "No permission to read the file");
+constexpr const char* fileWritePermissionMsg =
+    QT_TRANSLATE_NOOP("Exceptions", "No write permission for the file or the file is read-only");
+constexpr const char* fileFormatMsg = QT_TRANSLATE_NOOP("Exceptions", "File format not supported");
+constexpr const char* fileReadMsg = QT_TRANSLATE_NOOP("Exceptions", "Error reading from file");
+constexpr const char* fileWriteMsg = QT_TRANSLATE_NOOP("Exceptions", "Error writing to file");
+constexpr const char* directoryNotFoundMsg =
+    QT_TRANSLATE_NOOP("Exceptions", "Directory does not exist");
+}  // namespace
+
+FileNotFoundException::FileNotFoundException(const std::string& fileName)
+    : FileException(fileNotFoundMsg, fileName)
+{
+    setTranslatable(true);
+}
+
+FileNotFoundException::FileNotFoundException(const FileInfo& file)
+    : FileException(fileNotFoundMsg, file)
+{
+    setTranslatable(true);
+}
+
+// ---------------------------------------------------------
+
+FileReadPermissionException::FileReadPermissionException(const std::string& fileName)
+    : FileException(fileReadPermissionMsg, fileName)
+{
+    setTranslatable(true);
+}
+
+FileReadPermissionException::FileReadPermissionException(const FileInfo& file)
+    : FileException(fileReadPermissionMsg, file)
+{
+    setTranslatable(true);
+}
+
+// ---------------------------------------------------------
+
+FileWritePermissionException::FileWritePermissionException(const std::string& fileName)
+    : FileException(fileWritePermissionMsg, fileName)
+{
+    setTranslatable(true);
+}
+
+FileWritePermissionException::FileWritePermissionException(const FileInfo& file)
+    : FileException(fileWritePermissionMsg, file)
+{
+    setTranslatable(true);
+}
+
+// ---------------------------------------------------------
+
+FileFormatException::FileFormatException(const std::string& fileName)
+    : FileException(fileFormatMsg, fileName)
+{
+    setTranslatable(true);
+}
+
+FileFormatException::FileFormatException(const FileInfo& file)
+    : FileException(fileFormatMsg, file)
+{
+    setTranslatable(true);
+}
+
+// ---------------------------------------------------------
+
+FileReadException::FileReadException(const std::string& fileName)
+    : FileException(fileReadMsg, fileName)
+{
+    setTranslatable(true);
+}
+
+FileReadException::FileReadException(const FileInfo& file)
+    : FileException(fileReadMsg, file)
+{
+    setTranslatable(true);
+}
+
+// ---------------------------------------------------------
+
+FileWriteException::FileWriteException(const std::string& fileName)
+    : FileException(fileWriteMsg, fileName)
+{
+    setTranslatable(true);
+}
+
+FileWriteException::FileWriteException(const FileInfo& file)
+    : FileException(fileWriteMsg, file)
+{
+    setTranslatable(true);
+}
+
+// ---------------------------------------------------------
+
+DirectoryNotFoundException::DirectoryNotFoundException(const std::string& dirName)
+    : FileException(directoryNotFoundMsg, dirName)
+{
+    setTranslatable(true);
+}
+
+DirectoryNotFoundException::DirectoryNotFoundException(const FileInfo& directory)
+    : FileException(directoryNotFoundMsg, directory)
+{
+    setTranslatable(true);
 }
 
 // ---------------------------------------------------------

--- a/src/Base/Exception.h
+++ b/src/Base/Exception.h
@@ -272,6 +272,102 @@ private:
     void setFileName(const std::string& fileName);
 };
 
+/** File not found or does not exist */
+class BaseExport FileNotFoundException: public FileException
+{
+public:
+    explicit FileNotFoundException(const std::string& fileName)
+        : FileException("File not found", fileName)
+    {
+        setTranslatable(true);
+    }
+    explicit FileNotFoundException(const FileInfo& file)
+        : FileException("File not found", file)
+    {
+        setTranslatable(true);
+    }
+};
+
+/** No write permission for file or file is read-only */
+class BaseExport FilePermissionException: public FileException
+{
+public:
+    explicit FilePermissionException(const std::string& fileName)
+        : FileException("No write permission for file or file is read-only", fileName)
+    {
+        setTranslatable(true);
+    }
+    explicit FilePermissionException(const FileInfo& file)
+        : FileException("No write permission for file or file is read-only", file)
+    {
+        setTranslatable(true);
+    }
+};
+
+/** File extension or format not supported */
+class BaseExport FileFormatException: public FileException
+{
+public:
+    explicit FileFormatException(const std::string& fileName)
+        : FileException("File extension not supported", fileName)
+    {
+        setTranslatable(true);
+    }
+    explicit FileFormatException(const FileInfo& file)
+        : FileException("File extension not supported", file)
+    {
+        setTranslatable(true);
+    }
+};
+
+/** Error reading from file */
+class BaseExport FileReadException: public FileException
+{
+public:
+    explicit FileReadException(const std::string& fileName, const std::string& details = "")
+        : FileException(details.empty() ? "Error reading from file" : details, fileName)
+    {
+        setTranslatable(details.empty());
+    }
+    explicit FileReadException(const FileInfo& file, const std::string& details = "")
+        : FileException(details.empty() ? "Error reading from file" : details, file)
+    {
+        setTranslatable(details.empty());
+    }
+};
+
+/** Error writing to file */
+class BaseExport FileWriteException: public FileException
+{
+public:
+    explicit FileWriteException(const std::string& fileName, const std::string& details = "")
+        : FileException(details.empty() ? "Error writing to file" : details, fileName)
+    {
+        setTranslatable(details.empty());
+    }
+    explicit FileWriteException(const FileInfo& file, const std::string& details = "")
+        : FileException(details.empty() ? "Error writing to file" : details, file)
+    {
+        setTranslatable(details.empty());
+    }
+};
+
+/** Directory does not exist */
+class BaseExport DirectoryNotFoundException: public FileException
+{
+public:
+    explicit DirectoryNotFoundException(const std::string& dirName)
+        : FileException("Directory does not exist", dirName)
+    {
+        setTranslatable(true);
+    }
+    explicit DirectoryNotFoundException(const FileInfo& file)
+        : FileException("Directory does not exist", file)
+    {
+        setTranslatable(true);
+    }
+};
+
 class BaseExport FileSystemError: public Exception
 {
 public:

--- a/src/Base/Exception.h
+++ b/src/Base/Exception.h
@@ -175,6 +175,9 @@ public:
     virtual const char* what() const noexcept;
     virtual void reportException() const;  // once only
 
+    /// Message looked up in the "Exceptions" context when it is marked translatable
+    virtual std::string getTranslatedMessage() const;
+
     inline void setMessage(const std::string& message);
     // what may differ from the message given by the user in
     // derived classes
@@ -257,6 +260,7 @@ public:
 
     const char* what() const noexcept override;
     void reportException() const override;
+    std::string getTranslatedMessage() const override;
     std::string getFileName() const;
     PyObject* getPyObject() override;
 
@@ -272,100 +276,53 @@ private:
     void setFileName(const std::string& fileName);
 };
 
-/** File not found or does not exist */
 class BaseExport FileNotFoundException: public FileException
 {
 public:
-    explicit FileNotFoundException(const std::string& fileName)
-        : FileException("File not found", fileName)
-    {
-        setTranslatable(true);
-    }
-    explicit FileNotFoundException(const FileInfo& file)
-        : FileException("File not found", file)
-    {
-        setTranslatable(true);
-    }
+    explicit FileNotFoundException(const std::string& fileName);
+    explicit FileNotFoundException(const FileInfo& file);
 };
 
-/** No write permission for file or file is read-only */
-class BaseExport FilePermissionException: public FileException
+class BaseExport FileReadPermissionException: public FileException
 {
 public:
-    explicit FilePermissionException(const std::string& fileName)
-        : FileException("No write permission for file or file is read-only", fileName)
-    {
-        setTranslatable(true);
-    }
-    explicit FilePermissionException(const FileInfo& file)
-        : FileException("No write permission for file or file is read-only", file)
-    {
-        setTranslatable(true);
-    }
+    explicit FileReadPermissionException(const std::string& fileName);
+    explicit FileReadPermissionException(const FileInfo& file);
 };
 
-/** File extension or format not supported */
+class BaseExport FileWritePermissionException: public FileException
+{
+public:
+    explicit FileWritePermissionException(const std::string& fileName);
+    explicit FileWritePermissionException(const FileInfo& file);
+};
+
 class BaseExport FileFormatException: public FileException
 {
 public:
-    explicit FileFormatException(const std::string& fileName)
-        : FileException("File extension not supported", fileName)
-    {
-        setTranslatable(true);
-    }
-    explicit FileFormatException(const FileInfo& file)
-        : FileException("File extension not supported", file)
-    {
-        setTranslatable(true);
-    }
+    explicit FileFormatException(const std::string& fileName = "");
+    explicit FileFormatException(const FileInfo& file);
 };
 
-/** Error reading from file */
 class BaseExport FileReadException: public FileException
 {
 public:
-    explicit FileReadException(const std::string& fileName, const std::string& details = "")
-        : FileException(details.empty() ? "Error reading from file" : details, fileName)
-    {
-        setTranslatable(details.empty());
-    }
-    explicit FileReadException(const FileInfo& file, const std::string& details = "")
-        : FileException(details.empty() ? "Error reading from file" : details, file)
-    {
-        setTranslatable(details.empty());
-    }
+    explicit FileReadException(const std::string& fileName);
+    explicit FileReadException(const FileInfo& file);
 };
 
-/** Error writing to file */
 class BaseExport FileWriteException: public FileException
 {
 public:
-    explicit FileWriteException(const std::string& fileName, const std::string& details = "")
-        : FileException(details.empty() ? "Error writing to file" : details, fileName)
-    {
-        setTranslatable(details.empty());
-    }
-    explicit FileWriteException(const FileInfo& file, const std::string& details = "")
-        : FileException(details.empty() ? "Error writing to file" : details, file)
-    {
-        setTranslatable(details.empty());
-    }
+    explicit FileWriteException(const std::string& fileName);
+    explicit FileWriteException(const FileInfo& file);
 };
 
-/** Directory does not exist */
 class BaseExport DirectoryNotFoundException: public FileException
 {
 public:
-    explicit DirectoryNotFoundException(const std::string& dirName)
-        : FileException("Directory does not exist", dirName)
-    {
-        setTranslatable(true);
-    }
-    explicit DirectoryNotFoundException(const FileInfo& file)
-        : FileException("Directory does not exist", file)
-    {
-        setTranslatable(true);
-    }
+    explicit DirectoryNotFoundException(const std::string& dirName);
+    explicit DirectoryNotFoundException(const FileInfo& directory);
 };
 
 class BaseExport FileSystemError: public Exception

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1707,7 +1707,7 @@ bool Document::save()
         }
         catch (const Base::FileException& e) {
             e.reportException();
-            return askIfSavingFailed(QString::fromUtf8(e.what()));
+            return askIfSavingFailed(QString::fromUtf8(e.getTranslatedMessage().c_str()));
         }
         catch (const Base::Exception& e) {
             QMessageBox::critical(
@@ -1771,7 +1771,7 @@ bool Document::saveAs()
         }
         catch (const Base::FileException& e) {
             e.reportException();
-            return askIfSavingFailed(QString::fromUtf8(e.what()));
+            return askIfSavingFailed(QString::fromUtf8(e.getTranslatedMessage().c_str()));
         }
         catch (const Base::Exception& e) {
             QMessageBox::critical(

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1707,7 +1707,7 @@ bool Document::save()
         }
         catch (const Base::FileException& e) {
             e.reportException();
-            return askIfSavingFailed(QString::fromUtf8(e.getTranslatedMessage().c_str()));
+            return askIfSavingFailed(QString::fromStdString(e.getTranslatedMessage()));
         }
         catch (const Base::Exception& e) {
             QMessageBox::critical(

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -217,7 +217,7 @@ MeshIO::Format MeshInput::getFormat(const char* FileName)
         return MeshIO::Format::SMF;
     }
 
-    throw Base::FileException("File extension not supported", FileName);
+    throw Base::FileFormatException(FileName);
 }
 
 bool MeshInput::LoadAny(const char* FileName)
@@ -225,10 +225,10 @@ bool MeshInput::LoadAny(const char* FileName)
     // ask for read permission
     Base::FileInfo fi(FileName);
     if (!fi.exists() || !fi.isFile()) {
-        throw Base::FileException("File does not exist", FileName);
+        throw Base::FileNotFoundException(FileName);
     }
     if (!fi.isReadable()) {
-        throw Base::FileException("No permission on the file", FileName);
+        throw Base::FilePermissionException(FileName);
     }
 
     Base::ifstream str(fi, std::ios::in | std::ios::binary);
@@ -274,7 +274,7 @@ bool MeshInput::LoadAny(const char* FileName)
         ok = LoadPLY(str);
     }
     else {
-        throw Base::FileException("File extension not supported", FileName);
+        throw Base::FileFormatException(FileName);
     }
 
     return ok;
@@ -308,7 +308,7 @@ bool MeshInput::LoadFormat(std::istream& input, MeshIO::Format fmt)
         case MeshIO::NAS:
             return LoadNastran(input);
         default:
-            throw Base::FileException("Unsupported file format");
+            throw Base::FileFormatException("");
     }
 }
 
@@ -1389,10 +1389,10 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
     Base::FileInfo file(FileName);
     Base::FileInfo directory(file.dirPath());
     if (!directory.exists()) {
-        throw Base::FileException("Directory does not exist", FileName);
+        throw Base::DirectoryNotFoundException(FileName);
     }
     if ((file.exists() && !file.isWritable()) || !directory.isWritable()) {
-        throw Base::FileException("No write permission for file", FileName);
+        throw Base::FilePermissionException(FileName);
     }
 
     MeshIO::Format fileformat = format;
@@ -1413,7 +1413,7 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         bool ok = false;
         ok = aWriter.SaveBinarySTL(str);
         if (!ok) {
-            throw Base::FileException("Export of STL mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of STL mesh failed");
         }
     }
     else if (fileformat == MeshIO::ASTL) {
@@ -1425,37 +1425,37 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         bool ok = false;
         ok = aWriter.SaveAsciiSTL(str);
         if (!ok) {
-            throw Base::FileException("Export of STL mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of STL mesh failed");
         }
     }
     else if (fileformat == MeshIO::OBJ) {
         // write file
         if (!SaveOBJ(str, FileName)) {
-            throw Base::FileException("Export of OBJ mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of OBJ mesh failed");
         }
     }
     else if (fileformat == MeshIO::SMF) {
         // write file
         if (!SaveSMF(str)) {
-            throw Base::FileException("Export of SMF mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of SMF mesh failed");
         }
     }
     else if (fileformat == MeshIO::OFF) {
         // write file
         if (!SaveOFF(str)) {
-            throw Base::FileException("Export of OFF mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of OFF mesh failed");
         }
     }
     else if (fileformat == MeshIO::PLY) {
         // write file
         if (!SaveBinaryPLY(str)) {
-            throw Base::FileException("Export of PLY mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of PLY mesh failed");
         }
     }
     else if (fileformat == MeshIO::APLY) {
         // write file
         if (!SaveAsciiPLY(str)) {
-            throw Base::FileException("Export of PLY mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of PLY mesh failed");
         }
     }
     else if (fileformat == MeshIO::IDTF) {

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -228,7 +228,7 @@ bool MeshInput::LoadAny(const char* FileName)
         throw Base::FileNotFoundException(FileName);
     }
     if (!fi.isReadable()) {
-        throw Base::FilePermissionException(FileName);
+        throw Base::FileReadPermissionException(FileName);
     }
 
     Base::ifstream str(fi, std::ios::in | std::ios::binary);
@@ -308,7 +308,7 @@ bool MeshInput::LoadFormat(std::istream& input, MeshIO::Format fmt)
         case MeshIO::NAS:
             return LoadNastran(input);
         default:
-            throw Base::FileFormatException("");
+            throw Base::FileFormatException();
     }
 }
 
@@ -1394,10 +1394,10 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
     Base::FileInfo file(FileName);
     Base::FileInfo directory(file.dirPath());
     if (!directory.exists()) {
-        throw Base::DirectoryNotFoundException(FileName);
+        throw Base::DirectoryNotFoundException(directory);
     }
     if ((file.exists() && !file.isWritable()) || !directory.isWritable()) {
-        throw Base::FilePermissionException(FileName);
+        throw Base::FileWritePermissionException(FileName);
     }
 
     MeshIO::Format fileformat = format;
@@ -1418,7 +1418,7 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         bool ok = false;
         ok = aWriter.SaveBinarySTL(str);
         if (!ok) {
-            throw Base::FileWriteException(FileName, "Export of STL mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::ASTL) {
@@ -1430,37 +1430,37 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         bool ok = false;
         ok = aWriter.SaveAsciiSTL(str);
         if (!ok) {
-            throw Base::FileWriteException(FileName, "Export of STL mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::OBJ) {
         // write file
         if (!SaveOBJ(str, FileName)) {
-            throw Base::FileWriteException(FileName, "Export of OBJ mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::SMF) {
         // write file
         if (!SaveSMF(str)) {
-            throw Base::FileWriteException(FileName, "Export of SMF mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::OFF) {
         // write file
         if (!SaveOFF(str)) {
-            throw Base::FileWriteException(FileName, "Export of OFF mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::PLY) {
         // write file
         if (!SaveBinaryPLY(str)) {
-            throw Base::FileWriteException(FileName, "Export of PLY mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::APLY) {
         // write file
         if (!SaveAsciiPLY(str)) {
-            throw Base::FileWriteException(FileName, "Export of PLY mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::IDTF) {
@@ -1545,7 +1545,7 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         }
     }
     else {
-        throw Base::FileException("File format not supported", FileName);
+        throw Base::FileFormatException(FileName);
     }
 
     return true;
@@ -1595,7 +1595,7 @@ bool MeshOutput::SaveFormat(std::ostream& str, MeshIO::Format fmt) const
         case MeshIO::ASY:
             return SaveAsymptote(str);
         default:
-            throw Base::FileException("Unsupported file format");
+            throw Base::FileFormatException();
     }
 }
 

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -228,7 +228,7 @@ bool MeshInput::LoadAny(const char* FileName)
         throw Base::FileNotFoundException(FileName);
     }
     if (!fi.isReadable()) {
-        throw Base::FilePermissionException(FileName);
+        throw Base::FileReadPermissionException(FileName);
     }
 
     Base::ifstream str(fi, std::ios::in | std::ios::binary);
@@ -308,7 +308,7 @@ bool MeshInput::LoadFormat(std::istream& input, MeshIO::Format fmt)
         case MeshIO::NAS:
             return LoadNastran(input);
         default:
-            throw Base::FileFormatException("");
+            throw Base::FileFormatException();
     }
 }
 
@@ -1389,10 +1389,10 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
     Base::FileInfo file(FileName);
     Base::FileInfo directory(file.dirPath());
     if (!directory.exists()) {
-        throw Base::DirectoryNotFoundException(FileName);
+        throw Base::DirectoryNotFoundException(directory);
     }
     if ((file.exists() && !file.isWritable()) || !directory.isWritable()) {
-        throw Base::FilePermissionException(FileName);
+        throw Base::FileWritePermissionException(FileName);
     }
 
     MeshIO::Format fileformat = format;
@@ -1413,7 +1413,7 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         bool ok = false;
         ok = aWriter.SaveBinarySTL(str);
         if (!ok) {
-            throw Base::FileWriteException(FileName, "Export of STL mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::ASTL) {
@@ -1425,37 +1425,37 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         bool ok = false;
         ok = aWriter.SaveAsciiSTL(str);
         if (!ok) {
-            throw Base::FileWriteException(FileName, "Export of STL mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::OBJ) {
         // write file
         if (!SaveOBJ(str, FileName)) {
-            throw Base::FileWriteException(FileName, "Export of OBJ mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::SMF) {
         // write file
         if (!SaveSMF(str)) {
-            throw Base::FileWriteException(FileName, "Export of SMF mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::OFF) {
         // write file
         if (!SaveOFF(str)) {
-            throw Base::FileWriteException(FileName, "Export of OFF mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::PLY) {
         // write file
         if (!SaveBinaryPLY(str)) {
-            throw Base::FileWriteException(FileName, "Export of PLY mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::APLY) {
         // write file
         if (!SaveAsciiPLY(str)) {
-            throw Base::FileWriteException(FileName, "Export of PLY mesh failed");
+            throw Base::FileWriteException(FileName);
         }
     }
     else if (fileformat == MeshIO::IDTF) {
@@ -1540,7 +1540,7 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         }
     }
     else {
-        throw Base::FileException("File format not supported", FileName);
+        throw Base::FileFormatException(FileName);
     }
 
     return true;
@@ -1590,7 +1590,7 @@ bool MeshOutput::SaveFormat(std::ostream& str, MeshIO::Format fmt) const
         case MeshIO::ASY:
             return SaveAsymptote(str);
         default:
-            throw Base::FileException("Unsupported file format");
+            throw Base::FileFormatException();
     }
 }
 

--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -217,7 +217,7 @@ MeshIO::Format MeshInput::getFormat(const char* FileName)
         return MeshIO::Format::SMF;
     }
 
-    throw Base::FileException("File extension not supported", FileName);
+    throw Base::FileFormatException(FileName);
 }
 
 bool MeshInput::LoadAny(const char* FileName)
@@ -225,10 +225,10 @@ bool MeshInput::LoadAny(const char* FileName)
     // ask for read permission
     Base::FileInfo fi(FileName);
     if (!fi.exists() || !fi.isFile()) {
-        throw Base::FileException("File does not exist", FileName);
+        throw Base::FileNotFoundException(FileName);
     }
     if (!fi.isReadable()) {
-        throw Base::FileException("No permission on the file", FileName);
+        throw Base::FilePermissionException(FileName);
     }
 
     Base::ifstream str(fi, std::ios::in | std::ios::binary);
@@ -274,7 +274,7 @@ bool MeshInput::LoadAny(const char* FileName)
         ok = LoadPLY(str);
     }
     else {
-        throw Base::FileException("File extension not supported", FileName);
+        throw Base::FileFormatException(FileName);
     }
 
     return ok;
@@ -308,7 +308,7 @@ bool MeshInput::LoadFormat(std::istream& input, MeshIO::Format fmt)
         case MeshIO::NAS:
             return LoadNastran(input);
         default:
-            throw Base::FileException("Unsupported file format");
+            throw Base::FileFormatException("");
     }
 }
 
@@ -1394,10 +1394,10 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
     Base::FileInfo file(FileName);
     Base::FileInfo directory(file.dirPath());
     if (!directory.exists()) {
-        throw Base::FileException("Directory does not exist", FileName);
+        throw Base::DirectoryNotFoundException(FileName);
     }
     if ((file.exists() && !file.isWritable()) || !directory.isWritable()) {
-        throw Base::FileException("No write permission for file", FileName);
+        throw Base::FilePermissionException(FileName);
     }
 
     MeshIO::Format fileformat = format;
@@ -1418,7 +1418,7 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         bool ok = false;
         ok = aWriter.SaveBinarySTL(str);
         if (!ok) {
-            throw Base::FileException("Export of STL mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of STL mesh failed");
         }
     }
     else if (fileformat == MeshIO::ASTL) {
@@ -1430,37 +1430,37 @@ bool MeshOutput::SaveAny(const char* FileName, MeshIO::Format format) const
         bool ok = false;
         ok = aWriter.SaveAsciiSTL(str);
         if (!ok) {
-            throw Base::FileException("Export of STL mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of STL mesh failed");
         }
     }
     else if (fileformat == MeshIO::OBJ) {
         // write file
         if (!SaveOBJ(str, FileName)) {
-            throw Base::FileException("Export of OBJ mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of OBJ mesh failed");
         }
     }
     else if (fileformat == MeshIO::SMF) {
         // write file
         if (!SaveSMF(str)) {
-            throw Base::FileException("Export of SMF mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of SMF mesh failed");
         }
     }
     else if (fileformat == MeshIO::OFF) {
         // write file
         if (!SaveOFF(str)) {
-            throw Base::FileException("Export of OFF mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of OFF mesh failed");
         }
     }
     else if (fileformat == MeshIO::PLY) {
         // write file
         if (!SaveBinaryPLY(str)) {
-            throw Base::FileException("Export of PLY mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of PLY mesh failed");
         }
     }
     else if (fileformat == MeshIO::APLY) {
         // write file
         if (!SaveAsciiPLY(str)) {
-            throw Base::FileException("Export of PLY mesh failed", FileName);
+            throw Base::FileWriteException(FileName, "Export of PLY mesh failed");
         }
     }
     else if (fileformat == MeshIO::IDTF) {

--- a/src/Mod/Mesh/App/Exporter.cpp
+++ b/src/Mod/Mesh/App/Exporter.cpp
@@ -144,7 +144,7 @@ void Exporter::throwIfNoPermission(const std::string& filename)
     Base::FileInfo fi(filename);
     Base::FileInfo di(fi.dirPath());
     if ((fi.exists() && !fi.isWritable()) || !di.exists() || !di.isWritable()) {
-        throw Base::FileException("No write permission for file", fi);
+        throw Base::FilePermissionException(fi);
     }
 }
 

--- a/src/Mod/Mesh/App/Exporter.cpp
+++ b/src/Mod/Mesh/App/Exporter.cpp
@@ -144,7 +144,7 @@ void Exporter::throwIfNoPermission(const std::string& filename)
     Base::FileInfo fi(filename);
     Base::FileInfo di(fi.dirPath());
     if ((fi.exists() && !fi.isWritable()) || !di.exists() || !di.isWritable()) {
-        throw Base::FilePermissionException(fi);
+        throw Base::FileWritePermissionException(fi);
     }
 }
 

--- a/src/Mod/Part/App/ImportIges.cpp
+++ b/src/Mod/Part/App/ImportIges.cpp
@@ -67,7 +67,7 @@ int Part::ImportIgesParts(App::Document* pcDoc, const char* FileName)
 
         IGESControl_Reader aReader;
         if (aReader.ReadFile((Standard_CString)FileName) != IFSelect_RetDone) {
-            throw Base::FileException("Error in reading IGES");
+            throw Base::FileReadException(FileName, "Error in reading IGES");
         }
 
         // Ignore construction elements

--- a/src/Mod/Part/App/ImportIges.cpp
+++ b/src/Mod/Part/App/ImportIges.cpp
@@ -67,7 +67,7 @@ int Part::ImportIgesParts(App::Document* pcDoc, const char* FileName)
 
         IGESControl_Reader aReader;
         if (aReader.ReadFile((Standard_CString)FileName) != IFSelect_RetDone) {
-            throw Base::FileReadException(FileName, "Error in reading IGES");
+            throw Base::FileReadException(FileName);
         }
 
         // Ignore construction elements

--- a/src/Mod/Part/App/ImportIges.cpp
+++ b/src/Mod/Part/App/ImportIges.cpp
@@ -66,7 +66,7 @@ int Part::ImportIgesParts(App::Document* pcDoc, const char* FileName)
 
         IGESControl_Reader aReader;
         if (aReader.ReadFile((Standard_CString)FileName) != IFSelect_RetDone) {
-            throw Base::FileException("Error in reading IGES");
+            throw Base::FileReadException(FileName, "Error in reading IGES");
         }
 
         // Ignore construction elements

--- a/src/Mod/Part/App/ImportIges.cpp
+++ b/src/Mod/Part/App/ImportIges.cpp
@@ -66,7 +66,7 @@ int Part::ImportIgesParts(App::Document* pcDoc, const char* FileName)
 
         IGESControl_Reader aReader;
         if (aReader.ReadFile((Standard_CString)FileName) != IFSelect_RetDone) {
-            throw Base::FileReadException(FileName, "Error in reading IGES");
+            throw Base::FileReadException(FileName);
         }
 
         // Ignore construction elements

--- a/src/Mod/Part/App/ImportStep.cpp
+++ b/src/Mod/Part/App/ImportStep.cpp
@@ -73,15 +73,13 @@ int Part::ImportStepParts(App::Document* pcDoc, const char* Name)
     FC_WARN("Importing STEP via 'Part' is deprecated. Use 'ImportGui' instead.");
 
     if (!fi.exists()) {
-        std::stringstream str;
-        str << "File '" << Name << "' does not exist!";
-        throw Base::FileException(str.str().c_str());
+        throw Base::FileNotFoundException(Name);
     }
     std::string encodednamestr = encodeFilename(std::string(Name));
     const char* encodedname = encodednamestr.c_str();
 
     if (aReader.ReadFile((Standard_CString)encodedname) != IFSelect_RetDone) {
-        throw Base::FileException("Cannot open STEP file");
+        throw Base::FileReadException(Name, "Cannot open STEP file");
     }
 
     // Root transfers
@@ -94,7 +92,7 @@ int Part::ImportStepParts(App::Document* pcDoc, const char* Name)
     // Collecting resulting entities
     Standard_Integer nbs = aReader.NbShapes();
     if (nbs == 0) {
-        throw Base::FileException("No shapes found in file ");
+        throw Base::FileReadException(Name, "No shapes found in file");
     }
     else {
 

--- a/src/Mod/Part/App/ImportStep.cpp
+++ b/src/Mod/Part/App/ImportStep.cpp
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 #include <fcntl.h>
-#include <sstream>
 #include <Quantity_Color.hxx>
 #include <BRep_Builder.hxx>
 #include <STEPControl_Reader.hxx>
@@ -77,7 +76,7 @@ int Part::ImportStepParts(App::Document* pcDoc, const char* Name)
     const char* encodedname = encodednamestr.c_str();
 
     if (aReader.ReadFile((Standard_CString)encodedname) != IFSelect_RetDone) {
-        throw Base::FileReadException(Name, "Cannot open STEP file");
+        throw Base::FileReadException(Name);
     }
 
     // Root transfers
@@ -90,7 +89,7 @@ int Part::ImportStepParts(App::Document* pcDoc, const char* Name)
     // Collecting resulting entities
     Standard_Integer nbs = aReader.NbShapes();
     if (nbs == 0) {
-        throw Base::FileReadException(Name, "No shapes found in file");
+        throw Base::FileException("No shapes found in file", Name);
     }
     else {
 

--- a/src/Mod/Part/App/ImportStep.cpp
+++ b/src/Mod/Part/App/ImportStep.cpp
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 #include <fcntl.h>
-#include <sstream>
 #include <Quantity_Color.hxx>
 #include <BRep_Builder.hxx>
 #include <STEPControl_Reader.hxx>
@@ -79,7 +78,7 @@ int Part::ImportStepParts(App::Document* pcDoc, const char* Name)
     const char* encodedname = encodednamestr.c_str();
 
     if (aReader.ReadFile((Standard_CString)encodedname) != IFSelect_RetDone) {
-        throw Base::FileReadException(Name, "Cannot open STEP file");
+        throw Base::FileReadException(Name);
     }
 
     // Root transfers
@@ -92,7 +91,7 @@ int Part::ImportStepParts(App::Document* pcDoc, const char* Name)
     // Collecting resulting entities
     Standard_Integer nbs = aReader.NbShapes();
     if (nbs == 0) {
-        throw Base::FileReadException(Name, "No shapes found in file");
+        throw Base::FileException("No shapes found in file", Name);
     }
     else {
 

--- a/src/Mod/Part/App/ImportStep.cpp
+++ b/src/Mod/Part/App/ImportStep.cpp
@@ -71,15 +71,13 @@ int Part::ImportStepParts(App::Document* pcDoc, const char* Name)
     Base::FileInfo fi(Name);
 
     if (!fi.exists()) {
-        std::stringstream str;
-        str << "File '" << Name << "' does not exist!";
-        throw Base::FileException(str.str().c_str());
+        throw Base::FileNotFoundException(Name);
     }
     std::string encodednamestr = encodeFilename(std::string(Name));
     const char* encodedname = encodednamestr.c_str();
 
     if (aReader.ReadFile((Standard_CString)encodedname) != IFSelect_RetDone) {
-        throw Base::FileException("Cannot open STEP file");
+        throw Base::FileReadException(Name, "Cannot open STEP file");
     }
 
     // Root transfers
@@ -92,7 +90,7 @@ int Part::ImportStepParts(App::Document* pcDoc, const char* Name)
     // Collecting resulting entities
     Standard_Integer nbs = aReader.NbShapes();
     if (nbs == 0) {
-        throw Base::FileException("No shapes found in file ");
+        throw Base::FileReadException(Name, "No shapes found in file");
     }
     else {
 

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -695,7 +695,7 @@ void TopoShape::read(const char* FileName)
 
     // checking on the file
     if (!File.isReadable()) {
-        throw Base::FileException("File to load not existing or not readable", FileName);
+        throw Base::FileNotFoundException(FileName);
     }
 
     if (File.hasExtension({"igs", "iges"})) {
@@ -710,7 +710,7 @@ void TopoShape::read(const char* FileName)
         importBrep(File.filePath().c_str());
     }
     else {
-        throw Base::FileException("Unknown extension");
+        throw Base::FileFormatException(FileName);
     }
 }
 
@@ -758,7 +758,7 @@ void TopoShape::importIges(const char* FileName)
         // http://www.opencascade.org/org/forum/thread_20603/?forum=3
         aReader.SetReadVisible(Standard_True);
         if (aReader.ReadFile(encodeFilename(FileName).c_str()) != IFSelect_RetDone) {
-            throw Base::FileException("Error in reading IGES");
+            throw Base::FileReadException(FileName, "Error in reading IGES");
         }
 
         // make brep
@@ -777,7 +777,7 @@ void TopoShape::importStep(const char* FileName)
     try {
         STEPControl_Reader aReader;
         if (aReader.ReadFile(encodeFilename(FileName).c_str()) != IFSelect_RetDone) {
-            throw Base::FileException("Error in reading STEP");
+            throw Base::FileReadException(FileName, "Error in reading STEP");
         }
 
         // Root transfers
@@ -866,7 +866,7 @@ void TopoShape::write(const char* FileName) const
         exportStl(File.filePath().c_str(), 0.01);
     }
     else {
-        throw Base::FileException("Unknown extension");
+        throw Base::FileFormatException(FileName);
     }
 }
 
@@ -884,7 +884,7 @@ void TopoShape::exportIges(const char* filename) const
         aWriter.AddShape(this->_Shape);
         aWriter.ComputeModel();
         if (aWriter.Write(encodeFilename(filename).c_str()) != IFSelect_RetDone) {
-            throw Base::FileException("Writing of IGES failed");
+            throw Base::FileWriteException(filename, "Writing of IGES failed");
         }
     }
     catch (Standard_Failure& e) {
@@ -915,7 +915,7 @@ void TopoShape::exportStep(const char* filename) const
         Handle(Transfer_FinderProcess) hFinder = hTransferWriter->FinderProcess();
 
         if (aWriter.Transfer(this->_Shape, STEPControl_AsIs) != IFSelect_RetDone) {
-            throw Base::FileException("Error in transferring STEP");
+            throw Base::FileWriteException(filename, "Error in transferring STEP");
         }
 
         APIHeaderSection_MakeHeader makeHeader(aWriter.Model());
@@ -927,7 +927,7 @@ void TopoShape::exportStep(const char* filename) const
         makeHeader.SetDescriptionValue(1, new TCollection_HAsciiString("FreeCAD Model"));
 
         if (aWriter.Write(encodeFilename(filename).c_str()) != IFSelect_RetDone) {
-            throw Base::FileException("Writing of STEP failed");
+            throw Base::FileWriteException(filename, "Writing of STEP failed");
         }
     }
     catch (Standard_Failure& e) {
@@ -945,11 +945,11 @@ void TopoShape::exportBrep(const char* filename) const
             Standard_False,
             TopTools_FormatVersion_VERSION_1
         )) {
-        throw Base::FileException("Writing of BREP failed");
+        throw Base::FileWriteException(filename, "Writing of BREP failed");
     }
 #else
     if (!BRepTools::Write(this->_Shape, encodeFilename(filename).c_str())) {
-        throw Base::FileException("Writing of BREP failed");
+        throw Base::FileWriteException(filename, "Writing of BREP failed");
     }
 #endif
 }

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -694,8 +694,11 @@ void TopoShape::read(const char* FileName)
     Base::FileInfo File(FileName);
 
     // checking on the file
-    if (!File.isReadable()) {
+    if (!File.exists()) {
         throw Base::FileNotFoundException(FileName);
+    }
+    if (!File.isReadable()) {
+        throw Base::FileReadPermissionException(FileName);
     }
 
     if (File.hasExtension({"igs", "iges"})) {
@@ -758,7 +761,7 @@ void TopoShape::importIges(const char* FileName)
         // http://www.opencascade.org/org/forum/thread_20603/?forum=3
         aReader.SetReadVisible(Standard_True);
         if (aReader.ReadFile(encodeFilename(FileName).c_str()) != IFSelect_RetDone) {
-            throw Base::FileReadException(FileName, "Error in reading IGES");
+            throw Base::FileReadException(FileName);
         }
 
         // make brep
@@ -777,7 +780,7 @@ void TopoShape::importStep(const char* FileName)
     try {
         STEPControl_Reader aReader;
         if (aReader.ReadFile(encodeFilename(FileName).c_str()) != IFSelect_RetDone) {
-            throw Base::FileReadException(FileName, "Error in reading STEP");
+            throw Base::FileReadException(FileName);
         }
 
         // Root transfers
@@ -884,7 +887,7 @@ void TopoShape::exportIges(const char* filename) const
         aWriter.AddShape(this->_Shape);
         aWriter.ComputeModel();
         if (aWriter.Write(encodeFilename(filename).c_str()) != IFSelect_RetDone) {
-            throw Base::FileWriteException(filename, "Writing of IGES failed");
+            throw Base::FileWriteException(filename);
         }
     }
     catch (Standard_Failure& e) {
@@ -915,7 +918,7 @@ void TopoShape::exportStep(const char* filename) const
         Handle(Transfer_FinderProcess) hFinder = hTransferWriter->FinderProcess();
 
         if (aWriter.Transfer(this->_Shape, STEPControl_AsIs) != IFSelect_RetDone) {
-            throw Base::FileWriteException(filename, "Error in transferring STEP");
+            throw Base::FileException("Error in transferring STEP", filename);
         }
 
         APIHeaderSection_MakeHeader makeHeader(aWriter.Model());
@@ -927,7 +930,7 @@ void TopoShape::exportStep(const char* filename) const
         makeHeader.SetDescriptionValue(1, new TCollection_HAsciiString("FreeCAD Model"));
 
         if (aWriter.Write(encodeFilename(filename).c_str()) != IFSelect_RetDone) {
-            throw Base::FileWriteException(filename, "Writing of STEP failed");
+            throw Base::FileWriteException(filename);
         }
     }
     catch (Standard_Failure& e) {
@@ -945,11 +948,11 @@ void TopoShape::exportBrep(const char* filename) const
             Standard_False,
             TopTools_FormatVersion_VERSION_1
         )) {
-        throw Base::FileWriteException(filename, "Writing of BREP failed");
+        throw Base::FileWriteException(filename);
     }
 #else
     if (!BRepTools::Write(this->_Shape, encodeFilename(filename).c_str())) {
-        throw Base::FileWriteException(filename, "Writing of BREP failed");
+        throw Base::FileWriteException(filename);
     }
 #endif
 }

--- a/src/Mod/Points/App/PointsAlgos.cpp
+++ b/src/Mod/Points/App/PointsAlgos.cpp
@@ -54,7 +54,7 @@ void PointsAlgos::Load(PointKernel& points, const char* FileName)
 
     // checking on the file
     if (!File.isReadable()) {
-        throw Base::FileException("File to load not existing or not readable", FileName);
+        throw Base::FileNotFoundException(FileName);
     }
 
     if (File.hasExtension("asc")) {

--- a/src/Mod/Points/App/PointsAlgos.cpp
+++ b/src/Mod/Points/App/PointsAlgos.cpp
@@ -53,8 +53,11 @@ void PointsAlgos::Load(PointKernel& points, const char* FileName)
     Base::FileInfo File(FileName);
 
     // checking on the file
-    if (!File.isReadable()) {
+    if (!File.exists()) {
         throw Base::FileNotFoundException(FileName);
+    }
+    if (!File.isReadable()) {
+        throw Base::FileReadPermissionException(FileName);
     }
 
     if (File.hasExtension("asc")) {

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(Base_tests_run
         CoordinateSystem.cpp
         DualNumber.cpp
         DualQuaternion.cpp
+        Exception.cpp
         FileLock.cpp
         FileInfo.cpp
         InputSource.cpp

--- a/tests/src/Base/Exception.cpp
+++ b/tests/src/Base/Exception.cpp
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <Base/Exception.h>
+
+TEST(FileException, TestWhatCombinesUntranslatedMessageAndPath)
+{
+    const Base::FileWritePermissionException exception("/home/user/model.FCStd");
+
+    EXPECT_EQ(exception.getMessage(), "No write permission for the file or the file is read-only");
+    EXPECT_STREQ(
+        exception.what(),
+        "No write permission for the file or the file is read-only: /home/user/model.FCStd"
+    );
+}
+
+TEST(FileException, TestTranslatedMessageFallsBackToSourceAndKeepsPath)
+{
+    const Base::FileNotFoundException exception("/home/user/missing.step");
+
+    EXPECT_EQ(exception.getTranslatedMessage(), "File not found: /home/user/missing.step");
+}
+
+// The messages double as the "Exceptions" translation keys, so changing one
+// silently orphans the translations already made for it.
+TEST(FileException, TestMessagesMatchTheTranslationKeys)
+{
+    EXPECT_EQ(Base::FileNotFoundException("f").getMessage(), "File not found");
+    EXPECT_EQ(Base::FileReadPermissionException("f").getMessage(), "No permission to read the file");
+    EXPECT_EQ(
+        Base::FileWritePermissionException("f").getMessage(),
+        "No write permission for the file or the file is read-only"
+    );
+    EXPECT_EQ(Base::FileFormatException("f").getMessage(), "File format not supported");
+    EXPECT_EQ(Base::FileReadException("f").getMessage(), "Error reading from file");
+    EXPECT_EQ(Base::FileWriteException("f").getMessage(), "Error writing to file");
+    EXPECT_EQ(Base::DirectoryNotFoundException("d").getMessage(), "Directory does not exist");
+}


### PR DESCRIPTION
## Problem
Currently, FreeCAD throws a generic `Base::FileException` with hardcoded English error messages for all file-related errors. These messages cannot be translated, creating a poor user experience for non-English speakers. The issue is particularly problematic when trying to save files marked as read-only or write-protected.

Closes #25531

## Solution
This PR implements **Method A** from the issue discussion

All classes:
- Accept filename/filepath as parameter
- Set `translatable` flag to enable UI translation
- Provide consistent, user-friendly error messages