### PR TITLE
[Sketcher] set vertex size for new sketches to preference otherwise …

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -630,7 +630,7 @@ ViewProviderSketch::ViewProviderSketch()
 
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    int psize = hGrp->GetInt("DefaultShapePointSize", 4);
+    auto psize = hGrp->GetInt("DefaultShapePointSize", 4L);
 
     PointSize.setValue(psize);
 


### PR DESCRIPTION
…set to 4px

This anomaly has existed for at least a few years, if the user has set the default vertex size (parameter Preferences/View/DefaultShapePointSize) to for example 7px then they create a new sketch when viewed in the 3D view it is still created with a vertex size of 4px contrary to the existing comment in the code. This PR corrects the anomaly.
