### PR TITLE
Sketcher: Remove unneeded parameters from seekConstraintPosition

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -363,13 +363,7 @@ Restart:
                             }
                         }
 
-                        Base::Vector3d relpos = seekConstraintPosition(
-                            midpos,
-                            norm,
-                            dir,
-                            2.5,
-                            editModeScenegraphNodes.constrGroup->getChild(i)
-                        );
+                        Base::Vector3d relpos = seekConstraintPosition(norm, 2.5);
 
                         auto translation = static_cast<SoZoomTranslation*>(sep->getChild(
                             static_cast<int>(ConstraintNodePosition::FirstTranslationIndex)
@@ -399,13 +393,7 @@ Restart:
                         norm1 = Base::Vector3d(-dir1.y, dir1.x, 0.);
                         norm2 = norm1;
 
-                        Base::Vector3d relpos1 = seekConstraintPosition(
-                            midpos1,
-                            norm1,
-                            dir1,
-                            4.0,
-                            editModeScenegraphNodes.constrGroup->getChild(i)
-                        );
+                        Base::Vector3d relpos1 = seekConstraintPosition(norm1, 4.0);
 
                         auto translation = static_cast<SoZoomTranslation*>(sep->getChild(
                             static_cast<int>(ConstraintNodePosition::FirstTranslationIndex)
@@ -414,14 +402,7 @@ Restart:
                         translation->abPos = SbVec3f(midpos1.x, midpos1.y, zConstrH);
                         translation->translation = SbVec3f(relpos1.x, relpos1.y, 0);
 
-                        Base::Vector3d relpos2 = seekConstraintPosition(
-                            midpos2,
-                            norm2,
-                            dir2,
-                            4.0,
-                            editModeScenegraphNodes.constrGroup->getChild(i)
-                        );
-
+                        Base::Vector3d relpos2 = seekConstraintPosition(norm2, 4.0);
                         Base::Vector3d secondPos = midpos2 - midpos1;
 
                         translation = static_cast<SoZoomTranslation*>(sep->getChild(
@@ -540,13 +521,7 @@ Restart:
                         twoIcons = true;
                     }
 
-                    Base::Vector3d relpos1 = seekConstraintPosition(
-                        midpos1,
-                        norm1,
-                        dir1,
-                        4.0,
-                        editModeScenegraphNodes.constrGroup->getChild(i)
-                    );
+                    Base::Vector3d relpos1 = seekConstraintPosition(norm1, 4.0);
 
                     auto translation = static_cast<SoZoomTranslation*>(
                         sep->getChild(static_cast<int>(ConstraintNodePosition::FirstTranslationIndex))
@@ -556,14 +531,7 @@ Restart:
                     translation->translation = SbVec3f(relpos1.x, relpos1.y, 0);
 
                     if (twoIcons) {
-                        Base::Vector3d relpos2 = seekConstraintPosition(
-                            midpos2,
-                            norm2,
-                            dir2,
-                            4.0,
-                            editModeScenegraphNodes.constrGroup->getChild(i)
-                        );
-
+                        Base::Vector3d relpos2 = seekConstraintPosition(norm2, 4.0);
                         Base::Vector3d secondPos = midpos2 - midpos1;
                         auto translation = static_cast<SoZoomTranslation*>(sep->getChild(
                             static_cast<int>(ConstraintNodePosition::SecondTranslationIndex)
@@ -800,20 +768,8 @@ Restart:
                         norm2 = Base::Vector3d(-dir2.y, dir2.x, 0.);
                     }
 
-                    Base::Vector3d relpos1 = seekConstraintPosition(
-                        midpos1,
-                        norm1,
-                        dir1,
-                        4.0,
-                        editModeScenegraphNodes.constrGroup->getChild(i)
-                    );
-                    Base::Vector3d relpos2 = seekConstraintPosition(
-                        midpos2,
-                        norm2,
-                        dir2,
-                        4.0,
-                        editModeScenegraphNodes.constrGroup->getChild(i)
-                    );
+                    Base::Vector3d relpos1 = seekConstraintPosition(norm1, 4.0);
+                    Base::Vector3d relpos2 = seekConstraintPosition(norm2, 4.0);
 
                     auto translation = static_cast<SoZoomTranslation*>(
                         sep->getChild(static_cast<int>(ConstraintNodePosition::FirstTranslationIndex))
@@ -1112,13 +1068,7 @@ Restart:
                         Base::Vector3d dir = norm;
                         dir.RotateZ(-pi / 2.0);
 
-                        relPos = seekConstraintPosition(
-                            pos,
-                            norm,
-                            dir,
-                            2.5,
-                            editModeScenegraphNodes.constrGroup->getChild(i)
-                        );
+                        relPos = seekConstraintPosition(norm, 2.5);
 
                         auto translation = static_cast<SoZoomTranslation*>(sep->getChild(
                             static_cast<int>(ConstraintNodePosition::FirstTranslationIndex)
@@ -1149,20 +1099,8 @@ Restart:
                             Base::Vector3d norm1 = Base::Vector3d(-dir1.y, dir1.x, 0.f);
                             Base::Vector3d norm2 = Base::Vector3d(-dir2.y, dir2.x, 0.f);
 
-                            Base::Vector3d relpos1 = seekConstraintPosition(
-                                midpos1,
-                                norm1,
-                                dir1,
-                                4.0,
-                                editModeScenegraphNodes.constrGroup->getChild(i)
-                            );
-                            Base::Vector3d relpos2 = seekConstraintPosition(
-                                midpos2,
-                                norm2,
-                                dir2,
-                                4.0,
-                                editModeScenegraphNodes.constrGroup->getChild(i)
-                            );
+                            Base::Vector3d relpos1 = seekConstraintPosition(norm1, 4.0);
+                            Base::Vector3d relpos2 = seekConstraintPosition(norm2, 4.0);
 
                             auto translation = static_cast<SoZoomTranslation*>(sep->getChild(
                                 static_cast<int>(ConstraintNodePosition::FirstTranslationIndex)
@@ -1703,11 +1641,8 @@ void EditModeConstraintCoinManager::findHelperAngles(
 }
 
 Base::Vector3d EditModeConstraintCoinManager::seekConstraintPosition(
-    const Base::Vector3d& origPos,
     const Base::Vector3d& norm,
-    const Base::Vector3d& dir,
-    float step,
-    const SoNode* constraint
+    float step
 )
 {
     return norm * 0.5f * step;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -151,13 +151,7 @@ private:
     );
 
     /// finds a free position for placing a constraint icon
-    Base::Vector3d seekConstraintPosition(
-        const Base::Vector3d& origPos,
-        const Base::Vector3d& norm,
-        const Base::Vector3d& dir,
-        float step,
-        const SoNode* constraint
-    );
+    Base::Vector3d seekConstraintPosition(const Base::Vector3d& norm, float step);
 
     /// Return display string for constraint including hiding units if
     // requested.


### PR DESCRIPTION
In be6be63764f86e02c5562e14c38067f5e65dfa17 the method was simplified, but its parameters were left alone. This PR eliminates all of the now-superfluous parameters.