### PR TITLE
TechDraw: Polish Balloon task panel UI

### DIFF
--- a/src/Mod/TechDraw/Gui/TaskBalloon.cpp
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.cpp
@@ -82,6 +82,8 @@ TaskBalloon::TaskBalloon(QGIViewBalloon *parent, ViewProviderBalloon *balloonVP)
     ui->qsbLineWidth->setSingleStep(0.100);
     ui->qsbLineWidth->setMinimum(0);
 
+    ui->gbLeader->setChecked(balloonVP->LineVisible.getValue() != 0);
+
     // negative kink length is allowed, thus no minimum
     ui->qsbKinkLength->setUnit(Base::Unit::Length);
 
@@ -89,17 +91,17 @@ TaskBalloon::TaskBalloon(QGIViewBalloon *parent, ViewProviderBalloon *balloonVP)
         ui->textColor->setColor(balloonVP->Color.getValue().asValue<QColor>());
         connect(ui->textColor, &ColorButton::changed, this, &TaskBalloon::onColorChanged);
         ui->qsbFontSize->setValue(balloonVP->Fontsize.getValue());
-        ui->comboLineVisible->setCurrentIndex(balloonVP->LineVisible.getValue());
         ui->qsbLineWidth->setValue(balloonVP->LineWidth.getValue());
     }
     // new balloons have already the preferences BalloonKink length
     ui->qsbKinkLength->setValue(parent->getBalloonFeat()->KinkLength.getValue());
 
     connect(ui->qsbFontSize, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskBalloon::onFontsizeChanged);
-    connect(ui->comboLineVisible, qOverload<int>(&QComboBox::currentIndexChanged), this, &TaskBalloon::onLineVisibleChanged);
+    connect(ui->gbLeader,&QGroupBox::toggled, this, &TaskBalloon::onLineVisibleChanged);
     connect(ui->qsbLineWidth, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskBalloon::onLineWidthChanged);
     connect(ui->qsbKinkLength, qOverload<double>(&QuantitySpinBox::valueChanged), this, &TaskBalloon::onKinkLengthChanged);
 
+    onLineVisibleChanged(ui->gbLeader->isChecked());
 }
 
 TaskBalloon::~TaskBalloon()
@@ -201,9 +203,9 @@ void TaskBalloon::onEndSymbolScaleChanged()
     recomputeFeature();
 }
 
-void TaskBalloon::onLineVisibleChanged()
+void TaskBalloon::onLineVisibleChanged(bool isVisible)
 {
-    m_balloonVP->LineVisible.setValue(ui->comboLineVisible->currentIndex());
+    m_balloonVP->LineVisible.setValue(isVisible ? 1 : 0);
     recomputeFeature();
 }
 

--- a/src/Mod/TechDraw/Gui/TaskBalloon.h
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.h
@@ -63,7 +63,7 @@ private Q_SLOTS:
     void onShapeScaleChanged();
     void onEndSymbolChanged();
     void onEndSymbolScaleChanged();
-    void onLineVisibleChanged();
+    void onLineVisibleChanged(bool isVisible);
     void onLineWidthChanged();
     void onKinkLengthChanged();
 

--- a/src/Mod/TechDraw/Gui/TaskBalloon.ui
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>279</height>
+    <width>337</width>
+    <height>440</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,348 +15,354 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Text</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="leText">
-       <property name="toolTip">
-        <string>Text to be displayed</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Text color</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="Gui::ColorButton" name="textColor">
-       <property name="toolTip">
-        <string>Color for text</string>
-       </property>
-       <property name="color">
-        <color>
-         <red>0</red>
-         <green>0</green>
-         <blue>0</blue>
-        </color>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Font size</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbFontSize">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Font size for text</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="value">
-        <double>4.000000000000000</double>
-       </property>
-       <property name="prefEntry" stdset="0">
-        <cstring>BalloonKink</cstring>
-       </property>
-       <property name="prefPath" stdset="0">
-        <cstring>Mod/TechDraw/Dimensions</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Bubble shape</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="comboBubbleShape">
-       <property name="toolTip">
-        <string>Shape of the balloon bubble</string>
-       </property>
-       <item>
+    <widget class="QGroupBox" name="gbAnnotation">
+     <property name="title">
+      <string>Annotation</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout" columnstretch="1,1">
+      <property name="verticalSpacing">
+       <number>12</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lText">
         <property name="text">
-         <string>Circular</string>
+         <string>Text</string>
         </property>
-        <property name="icon">
-         <iconset resource="Resources/TechDraw.qrc">
-          <normaloff>:/icons/circular.svg</normaloff>:/icons/circular.svg</iconset>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="leText">
+        <property name="toolTip">
+         <string>Text to be displayed</string>
         </property>
