### PR TITLE
CAM: Adjusted fanuc post processor to always use required drill parameters.

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -150,6 +150,11 @@ POST_OPERATION = """"""
 TOOL_CHANGE = """G28 G91 Z0
 """
 
+# List of drill G codes where some parameters are required and their
+# required parameters.
+DRILL_OPERATION = ("G73", "G81", "G82", "G83", "G84", "G85")
+DRILL_PARAM_REQ = ("L", "P", "Q", "R", "Z")
+
 
 def processArguments(argstring):
     global OUTPUT_HEADER
@@ -395,6 +400,8 @@ def linenumber():
 
 def parse(pathobj):
     global PRECISION
+    global DRILL_OPERATION
+    global DRILL_PARAM_REQ
     global MODAL
     global OUTPUT_DOUBLES
     global UNIT_FORMAT
@@ -627,7 +634,11 @@ def parse(pathobj):
                         if (
                             (not OUTPUT_DOUBLES)
                             and (param in currLocation)
-                            and (currLocation[param] == c.Parameters[param])
+                            and currLocation[param] == c.Parameters[param]
+                            and (
+                                command not in DRILL_OPERATION
+                                or (command in DRILL_OPERATION and param not in DRILL_PARAM_REQ)
+                            )
                         ):
                             continue
                         else:


### PR DESCRIPTION
At least for G73, the Z, Q and R parameters seem to be required. Assuming drill related parameters are required for all drill operations to err on the safe side.

Fixes #27413

This is the part of PR #27424 I believe should be included in the 1.1 release.