### PR TITLE
BIM: remove superfluous transaction handling when editing IFC props

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -2589,13 +2589,11 @@ class ComponentTaskPanel:
             ifcData["IfcUID"] = self.ifcEditor.labelUUID.text()
             ifcData["FlagForceBrep"] = str(self.ifcEditor.checkBrep.isChecked())
             ifcData["FlagParametric"] = str(self.ifcEditor.checkParametric.isChecked())
-            if (ifcdict != self.obj.IfcProperties) or (ifcData != self.obj.IfcData):
-                FreeCAD.ActiveDocument.openTransaction("Change Ifc Properties")
-                if ifcdict != self.obj.IfcProperties:
-                    self.obj.IfcProperties = ifcdict
-                if ifcData != self.obj.IfcData:
-                    self.obj.IfcData = ifcData
-                FreeCAD.ActiveDocument.commitTransaction()
+            # The transaction context is implicitly opened by the C++ layer when entering edit mode.
+            if ifcdict != self.obj.IfcProperties:
+                self.obj.IfcProperties = ifcdict
+            if ifcData != self.obj.IfcData:
+                self.obj.IfcData = ifcData
             del self.ifcEditor
 
     def addIfcProperty(self, idx=0, pset=None, prop=None, ptype=None):


### PR DESCRIPTION
As pointed out here:
https://github.com/FreeCAD/FreeCAD/pull/26758#issuecomment-3830289031