### PR TITLE
CAM: CircularHoleBase - Filter positions to exclude repeats

### DIFF
--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -218,16 +218,31 @@ class ObjectOp(PathOp.ObjectOp):
         for base, subs in obj.Base:
             for sub in subs:
                 Path.Log.debug("processing {} in {}".format(sub, base.Name))
-                if self.isHoleEnabled(obj, base, sub):
-                    pos = self.holePosition(base, sub)
-                    if pos:
-                        holes.append(
-                            {
-                                "x": pos.x,
-                                "y": pos.y,
-                                "d": self.holeDiameter(base, sub),
-                            }
-                        )
+                if not self.isHoleEnabled(obj, base, sub):
+                    continue
+                pos = self.holePosition(base, sub)
+                if not pos:
+                    continue
+                diam = self.holeDiameter(base, sub)
+                for hole in holes:  # check positions repeats
+                    if Path.Geom.pointsCoincide((pos.x, pos.y), (hole["x"], hole["y"])):
+                        if diam > hole["d"] and not Path.Geom.isRoughly(diam, hole["d"]):
+                            # use bigger hole and disable with less diameter
+                            name = "%s.%s" % (base.Name, hole["sub"])
+                            disabled = obj.Disabled
+                            disabled.append(name)
+                            obj.Disabled = disabled
+                            hole["d"] = diam
+                            hole["sub"] = sub
+                        else:
+                            # disable repeat with less diameter
+                            name = "%s.%s" % (base.Name, sub)
+                            disabled = obj.Disabled
+                            disabled.append(name)
+                            obj.Disabled = disabled
+                        break
+                else:  # is not a repeat, add unique position
+                    holes.append({"x": pos.x, "y": pos.y, "d": diam, "sub": sub})
 
         if haveLocations(self, obj):
             for location in obj.Locations:

--- a/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
@@ -349,6 +349,21 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         self.obj.Disabled = disabled
         FreeCAD.ActiveDocument.recompute()
 
+    def updateChecked(self):
+        self.updating = True
+        for i in range(self.form.baseList.rowCount()):
+            item = self.form.baseList.item(i, COL_FEATURE)
+            base_name = item.data(self.DataObjectName)
+            base = FreeCAD.ActiveDocument.getObject(base_name)
+            sub = str(item.data(self.DataObjectSub))
+            guiState = item.checkState() == QtCore.Qt.Checked
+            holeEnabled = self.obj.Proxy.isHoleEnabled(self.obj, base, sub)
+            if not holeEnabled and guiState:
+                item.setCheckState(QtCore.Qt.Unchecked)
+            elif holeEnabled and not guiState:
+                item.setCheckState(QtCore.Qt.Checked)
+        self.updating = False
+
     def updateOrderNumbers(self):
         """Update the order numbers in the first column after row reordering or sorting."""
         table = self.form.baseList
@@ -512,7 +527,7 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
 
     def itemChanged(self, item):
         """itemChanged(item) ... callback when any item in the table changes"""
-        if item.column() == COL_FEATURE:
+        if not self.updating and item.column() == COL_FEATURE:
             self.checkedChanged()
 
 
@@ -522,6 +537,14 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
     def taskPanelBaseGeometryPage(self, obj, features):
         """taskPanelBaseGeometryPage(obj, features) ... Return circular hole specific page controller for Base Geometry."""
         return TaskPanelHoleGeometryPage(obj, features)
+
+    def pageUpdateData(self, obj, prop):
+        if prop == "Disabled" and getattr(self, "parent", None):
+            for page in self.parent.featurePages:
+                if isinstance(page, TaskPanelHoleGeometryPage):
+                    page.updateChecked()
+
+        self.updateData(obj, prop)
 
 
 class LineEditEventFilter(QtCore.QObject):


### PR DESCRIPTION
Model can contain 'splited' holes
If select all inner edges get drilling in same position twice

[Y-END-Plate-Left-1.zip](https://github.com/user-attachments/files/25238234/Y-END-Plate-Left-1.zip)
 
This commit add filter to process only unique positions
Repeats added to `Disabled` list

<img width="669" height="399" alt="Screenshot_20260210_185939_lossy" src="https://github.com/user-attachments/assets/d98c0bb0-2e51-41fe-8e1d-915bc948a6d3" />

https://github.com/user-attachments/assets/d4daf91c-938d-44f6-b6c5-c9d3ea57faac