### PR TITLE
Assembly: Fix isolate not working on sub assembly components

### DIFF
--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -1381,6 +1381,7 @@ void ViewProviderAssembly::applyIsolationRecursively(
         for (auto* child : group->Group.getValues()) {
             applyIsolationRecursively(child, isolateSet, mode, visited);
         }
+        return;
     }
     else if (auto* part = dynamic_cast<App::Part*>(current)) {
         // As App::Part currently don't have material override
@@ -1396,6 +1397,7 @@ void ViewProviderAssembly::applyIsolationRecursively(
         for (auto* child : part->Group.getValues()) {
             applyIsolationRecursively(child, isolateSet, mode, visited);
         }
+        return;
     }
 
     auto* vp = Gui::Application::Instance->getViewProvider(current);


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/27168

Recently `ViewProviderPart `has become a `ViewProviderGeometryObject`. (https://github.com/FreeCAD/FreeCAD/pull/25009)

And in Assembly, `applyIsolationRecursively `was handling the case of App::Part, but failed to return. It wasn't a problem before because `ViewProviderPart` was not a  `ViewProviderGeometryObject` so it would return right after.

This PR adds the early returns that were intended

Safe to backport @kadet1090