### PR TITLE
Expression Completer: speedup property completion

### DIFF
--- a/src/Gui/ExpressionCompleter.cpp
+++ b/src/Gui/ExpressionCompleter.cpp
@@ -288,9 +288,11 @@ public:
 
     // Store named object property list in cache for performance purposes,
     // to avoid building it again for each requested index
-    std::vector<std::pair<const char*, App::Property*>>& getCachedPropertyNamedList(DocumentObject* obj) const {
-        if (!this->namedPropsCache.contains(obj))
-        {
+    std::vector<std::pair<const char*, App::Property*>>& getCachedPropertyNamedList(
+        DocumentObject* obj
+    ) const
+    {
+        if (!this->namedPropsCache.contains(obj)) {
             this->namedPropsCache[obj];
             obj->getPropertyNamedList(this->namedPropsCache[obj]);
         }


### PR DESCRIPTION

<!-- Include a brief summary of the changes. -->

Cache object property list in expression completer, so it is not rebuilt for every requested index. This helps with performance when an object has a large number of properties.

Before this change, `getCachedPropertyNamedList` was called for every index property of the object, creating a new list every time. This had a significative impact on completion speed when the number of properties is in the thousands.

A new `ExpressionCompleterModel` object is created every time the expression dialog is brought up, so there should not be cache invalidation issues (feel free to confirm that).

`mutable` keyword is required for const-correctness.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Fix #5644 (originally opened almost 10 years ago!)

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

On this statefile, open an expression dialog:

[prop_complete.FCStd.zip](https://github.com/user-attachments/files/24840168/prop_complete.FCStd.zip)

This file has an object with 10k props.

Before change (real time):
![Prop_bugged](https://github.com/user-attachments/assets/ce62e50e-69b4-4a12-aa45-aea03905595b)

After change:
![Prop_fixed](https://github.com/user-attachments/assets/b1506c2a-a047-4d39-a873-71b09b92747d)


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
