### PR TITLE
TD: Migrate version check to ProgramVersion class

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDimension.cpp
@@ -30,6 +30,7 @@
 
 #include <QMessageBox>
 
+#include <Base/ProgramVersion.h>
 #include <Base/Parameter.h>
 #include <App/Application.h>
 #include <App/DocumentObject.h>
@@ -361,7 +362,7 @@ void ViewProviderDimension::finishRestoring()
 void ViewProviderDimension::fixTextSize()
 {
     App::Document* ourDoc = getDocument()->getDocument();
-    if (checkMiniumumDocumentVersion(ourDoc, 1, 1)) {
+    if (checkMinimumDocumentVersion(ourDoc, Base::Version::v1_1)) {
         return;
     }
 
@@ -376,7 +377,7 @@ void ViewProviderDimension::fixTextSize()
 void ViewProviderDimension::fixArrowSize()
 {
     App::Document* ourDoc = getDocument()->getDocument();
-    if (checkMiniumumDocumentVersion(ourDoc, 1, 1)) {
+    if (checkMinimumDocumentVersion(ourDoc, Base::Version::v1_1)) {
         return;
     }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -31,6 +31,7 @@
 #include <App/Metadata.h>
 #include <Base/Color.h>
 #include <Base/Console.h>
+#include <Base/ProgramVersion.h>
 #include <Gui/Application.h>
 #include <Gui/Control.h>
 #include <Gui/Document.h>
@@ -524,7 +525,7 @@ std::vector<App::DocumentObject*> ViewProviderDrawingView::claimChildren() const
 void ViewProviderDrawingView::fixColorAlphaValues()
 {
     if (!Preferences::fixColorAlphaOnLoad() ||
-        checkMiniumumDocumentVersion(1, 1)) {
+        checkMinimumDocumentVersion(Base::Version::v1_1)) {
         return;
     }
 
@@ -550,27 +551,12 @@ void ViewProviderDrawingView::fixColorAlphaValues()
     }
 }
 
-
-//! true if document toBeChecked was written by a program with version >= minMajor.minMinor.
-//! note that we can not check point releases as only the major and minor are recorded in the Document.xml
-//! file.
-//! (ex <Document SchemaVersion="4" ProgramVersion="1.2R44322 +1 (Git)" FileVersion="1" StringHasher="1">)
-bool ViewProviderDrawingView::checkMiniumumDocumentVersion(App::Document* toBeChecked,
-                                                           int minMajor,
-                                                           int minMinor)
+bool ViewProviderDrawingView::checkMinimumDocumentVersion(App::Document* toBeChecked,
+                                                           Base::Version minVersion)
 {
     const char* docVersionText = toBeChecked->getProgramVersion();
-    int docMajor{0};
-    int docMinor{0};
-    // stole this bit from App::AttachExtension.
-    // NOLINTNEXTLINE
-    if (sscanf(docVersionText, "%d.%d", &docMajor, &docMinor) != 2) {
-        Base::Console().warning("Failed to retrieve document version number for %s\n",
-                    toBeChecked ? toBeChecked->getName() : "noname");
-        return false;   // ?? should we fail here? the file appears broken.
-    }
-
-    return std::tie(docMajor, docMinor) >= std::tie(minMajor, minMinor);
+    Base::Version documentVersion = Base::getVersion(docVersionText);
+    return documentVersion >= minVersion;
 }
 
 

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.h
@@ -28,6 +28,7 @@
 
 #include <fastsignals/signal.h>
 
+#include <Base/ProgramVersion.h>
 #include <Gui/Document.h>
 #include <Gui/ViewProviderDocumentObject.h>
 #include <Mod/TechDraw/App/DrawView.h>
@@ -105,9 +106,14 @@ public:
     std::vector<App::DocumentObject*> claimChildren() const override;
 
     void fixColorAlphaValues();
-    bool checkMiniumumDocumentVersion(int minMajor, int minMinor) const
-        { return checkMiniumumDocumentVersion(this->getDocument()->getDocument(), minMajor, minMinor); }
-    static bool checkMiniumumDocumentVersion(App::Document* toBeChecked, int minMajor, int minMinor);
+    bool checkMinimumDocumentVersion(Base::Version minimumVersion) const
+        { return checkMinimumDocumentVersion(this->getDocument()->getDocument(), minimumVersion); }
+
+    //! True if document toBeChecked was written by a program with version >= minimumVersion.
+    //! Note that we cannot check patch releases as only the major and minor are recorded in the
+    //! Document.xml file.
+    //! (ex <Document SchemaVersion="4" ProgramVersion="1.2R44322 +1 (Git)" FileVersion="1" StringHasher="1">)
+    static bool checkMinimumDocumentVersion(App::Document* toBeChecked, Base::Version minimumVersion);
 
 
 private:


### PR DESCRIPTION
Eliminates a use of deprecated `sscanf`. I also corrected the spelling to `checkMinimumDocumentVersion()` (I presume `checkMiniumumDocumentVersion()` was a typo).