### PR TITLE
BIM: titles in default task panel in title case

### DIFF
--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -636,8 +636,8 @@ class BIMWorkbench(Workbench):
 
         FreeCADGui.Control.addTaskWatcher(
             [
-                BimWatcher(self.draftingtools + self.annotationtools, "2D geometry"),
-                BimWatcher(self.bimtools, "3D/BIM geometry"),
+                BimWatcher(self.draftingtools + self.annotationtools, "2D Geometry"),
+                BimWatcher(self.bimtools, "3D/BIM Geometry"),
                 BimWatcher(self.modify, "Modify", invert=True),
             ]
         )


### PR DESCRIPTION
This task panel appears when no command is active. There are 2 versions. One appears if there is a selection, the other if there is none.