### PR TITLE
3rdParty: Fix invalid doxygen syntax in Json @requirement

### DIFF
--- a/src/3rdParty/json/single_include/nlohmann/json.hpp
+++ b/src/3rdParty/json/single_include/nlohmann/json.hpp
@@ -13578,7 +13578,7 @@ This class implements a both iterators (iterator and const_iterator) for the
       been set (e.g., by a constructor or a copy assignment). If the iterator is
       default-constructed, it is *uninitialized* and most methods are undefined.
       **The library uses assertions to detect calls on uninitialized iterators.**
-@requirement The class satisfies the following concept requirements:
+@requirement REQ-JSON-02 The class satisfies the following concept requirements:
 -
 [BidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator):
   The iterator that can be moved can be moved in both directions (i.e.
@@ -14337,7 +14337,7 @@ namespace detail
 iterator (to create @ref reverse_iterator) and @ref const_iterator (to
 create @ref const_reverse_iterator).
 
-@requirement The class satisfies the following concept requirements:
+@requirement REQ-JSON-01 The class satisfies the following concept requirements:
 -
 [BidirectionalIterator](https://en.cppreference.com/w/cpp/named_req/BidirectionalIterator):
   The iterator that can be moved can be moved in both directions (i.e.


### PR DESCRIPTION
Correct syntax requires an ID to be the first argument of `@requirement`. Because an ID is missing, Doxygen uses 'The' as requirement ID. This in turn creates a link on *every* instance of the word 'The' during autolinking.

Relates to https://github.com/nlohmann/json/issues/5095
You could alternatively wait for a fix upstream and then include theirs.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
- https://github.com/nlohmann/json/issues/5095

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

### Before:

<img width="1165" height="515" alt="image" src="https://github.com/user-attachments/assets/ccd1be82-102f-4b95-a2a0-bf9934696d47" />

<img width="1052" height="321" alt="image" src="https://github.com/user-attachments/assets/ded21c1e-c3fd-410f-b74c-3fba0e236499" />


### After:

<img width="1141" height="519" alt="image" src="https://github.com/user-attachments/assets/01a5f483-2428-45b1-a11f-6dd7e88ad6f3" />

<img width="1241" height="979" alt="image" src="https://github.com/user-attachments/assets/8aec39da-0870-4f7e-b184-66d5bee1b617" />

(Note that the requirements page is not linked to anywhere, and must be accessed directly. However, **only** json uses it.)

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
