### PR TITLE
CAM: Fix case when CAM operation `Start depth` equal to `Final depth` and `Step down` is zero

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathDepthParams.py
+++ b/src/Mod/CAM/CAMTests/TestPathDepthParams.py
@@ -262,3 +262,19 @@ class depthTestCases(unittest.TestCase):
         d = PathUtils.depth_params(**args)
         r = [i for i in d]
         self.assertListEqual(r, expected, "Expected {}, but result of {}".format(expected, r))
+
+    def test_0_step_down_and_start_depth_equal_to_final_depth(self):
+        target_depth = 10
+
+        sut = PathUtils.depth_params(
+            clearance_height=target_depth + 10,
+            safe_height=target_depth + 5,
+            start_depth=target_depth,
+            step_down=0,
+            z_finish_step=0,
+            final_depth=target_depth,
+        )
+
+        self.assertListEqual(
+            sut.data, [target_depth], f"Expected [{target_depth}] but got {sut.data}"
+        )

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -912,6 +912,9 @@ class depth_params(object):
         all steps are of size 'size' except the one at the bottom which can be
         smaller."""
 
+        if Path.Geom.isRoughly(start, stop):
+            return [stop]
+
         fullsteps = int((start - stop) / size)
         last_step = start - (fullsteps * size)
         depths = list(linspace(last_step, start, fullsteps, endpoint=False))


### PR DESCRIPTION
This change fixes the case in the CAM workbench when an operation's `Start depth` is equal to `Final depth` and `Step down` is zero.

<img width="489" height="400" alt="20260129_23h04m40s_grim" src="https://github.com/user-attachments/assets/2295ffbb-c5ec-49ab-84f2-aea1eabda0e2" />

## Issues
#27246
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
Before:

<img width="1920" height="1080" alt="20260129_22h13m25s_grim" src="https://github.com/user-attachments/assets/ff793d4f-e47d-4a0f-9a04-59629c847c92" />

After:

<img width="1920" height="1080" alt="20260130_01h01m39s_grim" src="https://github.com/user-attachments/assets/7f387663-2a5d-412b-b375-0e8183210270" />
