### PR TITLE
CAM: Fix transform tool for operations and dress-ups

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/Array.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Array.py
@@ -35,6 +35,8 @@ class DressupArrayViewProvider(object):
         return True
 
     def setEdit(self, vobj, mode=0):
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
         return True
 
     def unsetEdit(self, vobj, mode=0):

--- a/src/Mod/CAM/Path/Dressup/Gui/AxisMap.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/AxisMap.py
@@ -222,10 +222,13 @@ class ViewProviderDressup:
         return False
 
     def setEdit(self, vobj, mode=0):
-        FreeCADGui.Control.closeDialog()
-        panel = TaskPanel(vobj.Object)
-        FreeCADGui.Control.showDialog(panel)
-        panel.setupUi()
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
+        elif mode == 0:
+            FreeCADGui.Control.closeDialog()
+            panel = TaskPanel(vobj.Object)
+            FreeCADGui.Control.showDialog(panel)
+            panel.setupUi()
         return True
 
     def claimChildren(self):

--- a/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Boundary.py
@@ -225,12 +225,15 @@ class DressupPathBoundaryViewProvider(object):
         return True
 
     def setEdit(self, vobj, mode=0):
-        panel = TaskPanel(vobj.Object, self)
-        self.setupTaskPanel(panel)
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
+        elif mode == 0:
+            panel = TaskPanel(vobj.Object, self)
+            self.setupTaskPanel(panel)
         return True
 
     def unsetEdit(self, vobj, mode=0):
-        if self.panel:
+        if mode == 0 and self.panel:
             self.panel.abort()
 
     def setupTaskPanel(self, panel):

--- a/src/Mod/CAM/Path/Dressup/Gui/DogboneII.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/DogboneII.py
@@ -280,10 +280,13 @@ class ViewProviderDressup(object):
         return [self.obj.Base]
 
     def setEdit(self, vobj, mode=0):
-        FreeCADGui.Control.closeDialog()
-        panel = TaskPanel(self, vobj.Object)
-        FreeCADGui.Control.showDialog(panel)
-        panel.setupUi()
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
+        elif mode == 0:
+            FreeCADGui.Control.closeDialog()
+            panel = TaskPanel(self, vobj.Object)
+            FreeCADGui.Control.showDialog(panel)
+            panel.setupUi()
         return True
 
     def dumps(self):

--- a/src/Mod/CAM/Path/Dressup/Gui/DogboneII.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/DogboneII.py
@@ -281,10 +281,13 @@ class ViewProviderDressup(object):
         return [self.obj.Base]
 
     def setEdit(self, vobj, mode=0):
-        FreeCADGui.Control.closeDialog()
-        panel = TaskPanel(self, vobj.Object)
-        FreeCADGui.Control.showDialog(panel)
-        panel.setupUi()
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
+        elif mode == 0:
+            FreeCADGui.Control.closeDialog()
+            panel = TaskPanel(self, vobj.Object)
+            FreeCADGui.Control.showDialog(panel)
+            panel.setupUi()
         return True
 
     def dumps(self):

--- a/src/Mod/CAM/Path/Dressup/Gui/Dragknife.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Dragknife.py
@@ -554,10 +554,13 @@ class ViewProviderDressup:
         return False
 
     def setEdit(self, vobj, mode=0):
-        FreeCADGui.Control.closeDialog()
-        panel = TaskPanel(vobj.Object)
-        FreeCADGui.Control.showDialog(panel)
-        panel.setupUi()
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
+        elif mode == 0:
+            FreeCADGui.Control.closeDialog()
+            panel = TaskPanel(vobj.Object)
+            FreeCADGui.Control.showDialog(panel)
+            panel.setupUi()
         return True
 
     def claimChildren(self):

--- a/src/Mod/CAM/Path/Dressup/Gui/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Tags.py
@@ -499,12 +499,15 @@ class PathDressupTagViewProvider:
         #    tag.purgeTouched()
 
     def setEdit(self, vobj, mode=0):
-        panel = PathDressupTagTaskPanel(vobj.Object, self)
-        self.setupTaskPanel(panel)
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
+        elif mode == 0:
+            panel = PathDressupTagTaskPanel(vobj.Object, self)
+            self.setupTaskPanel(panel)
         return True
 
     def unsetEdit(self, vobj, mode):
-        if hasattr(self, "panel") and self.panel:
+        if mode == 0 and hasattr(self, "panel") and self.panel:
             self.panel.abort()
 
     def setupTaskPanel(self, panel):

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -207,7 +207,10 @@ class ViewProvider(object):
     def setEdit(self, vobj=None, mode=0):
         """setEdit(vobj, mode=0) ... initiate editing of receivers model."""
         Path.Log.track()
