### PR TITLE
Gui: Show full file path in tooltip for FileName properties

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -880,6 +880,15 @@ QVariant PropertyStringItem::editorData(QWidget* editor) const
     return {le->text()};
 }
 
+QVariant PropertyStringItem::toolTip(const App::Property* prop) const
+{
+    // For the FileName property, show the actual file path in the tooltip
+    if (prop && std::string(prop->getName()) == "FileName") {
+        return value(prop);
+    }
+    return PropertyItem::toolTip(prop);
+}
+
 // --------------------------------------------------------------------
 
 PROPERTYITEM_SOURCE(Gui::PropertyEditor::PropertyFontItem)

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -274,6 +274,7 @@ class GuiExport PropertyStringItem: public PropertyItem
     ) const override;
     void setEditorData(QWidget* editor, const QVariant& data) const override;
     QVariant editorData(QWidget* editor) const override;
+    QVariant toolTip(const App::Property*) const override;
 
 protected:
     QVariant value(const App::Property*) const override;


### PR DESCRIPTION
The user complaint was that the FileName field would display a tooltip that wasn't helpful:  "The path to the file the document is saved to".  The user request is for the tooltip to display the actual filename, because most likely the filename is truncated and can't be seen.

Changes:
Overrides PropertyStringItem:toolTip().  For the "FileName" property, display the full property value.  All other behavior is preserved.  Tested only in Windows, did not build and test in Linux or MacOS, but I don't anticipate any issues.

I could extend this to handle other fields the same way if desired.

## Issues
Closes #27092 

## Before and After Images

Before (from parent issue):
<img width="557" height="88" alt="539434364-900f8ca8-8914-4259-98cf-d4f3cde5c552" src="https://github.com/user-attachments/assets/02e42c5a-67d5-477d-8594-2149ab5f3e84" />

After screenshot:

![freecad_issue_27092](https://github.com/user-attachments/assets/4de1e45e-78e7-433d-b301-d37f86f22cb8)
