### PR TITLE
Gui: Fix property checkbox regression

### DIFF
--- a/src/Gui/propertyeditor/PropertyItemDelegate.cpp
+++ b/src/Gui/propertyeditor/PropertyItemDelegate.cpp
@@ -401,4 +401,3 @@ void PropertyItemDelegate::setModelData(
 }
 
 #include "moc_PropertyItemDelegate.cpp"
-


### PR DESCRIPTION
Fix regression from https://github.com/FreeCAD/FreeCAD/pull/26955

After that PR it was impossible to toggle properties.
Now it works properly and still fix the original issue

Additionally, make the checkbox responsive to Enter when it has the focus. So that you can browse with tab, then press enter to toggle it's value. As suggested by @pieterhijma 

@Syres916 @kadet1090 