### PR TITLE
Draft: fix autogroup behavior if active group is a layer

### DIFF
--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -143,7 +143,7 @@ def autogroup(obj):
                     active_group.Group += [obj]
             return
 
-    elif Gui.ActiveDocument.ActiveView.getActiveObject("NativeIFC") is not None:
+    if Gui.ActiveDocument.ActiveView.getActiveObject("NativeIFC") is not None:
         # NativeIFC handling
         try:
             from nativeifc import ifc_tools


### PR DESCRIPTION
The changes in #22295 did not consider that an object can be put in a layer as well as in another active container (such as a Building Part). This PR fixes that.