### PR TITLE
CAM: Profile - Fix for open wire

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -672,25 +672,12 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                         msg += "Please set to an acceptable value greater than zero."
                         Path.Log.error(msg)
                     else:
-                        flattened = self._flattenWire(obj, wire, obj.FinalDepth.Value)
+                        flattened = self._flattenWire(obj, wire, wire.BoundBox.Center.z)
                         if flattened:
                             origWire, flatWire = flattened
-
-                            if Path.Geom.isRoughly(origWire.BoundBox.ZMax, obj.FinalDepth.Value):
-                                # FinalDepth in extreme height
-                                diffDepth = self._getOpenProfileDiffDepth(base, edgelist)
-                                # translate wire in Z to get correct cross-section with model
-                                flatWire.translate(FreeCAD.Vector(0, 0, diffDepth))
-                            else:
-                                # FinalDepth not on the wire
-                                msg = translate(
-                                    "PathProfile",
-                                    "For open profile uses cross-section with model.\n"
-                                    "Check edge selection and Final Depth requirements for profiling open edge(s).\n"
-                                    "Verify that Final Depth inside shape.",
-                                )
-                                Path.Log.warning(msg)
-
+                            diffDepth = self._getOpenProfileDiffDepth(base, edgelist)
+                            # translate wire in Z to get correct cross-section with model
+                            flatWire.translate(FreeCAD.Vector(0, 0, diffDepth))
                             self._addDebugObject("FlatWire", flatWire)
 
                             params = self.areaOpAreaParams(obj, False)
@@ -781,11 +768,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
         useWire = origWire.Wires[0]
         numOrigEdges = len(useWire.Edges)
-        sdv = wBB.ZMax
         fdv = fwBB.ZMax
-        extLenFwd = sdv - fdv
-        if extLenFwd <= 0.0:
-            extLenFwd = 0.1
         WIRE = flatWire.Wires[0]
         numEdges = len(WIRE.Edges)
 
@@ -820,7 +803,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
         # Create extended wire boundbox, and extrude
         extBndbox = self._makeExtendedBoundBox(wBB, bbBfr, fdv)
-        extBndboxEXT = extBndbox.extrude(FreeCAD.Vector(0, 0, extLenFwd))
+        extBndboxEXT = extBndbox.extrude(FreeCAD.Vector(0, 0, 1))
 
         # Cut model(selected edges) from extended edges boundbox
         cutArea = extBndboxEXT.cut(base.Shape)
@@ -990,7 +973,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         rtnWIRES = []
         osWrIdxs = []
         subDistFactor = 1.0  # Raise to include sub wires at greater distance from original
-        fdv = obj.FinalDepth.Value
+        fdv = flatWire.BoundBox.ZMax
         wire = flatWire
         lstVrtIdx = len(wire.Vertexes) - 1
         lstVrt = wire.Vertexes[lstVrtIdx]


### PR DESCRIPTION
Fixes #25959
Fixes #28340
Fixes #21882

To get path with open wire need to change manually depth at least for `Job.GeometryTolerance.Value` and after use `Placement` to get needed depth

This pull request changes behavior and allows get path much simpler

> [!CAUTION]
> There is two solutions (commits) in this PR
>
> 1. If depth in extreme height (default `FinalDepth`), automatically translate flattened wire vertical to get correct cross-section with model 
So user no need to change depth and after use Placement to return correct depth
If user changes `FinalDepth`, get old behavior and all old problems
>
> 2. Create cross-section with model only at wire height
This allows to set any `FinalDepth`, e.g. depth lower and upper than model
But we lost ability to get cross-section with model on different depth
Please read [comment](https://github.com/FreeCAD/FreeCAD/pull/27203#issuecomment-4102942650)

[openEdge.zip](https://github.com/user-attachments/files/25332639/openEdge.zip)

https://github.com/user-attachments/assets/0e3098f7-6ba7-429e-aba5-abfb88d290da
