### PR TITLE
BIM: prevent child objects from moving during Arch Wall debasing

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2233,6 +2233,12 @@ def debaseWall(wall):
     doc = wall.Document
 
     try:
+        # Record the current global placements of all children that move with the host.
+        # ArchComponent.onChanged will attempt to shift them when the wall's placement is updated
+        # below.
+        children = wall.Proxy.getMovableChildren(wall)
+        child_placements = {child: child.Placement.copy() for child in children}
+
         # --- Calculation of the final placement ---
         base_obj = wall.Base
         base_edge = base_obj.Shape.Edges[0]
@@ -2278,6 +2284,11 @@ def debaseWall(wall):
 
         # 1. Apply the final placement first.
         wall.Placement = final_placement
+
+        # Restore original placements to counteract the shift from onChanged.
+        # This keeps all hosted elements stationary in world space.
+        for child, original_placement in child_placements.items():
+            child.Placement = original_placement
 
         # 2. Now, remove the base. The recompute triggered by this change
         #    will already have the correct placement to work with.

--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -485,8 +485,7 @@ class TestArchWall(TestArchBase.TestArchBase):
         line.Placement.Base = App.Vector(5000, 0, 0)
         self.document.recompute()
 
-        # Create the wall. Initially, wall.Placement is (0,0,0) because its position is derived from
-        # its Base object.
+        # Create the wall. Initially, wall.Placement is (0,0,0).
         wall = Arch.makeWall(line, width=200, height=3000)
         self.document.recompute()
 

--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -473,3 +473,96 @@ class TestArchWall(TestArchBase.TestArchBase):
         # Integrity check: volume correctness
         expected_vol = L * W * H
         self.assertAlmostEqual(wall.Shape.Volume, expected_vol, places=3)
+
+    def test_debase_wall_stationary_children(self):
+        """Test that debasing a wall does not shift its children in world space."""
+        self.printTestMessage("Arch.debaseWall stationary children...")
+
+        # Create a base line offset by 5 meters for a clear distinction between local (0,0,0) and
+        # global coordinates.
+        # Line start/end: (5000,0,0) / (7000,0,0). Midpoint/new placement: (6000,0,0).
+        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(2000, 0, 0))
+        line.Placement.Base = App.Vector(5000, 0, 0)
+        self.document.recompute()
+
+        # Create the wall. Initially, wall.Placement is (0,0,0) because its position is derived from
+        # its Base object.
+        wall = Arch.makeWall(line, width=200, height=3000)
+        self.document.recompute()
+
+        # Create a set of different types of children, with different properties
+
+        # Child A: a standard Part::Box primitive. Lacks MoveWithHost property. It should be handled
+        # by the default move logic.
+        box = self.document.addObject("Part::Box", "ChildBox")
+        box.Placement.Base = App.Vector(5250, -150, 500)
+
+        # Child B: an ArchComponent with MoveWithHost=True. This should be explicitly included in
+        # the move logic.
+        comp_true_base = self.document.addObject("Part::Box", "CompTrueBase")
+        comp_true = Arch.makeComponent(comp_true_base, name="CompWithMove")
+        comp_true.MoveWithHost = True
+        comp_true.Placement.Base = App.Vector(5750, -150, 500)
+
+        # Child C: an ArchComponent with MoveWithHost=False. This should be ignored by the move
+        # logic.
+        comp_false_base = self.document.addObject("Part::Box", "CompFalseBase")
+        comp_false = Arch.makeComponent(comp_false_base, name="CompNoMove")
+        comp_false.MoveWithHost = False
+        comp_false.Placement.Base = App.Vector(6250, -150, 500)
+
+        # Child D: a hosted Arch.Window. This is not an Addition but is found via InList by
+        # getMovableChildren.
+        win_base = Draft.makeRectangle(length=500, height=800)
+        win_base.Placement.Rotation = App.Rotation(App.Vector(1, 0, 0), 90)  # Orient vertically
+        win_base.Placement.Base = App.Vector(6500, 100, 1000)  # Position in wall center
+        self.document.recompute()
+        window = Arch.makeWindow(win_base)
+
+        # Add all children/guests to the wall
+        wall.Additions = [box, comp_true, comp_false]
+        window.Hosts = [wall]
+        self.document.recompute()
+
+        # Record initial global placements for all children/hosts before debasing.
+        initial_placements = {
+            "Box": box.Placement.copy(),
+            "CompTrue": comp_true.Placement.copy(),
+            "CompFalse": comp_false.Placement.copy(),
+            "Window": window.Placement.copy(),
+        }
+
+        # Perform the debase operation. This will reset wall.Placement from (0,0,0) to (6000,0,0)
+        # and trigger the onChanged -> getMovableChildren -> move logic.
+        Arch.debaseWall(wall)
+        self.document.recompute()
+
+        # All children must remain at their original global coordinates. Use subtests to get a clear
+        # report for each child type.
+        with self.subTest(child_type="Part Primitive (Box)"):
+            self.assertTrue(
+                box.Placement.Base.isEqual(initial_placements["Box"].Base, 1e-6),
+                f"Part Primitive Box position shifted! Expected {initial_placements['Box'].Base}, got {box.Placement.Base}",
+            )
+
+        with self.subTest(child_type="ArchComponent (MoveWithHost=True)"):
+            self.assertTrue(
+                comp_true.Placement.Base.isEqual(initial_placements["CompTrue"].Base, 1e-6),
+                f"Component with MoveWithHost=True position shifted! Expected {initial_placements['CompTrue'].Base}, got {comp_true.Placement.Base}",
+            )
+
+        with self.subTest(child_type="ArchComponent (MoveWithHost=False)"):
+            self.assertTrue(
+                comp_false.Placement.Base.isEqual(initial_placements["CompFalse"].Base, 1e-6),
+                f"Component with MoveWithHost=False position shifted! Expected {initial_placements['CompFalse'].Base}, got {comp_false.Placement.Base}",
+            )
+
+        with self.subTest(child_type="Hosted Window"):
+            self.assertTrue(
+                window.Placement.Base.isEqual(initial_placements["Window"].Base, 1e-6),
+                f"Hosted Window position shifted! Expected {initial_placements['Window'].Base}, got {window.Placement.Base}",
+            )
+
+        # Final verification that the wall itself was correctly debased
+        self.assertIsNone(wall.Base, "Wall was not successfully debased (Base still exists).")
+        self.assertAlmostEqual(wall.Placement.Base.x, 6000.0, places=3)


### PR DESCRIPTION
This PR prevents geometry attached to an Arch Wall (Additions, Hosted objects like Windows) from shifting when the wall is debased.

Debasing a wall recalculates its `Placement` property. The `onChanged` propagation logic treats this as a physical move, applying a displacement to all children, causing them to jump.

The fix involves capturing and restoring the children's original placement within `Arch.debaseWall()`:
1.  The global placements of all movable children are recorded *before* the wall's placement is updated.
2.  After the wall's placement is set to its new coordinate system, the children's placements are explicitly restored to their original world-space values.

This makes the debasing operation transparent to all associated BIM elements, as intended.

## Issues

Fixes https://github.com/FreeCAD/FreeCAD/issues/27267