### PR TITLE
Remove unnecessary warnings during Mod scanning.

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -1279,8 +1279,6 @@ class DirModScanner:
         if not base.exists():
             if warning:
                 Wrn(warning)
-            else:
-                Wrn(f"No modules found in {base!s}")
             return
 
         if warning:


### PR DESCRIPTION
During Init refactoring, a new warning was introduced to indicate non existent Mods from well known locations but this warning gives nothing useful and is confusing users. So it is better to remove  it.