### PR TITLE
switch Imperial units set to use decimal-degrees and not DMS

### DIFF
--- a/src/Base/UnitsSchemasData.h
+++ b/src/Base/UnitsSchemasData.h
@@ -648,7 +648,7 @@ inline const UnitsSchemaSpec s9
         { "Pressure" , {{ 0   , "psi"   , psi                      }}},
         { "Stiffness", {{ 0   , "lbf/in", lbf / in * 1000          }}},
         { "Velocity" , {{ 0   , "mph"   , mi / 3600                }}},
-        { "Angle"    , {{ 0   , "toDMS" , 0                        }}}  // <== !
+        { "Angle"    , {{ 0   , "°"     , 1.0                      }}}
     }
 };
 

--- a/src/Base/UnitsSchemasData.h
+++ b/src/Base/UnitsSchemasData.h
@@ -689,7 +689,7 @@ inline const UnitsSchemaSpec s9
         { "Pressure" , {{ 0   , "psi"   , psi                      }}},
         { "Stiffness", {{ 0   , "lbf/in", lbf / in * 1000          }}},
         { "Velocity" , {{ 0   , "mph"   , mi / 3600                }}},
-        { "Angle"    , {{ 0   , "toDMS" , 0                        }}}  // <== !
+        { "Angle"    , {{ 0   , "°"     , 1.0                      }}}
     }
 };
 

--- a/tests/src/Base/SchemaTests.cpp
+++ b/tests/src/Base/SchemaTests.cpp
@@ -568,38 +568,38 @@ TEST_F(SchemaTest, imperial_building_special_function_length_neg)
     EXPECT_EQ(result, expect);
 }
 
-TEST_F(SchemaTest, imperial_civil_special_function_angle_degrees)
+TEST_F(SchemaTest, imperial_civil_angle_whole_degree)
 {
-    constexpr auto val {180};
-    const auto result = set("ImperialCivil", Unit::Angle, val);
-    const auto expect {"180°"};
+    constexpr auto val {180.0};
+    const auto result = setWithPrecision("ImperialCivil", val, Unit::Angle, 2);
+    const auto expect {"180.00°"};
 
     EXPECT_EQ(result, expect);
 }
 
-TEST_F(SchemaTest, imperial_civil_special_function_angle_minutes)
+TEST_F(SchemaTest, imperial_civil_angle_half_degree)
 {
     constexpr auto val {180.5};
-    const auto result = set("ImperialCivil", Unit::Angle, val);
-    const auto expect {"180°30′"};
+    const auto result = setWithPrecision("ImperialCivil", val, Unit::Angle, 2);
+    const auto expect {"180.50°"};
 
     EXPECT_EQ(result, expect);
 }
 
-TEST_F(SchemaTest, imperial_civil_special_function_angle_seconds)
+TEST_F(SchemaTest, imperial_civil_angle_fractional_degree)
 {
     constexpr auto val {180.11};
-    const auto result = set("ImperialCivil", Unit::Angle, val);
-    const auto expect {"180°6′36″"};
+    const auto result = setWithPrecision("ImperialCivil", val, Unit::Angle, 2);
+    const auto expect {"180.11°"};
 
     EXPECT_EQ(result, expect);
 }
 
-TEST_F(SchemaTest, imperial_civil_special_function_angle_no_degrees)
+TEST_F(SchemaTest, imperial_civil_angle_below_one_degree)
 {
     constexpr auto val {0.11};
-    const auto result = set("ImperialCivil", Unit::Angle, val);
-    const auto expect {"0°6′36″"};
+    const auto result = setWithPrecision("ImperialCivil", val, Unit::Angle, 2);
+    const auto expect {"0.11°"};
 
     EXPECT_EQ(result, expect);
 }
@@ -1378,8 +1378,8 @@ TEST_F(SchemaTest, sweep_imperial_civil)
         {"1 lb*ft^2", "10 lb*ft^2", "100 lb*ft^2"},
         {"1 psi", "10 psi", "100 psi"},
         {"1 mph", "10 mph", "100 mph"},
-        // Angle (toDMS)
-        {"1°", "1°30′", "10°", "10°6′36″", "45°", "45°30′", "90°", "180°", "360°"},
+        // Angle (decimal degrees)
+        {"1°", "1.5°", "10°", "10.11°", "45°", "45.5°", "90°", "180°", "360°"},
     });
 }
 


### PR DESCRIPTION
The Imperial units set is useful for me because I am actually welding up an elaborate 5000 sq-ft structure and want to use feet but not inches.  I have an engineering tape measure that is in feet only, let's call it decimal-feet, accurate to 1/100th of a foot.

However I found the DMS angle support abysmally horrible.    I think DMS should be for entry only, and never for display.  Here is my problem and reasoning on why this patch is not only best for me, but also for the project as a whole:

https://forum.freecad.org/viewtopic.php?p=868992#p868992

An alternative is to create another units set, but as mentioned in the link above, I think this is far less beneficial to the project.

