### PR TITLE
TechDraw: fix Page tab renamed after Save As

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -293,6 +293,15 @@ void MDIViewPage::setTabText(std::string tabText)
     }
 }
 
+// The tab title for a TechDraw Page always shows the DrawPage's Label, not the document Label.
+void MDIViewPage::onRelabel(Gui::Document* /*pDoc*/)
+{
+    TechDraw::DrawPage* page = m_vpPage->getDrawPage();
+    if (page) {
+        setTabText(page->Label.getValue());
+    }
+}
+
 // advise the page to check QGraphicsScene parent/child relationships after undo
 void MDIViewPage::fixSceneDependencies()
 {

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -74,6 +74,7 @@ public:
 
     bool onMsg(const char* pMsg) override;
     bool onHasMsg(const char* pMsg) const override;
+    void onRelabel(Gui::Document* pDoc) override;
 
     void print() override;
     void print(QPrinter* printer) override;


### PR DESCRIPTION
When Save As was used with a TechDraw Page tab open, the tab title changed from the page label (e.g. "Page") to the new filename stem (e.g. "example").

Root cause: `
App::Document::saveAs()` updates the document Label to the new filename, which fires a relabel signal. `Gui::Document::onRelabel()` loops it over all open views and calls `MDIView::onRelabel()` on each one. The base implementation overwrittes the window title with the document Label. `MDIViewPage` had no overrie, so it silently inherited this behaviour.

Fix: override `onRelabel()` in `MDIViewPage` to apply again the `DrawPage`'s own Label via the existing `setTabText()` method, ignoring the document Label change entirely.

## Issues
Fixes #27897

## Before and After Images
**Before: TechDraw Page tab changes from "Page" to the new filename (e.g. "example") after Save As.
<img width="884" height="713" alt="before" src="https://github.com/user-attachments/assets/595dcf36-a613-424a-9005-f46a9a45cc07" />

**After:TechDraw Page tab keeps displaying the page label ("Page") after Save As.
[
<img width="1044" height="759" alt="after" src="https://github.com/user-attachments/assets/f14ad6f4-f378-453a-9456-b5b8f080e312" />
](url)
