### PR TITLE
CAM: Fix calculation arc move length

### DIFF
--- a/src/Mod/CAM/App/Path.cpp
+++ b/src/Mod/CAM/App/Path.cpp
@@ -206,8 +206,8 @@ double Toolpath::getCycleTime(double hFeed, double vFeed, double hRapid, double 
         else if ((name == "G2") || (name == "G02") || (name == "G3") || (name == "G03")) {
             // Arc Move
             Vector3d center = (*it)->getCenter();
-            double radius = (last - center).Length();
-            double angle = (next - center).GetAngle(last - center);
+            double radius = center.Length();
+            double angle = (next - last - center).GetAngle(-center);
             l += angle * radius;
         }
 


### PR DESCRIPTION
There is wrong calculation of arcs length and time milling

Example: [cone2.zip](https://github.com/user-attachments/files/25136096/cone2.zip)

Diameter = 100 mm
One circle length = pi * diameter = 3.14 * 100 = 314 mm
Amount circles = 5
Total length = 314 * 5 = **1570** + vertical moves

But in Properties view showing **979** mm

<img width="1531" height="325" alt="Screenshot_20260208_115720_lossy" src="https://github.com/user-attachments/assets/6b8e5dec-bbcb-4b62-a326-8198e3362d86" />

Also to check length can enable `SplitArcs`
<img width="828" height="444" alt="Screenshot_20260212_083854_hor_lossy" src="https://github.com/user-attachments/assets/f7c1f402-6e26-4fe9-893c-2a3d00ab89f3" />

https://github.com/FreeCAD/FreeCAD/blob/dfdabbfc87a89caee001e7635768e8ecfedbef8e/src/Mod/CAM/App/Path.cpp#L140-L142

The reason for mistake in calculation above is that the `getCenter()` return not a vector to center point,
but I, J, K - offset from start point

https://github.com/FreeCAD/FreeCAD/blob/dfdabbfc87a89caee001e7635768e8ecfedbef8e/src/Mod/CAM/App/Command.cpp#L84-L91

> [!NOTE]
> Macro to calculate path length of operation or path segments selected in 3d view
> [PathLength.FCMacro](https://github.com/tarman3/FreeCAD_Macros/blob/main/PathLength.FCMacro)
