### PR TITLE
Sketcher: Fix dimension label alignment and inactive strikethrough

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -147,6 +147,7 @@ SoDatumLabel::SoDatumLabel()
     SO_NODE_ADD_FIELD(textColor, (SbVec3f(1.0F, 1.0F, 1.0F)));
     SO_NODE_ADD_FIELD(pnts, (SbVec3f(.0F, .0F, .0F)));
     SO_NODE_ADD_FIELD(norm, (SbVec3f(.0F, .0F, 1.F)));
+    SO_NODE_ADD_FIELD(strikethrough, (false));
 
     SO_NODE_ADD_FIELD(name, ("Helvetica"));
     SO_NODE_ADD_FIELD(size, (10.F));
@@ -215,9 +216,13 @@ void SoDatumLabel::drawImage()
         painter.setRenderHint(QPainter::Antialiasing);
     }
 
-    painter.setPen(front);
+    painter.setPen(QPen(front, 2));
     painter.setFont(font);
     painter.drawText(0, fm.ascent() + rect.y(), w, rect.height(), Qt::AlignLeft, str);
+    if (strikethrough.getValue()) {
+        int strikepos = fm.ascent() - fm.strikeOutPos();
+        painter.drawLine(0, strikepos, w, strikepos);
+    }
     painter.end();
 
     Gui::BitmapFactory().convert(image, this->image);

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -24,6 +24,7 @@
 #define GUI_SODATUMLABEL_H
 
 #include <Inventor/SbBox3f.h>
+#include <Inventor/fields/SoSFBool.h>
 #include <Inventor/fields/SoSFColor.h>
 #include <Inventor/fields/SoSFEnum.h>
 #include <Inventor/fields/SoSFFloat.h>
@@ -87,6 +88,7 @@ public:
     SoSFFloat param8;
     SoMFVec3f pnts;
     SoSFVec3f norm;
+    SoSFBool strikethrough;
     SoSFImage image;
     SoSFFloat lineWidth;
     SoSFFloat sampling;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -936,6 +936,7 @@ Restart:
                             asciiText->string = SbString(
                                 getPresentationString(Constr, "◠ ").toUtf8().constData()
                             );
+                            asciiText->strikethrough = !Constr->isActive;
 
                             asciiText->pnts.setNum(3);
                             SbVec3f* verts = asciiText->pnts.startEditing();
@@ -958,6 +959,7 @@ Restart:
 
                     // Get presentation string (w/o units if option is set)
                     asciiText->string = SbString(getPresentationString(Constr).toUtf8().constData());
+                    asciiText->strikethrough = !Constr->isActive;
 
                     if (Constr->Type == Distance) {
                         asciiText->datumtype = SoDatumLabel::DISTANCE;
@@ -1468,6 +1470,7 @@ Restart:
                         sep->getChild(static_cast<int>(ConstraintNodePosition::DatumLabelIndex))
                     );
                     asciiText->string = SbString(getPresentationString(Constr).toUtf8().constData());
+                    asciiText->strikethrough = !Constr->isActive;
                     asciiText->datumtype = SoDatumLabel::ANGLE;
                     asciiText->param1 = distance;
                     asciiText->param2 = startangle;
@@ -1543,6 +1546,7 @@ Restart:
                     asciiText->string = SbString(
                         getPresentationString(Constr, "⌀").toUtf8().constData()
                     );
+                    asciiText->strikethrough = !Constr->isActive;
 
                     asciiText->datumtype = SoDatumLabel::DIAMETER;
                     asciiText->param1 = Constr->LabelDistance;
@@ -1625,6 +1629,7 @@ Restart:
                         asciiText->string = SbString(
                             getPresentationString(Constr, "R").toUtf8().constData()
                         );
+                        asciiText->strikethrough = !Constr->isActive;
                     }
 
                     asciiText->datumtype = SoDatumLabel::RADIUS;
@@ -2164,14 +2169,6 @@ QString EditModeConstraintCoinManager::getPresentationString(
 
     if (!constraint->isDriving) {
         fixedValueStr = QStringLiteral("(") + fixedValueStr + QStringLiteral(")");
-    }
-
-    if (!constraint->isActive) {
-        QString result = QStringLiteral("\u0336");
-        for (auto c : std::as_const(fixedValueStr)) {
-            result += c + QStringLiteral("\u0336");
-        }
-        return result;
     }
 
     return fixedValueStr;


### PR DESCRIPTION

Constraints in Sketcher use multiple Unicode characters (such as the diameter symbol and the arc-length symbol) that are not present in all fonts. Due to the fallback mechanism, a different font is selected for missing characters (on Linux, this is handled by fontconfig). As a result, a label may contain multiple fonts, which can lead to misalignment and cropping, as reported in issue #21889.

The first commit adjusts the vertical alignment of the text. The height and position of the bounding box are determined using QFontMetrics::boundingRect and used to shift the text accordingly.

In the second commit, I reimplemented the strikethrough for inactive constraints by drawing a line instead of overwriting individual characters. This makes the line continuous, without gaps. It also fixes an issue where ?? was displayed instead of 𝕏 (U+1D54F).

The two commits could be merged separately, but since they both address font-related issues in labels, I am submitting them together.

## Issues
This should hopefully fix all the issues reported in #21889. I have tested it on two Linux machines, where it worked fine, but it definitely requires testing on other platforms.

With these changes, I believe it may be safe to merge #26600, but it still requires testing.

## Before and After Images

<img width="1224" height="647" alt="PR-3" src="https://github.com/user-attachments/assets/6c9d72bd-6837-43ea-98bd-f4a782a370a2" />

<img width="1224" height="647" alt="PR-1" src="https://github.com/user-attachments/assets/09a4694b-db23-473d-a9dd-f364e2cd4a69" />

<img width="1224" height="647" alt="PR-2" src="https://github.com/user-attachments/assets/fd0d03ac-ad42-4688-9877-c6270828fff8" />
