### PR TITLE
BIM: workaround for WP switch crash (issue #26539)

### DIFF
--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -71,7 +71,7 @@ class BIMWorkbench(Workbench):
         from nativeifc import ifc_commands
 
         # build menus and toolbars
-        
+
         # as a workaround for issue #26539 a list without grouped commands
         # is created later (self.draftingtools_for_watcher)
         # https://github.com/FreeCAD/FreeCAD/issues/26539
@@ -401,14 +401,14 @@ class BIMWorkbench(Workbench):
         FreeCADGui.addCommand("BIM_ReportTools", BIM_ReportTools())
         FreeCADGui.addCommand("BIM_GenericTools", BIM_GenericTools(self.generictools))
         FreeCADGui.addCommand("BIM_Create2DViews", BIM_Create2DViews(self.create_2dviews))
-        
+
         # workaround for issue #26539: create draftingtools list without grouped commands
         # https://github.com/FreeCAD/FreeCAD/issues/26539
         tmplist = self.draftingtools[:]
         for itm in (("BIM_ArcTools", BIM_ArcTools), ("BIM_SplineTools", BIM_SplineTools)):
             idx = tmplist.index(itm[0])
             cmds = list(itm[1].GetCommands(itm[1]))
-            tmplist = tmplist[:idx] + cmds + tmplist[idx + 1:]
+            tmplist = tmplist[:idx] + cmds + tmplist[idx + 1 :]
         self.draftingtools_for_watcher = tmplist
 
         # Inject some of the grouped commands


### PR DESCRIPTION
Fixes #26539.

Updated drafting tools list for BIM to work around issue #26539 by creating a separate list (without grouped commands) for the task watcher.

The workaround has been tested:
https://github.com/FreeCAD/FreeCAD/issues/26539#issuecomment-3845484932
