### PR TITLE
[ Sketcher ]: Fix Windows Include

### DIFF
--- a/src/Mod/Sketcher/App/PreCompiled.h
+++ b/src/Mod/Sketcher/App/PreCompiled.h
@@ -108,5 +108,5 @@
 #include <gp_Pnt.hxx>
 
 #ifdef FC_OS_WIN32
-#   include <windows.h>
+# include <windows.h>
 #endif


### PR DESCRIPTION
Sketcher include fix for #27154