### PR TITLE
Improve Issue Overview & Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-FUNCTIONAL_PROBLEM_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/1-FUNCTIONAL_PROBLEM_REPORT.yml
@@ -5,7 +5,11 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to fill out this problem report! Please [search](https://github.com/FreeCAD/FreeCAD/issues) if a similar issue already exists and check out [how to report issues](https://github.com/FreeCAD/FreeCAD?tab=readme-ov-file#reporting-issues). By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/FreeCAD/FreeCAD/blob/main/CODE_OF_CONDUCT.md).
+        
+        > [!TIP]
+        > If this is your first time, read [how to report an issue to FreeCAD][Guide].
+        
+        [Guide]: https://github.com/FreeCAD/FreeCAD?tab=readme-ov-file#reporting-issues
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,20 @@
-blank_issues_enabled: false
+
+blank_issues_enabled : false
+
 contact_links:
-  - name: 💬 START HERE -- FreeCAD Forum
-    url: https://forum.freecad.org/
-    about: You are encouraged to discuss the problem you are seeing on the FreeCAD Forums before opening an issue on GitHub
+
+-   about : Join the community on our Discord.
+    name : 💬 𝗗𝗶𝘀𝗰𝗼𝗿𝗱
+    url : https://discord.gg/w2cTKGzccC
+
+-   about : Join the community on our Forum.
+    name : 💬 𝗙𝗼𝗿𝘂𝗺
+    url : https://forum.freecad.org
+
+-   about : Read on how FreeCAD is developed.
+    name : 📕 𝗛𝗮𝗻𝗱𝗯𝗼𝗼𝗸
+    url : https://freecad.github.io/DevelopersHandbook
+
+-   about : Look up information about FreeCAD.
+    name : 🌐 𝗪𝗶𝗸𝗶
+    url : https://wiki.freecad.org

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ exclude: |
     (?x)^(
         .*vcproj.*|
         .*vcxproj.*|
+        .github/ISSUE_TEMPLATE|
         src/App/ExpressionParser.tab.c|
         src/App/ExpressionParser.tab.h|
         src/App/ExpressionParser.y|


### PR DESCRIPTION

### Changes

- Improved / extended issue options / overview
- Rewrote the pretext of the Functional-Problem issue template

### Background

- We want to encourage users to talk about their problem  
  with us before creating issues for various reasons.

- The issues overview that is supplemented by custom entries  
  configured in the `config.yml` is the entry point for all users.

- The custom entries cannot be placed before the issues  
  template nor the auto generated security report option.

### Changes

Since users are unlikely to read the bottom entry that points them 
to the forum and aren't prevented to submit reports before knowing 
this nor informed in the report template, I've moved that information 
there and made it easy to digest and hard to overlook.

I've also added new options to the overview that address users 
that simply want to connect or find information about FreeCAD.

<br/>

## Preview

#### Overview

<img width="811" height="576" alt="image" src="https://github.com/user-attachments/assets/5f70faeb-394a-481c-b22d-afc1e7530ff8" />

#### Template

<img width="813" height="774" alt="image" src="https://github.com/user-attachments/assets/7a925143-a205-4070-a340-645fc43099ff" />

