### PR TITLE
Sketcher: Added sketch overlay feature and toggle button 

### DIFF
--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -1163,6 +1163,8 @@ void GridSpaceAction::updateWidget()
 
         updateCheckBoxFromProperty(gridAutoSpacing, sketchView->GridAuto);
 
+        updateCheckBoxFromProperty(overlaySketch, sketchView->overlaySketch);
+
         ParameterGrp::handle hGrp = getParameterPath();
         updateCheckBox(snapToGrid, hGrp->GetBool("SnapToGrid", false));
 
@@ -1188,6 +1190,10 @@ void GridSpaceAction::languageChange()
         tr("New points will snap to the nearest grid line.\nPoints must be set closer than a "
             "fifth of the grid spacing to a grid line to snap."));
     snapToGrid->setStatusTip(snapToGrid->toolTip());
+
+    overlaySketch->setText(tr("Overlay sketch"));
+    overlaySketch->setToolTip(tr("Brings sketch on top of everything."));
+    overlaySketch->setStatusTip(overlaySketch->toolTip());
 }
 
 QWidget* GridSpaceAction::createWidget(QWidget* parent)
@@ -1197,6 +1203,8 @@ QWidget* GridSpaceAction::createWidget(QWidget* parent)
     gridAutoSpacing = new QCheckBox();
 
     snapToGrid = new QCheckBox();
+
+    overlaySketch = new QCheckBox();
 
     sizeLabel = new QLabel();
 
@@ -1211,8 +1219,9 @@ QWidget* GridSpaceAction::createWidget(QWidget* parent)
     layout->addWidget(gridShow, 0, 0, 1, 2);
     layout->addWidget(gridAutoSpacing, 1, 0, 1, 2);
     layout->addWidget(snapToGrid, 2, 0, 1, 2);
-    layout->addWidget(sizeLabel, 3, 0);
-    layout->addWidget(gridSizeBox, 3, 1);
+    layout->addWidget(overlaySketch, 3, 0, 1, 2);
+    layout->addWidget(sizeLabel, 4, 0);
+    layout->addWidget(gridSizeBox, 4, 1);
 
     languageChange();
 
@@ -1249,6 +1258,19 @@ QWidget* GridSpaceAction::createWidget(QWidget* parent)
 #endif
         ParameterGrp::handle hGrp = this->getParameterPath();
         hGrp->SetBool("SnapToGrid", state == Qt::Checked);
+    });
+
+#if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
+    QObject::connect(overlaySketch, &QCheckBox::checkStateChanged, [this](int state) {
+#else
+    QObject::connect(overlaySketch, &QCheckBox::stateChanged, [this](int state) {
+#endif
+        auto* sketchView = getView();
+
+        if (sketchView) {
+            auto enable = (state == Qt::Checked);
+            sketchView->overlaySketch.setValue(enable);
+        }
     });
 
     QObject::connect(gridSizeBox,

--- a/src/Mod/Sketcher/Gui/Command.h
+++ b/src/Mod/Sketcher/Gui/Command.h
@@ -70,6 +70,7 @@ private:
     QCheckBox* gridShow;
     QCheckBox* gridAutoSpacing;
     QCheckBox* snapToGrid;
+    QCheckBox* overlaySketch;
     QLabel* sizeLabel;
     Gui::QuantitySpinBox* gridSizeBox;
 };

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -243,6 +243,7 @@ public:
     void drawConstraintIcons(const GeoListFacade& geolistfacade);
 
     void updateGeometryLayersConfiguration();
+    void updateEditRootType();
     //@}
 
     /** @name coin node access*/

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -401,6 +401,8 @@ struct EditModeScenegraphNodes
     /** @name Point nodes*/
     //@{
     SoSeparator* EditRoot;
+    SoGroup* ModeRoot;
+    SoSeparator* ContentRoot;
     SmSwitchboard* PointsGroup;
     std::vector<SoMaterial*> PointsMaterials;
     std::vector<SoCoordinate3*> PointsCoordinate;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -2971,37 +2971,37 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
     SoMaterialBinding* MtlBind = new SoMaterialBinding;
     MtlBind->setName("ConstraintMaterialBinding");
     MtlBind->value = SoMaterialBinding::OVERALL;
-    editModeScenegraphNodes.EditRoot->addChild(MtlBind);
+    editModeScenegraphNodes.ContentRoot->addChild(MtlBind);
 
     // use small line width for the Constraints
     editModeScenegraphNodes.ConstraintDrawStyle = new SoDrawStyle;
     editModeScenegraphNodes.ConstraintDrawStyle->setName("ConstraintDrawStyle");
     editModeScenegraphNodes.ConstraintDrawStyle->lineWidth = 1 * drawingParameters.pixelScalingFactor;
-    editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.ConstraintDrawStyle);
+    editModeScenegraphNodes.ContentRoot->addChild(editModeScenegraphNodes.ConstraintDrawStyle);
 
     // add the group where all the constraints has its SoSeparator
     editModeScenegraphNodes.constrGrpSelect = new SoPickStyle();  // used to toggle constraints
                                                                   // selectability
     editModeScenegraphNodes.constrGrpSelect->style.setValue(SoPickStyle::SHAPE);
-    editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.constrGrpSelect);
+    editModeScenegraphNodes.ContentRoot->addChild(editModeScenegraphNodes.constrGrpSelect);
     setConstraintSelectability();  // Ensure default value;
 
     // disable depth testing for constraint icons so they render ON TOP of geometry lines
     // check issues #25840 and #11603
     SoDepthBuffer* constrDepthOff = new SoDepthBuffer();
     constrDepthOff->test.setValue(false);
