### PR TITLE
BIM: simplify and unify SketchArch add-on checks

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -1784,27 +1784,26 @@ def joinWalls(walls, delete=False, deletebase=False):
         return None
     deleteList = []
     base = walls.pop()
+
     if base.Base:
         if base.Base.Shape.Faces:
             return None
-        # Use ArchSketch if SketchArch add-on is present
-        if Draft.getType(base.Base) == "ArchSketch":
-            sk = base.Base
-        else:
-            try:
-                import ArchSketchObject
+        # Check if we need to upgrade the base to a Sketch or ArchSketch
+        if Draft.getType(base.Base) != "ArchSketch":
+            import ArchSketchObject
 
+            newSk = None
+
+            if ArchSketchObject.is_installed():
                 newSk = ArchSketchObject.makeArchSketch()
-            except:
-                if Draft.getType(base.Base) != "Sketcher::SketchObject":
-                    newSk = FreeCAD.ActiveDocument.addObject("Sketcher::SketchObject", "WallTrace")
-                else:
-                    newSk = None
+            elif Draft.getType(base.Base) != "Sketcher::SketchObject":
+                # Upgrade non-sketch (e.g. Draft Wire) to standard Sketch if ArchSketch isn't available
+                newSk = FreeCAD.ActiveDocument.addObject("Sketcher::SketchObject", "WallTrace")
+
             if newSk:
                 sk = Draft.makeSketch(base.Base, autoconstraints=True, addTo=newSk)
                 base.Base = sk
-            else:
-                sk = base.Base
+
     for w in walls:
         if w.Base and not w.Base.Shape.Faces:
             for hostedObj in w.Proxy.getHosts(w):

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -206,6 +206,9 @@ class Component(ArchIFC.IfcProduct):
         self.Type = "Component"
         Component.setProperties(self, obj)
 
+        # Add features from the SketchArch External Add-on, if present
+        self.addSketchArchFeatures(obj)
+
     def setProperties(self, obj):
         """Give the component its component specific properties, such as material.
 
@@ -377,6 +380,9 @@ class Component(ArchIFC.IfcProduct):
             The component object.
         """
         Component.setProperties(self, obj)
+
+        # Add features from the SketchArch External Add-on, if present
+        self.addSketchArchFeatures(obj)
 
     def execute(self, obj):
         """Method run when the object is recomputed.

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1304,6 +1304,48 @@ class Component(ArchIFC.IfcProduct):
                 return True
         return False
 
+    # Hooks for the external SketchArch add-on.
+    # SketchArch enhances standard Sketches with BIM-specific features when used
+    # as the base for Arch objects (Walls, Structures, etc.).
+    # https://github.com/paullee0/FreeCAD_SketchArch
+
+    def addSketchArchFeatures(self, obj, linkObj=None, mode=None):
+        """
+        Injects properties from the external SketchArch add-on if available.
+
+        This method checks if the SketchArch add-on is installed. If so, it delegates
+        to the add-on to add specific properties (like extended linking attributes)
+        to the object.
+        """
+        import ArchSketchObject
+
+        if ArchSketchObject.is_installed():
+            ArchSketchObject.ArchSketch.setPropertiesLinkCommon(self, obj, linkObj, mode)
+
+    def executeSketchArchFeatures(self, obj, linkObj=None, index=None, linkElement=None):
+        """
+        Executes geometry updates from the external SketchArch add-on if available.
+
+        This method checks if the SketchArch add-on is installed. If so, it triggers
+        updates for specific behaviors like intuitive automatic placement offsets.
+        """
+        import ArchSketchObject
+
+        if ArchSketchObject.is_installed():
+            ArchSketchObject.updateAttachmentOffset(obj, linkObj)
+
+    def appLinkExecute(self, obj, linkObj, index, linkElement):
+        """
+        Callback executed when this object is linked via an App::Link.
+
+        This ensures that SketchArch features (properties and placement logic)
+        are correctly applied/updated when the object is referenced by a Link.
+
+        See https://forum.freecad.org/viewtopic.php?f=22&t=42184&start=10#p361124
+        """
+        self.addSketchArchFeatures(obj, linkObj)
+        self.executeSketchArchFeatures(obj, linkObj)
+
 
 class AreaCalculator:
     """Helper class to compute vertical area, horizontal area, and perimeter length.

