### PR TITLE
BIM: initial implementation of Sliding Door preset

### DIFF
--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -546,29 +546,23 @@ class _Window(ArchComponent.Component):
                             vsymbols.append(Part.LineSegment(v4, ev2).toShape())
                             if opening:
                                 rotdata = [v1, ev2.sub(ev1), -90 * opening]
-                        elif omode == 9:  # sliding
-                            # Direction: Vertex 0 -> Vertex 1
-                            travel = ev2.sub(ev1)
+                        elif omode in [9, 10]:  # Sliding or -Sliding
+                            # Determine direction based on mode
+                            p_start, p_end = (ev1, ev2) if omode == 9 else (ev2, ev1)
+
+                            travel = p_end.sub(p_start)
+
                             if opening:
                                 # Limit travel to 70% of the sliding track to keep the door visible
                                 # and its handle accessible
                                 dist = travel.Length * 0.7
                                 travel.normalize()
                                 transdata = [travel.multiply(dist * opening)]
+
                             # 2D Symbol: Line from current position indicating movement
                             # ISO 7519: arrow or line. Use line for simplicity.
-                            ssymbols.append(Part.LineSegment(ev1, ev2).toShape())
-                        elif omode == 10:  # -sliding (inverted)
-                            # Direction: Vertex 1 -> Vertex 0
-                            travel = ev1.sub(ev2)
-                            if opening:
-                                # Limit travel to 70% of the sliding track to keep the door visible
-                                # and its handle accessible
-                                dist = travel.Length * 0.7
-                                travel.normalize()
-                                transdata = [travel.multiply(dist * opening)]
-                            # 2D Symbol
-                            ssymbols.append(Part.LineSegment(ev2, ev1).toShape())
+                            ssymbols.append(Part.LineSegment(p_start, p_end).toShape())
+
                 exv = FreeCAD.Vector()
                 zov = FreeCAD.Vector()
                 V = 0

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -568,10 +568,6 @@ class _Window(ArchComponent.Component):
                                 travel.normalize()
                                 transdata = [travel.multiply(dist)]
 
-                            # 2D Symbol: Line from current position indicating movement
-                            # ISO 7519: arrow or line. Use line for simplicity.
-                            ssymbols.append(Part.LineSegment(p_start, p_end).toShape())
-
                 exv = FreeCAD.Vector()
                 zov = FreeCAD.Vector()
                 V = 0

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -1493,11 +1493,15 @@ class _ArchWindowTaskPanel:
             self.retranslateUi(self.baseform)
             self.basepanel.obj = self.obj
             self.basepanel.update()
+            has_movement = False
+            is_sliding = False
             for wp in self.obj.WindowParts:
                 if ("Edge" in wp) and ("Mode" in wp):
-                    self.invertOpeningButton.setEnabled(True)
-                    self.invertHingeButton.setEnabled(True)
-                    break
+                    has_movement = True
+                    if "Mode9" in wp or "Mode10" in wp:
+                        is_sliding = True
+            self.invertOpeningButton.setEnabled(has_movement)
+            self.invertHingeButton.setEnabled(has_movement and not is_sliding)
 
     def addElement(self):
         "opens the component creation dialog"
@@ -1722,7 +1726,7 @@ class _ArchWindowTaskPanel:
         self.new3.setText(QtGui.QApplication.translate("Arch", "Wires", None))
         self.new4.setText(QtGui.QApplication.translate("Arch", "Frame depth", None))
         self.new5.setText(QtGui.QApplication.translate("Arch", "Offset", None))
-        self.new6.setText(QtGui.QApplication.translate("Arch", "Hinge", None))
+        self.new6.setText(QtGui.QApplication.translate("Arch", "Hinge/Track", None))
         self.new7.setText(QtGui.QApplication.translate("Arch", "Opening mode", None))
         self.addp4.setText(QtGui.QApplication.translate("Arch", "+ Frame property", None))
         self.addp4.setToolTip(

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -630,10 +630,10 @@ class _Window(ArchComponent.Component):
                                 )
                                 shape = shape.cut(self.boxes)
                 if rotdata:
+                    # Apply rotation for hinged parts if it exists
                     shape.rotate(rotdata[0], rotdata[1], rotdata[2])
-
-                # Apply translation for sliding parts if it exists
-                if transdata:
+                elif transdata:
+                    # Apply translation for sliding parts if it exists
                     shape.translate(transdata[0])
 
                 shapes.append(shape)

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -1021,7 +1021,7 @@ class _ViewProviderWindow(ArchComponent.ViewProviderComponent):
                 # color is an RGBA tuple (0.0-1.0)
                 sapp_mat = (
                     FreeCAD.Material()
-                )  # ShapeAppearance material with default v0.21 properties.a
+                )  # ShapeAppearance material with default v0.21 properties.
                 sapp_mat.DiffuseColor = color[:3] + (1.0,)
                 sapp_mat.Transparency = 1.0 - color[3]
             sapp.extend((sapp_mat,) * len(solids[i].Faces))

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -547,8 +547,17 @@ class _Window(ArchComponent.Component):
                             if opening:
                                 rotdata = [v1, ev2.sub(ev1), -90 * opening]
                         elif omode in [9, 10]:  # Sliding or -Sliding
