### PR TITLE
Gui: Prevent unhandled exception adding properties

### DIFF
--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -804,6 +804,9 @@ bool DlgAddProperty::clearBoundProperty()
 
     if (App::Property* prop = propertyItem->getFirstProperty()) {
         propertyItem->unbind();
+        if (auto* eb = dynamic_cast<ExpressionBinding*>(editor.get())) {
+            eb->unbind();
+        }
         propertyItem->removeProperty(prop);
         container->removeDynamicProperty(prop->getName());
         closeTransaction(TransactionOption::Abort);

--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -334,6 +334,12 @@ QPixmap ExpressionWidget::getIcon(const char* name, const QSize& size) const
     return icon;
 }
 
+void ExpressionWidget::unbind()
+{
+    iconLabel->hide();
+    ExpressionBinding::unbind();
+}
+
 void ExpressionWidget::makeLabel(QLineEdit* le)
 {
     defaultPalette = le->palette();

--- a/src/Gui/ExpressionBinding.h
+++ b/src/Gui/ExpressionBinding.h
@@ -49,7 +49,7 @@ public:
     virtual void bind(const App::ObjectIdentifier& _path);
     virtual void bind(const App::Property& prop);
     bool isBound() const;
-    void unbind();
+    virtual void unbind();
     virtual bool apply(const std::string& propName);
     virtual bool apply();
     bool hasExpression() const;
@@ -99,6 +99,7 @@ class GuiExport ExpressionWidget: public ExpressionBinding
 public:
     ExpressionWidget();
     QPixmap getIcon(const char* name, const QSize& size) const;
+    void unbind() override;
 
 protected:
     void makeLabel(QLineEdit* parent);


### PR DESCRIPTION
This commit prevents unhandled exceptions to be thrown in the Add Property dialog.  When the user provides a valid name, for example 'Abc' and then an invalid name, for example 'Abc^', an exception is thrown that is caught by Qt's notify which may lead to a crash.  This is caused by the fact that the editor is still bound to the old property that has been removed.  The main idea was to preserve values that were provided by the user as long as possible, also when a property name changes. This design goal tried to preserve the user provided value even if the property name is not valid.  Although the underlying property item is explicitly unbound in that situation, the editor is not.

The solution is to also explicitly unbind the editor if there is an editor that can have bindings.  Unbinding an editor does not automatically hide the f(x) symbol in the editor (leading to errors on unbound editors), so this commit also adds a bit of logic to hide the f(x) symbol when an editor is unbound.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

Reported in [this comment](https://github.com/FreeCAD/FreeCAD/issues/27741#issuecomment-3960701427).

## Before and After Images

### Before

<img width="1361" height="1012" alt="screenshot" src="https://github.com/user-attachments/assets/8253e11c-ca64-448f-849b-63c4a9f7b6c4" />


### After
<img width="1358" height="1011" alt="screenshot_000" src="https://github.com/user-attachments/assets/8a0e85fb-9b9b-4803-8984-29ec81f5d6bd" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
