### PR TITLE
Gui: Add line number selection to TextEditor

### DIFF
--- a/src/Gui/TextEdit.h
+++ b/src/Gui/TextEdit.h
@@ -156,22 +156,34 @@ protected:
     void keyPressEvent(QKeyEvent*) override;
 };
 
-
+/**
+ * @brief Line number widget (left margin gutter).
+ *
+ * Handles line number and mouse-based line range selections.
+ */
 class LineMarker: public QWidget
 {
     Q_OBJECT
 
 public:
     explicit LineMarker(TextEditor* editor);
-    ~LineMarker() override;
+    ~LineMarker() override = default;
 
     QSize sizeHint() const override;
 
 protected:
-    void paintEvent(QPaintEvent*) override;
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
 
 private:
-    TextEditor* textEditor;
+    TextEditor* const textEditor;
+    int anchorLine = -1;
+    bool dragging = false;
+
+    QTextBlock blockAtPosition(int y) const;
+    void selectBlocks(int startLine, int endLine);
 };
 
 /**


### PR DESCRIPTION
Add a small but nice DX feature present in many standard text editors/IDE:
when clicking on the line number in the left margin (also called gutter), the corresponding line text is selected. Range/contiguous selection (<kbd>Shift</kbd> + <kbd>click</kbd>) and click-drag-release is also supported to select multiple lines.

![pr-lineselect](https://github.com/user-attachments/assets/507f5e8c-a7d3-4bd8-82fd-37a1575fe72c)

Not included in this PR (future nice-to-have):
- Some kind of visual feedback before selection (e.g. Status bar input hints).
- Support additive selection (e.g. Ctrl/Cmd + click)