### PR TITLE
Gui: Prevent the editing root from getting clipped

### DIFF
--- a/src/Gui/Clipping.cpp
+++ b/src/Gui/Clipping.cpp
@@ -129,10 +129,14 @@ Clipping::Clipping(Gui::View3DInventor* view, QWidget* parent)
     View3DInventorViewer* viewer = view->getViewer();
     d->node = static_cast<SoGroup*>(viewer->getSceneGraph());
     d->node->ref();
-    d->node->insertChild(d->clipX, 0);
-    d->node->insertChild(d->clipY, 0);
-    d->node->insertChild(d->clipZ, 0);
-    d->node->insertChild(d->clipView, 0);
+    int index = -1;
+    if (auto editingRoot = viewer->getEditingRoot()) {
+        index = d->node->findChild(editingRoot);
+    }
+    d->node->insertChild(d->clipX, index + 1);
+    d->node->insertChild(d->clipY, index + 1);
+    d->node->insertChild(d->clipZ, index + 1);
+    d->node->insertChild(d->clipView, index + 1);
 
     SoGetBoundingBoxAction action(viewer->getSoRenderManager()->getViewportRegion());
     action.apply(viewer->getSceneGraph());

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -999,6 +999,11 @@ void View3DInventorViewer::setEditingTransform(const Base::Matrix4D& mat)
     // NOLINTEND
 }
 
+SoNode* View3DInventorViewer::getEditingRoot() const
+{
+    return pcEditingRoot;
+}
+
 void View3DInventorViewer::setupEditingRoot(SoNode* node, const Base::Matrix4D* mat)
 {
     if (!editViewProvider) {

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -249,6 +249,7 @@ public:
     ViewProvider* getEditingViewProvider() const;
     /// reset from edit mode
     void resetEditingViewProvider();
+    SoNode* getEditingRoot() const;
     void setupEditingRoot(SoNode* node = nullptr, const Base::Matrix4D* mat = nullptr);
     void resetEditingRoot(bool updateLinks = true);
     void setEditingTransform(const Base::Matrix4D& mat);


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/17336
This PR ensures that the SoClipPlane nodes are inserted after the editing root node so that it doesn't get clipped. This prevents the interactive gizmos, transform dragger, link dragger and the sketch constraints from getting clipped.
This doesn't fix the axis cross.
<img width="479" height="449" alt="image" src="https://github.com/user-attachments/assets/bd4c98f9-be88-4b01-975d-2094fcaf5036" />
