### PR TITLE
Measure: Fix crash while dragging label of unsaved measurement (fixes #27705)

### DIFF
--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -207,6 +207,7 @@ ViewProviderMeasureBase::ViewProviderMeasureBase()
 
 ViewProviderMeasureBase::~ViewProviderMeasureBase()
 {
+    pDragger->removeValueChangedCallback(draggerChangedCallback, this);
     _mVisibilityChangedConnection.disconnect();
     pGlobalSeparator->unref();
     pLabel->unref();


### PR DESCRIPTION
fixes https://github.com/FreeCAD/FreeCAD/issues/27705