### PR TITLE
Measurement: Moved buttons to top

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -95,7 +95,7 @@ QString extractUnitFromResultString(const QString& resultString)
 
 TaskMeasure::TaskMeasure()
 {
-    this->setButtonPosition(TaskMeasure::South);
+    this->setButtonPosition(TaskMeasure::North);
     auto taskbox = new Gui::TaskView::TaskBox(
         Gui::BitmapFactory().pixmap("umf-measurement"),
         tr("Measurement"),

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -95,7 +95,6 @@ QString extractUnitFromResultString(const QString& resultString)
 
 TaskMeasure::TaskMeasure()
 {
-    this->setButtonPosition(TaskMeasure::North);
     auto taskbox = new Gui::TaskView::TaskBox(
         Gui::BitmapFactory().pixmap("umf-measurement"),
         tr("Measurement"),


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Changed the location of the buttons in the measurement task. From the bottom of the task to the top

This is a very minimal change. And was requested on discord

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


### Before
<img width="423" height="755" alt="image" src="https://github.com/user-attachments/assets/c2d648b1-9b67-4a65-b2f2-8d61dae44500" />

 ### After
<img width="419" height="378" alt="Skærmbillede 2026-02-21 171408" src="https://github.com/user-attachments/assets/5c9adf79-0dd7-4556-873b-8d40bc009bdb" />





