### PR TITLE
Fix Collada exporter skipping App::Link geometry

### DIFF
--- a/src/Mod/BIM/importers/importDAE.py
+++ b/src/Mod/BIM/importers/importDAE.py
@@ -168,6 +168,7 @@ def read(filename):
     if FreeCAD.GuiUp:
         FreeCAD.Gui.SendMsgToActiveView("ViewFit")
 
+
 def get_global_placement(obj):
     """
     Compute the global placement of an object by accumulating
@@ -183,6 +184,7 @@ def get_global_placement(obj):
         parent = parent.getParentGeoFeatureGroup()
 
     return pl
+
 
 def export(
     exports: list[FreeCAD.DocumentObject],


### PR DESCRIPTION

The Collada exporter skipped geometry for `App::Link` objects because it
only exported objects directly present in the document.

This PR resolves `App::Link` objects recursively to their referenced
objects and exports their geometry while preserving placement from the
link object.

Tested with:

* Simple Body + Link
* Links inside App::Part
* Nested links
* Multiple links to same object
* Mesh::Feature links

Existing export behavior without links is unchanged.

## issues:

Fixes #24117

## before:

before exporting:
<img width="736" height="504" alt="Screenshot 2026-03-01 124049" src="https://github.com/user-attachments/assets/31fc33ee-74a5-4dcd-b0fa-987b407e0d29" />

after exporting:
<img width="840" height="454" alt="Screenshot 2026-03-01 124100" src="https://github.com/user-attachments/assets/2a6ce900-3bd8-4bb4-9445-d1d33db43dba" />

## after

before exporting:
<img width="1108" height="714" alt="Screenshot 2026-03-01 153620" src="https://github.com/user-attachments/assets/4a733932-5f2c-4914-8ee4-0fbd27a4866f" />

after exporting:
<img width="873" height="478" alt="Screenshot 2026-03-01 153557" src="https://github.com/user-attachments/assets/e9aa7055-a642-4e19-867e-40a4183f39c5" />


