### PR TITLE
TechDraw: Draw smooth edges with thin line

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -418,8 +418,10 @@ void QGIViewPart::drawAllEdges()
                 showItem = formatGeomFromCenterLine(cTag, item);
             }
             else {
-                Base::Console().message("QGIVP::drawVP - cosmetic edge: %d is confused - source: %d\n",
-                                        iEdge, static_cast<int>(source));
+                // there are 3 source types (GEOMETRY, COSMETICEDGE, CENTERLINE). Something broke if we
+                // get here for for an edge that claims to be cosmetic.
+                Base::Console().warning("In %s, cosmetic edge: %d is neither COSMETICEDGE nor CENTERLINE - actual source type: %d\n",
+                                        dvp->Label.getValue(), iEdge, static_cast<int>(source));
             }
         } else {
             // geometry edge - apply format if applicable


### PR DESCRIPTION
This PR implements a fix for issue #25929.

ISO drawing standards require "smooth" edges to be drawn with a "thin" line. Currently, they are drawn
with a thick line.

This change will use the view's "thin" line width to draw any unformatted edges that have been marked
by the HLR algorithm as "smooth".

Caveats:
- once an edge's format has been modified, the edge will be drawn using the assigned format, which may
    not have a thin line width.
- OCCT may not mark all smooth edges correctly.
<img width="739" height="491" alt="SmoothAndOutlineEdge" src="https://github.com/user-attachments/assets/df6a473d-768a-45e9-8891-e2daad4be722" />
