### PR TITLE
Measurement: Fix: Implicit C-string to QString conversions causing build failure

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -478,7 +478,9 @@ void TaskMeasure::updateResultWithUnit()
     if (currentUnit != QLatin1String("-") && !resultString.isEmpty()) {
         Base::Quantity resultQty = Base::Quantity::parse(resultString.toStdString());
         // Parse unit string like "1 mm" to get the target quantity
-        Base::Quantity targetUnit = Base::Quantity::parse((QLatin1String("1 ") + currentUnit).toStdString());
+        Base::Quantity targetUnit = Base::Quantity::parse(
+            (QLatin1String("1 ") + currentUnit).toStdString()
+        );
         double convertedValue = resultQty.getValueAs(targetUnit);
 
         QString formattedValue;


### PR DESCRIPTION
Recent merge in PR #27462  introduced three implicit C-string to QString conversions, this causes compilation errors when QT_NO_CAST_FROM_ASCII is enabled. 
This PR fixes this by wrapping the C-strings in `tr()`. 