### PR TITLE
Gui: Combine getFocalPoint() and getCenterPointOnFocalPlane()

### DIFF
--- a/src/Gui/DemoMode.cpp
+++ b/src/Gui/DemoMode.cpp
@@ -194,14 +194,13 @@ void DemoMode::onAngleSliderValueChanged(int v)
 void DemoMode::reorientCamera(SoCamera* cam, const SbRotation& rot)
 {
     // Find global coordinates of focal point.
-    SbVec3f direction;
-    cam->orientation.getValue().multVec(SbVec3f(0, 0, -1), direction);
-    SbVec3f focalpoint = cam->position.getValue() + cam->focalDistance.getValue() * direction;
+    SbVec3f focalpoint = activeView()->getViewer()->getFocalPoint();
 
     // Set new orientation value by accumulating the new rotation.
     cam->orientation = rot * cam->orientation.getValue();
 
     // Reposition camera so we are still pointing at the same old focal point.
+    SbVec3f direction;
     cam->orientation.getValue().multVec(SbVec3f(0, 0, -1), direction);
     cam->position = focalpoint - cam->focalDistance.getValue() * direction;
 }

--- a/src/Gui/Navigation/GestureNavigationStyle.cpp
+++ b/src/Gui/Navigation/GestureNavigationStyle.cpp
@@ -710,7 +710,7 @@ public:
         : my_base(ctx)
     {
         auto& ns = this->outermost_context().ns;
-        ns.setRotationCenter(ns.getFocalPoint());
+        ns.setRotationCenter(ns.viewer->getFocalPoint());
         ns.setViewingMode(NavigationStyle::DRAGGING);
         this->base_pos
             = static_cast<const NS::Event*>(this->triggering_event())->inventor_event->getPosition();

--- a/src/Gui/Navigation/MayaGestureNavigationStyle.cpp
+++ b/src/Gui/Navigation/MayaGestureNavigationStyle.cpp
@@ -589,7 +589,7 @@ SbBool MayaGestureNavigationStyle::processSoEvent(const SoEvent* const ev)
                         if (comboAfter & BUTTON1DOWN || comboAfter & BUTTON2DOWN) {
                             // don't leave navigation till all buttons have been released
                             if (comboAfter & BUTTON1DOWN && comboAfter & BUTTON2DOWN) {
-                                setRotationCenter(getFocalPoint());
+                                setRotationCenter(viewer->getFocalPoint());
                             }
                             else {
                                 saveCursorPosition(ev);

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -166,7 +166,6 @@ public:
     void setRotationCenterMode(RotationCenterModes);
     RotationCenterModes getRotationCenterMode() const;
     void setRotationCenter(const SbVec3f& cnt);
-    SbVec3f getFocalPoint() const;
 
     SoCamera* getCamera() const;
     std::shared_ptr<NavigationAnimation> setCameraOrientation(

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2678,16 +2678,16 @@ void View3DInventorViewer::setSeekMode(bool on)
     );
 }
 
-SbVec3f View3DInventorViewer::getCenterPointOnFocalPlane() const
+SbVec3f View3DInventorViewer::getFocalPoint() const
 {
-    SoCamera* cam = getSoRenderManager()->getCamera();
-    if (!cam) {
+    const SoCamera* camera = getCamera();
+    if (!camera) {
         return {0., 0., 0.};
     }
 
     SbVec3f direction;
-    cam->orientation.getValue().multVec(SbVec3f(0, 0, -1), direction);
-    return cam->position.getValue() + cam->focalDistance.getValue() * direction;
+    camera->orientation.getValue().multVec(SbVec3f(0, 0, -1), direction);
+    return camera->position.getValue() + camera->focalDistance.getValue() * direction;
 }
 
 float View3DInventorViewer::getMaxDimension() const

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -506,7 +506,7 @@ public:
 
     void getDimensions(float& fHeight, float& fWidth) const;
     float getMaxDimension() const;
-    SbVec3f getCenterPointOnFocalPlane() const;
+    SbVec3f getFocalPoint() const;
 
     NavigationStyle* navigationStyle() const;
 

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -191,7 +191,7 @@ bool GridExtensionP::checkCameraTranslationChange(const Gui::View3DInventorViewe
 {
     // Then we check if user moved by more than 10% of camera dimension (must be after updating
     // camera dimension).
-    SbVec3f newCamCenterPointOnFocalPlane = viewer->getCenterPointOnFocalPlane();
+    SbVec3f newCamCenterPointOnFocalPlane = viewer->getFocalPoint();
 
     if ((camCenterPointOnFocalPlane - newCamCenterPointOnFocalPlane).length()
         > 0.1 * camMaxDimension) {


### PR DESCRIPTION
I noticed that `getFocalPoint()` and `getCenterPointOnFocalPlane()` are duplicates. I even found other places in the code that had the same code as part of other functions. I removed one and used the `getFocalPoint()` function in other places.