### PR TITLE
TD: Fix warnings

### DIFF
--- a/src/Mod/TechDraw/App/DrawComplexSection.cpp
+++ b/src/Mod/TechDraw/App/DrawComplexSection.cpp
@@ -1567,17 +1567,16 @@ DrawComplexSection::findNormalForFace(const TopoDS_Face& face,
                                       const std::vector<std::pair<int, Base::Vector3d>>& normalKV,
                                       const std::vector<TopoDS_Edge>& segmentEdges)
 {
-    size_t index = getSegmentIndex(face, segmentEdges);
-    if (index < 0  ||
-        index >= segmentEdges.size()) {     //NOLINT
+    int index = getSegmentIndex(face, segmentEdges);
+    if (index < 0) {
         throw Base::RuntimeError("DCS::findNormalForFace - did not find normal for face!");
     }
     for (auto& keyValue : normalKV) {
-        if (static_cast<size_t>(keyValue.first) == index) {
+        if (keyValue.first == index) {
             return keyValue;
         }
     }
-     throw Base::RuntimeError("DCS::findNormalForFace - no keyValue pair for segment!");
+    throw Base::RuntimeError("DCS::findNormalForFace - no keyValue pair for segment!");
 }
 
 

--- a/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
@@ -209,7 +209,7 @@ void QGIRichAnno::setTextItem()
     }
 
     if (m_isEditing) {
-        Q_EMIT positionChanged(scenePos());
+        Q_EMIT positionChanged();
     }
 }
 
@@ -477,7 +477,7 @@ void QGIRichAnno::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
 
         QTimer::singleShot(0, this, [this]() {
             if (this && scene()) {
-                Q_EMIT positionChanged(scenePos());
+                Q_EMIT positionChanged();
             }
         });
 
@@ -508,7 +508,7 @@ void QGIRichAnno::mouseReleaseEvent(QGraphicsSceneMouseEvent* event)
         // Ensure focus returns to the text item after the resize handle is released
         refocusAnnotation();
 
-        Q_EMIT positionChanged(scenePos());
+        Q_EMIT positionChanged();
 
         if (!isUnderMouse()) {
             QGraphicsSceneHoverEvent leaveEvent(QEvent::GraphicsSceneHoverLeave);
@@ -585,7 +585,7 @@ void QGIRichAnno::setEditMode(bool enable)
 
         refocusAnnotation();
 
-        Q_EMIT positionChanged(scenePos());
+        Q_EMIT positionChanged();
     }
     else {
         m_text->setTextInteractionFlags(Qt::NoTextInteraction);
@@ -637,7 +637,7 @@ QVariant QGIRichAnno::itemChange(GraphicsItemChange change, const QVariant& valu
 {
     if (change == QGraphicsItem::ItemScenePositionHasChanged
         && scene()) {
-        Q_EMIT positionChanged(scenePos());
+        Q_EMIT positionChanged();
     }
     return QGIView::itemChange(change, value);
 }
@@ -661,7 +661,7 @@ void QGIRichAnno::updateLayout()
     update();
 
     if (scene()) {
-        Q_EMIT positionChanged(scenePos());
+        Q_EMIT positionChanged();
     }
     drawBorder();
 }

--- a/src/Mod/TechDraw/Gui/QGIRichAnno.h
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.h
@@ -113,7 +113,7 @@ public:
     void widthChanged();
     void textChanged();
     void selectionChanged();
-    void positionChanged(const QPointF& scenePos);
+    void positionChanged();
 
 protected:
     void draw() override;

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.cpp
@@ -303,7 +303,7 @@ void TaskRichAnno::onViewTransformed()
     // When the view pans, the item's scene position hasn't changed.
     // We just need to re-run the position calculation with its current scenePos.
     if (m_qgiAnno) {
-        onViewPositionChanged(m_qgiAnno->scenePos());
+        onViewPositionChanged();
     }
 }
 
@@ -326,7 +326,7 @@ void TaskRichAnno::onViewSelectionChanged()
 
 }
 
