### PR TITLE
CAM: Engrave - Fix regression in Task panel after #22304

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Gui/Engrave.py
@@ -53,16 +53,13 @@ class TaskPanelBaseGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
     def super(self):
         return super(TaskPanelBaseGeometryPage, self)
 
-    def selectionSupportedAsBaseGeometry(self, selection, ignoreErrors):
+    def selectionSupportedAsBaseGeometry(self, sel, ignoreErrors):
         # allow selection of an entire 2D object, which is generally not the case
-        if (
-            len(selection) == 1
-            and not selection[0].HasSubObjects
-            and selection[0].Object.isDerivedFrom("Part::Part2DObject")
-        ):
+        if not sel.HasSubObjects and sel.Object.isDerivedFrom("Part::Part2DObject"):
             return True
+
         # Let general logic handle all other cases.
-        return self.super().selectionSupportedAsBaseGeometry(selection, ignoreErrors)
+        return self.super().selectionSupportedAsBaseGeometry(sel, ignoreErrors)
 
     def addBaseGeometry(self, selection):
         added = False


### PR DESCRIPTION
At this moment `Task panel` of `Engrave` operation is broken
This PR fix this

Sorry, my mistake. This is regression after
- #22304
<br><br>

<details>
<summary>Errors while create Engrave operation</summary>

```
Traceback (most recent call last):
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Gui/Base.py", line 109, in setEdit
    self.setupTaskPanel(
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Gui/Base.py", line 122, in setupTaskPanel
    panel.setupUi()
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Gui/Base.py", line 1368, in setupUi
    page.addBaseGeometry(sel)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Gui/Engrave.py", line 101, in addBaseGeometry
    base = self.super().addBaseGeometry(selection)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Gui/Base.py", line 696, in addBaseGeometry
    if self.selectionSupportedAsBaseGeometry(sel, False):
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Gui/Engrave.py", line 59, in selectionSupportedAsBaseGeometry
    len(selection) == 1
<class 'TypeError'>: object of type 'Gui.SelectionObject' has no len()
```

</details>

