### PR TITLE
Sketcher : SketchObject::getHigherElements fix

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -12369,4 +12369,3 @@ template class SketcherExport FeaturePythonT<Sketcher::SketchObject>;
 }// namespace App
 
 // clang-format on
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/20753

This PR adds the if block that was removed by formating which broke the logic of this function. And add a comment explaining that this function is currently unused.

The PR also updates the function to match latest version of linkstage.