### PR TITLE
CAM: Adjusted Fanuc post processor to include body and job info.

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -265,9 +265,16 @@ def export(objectslist, filename, argstring):
         major = int(FreeCAD.ConfigGet("BuildVersionMajor"))
         minor = int(FreeCAD.ConfigGet("BuildVersionMinor"))
 
-        # the filename variable always contain "-", so unable to
-        # provide more accurate information.
-        gcode += "(" + "FREECAD-FILENAME-GOES-HERE" + ", " + "JOB-NAME-GOES-HERE" + ")\n"
+        # the filename variable always contain "-", use more relevant
+        # information
+        job = PathUtils.findParentJob(objectslist[0])
+        if job:
+            body, job = job.FullName.split("#")
+        else:
+            # Workaround for the TestFanucPost code, where there is no
+            # job returned by findParentJob
+            body, job = ("FREECAD-FILENAME-GOES-HERE", "JOB-NAME-GOES-HERE")
+        gcode += "(" + body.upper() + ", " + job.upper() + ")\n"
         gcode += (
             linenumber() + "(POST PROCESSOR: FANUC USING FREECAD %d.%d" % (major, minor) + ")\n"
         )


### PR DESCRIPTION
The first comment is shown on the machine controller, and should contain useful information to identify jobs.  Fetch the body and job label using findParentJob and insert it into the G code.  For some reason this information is not available when called from TestFanucPost.py, so handle this case the old way.