### PR TITLE
Use QImage::flipped

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -534,7 +534,7 @@ void NaviCubeImplementation::createCubeFaceTextures()
         if (m_LabelTextures[pickId].texture) {
             delete m_LabelTextures[pickId].texture;
         }
-        m_LabelTextures[pickId].texture = new QOpenGLTexture(image.mirrored());
+        m_LabelTextures[pickId].texture = new QOpenGLTexture(image.flipped());
         m_LabelTextures[pickId].texture->setMaximumAnisotropy(4.0);
         m_LabelTextures[pickId].texture->setMinificationFilter(QOpenGLTexture::LinearMipMapLinear);
         m_LabelTextures[pickId].texture->setMagnificationFilter(QOpenGLTexture::Linear);

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1729,7 +1729,7 @@ void View3DInventorViewer::savePicture(int width, int height, int sample, const 
     if (useGrabFramebuffer) {
         auto self = const_cast<View3DInventorViewer*>(this);  // NOLINT
         img = self->grabFramebuffer();
-        img = img.mirrored();
+        img = img.flipped();
         img = img.scaledToWidth(width);
         return;
     }

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -693,7 +693,7 @@ Py::Object View3DInventorViewerPy::grabFramebuffer(const Py::Tuple& args)
 
     PythonWrapper wrap;
     wrap.loadGuiModule();
-    return wrap.fromQImage(img.mirrored());
+    return wrap.fromQImage(img.flipped());
 }
 
 Py::Object View3DInventorViewerPy::setOverrideMode(const Py::Tuple& args)


### PR DESCRIPTION
`QImage::mirrored` has been deprecated in favor of `QImage::flipped`. See [here](https://doc.qt.io/qt-6/qimage.html#mirrored-1).