### PR TITLE
Fem: Add property to set pipeline and filters color if Field is None - fixes #21352

### DIFF
--- a/src/Mod/Fem/Gui/Command.cpp
+++ b/src/Mod/Fem/Gui/Command.cpp
@@ -2089,6 +2089,18 @@ void setupFilter(Gui::Command* cmd, std::string Name)
     auto objFilter = App::GetApplication().getActiveDocument()->getActiveObject();
     auto femFilter = static_cast<Fem::FemPostFilter*>(objFilter);
 
+    auto selObjectView = static_cast<FemGui::ViewProviderFemPostObject*>(
+        Gui::Application::Instance->getViewProvider(selObject)
+    );
+    // use none field color from base filter
+    Base::color_traits<Base::Color> ct {selObjectView->NoneFieldColor.getValue()};
+    cmd->doCommand(
+        Gui::Command::Doc,
+        "App.activeDocument().ActiveObject.ViewObject.NoneFieldColor = (%d, %d, %d)",
+        ct.red(),
+        ct.green(),
+        ct.blue()
+    );
     // TODO: FIX
     /*
     auto selObjectView = static_cast<FemGui::ViewProviderFemPostObject*>(

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -167,6 +167,13 @@ ViewProviderFemPostObject::ViewProviderFemPostObject()
         "Set wireframe line color."
     );
     ADD_PROPERTY_TYPE(
+        NoneFieldColor,
+        (0.8f, 0.8f, 0.8f),
+        "Object Style",
+        App::Prop_None,
+        "Shape color used if Field property is None."
+    );
+    ADD_PROPERTY_TYPE(
         PlainColorEdgeOnSurface,
         (false),
         "Object Style",
@@ -689,7 +696,8 @@ void ViewProviderFemPostObject::WriteColorData(bool ResetColorBarRange)
     }
 
     if (Field.getEnumVector().empty() || Field.getValue() == 0) {
-        m_material->diffuseColor.setValue(SbColor(0.8, 0.8, 0.8));
+        Base::Color cNone = NoneFieldColor.getValue();
+        m_material->diffuseColor.setValue(SbColor(cNone.r, cNone.g, cNone.b));
         float trans = Base::fromPercent(Transparency.getValue());
         m_material->transparency.setValue(trans);
         m_materialBinding->value = SoMaterialBinding::OVERALL;
@@ -866,6 +874,9 @@ void ViewProviderFemPostObject::onChanged(const App::Property* prop)
             && (strcmp("Surface with Edges", DisplayMode.getValueAsString()) == 0);
         int child = plainColor ? 1 : 0;
         m_switchMatEdges->whichChild.setValue(child);
+    }
+    else if (prop == &NoneFieldColor) {
+        WriteColorData(ResetColorBarRange);
     }
 
     ViewProviderDocumentObject::onChanged(prop);

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.h
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.h
@@ -84,6 +84,7 @@ public:
     App::PropertyPercent Transparency;
     App::PropertyBool PlainColorEdgeOnSurface;
     App::PropertyColor EdgeColor;
+    App::PropertyColor NoneFieldColor;
     App::PropertyFloatConstraint LineWidth;
     App::PropertyFloatConstraint PointSize;
 

--- a/src/Mod/Fem/femcommands/manager.py
+++ b/src/Mod/Fem/femcommands/manager.py
@@ -406,6 +406,9 @@ class CommandManager:
         FreeCADGui.doCommand(
             'FreeCAD.ActiveDocument.ActiveObject.ViewObject.SelectionStyle = "BoundBox"'
         )
+        FreeCADGui.doCommand(
+            f"FreeCAD.ActiveDocument.ActiveObject.ViewObject.NoneFieldColor = {self.selobj.ViewObject.NoneFieldColor}"
+        )
 
         # hide selected filter
         FreeCADGui.doCommand(


### PR DESCRIPTION


<!-- Include a brief summary of the changes. -->
The property is `NoneFieldColor`.
The initial color is based on the selected object.
The default is the current gray color (although I don't have a strong opinion on this).

@FEA-eng 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #21352 
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
