### PR TITLE
CAM: Fix compiler warnings in Adaptive.cpp:CalcCutArea

### DIFF
--- a/src/Mod/CAM/libarea/Adaptive.cpp
+++ b/src/Mod/CAM/libarea/Adaptive.cpp
@@ -1281,7 +1281,7 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
 
         vector<DoublePoint> polygon;
         for (const auto p : path) {
-            polygon.push_back({(double)p.X, (double)p.Y});
+            polygon.emplace_back((double)p.X, (double)p.Y);
         }
         polygons.push_back(polygon);
     }
@@ -1309,15 +1309,15 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
     vector<double> xs;
     for (const auto& polygon : polygons) {
         // 1.a) All polygon vertices
-        for (const auto p : polygon) {
+        for (const auto& p : polygon) {
             xs.push_back(p.X);
         }
 
         // 1.b) Intersection of all polygons with c1
         // 1.c) Intersection of all polygons with c2
         for (size_t i = 0; i < polygon.size(); i++) {
-            const auto p0 = polygon[i];
-            const auto p1 = polygon[(i + 1) % polygon.size()];
+            const auto& p0 = polygon[i];
+            const auto& p1 = polygon[(i + 1) % polygon.size()];
             if (Line2CircleIntersect(c1, toolRadiusScaled, p0, p1, inters)) {
                 for (const auto p : inters) {
                     xs.push_back(p.X);
@@ -1366,7 +1366,7 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
 
     const auto interpX = [](const DoublePoint p0, const DoublePoint p1, double x) {
         const double interp = (x - p0.X) / (p1.X - p0.X);
-        const double y = p1.Y * interp + p0.Y * (1 - interp);
+        const double y = (p1.Y * interp) + (p0.Y * (1 - interp));
         return y;
     };
 
@@ -1374,7 +1374,7 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
     const vector<DoublePoint> circles = {c2, c1};
     double area = 0;
     double conventionalArea = 0;
-    for (size_t ix = 0; ix < xs.size() - 1; ix++) {
+    for (size_t ix = 0; ix + 1 < xs.size(); ix++) {
         const double x0 = xs[ix];
         const double x1 = xs[ix + 1];
         if (x0 == x1) {
@@ -1390,14 +1390,14 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
         vector<tuple<double, size_t, size_t>> ys;
 
         for (size_t ipolygon = 0; ipolygon < polygons.size(); ipolygon++) {
-            const auto polygon = polygons[ipolygon];
+            const auto& polygon = polygons[ipolygon];
             for (size_t iedge = 0; iedge < polygon.size(); iedge++) {
-                const auto p0 = polygon[iedge];
-                const auto p1 = polygon[(iedge + 1) % polygon.size()];
+                const auto& p0 = polygon[iedge];
+                const auto& p1 = polygon[(iedge + 1) % polygon.size()];
                 // note: we skip if the edge is vertical, p0.X == p1.X == xtest
                 if (min(p0.X, p1.X) < xtest && max(p0.X, p1.X) > xtest) {
                     const double y = interpX(p0, p1, xtest);
-                    ys.push_back({y, ipolygon, iedge});
+                    ys.emplace_back(y, ipolygon, iedge);
                 }
             }
         }
@@ -1406,9 +1406,9 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
             const DoublePoint c = circles[icircle];
             const double dx = abs(xtest - c.X);
             if (dx < toolRadiusScaled) {  // skip tangent; xtest can't be a tangent anyway
-                const double dy = sqrt(toolRadiusScaled * toolRadiusScaled - dx * dx);
-                ys.push_back({c.Y + dy, polygons.size() + icircle, 0});
-                ys.push_back({c.Y - dy, polygons.size() + icircle, 1});
+                const double dy = sqrt((toolRadiusScaled * toolRadiusScaled) - (dx * dx));
+                ys.emplace_back(c.Y + dy, polygons.size() + icircle, 0);
+                ys.emplace_back(c.Y - dy, polygons.size() + icircle, 1);
             }
         }
 
@@ -1425,14 +1425,12 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
         // that crossing:
         //     Init (i.e. y=-inf): outsideCount = 1 (outside c2 and inside all other shapes)
         std::vector<bool> outside;
+        outside.reserve(polygons.size() + circles.size());
         for (size_t i = 0; i < polygons.size() + circles.size(); i++) {
             outside.push_back(i == (polygons.size()));  // poly_0, ..., poly_n-1, c2, c1
         }
         int outsideCount = 1;
-        for (size_t iy = 0; iy < ys.size(); iy++) {
-            const size_t ishape = std::get<1>(ys[iy]);
-            const size_t ipart = std::get<2>(ys[iy]);
-
+        for (const auto& [_, ishape, ipart] : ys) {
             const bool prevOutside = outside[ishape];
             const int prevCount = outsideCount;
             outside[ishape] = !outside[ishape];
@@ -1446,9 +1444,9 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
             if (outsideCount == 0 || prevCount == 0) {
                 if (ishape < polygons.size()) {
                     // crossed a polygon
-                    const auto polygon = polygons[ishape];
-                    const auto p0 = polygon[ipart];
-                    const auto p1 = polygon[(ipart + 1) % polygon.size()];
+                    const auto& polygon = polygons[ishape];
+                    const auto& p0 = polygon[ipart];
+                    const auto& p1 = polygon[(ipart + 1) % polygon.size()];
                     const auto y0 = interpX(p0, p1, x0);
                     const auto y1 = interpX(p0, p1, x1);
                     const double newArea = (y0 + y1) / 2 * (x1 - x0);
@@ -1482,7 +1480,7 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
                     const double tmidx = (x0 + x1) / 2;
                     const double tmidy = (y0 + y1) / 2;
                     const double th = sqrt(
-                        (tmidx - c.X) * (tmidx - c.X) + (tmidy - c.Y) * (tmidy - c.Y)
+                        ((tmidx - c.X) * (tmidx - c.X)) + ((tmidy - c.Y) * (tmidy - c.Y))
                     );
                     const double areaTriangle = tbase * th / 2;
                     const double areaSegment = areaSector - areaTriangle;
@@ -1491,7 +1489,7 @@ std::pair<double, double> Adaptive2d::CalcCutArea(IntPoint c1, IntPoint c2, Clea
                     // the sign of the segment area is negative for bottom half of the circle,
                     // positive for top half
                     const double areaTrapezoid = (x1 - x0) * (y0 + y1) / 2;
-                    const double newArea = circleSign * areaSegment + areaTrapezoid;
+                    const double newArea = (circleSign * areaSegment) + areaTrapezoid;
                     area += entranceExitSign * newArea;
                     if (xtest < c2.X) {
                         conventionalArea += entranceExitSign * newArea;


### PR DESCRIPTION
Fixes compiler warnings and applies LSP suggestions in `src/Mod/CAM/libarea/Adaptive.cpp:CalcCutArea`

<details>
  <summary>Compiler output that's being addressed</summary>
  
  ```
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp: In member function ‘double AdaptivePath::Adaptive2d::CalcCutArea(ClipperLib::Clipper&, const ClipperLib::IntPoint&, const ClipperLib::IntPoint&, AdaptivePath::ClearedArea&, bool)’:
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1477:21: warning: loop variable ‘polygon’ creates a copy from type ‘const std::vector<ClipperLib::DoublePoint>’ [-Wrange-loop-construct]
 1477 |     for (const auto polygon : polygons) {
      |                     ^~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1477:21: note: use reference type to prevent copying
 1477 |     for (const auto polygon : polygons) {
      |                     ^~~~~~~
      |                     &
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1485:27: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<ClipperLib::DoublePoint>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1485 |         for (int i = 0; i < polygon.size(); i++) {
      |                         ~~^~~~~~~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1540:25: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<double>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1540 |     for (int ix = 0; ix < xs.size() - 1; ix++) {
      |                      ~~~^~~~~~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1555:41: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::vector<ClipperLib::DoublePoint> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1555 |         for (int ipolygon = 0; ipolygon < polygons.size(); ipolygon++) {
      |                                ~~~~~~~~~^~~~~~~~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1557:39: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<ClipperLib::DoublePoint>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1557 |             for (int iedge = 0; iedge < polygon.size(); iedge++) {
      |                                 ~~~~~~^~~~~~~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1568:39: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<ClipperLib::DoublePoint>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1568 |         for (int icircle = 0; icircle < circles.size(); icircle++) {
      |                               ~~~~~~~~^~~~~~~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1591:27: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::vector<ClipperLib::DoublePoint> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1591 |         for (int i = 0; i < polygons.size() + circles.size(); i++) {
      |                         ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1592:33: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::vector<ClipperLib::DoublePoint> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1592 |             outside.push_back(i == (polygons.size()));  // poly_0, ..., poly_n-1, c2, c1
      |                               ~~^~~~~~~~~~~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1595:29: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<std::tuple<double, int, int> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1595 |         for (int iy = 0; iy < ys.size(); iy++) {
      |                          ~~~^~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1610:28: warning: comparison of integer expressions of different signedness: ‘const int’ and ‘std::vector<std::vector<ClipperLib::DoublePoint> >::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
 1610 |                 if (ishape < polygons.size()) {
      |                     ~~~~~~~^~~~~~~~~~~~~~~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1428:14: warning: unused parameter ‘clip’ [-Wunused-parameter]
 1428 |     Clipper& clip,
      |     ~~~~~~~~~^~~~
/home/greg/Work/FreeCAD/src/Mod/CAM/libarea/Adaptive.cpp:1432:10: warning: unused parameter ‘preventConventional’ [-Wunused-parameter]
 1432 |     bool preventConventional
      |     ~~~~~^~~~~~~~~~~~~~~~~~~
  ```
  
</details>