### PR TITLE
[Sketcher] High Priority Fix for serious integer typo

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -630,7 +630,8 @@ ViewProviderSketch::ViewProviderSketch()
 
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    auto psize = hGrp->GetInt("DefaultShapePointSize", 4L);
+    const int defaultSketchVertexSize = 4;
+    auto psize = hGrp->GetInt("DefaultShapePointSize", defaultSketchVertexSize);
 
     PointSize.setValue(psize);
 


### PR DESCRIPTION
Fixes #26996 

Unfortunately I must have caught the 'L' key so instead of an integer of 4 the default was 4L which I was extremely surprised to find compiles without error even when explicitly set as int, humble apologies.