--- a/src/Mod/BIM/ArchEquipment.py
+++ b/src/Mod/BIM/ArchEquipment.py
@@ -167,23 +167,6 @@ class _Equipment(ArchComponent.Component):
         # Add features in the SketchArch External Add-on, if present
         self.addSketchArchFeatures(obj)
 
-    def addSketchArchFeatures(self, obj, linkObj=None, mode=None):
-        """
-        To add features in the SketchArch External Add-on, if present (https://github.com/paullee0/FreeCAD_SketchArch)
-        -  import ArchSketchObject module, and
-        -  set properties that are common to ArchObjects (including Links) and ArchSketch
-           to support the additional features
-
-        To install SketchArch External Add-on, see https://github.com/paullee0/FreeCAD_SketchArch#iv-install
-        """
-
-        try:
-            import ArchSketchObject
-
-            ArchSketchObject.ArchSketch.setPropertiesLinkCommon(self, obj, linkObj, mode)
-        except:
-            pass
-
     def setProperties(self, obj):
 
         pl = obj.PropertiesList
@@ -267,38 +250,6 @@ class _Equipment(ArchComponent.Component):
 
         # Execute features in the SketchArch External Add-on, if present
         self.executeSketchArchFeatures(obj)
-
-    def executeSketchArchFeatures(self, obj, linkObj=None, index=None, linkElement=None):
-        """
-        To execute features in the SketchArch External Add-on  (https://github.com/paullee0/FreeCAD_SketchArch)
-        -  import ArchSketchObject module, and
-        -  execute features that are common to ArchObjects (including Links) and ArchSketch
-
-        To install SketchArch External Add-on, see https://github.com/paullee0/FreeCAD_SketchArch#iv-install
-        """
-
-        # To execute features in SketchArch External Add-on, if present
-        try:
-            import ArchSketchObject
-
-            # Execute SketchArch Feature - Intuitive Automatic Placement for Arch Windows/Doors, Equipment etc.
-            # see https://forum.freecad.org/viewtopic.php?f=23&t=50802
-            ArchSketchObject.updateAttachmentOffset(obj, linkObj)
-        except:
-            pass
-
-    def appLinkExecute(self, obj, linkObj, index, linkElement):
-        """
-        Default Link Execute method() -
-        See https://forum.freecad.org/viewtopic.php?f=22&t=42184&start=10#p361124
-        @realthunder added support to Links to run Linked Scripted Object's methods()
-        """
-
-        # Add features in the SketchArch External Add-on, if present
-        self.addSketchArchFeatures(obj, linkObj)
-
-        # Execute features in the SketchArch External Add-on, if present
-        self.executeSketchArchFeatures(obj, linkObj)
 
     def computeAreas(self, obj):
         return

--- a/src/Mod/BIM/ArchEquipment.py
+++ b/src/Mod/BIM/ArchEquipment.py
@@ -164,8 +164,6 @@ class _Equipment(ArchComponent.Component):
             obj.IfcType = "Furnishing Element"
         else:
             obj.IfcType = "Building Element Proxy"
-        # Add features in the SketchArch External Add-on, if present
-        self.addSketchArchFeatures(obj)
 
     def setProperties(self, obj):
 
@@ -220,9 +218,6 @@ class _Equipment(ArchComponent.Component):
 
         ArchComponent.Component.onDocumentRestored(self, obj)
         self.setProperties(obj)
-
-        # Add features in the SketchArch External Add-on, if present
-        self.addSketchArchFeatures(obj)
 
     def loads(self, state):
 

--- a/src/Mod/BIM/ArchSketchObject.py
+++ b/src/Mod/BIM/ArchSketchObject.py
@@ -26,6 +26,15 @@ import ArchWindow
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 
+def is_installed():
+    """Checks if the external SketchArch add-on is installed and active.
+
+    Returns True if the 'makeArchSketch' function (provided by the add-on)
+    is available in this module's namespace.
+    """
+    return "makeArchSketch" in globals()
+
+
 class ArchSketchObject:
     def __init__(self, obj):
         pass

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -946,34 +946,32 @@ class _Wall(ArchComponent.Component):
                     # Return a list of Width corresponding to indexes of sorted
                     # edges of Sketch.
                     widths = obj.Base.Proxy.getWidths(obj.Base, propSetUuid=propSetUuid)
+
         # Get width of each edge/wall segment from ArchWall.OverrideWidth if
         # Base Object does not provide it
         if not widths:
             if obj.OverrideWidth:
                 if obj.Base and obj.Base.isDerivedFrom("Sketcher::SketchObject"):
