### PR TITLE
Move boost includes out of core headers (10% faster build)

### DIFF
--- a/src/App/ComplexGeoData.cpp
+++ b/src/App/ComplexGeoData.cpp
@@ -41,6 +41,7 @@
 
 #include <boost/iostreams/device/array.hpp>
 #include <boost/iostreams/stream.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 
 using namespace Data;

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -39,6 +39,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/bimap.hpp>
 #include <boost/graph/strong_components.hpp>
+#include <boost/graph/topological_sort.hpp>
 
 #include <boost/regex.hpp>
 #include <random>

--- a/src/App/DynamicProperty.h
+++ b/src/App/DynamicProperty.h
@@ -30,12 +30,9 @@
 #include <string>
 #include <vector>
 #include <utility>
+#include <memory>
+#include <functional>
 
-#include <boost/multi_index_container.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/mem_fun.hpp>
 #include <FCGlobal.h>
 
 
@@ -51,27 +48,10 @@ namespace App
 class Property;
 class PropertyContainer;
 
-namespace bmi = boost::multi_index;
-
-struct CStringHasher
+struct AppExport CStringHasher
 {
-    inline std::size_t operator()(const char* s) const
-    {
-        if (!s) {
-            return 0;
-        }
-        return boost::hash_range(s, s + std::strlen(s));
-    }
-    inline bool operator()(const char* a, const char* b) const
-    {
-        if (!a) {
-            return !b;
-        }
-        if (!b) {
-            return false;
-        }
-        return std::strcmp(a, b) == 0;
-    }
+    std::size_t operator()(const char* s) const;
+    bool operator()(const char* a, const char* b) const;
 };
 
 /** This class implements an interface to add properties at run-time to an object
@@ -161,10 +141,7 @@ public:
     void clear();
 
     /// Get property count
-    size_t size() const
-    {
-        return props.size();
-    }
+    size_t size() const;
 
     void save(const Property* prop, Base::Writer& writer) const;
 
@@ -218,14 +195,8 @@ private:
     std::string getUniquePropertyName(const PropertyContainer& pc, const char* Name) const;
 
 private:
-    bmi::multi_index_container<
-        PropData,
-        bmi::indexed_by<
-            bmi::hashed_unique<bmi::const_mem_fun<PropData, const char*, &PropData::getName>,
-                               CStringHasher,
-                               CStringHasher>,
-            bmi::hashed_unique<bmi::member<PropData, Property*, &PropData::property>>>>
-        props;
+    struct Impl;
+    std::unique_ptr<Impl> impl;
 };
 
 }  // namespace App

--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -14,6 +14,7 @@
 #include "DocumentObject.h"
 
 #include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/io/ios_state.hpp>
 

--- a/src/App/Link.h
+++ b/src/App/Link.h
@@ -25,6 +25,9 @@
 #ifndef APP_LINK_H
 #define APP_LINK_H
 
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+
 #include <unordered_set>
 #include <Base/Parameter.h>
 #include <Base/Bitmask.h>

--- a/src/App/MappedName.cpp
+++ b/src/App/MappedName.cpp
@@ -28,6 +28,7 @@
 
 #include "Base/Console.h"
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/iostreams/device/array.hpp>
 #include <boost/iostreams/stream.hpp>
 
@@ -48,6 +49,30 @@ void MappedName::compact() const
     }
 }
 
+
+MappedName::MappedName(const char* name, int size) : raw(false)
+{
+    if (!name) {
+        return;
+    }
+    if (boost::starts_with(name, ELEMENT_MAP_PREFIX)) {
+        name += ELEMENT_MAP_PREFIX_SIZE;
+    }
+
+    data = size < 0 ? QByteArray(name) : QByteArray(name, size);
+}
+
+MappedName::MappedName(const std::string& nameString)
+    : raw(false)
+{
+    auto size = nameString.size();
+    const char* name = nameString.c_str();
+    if (boost::starts_with(nameString, ELEMENT_MAP_PREFIX)) {
+        name += ELEMENT_MAP_PREFIX_SIZE;
+        size -= ELEMENT_MAP_PREFIX_SIZE;
+    }
+    data = QByteArray(name, static_cast<int>(size));
+}
 
 int MappedName::findTagInElementName(long* tagOut,
                                      int* lenOut,

--- a/src/App/MappedName.h
+++ b/src/App/MappedName.h
@@ -28,8 +28,6 @@
 #include <memory>
 #include <string>
 
-#include <boost/algorithm/string/predicate.hpp>
-
 #include <QByteArray>
 #include <QHash>
 #include <QVector>
@@ -69,18 +67,7 @@ public:
      * @param[in] size Optional, the length of the name string. If not
      * provided, the string must be null-terminated.
      */