-        if 0 == mode:
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
+            return True
+        elif mode == 0:
             if vobj is None:
                 vobj = self.vobj
             # Mark as selected and update workplane visualization
@@ -245,12 +248,12 @@ class ViewProvider(object):
         if job:
             job.ViewObject.Proxy.resetEditVisibility(job)
 
-    def unsetEdit(self, arg1, arg2):
+    def unsetEdit(self, vobj, mode):
         # Mark as not selected and hide workplane visualization
         self._selected = False
         self.updateWorkplaneVisualization()
 
-        if self.panel:
+        if mode == 0 and self.panel:
             self.panel.reject(False)
 
     def dumps(self):

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -208,7 +208,10 @@ class ViewProvider(object):
     def setEdit(self, vobj=None, mode=0):
         """setEdit(vobj, mode=0) ... initiate editing of receivers model."""
         Path.Log.track()
-        if 0 == mode:
+        if mode == 1:
+            FreeCADGui.runCommand("Std_TransformManip")
+            return True
+        elif mode == 0:
             if vobj is None:
                 vobj = self.vobj
             # Mark as selected and update workplane visualization
@@ -246,12 +249,12 @@ class ViewProvider(object):
         if job:
             job.ViewObject.Proxy.resetEditVisibility(job)
 
-    def unsetEdit(self, arg1, arg2):
+    def unsetEdit(self, vobj, mode):
         # Mark as not selected and hide workplane visualization
         self._selected = False
         self.updateWorkplaneVisualization()
 
-        if self.panel:
+        if mode == 0 and self.panel:
             self.panel.reject(False)
 
     def dumps(self):

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -47,6 +47,7 @@ from Path.Post.DrillCycleExpander import DrillCycleExpander
 from Path.Post.CAMErrors import CAMError, CAMValueError, CAMAttributeError
 from Path.Base.MachineState import MachineState
 from Machine.models.machine import MachineFactory, OutputUnits
+from PathScripts.PathUtils import getPathWithPlacement
 
 translate = FreeCAD.Qt.translate
 
@@ -1080,6 +1081,13 @@ class PostProcessor:
 
         return gcodeheader
 
+    def _expand_placement(self, postables):
+        """Apply placement to path if needed."""
+        for section_name, sublist in postables:
+            for item in sublist:
+                if item.path and hasattr(item, "Placement"):
+                    item.path = getPathWithPlacement(item)
+
     def _expand_canned_cycles(self, postables):
         """Terminate canned drill cycles in postable paths.
 
@@ -2043,7 +2051,8 @@ class PostProcessor:
         self._expand_prefix(postables)
         # postables = self._expand_pre_job(postables) # FIXME: need an item for a job, handled by _expand_prefix for now
         postables = self._expand_pre_item(postables)
-
+        
+        self._expand_placement(postables)
         self._expand_translate_drill_cycles(postables)
         self._expand_canned_cycles(postables)
         self._expand_split_arcs(postables)

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -2051,7 +2051,7 @@ class PostProcessor:
         self._expand_prefix(postables)
         # postables = self._expand_pre_job(postables) # FIXME: need an item for a job, handled by _expand_prefix for now
         postables = self._expand_pre_item(postables)
-        
+
         self._expand_placement(postables)
         self._expand_translate_drill_cycles(postables)
         self._expand_canned_cycles(postables)

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -50,6 +50,7 @@ from Path.Post.UtilsParse import format_command_line
 from Path.Post.PathOptimizationUtils import modal_gcode, modal_axis
 from Path.Base.MachineState import MachineState
 from Machine.models.machine import MachineFactory, OutputUnits
+from PathScripts.PathUtils import getPathWithPlacement
 
 translate = FreeCAD.Qt.translate
 
@@ -1075,6 +1076,13 @@ class PostProcessor:
                                     gcodeheader.add_fixture(fixture_name)
 
         return gcodeheader
+
+    def _expand_placement(self, postables):
+        """Apply placement to path if needed."""
+        for section_name, sublist in postables:
+            for item in sublist:
+                if item.path and hasattr(item, "Placement"):
+                    item.path = getPathWithPlacement(item)
 
     def _add_line_numbers(self, postables):
         """Add N word if we are line-numbering
@@ -2119,6 +2127,7 @@ class PostProcessor:
         # postables = self._expand_pre_job(postables) # FIXME: need an item for a job, handled by _expand_prefix for now
         postables = self._expand_pre_item(postables)
 
