### PR TITLE
CAM: Profile and Pocket - SortingMode

### DIFF
--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -761,7 +761,7 @@ def makeBoundBoxFace(bBox, offset=0.0, zHeight=0.0):
 
 
 # Method to combine faces if connected
-def combineHorizontalFaces(faces):
+def combineHorizontalFaces(faces, keepOrder=False):
     """combineHorizontalFaces(faces)...
     This function successfully identifies and combines multiple connected faces and
     works on multiple independent faces with multiple connected faces within the list.
@@ -770,6 +770,8 @@ def combineHorizontalFaces(faces):
 
     Attempts to do the same shape connecting failed with TechDraw.findShapeOutline() and
     Path.Geom.combineConnectedShapes(), so this algorithm was created.
+
+    If keepOrder is True, returns shapes with original order
     """
     horizontal = list()
     offset = 10.0
@@ -845,5 +847,19 @@ def combineHorizontalFaces(faces):
                 horizontal.append(f)
         else:
             horizontal = outer
+
+    # restore order
+    if keepOrder:
+        ordered = [None] * len(faces)
+        for face in horizontal:
+            for i, f in enumerate(faces):
+                if face.isInside(f.Vertexes[0].Point, Tolerance, False):
+                    ordered[i] = face
+                    break
+        ordered = [x for x in ordered if x]
+        if len(ordered) == len(horizontal):
+            horizontal = ordered
+        else:
+            Path.Log.info(translate("PathGeom", "Can not restore order of faces."))
 
     return horizontal

--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -470,7 +470,11 @@ class ObjectOp(PathOp.ObjectOp):
             else:
                 shapes.append(shp)
 
-        if len(shapes) > 1:
+        if (
+            len(shapes) > 1
+            and getattr(obj, "SortingMode", None) != "Manual"
+            and getattr(obj, "HandleMultipleFeatures", False) != "Collectively"
+        ):
             locations = []
             for s in shapes:
                 if s[2] == "OpenEdge":

--- a/src/Mod/CAM/Path/Op/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/PocketBase.py
@@ -74,6 +74,10 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 (translate("CAM_Pocket", "Line"), "Line"),
                 (translate("CAM_Pocket", "Grid"), "Grid"),
             ],  # Fill Pattern
+            "SortingMode": [
+                (translate("CAM_Pocket", "Automatic"), "Automatic"),
+                (translate("CAM_Pocket", "Manual"), "Manual"),
+            ],
         }
 
         if dataType == "raw":
@@ -198,6 +202,17 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 "Skips machining regions that have already been cleared by previous operations.",
             ),
         )
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "SortingMode",
+            "Path",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Order processing of the shapes"
+                "\nAutomatic: uses nearest neighbour algorithm to sort shapes"
+                "\nManual: uses order of shapes selection",
+            ),
+        )
 
         for n in self.pocketPropertyEnumerations():
             setattr(obj, n[0], n[1])
@@ -274,6 +289,18 @@ class ObjectPocket(PathAreaOp.ObjectOp):
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Set distance which will attempts to avoid unnecessary retractions.",
+                ),
+            )
+        if not hasattr(obj, "SortingMode"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "SortingMode",
+                "Path",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Order processing of the shapes"
+                    "\nAutomatic: uses nearest neighbour algorithm to sort shapes"
+                    "\nManual: uses order of shapes selection",
                 ),
             )
         if hasattr(obj, "OffsetPattern"):

--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -248,7 +248,8 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                             self.exts.append(f)
 
             # check all faces and see if they are touching/overlapping and combine and simplify
-            self.horizontal = Path.Geom.combineHorizontalFaces(self.horiz)
+            keepOrder = getattr(obj, "SortingMode", None) == "Manual"
+            self.horizontal = Path.Geom.combineHorizontalFaces(self.horiz, keepOrder=keepOrder)
 
             # Move all faces to final depth less buffer before extrusion
             # Small negative buffer is applied to compensate for internal significant digits/rounding issue

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -211,6 +211,17 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                     "Set distance which will attempts to avoid unnecessary retractions",
                 ),
             ),
+            (
+                "App::PropertyEnumeration",
+                "SortingMode",
+                "Path",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Order processing of the shapes"
+                    "\nAutomatic: uses nearest neighbour algorithm to sort shapes"
+                    "\nManual: uses order of shapes selection",
+                ),
+            ),
         ]
 
     @classmethod
@@ -243,6 +254,10 @@ class ObjectProfile(PathAreaOp.ObjectOp):
                 (translate("PathProfile", "Outside"), "Outside"),
                 (translate("PathProfile", "Inside"), "Inside"),
             ],  # side of profile that cutter is on in relation to direction of profile
+            "SortingMode": [
+                (translate("PathProfile", "Automatic"), "Automatic"),
+                (translate("PathProfile", "Manual"), "Manual"),
+            ],
         }
 
         if dataType == "raw":
@@ -317,6 +332,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         useLongestEdgeMode = (
             0 if obj.HandleMultipleFeatures == "Individually" and not obj.UseStartPoint else 2
         )
+        sortingMode = 0 if obj.HandleMultipleFeatures == "Individually" else 2
 
         obj.setEditorMode("JoinType", 2)
         obj.setEditorMode("MiterLimit", 2)  # ml
@@ -326,6 +342,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         obj.setEditorMode("processHoles", fc)
         obj.setEditorMode("processPerimeter", fc)
         obj.setEditorMode("UseLongestEdge", useLongestEdgeMode)
+        obj.setEditorMode("SortingMode", sortingMode)
 
     def _getOperationType(self, obj):
         if len(obj.Base) == 0:


### PR DESCRIPTION
Added property `SortingMode` to **Profile** and **Pocket** operation with two option: `Automatic` and `Manual`

`Automatic`: old behavior (uses nearest neighbor algorithm to sort shapes)
`Manual`: shapes processing will follow order of shapes selection

<img width="820" height="582" alt="Screenshot_20260209_100247_hor" src="https://github.com/user-attachments/assets/3b47aad6-c715-4e4a-9cd8-d3a925f306b9" />
