### PR TITLE
BIM: add window options task box

### DIFF
--- a/src/Mod/BIM/ArchWindow.py
+++ b/src/Mod/BIM/ArchWindow.py
@@ -1420,12 +1420,10 @@ class _ArchWindowTaskPanel:
         if self.obj:
 
             FreeCADGui.ExpressionBinding(self.widthWidget).bind(self.obj, "Width")
-            self.widthWidget.setProperty("unit", self.obj.Width.getUserPreferred()[2])
-            self.widthWidget.setProperty("rawValue", self.obj.Width.Value)
+            self.widthWidget.setProperty("value", self.obj.Width)
 
             FreeCADGui.ExpressionBinding(self.heightWidget).bind(self.obj, "Height")
-            self.heightWidget.setProperty("unit", self.obj.Height.getUserPreferred()[2])
-            self.heightWidget.setProperty("rawValue", self.obj.Height.Value)
+            self.heightWidget.setProperty("value", self.obj.Height)
 
             FreeCADGui.ExpressionBinding(self.openingWidget).bind(self.obj, "Opening")
             # Opening is a scalar property, as opposed to a quantity property. It appears to have
@@ -1730,8 +1728,8 @@ class _ArchWindowTaskPanel:
 
     def accept(self):
         if self.obj:
-            self.obj.Width = self.widthWidget.property("rawValue")
-            self.obj.Height = self.heightWidget.property("rawValue")
+            self.obj.Width = self.widthWidget.property("value")
+            self.obj.Height = self.heightWidget.property("value")
             self.obj.Opening = self.openingWidget.property("value")
         self.basepanel.obj = self.obj
         return self.basepanel.accept()


### PR DESCRIPTION
To make the window edition workflow more efficient, this PR adds a new task box to a window's task panel to edit the most common options. This removes the dependency on the Property Editor and the scroll, search, edit loop it implies whenever changing a property.

With this change, editing multiple of the most common features is a matter of a double-click on the object in the Tree View. They can all be changed at once if necessary, and they support units and expressions.

Additionally, a Cancel button allows cancelling the changes before them being committed

| Before | After |
| --- | --- |
| <img width="481" height="645" alt="image" src="https://github.com/user-attachments/assets/a29aec04-0b19-44db-b14e-fc628ee4d436" /> | <img width="481" height="645" alt="image" src="https://github.com/user-attachments/assets/0865f425-5a76-4658-9a56-8604f46cacc0" /> |

## Use case

A common scenario is to change multiple basic properties of a window after having created it: e.g. `Height` and `Width` 

- **Workflow before** (5 steps for the first property, 4 additional ones for each extra property to change):
  1. Select window
  2. Navigate to Property Editor
  3. Search the property, potentially with scrolling
  4. Change the property,
  5. Click somewhere else to apply the property change
  6. Repeat steps 3-5 for the next property
- **Workflow after** (4 steps for all properties at once):
  1. Double-click on window
  2. Find all basic properties in the task panel
  3. Change those required
  4. Press Enter or press OK to apply changes to all properties at once.
 
## Notes

- The Window task panel is quite busy. We should consider collapsing the least commonly used task boxes, but this might be best discussed as a separate PR.
- This is essentially the same as https://github.com/FreeCAD/FreeCAD/pull/26758 but for windows, with the extra that this PR is using expression-aware widgets.
-  Addresses https://github.com/FreeCAD/FreeCAD/discussions/24106 for windows specifically.
