### PR TITLE
Sketcher : arc with symmetric + 2 coincidence fix

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArc.h
@@ -1028,4 +1028,3 @@ void DSHArcController::doConstructionMethodChanged()
 }
 
 }  // namespace SketcherGui
-


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/26822

Downgrade symmetric constraint to point on object for case where arc has 1 symmetric + 2 coincidences to avoid overconstraining.