### PR TITLE
Core: Autocomplete fix for linked object properties

### DIFF
--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -1608,4 +1608,31 @@ App::PropertyPlacement* DocumentObject::getPlacementProperty() const
     return getPropertyByName<App::PropertyPlacement>("Placement");
 }
 
+void DocumentObject::getPropertyNamedList(std::vector<std::pair<const char*, Property*>>& List) const
+{
+    TransactionalObject::getPropertyNamedList(List);
+
+    // Get all properties for a linked object if it exists
+    if (this->canLinkProperties()) {
+        auto linked = this->getLinkedObject(true);
+        if (linked && linked != this && linked->isAttachedToDocument()) {
+            std::vector<std::pair<const char*, App::Property*>> linkedProps;
+            linked->getPropertyNamedList(linkedProps);
+
+            for (const auto& lp : linkedProps) {
+                auto it = std::find_if(
+                    List.begin(),
+                    List.end(),
+                    [&](const std::pair<const char*, Property*>& p) {
+                        return std::strcmp(p.first, lp.first) == 0;
+                    }
+                );
+                if (it == List.end()) {
+                    List.push_back(lp);
+                }
+            }
+        }
+    }
+}
+
 

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -1614,20 +1614,25 @@ void DocumentObject::getPropertyNamedList(std::vector<std::pair<const char*, Pro
 
     // Get all properties for a linked object if it exists
     if (this->canLinkProperties()) {
+        // depth is needed to prevent an infinite recursion
+        thread_local int depth = 0;
+        if (!GetApplication().checkLinkDepth(depth, MessageOption::Error)) {
+            return;
+        }
+
         auto linked = this->getLinkedObject(true);
         if (linked && linked != this && linked->isAttachedToDocument()) {
             std::vector<std::pair<const char*, App::Property*>> linkedProps;
+
+            ++depth;
             linked->getPropertyNamedList(linkedProps);
+            --depth;
 
             for (const auto& lp : linkedProps) {
-                auto it = std::find_if(
-                    List.begin(),
-                    List.end(),
-                    [&](const std::pair<const char*, Property*>& p) {
+                if (std::ranges::none_of(List, [&](const auto& p) {
                         return std::strcmp(p.first, lp.first) == 0;
-                    }
-                );
-                if (it == List.end()) {
+                    }))
+                {
                     List.push_back(lp);
                 }
             }

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -1252,6 +1252,9 @@ public:
     /// Returns the Placement property to use if any.
     virtual App::PropertyPlacement* getPlacementProperty() const;
 
+    /// Get a list of all properties of the object with their names.
+    void getPropertyNamedList(std::vector<std::pair<const char*, Property*> > &List) const override;
+
 protected:
     /// Recompute only this object.
     virtual App::DocumentObjectExecReturn* recompute();


### PR DESCRIPTION
Now autocomplete suggests properties of linked objects such as Spreadsheets and VarSets

Closes #12252 and closes #17104

Added a getPropertyNamedList() override to the DocumentObject class to return not only the object's own properties, but also the properties of the linked object when it is a link.