### PR TITLE
Material: add transaction support to Std_SetMaterial task

### DIFF
--- a/src/Mod/Material/Gui/DlgMaterialImp.cpp
+++ b/src/Mod/Material/Gui/DlgMaterialImp.cpp
@@ -30,6 +30,7 @@
 
 #include <Base/Console.h>
 #include <Gui/Application.h>
+#include <Gui/Command.h>
 #include <Gui/DockWindowManager.h>
 #include <Gui/Document.h>
 #include <Gui/Selection/Selection.h>
@@ -258,17 +259,26 @@ TaskMaterial::TaskMaterial()
     taskbox = new Gui::TaskView::TaskBox(QPixmap(), widget->windowTitle(), true, nullptr);
     taskbox->groupLayout()->addWidget(widget);
     Content.push_back(taskbox);
+
+    Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Set Material"));
 }
 
 TaskMaterial::~TaskMaterial() = default;
 
 QDialogButtonBox::StandardButtons TaskMaterial::getStandardButtons() const
 {
-    return QDialogButtonBox::Close;
+    return QDialogButtonBox::Ok | QDialogButtonBox::Cancel;
+}
+
+bool TaskMaterial::accept()
+{
+    Gui::Command::commitCommand();
+    return true;
 }
 
 bool TaskMaterial::reject()
 {
+    Gui::Command::abortCommand();
     widget->reject();
     return (widget->result() == QDialog::Rejected);
 }

--- a/src/Mod/Material/Gui/DlgMaterialImp.h
+++ b/src/Mod/Material/Gui/DlgMaterialImp.h
@@ -94,6 +94,7 @@ public:
     ~TaskMaterial() override;
 
 public:
+    bool accept() override;
     bool reject() override;
 
     bool isAllowedAlterDocument() const override


### PR DESCRIPTION
Summary
Wrap Std SetMaterial in a transaction so material changes can be undone and cancelled.

Replace the "Close" button with "OK" and "Cancel'
OK commits the transaction, creating an undo entry
Cancel aborts the transaction, restoring the previous material


Issues
Closes #27639

Before and After Images
Before: Only a "Close" button — no way to abort or undo material changes.

After: "OK" and "Cancel" buttons — Cancel reverts the material ; OK creates an entry in the undo tree.
<img width="708" height="424" alt="hi1" src="https://github.com/user-attachments/assets/7e196887-0a6d-409f-aaa2-996a8350186f" />
