### PR TITLE
part: fixes #27592 add tooltips for part primitives

### DIFF
--- a/src/Mod/Part/Gui/DlgPrimitives.ui
+++ b/src/Mod/Part/Gui/DlgPrimitives.ui
@@ -19,6 +19,9 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="QComboBox" name="PrimitiveTypeCB">
+     <property name="toolTip">
+      <string>Select the type of geometric primitive to create</string>
+     </property>
      <property name="sizePolicy">
       <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
        <horstretch>0</horstretch>
@@ -243,6 +246,9 @@
             </item>
             <item row="0" column="2">
              <widget class="Gui::QuantitySpinBox" name="planeLength">
+              <property name="toolTip">
+               <string>Length of the plane in the local X direction</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -263,6 +269,9 @@
             </item>
             <item row="1" column="2">
              <widget class="Gui::QuantitySpinBox" name="planeWidth">
+              <property name="toolTip">
+               <string>Width of the plane in the local Y direction</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -334,6 +343,9 @@
             </item>
             <item row="0" column="2">
              <widget class="Gui::QuantitySpinBox" name="boxLength">
+              <property name="toolTip">
+               <string>Length of the box in the local X direction</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -354,6 +366,9 @@
             </item>
             <item row="1" column="2">
              <widget class="Gui::QuantitySpinBox" name="boxWidth">
+              <property name="toolTip">
+               <string>Width of the box in the local Y direction</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -374,6 +389,9 @@
             </item>
             <item row="2" column="2">
              <widget class="Gui::QuantitySpinBox" name="boxHeight">
+              <property name="toolTip">
+               <string>Height of the box in the local Z direction</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -448,6 +466,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="cylinderRadius">
+              <property name="toolTip">
+               <string>Radius of the cylinder</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -468,6 +489,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="cylinderHeight">
+              <property name="toolTip">
+               <string>Height of the cylinder along the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -489,7 +513,7 @@
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="cylinderXSkew">
               <property name="toolTip">
-               <string>Angle in first direction</string>
+               <string>Skew angle of the cylinder in the first direction</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -515,7 +539,7 @@
             <item row="3" column="1">
              <widget class="Gui::QuantitySpinBox" name="cylinderYSkew">
               <property name="toolTip">
-               <string>Angle in second direction</string>
+               <string>Skew angle of the cylinder in the second direction</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -572,6 +596,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="cylinderAngle">
+              <property name="toolTip">
+               <string>Rotation angle of the cylinder cross-section</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -646,6 +673,9 @@
             </item>
             <item row="0" column="2">
              <widget class="Gui::QuantitySpinBox" name="coneRadius1">
+              <property name="toolTip">
+               <string>Radius of the cone at the bottom</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -666,6 +696,9 @@
             </item>
             <item row="1" column="2">
              <widget class="Gui::QuantitySpinBox" name="coneRadius2">
+              <property name="toolTip">
+               <string>Radius of the cone at the top</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -686,6 +719,9 @@
             </item>
             <item row="3" column="2">
              <widget class="Gui::QuantitySpinBox" name="coneHeight">
+              <property name="toolTip">
+               <string>Height of the cone along the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -732,6 +768,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="coneAngle">
+              <property name="toolTip">
+               <string>Rotation angle of the cone cross-section</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -806,6 +845,9 @@
             </item>
             <item>
              <widget class="Gui::QuantitySpinBox" name="sphereRadius">
+              <property name="toolTip">
+               <string>Radius of the sphere</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -855,6 +897,9 @@
             </item>
             <item row="0" column="2">
              <widget class="Gui::QuantitySpinBox" name="sphereAngle3">
+              <property name="toolTip">
+               <string>Rotation angle of the sphere cross-section around the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -875,6 +920,9 @@
             </item>
             <item row="1" column="2">
              <widget class="Gui::QuantitySpinBox" name="sphereAngle1">
+              <property name="toolTip">
+               <string>Start angle of the sphere along the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -904,6 +952,9 @@
             </item>
             <item row="2" column="2">
              <widget class="Gui::QuantitySpinBox" name="sphereAngle2">
+              <property name="toolTip">
+               <string>End angle of the sphere along the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -978,6 +1029,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius1">
+              <property name="toolTip">
+               <string>Radius of the ellipsoid along the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -998,6 +1052,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius2">
+              <property name="toolTip">
+               <string>Radius of the ellipsoid along the local X axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1018,6 +1075,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipsoidRadius3">
+              <property name="toolTip">
+               <string>Radius of the ellipsoid along the local Y axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1067,6 +1127,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle3">
+              <property name="toolTip">
+               <string>Rotation angle of the ellipsoid cross-section around the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1087,6 +1150,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle1">
+              <property name="toolTip">
+               <string>Start angle of the ellipsoid along the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1116,6 +1182,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipsoidAngle2">
+              <property name="toolTip">
+               <string>End angle of the ellipsoid along the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1187,6 +1256,9 @@
             </item>
             <item row="0" column="2">
              <widget class="Gui::QuantitySpinBox" name="torusRadius1">