-void TaskRichAnno::onViewPositionChanged(const QPointF& scenePos)
+void TaskRichAnno::onViewPositionChanged()
 {
     // Make sure you have a local variable for the QGVPage to make the code cleaner
     QGVPage* graphicsView = nullptr;

--- a/src/Mod/TechDraw/Gui/TaskRichAnno.h
+++ b/src/Mod/TechDraw/Gui/TaskRichAnno.h
@@ -99,7 +99,7 @@ protected Q_SLOTS:
     void refocusAnnotation();
 
     void onViewSelectionChanged();
-    void onViewPositionChanged(const QPointF& scenePos);
+    void onViewPositionChanged();
 
 private:
     void removeViewFilter();

--- a/src/Mod/TechDraw/Gui/mrichtextedit.cpp
+++ b/src/Mod/TechDraw/Gui/mrichtextedit.cpp
@@ -819,7 +819,7 @@ void MRichTextEdit::addFontSize(QString fontSize)
     }
 
     // 2. Check if the new size is already in the list (using fuzzy comparison for doubles)
-    for (double existingSize : qAsConst(sizes)) {
+    for (double existingSize : std::as_const(sizes)) {
         if (qFuzzyCompare(existingSize, newSize)) {
             // Already exists, just make sure it's the current text
             f_fontsize->setCurrentText(QString::number(newSize, 'g', 4));
@@ -833,7 +833,7 @@ void MRichTextEdit::addFontSize(QString fontSize)
 
     // 4. Repopulate the combobox with the sorted, correctly formatted list
     QStringList newList;
-    for (double size : qAsConst(sizes)) {
+    for (double size : std::as_const(sizes)) {
         newList << QString::number(size, 'g', 4);
     }
 


### PR DESCRIPTION
Fixes
```
src/Mod/TechDraw/App/DrawComplexSection.cpp:1571:15: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
 1571 |     if (index < 0  ||
      |         ~~~~~~^~~
```
and
```
src/Mod/TechDraw/Gui/mrichtextedit.cpp: In member function ‘void MRichTextEdit::addFontSize(QString)’:
src/Mod/TechDraw/Gui/mrichtextedit.cpp:822:40: warning: ‘constexpr typename std::add_const<_Tp>::type& qAsConst(T&) [with T = QList<double>; typename std::add_const<_Tp>::type = const QList<double>]’ is deprecated: Use std::as_const() instead. [-Wdeprecated-declarations]
  822 |     for (double existingSize : qAsConst(sizes)) {
      |                                ~~~~~~~~^~~~~~~
In file included from /usr/include/x86_64-linux-gnu/qt6/QtCore/qforeach.h:11,
                 from /usr/include/x86_64-linux-gnu/qt6/QtCore/qglobal.h:57,
                 from /usr/include/x86_64-linux-gnu/qt6/QtGui/qtguiglobal.h:7,
                 from /usr/include/x86_64-linux-gnu/qt6/QtWidgets/qtwidgetsglobal.h:7,
                 from /usr/include/x86_64-linux-gnu/qt6/QtWidgets/qapplication.h:7,
                 from /usr/include/x86_64-linux-gnu/qt6/QtWidgets/QApplication:1,
                 from /home/ladis/src/FreeCAD/src/Mod/TechDraw/Gui/mrichtextedit.cpp:32:
/usr/include/x86_64-linux-gnu/qt6/QtCore/qttypetraits.h:36:45: note: declared here
   36 | constexpr typename std::add_const<T>::type &qAsConst(T &t) noexcept { return t; }
      |                                             ^~~~~~~~
src/Mod/TechDraw/Gui/mrichtextedit.cpp:836:32: warning: ‘constexpr typename std::add_const<_Tp>::type& qAsConst(T&) [with T = QList<double>; typename std::add_const<_Tp>::type = const QList<double>]’ is deprecated: Use std::as_const() instead. [-Wdeprecated-declarations]
  836 |     for (double size : qAsConst(sizes)) {
      |                        ~~~~~~~~^~~~~~~
/usr/include/x86_64-linux-gnu/qt6/QtCore/qttypetraits.h:36:45: note: declared here
   36 | constexpr typename std::add_const<T>::type &qAsConst(T &t) noexcept { return t; }
      |                                             ^~~~~~~~
```
There is also
```
src/Mod/TechDraw/Gui/TaskRichAnno.cpp:329:57: warning: unused parameter ‘scenePos’ [-Wunused-parameter]
  329 | void TaskRichAnno::onViewPositionChanged(const QPointF& scenePos)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~
```
introduced by #24624 which is left unresolved. @PaddleStroke?