### PR TITLE
Sketcher: Fix: Arc of ellipse when first and second X coordinates are the same

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -126,7 +126,7 @@ public:
 
             double cosT = max(-1.0, min(1.0, delta13Prime.x / a));
             double sinT = sqrt(max(0.0, 1 - cosT * cosT));
-            
+
             double b = abs(delta13Prime.y) / sinT;
             if (sinT == 0.0) {
                 b = 0.0;
@@ -203,10 +203,12 @@ public:
                 setPositionText(onSketchPos, text);
             }
 
-            if (onSketchPos != centerPoint)
+            if (onSketchPos != centerPoint) {
                 drawEdit(EditCurve);
-            else
+            }
+            else {
                 drawEdit(std::vector<Base::Vector2d>());
+            }
             seekAndRenderAutoConstraint(sugConstr4, onSketchPos, Base::Vector2d(0.f, 0.f));
         }
     }
@@ -221,7 +223,8 @@ public:
             setAngleSnapping(true, centerPoint);
             Mode = SelectMode::Second;
         }
-        else if (Mode == SelectMode::Second && (centerPoint-onSketchPos).Length() >= Precision::Confusion()) {
+        else if (Mode == SelectMode::Second
+                 && (centerPoint - onSketchPos).Length() >= Precision::Confusion()) {
             EditCurve[1] = onSketchPos;
             axisPoint = onSketchPos;
             Mode = SelectMode::Third;
@@ -231,8 +234,8 @@ public:
             arcAngle = 0.;
             Mode = SelectMode::Fourth;
         }
-        else if (Mode == SelectMode::Fourth && centerPoint != onSketchPos && 
-            arcAngle != 0 && abs(arcAngle) != 2*pi) { 
+        else if (Mode == SelectMode::Fourth && centerPoint != onSketchPos && arcAngle != 0
+                 && abs(arcAngle) != 2 * pi) {
             endPoint = onSketchPos;
 
             setAngleSnapping(false);


### PR DESCRIPTION
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->
Fixed a bug that causes the ellipse to flicker and not be correct to the user input when placing the 3. point, when the X coordinates of the 1. and 2. points are the same. Happened do to the angle between them being 90 degrees then this angle was used in a tangent function, where `tan(90)` becomes unbounded, leading to severe numerical instability.

This code only changes the GUI to show the expected result.

## Issue
Fixes #13175 
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Before:

https://github.com/user-attachments/assets/fb6e29d1-62d6-4190-b199-fa8105d85a54

After:

https://github.com/user-attachments/assets/f4fa03e1-1e19-4288-b0b7-61a57dbd6065

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
