### PR TITLE
log about missing SVG support

### DIFF
--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -223,10 +223,10 @@ void StartupPostProcess::setLoadFromPythonModule(bool value)
 
 void StartupPostProcess::execute()
 {
-    checkQtSvgImageFormatSupport();
     setWindowTitle();
     setProcessMessages();
     setAutoSaving();
+    checkQtSvgImageFormatSupport();
     setToolBarIconSize();
     setWheelEventFilter();
     setLocale();
@@ -240,14 +240,6 @@ void StartupPostProcess::execute()
     activateWorkbench();
     checkParameters();
     checkVersionMigration();
-}
-
-void StartupPostProcess::checkQtSvgImageFormatSupport()
-{
-    auto const supportedFormats = QImageReader::supportedImageFormats();
-    if (!supportedFormats.contains("svg")) {
-        Base::Console().warning("Qt SVG image format not supported; missing Qt SVG plugin?\n");
-    }
 }
 
 void StartupPostProcess::setWindowTitle()
@@ -278,6 +270,14 @@ void StartupPostProcess::setAutoSaving()
 
     AutoSaver::instance()->setTimeout(timeout * 60000);  // NOLINT
     AutoSaver::instance()->setCompressed(hDocGrp->GetBool("AutoSaveCompressed", true));
+}
+
+void StartupPostProcess::checkQtSvgImageFormatSupport()
+{
+    auto const supportedFormats = QImageReader::supportedImageFormats();
+    if (!supportedFormats.contains("svg")) {
+        Base::Console().warning("Qt SVG image format not supported; missing Qt SVG plugin?\n");
+    }
 }
 
 void StartupPostProcess::setToolBarIconSize()

--- a/src/Gui/StartupProcess.h
+++ b/src/Gui/StartupProcess.h
@@ -60,10 +60,10 @@ public:
     void execute();
 
 private:
-    void checkQtSvgImageFormatSupport();
     void setWindowTitle();
     void setProcessMessages();
     void setAutoSaving();
+    void checkQtSvgImageFormatSupport();
     void setToolBarIconSize();
     void setWheelEventFilter();
     void setLocale();


### PR DESCRIPTION
On a new Debian based system, `qt6-svg-plugins` package was not installed, leading to issues with the FreeCAD Light and FreeCAD Dark themes, and seemingly SVG support in general.  Specifically:
- indicators in `QCheckBox`es and `QRadioButton`s did not render, making it impossible to tell their state
- `QIcon`s used in the Start module would not render

After much digging, I found the culprit (missing the Qt6 SVG plugin / image format support).  I was surprised to find that FreeCAD didn't indicate the issue at all, and diagnosing the issue very difficult -- `QPixmap::isNull() == 1` ultimately led me to the solution.

This change adds a log message about the situation.  I assume it will also work well for Qt5, but I have not tested that.  I wasn't sure where to add the check, or in what way to indicate the situation, but this seems like it will help those that fall down the same pit.