### PR TITLE
CAM: ObjectOp - Catch base error

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -339,6 +339,7 @@ class ObjectOp(object):
         self.vertFeed = None
         self.vertRapid = None
         self.addNewProps = None
+        self.isBaseValid = True
 
         self.initOperation(obj)
 
@@ -406,6 +407,7 @@ class ObjectOp(object):
 
     def onDocumentRestored(self, obj):
         Path.Log.track()
+        self.checkBase(obj)
         features = self.opFeatures(obj)
         if (
             FeatureBaseGeometry & features
@@ -547,14 +549,13 @@ class ObjectOp(object):
     def onChanged(self, obj, prop):
         """onChanged(obj, prop) ... base implementation of the FC notification framework.
         Do not overwrite, overwrite opOnChanged() instead."""
-
-        # there's a bit of cycle going on here, if sanitizeBase causes the transaction to
-        # be cancelled we end right here again with the unsainitized Base - if that is the
-        # case, stop the cycle and return immediately
-        if prop == "Base" and self.sanitizeBase(obj):
+        if prop == "Base" and not self.checkBase(obj):
             return
 
-        if "Restore" not in obj.State and prop in ["Base", "StartDepth", "FinalDepth"]:
+        if not getattr(self, "isBaseValid", True):
+            return
+
+        if "Restore" not in obj.State and prop in ("Base", "StartDepth", "FinalDepth"):
             self.updateDepths(obj, True)
 
         self.opOnChanged(obj, prop)
@@ -735,18 +736,22 @@ class ObjectOp(object):
 
         self.opUpdateDepths(obj)
 
-    def sanitizeBase(self, obj):
-        """sanitizeBase(obj) ... check if Base is valid and clear on errors."""
+    def checkBase(self, obj):
+        """checkBase(obj) ... check if Base is valid."""
         if hasattr(obj, "Base"):
             try:
                 for o, sublist in obj.Base:
                     for sub in sublist:
                         o.Shape.getElement(sub)
-            except Part.OCCError:
-                Path.Log.error("{} - stale base geometry detected - clearing.".format(obj.Label))
-                obj.Base = []
-                return True
-        return False
+            except Exception:
+                Path.Log.error(
+                    "%s - stale base geometry detected - %s, %s" % (obj.Label, o.Label, sub)
+                )
+                self.isBaseValid = False
+                return False
+
+        self.isBaseValid = True
+        return True
 
     @waiting_effects
     def execute(self, obj):
@@ -779,8 +784,10 @@ class ObjectOp(object):
         if not self._setBaseAndStock(obj):
             return
 
-        # make sure Base is still valid or clear it
-        self.sanitizeBase(obj)
+        # make sure Base is still valid
+        if not self.checkBase(obj):
+            obj.Path = Path.Path()
+            raise Exception("Base geometry error!")
 
         if FeatureTool & self.opFeatures(obj):
             tc = obj.ToolController

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -161,7 +161,7 @@ class ObjectOp(PathOp.ObjectOp):
                 )
             )
             return shape.BoundBox.XLength
-        except Part.OCCError as e:
+        except Exception as e:
             Path.Log.error(e)
 
         return 0
@@ -186,7 +186,7 @@ class ObjectOp(PathOp.ObjectOp):
                     if all(Path.Geom.pointsCoincide(center, e.Curve.Center) for e in shape.Edges):
                         return FreeCAD.Vector(center.x, center.y, 0)
             return FreeCAD.Vector(shape.CenterOfMass.x, shape.CenterOfMass.y, 0)
-        except Part.OCCError as e:
+        except Exception as e:
             Path.Log.error(e)
 
         Path.Log.error(

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -1523,7 +1523,7 @@ class TaskPanel(object):
     def panelSetFields(self):
         """panelSetFields() ... invoked to trigger a complete transfer of the model's properties to the UI."""
         Path.Log.track()
-        self.obj.Proxy.sanitizeBase(self.obj)
+        self.obj.Proxy.checkBase(self.obj)
         for page in self.featurePages:
             page.pageSetFields()
 


### PR DESCRIPTION
Fixes #17924 
Fixes #30105

---

If change `Base` model and sub shapes not exists any more, get Python errors
User can not use `Task panel` to remove incorrect names from `Base` list 
The only way to fix this, use `Console` or `Property view`, which is not obvious for regular users 

**Before**

https://github.com/user-attachments/assets/86c8ecac-3fe6-448d-8458-bf3665b66070

---

Changes by this commit, if can not get `Base` shapes:
- stop processing `ObjectOp`
- clear `Path`
- raise error to change icon
- allow to remove incorrect `Base` shapes from `Task panel`



https://github.com/user-attachments/assets/49f4c3b8-cae1-496c-83a9-ca8bce7a6a37



