### PR TITLE
Draft: fix snapping to geometry on image

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -351,7 +351,7 @@ class Snapper:
 
     def cycleSnapObject(self):
         """Increase the index of the snap object by one."""
-        self.snapObjectIndex = self.snapObjectIndex + 1
+        self.snapObjectIndex += 1
 
     def snapToObject(self, lastpoint, active, constrain, eline, point):
         """Snap to an object."""
@@ -373,6 +373,8 @@ class Snapper:
             or Draft.getType(obj) in UNSNAPPABLES
             or not getattr(obj.ViewObject, "Selectable", True)
         ):
+            # increase snapObjectIndex to find other objects under the cursor:
+            self.snapObjectIndex += 1
             return None
 
         snaps = []


### PR DESCRIPTION
Fixes #26965

`self.snapObjectIndex` should be increased if the object under the cursor is not 'snappable'. This is the same principle as is used in the `cycleSnapObject` function.