### PR TITLE
BIM: BIM_DrawingView: always create Cut lines view

### DIFF
--- a/src/Mod/BIM/bimcommands/BimDrawingView.py
+++ b/src/Mod/BIM/bimcommands/BimDrawingView.py
@@ -72,18 +72,13 @@ class BIM_DrawingView:
                 FreeCADGui.doCommand('vobj.Label = "' + translate("BIM", "Viewed lines") + '"')
                 FreeCADGui.doCommand("vobj.InPlace = False")
                 FreeCADGui.doCommand("obj.addObject(vobj)")
-                bb = FreeCAD.BoundBox()
-                for so in s.Objects:
-                    if hasattr(so, "Shape"):
-                        bb.add(so.Shape.BoundBox)
-                if bb.isInside(s.Shape.CenterOfMass):
-                    FreeCADGui.doCommand(
-                        "cobj = Draft.make_shape2dview(FreeCAD.ActiveDocument." + s.Name + ")"
-                    )
-                    FreeCADGui.doCommand('cobj.Label = "' + translate("BIM", "Cut lines") + '"')
-                    FreeCADGui.doCommand("cobj.InPlace = False")
-                    FreeCADGui.doCommand('cobj.ProjectionMode = "Cutfaces"')
-                    FreeCADGui.doCommand("obj.addObject(cobj)")
+                FreeCADGui.doCommand(
+                    "cobj = Draft.make_shape2dview(FreeCAD.ActiveDocument." + s.Name + ")"
+                )
+                FreeCADGui.doCommand('cobj.Label = "' + translate("BIM", "Cut lines") + '"')
+                FreeCADGui.doCommand("cobj.InPlace = False")
+                FreeCADGui.doCommand('cobj.ProjectionMode = "Cutfaces"')
+                FreeCADGui.doCommand("obj.addObject(cobj)")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()
 


### PR DESCRIPTION
Fixes #27803.

As suggested by @semhustej: always create the "Cut lines" view, even of there are no solids (yet) that intersect the section plane.