### PR TITLE
pd: part design: preserve selection after cancel of dressup feature

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.cpp
@@ -374,7 +374,7 @@ void TaskDressUpParameters::keyPressEvent(QKeyEvent* ke)
 
 const std::vector<std::string> TaskDressUpParameters::getReferences() const
 {
-    PartDesign::DressUp* pcDressUp = DressUpView->getObject<PartDesign::DressUp>();
+    auto* pcDressUp = DressUpView->getObject<PartDesign::DressUp>();
     std::vector<std::string> result = pcDressUp->Base.getSubValues();
     return result;
 }
@@ -481,6 +481,15 @@ TaskDlgDressUpParameters::TaskDlgDressUpParameters(ViewProviderDressUp* DressUpV
     if (changed) {
         pcDressUp->Base.setValue(base, newSubList);
     }
+
+    auto baseObj = pcDressUp->Base.getValue();
+    auto subValues = pcDressUp->Base.getSubValues();
+    if (baseObj && !subValues.empty()) {
+        m_hadPreSelection = true;
+        m_savedDocName = baseObj->getDocument()->getName();
+        m_savedObjName = baseObj->getNameInDocument();
+        m_savedSubNames = subValues;
+    }
 }
 
 TaskDlgDressUpParameters::~TaskDlgDressUpParameters() = default;
@@ -505,7 +514,27 @@ bool TaskDlgDressUpParameters::accept()
 bool TaskDlgDressUpParameters::reject()
 {
     getViewObject<ViewProviderDressUp>()->highlightReferences(false);
-    return TaskDlgFeatureParameters::reject();
+
+    // capture saved state before reject potentially destroys things
+    bool hadPreSel = m_hadPreSelection;
+    std::string docName = m_savedDocName;
+    std::string objName = m_savedObjName;
+    std::vector<std::string> subNames = m_savedSubNames;
+
+    bool result = TaskDlgFeatureParameters::reject();
+
+    // restore user's selection if they had pre-selected
+    // ie. edges before invoking the tool
+    // and restore it on the next event loop tick, after cleanup is done
+    if (hadPreSel) {
+        QTimer::singleShot(0, [docName, objName, subNames]() {
+            for (const auto& sub : subNames) {
+                Gui::Selection().addSelection(docName.c_str(), objName.c_str(), sub.c_str());
+            }
+        });
+    }
+
+    return result;
 }
 
 #include "moc_TaskDressUpParameters.cpp"

--- a/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
+++ b/src/Mod/PartDesign/Gui/TaskDressUpParameters.h
@@ -138,6 +138,13 @@ public:
     bool accept() override;
     bool reject() override;
 
+private:
+    // prefixed variable names with `m_` because their member variables NOT berries
+    bool m_hadPreSelection = false;
+    std::string m_savedDocName;
+    std::string m_savedObjName;
+    std::vector<std::string> m_savedSubNames;
+
 protected:
     TaskDressUpParameters* parameter;
 };


### PR DESCRIPTION
this PR handles case #2 below

1. the user has created a pd body, a sketch, padded the sketch, and then with nothing selected opens the chamfer tool.
  - within this scenario the selection of say ie. edges should be lost IMHO.
2. the user creates pd body, sketch, pads sketch. then selects say two edges. **then selects / runs the chamfer tool**

this is where this PR addresses sceanrio #2

if the user has a rather complex selection before running a dressup feature then that selection should be restored IMHO.

---

i don't mind writing a few tests to handle the different scenarios, but would like to see / hear some feedback from other users / developers about how the different situations should be handled.

## Issues

- https://github.com/freecad/freecad/issues/28015

## Before and After Images

https://github.com/user-attachments/assets/c1756cb5-b4c7-4acd-97e6-5fbb8e09d451


