### PR TITLE
cmake: build: fix #27121 explicitly mark FREECAD_USE_EXTERNAL_ONDSELSOLVER as obsolete

### DIFF
--- a/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+++ b/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
@@ -10,6 +10,20 @@ macro(InitializeFreeCADBuildOptions)
     option(FREECAD_USE_EXTERNAL_KDL "Use system installed orocos-kdl instead of the bundled." OFF)
     option(FREECAD_USE_EXTERNAL_FMT "Use system installed fmt library if available instead of fetching the source." ON)
     option(FREECAD_USE_EXTERNAL_ONDSELSOLVER "Use system installed OndselSolver instead of git submodule." OFF)
+
+    if(FREECAD_USE_EXTERNAL_ONDSELSOLVER)
+        message(FATAL_ERROR
+" --------------------------------------------------------
+ The cmake configuration variable FREECAD_USE_EXTERNAL_ONDSELSOLVER is obsolete.
+ 
+ The external OndselSolver library https://github.com/ondsel-development/ondselsolver has been archived.
+ FreeCAD has since integrated the external project as a git submodule.
+ 
+ Run `git submodule status` to check if your freecad git repo has the submodule setup.
+ --------------------------------------------------------"
+        )
+    endif()
+
     option(FREECAD_USE_EXTERNAL_E57FORMAT "Use system installed libE57Format instead of the bundled." OFF)
     option(FREECAD_USE_EXTERNAL_GTEST "Use system installed Google Test and Google Mock" OFF)
     option(FREECAD_USE_FREETYPE "Builds the features using FreeType libs" ON)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR updates the cmake process to explicitly mark the below cmake var as obsolete, and notify the user during the cmake configure process of the error message to prevent wasted time attempting to build freecad.

```
FREECAD_USE_EXTERNAL_ONDSELSOLVER
```

the freecad project ie. github.com/freecad/freecad has since moved the ondselsolver as a (internal / bundled) (package / project) via the use of git submodules. so that variable only confuses users, and the freecad source has since been updated so that it will not compile with that variable set. as reported in freecad issue,

- https://github.com/FreeCAD/FreeCAD/issues/27121

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/27121

## Before and After Images

configuring freecad with the above cmake var set to `1` ie. `:BOOL=1` will yield the below cmake error during the cmake configure process.

```
-- Compiler: Clang, version: 21.1.8
-- Force BOOST_PP_VARIADICS=1 for clang
-- prefix: /opt/code/fcgit/installs/issue.tshooting.qt6.py313
-- bindir: bin
-- datadir: share
-- docdir: share/doc/FreeCAD
-- includedir: include
-- libdir: lib
-- cmake: 4.2.1
CMake Error at cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake:15 (message):
   --------------------------------------------------------
   The cmake configuration variable FREECAD_USE_EXTERNAL_ONDSELSOLVER is obsolete.

   The external OndselSolver library https://github.com/ondsel-development/ondselsolver has been archived.
   FreeCAD has since integrated the external project as a git submodule.

   Run `git submodule status` to check if your freecad git repo has the submodule setup
   --------------------------------------------------------
Call Stack (most recent call first):
  CMakeLists.txt:74 (InitializeFreeCADBuildOptions)


-- Configuring incomplete, errors occurred!
```

