### PR TITLE
BIM: fix crazy edge issue with area calculation

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1460,6 +1460,15 @@ class AreaCalculator:
         import TechDraw
         import DraftGeomUtils
 
+        # In TechDraw edges longer than 9999.9 (ca. 10m) are considered 'crazy'.
+        # See also Draft/draftobjects/hatch.py.
+        param_grp = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/TechDraw/debug")
+        if "allowCrazyEdge" not in param_grp.GetBools():
+            old_allow_crazy_edge = None
+        else:
+            old_allow_crazy_edge = param_grp.GetBool("allowCrazyEdge")
+        param_grp.SetBool("allowCrazyEdge", True)
+
         direction = FreeCAD.Vector(0, 0, 1)
         projectedFaces = []
         for face in horizontalAreaFaces:
@@ -1496,6 +1505,11 @@ class AreaCalculator:
                 )
                 self.resetAreas()
                 return
+
+        if old_allow_crazy_edge is None:
+            param_grp.RemBool("allowCrazyEdge")
+        else:
+            param_grp.SetBool("allowCrazyEdge", old_allow_crazy_edge)
 
         if projectedFaces:
             fusedFace = projectedFaces.pop()


### PR DESCRIPTION
Fixes #26777.

The code uses a TechDraw function that considers overly long edges (> ca. 10m) 'crazy'. We need to temporarily change a parameter.

The same trick is also used in Draft/draftobjects/hatch.py.