### PR TITLE
Assembly: Fix help text height in CreateBom

### DIFF
--- a/src/Mod/Assembly/CommandCreateBom.py
+++ b/src/Mod/Assembly/CommandCreateBom.py
@@ -357,6 +357,7 @@ class TaskAssemblyCreateBom(QtCore.QObject):
         help_dialog.setWindowFlags(QtCore.Qt.Popup)
         help_dialog.setWindowModality(QtCore.Qt.NonModal)
         help_dialog.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        help_dialog.setFixedWidth(500)
 
         layout = QtWidgets.QVBoxLayout()
         layout.setContentsMargins(10, 10, 10, 10)
@@ -413,9 +414,14 @@ class TaskAssemblyCreateBom(QtCore.QObject):
             + "\n"
         )
 
-        options_text.setWordWrap(True)
-        columns_text.setWordWrap(True)
-        export_text.setWordWrap(True)
+        layout_width = (
+            help_dialog.contentsRect().width()
+            - layout.contentsMargins().left()
+            - layout.contentsMargins().right()
+        )
+        for label in (options_text, columns_text, export_text):
+            label.setWordWrap(True)
+            label.setFixedWidth(layout_width)
 
         layout.addWidget(options_title)
         layout.addWidget(options_text)
@@ -425,7 +431,6 @@ class TaskAssemblyCreateBom(QtCore.QObject):
         layout.addWidget(export_text)
 
         help_dialog.setLayout(layout)
-        help_dialog.setFixedWidth(500)
 
         help_dialog.show()
 


### PR DESCRIPTION
The height of the help dialog for the BOM in Assembly did not scale properly with the text, causing the text to be cropped.

When `setWordWrap(True)` is enabled, the widget height is apparently not automatically calculated if its width is not set.

## Issues
Fixes point 3 in #22936.

## Before and After Images
<img width="525" height="520" alt="screenshot-before" src="https://github.com/user-attachments/assets/c522bf6f-50da-47dd-9c12-c0c5dfe0142c" />
<img width="525" height="686" alt="screenshot-after" src="https://github.com/user-attachments/assets/2615be72-1c29-4679-8db2-abf2cdc37e5a" />