### PR TITLE
Sketch: Rename "Attachment Editor" to "Edit Attachment" in context menu

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderAttachExtension.cpp
@@ -97,7 +97,7 @@ void ViewProviderAttachExtension::extensionSetupContextMenu(QMenu* menu, QObject
     if (attach) {
         // toggle command to display components
         Gui::ActionFunction* func = new Gui::ActionFunction(menu);
-        QAction* act = menu->addAction(QObject::tr("Attachment Editor"));
+        QAction* act = menu->addAction(QObject::tr("Edit Attachment"));
         if (Gui::Control().activeDialog()) {
             act->setDisabled(true);
         }


### PR DESCRIPTION
## Issues
fixes [#24817](https://github.com/FreeCAD/FreeCAD/issues/24817)

## Notes
It is worth noting, that I didn't change anything in the translation files apart from changing the english `Attachment Editor` to `Edit Attachment`, so that they will not break, this means that translations now incorrectly still translate the old `Attachment Editor` and not `Edit Attachment`, eg. in polish `Edycja Szkicu / Edytuj Dołączenie` and not `Edycja Szkicu / Edycja Dołączenia`. I think this can be probably easily targeted with LLM or even Google Translate, but I didn't want to use AI, not to mention messing up the translators work.

## Before and After Images
Before:
<img width="747" height="194" alt="image" src="https://github.com/user-attachments/assets/744c08ab-1db4-4f90-aa52-a976ebc97377" />
After:
<img width="771" height="186" alt="image" src="https://github.com/user-attachments/assets/0de033ac-13f5-4e1e-abc2-94ae26d8affb" />
