### PR TITLE
PartDesign: enable LCS in 'Move after feature'

### DIFF
--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -1034,6 +1034,11 @@ void CmdPartDesignMoveFeatureInTree::activated(int iMsg)
     );
     features.insert(features.end(), datums.begin(), datums.end());
 
+    std::vector<App::DocumentObject*> lcs = getSelection().getObjectsOfType(
+        App::LocalCoordinateSystem::getClassTypeId()
+    );
+    features.insert(features.end(), lcs.begin(), lcs.end());
+
     if (features.empty()) {
         return;
     }


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/27011