### PR TITLE
BIM: fix regression caused by Link Hosts handling

### DIFF
--- a/src/Mod/BIM/ArchSketchObject.py
+++ b/src/Mod/BIM/ArchSketchObject.py
@@ -55,8 +55,8 @@ class ArchSketch(ArchSketchObject):
                     locked=True,
                 )
                 fp.Hosts = old_hosts
-                for obj in old_hosts:
-                    obj.touch()
+                for host in old_hosts:
+                    host.touch()
                 # Arch Window's code
 
 


### PR DESCRIPTION
#19378 adds a new Hosts property to Links that reference windows. This property overrides the inherited Hosts property. The code failed to copy the value from the inherited property to the new property.