### PR TITLE
BIM: Prevent incorrect assembly icon for baseless parametric walls

### DIFF
--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1810,7 +1810,9 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         if hasattr(self, "Object"):
             if self.Object.CloneOf:
                 return ":/icons/Arch_Wall_Clone.svg"
-            elif (not self.Object.Base) and self.Object.Additions:
+            elif (not self.Object.Base) and self.Object.Additions and not self.Object.Length.Value:
+                # The wall is an assembly: it is built from additions only, yet it is not
+                # strictly a baseless wall, since baseless walls are parametric.
                 return ":/icons/Arch_Wall_Tree_Assembly.svg"
         return ":/icons/Arch_Wall_Tree.svg"
 


### PR DESCRIPTION
The icon logic in _ViewProviderWall.getIcon previously switched to the
assembly icon for any wall without a Base that contained Additions. This
caused an unexpected icon change when a wall was debased, as it still
retains a parametric body defined by its Length property.

Update the logic to only show the assembly icon if the wall has no Base,
has Additions, and its Length is zero. This ensures that baseless walls
driven by their own dimensions maintain the standard wall icon.

Fixes https://github.com/FreeCAD/FreeCAD/issues/27268