### PR TITLE
Revert "[Backport releases/FreeCAD-1-1] Navigation: set client name to FreeCAD when connecting to spacenav"

### DIFF
--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -55,7 +55,6 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
         );
     }
     else {
-        spnav_client_name("FreeCAD");
         Base::Console().log("Connected to spacenav daemon\n");
         QSocketNotifier* SpacenavNotifier
             = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);

--- a/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinuxX11.cpp
@@ -75,7 +75,6 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
             .log("Couldn't connect to spacenav daemon on X11. Please ignore if you don't have a spacemouse.\n");
     }
     else {
-        spnav_client_name("FreeCAD");
         Base::Console().log("Connected to spacenav daemon on X11\n");
         mainApp->setSpaceballPresent(true);
         mainApp->installNativeEventFilter(new Gui::RawInputEventFilter(&xcbEventFilter));

--- a/src/Gui/Quarter/SpaceNavigatorDevice.cpp
+++ b/src/Gui/Quarter/SpaceNavigatorDevice.cpp
@@ -94,9 +94,6 @@ SpaceNavigatorDevice::SpaceNavigatorDevice(QuarterWidget* quarter) :
   if (!PRIVATE(this)->hasdevice) {
     fprintf(stderr, "Quarter:: Could not hook up to Spacenav device.\n");
   }
-  else {
-    spnav_client_name("FreeCAD");
-  }
 
 #endif // HAVE_SPACENAV_LIB
 }


### PR DESCRIPTION
Reverts FreeCAD/FreeCAD#27466 due to reported bug in https://github.com/FreeCAD/FreeCAD/issues/27604