### PR TITLE
CAM: CircularHoleBase - Fix holePosition() for face with several arcs

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelix.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelix.py
@@ -71,7 +71,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
         for base in op.Base:
             model = base[0]
             for sub in base[1]:
-                pos = proxy.holePosition(op, model, sub)
+                pos = proxy.holePosition(model, sub)
                 self.assertRoughly(round(pos.Length / 10, 0), proxy.holeDiameter(op, model, sub))
 
     def test02(self):
@@ -86,7 +86,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
             for base in op.Base:
                 model = base[0]
                 for sub in base[1]:
-                    pos = proxy.holePosition(op, model, sub)
+                    pos = proxy.holePosition(model, sub)
                     # Path.Log.track(deg, pos, pos.Length)
                     self.assertRoughly(
                         round(pos.Length / 10, 0), proxy.holeDiameter(op, model, sub)
@@ -110,7 +110,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
             for base in op.Base:
                 model = base[0]
                 for sub in base[1]:
-                    pos = proxy.holePosition(op, model, sub)
+                    pos = proxy.holePosition(model, sub)
                     # Path.Log.track(deg, pos, pos.Length)
                     self.assertRoughly(
                         round(pos.Length / 10, 0), proxy.holeDiameter(op, model, sub)
@@ -134,7 +134,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
             for base in op.Base:
                 model = base[0]
                 for sub in base[1]:
-                    pos = proxy.holePosition(op, model, sub)
+                    pos = proxy.holePosition(model, sub)
                     # Path.Log.track(deg, pos, pos.Length)
                     self.assertRoughly(
                         round(pos.Length / 10, 0), proxy.holeDiameter(op, model, sub)

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -121,8 +121,8 @@ class ObjectOp(PathOp.ObjectOp):
 
         return 0
 
-    def holePosition(self, obj, base, sub):
-        """holePosition(obj, base, sub) ... returns a Vector for the position defined by the given features.
+    def holePosition(self, base, sub):
+        """holePosition(base, sub) ... returns a Vector for the position defined by the given features.
         Note that the value for Z is set to 0."""
 
         try:
@@ -177,7 +177,7 @@ class ObjectOp(PathOp.ObjectOp):
             for sub in subs:
                 Path.Log.debug("processing {} in {}".format(sub, base.Name))
                 if self.isHoleEnabled(obj, base, sub):
-                    pos = self.holePosition(obj, base, sub)
+                    pos = self.holePosition(base, sub)
                     if pos:
                         holes.append(
                             {


### PR DESCRIPTION
> [!CAUTION]
> There is two PRs about this
> 1. This one allows to process (get hole position) from shape and should be merged first
> 2. Another allows to use `Auto-Select` - #27585

---

[holes.zip](https://github.com/user-attachments/files/25239457/holes.zip)

Get error, if try to use face which contain several edges:
> CircularHoleBase.ERROR:
> Feature Model-Body001.Face28 cannot be processed as a circular hole
> please remove from Base geometry list.`

https://github.com/FreeCAD/FreeCAD/blob/379179ce2b2188d5b873a077bb9a44a01c15cee8/src/Mod/CAM/Path/Op/CircularHoleBase.py#L136-L140

This commit change behavior of function `holePosition()` and allow face which contains several edges, if:
- all edges of the face is arcs
- all arcs have identical center point

<img width="506" height="398" alt="Screenshot_20260211_180333_lossy" src="https://github.com/user-attachments/assets/66e49fe0-3765-4d29-b70c-9ecab15a260f" />


### Before
https://github.com/user-attachments/assets/f19ec76c-fdbc-40a6-ab94-e153ef949503

### After
https://github.com/user-attachments/assets/1e5c31ed-49de-49d9-a8d5-d955c65b3bdb