### PR TITLE
CAM: CircularHoleBase - Manual selection 2

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelix.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelix.py
@@ -55,6 +55,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
         """Verify Helix does not throw an exception."""
 
         op = PathHelix.Create("Helix")
+        op.Proxy.findAllHoles(op)
         op.Proxy.execute(op)
 
     def testCreateWithPrototype(self):
@@ -67,6 +68,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
         """Verify Helix generates proper holes from model"""
 
         op = PathHelix.Create("Helix")
+        op.Proxy.findAllHoles(op)
         proxy = op.Proxy
         for base in op.Base:
             model = base[0]
@@ -78,6 +80,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
         """Verify Helix generates proper holes for rotated model"""
 
         op = PathHelix.Create("Helix")
+        op.Proxy.findAllHoles(op)
         proxy = op.Proxy
         model = self.job.Model.Group[0]
 
@@ -102,6 +105,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
             self.job.Tools.Group[0].Tool.Diameter = 0.5
 
             op = PathHelix.Create("Helix")
+            op.Proxy.findAllHoles(op)
             proxy = op.Proxy
             model = self.job.Model.Group[0]
 
@@ -124,6 +128,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
             self.job.Tools.Group[0].Tool.Diameter = 0.5
 
             op = PathHelix.Create("Helix")
+            op.Proxy.findAllHoles(op)
             proxy = op.Proxy
             model = self.job.Model.Group[0]
 
@@ -137,6 +142,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
     def testPathDirection(self):
         """Verify that the generated paths obeys the given parameters"""
         helix = PathHelix.Create("Helix")
+        helix.Proxy.findAllHoles(helix)
 
         def check(start_side, cut_mode, expected_direction):
             with self.subTest(f"({start_side}, {cut_mode}) => {expected_direction}"):

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -206,9 +206,6 @@ class ObjectOp(PathOp.ObjectOp):
     def opExecute(self, obj):
         """opExecute(obj) ... processes all Base features and Locations and collects
         them in a list of positions and radii which is then passed to circularHoleExecute(obj, holes).
-        If no Base geometries and no Locations are present, the job's Base is inspected and all
-        drillable features are added to Base. In this case appropriate values for depths are also
-        calculated and assigned.
         Do not overwrite, implement circularHoleExecute(obj, holes) instead."""
         Path.Log.track()
 

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -575,9 +575,5 @@ def Create(name, obj=None, parentJob=None):
     """Create(name) ... Creates and returns a Drilling operation."""
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-
     obj.Proxy = ObjectDrilling(obj, name, parentJob)
-    if obj.Proxy:
-        obj.Proxy.findAllHoles(obj)
-
     return obj

--- a/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
@@ -130,7 +130,7 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
     DataObjectName = QtCore.Qt.ItemDataRole.UserRole + 1
     DataObjectSub = QtCore.Qt.ItemDataRole.UserRole + 2
 
-    InitBase = False
+    InitBase = True
 
     def getForm(self):
         form = FreeCADGui.PySideUic.loadUi(":/panels/PageBaseHoleGeometryEdit.ui")

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -301,6 +301,4 @@ def Create(name, obj=None, parentJob=None):
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     obj.Proxy = ObjectHelix(obj, name, parentJob)
-    if obj.Proxy:
-        obj.Proxy.findAllHoles(obj)
     return obj

--- a/src/Mod/CAM/Path/Op/Tapping.py
+++ b/src/Mod/CAM/Path/Op/Tapping.py
@@ -315,9 +315,5 @@ def Create(name, obj=None, parentJob=None):
     """Create(name) ... Creates and returns a Tapping operation."""
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
-
     obj.Proxy = ObjectTapping(obj, name, parentJob)
-    if obj.Proxy:
-        obj.Proxy.findAllHoles(obj)
-
     return obj

--- a/src/Mod/CAM/Path/Op/ThreadMilling.py
+++ b/src/Mod/CAM/Path/Op/ThreadMilling.py
@@ -535,6 +535,4 @@ def Create(name, obj=None, parentJob=None):
     if obj is None:
         obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
     obj.Proxy = ObjectThreadMilling(obj, name, parentJob)
-    if obj.Proxy:
-        obj.Proxy.findAllHoles(obj)
     return obj


### PR DESCRIPTION
Changes:
- Uses `InitBase` in `Path.Op.Gui.Base.TaskPanel.setupUi()` like for all other operations

   https://github.com/FreeCAD/FreeCAD/blob/5ea732ef3cad27d573e80354632c2032e94e6724/src/Mod/CAM/Path/Op/Gui/Base.py#L1552-L1556

- Do not run `findAllHoles()` for automatic search holes while creating operation
User should click `Auto-select` in `Task panel`

---

**With selection**
 
https://github.com/user-attachments/assets/1159d3c6-3508-4071-8faa-5ab7a34ce4b1

---

**Without selection**
 
https://github.com/user-attachments/assets/1d6b0e71-df37-4a26-9f10-80b2794c603b