### PR TITLE
Measurement: Solved Vertex Issue

### DIFF
--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -26,6 +26,8 @@
 #include <App/Application.h>
 #include <App/MeasureManager.h>
 #include <App/Document.h>
+#include <Base/Quantity.h>
+#include <Base/Precision.h>
 
 #include "MeasurePosition.h"
 
@@ -129,15 +131,17 @@ QString MeasurePosition::getResultString()
     if (prop == nullptr) {
         return {};
     }
-
+    
     Base::Vector3d value = Position.getValue();
-    QString unit = QString::fromStdString(Position.getUnit().getString());
-    int precision = 2;
+    QString xValue = QString::fromStdString(Base::Quantity(value.x, Base::Unit::Length).getUserString());
+    QString yValue = QString::fromStdString(Base::Quantity(value.y, Base::Unit::Length).getUserString());
+    QString zValue = QString::fromStdString(Base::Quantity(value.z, Base::Unit::Length).getUserString());
+    
     QString text;
 
-    QTextStream(&text) << "X: " << QString::number(value.x, 'f', precision) << " " << unit << Qt::endl
-                       << "Y: " << QString::number(value.y, 'f', precision) << " " << unit << Qt::endl
-                       << "Z: " << QString::number(value.z, 'f', precision) << " " << unit;
+    QTextStream(&text) << "X: " << xValue << Qt::endl
+                       << "Y: " << yValue << Qt::endl
+                       << "Z: " << zValue;
     return text;
 }
 

--- a/src/Mod/Measure/App/MeasurePosition.cpp
+++ b/src/Mod/Measure/App/MeasurePosition.cpp
@@ -131,12 +131,18 @@ QString MeasurePosition::getResultString()
     if (prop == nullptr) {
         return {};
     }
-    
+
     Base::Vector3d value = Position.getValue();
-    QString xValue = QString::fromStdString(Base::Quantity(value.x, Base::Unit::Length).getUserString());
-    QString yValue = QString::fromStdString(Base::Quantity(value.y, Base::Unit::Length).getUserString());
-    QString zValue = QString::fromStdString(Base::Quantity(value.z, Base::Unit::Length).getUserString());
-    
+    QString xValue = QString::fromStdString(
+        Base::Quantity(value.x, Base::Unit::Length).getUserString()
+    );
+    QString yValue = QString::fromStdString(
+        Base::Quantity(value.y, Base::Unit::Length).getUserString()
+    );
+    QString zValue = QString::fromStdString(
+        Base::Quantity(value.z, Base::Unit::Length).getUserString()
+    );
+
     QString text;
 
     QTextStream(&text) << "X: " << xValue << Qt::endl

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -478,8 +478,8 @@ void TaskMeasure::updateResultWithUnit()
     if (currentUnit != QLatin1String("-") && !resultString.isEmpty()) {
         if (resultString.contains(QLatin1String("X:")) && resultString.contains(QLatin1String("Y:"))
             && resultString.contains(QLatin1String("Z:"))) {
-            
-                Base::Quantity targetUnit = Base::Quantity::parse(
+
+            Base::Quantity targetUnit = Base::Quantity::parse(
                 (QLatin1String("1 ") + currentUnit).toStdString()
             );
 
@@ -509,7 +509,8 @@ void TaskMeasure::updateResultWithUnit()
                     else {
                         formattedValue = QString::number(convertedValue, 'f', 4);
                     }
-                    line = QString::fromLatin1("%1: %2 %3").arg(QChar::fromLatin1(text[0]), formattedValue, currentUnit);
+                    line = QString::fromLatin1("%1: %2 %3")
+                               .arg(QChar::fromLatin1(text[0]), formattedValue, currentUnit);
                 }
                 catch (const Base::Exception&) {
                 }

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -31,6 +31,7 @@
 #include <App/DocumentObjectGroup.h>
 #include <App/Link.h>
 #include <Mod/Measure/App/MeasureDistance.h>
+#include <App/PropertyUnits.h>
 #include <App/PropertyStandard.h>
 #include <Gui/MainWindow.h>
 #include <Gui/Application.h>
@@ -475,6 +476,48 @@ void TaskMeasure::updateResultWithUnit()
     QString currentUnit = unitSwitch->currentText();
 
     if (currentUnit != QLatin1String("-") && !resultString.isEmpty()) {
+        if (resultString.contains(QLatin1String("X:")) && resultString.contains(QLatin1String("Y:"))
+            && resultString.contains(QLatin1String("Z:"))) {
+            
+                Base::Quantity targetUnit = Base::Quantity::parse(
+                (QLatin1String("1 ") + currentUnit).toStdString()
+            );
+
+            QStringList lines = resultString.split(QLatin1Char('\n'));
+
+            for (QString& line : lines) {
+                std::string text = line.toStdString();
+
+                std::string valuePart = text.substr(2);
+
+                auto first = valuePart.find_first_not_of(" \t");
+                if (first == std::string::npos) {
+                    continue;
+                }
+
+                auto last = valuePart.find_last_not_of(" \t");
+                valuePart = valuePart.substr(first, last - first + 1);
+
+                try {
+                    Base::Quantity qty = Base::Quantity::parse(valuePart);
+                    double convertedValue = qty.getValueAs(targetUnit);
+
+                    QString formattedValue;
+                    if (std::abs(convertedValue) < 1.0 && convertedValue != 0.0) {
+                        formattedValue = QString::number(convertedValue, 'g', 4);
+                    }
+                    else {
+                        formattedValue = QString::number(convertedValue, 'f', 4);
+                    }
+                    line = QString::fromLatin1("%1: %2 %3").arg(QChar::fromLatin1(text[0]), formattedValue, currentUnit);
+                }
+                catch (const Base::Exception&) {
+                }
+            }
+            valueResult->setText(lines.join(QLatin1Char('\n')));
+            return;
+        }
+
         Base::Quantity resultQty = Base::Quantity::parse(resultString.toStdString());
         // Parse unit string like "1 mm" to get the target quantity
         Base::Quantity targetUnit = Base::Quantity::parse(


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Solved an issue where an user no longer can pick a vertex to measure.

The issue was linked to the fact that a multiline result string was parsed into the quantity system, which is not allowed. 
I have fixed the issue and made sure the the measurement type: "Position" now works correctly with units.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
#27907

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
The normal position measurement only works with mm and 2 digits
<img width="341" height="213" alt="image" src="https://github.com/user-attachments/assets/4e35c621-7445-4b9f-9154-280e7331cf37" />

I changed it to look at the user preffered units and number of decimals. This is how every other measurement type works.
Set my preffered units to inches and 6 decimals in this case
<img width="352" height="215" alt="image" src="https://github.com/user-attachments/assets/1fe83b53-4d7b-47ab-856c-67a5db2f6854" />
