### PR TITLE
Core: Allow implicit construction of QString from ASCII

### DIFF
--- a/src/FCConfig.h
+++ b/src/FCConfig.h
@@ -194,11 +194,6 @@ typedef unsigned __int64    uint64_t;
 //**************************************************************************
 // Qt
 
-// Make sure to explicitly use the correct conversion
-#ifndef QT_NO_CAST_FROM_ASCII
-# define QT_NO_CAST_FROM_ASCII
-#endif
-
 #ifndef QT_NO_KEYWORDS
 # define QT_NO_KEYWORDS
 #endif


### PR DESCRIPTION
As discussed in a recent developer meeting, this setting is contrary to Qt's recommendations, causes us headaches on a regular basis, decreases code readability, and does not *really* have the intended effect of forcing developers to consider translations. Remove it.