### PR TITLE
TechDraw: handle ComplexSection profile with only a single edge

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.h
+++ b/src/Mod/TechDraw/App/DrawComplexSection.h
@@ -71,6 +71,8 @@ public:
     TopoDS_Shape makeCuttingToolFromClosedProfile(const TopoDS_Wire& profileWire, double dMax);
     TopoDS_Shape cuttingToolFromProfile(const TopoDS_Wire& inProfileWire,
                                         double dMax) const;
+    TopoDS_Wire closeSingleEdgeProfile(const TopoDS_Edge& singleEdge,
+                                       double dMax) const;
 
 
     void makeAlignedPieces(const TopoDS_Shape& rawShape);


### PR DESCRIPTION
This PR implements a fix for issue #26838.

ComplexSection was expecting a cutting profile with at least 2 edges, but did not prevent the user
from using a profile with a single edge.  

The single edge profile case is shown in the [wiki examples](https://wiki.freecad.org/TechDraw_Section_Examples) and is a legitimate profile.

This change adds support for a single edge profile. 

<img width="784" height="575" alt="DCSSingleEdgeProfileFixed" src="https://github.com/user-attachments/assets/3b06ccdb-98ee-4f01-afb9-70fbede7c125" />
