### PR TITLE
CAM: Added M8x1.25 (aka M8 coarse) thread tapping bit.

### DIFF
--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -458,6 +458,7 @@ SET(Tools_Bit_SRCS
     Tools/Bit/6mm_Ball_End.fctb
     Tools/Bit/6mm_Bullnose.fctb
     Tools/Bit/90degree_Vbit.fctb
+    Tools/Bit/M8x1.25_Tap.fctb
     Tools/Bit/probe.fctb
     Tools/Bit/slittingsaw.fctb
 )

--- a/src/Mod/CAM/Tools/Bit/M8x1.25_Tap.fctb
+++ b/src/Mod/CAM/Tools/Bit/M8x1.25_Tap.fctb
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "name": "M8x1.25_Tap",
+  "shape": "tap.fcstd",
+  "shape-type": "tap",
+  "parameter": {
+    "CuttingEdgeLength": "24 mm",
+    "Diameter": "9.25 mm",
+    "Flutes": "4",
+    "Length": "79 mm",
+    "Pitch": "1.25 mm",
+    "ShankDiameter": "8 mm",
+    "TipAngle": "90.000 \u00b0"
+  },
+  "attribute": {}
+}


### PR DESCRIPTION
This provide a metric thread tap example alongside the imperial 3/8"-16 tap example.