### PR TITLE
Navigation: set client name to FreeCAD when connecting to spacenav

### DIFF
--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -55,6 +55,7 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
         );
     }
     else {
+        spnav_client_name("FreeCAD");
         Base::Console().log("Connected to spacenav daemon\n");
         QSocketNotifier* SpacenavNotifier
             = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);

--- a/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
@@ -75,6 +75,7 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
             .log("Couldn't connect to spacenav daemon on X11. Please ignore if you don't have a spacemouse.\n");
     }
     else {
+        spnav_client_name("FreeCAD");
         Base::Console().log("Connected to spacenav daemon on X11\n");
         mainApp->setSpaceballPresent(true);
         mainApp->installNativeEventFilter(new Gui::RawInputEventFilter(&xcbEventFilter));

--- a/src/Gui/Quarter/SpaceNavigatorDevice.cpp
+++ b/src/Gui/Quarter/SpaceNavigatorDevice.cpp
@@ -94,6 +94,9 @@ SpaceNavigatorDevice::SpaceNavigatorDevice(QuarterWidget* quarter) :
   if (!PRIVATE(this)->hasdevice) {
     fprintf(stderr, "Quarter:: Could not hook up to Spacenav device.\n");
   }
+  else {
+    spnav_client_name("FreeCAD");
+  }
 
 #endif // HAVE_SPACENAV_LIB
 }


### PR DESCRIPTION
## Background

Integration with 3DConnexion devices (e.g. the SpaceMouse) on Linux is achieved via the `libspnav` library.

## Changes

   + *Identify FreeCAD to the daemon*
    libspnav allows applications to identify themselves to the daemon via the `spnav_client_name(...)` fn.
    This allows the daemon to, for example, provide application level default settings.

## Issues

Fixes https://github.com/FreeCAD/FreeCAD/issues/27263

## Before and After Images

N/A
