### PR TITLE
Assembly: fix crash when measure active

### DIFF
--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -789,7 +789,6 @@ bool ViewProviderAssembly::getSelectedObjectsWithinAssembly(bool addPreselection
             if (!alreadyIn) {
                 auto* pPlc = dynamic_cast<App::PropertyPlacement*>(obj->getPropertyByName("Placement"));
                 if (!ctrlPressed && !moveOnlyPreselected) {
-                    Gui::Selection().clearSelection();
                     docsToMove.clear();
                 }
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/26729

The crash was triggered by clearing the selection when initiating the drag.

The clear selection was introduced by https://github.com/FreeCAD/FreeCAD/commit/e37d15f081cf5fa974ea764964de181f2cc19bd4 to fix https://github.com/FreeCAD/FreeCAD/issues/13058

But after analysis, clearing the selection is not really necessary. Removing it permits to preserve selection which could be argued to be even better.