+        self._expand_placement(postables)
         self._expand_canned_cycles(postables)
         self._expand_translate_drill_cycles(postables)
         self._expand_split_arcs(postables)

--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -40,6 +40,7 @@ import Path
 import Path.Post.Utils as PostUtils
 from Path.Base.MachineState import MachineState
 from Path.Post.DrillCycleExpander import DrillCycleExpander
+from PathScripts.PathUtils import getPathWithPlacement
 
 # Define some types that are used throughout this file
 CommandLine = List[str]
@@ -710,7 +711,8 @@ def parse_a_path(values: Values, gcode: Gcode, pathobj) -> None:
     )
     adaptive_op_variables = determine_adaptive_op(values, pathobj)
 
-    path_to_process = pathobj.Path
+    # Apply placement to operations
+    path_to_process = getPathWithPlacement(pathobj)
 
     # Process canned cycles for drilling operations
     path_to_process = PostUtils.cannedCycleTerminator(path_to_process)

--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -40,6 +40,7 @@ import Path
 import Path.Post.Utils as PostUtils
 from Path.Base.MachineState import MachineState
 from Path.Post.DrillCycleExpander import DrillCycleExpander
+from PathScripts.PathUtils import getPathWithPlacement
 
 # Define some types that are used throughout this file
 CommandLine = List[str]
@@ -698,7 +699,8 @@ def parse_a_path(values: Values, gcode: Gcode, pathobj) -> None:
 
     adaptive_op_variables = determine_adaptive_op(values, pathobj)
 
-    path_to_process = pathobj.Path
+    # Apply placement to operations
+    path_to_process = getPathWithPlacement(pathobj)
 
     # Process canned cycles for drilling operations
     path_to_process = PostUtils.cannedCycleTerminator(path_to_process)

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -27,7 +27,6 @@ import FreeCAD
 from FreeCAD import Vector
 from PySide import QtCore
 import Path
-import Path.Main.Job as PathJob
 import math
 from numpy import linspace
 import tsp_solver
@@ -516,6 +515,8 @@ def findToolController(obj, proxy, name=None):
 
 def findParentJob(obj):
     """retrieves a parent job object for an operation or other Path object"""
+    import Path.Main.Job as PathJob
+
     Path.Log.track()
     if hasattr(obj, "Proxy") and isinstance(obj.Proxy, PathJob.ObjectJob):
         return obj
@@ -548,6 +549,8 @@ def findParentJob(obj):
 
 def GetJobs(jobname=None):
     """returns all jobs in the current document.  If name is given, returns that job"""
+    import Path.Main.Job as PathJob
+
     if jobname:
         return [job for job in PathJob.Instances() if job.Name == jobname]
     return PathJob.Instances()

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -27,7 +27,6 @@ import FreeCAD
 from FreeCAD import Vector
 from PySide import QtCore
 import Path
-import Path.Main.Job as PathJob
 import math
 from numpy import linspace
 import tsp_solver
@@ -525,6 +524,8 @@ def findToolController(obj, proxy, name=None):
 
 def findParentJob(obj):
     """retrieves a parent job object for an operation or other Path object"""
+    import Path.Main.Job as PathJob
+
     Path.Log.track()
     if hasattr(obj, "Proxy") and isinstance(obj.Proxy, PathJob.ObjectJob):
         return obj
@@ -557,6 +558,8 @@ def findParentJob(obj):
 
 def GetJobs(jobname=None):
     """returns all jobs in the current document.  If name is given, returns that job"""
+    import Path.Main.Job as PathJob
+
     if jobname:
         return [job for job in PathJob.Instances() if job.Name == jobname]
     return PathJob.Instances()


### PR DESCRIPTION
### Changes:

- Allows to use Transform tool with operations and dressups
- Processing placement with refactored and machine post-processors 

---

`Transform` tool not works with operations

This PR continues of changes by
- #27757

<img width="841" height="327" alt="Screenshot_20260226_111853_lossy" src="https://github.com/user-attachments/assets/c1c9b521-57e8-4dd8-a03f-9b0cfed7787e" />

---

I using placement with **PathShape** tool and legacy post-processor
In example below it uses to get good corners during milling

<img width="762" height="498" alt="Screenshot_20260529_191304_lossy" src="https://github.com/user-attachments/assets/c27b3579-3b77-4d43-809b-c04f1ba11a7c" />

https://github.com/user-attachments/assets/ea0b2760-137f-4e86-82b4-3b61fad18d91


