### PR TITLE
Sketcher: speedup solving

### DIFF
--- a/src/Mod/Sketcher/App/planegcs/GCS.cpp
+++ b/src/Mod/Sketcher/App/planegcs/GCS.cpp
@@ -5412,12 +5412,12 @@ void System::eliminateNonZerosOverPivotInUpperTriangularMatrix(Eigen::MatrixXd& 
         // eliminate non zeros above pivot
         assert(R(i, i) != 0);
         for (int row = 0; row < i; row++) {
-            if (R(row, i) != 0) {
+            if (fabs(R(row, i)) > 1e-10) {
                 double coef = R(row, i) / R(i, i);
                 R.block(row, i + 1, 1, R.cols() - i - 1) -= coef
                     * R.block(i, i + 1, 1, R.cols() - i - 1);
-                R(row, i) = 0;
             }
+            R(row, i) = 0;
         }
     }
 }


### PR DESCRIPTION
## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Fixes https://github.com/FreeCAD/FreeCAD/issues/21250 (or at least improves the situation).

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

Benchmarking #21250 proved that the function `eliminateNonZerosOverPivotInUpperTriangularMatrix` takes a large portion of the time of sketch constraint solving. This function iterates over values in the upper triangle of the matrix, and eliminates zeroes using the gaussian elimination method.

Sketch constraint matrices are large but sparse, so there should not be that many values to eliminate. But this function is susceptible to numerical instability, and propagates float precision errors along the row, creating more "non-zero" values to eliminate on the next columns. By checking for values below a small epsilon instead of 0, we lower the number of values to eliminate and vastly speeds up the function.

The following test macro creates a sketch with a rounded square, and applies an array transform twice to get a 12*5 array. `eliminateNonZerosOverPivotInUpperTriangularMatrix` takes about 2.3 seconds with the fix, and 9.1s without it. The routine may be optimized further, especially by parallelizing over lines for a given column. However, this is still a sizeable improvement.

[array_transform.FCMacro.zip](https://github.com/user-attachments/files/24681374/array_transform.FCMacro.zip)

I believe the fix is correct, because other functions in the module check that values are below `1e-10` rather than a straight 0. I'd love feedback from linear algebra experts to confirm it though.
