### PR TITLE
App: Check for empty path component name before appending

### DIFF
--- a/src/App/ApplicationDirectories.cpp
+++ b/src/App/ApplicationDirectories.cpp
@@ -138,7 +138,10 @@ fs::path ApplicationDirectories::findPath(const fs::path& stdHome, const fs::pat
     // If a custom user home path is given, then don't modify it
     if (customHome.empty()) {
         for (const auto& it : subdirs) {
-            appData = appData / it;
+            if (!it.empty()) {
+                // Refuse to add an empty directory path component
+                appData = appData / it;
+            }
         }
     }
 


### PR DESCRIPTION
I'm not sure if this is the problem with #27608, but it should be safe to add (and an overall safety improvement) nevertheless.