### PR TITLE
CAM: Profile - Fixes _processEachModel() for Compound

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -569,9 +569,15 @@ class ObjectProfile(PathAreaOp.ObjectOp):
     def _processEachModel(self, obj):
         shapeTups = []
         for base in self.model:
-            if hasattr(base, "Shape"):
+            if not hasattr(base, "Shape"):
+                continue
+            if isinstance(base.Shape, Part.Compound):
+                shapes = [shape for shape in base.Shape.SubShapes]
+            else:
+                shapes = [base.Shape]
+            for shape in shapes:
                 env = PathUtils.getEnvelope(
-                    partshape=base.Shape, subshape=None, depthparams=self.depthparams
+                    partshape=shape, subshape=None, depthparams=self.depthparams
                 )
                 if env:
                     shapeTups.append((env, False))


### PR DESCRIPTION
Without shapes selection `Part.Compound` object processing like `Collectively`
This commit provides to processing each sub shape independently

Test file: [test_compound.zip](https://github.com/user-attachments/files/25187303/test_compound.zip)


<img width="2038" height="477" alt="1_hor_lossy" src="https://github.com/user-attachments/assets/f015abe8-f6a8-4d60-98fd-f68fba073242" />