-    explicit MappedName(const char* name, int size = -1)
-        : raw(false)
-    {
-        if (!name) {
-            return;
-        }
-        if (boost::starts_with(name, ELEMENT_MAP_PREFIX)) {
-            name += ELEMENT_MAP_PREFIX_SIZE;
-        }
-
-        data = size < 0 ? QByteArray(name) : QByteArray(name, size);
-    }
+    explicit MappedName(const char* name, int size = -1);
 
     /**
      * @brief Create a MappedName from a C++ std::string.
@@ -90,17 +77,7 @@ public:
      *
      * @param nameString The new name. A deep copy is made.
      */
-    explicit MappedName(const std::string& nameString)
-        : raw(false)
-    {
-        auto size = nameString.size();
-        const char* name = nameString.c_str();
-        if (boost::starts_with(nameString, ELEMENT_MAP_PREFIX)) {
-            name += ELEMENT_MAP_PREFIX_SIZE;
-            size -= ELEMENT_MAP_PREFIX_SIZE;
-        }
-        data = QByteArray(name, static_cast<int>(size));
-    }
+    explicit MappedName(const std::string& nameString);
 
     /**
      * @brief Create a MappedName from an IndexedName.

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -27,9 +27,9 @@
 #define SRC_APP_PROPERTYCONTAINER_H_
 
 #include <map>
-#include <cstring>
 #include <vector>
 #include <string>
+#include <memory>
 #include <Base/Persistence.h>
 
 #include "DynamicProperty.h"
@@ -75,6 +75,8 @@ enum PropertyType
 
 struct AppExport PropertyData
 {
+  PropertyData();
+  ~PropertyData();
 
   /// @brief Struct to hold the property specification.
   struct PropertySpec
@@ -156,32 +158,6 @@ struct AppExport PropertyData
   private:
       const void* m_container;
   };
-
-    // clang-format off
-
-    /**
-     * @brief A multi index container for holding the property spec.
-     *
-     * The multi index has the following index:
-     * - a sequence, to preserve creation order
-     * - hash index on property name
-     * - hash index on property pointer offset
-     */
-    mutable bmi::multi_index_container<
-        PropertySpec,
-        bmi::indexed_by<
-            bmi::sequenced<>,
-            bmi::hashed_unique<
-                bmi::member<PropertySpec, const char*, &PropertySpec::Name>,
-                CStringHasher,
-                CStringHasher
-            >,
-            bmi::hashed_unique<
-                bmi::member<PropertySpec, short, &PropertySpec::Offset>
-            >
-        >
-    > propertyData;
-    // clang-format on
 
   /// Whether the property data is merged with the parent.
   mutable bool parentMerged = false;
@@ -301,6 +277,10 @@ struct AppExport PropertyData
    * @param[in] other The other PropertyData to split with; this can be the parent PropertyData.
    */
   void split(PropertyData *other);
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl;
 };
 
 

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -28,10 +28,7 @@
 #include <functional>
 #include <set>
 
-#include <boost/unordered/unordered_map.hpp>
 #include <fastsignals/signal.h>
-#include <boost_graph_adjacency_list.hpp>
-#include <boost/graph/topological_sort.hpp>
 
 #include <FCConfig.h>
 
@@ -324,7 +321,6 @@ protected:
     void hasSetValue() override;
 
 private:
-    using DiGraph = boost::adjacency_list<boost::listS, boost::vecS, boost::directedS>;
     using Edge = std::pair<int, int>;
 // Note: use std::map instead of unordered_map to keep the binding order stable
 #if defined(FC_OS_MACOSX) || defined(FC_OS_BSD) || defined(_LIBCPP_VERSION)
@@ -348,31 +344,6 @@ private:
      * @throws Base::RuntimeError if a circular dependency is detected.
      */
     std::vector<App::ObjectIdentifier> computeEvaluationOrder(ExecuteOption option);
-
-    /**
-     * @brief Update graph structure with given path and expression.
-     * @param path Path
-     * @param expression Expression to query for dependencies
-     * @param nodes Map with nodes of graph, including dependencies of 'expression'
-     * @param revNodes Reverse map of the nodes, containing only the given paths, without dependencies.
-     * @param edges Edges in graph
-     */
-    void buildGraphStructures(const App::ObjectIdentifier& path,
-                              const std::shared_ptr<Expression> expression,
-                              boost::unordered_map<App::ObjectIdentifier, int>& nodes,
-                              boost::unordered_map<int, App::ObjectIdentifier>& revNodes,
-                              std::vector<Edge>& edges) const;
-    /**
-     * @brief Build a graph of all expressions in \a exprs.
-     * @param exprs Expressions to use in graph
-     * @param revNodes Map from int[nodeid] to ObjectIndentifer.
-     * @param g Graph to update. May contain additional nodes than in revNodes, because of outside
-     * dependencies.
-     */
-    void buildGraph(const ExpressionMap& exprs,
-                    boost::unordered_map<int, App::ObjectIdentifier>& revNodes,
-                    DiGraph& g,
-                    ExecuteOption option = ExecuteAll) const;
 
     void slotChangedObject(const App::DocumentObject& obj, const App::Property& prop);
     void slotChangedProperty(const App::DocumentObject& obj, const App::Property& prop);

