### PR TITLE
Draft: fix tree duplication when moving objects between Layers and Groups

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -155,15 +155,28 @@ def moveToGroup(group):
     """
     Place the selected objects in the chosen group.
     """
+    from draftobjects.layer import get_layer
 
+    layer_for_group = None
     for obj in Gui.Selection.getSelection():
         try:
-            # retrieve group's visibility
             obj.ViewObject.Visibility = group.ViewObject.Visibility
-            group.addObject(obj)
 
+            # Remove from Layer first — C++ GroupExtension doesn't know
+            # about Python-based Layer containers
+            lyr = get_layer(obj)
+            if lyr is not None:
+                lyr.Proxy.removeObject(lyr, obj)
+                if layer_for_group is None:
+                    layer_for_group = lyr
+
+            group.addObject(obj)
         except Exception:
             pass
+
+    # Place the Group itself on the Layer the objects came from
+    if layer_for_group is not None:
+        layer_for_group.Proxy.addObject(layer_for_group, group)
 
 
 class SelectGroup(gui_base.GuiCommandNeedsSelection):

--- a/src/Mod/Draft/draftviewproviders/view_layer.py
+++ b/src/Mod/Draft/draftviewproviders/view_layer.py
@@ -420,63 +420,12 @@ class ViewProviderLayer:
 
         The function processes the parent group data stored in the
         old_parent_data dictionary by canDragObject and canDropObject.
+
+        Previously this restored old parent Group contents after a drag/drop,
+        but that caused tree duplication when moving objects between Layers
+        and Groups. The dragObject()/dropObject() pair already handles the
+        move correctly, so we just clear the saved state.
         """
-
-        # The function can be called multiple times, old_parent_data will be
-        # empty after the first call.
-        if (not hasattr(self, "old_parent_data")) or (not self.old_parent_data):
-            return
-
-        # List to collect parents whose Group must be updated.
-        # This has to happen later in a separate loop as we need the unmodified
-        # InList properties of the children in the main loop.
-        parents_to_update = []
-
-        # Main loop:
-        for child, old_data in self.old_parent_data.items():
-
-            # We assume a single old and a single new layer...
-
-            old_layer = None
-            for old_parent, old_parent_group in old_data:
-                if utils.get_type(old_parent) == "Layer":
-                    old_layer = old_parent
-                    break
-
-            new_layer = get_layer(child)
-            if new_layer == old_layer:
-                continue
-
-            elif new_layer is None:
-                # An object was dragged out of a layer.
-                # We need to check if it was put in a new group. If that is
-                # the case the content of old_layer should be restored.
-                # If the object was not put in a new group it was dropped on
-                # the document node, in that case we do nothing.
-                old_parents = [sub[0] for sub in old_data]
-                for new_parent in child.InList:
-                    if (
-                        hasattr(new_parent, "Group") and new_parent not in old_parents
-                    ):  # New group check.
-                        for old_parent, old_parent_group in old_data:
-                            if old_parent == old_layer:
-                                parents_to_update.append([old_parent, old_parent_group])
-                                break
-                        break
-
-            else:
-                # A new layer was assigned.
-                # The content of all `non-layer` groups should be restored.
-                for old_parent, old_parent_group in old_data:
-                    if utils.get_type(old_parent) != "Layer":
-                        parents_to_update.append([old_parent, old_parent_group])
-
-        # Update parents:
-        if parents_to_update:
-            for old_parent, old_parent_group in parents_to_update:
-                old_parent.Group = old_parent_group
-            App.ActiveDocument.recompute()
-
         self.old_parent_data = {}
 
     def replaceObject(self, old_obj, new_obj):


### PR DESCRIPTION
Fixes #28136

Objects appeared in both a Layer and a Group after using Draft → Move to Group or drag-and-drop in the tree view.

**gui_groups.py — moveToGroup():** Remove objects from their Draft Layer before calling `group.addObject()`. C++ `GroupExtension` does not know about Python-based Layer containers, so it never removed them. Also places the target Group on the Layer to preserve hierarchy.

**view_layer.py — update_groups_after_drag_drop():** Remove the logic that restored old parent Group contents after drag/drop, as it was undoing valid user moves. `dragObject()`/`dropObject()` already handle the move correctly.

Testing performed:
- Move to Group: object moves cleanly from Layer to Group, no duplication
- Drag-and-drop: object moves cleanly between containers
- Layer-to-Layer moves still work
- Objects not in any Layer can still be added to Groups
- No UI changes, no new dependencies

Related issues:
- Related to #26417 (recursive Layer delete fails) — same root cause: objects end up in multiple containers. This fix prevents the duplication.
- Related to #20985 (BIM ghost objects) — same architectural issue (Python containers vs C++ GroupExtension), different code path.
