### PR TITLE
Sketcher: Use PreferTypoLineMetrics for constrain label font

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -192,10 +192,10 @@ void SoDatumLabel::drawImage()
     QFontMetrics fm(font);
     QString str = QString::fromUtf8(s[0].getString());
 
-#if QT_VERSION >= QT_VERSION_CHECK(6,8,0)
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
     font.setStyleStrategy(QFont::PreferTypoLineMetrics);
 #endif
-    
+
     int w = Gui::QtTools::horizontalAdvance(fm, str);
     int h = fm.height();
 


### PR DESCRIPTION
Constraints in Sketcher use multiple Unicode characters (such as the diameter symbol and the arc-length symbol) that are not present in all fonts. Due to the fallback mechanism, a different font is selected for missing characters (on Linux, this is handled by `fontconfig`). As a result, a label may contain multiple fonts, which can lead to misalignment and cropping, as reported in issue #21889.

This change fixes the issue. See the documentation for [QFont::PreferTypoLineMetrics](https://doc.qt.io/qt-6/qfont.html#StyleStrategy-enum) for an explanation. 

## Issues
fixes #21889 (only for Qt >=6.8, unfortunately)

## Before and After Images

<img width="824" height="467" alt="norm" src="https://github.com/user-attachments/assets/becba3e6-875b-4a92-959f-c668d6025d70" />

<img width="824" height="467" alt="fx" src="https://github.com/user-attachments/assets/d0f6474f-9fc4-49d8-982f-41b9468bc9e5" />

<img width="824" height="467" alt="ref" src="https://github.com/user-attachments/assets/59989288-6019-4797-9d4f-1c9f5c66cff6" />

![disabled](https://github.com/user-attachments/assets/677c3e76-f8cc-4027-a169-0802cac79bf7)
