### PR TITLE
TechDraw: clear selection after editing Annotation from 2D page

### DIFF
--- a/src/Mod/TechDraw/Gui/ViewProviderAnnotation.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderAnnotation.cpp
@@ -26,6 +26,7 @@
 #include <App/DocumentObject.h>
 #include <Gui/ComboView.h>
 #include <Gui/DockWindowManager.h>
+#include <Gui/Selection/Selection.h>
 #include <Gui/propertyeditor/PropertyEditor.h>
 #include <Gui/propertyeditor/PropertyModel.h>
 #include <Mod/TechDraw/App/DrawLeaderLine.h>
@@ -95,6 +96,7 @@ TechDraw::DrawViewAnnotation* ViewProviderAnnotation::getViewObject() const
 bool ViewProviderAnnotation::doubleClicked()
 {
     setEdit(ViewProvider::Default);
+    Gui::Selection().clearSelection();
     return true;
 }
 


### PR DESCRIPTION
Issues
Closes #27983

Before: Double-clicking a TechDraw Annotation on the 2D page to edit it leaves the object highlighted in blue in the project tree after editing.

After: The highlight is cleared when the editor closes.