### PR TITLE
BIM: fix addition and subtraction of window links

### DIFF
--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -139,7 +139,9 @@ def addComponents(objectsList, host):
                 if Draft.getType(o) == "Window":
                     if hasattr(o, "Hosts") and not host in o.Hosts:
                         o.Hosts += [host]
-                elif hasattr(o, "getLinkedObject") and Draft.getType(o.getLinkedObject()) == "Window":
+                elif (
+                    hasattr(o, "getLinkedObject") and Draft.getType(o.getLinkedObject()) == "Window"
+                ):
                     # Override the inherited Hosts property (required if Link has not been recomputed):
                     o.getLinkedObject().Proxy.addSketchArchFeatures(o)
                     if hasattr(o, "Hosts") and not host in o.Hosts:
@@ -211,7 +213,9 @@ def removeComponents(objectsList, host=None):
                 if Draft.getType(o) == "Window":
                     if hasattr(o, "Hosts") and not host in o.Hosts:
                         o.Hosts += [host]
-                elif hasattr(o, "getLinkedObject") and Draft.getType(o.getLinkedObject()) == "Window":
+                elif (
+                    hasattr(o, "getLinkedObject") and Draft.getType(o.getLinkedObject()) == "Window"
+                ):
                     # Override the inherited Hosts property (required if Link has not been recomputed):
                     o.getLinkedObject().Proxy.addSketchArchFeatures(o)
                     if hasattr(o, "Hosts") and not host in o.Hosts:

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -99,7 +99,7 @@ def getDefaultColor(objectType):
 
 def _check_and_setup_window(obj):
     """Returns `True` of obj is a (Link to a) Window. The function ensures that
-    a Link has its own Hosts property. Used by addComponents and removeComponents"""
+    a Link has its own Hosts property. Used by addComponents and removeComponents."""
     if Draft.getType(obj) == "Window":
         return True
     if hasattr(obj, "getLinkedObject") and Draft.getType(obj.getLinkedObject()) == "Window":

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -97,6 +97,19 @@ def getDefaultColor(objectType):
     return (r, g, b, alpha)
 
 
+def _check_and_setup_window(obj):
+    """Returns `True` of obj is a (Link to a) Window. The function ensures that
+    a Link has its own Hosts property. Used by addComponents and removeComponents"""
+    if Draft.getType(obj) == "Window":
+        return True
+    if hasattr(obj, "getLinkedObject") and Draft.getType(obj.getLinkedObject()) == "Window":
+        # Make sure the link has its own Hosts property to override the inherited property
+        # (required if Link has not been recomputed):
+        obj.getLinkedObject().Proxy.addSketchArchFeatures(obj)
+        return True
+    return False
+
+
 def _usedForAttachment(host, obj):
     if not getattr(obj, "AttachmentSupport", []):
         return False
@@ -136,15 +149,8 @@ def addComponents(objectsList, host):
         x = getattr(host, "Axes", [])
         for o in objectsList:
             if hasattr(o, "Shape"):
-                if Draft.getType(o) == "Window":
-                    if hasattr(o, "Hosts") and not host in o.Hosts:
-                        o.Hosts += [host]
-                elif (
-                    hasattr(o, "getLinkedObject") and Draft.getType(o.getLinkedObject()) == "Window"
-                ):
-                    # Override the inherited Hosts property (required if Link has not been recomputed):
-                    o.getLinkedObject().Proxy.addSketchArchFeatures(o)
-                    if hasattr(o, "Hosts") and not host in o.Hosts:
+                if _check_and_setup_window(o):
+                    if hasattr(o, "Hosts") and host not in o.Hosts:
                         o.Hosts += [host]
                 elif o in outList:
                     FreeCAD.Console.PrintWarning(
@@ -210,15 +216,8 @@ def removeComponents(objectsList, host=None):
                 host.Axes = a
             s = host.Subtractions
             for o in objectsList:
-                if Draft.getType(o) == "Window":
-                    if hasattr(o, "Hosts") and not host in o.Hosts:
-                        o.Hosts += [host]
-                elif (
-                    hasattr(o, "getLinkedObject") and Draft.getType(o.getLinkedObject()) == "Window"
-                ):
-                    # Override the inherited Hosts property (required if Link has not been recomputed):
-                    o.getLinkedObject().Proxy.addSketchArchFeatures(o)
-                    if hasattr(o, "Hosts") and not host in o.Hosts:
+                if _check_and_setup_window(o):
+                    if hasattr(o, "Hosts") and host not in o.Hosts:
                         o.Hosts += [host]
                 elif not o in s:
                     s.append(o)

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -137,11 +137,13 @@ def addComponents(objectsList, host):
         for o in objectsList:
             if hasattr(o, "Shape"):
                 if Draft.getType(o) == "Window":
-                    if hasattr(o, "Hosts"):
-                        if not host in o.Hosts:
-                            g = o.Hosts
-                            g.append(host)
-                            o.Hosts = g
+                    if hasattr(o, "Hosts") and not host in o.Hosts:
+                        o.Hosts += [host]
+                elif hasattr(o, "getLinkedObject") and Draft.getType(o.getLinkedObject()) == "Window":
+                    # Override the inherited Hosts property (required if Link has not been recomputed):
+                    o.getLinkedObject().Proxy.addSketchArchFeatures(o)
+                    if hasattr(o, "Hosts") and not host in o.Hosts:
+                        o.Hosts += [host]
                 elif o in outList:
                     FreeCAD.Console.PrintWarning(
                         translate(
@@ -207,11 +209,13 @@ def removeComponents(objectsList, host=None):
             s = host.Subtractions
             for o in objectsList:
                 if Draft.getType(o) == "Window":
-                    if hasattr(o, "Hosts"):
-                        if not host in o.Hosts:
-                            g = o.Hosts
-                            g.append(host)
-                            o.Hosts = g
+                    if hasattr(o, "Hosts") and not host in o.Hosts:
+                        o.Hosts += [host]
+                elif hasattr(o, "getLinkedObject") and Draft.getType(o.getLinkedObject()) == "Window":
+                    # Override the inherited Hosts property (required if Link has not been recomputed):
+                    o.getLinkedObject().Proxy.addSketchArchFeatures(o)
+                    if hasattr(o, "Hosts") and not host in o.Hosts:
+                        o.Hosts += [host]
                 elif not o in s:
                     s.append(o)
                     if FreeCAD.GuiUp:


### PR DESCRIPTION
Fixes #26255.

By treating links to windows the same as 'original' windows the cyclic dependency in the issue is avoided. This behavior is also more logical from the user perspective.

Notes:
* Since #27406, links to windows inherit the Hosts value from their original. This did not happen when the issue was created.
* The `getLinkedObject` method always finds the deepest linked object. The `recursive` argument seems obsolete.