### PR TITLE
Part: Add MapFaceColor property to preserve face colors through Boolean ops

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -1621,11 +1621,13 @@ static bool tryGetColorFromHashTags(
 // Helper function to try getting color from a source object for a given face element
 // If notReadyYet is provided, it will be set to true if the source VP is still restoring
 // recursionDepth prevents infinite recursion when tracing through objects with MapFaceColor
-static bool tryGetSourceColor(App::DocumentObject* sourceObj,
-                              const std::string& sourceElement,
-                              App::Material& outMaterial,
-                              bool* notReadyYet = nullptr,
-                              int recursionDepth = 0)
+static bool tryGetSourceColor(
+    App::DocumentObject* sourceObj,
+    const std::string& sourceElement,
+    App::Material& outMaterial,
+    bool* notReadyYet = nullptr,
+    int recursionDepth = 0
+)
 {
     if (!sourceObj || sourceElement.empty()) {
         return false;
@@ -1699,8 +1701,8 @@ static bool tryGetSourceColor(App::DocumentObject* sourceObj,
     // If we have per-face materials, use the appropriate one
     // Otherwise use the first (default) material
     size_t matIndex = (materials.size() > 1 && faceIndex <= static_cast<int>(materials.size()))
-                          ? static_cast<size_t>(faceIndex - 1)
-                          : 0;
+        ? static_cast<size_t>(faceIndex - 1)
+        : 0;
 
     outMaterial = materials[matIndex];
     return true;
@@ -1869,7 +1871,8 @@ static bool tryGetColorFromModifiedSource(
                             indexEnd++;
                         }
                         if (indexEnd > indexPos) {
-                            faceIndex = std::stoi(afterM.substr(indexPos, indexEnd - indexPos), nullptr, 16);
+                            faceIndex
+                                = std::stoi(afterM.substr(indexPos, indexEnd - indexPos), nullptr, 16);
                         }
                     }
 
@@ -1973,7 +1976,8 @@ static bool tryGetColorFromHashTags(
                     typePos++;
                     if (typePos < elemStr.size() && elemStr[typePos] == 'F') {
                         // This is a Face element
-                        std::string sourceElement = "Face" + std::to_string(faceIndex > 0 ? faceIndex : 1);
+                        std::string sourceElement = "Face"
+                            + std::to_string(faceIndex > 0 ? faceIndex : 1);
 
                         if (tryGetSourceColor(sourceObj, sourceElement, outMaterial)) {
                             return true;
@@ -2133,8 +2137,8 @@ void ViewProviderPartExt::applyMappedColors()
         mapColorRetryCount = 0;  // Reset retry counter on success
     }
     else if (hasSourceHistory && mapColorRetryCount < 5) {
-        // We have source history but couldn't get colors - source objects may not be fully restored yet.
-        // Apply ShapeAppearance as fallback so display isn't blank, then schedule a retry.
+        // We have source history but couldn't get colors - source objects may not be fully restored
+        // yet. Apply ShapeAppearance as fallback so display isn't blank, then schedule a retry.
         setHighlightedFaces(ShapeAppearance.getValues());
         mapColorRetryCount++;
         QTimer::singleShot(100, [this]() {

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -95,6 +95,8 @@ public:
     App::PropertyColor LineColor;
     App::PropertyMaterial LineMaterial;
     App::PropertyColorList LineColorArray;
+    // Color mapping from element history
+    App::PropertyBool MapFaceColor;
 
     void attach(App::DocumentObject*) override;
     void setDisplayMode(const char* ModeName) override;
@@ -214,6 +216,8 @@ protected:
     void onChanged(const App::Property* prop) override;
     bool loadParameter();
     void updateVisual();
+    /// Apply colors mapped from source element history
+    void applyMappedColors();
     void handleChangedPropertyName(
         Base::XMLReader& reader,
         const char* TypeName,
@@ -245,6 +249,7 @@ private:
     Gui::ViewProviderFaceTexture texture;
     // settings stuff
     int forceUpdateCount;
+    int mapColorRetryCount = 0;  // Counter for color mapping retries during file restore
     static App::PropertyFloatConstraint::Constraints sizeRange;
     static App::PropertyFloatConstraint::Constraints tessRange;
     static App::PropertyQuantityConstraint::Constraints angDeflectionRange;


### PR DESCRIPTION
## Summary
Adds a new `MapFaceColor` view property to Part view providers that enables automatic face color inheritance through Boolean operations. When enabled, faces in the result object trace their colors back to source objects using FreeCAD's element history system.

Fixes #11210

## Implementation Details

### Element History Tracing
- Parses mapped element names to find source element references
- Follows hash tags (`;:H` tags) to trace back to original geometry
- Handles modified face patterns (`;:M` and `;:M(...)`) to find true geometric sources

### Recursive Color Tracing
- When a source object also has `MapFaceColor` enabled, recursively traces through intermediate objects
- Enables color preservation through chains of Boolean operations

### File Restore Handling
- Includes retry mechanism during document restore when source objects may not yet have computed shapes
- Uses `isRestoring()` checks to defer color mapping until shapes are available

### Visibility Change Handling
- Reapplies mapped colors when object visibility changes
- Prevents parent class `setCoinAppearance()` from overwriting per-face colors

## Test Plan
- [ ] Create two primitives with different colors (e.g., red box, green cylinder)
- [ ] Create Boolean operations (Cut, Fuse, Common) between them
- [ ] Enable `MapFaceColor` on the result objects
- [ ] Verify faces inherit colors from their source objects
- [ ] Save and reload the document to verify colors persist
- [ ] Test with chains of Boolean operations (e.g., Cut result used in another Cut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)