### PR TITLE
PartDesign: Add strikethrough strike in tree view for suppressed items / features

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -53,6 +53,7 @@
 #include <App/AutoTransaction.h>
 #include <App/GeoFeatureGroupExtension.h>
 #include <App/Link.h>
+#include <App/SuppressibleExtension.h>
 
 #include "Tree.h"
 #include "BitmapFactory.h"
@@ -6157,6 +6158,17 @@ void DocumentObjectItem::testStatus(bool resetStatus)
 {
     QIcon icon, icon2;
     testStatus(resetStatus, icon, icon2);
+    // check if the object is suppressed and apply strikethrough
+    auto docObj = object()->getObject();
+    bool suppressed = false;
+    if (docObj && docObj->hasExtension(App::SuppressibleExtension::getExtensionClassTypeId())) {
+        suppressed = docObj->getExtensionByType<App::SuppressibleExtension>()->Suppressed.getValue();
+    }
+    QFont f = font(0);
+    if (f.strikeOut() != suppressed) {
+        f.setStrikeOut(suppressed);
+        setFont(0, f);
+    }
 }
 
 namespace

--- a/src/Mod/PartDesign/CMakeLists.txt
+++ b/src/Mod/PartDesign/CMakeLists.txt
@@ -63,6 +63,7 @@ set(PartDesign_TestScripts
 if(BUILD_GUI)
     list(APPEND PartDesign_TestScripts
         PartDesignTests/TestMaterial.py
+        PartDesignTests/TestSuppressed.py
     )
 endif(BUILD_GUI)
 

--- a/src/Mod/PartDesign/PartDesignTests/TestSuppressed.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestSuppressed.py
@@ -44,8 +44,6 @@ import unittest
 
 import FreeCAD
 import FreeCADGui
-import Part
-import Sketcher
 import TestSketcherApp
 
 from PySide import QtGui

--- a/src/Mod/PartDesign/PartDesignTests/TestSuppressed.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestSuppressed.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Chris Jones github.com/ipatch
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""Tests for SuppressibleExtension persistence (github issue #24587).
+
+When a PartDesign feature is suppressed, the tree view should show a red slash
+overlay on the icon AND strikethrough text on the label. Previously, the
+strikethrough was lost after save/close/reopen because it was only applied via
+a transient signal. The fix in Tree.cpp queries the Suppressed state in
+DocumentObjectItem::testStatus() so the strikethrough is re-applied on load.
+
+These tests verify that the underlying Suppressed property and extension
+persist correctly across save/reload cycles.
+
+To run the gui tests as github ci runs them, useful for running gui tests locally
+use the below command, ie.
+
+xvfb-run \
+/path/to/local/freecad/install/bin/FreeCAD -t TestPartDesignGui.TestSuppressedStrikethrough
+"""
+
+import os
+import tempfile
+import time
+import unittest
+
+import FreeCAD
+import FreeCADGui
+import Part
+import Sketcher
+import TestSketcherApp
+
+from PySide import QtGui
+
+
+class TestSuppressed(unittest.TestCase):
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PartDesignTestSuppressed")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def _createBodyWithPadAndFillet(self):
+        """Create a Body with a Pad (10x10x10 box) and a Fillet."""
+        self.Body = self.Doc.addObject("PartDesign::Body", "Body")
+        self.PadSketch = self.Doc.addObject("Sketcher::SketchObject", "SketchPad")
+        self.Body.addObject(self.PadSketch)
+        TestSketcherApp.CreateRectangleSketch(self.PadSketch, (0, 0), (10, 10))
+        self.Doc.recompute()
+        self.Pad = self.Doc.addObject("PartDesign::Pad", "Pad")
+        self.Body.addObject(self.Pad)
+        self.Pad.Profile = self.PadSketch
+        self.Pad.Length = 10
+        self.Doc.recompute()
+        self.Fillet = self.Doc.addObject("PartDesign::Fillet", "Fillet")
+        self.Body.addObject(self.Fillet)
+        self.Fillet.Base = (self.Pad, ["Edge1"])
+        self.Fillet.Radius = 1.0
+        self.Doc.recompute()
+
+    def testSuppressibleExtensionExists(self):
+        """PartDesign features should have SuppressibleExtension."""
+        self._createBodyWithPadAndFillet()
+        self.assertTrue(
+            self.Pad.hasExtension("App::SuppressibleExtension"),
+            "Pad should have SuppressibleExtension",
+        )
+        self.assertTrue(
+            self.Fillet.hasExtension("App::SuppressibleExtension"),
+            "Fillet should have SuppressibleExtension",
+        )
+
+    def testSuppressChangesShape(self):
+        """Suppressing a feature should change the body shape."""
+        self._createBodyWithPadAndFillet()
+        volumeWithFillet = self.Body.Shape.Volume
+
+        self.Fillet.Suppressed = True
+        self.Doc.recompute()
+        self.assertTrue(self.Fillet.Suppressed)
+
+        volumeWithoutFillet = self.Body.Shape.Volume
+        self.assertNotAlmostEqual(
+            volumeWithFillet,
+            volumeWithoutFillet,
+            places=2,
+            msg="Suppressing fillet should change body volume",
+        )
+
+        # Unsuppress should restore
+        self.Fillet.Suppressed = False
+        self.Doc.recompute()
+        self.assertFalse(self.Fillet.Suppressed)
+        self.assertAlmostEqual(
+            self.Body.Shape.Volume,
+            volumeWithFillet,
+            places=2,
+            msg="Unsuppressing should restore original volume",
+        )
+
+    def testSuppressedPersistsAfterReload(self):
+        """Suppressed property must persist after save/close/reopen (github issue #24587)."""
+        self._createBodyWithPadAndFillet()
+
+        self.Fillet.Suppressed = True
+        self.Doc.recompute()
+        volumeSuppressed = self.Body.Shape.Volume
+
+        # Save, close, reopen
+        with tempfile.TemporaryDirectory(prefix="freecad_test_suppressed_") as tmpdir:
+            filepath = os.path.join(tmpdir, "test_suppressed.FCStd")
+            self.Doc.saveAs(filepath)
+            FreeCAD.closeDocument(self.Doc.Name)
+            self.Doc = FreeCAD.openDocument(filepath)
+
+        filletReloaded = self.Doc.getObject("Fillet")
+        bodyReloaded = self.Doc.getObject("Body")
+
+        self.assertIsNotNone(filletReloaded)
+        self.assertIsNotNone(bodyReloaded)
+        self.assertTrue(
+            filletReloaded.Suppressed,
+            "Fillet.Suppressed should be True after reload",
+        )
+        self.assertTrue(
+            filletReloaded.hasExtension("App::SuppressibleExtension"),
+            "SuppressibleExtension should persist after reload",
+        )
+        self.assertAlmostEqual(
+            bodyReloaded.Shape.Volume,
+            volumeSuppressed,
+            places=2,
+            msg="Body volume should reflect suppressed state after reload",
+        )
+
+    def testUnsuppressedPersistsAfterReload(self):
+        """A feature suppressed then unsuppressed should stay unsuppressed after reload."""
+        self._createBodyWithPadAndFillet()
+
+        self.Fillet.Suppressed = True
+        self.Doc.recompute()
+        self.Fillet.Suppressed = False
+        self.Doc.recompute()
+        volumeActive = self.Body.Shape.Volume
+
+        with tempfile.TemporaryDirectory(prefix="freecad_test_suppressed_") as tmpdir:
+            filepath = os.path.join(tmpdir, "test_unsuppressed.FCStd")
+            self.Doc.saveAs(filepath)
+            FreeCAD.closeDocument(self.Doc.Name)
+            self.Doc = FreeCAD.openDocument(filepath)
+
+        filletReloaded = self.Doc.getObject("Fillet")
+        bodyReloaded = self.Doc.getObject("Body")
+
+        self.assertFalse(
+            filletReloaded.Suppressed,
+            "Fillet.Suppressed should be False after reload",
+        )
+        self.assertAlmostEqual(
+            bodyReloaded.Shape.Volume,
+            volumeActive,
+            places=2,
+            msg="Body volume should reflect active fillet after reload",
+        )
+
+    def testMultipleSuppressedFeaturesReload(self):
+        """Multiple suppressed features should all persist after reload."""
+        self._createBodyWithPadAndFillet()
+
+        # Add a Chamfer too
+        self.Chamfer = self.Doc.addObject("PartDesign::Chamfer", "Chamfer")
+        self.Body.addObject(self.Chamfer)
+        self.Chamfer.Base = (self.Fillet, ["Edge2"])
+        self.Chamfer.Size = 0.5
+        self.Doc.recompute()
+
+        self.Fillet.Suppressed = True
+        self.Chamfer.Suppressed = True
+        self.Doc.recompute()
+
+        with tempfile.TemporaryDirectory(prefix="freecad_test_suppressed_") as tmpdir:
+            filepath = os.path.join(tmpdir, "test_multi_suppressed.FCStd")
+            self.Doc.saveAs(filepath)
+            FreeCAD.closeDocument(self.Doc.Name)
+            self.Doc = FreeCAD.openDocument(filepath)
+
+        self.assertTrue(
+            self.Doc.getObject("Fillet").Suppressed,
+            "Fillet should remain suppressed after reload",
+        )
+        self.assertTrue(
+            self.Doc.getObject("Chamfer").Suppressed,
+            "Chamfer should remain suppressed after reload",
+        )
+
+
+def _findTreeWidget():
+    """Find the main tree widget (QTreeWidget) in the FreeCAD GUI."""
+    mw = FreeCADGui.getMainWindow()
+    if mw is None:
+        return None
+    trees = mw.findChildren(QtGui.QTreeWidget)
+    # under xvfb, objectName may be empty - pick the tree with content
+    for tree in trees:
+        if tree.topLevelItemCount() > 0:
+            return tree
+    # no tree has items yet, return the last one (usally the model tree)
+    if trees:
+        return trees[-1]
+    return None
+
+
+def _getTreeItemStrikeOut(tree, label, parent=None):
+    """Recursively find a QTreeWidgetItem by label and return its strikeOut state.
+
+    Returns the font's strikeOut() bool, or None if item not found.
+    Reads the font immediately to avoid C++ object lifetime issues.
+    """
+    if parent is None:
+        for i in range(tree.topLevelItemCount()):
+            result = _getTreeItemStrikeOut(tree, label, tree.topLevelItem(i))
+            if result is not None:
+                return result
+    else:
+        if parent.text(0) == label:
+            # Read font data immediately before the item can be invalidated
+            return parent.font(0).strikeOut()
+        for i in range(parent.childCount()):
+            result = _getTreeItemStrikeOut(tree, label, parent.child(i))
+            if result is not None:
+                return result
+    return None
+
+
+class TestSuppressedStrikethrough(unittest.TestCase):
+    """Test that suppressed features show strikethrough in the tree after reload."""
+
+    def setUp(self):
+        if not hasattr(FreeCADGui, "getMainWindow") or FreeCADGui.getMainWindow() is None:
+            self.skipTest("Requires GUI")
+        self.Doc = FreeCAD.newDocument("TestSuppressedStrikethrough")
+        FreeCADGui.activateView("Gui::View3DInventor", True)
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def _createBodyWithBox(self):
+        self.Body = self.Doc.addObject("PartDesign::Body", "Body")
+        FreeCADGui.activeView().setActiveObject("pdbody", self.Body)
+        self.Box = self.Doc.addObject("PartDesign::AdditiveBox", "Box")
+        self.Body.addObject(self.Box)
+        self.Box.Length = 10.0
+        self.Box.Width = 10.0
+        self.Box.Height = 10.0
+        self.Doc.recompute()
+        QtGui.QApplication.processEvents()
+
+    def testSuppressedShowsStrikethrough(self):
+        """Suppressing a feature should immediately show strikethrough in tree."""
+        self._createBodyWithBox()
+
+        self.Box.Suppressed = True
+        self.Doc.recompute()
+        QtGui.QApplication.processEvents()
+
+        tree = _findTreeWidget()
+        self.assertIsNotNone(tree, "Could not find tree widget")
+
+        # retry up to 50 times with 50ms naps
+        strikeOut = None
+        for _ in range(50):
+            QtGui.QApplication.processEvents()
+            strikeOut = _getTreeItemStrikeOut(tree, "Box")
+            if strikeOut is not None:
+                break
+            time.sleep(0.05)
+
+        self.assertIsNotNone(strikeOut, "Could not find 'Box' tree item")
+        self.assertTrue(
+            strikeOut,
+            "Suppressed feature should have strikethrough font in tree",
+        )
+
+    def testUnsuppressedNoStrikethrough(self):
+        """Unsuppressing a feature should remove strikethrough."""
+        self._createBodyWithBox()
+
+        self.Box.Suppressed = True
+        self.Doc.recompute()
+        QtGui.QApplication.processEvents()
+
+        self.Box.Suppressed = False
+        self.Doc.recompute()
+        QtGui.QApplication.processEvents()
+
+        tree = _findTreeWidget()
+
+        strikeOut = None
+        for _ in range(50):
+            QtGui.QApplication.processEvents()
+            strikeOut = _getTreeItemStrikeOut(tree, "Box")
+            if strikeOut is not None:
+                break
+            time.sleep(0.05)
+
+        self.assertIsNotNone(strikeOut, "Could not find 'Box' tree item")
+        self.assertFalse(
+            strikeOut,
+            "Unsuppressed feature should not have strikethrough font",
+        )
+
+    def testStrikethroughPersistsAfterReload(self):
+        """github issue #24587: strikethrough must persist after save/close/reopen."""
+        self._createBodyWithBox()
+
+        self.Box.Suppressed = True
+        self.Doc.recompute()
+        QtGui.QApplication.processEvents()
+
+        # Save
+        with tempfile.TemporaryDirectory(prefix="freecad_test_suppressed_") as tmpdir:
+            filepath = os.path.join(tmpdir, "test_strikethrough.FCStd")
+            self.Doc.saveAs(filepath)
+
+            # Close
+            FreeCAD.closeDocument(self.Doc.Name)
+            QtGui.QApplication.processEvents()
+
+            # Reopen
+            self.Doc = FreeCAD.openDocument(filepath)
+            QtGui.QApplication.processEvents()
+
+        # Verify the property persisted
+        boxReloaded = self.Doc.getObject("Box")
+        self.assertIsNotNone(boxReloaded, "Box should exist in reloaded doc")
+        self.assertTrue(boxReloaded.Suppressed, "Box.Suppressed should be True after reload")
+
+        # wait & verify for the tree to populate - it's possible the ci operates slower than my local m1
+        tree = _findTreeWidget()
+        self.assertIsNotNone(tree, "could not find tree widget after reload")
+
+        strikeOut = None
+        for _ in range(50):
+            QtGui.QApplication.processEvents()
+            strikeOut = _getTreeItemStrikeOut(tree, "Box")
+            if strikeOut is not None:
+                break
+            time.sleep(0.05)
+
+        self.assertIsNotNone(strikeOut, "Could not find 'Box' tree item after reload")
+        self.assertTrue(
+            strikeOut,
+            "Suppressed feature should have strikethrough font after file reload "
+            "(github issue #24587)",
+        )

--- a/src/Mod/PartDesign/PartDesignTests/TestSuppressed.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestSuppressed.py
@@ -220,7 +220,7 @@ def _findTreeWidget():
     for tree in trees:
         if tree.topLevelItemCount() > 0:
             return tree
-    # no tree has items yet, return the last one (usally the model tree)
+    # no tree has items yet, return the last one (usually the model tree)
     if trees:
         return trees[-1]
     return None

--- a/src/Mod/PartDesign/PartDesignTests/__init__.py
+++ b/src/Mod/PartDesign/PartDesignTests/__init__.py
@@ -19,5 +19,6 @@ from . import TestPolarPattern
 from . import TestPrimitive
 from . import TestRevolve
 from . import TestShapeBinder
+from . import TestSuppressed
 from . import TestThickness
 from . import TestTopologicalNamingProblem

--- a/src/Mod/PartDesign/TestPartDesignApp.py
+++ b/src/Mod/PartDesign/TestPartDesignApp.py
@@ -58,6 +58,7 @@ from PartDesignTests.TestThickness import TestThickness
 # extras
 from PartDesignTests.TestInvoluteGear import TestInvoluteGear
 from PartDesignTests.TestSketch import TestSketch
+from PartDesignTests.TestSuppressed import TestSuppressed
 
 # Topological naming problem
 from PartDesignTests.TestTopologicalNamingProblem import TestTopologicalNamingProblem

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -38,6 +38,7 @@ from PySide.QtGui import QApplication
 
 from PartDesignTests.TestMaterial import TestMaterial
 from PartDesignTests.TestActiveObject import TestActiveObject
+from PartDesignTests.TestSuppressed import TestSuppressedStrikethrough
 
 
 # timer runs this class in order to access modal dialog


### PR DESCRIPTION
**updated apr 16 2026**

updated the `TestSuppressed.py` to hopefully pass with the ubuntu github ci runner. took a look at several of the yaml files in this repo, ie.

```yaml
      - name: FreeCAD GUI tests on install
        timeout-minutes: 15
        uses: ./.github/workflows/actions/runPythonTests
        with:
          testDescription: "GUI tests on install"
          # Use Python wrapper to run only GUI-registered tests using the installed FreeCAD
          testCommand: xvfb-run python3 ./.github/scripts/run_gui_tests.py "FreeCAD"
          logFile: ${{ env.logdir }}TestGUIInstall.log
          reportFile: ${{env.reportdir}}${{ env.reportfilename }}
```

so to test this locally on my asahi m1 box, and to mimic the ci as close as i could i used the below command,

``` 
xvfb-run \
 /opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD -t TestPartDesignGui.TestSuppressedStrikethrough
```

**output**

```
FreeCAD 1.2.0, Libs: 1.2.0devR46417 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

testStrikethroughPersistsAfterReload (PartDesignTests.TestSuppressed.TestSuppressedStrikethrough.testStrikethroughPersistsAfterReload)
Body: Tip shape is empty
github issue #24587: strikethrough must persist after save/close/reopen. ... ok
testSuppressedShowsStrikethrough (PartDesignTests.TestSuppressed.TestSuppressedStrikethrough.testSuppressedShowsStrikethrough)
Body: Tip shape is empty
Suppressing a feature should immediately show strikethrough in tree. ... ok
testUnsuppressedNoStrikethrough (PartDesignTests.TestSuppressed.TestSuppressedStrikethrough.testUnsuppressedNoStrikethrough)
Body: Tip shape is empty
Unsuppressing a feature should remove strikethrough. ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.680s

OK
System exit
```

---

**updated mar 22 2026**

this PR adds a single test file within the PartDesign testsuite, and contains unit tests for both the GUI and the application layer of freecad. to run the tests contained within this PR run the below commands.

```
./FreeCADCmd -t PartDesignTests.TestSuppressed
```

```
./FreeCAD -t TestPartDesignGui
```

This pr fixes #24587 by properly adding a strikethrough to items that have been marked as suppressed. there was an issue, when reopening a document with a suppressed feature the strikethrough was not appearing in the tree view for the feature name. this PR adds some unit test to help future proof this error from popping up in the future. 🤞

testing via the unit test without this fix,

```
╰─λ /opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD -t TestPartDesignGui
FreeCAD 1.2.0, Libs: 1.2.0devR45426 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

asahi: driver missing
glx: failed to create dri3 screen
failed to load driver: asahi
Testing the creation of a sketch
Testing moving one feature from one body to another
PartDesign::Body: Link(s) to object(s) 'Pad' go out of the allowed scope 'Body'. Instead, the linked object(s) reside within 'Body001 Body001'.
Testing refuse to move the feature with dependencies from one body to another
Testing applying MultiTransform to the Box outside the body
PartDesignTestMaterial.testDiffuseColor()
Body: Tip shape is empty
FAILED: testStrikethroughPersistsAfterReload (PartDesignTests.TestSuppressed.TestSuppressedStrikethrough.testStrikethroughPersistsAfterReload)
Traceback (most recent call last):
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/PartDesign/PartDesignTests/TestSuppressed.py", line 350, in testStrikethroughPersistsAfterReload
    self.assertTrue(
    ~~~~~~~~~~~~~~~^
        strikeOut,
        ^^^^^^^^^^
        "Suppressed feature should have strikethrough font after file reload (issue #24587)",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: False is not true : Suppressed feature should have strikethrough font after file reload (issue #24587)

Body: Tip shape is empty
Body: Tip shape is empty

----------------------------------------------------------------------
Ran 12 tests in 11.6s

FAILED (failures=1)
System exit
```

and no mention about "supppression _feature_" in the wiki

https://wiki.freecad.org/Tree_View

<img width="3667" height="2064" alt="image" src="https://github.com/user-attachments/assets/2ed60475-22e3-4515-a73d-49b9f2aad0bd" />



## Issues

- https://github.com/FreeCAD/FreeCAD/issues/24587

## Before and After Images

i'll upload some pictures in a few.

before

<img width="2563" height="2155" alt="image" src="https://github.com/user-attachments/assets/71dbb0ad-b06d-49a7-b6a1-24b854ae143c" />


after

<img width="2469" height="2148" alt="image" src="https://github.com/user-attachments/assets/8a1b83d3-b0f0-47fe-916a-0f77b79cfbcf" />


