### PR TITLE
CAM: Profile - fix _getCutAreaCrossSection()

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -756,6 +756,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
 
         # Cut model(selected edges) from extended edges boundbox
         cutArea = extBndboxEXT.cut(base.Shape)
+        cutArea.tessellate(tolerance)
         self._addDebugObject("CutArea", cutArea)
 
         # Get top and bottom faces of cut area (CA), and combine faces when necessary


### PR DESCRIPTION
`_getCutAreaCrossSection()` in some cases return `False` because incorrectly defines `BoundBox` for `cutArea`

https://github.com/FreeCAD/FreeCAD/blob/3d7cc53317a8cb03052da0e6428360cde85b9346/src/Mod/CAM/Path/Op/Profile.py#L758

Asked question in [forum](https://forum.freecad.org/viewtopic.php?t=103008) and got advice to apply `tessellate()` to new shape before `BoundBox`

> BoundBox uses the mesh of the shape.
> When you create a shape by script, it has no tessellation, until you show it, or call shape.tessellate().

Thanks, @tomate44

[open_profile_test.zip](https://github.com/user-attachments/files/25002814/open_profile_test.zip)

### Before this commit:
<img width="814" height="361" alt="Screenshot_20260202_095057_lossy" src="https://github.com/user-attachments/assets/927d6faf-30f3-4e55-8cce-f676aa4248a2" />

```
Profile.ERROR: Failed to identify top faces of cut area.
Profile.ERROR: The selected edge(s) are inaccessible. If multiple, re-ordering selection might work.
```

### After this commit:
<img width="814" height="361" alt="Screenshot_20260202_094315_lossy" src="https://github.com/user-attachments/assets/ee1e625c-ee4d-4ff7-983d-08ecbd285868" />
