### PR TITLE
CAM: CircularHoleBase - Show position in Task panel

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageBaseHoleGeometryEdit.ui
@@ -129,6 +129,21 @@ Reset deletes all current items from the list and fills the list with all circul
        <string>Diameter</string>
       </property>
      </column>
+     <column>
+      <property name="text">
+       <string>X</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Y</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Blind</string>
+      </property>
+     </column>
     </widget>
    </item>
    <item>

--- a/src/Mod/CAM/Path/Base/Drillable.py
+++ b/src/Mod/CAM/Path/Base/Drillable.py
@@ -348,3 +348,16 @@ def getDrillableTargets(obj, toolDiameter=None, vector=App.Vector(0, 0, 1)):
         return [(obj, f"Face{i + 1}") for i, f in enumerate(faces) if f.hashCode() in hashList]
 
     return []
+
+
+def isBlind(base, faceName):
+    """isBlind(base, name) ... returns True if cylinder face creates blind hole
+    base: Part::Feature  # base model
+    faceName: str  # is a name of cylinder face
+    """
+    try:
+        sub = base.Shape.getElement(faceName)
+        if isinstance(sub, Part.Face) and isinstance(sub.Surface, Part.Cylinder):
+            return not Path.Geom.isRoughly(sub.BoundBox.ZMin, base.Shape.BoundBox.ZMin)
+    except Exception:
+        return

--- a/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
@@ -28,6 +28,7 @@ import Path
 import Path.Op.Gui.Base as PathOpGui
 import PathGui
 
+from Path.Base import Drillable
 from Path.Base.Gui.Util import NaturalSortTableWidgetItem
 from PySide import QtCore, QtGui
 
@@ -49,6 +50,9 @@ else:
 COL_ORDER = 0
 COL_FEATURE = 1
 COL_DIAMETER = 2
+COL_X = 3
+COL_Y = 4
+COL_BLIND = 5
 
 
 class RowMoveTableWidget(QtGui.QTableWidget):
@@ -247,14 +251,50 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                 item.setFlags(item.flags() & ~QtCore.Qt.ItemIsDropEnabled)
                 self.form.baseList.setItem(self.form.baseList.rowCount() - 1, COL_FEATURE, item)
 
-                dia = obj.Proxy.holeDiameter(base, sub)
-                diameterQty = FreeCAD.Units.Quantity(dia, FreeCAD.Units.Length)
-                displayString = diameterQty.getUserPreferred("Length")[0]
-                item = NaturalSortTableWidgetItem(displayString)
+                pos = obj.Proxy.holePosition(base, sub)
+                if pos:
+                    dia = obj.Proxy.holeDiameter(base, sub)
+                    diameterQty = FreeCAD.Units.Quantity(dia, FreeCAD.Units.Length)
+                    diaString = diameterQty.getUserPreferred("Length")[0]
+                    prec = int(diameterQty.Format["Precision"] / 2)
+                    posXString = f"{pos[0]:.{prec}f}"
+                    posYString = f"{pos[1]:.{prec}f}"
+                else:
+                    diaString = "---"
+                    posXString = "---"
+                    posYString = "---"
+
+                blind = Drillable.isBlind(base, sub)
+                if blind is None:
+                    blindString = "---"
+                elif blind:
+                    blindString = "Yes"
+                else:
+                    blindString = "No"
+
+                item = NaturalSortTableWidgetItem(diaString)
                 item.setTextAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter)
                 item.setFlags(item.flags() & ~QtCore.Qt.ItemIsEditable)
                 item.setFlags(item.flags() & ~QtCore.Qt.ItemIsDropEnabled)
                 self.form.baseList.setItem(self.form.baseList.rowCount() - 1, COL_DIAMETER, item)
+
+                item = NaturalSortTableWidgetItem(posXString)
+                item.setTextAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter)
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemIsEditable)
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemIsDropEnabled)
+                self.form.baseList.setItem(self.form.baseList.rowCount() - 1, COL_X, item)
+
+                item = NaturalSortTableWidgetItem(posYString)
+                item.setTextAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter)
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemIsEditable)
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemIsDropEnabled)
+                self.form.baseList.setItem(self.form.baseList.rowCount() - 1, COL_Y, item)
+
+                item = NaturalSortTableWidgetItem(blindString)
+                item.setTextAlignment(QtCore.Qt.AlignHCenter | QtCore.Qt.AlignVCenter)
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemIsEditable)
+                item.setFlags(item.flags() & ~QtCore.Qt.ItemIsDropEnabled)
+                self.form.baseList.setItem(self.form.baseList.rowCount() - 1, COL_BLIND, item)
 
         # Ensure the combo box reflects the current SortingMode
         idx = self.form.sortMode.findText(obj.SortingMode)
@@ -273,6 +313,9 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
         header.setSectionResizeMode(COL_ORDER, QtGui.QHeaderView.ResizeToContents)
         header.setSectionResizeMode(COL_FEATURE, QtGui.QHeaderView.ResizeToContents)
         header.setSectionResizeMode(COL_DIAMETER, QtGui.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(COL_X, QtGui.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(COL_Y, QtGui.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(COL_BLIND, QtGui.QHeaderView.ResizeToContents)
 
         self.form.baseList.resizeColumnToContents(0)
         self.form.baseList.blockSignals(False)
@@ -495,6 +538,9 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                 order_item = self.form.baseList.item(row, COL_ORDER)
                 feature_item = self.form.baseList.item(row, COL_FEATURE)
                 diameter_item = self.form.baseList.item(row, COL_DIAMETER)
+                posX_item = self.form.baseList.item(row, COL_X)
+                posY_item = self.form.baseList.item(row, COL_Y)
+                blind_item = self.form.baseList.item(row, COL_BLIND)
                 try:
                     order = int(order_item.text())
                 except (ValueError, AttributeError):
@@ -506,6 +552,9 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                             order_item.clone() if order_item else None,
                             feature_item.clone() if feature_item else None,
                             diameter_item.clone() if diameter_item else None,
+                            posX_item.clone() if posX_item else None,
+                            posY_item.clone() if posY_item else None,
+                            blind_item.clone() if blind_item else None,
                         ],
                     )
                 )

--- a/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/CircularHoleBase.py
@@ -256,9 +256,10 @@ class TaskPanelHoleGeometryPage(PathOpGui.TaskPanelBaseGeometryPage):
                     dia = obj.Proxy.holeDiameter(base, sub)
                     diameterQty = FreeCAD.Units.Quantity(dia, FreeCAD.Units.Length)
                     diaString = diameterQty.getUserPreferred("Length")[0]
-                    prec = int(diameterQty.Format["Precision"] / 2)
-                    posXString = f"{pos[0]:.{prec}f}"
-                    posYString = f"{pos[1]:.{prec}f}"
+                    posXQty = FreeCAD.Units.Quantity(pos[0], FreeCAD.Units.Length)
+                    posXString = posXQty.getUserPreferred("Length")[0]
+                    posYQty = FreeCAD.Units.Quantity(pos[1], FreeCAD.Units.Length)
+                    posYString = posYQty.getUserPreferred("Length")[0]
                 else:
                     diaString = "---"
                     posXString = "---"


### PR DESCRIPTION
It is not convenient to use sub names to find needed hole with big amount of them
In this case showing positions can be useful
Also position can be used for sorting list

Blind state defines only for cylinder faces
For all other shapes showing `---`

<img width="561" height="328" alt="Screenshot_20260302_133436_lossy" src="https://github.com/user-attachments/assets/9c78a255-5868-4a8f-b552-f56d16013035" />
