### PR TITLE
Techdraw: supplementary angle display support

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -186,6 +186,12 @@ DrawViewDimension::DrawViewDimension()
                       App::Prop_Output,
                       "The dimensional value is displayed inverted");
 
+    ADD_PROPERTY_TYPE(ShowSupplementary, 
+                      (false), 
+                      "", 
+                      App::Prop_Output, 
+                      "Toggle supplementary angle\nAngle displayed is dependent on selection order");
+
     ADD_PROPERTY_TYPE(AngleOverride,
                       (false),
                       "Override",
@@ -678,6 +684,11 @@ double DrawViewDimension::getDimValue()
     }
 
     result = fabs(result);
+
+    if (ShowSupplementary.getValue() && (Type.isValue("Angle") || Type.isValue("Angle3Pt"))) {
+        result = CircleDegrees/2.0 - result;
+    }
+
     if (Inverted.getValue()) {
         if (Type.isValue("Angle") || Type.isValue("Angle3Pt")) {
             result = CircleDegrees - result;

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -81,6 +81,7 @@ public:
 
     App::PropertyBool TheoreticalExact;
     App::PropertyBool Inverted;
+    App::PropertyBool ShowSupplementary;
     App::PropertyString FormatSpec;
     App::PropertyString FormatSpecOverTolerance;
     App::PropertyString FormatSpecUnderTolerance;

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -2038,6 +2038,12 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
     Base::Vector2d angleVertex = fromQtApp(anglePoints.vertex());
     Base::Vector2d firstDimPoint = fromQtApp(anglePoints.first());
     Base::Vector2d secondDimPoint = fromQtApp(anglePoints.second());
+    
+    bool supplementary = dimension->ShowSupplementary.getValue();
+    if (supplementary) {
+        // flip the first point wrt. vertex to opposite side
+        firstDimPoint = angleVertex - (firstDimPoint - angleVertex);
+    }
 
     double endAngle = (secondDimPoint - angleVertex).Angle();
     double startAngle = (firstDimPoint - angleVertex).Angle();
@@ -2074,7 +2080,7 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
             jointDirections[0] = getAsmeRefJointPoint(labelRectangle, false) - angleVertex;
             jointDirections[1] = getAsmeRefJointPoint(labelRectangle, true) - angleVertex;
         }
-
+         
         // Get radiuses of the angle dimension arcs
         double arcRadii[2];
         arcRadii[0] = jointDirections[0].Length();
@@ -2202,7 +2208,7 @@ void QGIViewDimension::drawAngle(TechDraw::DrawViewDimension* dimension,
 
         if (arrowCount > 1) {
             extensionTarget = computeExtensionLinePoints(
-                firstDimPoint, angleVertex + Base::Vector2d::FromPolar(arcRadius, startAngle),
+                supplementary ? angleVertex : firstDimPoint, angleVertex + Base::Vector2d::FromPolar(arcRadius, startAngle),
                 startAngle, getDefaultExtensionLineOverhang(), gapSize, extensionOrigin);
             anglePath.moveTo(toQtGui(extensionOrigin));
             anglePath.lineTo(toQtGui(extensionTarget));

--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -179,7 +179,8 @@ void ViewProviderDimension::updateData(const App::Property* prop)
         prop == &(getViewObject()->EqualTolerance) ||
         prop == &(getViewObject()->OverTolerance) ||
         prop == &(getViewObject()->UnderTolerance) ||
-        prop == &(getViewObject()->Inverted)) {
+        prop == &(getViewObject()->Inverted) ||
+        prop == &(getViewObject()->ShowSupplementary)) {
 
         QGIView* qgiv = getQView();
         if (qgiv) {


### PR DESCRIPTION
Added supplementary angle support in Mod Techdraw. ( 180 degrees - Angle )

The side the angle gets displayed, depends on the selection order of the two lines (or the three points)

## Issues
addresses issue #25096

## Before and After Images
![1](https://github.com/user-attachments/assets/8011b3c7-c1ca-4617-a4f6-e8f96ef9d65e)
![2](https://github.com/user-attachments/assets/095a184f-f969-4b1b-a0e8-93f2c0593301)

