### PR TITLE
Sketcher: skip non-toggleable geometry in ToggleConstruction

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
+++ b/src/Mod/Sketcher/Gui/CommandAlterGeometry.cpp
@@ -207,6 +207,10 @@ void CmdSketcherToggleConstruction::activated(int iMsg)
             // only handle edges
             if (subname.size() > 4 && subname.substr(0, 4) == "Edge") {
                 int geoId = std::atoi(subname.substr(4, 4000).c_str()) - 1;
+                auto gf = Obj->getGeometryFacade(geoId);
+                if (!gf || gf->isInternalAligned()) {
+                    continue;
+                }
                 // issue the actual commands to toggle
                 Gui::cmdAppObjectArgs(Obj, "toggleConstruction(%d) ", geoId);
             }


### PR DESCRIPTION
Fixes #28055.

When box-selecting a sketch with a B-spline, internally-aligned geometry (weight circles, control polygon edges) gets included in the selection. These cannot be toggled and previously caused an exception that aborted the loop early, leaving only part of the selection toggled and showing an error dialog.

Fixed by checking `isInternalAligned()` in the command before calling `toggleConstruction()`, so such edges are skipped and the rest of the selection is processed normally.