### PR TITLE
CAM: don't ignore DefaultJobTemplates even if not in settings folder

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/JobDlg.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobDlg.py
@@ -415,6 +415,11 @@ class JobCreate:
             ]  # Standardize slashes used across os platforms
             templateFiles.extend(cleanPaths)
 
+        selectTemplate = Path.Preferences.defaultJobTemplate()
+        if os.path.isfile(selectTemplate):
+            if selectTemplate not in templateFiles:
+                templateFiles.insert(0, selectTemplate)
+
         template = {}
         for tFile in templateFiles:
             name = os.path.split(os.path.splitext(tFile)[0])[1][4:]
@@ -426,7 +431,7 @@ class JobCreate:
                     name = basename + " (%s)" % i
             Path.Log.track(name, tFile)
             template[name] = tFile
-        selectTemplate = Path.Preferences.defaultJobTemplate()
+
         index = 0
         self.dialog.jobTemplate.addItem(translate("CAM_Job", "<none>"), "")
         for name in sorted(template):

--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -279,9 +279,12 @@ def searchPathsPost():
 
 def defaultJobTemplate():
     template = preferences().GetString(DefaultJobTemplate)
-    if "xml" not in template:
-        return template
-    return ""
+
+    # before b4d0428 .xml files were used as templates, ignore very old settings
+    if os.path.splitext(template)[1] == ".xml":
+        return ""
+
+    return template
 
 
 def setJobDefaults(jobTemplate, geometryTolerance, curveAccuracy):


### PR DESCRIPTION
fixes #27711

I also noticed that if the path of the DefaultJobTemplate somehwere contains the string "xml", the template is ignored. It seems to me this is trying to handle old preferences when the templates were still xml files (see b4d0428 and e56897df76530eb9e32d28f385c0957f0b4e6c21). Instead of searching the whole path now it only checks the extension.