### PR TITLE
Package: Make Windows uninstaller preferences language clearer

### DIFF
--- a/package/WindowsInstaller/lang/english.nsh
+++ b/package/WindowsInstaller/lang/english.nsh
@@ -64,7 +64,8 @@ ${LangFileString} SecUnPreferencesDescription 'Deletes FreeCAD$\'s configuration
 						$AppSuff\$\r$\n\
 						${APP_DIR_USERDATA}$\")$\r$\n\
 						for you or for all users (if you are admin).'
-${LangFileString} DialogUnPreferences 'You chose to delete the FreeCADs user configuration.$\r$\n\
-						This will also delete all installed FreeCAD addons.$\r$\n\
-						Do you agree with this?'
+${LangFileString} DialogUnPreferences 'You chose to delete the FreeCAD user configuration.$\r$\n\
+						This will also delete all installed FreeCAD addons, and will affect the$\r$\n\
+						preferences for all versions of FreeCAD.\r$\n\
+						Are you sure you want to proceed?'
 ${LangFileString} SecUnProgramFilesDescription "Uninstall FreeCAD and all of its components."


### PR DESCRIPTION
It has been pointed out that it's not completely clear during Windows uninstallation that electing to remove the preferences directory there will remove it for ALL versions of the software, not just the one being uninstalled. This modifies the confirmation dialog to be more explicit about that. A possible future TODO could detect if this is version 1.1 or later, and if so, offer to only remove the preferences for that specific version.