### PR TITLE
Spreadsheet: restore Ctrl+A select-all when table has focus

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -484,6 +484,10 @@ bool SheetTableView::event(QEvent* event)
             default:
                 break;
         }
+        if (kevent->matches(QKeySequence::SelectAll)) {
+            QTableView::selectAll();
+            return true;
+        }
         if (kevent->matches(QKeySequence::Delete) || kevent->matches(QKeySequence::Backspace)) {
             deleteSelection();
         }
@@ -535,6 +539,9 @@ bool SheetTableView::event(QEvent* event)
             }
         }
 
+        if (kevent->matches(QKeySequence::SelectAll)) {
+            kevent->accept();
+        }
         if (kevent->matches(QKeySequence::Delete) || kevent->matches(QKeySequence::Backspace)) {
             kevent->accept();
         }


### PR DESCRIPTION
Fixes Ctrl+A not selecting all cells in the Spreadsheet view. The ShortcutOverride handler wasn't accepting QKeySequence::SelectAll, so Qt routed it to the global Std_SelectAll instead.

Issues
Fixes #27151