### PR TITLE
CAM: Warn before post processing with zero spindle speed

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathPost.py
+++ b/src/Mod/CAM/CAMTests/TestPathPost.py
@@ -426,6 +426,94 @@ class TestResolvingPostProcessorName(unittest.TestCase):
                     PathCommand._resolve_post_processor_name(self.job)
 
 
+class TestPostProcessZeroSpindleWarnings(unittest.TestCase):
+    class DummyContainer:
+        def __init__(self, group):
+            self.Group = group
+
+    class DummyToolController:
+        def __init__(self, name, label, spindle_speed, spindle_direction):
+            self.Name = name
+            self.Label = label
+            self.SpindleSpeed = spindle_speed
+            self.SpindleDir = spindle_direction
+
+    class DummyOperation:
+        def __init__(self, name, tool_controller=None):
+            self.Name = name
+            self.ToolController = tool_controller
+
+    class DummyJob:
+        def __init__(self, operations):
+            self.Operations = TestPostProcessZeroSpindleWarnings.DummyContainer(operations)
+
+    def test010_resolve_operations_prefers_explicit_operations(self):
+        tc = self.DummyToolController("TC1", "TC1", 1000.0, "Forward")
+        op_a = self.DummyOperation("OpA", tc)
+        op_b = self.DummyOperation("OpB", tc)
+        job = self.DummyJob([op_a])
+
+        resolved = PathCommand._resolve_operations(job, [op_b])
+        self.assertEqual([op_b], resolved)
+
+    def test020_get_zero_spindle_tool_controllers(self):
+        tc_zero_forward = self.DummyToolController("TC1", "Zero Forward", 0.0, "Forward")
+        tc_zero_reverse = self.DummyToolController("TC2", "Zero Reverse", 0.0, "Reverse")
+        tc_zero_none = self.DummyToolController("TC3", "Zero None", 0.0, "None")
+        tc_nonzero = self.DummyToolController("TC4", "Non Zero", 12000.0, "Forward")
+
+        operations = [
+            self.DummyOperation("Op1", tc_zero_forward),
+            self.DummyOperation("Op2", tc_zero_forward),  # duplicate should only appear once
+            self.DummyOperation("Op3", tc_zero_reverse),
+            self.DummyOperation("Op4", tc_zero_none),
+            self.DummyOperation("Op5", tc_nonzero),
+            self.DummyOperation("Op6", None),  # no tool controller
+        ]
+        job = self.DummyJob(operations)
+
+        zero_spindle_tool_controllers = PathCommand._get_zero_spindle_tool_controllers(job)
+        self.assertEqual(2, len(zero_spindle_tool_controllers))
+        self.assertEqual(
+            {"TC1", "TC2"},
+            {tool_controller.Name for tool_controller in zero_spindle_tool_controllers},
+        )
+
+    def test030_resolve_operations_falls_back_to_job_when_none(self):
+        tc = self.DummyToolController("TC1", "TC1", 1000.0, "Forward")
+        op_a = self.DummyOperation("OpA", tc)
+        job = self.DummyJob([op_a])
+
+        resolved = PathCommand._resolve_operations(job, None)
+        self.assertEqual([op_a], resolved)
+
+    def test040_resolve_operations_returns_empty_when_job_has_no_operations(self):
+        class NoOpJob:
+            pass
+
+        resolved = PathCommand._resolve_operations(NoOpJob(), None)
+        self.assertEqual([], resolved)
+
+    def test050_get_zero_spindle_handles_dressup_operations(self):
+        tc_zero = self.DummyToolController("TC1", "Zero Forward", 0.0, "Forward")
+        base_op = self.DummyOperation("Profile", tc_zero)
+
+        class DummyDressup:
+            Name = "ProfileDressup"
+            Base = base_op
+
+        job = self.DummyJob([DummyDressup()])
+        result = PathCommand._get_zero_spindle_tool_controllers(job)
+        self.assertEqual(1, len(result))
+        self.assertEqual("TC1", result[0].Name)
+
+    def test060_get_zero_spindle_returns_empty_when_all_speeds_nonzero(self):
+        tc = self.DummyToolController("TC1", "Non Zero", 5000.0, "Forward")
+        job = self.DummyJob([self.DummyOperation("Op1", tc)])
+        result = PathCommand._get_zero_spindle_tool_controllers(job)
+        self.assertEqual([], result)
+
+
 class TestPostProcessorFactory(unittest.TestCase):
     """Test creation of postprocessor objects."""
 

