### PR TITLE
[MeshPart] Fix string encoding document, object and subobject names

### DIFF
--- a/src/Mod/MeshPart/Gui/Tessellation.cpp
+++ b/src/Mod/MeshPart/Gui/Tessellation.cpp
@@ -247,7 +247,7 @@ bool Tessellation::accept()
         return false;
     }
 
-    this->document = QString::fromLatin1(activeDoc->getName());
+    this->document = QString::fromUtf8(activeDoc->getName());
 
     bool bodyWithNoTip = false;
     bool partWithNoFace = false;
@@ -318,8 +318,8 @@ void Tessellation::process(int method, App::Document* doc, const std::list<App::
 
         doc->openTransaction("Meshing");
         for (auto& info : shapeObjects) {
-            QString subname = QString::fromLatin1(info.getSubName().c_str());
-            QString objname = QString::fromLatin1(info.getObjectName().c_str());
+            QString subname = QString::fromUtf8(info.getSubName().c_str());
+            QString objname = QString::fromUtf8(info.getObjectName().c_str());
 
             auto obj = info.getObject();
             if (!obj) {
@@ -347,7 +347,7 @@ void Tessellation::process(int method, App::Document* doc, const std::list<App::
                               "__mesh__.Label=\"%5 (Meshed)\"\n"
                               "del __doc__, __mesh__, __part__, __shape__\n"
             )
-                              .arg(this->document, objname, subname, param, label);
+                              .arg(QString::fromUtf8(doc->getName()), objname, subname, param, label);
 
             Gui::Command::runCommand(Gui::Command::Doc, cmd.toUtf8());
 
@@ -496,8 +496,8 @@ QString Tessellation::getStandardParameters(App::DocumentObject* obj) const
         //
         param += QStringLiteral(",GroupColors=Gui.getDocument('%1').getObject('%2').DiffuseColor")
                      .arg(
-                         QString::fromLatin1(obj->getDocument()->getName()),
-                         QString::fromLatin1(obj->getNameInDocument())
+                         QString::fromUtf8(obj->getDocument()->getName()),
+                         QString::fromUtf8(obj->getNameInDocument())
                      );
     }
 


### PR DESCRIPTION
As reported on the forum https://forum.freecad.org/viewtopic.php?t=103382 meshing fails for files containing non-ascii characters.
This should be backported to releases/FreeCAD-1-1
