### PR TITLE
CAM: ToolController - Default RampFeed after migration

### DIFF
--- a/src/Mod/CAM/Path/Tool/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Controller.py
@@ -274,6 +274,7 @@ class ToolController:
                 "Feed",
                 QT_TRANSLATE_NOOP("App::Property", "Feed rate for ramp moves"),
             )
+            obj.setExpression("RampFeed", "HorizFeed")
             _migrateRampDressups(obj)
             needsRecompute = True
 


### PR DESCRIPTION
I am sure this is a rare case, but

Document created in FreeCAD 1.0.2 with one `DressupRampEntry` and several tool controllers

[x0y0.zip](https://github.com/user-attachments/files/24883704/x0y0.zip)

<img width="722" height="309" alt="Screenshot_20260127_100831_lossy" src="https://github.com/user-attachments/assets/844a3eac-538e-4e3b-94c8-a44eaedf57a6" />

`_migrateRampDressups()` do not process tool controllers which not used in `DressupRampEntry` and set zero `RampFeed` for this tool controllers

<img width="1937" height="343" alt="Screenshot_20260127_074638_hor_lossy" src="https://github.com/user-attachments/assets/8fa5768e-cd90-4aed-94a5-c734e2b8ee1f" />

If create new operation and `DressupRampEntry` with tool, which not used before, will get zero `RampFeed`

<img width="957" height="376" alt="Screenshot_20260127_075359" src="https://github.com/user-attachments/assets/ae49a613-3642-41b6-ad83-af0e8acff1cd" />

While add new tool controller, all feeds zero and user know about this
But while migration to new version, user do not know nothing about this

While migration for `LeadInFeed` and `LeadOutFeed` automatically set `HorizFeed` 
I offer to set `RampFeed` min of `VertFeed` or `HorizFeed` as most safety for this 