### PR TITLE
BIM: Update coding conventions

### DIFF
--- a/src/Mod/BIM/BIM_README.md
+++ b/src/Mod/BIM/BIM_README.md
@@ -1,0 +1,440 @@
+<!--
+SPDX-License-Identifier: LGPL-2.1-or-later
+SPDX-FileCopyrightText: 2026 FreeCAD
+SPDX-FileNotice: Part of the FreeCAD project.
+-->
+
+# FreeCAD BIM
+
+## Welcome to the FreeCAD BIM Module!
+
+The BIM Module is FreeCAD's core Building Information Modeling (BIM) functionality, exposed to users as the BIM Workbench.
+It implements BIM-specific parametric objects, tools, workflows, Industry Foundation Classes (IFC) interoperability, BIM project organization, quantity extraction, scheduling, reporting, and much more, useful for projects in architecture, engineering, and construction (AEC) of the build environment.
+
+This document provides a high-level overview of the Module structure, organization, coding conventions, and development guidelines for contributors. Please feel free to improve this document while discovering the Module and contributing to it, so it stays relevant and effective.
+
+Creation Date: July 2026, 26.3 development cycle
+
+Last Update: July 2026
+
+---
+
+## 1. What is the BIM Module?
+
+The BIM Module is FreeCAD's integrated Building Information Modeling framework and Workbench. It provides:
+
+- Parametric architectural and construction objects (e.g. Wall, Slab, Window, Roof, Space)
+- BIM project organization tools (e.g. Project, Site, Building, Storey)
+- Documentation tools (e.g. Section Plan, Axis, Views, Dimensions)
+- IFC-based workflows and Native IFC document support (e.g. Classes, Types, Property Sets)
+- Import and export capabilities for common AEC formats (e.g. OBJ, DAE, SH3D, 3DS)
+- Quantity surveying and reporting tools (e.g. Schedule, Report)
+- Many misc utilities and tools to edit and manage project objects and data
+
+Since FreeCAD 1.0, the BIM Module integrates and extends the historical `Arch` Workbench, Draft tools, and NativeIFC functionality into a unified BIM workbench. Much of the underlying implementation still resides in the legacy `Arch*` modules and packages that provide the foundation of the BIM object model.
+
+The BIM Module is integrated with the rest of FreeCAD and relies heavily on existing FreeCAD core concepts, other important Modules, and API such as:
+
+- App and Gui document architecture
+- Part geometry
+- Draft tools and utilities
+- Sketcher
+- TechDraw
+- Link objects
+
+The BIM Module is therefore a layer built on top of FreeCAD's parametric document and geometric infrastructure, and extends it with BIM semantics and workflows.
+
+---
+
+## 2. Project Organization and Maintainers
+
+The BIM Module is maintained by the FreeCAD BIM contributors community as part of the main FreeCAD project.
+
+Similarly to other modules in FreeCAD, the development, discussions, bug reports and feature proposals take place through:
+
+- FreeCAD git repository
+- Pull requests and code reviews
+- Issue tracker
+- FreeCAD user and developers forum
+
+New contributors should consult the repository documentation, discussions, and reach out to current contributors before implementing major architectural changes.
+
+---
+
+## 3. Architecture and Dependencies
+
+The BIM Module is almost entirely Python3-based and follows the architectural conventions used throughout FreeCAD.
+It builds upon FreeCAD's existing document, property, and geometric infrastructure.
+
+Its main components are:
+
+```
+src/Mod/BIM/
+
+Workbench Integration
+├── Init.py
+├── InitGui.py
+
+Core BIM Objects
+├── Arch*.py
+
+Workbench Commands
+├── bimcommands/
+│   └── Bim*.py
+
+IFC and file formats Infrastructure
+├── nativeifc/
+│   └── ifc_*.py
+├── importers/
+│   └── import/export*.py
+
+Resources
+├── Resources/
+│   ├── icons/
+│   |   └── *.svg
+│   ├── templates/
+│   ├── translations/
+│   |   └── *.ts
+│   └── ui/
+│       └── *.ui
+
+Presets and Schemas
+├── Presets/
+│   └── *.json/csv
+
+Unit Tests
+├── bimtests/
+│   └── Test*.py
+
+Utilities
+└── utils/
+    └── *.py
+```
+
+Main dependencies include:
+
+- FreeCAD App API
+- FreeCAD Gui API for both Qt (UI) and Coin3D (viewport)
+- Part
+- Draft
+- Sketcher
+- TechDraw
+
+External libraries:
+
+- Qt / PySide
+- Coin3D / Pivy
+- IfcOpenShell (when available)
+
+---
+
+## 4. Core BIM Object Model
+
+The core BIM object system is implemented primarily through the `Arch*.py` modules.
+
+BIM objects are implemented as parametric FreeCAD document objects using the Property system and recompute framework.
+Their geometry is typically generated from underlying geometric primitives, profiles, sketches, or other supporting objects referenced through properties such as `Base`.
+
+Examples:
+
+```
+ArchWall.py
+ArchStructure.py
+ArchWindow.py
+ArchRoof.py
+ArchSpace.py
+ArchSite.py
+ArchProject.py
+```
+
+Most BIM objects share common behavior through base classes such as:
+
+```
+ArchComponent.py
+```
+
+These base classes provide:
+
+- Property management
+- IFC classification support
+- Placement handling
+- Shape generation
+- Material support
+- Quantity extraction
+- View integration
+
+Many BIM objects reuse functionality and utilities from the `Draft` module.
+
+Most BIM objects also follow FreeCAD's App object / View Provider pattern, where document data and behavior are separated from visualization and user-interface interaction.
+
+---
+
+## 5. Command and GUI Layer
+
+User-facing BIM tools commands are primarily implemented in:
+
+```
+bimcommands/
+```
+
+Examples:
+
+```
+BimWall.py
+BimWindow.py
+BimRoof.py
+BimProject.py
+BimMaterial.py
+```
+
+These modules typically contain:
+
+- FreeCAD commands (e.g. menu, toolbar, shortcuts)
+- Task panels
+- Interactive workflows (e.g. 3D view)
+- Selection handling
+
+---
+
+## 6. Document Structure and BIM Logic
+
+Unlike many CAD workflows that are feature-based (e.g. additions and subtraction), BIM models rely on semantic relationships in addition to geometry.
+
+A typical BIM document structure is organized as:
+
+```
+Project
+└── Site
+    └── Building
+        └── BuildingPart / Storey
+            ├── Walls
+            ├── Slabs
+            ├── Structures
+            ├── Spaces
+            └── Equipment
+```
+
+Key concepts include:
+
+- Hierarchical building organization
+- IFC classification
+- Host-child relationships
+- Base or baseless objects
+- Parametric generation
+- Quantity extraction
+- Material assignment
+
+---
+
+## 7. IFC and NativeIFC Architecture
+
+The IFC support is a central aspect of the BIM Module.
+
+Its functionality is implemented via:
+
+```
+ArchIFC.py
+ArchIFCSchema.py
+importIFC.py
+exportIFC.py
+```
+
+The IFC layer is responsible for:
+
+- IFC schemas
+- Entity creation and mapping
+- Import/export pipelines
+- Property Set management
+- Geometry translation
+
+The newer NativeIFC infrastructure is located in:
+
+```
+nativeifc/
+```
+
+Key components include:
+
+```
+ifc_import.py
+ifc_export.py
+ifc_geometry.py
+ifc_objects.py
+ifc_materials.py
+ifc_psets.py
+```
+
+NativeIFC enables:
+
+- IFC-native document workflows
+- Direct IFC entity representations
+- Improved IFC round-tripping
+- Better preservation of BIM semantics
+
+As of 2026, NativeIFC is still under development and remains an evolving system.
+Contributors should expect *architectural- changes as IFC-native workflows continue to mature.
+
+---
+
+## 8. Import and Export Framework
+
+A variety of BIM, CAD and visualization formats are supported.
+
+The import/export implementations are located primarily in:
+
+```
+importers/
+```
+
+The supported formats include:
+
+- IFC
+- OBJ
+- DAE (Collada)
+- JSON
+- SH3D
+- GBXML
+- 3DS
+- WebGL exports
+
+---
+
+## 9. Resources, Presets and Localization
+
+The static assets are stored in:
+
+```
+Resources/
+Presets/
+```
+
+Resources include:
+
+- Icons used for UI
+- UI definitions (e.g. preferences pages and dialog windows)
+- Translation files
+- Export Templates
+
+Presets include:
+
+- IFC schemas and mappings
+- Property set definitions
+- Quantity definitions
+- Classification data
+- Reporting presets
+- Profile libraries
+
+---
+
+## 10. Testing Infrastructure
+
+Automated tests are located in:
+
+```
+bimtests/
+```
+
+Tests cover:
+
+- BIM object behavior
+- Geometry generation
+- IFC functionality
+- GUI workflows
+- Import/export operations
+- Regression scenarios
+
+Typical structure:
+
+```
+TestArchWall.py
+TestArchStructure.py
+TestArchWindow.py
+TestArchRoof.py
+```
+
+When introducing new functionality:
+
+- Add unit tests whenever possible.
+- Extend existing test suites.
+- Add regression tests.
+- Avoid introducing GUI-only behavior without corresponding tests.
+
+---
+
+## 11. Coding Conventions
+
+All BIM code should follow the [FreeCAD Development Handbook](https://freecad.github.io/DevelopersHandbook/bestpractices/pythonpractices).
+
+Basically, this means:
+
+- PEP 8 and PEP 257 (docstrings)
+- Descriptive and standard naming
+- SPDX metadata
+- Clear [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html) docstrings and comments
+- Double quotes for `"strings"`
+- Explicit imports and no lazy import if possible
+- Small focused functions
+- Early returns, limited nesting and indentation
+- Explicit is clearer than implicit
+- Max 100 chars per line (current pylint limit)
+- Manageable structure and files size
+- DRY (do-not-repeat-yourself) and KISS (keep-it-super-simple)
+- Appropriate licensing for code (LGPL-2.1), assets, and other resources (e.g. CC BY-SA-4.0)
+- When in doubt, ask fellow contributors
+
+### App/Gui Separation
+
+Keep document logic independent from GUI code whenever possible.
+
+```
+App Layer
+    ↓
+Document Objects (Arch*.py)
+
+Gui Layer
+    ↓
+Commands (bimcommands/Bim*.py)
+```
+
+### Reuse Existing Foundations
+
+Prefer reusing and extending `ArchComponent.py`, `ArchCommands.py`, and other existing BIM utilities instead of creating duplicate implementations.
+
+If adding new BIM objects, make sure IFC is properly handled: IFC classification and export compatibility (multiple IFC schemas), Property Sets support, quantity extraction, etc. Check with other IFC viewers or editors (e.g. buildingSMART IFC Validation Service, Bonsai, etc) everything is correct.
+
+Also make sure icons are added, translations are supported based on FreeCAD existing tooling, menus, toolbars, tests, and documentation are updated.
+
+### Modern Python
+
+The BIM Module (and the `Arch` one before it) has a long legacy. Many modern Python concepts and practices (e.g. full type hinting, parallelism/concurrency) are not yet implemented. Please prefer consistency with surrounding BIM code to stylistic rewrites.
+
+### Recommended tools
+
+- [`pre-commit`](https://freecad.github.io/DevelopersHandbook/gettingstarted/)
+- [flake8](https://flake8.pycqa.org/en/latest/)
+- [codespell](https://github.com/codespell-project/codespell)
+
+---
+
+## 12. Contributing
+
+Before submitting contributions:
+
+1. Review existing BIM architecture.
+2. Follow FreeCAD coding guidelines.
+3. Reuse existing BIM infrastructure.
+4. Add or update tests.
+5. Verify IFC compatibility where applicable.
+6. Update documentation and resources.
+7. Keep pull requests focused and reviewable.
+
+For major changes:
+
+- Open a discussion first.
+- Present architectural rationale.
+- Consider existing workflows, backward file compatibility, and IFC implications.
+- Coordinate with other FreeCAD contributors.
+
+Thanks for reading up to this point =D
+
+Have fun contributing and keep FreeCADing!

--- a/src/Mod/BIM/coding_conventions.md
+++ b/src/Mod/BIM/coding_conventions.md
@@ -9,7 +9,8 @@ SPDX-FileNotice: Part of the FreeCAD project.
 - These coding conventions apply to the BIM module code.
   Other FreeCAD modules or the core/base system may use slightly different coding conventions.
   See the [FreeCAD Developers Handbook](https://freecad.github.io/DevelopersHandbook/) for more info.
-- They are essentially the same well-known PEP 8 guidelines recommended for all Python projects.
+- They are essentially the same well-known [PEP 8](https://www.python.org/dev/peps/pep-0008/)
+  guidelines recommended for all Python projects.
   The [Draft module](../Draft) and [FEM module](../Fem) use similar conventions.
 - New code added to the BIM module should adhere to these conventions.
 
@@ -26,8 +27,9 @@ SPDX-FileNotice: Part of the FreeCAD project.
 - Never use mixed line endings in the same file.
 - Use 4 spaces for a single level of indentation. Do not use tabs.
 - Remove trailing whitespaces.
-- Keep files at less than 1000 lines in size.
+- Keep files at less than 1000 lines in size:
   - Break a module into smaller ones, or into a package (a subdirectory with various modules).
+  - Split a module into App and Gui ones (e.g. Object has data and geometry, Object Gui has view provider, task panel).
   - A big function should be broken into smaller functions.
   - A big class should be broken into smaller classes.
     Then one class can subclass the other ones in order to inherit their methods.
@@ -38,13 +40,11 @@ SPDX-FileNotice: Part of the FreeCAD project.
 > [!NOTE] As of early 2026, the FreeCAD codebase supports Python version 3.10 to 3.13.
 > Many advanced features introduced in these versions and even before are not yet used
 > (e.g. type hinting, pattern matching, parallelism/concurrency, etc).
-> The introduction of such features for the BIM module is pending. Reach out if interested.
 
 ### Code formatting
 
-- In general, code should follow [PEP 8](https://www.python.org/dev/peps/pep-0008/)
-  and [PEP 257](https://www.python.org/dev/peps/pep-0257/) (docstrings).
-- Maximum line length should be 100 characters.
+- In general, code should follow PEP 8 and PEP 257 [docstrings](#source-code-documentation).
+- Keep line length below 100 characters if possible with a maximum of 120 (current pylint limit).
   - Find ways to reduce nested blocks of code by using auxiliary variables,
     and functions that encapsulate the operations inside these blocks.
   - If you have more than 3 levels of indentation, this is a sign that the code should be refactored.
@@ -61,7 +61,7 @@ SPDX-FileNotice: Part of the FreeCAD project.
 - Sort each import group alphabetically.
 - Do not use wildcard/asterisk imports, `from module import *`, as this
   makes it hard to validate imported functions and classes.
-- In general, do not import modules inside a function or class.
+- In general, do not import modules inside a function or class (lazy import).
 - The import of modules that require the graphical interface,
   such as `FreeCADGui`, should be guarded by an `if FreeCAD.GuiUp:` test.
 - In general, the code should be structured in such a way that console-only functions
@@ -75,6 +75,8 @@ SPDX-FileNotice: Part of the FreeCAD project.
   - `CamelCaseClass` for classes.
   - `CONSTANTS_USE_CAPITALS` for constants.
   - `functions_without_capitals()` for functions and class methods.
+- Do not use one-letter variables (e.g. `f` for `face`, `b` for `base`) unless established convention (`i` for `index`)
+  or short-lived scope. Use descriptive names for improved readability instead
 - Functions expected to return a value should indicate what is expected,
   so `is_mesh_valid` is a good name, but `check_mesh` is not a good name.
 - Class names, method names, and variables that are auxiliary,
@@ -114,18 +116,75 @@ codespell -i 3 -w -S *.ts -S *.svg -L beginn,childs,dof,dum,eiter,freez,inout,me
 
 ### Source code documentation
 
-> [!NOTE] As of early 2026, the FreeCAD codebase has no consistent source code documentation.
+> [!NOTE] As of early 2026, the FreeCAD codebase does not yet follow a consistent source code documentation standard.
 > Docstrings are the main approach currently used, in addition to sparse Doxygen comments.
 > Contributions in the area are most welcome!
 
-Python style docstrings are used at the module level, for classes, functions/methods and inline comments.
-They contain a short description and a longer explanation of purpose, scope, and usage notes:
+[Python style docstrings](https://peps.python.org/pep-0257/) are used at the module, class, function/method levels.
+Inline `# comments` may be used sparingly for implementation details.
+They contain a short one-line summary, a blank line, and a more elaborate description clarify functionality.
+For methods part of the public API, optional sections based on [numpydoc](https://numpydoc.readthedocs.io/en/latest/format.html)
+syntax are recommended:
 
 ```py
 """
-Short description.
+Short summary.
 
-Longer explanation of purpose, scope, and usage notes.
+More elaborate description clarify functionality.
+
+Parameters
+----------
+Optional description of the function arguments, keywords and their respective types.
+
+list : list of Part::FeaturePython, optional
+    A list of objects to include. Defaults to None.
+base : Part::FeaturePython, optional
+    The base object. Defaults to None.
+name : str, optional
+    The name to assign. Defaults to None.
+
+Attributes
+----------
+Optional description of the class attributes (class docstrings only).
+
+x : float
+    Description of attribute `x`.
+y : int
+    Description of attribute `y`.
+
+Methods
+-------
+Optional description of the class methods (class docstrings only).
+
+color(c='rgb')
+    Represent the color.
+
+Returns
+-------
+Optional description of the returned values and their types.
+
+result : Part::FeaturePython
+    The created object.
+
+See Also
+--------
+Optional section referring to related code (e.g. other useful functions).
+
+package.module.submodule.func_a :
+    A somewhat long description of the useful related function.
+
+Notes
+----
+Optional section providing additional info about the code (e.g. algorithm, references).
+
+Examples
+--------
+Optional comment explaining the example below.
+
+>>> import FreeCADGui as Gui
+>>> obj = make_feature(name="MyFeature")
+>>> Gui.ActiveDocument.getObject(obj.Name).Visibility
+True
 """
 ```
 

--- a/src/Mod/BIM/coding_conventions.md
+++ b/src/Mod/BIM/coding_conventions.md
@@ -1,4 +1,136 @@
-# Arch coding conventions
+<!--
+SPDX-License-Identifier: LGPL-2.1-or-later
+SPDX-FileCopyrightText: 2026 FreeCAD
+SPDX-FileNotice: Part of the FreeCAD project.
+-->
 
-Since Arch is also a Python workbench, follow the same coding conventions
-for the [Draft Workbench](../Draft).
+# BIM module coding conventions
+
+- These coding conventions apply to the BIM module code.
+  Other FreeCAD modules or the core/base system may use slightly different coding conventions.
+  See the [FreeCAD Developers Handbook](https://freecad.github.io/DevelopersHandbook/) for more info.
+- They are essentially the same well-known PEP 8 guidelines recommended for all Python projects.
+  The [Draft module](../Draft) and [FEM module](../Fem) use similar conventions.
+- New code added to the BIM module should adhere to these conventions.
+
+> [!NOTE] The BIM module (previously called `Arch`) is old with lot of legacy code,
+> thus the conventions below are currently not followed strictly.
+> Contributions to make the code more coherent and compliant, and improve these conventions are most welcome!
+
+
+## General
+
+- All files should have the license header at the beginning with SPDX metadata.
+  See examples on the [Developers Handbook](https://freecad.github.io/DevelopersHandbook/codeformatting/).
+- Unix line endings should be used.
+- Never use mixed line endings in the same file.
+- Use 4 spaces for a single level of indentation. Do not use tabs.
+- Remove trailing whitespaces.
+- Keep files at less than 1000 lines in size.
+  - Break a module into smaller ones, or into a package (a subdirectory with various modules).
+  - A big function should be broken into smaller functions.
+  - A big class should be broken into smaller classes.
+    Then one class can subclass the other ones in order to inherit their methods.
+
+
+## Python
+
+> [!NOTE] As of early 2026, the FreeCAD codebase supports Python version 3.10 to 3.13.
+> Many advanced features introduced in these versions and even before are not yet used
+> (e.g. type hinting, pattern matching, parallelism/concurrency, etc).
+> The introduction of such features for the BIM module is pending. Reach out if interested.
+
+### Code formatting
+
+- In general, code should follow [PEP 8](https://www.python.org/dev/peps/pep-0008/)
+  and [PEP 257](https://www.python.org/dev/peps/pep-0257/) (docstrings).
+- Maximum line length should be 100 characters.
+  - Find ways to reduce nested blocks of code by using auxiliary variables,
+    and functions that encapsulate the operations inside these blocks.
+  - If you have more than 3 levels of indentation, this is a sign that the code should be refactored.
+- Use double quotes for `"strings"`.
+
+### Imports
+
+- Imports should be at the beginning of the file after the license header and module docstring,
+  and they should be grouped in three types in order:
+  - Standard library imports
+  - Third party imports
+  - FreeCAD specific imports
+- Import only one module per line.
+- Sort each import group alphabetically.
+- Do not use wildcard/asterisk imports, `from module import *`, as this
+  makes it hard to validate imported functions and classes.
+- In general, do not import modules inside a function or class.
+- The import of modules that require the graphical interface,
+  such as `FreeCADGui`, should be guarded by an `if FreeCAD.GuiUp:` test.
+- In general, the code should be structured in such a way that console-only functions
+  are separate from their graphical interface implementations (GuiCommands).
+
+### Naming
+
+- Follow [PEP 8](https://www.python.org/dev/peps/pep-0008/):
+  - `snake_case_names.py` for modules.
+  - `variable_names_without_capitals` for variables.
+  - `CamelCaseClass` for classes.
+  - `CONSTANTS_USE_CAPITALS` for constants.
+  - `functions_without_capitals()` for functions and class methods.
+- Functions expected to return a value should indicate what is expected,
+  so `is_mesh_valid` is a good name, but `check_mesh` is not a good name.
+- Class names, method names, and variables that are auxiliary,
+  and not meant to be part of the public interface should start
+  with an underscore like `_MyInternalClass` or `_my_small_variable`.
+
+### Python code formatting tools
+
+- See [here how to set up](https://freecad.github.io/DevelopersHandbook/gettingstarted/) `pre-commit`.
+- Using a code editor that automatically checks compliance with PEP 8 is recommended.
+- Compliance can be manually checked with [flake8](https://flake8.pycqa.org/en/latest/).
+
+```bash
+flake8 --ignore=E226,E266,W503 file.py
+```
+
+
+## Spelling
+
+- Take care of spelling mistakes in the default English messages,
+  graphical user interfaces, documentation strings, and source code comments.
+- Use [codespell](https://github.com/codespell-project/codespell) to find common errors.
+
+To find typos in the BIM module, but skips translation files
+and certain words which could be custom defined variables, functions, and classes:
+
+```bash
+codespell -q 3 -S *.ts -S *.svg -L beginn,childs,dof,dum,eiter,freez,inout,methode,nd,normaly,programm,som,uint,vertexes src/Mod/BIM
+```
+
+Interactively fix the errors found:
+
+```bash
+codespell -i 3 -w -S *.ts -S *.svg -L beginn,childs,dof,dum,eiter,freez,inout,methode,nd,normaly,programm,som,uint,vertexes src/Mod/BIM
+```
+
+
+### Source code documentation
+
+> [!NOTE] As of early 2026, the FreeCAD codebase has no consistent source code documentation.
+> Docstrings are the main approach currently used, in addition to sparse Doxygen comments.
+> Contributions in the area are most welcome!
+
+Python style docstrings are used at the module level, for classes, functions/methods and inline comments.
+They contain a short description and a longer explanation of purpose, scope, and usage notes:
+
+```py
+"""
+Short description.
+
+Longer explanation of purpose, scope, and usage notes.
+"""
+```
+
+
+## Icons and resources
+
+- Command icons filenames use the same command name.
+- Icons and resources use a compliant Creative Commons license (e.g. CC BY-SA-4.0).


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/issues/20758

Update the BIM module coding conventions to be in-line with current status, refactors, and formatting changes (e.g. done during 1.1 dev cycle).
They are heavily inspired by similar coding conventions in Draft and FEM.

For now these conventions are quite generic, but serve as a base for future improvements specific to BIM (dependencies, cleanup of legacy code, performance, documentation, etc).
Open for discussion as always 😉 

As a next step, how about having an introductory README at the root of /src/Mod/BIM, like some other modules?