### PR TITLE
Draft: fix ghost preview of Draft_Labels

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -873,7 +873,7 @@ class ghostTracker(Tracker):
             sep.addChild(obj.ViewObject.RootNode.copy())
             # add Part container offset
             if parent_place is not None:
-                if hasattr(obj, "Placement"):
+                if hasattr(obj, "Placement") and utils.get_type(obj) != "Label":
                     gpl = parent_place * obj.Placement
                 else:
                     gpl = parent_place


### PR DESCRIPTION
Fixes #27418.

Draft_Labels have a unique Placement implementation. A ghost preview therefore cannot be generated in the standard manner. This was missed in #18795 (my bad).