### PR TITLE
Packaging: Fix typo in end-of-line format

### DIFF
--- a/package/WindowsInstaller/lang/english.nsh
+++ b/package/WindowsInstaller/lang/english.nsh
@@ -66,6 +66,6 @@ ${LangFileString} SecUnPreferencesDescription 'Deletes FreeCAD$\'s configuration
 						for you or for all users (if you are admin).'
 ${LangFileString} DialogUnPreferences 'You chose to delete the FreeCAD user configuration.$\r$\n\
 						This will also delete all installed FreeCAD addons, and will affect the$\r$\n\
-						preferences for all versions of FreeCAD.\r$\n\
+						preferences for all versions of FreeCAD.$\r$\n\
 						Are you sure you want to proceed?'
 ${LangFileString} SecUnProgramFilesDescription "Uninstall FreeCAD and all of its components."


### PR DESCRIPTION
Recent PR #27326 had a typo in the end-of-line formatting on the new text, so the display was slightly broken.