### PR TITLE
View: Move (get|set)Camera to methods

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -876,10 +876,8 @@ void Application::importFrom(const char* FileName, const char* DocName, const ch
                         "User parameter:BaseApp/Preferences/View"
                     );
                     if (hGrp->GetBool("AutoFitToView", true)) {
-                        MDIView* view = doc->getActiveView();
-                        if (view) {
-                            const char* ret = nullptr;
-                            if (view->onMsg("ViewFit", &ret)) {
+                        if (MDIView* view = doc->getActiveView()) {
+                            if (view->onMsg("ViewFit")) {
                                 updateActions(true);
                             }
                         }
@@ -1404,10 +1402,10 @@ void Application::onLastWindowClosed(Gui::Document* pcDoc)
 }
 
 /// send Messages to the active view
-bool Application::sendMsgToActiveView(const char* pMsg, const char** ppReturn)
+bool Application::sendMsgToActiveView(const char* pMsg)
 {
     MDIView* pView = getMainWindow()->activeWindow();
-    bool res = pView ? pView->onMsg(pMsg, ppReturn) : false;
+    bool res = pView ? pView->onMsg(pMsg) : false;
     updateActions(true);
     return res;
 }
@@ -1419,7 +1417,7 @@ bool Application::sendHasMsgToActiveView(const char* pMsg)
 }
 
 /// send Messages to the active view
-bool Application::sendMsgToFocusView(const char* pMsg, const char** ppReturn)
+bool Application::sendMsgToFocusView(const char* pMsg)
 {
     MDIView* pView = getMainWindow()->activeWindow();
     if (!pView) {
@@ -1427,7 +1425,7 @@ bool Application::sendMsgToFocusView(const char* pMsg, const char** ppReturn)
     }
     for (auto focus = qApp->focusWidget(); focus; focus = focus->parentWidget()) {
         if (focus == pView) {
-            bool res = pView->onMsg(pMsg, ppReturn);
+            bool res = pView->onMsg(pMsg);
             updateActions(true);
             return res;
         }

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -92,11 +92,11 @@ public:
     /** @name methods for View handling */
     //@{
     /// send Messages to the active view
-    bool sendMsgToActiveView(const char* pMsg, const char** ppReturn = nullptr);
+    bool sendMsgToActiveView(const char* pMsg);
     /// send Messages test to the active view
     bool sendHasMsgToActiveView(const char* pMsg);
     /// send Messages to the focused view
-    bool sendMsgToFocusView(const char* pMsg, const char** ppReturn = nullptr);
+    bool sendMsgToFocusView(const char* pMsg);
     /// send Messages test to the focused view
     bool sendHasMsgToFocusView(const char* pMsg);
     /// Attach a view (get called by the FCView constructor)

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -253,7 +253,7 @@ PyMethodDef ApplicationPy::Methods[] = {
     {"SendMsgToActiveView",
      (PyCFunction)ApplicationPy::sSendActiveView,
      METH_VARARGS,
-     "SendMsgToActiveView(name, suppress=False) -> str or None\n"
+     "SendMsgToActiveView(name, suppress=False) -> None\n"
      "\n"
      "Send message to the active view. Deprecated, use class View.\n"
      "\n"
@@ -262,7 +262,7 @@ PyMethodDef ApplicationPy::Methods[] = {
     {"sendMsgToFocusView",
      (PyCFunction)ApplicationPy::sSendFocusView,
      METH_VARARGS,
-     "sendMsgToFocusView(name, suppress=False) -> str or None\n"
+     "sendMsgToFocusView(name, suppress=False) -> None\n"
      "\n"
      "Send message to the focused view.\n"
      "\n"
@@ -928,16 +928,10 @@ PyObject* ApplicationPy::sSendActiveView(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    const char* ppReturn = nullptr;
-    if (!Application::Instance->sendMsgToActiveView(psCommandStr, &ppReturn)) {
+    if (!Application::Instance->sendMsgToActiveView(psCommandStr)) {
         if (!Base::asBoolean(suppress)) {
             Base::Console().warning("Unknown view command: %s\n", psCommandStr);
         }
-    }
-
-    // Print the return value to the output
-    if (ppReturn) {
-        return Py_BuildValue("s", ppReturn);
     }
 
     Py_Return;
@@ -952,16 +946,10 @@ PyObject* ApplicationPy::sSendFocusView(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    const char* ppReturn = nullptr;
-    if (!Application::Instance->sendMsgToFocusView(psCommandStr, &ppReturn)) {
+    if (!Application::Instance->sendMsgToFocusView(psCommandStr)) {
         if (!Base::asBoolean(suppress)) {
             Base::Console().warning("Unknown view command: %s\n", psCommandStr);
         }
-    }
-
-    // Print the return value to the output
-    if (ppReturn) {
-        return Py_BuildValue("s", ppReturn);
     }
 
     Py_Return;

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -393,8 +393,15 @@ void StdCmdFreezeViews::activated(int iMsg)
     }
     else if (iMsg == 3) {
         // Create a new view
-        const std::string& camera
-            = freecad_cast<View3DInventor*>(getGuiApplication()->activeView())->getCamera();
+        auto* view3d = freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
+        if (view3d == nullptr) {
+            Base::Console().developerError(
+                "StdCmdFreezeViews",
+                "Expected the active view to be View3DInventor\n"
+            );
+            return;
+        }
+        const std::string& camera = view3d->getCamera();
 
         QList<QAction*> acts = pcAction->actions();
         int index = 1;
@@ -428,6 +435,21 @@ void StdCmdFreezeViews::activated(int iMsg)
             view3D->setCamera(data.toLatin1());
         }
     }
+}
+
+bool StdCmdFreezeViews::isActive()
+{
+    auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
+
+    separator->setVisible(savedViews > 0);
+    if (view) {
+        saveView->setEnabled(savedViews > 0);
+        freezeView->setEnabled(savedViews < maxViews);
+        clearView->setEnabled(savedViews > 0);
+        return true;
+    }
+
+    return false;
 }
 
 void StdCmdFreezeViews::onSaveViews()
@@ -589,23 +611,6 @@ void StdCmdFreezeViews::onRestoreViews()
             acts[index]->setVisible(false);
         }
     }
-}
-
-bool StdCmdFreezeViews::isActive()
-{
-    auto view = qobject_cast<View3DInventor*>(getMainWindow()->activeWindow());
-    if (view) {
-        saveView->setEnabled(savedViews > 0);
-        freezeView->setEnabled(savedViews < maxViews);
-        clearView->setEnabled(savedViews > 0);
-        separator->setVisible(savedViews > 0);
-        return true;
-    }
-    else {
-        separator->setVisible(savedViews > 0);
-    }
-
-    return false;
 }
 
 void StdCmdFreezeViews::languageChange()
@@ -2633,7 +2638,15 @@ void StdCmdViewIvIssueCamPos::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    std::string camera = freecad_cast<View3DInventor*>(getGuiApplication()->activeView())->getCamera();
+    auto* view3d = freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
+    if (view3d == nullptr) {
+        Base::Console().developerError(
+            "StdCmdViewIvIssueCameraPos",
+            "Expected the active view to be View3DInventor\n"
+        );
+        return;
+    }
+    std::string camera = view3d->getCamera();
 
     // remove the #inventor line...
     std::string::size_type pos = camera.find_first_of('\n');

--- a/src/Gui/DockWindow.h
+++ b/src/Gui/DockWindow.h
@@ -72,7 +72,7 @@ public:
         return "DockWindow";
     }
     /// Message handler
-    bool onMsg(const char*, const char**) override
+    bool onMsg(const char*) override
     {
         return false;
     }

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -219,7 +219,7 @@ public:
      * first checked view is the current active view.
      * If a view supports the message true is returned and false otherwise.
      */
-    bool sendMsgToFirstView(const Base::Type& typeId, const char* pMsg, const char** ppReturn);
+    bool sendMsgToFirstView(const Base::Type& typeId, const char* pMsg);
     /// Attach a view (get called by the MDIView constructor)
     void attachView(Gui::BaseView* pcView, bool bPassiv = false);
     /// Detach a view (get called by the MDIView destructor)

--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -233,7 +233,7 @@ void EditorView::checkTimestamp()
 /**
  * Runs the action specified by \a pMsg.
  */
-bool EditorView::onMsg(const char* pMsg, const char** /*ppReturn*/)
+bool EditorView::onMsg(const char* pMsg)
 {
     // don't allow any actions if the editor is being closed
     if (d->aboutToClose) {
@@ -663,7 +663,7 @@ PythonEditorView::~PythonEditorView()
 /**
  * Runs the action specified by \a pMsg.
  */
-bool PythonEditorView::onMsg(const char* pMsg, const char** ppReturn)
+bool PythonEditorView::onMsg(const char* pMsg)
 {
     if (strcmp(pMsg, "Run") == 0) {
         executeScript();
@@ -677,7 +677,7 @@ bool PythonEditorView::onMsg(const char* pMsg, const char** ppReturn)
         toggleBreakpoint();
         return true;
     }
-    return EditorView::onMsg(pMsg, ppReturn);
+    return EditorView::onMsg(pMsg);
 }
 
 /**
@@ -705,7 +705,7 @@ void PythonEditorView::executeScript()
 {
     // always save the macro when it is modified
     if (EditorView::onHasMsg("Save")) {
-        EditorView::onMsg("Save", nullptr);
+        EditorView::onMsg("Save");
     }
     try {
         getMainWindow()->setCursor(Qt::WaitCursor);

--- a/src/Gui/EditorView.h
+++ b/src/Gui/EditorView.h
@@ -77,7 +77,7 @@ public:
     void onUpdate() override
     {}
 
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
 
     bool canClose() override;
@@ -136,7 +136,7 @@ public:
     PythonEditorView(PythonEditor* editor, QWidget* parent);
     ~PythonEditorView() override;
 
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
 
 public Q_SLOTS:

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -471,7 +471,7 @@ QByteArray GraphvizView::exportGraph(const QString& format)
     return dotProc.readAll();
 }
 
-bool GraphvizView::onMsg(const char* pMsg, const char**)
+bool GraphvizView::onMsg(const char* pMsg)
 {
     if (strcmp("Save", pMsg) == 0 || strcmp("SaveAs", pMsg) == 0) {
         QList<QPair<QString, QString>> formatMap;

--- a/src/Gui/GraphvizView.h
+++ b/src/Gui/GraphvizView.h
@@ -49,7 +49,7 @@ public:
     QByteArray exportGraph(const QString& filter);
 
     /// Message handler
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     /// Message handler test
     bool onHasMsg(const char* pMsg) const override;
     /** @name Printing */

--- a/src/Gui/ImageView.cpp
+++ b/src/Gui/ImageView.cpp
@@ -311,9 +311,8 @@ void ImageView::print(QPrinter* printer)
     painter.drawPixmap(0, 0, pixmap);
 }
 
-bool ImageView::onMsg(const char* pMsg, const char** ppReturn)
+bool ImageView::onMsg(const char* pMsg)
 {
-    Q_UNUSED(ppReturn)
     if (strcmp("ViewFit", pMsg) == 0) {
         fitToWindow(true);
         return true;

--- a/src/Gui/ImageView.h
+++ b/src/Gui/ImageView.h
@@ -49,7 +49,7 @@ public:
     }
 
     /// Message handler
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     /// Message handler test
     bool onHasMsg(const char* pMsg) const override;
 

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -202,10 +202,9 @@ void MDIView::viewAll()
 {}
 
 /// receive a message
-bool MDIView::onMsg(const char* pMsg, const char** ppReturn)
+bool MDIView::onMsg(const char* pMsg)
 {
     Q_UNUSED(pMsg);
-    Q_UNUSED(ppReturn);
     return false;
 }
 

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -82,7 +82,7 @@ public:
     void setWindowTitle(const QString& title);
 
     /// Message handler
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     /// Message handler test
     bool onHasMsg(const char* pMsg) const override;
     /// overwrite when checking on close state

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -179,7 +179,6 @@ Py::Object MDIViewPy::redoActions(const Py::Tuple& args)
 
 Py::Object MDIViewPy::sendMessage(const Py::Tuple& args)
 {
-    const char** ppReturn = nullptr;
     char* psMsgStr;
     if (!PyArg_ParseTuple(args.ptr(), "s;Message string needed (string)", &psMsgStr)) {
         throw Py::Exception();
@@ -188,7 +187,7 @@ Py::Object MDIViewPy::sendMessage(const Py::Tuple& args)
     try {
         bool ok = false;
         if (_view) {
-            ok = _view->onMsg(psMsgStr, ppReturn);
+            ok = _view->onMsg(psMsgStr);
         }
         return Py::Boolean(ok);
     }

--- a/src/Gui/MDIViewPyWrap.cpp
+++ b/src/Gui/MDIViewPyWrap.cpp
@@ -212,16 +212,16 @@ PyObject* MDIViewPyWrap::getPyObject()
     return MDIView::getPyObject();
 }
 
-bool MDIViewPyWrap::onMsg(const char* pMsg, const char** ppReturn)
+bool MDIViewPyWrap::onMsg(const char* pMsg)
 {
     try {
         if (ptr->onMsg(pMsg)) {
             return true;
         }
-        return MDIView::onMsg(pMsg, ppReturn);
+        return MDIView::onMsg(pMsg);
     }
     catch (const std::exception&) {
-        return MDIView::onMsg(pMsg, ppReturn);
+        return MDIView::onMsg(pMsg);
     }
     catch (Py::Exception&) {
         Base::PyGILStateLocker lock;

--- a/src/Gui/MDIViewPyWrap.h
+++ b/src/Gui/MDIViewPyWrap.h
@@ -56,7 +56,7 @@ public:
     ~MDIViewPyWrap() override;
 
     /// Message handler
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     /// Message handler test
     bool onHasMsg(const char* pMsg) const override;
     /// overwrite when checking on close state

--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -687,7 +687,7 @@ void SelectionView::onItemContextMenu(const QPoint& point)
 void SelectionView::onUpdate()
 {}
 
-bool SelectionView::onMsg(const char* /*pMsg*/, const char** /*ppReturn*/)
+bool SelectionView::onMsg(const char* /*pMsg*/)
 {
     return false;
 }

--- a/src/Gui/Selection/SelectionView.h
+++ b/src/Gui/Selection/SelectionView.h
@@ -76,7 +76,7 @@ public:
 
     void leaveEvent(QEvent*) override;
 
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
 
     const char* getName() const override
     {

--- a/src/Gui/SplitView3DInventor.cpp
+++ b/src/Gui/SplitView3DInventor.cpp
@@ -141,7 +141,7 @@ const char* AbstractSplitView::getName() const
     return "SplitView3DInventor";
 }
 
-bool AbstractSplitView::onMsg(const char* pMsg, const char**)
+bool AbstractSplitView::onMsg(const char* pMsg)
 {
     if (strcmp("ViewFit", pMsg) == 0) {
         viewAll();
@@ -374,7 +374,7 @@ Py::Object AbstractSplitViewPy::fitAll(const Py::Tuple& args)
     }
 
     try {
-        getSplitViewPtr()->onMsg("ViewFit", nullptr);
+        getSplitViewPtr()->onMsg("ViewFit");
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -395,7 +395,7 @@ Py::Object AbstractSplitViewPy::viewBottom(const Py::Tuple& args)
     }
 
     try {
-        getSplitViewPtr()->onMsg("ViewBottom", nullptr);
+        getSplitViewPtr()->onMsg("ViewBottom");
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -417,7 +417,7 @@ Py::Object AbstractSplitViewPy::viewFront(const Py::Tuple& args)
     }
 
     try {
-        getSplitViewPtr()->onMsg("ViewFront", nullptr);
+        getSplitViewPtr()->onMsg("ViewFront");
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -439,7 +439,7 @@ Py::Object AbstractSplitViewPy::viewLeft(const Py::Tuple& args)
     }
 
     try {
-        getSplitViewPtr()->onMsg("ViewLeft", nullptr);
+        getSplitViewPtr()->onMsg("ViewLeft");
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -461,7 +461,7 @@ Py::Object AbstractSplitViewPy::viewRear(const Py::Tuple& args)
     }
 
     try {
-        getSplitViewPtr()->onMsg("ViewRear", nullptr);
+        getSplitViewPtr()->onMsg("ViewRear");
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -483,7 +483,7 @@ Py::Object AbstractSplitViewPy::viewRight(const Py::Tuple& args)
     }
 
     try {
-        getSplitViewPtr()->onMsg("ViewRight", nullptr);
+        getSplitViewPtr()->onMsg("ViewRight");
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -505,7 +505,7 @@ Py::Object AbstractSplitViewPy::viewTop(const Py::Tuple& args)
     }
 
     try {
-        getSplitViewPtr()->onMsg("ViewTop", nullptr);
+        getSplitViewPtr()->onMsg("ViewTop");
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -527,7 +527,7 @@ Py::Object AbstractSplitViewPy::viewIsometric(const Py::Tuple& args)
     }
 
     try {
-        getSplitViewPtr()->onMsg("ViewAxo", nullptr);
+        getSplitViewPtr()->onMsg("ViewAxo");
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());

--- a/src/Gui/SplitView3DInventor.h
+++ b/src/Gui/SplitView3DInventor.h
@@ -56,7 +56,7 @@ public:
     const char* getName() const override;
 
     /// Message handler
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
     void onUpdate() override;
     void deleteSelf() override;

--- a/src/Gui/TextDocumentEditorView.cpp
+++ b/src/Gui/TextDocumentEditorView.cpp
@@ -177,10 +177,8 @@ bool TextDocumentEditorView::onHasMsg(const char* msg) const
     return false;
 }
 
-bool TextDocumentEditorView::onMsg(const char* msg, const char** output)
+bool TextDocumentEditorView::onMsg(const char* msg)
 {
-    Q_UNUSED(output)
-
     // don't allow any actions if the editor is being closed
     if (aboutToClose) {
         return false;

--- a/src/Gui/TextDocumentEditorView.h
+++ b/src/Gui/TextDocumentEditorView.h
@@ -45,7 +45,7 @@ public:
     {
         return "TextDocumentEditorView";
     }
-    bool onMsg(const char* msg, const char** output) override;
+    bool onMsg(const char* msg) override;
     bool onHasMsg(const char* msg) const override;
 
     QPlainTextEdit* getEditor() const

--- a/src/Gui/View.h
+++ b/src/Gui/View.h
@@ -105,7 +105,7 @@ public:
         return "Base view";
     }
     /// Message handler
-    virtual bool onMsg(const char* pMsg, const char** ppReturn) = 0;
+    virtual bool onMsg(const char* pMsg) = 0;
     /// Message handler test
     virtual bool onHasMsg(const char* pMsg) const = 0;
     /// overwrite when checking on close state

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -58,6 +58,7 @@
 #include <Gui/PreferencePages/DlgSettingsPDF.h>
 
 #include "View3DInventor.h"
+#include "Base/Exception.h"
 #include "View3DSettings.h"
 #include "Application.h"
 #include "BitmapFactory.h"
@@ -350,7 +351,7 @@ bool View3DInventor::containsViewProvider(const ViewProvider* vp) const
 
 // **********************************************************************************
 
-bool View3DInventor::onMsg(const char* pMsg, const char** ppReturn)
+bool View3DInventor::onMsg(const char* pMsg)
 {
     if (strcmp("ViewFit", pMsg) == 0) {
         _viewer->viewAll();
@@ -384,17 +385,6 @@ bool View3DInventor::onMsg(const char* pMsg, const char** ppReturn)
     else if (strcmp("SetStereoOff", pMsg) == 0) {
         _viewer->setStereoMode(Quarter::SoQTQuarterAdaptor::MONO);
         return true;
-    }
-    else if (strcmp("GetCamera", pMsg) == 0) {
-        SoCamera* Cam = _viewer->getSoRenderManager()->getCamera();
-        if (!Cam) {
-            return false;
-        }
-        *ppReturn = SoFCDB::writeNodesToString(Cam).c_str();
-        return true;
-    }
-    else if (strncmp("SetCamera", pMsg, 9) == 0) {
-        return setCamera(pMsg + 10);
     }
     else if (strncmp("Dump", pMsg, 4) == 0) {
         dump(pMsg + 5);
@@ -561,12 +551,6 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
     else if (strcmp("ViewAxo", pMsg) == 0) {
         return true;
     }
-    else if (strcmp("GetCamera", pMsg) == 0) {
-        return true;
-    }
-    else if (strncmp("SetCamera", pMsg, 9) == 0) {
-        return true;
-    }
     else if (strncmp("Dump", pMsg, 4) == 0) {
         return true;
     }
@@ -584,6 +568,15 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
     }
 
     return false;
+}
+
+const std::string& View3DInventor::getCamera() const
+{
+    SoCamera* Cam = _viewer->getSoRenderManager()->getCamera();
+    if (!Cam) {
+        throw Base::RuntimeError("Could not find reference to 3D View camera");
+    }
+    return SoFCDB::writeNodesToString(Cam);
 }
 
 bool View3DInventor::setCamera(const char* pCamera)

--- a/src/Gui/View3DInventor.h
+++ b/src/Gui/View3DInventor.h
@@ -97,7 +97,7 @@ public:
     View3DInventor* clone() override;
 
     /// Message handler
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
     void deleteSelf() override;
     /// get called when the document is updated
@@ -122,6 +122,7 @@ public:
      */
     void setCurrentViewMode(ViewMode b) override;
     RayPickInfo getObjInfoRay(Base::Vector3d* startvec, Base::Vector3d* dirvec);
+    const std::string& getCamera() const;
     bool setCamera(const char* pCamera);
     void toggleClippingPlane();
     bool hasClippingPlane() const;

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -161,7 +161,7 @@ SheetView::~SheetView()
     delete delegate;
 }
 
-bool SheetView::onMsg(const char* pMsg, const char**)
+bool SheetView::onMsg(const char* pMsg)
 {
     if (strcmp("Undo", pMsg) == 0) {
         getGuiDocument()->undo(1);

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.h
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.h
@@ -75,7 +75,7 @@ public:
         return "SheetView";
     }
 
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
 
     /** @name Printing */

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -179,7 +179,7 @@ void MDIViewPage::onDeleteObject(const App::DocumentObject& obj)
     blockSceneSelection(false);
 }
 
-bool MDIViewPage::onMsg(const char* pMsg, const char**)
+bool MDIViewPage::onMsg(const char* pMsg)
 {
     Gui::Document* doc(getGuiDocument());
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -73,7 +73,7 @@ public:
     void clearSceneSelection();
     void blockSceneSelection(bool isBlocked);
 
-    bool onMsg(const char* pMsg, const char** ppReturn) override;
+    bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
 
     void print() override;


### PR DESCRIPTION
Per #27779.

Removes the "getCamera" and "setCamera" messages and uses the `View3DInventor::(get|set)Camera` methods instead. This allowed the removal of the output parameter from `onMsg` which was ignored in every command other than `getCamera`.

I tested the:

- camera restore on document open
- camera serialization on document save
- "View > Camera > Stereo > Issue Camera Position" command
- "View > Freeze Display" commands

And they seem to work correctly.