### PR TITLE
PartDesign: Fix wireframe not working on external link to body

### DIFF
--- a/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBody.cpp
@@ -113,6 +113,29 @@ void ViewProviderBody::setOverrideMode(const std::string& mode)
     }
     else {
         overrideMode = mode;
+
+        // Propagate the override mode to child features.
+        // When the Body is an external link, the global viewport loop
+        // won't reach these children automatically.
+        if (pcObject && !isRestoring()) {
+            Gui::Document* gdoc = Gui::Application::Instance->getDocument(pcObject->getDocument());
+            if (gdoc) {
+                PartDesign::Body* body = static_cast<PartDesign::Body*>(getObject());
+                auto features = body->Group.getValues();
+                for (auto feature : features) {
+                    if (feature && feature->isDerivedFrom<PartDesign::Feature>()) {
+                        if (Gui::ViewProvider* vp = gdoc->getViewProvider(feature)) {
+                            vp->setOverrideMode(mode);
+                        }
+                    }
+                }
+                if (App::DocumentObject* base = body->BaseFeature.getValue()) {
+                    if (Gui::ViewProvider* vp = gdoc->getViewProvider(base)) {
+                        vp->setOverrideMode(mode);
+                    }
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/27980
Fix https://github.com/FreeCAD/FreeCAD/issues/16830
Fix https://github.com/FreeCAD/FreeCAD/issues/7245

Before this PR, `ViewProviderBody::setOverrideMode` is relying on `View3DInventorViewer::setOverrideMode` to set the override to the body child. The catch is that if we are setting the override from an external file (so a file containing a link to the body), then it will not happen. So we apply the override to the features in the body.