### PR TITLE
bim: attempt to fix crash with issue #27984 bim text in td doc

### DIFF
--- a/src/Mod/BIM/bimcommands/BimText.py
+++ b/src/Mod/BIM/bimcommands/BimText.py
@@ -78,7 +78,7 @@ class BIM_Text:
             anno.TextColor = (r, g, b)
             self.finish()
 
-    def finish(self, arg=False):
+    def finish(self, cont=False):
         FreeCADGui.draftToolBar.sourceCmd = None
         FreeCADGui.draftToolBar.offUi()
 


### PR DESCRIPTION
was checking the blockers and came across the below blocking issue that was causing a crash with some freecad setups. i could not personally reproduce a crash with my local daily build of freecad. however i did get some errors in the console in which i launched freecad from.

i updated the `finish` function within `BimText.py` to match other finish functions / commands from the source files contained within the BIM workbench.

i can not confirm this PR will fix the linked issue, but does indeed seem to handle a case where the type is incorrect.

```
╰─λ grep -n "def finish" src/Mod/Draft/draftguitools/*.py | head -20
src/Mod/Draft/draftguitools/gui_arcs.py:93:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_arcs.py:638:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_base.py:184:    def finish(self):
src/Mod/Draft/draftguitools/gui_base_original.py:158:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_beziers.py:190:    def finish(self, cont=False, closed=False):
src/Mod/Draft/draftguitools/gui_beziers.py:441:    def finish(self, cont=False, closed=False):
src/Mod/Draft/draftguitools/gui_clone.py:118:    def finish(self):
src/Mod/Draft/draftguitools/gui_dimensions.py:170:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_edit.py:327:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_ellipses.py:77:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_labels.py:96:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_lines.py:144:    def finish(self, cont=False, closed=False):
src/Mod/Draft/draftguitools/gui_mirror.py:99:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_move.py:98:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_offset.py:264:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_points.py:156:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_polygons.py:88:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_rectangles.py:72:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_rotate.py:262:    def finish(self, cont=False):
src/Mod/Draft/draftguitools/gui_scale.py:271:    def finish(self, cont=False):
```


## Issues

- https://github.com/freecad/freecad/issues/27984

## Before and After Images

see linked issue above for demo of crash
