### PR TITLE
README: Update compiling section to recommend pixi

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,18 +56,8 @@ Other options are described on the [wiki Download page](https://wiki.freecad.org
 Compiling
 ---------
 
-The recommended way to build FreeCAD is with [pixi](https://pixi.sh/), which
-sets up an isolated build environment with all dependencies on any platform.
 See the [Developers Handbook – Getting Started](https://freecad.github.io/DevelopersHandbook/gettingstarted/)
-for full instructions.
-
-Quick start with pixi:
-
-```sh
-pixi run configure
-pixi run build
-pixi run freecad
-```
+for build instructions.
 
 
 Reporting Issues


### PR DESCRIPTION
## Summary
- Replace outdated wiki compilation links (Compile_on_Linux/Windows/macOS/MinGW) with a reference to the [Developers Handbook – Getting Started](https://freecad.github.io/DevelopersHandbook/gettingstarted/) page
- Recommend [pixi](https://pixi.sh/) as the primary build method, with a quick-start snippet

## Motivation
The old wiki links in the README are outdated and can mislead newcomers.
For example, I myself followed those links instead of the Developers Handbook and ended up submitting #27495 — an unnecessary Nix flake PR — because I didn't realize pixi was already the recommended approach.

Pointing the README directly to the Developers Handbook should help prevent this kind of confusion.

## Test plan
- [ ] Verify all links in the updated section resolve correctly