### PR TITLE
PartDesign: Enable multi-selection in Additive/Subtractive Pipe edges list

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskPipeParameters.cpp
@@ -293,8 +293,9 @@ void TaskPipeParameters::removeFromListWidget(QListWidget* widget, QString items
 void TaskPipeParameters::onDeleteEdge()
 {
     auto items = ui->listWidgetReferences->selectedItems();
-    if (items.empty())
+    if (items.empty()) {
         return;
+    }
 
     const auto pipe = getObject<PartDesign::Pipe>();
     std::vector<std::string> refs = pipe->Spine.getSubValues();
@@ -303,11 +304,11 @@ void TaskPipeParameters::onDeleteEdge()
         QByteArray data = item->data(Qt::UserRole).toByteArray();
         std::string obj = data.constData();
 
-        delete ui->listWidgetReferences->takeItem(
-            ui->listWidgetReferences->row(item));
+        delete ui->listWidgetReferences->takeItem(ui->listWidgetReferences->row(item));
 
-        if (const auto f = std::ranges::find(refs, obj); f != refs.end())
+        if (const auto f = std::ranges::find(refs, obj); f != refs.end()) {
             refs.erase(f);
+        }
     }
 
     pipe->Spine.setValue(pipe->Spine.getValue(), refs);


### PR DESCRIPTION
Fixes #24368

This PR enables proper multi-selection in the PartDesign Additive/Subtractive Pipe edges list.

Changes:
- Allow Ctrl/Shift multi-selection in edges list
- Fix "Remove edge" button to delete multiple selected edges
- Add Ctrl+A support for selecting all edges

This improves usability and makes the Pipe tool consistent with other tools like Fillet/Chamfer.

## Before and After Images

Before: Could only add/remove one edge at a time  

<img width="361" height="231" alt="image" src="https://github.com/user-attachments/assets/6f57e204-7ae0-45b6-845d-592df53a4136" />

After: Multiple edges can be selected and removed together
<img width="365" height="163" alt="Screenshot 2026-02-28 225128" src="https://github.com/user-attachments/assets/1f9b10b2-e5cb-465b-ace8-9254e69f5087" />
