### PR TITLE
CAM: fix findParentJob returning the wrong job in some cases

### DIFF
--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -515,17 +515,29 @@ def findParentJob(obj):
     if hasattr(obj, "Proxy") and isinstance(obj.Proxy, PathJob.ObjectJob):
         return obj
 
+    # we need to traverse the document tree in reverse order:
+    #
+    #    Job <- Operations <- Dressup <- Operation
+    #        <- Model <- Body
+    #        <- Stock <- Body
+    #        <- SetupSheet
+    #        <- Tools <- ToolController
+
     for i in obj.InList:
-        if hasattr(i, "Proxy") and isinstance(i.Proxy, PathJob.ObjectJob):
-            return i
         if (
-            i.TypeId == "Path::FeaturePython"
-            or i.TypeId == "Path::FeatureCompoundPython"
-            or i.TypeId == "App::DocumentObjectGroup"
+            hasattr(i, "Proxy")
+            and isinstance(i.Proxy, PathJob.ObjectJob)
+            and obj in [i.Operations, i.Model, i.Stock, i.SetupSheet, i.Tools]
+        ):
+            return i
+
+        if (i.isDerivedFrom("App::DocumentObjectGroup") and obj in i.Group) or (
+            i.isDerivedFrom("Path::Feature") and obj == getattr(i, "Base", None)
         ):
             grandParent = findParentJob(i)
             if grandParent is not None:
                 return grandParent
+
     return None
 
 


### PR DESCRIPTION
fixes #28070

My attempt to fix that bug, see bug details for a description of when this happens.

This PR tries to be more picky what objects to consider when searching for the parent job. Inspired by @tarman3's [answer](https://github.com/FreeCAD/FreeCAD/issues/28070#issuecomment-3995588920) to the issue.

I'm marking this as a draft. I'll try to run it for a while and check that there are no unforseen consequences. In case someone has a better idea on how to implement this or some other comments, I'm all ears :+1: 