### PR TITLE
[Backport releases/FreeCAD-1-1] BIM: fix coordinate normalization and area calculation for generic ArchComponents (partial)

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -391,16 +391,36 @@ class Component(ArchIFC.IfcProduct):
         obj: <App::FeaturePython>
             The component object.
         """
+        import Part
 
         if self.clone(obj):
             return
-        if not self.ensureBase(obj):
+        if self.ensureBase(obj) is False:
+            # This will fall through if the Component object has no base, allowing the base shapeto
+            # be cleared
             return
-        if obj.Base:
-            shape = self.spread(obj, obj.Base.Shape)
-            if obj.Additions or obj.Subtractions:
-                shape = self.processSubShapes(obj, shape)
-            obj.Shape = shape
+
+        # Only proceed if a Base object is linked and contains valid geometry.
+        if obj.Base and hasattr(obj.Base, "Shape") and not obj.Base.Shape.isNull():
+            # Create a standalone shape as a deep copy of the base geometry, to avoid modifying
+            # the original source.
+            base_shape = Part.Shape(obj.Base.Shape)
+
+            # Reset the shape's internal placement to Identity. This strips the placement
+            # inherited from the Base object, ensuring the geometry is centered at (0,0,0) for
+            # Boolean operations in processSubShapes. This also prevents the shape's placement from
+            # overwriting the Component's own Placement property during assignment in applyShape.
+            base_shape.Placement = FreeCAD.Placement()
+
+            # Localize the CSG shapes: pass the object's placement to processSubShapes, so that the
+            # placements of any additions and subtractions are also localized to the local origin of
+            # the Arch Component.
+            final_shape = self.processSubShapes(obj, base_shape, obj.Placement)
+            self.applyShape(obj, final_shape, obj.Placement, allownosolid=True)
+        else:
+            # Clear the shape if the base has been removed. This avoids leaving a stale shape that
+            # is not updated when the base is removed.
+            obj.Shape = Part.Shape()
 
     def dumps(self):
         return None
@@ -1453,15 +1473,6 @@ class AreaCalculator:
         import TechDraw
         import DraftGeomUtils
 
-        # In TechDraw edges longer than 9999.9 (ca. 10m) are considered 'crazy'.
-        # See also Draft/draftobjects/hatch.py.
-        param_grp = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/TechDraw/debug")
-        if "allowCrazyEdge" not in param_grp.GetBools():
-            old_allow_crazy_edge = None
-        else:
-            old_allow_crazy_edge = param_grp.GetBool("allowCrazyEdge")
-        param_grp.SetBool("allowCrazyEdge", True)
-
         direction = FreeCAD.Vector(0, 0, 1)
         projectedFaces = []
         for face in horizontalAreaFaces:
@@ -1498,11 +1509,6 @@ class AreaCalculator:
                 )
                 self.resetAreas()
                 return
-
-        if old_allow_crazy_edge is None:
-            param_grp.RemBool("allowCrazyEdge")
-        else:
-            param_grp.SetBool("allowCrazyEdge", old_allow_crazy_edge)
 
         if projectedFaces:
             fusedFace = projectedFaces.pop()

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1473,6 +1473,15 @@ class AreaCalculator:
         import TechDraw
         import DraftGeomUtils
 
+        # In TechDraw edges longer than 9999.9 (ca. 10m) are considered 'crazy'.
+        # See also Draft/draftobjects/hatch.py.
+        param_grp = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/TechDraw/debug")
+        if "allowCrazyEdge" not in param_grp.GetBools():
+            old_allow_crazy_edge = None
+        else:
+            old_allow_crazy_edge = param_grp.GetBool("allowCrazyEdge")
+        param_grp.SetBool("allowCrazyEdge", True)
+
         direction = FreeCAD.Vector(0, 0, 1)
         projectedFaces = []
         for face in horizontalAreaFaces:
@@ -1509,6 +1518,11 @@ class AreaCalculator:
                 )
                 self.resetAreas()
                 return
+
+        if old_allow_crazy_edge is None:
+            param_grp.RemBool("allowCrazyEdge")
+        else:
+            param_grp.SetBool("allowCrazyEdge", old_allow_crazy_edge)
 
         if projectedFaces:
             fusedFace = projectedFaces.pop()


### PR DESCRIPTION
Manual backport of #27322 (only the modified execute function).