-                            # Determine direction based on mode
-                            p_start, p_end = (ev1, ev2) if omode == 9 else (ev2, ev1)
+
+                            # Sort points by coordinate (X, then Y, then Z) to ensure predictable
+                            # direction regardless of edge geometry construction.
+                            pts = [ev1, ev2]
+                            pts.sort(key=lambda p: (round(p.x, 3), round(p.y, 3), round(p.z, 3)))
+
+                            # Mode 9: Slide from Min Coords -> Max Coords
+                            # Mode 10: Slide from Max Coords -> Min Coords
+                            p_start = pts[0] if omode == 9 else pts[1]
+                            p_end = pts[1] if omode == 9 else pts[0]
+
                             travel = p_end.sub(p_start)
 
                             if opening:

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -549,15 +549,15 @@ class _Window(ArchComponent.Component):
                         elif omode in [9, 10]:  # Sliding or -Sliding
                             # Determine direction based on mode
                             p_start, p_end = (ev1, ev2) if omode == 9 else (ev2, ev1)
-
                             travel = p_end.sub(p_start)
 
                             if opening:
-                                # Limit travel to 70% of the sliding track to keep the door visible
-                                # and its handle accessible
-                                dist = travel.Length * 0.7
+                                # Travel is exactly % of width, but clamped to (width - 80mm)
+                                # so the door handle is left exposed at 100% opening.
+                                width = travel.Length
+                                dist = min(width * opening, max(0.0, width - 80.0))
                                 travel.normalize()
-                                transdata = [travel.multiply(dist * opening)]
+                                transdata = [travel.multiply(dist)]
 
                             # 2D Symbol: Line from current position indicating movement
                             # ISO 7519: arrow or line. Use line for simplicity.

--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -550,7 +550,11 @@ class _Window(ArchComponent.Component):
                             # Direction: Vertex 0 -> Vertex 1
                             travel = ev2.sub(ev1)
                             if opening:
-                                transdata = [travel.multiply(opening)]
+                                # Limit travel to 70% of the sliding track to keep the door visible
+                                # and its handle accessible
+                                dist = travel.Length * 0.7
+                                travel.normalize()
+                                transdata = [travel.multiply(dist * opening)]
                             # 2D Symbol: Line from current position indicating movement
                             # ISO 7519: arrow or line. Use line for simplicity.
                             ssymbols.append(Part.LineSegment(ev1, ev2).toShape())
@@ -558,7 +562,11 @@ class _Window(ArchComponent.Component):
                             # Direction: Vertex 1 -> Vertex 0
                             travel = ev1.sub(ev2)
                             if opening:
-                                transdata = [travel.multiply(opening)]
+                                # Limit travel to 70% of the sliding track to keep the door visible
+                                # and its handle accessible
+                                dist = travel.Length * 0.7
+                                travel.normalize()
+                                transdata = [travel.multiply(dist * opening)]
                             # 2D Symbol
                             ssymbols.append(Part.LineSegment(ev2, ev1).toShape())
                 exv = FreeCAD.Vector()

