### PR TITLE
CAM: Improved Fanuc support (header, python warnings).

### DIFF
--- a/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/fanuc_post.py
@@ -1,5 +1,11 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+"""
+
+CAM post processor for CNC machines with a Fanuc controller.
+
+"""
+
 # ***************************************************************************
 # *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
 # *   Copyright (c) 2021 shadowbane1000 <tyler@colberts.us>                 *
@@ -33,7 +39,7 @@ import shlex
 import os.path
 import Path.Base.Util as PathUtil
 import Path.Post.Utils as PostUtils
-import PathScripts.PathUtils as PathUtils
+from PathScripts import PathUtils
 from builtins import open as pyopen
 
 TOOLTIP = """
@@ -79,7 +85,8 @@ parser.add_argument(
 )
 parser.add_argument(
     "--postamble",
-    help='set commands to be issued after the last command, default="'
+    help="set commands to be issued after the last command, "
+    + 'default="'
     + DEFAULT_POSTAMBLE.replace("\n", "\\n")
     + '"',
 )
@@ -155,8 +162,17 @@ TOOL_CHANGE = """G28 G91 Z0
 DRILL_OPERATION = ("G73", "G81", "G82", "G83", "G85")
 DRILL_PARAM_REQ = ("L", "P", "Q", "R", "Z")
 
+# The settings shared between methods
+PREAMBLE = None
+POSTAMBLE = None
+
 
 def processArguments(argstring):
+    """
+    Apply default values and command line arguments before
+    processing commands.
+
+    """
     global OUTPUT_HEADER
     global OUTPUT_COMMENTS
     global OUTPUT_LINE_NUMBERS
@@ -265,9 +281,16 @@ def export(objectslist, filename, argstring):
         major = int(FreeCAD.ConfigGet("BuildVersionMajor"))
         minor = int(FreeCAD.ConfigGet("BuildVersionMinor"))
 
-        # the filename variable always contain "-", so unable to
-        # provide more accurate information.
-        gcode += "(" + "FREECAD-FILENAME-GOES-HERE" + ", " + "JOB-NAME-GOES-HERE" + ")\n"
+        # the filename variable always contain "-", use more relevant
+        # information
+        job = PathUtils.findParentJob(objectslist[0])
+        if job:
+            body, job = job.FullName.split("#")
+        else:
+            # Workaround for the TestFanucPost code, where there is no
+            # job returned by findParentJob
+            body, job = ("FREECAD-FILENAME-GOES-HERE", "JOB-NAME-GOES-HERE")
+        gcode += "(" + body.upper() + ", " + job.upper() + ")\n"
         gcode += (
             linenumber() + "(POST PROCESSOR: FANUC USING FREECAD %d.%d" % (major, minor) + ")\n"
         )
@@ -365,13 +388,7 @@ def export(objectslist, filename, argstring):
 
     if FreeCAD.GuiUp and SHOW_EDITOR:
         dia = PostUtils.GCodeEditorDialog()
-
-        # Workaround for 1.1 while we wait for
-        # https://github.com/FreeCAD/FreeCAD/pull/26008 to be merged.
-        if hasattr(dia.editor, "setPlainText"):
-            dia.editor.setPlainText(gcode)
-        else:
-            dia.editor.setText(gcode)
+        dia.editor.setText(gcode)
         result = dia.exec_()
         if result:
             final = dia.editor.toPlainText()


### PR DESCRIPTION
Adjusted G code output to include FreeCAD body and job information. The first comment in the G code is shown on the machine controller, and should contain useful information for operators to to identify jobs.  Fetch the body and job label using findParentJob and insert it into the G code.  For some reason the body and job information is not available when called from TestFanucPost.py, so handle case where it is undefined as earlier.  This new use of findParentJob exposes error in mock code used in code tests.  This is fixed in a different pull request to make this patch easily backportable to the 1.1 branch.

Fixed issues with Fanuc post processor discovered by lint.  Made sure global variables used are declared.  This fixes issue updating the postamble and preamble introduced in
ef794c31bd85cd2d5a11df47b8a07e93e8982be3

Added docstrings, adjusted import statements and wrapped long line to keep linter happy.

Reformatted code with black for consistent formatting.

Also reverted obsolete setText() workaround from commit 9c78ced00c67a6c2554d8fbfbeb84282a90d3363 now
that https://github.com/FreeCAD/FreeCAD/pull/26008 is merged.