### PR TITLE
Gui: Prompt user before clearing recent files

### DIFF
--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -879,7 +879,7 @@ RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent)
     this->groupAction()->addAction(&sep);
 
     //: Empties the list of recent files
-    clearRecentFilesListAction.setText(tr("Clear Recent Files..."));
+    clearRecentFilesListAction.setText(tr("Clear Recent Files…"));
     clearRecentFilesListAction.setIcon(QIcon(QStringLiteral(":/icons/edit-delete.svg")));
     clearRecentFilesListAction.setToolTip({});
     this->groupAction()->addAction(&clearRecentFilesListAction);
@@ -889,8 +889,7 @@ RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent)
         QMessageBox::StandardButton reply = QMessageBox::question(
             getMainWindow(),
             tr("Clear Recent Files"),
-            tr("Are you sure you want to clear the list of recent files?\n This action can not be "
-               "undone!"),
+            tr("Clear the list of recent files?"),
             QMessageBox::Yes | QMessageBox::No,
             QMessageBox::No
         );

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -26,6 +26,7 @@
 #include <QEvent>
 #include <QFileInfo>
 #include <QMenu>
+#include <QMessageBox>
 #include <QRegularExpression>
 #include <QScreen>
 #include <QTimer>
@@ -878,12 +879,26 @@ RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent)
     this->groupAction()->addAction(&sep);
 
     //: Empties the list of recent files
-    clearRecentFilesListAction.setText(tr("Clear Recent Files"));
+    clearRecentFilesListAction.setText(tr("Clear Recent Files..."));
     clearRecentFilesListAction.setIcon(QIcon(QStringLiteral(":/icons/edit-delete.svg")));
     clearRecentFilesListAction.setToolTip({});
     this->groupAction()->addAction(&clearRecentFilesListAction);
 
     auto clearFun = [this, hGrp = _pimpl->handle]() {
+        // prompt user before clearing the recent files list
+        QMessageBox::StandardButton reply = QMessageBox::question(
+            getMainWindow(),
+            tr("Clear Recent Files"),
+            tr("Are you sure you want to clear the list of recent files?\n This action can not be "
+               "undone!"),
+            QMessageBox::Yes | QMessageBox::No,
+            QMessageBox::No
+        );
+
+        if (reply != QMessageBox::Yes) {
+            return;
+        }
+
         const size_t recentFilesListSize = hGrp->GetASCIIs("MRU").size();
         for (size_t i = 0; i < recentFilesListSize; i++) {
             const QByteArray key = QStringLiteral("MRU%1").arg(i).toLocal8Bit();

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -879,7 +879,7 @@ RecentFilesAction::RecentFilesAction(Command* pcCmd, QObject* parent)
     this->groupAction()->addAction(&sep);
 
     //: Empties the list of recent files
-    clearRecentFilesListAction.setText(tr("Clear Recent Files…"));
+    clearRecentFilesListAction.setText(tr("Clear Recent Files"));
     clearRecentFilesListAction.setIcon(QIcon(QStringLiteral(":/icons/edit-delete.svg")));
     clearRecentFilesListAction.setToolTip({});
     this->groupAction()->addAction(&clearRecentFilesListAction);


### PR DESCRIPTION
this PR aims at resolving the topic discussed in issue #27270. this is a simple fix, ie. wrap the clear recent files action in a qt qmessagebox and set the default action to no, and let the user know once the list has been cleared it can not be undone.

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/27270

## Before and After Images

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/4c23d5b9-cec3-439e-975a-5b58920d69af" />

the above image shows a list of recent files. without the prompt.

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/caf0b143-3188-4844-af20-36c8c14af86d" />

the above image shows the prompt with the two statements and the two buttons for clearing the recent files.



