### PR TITLE
Gui: Fix Tab key toggling boolean fields in property editor

### DIFF
--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -258,13 +258,6 @@ QWidget* PropertyItemDelegate::createEditor(
     }
 
     auto createEditor = [this, childItem, parent]() {
-        // Can't use a terniary here because the lambdas have different types.
-        if (qobject_cast<PropertyBoolItem*>(childItem)) {
-            // Boolean properties use a checkbox that is basically artificial
-            // (it is not rendered).  Therefore, the callback is handled in
-            // eventFilter()
-            return childItem->createEditor(parent, []() noexcept {});
-        }
         return childItem->createEditor(parent, [this]() {
             const_cast<PropertyItemDelegate*>(this)->valueChanged();  // NOLINT
         });
@@ -297,7 +290,7 @@ QWidget* PropertyItemDelegate::createEditor(
     if (editor && childItem->isReadOnly()) {
         editor->setDisabled(true);
     }
-    else if (editor /*&& this->pressed*/) {
+    else if (editor) {
         // We changed the way editor is activated in PropertyEditor (in response
         // of signal activated and clicked), so now we should grab focus
         // regardless of "pressed" or not (e.g. when activated by keyboard
@@ -325,6 +318,7 @@ void PropertyItemDelegate::valueChanged()
     if (propertyEditor) {
         Base::FlagToggler<> flag(changed);
         Q_EMIT commitData(propertyEditor);
+        // Close editor for combo boxes and checkboxes after committing
         if (qobject_cast<QComboBox*>(propertyEditor) || qobject_cast<QCheckBox*>(propertyEditor)) {
             Q_EMIT closeEditor(propertyEditor);
             return;


### PR DESCRIPTION
## Summary

- Fixes #22742 - Tab key no longer toggles boolean (Yes/No) fields in the property editor
- Boolean fields now only toggle on explicit user action: mouse click or edit key (Return on macOS, F2 on Windows/Linux)
- Tab navigation properly visits boolean fields without toggling them
- Fixes rapid/double-clicking losing every other click

## Changes

**PropertyItemDelegate.h:**
- Added `activatedByMouse` member to track activation method

**PropertyItemDelegate.cpp:**
- Track mouse press state separately from other events
- Only toggle checkbox on mouse-activated focus, not keyboard navigation
- Handle double-clicks on boolean fields to fix rapid clicking

**PropertyEditor.cpp:**
- Tab to boolean field: select row without opening editor (keeps Yes/No text visible)
- Tab from boolean field: navigate to next property instead of leaving widget
- Edit key (Return/F2) on boolean field: toggle value directly

## Test plan

- [ ] Click on boolean field toggles value
- [ ] Rapid/double-clicking toggles on each click (no lost clicks)
- [ ] Tab into boolean field does NOT toggle value
- [ ] Tab from boolean field goes to next property
- [ ] Shift+Tab works in reverse
- [ ] Return (macOS) / F2 (Windows/Linux) toggles value
- [ ] Value persists after toggle

Tested on macOS and Windows.

🤖 Generated with [Claude Code](https://claude.ai/code)