### PR TITLE
LibE57format to v3.3.0

### DIFF
--- a/src/3rdParty/libE57Format/.github/workflows/build.yml
+++ b/src/3rdParty/libE57Format/.github/workflows/build.yml
@@ -92,12 +92,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
       - name: Checkout Test Data
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: 'asmaloney/libE57Format-test-data'
           path: libE57Format-test-data
@@ -105,7 +105,7 @@ jobs:
       - name: Install Dependencies (macOS)
         if: matrix.platform == 'macos'
         run: |
-          brew install ccache ninja xerces-c
+          brew install ccache xerces-c
 
       - name: Install Dependencies (Linux)
         if: matrix.platform == 'linux'
@@ -118,13 +118,14 @@ jobs:
         if: matrix.platform == 'windows'
         uses: conda-incubator/setup-miniconda@v3
         with:
-          channels: conda-forge
+          channels: conda-forge,defaults
 
       - name: Install More Dependencies (Windows)
         if: matrix.platform == 'windows'
         shell: bash -el {0}
         run: |
           conda install conda-forge::xerces-c
+          echo "CMAKE_PREFIX_PATH=${CONDA_PREFIX}/Library" >> "$GITHUB_ENV"
           choco upgrade ccache ninja
           ccache --version | head -n 1
           echo "ninja $(ninja --version)"

--- a/src/3rdParty/libE57Format/CHANGELOG.md
+++ b/src/3rdParty/libE57Format/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 3.3.0 - (in progress)
+## [3.3.0](https://github.com/asmaloney/libE57Format/releases/tag/v3.3.0) - 2025-10-24
 
 ### Added
 
