### PR TITLE
CAM: Fix Path.Machine.ui/editor install and packaging

### DIFF
--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -170,6 +170,10 @@ SET(PathPythonToolsGui_SRCS
     Path/Tool/Gui/Controller.py
 )
 
+SET(PathPythonMachineUi_SRCS
+    Path/Machine/ui/__init__.py
+)
+
 SET(PathPythonMachineUiEditor_SRCS
     Path/Machine/ui/editor/machine_editor.py
     Path/Machine/ui/editor/__init__.py
@@ -641,6 +645,7 @@ SET(all_files
     ${PathPythonToolsLibrarySerializers_SRCS}
     ${PathPythonToolsLibraryUi_SRCS}
     ${PathPythonMachineModels_SRCS}
+    ${PathPythonMachineUi_SRCS}
     ${PathPythonMachineUiEditor_SRCS}
     ${PathPythonGui_SRCS}
     ${Tools_SRCS}
@@ -912,13 +917,6 @@ INSTALL(
 
 INSTALL(
     FILES
-        ${PathPythonToolsMachine_SRCS}
-    DESTINATION
-        Mod/CAM/Path/Tool/machine
-)
-
-INSTALL(
-    FILES
         ${PathPythonMachineModels_SRCS}
     DESTINATION
         Mod/CAM/Path/Machine/models
@@ -926,16 +924,16 @@ INSTALL(
 
 INSTALL(
     FILES
-        ${PathPythonToolsMachineUiEditor_SRCS}
+        ${PathPythonMachineUi_SRCS}
     DESTINATION
-        Mod/CAM/Path/Machine/ui/editor
+        Mod/CAM/Path/Machine/ui
 )
 
 INSTALL(
     FILES
-        ${PathPythonToolsMachineModels_SRCS}
+        ${PathPythonMachineUiEditor_SRCS}
     DESTINATION
-        Mod/CAM/Path/Tool/machine/models
+        Mod/CAM/Path/Machine/ui/editor
 )
 
 INSTALL(

--- a/src/Mod/CAM/Path/Machine/ui/__init__.py
+++ b/src/Mod/CAM/Path/Machine/ui/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   © 2026 Billy Huddleston <billy@ivdc.com>                                   #
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""Machine UI package"""


### PR DESCRIPTION
Corrected CMakeLists.txt to ensure Path/Machine/ui/editor Python files are installed and packaged properly. The previous variable name typo prevented these files from being included in AppImage and install targets, though local builds worked due to build directory copying. This resolves missing module errors on some systems and in AppImage.

src/Mod/CAM/CMakeLists.txt:
- Fixed INSTALL command to use the correct PathPythonMachineUiEditor_SRCS variable for Path/Machine/ui/editor
- Ensured all relevant Python files are included in both build and install steps