### PR TITLE
BIM: fix BuildingPart color issues including v1.0 regressions

### DIFF
--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -336,8 +336,8 @@ class BuildingPart(ArchIFC.IfcProduct):
                 # v1.0 and v1.1dev
                 material = vobj.ChildrenShapeColor
                 # correct the alpha value of the diffuse color which is wrongly zero:
-                material.DiffuseColor = material.DiffuseColor[:-1] + (1.0, )
-            vobj.ChildrenShapeAppearance = (material, )
+                material.DiffuseColor = material.DiffuseColor[:-1] + (1.0,)
+            vobj.ChildrenShapeAppearance = (material,)
             vobj.setPropertyStatus("ChildrenShapeColor", "-LockDynamic")
             vobj.removeProperty("ChildrenShapeColor")
 
@@ -459,9 +459,7 @@ class BuildingPart(ArchIFC.IfcProduct):
                     if hasattr(child, "Material") and child.Material:
                         matname = child.Material.Name
                     if matname in materialstable:
-                        materialstable[matname] = (
-                            materialstable[matname] + "," + str(solidindex)
-                        )
+                        materialstable[matname] = materialstable[matname] + "," + str(solidindex)
                     else:
                         materialstable[matname] = str(solidindex)
                     solidindex += 1
@@ -535,7 +533,7 @@ class ViewProviderBuildingPart:
             self.setProperties(vobj)
             material = vobj.ShapeAppearance[0]  # App.Material() based on current preferences.
             material.DiffuseColor = ArchCommands.getDefaultColor("Helpers")
-            vobj.ShapeAppearance = (material, )
+            vobj.ShapeAppearance = (material,)
             self.Object = vobj.Object
 
     def setProperties(self, vobj):
@@ -755,7 +753,7 @@ class ViewProviderBuildingPart:
                 locked=True,
             )
             # The default App::PropertyMaterialList does not match the preferences, we have to do:
-            vobj.ChildrenShapeAppearance = (utils.get_view_material(), )
+            vobj.ChildrenShapeAppearance = (utils.get_view_material(),)
         if not "ChildrenTransparency" in pl:
             vobj.addProperty(
                 "App::PropertyPercent",
@@ -933,7 +931,6 @@ class ViewProviderBuildingPart:
         "get the colors of objects inside this BuildingPart"
 
         return Draft.get_diffuse_color(Draft.get_group_contents(obj, walls=True))
-
 
     def onChanged(self, vobj, prop):
 


### PR DESCRIPTION
Fixes #27136.

1. The ChildrenShapeColor property was no longer propagated as children no longer have a ShapeColor. Fixed by renaming the property to ChildrenShapeAppearance. V1.0 regression.
2. That property was of the type `App::PropertyMaterial` which cannot be properly edited in the Property View. Fixed by using `App::PropertyMaterialList` instead. V1.0 regression.
3. Changing the ShapeAppearance of the BP did not change the color of the 3D View annotation elements (label and axes indicators). The name ShapeColor was still used in parts of the code. V1.0 regression.
4. ChildrenLineColor had incorrect alpha value handling. V1.0 regression.
5. ChildrenLineWidth was sometimes misspelled and therefore never propagated.
6. The `getColors` function calls `Draft.get_diffuse_color()`. This fixes the diffuse color issue mentioned above.
7. The `onDocumentRestored` function has been extended to handle older files.
8. `onDocumentRestored` has been removed from the view provider class as it is not supported for view objects.

Additionally:
* The return value of `Draft.get_group_contents(obj, walls=True)` does not contain Space objects. Therefore there is no need to filter them out (2x).