### PR TITLE
measurement: fix area unit and decimal display

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -49,6 +49,7 @@
 #include <QSignalBlocker>
 
 #include <Base/Quantity.h>
+#include <Base/UnitsApi.h>
 #include <array>
 
 using namespace MeasureGui;
@@ -86,7 +87,9 @@ QString extractUnitFromResultString(const QString& resultString)
     auto lastSpace = str.find_last_of(' ');
 
     if (lastSpace != std::string::npos && lastSpace < str.length() - 1) {
-        return QString::fromStdString(str.substr(lastSpace + 1));
+        QString unit = QString::fromStdString(str.substr(lastSpace + 1));
+        unit.replace(QLatin1String("^2"), QChar(0x00B2));
+        return unit;
     }
 
     return QString();
@@ -476,23 +479,41 @@ void TaskMeasure::updateResultWithUnit()
 
     if (currentUnit != QLatin1String("-") && !resultString.isEmpty()) {
         Base::Quantity resultQty = Base::Quantity::parse(resultString.toStdString());
+        QString unitForParse = currentUnit;
+        unitForParse.replace(QChar(0x00B2), QLatin1String("^2"));
         // Parse unit string like "1 mm" to get the target quantity
         Base::Quantity targetUnit = Base::Quantity::parse(
-            (QLatin1String("1 ") + currentUnit).toStdString()
+            (QLatin1String("1 ") + unitForParse).toStdString()
         );
         double convertedValue = resultQty.getValueAs(targetUnit);
 
-        QString formattedValue;
-        // 4 decimal places, if between -1 and 1: 4 significant digits
-        if (std::abs(convertedValue) < 1.0 && convertedValue != 0.0) {
-            formattedValue = QString::number(convertedValue, 'g', 4);
-        }
-        else {
-            formattedValue = QString::number(convertedValue, 'f', 4);
-        }
+        // format the value to respect decimal scheme in prefrences
+        const Base::QuantityFormat& fmt = resultQty.getFormat();
+        char formatChar = fmt.toFormat();
+        int decimals = Base::UnitsApi::getDecimals();
+        QString formattedValue = QString::number(convertedValue, formatChar, decimals);
 
         QString formattedResult = formattedValue + QLatin1String(" ") + currentUnit;
         valueResult->setText(formattedResult);
+
+        // Keep 3D label in sync with task panel
+        Gui::Document* guiDoc = Gui::Application::Instance->activeDocument();
+        if (!guiDoc) {
+            return;
+        }
+
+        Gui::ViewProvider* viewObject = guiDoc->getViewProvider(_mMeasureObject);
+        if (!viewObject) {
+            return;
+        }
+
+        auto* measureVp = dynamic_cast<ViewProviderMeasureBase*>(viewObject);
+        if (!measureVp) {
+            return;
+        }
+
+        measureVp->setLabelValue(formattedResult);
+
     }
     else {
         valueResult->setText(resultString);

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -60,6 +60,7 @@ constexpr auto taskMeasureSettingsGroup = "TaskMeasure";
 constexpr auto taskMeasureShowDeltaSettingsName = "ShowDelta";
 constexpr auto taskMeasureAutoSaveSettingsName = "AutoSave";
 constexpr auto taskMeasureGreedySelection = "GreedySelection";
+constexpr char32_t UnicodeSuperscript2 = 0x00B2;
 
 using SelectionStyle = Gui::SelectionSingleton::SelectionStyle;
 
@@ -88,7 +89,7 @@ QString extractUnitFromResultString(const QString& resultString)
 
     if (lastSpace != std::string::npos && lastSpace < str.length() - 1) {
         QString unit = QString::fromStdString(str.substr(lastSpace + 1));
-        unit.replace(QLatin1String("^2"), QChar(0x00B2));
+        unit.replace(QLatin1String("^2"), QChar(UnicodeSuperscript2));
         return unit;
     }
 
@@ -480,7 +481,7 @@ void TaskMeasure::updateResultWithUnit()
     if (currentUnit != QLatin1String("-") && !resultString.isEmpty()) {
         Base::Quantity resultQty = Base::Quantity::parse(resultString.toStdString());
         QString unitForParse = currentUnit;
-        unitForParse.replace(QChar(0x00B2), QLatin1String("^2"));
+        unitForParse.replace(QChar(UnicodeSuperscript2), QLatin1String("^2"));
         // Parse unit string like "1 mm" to get the target quantity
         Base::Quantity targetUnit = Base::Quantity::parse(
             (QLatin1String("1 ") + unitForParse).toStdString()

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -513,7 +513,6 @@ void TaskMeasure::updateResultWithUnit()
         }
 
         measureVp->setLabelValue(formattedResult);
-
     }
     else {
         valueResult->setText(resultString);

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -693,7 +693,9 @@ void ViewProviderMeasure::redrawAnnotation()
     Base::Vector3d basePos = getBasePosition();
     pcTransform->translation.setValue(SbVec3f(basePos.x, basePos.y, basePos.z));
 
-    setLabelValue(getMeasureObject()->getResultString());
+    QString labelText = getMeasureObject()->getResultString();
+    labelText.replace(QLatin1String("^2"), QChar(0x00B2));
+    setLabelValue(labelText);
 
     ViewProviderMeasureBase::redrawAnnotation();
     ViewProviderDocumentObject::updateView();

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -694,7 +694,7 @@ void ViewProviderMeasure::redrawAnnotation()
     pcTransform->translation.setValue(SbVec3f(basePos.x, basePos.y, basePos.z));
 
     QString labelText = getMeasureObject()->getResultString();
-    labelText.replace(QLatin1String("^2"), QChar(0x00B2));
+    labelText.replace(QLatin1String("^2"), QChar(UnicodeSuperscript2));
     setLabelValue(labelText);
 
     ViewProviderMeasureBase::redrawAnnotation();

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
@@ -145,6 +145,7 @@ protected:
     SoDrawStyle* getSoLineStyleSecondary();
     SoSeparator* getSoSeparatorText();
 
+    static constexpr char32_t UnicodeSuperscript2 = 0x00B2;
     static constexpr double defaultTolerance = 10e-6;
     virtual Base::Vector3d getTextDirection(
         Base::Vector3d elementDirection,

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.h
@@ -130,13 +130,13 @@ public:
     void onSubjectVisibilityChanged(const App::DocumentObject& docObj, const App::Property& prop);
     void connectToSubject(App::DocumentObject* subject);
     void connectToSubject(std::vector<App::DocumentObject*> subject);
+    void setLabelValue(const Base::Quantity& value);
+    void setLabelValue(const QString& value);
 
 protected:
     static void draggerChangedCallback(void* data, SoDragger*);
     void onChanged(const App::Property* prop) override;
     virtual void onLabelMoved() {};
-    void setLabelValue(const Base::Quantity& value);
-    void setLabelValue(const QString& value);
     void setLabelTranslation(const SbVec3f& position);
     void updateIcon();
 


### PR DESCRIPTION
The fix makes three changes for area measurement annotations

1. Change the display from caret (^) to raised powers
2. Update the labels based on unit selected in the Task Pane drop-down ( fixes #27948 )
3. Tracks the global decimal preferences of the app for the value in label ( fixes #27949 )


<img width="387" height="382" alt="1" src="https://github.com/user-attachments/assets/f8056afd-5401-446e-bf1d-07968f728746" />



