### PR TITLE
BIM: fix ArchWallGui tests

### DIFF
--- a/src/Mod/BIM/bimtests/TestArchWallGui.py
+++ b/src/Mod/BIM/bimtests/TestArchWallGui.py
@@ -313,6 +313,7 @@ class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
         cmd.Align = "Center"
         cmd.Width = 200.0
         cmd.Height = 1500.0
+        cmd.MultiMat = None
 
         # Use a mock tracker to isolate logic tests from the 3D view environment
         cmd.tracker = MockTracker()
@@ -358,6 +359,7 @@ class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
         cmd.Align = "Left"
         cmd.Width = 200.0
         cmd.Height = 1500.0
+        cmd.MultiMat = None
         cmd.tracker = MockTracker()
         cmd.existing = []
 


### PR DESCRIPTION
While developing https://github.com/FreeCAD/FreeCAD/pull/24595 I did not run tests locally for the last 3 commits. [CI GUI tests are not being run at the moment](https://github.com/FreeCAD/FreeCAD/issues/26890), so two GUI test failures due to test setup mistakes were not caught.

<details>

```
Test Testing baseless wall creation on a rotated working plane...
======================================================================
ERROR: test_create_baseless_wall_on_rotated_working_plane (bimtests.TestArchWallGui.TestArchWallGui.test_create_baseless_wall_on_rotated_working_plane)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/Mod/BIM/bimtests/TestArchWallGui.py", line 322, in test_create_baseless_wall_on_rotated_working_plane
    cmd.create_wall()
  File "/usr/local/Mod/BIM/bimcommands/BimWall.py", line 395, in create_wall
    wall_obj = self._create_baseless_wall(p0, p1)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Mod/BIM/bimcommands/BimWall.py", line 225, in _create_baseless_wall
    if self.MultiMat:
       ^^^^^^^^^^^^^
AttributeError: 'Arch_Wall' object has no attribute 'MultiMat'

Test Testing interactive creation of a Draft.Line based wall...
Test Testing creation of multiple sketch-based walls...
======================================================================
ERROR: test_create_multiple_sketch_based_walls (bimtests.TestArchWallGui.TestArchWallGui.test_create_multiple_sketch_based_walls)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.12/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.12/unittest/case.py", line 634, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.12/unittest/case.py", line 589, in _callTestMethod
    if method() is not None:
       ^^^^^^^^
  File "/usr/local/Mod/BIM/bimtests/TestArchWallGui.py", line 368, in test_create_multiple_sketch_based_walls
    cmd.create_wall()
  File "/usr/local/Mod/BIM/bimcommands/BimWall.py", liCustom webgl template file '/nonexistent/template.html' does not exist or is not a file.
Export cancelled: Custom template '/nonexistent/template.html' not available.
ne 399, in create_wall
    wall_obj = self._create_wall_from_baseline(baseline_obj)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/Mod/BIM/bimcommands/BimWall.py", line 322, in _create_wall_from_baseline
    if self.MultiMat:
       ^^^^^^^^^^^^^
AttributeError: 'Arch_Wall' object has no attribute 'MultiMat'
```

</details>

This PR corrects that (the `self.MultiMat` variable was not initialized in those tests because the call to `Activate()` is bypassed). They now follow the same pattern as the other tests which also bypass `Activate()` to create a wall, and the variable is initialized manually.

## Testing

To check this PR makes the ArchWallGui tests pass:

```
# Run on the command line, headless. Only for Linux
xvfb-run ./FreeCAD -t TestArchGui.TestArchWallGui

# Alternatively, run tests with the interactive GUI. All platforms. 
./FreeCAD -r TestArchGui.TestArchWallGui

# Alternatively,
# 1. Start FreeCAD
# 2. Load the Test Framework workbench
# 3. Click on the `Self-test` command
# 4. On the `Select test name` input box, select `TestArchGui.TestArchWallGui`
# 5. Press `Start`

```

<img width="718" height="491" alt="image" src="https://github.com/user-attachments/assets/34b5245b-9821-4d25-a5a9-a435d31543d6" />

