### PR TITLE
Sketcher: fix segfault during autoscale

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -536,9 +536,8 @@ private:
                     newConstr->First = firstIndex;
                     newConstr->Second = secondIndex;
                 }
-                else if (cstr->Type == Angle
-                         && firstIndex != GeoEnum::GeoUndef && secondIndex == GeoEnum::GeoUndef
-                         && thirdIndex == GeoEnum::GeoUndef) {
+                else if (cstr->Type == Angle && firstIndex != GeoEnum::GeoUndef
+                         && secondIndex == GeoEnum::GeoUndef && thirdIndex == GeoEnum::GeoUndef) {
                     newConstr->First = firstIndex;
                 }
                 else if ((cstr->Type == Radius || cstr->Type == Diameter)


### PR DESCRIPTION
A bug in eab485656f7e40a232a361414cde19f6b78cdb05 caused deletion of single line angle constraints and arc angle constraints during sketch autoscale.
Combined with cc605027086cb46de257a30911461f040f1ee2ae that causes segfault during autoscale if sketch contains any of those constraints.