--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -28,6 +28,7 @@ Processor entries in PathJob"""
 import FreeCAD
 import FreeCADGui
 import Path
+import Path.Dressup.Utils as PathDressup
 from PathScripts import PathUtils
 from Path.Post.Utils import FilenameGenerator
 import os
@@ -46,6 +47,66 @@ else:
 
 
 translate = FreeCAD.Qt.translate
+
+
+def _resolve_operations(job, operations=None):
+    if operations is not None:
+        return operations
+    if hasattr(job, "Operations") and hasattr(job.Operations, "Group"):
+        return job.Operations.Group
+    return []
+
+
+def _get_zero_spindle_tool_controllers(job, operations=None):
+    zero_spindle_tool_controllers = []
+    seen_tool_controllers = set()
+
+    for operation in _resolve_operations(job, operations):
+        base_operation = PathDressup.baseOp(operation)
+        tool_controller = getattr(base_operation, "ToolController", None)
+        if not tool_controller:
+            continue
+        if tool_controller.Name in seen_tool_controllers:
+            continue
+        seen_tool_controllers.add(tool_controller.Name)
+
+        spindle_speed = getattr(tool_controller, "SpindleSpeed", None)
+        spindle_direction = getattr(tool_controller, "SpindleDir", None)
+        if spindle_speed == 0.0 and spindle_direction in ("Forward", "Reverse"):
+            zero_spindle_tool_controllers.append(tool_controller)
+
+    return zero_spindle_tool_controllers
+
+
+def _confirm_post_process_with_zero_spindle_speed(job, operations=None):
+    zero_spindle_tool_controllers = _get_zero_spindle_tool_controllers(job, operations)
+    if not zero_spindle_tool_controllers:
+        return True
+
+    if not FreeCAD.GuiUp:
+        return True
+
+    tool_controller_labels = "\n".join(
+        f" - {tool_controller.Label}" for tool_controller in zero_spindle_tool_controllers
+    )
+
+    warning_text = translate(
+        "CAM_Post",
+        "One or more Tool Controllers have spindle speed set to 0 RPM:\n"
+        "{tool_controllers}\n\n"
+        "Post processing may generate G-code without spindle start/speed commands "
+        "(for example M3/S).\n\n"
+        "Do you want to continue?",
+    ).format(tool_controllers=tool_controller_labels)
+
+    response = QtGui.QMessageBox.warning(
+        None,
+        translate("CAM_Post", "Post Process"),
+        warning_text,
+        QtGui.QMessageBox.Yes | QtGui.QMessageBox.No,
+        QtGui.QMessageBox.No,
+    )
+    return response == QtGui.QMessageBox.Yes
 
 
 def _resolve_post_processor_name(job):
@@ -200,8 +261,11 @@ class CommandPathPost:
         on user selection and document context.
         """
         Path.Log.debug(self.candidate.Name)
-        FreeCAD.ActiveDocument.openTransaction("Post Process the Selected Job")
 
+        if not _confirm_post_process_with_zero_spindle_speed(self.candidate):
+            return
+
+        FreeCAD.ActiveDocument.openTransaction("Post Process the Selected Job")
         postprocessor_name = _resolve_post_processor_name(self.candidate)
         Path.Log.debug(f"Post Processor: {postprocessor_name}")
 
@@ -281,8 +345,6 @@ class CommandPathPostSelected(CommandPathPost):
         Handles the activation of post processing, initiating the process based
         on user selection and document context.
         """
-        FreeCAD.ActiveDocument.openTransaction("Post Process the Selected operations")
-
         selection = FreeCADGui.Selection.getSelection()
         job = PathUtils.findParentJob(selection[0])
         if (
@@ -296,7 +358,7 @@ class CommandPathPostSelected(CommandPathPost):
             job = PathUtils.findParentJob(baseOp)
 
         opCandidates = [op for op in selection if hasattr(op, "Path") and "Job" not in op.Name]
-        operations = []
+        operations = None
         if opCandidates and job.Operations.Group != opCandidates:
             msgBox = QtGui.QMessageBox()
             msgBox.setWindowTitle("Post Process")
@@ -316,6 +378,10 @@ class CommandPathPostSelected(CommandPathPost):
                 )
                 operations = opCandidates
 
+        if not _confirm_post_process_with_zero_spindle_speed(job, operations):
+            return
+
+        FreeCAD.ActiveDocument.openTransaction("Post Process the Selected operations")
         postprocessor_name = _resolve_post_processor_name(job)
         Path.Log.debug(f"Post Processor: {postprocessor_name}")
 


### PR DESCRIPTION
## Summary
Add a safety confirmation before CAM post-processing when any selected operation uses a Tool Controller with:

- 'SpindleSpeed == 0'
- `SpindleDir` is `Forward` or `Reverse`

This helps prevent exporting G-code without spindle start/speed commands (for example `M3` / `S...`) by mistake.

### Implementation details
- Added warning-check helpers in `Path/Post/Command.py`:
  - operation resolution for selected ops vs full job
  - zero-spindle tool controller detection (including dressup base-op handling)
  - confirmation dialog (`Yes/No`, default `No`)
- Integrated the check in:
  - `Post Process` (job)
  - `Post Process Selected` (operations)

### Tests
Added unit tests in `CAMTests/TestPathPost.py` for:
- operation resolution behavior
- zero-spindle detection behavior
- dressup/base operation handling
- non-zero spindle nowarning path

## Issues
Closes #27830

## Before and After Images
Before:
- Post-processing procceeds with no warning when spindle speed is `0`.

After:
- A confirmation dialog appears listing affected Tool Controllers and warning about possible missing spindle commands.
<img width="482" height="178" alt="hi" src="https://github.com/user-attachments/assets/84104718-82f2-48ab-a2d1-af5f5d0c9866" />

