### PR TITLE
TechDraw: FCBRepAlgoAPI_Cut returns null shape for BrokenView break

### DIFF
--- a/src/Mod/TechDraw/App/DrawBrokenView.cpp
+++ b/src/Mod/TechDraw/App/DrawBrokenView.cpp
@@ -204,7 +204,10 @@ TopoDS_Shape DrawBrokenView::apply1Break(const App::DocumentObject& breakObj, co
     moveDir0 = DU::closestBasisOriented(moveDir0);
     auto halfSpace0 = makeHalfSpace(breakPoints.first, moveDir0, breakPoints.second);
 
-    FCBRepAlgoAPI_Cut mkCut0(inShape, halfSpace0);
+    // FCBRepAlgoAPI_Cut gets upset about cutting non-solids?? "XXX is not a solid" from Boolean::execute().
+    // We are cutting Compounds and that is valid in BRepAlgoAPI_Cut, but maybe not in FCBRepAlgoAPI_Cut?
+    // See sample file here: https://github.com/FreeCAD/FreeCAD/issues/27414
+    BRepAlgoAPI_Cut mkCut0(inShape, halfSpace0);
     if (!mkCut0.IsDone() || mkCut0.Shape().IsNull()) {
         Base::Console().warning("Failed to make first cut for break %s.\n", breakObj.Label.getValue());
         return {};
@@ -219,7 +222,8 @@ TopoDS_Shape DrawBrokenView::apply1Break(const App::DocumentObject& breakObj, co
     moveDir1 = DU::closestBasisOriented(moveDir1);
     auto halfSpace1 = makeHalfSpace(breakPoints.second, moveDir1, breakPoints.first);
 
-    FCBRepAlgoAPI_Cut mkCut1(inShape, halfSpace1);
+    // see mkCut0 above
+    BRepAlgoAPI_Cut mkCut1(inShape, halfSpace1);
     if (!mkCut1.IsDone()|| mkCut1.Shape().IsNull()) {
         Base::Console().warning("Failed to make second cut for break %s.\n", breakObj.Label.getValue());
         return {};


### PR DESCRIPTION
This PR implements a fix for issue #27414.  The issue reports a situation where an additional break
is added to a BrokenView object causing a failure.

There are two aspects to the fix.  

a) handle a null shape returned by FCBrepAlgoAPI_cut.  It is not clear why the resulting shape is 
   null.  This prevents the crash, but the result is not correct as the additional break is not displayed.  After     one or more additional recomputes, the display of the broken view includes the added break.

b) replace FCBRepAlgoAPI_Cut with BRepAlgoAPI, which returns the expected shape.  This change is 
   sufficient in itself to correct the reported failure without a).  It may be possible to choose a 
   break object that causes a null shape result (?), so the test for null is still a good idea.
   
I don't know why FCBrepAlgoAPI_Cut returns the null shape.  It may be because the input shapes are
nested Compounds or that the cutting tool is an infinite shape, but the other 5 breaks meet these
conditions and work correctly.