### PR TITLE
allow object deletion while edit task is open and auto-close if edite…

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1474,16 +1474,9 @@ void StdCmdDelete::activated(int iMsg)
             }
         }
         if (!handledInEditDeletion) {
-            bool shouldResetEdit = false;
-            if (vpedit) {
-                for (const auto& sel : sels) {
-                    if (sel.getObject() == vpedit->getObject()) {
-                        shouldResetEdit = true;
-                        break;
-                    }
-                }
-            }
-            if (shouldResetEdit) {
+            if (vpedit && std::ranges::any_of(sels, [&](const auto& sel) {
+                    return sel.getObject() == vpedit->getObject();
+                })) {
                 editDoc->resetEdit();
                 vpedit = nullptr;
             }


### PR DESCRIPTION
Fixes #27549: "Part: Can't delete objects if edit task is open"

**Behavior now**
1. Deleting the edited object → task closes automatically + object deleted
2. Deleting unrelated objects while edit task open → deletes normally, task stays open
3. Sub-element deletion while editing still works as before

**Changes**
- In `src/Gui/CommandDoc.cpp` (StdCmdDelete::activated):
  - Keep existing special handling for sub-element deletion in edit mode
  - Before normal object deletion: if the currently edited object is in the selection, call `editDoc->resetEdit()` to cleanly close the edit mode/task panel
  - Then proceed with deletion
- No change to command availability (Delete stays enabled)

Result of my local testing :-

https://github.com/user-attachments/assets/e8adcb6f-af53-457d-b98a-dbe92714596f





