### PR TITLE
BIM: add quick-access options task boxes to all relevant objects

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -2758,6 +2758,174 @@ class ComponentTaskPanel:
         FreeCADGui.runCommand("BIM_Classification")
 
 
+class ComponentOptionsTaskPanel(ComponentTaskPanel):
+    """
+    A generic TaskPanel that generates UI widgets based on a provided configuration.
+    It inherits from ComponentTaskPanel to keep the standard 'Components' tree functionality.
+    """
+
+    def __init__(self, obj, property_definitions):
+        """
+        obj: The FreeCAD object being edited.
+        property_definitions: A list of dictionaries defining the properties.
+                              e.g. [{'prop': 'Length'}]
+                              or [{'prop': 'Length', 'label': translate("Arch", "Total Length")}]
+        """
+        import re
+
+        super().__init__()
+        self.obj = obj
+        self.update()  # Populate the components tree now that self.obj is set
+        self.property_definitions = property_definitions
+        self.property_widgets = {}  # Map property name to {'widget': widget, 'type': type_id}
+
+        self.options_widget = QtGui.QWidget()
+        self.options_widget.setWindowTitle(translate("Arch", "Options"))
+        layout = QtGui.QFormLayout(self.options_widget)
+        loader = FreeCADGui.UiLoader()
+
+        for item in self.property_definitions:
+            prop_name = item["prop"]
+
+            # Heuristics for label: Use provided label or fallback to split CamelCase
+            label_text = item.get("label", re.sub(r"(?<!^)(?=[A-Z])", " ", prop_name))
+
+            # Check if property exists on Data object or View object
+            target_obj = self.obj
+            if not hasattr(target_obj, prop_name):
+                if hasattr(self.obj, "ViewObject") and hasattr(self.obj.ViewObject, prop_name):
+                    target_obj = self.obj.ViewObject
+                else:
+                    continue
+
+            prop_val = getattr(target_obj, prop_name)
+            prop_type_id = target_obj.getTypeIdOfProperty(prop_name)
+            widget = None
+
+            # Quantity types
+            if prop_type_id in [
+                "App::PropertyLength",
+                "App::PropertyDistance",
+                "App::PropertyArea",
+                "App::PropertyVolume",
+                "App::PropertyAngle",
+            ]:
+                widget = loader.createWidget("Gui::QuantitySpinBox")
+                FreeCADGui.ExpressionBinding(widget).bind(target_obj, prop_name)
+                widget.setProperty("value", prop_val)
+
+            # Float
+            elif prop_type_id == "App::PropertyFloat":
+                widget = loader.createWidget("Gui::DoubleSpinBox")
+                FreeCADGui.ExpressionBinding(widget).bind(target_obj, prop_name)
+                # Unlike `Gui::QuantitySpinbox`, `Gui::DoubleSpinBox` requires explicit initialization
+                widget.setDecimals(
+                    FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
+                        "Decimals", 2
+                    )
+                )
+                widget.setRange(-(2**31), 2**31)
+                widget.setValue(float(prop_val))
+
+            # Integer types
+            elif prop_type_id in ["App::PropertyInteger", "App::PropertyPercent"]:
+                widget = loader.createWidget("Gui::IntSpinBox")
+                FreeCADGui.ExpressionBinding(widget).bind(target_obj, prop_name)
+                widget.setProperty("value", int(prop_val))
+
+                if prop_type_id == "App::PropertyPercent":
+                    widget.setProperty("minimum", 0)
+                    widget.setProperty("maximum", 100)
+
+            # Boolean
+            elif prop_type_id == "App::PropertyBool":
+                widget = QtGui.QCheckBox()
+                widget.setChecked(prop_val)
+
+            # Enumeration (ComboBox)
+            elif prop_type_id == "App::PropertyEnumeration":
+                widget = QtGui.QComboBox()
+                # Combo boxes tend to have long texts in BIM. Do not use them to calculate the
+                # size of the task boxes, which would appear too wide and would grow beyond their
+                # task panel container
+                widget.setSizeAdjustPolicy(QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon)
+                widget.setMinimumContentsLength(20)
+                widget.addItems(target_obj.getEnumerationsOfProperty(prop_name))
+                idx = widget.findText(prop_val)
+                if idx >= 0:
+                    widget.setCurrentIndex(idx)
+
+            # String
+            elif prop_type_id == "App::PropertyString":
+                widget = loader.createWidget("Gui::ExpLineEdit")
+                FreeCADGui.ExpressionBinding(widget).bind(target_obj, prop_name)
+                widget.setProperty("text", prop_val)
+
+            # String List
+            elif prop_type_id == "App::PropertyStringList":
+                widget = QtGui.QPlainTextEdit()
+                widget.setVerticalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOn)
+                if prop_val:
+                    widget.setPlainText("\n".join(prop_val))
+
+            if widget:
+                tooltip = target_obj.getDocumentationOfProperty(prop_name)
+                if tooltip:
+                    widget.setToolTip(tooltip)
+                layout.addRow(label_text, widget)
+                self.property_widgets[prop_name] = {
+                    "widget": widget,
+                    "type": prop_type_id,
+                    "object": target_obj,
+                }
+
+        # Prepend the options widget to the form list (inherited from ComponentTaskPanel)
+        self.form = [self.options_widget, self.baseform]
+
+    def accept(self):
+        """Automatically save values back to the object"""
+        for prop_name, data in self.property_widgets.items():
+            widget = data["widget"]
+            prop_type = data["type"]
+            target_obj = data["object"]
+
+            try:
+                # Quantities, Floats and Integers
+                if prop_type in [
+                    "App::PropertyLength",
+                    "App::PropertyDistance",
+                    "App::PropertyArea",
+                    "App::PropertyVolume",
+                    "App::PropertyAngle",
+                    "App::PropertyFloat",
+                    "App::PropertyInteger",
+                    "App::PropertyPercent",
+                ]:
+                    setattr(target_obj, prop_name, widget.property("value"))
+
+                # Bools
+                elif prop_type == "App::PropertyBool":
+                    setattr(target_obj, prop_name, widget.isChecked())
+
+                # Enumerations
+                elif prop_type == "App::PropertyEnumeration":
+                    setattr(target_obj, prop_name, widget.currentText())
+
+                # Strings
+                elif prop_type == "App::PropertyString":
+                    setattr(target_obj, prop_name, widget.text())
+
+                # String Lists
+                elif prop_type == "App::PropertyStringList":
+                    setattr(target_obj, prop_name, widget.toPlainText().splitlines())
+
+            except Exception as e:
+                msg = translate("Arch", "Error saving property")
+                FreeCAD.Console.PrintError(f"{msg} {prop_name}: {str(e)}\n")
+
+        return super().accept()
+
+
 if FreeCAD.GuiUp:
 
     class IfcEditorDelegate(QtGui.QStyledItemDelegate):