-    editModeScenegraphNodes.EditRoot->addChild(constrDepthOff);
+    editModeScenegraphNodes.ContentRoot->addChild(constrDepthOff);
 
     editModeScenegraphNodes.constrGroup = new SmSwitchboard();
     editModeScenegraphNodes.constrGroup->setName("ConstraintGroup");
-    editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.constrGroup);
+    editModeScenegraphNodes.ContentRoot->addChild(editModeScenegraphNodes.constrGroup);
 
     // re-enable depth testing for the rest of the nodes
     SoDepthBuffer* constrDepthOn = new SoDepthBuffer();
     constrDepthOn->test.setValue(true);
-    editModeScenegraphNodes.EditRoot->addChild(constrDepthOn);
+    editModeScenegraphNodes.ContentRoot->addChild(constrDepthOn);
 
     SoPickStyle* ps = new SoPickStyle();  // used to following nodes aren't impacted
     ps->style.setValue(SoPickStyle::SHAPE);
-    editModeScenegraphNodes.EditRoot->addChild(ps);
+    editModeScenegraphNodes.ContentRoot->addChild(ps);
 }

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -619,11 +619,11 @@ void EditModeGeometryCoinManager::createGeometryRootNodes()
 {
     // stuff for the points ++++++++++++++++++++++++++++++++++++++
     editModeScenegraphNodes.PointsGroup = new SmSwitchboard;
-    editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.PointsGroup);
+    editModeScenegraphNodes.ContentRoot->addChild(editModeScenegraphNodes.PointsGroup);
 
     // stuff for the Curves +++++++++++++++++++++++++++++++++++++++
     editModeScenegraphNodes.CurvesGroup = new SmSwitchboard;
-    editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.CurvesGroup);
+    editModeScenegraphNodes.ContentRoot->addChild(editModeScenegraphNodes.CurvesGroup);
 }
 
 void EditModeGeometryCoinManager::emptyGeometryRootNodes()

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -621,6 +621,13 @@ ViewProviderSketch::ViewProviderSketch()
         (App::PropertyType)(App::Prop_None),
         "If true, this sketch will be colored based on user preferences. Turn it off to set color explicitly.");
 
+    ADD_PROPERTY_TYPE(
+        overlaySketch,
+        (true),
+        "Visibility automation",
+        (App::PropertyType)(App::Prop_None),
+        "If true, the edit geometry is rendered on top of everything.");
+
     // TODO: This is part of a naive minimal implementation to substitute rendering order
     // Three equally visual layers to enable/disable layer.
     std::vector<VisualLayer> layers;
@@ -3339,6 +3346,13 @@ void ViewProviderSketch::onChanged(const App::Property* prop)
         if (isInEditMode()) {
             // Configure and rebuild Coin SceneGraph
             editCoinManager->updateGeometryLayersConfiguration();
+        }
+        return;
+    }
+
+    if (prop == &overlaySketch) {
+        if (isInEditMode()) {
+            editCoinManager->updateEditRootType();
         }
         return;
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -533,6 +533,7 @@ public:
     App::PropertyBool SectionView;
     App::PropertyBool AutoColor;
     App::PropertyString EditingWorkbench;
+    App::PropertyBool overlaySketch;
     SketcherGui::PropertyVisualLayerList VisualLayerList;
     //@}
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/5a39b671-1e14-4068-8f36-d38ac297ab35

Added a Overlay Sketch checkbox to the sketcher task panel that forces sketch geometry to render on top of all other objects in the scene.

solves the issue where sketch elements become hidden inside or behind solid bodies during editing.