### PR TITLE
[TD]fix vertex display

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -120,12 +120,9 @@ void CmdTechDrawToggleFrame::activated(int iMsg)
 
 bool CmdTechDrawToggleFrame::isActive()
 {
-    if (PreferencesGui::getViewFrameMode() != ViewFrameMode::Manual) {
-        return false;
-    }
-
-    auto mvp = dynamic_cast<MDIViewPage *>(Gui::getMainWindow()->activeWindow());
-    return mvp != nullptr;
+    bool havePage = DrawGuiUtil::needPage(this);
+    bool haveView = DrawGuiUtil::needView(this);
+    return (havePage && haveView && PreferencesGui::getViewFrameMode() == ViewFrameMode::Manual);
 }
 
 //===========================================================================

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -447,7 +447,9 @@ void MDIViewPage::contextMenuEvent(QContextMenuEvent* event)
         menu.addAction(m_exportDXFAction);
         menu.addAction(m_exportPDFAction);
         menu.addAction(m_printAllAction);
-        if (PreferencesGui::getViewFrameMode() != ViewFrameMode::Manual) {
+        if (PreferencesGui::getViewFrameMode() == ViewFrameMode::Manual) {
+            m_toggleFrameAction->setEnabled(true);
+        } else {
             m_toggleFrameAction->setEnabled(false);
         }
         menu.exec(event->globalPos());

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -470,6 +470,7 @@ void QGIViewPart::drawAllVertexes()
     // dvp and vp already validated
     auto dvp(static_cast<TechDraw::DrawViewPart*>(getViewObject()));
     auto vp(static_cast<ViewProviderViewPart*>(getViewProvider(getViewObject())));
+    ViewProviderPage* vpPage = vp->getViewProviderPage();
     QColor vertexColor = PreferencesGui::getAccessibleQColor(PreferencesGui::vertexQColor());
 
     const std::vector<TechDraw::VertexPtr>& verts = dvp->getVertexGeometry();
@@ -485,7 +486,8 @@ void QGIViewPart::drawAllVertexes()
             cmItem->setZValue(ZVALUE::VERTEX);
             bool showMark =
                 ( (!isExporting() && vp->ArcCenterMarks.getValue()) ||
-                  (isExporting() && Preferences::printCenterMarks()) );
+                  (isExporting() && Preferences::printCenterMarks()) ||
+                  (vpPage->getFrameState() && PreferencesGui::getViewFrameMode() == ViewFrameMode::Manual));
             cmItem->setVisible(showMark);
         } else {
             //regular Vertex
@@ -498,7 +500,8 @@ void QGIViewPart::drawAllVertexes()
                 item->setRadius(getVertexSize());
                 item->setPrettyNormal();
                 item->setZValue(ZVALUE::VERTEX);
-                item->setVisible(m_isHovered || isSelected());
+                item->setVisible(m_isHovered || isSelected() ||
+                (vpPage->getFrameState() && PreferencesGui::getViewFrameMode() == ViewFrameMode::Manual));
             }
         }
     }
@@ -1350,6 +1353,13 @@ void QGIViewPart::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
     if (isSelected()) {
         // if the view is selected, we should leave things alone.
+        return;
+    }
+
+    auto vp(static_cast<ViewProviderViewPart*>(getViewProvider(getViewObject())));
+    ViewProviderPage* vpPage = vp->getViewProviderPage();
+    if (vpPage->getFrameState() &&
+        PreferencesGui::getViewFrameMode() == ViewFrameMode::Manual) {
         return;
     }
 


### PR DESCRIPTION
This PR fixes an error in PR #26125 as reported here: https://forum.freecad.org/viewtopic.php?p=867617#p867617

Frame and vertex behaviour should now be:

Manual
- frames and vertices of all views are on or off depending on the "show frames" toggle.
- vertices (but not frames) are visible if the mouse is in the bounding rectangle of view (mouse over) (a)
- frames (but not vertices) are visible if a view is selected in the tree (b)

Off 
- frames or vertices are never on

On 
- frames and vertices are always on

Auto 
- frames and vertices are on if
-- mouse is in the bounding rectangle of view (a) 
-- view is selected
-- a child of view is selected

(a) Actually, only the "visible" portion of the bounding rectangle if the view stacks below another view.
(b) Vertices will show as soon as the mouse is in the view.
  
Edit: formatting