+              <property name="toolTip">
+               <string>Radius from the center of the torus to the center of the cross-section</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1207,6 +1279,9 @@
             </item>
             <item row="1" column="2">
              <widget class="Gui::QuantitySpinBox" name="torusRadius2">
+              <property name="toolTip">
+               <string>Radius of the torus cross-section</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1256,6 +1331,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="torusAngle3">
+              <property name="toolTip">
+               <string>Rotation angle of the torus cross-section around the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1276,6 +1354,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="torusAngle1">
+              <property name="toolTip">
+               <string>Start angle of the torus cross-section</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1305,6 +1386,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="torusAngle2">
+              <property name="toolTip">
+               <string>End angle of the torus cross-section</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1379,6 +1463,9 @@
             </item>
             <item row="0" column="2">
              <widget class="QSpinBox" name="prismPolygon">
+              <property name="toolTip">
+               <string>Number of sides of the polygon cross-section</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1402,6 +1489,9 @@
             </item>
             <item row="1" column="2">
              <widget class="Gui::QuantitySpinBox" name="prismCircumradius">
+              <property name="toolTip">
+               <string>Circumradius of the polygon cross-section</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1422,6 +1512,9 @@
             </item>
             <item row="2" column="2">
              <widget class="Gui::QuantitySpinBox" name="prismHeight">
+              <property name="toolTip">
+               <string>Height of the prism along the local Z axis</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1443,7 +1536,7 @@
             <item row="3" column="2">
              <widget class="Gui::QuantitySpinBox" name="prismXSkew">
               <property name="toolTip">
-               <string>Angle in first direction</string>
+               <string>Skew angle of the prism in the first direction</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -1469,7 +1562,7 @@
             <item row="4" column="2">
              <widget class="Gui::QuantitySpinBox" name="prismYSkew">
               <property name="toolTip">
-               <string>Angle in second direction</string>
+               <string>Skew angle of the prism in the second direction</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -1521,6 +1614,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="wedgeXmin">
+              <property name="toolTip">
+               <string>Minimum X value of the base face</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1531,6 +1627,9 @@
             </item>
             <item row="0" column="2">
              <widget class="Gui::QuantitySpinBox" name="wedgeXmax">
+              <property name="toolTip">
+               <string>Maximum X value of the base face</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1551,6 +1650,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="wedgeYmin">
+              <property name="toolTip">
+               <string>Minimum Y value (height start)</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1561,6 +1663,9 @@
             </item>
             <item row="1" column="2">
              <widget class="Gui::QuantitySpinBox" name="wedgeYmax">
+              <property name="toolTip">
+               <string>Maximum Y value (height end)</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1581,6 +1686,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="wedgeZmin">
+              <property name="toolTip">
+               <string>Minimum Z value of the base face</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1591,6 +1699,9 @@
             </item>
             <item row="2" column="2">
              <widget class="Gui::QuantitySpinBox" name="wedgeZmax">
+              <property name="toolTip">
+               <string>Maximum Z value of the base face</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1611,6 +1722,9 @@
             </item>
             <item row="3" column="1">
              <widget class="Gui::QuantitySpinBox" name="wedgeX2min">
+              <property name="toolTip">
+               <string>Minimum X value of the top face</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1624,6 +1738,9 @@
             </item>
             <item row="3" column="2">
              <widget class="Gui::QuantitySpinBox" name="wedgeX2max">
+              <property name="toolTip">
+               <string>Maximum X value of the top face</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1644,6 +1761,9 @@
             </item>
             <item row="4" column="1">
              <widget class="Gui::QuantitySpinBox" name="wedgeZ2min">
+              <property name="toolTip">
+               <string>Minimum Z value of the top face</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1657,6 +1777,9 @@
             </item>
             <item row="4" column="2">
              <widget class="Gui::QuantitySpinBox" name="wedgeZ2max">
+              <property name="toolTip">
+               <string>Maximum Z value of the top face</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1728,6 +1851,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="helixPitch">
+              <property name="toolTip">
+               <string>Distance between consecutive turns of the helix</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1748,6 +1874,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="helixHeight">
+              <property name="toolTip">
+               <string>Total height of the helix</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1768,6 +1897,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="helixRadius">
+              <property name="toolTip">
+               <string>Radius of the helix</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1788,6 +1920,9 @@
             </item>
             <item row="3" column="1">
              <widget class="Gui::QuantitySpinBox" name="helixAngle">
