### PR TITLE
BIM: fix ArchReference Placement if whole file is used

### DIFF
--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -147,7 +147,6 @@ class ArchReference:
 
         import Part
 
-        pl = obj.Placement
         filename = self.getFile(obj)
         if filename and self.reload and obj.ReferenceMode in ["Normal", "Transient"]:
             self.parts = self.getPartsList(obj)
@@ -155,6 +154,7 @@ class ArchReference:
                 if filename.lower().endswith(".fcstd"):
                     zdoc = zipfile.ZipFile(filename)
                     if zdoc:
+                        pl = obj.Placement
                         self.shapes = []
                         if obj.Part:
                             if obj.Part in self.parts:
@@ -166,8 +166,6 @@ class ArchReference:
                                     shape = self.cleanShape(shapedata, obj, self.parts[obj.Part][2])
                                     self.shapes.append(shape)
                                     obj.Shape = shape
-                                    if not pl.isIdentity():
-                                        obj.Placement = pl
                                 else:
                                     t = translate("Arch", "Part not found in file")
                                     FreeCAD.Console.PrintError(t + "\n")
@@ -181,6 +179,7 @@ class ArchReference:
                                 self.shapes.append(shape)
                             if self.shapes:
                                 obj.Shape = Part.makeCompound(self.shapes)
+                        obj.Placement = pl
                 elif filename.lower().endswith(".ifc"):
                     ifcfile = self.getIfcFile(filename)
                     if not ifcfile:


### PR DESCRIPTION
PR to fix a v1.1 regression reported on the forum:
https://forum.freecad.org/viewtopic.php?t=102603

The regression is a side-effect of #25777.
