### PR TITLE
App: Get Addon name from Metadata

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -3584,14 +3584,18 @@ void Application::addModuleInfo(QTextStream& str, const QString& modPath, bool& 
         firstMod = false;
         str << "Installed mods: \n";
     }
-    str << "  * " << (mod.isDir() ? QDir(modPath).dirName() : mod.fileName());
+    QString addonName = mod.isDir() ? QDir(modPath).dirName() : mod.fileName();
+    QString versionString;
     try {
         auto metadataFile =
             std::filesystem::path(mod.absoluteFilePath().toStdString()) / "package.xml";
         if (std::filesystem::exists(metadataFile)) {
             App::Metadata metadata(metadataFile);
+            if (!metadata.name().empty()) {
+                addonName = QString::fromStdString(metadata.name());
+            }
             if (metadata.version() != App::Meta::Version()) {
-                str << QLatin1String(" ") + QString::fromStdString(metadata.version().str());
+                versionString = QString::fromStdString(" " + metadata.version().str());
             }
         }
     }
@@ -3600,6 +3604,7 @@ void Application::addModuleInfo(QTextStream& str, const QString& modPath, bool& 
                                                                   QChar::fromLatin1(' '));
         str << " (Malformed metadata: " << what << ")";
     }
+    str << "  * " << addonName << versionString;
     QFileInfo disablingFile(mod.absoluteFilePath(), QStringLiteral("ADDON_DISABLED"));
     if (disablingFile.exists()) {
         str << " (Disabled)";


### PR DESCRIPTION
In anticipation of the Addon Manager migrating to using UUIDs for these folder names, make sure to read the addon's name as set in its metadata file, rather than always using the folder name. Still fall back to the folder name if no metadata file is present (to support manual installation as well as older addons with no UUID set).