### PR TITLE
material: fixes #25817 prevent unecessary save over dialogue

### DIFF
--- a/src/Mod/Material/Gui/MaterialSave.cpp
+++ b/src/Mod/Material/Gui/MaterialSave.cpp
@@ -139,7 +139,9 @@ void MaterialSave::onOk(bool checked)
     QFileInfo filepath(_selectedPath + QStringLiteral("/") + name
                        + QStringLiteral(".FCMat"));
 
-    /*if (library->fileExists(filepath.filePath()))*/ {
+    auto localLibrary = std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
+    if (localLibrary && localLibrary->fileExists(filepath.filePath()))
+    {
         // confirm overwrite
         auto res = confirmOverwrite(_filename);
         if (res == QMessageBox::Cancel) {


### PR DESCRIPTION
this PR fixes #25817 ie. when saving a new material with the material workbench recent dev builds would prompt the user with the "save over" dialogue as if they were overwritting an existing material even though they were not. this pr prevents that uncessary dialogue from prompting when saving new materials but also keeps the dialogue ie. presents if the user does attempt to overwrite and existing material with save.

unfortunately just uncommenting the commented line did not fix the issue due to a type mismatch, and would result in a compiler error.

```cpp
 /* if (library->fileExists(filepath.filePath())) */ {
```

```
/opt/code/fcgit/fcsrc/src/Mod/Material/Gui/MaterialSave.cpp:142:18: error: no member named 'fileExists' in 'Materials::MaterialLibrary'
  142 |     if (library->fileExists(filepath.filePath()))
      |         ~~~~~~~~~^
1 error generated.
ninja: build stopped: subcommand failed.
```
 

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/25817

## Before and After Images

