### PR TITLE
CAM: Fixed issues with Fanuc post processor discovered by lint

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+"""
+
+CAM post processor for CNC machines with a Fanuc controller.
+
+"""
+
 # ***************************************************************************
 # *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
 # *   Copyright (c) 2021 shadowbane1000 <tyler@colberts.us>                 *
@@ -33,7 +39,7 @@ import shlex
 import os.path
 import Path.Base.Util as PathUtil
 import Path.Post.Utils as PostUtils
-import PathScripts.PathUtils as PathUtils
+from PathScripts import PathUtils
 from builtins import open as pyopen
 
 TOOLTIP = """
@@ -79,7 +85,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="'
+    help="set commands to be issued after the last command, "
+    + 'default="'
     + DEFAULT_POSTAMBLE.replace("\n", "\\n")
     + '"',
 )
@@ -155,8 +162,17 @@ TOOL_CHANGE = """G28 G91 Z0
 DRILL_OPERATION = ("G73", "G81", "G82", "G83", "G85")
 DRILL_PARAM_REQ = ("L", "P", "Q", "R", "Z")
 
+# The settings shared between methods
+PREAMBLE = None
+POSTAMBLE = None
+
 
 def processArguments(argstring):
+    """
+    Apply default values and command line arguments before
+    processing commands.
+
+    """
     global OUTPUT_HEADER
     global OUTPUT_COMMENTS
     global OUTPUT_LINE_NUMBERS


### PR DESCRIPTION
Made sure global variables used are declared.  This fixes issue updating the postamble and preamble introduced in ef794c31bd85cd2d5a11df47b8a07e93e8982be3

Added docstrings, adjusted import statements and wrapped long line to keep linter happy.