### PR TITLE
App: Fix spurious recompute prompts on file load

### DIFF
--- a/src/App/PropertyGeo.cpp
+++ b/src/App/PropertyGeo.cpp
@@ -1319,9 +1319,14 @@ bool PropertyComplexGeoData::checkElementMapVersion(const char* ver) const
         return false;
     }
     auto owner = freecad_cast<DocumentObject*>(getContainer());
-    std::ostringstream ss;
     const char* prefix;
-    if (owner && owner->getDocument() && owner->getDocument()->getStringHasher() == data->Hasher) {
+    // Use the same condition as getElementMapVersion() to determine expected prefix.
+    // The prefix "1." indicates both that there is an element map and that the hasher
+    // matches the document's hasher. Without checking hasElementMap() and getElementMapSize(),
+    // we could get a spurious version mismatch when a shape has no element map but its
+    // hasher was assigned from the document (common for imported geometry like KiCAD).
+    if (owner && owner->getDocument() && data->hasElementMap() && data->getElementMapSize()
+        && owner->getDocument()->getStringHasher() == data->Hasher) {
         prefix = "1.";
     }
     else {


### PR DESCRIPTION
## Summary
- Fix `checkElementMapVersion()` to use the same condition as `getElementMapVersion()` when determining the expected version prefix
- Add missing `data->hasElementMap() && data->getElementMapSize()` checks to the prefix determination logic
- Prevents spurious "recomputation required" warnings when loading files with imported geometry (like KiCAD imports)

## Problem
The element map version has format `{prefix}.{version}` where prefix is "0." or "1.". The prefix "1." is used when the shape has an element map AND the hasher matches the document's string hasher.

Previously, `checkElementMapVersion()` only checked if the hasher matched, not whether there was actually an element map:

```cpp
// getElementMapVersion() - line 1305
if (owner && owner->getDocument() && data->hasElementMap() && data->getElementMapSize() && ...)

// checkElementMapVersion() - line 1324 (MISSING hasElementMap checks!)
if (owner && owner->getDocument() && owner->getDocument()->getStringHasher() == data->Hasher)
```

This caused a version mismatch when:
1. A shape has no element map (or empty map)
2. But the shape's hasher was assigned from the document (during restore)

In this case, `getElementMapVersion()` would return "0.X.Y.Z" (no element map), but `checkElementMapVersion("0.X.Y.Z")` would expect "1.X.Y.Z" (hasher matches), triggering a spurious recompute warning.

## Test results

**Before fix (unfixed build):**
```
<App> PropertyTopoShape.cpp(507): Recomputation required for document 'test_27045' on geo element version change in test_27045#Pcb_b186.Shape: 0.15.70200.5 -> 0.15.70200.5
Objects needing recompute: ['Pcb_b186']
Total touched: 1
```

**After fix:**
```
Objects needing recompute: []
Total touched: 0
```

## Test plan
- [x] Build compiles without errors
- [x] Verified bug exists in unfixed build using test file from issue
- [x] Verified fix resolves the issue - no spurious recompute prompt
- [x] App_tests_run: 444 passed, 0 failed (2 disabled)

Fixes #27045

🤖 Generated with [Claude Code](https://claude.com/claude-code)