### PR TITLE
Base: Removed unused private variable decimals to avoid lint issue.

### DIFF
--- a/src/Base/UnitsSchemas.cpp
+++ b/src/Base/UnitsSchemas.cpp
@@ -44,7 +44,6 @@ using Base::UnitsSchemaSpec;
 UnitsSchemas::UnitsSchemas(const UnitsSchemasDataPack& pack)
     : pack {pack}
     , denominator {pack.defDenominator}
-    , decimals {pack.defDecimals}
 {}
 
 size_t UnitsSchemas::count() const

--- a/src/Base/UnitsSchemas.h
+++ b/src/Base/UnitsSchemas.h
@@ -71,7 +71,6 @@ private:
     UnitsSchemasDataPack pack;
     std::unique_ptr<UnitsSchema> current {std::make_unique<UnitsSchema>(spec())};
     std::size_t denominator;
-    std::size_t decimals;
 };
 
 


### PR DESCRIPTION
The linter report 'private field 'decimals' is not used'.  The getDecimals() method return pack.defDecimals, which was also used to set the value of the decimals variable in the initializer, so the decimals variable is redundant.