### PR TITLE
part: fixes #27365 mirror place copy at correct location

### DIFF
--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -79,6 +79,7 @@ set(Part_tests
     parttests/ColorTransparencyTest.py
     parttests/TopoShapeTest.py
     parttests/TestTangentMode3-0.21.FCStd
+    parttests/TestPartMirror.py
 )
 
 add_custom_target(PartScripts ALL SOURCES

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -35,6 +35,7 @@ from parttests.Geom2d_tests import Geom2dTests
 from parttests.regression_tests import RegressionTests
 from parttests.TopoShapeListTest import TopoShapeListTest
 from parttests.TopoShapeTest import TopoShapeTest
+from parttests.TestPartMirror import TestPartMirroringRegression
 
 
 # ---------------------------------------------------------------------------

--- a/src/Mod/Part/parttests/TestPartMirror.py
+++ b/src/Mod/Part/parttests/TestPartMirror.py
@@ -11,7 +11,7 @@ import Draft
 
 class TestPartMirroringRegression(unittest.TestCase):
     """Regression test for GitHub issue #27365.
-    
+
     Part::Mirroring with Draft Clone produces incorrect results after PR #26963.
     The mirror position shifts on recompute when the source has non-identity Placement.
     """
@@ -24,11 +24,11 @@ class TestPartMirroringRegression(unittest.TestCase):
 
     def testMirroringWithDraftCloneStability(self):
         """Test that Part::Mirroring position is stable across recomputes.
-        
+
         This test reproduces issue #27365: mirroring a Draft Clone that has
         placement, and causes the mirror position to be incorrect and/or shift
         on recompute.
-        
+
         This test FAILS on current main (after PR #26963) and should pass after a fix is applied.
         """
         # create sketch at origin
@@ -41,17 +41,18 @@ class TestPartMirroringRegression(unittest.TestCase):
 
         # create draft clone at X=30 with 90° rotation around Z
         clone = Draft.make_clone(sketch)
-        clone.Placement = App.Placement(
-            App.Vector(30, 0, 0),
-            App.Rotation(App.Vector(0, 0, 1), 90)
-        )
+        clone.Placement = App.Placement(App.Vector(30, 0, 0), App.Rotation(App.Vector(0, 0, 1), 90))
         self.doc.recompute()
 
         # verify clone is positioned correctly
         clone_bbox = clone.Shape.BoundBox
         clone_center_x = (clone_bbox.XMin + clone_bbox.XMax) / 2
-        self.assertAlmostEqual(clone_center_x, 30.0, delta=5.0,
-            msg=f"clone should be centered around X=30, but is at X={clone_center_x:.2f}")
+        self.assertAlmostEqual(
+            clone_center_x,
+            30.0,
+            delta=5.0,
+            msg=f"clone should be centered around X=30, but is at X={clone_center_x:.2f}",
+        )
 
         # mirror across YZ plane (X=0, normal in +X direction)
         mirror = self.doc.addObject("Part::Mirroring", "Mirror")
@@ -66,9 +67,12 @@ class TestPartMirroringRegression(unittest.TestCase):
 
         # mirror should be on opposite side of plane from clone
         # clone is at X≈30, plane at X=0, so mirror should be at X≈-30
-        self.assertLess(initial_center_x, -20.0,
+        self.assertLess(
+            initial_center_x,
+            -20.0,
             msg=f"mirror should be at X≈-30 (opposite side of X=0 from clone at X≈30), "
-                f"but is at X={initial_center_x:.2f}")
+            f"but is at X={initial_center_x:.2f}",
+        )
 
         # position must be stable across recompute
         # this is the core bug, ie. position shifts on recompute
@@ -79,13 +83,17 @@ class TestPartMirroringRegression(unittest.TestCase):
         final_center_x = (final_bbox.XMin + final_bbox.XMax) / 2
 
         # position should not change (within tolerance)
-        self.assertAlmostEqual(initial_center_x, final_center_x, places=3,
+        self.assertAlmostEqual(
+            initial_center_x,
+            final_center_x,
+            places=3,
             msg=f"mirror position shifted on recompute: "
-                f"X={initial_center_x:.6f} -> X={final_center_x:.6f}")
+            f"X={initial_center_x:.6f} -> X={final_center_x:.6f}",
+        )
 
 
 # for standalone execution
-if __name__ == '__main__':
+if __name__ == "__main__":
     suite = unittest.TestSuite()
     suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestPartMirroringRegression))
     runner = unittest.TextTestRunner()

