### PR TITLE
CAM: Remove remaining reference to deprecated Dogbone dressup

### DIFF
--- a/src/Mod/CAM/Path/GuiInit.py
+++ b/src/Mod/CAM/Path/GuiInit.py
@@ -43,7 +43,6 @@ def Startup():
         from Path.Base.Gui import SetupSheet
         from Path.Dressup.Gui import Array
         from Path.Dressup.Gui import AxisMap
-        from Path.Dressup.Gui import Dogbone
         from Path.Dressup.Gui import DogboneII
         from Path.Dressup.Gui import Dragknife
         from Path.Dressup.Gui import LeadInOut


### PR DESCRIPTION
#27927 missed a reference to deprecated dogbone dressup. This prevents the CAM workbench from loading in the current main.

@sliptonic 