### PR TITLE
Sketcher: Show sketch name in "Autoconstraints cause redundancy, Removing them" error message

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -976,6 +976,7 @@ protected:
 
         if (sketchobject->getLastHasRedundancies()) {
             Base::Console().warning(
+                sketchobject->getFullLabel(),
                 QT_TRANSLATE_NOOP("Notifications", "Autoconstraints cause redundancy. Removing them") "\n"
             );
 


### PR DESCRIPTION
"Autoconstraints cause redundancy, Removing them" now shows which sketch it refers to.

Closes #24075

<img width="650" height="27" alt="image" src="https://github.com/user-attachments/assets/92033f89-4b1c-474e-900c-a0ae0f1cc7ec" />
