### PR TITLE
fixes #27444 update netgen src files to fix builds with netgen >= 6.2.2601

### DIFF
--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
+++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_Mesher.cpp
@@ -126,7 +126,11 @@ namespace netgen {
 #endif
   //extern void OCCSetLocalMeshSize(OCCGeometry & geom, Mesh & mesh);
   DLL_HEADER extern MeshingParameters mparam;
-  DLL_HEADER extern volatile multithreadt multithread;
+#if NETGEN_VERSION >= NETGEN_VERSION_STRING(6,2,2601)
+    using ngcore::multithread;
+#else
+    DLL_HEADER extern volatile multithreadt multithread;
+#endif
   DLL_HEADER extern bool merge_solids;
 }
 

--- a/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_NETGEN_3D.cpp
+++ b/src/3rdParty/salomesmesh/src/NETGENPlugin/NETGENPlugin_NETGEN_3D.cpp
@@ -112,7 +112,11 @@ namespace netgen {
   DLL_HEADER extern int OCCGenerateMesh (OCCGeometry&, Mesh*&, int, int, char*);
 #endif
   DLL_HEADER extern MeshingParameters mparam;
-  DLL_HEADER extern volatile multithreadt multithread;
+#if NETGEN_VERSION >= NETGEN_VERSION_STRING(6,2,2601)
+    using ngcore::multithread;
+#else
+    DLL_HEADER extern volatile multithreadt multithread;
+#endif
 }
 using namespace nglib;
 using namespace std;


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this pr aims at fixing / resolving issue #27444 ie. fixes #27444 with recent update to netgen, ie. 6.2.2601 `multithread` was moved to a new namespace. this was causing build errors at mentioned in the issue linked below. this pr add some preprocessor guards to handle the new namespace ie. `ngcore::multithread` two files were updated to make the build work while still allowing freecad to build with older versions of netgen.

i tested the build processes locally with asahi linux setup on mac mini m1 with both netgen v6.2.2601 and v6.2.2505 using the newly created netgen formula i setup in the homebrew-freecad tap.

## Issues

- https://github.com/freecad/freecad/issues/27444

## Before and After Images

N/A
