### PR TITLE
Sketcher: Fix snap while drag and fix drag for arc

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1621,7 +1621,14 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
             // 2 cases : either the edge was added or a point of it.
             // If its a point then we replace it by the edge.
             // If it's the edge it's replaced by itself so it's ok.
-            drag.Dragged[0].Pos = Sketcher::PointPos::none;
+
+            // for arcs preserve mid point drags for rigid movement
+            const Part::Geometry* geo = getSketchObject()->getGeometry(geoIdi);
+            bool isArcMidDrag = (pos == Sketcher::PointPos::mid) && isArcOfCircle(*geo);
+
+            if (!isArcMidDrag) {
+                drag.Dragged[0].Pos = Sketcher::PointPos::none;
+            }
         }
         else {
             // For group dragging, we skip the internal geos.
@@ -1740,7 +1747,9 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
             }
         }
 
-        if (geo->is<Part::GeomLineSegment>() || geo->is<Part::GeomBSplineCurve>()) {
+        if (geo->is<Part::GeomLineSegment>() || geo->is<Part::GeomBSplineCurve>()
+            || isEllipse(*geo) || isArcOfEllipse(*geo)
+            || isArcOfHyperbola(*geo) || isArcOfParabola(*geo)) {
             setRelative();
         }
 


### PR DESCRIPTION
Issue :#26907

***issue***

https://github.com/user-attachments/assets/43b75244-c638-467b-b2ab-f595f86fc4ca

***Snap Fix***

https://github.com/user-attachments/assets/ebf936e9-84a8-43d2-9288-8fcd49a0a062


## found another issue

***Arc issue***

https://github.com/user-attachments/assets/db241e64-c278-4c72-bfc8-5f420b552fed

***Arc Fix***

https://github.com/user-attachments/assets/36431c19-6044-492b-959d-10669c3e91e9


earlier we are converting points selected on curve to edge drag , but for arcs only even we select all point curve and try to drage entire arc it wont and it deforms .
So in order to make dragging arc possible we need to prevent mid point and rest as it , so when we select all points and drag via mid point it drags entire arc rigidly .
and reset have similar behaviour 

