### PR TITLE
CAM: Profile - Hide 'Stepover' if not needed

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -333,7 +333,9 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             0 if obj.HandleMultipleFeatures == "Individually" and not obj.UseStartPoint else 2
         )
         sortingMode = 0 if obj.HandleMultipleFeatures == "Individually" else 2
+        multiPassMode = 0 if obj.NumPasses > 1 else 2
 
+        obj.setEditorMode("Stepover", multiPassMode)
         obj.setEditorMode("JoinType", 2)
         obj.setEditorMode("MiterLimit", 2)  # ml
         obj.setEditorMode("Side", side)


### PR DESCRIPTION
Suggest to hide property `Stepover` if `NumPasses == 1`

<img width="996" height="205" alt="Screenshot_20260111_164310_hor" src="https://github.com/user-attachments/assets/21640959-5e82-4052-bdb9-b0a955791331" />