-       </item>
-       <item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lColor">
         <property name="text">
-         <string>None</string>
+         <string>Color</string>
         </property>
-        <property name="icon">
-         <iconset resource="Resources/TechDraw.qrc">
-          <normaloff>:/icons/none.svg</normaloff>:/icons/none.svg</iconset>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::ColorButton" name="textColor">
+        <property name="toolTip">
+         <string>Color for text</string>
         </property>
-       </item>
-       <item>
+        <property name="color" stdset="0">
+         <color>
+          <red>0</red>
+          <green>0</green>
+          <blue>0</blue>
+         </color>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="lFSize">
         <property name="text">
-         <string>Triangle</string>
+         <string>Font size</string>
         </property>
-        <property name="icon">
-         <iconset resource="Resources/TechDraw.qrc">
-          <normaloff>:/icons/triangle.svg</normaloff>:/icons/triangle.svg</iconset>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::QuantitySpinBox" name="qsbFontSize" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-       </item>
-       <item>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Font size for text</string>
+        </property>
+        <property name="value" stdset="0">
+         <double>4.000000000000000</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>BalloonKink</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/TechDraw/Dimensions</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbBubble">
+     <property name="title">
+      <string>Bubble Appearance</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="1,1">
+      <property name="verticalSpacing">
+       <number>12</number>
+      </property>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lBShape">
         <property name="text">
-         <string>Inspection</string>
+         <string>Bubble shape</string>
         </property>
-        <property name="icon">
-         <iconset resource="Resources/TechDraw.qrc">
-          <normaloff>:/icons/inspection.svg</normaloff>:/icons/inspection.svg</iconset>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="comboBubbleShape">
+        <property name="toolTip">
+         <string>Shape of the balloon bubble</string>
         </property>
-       </item>
-       <item>
+        <item>
+         <property name="text">
+          <string>Circular</string>
+         </property>
+         <property name="icon">
+          <iconset resource="Resources/TechDraw.qrc">
+           <normaloff>:/icons/circular.svg</normaloff>:/icons/circular.svg</iconset>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+         <property name="icon">
+          <iconset resource="Resources/TechDraw.qrc">
+           <normaloff>:/icons/none.svg</normaloff>:/icons/none.svg</iconset>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Triangle</string>
+         </property>
+         <property name="icon">
+          <iconset resource="Resources/TechDraw.qrc">
+           <normaloff>:/icons/triangle.svg</normaloff>:/icons/triangle.svg</iconset>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Inspection</string>
+         </property>
+         <property name="icon">
+          <iconset resource="Resources/TechDraw.qrc">
+           <normaloff>:/icons/inspection.svg</normaloff>:/icons/inspection.svg</iconset>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Hexagon</string>
+         </property>
+         <property name="icon">
+          <iconset resource="Resources/TechDraw.qrc">
+           <normaloff>:/icons/hexagon.svg</normaloff>:/icons/hexagon.svg</iconset>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Square</string>
+         </property>
+         <property name="icon">
+          <iconset resource="Resources/TechDraw.qrc">
+           <normaloff>:/icons/square.svg</normaloff>:/icons/square.svg</iconset>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Rectangle</string>
+         </property>
+         <property name="icon">
+          <iconset resource="Resources/TechDraw.qrc">
+           <normaloff>:/icons/rectangle.svg</normaloff>:/icons/rectangle.svg</iconset>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Line</string>
+         </property>
+         <property name="icon">
+          <iconset resource="Resources/TechDraw.qrc">
+           <normaloff>:/icons/bottomline.svg</normaloff>:/icons/bottomline.svg</iconset>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lBScale">
         <property name="text">
-         <string>Hexagon</string>
+         <string>Shape scale</string>
         </property>
-        <property name="icon">
-         <iconset resource="Resources/TechDraw.qrc">
-          <normaloff>:/icons/hexagon.svg</normaloff>:/icons/hexagon.svg</iconset>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::QuantitySpinBox" name="qsbShapeScale" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
         </property>
-       </item>
-       <item>
+        <property name="toolTip">
+         <string>Bubble shape scale factor</string>
+        </property>
+        <property name="minimum" stdset="0">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="singleStep" stdset="0">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value" stdset="0">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbLeader">
+     <property name="title">
+      <string>Leader Line</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3" columnstretch="1,0" columnminimumwidth="0,0">
+      <property name="verticalSpacing">
+       <number>12</number>
+      </property>
+      <item row="1" column="1">
+       <widget class="Gui::QuantitySpinBox" name="qsbSymbolScale" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>End symbol scale factor</string>
+        </property>
+        <property name="minimum" stdset="0">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="singleStep" stdset="0">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value" stdset="0">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="Gui::QuantitySpinBox" name="qsbLineWidth" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Leader line width</string>
+        </property>
+        <property name="value" stdset="0">
+         <double>0.350000000000000</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>BalloonKink</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/TechDraw/Dimensions</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="lKink">
         <property name="text">
