### PR TITLE
Measure: corrected angle measurements bug

### DIFF
--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -233,7 +233,7 @@ App::DocumentObjectExecReturn* MeasureAngle::execute()
     Base::Vector3d vec2;
     getVec(*ob2, subs2.at(0), vec2);
 
-    if (vec1.IsParallel(vec2, Precision::Angular())) {
+    if (vec1.IsParallel(vec2, Base::Precision::Angular())) {
         // handle case when both vectors are parallel
         Angle.setValue(0);
     }


### PR DESCRIPTION
Mod:Measure measurement tool has a bug when measuring the angles.
The problem comes because the current implementation uses `vector3d::getAngle` directly. OCC can flip the vectors of the edges when it stores them. So `getAngle` function which just returns the smallest angle, sometimes returns wrong values.

## Issues
fixes #14269

## Before and After Images
Before:
<img width="939" height="358" alt="before" src="https://github.com/user-attachments/assets/4eb1f34d-aeaf-4338-88e0-78dde286501e" />
<img width="796" height="577" alt="before2" src="https://github.com/user-attachments/assets/948231a8-687e-4568-9832-2bdfe83d2b26" />

After:

<img width="1037" height="336" alt="after1" src="https://github.com/user-attachments/assets/fdfce140-5635-45fb-9e4b-e5688e7e012e" />
<img width="837" height="667" alt="after2" src="https://github.com/user-attachments/assets/65271252-a359-4b00-90c4-cf441d80306d" />


@luzpaz cc