--- a/src/Mod/Part/parttests/TestPartMirror.py
+++ b/src/Mod/Part/parttests/TestPartMirror.py
@@ -1,0 +1,92 @@
+"""
+this test will FAIL on current main branch (with PR #26963) and PASS after the fix.
+current main at: https://github.com/FreeCAD/FreeCAD/tree/24f0c8e2c321bb202410feae84eb58779ba8e8d2
+"""
+
+import unittest
+import FreeCAD as App
+import Part
+import Draft
+
+
+class TestPartMirroringRegression(unittest.TestCase):
+    """Regression test for GitHub issue #27365.
+    
+    Part::Mirroring with Draft Clone produces incorrect results after PR #26963.
+    The mirror position shifts on recompute when the source has non-identity Placement.
+    """
+
+    def setUp(self):
+        self.doc = App.newDocument("TestMirrorRegression")
+
+    def tearDown(self):
+        App.closeDocument(self.doc.Name)
+
+    def testMirroringWithDraftCloneStability(self):
+        """Test that Part::Mirroring position is stable across recomputes.
+        
+        This test reproduces issue #27365: mirroring a Draft Clone that has
+        placement, and causes the mirror position to be incorrect and/or shift
+        on recompute.
+        
+        This test FAILS on current main (after PR #26963) and should pass after a fix is applied.
+        """
+        # create sketch at origin
+        sketch = self.doc.addObject("Sketcher::SketchObject", "Sketch")
+        sketch.addGeometry(Part.LineSegment(App.Vector(0, 0, 0), App.Vector(10, 0, 0)), False)
+        sketch.addGeometry(Part.LineSegment(App.Vector(10, 0, 0), App.Vector(10, 10, 0)), False)
+        sketch.addGeometry(Part.LineSegment(App.Vector(10, 10, 0), App.Vector(0, 10, 0)), False)
+        sketch.addGeometry(Part.LineSegment(App.Vector(0, 10, 0), App.Vector(0, 0, 0)), False)
+        self.doc.recompute()
+
+        # create draft clone at X=30 with 90° rotation around Z
+        clone = Draft.make_clone(sketch)
+        clone.Placement = App.Placement(
+            App.Vector(30, 0, 0),
+            App.Rotation(App.Vector(0, 0, 1), 90)
+        )
+        self.doc.recompute()
+
+        # verify clone is positioned correctly
+        clone_bbox = clone.Shape.BoundBox
+        clone_center_x = (clone_bbox.XMin + clone_bbox.XMax) / 2
+        self.assertAlmostEqual(clone_center_x, 30.0, delta=5.0,
+            msg=f"clone should be centered around X=30, but is at X={clone_center_x:.2f}")
+
+        # mirror across YZ plane (X=0, normal in +X direction)
+        mirror = self.doc.addObject("Part::Mirroring", "Mirror")
+        mirror.Source = clone
+        mirror.Base = App.Vector(0, 0, 0)
+        mirror.Normal = App.Vector(1, 0, 0)
+        self.doc.recompute()
+
+        # get initial mirror position
+        initial_bbox = mirror.Shape.BoundBox
+        initial_center_x = (initial_bbox.XMin + initial_bbox.XMax) / 2
+
+        # mirror should be on opposite side of plane from clone
+        # clone is at X≈30, plane at X=0, so mirror should be at X≈-30
+        self.assertLess(initial_center_x, -20.0,
+            msg=f"mirror should be at X≈-30 (opposite side of X=0 from clone at X≈30), "
+                f"but is at X={initial_center_x:.2f}")
+
+        # position must be stable across recompute
+        # this is the core bug, ie. position shifts on recompute
+        for i in range(5):
+            self.doc.recompute()
+
+        final_bbox = mirror.Shape.BoundBox
+        final_center_x = (final_bbox.XMin + final_bbox.XMax) / 2
+
+        # position should not change (within tolerance)
+        self.assertAlmostEqual(initial_center_x, final_center_x, places=3,
+            msg=f"mirror position shifted on recompute: "
+                f"X={initial_center_x:.6f} -> X={final_center_x:.6f}")
+
+
+# for standalone execution
+if __name__ == '__main__':
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.TestLoader().loadTestsFromTestCase(TestPartMirroringRegression))
+    runner = unittest.TextTestRunner()
+    runner.run(suite)


### PR DESCRIPTION
this pr fixes #27365 while also providing a unit test to hopefully pick up on issues like this in the future to prevent regression like this from happening again.

results from the current main branch without this fix, running the newly created unit test.

```
╰─λ /opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD -t TestPartApp
FreeCAD 1.2.0, Libs: 1.2.0devR45261 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

<AnaFilletAlgo object>
<ChamferAPI object>
<FilletAlgo object>
<ShapeFix_Edge object>
<ShapeFix_Face object>
<ShapeFix_Root object>
<ShapeFix_Shape object>
<ShapeFix_Shell object>
<ShapeFix_Solid object>
<ShapeFix_Wire object>
Converting attachment offset of Sketch003
Converting attachment offset of Sketch002
FAILED: testMirroringWithDraftCloneStability (parttests.TestPartMirror.TestPartMirroringRegression.testMirroringWithDraftCloneStability)
Traceback (most recent call last):
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.11/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.11/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.11/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/Part/parttests/TestPartMirror.py", line 69, in testMirroringWithDraftCloneStability
    self.assertLess(initial_center_x, -20.0,
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
        msg=f"mirror should be at X≈-30 (opposite side of X=0 from clone at X≈30), "
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
            f"but is at X={initial_center_x:.2f}")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 4.999999999999988 not less than -20.0 : mirror should be at X≈-30 (opposite side of X=0 from clone at X≈30), but is at X=5.00

TopoShapeListTest - setting up
TopoShapeListTest: setUp complete
running TopoShapeListTest
TopoShapeListTest finished

----------------------------------------------------------------------
Ran 129 tests in 36.4s

FAILED (failures=1)
System exit

```

results after the fix is applied.

```
╰─λ /opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD -t TestPartApp
FreeCAD 1.2.0, Libs: 1.2.0devR45264 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

<AnaFilletAlgo object>
<ChamferAPI object>
<FilletAlgo object>
<ShapeFix_Edge object>
<ShapeFix_Face object>
<ShapeFix_Root object>
<ShapeFix_Shape object>
<ShapeFix_Shell object>
<ShapeFix_Solid object>
<ShapeFix_Wire object>
Converting attachment offset of Sketch003
Converting attachment offset of Sketch002
TopoShapeListTest - setting up
TopoShapeListTest: setUp complete
running TopoShapeListTest
TopoShapeListTest finished

----------------------------------------------------------------------
Ran 129 tests in 36.2s

OK
System exit

```


## Issues

- https://github.com/freecad/freecad/issues/27365

## Before and After Images

