### PR TITLE
BIM: fix zero level height warning dialog

### DIFF
--- a/src/Mod/BIM/bimcommands/BimProjectManager.py
+++ b/src/Mod/BIM/bimcommands/BimProjectManager.py
@@ -370,7 +370,7 @@ class BIM_ProjectManager:
                 msg.setInformativeText(
                     translate("BIM", "Please set the level height to a non-zero value.")
                 )
-                msg.exec_()
+                msg.exec()
             if self.form.countLevels.value() and levelHeight:
                 h = 0
                 alabels = []


### PR DESCRIPTION
Fixes the BIM Project Setup dialog not explaining why levels are not created when level height is zero. Also addresses additional issues  reported in the comments: the level height field now shows the system unit (for example 0 mm), levels no longer get created with 0 height silently , and the human figure is restored.

Issues
Fixes #25033

Before: No warning shown, levels silently not created, height field shows no unit, no human figure

After: Warning dialog shown when height is zero, height field shows 0 mm, human figure works correctly