@@ -14,9 +14,19 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 
-- {cmake} Added missing include for GNUInstallDirs ([#315](https://github.com/asmaloney/libE57Format/pull/315)) (Thanks Adrian!)
+- Fix clang 17 warnings about `@throw` documentation. ([#327](https://github.com/asmaloney/libE57Format/pull/327))
+
+- Fix MSVC C++17 deprecation of `codecvt_utf8_utf16`; replaced with `MultiByteToWideChar` if compiling with C++ &gt;= 17. ([#326](https://github.com/asmaloney/libE57Format/pull/326)) (Thanks Christophe!)
+
+- {ci} Fix some CI warnings and update actions. ([#328](https://github.com/asmaloney/libE57Format/pull/328))
+
+- {ci} Fix GitHub CI for Windows. ([#325](https://github.com/asmaloney/libE57Format/pull/325)) (Thanks Christophe!)
+
+- {cmake} Add missing include for GNUInstallDirs ([#315](https://github.com/asmaloney/libE57Format/pull/315)) (Thanks Adrian!)
 
   If you built without testing on, the cmake files were not installed to the correct location.
+
+- {standard conformance} Don't try to fill in intensity limits when using the simple API. They are for the limits that the sensor can produce, not the limits of the data (8.4.19).
 
 ## [3.2.0](https://github.com/asmaloney/libE57Format/releases/tag/v3.2.0) - 2024-06-27
 

--- a/src/3rdParty/libE57Format/CMakeLists.txt
+++ b/src/3rdParty/libE57Format/CMakeLists.txt
@@ -36,12 +36,12 @@ set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/"
 message( STATUS "Using CMake ${CMAKE_VERSION}" )
 
 project( E57Format
-	DESCRIPTION
-	    "E57Format is a library to read and write E57 files"
-	LANGUAGES
-	    CXX
-	VERSION
-	    3.2.0
+    DESCRIPTION
+        "E57Format is a library to read and write E57 files"
+    LANGUAGES
+        CXX
+    VERSION
+        3.3.0
 )
 
 string( TOUPPER ${PROJECT_NAME} PROJECT_NAME_UPPERCASE )

--- a/src/3rdParty/libE57Format/README.md
+++ b/src/3rdParty/libE57Format/README.md
@@ -106,6 +106,7 @@ This _Simple API_ has evolved since this original port to fix some problems and 
 These projects use hard forks of libE57Format:
 
 - [FreeCAD](https://github.com/FreeCAD/FreeCAD)
+- [MicMac](https://github.com/micmacIGN/micmac)
 - [PDAL](https://github.com/PDAL/PDAL)
 
 There are also many commercial products using libE57Format. If any of them would like to sponsor the project and be listed here, please <a href="mailto:asmaloney@gmail.com?subject=libE57Format Sponsorship">contact Andy</a>.

--- a/src/3rdParty/libE57Format/include/E57SimpleData.h
+++ b/src/3rdParty/libE57Format/include/E57SimpleData.h
@@ -634,8 +634,8 @@ namespace e57
 
       @param [in] data3D Completed header which indicates the fields we are using
 
-      @throw ::ErrorValueOutOfBounds
-      @throw ::ErrorInvalidNodeType
+      @throw ::ErrorValueOutOfBounds (n/c)
+      @throw ::ErrorInvalidNodeType (n/c)
       */
       explicit Data3DPointsData_t( e57::Data3D &data3D );
 

--- a/src/3rdParty/libE57Format/src/BlobNode.cpp
+++ b/src/3rdParty/libE57Format/src/BlobNode.cpp
@@ -126,10 +126,10 @@ is an error to attempt to attach the BlobNode to a different ImageFile.
 must be true).
 @pre byteCount >= 0
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorInternal All objects in undocumented state
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorInternal All objects in undocumented state (n/c)
 
 @see Node, BlobNode::read, BlobNode::write
 */
@@ -200,7 +200,7 @@ bool BlobNode::isAttached() const
 
 @return The declared size of the blob when it was created.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see BlobNode::read, BlobNode::write
@@ -233,11 +233,11 @@ zero or more times.
 @pre 0 <= count
 @pre (@a start + @a count) < byteCount()
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorSeekFailed
-@throw ::ErrorReadFailed
-@throw ::ErrorBadChecksum
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorSeekFailed (n/c)
+@throw ::ErrorReadFailed (n/c)
+@throw ::ErrorBadChecksum (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see BlobNode::byteCount, BlobNode::write
@@ -276,14 +276,14 @@ destImageFile().isWritable()).
 @pre 0 <= count
 @pre (@a start + @a count) < byteCount()
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorNodeUnattached
-@throw ::ErrorSeekFailed
-@throw ::ErrorReadFailed
-@throw ::ErrorWriteFailed
-@throw ::ErrorBadChecksum
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorNodeUnattached (n/c)
+@throw ::ErrorSeekFailed (n/c)
+@throw ::ErrorReadFailed (n/c)
+@throw ::ErrorWriteFailed (n/c)
+@throw ::ErrorBadChecksum (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see BlobNode::byteCount, BlobNode::read
@@ -340,7 +340,7 @@ The handle @a n must be for an underlying BlobNode, otherwise an exception is th
 that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
 downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
 
-@throw ::ErrorBadNodeDowncast
+@throw ::ErrorBadNodeDowncast (n/c)
 
 @see Node::type(), BlobNode::operator Node()
 */

--- a/src/3rdParty/libE57Format/src/CompressedVectorNode.cpp
+++ b/src/3rdParty/libE57Format/src/CompressedVectorNode.cpp
@@ -197,12 +197,12 @@ prototype.isRoot())
 @post prototype.isAttached()
 @post codecs.isAttached()
 
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorBadPrototype
-@throw ::ErrorBadCodecs
-@throw ::ErrorAlreadyHasParent
-@throw ::ErrorDifferentDestImageFile
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorBadPrototype (n/c)
+@throw ::ErrorBadCodecs (n/c)
+@throw ::ErrorAlreadyHasParent (n/c)
+@throw ::ErrorDifferentDestImageFile (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see SourceDestBuffer, Node, CompressedVectorNode::reader, CompressedVectorNode::writer
@@ -275,7 +275,7 @@ any writes completed.
 
 @return Current number of records in CompressedVectorNode.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorNode::reader, CompressedVectorNode::writer
@@ -293,7 +293,7 @@ int64_t CompressedVectorNode::childCount() const
 
 @return A smart Node handle referencing the root of the prototype tree.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorNode::CompressedVectorNode, SourceDestBuffer, CompressedVectorNode::reader,
@@ -313,7 +313,7 @@ CompressedVectorNode.
 
 @return A smart VectorNode handle referencing the root of the codecs tree.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorNode::CompressedVectorNode, SourceDestBuffer, CompressedVectorNode::reader,
@@ -372,7 +372,7 @@ designs that need to avoid the exception, use Node::type() to determine the actu
 before downcasting. This function must be explicitly called (c++ compiler cannot insert it
 automatically).
 
-@throw ::ErrorBadNodeDowncast
+@throw ::ErrorBadNodeDowncast (n/c)
 
 @see Node::type(), CompressedVectorNode::operator, Node()
 */
@@ -422,17 +422,17 @@ CompressedVectorNode cannot be set twice).
 
 @return A smart CompressedVectorWriter handle referencing the underlying iterator object.
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorSetTwice
-@throw ::ErrorTooManyWriters
-@throw ::ErrorTooManyReaders
-@throw ::ErrorNodeUnattached
-@throw ::ErrorPathUndefined
-@throw ::ErrorBufferSizeMismatch
-@throw ::ErrorBufferDuplicatePathName
-@throw ::ErrorNoBufferForElement
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorSetTwice (n/c)
+@throw ::ErrorTooManyWriters (n/c)
+@throw ::ErrorTooManyReaders (n/c)
+@throw ::ErrorNodeUnattached (n/c)
+@throw ::ErrorPathUndefined (n/c)
+@throw ::ErrorBufferSizeMismatch (n/c)
+@throw ::ErrorBufferDuplicatePathName (n/c)
+@throw ::ErrorNoBufferForElement (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorWriter, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,
@@ -461,14 +461,14 @@ prototype. It is not an error to create a CompressedVectorReader for an empty Co
 
 @return A smart CompressedVectorReader handle referencing the underlying iterator object.
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorTooManyWriters
-@throw ::ErrorNodeUnattached
-@throw ::ErrorPathUndefined
-@throw ::ErrorBufferSizeMismatch
-@throw ::ErrorBufferDuplicatePathName
-@throw ::ErrorBadCVHeader
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorTooManyWriters (n/c)
+@throw ::ErrorNodeUnattached (n/c)
+@throw ::ErrorPathUndefined (n/c)
+@throw ::ErrorBufferSizeMismatch (n/c)
+@throw ::ErrorBufferDuplicatePathName (n/c)
+@throw ::ErrorBadCVHeader (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorReader, SourceDestBuffer, CompressedVectorNode::CompressedVectorNode,

--- a/src/3rdParty/libE57Format/src/CompressedVectorReader.cpp
+++ b/src/3rdParty/libE57Format/src/CompressedVectorReader.cpp
@@ -162,29 +162,19 @@ destroyed.
 
 @return The number of records read.
 
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorReaderNotOpen
-@throw ::ErrorConversionRequired            This CompressedVectorReader
-in undocumented state
-@throw ::ErrorValueNotRepresentable        This CompressedVectorReader
-in undocumented state
-@throw ::ErrorScaledValueNotRepresentable This CompressedVectorReader
-in undocumented state
-@throw ::ErrorReal64TooLarge               This CompressedVectorReader
-in undocumented state
-@throw ::ErrorExpectingNumeric              This CompressedVectorReader
-in undocumented state
-@throw ::ErrorExpectingUString              This CompressedVectorReader
-in undocumented state
-@throw ::ErrorBadCVPacket      This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw ::ErrorSeekFailed       This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw ::ErrorReadFailed        This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw ::ErrorBadChecksum       This CompressedVectorReader, associated
-ImageFile in undocumented state
-@throw ::ErrorInternal           All objects in undocumented state
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorReaderNotOpen (n/c)
+@throw ::ErrorConversionRequired This CompressedVectorReader in undocumented state
+@throw ::ErrorValueNotRepresentable This CompressedVectorReader in undocumented state
+@throw ::ErrorScaledValueNotRepresentable This CompressedVectorReader in undocumented state
+@throw ::ErrorReal64TooLarge This CompressedVectorReader in undocumented state
+@throw ::ErrorExpectingNumeric This CompressedVectorReader in undocumented state
+@throw ::ErrorExpectingUString This CompressedVectorReader in undocumented state
+@throw ::ErrorBadCVPacket This CompressedVectorReader, associated ImageFile in undocumented state
+@throw ::ErrorSeekFailed This CompressedVectorReader, associated ImageFile in undocumented state
+@throw ::ErrorReadFailed This CompressedVectorReader, associated ImageFile in undocumented state
+@throw ::ErrorBadChecksum This CompressedVectorReader, associated ImageFile in undocumented state
+@throw ::ErrorInternal  All objects in undocumented state
 
 @see CompressedVectorReader::read(std::vector<SourceDestBuffer>&),
 CompressedVectorNode::reader, SourceDestBuffer,
@@ -230,11 +220,11 @@ detect that a memory buffer been destroyed.
 
 @return The number of records read.
 
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorReaderNotOpen
-@throw ::ErrorPathUndefined
-@throw ::ErrorBufferSizeMismatch
-@throw ::ErrorBufferDuplicatePathName
+@throw ::ErrorImageFileNotOpen nc
+@throw ::ErrorReaderNotOpen (n/c)
+@throw ::ErrorPathUndefined (n/c)
+@throw ::ErrorBufferSizeMismatch (n/c)
+@throw ::ErrorBufferDuplicatePathName (n/c)
 @throw ::ErrorConversionRequired This CompressedVectorReader in undocumented state
 @throw ::ErrorValueNotRepresentable This CompressedVectorReader in undocumented state
 @throw ::ErrorScaledValueNotRepresentable This CompressedVectorReader in undocumented state
@@ -269,13 +259,13 @@ childCount() (i.e. to one record past end of CompressedVectorNode).
 @pre The associated ImageFile must be open.
 @pre This CompressedVectorReader must be open (i.e isOpen())
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorReaderNotOpen
-@throw ::ErrorBadCVPacket
-@throw ::ErrorSeekFailed
-@throw ::ErrorReadFailed
-@throw ::ErrorBadChecksum
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorReaderNotOpen (n/c)
+@throw ::ErrorBadCVPacket (n/c)
+@throw ::ErrorSeekFailed (n/c)
+@throw ::ErrorReadFailed (n/c)
+@throw ::ErrorBadChecksum (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorNode::reader
@@ -308,7 +298,7 @@ void CompressedVectorReader::close()
 
 @pre The associated ImageFile must be open.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal           All objects in undocumented state
 
 @see CompressedVectorReader::close, CompressedVectorNode::reader
@@ -328,7 +318,7 @@ It is not an error if this CompressedVectorReader is closed.
 
 @return A smart CompressedVectorNode handle referencing the underlying object being read from.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal           All objects in undocumented state
 
 @see CompressedVectorReader::close, CompressedVectorNode::reader

--- a/src/3rdParty/libE57Format/src/CompressedVectorWriter.cpp
+++ b/src/3rdParty/libE57Format/src/CompressedVectorWriter.cpp
@@ -152,13 +152,13 @@ all writes to the CompressedVectorNode will be lost (it will have zero children)
 @pre The associated ImageFile must be open.
 @pre This CompressedVectorWriter must be open (i.e isOpen())
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorWriterNotOpen
-@throw ::ErrorPathUndefined
-@throw ::ErrorNoBufferForElement
-@throw ::ErrorBufferSizeMismatch
-@throw ::ErrorBufferDuplicatePathName
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorWriterNotOpen (n/c)
+@throw ::ErrorPathUndefined (n/c)
+@throw ::ErrorNoBufferForElement (n/c)
+@throw ::ErrorBufferSizeMismatch (n/c)
+@throw ::ErrorBufferDuplicatePathName (n/c)
 @throw ::ErrorConversionRequired This CompressedVectorWriter in undocumented state, associated
 CompressedVectorNode modified but consistent, associated ImageFile modified but consistent.
 @throw ::ErrorValueOutOfBounds This CompressedVectorWriter in undocumented state, associated
@@ -218,13 +218,13 @@ is invoked, all writes to the CompressedVectorNode will be lost (it will have ze
 @pre The associated ImageFile must be open.
 @pre This CompressedVectorWriter must be open (i.e isOpen())
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorWriterNotOpen
-@throw ::ErrorPathUndefined
-@throw ::ErrorNoBufferForElement
-@throw ::ErrorBufferSizeMismatch
-@throw ::ErrorBufferDuplicatePathName
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorWriterNotOpen (n/c)
+@throw ::ErrorPathUndefined (n/c)
+@throw ::ErrorNoBufferForElement (n/c)
+@throw ::ErrorBufferSizeMismatch (n/c)
+@throw ::ErrorBufferDuplicatePathName (n/c)
 @throw ::ErrorConversionRequired This CompressedVectorWriter in undocumented state, associated
 ImageFile modified but consistent.
 @throw ::ErrorValueOutOfBounds This CompressedVectorWriter in undocumented state, associated
@@ -269,7 +269,7 @@ writes to the CompressedVectorNode will be lost (it will have zero children).
 @pre The associated ImageFile must be open.
 @post This CompressedVectorWriter is closed (i.e !isOpen())
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorSeekFailed This CompressedVectorWriter, associated ImageFile in undocumented state
 @throw ::ErrorReadFailed  This CompressedVectorWriter, associated ImageFile in undocumented state
 @throw ::ErrorWriteFailed This CompressedVectorWriter, associated ImageFile in undocumented state
@@ -288,7 +288,7 @@ void CompressedVectorWriter::close()
 
 @pre The associated ImageFile must be open.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorWriter::close, CompressedVectorNode::writer
@@ -305,7 +305,7 @@ bool CompressedVectorWriter::isOpen()
 
 @return A smart CompressedVectorNode handle referencing the underlying object being written to.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorNode::writer

--- a/src/3rdParty/libE57Format/src/FloatNode.cpp
+++ b/src/3rdParty/libE57Format/src/FloatNode.cpp
@@ -141,10 +141,10 @@ if 0 is within bounds, or a @a value = @a minimum if 0 is not within bounds.
 be true).
 @pre minimum <= value <= maximum
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorValueOutOfBounds
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorValueOutOfBounds (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see FloatPrecision, FloatNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
@@ -222,7 +222,7 @@ is ::PrecisionDouble, the double precision value is returned as a double.
 
 @return The IEEE floating point value stored, represented as a double.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal           All objects in undocumented state
 
 @see FloatNode::minimum, FloatNode::maximum
@@ -241,7 +241,7 @@ double FloatNode::value() const
 @return The declared precision of the floating point number, either ::PrecisionSingle or
 ::PrecisionDouble.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see FloatPrecision
@@ -263,7 +263,7 @@ precision is ::PrecisionDouble, the double precision minimum is returned as a do
 
 @return The declared minimum that the value may take.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see FloatNode::maximum, FloatNode::value
@@ -285,7 +285,7 @@ precision is ::PrecisionDouble, the double precision maximum is returned as a do
 
 @return The declared maximum that the value may take.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see FloatNode::minimum, FloatNode::value
@@ -340,7 +340,7 @@ The handle @a n must be for an underlying FloatNode, otherwise an exception is t
 that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
 downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
 
-@throw ::ErrorBadNodeDowncast
+@throw ::ErrorBadNodeDowncast (n/c)
 
 @see Node::type(), FloatNode::operator Node()
 */

--- a/src/3rdParty/libE57Format/src/ImageFile.cpp
+++ b/src/3rdParty/libE57Format/src/ImageFile.cpp
@@ -265,19 +265,19 @@ read-only). There is no API support for appending data onto an existing E57 data
 
 @post Resulting ImageFile is in @c open state if constructor succeeds (no exception thrown).
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorOpenFailed
-@throw ::ErrorSeekFailed
-@throw ::ErrorReadFailed
-@throw ::ErrorWriteFailed
-@throw ::ErrorBadChecksum
-@throw ::ErrorBadFileSignature
-@throw ::ErrorUnknownFileVersion
-@throw ::ErrorBadFileLength
-@throw ::ErrorXMLParserInit
-@throw ::ErrorXMLParser
-@throw ::ErrorBadXMLFormat
-@throw ::ErrorBadConfiguration
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorOpenFailed (n/c)
+@throw ::ErrorSeekFailed (n/c)
+@throw ::ErrorReadFailed (n/c)
+@throw ::ErrorWriteFailed (n/c)
+@throw ::ErrorBadChecksum (n/c)
+@throw ::ErrorBadFileSignature (n/c)
+@throw ::ErrorUnknownFileVersion (n/c)
+@throw ::ErrorBadFileLength (n/c)
+@throw ::ErrorXMLParserInit (n/c)
+@throw ::ErrorXMLParser (n/c)
+@throw ::ErrorBadXMLFormat (n/c)
+@throw ::ErrorBadConfiguration (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see IntegerNode, ScaledIntegerNode, FloatNode, StringNode, BlobNode, StructureNode, VectorNode,
@@ -307,7 +307,7 @@ is empty in a newly created write mode ImageFile.
 
 @return A smart StructureNode handle referencing the underlying object.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see StructureNode.
@@ -339,11 +339,11 @@ It is not an error if ImageFile is already closed.
 
 @post ImageFile is in @c closed state.
 
-@throw ::ErrorSeekFailed
-@throw ::ErrorReadFailed
-@throw ::ErrorWriteFailed
-@throw ::ErrorCloseFailed
-@throw ::ErrorBadChecksum
+@throw ::ErrorSeekFailed (n/c)
+@throw ::ErrorReadFailed (n/c)
+@throw ::ErrorWriteFailed (n/c)
+@throw ::ErrorCloseFailed (n/c)
+@throw ::ErrorBadChecksum (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::cancel, ImageFile::isOpen
@@ -432,7 +432,7 @@ CompressedVectorWriter objects are created by the CompressedVectorNode::writer f
 
 @return The current number of open CompressedVectorWriter objects writing to ImageFile.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see  CompressedVectorNode::writer, CompressedVectorWriter
@@ -454,7 +454,7 @@ CompressedVectorReader objects are created by the CompressedVectorNode::reader f
 
 @return The current number of open CompressedVectorReader objects reading from ImageFile.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see CompressedVectorNode::reader, CompressedVectorReader
@@ -496,11 +496,11 @@ See the class discussion at bottom of ImageFile page for more details about name
 @pre prefix != ""
 @pre uri != ""
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorDuplicateNamespacePrefix
-@throw ::ErrorDuplicateNamespaceURI
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorDuplicateNamespacePrefix (n/c)
+@throw ::ErrorDuplicateNamespaceURI (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::extensionsCount, ImageFile::extensionsLookupPrefix, ImageFile::extensionsLookupUri
@@ -524,8 +524,8 @@ an error if @a prefix contains an illegal character combination for E57 namespac
 
 @return true if prefix is declared in the ImageFile.
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::extensionsLookupUri
@@ -554,8 +554,8 @@ namespace prefixes. It is not an error if @a prefix is well-formed, but not defi
 
 @return true if prefix is declared in the ImageFile.
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 
 @throw ::ErrorInternal All objects in undocumented state
 
@@ -584,8 +584,8 @@ function just returns false).
 
 @return true if URI is declared in the ImageFile.
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::extensionsLookupPrefix
@@ -606,7 +606,7 @@ The default E57 namespace does not count as an extension.
 
 @return The number of E57 extensions defined in the ImageFile.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::extensionsPrefix, ImageFile::extensionsUri
@@ -632,8 +632,8 @@ counted as an extension.
 
 @return The E57 extension prefix at the given index.
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see  ImageFile::extensionsCount, ImageFile::extensionsUri
@@ -659,8 +659,8 @@ as an extension.
 
 @return The E57 extension URI at the given index.
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::extensionsCount, ImageFile::extensionsPrefix
@@ -704,7 +704,7 @@ prefixed form, the prefix does not have to be declared in the ImageFile.
 
 @post No visible state is modified.
 
-@throw ::ErrorBadPathName
+@throw ::ErrorBadPathName (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::isElementNameExtended

--- a/src/3rdParty/libE57Format/src/IntegerNode.cpp
+++ b/src/3rdParty/libE57Format/src/IntegerNode.cpp
@@ -134,10 +134,10 @@ ignored). If the IntegerNode is to be used in a prototype, it is recommended to 
 be true).
 @pre minimum <= value <= maximum
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorValueOutOfBounds
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorValueOutOfBounds (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see IntegerNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
@@ -211,7 +211,7 @@ bool IntegerNode::isAttached() const
 
 @return integer value stored.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal  All objects in undocumented state
 
 @see IntegerNode::minimum, IntegerNode::maximum
@@ -229,7 +229,7 @@ int64_t IntegerNode::value() const
 
 @return The declared minimum that the value may take.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see IntegerNode::value
@@ -247,7 +247,7 @@ int64_t IntegerNode::minimum() const
 
 @return The declared maximum that the value may take.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see IntegerNode::value
@@ -303,7 +303,7 @@ The handle @a n must be for an underlying IntegerNode, otherwise an exception is
 that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
 downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
 
-@throw ::ErrorBadNodeDowncast
+@throw ::ErrorBadNodeDowncast (n/c)
 
 @see Node::type(), IntegerNode::operator Node()
 */

--- a/src/3rdParty/libE57Format/src/Node.cpp
+++ b/src/3rdParty/libE57Format/src/Node.cpp
@@ -372,7 +372,7 @@ relationship (see Node::isAttached and CompressedVectorNode::CompressedVectorNod
 
 @return true if this node is a root node.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see Node::parent, Node::isAttached, CompressedVectorNode::CompressedVectorNode
@@ -407,7 +407,7 @@ infinite recursion.
 
 @return A smart Node handle referencing the parent node or this node if is a root node.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see Node::isRoot, Node::isAttached, CompressedVectorNode::CompressedVectorNode, Node::elementName
@@ -441,7 +441,7 @@ root node has the empty string ("") as its elementName.
 
 @return The absolute path name of the node.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see Node::elementName, Node::parent, Node::isRoot
@@ -473,7 +473,7 @@ by the position of the child.
 
 @return The element name of the node, or "" if a root node.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see Node::pathName, Node::parent, Node::isRoot
@@ -524,7 +524,7 @@ eventually attached to the ImageFile.
 @return @c true if node is child of (or in codecs or prototype of a child CompressedVectorNode of)
 the root node of an ImageFile.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see Node::destImageFile, ImageFile::root

--- a/src/3rdParty/libE57Format/src/ScaledIntegerNode.cpp
+++ b/src/3rdParty/libE57Format/src/ScaledIntegerNode.cpp
@@ -139,10 +139,10 @@ be true).
 @pre minimum <= rawValue <= maximum
 @pre scale != 0
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorValueOutOfBounds
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorValueOutOfBounds (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::rawValue, Node, CompressedVectorNode, CompressedVectorNode::prototype
@@ -201,10 +201,10 @@ be true).
 @pre scaledMinimum <= scaledValue <= scaledMaximum
 @pre scale != 0
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
-@throw ::ErrorValueOutOfBounds
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorValueOutOfBounds (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::scaledValue, Node, CompressedVectorNode, CompressedVectorNode::prototype
@@ -280,7 +280,7 @@ bool ScaledIntegerNode::isAttached() const
 
 @return The raw unscaled integer value stored.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::scaledValue, ScaledIntegerNode::minimum, ScaledIntegerNode::maximum
@@ -298,7 +298,7 @@ int64_t ScaledIntegerNode::rawValue() const
 
 @return The scaled value (rawValue*scale + offset) calculated from the rawValue stored.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::rawValue
@@ -316,7 +316,7 @@ double ScaledIntegerNode::scaledValue() const
 
 @return The declared minimum that the rawValue may take.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::maximum, ScaledIntegerNode::rawValue
@@ -334,7 +334,7 @@ int64_t ScaledIntegerNode::minimum() const
 
 @return The declared minimum that the rawValue may take.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::scaledMaximum, ScaledIntegerNode::scaledValue
@@ -352,7 +352,7 @@ double ScaledIntegerNode::scaledMinimum() const
 
 @return The declared maximum that the rawValue may take.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::minimum, ScaledIntegerNode::rawValue
@@ -370,7 +370,7 @@ int64_t ScaledIntegerNode::maximum() const
 
 @return The declared maximum that the rawValue may take.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::scaledMinimum, ScaledIntegerNode::scaledValue
@@ -388,7 +388,7 @@ double ScaledIntegerNode::scaledMaximum() const // Added by SC
 
 @return The scaling factor used to compute scaledValue from rawValue.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::scaledValue
@@ -406,7 +406,7 @@ double ScaledIntegerNode::scale() const
 
 @return The offset used to compute scaledValue from rawValue.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ScaledIntegerNode::scaledValue
@@ -463,7 +463,7 @@ designs that need to avoid the exception, use Node::type() to determine the actu
 before downcasting. This function must be explicitly called (c++ compiler cannot insert it
 automatically).
 
-@throw ::ErrorBadNodeDowncast
+@throw ::ErrorBadNodeDowncast (n/c)
 
 @see Node::type(), ScaledIntegerNode::operator, Node()
 */

--- a/src/3rdParty/libE57Format/src/SourceDestBuffer.cpp
+++ b/src/3rdParty/libE57Format/src/SourceDestBuffer.cpp
@@ -149,10 +149,10 @@ transfer with a CompressedVectorNode.
 @pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
 @pre The stride must be >= sizeof(*b)
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorBadPathName
-@throw ::ErrorBadBuffer
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorBadBuffer (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::reader, ImageFile::writer,
@@ -287,10 +287,10 @@ destroyed).
 @pre b.size() must be > 0.
 @pre The @a destImageFile must be open (i.e. destImageFile.isOpen() must be true).
 
-@throw ::ErrorBadAPIArgument
-@throw ::ErrorBadPathName
-@throw ::ErrorBadBuffer
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadAPIArgument (n/c)
+@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorBadBuffer (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see SourceDestBuffer::doConversion for discussion on representations compatible with string
@@ -397,7 +397,7 @@ CompressedVectorReader or CompressedVectorWriter is created).
 
 @return true if conversions will be performed to match the memory type of buffer.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 */
 bool SourceDestBuffer::doConversion() const

--- a/src/3rdParty/libE57Format/src/StringNode.cpp
+++ b/src/3rdParty/libE57Format/src/StringNode.cpp
@@ -103,8 +103,8 @@ If the StringNode is to be used in a CompressedVectorNode prototype, it is recom
 @pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
 be true).
 
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorFileReadOnly
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorFileReadOnly (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see StringNode::value, Node, CompressedVectorNode, CompressedVectorNode::prototype
@@ -177,7 +177,7 @@ bool StringNode::isAttached() const
 
 @return  The Unicode character string value stored.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 */
 ustring StringNode::value() const
@@ -232,7 +232,7 @@ The handle @a n must be for an underlying StringNode, otherwise an exception is 
 that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
 downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
 
-@throw ::ErrorBadNodeDowncast
+@throw ::ErrorBadNodeDowncast (n/c)
 
 @see Node::type(), StringNode::operator Node()
 */

--- a/src/3rdParty/libE57Format/src/StructureNode.cpp
+++ b/src/3rdParty/libE57Format/src/StructureNode.cpp
@@ -127,7 +127,7 @@ to attach the StructureNode to a different ImageFile.
 @pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
 be true).
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see Node
@@ -199,7 +199,7 @@ bool StructureNode::isAttached() const
 
 @return Number of child nodes contained by this StructureNode.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see StructureNode::get(int64_t) const,
@@ -225,8 +225,8 @@ is not attached to an ImageFile, the @a pathName origin root will not the root n
 
 @return true if pathName is currently defined.
 
-@throw ::ErrorBadPathName
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ImageFile::root, VectorNode::isDefined
@@ -251,8 +251,8 @@ the StructureNode. The order of children may change if more children are added t
 
 @return A smart Node handle referencing the child node.
 
-@throw ::ErrorChildIndexOutOfBounds
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorChildIndexOutOfBounds (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see StructureNode::childCount,
@@ -278,9 +278,9 @@ an ImageFile.
 
 @return A smart Node handle referencing the child node.
 
-@throw ::ErrorBadPathName
-@throw ::ErrorPathUndefined
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathUndefined (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see StructureNode::get(int64_t) const
@@ -321,14 +321,14 @@ destImageFile().isWritable()).
 destImageFile() == n.destImageFile()).
 @post The @a pathName will be defined (i.e. isDefined(pathName)).
 
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorBadPathName
-@throw ::ErrorPathUndefined
-@throw ::ErrorSetTwice
-@throw ::ErrorAlreadyHasParent
-@throw ::ErrorDifferentDestImageFile
-@throw ::ErrorHomogeneousViolation
-@throw ::ErrorFileReadOnly
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathUndefined (n/c)
+@throw ::ErrorSetTwice (n/c)
+@throw ::ErrorAlreadyHasParent (n/c)
+@throw ::ErrorDifferentDestImageFile (n/c)
+@throw ::ErrorHomogeneousViolation (n/c)
+@throw ::ErrorFileReadOnly (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see VectorNode::append
@@ -386,7 +386,7 @@ designs that need to avoid the exception, use Node::type() to determine the actu
 before downcasting. This function must be explicitly called (c++ compiler cannot insert it
 automatically).
 
-@throw ::ErrorBadNodeDowncast
+@throw ::ErrorBadNodeDowncast (n/c)
 
 @see Node::type(), StructureNode::operator Node()
 */

--- a/src/3rdParty/libE57Format/src/VectorNode.cpp
+++ b/src/3rdParty/libE57Format/src/VectorNode.cpp
@@ -146,7 +146,7 @@ unconstrained.
 @pre The @a destImageFile must have been opened in write mode (i.e. destImageFile.isWritable() must
 be true).
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see Node, VectorNode::allowHeteroChildren, ::ErrorHomogeneousViolation
@@ -223,7 +223,7 @@ changed.
 
 @return True if child elements can be different types.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see ::ErrorHomogeneousViolation
@@ -241,7 +241,7 @@ bool VectorNode::allowHeteroChildren() const
 
 @return Number of child elements in this VectorNode.
 
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see VectorNode::get(int64_t), VectorNode::append, StructureNode::childCount
@@ -268,8 +268,8 @@ The element names of child elements of VectorNodes are numbers, encoded as strin
 
 @return true if pathName is currently defined.
 
-@throw ::ErrorBadPathName
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see StructureNode::isDefined
@@ -290,8 +290,8 @@ bool VectorNode::isDefined( const ustring &pathName ) const
 
 @return A smart Node handle referencing the child node.
 
-@throw ::ErrorChildIndexOutOfBounds
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorChildIndexOutOfBounds (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see VectorNode::childCount, VectorNode::append, StructureNode::get(int64_t) const
@@ -319,9 +319,9 @@ The element names of child elements of VectorNodes are numbers, encoded as strin
 
 @return A smart Node handle referencing the child node.
 
-@throw ::ErrorBadPathName
-@throw ::ErrorPathUndefined
-@throw ::ErrorImageFileNotOpen
+@throw ::ErrorBadPathName (n/c)
+@throw ::ErrorPathUndefined (n/c)
+@throw ::ErrorImageFileNotOpen (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see VectorNode::childCount, VectorNode::append, StructureNode::get(int64_t) const
@@ -352,11 +352,11 @@ The VectorNode must not be a descendent of a homogeneous VectorNode with more th
 destImageFile().isWritable()).
 @post the childCount is incremented.
 
-@throw ::ErrorImageFileNotOpen
-@throw ::ErrorHomogeneousViolation
-@throw ::ErrorFileReadOnly
-@throw ::ErrorAlreadyHasParent
-@throw ::ErrorDifferentDestImageFile
+@throw ::ErrorImageFileNotOpen (n/c)
+@throw ::ErrorHomogeneousViolation (n/c)
+@throw ::ErrorFileReadOnly (n/c)
+@throw ::ErrorAlreadyHasParent (n/c)
+@throw ::ErrorDifferentDestImageFile (n/c)
 @throw ::ErrorInternal All objects in undocumented state
 
 @see VectorNode::childCount, VectorNode::get(int64_t), StructureNode::set
@@ -413,7 +413,7 @@ The handle @a n must be for an underlying VectorNode, otherwise an exception is 
 that need to avoid the exception, use Node::type() to determine the actual type of the @a n before
 downcasting. This function must be explicitly called (c++ compiler cannot insert it automatically).
 
-@throw ::ErrorBadNodeDowncast
+@throw ::ErrorBadNodeDowncast (n/c)
 
 @see Node::type(), VectorNode::operator Node()
 */


### PR DESCRIPTION
Done via:
```
git subtree pull --prefix=src/3rdParty/libE57Format libE57Format v3.3.0 --squash
```
where `libE57Format` is the remote `https://github.com/asmaloney/libE57Format` and v3.3.0 is the tag name at that repo.

Replaces #25582