### PR TITLE
Draft: fix depency of patharray normal on view direction

### DIFF
--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -604,7 +604,7 @@ def placements_on_path(
     if forceNormal and normalOverride:
         normal = normalOverride
     else:
-        normal = DraftGeomUtils.get_normal(pathwire)
+        normal = DraftGeomUtils.get_shape_normal(pathwire)
         if normal is None:
             normal = App.Vector(0, 0, 1)
 


### PR DESCRIPTION
Issue reported on the forum:
https://forum.freecad.org/viewtopic.php?t=103227

The code used the `get_normal` function which can flip the normal depending on the view direction. As a result a patharray's shape could depend on the current view. This was fixed by using the `get_shape_normal` function instead.
