### PR TITLE
Measurement: Removed unnecessary sign

### DIFF
--- a/src/Mod/Measure/MeasureCOM.py
+++ b/src/Mod/Measure/MeasureCOM.py
@@ -148,6 +148,13 @@ class MeasureCOM(MeasureBasePython):
 
             com = shape.CenterOfMass
 
+        if f"{com.x:.2f}".startswith("-0.00"): 
+            com.x = 0.0
+        if f"{com.y:.2f}".startswith("-0.00"): 
+            com.y = 0.0
+        if f"{com.z:.2f}".startswith("-0.00"): 
+            com.z = 0.0
+
         obj.Result = com
         placement = Placement()
         placement.Base = com

--- a/src/Mod/Measure/MeasureCOM.py
+++ b/src/Mod/Measure/MeasureCOM.py
@@ -148,11 +148,11 @@ class MeasureCOM(MeasureBasePython):
 
             com = shape.CenterOfMass
 
-        if f"{com.x:.2f}".startswith("-0.00"): 
+        if f"{com.x:.2f}".startswith("-0.00"):
             com.x = 0.0
-        if f"{com.y:.2f}".startswith("-0.00"): 
+        if f"{com.y:.2f}".startswith("-0.00"):
             com.y = 0.0
-        if f"{com.z:.2f}".startswith("-0.00"): 
+        if f"{com.z:.2f}".startswith("-0.00"):
             com.z = 0.0
 
         obj.Result = com


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
The changes is only about 6 lines that just checks if the center of mass is equal to -0.00, and if so it should change it to 0.0
This is more of a aesthetic change that just does so that there is not an unnecessary sign

Version 1.0.2
<img width="365" height="301" alt="image" src="https://github.com/user-attachments/assets/4d979da9-da87-47a7-b912-67d94e7d2f55" />

Version 1.2.0dev (After change)
<img width="336" height="274" alt="image" src="https://github.com/user-attachments/assets/4ddb2385-6ee5-44fa-9eef-40117072f0f1" />

## Issues
closes #17271 

I have not been able to show that any other measurement type (radius, length etc.) has the same issues. I think it is only center of mass that has this problem


