### PR TITLE
PD: Return inversion status by reference

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -850,7 +850,6 @@ TopoShape FeatureExtrude::generateSingleExtrusionSide(
         || method == "UpToShape") {
         // Note: This will return an unlimited planar face if support is a datum plane
         TopoShape supportface = getTopoShapeSupportFace();
-        invObjLoc = getLocation().Inverted();
         supportface.move(invObjLoc);
 
         if (!supportface.hasSubShape(TopAbs_WIRE)) {


### PR DESCRIPTION
`invObjLoc` is currently an unused reference parameter: it appears the intention was to return that value by reference, rather than create a new local variable that hides it.