### PR TITLE
CAM: Update SVG annotation IDs for tool shapes

### DIFF
--- a/src/Mod/CAM/Tools/Shape/bullnose.svg
+++ b/src/Mod/CAM/Tools/Shape/bullnose.svg
@@ -434,7 +434,7 @@
              d="m 76.574219,239.24609 a 0.18591908,0.18591908 0 0 0 -0.19336,0.10743 l -2.826172,6.32226 a 0.18591908,0.18591908 0 0 0 0.25,0.24414 l 6.248047,-2.98633 A 0.18591908,0.18591908 0 0 0 80,242.58203 c -1.67308,-0.25297 -2.995101,-1.53528 -3.267578,-3.18359 a 0.18591908,0.18591908 0 0 0 -0.158203,-0.15235 z m -0.0059,0.59766 c 0.404884,1.45072 1.518948,2.53298 2.990235,2.91406 l -5.457032,2.60742 z"
              id="path30745" /></g></g></g><text
        transform="scale(0.97131606,1.029531)"
-       id="torus_radius"
+       id="corner_radius"
        y="279.48972"
        x="34.310169"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.7707px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.35351"

--- a/src/Mod/CAM/Tools/Shape/radius.svg
+++ b/src/Mod/CAM/Tools/Shape/radius.svg
@@ -554,7 +554,7 @@
      d="m 175.2226,135.00003 h 18.38097"
      style="fill:none;stroke:#000000;stroke-width:0.592962;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><text
      transform="scale(0.97096033,1.0299082)"
-     id="cutting_edge_height-7"
+     id="cutting_radius"
      y="195.87868"
      x="156.38969"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:28.2222px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28362"
@@ -564,7 +564,7 @@
        id="tspan7855-5"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:28.2222px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">r</tspan></text><text
      transform="scale(0.97096033,1.0299082)"
-     id="diameter-9"
+     id="tip_diameter"
      y="244.40749"
      x="70.96611"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32.286px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.02681"

--- a/src/Mod/CAM/Tools/Shape/svg_source/bullnose.svg
+++ b/src/Mod/CAM/Tools/Shape/svg_source/bullnose.svg
@@ -378,7 +378,7 @@
        style="fill:none;stroke:#000000;stroke-width:0.540802;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#marker1185-7)"
        sodipodi:nodetypes="cc" /><text
        transform="scale(0.97131606,1.029531)"
-       id="torus_radius"
+       id="corner_radius"
        y="279.48972"
        x="34.310169"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:35.7707px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.35351"

--- a/src/Mod/CAM/Tools/Shape/svg_source/radius.svg
+++ b/src/Mod/CAM/Tools/Shape/svg_source/radius.svg
@@ -483,7 +483,7 @@
      d="m 175.2226,135.00003 h 18.38097"
      style="fill:none;stroke:#000000;stroke-width:0.592962;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" /><text
      transform="scale(0.97096033,1.0299082)"
-     id="cutting_edge_height-7"
+     id="cutting_radius"
      y="195.87868"
      x="156.38969"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:28.2222px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.28362"
@@ -493,7 +493,7 @@
        id="tspan7855-5"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:28.2222px;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">r</tspan></text><text
      transform="scale(0.97096033,1.0299082)"
-     id="diameter-9"
+     id="tip_diameter"
      y="244.40749"
      x="70.96611"
      style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:32.286px;line-height:1.25;font-family:'URW Bookman L';-inkscape-font-specification:'URW Bookman L, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3.02681"


### PR DESCRIPTION
Renamed several SVG text element IDs in tool shape files that did not match the expected naming conventions used. This ensures that the tool parameters are correctly recognized and utilized by the Tool library editor.

src/Mod/CAM/Tools/Shape/bullnose.svg:
- Changed text element id from "torus_radius" to "corner_radius"

src/Mod/CAM/Tools/Shape/radius.svg:
- Changed text element id from "cutting_edge_height-7" to "cutting_radius"
- Changed text element id from "diameter-9" to "tip_diameter"

src/Mod/CAM/Tools/Shape/svg_source/bullnose.svg:
- Changed text element id from "torus_radius" to "corner_radius"

src/Mod/CAM/Tools/Shape/svg_source/radius.svg:
- Changed text element id from "cutting_edge_height-7" to "cutting_radius"
- Changed text element id from "diameter-9" to "tip_diameter"

@maxwxyz Backport to v1.1