### PR TITLE
polar bug

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
+++ b/src/Mod/PartDesign/App/FeaturePolarPattern.cpp
@@ -301,12 +301,12 @@ const std::list<gp_Trsf> PolarPattern::getTransformations(const std::vector<App:
     // Note: The original feature is already included in the list of transformations!
     // Therefore we start with occurrence number 1
     for (int i = 1; i < occurrences; i++) {
-   // just taken high value like 40
-        if (i > 40) { 
+        // just taken high value like 40
+        if (i > 40) {
             Base::Console().Error("Occurrence count too high. Aborting to prevent system hang.\n");
-            break; 
+            break;
         }
-        
+
         if (Mode.getValue() == (int)PolarPatternMode::Spacing) {
             double spacing;
             if (spacings[i - 1] != -1.0) {

--- a/src/Mod/PartDesign/App/FeatureTransformed.cpp
+++ b/src/Mod/PartDesign/App/FeatureTransformed.cpp
@@ -432,13 +432,14 @@ App::DocumentObjectExecReturn* Transformed::execute()
             auto shapes = getTransformedCompShape(supportShape, supportShape);
             if (OCCTProgressIndicator::getAppIndicator().UserBreak()) {
                 return new App::DocumentObjectExecReturn("User aborted");
-            }// check if shapes are valid for fusion
-          if (!shapes.empty()){
-            supportShape.makeElementFuse(shapes);
-          } else{
-            Base::Console().Warning("Transformation generated no valid shapes to fuse.\n");
-          }
-          break;
+            }  // check if shapes are valid for fusion
+            if (!shapes.empty()) {
+                supportShape.makeElementFuse(shapes);
+            }
+            else {
+                Base::Console().Warning("Transformation generated no valid shapes to fuse.\n");
+            }
+            break;
         }
     }
 


### PR DESCRIPTION
This PR addresses a stability and rendering issue in the PartDesign PolarPattern workbench when dealing with tapered pads.
gometric fix and safty guard from FeatureTransformed.cpp and FeaturePolarPattern.cpp respectively.when high occurrence counts are entered eg i taken 40.
Before:Polar Pattern fails to render correctly for more than 5 occurrences of a tapered pad or becomes invisible at 3 occurrences. Entering high values leads to an unresponsive application.
After:Pattern remains visible at low counts due to improved fusion handling, and high counts are capped/warned to prevent CPU exhaustion on ARM64 systems.