### PR TITLE
App: Eliminate use of os.path.realpath for libdir

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -95,7 +95,7 @@ def InitApplications():
     if (os.path.exists(LibPyDir)):
         libpaths.append(LibPyDir)
     LibFcDir = FreeCAD.getLibraryDir()
-    LibFcDir = os.path.realpath(LibFcDir)
+    LibFcDir = os.path.normpath(os.path.abspath(LibFcDir))
     if (os.path.exists(LibFcDir) and not LibFcDir in libpaths):
         libpaths.append(LibFcDir)
     AddPath = FreeCAD.ConfigGet("AdditionalModulePaths").split(";") + \


### PR DESCRIPTION
Some Windows users report that when given a non-existent path, `os.path.realpath` is raising an exception (despite not setting `strict=true`). To eliminate this error, switch processing of the usually-non-existent `LibFcDir` to be entirely string-based, with no filesystem access at all. This is a minimal fix to the reported bug and does not attempt any larger, more systematic change.

See bug #26864 for details.
