### PR TITLE
CAM: DressupTag - Change precision for checks disabled tags

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -869,7 +869,7 @@ class PathData:
                 t
                 for t in tags
                 if Path.Geom.isRoughly(
-                    0, Part.Vertex(t.originAt(self.minZ)).distToShape(edge)[0], 0.1
+                    0, Part.Vertex(t.originAt(self.minZ)).distToShape(edge)[0], 1
                 )
             ]
             for t in sorted(


### PR DESCRIPTION
If user change path a little bit, tags will be disabled, because allows deviation < 0.1 mm

https://github.com/FreeCAD/FreeCAD/blob/6abb2b447f26e2861614ec4e9c2d3ba51e26336c/src/Mod/CAM/Path/Dressup/Tags.py#L868-L874

There are a lot of cases in which this such low limit creates problems
E.g. copy tags to create finish mill, change tool diameter after sharpening 

I suggest to increase this distance from 0.1 to 1.0 mm
If user change diameter of the tool after sharpening from 10 to 9.7 mm, tags still be enabled