### PR TITLE
Draft: Fix switchUi method bug

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1030,7 +1030,7 @@ class DraftToolBar:
                 if self.state[5]:
                     self.zValue.show()
                 if self.state[6]:
-                    self.labellength.show() 
+                    self.labellength.show()
                 if self.state[7]:
                     self.labelangle.show()
                 if self.state[8]:


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
This fixes #27298 `Draft_Dimension Relative and Global not offered in taskbar after Alt is pressed`.

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
### Before: Relative and Global Checkboxes disappear

https://github.com/user-attachments/assets/cf2b6c33-0d68-400e-88fa-c9735107f1dd

### After: UI switched comes back properly

https://github.com/user-attachments/assets/04f1fd8c-674d-40f4-8f5c-6b700552496a

## Explanation
`switchUi()` is a Draft method defined in `DraftGui.py` switch that hides and restores shared widgets when entering or leaving an alternate input mode by alt modifier in `gui_dimension.py`, `gui_arcs.py` and `gui_polygons` commands. It assumes a symmetric enter/exit lifecycle. During Draft_Dimension (gui_dimension.py), holding Alt triggers the enter path switchUi(store=True), but the corresponding restore path is not reliably executed, leaving the UI in an altered state where the Relative/Global checkboxes remain hidden.

I modified switchUi(), so that it can hide and show again properly when pressed alt, by making self.state saves everything that self.hideXYZ hides and is visible.

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