+              <property name="toolTip">
+               <string>Taper angle of the helix</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1805,6 +1940,9 @@
             </item>
             <item row="4" column="1">
              <widget class="QComboBox" name="helixLocalCS">
+              <property name="toolTip">
+               <string>Handedness of the helix: right-handed or left-handed</string>
+              </property>
               <item>
                <property name="text">
                 <string>Right-handed</string>
@@ -1877,6 +2015,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="spiralGrowth">
+              <property name="toolTip">
+               <string>Radial growth per rotation of the spiral</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1897,6 +2038,9 @@
             </item>
             <item row="1" column="1">
              <widget class="QDoubleSpinBox" name="spiralRotation">
+              <property name="toolTip">
+               <string>Total number of rotations of the spiral</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1917,6 +2061,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="spiralRadius">
+              <property name="toolTip">
+               <string>Starting radius of the spiral</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1973,6 +2120,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="circleRadius">
+              <property name="toolTip">
+               <string>Radius of the circle</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -1993,6 +2143,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="circleAngle1">
+              <property name="toolTip">
+               <string>Start angle of the circular arc</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2010,6 +2163,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="circleAngle2">
+              <property name="toolTip">
+               <string>End angle of the circular arc</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2040,6 +2196,9 @@
             </item>
             <item>
              <widget class="QPushButton" name="buttonCircleFromThreePoints">
+              <property name="toolTip">
+               <string>Define the circle by selecting 3 points in the 3D view</string>
+              </property>
               <property name="text">
                <string>From 3 Points</string>
               </property>
@@ -2075,6 +2234,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipseMajorRadius">
+              <property name="toolTip">
+               <string>Major radius of the ellipse</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2095,6 +2257,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipseMinorRadius">
+              <property name="toolTip">
+               <string>Minor radius of the ellipse</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2115,6 +2280,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipseAngle1">
+              <property name="toolTip">
+               <string>Start angle of the elliptical arc</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2132,6 +2300,9 @@
             </item>
             <item row="3" column="1">
              <widget class="Gui::QuantitySpinBox" name="ellipseAngle2">
+              <property name="toolTip">
+               <string>End angle of the elliptical arc</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2176,6 +2347,9 @@
             </item>
             <item row="0" column="1">
              <widget class="Gui::QuantitySpinBox" name="vertexX">
+              <property name="toolTip">
+               <string>X coordinate of the point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2196,6 +2370,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="vertexY">
+              <property name="toolTip">
+               <string>Y coordinate of the point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2216,6 +2393,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="vertexZ">
+              <property name="toolTip">
+               <string>Z coordinate of the point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2274,6 +2454,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="edgeX1">
+              <property name="toolTip">
+               <string>X coordinate of the start point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2284,6 +2467,9 @@
             </item>
             <item row="1" column="2">
              <widget class="Gui::QuantitySpinBox" name="edgeX2">
+              <property name="toolTip">
+               <string>X coordinate of the end point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2307,6 +2493,9 @@
             </item>
             <item row="2" column="1">
              <widget class="Gui::QuantitySpinBox" name="edgeY1">
+              <property name="toolTip">
+               <string>Y coordinate of the start point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2317,6 +2506,9 @@
             </item>
             <item row="2" column="2">
              <widget class="Gui::QuantitySpinBox" name="edgeY2">
+              <property name="toolTip">
+               <string>Y coordinate of the end point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2340,6 +2532,9 @@
             </item>
             <item row="3" column="1">
              <widget class="Gui::QuantitySpinBox" name="edgeZ1">
+              <property name="toolTip">
+               <string>Z coordinate of the start point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2350,6 +2545,9 @@
             </item>
             <item row="3" column="2">
              <widget class="Gui::QuantitySpinBox" name="edgeZ2">
+              <property name="toolTip">
+               <string>Z coordinate of the end point</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2421,6 +2619,9 @@
             </item>
             <item row="0" column="1">
              <widget class="QSpinBox" name="regularPolygonPolygon">
+              <property name="toolTip">
+               <string>Number of sides of the regular polygon</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>
@@ -2444,6 +2645,9 @@
             </item>
             <item row="1" column="1">
              <widget class="Gui::QuantitySpinBox" name="regularPolygonCircumradius">
+              <property name="toolTip">
+               <string>Circumradius of the regular polygon</string>
+              </property>
               <property name="keyboardTracking">
                <bool>false</bool>
               </property>


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this pr fixes #27592 by adding tooltips for the part primitives in the part workbench.

## Issues

- https://github.com/freecad/freecad/issues/27592

## Before and After Images

~~give me a second.~~

### before

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/db07c4a8-b740-4588-9934-e30a4153ea79" />


### after

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/f9b65fd6-cf04-44ad-bac9-bb559521e6fb" />

