### PR TITLE
CAM: SimulatorGL - Set in Task panel default CheckState as op.Visibility

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/TaskCAMSimulator.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/TaskCAMSimulator.ui
@@ -120,6 +120,20 @@
     </layout>
    </item>
    <item>
+    <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="followsVisibility">
+        <property name="toolTip">
+         <string>Set default state in accordance with operations visibility</string>
+        </property>
+        <property name="text">
+         <string>Follow operations visibility</string>
+        </property>
+       </widget>
+      </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QListWidget" name="listOperations">
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>

--- a/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
+++ b/src/Mod/CAM/Path/Main/Gui/SimulatorGL.py
@@ -217,6 +217,12 @@ class CAMSimulation:
         self.Connect(form.toolButtonPlay, self.SimPlay)
         form.sliderAccuracy.valueChanged.connect(self.onAccuracyBarChange)
         self.onAccuracyBarChange()
+
+        prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
+        if prefs.GetBool("SimulatorFollowsVisibility"):
+            form.followsVisibility.setCheckState(QtCore.Qt.CheckState.Checked)
+        form.followsVisibility.clicked.connect(self.followsVisibilityChange)
+
         self._populateJobSelection(form)
         form.comboJobs.currentIndexChanged.connect(self.onJobChange)
         self.onJobChange()
@@ -276,16 +282,24 @@ class CAMSimulation:
 
     def onJobChange(self):
         """When a new job is selected from the drop-down, update job operation list"""
+        prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
+        followsVisibility = prefs.GetBool("SimulatorFollowsVisibility")
         form = self.taskForm.form
         j = self.jobs[form.comboJobs.currentIndex()]
         self.job = j
         form.listOperations.clear()
         self.operations = []
+        allhidden = all(
+            not op.Visibility for op in j.Operations.OutList if PathUtil.opProperty(op, "Active")
+        )
         for op in j.Operations.OutList:
             if PathUtil.opProperty(op, "Active"):
                 listItem = QtGui.QListWidgetItem(op.ViewObject.Icon, op.Label)
                 listItem.setFlags(listItem.flags() | QtCore.Qt.ItemIsUserCheckable)
-                listItem.setCheckState(QtCore.Qt.CheckState.Checked)
+                if followsVisibility and not op.Visibility and not allhidden:
+                    listItem.setCheckState(QtCore.Qt.CheckState.Unchecked)
+                else:
+                    listItem.setCheckState(QtCore.Qt.CheckState.Checked)
                 self.operations.append(op)
                 form.listOperations.addItem(listItem)
         if len(j.Model.OutList) > 0:
@@ -303,6 +317,14 @@ class CAMSimulation:
         elif self.quality < 9:
             qualText = QtCore.QT_TRANSLATE_NOOP("CAM_Simulator", "Medium")
         form.labelAccuracy.setText(qualText)
+
+    def followsVisibilityChange(self):
+        """Update job list in accordance with operations visibility"""
+        form = self.taskForm.form
+        state = form.followsVisibility.isChecked()
+        prefs = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
+        prefs.SetBool("SimulatorFollowsVisibility", state)
+        self.onJobChange()
 
     def onOperationItemChange(self, _item):
         """Check if at least one operation is selected to enable the Play button"""


### PR DESCRIPTION
Partial fixes #26903
- #26903 

---

### Changes:

- Added option `Follow operations visibility` which synchronize state of job list in Task panel accordingly to operation visibility

- State of option `Follow operations visibility` saves to preferences and restore while activates Simulator Task panel

<img width="884" height="348" alt="Screenshot_20260418_175952_hor" src="https://github.com/user-attachments/assets/3e03040f-9032-49cb-b8e9-8ecc9ed8e881" />
