### PR TITLE
Sketcher: Dimension tool: Filter coincident points

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -2064,7 +2064,7 @@ protected:
         // Remove redundant coincident points from the selection
         // This ensures box-selecting a junction of multiple lines is treated as 1 point.
         filterCoincidentPoints();
-        
+
         // See if the selection is valid
         bool selAllowed = makeAppropriateConstraint(Base::Vector2d(0.,0.));
 


### PR DESCRIPTION
Fix the 'dimension tool not working' part of the issue https://github.com/FreeCAD/FreeCAD/issues/27589

See explanation of why this was happening in https://github.com/FreeCAD/FreeCAD/issues/27589#issuecomment-3907422687