### PR TITLE
Add missing NOLINTEND clang-tidy comments

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2182,6 +2182,7 @@ bool CDxfRead::ReadText()
     // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
     double height = 0.03082;
     double rotation = 0;
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)
     std::string textPrefix;
 
     Setup3DVectorAttribute(ePrimaryPoint, insertionPoint);

--- a/tests/src/Base/Unit.cpp
+++ b/tests/src/Base/Unit.cpp
@@ -154,3 +154,4 @@ TEST(Unit, representation_no_name)
     const auto actual = unit.representation();
     EXPECT_EQ(actual, expect);
 }
+// NOLINTEND


### PR DESCRIPTION
Fixes clang-tidy build, not covered by any CI job