### PR TITLE
sketcher: fixes #27281 fix access out of bounds crash with "remove axes alignment"

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstddef>
 #include <limits>
 #include <vector>
 
@@ -5666,9 +5667,10 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
         {{Sketcher::Horizontal, GeoEnum::GeoUndef},
          {Sketcher::Vertical, GeoEnum::GeoUndef}};
 
-    int cindex = 0;
+    size_t cindex = 0;
     for (size_t i = 0; i < constrvals.size(); i++) {
-        if (i != changeConstraintIndices[cindex].first) {
+        if (cindex >= changeConstraintIndices.size()
+        || i != changeConstraintIndices[cindex].first) {
             newconstrVals.push_back(constrvals[i]);
             continue;
         }


### PR DESCRIPTION
this pr fixes #27281, presently with the latest dev build a crash can occur if one builds freecad with the below cxx flag

```
-D_GLIBCXX_ASSERTIONS
```

for my local build i used the following cxx flags,

```
-DCMAKE_CXX_FLAGS="-I$bp/opt/mesa/include -I$bp/opt/pybind11_py312/include -I$bp/opt/mesa-glu/include -D_GLIBCXX_ASSERTIONS" \
```

## Issues

fixes issue #27281

- https://github.com/FreeCAD/FreeCAD/issues/27281

## Before and After Images

see above mentioned issue for images of crash.

see below attached video for demo with fix applied.

https://github.com/user-attachments/assets/2c80bc05-da1d-4423-99d6-21ca47186e49

