### PR TITLE
Draft: fix constrain error if there is no new point

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1720,7 +1720,9 @@ class DraftToolBar:
             if hasattr(FreeCADGui, "Snapper"):
                 FreeCADGui.Snapper.mask = val
                 if self.new_point is not None:
-                    self.new_point = FreeCADGui.Snapper.constrain(self.new_point, self.get_last_point())
+                    self.new_point = FreeCADGui.Snapper.constrain(
+                        self.new_point, self.get_last_point()
+                    )
 
     def changeXValue(self, d):
         if self.display_point_active:


### PR DESCRIPTION
Fixes #26850

If a Draft X, Y or Z constrain option was entered before moving the mouse, there would be no new point yet to constrain and an error would occur.