### PR TITLE
Sketcher: Fix arrow keys panning view instead of editing input value

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchKeyboardManager.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchKeyboardManager.cpp
@@ -97,7 +97,9 @@ void DrawSketchKeyboardManager::detectKeyboardEventHandlingMode(QKeyEvent* keyEv
     auto match = rx.match(keyEvent->text());
     if (keyEvent->key() == Qt::Key_Enter || keyEvent->key() == Qt::Key_Return
         || keyEvent->key() == Qt::Key_Minus || keyEvent->key() == Qt::Key_Period
-        || keyEvent->key() == Qt::Key_Comma
+        || keyEvent->key() == Qt::Key_Comma || keyEvent->key() == Qt::Key_Left
+        || keyEvent->key() == Qt::Key_Right || keyEvent->key() == Qt::Key_Up
+        || keyEvent->key() == Qt::Key_Down
         || match.hasMatch()
         // double check for backspace as there may be windows/unix inconsistencies
         || keyEvent->key() == Qt::Key_Backspace || keyEvent->matches(QKeySequence::Backspace)


### PR DESCRIPTION
Closes #22559.

The arrow keys were panning the view instead of editing the value in the active tool’s dynamic input box.

Left/Right arrows now move the cursor inside the input field.
Up/Down arrows now increase or decrease the value by one unit. (Filtering the arrow key events to prevent the view from panning automatically led to value modification behavior)


https://github.com/user-attachments/assets/95cc05fe-603b-4aba-af76-80fc59c35be3