### PR TITLE
CI: pin swig on release builds.

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -22,7 +22,7 @@ requirements:
     - noqt5
     - python>=3.11,<3.12
     - qt6-main>=6.8,<6.9
-    - swig
+    - swig>=4.3,<4.4
 
     - if: linux and x86_64
       then:


### PR DESCRIPTION
Some of the `rattler-build` dependencies do not get locked in the `pixi.lock` file, and consequently a newer version may be installed.  `swig >= 4.4` is not compatible with libraries built with `swig == 4.3` such as `pivy`.  This PR pins to `swig==4.3`.

## Issues

* None

## Before and After Images

* N/A