--- a/src/Mod/BIM/ArchWindowPresets.py
+++ b/src/Mod/BIM/ArchWindowPresets.py
@@ -488,7 +488,7 @@ def makeWindowPreset(windowtype, width, height, h1, h2, h3, w1, w2, o1, o2, plac
 
         elif windowtype == "Sliding door":
             wp = doorFrame(s, width, height, h1, w1, o1)
-            # Use Wire1 as the inner opening
+            # Use Wire1 (inner frame boundary) as the door leaf profile to be extruded
             # Use Edge 7 (the top edge of the inner frame) as the track. Edge5 (bottom edge) could
             # be an alternative, but it's difficult to select in the window editor, as the outer
             # frame's bottom edge is drawn on top.

--- a/src/Mod/BIM/ArchWindowPresets.py
+++ b/src/Mod/BIM/ArchWindowPresets.py
@@ -489,9 +489,11 @@ def makeWindowPreset(windowtype, width, height, h1, h2, h3, w1, w2, o1, o2, plac
         elif windowtype == "Sliding door":
             wp = doorFrame(s, width, height, h1, w1, o1)
             # Use Wire1 as the inner opening
-            # Use Edge 1 (the bottom edge of the frame) as the track
-            # Use Mode 9 (sliding)
-            wp.extend(["Door", "Solid panel", "Wire1,Edge1,Mode9", str(w2), str(o2) + "+V"])
+            # Use Edge 7 (the top edge of the inner frame) as the track. Edge5 (bottom edge) could
+            # be an alternative, but it's difficult to select in the window editor, as the outer
+            # frame's bottom edge is drawn on top.
+            # Use Mode 10 (Sliding inv) to counteract Edge 7's Right-to-Left geometry.
+            wp.extend(["Door", "Solid panel", "Wire1,Edge7,Mode10", str(w2), str(o2) + "+V"])
 
         elif windowtype == "Glass door":
 

--- a/src/Mod/BIM/ArchWindowPresets.py
+++ b/src/Mod/BIM/ArchWindowPresets.py
@@ -35,6 +35,7 @@ WindowPresets = [
     "Sash 2-pane",
     "Sliding 2-pane",
     "Simple door",
+    "Sliding door",
     "Glass door",
     "Sliding 4-pane",
     "Awning",
@@ -484,6 +485,13 @@ def makeWindowPreset(windowtype, width, height, h1, h2, h3, w1, w2, o1, o2, plac
 
             wp = doorFrame(s, width, height, h1, w1, o1)
             wp.extend(["Door", "Solid panel", "Wire1,Edge8,Mode1", str(w2), str(o2) + "+V"])
+
+        elif windowtype == "Sliding door":
+            wp = doorFrame(s, width, height, h1, w1, o1)
+            # Use Wire1 as the inner opening
+            # Use Edge 1 (the bottom edge of the frame) as the track
+            # Use Mode 9 (sliding)
+            wp.extend(["Door", "Solid panel", "Wire1,Edge1,Mode9", str(w2), str(o2) + "+V"])
 
         elif windowtype == "Glass door":
 

--- a/src/Mod/BIM/ArchWindowPresets.py
+++ b/src/Mod/BIM/ArchWindowPresets.py
@@ -492,8 +492,8 @@ def makeWindowPreset(windowtype, width, height, h1, h2, h3, w1, w2, o1, o2, plac
             # Use Edge 7 (the top edge of the inner frame) as the track. Edge5 (bottom edge) could
             # be an alternative, but it's difficult to select in the window editor, as the outer
             # frame's bottom edge is drawn on top.
-            # Use Mode 10 (Sliding inv) to counteract Edge 7's Right-to-Left geometry.
-            wp.extend(["Door", "Solid panel", "Wire1,Edge7,Mode10", str(w2), str(o2) + "+V"])
+            # Use Mode 9 (Sliding) to open from left to right.
+            wp.extend(["Door", "Solid panel", "Wire1,Edge7,Mode9", str(w2), str(o2) + "+V"])
 
         elif windowtype == "Glass door":
 

--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -541,17 +541,17 @@ class Arch_Window:
             self.im.show()
             if i == 0:
                 self.im.load(":/ui/ParametersWindowFixed.svg")
-            elif i in [1, 8]:
+            elif i in [1, 9]:
                 self.im.load(":/ui/ParametersWindowSimple.svg")
-            elif i in [2, 4, 7]:
+            elif i in [2, 4, 8]:
                 self.im.load(":/ui/ParametersWindowDouble.svg")
             elif i == 3:
                 self.im.load(":/ui/ParametersWindowStash.svg")
-            elif i == 5:
+            elif i in [5, 6]:
                 self.im.load(":/ui/ParametersDoorSimple.svg")
-            elif i == 6:
+            elif i == 7:
                 self.im.load(":/ui/ParametersDoorGlass.svg")
-            elif i == 9:
+            elif i == 10:
                 self.im.load(":/ui/ParametersOpening.svg")
             else:
                 # From Library


### PR DESCRIPTION
This PR adds a new Door preset: (horizontal) Sliding Door, which has the ability to react to the `Opening` property value and accordingly show the door's opening position (from 0 to 100%). From looking at the original code, it also appears there was an initial intention to have this preset, but it was never implemented.

The preset is available in the same place as the other presets (task panel which opens when running the BIM_Window command):

<img width="676" height="735" alt="image" src="https://github.com/user-attachments/assets/078a7ac0-8f47-456f-897e-e2dc7277defa" />

`Opening` property set to `60`:

<img width="707" height="661" alt="image" src="https://github.com/user-attachments/assets/7af39762-1faa-4aca-8da8-6429a640431f" />

The context menu on the Tree View for sliding doors now has an "Invert Sliding Direction"

<img width="874" height="582" alt="image" src="https://github.com/user-attachments/assets/2c005b11-ca1f-44e9-be8e-3a2e852d7a74" />

## Future work

I've left the following features for a subsequent iteration on a follow-up PR to minimize the changes:

1. Add a subvolume to subtract the recess or pocket the door is lodged into when retracted (open). This can then be used to calculate the length of wall required to host the door. Also for sections for tech drawings to accurately represent the door construction
2. Add an arrow symbol to indicate sliding direction for 2D drawings.
3. The ability to choose the sliding edge in the interactive window parts editor, similarly as to how it is currently done with the hinge.