### PR TITLE
PD: Improve error handling for RevolMethod::ToFirst

### DIFF
--- a/src/Mod/PartDesign/App/FeatureGroove.cpp
+++ b/src/Mod/PartDesign/App/FeatureGroove.cpp
@@ -194,9 +194,8 @@ App::DocumentObjectExecReturn* Groove::execute()
                 upToFace.move(invObjLoc);
             }
             else {
-                throw Base::RuntimeError(
-                    "ProfileBased: Revolution up to first/last is not yet supported"
-                );
+                // TODO: Implement finding the first face this revolution would intersect with
+                return new App::DocumentObjectExecReturn("Groove up to first is not yet supported");
             }
 
             if (Reversed.getValue()) {

--- a/src/Mod/PartDesign/App/FeatureRevolution.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolution.cpp
@@ -216,9 +216,8 @@ App::DocumentObjectExecReturn* Revolution::execute()
                 upToFace.move(invObjLoc);
             }
             else {
-                throw Base::RuntimeError(
-                    "ProfileBased: Revolution up to first/last is not yet supported"
-                );
+                // TODO: Implement finding the first face this revolution would intersect with
+                return new App::DocumentObjectExecReturn("Revolve up to first is not yet supported");
             }
 
             if (Reversed.getValue()) {

--- a/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskRevolutionParameters.cpp
@@ -46,6 +46,8 @@
 #include "ViewProviderRevolution.h"
 #include "ReferenceSelection.h"
 
+#include <QStandardItemModel>
+
 using namespace PartDesignGui;
 using namespace Gui;
 
@@ -202,6 +204,16 @@ void TaskRevolutionParameters::translateModeList(int index)
         ui->changeMode->addItem(tr("Through all"));
     }
     ui->changeMode->addItem(tr("To first"));
+
+    // "To first" is not available for revolutions right now, but if we just don't add it, the index
+    // will be wrong. So disable it instead. Messy workaround for #27403
+    auto toFirstIndex = ui->changeMode->count() - 1;
+    auto* model = qobject_cast<QStandardItemModel*>(ui->changeMode->model());
+    if (model) {
+        QStandardItem* item = model->item(toFirstIndex);
+        item->setFlags(item->flags() & ~Qt::ItemIsEnabled);
+    }
+
     ui->changeMode->addItem(tr("Up to face"));
     ui->changeMode->addItem(tr("Two angles"));
     ui->changeMode->setCurrentIndex(index);


### PR DESCRIPTION
Workaround for #27403, if we accept that actually solving that Issue is really to implement the "ToFirst" feature (which this PR does not do). Instead, it corrects the error handling to return a new `DocumentObjectExecReturn` object instead of raising an exception, and it disables (but does not *hide*) the "ToFirst" option in the dialog. I went with disabling because I don't trust that the index isn't being relied upon someplace and didn't want to risk changing it (since this is intended for backport to 1.1).