### PR TITLE
CAM: Path.Geom.pointsCoincide - allow list and tuple

### DIFF
--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -103,11 +103,7 @@ def isRoughly(float1, float2, error=Tolerance):
 def pointsCoincide(p1, p2, error=Tolerance):
     """pointsCoincide(p1, p2, [error=Tolerance])
     Return True if two points are roughly identical (see also isRoughly)."""
-    return (
-        isRoughly(p1.x, p2.x, error)
-        and isRoughly(p1.y, p2.y, error)
-        and isRoughly(p1.z, p2.z, error)
-    )
+    return len(p1) == len(p2) and all(isRoughly(p1[i], p2[i], error) for i in range(len(p1)))
 
 
 def edgesMatch(e0, e1, error=Tolerance):


### PR DESCRIPTION
At this moment `Path.Geom.pointsCoincide` can compare only `FreeCAD.Vector` objects
Lets allow compare also points represented by any iterable objects, list and tuple

```
p1 = (10,10,10)
p2 = [10,10,10]
Path.Geom.pointsCoincide(p1, p2)
```

https://github.com/FreeCAD/FreeCAD/blob/c14d6f8848f3eb5b120bb89b4f2955ba70f7b027/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py#L326

https://github.com/FreeCAD/FreeCAD/blob/c14d6f8848f3eb5b120bb89b4f2955ba70f7b027/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py#L471-L475

So this can be represented as
```
if Path.Geom.pointsCoincide(edge.end_point, candidate.end_point):
```