### PR TITLE
Sketcher: fix logic flaw in ConstraintLineByAngle

### DIFF
--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -750,16 +750,11 @@ void SketcherGui::ConstraintToAttachment(
 void SketcherGui::ConstraintLineByAngle(int geoId, double angle, App::DocumentObject* obj)
 {
     using std::numbers::pi;
-    double angleModPi = std::fmod(angle, pi);
-    double angleModHalfPi = std::fmod(angle, pi / 2);
 
-    if (fabs(angleModPi - pi) < Precision::Confusion()
-        || fabs(angleModPi + pi) < Precision::Confusion()
-        || fabs(angleModPi) < Precision::Confusion()) {
+    if (fabs(std::remainder(angle, pi)) < Precision::Confusion()) {
         Gui::cmdAppObjectArgs(obj, "addConstraint(Sketcher.Constraint('Horizontal',%d)) ", geoId);
     }
-    else if (fabs(angleModHalfPi - pi / 2) < Precision::Confusion()
-             || fabs(angleModHalfPi + pi / 2) < Precision::Confusion()) {
+    else if (fabs(std::remainder(angle, pi / 2)) < Precision::Confusion()) {
         Gui::cmdAppObjectArgs(obj, "addConstraint(Sketcher.Constraint('Vertical',%d)) ", geoId);
     }
     else {


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/27124
Fix 90 deg in OVP not turning into vertical when you use the line tool.

The reason is that ConstraintLineByAngle was logically flawed. So the vertical case was not triggering.
This fixes the logic of this function. And so now it works as expected.