### PR TITLE
Macro: Fix shortcuts in macro editor #26807

### DIFF
--- a/src/Gui/ShortcutManager.cpp
+++ b/src/Gui/ShortcutManager.cpp
@@ -315,10 +315,7 @@ bool ShortcutManager::eventFilter(QObject* o, QEvent* ev)
                 auto* maybeProxy = focus->focusProxy();
                 auto* focusOrProxy = maybeProxy ? maybeProxy : focus;
 
-                bool isFocusedWidgetTextInput = focusOrProxy->inherits("QLineEdit")
-                    || focusOrProxy->inherits("QTextEdit")
-                    || focusOrProxy->inherits("QPlainTextEdit");
-                if (isFocusedWidgetTextInput) {
+                if (focusOrProxy->inherits("QLineEdit")) {
                     ev->accept();
                     return true;
                 }


### PR DESCRIPTION
- The initial commit to block shortcuts in text edit fields (particularly for MacOS, where those shortcuts would activate FreeCAD functionality rather than text edit functionality) made a wrong assumption.
- It assumed that there were no text edit fields where we would want to actually use application shortcuts.
- In retrospect, this was very wrong, and I completely missed the macro editor.
- For now, it should be fine to change the field to only cover 'LineEdit'. I cannot imagine a case where you'd want to (e.g.) save text from a LineEdit, but if anyone knows of one then please let me know.

Note, I've since learned that freecad also has a text editor functionality, and I expect this would be broken there too. I'll test that it works fine.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
fixes regression #26807
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
