### PR TITLE
TechDraw: Fix inconsistent cosmetic thread diameters in bottom view

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -471,7 +471,7 @@ bool CmdTechDrawExtensionThreadBoltSide::isActive()
 
 void execThreadHoleBottom(Gui::Command* cmd)
 {
-    constexpr double ThreadFactor{1.177};           // factor above is 1.176. should they be the same?
+    constexpr double ThreadFactor{1.176};
     // add cosmetic thread to bottom view of hole
     std::vector<Gui::SelectionObject> selection;
     TechDraw::DrawViewPart* objFeat{nullptr};


### PR DESCRIPTION
## Issues
fixes #10894

## Description
This PR fixes a bug with TechDraw cosmetic threads. The side view was using a 1.176 multiplier, but the bottom view was using 1.177. Because of that, if you sized an M6 hole to give exactly 6.00mm in the side view, it would annoyingly show up as 6.01mm in the bottom view. I just updated the bottom view to use 1.176 so everything is consistent.