### PR TITLE
Draft: Filter windows in Shape2DView based on Additions and Subtractions

### DIFF
--- a/src/Mod/Draft/draftutils/groups.py
+++ b/src/Mod/Draft/draftutils/groups.py
@@ -175,7 +175,8 @@ def get_windows(obj):
     out = []
     if utils.get_type(obj) in ("Wall", "Structure"):
         for o in obj.OutList:
-            out.extend(get_windows(o))
+            if o not in obj.Additions and o not in obj.Subtractions:
+                out.extend(get_windows(o))
         for i in obj.InList:
             if utils.get_type(i.getLinkedObject()) == "Window" or utils.is_clone(obj, "Window"):
                 if hasattr(i, "Hosts"):


### PR DESCRIPTION
The Draft_Shape2DView object uses `get_windows` from groups.py to find the windows (and rebars) that need to be included. Windows in walls that were added to, or subtracted from another object were wrongly also included.

Reported on the forum:
https://forum.freecad.org/viewtopic.php?t=102970

<s>Note that it is strange that Draft_Shape2DView uses a different algorithm for Arch_SectionPlanes than that used for TD ArchViews.</s>