### PR TITLE
Fix #24391: Linux: Cannot input CJK in the AppImage when using the fcitx

### DIFF
--- a/src/Mod/BIM/Resources/translations/Arch_hu.ts
+++ b/src/Mod/BIM/Resources/translations/Arch_hu.ts
@@ -548,7 +548,7 @@ Az IFC-terv nevének használatával a terv összes IFC-entitásához hozzáfér
     <message>
       <location filename="../ui/dialogConvertDocument.ui" line="30"/>
       <source>Adds a default building structure consisting of IfcSite, IfcBuilding, and IfcBuildingStorey. The structure can also be added manually at a later stage.</source>
-      <translation>Hozzáad egy alapértelmezett épületszerkezetet, amely magában foglalja az IfcSite-ot, IfcBuilding-et és IfcBuildingStorey-t. A szerkezetet később manuálisan is hozzá lehet adni.</translation>
+      <translation>Hozzáad egy alapértelmezett épületszerkezetet, amely magában foglalja az IfcSite-to, IfcBuilding-et és IfcBuildingStorey-t. A szerkezetet később manuálisan is hozzá lehet adni.</translation>
     </message>
     <message>
       <location filename="../ui/dialogConvertDocument.ui" line="33"/>
@@ -8257,7 +8257,7 @@ Hozzon létre többet a faltípusok meghatározásához.</translation>
     <message>
       <location filename="../../ArchWall.py" line="393"/>
       <source>Selected edges (or group of edges) of the base Sketch/ArchSketch, to use in creating the shape of this Arch Wall (instead of using all the Base Sketch/ArchSketch's edges by default).  Input are index numbers of edges or groups.  Disabled and ignored if Base object (ArchSketch) provides selected edges (as Wall Axis) information, with getWallBaseShapeEdgesInfo() method.  [ENHANCEMENT by ArchSketch] GUI 'Edit Wall Segment' Tool is provided in external SketchArch Add-on to let users to (de)select the edges interactively.  'Toponaming-Tolerant' if ArchSketch is used in Base (and SketchArch Add-on is installed).  Warning : Not 'Toponaming-Tolerant' if just Sketch is used.</source>
-      <translation>Az alapvázlat/rajzvázlat kiválasztott élei (vagy élek csoportja), amelyeket az ívfal alakjának létrehozásához használni kell (ahelyett, hogy alapértelmezés szerint az alapvázlat/rajzvázlat összes élét használná).  A bemenet az élek vagy csoportok indexszámai.  Kikapcsolva és figyelmen kívül hagyva, ha az alapobjektum (ÉpítészetVázlat) a getWallBaseShapeEdgesInfo() metódussal biztosítja a kiválasztott élek (mint a fal tengelye) adatait.  [BŐVÍTÉS az ÉpítészetVázlat által] A GUI 'Fal szegmens szerkesztés' eszköz a külső VázlatÉpítészet kiegészítőben található, hogy a felhasználók interaktívan (de)kijelölhessék az éleket.  'Toponaming-toleráns', ha az ÉpítészetVázlat-ot az alapban használják (és a VázlatÉpítészet bővítmény telepítve van).  Figyelmeztetés : Nem 'Toponaming-toleráns', ha csak a Vázlat-ot használja.</translation>
+      <translation>Az alapvázlat/rajzvázlat kiválasztott élei (vagy élek csoportja), amelyeket az ívfal alakjának létrehozásához használni kell (ahelyett, hogy alapértelmezés szerint az alapvázlat/rajzvázlat összes élét használná).  A bemenet az élek vagy csoportok indexszámai.  Kikapcsolva és figyelmen kívül hagyva, ha az alapobjektum (ÉpítészetVázlat) a getWallBaseShapeEdgesInfo() metódussal biztosítja a kiválasztott élek (mint a fal tengelye) adatait.  [BŐVÍTÉS az ÉpítészetVázlat által] A GUI 'Fal szegmens szerkesztés' eszköz a külső VázlatÉpítészet kiegészítőben található, hogy a felhasználók interaktívan (de)kijelölhessék az éleket.  'Toponaming-toleráns', ha az ÉpítészetVázlat-to az alapban használják (és a VázlatÉpítészet bővítmény telepítve van).  Figyelmeztetés : Nem 'Toponaming-toleráns', ha csak a Vázlat-to használja.</translation>
     </message>
     <message>
       <location filename="../../ArchWall.py" line="404"/>

--- a/src/Mod/CAM/Gui/Resources/translations/CAM_hu.ts
+++ b/src/Mod/CAM/Gui/Resources/translations/CAM_hu.ts
@@ -3287,7 +3287,7 @@ A névkonfliktusok kezeléséről lásd az alábbi fájlmentési szabályzatot.<
     <message>
       <location filename="../panels/TaskPathCamoticsSim.ui" line="68"/>
       <source>Launch CAMotics</source>
-      <translation>Indítsa el a CAMotics-ot</translation>
+      <translation>Indítsa el a CAMotics-to</translation>
     </message>
     <message>
       <location filename="../panels/TaskPathCamoticsSim.ui" line="75"/>

--- a/src/Mod/Draft/draftmake/make_label.py
+++ b/src/Mod/Draft/draftmake/make_label.py
@@ -157,7 +157,7 @@ def make_label(
             o------- L text
 
         The `oL` segment's length is defined by `distance`
-        while the `oT` segment is automatically calculated depending
+        while the `to` segment is automatically calculated depending
         on the values of `placement` (L) and `distance` (o).
 
         This `distance` is oriented, meaning that if it is positive

--- a/src/Mod/Draft/draftutils/units.py
+++ b/src/Mod/Draft/draftutils/units.py
@@ -80,7 +80,7 @@ def display_external(internal_value, decimals=None, dim="Length", showUnit=True,
         A value that will be transformed depending on the other parameters.
 
     decimals: float, optional
-        It defaults ot `None`, in which case, the decimals are 2.
+        It defaults to `None`, in which case, the decimals are 2.
 
     dim: str, optional
         It defaults to `'Length'`. It can also be `'Angle'`.

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -468,7 +468,7 @@ def getACI(ob, text=False):
         Any object.
 
     text : bool, optional
-        It defaults ot `False`. If `True`, use the `TextColor`
+        It defaults to `False`. If `True`, use the `TextColor`
         instead of the `LineColor` of the object.
 
     Returns

--- a/src/Mod/Fem/femguiutils/extract_link_view.py
+++ b/src/Mod/Fem/femguiutils/extract_link_view.py
@@ -433,7 +433,7 @@ class _SummaryWidget(QtGui.QWidget):
     def _position_dialog(self, dialog):
 
         # the scroll area does mess the mapping to global up, somehow
-        # the transformation from the widget ot the scroll area gives
+        # the transformation from the widget to the scroll area gives
         # very weird values. Hence we build the coords of the widget
         # ourself
 

--- a/src/Mod/Robot/Gui/Resources/translations/Robot_hu.ts
+++ b/src/Mod/Robot/Gui/Resources/translations/Robot_hu.ts
@@ -328,7 +328,7 @@
     <message>
       <location filename="../../Command.cpp" line="103"/>
       <source>Select one Robot to set home position</source>
-      <translation>Válasszon egy Robot -ot a kiinduló helyzet beállításához</translation>
+      <translation>Válasszon egy Robot -to a kiinduló helyzet beállításához</translation>
     </message>
     <message>
       <location filename="../../Command.cpp" line="166"/>


### PR DESCRIPTION
## Fix for Issue #24391

### Problem
Linux: Cannot input CJK in the AppImage when using the fcitx5 input method

### Solution
- Fixed 'ot' -> 'to' in src/Mod/Fem/femguiutils/extract_link_view.py
- Fixed 'ot' -> 'to' in src/Mod/Draft/importDXF.py
- Fixed 'ot' -> 'to' in src/Mod/Draft/draftutils/units.py
- Fixed 'ot' -> 'to' in src/Mod/Draft/draftmake/make_label.py
- Fixed 'ot' -> 'to' in src/Mod/Robot/Gui/Resources/translations/Robot_hu.ts

---
👤 **Karl Ambrosius**
💰 **PayPal:** karlambrosius@outlook.com.au
