### PR TITLE
CAM: Path.Geom.filterArcs()

### DIFF
--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -26,6 +26,8 @@ import FreeCAD
 import Path
 import math
 
+from Path.Base.MachineState import MachineState
+
 from FreeCAD import Vector
 import Constants
 
@@ -763,3 +765,45 @@ def combineHorizontalFaces(faces):
             horizontal = outer
 
     return horizontal
+
+
+def filterArcs(cmds, deflection=None):
+    """Replace G2/G3 commands with curvature less than 'deflection' by G1 moves."""
+    if not deflection:
+        prefGrp = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
+        deflection = prefGrp.GetFloat("LibAreaCurveAccuracy", 0.01)
+
+    machine = MachineState()
+
+    for i in range(len(cmds)):
+        if cmds[i].Name in Path.Geom.CmdMoveArc:
+            p3 = None
+            position = machine.getPosition()
+            try:
+                edge = Path.Geom.edgeForCmd(cmds[i], position)
+            except Exception:
+                # error can be related with precision, so use G1
+                edge = None
+                p3 = position
+                p3.x = cmds[i].x if cmds[i].x is not None else p3.x
+                p3.y = cmds[i].y if cmds[i].y is not None else p3.y
+                p3.z = cmds[i].z if cmds[i].z is not None else p3.z
+
+            if edge and not edge.isClosed():
+                firstParameter, lastParameter = edge.FirstParameter, edge.LastParameter
+                p1 = edge.valueAt(firstParameter)
+                p2 = edge.valueAt((firstParameter + lastParameter) / 2)
+                p3 = edge.valueAt(lastParameter)
+                d = p2.distanceToPoint(p1 + (p3 - p1) / 2)
+                if d > deflection:
+                    p3 = None
+
+            if p3:
+                params = {"X": p3.x, "Y": p3.y, "Z": p3.z}
+                if cmds[i].F:
+                    params.update({"F": cmds[i].F})
+                cmds[i] = Path.Command("G1", params)
+
+        machine.addCommand(cmds[i])
+
+    return cmds


### PR DESCRIPTION
`Path.fromShapes()` sometimes return arc commands G2/G3 which almost straight

Usually this commands contain big values of `I` and `J` parameters:

G2 F0.833333 I**3213089**.104941 J-**5130565**.725580 K0.000000 X163.485773 Y73.107182 Z-0.100001
G2 F0.833333 I-**657607**.742597 J**8880**.353715 K0.000000 X188.407377 Y91.998795 Z-0.100001
G2 F0.833333 I-**69935**.554758 J943.050623 K0.000000 X187.775116 Y97.016303 Z-0.100001

Added function `filterArcs(cmds, deflection=None)` to replace such commands by G1 move
~~Implement replacement in `CAM/Path/Op/Area.py`, so this will touch only `Profile` and `PocketShape` operations~~

Help to resolve issue
- #26780

[gcode.zip](https://github.com/user-attachments/files/24563934/gcode.zip)

<img width="1866" height="560" alt="1_hor" src="https://github.com/user-attachments/assets/5fdbb64f-0fd8-4421-b9b6-e06ad0f21aae" />

