### PR TITLE
Sketcher: Fix external geometry from App::Link and Link Arrays

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -187,8 +187,8 @@ public:
                     // Use original (non-resolved) selection if available.
                     // This is important for Link Arrays where msg may have resolved
                     // "Array" + "2.Face6" to "Extrude" + "Face6", losing the array element path.
-                    // For mapped element names (TNP), convert to simple names using oldElementName()
-                    // which transforms "2.;#14:...Face6" back to "2.Face6".
+                    // For mapped element names (TNP), convert to simple names using
+                    // oldElementName() which transforms "2.;#14:...Face6" back to "2.Face6".
                     const char* objName = msg.pObjectName;
                     std::string subElemStr(msg.pSubName);
                     if (msg.pOriginalMsg) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -26,6 +26,7 @@
 #define SKETCHERGUI_DrawSketchHandlerExternal_H
 
 #include <App/Datums.h>
+#include <App/ElementNamingUtils.h>
 #include <Mod/Part/App/DatumFeature.h>
 
 #include <Gui/Notifications.h>
@@ -183,11 +184,23 @@ public:
                 || (subName.size() > 4 && subName.substr(0, 4) == "Face")) {
                 try {
                     Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add external geometry"));
+                    // Use original (non-resolved) selection if available.
+                    // This is important for Link Arrays where msg may have resolved
+                    // "Array" + "2.Face6" to "Extrude" + "Face6", losing the array element path.
+                    // For mapped element names (TNP), convert to simple names using oldElementName()
+                    // which transforms "2.;#14:...Face6" back to "2.Face6".
+                    const char* objName = msg.pObjectName;
+                    std::string subElemStr(msg.pSubName);
+                    if (msg.pOriginalMsg) {
+                        objName = msg.pOriginalMsg->pObjectName;
+                        // Convert mapped element name to simple element name, preserving path prefix
+                        subElemStr = Data::oldElementName(msg.pOriginalMsg->pSubName);
+                    }
                     Gui::cmdAppObjectArgs(
                         sketchgui->getObject(),
                         "addExternal(\"%s\",\"%s\", %s, %s)",
-                        msg.pObjectName,
-                        msg.pSubName,
+                        objName,
+                        subElemStr.c_str(),
                         alwaysReference || isConstructionMode() ? "False" : "True",
                         intersection ? "True" : "False"
                     );


### PR DESCRIPTION
## Summary

- Fixes external geometry references from App::Link objects (including Link Arrays)
- The bug caused a `TypeError: Datum feature type is not yet supported` error when trying to reference geometry from linked objects

## Root Cause

Three issues prevented external geometry from App::Link:

1. **GUI selection resolution**: The selection system resolves Link references before passing them to `addExternal()`. For Link Arrays, "Array" + "2.Face6" becomes "Extrude" + "Face6", losing the array element path.

2. **Missing Link support in rebuild**: `rebuildExternalGeometry()` only handled `Part::Feature`, not objects with `LinkBaseExtension`.

3. **Path prefix loss**: `addExternal()` didn't preserve array element path prefixes (like "2." in "2.Face6") when storing references.

## Changes

- **DrawSketchHandlerExternal.h**: Uses the original (non-resolved) selection message via `msg.pOriginalMsg` to preserve the Link object name and array element path
- **SketchObject.cpp (addExternal)**: Properly parses and preserves array element path prefixes when adding external geometry
- **SketchObject.cpp (rebuildExternalGeometry)**: Extends to handle objects with `LinkBaseExtension`, using `Part::Feature::getTopoShape()` with proper path handling

Fixes #15663

## Test plan

1. Create a Part with a sketch and extrusion
2. Create a Link Array of the Part
3. Create a new sketch
4. Try to add external geometry from an edge of the Link Array
5. **Before fix**: Error "Datum feature type is not yet supported"
6. **After fix**: External geometry is added successfully and updates when the array element moves

🤖 Generated with [Claude Code](https://claude.ai/code)