### PR TITLE
Sketcher: Double click geometric constraint trigger rename.

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1916,4 +1916,3 @@ void TaskSketcherConstraints::onFilterListItemChanged(QListWidgetItem* item)
 
 #include "moc_TaskSketcherConstraints.cpp"
 // clang-format on
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/27548