### PR TITLE
Fix compile Error

### DIFF
--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -29,7 +29,7 @@
 #include <vector>
 #include <string>
 #include <memory>
-#include <climits>
+#include <limits>
 #include <Base/Persistence.h>
 
 #include "DynamicProperty.h"
@@ -144,7 +144,7 @@ struct AppExport PropertyData
       short int getOffsetTo(const App::Property* prop) const {
             auto *pt = (const char*)prop;
             auto *base = (const char *)m_container;
-            if(pt<base || pt>base+SHRT_MAX)
+            if(pt<base || pt>base+std::numeric_limits<short>::max())
                 return -1;
             return (short) (pt-base);
       }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fix for build in recent fedora

https://download.copr.fedorainfracloud.org/results/filippor/freecad/fedora-44-x86_64/10153844-freecad/builder-live.log.gz
```
/usr/bin/g++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CHRONO_DYN_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_CONTAINER_DYN_LINK -DBOOST_CONTAINER_NO_LIB -DBOOST_DATE_TIME_DYN_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DDOCDIR=\"/usr/share/doc/freecad\" -DFMT_SHARED -DFreeCADApp_EXPORTS -DHAVE_CONFIG_H -DLIBRARYDIR=\"lib64\" -DPYCXX_6_2_COMPATIBILITY -DQT_CORE_LIB -DQT_NO_DEBUG -DQT_NO_KEYWORDS -DQT_XML_LIB -DRESOURCEDIR=\"share\" -D_OCC64 -I/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/redhat-linux-build/src/App/FreeCADApp_autogen/include -I/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/redhat-linux-build -I/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/redhat-linux-build/src -I/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src -I/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/redhat-linux-build/src/App -I/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/3rdParty/FastSignals/libfastsignals/include -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtXml -isystem /usr/include/python3.14 -isystem /builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/3rdParty -isystem /usr/lib64/qt6/mkspecs/linux-g++ -Wall -Wextra -Wno-write-strings -fdiagnostics-color -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -std=c++20 -fPIC -I/usr/include/openmpi-x86_64 -MD -MT src/App/CMakeFiles/FreeCADApp.dir/Annotation.cpp.o -MF src/App/CMakeFiles/FreeCADApp.dir/Annotation.cpp.o.d -o src/App/CMakeFiles/FreeCADApp.dir/Annotation.cpp.o -c /builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/Annotation.cpp
In file included from /builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/ExtensionContainer.h:33,
                 from /builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/TransactionalObject.h:29,
                 from /builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/DocumentObject.h:30,
                 from /builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/Annotation.h:29,
                 from /builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/Annotation.cpp:27:
/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/PropertyContainer.h: In member function ‘short int App::PropertyData::OffsetBase::getOffsetTo(const App::Property*) const’:
/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/PropertyContainer.h:147:35: error: ‘SHRT_MAX’ was not declared in this scope
  147 |             if(pt<base || pt>base+SHRT_MAX)
      |                                   ^~~~~~~~
/builddir/build/BUILD/freecad-weekly.2026.02.18-build/FreeCAD-1.0.2/src/App/PropertyContainer.h:36:1: note: ‘SHRT_MAX’ is defined in header ‘<climits>’; this is probably fixable by adding ‘#include <climits>’
   35 | #include "DynamicProperty.h"
  +++ |+#include <climits>
   36 | 
```

the error is for Fedora 44 and rawhide
https://copr.fedorainfracloud.org/coprs/filippor/freecad/build/10153844/
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