--- a/src/Mod/BIM/ArchCurtainWall.py
+++ b/src/Mod/BIM/ArchCurtainWall.py
@@ -719,6 +719,32 @@ class CurtainWall(ArchComponent.Component):
             return -proj.Length
 
 
+class CurtainWallTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
+    """A task panel for Curtain Walls using the generic options box"""
+
+    def __init__(self, obj):
+        property_definitions = [
+            {"prop": "VerticalSections", "label": translate("Arch", "Vertical Sections")},
+            {"prop": "HorizontalSections", "label": translate("Arch", "Horizontal Sections")},
+            {"prop": "VerticalMullionWidth", "label": translate("Arch", "Vertical Mullion Width")},
+            {
+                "prop": "VerticalMullionHeight",
+                "label": translate("Arch", "Vertical Mullion Height"),
+            },
+            {
+                "prop": "HorizontalMullionWidth",
+                "label": translate("Arch", "Horizontal Mullion Width"),
+            },
+            {
+                "prop": "HorizontalMullionHeight",
+                "label": translate("Arch", "Horizontal Mullion Height"),
+            },
+            {"prop": "PanelThickness", "label": translate("Arch", "Panel Thickness")},
+            {"prop": "Refine", "label": translate("Arch", "Refine")},
+        ]
+        super().__init__(obj, property_definitions)
+
+
 class ViewProviderCurtainWall(ArchComponent.ViewProviderComponent):
     "A View Provider for the CurtainWall object"
 
@@ -793,3 +819,11 @@ class ViewProviderCurtainWall(ArchComponent.ViewProviderComponent):
                     colors.append(panelcolor)
         if self.areDifferentColors(colors, obj.ViewObject.DiffuseColor) or force:
             obj.ViewObject.DiffuseColor = colors
