### PR TITLE
CAM: SelectLoop - Search several wires by several edges

### DIFF
--- a/src/Mod/CAM/PathCommands.py
+++ b/src/Mod/CAM/PathCommands.py
@@ -28,7 +28,7 @@ import Path
 import Path.Dressup.Utils as PathDressup
 
 from PathScripts.PathUtils import loopdetect
-from PathScripts.PathUtils import wiredetect
+from PathScripts.PathUtils import wiresdetect
 from PathScripts.PathUtils import horizontalEdgeLoop
 from PathScripts.PathUtils import tangentEdgeLoop
 from PathScripts.PathUtils import horizontalFaceLoop
@@ -68,6 +68,7 @@ class _CommandSelectLoop:
                 "\nor wire which contain selected edge."
                 "\n\nSelect two edges: searching loop edges in wires of the shape"
                 "\nor tangent edges."
+                "\n\nSelect three or more edges: searching horizontal wires",
                 "\n\nWithout sub selection all edges of the shape will be selected",
             ),
             "CmdType": "ForEdit",
@@ -104,7 +105,7 @@ class _CommandSelectLoop:
             if len(subs) == 1:
                 # one edge selected: searching horizontal edge loop
                 edges = horizontalEdgeLoop(obj, subs[0])
-            else:
+            elif len(subs) == 2:
                 # two edges selected: searching wire in shape which contain both edges
                 edges = loopdetect(obj, subs[0], subs[1])
                 if not edges:
@@ -113,7 +114,7 @@ class _CommandSelectLoop:
 
             if not edges:
                 # searching any wire with first selected edge
-                edges = wiredetect(obj, subs[0])
+                edges = wiresdetect(obj, subs)
 
         if edges and not names:
             hashList = [e.hashCode() for e in edges]

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -109,13 +109,18 @@ def loopdetect(obj, edge1, edge2):
         return None
 
 
-def wiredetect(obj, edge):
-    """Returns all edges from first wire which includes the edge."""
+def wiresdetect(obj, edges):
+    """Returns all edges from all horizontal wires which includes the edges."""
 
-    ehash = edge.hashCode()
+    ehashList = [e.hashCode() for e in edges]
+    wires = []
     for wire in obj.Shape.Wires:
-        if any(e.hashCode() == ehash for e in wire.Edges):
-            return wire.Edges
+        if not Path.Geom.isRoughly(wire.BoundBox.ZLength, 0):
+            continue
+        if any(e.hashCode() in ehashList for e in wire.Edges):
+            wires.append(wire)
+    if wires:
+        return [e for w in wires for e in w.Edges]
 
     return None
 


### PR DESCRIPTION
Allows to select several horizontal wires if select two or more edges, which not a part of one wire

https://github.com/user-attachments/assets/a5c1fd8e-e9cc-4658-a14d-ca7a7af8e4e1