### PR TITLE
fixes #27968 material: sunset usage of `reinterpret_cast`

### DIFF
--- a/src/Mod/Material/App/MaterialConfigLoader.cpp
+++ b/src/Mod/Material/App/MaterialConfigLoader.cpp
@@ -40,6 +40,7 @@
 #include "Exceptions.h"
 #include "MaterialConfigLoader.h"
 #include "MaterialLoader.h"
+#include "MaterialLibrary.h"
 #include "Model.h"
 #include "ModelUuids.h"
 
@@ -1056,8 +1057,7 @@ MaterialConfigLoader::getMaterialFromPath(const std::shared_ptr<MaterialLibraryL
     QString sourceReference = value(fcmat, "ReferenceSource", "");
     QString sourceURL = value(fcmat, "SourceURL", "");
 
-    auto baseLibrary =
-        reinterpret_cast<const std::shared_ptr<Materials::MaterialLibrary>&>(library);
+    auto baseLibrary = std::static_pointer_cast<Materials::MaterialLibrary>(library);
     std::shared_ptr<Material> finalModel =
         std::make_shared<Material>(baseLibrary, path, uuid, name);
     finalModel->setOldFormat(true);

--- a/src/Mod/Material/App/MaterialLoader.cpp
+++ b/src/Mod/Material/App/MaterialLoader.cpp
@@ -418,8 +418,8 @@ MaterialLoader::getMaterialFromPath(const std::shared_ptr<MaterialLibraryLocal>&
                                     const QString& path) const
 {
     std::shared_ptr<MaterialEntry> model = nullptr;
-    auto materialLibrary =
-        reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
+
+    const auto& materialLibrary = library;
 
     // Used for debugging
     std::string pathName = path.toStdString();
@@ -577,8 +577,10 @@ void MaterialLoader::loadLibraries(
         for (auto& it : *libraryList) {
             if (it->isLocal()) {
                 auto materialLibrary =
-                    reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(it);
-                loadLibrary(materialLibrary);
+                    std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(it);
+                if (materialLibrary) {
+                    loadLibrary(materialLibrary);
+                }
             }
         }
     }

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -396,9 +396,10 @@ MaterialManager::getMaterialFolders(const std::shared_ptr<MaterialLibrary>& libr
 {
     if (library->isLocal()) {
         auto materialLibrary =
-            reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
-
-        return _localManager->getMaterialFolders(materialLibrary);
+            std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
+        if (materialLibrary) {
+            return _localManager->getMaterialFolders(materialLibrary);
+        }
     }
 
     return std::make_shared<std::list<QString>>();
@@ -409,7 +410,7 @@ void MaterialManager::createFolder(const std::shared_ptr<MaterialLibrary>& libra
 {
     if (library->isLocal()) {
         auto materialLibrary =
-            reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
+            std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
 
         _localManager->createFolder(materialLibrary, path);
     }
@@ -429,9 +430,10 @@ void MaterialManager::renameFolder(const std::shared_ptr<MaterialLibrary>& libra
 {
     if (library->isLocal()) {
         auto materialLibrary =
-            reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
-
-        _localManager->renameFolder(materialLibrary, oldPath, newPath);
+            std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
+        if (materialLibrary) {
+            _localManager->renameFolder(materialLibrary, oldPath, newPath);
+        }
     }
 #if defined(BUILD_MATERIAL_EXTERNAL)
     else if (_useExternal) {
@@ -448,9 +450,10 @@ void MaterialManager::deleteRecursive(const std::shared_ptr<MaterialLibrary>& li
 {
     if (library->isLocal()) {
         auto materialLibrary =
-            reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
-
-        _localManager->deleteRecursive(materialLibrary, path);
+            std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
+        if (materialLibrary) {
+            _localManager->deleteRecursive(materialLibrary, path);
+        }
     }
 #if defined(BUILD_MATERIAL_EXTERNAL)
     else if (_useExternal) {
@@ -573,7 +576,10 @@ void MaterialManager::saveMaterial(const std::shared_ptr<MaterialLibrary>& libra
                                    bool saveInherited) const
 {
     auto materialLibrary =
-        reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
+        std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
+    if (!materialLibrary) {
+        return;
+    }
     _localManager
         ->saveMaterial(materialLibrary, material, path, overwrite, saveAsCopy, saveInherited);
 }

--- a/src/Mod/Material/App/MaterialManagerPyImp.cpp
+++ b/src/Mod/Material/App/MaterialManagerPyImp.cpp
@@ -145,7 +145,10 @@ Py::List MaterialManagerPy::getMaterialLibraries() const
         Py::Tuple libTuple(3);
         if (lib->isLocal()) {
             auto materialLibrary =
-                reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(lib);
+                std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(lib);
+            if (!materialLibrary) {
+                continue;
+            }
             libTuple.setItem(0, Py::String(materialLibrary->getName().toStdString()));
             libTuple.setItem(1, Py::String(materialLibrary->getDirectoryPath().toStdString()));
             libTuple.setItem(2,

--- a/src/Mod/Material/App/MaterialPyImp.cpp
+++ b/src/Mod/Material/App/MaterialPyImp.cpp
@@ -71,7 +71,7 @@ Py::String MaterialPy::getLibraryName() const
     auto library = getMaterialPtr()->getLibrary();
     if (library->isLocal()) {
         auto materialLibrary =
-            reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
+            std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
         return {materialLibrary ? materialLibrary->getName().toStdString() : ""};
     }
     return "";
@@ -82,7 +82,7 @@ Py::String MaterialPy::getLibraryRoot() const
     auto library = getMaterialPtr()->getLibrary();
     if (library->isLocal()) {
         auto materialLibrary =
-            reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
+            std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
         return {materialLibrary ? materialLibrary->getDirectoryPath().toStdString() : ""};
     }
     return "";
@@ -93,7 +93,10 @@ Py::Object MaterialPy::getLibraryIcon() const
     auto library = getMaterialPtr()->getLibrary();
     if (library->isLocal()) {
         auto materialLibrary =
-            reinterpret_cast<const std::shared_ptr<Materials::MaterialLibraryLocal>&>(library);
+            std::dynamic_pointer_cast<Materials::MaterialLibraryLocal>(library);
+        if (!materialLibrary) {
+            return Py::Bytes();
+        }
         auto icon = materialLibrary->getIcon();
         if (icon.isNull()) {
             return Py::Bytes();


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

this PR addresses the crash in #27968 ie. this PR fixes #27968. there was legitimate crash when i updated the saveas logic in the material workbench / module. the crash was due to the use of `reinterpret_cast` primarly. so i did a search for uses of `reinterpret_cast` throughout the codebase, and found several uses throughout the material module (workbench). and decided to remove / sunset them and use `dynamic_cast` instead. the way i understand it is that using `reinterpret_cast` performs **no runtime checks** thus producing issues like the one seen in #27968 where as using `dynamic_cast` there is runtime checking. added some additional `if` statements for null checking in certain situations.

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/27968

## Before and After Images

NA

