### PR TITLE
BIM: Fix ArchBuildingPart not moving child object base

### DIFF
--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -44,6 +44,7 @@ import Draft
 import DraftVecUtils
 
 from draftutils import params
+from draftutils import utils
 
 if FreeCAD.GuiUp:
     from PySide.QtCore import QT_TRANSLATE_NOOP
@@ -356,7 +357,9 @@ class BuildingPart(ArchIFC.IfcProduct):
                 deltar = obj.Placement.Rotation * self.oldPlacement.Rotation.inverted()
                 if deltar.Angle < 0.0001:
                     deltar = None
-                for child in self.getMovableChildren(obj):
+                children = self.getMovableChildren(obj)
+                children = utils._modifiers_filter_objects(children, False)
+                for child in children:
                     if deltar:
                         child.Placement.rotate(
                             self.oldPlacement.Base,


### PR DESCRIPTION
When a child (e.g. a Wall) of an ArchBuildingPart (e.g. of a Level) had both 'Move With Host' and 'Move Base' enabled, it failed to move the base (e.g. Line) of the child, and only displaced the child itself (effectively ignoring the 'Move Base' setting).

Example project structure:

```
Level
|
+- Wall ('Move With Host' = true, 'Move Base' = true)
   |
   +- (base of Wall) Line
```

This also affects the current 1.1 branch, so might need backporting (the patch applies cleanly).

To reproduce you can create a BIM Wall based on a Draft Line, then check both 'Move With Host' and 'Move Base' properties, then create a Level (or other BuildingPart) with the Wall inside, and then move the Level around.

Before:
level moves, wall moves, line stays in place.

After:
all three move.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
N/A

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
N/A


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
