### PR TITLE
CAM: Pocket_Shape - Allow horizontal edges

### DIFF
--- a/src/Mod/CAM/Path/Op/Gui/Selection.py
+++ b/src/Mod/CAM/Path/Op/Gui/Selection.py
@@ -214,11 +214,11 @@ class POCKETGate(PathBaseGate):
             pocketable = True
 
         elif obj.ShapeType == "Solid":
-            if sub and sub[0:4] == "Face":
+            if sub and sub[0:4] in ("Face", "Edge"):
                 pocketable = True
 
         elif obj.ShapeType == "Compound":
-            if sub and sub[0:4] == "Face":
+            if sub and sub[0:4] in ("Face", "Edge"):
                 pocketable = True
 
         return pocketable

--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -54,7 +54,11 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
     """Proxy object for Pocket operation."""
 
     def areaOpFeatures(self, obj):
-        return super(self.__class__, self).areaOpFeatures(obj) | PathOp.FeatureLocations
+        return (
+            super(self.__class__, self).areaOpFeatures(obj)
+            | PathOp.FeatureLocations
+            | PathOp.FeatureBaseEdges
+        )
 
     def removeHoles(self, solid, face):
         """removeHoles(solid, face) ... Remove hole wires from a face, keeping outer wire and boss wires.
@@ -200,13 +204,26 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             Path.Log.debug("base items exist.  Processing...")
             self.horiz = []
             self.vert = []
+            self.edges = []
             for base, subList in obj.Base:
                 for sub in subList:
-                    if "Face" in sub:
-                        if sub not in avoidFeatures and not self.classifySub(base, sub):
-                            Path.Log.error(
-                                "Pocket does not support shape {}.{}".format(base.Label, sub)
-                            )
+                    if sub in avoidFeatures:
+                        # skip this sub shape
+                        continue
+                    if "Edge" in sub and self.classifySubEdge(base, sub):
+                        # edge added to list
+                        continue
+                    if "Face" in sub and self.classifySubFace(base, sub):
+                        # face added to list
+                        continue
+                    Path.Log.error("Pocket does not support shape {}.{}".format(base.Label, sub))
+
+            # Create horizonatal faces from closed wires
+            for sortEdges in Part.sortEdges(self.edges):
+                wire = Part.Wire(sortEdges)
+                if wire.isClosed():
+                    face = Part.Face(wire)
+                    self.horiz.append((face, base))
 
             # Convert horizontal faces to use outline only if requested
             Path.Log.debug("UseOutline: {}".format(obj.UseOutline))
@@ -291,8 +308,19 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
 
         return self.removalshapes
 
-    def classifySub(self, bs, sub):
-        """classifySub(bs, sub)...
+    def classifySubEdge(self, bs, sub):
+        """classifySubFace(bs, sub)...
+        Given a base and a sub-feature name, returns True
+        if the sub-feature is a horizontal edge.
+        """
+        edge = bs.Shape.getElement(sub)
+        if Path.Geom.isHorizontal(edge):
+            self.edges.append(edge)
+            return True
+        return False
+
+    def classifySubFace(self, bs, sub):
+        """classifySubFace(bs, sub)...
         Given a base and a sub-feature name, returns True
         if the sub-feature is a horizontally or vertically oriented flat face.
         """


### PR DESCRIPTION
`Pocket_Shape` operation process only `Faces`
This commit add ability also processing horizontal edges, which creates closed wire 

`Edges` combines into `Wires`
If wire is closed, creates horizontal `Face`, which can be used for `Pocket`

<img width="1814" height="477" alt="Screenshot_20260220_174217_hor" src="https://github.com/user-attachments/assets/75e82ac9-70b1-4cf3-bd6e-3ee7da71ccbc" />

https://github.com/user-attachments/assets/05116ea1-1428-47bb-b621-646c22150aeb

