### PR TITLE
Gui: Fix crash in ExpressionBinding::hasExpression during paint event

### DIFF
--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -126,7 +126,12 @@ void ExpressionBinding::bind(const Property& prop)
 
 bool ExpressionBinding::hasExpression() const
 {
-    return isBound() && getExpression() != nullptr;
+    try {
+        return isBound() && getExpression() != nullptr;
+    }
+    catch (const Base::Exception&) {
+        return false;
+    }
 }
 
 std::shared_ptr<App::Expression> ExpressionBinding::getExpression() const


### PR DESCRIPTION
## Summary

- Fixes a crash (SIGABRT / `std::terminate`) triggered when typing a VarSet property name that starts with a letter matching an existing identifier (e.g. "i")
- `PropertyExpressionEngine::canonicalPath` throws `Base::RuntimeError` when the property path cannot be resolved, and this exception propagates uncaught through the Qt paint event chain: `QuantitySpinBox::paintEvent` → `ExpressionSpinBox::drawControl` → `ExpressionBinding::hasExpression` → `getExpression` → `canonicalPath`
- C++ exceptions cannot safely propagate through Qt event handlers, so this causes `std::terminate`
- The fix wraps `hasExpression()` in a try/catch that returns `false` when expression resolution fails transiently

## Steps to reproduce

1. Open the attached file `crash1.FCStd` (or any file with a VarSet)
2. Open the VarSet property editor
3. Start typing a new property name beginning with the letter "i"
4. FreeCAD crashes with SIGABRT

## Crash backtrace

```
frame #7: __cxxabiv1::failed_throw
frame #8: __cxa_throw
frame #9: App::PropertyExpressionEngine::canonicalPath at PropertyExpressionEngine.cpp:487
frame #10: App::PropertyExpressionEngine::getPathValue at PropertyExpressionEngine.cpp:565
frame #11: App::DocumentObject::getExpression at DocumentObject.cpp:1192
frame #12: Gui::ExpressionBinding::getExpression at ExpressionBinding.cpp:138
frame #13: Gui::ExpressionBinding::hasExpression at ExpressionBinding.cpp:129
frame #14: Gui::ExpressionSpinBox::drawControl at SpinBox.cpp:232
frame #15: Gui::QuantitySpinBox::paintEvent at QuantitySpinBox.cpp:476
```

## Test plan

- [x] Open a file with a VarSet, type property names starting with "i" — no crash
- [ ] Verify expression-bound spin boxes still display correctly
- [ ] Verify expression editing still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)