### PR TITLE
Fix Linux SpaceMouse performance: event coalescing, camera batching, per-axis deadzone

### DIFF
--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <FCConfig.h>
+#include <App/Application.h>
 
 #include "GuiNativeEventLinux.h"
 
@@ -87,6 +88,20 @@ void Gui::GuiNativeEvent::pollSpacenav()
         }
     }
     if (hasMotion) {
+        // Per-axis deadzone: zero out axes below their individual threshold.
+        // Configured via user.cfg BaseApp/Spaceball/Motion/{Axis}Deadzone.
+        static const char* axisDeadzoneKeys[] = {
+            "PanLRDeadzone", "PanUDDeadzone", "ZoomDeadzone",
+            "TiltDeadzone", "RollDeadzone", "SpinDeadzone"
+        };
+        auto hGrp = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Spaceball/Motion");
+        for (int i = 0; i < 6; i++) {
+            int dz = static_cast<int>(hGrp->GetInt(axisDeadzoneKeys[i], 0));
+            if (dz > 0 && motionDataArray[i] > -dz && motionDataArray[i] < dz) {
+                motionDataArray[i] = 0;
+            }
+        }
         mainApp->postMotionEvent(motionDataArray);
     }
 }

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -37,11 +37,8 @@
 
 #include <spnav.h>
 
-namespace
-{
-
 // Cached per-axis deadzone values, auto-updated via Observer when user.cfg changes.
-class DeadzoneCache: public ParameterGrp::ObserverType
+class Gui::DeadzoneCache: public ParameterGrp::ObserverType
 {
 public:
     static constexpr std::array<const char*, 6> keys = {
@@ -88,8 +85,6 @@ private:
     ParameterGrp::handle hGrp;
 };
 
-}  // namespace
-
 Gui::GuiNativeEvent::GuiNativeEvent(Gui::GUIApplicationNativeEventAware* app)
     : GuiAbstractNativeEvent(app)
 {}
@@ -118,6 +113,11 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
         QSocketNotifier* SpacenavNotifier
             = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
         connect(SpacenavNotifier, SIGNAL(activated(int)), this, SLOT(pollSpacenav()));
+        dzCache = std::make_unique<DeadzoneCache>(
+            App::GetApplication().GetParameterGroupByPath(
+                "User parameter:BaseApp/Spaceball/Motion"
+            )
+        );
         mainApp->setSpaceballPresent(true);
     }
 }
