### PR TITLE
BIM: Set default value of 'MoveWithHost' property to True

### DIFF
--- a/src/Mod/BIM/Resources/ui/preferences-arch.ui
+++ b/src/Mod/BIM/Resources/ui/preferences-arch.ui
@@ -106,13 +106,13 @@
       <item row="5" column="0" colspan="3">
        <widget class="Gui::PrefCheckBox" name="checkBox_MoveWithHost">
         <property name="toolTip">
-         <string>By default, new objects will have their &quot;Move with host&quot; property set to False, which means they will not move when their host object is moved</string>
+         <string>By default, new objects will have their &quot;Move with host&quot; property set to True, which means they will move when their host object is moved</string>
         </property>
         <property name="text">
          <string>Set &quot;Move with host&quot; property to True by default</string>
         </property>
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>MoveWithHost</cstring>


### PR DESCRIPTION
This PR proposes changing the default value of the `MoveWithHost` property of BIM objects derived from ArchComponent (that is, most BIM objects) from `False` to `True`.

- The main motivation is to have a sensible default to avoid issues such as https://github.com/FreeCAD/FreeCAD/issues/27288, whereby when moving a wall, its Additions/Substractions (CSG) and guests (e.g. Windows/Doors) that are BIM objects themselves are not affected by the move and are left behind.
- This would align the behaviour of BIM components used as CSG components or as guests with that of Part/PartDesign components used for the same purpose. For the later, they are always moved with the host, unconditionally.
- In most cases, we would want the substractions/additions and guests to move with the host
- There is probably only one use case for `MoveWithHost` to be set to `False`: Windows that have multiple `Hosts` walls, which does not work optimally in any case (https://github.com/FreeCAD/FreeCAD/issues/27666, https://github.com/FreeCAD/FreeCAD/issues/27665) . The minority should not determine the default value.
- Given the number of thumbs up in this PR description, this appears to be a welcome change by users and contributors.

Forum discussion: https://forum.freecad.org/viewtopic.php?t=103278
