### PR TITLE
CAM: Extended the post processor test mock code

### DIFF
--- a/src/Mod/CAM/CAMTests/PostTestMocks.py
+++ b/src/Mod/CAM/CAMTests/PostTestMocks.py
@@ -26,6 +26,7 @@ without requiring disk I/O or loading actual FreeCAD documents.
 """
 
 import Path
+import FreeCAD
 
 
 class MockTool:
@@ -42,12 +43,17 @@ class MockToolController:
         label="TC: Default Tool",
         spindle_speed=1000,
         spindle_dir="Forward",
+        feed=FreeCAD.Units.Quantity("1 mm/s"),
     ):
         self.Tool = MockTool()
         self.ToolNumber = tool_number
         self.Label = label
         self.SpindleSpeed = spindle_speed
         self.SpindleDir = spindle_dir
+        self.HorizFeed = feed
+        self.VertFeed = feed
+        self.HorizRapid = 2 * feed
+        self.VertRapid = 2 * feed
         self.Name = f"TC{tool_number}"
 
         # Create a simple path with tool change commands
@@ -191,7 +197,12 @@ def create_default_job_with_operation():
     job = MockJob()
 
     # Create default tool controller
-    tc = MockToolController(tool_number=1, label="TC: Default Tool", spindle_speed=1000)
+    tc = MockToolController(
+        tool_number=1,
+        label="TC: Default Tool",
+        spindle_speed=1000,
+        feed=FreeCAD.Units.Quantity("10 mm/s"),
+    )
     job.Tools.Group = [tc]
 
     # Create default operation


### PR DESCRIPTION
This made the Tool and ToolController behave more like the real thing. This allow the mock code to work with the extended OpenSBP post processor available from
https://github.com/awgrover/FreeCAD/blob/releases/opensbp_post-dev-pr/src/Mod/CAM/Path/Post/scripts/opensbp_post.py .

See also PR #27441.