### PR TITLE
CAM: Area - HandleMultipleFeatures for all operations

### DIFF
--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -365,7 +365,7 @@ class ObjectOp(PathOp.ObjectOp):
         Path.Log.debug("depths: {}".format(heights))
         for i in range(0, len(heights)):
             for baseShape in edgeList:
-                hWire = Part.Wire(Part.__sortEdges__(baseShape.Edges))
+                hWire = Part.Compound([Part.Wire(se) for se in Part.sortEdges(baseShape.Edges)])
                 hWire.translate(FreeCAD.Vector(0, 0, heights[i] - hWire.BoundBox.ZMin))
 
                 pathParams = {}
@@ -448,6 +448,7 @@ class ObjectOp(PathOp.ObjectOp):
             else:
                 shapes.append(shp)
 
+        # Sorting shapes
         if (
             len(shapes) > 1
             and getattr(obj, "SortingMode", None) != "Manual"
@@ -464,6 +465,30 @@ class ObjectOp(PathOp.ObjectOp):
             locations = PathUtils.sort_locations(locations, ["x", "y"])
 
             shapes = [j["shape"] for j in locations]
+
+        # Combine similar tasks for Collectively HandleMultipleFeatures
+        if (
+            obj.Proxy.__module__ == "Path.Op.Profile"
+            and len(shapes) > 1
+            and getattr(obj, "HandleMultipleFeatures", False) == "Collectively"
+        ):
+            keys = set((iH, desc) for _, iH, desc in shapes)
+            collectively = []
+            for key in keys:
+                combine = []
+                for sh, iH, desc in shapes:
+                    if (iH, desc) == key:
+                        if desc == "OpenEdge":  # is a list of shapes
+                            combine.extend(sh)
+                        else:
+                            combine.append(sh)
+                if desc == "OpenEdge":  # should be a list of shapes
+                    fc = [Part.makeCompound(combine)]
+                else:
+                    fc = Part.makeCompound(combine)
+                collectively.append((fc, key[0], key[1]))
+
+            shapes = collectively
 
         sims = []
         for shape, isHole, sub in shapes:

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -280,7 +280,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         for the operation's properties."""
         return {
             "Direction": "CW",
-            "HandleMultipleFeatures": "Collectively",
+            "HandleMultipleFeatures": "Individually",
             "JoinType": "Round",
             "MiterLimit": 0.1,
             "OffsetExtra": 0.0,
@@ -339,7 +339,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         obj.setEditorMode("JoinType", 2)
         obj.setEditorMode("MiterLimit", 2)  # ml
         obj.setEditorMode("Side", side)
-        obj.setEditorMode("HandleMultipleFeatures", fc)
+        obj.setEditorMode("HandleMultipleFeatures", 0)
         obj.setEditorMode("processCircles", fc)
         obj.setEditorMode("processHoles", fc)
         obj.setEditorMode("processPerimeter", fc)
@@ -551,34 +551,20 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                             shapes.append(tup)
 
                 if faces and obj.processPerimeter:
-                    if obj.HandleMultipleFeatures == "Collectively":
+                    for shape in faces:
                         custDepthparams = self.depthparams
-                        cont = True
-                        profileshape = Part.makeCompound(faces)
-
                         try:
-                            shapeEnv = PathUtils.getEnvelope(
-                                profileshape, depthparams=custDepthparams
-                            )
+                            shapeEnv = PathUtils.getEnvelope(shape, depthparams=custDepthparams)
                         except Exception as ee:
                             # PathUtils.getEnvelope() failed to return an object.
                             msg = translate("PathProfile", "Unable to create path for face(s).")
                             Path.Log.error(msg + "\n{}".format(ee))
-                            cont = False
+                            shapeEnv = None
 
-                        if cont:
-                            self._addDebugObject("CollectCutShapeEnv", shapeEnv)
-                            tup = shapeEnv, False, "pathProfile"
-                            shapes.append(tup)
-
-                    elif obj.HandleMultipleFeatures == "Individually":
-                        for shape in faces:
-                            custDepthparams = self.depthparams
-                            self._addDebugObject("Indiv_Shp", shape)
-                            shapeEnv = PathUtils.getEnvelope(shape, depthparams=custDepthparams)
-                            if shapeEnv:
-                                self._addDebugObject("IndivCutShapeEnv", shapeEnv)
-                                tup = shapeEnv, False, "pathProfile"
+                        if shapeEnv:
+                            for shEnv in shapeEnv.Solids:
+                                self._addDebugObject("CutShapeEnv", shEnv)
+                                tup = shEnv, False, "pathProfile"
                                 shapes.append(tup)
 
         else:  # Try to build targets from the job models


### PR DESCRIPTION
Fixes #27119
Fixes #22255
Fixes #29694

---

At this moment in `Profile` operation `HandleMultipleFeatures` with `Collectively` pattern implemented only with horizontal `Face` selections

https://github.com/FreeCAD/FreeCAD/blob/11d22e326c22110e2c26222438271283c0303fe3/src/Mod/CAM/Path/Op/Profile.py#L510-L511

This commit move `HandleMultipleFeatures` from `Path/Op/Profile.py` to `Path/Op/Area.py`, which give to process more cases:
- `Profile` with `Edge` selection
-  `Profile` without selection while process perimeter of all models from `Job`
- not in this PR , but property `HandleMultipleFeatures` can be added to `PocketShape`