-                    # If Base Object is ordinary Sketch (or when ArchSketch.getWidth() not implemented yet):-
-                    # sort the width list in OverrrideWidth to correspond to indexes of sorted edges of Sketch
-                    try:
-                        import ArchSketchObject
-                    except Exception:
-                        print("ArchSketchObject add-on module is not installed yet")
-                    try:
+                    # If the Base object is a Sketch, we try to use SketchArch's features
+                    # to sort the widths to match the sketch edge order.
+                    import ArchSketchObject
+
+                    if ArchSketchObject.is_installed():
                         widths = ArchSketchObject.sortSketchWidth(
                             obj.Base, obj.OverrideWidth, obj.ArchSketchEdges
                         )
-                    except Exception:
+                    else:
                         widths = obj.OverrideWidth
                 else:
-                    # If Base Object is not Sketch, but e.g. DWire, the width
-                    # list in OverrrideWidth just correspond to sequential
-                    # order of edges
+                    # If the Base object is not a Sketch (e.g. DWire), the width
+                    # list corresponds to the sequential order of edges
                     widths = obj.OverrideWidth
             elif obj.Width:
                 widths = [obj.Width.Value]
             else:
-                # having no width is valid for walls so the user doesn't need to be warned
-                # it just disables extrusions and return none
-                # print ("Width & OverrideWidth & base.getWidths() should not be all 0 or None or [] empty list ")
+                # If Width, OverrideWidth, and base.getWidths() are all empty or zero,
+                # the wall is considered valid but has no thickness/extrusion.
+                # Return None to disable extrusion without warning the user.
                 return None
 
         # Set 'default' width - for filling in any item in the list == 0 or None
@@ -995,29 +993,24 @@ class _Wall(ArchComponent.Component):
                     # Return a list of Align corresponds to indexes of sorted
                     # edges of Sketch.
                     aligns = obj.Base.Proxy.getAligns(obj.Base, propSetUuid=propSetUuid)
+
         # Get align of each edge/wall segment from ArchWall.OverrideAlign if
         # Base Object does not provide it
         if not aligns:
             if obj.OverrideAlign:
                 if obj.Base and obj.Base.isDerivedFrom("Sketcher::SketchObject"):
-                    # If Base Object is ordinary Sketch (or when
-                    # ArchSketch.getAligns() not implemented yet):- sort the
-                    # align list in OverrideAlign to correspond to indexes of
-                    # sorted edges of Sketch
-                    try:
-                        import ArchSketchObject
-                    except Exception:
-                        print("ArchSketchObject add-on module is not installed yet")
-                    try:
+
+                    # If the Base object is a Sketch, we try to use SketchArch's features
+                    # to sort the align list to match the sketch edge order.
+                    import ArchSketchObject
+
+                    if ArchSketchObject.is_installed():
                         aligns = ArchSketchObject.sortSketchAlign(
                             obj.Base, obj.OverrideAlign, obj.ArchSketchEdges
                         )
-                    except Exception:
-                        aligns = obj.OverrideAlign
                 else:
-                    # If Base Object is not Sketch, but e.g. DWire, the align
-                    # list in OverrideAlign just correspond to sequential order
-                    # of edges
+                    # If the Base object is not a Sketch (e.g. DWire), the align
+                    # list corresponds to the sequential order of edges
                     aligns = obj.OverrideAlign
             else:
                 aligns = [obj.Align]
@@ -1038,23 +1031,25 @@ class _Wall(ArchComponent.Component):
                     # Return a list of Offset corresponding to indexes of sorted
                     # edges of Sketch.
                     offsets = obj.Base.Proxy.getOffsets(obj.Base, propSetUuid=propSetUuid)
+
         # Get offset of each edge/wall segment from ArchWall.OverrideOffset if
         # Base Object does not provide it
         if not offsets:
             if obj.OverrideOffset:
                 if obj.Base and obj.Base.isDerivedFrom("Sketcher::SketchObject"):
-                    # If Base Object is ordinary Sketch (or when ArchSketch.getOffsets() not implemented yet):-
-                    # sort the offset list in OverrideOffset to correspond to indexes of sorted edges of Sketch
-                    if hasattr(ArchSketchObject, "sortSketchOffset"):
+                    # If the Base object is a Sketch, try to use SketchArch to sort
+                    # offsets to match the sketch edge order.
+                    import ArchSketchObject
+
+                    if ArchSketchObject.is_installed():
                         offsets = ArchSketchObject.sortSketchOffset(
                             obj.Base, obj.OverrideOffset, obj.ArchSketchEdges
                         )
                     else:
                         offsets = obj.OverrideOffset
                 else:
