### PR TITLE
Improve clarity of out-of-scope link error message

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -140,8 +140,7 @@ void DocumentObject::printInvalidLinks() const
             scopenames.pop_back();
         }
 
-        Base::Console().warning("%s: %s links are out of scope.\n"
-                                "Out of scope links to: %s\n",
+        Base::Console().warning("%s: %s links are out of scope. Out of scope links to: %s\n",
                                 getTypeId().getName(),
                                 getNameInDocument(),
                                 objnames.c_str());


### PR DESCRIPTION
## Summary
This PR improves the error message displayed when links in Sketcher objects go out of their allowed scope. The new message is more user-friendly by starting with the object that needs to be edited and clearly listing the out-of-scope links, making it easier for users to spot and fix the issue.

## Issue
Closes #25276

## Changes
- Modified the warning message in `src/App/DocumentObject.cpp` (around line 143) to be more concise and clear
- The message now begins with the problematic object and lists the links that are out of scope
- Removed the "Instead, the linked object(s) reside within..." part as it was deemed less essential for quick issue identification

## Before/After Images
<img width="1917" height="1015" alt="image" src="https://github.com/user-attachments/assets/94696ec2-4d84-420b-be1b-918ec777269d" />
<img width="1891" height="966" alt="image" src="https://github.com/user-attachments/assets/762fa062-2565-49b9-b368-601478382ed3" />

