### PR TITLE
PartDesign: Pass QByteArray to QString.fromUtf8 to allow build with Qt 5.

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -84,7 +84,7 @@ const QString TaskSketchBasedParameters::onAddSelection(
             subname = datum->getNameInDocument();
 
             refStr = QString::fromUtf8(selObj->getNameInDocument()) + QStringLiteral(":")
-                + QString::fromUtf8(subname);
+                + QString::fromUtf8(QByteArray::fromStdString(subname));
         }
         else {
             // Remove subname for planes and datum features


### PR DESCRIPTION
This fixes the following compiler error when building with Qt 5.15.15 in Debian 13 Trixie:

```
[ 95%] Built target PathGui
/home/user/freecad/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp: In member function ‘const QString PartDesignGui::TaskSketchBasedParameters::onAddSelection(const Gui::SelectionChanges&, App::PropertyLinkSub&)’: /home/user/freecad/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp:87:36: error: no matching function for call to ‘QString::fromUtf8(std::string&)’
   87 |                 + QString::fromUtf8(subname);
      |                   ~~~~~~~~~~~~~~~~~^~~~~~~~~
In file included from /usr/include/x86_64-linux-gnu/qt5/QtCore/qregularexpression.h:45,
                 from /usr/include/x86_64-linux-gnu/qt5/QtCore/QRegularExpression:1,
                 from /home/user/freecad/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp:27:
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:701:27: note: candidate: ‘static QString QString::fromUtf8(const char*, int)’
  701 |     static inline QString fromUtf8(const char *str, int size = -1)
      |                           ^~~~~~~~
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:701:48: note:   no known conversion for argument 1 from ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const char*’
  701 |     static inline QString fromUtf8(const char *str, int size = -1)
      |                                    ~~~~~~~~~~~~^~~
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:711:27: note: candidate: ‘static QString QString::fromUtf8(const QByteArray&)’
  711 |     static inline QString fromUtf8(const QByteArray &str)
      |                           ^~~~~~~~
/usr/include/x86_64-linux-gnu/qt5/QtCore/qstring.h:711:54: note:   no known conversion for argument 1 from ‘std::string’ {aka ‘std::__cxx11::basic_string<char>’} to ‘const QByteArray&’
  711 |     static inline QString fromUtf8(const QByteArray &str)
      |                                    ~~~~~~~~~~~~~~~~~~^~~
```