### PR TITLE
Dispatch the diff-link updater immediately after the weekly release is created

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   upload_src:
@@ -42,6 +43,30 @@ jobs:
           fi
           echo "BUILD_TAG=${BUILD_TAG}" >> "$GITHUB_ENV"
           echo "build_tag=${BUILD_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger notes updater workflow (only for weekly)
+        if: startsWith(steps.get_tag.outputs.build_tag, 'weekly-')
+        uses: actions/github-script@v7
+        env:
+          WEEKLY_TAG: ${{ steps.get_tag.outputs.build_tag }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+
+            // Reusable/dispatchable updater workflow file in .github/workflows/
+            const workflow_id = 'weekly-compare-link.yml';
+
+            // Use the default branch so the workflow file is available
+            const ref = (context.payload?.repository?.default_branch) || 'main';
+            const current_tag = process.env.WEEKLY_TAG || '';
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner, repo, workflow_id, ref,
+              inputs: { current_tag }
+            });
+
+            core.info(`Dispatched ${workflow_id} on ${ref} with current_tag='${current_tag}'.`)
 
       - name: Upload Source
         id: upload_source


### PR DESCRIPTION
The GitHub workflow to update the diff-link between weekly versions for the pre-release notes is not always triggered when a release is created. 
This changes the build workflow to dispatch the diff-link updater immediately after the weekly release is created.