### PR TITLE
CAM: SelectLoop - Horizontal face

### DIFF
--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -31,7 +31,9 @@ from PathScripts.PathUtils import loopdetect
 from PathScripts.PathUtils import wiresdetect
 from PathScripts.PathUtils import horizontalEdgeLoop
 from PathScripts.PathUtils import tangentEdgeLoop
+from PathScripts.PathUtils import horizontalFacesAtHeight
 from PathScripts.PathUtils import horizontalFaceLoops
+from PathScripts.PathUtils import innerEdgesFromFace
 from PathScripts.PathUtils import addToJob
 from PathScripts.PathUtils import findParentJob
 
@@ -59,6 +61,7 @@ class _CommandSelectLoop:
                 "CAM_SelectLoop",
                 "Completes the selection of edges or faces that forms a loop"
                 "\n\nSelect vertical faces: searching loops faces which forms the walls."
+                "\n\nSelect horizontal face: searching inner edges of the face or coplanar faces."
                 "\n\nSelect one edge: searching loop edges in horizontal plane"
                 "\nor wire which contain selected edge."
                 "\n\nSelect two edges: searching loop edges in wires of the shape"
@@ -94,8 +97,14 @@ class _CommandSelectLoop:
 
         elif all(isinstance(sub, Part.Face) for sub in subs):
             # face(s) selected
-            if all(Path.Geom.isVertical(face) for face in subs):
-                names = horizontalFaceLoops(obj, subs)
+            edges = innerEdgesFromFace(obj, subs[0])
+            if not edges:
+                if all(Path.Geom.isVertical(face) for face in subs):
+                    names = horizontalFaceLoops(obj, subs)
+                elif Path.Geom.isHorizontal(subs[0]):
+                    names = horizontalFacesAtHeight(obj, subs[0].CenterOfMass.z)
+                if not names:
+                    edges = [e for sub in subs for e in sub.Edges]
 
         elif isinstance(subs[0], Part.Edge):
             if len(subs) == 1:

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -223,6 +223,27 @@ def tangentEdgeLoop(obj, edge1, edge2):
     return None
 
 
+def innerEdgesFromFace(obj, face):
+    """innerEdgesFromFace(obj, face) ... returns a list of inner edges from face."""
+    outerHash = [e.hashCode() for e in face.OuterWire.Edges]
+    edges = [e for e in face.Edges if e.hashCode() not in outerHash]
+
+    return edges
+
+
+def horizontalFacesAtHeight(obj, z, tol=0.01):
+    """horizontalCoplanarFaces(obj, z) ... returns a list of face names with requested height."""
+    names = [
+        f"Face{i}"
+        for i, f in enumerate(obj.Shape.Faces, 1)
+        if Path.Geom.isHorizontal(f) and Path.Geom.isRoughly(f.CenterOfMass.z, z, tol)
+    ]
+    if len(names) > 1:
+        return names
+
+    return None
+
+
 def horizontalFaceLoops(obj, faces):
     """horizontalFaceLoops(obj, faces) ... returns a list of face names
     which form the walls of a vertical hole face is a part of."""


### PR DESCRIPTION
At this moment `CAM_SelectLoop` do not process horizontal face selection

Added new features, which can be useful for CAM tasks:
- select **inner edges** of selected horizontal face
- if method above not give result, select **horizontal faces with same height**
- if method above not give result, select **outer edges** of selected horizontal face

![Screenshot_20260109_075737_hor](https://github.com/user-attachments/assets/1bc5fd23-9169-453e-9101-341b74bd3015)

![Screenshot_20260126_105741](https://github.com/user-attachments/assets/bd387da9-46cd-4546-84c6-6aabd93441d4)