### PR TITLE
[CAM] separate tolerance variable used for arc fitting from tolerance used for section height offsets

### DIFF
--- a/src/Mod/CAM/libarea/Arc.cpp
+++ b/src/Mod/CAM/libarea/Arc.cpp
@@ -55,12 +55,6 @@ bool CArc::AlmostALine() const
         return true;
     }
 
-    const double max_arc_radius = 1.0 / CArea::get_accuracy();
-    double radius = m_c.dist(m_s);
-    if (radius > max_arc_radius) {
-        return true;  // We don't want to produce an arc whose radius is too large.
-    }
-
     return false;
 }
 

--- a/src/Mod/CAM/libarea/Curve.cpp
+++ b/src/Mod/CAM/libarea/Curve.cpp
@@ -110,6 +110,11 @@ bool CCurve::CheckForArc(
     Point p2(might_be_an_arc.back()->m_p);
     Circle c(p0, p1, p2);
 
+    const double max_arc_radius = 1.0 / CArea::get_accuracy();
+    if (c.m_radius > max_arc_radius) {
+        return false;
+    }
+
     const CVertex* current_vt = &prev_vt;
     // It seems that ClipperLib's offset ArcTolerance (same as m_accuracy here)
     // is not exactly what's documented at https://goo.gl/4odfQh. Test shows the


### PR DESCRIPTION
Fixes #26780 (note that this was previously marked as fixed by PR #26860 but OP correctly claims the PR does not fix the issue)

Somewhat fixes regression #27007, which is caused by a PR intended to fix #26780. That PR should still be reverted, as discussed in #27007, and this should be merged instead as an improved fix and backported to 1.1 for the release.

Supersedes #26871, which is an attempt to fix the same issue further down stream from the original problem

@Connor9220 @sliptonic @tarman3 @zoltan-ky fyi

---

The actual diff of this fix is a bit opaque, unfortunately. The crux of the fix is what I outlined in #26871 [comments](https://github.com/FreeCAD/FreeCAD/pull/26871#issuecomment-3740919321):  when converting back from clipper we attempt to fit arcs to clipper's lines, and evidently this can result in big-radius nearly-straight arcs that are hard to compute on reliably.

I said in my comment that this function probably ought to have a check that the candidate circle's radius is not to big. It turns out it already has that check. However, that check is run with tolerance `Point::tolerance`. This variable is clearly defined in code as `0.001mm`, but in fact it is overwritten within CArea initialization macros with a value passed in from python, which is ~1e-7. I don't think this value passed in from python makes sense here, and it fully explains why the large arcs reported in the issue are generated (they are large, but not compared to 1e7).

As a fix, I split off the tolerance variable used in the radius check and one other check of FitArcs from the tolerance ("section tolerance") controlled by python, and set the value to the likely-intended 0.001mm, which seems reasonable to me. I considered splitting off a couple other uses of `Point::tolerance` as well but decided against it even though they didn't look like they should be controlled by the python "section tolerance" because I was insufficiently confident about what impact that would have and I don't want to rock any boats in a regression fix PR.