+
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
+
+        taskd = CurtainWallTaskPanel(vobj.Object)
+        FreeCADGui.Control.showDialog(taskd)
+        return True

--- a/src/Mod/BIM/ArchEquipment.py
+++ b/src/Mod/BIM/ArchEquipment.py
@@ -54,6 +54,19 @@ else:
     # \endcond
 
 
+if FreeCAD.GuiUp:
+
+    class EquipmentTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
+        """A task panel for Arch Equipment using the generic options box"""
+
+        def __init__(self, obj):
+            property_definitions = [
+                {"prop": "Model", "label": translate("Arch", "Model")},
+                {"prop": "EquipmentPower", "label": translate("Arch", "Equipment Power")},
+            ]
+            super().__init__(obj, property_definitions)
+
+
 class _Equipment(ArchComponent.Component):
     "The Equipment object"
 
@@ -255,3 +268,11 @@ class _ViewProviderEquipment(ArchComponent.ViewProviderComponent):
                 self.coords.point.deleteValues(0)
         else:
             ArchComponent.ViewProviderComponent.updateData(self, obj, prop)
+
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
+
+        taskd = EquipmentTaskPanel(vobj.Object)
+        FreeCADGui.Control.showDialog(taskd)
+        return True

--- a/src/Mod/BIM/ArchPanel.py
+++ b/src/Mod/BIM/ArchPanel.py
@@ -568,6 +568,23 @@ class _Panel(ArchComponent.Component):
                         obj.Placement = pl
 
 
+class PanelTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
+    """A task panel for Curtain Walls using the generic options task box"""
+
+    def __init__(self, obj):
+        definitions = [
+            {"prop": "Length", "label": translate("Arch", "Length")},
+            {"prop": "Width", "label": translate("Arch", "Width")},
+            {"prop": "Thickness", "label": translate("Arch", "Thickness")},
+            {"prop": "Sheets", "label": translate("Arch", "Sheets")},
+            {"prop": "WaveLength", "label": translate("Arch", "Wave Length")},
+            {"prop": "WaveHeight", "label": translate("Arch", "Wave Height")},
+            {"prop": "WaveBottom", "label": translate("Arch", "Wave Bottom")},
+            {"prop": "WaveType", "label": translate("Arch", "Wave Type")},
+        ]
+        super().__init__(obj, definitions)
+
+
 class _ViewProviderPanel(ArchComponent.ViewProviderComponent):
     "A View Provider for the Panel object"
 
@@ -622,6 +639,12 @@ class _ViewProviderPanel(ArchComponent.ViewProviderComponent):
                             if obj.ViewObject.DiffuseColor != cols:
                                 obj.ViewObject.DiffuseColor = cols
         ArchComponent.ViewProviderComponent.updateData(self, obj, prop)
+
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
+        FreeCADGui.Control.showDialog(PanelTaskPanel(vobj.Object))
+        return True
 
 
 class PanelCut(Draft.DraftObject):

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -1709,6 +1709,9 @@ class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
         #  Initialize generic parent (creates self.options_widget and self.baseform)
         super().__init__(obj, property_definitions)
 
+        # Alias for compatibility with node/tool methods
+        self.Object = self.obj
+
         self.nodes_widget = QtGui.QWidget()
         self.nodes_widget.setWindowTitle(QtGui.QApplication.translate("Arch", "Node Tools", None))
         lay = QtGui.QVBoxLayout(self.nodes_widget)

--- a/src/Mod/BIM/ArchTruss.py
+++ b/src/Mod/BIM/ArchTruss.py
@@ -406,6 +406,23 @@ class Truss(ArchComponent.Component):
         return rod
 
 
+class TrussTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
+    """A task panel for Arch Trusses using the generic options box"""
+
+    def __init__(self, obj):
+        property_definitions = [
+            {"prop": "HeightStart", "label": translate("Arch", "Height Start")},
+            {"prop": "HeightEnd", "label": translate("Arch", "Height End")},
+            {"prop": "StrutHeight", "label": translate("Arch", "Strut Height")},
+            {"prop": "StrutWidth", "label": translate("Arch", "Strut Width")},
+            {"prop": "RodSections", "label": translate("Arch", "Rod Sections")},
+            {"prop": "RodSize", "label": translate("Arch", "Rod Size")},
+            {"prop": "RodMode", "label": translate("Arch", "Rod Mode")},
+            {"prop": "RodType", "label": translate("Arch", "Rod Type")},
+        ]
+        super().__init__(obj, property_definitions)
+
+
 class ViewProviderTruss(ArchComponent.ViewProviderComponent):
     "A View Provider for the Truss object"
 