-                    # If Base Object is not Sketch, but e.g. DWire, the width
-                    # list in OverrrideWidth just correspond to sequential
-                    # order of edges
+                    # If the Base object is not a Sketch (e.g. DWire), the offset
+                    # list corresponds to the sequential order of edges
                     offsets = obj.OverrideOffset
             elif obj.Offset:
                 offsets = [obj.Offset.Value]
@@ -1641,14 +1636,21 @@ class _Wall(ArchComponent.Component):
                     lwidths = obj.Base.Proxy.getWidths(
                         obj.Base, propSetUuid=self.ArchSkPropSetPickedUuid
                     )
+
         if not lwidths:
             if obj.OverrideWidth:
-                if obj.Base and obj.Base.isDerivedFrom("Sketcher::SketchObject"):
+                # Default to the unsorted list
+                lwidths = obj.OverrideWidth
+
+                # If Base is a Sketch and the add-on is present, try to sort the widths
+                if (
+                    obj.Base
+                    and obj.Base.isDerivedFrom("Sketcher::SketchObject")
+                    and ArchSketchObject.is_installed()
+                ):
                     lwidths = ArchSketchObject.sortSketchWidth(
                         obj.Base, obj.OverrideWidth, obj.ArchSketchEdges
                     )
-                else:
-                    lwidths = obj.OverrideWidth
             elif obj.Width:
                 lwidths = [obj.Width.Value]
             else:

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -113,9 +113,6 @@ class _Window(ArchComponent.Component):
         obj.IfcType = "Window"
         obj.MoveWithHost = True
 
-        # Add features in the SketchArch External Add-on
-        self.addSketchArchFeatures(obj)
-
     def setProperties(self, obj, mode=None):
 
         lp = obj.PropertiesList
@@ -295,9 +292,6 @@ class _Window(ArchComponent.Component):
 
         ArchComponent.Component.onDocumentRestored(self, obj)
         self.setProperties(obj, mode="ODR")
-
-        # Add features in the SketchArch External Add-on
-        self.addSketchArchFeatures(obj, mode="ODR")
 
         # During the v1.1 dev cycle an experiment with a new SillHeight handling was
         # undertaken. This did not work out as intended and was therefore reverted.

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -116,23 +116,6 @@ class _Window(ArchComponent.Component):
         # Add features in the SketchArch External Add-on
         self.addSketchArchFeatures(obj)
 
-    def addSketchArchFeatures(self, obj, linkObj=None, mode=None):
-        """
-        To add features in the SketchArch External Add-on  (https://github.com/paullee0/FreeCAD_SketchArch)
-        -  import ArchSketchObject module, and
-        -  set properties that are common to ArchObjects (including Links) and ArchSketch
-           to support the additional features
-
-        To install SketchArch External Add-on, see https://github.com/paullee0/FreeCAD_SketchArch#iv-install
-        """
-
-        try:
-            import ArchSketchObject
-
-            ArchSketchObject.ArchSketch.setPropertiesLinkCommon(self, obj, linkObj, mode)
-        except:
-            pass
-
     def setProperties(self, obj, mode=None):
 
         lp = obj.PropertiesList
@@ -677,38 +660,6 @@ class _Window(ArchComponent.Component):
             obj.Area = obj.Width.Value * obj.Height.Value
 
         self.executeSketchArchFeatures(obj)
