### PR TITLE
#25004: change the tooltip contents for correct line width location

### DIFF
--- a/src/Mod/BIM/Resources/ui/dialogSetup.ui
+++ b/src/Mod/BIM/Resources/ui/dialogSetup.ui
@@ -287,7 +287,7 @@
          <item row="10" column="1">
           <widget class="QSpinBox" name="settingLinewidth">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default line width. Location in preferences: &lt;span style=&quot; font-weight:600;&quot;&gt;Part/Part Design &amp;gt; Shape Appearance &amp;gt; Default line width &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Default line width. Location in preferences: &lt;span style=&quot; font-weight:600;&quot;&gt;Part/Part Design &amp;gt; Shape Appearance &amp;gt; Line width &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="suffix">
             <string> px</string>


### PR DESCRIPTION
## Summary

This PR updates the tooltip text for **“Default line width”** in the BIM Setup dialog to reflect the correct preference path in FreeCAD 1.2.

The previous tooltip referenced outdated locations in Preferences. This change corrects the path so it now matches the current UI structure.

---

## Issues
#25004 
Fixes incorrect/outdated tooltip information in the BIM Setup dialog.

---

## Description of Change

**Previous tooltip text:**

> Default line width. Location in preferences:
> Display > Part colors > Default line width,
> Draft > Visual settings > Default line width

**Updated tooltip text:**

> Default line width. Location in preferences:
> Part/Part Design > Shape Appearance > Line width

This now correctly reflects the current Preferences structure.

---

## Before and After

**Before:**
Tooltip referenced outdated preference paths under Display and Draft.
<img width="2940" height="1912" alt="image" src="https://github.com/user-attachments/assets/7388d485-b173-4533-b05a-b66d1cc2b862" />

**After:**
Tooltip correctly references:
Part/Part Design → Shape Appearance → Default line width.
<img width="1470" height="956" alt="Screenshot 2026-03-05 at 11 04 43 AM" src="https://github.com/user-attachments/assets/c43b23b7-9702-4308-96b4-b3b4c99bda1c" />

---

## Alignment

* Improves UI clarity and correctness.
* Keeps BIM Setup consistent with current Preferences layout.
* No workflow or functional changes.