### PR TITLE
App: Catch `OSError` during initialization with bad library dir

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -1311,8 +1311,14 @@ class InitPipeline:
     """
 
     std_home = Path(App.getHomePath()).resolve()
-    std_lib = Path(App.getLibraryDir()).resolve()
     user_home = Path(App.getUserAppDataDir()).resolve()
+    try:
+        std_lib = Path(App.getLibraryDir()).resolve()
+    except OSError:
+        # The library path is not strictly required, so if the OS itself raises an error when trying
+        # to resolve it, just fall back to something reasonable. See #26864.
+        std_lib = std_home / "lib"
+        Log(f"Resolving library directory '{App.getLibraryDir()}' failed, using fallback '{std_lib}'")
     dir_mod_scanner = DirModScanner()
     ext_mod_scanner = ExtModScanner()
     search_paths = SearchPaths()


### PR DESCRIPTION
FreeCAD doesn't actually *need* the path set in `getLibraryDir()` -- if it doesn't exist, everything still works. In some cases a call to `Path.resolve()` can raise an `OSError` if the drive being requested itself has a problem (for example, a card reader / optical drive with no media, a flaky removable drive, a mapped drive pointing to an unavailable network target, etc.). This is independent of whether the path in question exists. This commit catches that specific error and simply inserts a path that's already known to "work" (that is, it doesn't have to exist, but it has to be on a drive that doesn't fail path resolution). Any other errors (and any other paths) are failures that can't be handled quietly, so those exceptions are allowed to propagate up the call stack.

Note that the underlying problem here is that the packages we distribute are compiling in a path from the build system. This PR is part of a "defense-in-depth" strategy that should ultimately involve changing the build system so these bad library paths aren't compiled in at all. See #27083.

Fixes #26864 on main. Do not backport -- see #27082 for the equivalent fix on the 1.1 branch.