### PR TITLE
Part: Fix AttacherEngine property not synced with AttacherType

### DIFF
--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -292,6 +292,14 @@ void AttachExtension::setAttacher(AttachEngine* pAttacher, bool base)
                      // onChange->changeAttacherType->onChange...
             props.attacherType->setValue(typeName);
         }
+        // Also update the visible AttacherEngine property for non-base attachers
+        // to keep it in sync with AttacherType (fixes issue #15716)
+        if (!base) {
+            const char* enumVal = classToEnum(typeName);
+            if (strcmp(AttacherEngine.getValueAsString(), enumVal) != 0) {
+                AttacherEngine.setValue(enumVal);
+            }
+        }
         updateAttacherVals(base);
     }
     else {

--- a/src/Mod/Part/parttests/regression_tests.py
+++ b/src/Mod/Part/parttests/regression_tests.py
@@ -185,6 +185,31 @@ class RegressionTests(unittest.TestCase):
         for name, pos, normal, xaxis in expected_planes:
             check_plane(name, pos, normal, xaxis)
 
+    def test_issue_15716_AttacherEngine_sync(self):
+        """
+        15716: AttacherType and AttacherEngine property conflict
+
+        When creating a Part2DObject (like a Sketch), the AttacherEngine property
+        should be synchronized with AttacherType. Previously, AttacherType was
+        correctly set to "Attacher::AttachEnginePlane" but AttacherEngine stayed
+        at the default "Engine 3D" instead of "Engine Plane".
+        """
+        if "BUILD_SKETCHER" in FreeCAD.__cmake__:
+            # Create a new sketch (which inherits from Part2DObject)
+            sketch = self.Doc.addObject("Sketcher::SketchObject", "TestSketch")
+            self.Doc.recompute()
+
+            # The visible AttacherEngine property should match the actual engine type
+            # AttacherType is the internal type name, AttacherEngine is the user-visible enum
+            attacher_type = sketch.AttacherType
+            attacher_engine = sketch.AttacherEngine
+
+            # For a sketch, AttacherType should be AttachEnginePlane
+            self.assertEqual(attacher_type, "Attacher::AttachEnginePlane")
+
+            # AttacherEngine should show "Engine Plane" (not "Engine 3D")
+            self.assertEqual(attacher_engine, "Engine Plane")
+
     def tearDown(self):
         """Clean up our test, optionally preserving the test document"""
         # This flag allows doing something like this:


### PR DESCRIPTION
## Summary

Fixes #15716

- When creating a Part2DObject (e.g., Sketch), the visible `AttacherEngine` property now correctly shows "Engine Plane" instead of staying at the default "Engine 3D"
- The fix updates `setAttacher()` to sync `AttacherEngine` with `AttacherType` for non-base attachers
- Added regression test to verify the fix

## Root Cause

When `Part2DObject` is constructed, it calls `setAttacher(new AttachEnginePlane)`. This correctly updated the internal `AttacherType` property to `"Attacher::AttachEnginePlane"`, but left the user-visible `AttacherEngine` enum at its default value `"Engine 3D"`.

## Test plan

- [x] New test `test_issue_15716_AttacherEngine_sync` verifies the fix
- [x] Test fails without the fix (`'Engine 3D' != 'Engine Plane'`)
- [x] Test passes with the fix
- [x] All 258 Part C++ tests pass
- [x] All 96 Sketcher C++ tests pass
- [x] All 6 Part regression Python tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)