### PR TITLE
CAM: CircularHoleBase - Allow clear Base from Task panel while error

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -742,10 +742,10 @@ class ObjectOp(object):
                 for o, sublist in obj.Base:
                     for sub in sublist:
                         o.Shape.getElement(sub)
-            except Part.OCCError:
+            except Exception:
                 Path.Log.error("{} - stale base geometry detected - clearing.".format(obj.Label))
-                obj.Base = []
                 return True
+
         return False
 
     @waiting_effects

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -161,7 +161,7 @@ class ObjectOp(PathOp.ObjectOp):
                 )
             )
             return shape.BoundBox.XLength
-        except Part.OCCError as e:
+        except Exception as e:
             Path.Log.error(e)
 
         return 0
@@ -186,7 +186,7 @@ class ObjectOp(PathOp.ObjectOp):
                     if all(Path.Geom.pointsCoincide(center, e.Curve.Center) for e in shape.Edges):
                         return FreeCAD.Vector(center.x, center.y, 0)
             return FreeCAD.Vector(shape.CenterOfMass.x, shape.CenterOfMass.y, 0)
-        except Part.OCCError as e:
+        except Exception as e:
             Path.Log.error(e)
 
         Path.Log.error(


### PR DESCRIPTION
Partial fixes #17924
- #17924

---

If decrease amount of holes in model, subshapes become unavailable
```
<class 'ValueError'>: Invalid shape name ?Face7
Helix001: Invalid shape name ?Face7
```

`Task` panel in broken state and we can not clear `Base` to fix this
This commit changes this behavior

https://github.com/user-attachments/assets/f07c46bc-cf7b-4a72-8e8a-b5def6fc6529

