### PR TITLE
smesh: update file encoding of three files within smesh from latin1 to utf-8

### DIFF
--- a/src/3rdParty/salomesmesh/inc/SMESH_Octree.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMESH_Octree.hxx
@@ -23,7 +23,7 @@
 //  SMESH SMESH_Octree : Octree implementation
 //  File      : SMESH_Octree.hxx
 //  Created   : Tue Jan 16 16:00:00 2007
-//  Author    : Nicolas Geimer & Aurélien Motteux (OCC)
+//  Author    : Nicolas Geimer & AurÃ©lien Motteux (OCC)
 //  Module    : SMESH
 //
 #ifndef _SMESH_OCTREE_HXX_

--- a/src/3rdParty/salomesmesh/inc/SMESH_OctreeNode.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMESH_OctreeNode.hxx
@@ -24,7 +24,7 @@
 //  inherites global class SMESH_Octree
 //  File      : SMESH_OctreeNode.hxx
 //  Created   : Tue Jan 16 16:00:00 2007
-//  Author    : Nicolas Geimer & Aurelien Motteux  (OCC)
+//  Author    : Nicolas Geimer & Aurélien Motteux (OCC)
 //  Module    : SMESH
 //
 #ifndef _SMESH_OCTREENODE_HXX_

--- a/src/3rdParty/salomesmesh/inc/SMESH_tree.hxx
+++ b/src/3rdParty/salomesmesh/inc/SMESH_tree.hxx
@@ -23,7 +23,7 @@
 //  SMESH SMESH_Tree : tree implementation
 //  File      : SMESH_Tree.hxx
 //  Created   : Tue Jan 16 16:00:00 2007
-//  Author    : Nicolas Geimer & Aurélien Motteux (OCC)
+//  Author    : Nicolas Geimer & AurÃ©lien Motteux (OCC)
 //  Module    : SMESH
 //
 #ifndef _SMESH_Tree_HXX_


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR aims at suppressing output during compilation due to latin1 encoded files with the `é` which when viewed in a text editor ie. neovim and using `ga` the hex bytes in latin1 encoded files appear as `e9` utf-8 adds an extra two bytes and  thus removing the compiler warnings during a build from printing to STDOUT

**examples** of output printed during the `cmake`, `ninja`, `ninja install` process.

```
/opt/code/git/github/forks/freecad-git/fcsrc/src/3rdParty/salomesmesh/inc/SMESH_tree.hxx:26:37: warning: invalid UTF-8 in comment [-Winvalid-utf8]
   26 | //  Author    : Nicolas Geimer & Aur<E9>lien Motteux (OCC)
      |                                     ^
```

```
/opt/code/git/github/forks/freecad-git/fcsrc/src/3rdParty/salomesmesh/inc/SMESH_Octree.hxx:26:37: warning: invalid UTF-8 in comment [-Winvalid-utf8]
   26 | //  Author    : Nicolas Geimer & Aur<E9>lien Motteux (OCC)
      |                                     ^
In file included from /opt/code/git/github/forks/freecad-git/fcsrc/src/3rdParty/salomesmesh/src/StdMeshers/StdMeshers_Adaptive1D.cpp:30:
In file included from /opt/code/git/github/forks/freecad-git/fcsrc/src/3rdParty/salomesmesh/inc/SMESH_Octree.hxx:33:
/opt/code/git/github/forks/freecad-git/fcsrc/src/3rdParty/salomesmesh/inc/SMESH_tree.hxx:26:37: warning: invalid UTF-8 in comment [-Winvalid-utf8]
   26 | //  Author    : Nicolas Geimer & Aur<E9>lien Motteux (OCC)
      |                                     ^
```

and as viewed when viewing the diff with `git diff`

```
diff --git i/src/3rdParty/salomesmesh/inc/SMESH_tree.hxx w/src/3rdParty/salomesmesh/inc/SMESH_tree.hxx
old mode 100644
new mode 100755
index 137cd2e873..7b4222dd0b
--- i/src/3rdParty/salomesmesh/inc/SMESH_tree.hxx
+++ w/src/3rdParty/salomesmesh/inc/SMESH_tree.hxx
@@ -23,7 +23,7 @@
 //  SMESH SMESH_Tree : tree implementation
 //  File      : SMESH_Tree.hxx
 //  Created   : Tue Jan 16 16:00:00 2007
-//  Author    : Nicolas Geimer & Aur<E9>lien Motteux (OCC)
+//  Author    : Nicolas Geimer & Aurélien Motteux (OCC)
 //  Module    : SMESH
 //
 #ifndef _SMESH_Tree_HXX_
```

one way to verify the encoding of the file in question on a gnu+linux system is to use the `file` command to check the text encoding of the file.


## Issues

i don't think there are any open issues about this.

## Before and After Images

cuts down on the noise while compiling as mentioned above.

