### PR TITLE
Core: Add shortcut for Recompute object

### DIFF
--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -20,6 +20,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <unordered_map>
+#include <unordered_set>
 
 #include <App/DocumentObjectGroup.h>
 #include <App/GroupExtension.h>
@@ -56,12 +58,42 @@ StdCmdFeatRecompute::StdCmdFeatRecompute()
     sWhatsThis = "Std_Recompute";
     sStatusTip = sToolTipText;
     sPixmap = "view-refresh";
-    sAccel = "Ctrl+R";
+    sAccel = "Ctrl+Shift+R";
 }
 
 void StdCmdFeatRecompute::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
+
+    std::unordered_map<App::Document*, std::vector<App::DocumentObject*>> selectedObjectsByDocument;
+    std::unordered_set<App::DocumentObject*> uniqueObjects;
+
+    const auto selection = Selection().getCompleteSelection();
+    for (const auto& selObj : selection) {
+        App::DocumentObject* obj = selObj.pObject;
+        if (!obj || !uniqueObjects.insert(obj).second) {
+            continue;
+        }
+
+        obj->enforceRecompute();
+        selectedObjectsByDocument[obj->getDocument()].push_back(obj);
+    }
+
+    if (selectedObjectsByDocument.empty()) {
+        const auto doc = this->getDocument();
+        if (!doc) {
+            return;
+        }
+
+        App::AutoTransaction committer(doc, "Recompute");
+        doc->recompute();
+        return;
+    }
+
+    App::AutoTransaction committer(selectedObjectsByDocument.begin()->first, "Recompute object");
+    for (auto& [doc, objects] : selectedObjectsByDocument) {
+        doc->recompute(objects, true);
+    }
 }
 
 //===========================================================================

--- a/src/Gui/PreferencePackTemplates/Shortcuts.cfg
+++ b/src/Gui/PreferencePackTemplates/Shortcuts.cfg
@@ -690,7 +690,7 @@
           <FCText Name="Std_RecallWorkingView">End</FCText>
           <FCText Name="Std_RecentFiles"></FCText>
           <FCText Name="Std_RecentMacros"></FCText>
-          <FCText Name="Std_Recompute"></FCText>
+          <FCText Name="Std_Recompute">Ctrl+Shift+R</FCText>
           <FCText Name="Std_Redo">Ctrl+Shift+Z</FCText>
           <FCText Name="Std_Refresh">Ctrl+R</FCText>
           <FCText Name="Std_RemoveSelectionGate"></FCText>

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -643,6 +643,13 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
 
     this->recomputeObjectAction = new QAction(this);
     connect(this->recomputeObjectAction, &QAction::triggered, this, &TreeWidget::onRecomputeObject);
+    if (auto recomputeCmd
+        = Gui::Application::Instance->commandManager().getCommandByName("Std_Recompute")) {
+        // Register command action on the tree so its shortcut can trigger from the main window.
+        recomputeCmd->addTo(this);
+        this->recomputeObjectAction->setShortcut(recomputeCmd->getShortcut());
+        this->recomputeObjectAction->setShortcutVisibleInContextMenu(true);
+    }
     this->searchObjectsAction = new QAction(this);
     this->searchObjectsAction->setText(tr("Search Objects"));
     this->searchObjectsAction->setStatusTip(tr("Searches for objects in the tree"));
@@ -1591,23 +1598,13 @@ void TreeWidget::onMarkRecompute()
 
 void TreeWidget::onRecomputeObject()
 {
-    std::vector<App::DocumentObject*> objs;
-    const auto items = selectedItems();
-    for (auto ti : items) {
-        if (ti->type() == ObjectType) {
-            auto objitem = static_cast<DocumentObjectItem*>(ti);
-            objs.push_back(objitem->object()->getObject());
-            objs.back()->enforceRecompute();
-        }
-    }
-    if (objs.empty()) {
+    if (auto cmd = Gui::Application::Instance->commandManager().getCommandByName("Std_Recompute")) {
+        cmd->invoke(0, Command::TriggerAction);
         return;
     }
 
-    App::AutoTransaction committer(objs.front()->getDocument()->openTransaction("Recompute object"));
-    objs.front()->getDocument()->recompute(objs, true);
+    Base::Console().error("TreeWidget::onRecomputeObject: Std_Recompute command not found\n");
 }
-
 
 DocumentItem* TreeWidget::getDocumentItem(const Gui::Document* doc) const
 {


### PR DESCRIPTION
## Summary
Implement `Std_Recompute` so it recomputes selected objects (from tree selection), or recomputes the active document when nothing is selected.

Also:
- Set default shortcut for `Std_Recompute` to `Ctrl+Shift+R`
- Show the shortcut in the tree context menu for **Recompute Object**
- Route tree context menu recompute action through `Std_Recompute` command path

## Issues
Closes #24900

## Before and After Images
Before:
- No keyboard shortcut shown/available for **Recompute Object** in tree context menu.

After:
- **Recompute Object** shows `Ctrl+Shift+R` in tree context menu.
- `Ctrl+Shift+R` triggers recompute on selected tree object(s).