-         <string>Square</string>
+         <string>Kink length</string>
         </property>
-        <property name="icon">
-         <iconset resource="Resources/TechDraw.qrc">
-          <normaloff>:/icons/square.svg</normaloff>:/icons/square.svg</iconset>
-        </property>
-       </item>
-       <item>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="lWidth">
         <property name="text">
-         <string>Rectangle</string>
+         <string>Width</string>
         </property>
-        <property name="icon">
-         <iconset resource="Resources/TechDraw.qrc">
-          <normaloff>:/icons/rectangle.svg</normaloff>:/icons/rectangle.svg</iconset>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="comboEndSymbol">
+        <property name="toolTip">
+         <string>End symbol for the balloon line</string>
         </property>
-       </item>
-       <item>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="lSScale">
         <property name="text">
-         <string>Line</string>
+         <string>Symbol Scale</string>
         </property>
-        <property name="icon">
-         <iconset resource="Resources/TechDraw.qrc">
-          <normaloff>:/icons/bottomline.svg</normaloff>:/icons/bottomline.svg</iconset>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Shape scale</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbShapeScale">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Bubble shape scale factor</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="minimum">
-        <double>0.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>End symbol</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QComboBox" name="comboEndSymbol">
-       <property name="toolTip">
-        <string>End symbol for the balloon line</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_10">
-       <property name="text">
-        <string>End symbol scale</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbSymbolScale">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>End symbol scale factor</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="minimum">
-        <double>0.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>Line visible</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QComboBox" name="comboLineVisible">
-       <property name="toolTip">
-        <string>Controls whether the leader line is visible or not</string>
-       </property>
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <item>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="lSymbol">
         <property name="text">
-         <string>False</string>
+         <string>Symbol</string>
         </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>True</string>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="Gui::QuantitySpinBox" name="qsbKinkLength" native="true">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-       </item>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Line width</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbLineWidth">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Leader line width</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="value">
-        <double>0.350000000000000</double>
-       </property>
-       <property name="prefEntry" stdset="0">
-        <cstring>BalloonKink</cstring>
-       </property>
-       <property name="prefPath" stdset="0">
-        <cstring>Mod/TechDraw/Dimensions</cstring>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="text">
-        <string>Leader kink length</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="Gui::QuantitySpinBox" name="qsbKinkLength">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Length of balloon leader line kink</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="value">
-        <double>5.000000000000000</double>
-       </property>
-       <property name="prefEntry" stdset="0">
-        <cstring>BalloonKink</cstring>
-       </property>
-       <property name="prefPath" stdset="0">
-        <cstring>Mod/TechDraw/Dimensions</cstring>
-       </property>
-      </widget>
-     </item>
-    </layout>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Length of balloon leader line kink</string>
+        </property>
+        <property name="value" stdset="0">
+         <double>5.000000000000000</double>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>BalloonKink</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/TechDraw/Dimensions</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/Mod/TechDraw/Gui/TaskBalloon.ui
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.ui
@@ -40,7 +40,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="lColor">
         <property name="text">
-         <string>Color</string>
+         <string>Text color</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/TechDraw/Gui/TaskBalloon.ui
+++ b/src/Mod/TechDraw/Gui/TaskBalloon.ui
@@ -309,7 +309,7 @@
       <item row="1" column="0">
        <widget class="QLabel" name="lSScale">
         <property name="text">
-         <string>Symbol Scale</string>
+         <string>Symbol scale</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
## Summary
The Balloon task panel in TechDraw has a few UI issues.
1) There is no grouping of similiarly concerned tools
2) The columns of the grid aren't equal width
3) The "Line visible" combobox only displays True/False options, so it should be a checkbox instead

This PR:
1) Groups alike tools together
2) Fixes column width ratio
3) Replaces the "Line Visible" combobox with a checkbox.

## Issues
There are no existing issues for this change.

## Before
<img width="462" height="450" alt="20260305_11h54m49s_grim" src="https://github.com/user-attachments/assets/eea47eb0-9cec-40d2-86f3-0726a04da607" />


## After

<img width="461" height="657" alt="20260305_12h34m01s_grim" src="https://github.com/user-attachments/assets/b79408f2-0de7-40a5-8062-af3609bef878" />


## After with Disable of Leader Line

<img width="469" height="648" alt="20260305_14h10m55s_grim" src="https://github.com/user-attachments/assets/9ca3efeb-79f4-4f9d-85ad-0f52409a5560" />
