### PR TITLE
Gui: Add search prefilled text from selection in TextEditor

### DIFF
--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -820,11 +820,21 @@ void SearchBar::retranslateUi()
     matchWord->setText(tr("Whole words"));
 }
 
-void SearchBar::activate()
+/**
+ * Show the search bar with optional prefilled text from selection.
+ */
+void SearchBar::activate(const QString& prefill)
 {
     show();
+
+    if (!prefill.isEmpty()) {
+        QSignalBlocker blocker(searchText);  // block auto-search jump to next match after prefill
+        searchText->setText(prefill);
+    }
+
     searchText->selectAll();
     searchText->setFocus(Qt::ShortcutFocusReason);
+    updateButtons();
 }
 
 void SearchBar::deactivate()

--- a/src/Gui/EditorView.h
+++ b/src/Gui/EditorView.h
@@ -165,7 +165,7 @@ protected:
     void changeEvent(QEvent*) override;
 
 public Q_SLOTS:
-    void activate();
+    void activate(const QString& prefill = QString());
     void deactivate();
     void findPrevious();
     void findNext();

--- a/src/Gui/TextEdit.cpp
+++ b/src/Gui/TextEdit.cpp
@@ -68,7 +68,9 @@ TextEdit::TextEdit(QWidget* parent)
     auto shortcutFind = new QShortcut(this);
     shortcutFind->setKey(QKeySequence::Find);
     shortcutFind->setContext(Qt::WidgetShortcut);
-    connect(shortcutFind, &QShortcut::activated, this, &TextEdit::showSearchBar);
+    connect(shortcutFind, &QShortcut::activated, this, [this]() {
+        Q_EMIT showSearchBar(selectionForSearch());
+    });
 
     auto shortcutNext = new QShortcut(this);
     shortcutNext->setKey(QKeySequence::FindNext);
@@ -139,6 +141,25 @@ int TextEdit::getInputStringPosition()
 QString TextEdit::getInputString()
 {
     return textCursor().block().text();
+}
+
+/**
+ * Return selected text or word under cursor if none. Normalize line breaks.
+ */
+QString TextEdit::selectionForSearch() const
+{
+    QTextCursor cursor = textCursor();
+    QString text = cursor.selectedText();
+
+    if (text.isEmpty()) {
+        cursor.select(QTextCursor::WordUnderCursor);
+        text = cursor.selectedText();
+    }
+
+    // Qt replaces line breaks with U+2029 in selectedText
+    text.replace(QChar::ParagraphSeparator, QLatin1Char('\n'));
+
+    return text;
 }
 
 void TextEdit::wheelEvent(QWheelEvent* e)

--- a/src/Gui/TextEdit.h
+++ b/src/Gui/TextEdit.h
@@ -72,7 +72,7 @@ private Q_SLOTS:
     void complete();
 
 Q_SIGNALS:
-    void showSearchBar();
+    void showSearchBar(const QString& prefill);
     void findNext();
     void findPrevious();
 
@@ -85,6 +85,7 @@ private:
     void createListBox();
 
 private:
+    QString selectionForSearch() const;
     QString wordPrefix;
     int cursorPosition;
     CompletionList* listBox;


### PR DESCRIPTION
Add a small but nice DX feature present in many standard text editors/IDE:
when using search (<kbd>Ctrl</kbd> + <kbd>F</kbd>) the search field is prefilled  with the current selected text or word around the cursor position.

![pr-selectsearch](https://github.com/user-attachments/assets/3a7d8305-0f39-498e-b305-fb27eaba45a6)

Not included in this PR (future nice-to-have):
- Expose the search feature in menus and Status bar input hints.
- Support multi-line search (search field already becomes red with unsupported multi-line).