@@ -147,13 +147,12 @@ void Gui::GuiNativeEvent::pollSpacenav()
     if (hasMotion) {
         // Per-axis deadzone: zero out axes below their individual threshold.
         // Values cached and auto-updated via Observer when user.cfg changes.
-        static DeadzoneCache dzCache(
-            App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Spaceball/Motion")
-        );
-        for (size_t i = 0; i < dzCache.values.size(); i++) {
-            int dz = dzCache.values[i];
-            if (dz > 0 && std::abs(motionDataArray[i]) < dz) {
-                motionDataArray[i] = 0;
+        if (dzCache) {
+            for (size_t i = 0; i < dzCache->values.size(); i++) {
+                int dz = dzCache->values[i];
+                if (dz > 0 && std::abs(motionDataArray[i]) < dz) {
+                    motionDataArray[i] = 0;
+                }
             }
         }
         mainApp->postMotionEvent(motionDataArray);

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -21,6 +21,7 @@
  ***************************************************************************/
 
 #include <FCConfig.h>
+#include <array>
 #include <App/Application.h>
 
 #include "GuiNativeEventLinux.h"
@@ -90,7 +91,7 @@ void Gui::GuiNativeEvent::pollSpacenav()
     if (hasMotion) {
         // Per-axis deadzone: zero out axes below their individual threshold.
         // Configured via user.cfg BaseApp/Spaceball/Motion/{Axis}Deadzone.
-        static const char* axisDeadzoneKeys[] = {
+        static const std::array<const char*, 6> axisDeadzoneKeys = {
             "PanLRDeadzone",
             "PanUDDeadzone",
             "ZoomDeadzone",
@@ -101,7 +102,7 @@ void Gui::GuiNativeEvent::pollSpacenav()
         auto hGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Spaceball/Motion"
         );
-        for (int i = 0; i < 6; i++) {
+        for (size_t i = 0; i < axisDeadzoneKeys.size(); i++) {
             int dz = static_cast<int>(hGrp->GetInt(axisDeadzoneKeys[i], 0));
             if (dz > 0 && motionDataArray[i] > -dz && motionDataArray[i] < dz) {
                 motionDataArray[i] = 0;

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -67,8 +67,7 @@ public:
         hGrp->Detach(this);
     }
 
-    void OnChange(ParameterGrp::SubjectType& /*rCaller*/,
-                  ParameterGrp::MessageType reason) override
+    void OnChange(ParameterGrp::SubjectType& /*rCaller*/, ParameterGrp::MessageType reason) override
     {
         for (size_t i = 0; i < keys.size(); i++) {
             if (std::strcmp(reason, keys[i]) == 0) {
@@ -149,9 +148,7 @@ void Gui::GuiNativeEvent::pollSpacenav()
         // Per-axis deadzone: zero out axes below their individual threshold.
         // Values cached and auto-updated via Observer when user.cfg changes.
         static DeadzoneCache dzCache(
-            App::GetApplication().GetParameterGroupByPath(
-                "User parameter:BaseApp/Spaceball/Motion"
-            )
+            App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Spaceball/Motion")
         );
         for (size_t i = 0; i < dzCache.values.size(); i++) {
             int dz = dzCache.values[i];

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -22,17 +22,74 @@
 
 #include <FCConfig.h>
 #include <array>
+#include <cmath>
+#include <cstring>
 #include <App/Application.h>
 
 #include "GuiNativeEventLinux.h"
 
 #include "GuiApplicationNativeEventAware.h"
 #include <Base/Console.h>
+#include <Base/Parameter.h>
 #include <QMainWindow>
 
 #include <QSocketNotifier>
 
 #include <spnav.h>
+
+namespace
+{
+
+// Cached per-axis deadzone values, auto-updated via Observer when user.cfg changes.
+class DeadzoneCache: public ParameterGrp::ObserverType
+{
+public:
+    static constexpr std::array<const char*, 6> keys = {
+        "PanLRDeadzone",
+        "PanUDDeadzone",
+        "ZoomDeadzone",
+        "TiltDeadzone",
+        "RollDeadzone",
+        "SpinDeadzone",
+    };
+
+    std::array<int, 6> values {};
+
+    explicit DeadzoneCache(ParameterGrp::handle hGrp)
+        : hGrp(std::move(hGrp))
+    {
+        loadAll();
+        this->hGrp->Attach(this);
+    }
+
+    ~DeadzoneCache() override
+    {
+        hGrp->Detach(this);
+    }
+
+    void OnChange(ParameterGrp::SubjectType& /*rCaller*/,
+                  ParameterGrp::MessageType reason) override
+    {
+        for (size_t i = 0; i < keys.size(); i++) {
+            if (std::strcmp(reason, keys[i]) == 0) {
+                values[i] = static_cast<int>(hGrp->GetInt(keys[i], 0));
+                return;
+            }
+        }
+    }
+
+private:
+    void loadAll()
+    {
+        for (size_t i = 0; i < keys.size(); i++) {
+            values[i] = static_cast<int>(hGrp->GetInt(keys[i], 0));
+        }
+    }
+
+    ParameterGrp::handle hGrp;
+};
+
+}  // namespace
 
 Gui::GuiNativeEvent::GuiNativeEvent(Gui::GUIApplicationNativeEventAware* app)
     : GuiAbstractNativeEvent(app)
@@ -90,21 +147,15 @@ void Gui::GuiNativeEvent::pollSpacenav()
     }
     if (hasMotion) {
         // Per-axis deadzone: zero out axes below their individual threshold.
-        // Configured via user.cfg BaseApp/Spaceball/Motion/{Axis}Deadzone.
-        static const std::array<const char*, 6> axisDeadzoneKeys = {
-            "PanLRDeadzone",
-            "PanUDDeadzone",
-            "ZoomDeadzone",
-            "TiltDeadzone",
-            "RollDeadzone",
-            "SpinDeadzone"
-        };
-        auto hGrp = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Spaceball/Motion"
+        // Values cached and auto-updated via Observer when user.cfg changes.
+        static DeadzoneCache dzCache(
+            App::GetApplication().GetParameterGroupByPath(
+                "User parameter:BaseApp/Spaceball/Motion"
+            )
         );
-        for (size_t i = 0; i < axisDeadzoneKeys.size(); i++) {
-            int dz = static_cast<int>(hGrp->GetInt(axisDeadzoneKeys[i], 0));
-            if (dz > 0 && motionDataArray[i] > -dz && motionDataArray[i] < dz) {
+        for (size_t i = 0; i < dzCache.values.size(); i++) {
+            int dz = dzCache.values[i];
+            if (dz > 0 && std::abs(motionDataArray[i]) < dz) {
                 motionDataArray[i] = 0;
             }
         }

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -114,9 +114,7 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
             = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
         connect(SpacenavNotifier, SIGNAL(activated(int)), this, SLOT(pollSpacenav()));
         dzCache = std::make_unique<DeadzoneCache>(
-            App::GetApplication().GetParameterGroupByPath(
-                "User parameter:BaseApp/Spaceball/Motion"
-            )
+            App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Spaceball/Motion")
         );
         mainApp->setSpaceballPresent(true);
     }

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -67,6 +67,7 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
 void Gui::GuiNativeEvent::pollSpacenav()
 {
     spnav_event ev;
+    bool hasMotion = false;
     while (spnav_poll_event(&ev)) {
         switch (ev.type) {
             case SPNAV_EVENT_MOTION: {
@@ -76,7 +77,7 @@ void Gui::GuiNativeEvent::pollSpacenav()
                 motionDataArray[3] = -ev.motion.rx;
                 motionDataArray[4] = -ev.motion.rz;
                 motionDataArray[5] = -ev.motion.ry;
-                mainApp->postMotionEvent(motionDataArray);
+                hasMotion = true;
                 break;
             }
             case SPNAV_EVENT_BUTTON: {
@@ -84,6 +85,9 @@ void Gui::GuiNativeEvent::pollSpacenav()
                 break;
             }
         }
+    }
+    if (hasMotion) {
+        mainApp->postMotionEvent(motionDataArray);
     }
 }
 

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -91,11 +91,16 @@ void Gui::GuiNativeEvent::pollSpacenav()
         // Per-axis deadzone: zero out axes below their individual threshold.
         // Configured via user.cfg BaseApp/Spaceball/Motion/{Axis}Deadzone.
         static const char* axisDeadzoneKeys[] = {
-            "PanLRDeadzone", "PanUDDeadzone", "ZoomDeadzone",
-            "TiltDeadzone", "RollDeadzone", "SpinDeadzone"
+            "PanLRDeadzone",
+            "PanUDDeadzone",
+            "ZoomDeadzone",
+            "TiltDeadzone",
+            "RollDeadzone",
+            "SpinDeadzone"
         };
         auto hGrp = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Spaceball/Motion");
+            "User parameter:BaseApp/Spaceball/Motion"
+        );
         for (int i = 0; i < 6; i++) {
             int dz = static_cast<int>(hGrp->GetInt(axisDeadzoneKeys[i], 0));
             if (dz > 0 && motionDataArray[i] > -dz && motionDataArray[i] < dz) {

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.h
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.h
@@ -23,12 +23,14 @@
 #pragma once
 
 #include "GuiAbstractNativeEvent.h"
+#include <memory>
 
 class QMainWindow;
 
 namespace Gui
 {
 class GUIApplicationNativeEventAware;
+class DeadzoneCache;
 
 class GuiNativeEvent: public GuiAbstractNativeEvent
 {
@@ -42,6 +44,9 @@ private:
     GuiNativeEvent();
     GuiNativeEvent(const GuiNativeEvent&);
     GuiNativeEvent& operator=(const GuiNativeEvent&);
+
+    std::unique_ptr<DeadzoneCache> dzCache;
+
 private Q_SLOTS:
     void pollSpacenav();
 };

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -1934,9 +1934,14 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
     newRotation.multVec(SbVec3f(0.0, 0.0, -1.0), newDirection);
     newPosition = center - (newDirection * camera->focalDistance.getValue());
 
+    newRotation.multVec(dir, dir);
+    SbVec3f finalPosition = newPosition + (dir * translationFactor);
+
+    camera->enableNotify(false);
     camera->orientation.setValue(newRotation);
-    camera->orientation.getValue().multVec(dir, dir);
-    camera->position = newPosition + (dir * translationFactor);
+    camera->position = finalPosition;
+    camera->enableNotify(true);
+    camera->touch();
 
     return true;
 }


### PR DESCRIPTION
## Summary

Linux SpaceMouse (spnav) navigation is jerky and unresponsive, especially on complex models. This is caused by two performance issues in the event pipeline and a missing feature:

1. **No event coalescing** — `pollSpacenav()` posts every spnav motion event individually (125-250Hz from spacenavd), each triggering a full scene redraw
2. **Double redraws** — `camera->orientation` and `camera->position` each trigger separate Coin3D scene graph notifications
3. **No per-axis deadzone** — sensor noise causes unintended drift with no way to filter individual axes

On Windows/macOS, NavLib handles coalescing and deadzone internally. On Linux (where NavLib is unavailable), the raw spnav pipeline has none of this.

## Changes

### Commit 1: Event coalescing + camera batching (performance fix)

**GuiNativeEventLinux.cpp** — The drain loop now keeps only the latest motion state and posts once after all pending events are consumed. SpaceMouse events are absolute deflection (current puck position), not deltas, so the latest event always contains the complete state.

**NavigationStyle.cpp** — Camera property changes are wrapped in `enableNotify(false/true)` + `touch()` so Coin3D fires a single redraw instead of two per event.

Together this reduces redraws from ~500/sec to ~60/sec.

### Commit 2: Per-axis deadzone filtering

**GuiNativeEventLinux.cpp** — Reads per-axis deadzone thresholds from `user.cfg` (`BaseApp/Spaceball/Motion/{Axis}Deadzone`) and zeros axis values below their threshold before posting. Each axis (PanLR, PanUD, Zoom, Tilt, Roll, Spin) can be configured independently. Values default to 0 (no filtering). This is the Linux equivalent of the deadzone handling that NavLib provides on Windows/macOS.

## Testing

Tested on Arch Linux (KDE Plasma Wayland) with:
- SpaceNavigator (046d:c626) via spacenavd 1.3.1 / libspnav 1.2
- FreeCAD 1.0.2 and current main
- Complex models (>50k faces) where the jerkiness was most noticeable

Before: jerky, laggy navigation with visible stuttering on puck release
After: smooth, responsive 60fps navigation, instant stop on puck release

### Per-axis deadzone configuration

The deadzone values can be configured via **Tools → Edit Parameters**, navigate to `BaseApp/Spaceball/Motion`:

| Parameter | Axis | Type | Range |
|-----------|------|------|-------|
| `PanLRDeadzone` | Pan Left/Right | Integer | 0–350 |
| `PanUDDeadzone` | Pan Up/Down | Integer | 0–350 |
| `ZoomDeadzone` | Zoom In/Out | Integer | 0–350 |
| `TiltDeadzone` | Tilt Forward/Back | Integer | 0–350 |
| `RollDeadzone` | Roll Left/Right | Integer | 0–350 |
| `SpinDeadzone` | Spin CW/CCW | Integer | 0–350 |

A value of **100–150** works well as a starting point — small unintentional movements are filtered out while normal navigation feels natural. Setting it to **0** (or omitting the parameter) disables the deadzone for that axis. Values update live via Observer — no restart needed.

## Fixes

Fixes #25926 (Lag when moving standard mouse and SpaceMouse simultaneously)
Relates to #17521 (Spacemouse speed problem)
