### PR TITLE
Part: Restore stream locale after OCCT exception in loadFromStream

### DIFF
--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -687,6 +687,12 @@ void PropertyPartShape::loadFromFile(Base::Reader& reader)
 
 void PropertyPartShape::loadFromStream(Base::Reader& reader)
 {
+    // Save locale before calling OCCT. TopTools_ShapeSet::Read imbues the stream
+    // with std::locale::classic() and restores it on return, but uses a non-RAII
+    // pattern. When exceptions propagate out (due to the exception mask below),
+    // the locale is not restored, leaving the stream with the classic locale whose
+    // internal data is statically allocated and must not be freed.
+    auto savedLocale = reader.getloc();
     try {
         reader.exceptions(std::istream::failbit | std::istream::badbit);
         BRep_Builder builder;
@@ -695,6 +701,7 @@ void PropertyPartShape::loadFromStream(Base::Reader& reader)
         setValue(shape);
     }
     catch (const std::exception&) {
+        reader.imbue(savedLocale);
         if (!reader.eof()) {
             Base::Console().warning("Failed to load BRep file %s\n", reader.getFileName().c_str());
         }


### PR DESCRIPTION
I've noticed an error message when loading part design documents:
`Invalid Document.xml: End of document reached`

When loading documents with address sanitizer, it detects an issue.

From the commit message:

> OCCT's TopTools_ShapeSet::Read imbues the stream with
std::locale::classic() and restores it on return, but uses a non-RAII
pattern.
> 
> FreeCAD sets stream exceptions (failbit|badbit) as a workaround for an
OCCT infinite loop bug in BRepTools_ShapeSet::ReadGeometry on corrupted
files (https://github.com/FreeCAD/FreeCAD/commit/c3828d62259b5233da65c059e33b5310bade26ec).
> 
> When the stream is empty or corrupted, the exception propagates out of
OCCT before the locale can be restored, leaving the stream with the
classic locale whose internal data is statically allocated. When the
stream is later destroyed, its ~locale() attempts to free the static
data, causing memory corruption (detected by AddressSanitizer as
"attempting free on address which was not malloc()-ed").
> 
> Fix by saving the locale before calling BRepTools::Read and restoring
it in the catch block.