### PR TITLE
Part: Migrate version check to ProgramVersion class

### DIFF
--- a/src/Base/ProgramVersion.h
+++ b/src/Base/ProgramVersion.h
@@ -44,6 +44,7 @@ enum class Version : std::uint8_t
     v0_22,
     v1_0,
     v1_1,
+    v1_2,
     v1_x,
 };
 
@@ -65,6 +66,7 @@ inline Version getVersion(std::string_view str)
         {.name="0.22", .version=Version::v0_22},
         {.name="1.0" , .version=Version::v1_0 },
         {.name="1.1" , .version=Version::v1_1 },
+        {.name="1.2" , .version=Version::v1_2 },
     };
     // clang-format on
     auto it = std::ranges::find_if(items, [str](const auto& item) {

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -24,6 +24,7 @@
 
 
 #include <Base/Console.h>
+#include <Base/ProgramVersion.h>
 #include <Base/Tools.h>
 
 #include <App/Document.h>
@@ -522,12 +523,8 @@ void AttachExtension::handleLegacyTangentPlaneOrientation()
     }
 
     // check stored document program version (applies to v1.0 and earlier only)
-    int major, minor;
-    if (sscanf(getExtendedObject()->getDocument()->getProgramVersion(), "%d.%d", &major, &minor)
-        != 2) {
-        return;
-    }
-    if (major > 1 || (major == 1 && minor > 0)) {
+    if (Base::getVersion(getExtendedObject()->getDocument()->getProgramVersion())
+        > Base::Version::v1_0) {
         return;
     }
 


### PR DESCRIPTION
Also add v1.2 to the recognized program version enumeration. Eliminates a use of deprecated `sscanf`.
