### PR TITLE
Sketcher: Annotate unused parameter

### DIFF
--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -227,6 +227,7 @@ int EditDatumDialog::exec(bool atCursor)
 
 void EditDatumDialog::typeChanged(bool checked)
 {
+    Q_UNUSED(checked);
     if (!ui_ins_datum->rbRadius->isVisible()) {
         return;
     }


### PR DESCRIPTION
Qt includes the check status of the box in this callback, but we don't use it. Mark it unused.