### PR TITLE
Points: Switch to modern libE57 types

### DIFF
--- a/src/Mod/Points/App/PointsAlgos.cpp
+++ b/src/Mod/Points/App/PointsAlgos.cpp
@@ -1502,7 +1502,7 @@ private:
 
         for (int i = 0; i < prototype.childCount(); ++i) {
             e57::Node node(prototype.get(i));
-            if ((node.type() == e57::E57_FLOAT) || (node.type() == e57::E57_SCALED_INTEGER)) {
+            if ((node.type() == e57::TypeFloat) || (node.type() == e57::TypeScaledInteger)) {
                 if (readCartesian(node, proto)) {
                 }
                 else if (readNormal(node, proto)) {
@@ -1513,7 +1513,7 @@ private:
                     readOther(node, proto);
                 }
             }
-            else if (node.type() == e57::E57_INTEGER) {
+            else if (node.type() == e57::TypeInteger) {
                 if (readColor(node, proto)) {
                 }
                 else if (readCartesianInvalidState(node, proto)) {


### PR DESCRIPTION
We recently updated our internal copy of libE57 with the upstream project: this results in some deprecation warnings. Resole them by updating to the new recommended type names.