### PR TITLE
CAM: fix the transform tool

### DIFF
--- a/src/Gui/Inventor/Draggers/SoTransformDragger.cpp
+++ b/src/Gui/Inventor/Draggers/SoTransformDragger.cpp
@@ -491,7 +491,14 @@ void SoTransformDragger::setUpAutoScale(SoCamera* cameraIn)
         cameraSensor.attach(&localCamera->height);
         SoScale* localScaleNode = SO_GET_ANY_PART(this, "scaleNode", SoScale);
         localScaleNode->scaleFactor.disconnect();
-        autoScaleResult.disconnect(&draggerSize);
+        // This check shouldn't be needed but since CAM has its own
+        // ViewProvider classes that implement setEdit but doesn't inherit from
+        // ViewProviderDragger, we need to call Std_TransformManip twice.
+        // This causes setEditViewer to be called twice and Coin throws an error
+        // for trying to disconnect twice.
+        if (autoScaleResult.isConnectedFromField()) {
+            autoScaleResult.disconnect(&draggerSize);
+        }
         cameraCB(this, nullptr);
     }
     else if (cameraIn->getTypeId() == SoPerspectiveCamera::getClassTypeId()) {
@@ -500,7 +507,9 @@ void SoTransformDragger::setUpAutoScale(SoCamera* cameraIn)
         cameraSensor.attach(&localCamera->position);
         SoScale* localScaleNode = SO_GET_ANY_PART(this, "scaleNode", SoScale);
         localScaleNode->scaleFactor.disconnect();
-        autoScaleResult.disconnect(&draggerSize);
+        if (autoScaleResult.isConnectedFromField()) {
+            autoScaleResult.disconnect(&draggerSize);
+        }
         cameraCB(this, nullptr);
     }
 }

--- a/src/Mod/CAM/Path/Base/Gui/IconViewProvider.py
+++ b/src/Mod/CAM/Path/Base/Gui/IconViewProvider.py
@@ -21,6 +21,7 @@
 # ***************************************************************************
 
 import FreeCAD
+import FreeCADGui
 import Path
 import importlib
 
@@ -83,10 +84,14 @@ class ViewProvider(object):
     def setEdit(self, vobj=None, mode=0):
         if 0 == mode:
             self._onEditCallback(True)
+        elif 1 == mode:
+            FreeCADGui.runCommand("Std_TransformManip")
+            return True
         return False
 
-    def unsetEdit(self, arg1, arg2):
-        self._onEditCallback(False)
+    def unsetEdit(self, vobj, mode):
+        if 0 == mode:
+            self._onEditCallback(False)
 
     def setupContextMenu(self, vobj, menu):
         Path.Log.track()


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/27294
As the title suggests, this PR fixes the transform tool for CAM objects. This is created as a draft for the following reasons:
1. Is the IconViewProvider correct place to do this? On the C++ side I see that the relevant classes usually inherit from ViewProviderDragger but I am not sure what will be the proper approach in python.
2. ~~There is an error about `Coin error in SoField::disconnect(): can't disconnect from a field which we're not connected to!`. Need to address it.~~ See https://github.com/FreeCAD/FreeCAD/pull/27757#issuecomment-3941819723