### PR TITLE
TechDraw: fix Qt5 compatibility

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
+++ b/src/Mod/TechDraw/Gui/QGIProjGroup.cpp
@@ -246,7 +246,7 @@ QList<QGIViewPart*> QGIProjGroup::secondaryQViews() const
         if (!qview) {
             continue;
         }
-        result.emplace_back(qview);
+        result.append(qview);
     }
     return result;
 }


### PR DESCRIPTION
emplace_back was added in Qt6, replace by append which does the same thing.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Fix #27248
