### PR TITLE
gui: preferences fixes #27379

### DIFF
--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -151,7 +151,7 @@ public:
             }
         }
         else if (reason == "SubstituteDecimalSeparator") {
-            bool value = hGrp->GetBool("SubstituteDecimal");
+            bool value = hGrp->GetBool("SubstituteDecimalSeparator");
             client->enableDecimalPointConversion(value);
         }
     }


### PR DESCRIPTION
this pr fixes #27379. the most difficult part of this PR was coming up with a workflow to reproduce the steps without a physical numpad on my keyboard. Nonetheless, steps are provided below to reproduce and test the fix on keyboards without a numpad.

## Issues

- https://github.com/freecad/freecad/issues/27379

## Before and After Images

before the changes from this PR if one had a language defined where the decimal separator defaults to _comma_ ie. `,` and had the setting `Substitue decimal separator` checked in the preferences. then when using their numpad on their keyboard the period key ie. `.` would input a `,`. however once they opened the preferences, and then closed them the setting defaults to false even though the check mark remained checked. thus when the user inputted a `.` from their numpad a literal `.` aka period is inserted **instead of the** `,`.

## steps to reproduce

to test the changes ie. verify the fix from this pr.

1. set the  language setting in the freecad preferences to a language that defaults to a comma ie. `,` so choose something like german or french, i chose french for my local testing.
2. then check the box "Substitute decimal separator".
3. close preferences.

4. create a simple sketch, and add a dimension constraint.

then in a terminal run the below command,

```
sleep 5 && xdotool key KP_Decimal
```

then quickly switch back to freecad clear the values in the input field and a `,` comma should be inserted.

without this fix a literal `.` period will be inserted.

> requires opening and closing the preferences to reproduce the bug.

make sure to install the `xdotool` command using your preferred package manager.