-
-    def executeSketchArchFeatures(self, obj, linkObj=None, index=None, linkElement=None):
-        """
-        To execute features in the SketchArch External Add-on  (https://github.com/paullee0/FreeCAD_SketchArch)
-        -  import ArchSketchObject module, and
-        -  execute features that are common to ArchObjects (including Links) and ArchSketch
-
-        To install SketchArch External Add-on, see https://github.com/paullee0/FreeCAD_SketchArch#iv-install
-        """
-
-        # To execute features in SketchArch External Add-on
-        try:
-            import ArchSketchObject  # Why needed ? Should have try: addSketchArchFeatures() before !  Need 'per method' ?
-
-            # Execute SketchArch Feature - Intuitive Automatic Placement for Arch Windows/Doors, Equipment etc.
-            # see https://forum.freecad.org/viewtopic.php?f=23&t=50802
-            ArchSketchObject.updateAttachmentOffset(obj, linkObj)
-        except:
-            pass
-
-    def appLinkExecute(self, obj, linkObj, index, linkElement):
-        """
-        Default Link Execute method() -
-        See https://forum.freecad.org/viewtopic.php?f=22&t=42184&start=10#p361124
-        @realthunder added support to Links to run Linked Scripted Object's methods()
-        """
-
-        # Add features in the SketchArch External Add-on
-        self.addSketchArchFeatures(obj, linkObj)
-
-        # Execute features in the SketchArch External Add-on
-        self.executeSketchArchFeatures(obj, linkObj)
 
     def getSubFace(self):
         "returns a subface for creation of subvolume for cutting in a base object"

--- a/src/Mod/BIM/bimcommands/BimStairs.py
+++ b/src/Mod/BIM/bimcommands/BimStairs.py
@@ -79,20 +79,14 @@ class Arch_Stairs:
             FreeCADGui.doCommand("FreeCADGui.Selection.addSelection(stairs)")
 
             # ArchSketch Support
-            if len(sel) == 1 and Draft.getType(obj) == "ArchSketch":
+            if len(sel) == 1 and Draft.getType(sel[0]) == "ArchSketch":
                 # Get ArchSketch.FloorHeight as default and assign to Stairs
-                try:
-                    height = str(obj.FloorHeight.Value)  # vs obj.FloorHeight
-                    # Can only use Value to assign to PropertyLength
-                    FreeCADGui.doCommand("stairs.Height = " + height)
-                except:
-                    pass
-                # If base is ArchSketch, ArchSketchObject is already loaded, no
-                # need to load again : FreeCADGui.addModule("ArchSketchObject")
-                try:
+                if hasattr(sel[0], "FloorHeight"):
+                    FreeCADGui.doCommand(f"stairs.Height = {sel[0].FloorHeight.Value}")
+
+                # Launch EditStairs tool from SketchArch addon if available
+                if "EditStairs" in FreeCADGui.listCommands():
                     FreeCADGui.runCommand("EditStairs")
-                except:
-                    pass
 
         else:
             FreeCADGui.doCommand(
@@ -105,7 +99,6 @@ class Arch_Stairs:
 
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
-        print(" ActiveDocument.recompute, done ")
 
 
 FreeCADGui.addCommand("Arch_Stairs", Arch_Stairs())

--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -273,14 +273,14 @@ class Arch_Wall:
         elif self.baseline_mode == WallBaselineMode.SKETCH:
             import ArchSketchObject
 
-            if not hasattr(ArchSketchObject, "makeArchSketch"):
-                # Regular path without SketchArch add-on installed. Execute creation command with a
-                # suggested name. FreeCAD will ensure uniqueness.
+            if not ArchSketchObject.is_installed():
+                # Regular path (Common): Standard Sketcher object.
                 FreeCADGui.doCommand(
-                    "base = FreeCAD.ActiveDocument.addObject('Sketcher::SketchObject', 'WallTrace')"
+                    "FreeCAD.ActiveDocument.addObject('Sketcher::SketchObject', 'WallTrace')"
                 )
             else:
-                # Use ArchSketch if SketchArch add-on is present
+                # Add-on path: ArchSketch object.
+                # The module must be imported in the console scope for the command to run.
                 FreeCADGui.doCommand("import ArchSketchObject")
                 FreeCADGui.doCommand("base = ArchSketchObject.makeArchSketch()")
 


### PR DESCRIPTION
- Add `ArchSketchObject.is_installed()` method to streamline checking whether the SketchArch add-on is installed
- Moved SketchArch hooks (`addSketchArchFeatures`, `executeSketchArchFeatures`, `appLinkExecute`) to the parent class (`ArchComponents`) to remove code duplication. Remove duplicate code.
- Simplify SketchArch checking logic by using the new `ArchSketchObject.is_installed()` method.
- Added a SketchArch check in one instance where instantiation was not guarded (also flagged by CodeQL):

<img width="881" height="285" alt="image" src="https://github.com/user-attachments/assets/cbe091bc-ab87-4fed-b028-99e08733190c" />

There is a call site that I did not modify (`BimWindow.getPoint()`) - the logic is a complex if/else chain I preferred not to touch.