### PR TITLE
CAM: CircularHoleBase - Fix holeDiameter() for face

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelix.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelix.py
@@ -72,7 +72,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
             model = base[0]
             for sub in base[1]:
                 pos = proxy.holePosition(model, sub)
-                self.assertRoughly(round(pos.Length / 10, 0), proxy.holeDiameter(op, model, sub))
+                self.assertRoughly(round(pos.Length / 10, 0), proxy.holeDiameter(model, sub))
 
     def test02(self):
         """Verify Helix generates proper holes for rotated model"""
@@ -88,9 +88,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
                 for sub in base[1]:
                     pos = proxy.holePosition(model, sub)
                     # Path.Log.track(deg, pos, pos.Length)
-                    self.assertRoughly(
-                        round(pos.Length / 10, 0), proxy.holeDiameter(op, model, sub)
-                    )
+                    self.assertRoughly(round(pos.Length / 10, 0), proxy.holeDiameter(model, sub))
 
     def test03(self):
         """Verify Helix generates proper holes for rotated base model"""
@@ -112,9 +110,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
                 for sub in base[1]:
                     pos = proxy.holePosition(model, sub)
                     # Path.Log.track(deg, pos, pos.Length)
-                    self.assertRoughly(
-                        round(pos.Length / 10, 0), proxy.holeDiameter(op, model, sub)
-                    )
+                    self.assertRoughly(round(pos.Length / 10, 0), proxy.holeDiameter(model, sub))
 
     def test04(self):
         """Verify Helix generates proper holes for rotated clone base model"""
@@ -136,9 +132,7 @@ class TestPathHelix(PathTestUtils.PathTestBase):
                 for sub in base[1]:
                     pos = proxy.holePosition(model, sub)
                     # Path.Log.track(deg, pos, pos.Length)
-                    self.assertRoughly(
-                        round(pos.Length / 10, 0), proxy.holeDiameter(op, model, sub)
-                    )
+                    self.assertRoughly(round(pos.Length / 10, 0), proxy.holeDiameter(model, sub))
 
     def testPathDirection(self):
         """Verify that the generated paths obeys the given parameters"""

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -88,8 +88,8 @@ class ObjectOp(PathOp.ObjectOp):
         Can safely be overwritten by subclasses."""
         pass
 
-    def holeDiameter(self, obj, base, sub):
-        """holeDiameter(obj, base, sub) ... returns the diameter of the specified hole."""
+    def holeDiameter(self, base, sub):
+        """holeDiameter(base, sub) ... returns the diameter of the specified hole."""
         try:
             shape = base.Shape.getElement(sub)
             if isinstance(shape, Part.Vertex):
@@ -179,7 +179,7 @@ class ObjectOp(PathOp.ObjectOp):
                             {
                                 "x": pos.x,
                                 "y": pos.y,
-                                "r": self.holeDiameter(obj, base, sub),
+                                "r": self.holeDiameter(base, sub),
                             }
                         )
 

--- a/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
@@ -84,7 +84,7 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                 item.setData(self.DataObjectSub, sub)
                 self.form.baseList.setItem(self.form.baseList.rowCount() - 1, 0, item)
 
-                dia = obj.Proxy.holeDiameter(obj, base, sub)
+                dia = obj.Proxy.holeDiameter(base, sub)
                 item = QtGui.QTableWidgetItem()
                 item.setData(QtCore.Qt.DisplayRole, float(dia))
                 item.setTextAlignment(QtCore.Qt.AlignHCenter)


### PR DESCRIPTION
This is not obvious behavior of function `holeDiameter()` while processing `Face`

https://github.com/FreeCAD/FreeCAD/blob/3d14203fa496835b15ad320376422966df2377fe/src/Mod/CAM/Path/Op/CircularHoleBase.py#L101-L108

The compares with BoundBox of the shape was added by this PR
- #2416

Not obvious, what `tessilation inaccuracies` mean, while taking radius of the arc edge

I found the case in which this compare get incorrect result

This PR change behavior to get correct result with attached example

[cylinder.zip](https://github.com/user-attachments/files/25242682/cylinder.zip)


<img width="1246" height="446" alt="Screenshot_20260211_204957_hor_lossy" src="https://github.com/user-attachments/assets/f9e604f5-711b-44f4-bba9-dfcd8ef534df" />
