### PR TITLE
App: Prevent addObjects from extracting children of nested groups

### DIFF
--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -159,7 +159,6 @@ GeoFeatureGroupExtension::addObjects(std::vector<App::DocumentObject*> objects)
         // Prevent from extracting children of nested groups fixed issue:#26743
         // As groups manage their own local coordinate systems and children.
         if (object->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId())) {
-
             if (!hasObject(object)) {
                 grp.push_back(object);
                 ret.push_back(object);


### PR DESCRIPTION
issue: #26743

PartDesign::Body is itself a GeoFeatureGroupExtension and must be treated as a container that manages its own children. Its internal objects must not be extracted when the Body is added to another group.