### PR TITLE
BIM: remove switch to profile beam creation based on dimensions

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -463,9 +463,7 @@ class _CommandStructure:
             else:
                 # metal profile
                 FreeCADGui.doCommand("p = Arch.makeProfile(" + str(self.Profile) + ")")
-                if (
-                    abs(self.Length - self.Profile[4]) >= 0.1
-                ) or self.bmode:  # forgive rounding errors
+                if self.bmode:
                     # horizontal
                     FreeCADGui.doCommand(
                         "s = Arch.makeStructure(p,length=" + str(self.Length) + ")"


### PR DESCRIPTION
Fixes #28013.

When creating a structure from a profile the code could ignore `self.bmode` (beam-mode) and create a beam even if the user selected the column option in the task panel.

Rounding errors due to the conversion of numerical values read from the input boxes triggered the bug (89mm -> 3.5" -> 88.89999999999999mm).

But beyond that, it is IMO not correct to disregard user input. If the column option is specified, a column should be created irrespective of the dimensions.