### PR TITLE
Part design: fixes #28015 mv popup box to report view error with notification

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskFeatureParameters.cpp
@@ -234,7 +234,7 @@ bool TaskDlgFeatureParameters::accept()
                 );
             }
         }
-        QMessageBox::warning(Gui::getMainWindow(), tr("Input error"), errorText);
+        Base::Console().error("%s\n", errorText.toUtf8().constData());
         return false;
     }
     return true;


### PR DESCRIPTION
this PR addresses the issue in #28015 ie. this fixes #28015. instead of using a qmessagebox to report an error with using part design dressup features ie. chamfer and fillet, the error is now using the base.console.error handling to show a notificaiton in the notifications area and within the report view, thus no need for esc key handling as the user remains in the task panel.

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/28015

## Before and After Images

see original issue linked for example picture.

see attachment

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/7b810c44-70d9-4329-9df8-25eba1b07c87" />