@@ -418,3 +435,11 @@ class ViewProviderTruss(ArchComponent.ViewProviderComponent):
         import Arch_rc
 
         return ":/icons/Arch_Truss_Tree.svg"
+
+    def setEdit(self, vobj, mode):
+        if mode != 0:
+            return None
+
+        taskd = TrussTaskPanel(vobj.Object)
+        FreeCADGui.Control.showDialog(taskd)
+        return True

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1794,20 +1794,24 @@ if FreeCAD.GuiUp:
             self.wallWidget.setWindowTitle(translate("Arch", "Wall Options"))
 
             layout = QtGui.QFormLayout(self.wallWidget)
+            loader = FreeCADGui.UiLoader()
 
-            self.length = FreeCADGui.UiLoader().createWidget("Gui::InputField")
-            self.length.setProperty("unit", "mm")
-            self.length.setText(obj.Length.UserString)
+            # Length
+            self.length = loader.createWidget("Gui::QuantitySpinBox")
+            FreeCADGui.ExpressionBinding(self.length).bind(self.obj, "Length")
+            self.length.setProperty("value", self.obj.Length)
             layout.addRow(translate("Arch", "Length"), self.length)
 
-            self.width = FreeCADGui.UiLoader().createWidget("Gui::InputField")
-            self.width.setProperty("unit", "mm")
-            self.width.setText(obj.Width.UserString)
+            # Width
+            self.width = loader.createWidget("Gui::QuantitySpinBox")
+            FreeCADGui.ExpressionBinding(self.width).bind(self.obj, "Width")
+            self.width.setProperty("value", self.obj.Width)
             layout.addRow(translate("Arch", "Width"), self.width)
 
-            self.height = FreeCADGui.UiLoader().createWidget("Gui::InputField")
-            self.height.setProperty("unit", "mm")
-            self.height.setText(obj.Height.UserString)
+            # Height
+            self.height = loader.createWidget("Gui::QuantitySpinBox")
+            FreeCADGui.ExpressionBinding(self.height).bind(self.obj, "Height")
+            self.height.setProperty("value", self.obj.Height)
             layout.addRow(translate("Arch", "Height"), self.height)
 
             self.alignLayout = QtGui.QHBoxLayout()
@@ -1847,9 +1851,9 @@ if FreeCAD.GuiUp:
             self.obj.recompute()
 
         def accept(self):
-            self.obj.Length = self.length.text()
-            self.obj.Width = self.width.text()
-            self.obj.Height = self.height.text()
+            self.obj.Length = self.length.property("value")
+            self.obj.Width = self.width.property("value")
+            self.obj.Height = self.height.property("value")
             return super().accept()
 
 


### PR DESCRIPTION
Introduce task boxes to quickly edit the key properties of each BIM object, as a continuation of the work started with https://github.com/FreeCAD/FreeCAD/pull/26758 and https://github.com/FreeCAD/FreeCAD/pull/27381

Guiding principle: the options task box should stay focused on the main dimensions/properties 99% of the users need to change.

Workflow:

1. Double-click on a BIM object in the Tree View
2. Edit the necessary properties in the new Options task box
3. Press OK to apply the changes

Implementation details:

- Make the key properties translatable in the options box. This should be a significant usability improvement for non-English speakers: before this PR the properties were only available in English via the Property Editor.
- For code reusability, create a generic options task box in ArchComponent (https://github.com/FreeCAD/FreeCAD/pull/27746/changes/074825b03fcb5131072a3652b5461c5daad220b0), so that most BIM objects can inherit it, and simply use it by passing it the list of key features to expose in the box. This provides an extensible framework, since any new properties can simply be added to the list and they will automatically be exposed in the Options task box with the correct widget based on the property type.
  -  Some objects use a hybrid approach, whereby they reuse the generic options task box, but they augment it with their preexisting task boxes.
- `ArchWall._Wall` will not be using the generic box due to the custom live update to its `Align` radio buttons. It has simply been updated to use `Gui::QuantitySpinBox` to be able to use expressions and bind properties
- The most obvious/relevant objects have been enhanced with this feature. The rest are either slightly more complex because they have their own custom task boxes already, or need additional research. They will be implemented in a second PR.
- The list of key properties should be kept to a minimum to strike a balance between usability and bringing too many properties from the Property Editor to the task panel. In any case, discussion and feedback from other users and developers will be welcome.
- For easier review, each object changed is contained in its own separate commit.

| Object | Generic Options Box? | Properties in Options Box | Screenshot |
| :--- | :--- | :--- | :--- |
| [Wall](https://wiki.freecad.org/Arch_Wall) | **No** (Dedicated) | `Heigth`, `Width`, `Align`. Already implemented in https://github.com/FreeCAD/FreeCAD/pull/26758, refactored here for expression support| <img width="459" height="175" alt="image" src="https://github.com/user-attachments/assets/9dce5a60-dab3-47ca-86b9-e26468610b89" /> |
| [Window](https://wiki.freecad.org/Arch_Window) | **Yes** (Hybrid) | `Height`, `Width`, `Opening`, initially implemented in https://github.com/FreeCAD/FreeCAD/pull/27381, refactored here for generic taskbox use | <img width="459" height="155" alt="image" src="https://github.com/user-attachments/assets/e4cfe257-9529-4786-bb81-f6757f58fd93" /> |
| [Panel](https://wiki.freecad.org/Arch_Panel) | **Yes** | `Length`, `Width`, `Thickness`, `Sheets`, `WaveLength`, `WaveHeight`, `WaveBottom`, `WaveType` | <img width="469" height="307" alt="image" src="https://github.com/user-attachments/assets/d9bdc54d-f2a0-4edf-861f-e2a91cc92319" /> |
| [CurtainWall](https://wiki.freecad.org/Arch_CurtainWall) | **Yes** | `VerticalSections`, `HorizontalSections`, `VerticalMullionWidth`, `VerticalMullionHeight`, `HorizontalMullionWidth`, `HorizontalMullionHeight`, `PanelThickness`, `Refine` | <img width="469" height="306" alt="image" src="https://github.com/user-attachments/assets/ff2730c5-abb4-42ad-adf8-eb64afa2c8c4" /> |
| [Space](https://wiki.freecad.org/Arch_Space) | **Yes** (Hybrid) | `SpaceType`, `Text`, `FinishFloor`, `FinishWalls`, `FinishCeiling` | <img width="459" height="202" alt="image" src="https://github.com/user-attachments/assets/01089e60-49b6-4000-83fd-e893965b6cf7" /> |
| [Structure](https://wiki.freecad.org/Arch_Structure) (covers [Slab](https://wiki.freecad.org/Arch_Slab), [Column](https://wiki.freecad.org/Arch_Column), [Beam](https://wiki.freecad.org/Arch_Beam)) | **Yes** (Hybrid) | `Length`*, `Width`*, `Height` (as Thickness for Slabs). <br>*\*Length/Width shown for Beams/Columns only.* | <img width="459" height="92" alt="image" src="https://github.com/user-attachments/assets/bdf48b4e-4778-4808-a4a0-73186df54bcf" /><br><img width="459" height="152" alt="image" src="https://github.com/user-attachments/assets/d9c76168-47ae-4ac9-945d-bfa670ef4ed2" />|
| [Equipment](https://wiki.freecad.org/Arch_Equipment) | **Yes** | `Model`, `EquipmentPower` | <img width="469" height="124" alt="image" src="https://github.com/user-attachments/assets/559ad74e-5505-4250-8bb0-0b1c9d033421" /> |
| [Truss](https://wiki.freecad.org/Arch_Truss) | **Yes** | `HeightStart`, `HeightEnd`, `StrutHeight`, `StrutWidth`, `RodSections`, `RodSize`, `RodMode`, `RodType` | <img width="469" height="307" alt="image" src="https://github.com/user-attachments/assets/c748cd63-c342-4e4d-8814-f3470991a493" /> |

## Issues

Fixes: https://github.com/FreeCAD/FreeCAD/issues/24103 for the BIM objects listed in the table below. 



