### PR TITLE
BIM: do not process shapes of BuildingParts for TD BIMViews

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -89,7 +89,7 @@ def getSectionData(source):
     p = FreeCAD.Placement(source.Placement)
     direction = p.Rotation.multVec(FreeCAD.Vector(0, 0, 1))
     if objs:
-        objs = Draft.get_group_contents(objs, walls=True, addgroups=True)
+        objs = Draft.get_group_contents(objs, walls=True)
     return objs, cutplane, onlySolids, clip, direction
 
 


### PR DESCRIPTION
Fixes #17661.
Fixes #27396.
Fixes #27650.

In ArchSectionPlane.py the shape of BuildingParts was also processed. This resulted in duplicate geometry as BuildingParts inherit their shape from their (also processed) content.

This PR requires some testing, it should not be backported to v1.1.