### PR TITLE
BIM: Fix placement jump when uncloning objects

### DIFF
--- a/src/Mod/BIM/bimcommands/BimUnclone.py
+++ b/src/Mod/BIM/bimcommands/BimUnclone.py
@@ -87,7 +87,7 @@ class BIM_Unclone:
                     ]:
                         setattr(newobj, prop, getattr(cloned, prop))
                         FreeCAD.ActiveDocument.recompute()
-                        newobj.Placement = cloned.Placement.multiply(placement)
+                        newobj.Placement = placement
                 # update/reset view properties too? no i think...
                 # for prop in cloned.ViewObject.PropertiesList:
                 #    if not prop in ["Proxy"]:

--- a/src/Mod/BIM/bimcommands/BimUnclone.py
+++ b/src/Mod/BIM/bimcommands/BimUnclone.py
@@ -82,12 +82,14 @@ class BIM_Unclone:
                         "Area",
                         "VerticalArea",
                         "PerimeterLength",
+                        "Placement",
                         "Proxy",
                         "Shape",
                     ]:
                         setattr(newobj, prop, getattr(cloned, prop))
-                        FreeCAD.ActiveDocument.recompute()
-                        newobj.Placement = placement
+                newobj.Placement = placement
+                FreeCAD.ActiveDocument.recompute()
+
                 # update/reset view properties too? no i think...
                 # for prop in cloned.ViewObject.PropertiesList:
                 #    if not prop in ["Proxy"]:


### PR DESCRIPTION
The Unclone command incorrectly multiplied the parent's placement by the clone's placement. Since Arch clones store absolute placement (not relative to the parent), this resulted in a double transform.

This caused baseless walls to jump to a new position upon uncloning. Standard base-backed walls often masked this bug because their local placement is usually Identity (0,0,0), but they would also fail if moved independently of their base.

This fix assigns the clone's current placement directly to the new object, preserving its position.

## Issues

Fixes https://github.com/FreeCAD/FreeCAD/issues/26929