### PR TITLE
PartDesign/Part: prevent chamfer crash on OCC kernel failure

### DIFF
--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -31,6 +31,7 @@
 #include <TopTools_IndexedMapOfShape.hxx>
 
 
+#include <SignalException.h>
 #include "FeatureChamfer.h"
 #include "TopoShapeOpCode.h"
 
@@ -103,6 +104,7 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         }
         Edges.setValues(edges);
 
+        Part::SignalException sig;
         TopoDS_Shape shape = mkChamfer.Shape();
         if (shape.IsNull()) {
             return new App::DocumentObjectExecReturn("Resulting shape is null");
@@ -114,5 +116,10 @@ App::DocumentObjectExecReturn* Chamfer::execute()
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
+    }
+    catch (...) {
+        return new App::DocumentObjectExecReturn(
+            "Chamfer failed: OCC kernel error in chamfer computation"
+        );
     }
 }

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -101,6 +101,7 @@
 #include "Base/BoundBox.h"
 #include "Base/Exception.h"
 #include "Base/Tools.h"
+#include <SignalException.h>
 #include "OCCTProgressIndicator.h"
 
 #include <App/ElementMap.h>
@@ -4135,13 +4136,23 @@ TopoShape& TopoShape::makeElementChamfer(
         if (!shape.findShape(edge)) {
             FC_THROWM(Base::CADKernelError, "edge does not belong to the shape");
         }
+        if (BRep_Tool::Degenerated(TopoDS::Edge(edge))) {
+            FC_THROWM(Base::CADKernelError, "chamfer edge is degenerated");
+        }
         // Add edge to fillet algorithm
         TopoDS_Shape face;
         if (flipDirection == Flip::flip) {
-            face = shape.findAncestorsShapes(edge, TopAbs_FACE).back();
+            const auto faces = shape.findAncestorsShapes(edge, TopAbs_FACE);
+            if (faces.empty()) {
+                FC_THROWM(Base::CADKernelError, "chamfer edge has no adjacent face");
+            }
+            face = faces.back();
         }
         else {
             face = shape.findAncestorShape(edge, TopAbs_FACE);
+        }
+        if (face.IsNull()) {
+            FC_THROWM(Base::CADKernelError, "chamfer edge has no adjacent face");
         }
         switch (chamferType) {
             case ChamferType::equalDistance:  // Equal distance
@@ -4156,6 +4167,7 @@ TopoShape& TopoShape::makeElementChamfer(
                 break;
         }
     }
+    Part::SignalException sig;
     return makeElementShape(mkChamfer, shape, op);
 }
 

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -39,6 +39,7 @@
 #include <Base/Exception.h>
 #include <Base/Reader.h>
 #include <Base/Tools.h>
+#include <Mod/Part/App/SignalException.h>
 #include <Mod/Part/App/TopoShape.h>
 
 #include "FeatureChamfer.h"
@@ -160,6 +161,7 @@ App::DocumentObjectExecReturn* Chamfer::execute()
     }
     try {
         TopoShape shape(0);
+        Part::SignalException sig;
         shape.makeElementChamfer(
             TopShape,
             edges,
@@ -203,6 +205,11 @@ App::DocumentObjectExecReturn* Chamfer::execute()
     }
     catch (Standard_Failure& e) {
         return new App::DocumentObjectExecReturn(e.GetMessageString());
+    }
+    catch (...) {
+        return new App::DocumentObjectExecReturn(
+            QT_TRANSLATE_NOOP("Exception", "Chamfer failed: OCC kernel error in chamfer computation")
+        );
     }
 }
 


### PR DESCRIPTION
Summary

FreeCAD crashes (SIGSEGV) when a VarSet parameter change triggers recomputation of a Chamfer feature with geometry that OCC's chamfer kernel can't handle.

This adds defensive checks before calling OCC and installs a signal handler to convert the hard crash into a handled error, so the chamfer feature is marked as failed with an error message instead of killing the app.

Issues

Fixes #27221