### PR TITLE
Sketcher: Set attachment of created Sketch to Link object when Link surface is selected

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -515,7 +515,11 @@ std::vector<SelectionObject> SelectionSingleton::getObjectList(
             if (subelement && *subelement) {
                 temp.back().SubNames.emplace_back(subelement);
                 temp.back().SelPoses.emplace_back(sel.x, sel.y, sel.z);
-                temp.back().evaluateLinkParent(Base::Tools::splitSubName(sel.SubName));
+                auto linkCandidates = Base::Tools::splitSubName(sel.SubName);
+                if (sel.pObject && sel.pObject->getNameInDocument()) {
+                    linkCandidates.emplace_back(sel.pObject->getNameInDocument());
+                }
+                temp.back().evaluateLinkParent(linkCandidates);
                 if (resolve != ResolveMode::NoResolve) {
                     temp.back()._SubNameSet.insert(subelement);
                 }

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -515,6 +515,7 @@ std::vector<SelectionObject> SelectionSingleton::getObjectList(
             if (subelement && *subelement) {
                 temp.back().SubNames.emplace_back(subelement);
                 temp.back().SelPoses.emplace_back(sel.x, sel.y, sel.z);
+                temp.back().evaluateLinkParent(Base::Tools::splitSubName(sel.SubName));
                 if (resolve != ResolveMode::NoResolve) {
                     temp.back()._SubNameSet.insert(subelement);
                 }

--- a/src/Gui/Selection/SelectionObject.cpp
+++ b/src/Gui/Selection/SelectionObject.cpp
@@ -50,6 +50,7 @@ SelectionObject::SelectionObject(const Gui::SelectionChanges& msg)
     if (msg.pSubName) {
         SubNames.emplace_back(msg.pSubName);
         SelPoses.emplace_back(msg.x, msg.y, msg.z);
+        evaluateLinkParent(SubNames);
     }
 }
 
@@ -61,6 +62,21 @@ SelectionObject::SelectionObject(const App::DocumentObject* obj)
 }
 
 SelectionObject::~SelectionObject() = default;
+
+std::string SelectionObject::evaluateLinkParent(const std::vector<std::string>& candidates)
+{
+    const auto doc = getObject()->getDocument();
+    for (const auto& name : candidates) {
+        App::DocumentObject* obj = doc->getObject(name.c_str());
+        if (obj && obj->isLink()) {
+            if (LinkParentName != name) {
+                LinkParentName = name;
+            }
+            return name;
+        }
+    }
+    return "";
+}
 
 const App::DocumentObject* SelectionObject::getObject() const
 {

--- a/src/Gui/Selection/SelectionObject.cpp
+++ b/src/Gui/Selection/SelectionObject.cpp
@@ -65,7 +65,11 @@ SelectionObject::~SelectionObject() = default;
 
 std::string SelectionObject::evaluateLinkParent(const std::vector<std::string>& candidates)
 {
-    const auto doc = getObject()->getDocument();
+    auto* selObj = getObject();
+    if (!selObj) {
+        return {};
+    }
+    const auto doc = selObj->getDocument();
     auto it = std::ranges::find_if(candidates, [doc](const std::string& name) {
         const App::DocumentObject* obj = doc->getObject(name.c_str());
         return obj && obj->isLink();

--- a/src/Gui/Selection/SelectionObject.cpp
+++ b/src/Gui/Selection/SelectionObject.cpp
@@ -66,16 +66,20 @@ SelectionObject::~SelectionObject() = default;
 std::string SelectionObject::evaluateLinkParent(const std::vector<std::string>& candidates)
 {
     const auto doc = getObject()->getDocument();
-    for (const auto& name : candidates) {
-        App::DocumentObject* obj = doc->getObject(name.c_str());
-        if (obj && obj->isLink()) {
-            if (LinkParentName != name) {
-                LinkParentName = name;
-            }
-            return name;
+    auto it = std::ranges::find_if(candidates, [doc](const std::string& name) {
+        const App::DocumentObject* obj = doc->getObject(name.c_str());
+        return obj && obj->isLink();
+    });
+
+    if (it != candidates.end()) {
+        const std::string& name = *it;
+        if (LinkParentName != name) {
+            LinkParentName = name;
         }
+        return name;
     }
-    return "";
+
+    return {};
 }
 
 const App::DocumentObject* SelectionObject::getObject() const

--- a/src/Gui/Selection/SelectionObject.cpp
+++ b/src/Gui/Selection/SelectionObject.cpp
@@ -23,6 +23,9 @@
 
 
 #include <sstream>
+#include <ranges>
+#include <algorithm>
+#include <boost/algorithm/string.hpp>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -50,7 +53,12 @@ SelectionObject::SelectionObject(const Gui::SelectionChanges& msg)
     if (msg.pSubName) {
         SubNames.emplace_back(msg.pSubName);
         SelPoses.emplace_back(msg.x, msg.y, msg.z);
-        evaluateLinkParent(SubNames);
+
+        if (msg.pSubName && strlen(msg.pSubName) > 0) {
+            std::vector<std::string> subNameTokens;
+            boost::split(subNameTokens, msg.pSubName, boost::is_any_of("."));
+            evaluateLinkParent(subNameTokens);
+        }
     }
 }
 
@@ -77,9 +85,7 @@ std::string SelectionObject::evaluateLinkParent(const std::vector<std::string>& 
 
     if (it != candidates.end()) {
         const std::string& name = *it;
-        if (LinkParentName != name) {
-            LinkParentName = name;
-        }
+        LinkParentName = name;
         return name;
     }
 

--- a/src/Gui/Selection/SelectionObject.cpp
+++ b/src/Gui/Selection/SelectionObject.cpp
@@ -25,7 +25,7 @@
 #include <sstream>
 #include <ranges>
 #include <algorithm>
-#include <boost/algorithm/string.hpp>
+#include <Base/Tools.h>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -54,9 +54,8 @@ SelectionObject::SelectionObject(const Gui::SelectionChanges& msg)
         SubNames.emplace_back(msg.pSubName);
         SelPoses.emplace_back(msg.x, msg.y, msg.z);
 
-        if (msg.pSubName && strlen(msg.pSubName) > 0) {
-            std::vector<std::string> subNameTokens;
-            boost::split(subNameTokens, msg.pSubName, boost::is_any_of("."));
+        if (strlen(msg.pSubName) > 0) {
+            std::vector<std::string> subNameTokens = Base::Tools::splitSubName(msg.pSubName);
             evaluateLinkParent(subNameTokens);
         }
     }
@@ -71,11 +70,11 @@ SelectionObject::SelectionObject(const App::DocumentObject* obj)
 
 SelectionObject::~SelectionObject() = default;
 
-std::string SelectionObject::evaluateLinkParent(const std::vector<std::string>& candidates)
+void SelectionObject::evaluateLinkParent(const std::vector<std::string>& candidates)
 {
     auto* selObj = getObject();
     if (!selObj) {
-        return {};
+        return;
     }
     const auto doc = selObj->getDocument();
     auto it = std::ranges::find_if(candidates, [doc](const std::string& name) {
@@ -86,10 +85,7 @@ std::string SelectionObject::evaluateLinkParent(const std::vector<std::string>& 
     if (it != candidates.end()) {
         const std::string& name = *it;
         LinkParentName = name;
-        return name;
     }
-
-    return {};
 }
 
 const App::DocumentObject* SelectionObject::getObject() const

--- a/src/Gui/Selection/SelectionObject.h
+++ b/src/Gui/Selection/SelectionObject.h
@@ -89,6 +89,13 @@ public:
     {
         return SelPoses;
     }
+    /// get cached name of parent Link object
+    /// - returns empty string, if there is no link parent
+    /// - returns std::nullopt, if there was no evaluation for link parent
+    inline const std::optional<std::string> getLinkParent() const
+    {
+        return LinkParentName;
+    }
 
     /// returns the selected DocumentObject or NULL if the object is already deleted
     const App::DocumentObject* getObject() const;
@@ -121,6 +128,12 @@ protected:
     std::string FeatName;
     std::string TypeName;
     std::vector<Base::Vector3d> SelPoses;
+    std::optional<std::string> LinkParentName = std::nullopt;
+
+    /// evaluate and set link parent from passed candidates
+    /// - if found, returns name of Link parent object and caches it
+    /// - returns empty string, if there is no parent link among candidates
+    std::string evaluateLinkParent(const std::vector<std::string>& candidates);
 
 private:
     /// to make sure no duplicates of subnames

--- a/src/Gui/Selection/SelectionObject.h
+++ b/src/Gui/Selection/SelectionObject.h
@@ -28,6 +28,7 @@
 #include <Base/Vector3D.h>
 #include <FCGlobal.h>
 #include <string>
+#include <optional>
 
 namespace App
 {
@@ -92,7 +93,7 @@ public:
     /// get cached name of parent Link object
     /// - returns empty string, if there is no link parent
     /// - returns std::nullopt, if there was no evaluation for link parent
-    inline const std::optional<std::string> getLinkParent() const
+    inline std::optional<std::string> getLinkParent() const
     {
         return LinkParentName;
     }

--- a/src/Gui/Selection/SelectionObject.h
+++ b/src/Gui/Selection/SelectionObject.h
@@ -131,10 +131,9 @@ protected:
     std::vector<Base::Vector3d> SelPoses;
     std::optional<std::string> LinkParentName = std::nullopt;
 
-    /// evaluate and set link parent from passed candidates
-    /// - if found, returns name of Link parent object and caches it
-    /// - returns empty string, if there is no parent link among candidates
-    std::string evaluateLinkParent(const std::vector<std::string>& candidates);
+    /// Evaluate and set link parent from passed candidates
+    /// If found, caches name of Link parent object
+    void evaluateLinkParent(const std::vector<std::string>& candidates);
 
 private:
     /// to make sure no duplicates of subnames

--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -34,6 +34,7 @@ if(BUILD_GUI)
           SketcherTests/TestPlacementUpdate.py
           SketcherTests/TestOnViewParameterGui.py
           SketcherTests/TestExternalFacePreselection.py
+          SketcherTests/TestAttachmentSupport.py
     )
 endif(BUILD_GUI)
 

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -240,6 +240,17 @@ void CmdSketcherNewSketch::activated(int iMsg)
         std::vector<Gui::SelectionObject> objects = Gui::Selection().getSelectionEx();
         App::PropertyLinkSubList support;
         Gui::Selection().getAsPropertyLinkSubList(support);
+
+        // check if selected object is attached under any Link object
+        // if yes, then set support of created Sketch to this Link object
+        if (const auto LinkParentName = objects[0].getLinkParent(); LinkParentName && !LinkParentName.value().empty()) {
+            const auto LinkParentObj = objects[0].getObject()->getDocument()->getObject(LinkParentName.value().c_str());
+            auto subValues = support.getSubValues();
+            const std::string linkedObjName = support.getValue()->getNameInDocument();
+            std::transform(subValues.begin(), subValues.end(),  subValues.begin(), [linkedObjName](const auto& val)->std::string{return linkedObjName + "." + val; });
+            support.setValue(LinkParentObj, subValues);
+        }
+
         std::string supportString = support.getPyReprString();
 
         // create Sketch on Face

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -241,14 +241,16 @@ void CmdSketcherNewSketch::activated(int iMsg)
         App::PropertyLinkSubList support;
         Gui::Selection().getAsPropertyLinkSubList(support);
 
-        // check if selected object is attached under any Link object
-        // if yes, then set support of created Sketch to this Link object
-        if (const auto LinkParentName = objects[0].getLinkParent(); LinkParentName && !LinkParentName.value().empty()) {
-            const auto LinkParentObj = objects[0].getObject()->getDocument()->getObject(LinkParentName.value().c_str());
-            auto subValues = support.getSubValues();
-            const std::string linkedObjName = support.getValue()->getNameInDocument();
-            std::transform(subValues.begin(), subValues.end(),  subValues.begin(), [linkedObjName](const auto& val)->std::string{return linkedObjName + "." + val; });
-            support.setValue(LinkParentObj, subValues);
+        if(!objects.empty() && objects[0].getObject() && support.getValue() != nullptr) {
+            // check if selected object is attached under any Link object
+            // if yes, then set support of created Sketch to this Link object
+            if (const auto linkParentName = objects[0].getLinkParent(); linkParentName && !linkParentName.value().empty()) {
+                const auto linkParentObj = objects[0].getObject()->getDocument()->getObject(linkParentName.value().c_str());
+                auto subValues = support.getSubValues();
+                const std::string linkedObjName = support.getValue()->getNameInDocument();
+                std::transform(subValues.begin(), subValues.end(),  subValues.begin(), [linkedObjName](const auto& val)->std::string{return linkedObjName + "." + val; });
+                support.setValue(linkParentObj, subValues);
+            }
         }
 
         std::string supportString = support.getPyReprString();

--- a/src/Mod/Sketcher/SketcherTests/TestAttachmentSupport.py
+++ b/src/Mod/Sketcher/SketcherTests/TestAttachmentSupport.py
@@ -1,0 +1,135 @@
+# test for FreeCAD issue https://github.com/FreeCAD/FreeCAD/issues/22341
+
+import unittest
+import FreeCAD as App
+
+# check if GUI is available
+try:
+    import FreeCADGui as Gui
+    from PySide import QtCore, QtWidgets
+
+    GUI_AVAILABLE = Gui.getMainWindow() is not None
+except (ImportError, AttributeError):
+    GUI_AVAILABLE = False
+
+
+class TestSketchAttachmentSupport(unittest.TestCase):
+    """
+    - Test that Sketch created on selected face of Link object will be supported on that Link object, instead pf original object.
+    - Test that Sketch created on selected face of original object will be supported on original object.
+
+    These tests require GUI and will be skipped with freecadcmd.
+    """
+
+    def _accept_sketch_attachment_dialog(self):
+        """
+        Attempts to find and accept the 'Sketch Attachment' dialog.
+
+        WARNING: This implementation relies on internal GUI structure (widget hierarchy and window titles).
+        It is fragile and may break if the FreeCAD GUI for sketch attachment changes.
+        """
+        for top_widget in QtWidgets.QApplication.topLevelWidgets():
+            for widget in self._iterate_widgets(top_widget):
+                if widget and isinstance(widget, QtWidgets.QInputDialog):
+                    # Check if this is likely the attachment dialog.
+                    if widget.windowTitle() == "Sketch Attachment":
+                        buttons = widget.findChildren(QtWidgets.QPushButton)
+                        for button in buttons:
+                            if button.text() in ("OK", "&OK"):
+                                button.click()
+                                self._dialog_accepted = True
+                                return
+                        # If no OK button found, try to accept the dialog directly
+                        widget.accept()
+                        self._dialog_accepted = True
+                        return
+
+    def _iterate_widgets(self, widget):
+        yield widget
+        for child in widget.findChildren(QtWidgets.QWidget):
+            yield from self._iterate_widgets(child)
+
+    def _start_dialog_watcher(self):
+        if self._dialog_timer is None:
+            self._dialog_timer = QtCore.QTimer()
+            self._dialog_timer.timeout.connect(self._accept_sketch_attachment_dialog)
+            self._dialog_timer.start(1)  # Check every 1ms
+
+    def _stop_dialog_watcher(self):
+        if self._dialog_timer is not None:
+            self._dialog_timer.stop()
+            self._dialog_timer = None
+
+    def _runCommand_with_watcher(self):
+        """
+        Start a timer to watch for and accept the Sketch Attachment dialog.
+
+        Note: This is a workaround for GUI testing without a dedicated GUI automation framework (e.g., pytest-qt).
+        It relies on polling top-level widgets.
+        """
+        self._start_dialog_watcher()
+        QtWidgets.QApplication.processEvents()
+
+        # tested command -- start
+        Gui.runCommand("Sketcher_NewSketch", 0)
+        # tested command -- end
+        Gui.ActiveDocument.resetEdit()
+
+        self._stop_dialog_watcher()
+
+        self.sketchSupport = App.ActiveDocument.Sketch.AttachmentSupport
+
+    def setUp(self):
+        """
+        Create a document.
+        Add inside an object of type Part, including a Box object. Name it original object.
+        Then create object of Link type pointed to Original Part object.
+        Recompute deocument.
+        """
+        if not GUI_AVAILABLE:
+            self.skipTest("GUI not available")
+
+        self._dialog_timer = None
+        self._dialog_accepted = False
+
+        self.doc = App.newDocument("TestSketchAttachmentSupport")
+
+        self.originalPart = self.doc.addObject("App::Part", "OriginalPart")
+        self.box = self.doc.addObject("Part::Box", "Box")
+        self.originalPart.addObject(self.box)
+
+        self.partWithSketch = self.doc.addObject("App::Part", "PartWithSketch")
+        self.linkToPart = self.doc.addObject("App::Link", "LinkToPart")
+        self.linkToPart.setLink(self.originalPart)
+        self.partWithSketch.addObject(self.linkToPart)
+
+        self.doc.recompute()
+        Gui.Selection.clearSelection()
+
+    def tearDown(self):
+        """clean up the test document"""
+        # Stop dialog watcher if still running
+        self._stop_dialog_watcher()
+
+        if GUI_AVAILABLE and hasattr(self, "doc") and self.doc:
+            App.closeDocument(self.doc.Name)
+
+    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def test_attachment_link_to_part(self):
+        Gui.Selection.addSelection(self.doc.Name, self.linkToPart.Name, f"{self.box.Name}.Face6")
+
+        self._runCommand_with_watcher()
+
+        self.assertTrue(self._dialog_accepted)
+        self.assertEqual(self.sketchSupport[0][0], self.linkToPart)  # compare support object
+        self.assertEqual(self.sketchSupport[0][1][0], "Box.Face6")  # compare support face
+
+    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def test_attachment_original_part(self):
+        Gui.Selection.addSelection(self.doc.Name, self.originalPart.Name, f"{self.box.Name}.Face6")
+
+        self._runCommand_with_watcher()
+
+        self.assertTrue(self._dialog_accepted)
+        self.assertEqual(self.sketchSupport[0][0], self.box)  # compare support object
+        self.assertEqual(self.sketchSupport[0][1][0], "Face6")  # compare support face

--- a/src/Mod/Sketcher/SketcherTests/TestAttachmentSupport.py
+++ b/src/Mod/Sketcher/SketcherTests/TestAttachmentSupport.py
@@ -2,6 +2,7 @@
 
 import unittest
 import FreeCAD as App
+from PySide.QtGui import QApplication
 
 # check if GUI is available
 try:
@@ -13,6 +14,17 @@ except (ImportError, AttributeError):
     GUI_AVAILABLE = False
 
 
+class CallableAcceptDialog:
+    def __init__(self, test):
+        self.test = test
+
+    def __call__(self):
+        dialog = QApplication.activeModalWidget()
+        self.test.assertIsNotNone(dialog, "Dialog box could not be found")
+        if dialog is not None:
+            QtCore.QTimer.singleShot(0, dialog, QtCore.SLOT("accept()"))
+
+
 class TestSketchAttachmentSupport(unittest.TestCase):
     """
     - Test that Sketch created on selected face of Link object will be supported on that Link object, instead pf original object.
@@ -21,61 +33,13 @@ class TestSketchAttachmentSupport(unittest.TestCase):
     These tests require GUI and will be skipped with freecadcmd.
     """
 
-    def _accept_sketch_attachment_dialog(self):
-        """
-        Attempts to find and accept the 'Sketch Attachment' dialog.
-
-        WARNING: This implementation relies on internal GUI structure (widget hierarchy and window titles).
-        It is fragile and may break if the FreeCAD GUI for sketch attachment changes.
-        """
-        for top_widget in QtWidgets.QApplication.topLevelWidgets():
-            for widget in self._iterate_widgets(top_widget):
-                if widget and isinstance(widget, QtWidgets.QInputDialog):
-                    # Check if this is likely the attachment dialog.
-                    if widget.windowTitle() == "Sketch Attachment":
-                        buttons = widget.findChildren(QtWidgets.QPushButton)
-                        for button in buttons:
-                            if button.text() in ("OK", "&OK"):
-                                button.click()
-                                self._dialog_accepted = True
-                                return
-                        # If no OK button found, try to accept the dialog directly
-                        widget.accept()
-                        self._dialog_accepted = True
-                        return
-
-    def _iterate_widgets(self, widget):
-        yield widget
-        for child in widget.findChildren(QtWidgets.QWidget):
-            yield from self._iterate_widgets(child)
-
-    def _start_dialog_watcher(self):
-        if self._dialog_timer is None:
-            self._dialog_timer = QtCore.QTimer()
-            self._dialog_timer.timeout.connect(self._accept_sketch_attachment_dialog)
-            self._dialog_timer.start(1)  # Check every 1ms
-
-    def _stop_dialog_watcher(self):
-        if self._dialog_timer is not None:
-            self._dialog_timer.stop()
-            self._dialog_timer = None
-
-    def _runCommand_with_watcher(self):
-        """
-        Start a timer to watch for and accept the Sketch Attachment dialog.
-
-        Note: This is a workaround for GUI testing without a dedicated GUI automation framework (e.g., pytest-qt).
-        It relies on polling top-level widgets.
-        """
-        self._start_dialog_watcher()
-        QtWidgets.QApplication.processEvents()
+    def _runCommand(self):
+        QtCore.QTimer.singleShot(500, CallableAcceptDialog(self))
 
         # tested command -- start
         Gui.runCommand("Sketcher_NewSketch", 0)
         # tested command -- end
         Gui.ActiveDocument.resetEdit()
-
-        self._stop_dialog_watcher()
 
         self.sketchSupport = App.ActiveDocument.Sketch.AttachmentSupport
 
@@ -88,9 +52,6 @@ class TestSketchAttachmentSupport(unittest.TestCase):
         """
         if not GUI_AVAILABLE:
             self.skipTest("GUI not available")
-
-        self._dialog_timer = None
-        self._dialog_accepted = False
 
         self.doc = App.newDocument("TestSketchAttachmentSupport")
 
@@ -107,10 +68,6 @@ class TestSketchAttachmentSupport(unittest.TestCase):
         Gui.Selection.clearSelection()
 
     def tearDown(self):
-        """clean up the test document"""
-        # Stop dialog watcher if still running
-        self._stop_dialog_watcher()
-
         if GUI_AVAILABLE and hasattr(self, "doc") and self.doc:
             App.closeDocument(self.doc.Name)
 
@@ -118,9 +75,8 @@ class TestSketchAttachmentSupport(unittest.TestCase):
     def test_attachment_link_to_part(self):
         Gui.Selection.addSelection(self.doc.Name, self.linkToPart.Name, f"{self.box.Name}.Face6")
 
-        self._runCommand_with_watcher()
+        self._runCommand()
 
-        self.assertTrue(self._dialog_accepted)
         self.assertEqual(self.sketchSupport[0][0], self.linkToPart)  # compare support object
         self.assertEqual(self.sketchSupport[0][1][0], "Box.Face6")  # compare support face
 
@@ -128,8 +84,7 @@ class TestSketchAttachmentSupport(unittest.TestCase):
     def test_attachment_original_part(self):
         Gui.Selection.addSelection(self.doc.Name, self.originalPart.Name, f"{self.box.Name}.Face6")
 
-        self._runCommand_with_watcher()
+        self._runCommand()
 
-        self.assertTrue(self._dialog_accepted)
         self.assertEqual(self.sketchSupport[0][0], self.box)  # compare support object
         self.assertEqual(self.sketchSupport[0][1][0], "Face6")  # compare support face

--- a/src/Mod/Sketcher/TestSketcherApp.py
+++ b/src/Mod/Sketcher/TestSketcherApp.py
@@ -31,6 +31,17 @@ from SketcherTests.TestSketchValidateCoincidents import TestSketchValidateCoinci
 from SketcherTests.TestSketchCarbonCopyReverseMapping import TestSketchCarbonCopyReverseMapping
 from SketcherTests.TestSketchInternalFaces import TestSketchInternalFaces
 
+# GUI-dependent tests - only import if GUI is available
+try:
+    import FreeCADGui
+
+    if FreeCADGui.getMainWindow() is not None:
+        from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
+        from SketcherTests.TestAttachmentSupport import TestSketchAttachmentSupport
+except (ImportError, AttributeError):
+    pass  # GUI not available, skip GUI tests
+
+
 # Path and PartDesign tests use these functions that used to live here
 # but moved to SketcherTests/TestSketcherSolver.py
 from SketcherTests.TestSketcherSolver import CreateCircleSketch


### PR DESCRIPTION
### Problem
When creating a sketch by selecting the face of a linked Part, the program asks whether the sketch should be attached to the plane of selected face.

The problem is that the attachment is set on the face of the original object, rather than the linked object, which causes issues when trying to reference external geometry, and means that the sketch doesn't follow the link's placement.

See #22341  for more details.

### Issues
fixes #22341 

### Solution
1. If face of _Link_ object is selected, at _Sketch_ creation its support is set to that _Link_ object.
![solved1](https://github.com/user-attachments/assets/8f04bfb0-0c2d-4951-9e31-a475355ba879)

3. If face of original object is selected, at _Sketch_ creation support is set to original object.
![solved2](https://github.com/user-attachments/assets/5e50dba6-262b-4806-9e48-88fd7b93228a)