### PR TITLE
Base: Fix typo unexpection->unexpected

### DIFF
--- a/src/Base/SystemHandler.cpp
+++ b/src/Base/SystemHandler.cpp
@@ -160,7 +160,7 @@ static void unhandled_exception_handler()
     std::cerr << "Terminating..." << '\n';
 }
 
-static void unexpection_error_handler()
+static void unexpected_error_handler()
 {
     std::cerr << "Unexpected error occurred..." << '\n';
     // try to throw an exception and give the user chance to save their work
@@ -212,7 +212,7 @@ void SystemHandler::installSegfaultHandler()
     std::signal(SIGSEGV, segmentation_fault_handler);
     std::signal(SIGABRT, segmentation_fault_handler);
     std::set_terminate(unhandled_exception_handler);
-    ::set_unexpected(unexpection_error_handler);
+    ::set_unexpected(unexpected_error_handler);
 #elif defined(FC_OS_LINUX)
     std::signal(SIGSEGV, segmentation_fault_handler);
 #endif


### PR DESCRIPTION
I think this one's been around since almost the beginning -- it caught my eye when it was moved into another file. May as well fix :).