--- a/src/App/Transactions.h
+++ b/src/App/Transactions.h
@@ -32,6 +32,14 @@
 #include <Base/Persistence.h>
 #include <App/PropertyContainer.h>
 
+#include <boost/multi_index_container.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+
+namespace bmi = boost::multi_index;
+
 namespace App
 {
 

--- a/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
@@ -22,6 +22,8 @@
 
 #include "NavlibInterface.h"
 
+#include <boost/bind/bind.hpp>
+
 #include <QMatrix4x4>
 #include <QMdiArea>
 #include <QTabBar>

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -22,6 +22,8 @@
  *                                                                          *
  ***************************************************************************/
 
+#include <boost/smart_ptr/scoped_ptr.hpp>
+
 #include <QApplication>
 #include <QMessageBox>
 #include <QRegularExpression>

--- a/src/Gui/DocumentModel.cpp
+++ b/src/Gui/DocumentModel.cpp
@@ -20,6 +20,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <boost/unordered_set.hpp>
+
 #include <QApplication>
 #include <QFont>
 

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -20,6 +20,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <boost_graph_adjacency_list.hpp>
+#include <boost/graph/topological_sort.hpp>
 
 #include <QApplication>
 #include <QKeyEvent>
@@ -607,7 +609,6 @@ PyObject* ViewProvider::getPyObject()
     return pyViewObject;
 }
 
-#include <boost/graph/topological_sort.hpp>
 
 namespace Gui
 {

--- a/src/Mod/Fem/Gui/TaskPostBoxes.cpp
+++ b/src/Mod/Fem/Gui/TaskPostBoxes.cpp
@@ -20,6 +20,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <boost/bind/bind.hpp>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/events/SoMouseButtonEvent.h>
 #include <Inventor/nodes/SoCoordinate3.h>

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -81,6 +81,8 @@
 #include <ShapeFix_ShapeTolerance.hxx>
 #include <gp_Pln.hxx>
 
+#include <boost/algorithm/string/predicate.hpp>
+
 #include <utility>
 
 #include <OSD_Parallel.hxx>

--- a/src/Mod/Part/Gui/SoBrepEdgeSet.h
+++ b/src/Mod/Part/Gui/SoBrepEdgeSet.h
@@ -25,6 +25,7 @@
 #ifndef PARTGUI_SOBREPEDGESET_H
 #define PARTGUI_SOBREPEDGESET_H
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <Inventor/nodes/SoIndexedLineSet.h>
 #include <memory>
 #include <vector>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -22,6 +22,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <boost/bind/bind.hpp>
 #include <boost/core/ignore_unused.hpp>
 #include <Inventor/SbBox3f.h>
 #include <Inventor/SbLine.h>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -25,6 +25,8 @@
 #ifndef SKETCHERGUI_VIEWPROVIDERSKETCH_H
 #define SKETCHERGUI_VIEWPROVIDERSKETCH_H
 
+#include <boost/smart_ptr/scoped_ptr.hpp>
+
 #include <Inventor/SoRenderManager.h>
 #include <Inventor/sensors/SoNodeSensor.h>
 #include <QCoreApplication>

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -34,6 +34,9 @@
 #include <set>
 #include <vector>
 
+#include <boost_graph_adjacency_list.hpp>
+#include <boost/graph/topological_sort.hpp>
+
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DynamicProperty.h>


### PR DESCRIPTION
Use pimpl or move member function definitions to .cpp files in order to avoid including huge Boost headers in core FreeCAD headers. Due to boost includes in a few core headers, boost graph utilities, multi index and predicates headers were included in in a large portion of translation units, without them being actually required.

This helps reduce the overall build time of the project : from my local tests, this cuts build time by about 10% (Base config, linux, gcc 15.2 on i7-14700, `-j20`). I believe this will also have an impact on CI build times.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

This is a simple workaround to get "for free" some of the build optimizations that solving https://github.com/FreeCAD/FreeCAD/issues/26882 will get us, but without rewriting all of the boost data structures. This PR only moves code around.