### PR TITLE
Part: Fix regressions in MultiCommon boolean operation

### DIFF
--- a/src/Mod/Part/App/FeaturePartCommon.h
+++ b/src/Mod/Part/App/FeaturePartCommon.h
@@ -49,6 +49,12 @@ protected:
     //@}
 };
 
+enum CommonBehavior
+{
+    CommonOfAllShapes,
+    CommonOfFirstAndRest,
+};
+
 class PartExport MultiCommon: public Part::Feature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::MultiCommon);
@@ -59,6 +65,7 @@ public:
     App::PropertyLinkList Shapes;
     PropertyShapeHistory History;
     App::PropertyBool Refine;
+    App::PropertyEnumeration Behavior;
 
     /** @name methods override feature */
     //@{
@@ -66,11 +73,17 @@ public:
     App::DocumentObjectExecReturn* execute() override;
     short mustExecute() const override;
     //@}
+
+    void Restore(Base::XMLReader& reader) override;
+
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {
         return "PartGui::ViewProviderMultiCommon";
     }
+
+private:
+    static const char* BehaviorEnums[];
 };
 
 }  // namespace Part


### PR DESCRIPTION
This addresses two regressions in the MultiCommon feature:

1. Computation Logic: Fixed an issue where the common operation was calculated as the intersection of the first shape with the union of the rest (the default behavior of makeElementBoolean). It now correctly computes the intersection of all shapes sequentially.

2. Compound Handling: Added logic to expand a single compound input into its constituent shapes. Previously, a compound was treated as a single entity, leading to incorrect intersection results.

To maintain backward compatibility, a hidden 'Behavior' property is introduced. This ensures that documents created in FreeCAD 1.0, which rely on the previous behavior, continue to render as originally intended while new objects use the corrected logic.

In the end I decided to not go with the enum in makeElementBoolean - previously the logic was handled in the feature not in the operation and it should stay like this probably. This can be revisited later, but for now let's deal with regression.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
 - Fixes https://github.com/FreeCAD/FreeCAD/issues/17689
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
