### PR TITLE
CAM: Pocket - Rename property ZigZagAngle to Angle

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -166,14 +166,14 @@ The latter can be used to face of the entire stock area to ensure uniform height
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="zigZagAngle_label">
+       <widget class="QLabel" name="angle_label">
         <property name="text">
          <string>Angle</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="Gui::InputField" name="zigZagAngle">
+       <widget class="Gui::InputField" name="angle">
         <property name="toolTip">
          <string>Angle in which the pattern is applied</string>
         </property>

--- a/src/Mod/CAM/Path/Op/Gui/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/PocketBase.py
@@ -100,14 +100,14 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if setModel and obj.MinTravel != self.form.minTravel.isChecked():
             obj.MinTravel = self.form.minTravel.isChecked()
 
-    def updateZigZagAngle(self, obj, setModel=True):
-        if obj.ClearingPattern in ["Offset"]:
-            self.form.zigZagAngle.setEnabled(False)
+    def updateAngle(self, obj, setModel=True):
+        if obj.ClearingPattern == "Offset":
+            self.form.angle.setEnabled(False)
         else:
-            self.form.zigZagAngle.setEnabled(True)
+            self.form.angle.setEnabled(True)
 
         if setModel:
-            PathGuiUtil.updateInputField(obj, "ZigZagAngle", self.form.zigZagAngle)
+            PathGuiUtil.updateInputField(obj, "Angle", self.form.angle)
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
@@ -121,7 +121,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         PathGuiUtil.updateInputField(obj, "ExtraOffset", self.form.extraOffset)
         self.updateToolController(obj, self.form.toolController)
         self.updateCoolant(obj, self.form.coolantController)
-        self.updateZigZagAngle(obj)
+        self.updateAngle(obj)
 
         if obj.UseStartPoint != self.form.useStartPoint.isChecked():
             obj.UseStartPoint = self.form.useStartPoint.isChecked()
@@ -155,10 +155,8 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         if FeatureOutline & self.pocketFeatures():
             self.form.useOutline.setChecked(obj.UseOutline)
 
-        self.form.zigZagAngle.setText(
-            FreeCAD.Units.Quantity(obj.ZigZagAngle, FreeCAD.Units.Angle).UserString
-        )
-        self.updateZigZagAngle(obj, False)
+        self.form.angle.setText(FreeCAD.Units.Quantity(obj.Angle, FreeCAD.Units.Angle).UserString)
+        self.updateAngle(obj, False)
 
         self.form.minTravel.setChecked(obj.MinTravel)
         self.updateMinTravel(obj, False)
@@ -179,7 +177,7 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         signals.append(self.form.cutMode.currentIndexChanged)
         signals.append(self.form.clearingPattern.currentIndexChanged)
         signals.append(self.form.stepOverPercent.editingFinished)
-        signals.append(self.form.zigZagAngle.editingFinished)
+        signals.append(self.form.angle.editingFinished)
         signals.append(self.form.toolController.currentIndexChanged)
         signals.append(self.form.extraOffset.editingFinished)
         signals.append(self.form.useStartPoint.clicked)

--- a/src/Mod/CAM/Path/Op/MillFace.py
+++ b/src/Mod/CAM/Path/Op/MillFace.py
@@ -299,7 +299,7 @@ class ObjectFace(PathPocketBase.ObjectPocket):
     def areaOpSetDefaultValues(self, obj, job):
         """areaOpSetDefaultValues(obj, job) ... initialize mill facing properties"""
         obj.StepOver = 50
-        obj.ZigZagAngle = 45.0
+        obj.Angle = 45
         obj.ExcludeRaisedAreas = False
         obj.ClearEdges = False
 

--- a/src/Mod/CAM/Path/Op/Pocket.py
+++ b/src/Mod/CAM/Path/Op/Pocket.py
@@ -263,7 +263,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
     def areaOpSetDefaultValues(self, obj, job):
         """areaOpSetDefaultValues(obj, job) ... set default values"""
         obj.StepOver = 50
-        obj.ZigZagAngle = 45
+        obj.Angle = 45
         obj.HandleMultipleFeatures = "Collectively"
         obj.AdaptivePocketStart = False
         obj.AdaptivePocketFinish = False

--- a/src/Mod/CAM/Path/Op/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/PocketBase.py
@@ -110,6 +110,11 @@ class ObjectPocket(PathAreaOp.ObjectOp):
             return
         super().opExecute(obj)
 
+    def areaOpOnChanged(self, obj, prop):
+        if prop == "ClearingPattern":
+            angleMode = 0 if obj.ClearingPattern != "Offset" else 2
+            obj.setEditorMode("Angle", angleMode)
+
     def pocketInvertExtraOffset(self):
         """pocketInvertExtraOffset() ... return True if ExtraOffset's direction is inward.
         Can safely be overwritten by subclass."""
@@ -155,9 +160,9 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         )
         obj.addProperty(
             "App::PropertyFloat",
-            "ZigZagAngle",
+            "Angle",
             "Pocket",
-            QT_TRANSLATE_NOOP("App::Property", "Angle of the zigzag pattern"),
+            QT_TRANSLATE_NOOP("App::Property", "Angle of the grid, line and zigzag patterns"),
         )
         obj.addProperty(
             "App::PropertyEnumeration",
@@ -227,7 +232,7 @@ class ObjectPocket(PathAreaOp.ObjectOp):
         params["Coplanar"] = 0
         params["PocketMode"] = 1
         params["SectionCount"] = -1
-        params["Angle"] = obj.ZigZagAngle
+        params["Angle"] = obj.Angle
         params["FromCenter"] = obj.StartAt == "Center"
         params["PocketStepover"] = (self.radius * 2) * (float(obj.StepOver) / 100)
         extraOffset = obj.ExtraOffset.Value
@@ -297,6 +302,8 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                     "\nManual: uses order of shapes selection",
                 ),
             )
+        if hasattr(obj, "ZigZagAngle"):
+            obj.renameProperty("ZigZagAngle", "Angle")
         if hasattr(obj, "OffsetPattern"):
             obj.setGroupOfProperty("OffsetPattern", "Pocket")
             obj.renameProperty("OffsetPattern", "ClearingPattern")
@@ -339,7 +346,7 @@ def SetupProperties():
     setup.append("CutMode")
     setup.append("ExtraOffset")
     setup.append("StepOver")
-    setup.append("ZigZagAngle")
+    setup.append("Angle")
     setup.append("ClearingPattern")
     setup.append("StartAt")
     setup.append("MinTravel")

--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -177,7 +177,8 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         """areaOpSetDefaultValues(obj, job) ... set default values"""
         obj.ClearingPattern = "Offset"
         obj.StepOver = 50
-        obj.ZigZagAngle = 45
+        obj.Angle = 45
+        obj.setEditorMode("Angle", 2)  # hide for default Offset pattern
         obj.UseOutline = False
         FeatureExtensions.set_default_property_values(obj, job)
 


### PR DESCRIPTION
Property `ZigZagAngle` uses not only for patterns `ZigZag` and `ZigZagOffset`, but also for `Grid` and `Line`
I suggest to rename `ZigZagAngle` to `Angle` to be like in **MillFacing** operation

Also hide `Angle` property if selected pattern `Offset`

<img width="1148" height="255" alt="Screenshot_20260111_220127_hor" src="https://github.com/user-attachments/assets/95f46cc1-1712-4fd2-b509-29e1d2dc8782" />
