### PR TITLE
part: fix mirror with App::Link ignoring placement and add 2 new unit tests

### DIFF
--- a/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/src/Mod/Part/App/FeatureMirroring.cpp
@@ -169,7 +169,7 @@ App::DocumentObjectExecReturn* Mirroring::execute()
         if (refObject->isDerivedFrom<Part::Plane>() || refObject->isDerivedFrom<App::Plane>()
             || (strstr(refObject->getNameInDocument(), "Plane")
                 && refObject->isDerivedFrom<Part::Datum>())) {
-            Part::Feature* plane = static_cast<Part::Feature*>(refObject);
+            auto* plane = static_cast<Part::Feature*>(refObject);
             Base::Vector3d base = plane->Placement.getValue().getPosition();
             axbase = gp_Pnt(base.x, base.y, base.z);
             Base::Rotation rot = plane->Placement.getValue().getRotation();
@@ -216,8 +216,8 @@ App::DocumentObjectExecReturn* Mirroring::execute()
 
             // if there is only 1 face or 1 edge, then we don't need to force the user to select
             // that face or edge instead we can infer what was intended
-            int faceCount = Part::TopoShape(shape).countSubShapes(TopAbs_FACE);
-            int edgeCount = Part::TopoShape(shape).countSubShapes(TopAbs_EDGE);
+            auto faceCount = Part::TopoShape(shape).countSubShapes(TopAbs_FACE);
+            auto edgeCount = Part::TopoShape(shape).countSubShapes(TopAbs_EDGE);
 
             TopoDS_Face face;
             TopoDS_Edge edge;
@@ -312,31 +312,15 @@ App::DocumentObjectExecReturn* Mirroring::execute()
         // get shape without transform
         auto shape = Feature::getTopoShape(link, ShapeOption::ResolveLink);
 
-        // manually apply placement via setPlacement() before mirroring
-        if (link->isDerivedFrom(App::GeoFeature::getClassTypeId())) {
-            App::GeoFeature* geo = static_cast<App::GeoFeature*>(link);
-            Base::Placement placement = geo->Placement.getValue();
+        // check for placement property no matter the type hierarchy
+        // App::Link does not get its placement via GeoFeature inheritance
+        if (auto propPlacement = link->getPropertyByName<App::PropertyPlacement>("Placement")) {
+            Base::Placement placement = propPlacement->getValue();
 
             if (!placement.isIdentity()) {
-                // Convert Placement to gp_Trsf
                 gp_Trsf trsf;
-                Base::Matrix4D mat = placement.toMatrix();
-                trsf.SetValues(
-                    mat[0][0],
-                    mat[0][1],
-                    mat[0][2],
-                    mat[0][3],
-                    mat[1][0],
-                    mat[1][1],
-                    mat[1][2],
-                    mat[1][3],
-                    mat[2][0],
-                    mat[2][1],
-                    mat[2][2],
-                    mat[2][3]
-                );
+                TopoShape::convertTogpTrsf(placement.toMatrix(), trsf);
 
-                // actually transform the geometry (copy=true to create new shape)
                 BRepBuilderAPI_Transform mkTrf(shape.getShape(), trsf, Standard_True);
                 shape = TopoShape(mkTrf.Shape());
             }

--- a/src/Mod/Part/parttests/TestPartMirror.py
+++ b/src/Mod/Part/parttests/TestPartMirror.py
@@ -1,6 +1,31 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# --------------------------------------------------------------------------
+#                                                                          *
+#    Copyright (c) 2026 Chris Jones github.com/ipatch                      *
+#                                                                          *
+#    This file is part of FreeCAD.                                         *
+#                                                                          *
+#    FreeCAD is free software: you can redistribute it and/or modify it    *
+#    under the terms of the GNU Lesser General Public License as           *
+#    published by the Free Software Foundation, either version 2.1 of the  *
+#    License, or (at your option) any later version.                       *
+#                                                                          *
+#    FreeCAD is distributed in the hope that it will be useful, but        *
+#    WITHOUT ANY WARRANTY; without even the implied warranty of            *
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+#    Lesser General Public License for more details.                       *
+#                                                                          *
+#    You should have received a copy of the GNU Lesser General Public      *
+#    License along with FreeCAD. If not, see                               *
+#    <https://www.gnu.org/licenses/>.                                      *
+#                                                                          *
+# --------------------------------------------------------------------------
+
 """
-this test will FAIL on current main branch (with PR #26963) and PASS after the fix.
+this test will FAIL on current main branch, and will PASS with PR #26963 ie. the fix.
 current main at: https://github.com/FreeCAD/FreeCAD/tree/24f0c8e2c321bb202410feae84eb58779ba8e8d2
+
+add test to validate App:Link placement
 """
 
 import unittest
@@ -90,6 +115,122 @@ class TestPartMirroringRegression(unittest.TestCase):
             msg=f"mirror position shifted on recompute: "
             f"X={initial_center_x:.6f} -> X={final_center_x:.6f}",
         )
+
+    def testMirroringWithAppLinkPlacement(self):
+        """Test that Part::Mirroring respects App::Link placement.
+
+        App::Link provides its Placement via extension rather than GeoFeature
+        inheritance, so mirror code must not rely on isDerivedFrom(GeoFeature).
+        """
+        # create a simple body with a box
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        box = self.doc.addObject("PartDesign::AdditiveBox", "Box")
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+        body.addObject(box)
+        self.doc.recompute()
+
+        # body shape should be at origin
+        body_bbox = body.Shape.BoundBox
+        self.assertAlmostEqual(body_bbox.XMin, 0.0, places=2)
+        self.assertAlmostEqual(body_bbox.XMax, 10.0, places=2)
+
+        # create a link to the body and move it to X=20
+        link = self.doc.addObject("App::Link", "Link")
+        link.LinkedObject = body
+        link.Placement = App.Placement(
+            App.Vector(20, 0, 0),
+            App.Rotation(),
+        )
+        self.doc.recompute()
+
+        # mirror across YZ plane (X=0)
+        mirror = self.doc.addObject("Part::Mirroring", "Mirror")
+        mirror.Source = link
+        mirror.Base = App.Vector(0, 0, 0)
+        mirror.Normal = App.Vector(1, 0, 0)
+        self.doc.recompute()
+
+        # link is at X=[20,30], so mirror across X=0 should be at X=[-30,-20]
+        mirror_bbox = mirror.Shape.BoundBox
+        mirror_center_x = (mirror_bbox.XMin + mirror_bbox.XMax) / 2
+
+        self.assertAlmostEqual(
+            mirror_center_x,
+            -25.0,
+            delta=2.0,
+            msg=f"mirror should be centered at X=-25 (opposite of link at X=25), "
+            f"but is at X={mirror_center_x:.2f}",
+        )
+
+        # verify stability across recomputes
+        initial_center_x = mirror_center_x
+        for i in range(5):
+            self.doc.recompute()
+
+        final_bbox = mirror.Shape.BoundBox
+        final_center_x = (final_bbox.XMin + final_bbox.XMax) / 2
+
+        self.assertAlmostEqual(
+            initial_center_x,
+            final_center_x,
+            places=3,
+            msg=f"mirror position shifted on recompute: "
+            f"X={initial_center_x:.6f} -> X={final_center_x:.6f}",
+        )
+
+    def testMirroringWithAppLinkRotation(self):
+        """Test that Part::Mirroring respects App::Link rotation + translation."""
+        body = self.doc.addObject("PartDesign::Body", "Body")
+        box = self.doc.addObject("PartDesign::AdditiveBox", "Box")
+        box.Length = 10
+        box.Width = 20
+        box.Height = 5
+        body.addObject(box)
+        self.doc.recompute()
+
+        # link with translation and 90° rotation around Z
+        link = self.doc.addObject("App::Link", "Link")
+        link.LinkedObject = body
+        link.Placement = App.Placement(
+            App.Vector(30, 0, 0),
+            App.Rotation(App.Vector(0, 0, 1), 90),
+        )
+        self.doc.recompute()
+
+        # capture the link's transformed bbox for reference
+        link_bbox = link.Shape.BoundBox
+
+        # mirror across YZ plane (X=0)
+        mirror = self.doc.addObject("Part::Mirroring", "Mirror")
+        mirror.Source = link
+        mirror.Base = App.Vector(0, 0, 0)
+        mirror.Normal = App.Vector(1, 0, 0)
+        self.doc.recompute()
+
+        mirror_bbox = mirror.Shape.BoundBox
+
+        # mirroring across X=0 should negate X coordinates
+        # link XMin/XMax should become -XMax/-XMin on the mirror
+        self.assertAlmostEqual(
+            mirror_bbox.XMin,
+            -link_bbox.XMax,
+            delta=1.0,
+            msg=f"mirror XMin should be -{link_bbox.XMax:.2f}, got {mirror_bbox.XMin:.2f}",
+        )
+        self.assertAlmostEqual(
+            mirror_bbox.XMax,
+            -link_bbox.XMin,
+            delta=1.0,
+            msg=f"mirror XMax should be -{link_bbox.XMin:.2f}, got {mirror_bbox.XMax:.2f}",
+        )
+
+        # Y and Z extents should be unchanged by X-axis mirror
+        self.assertAlmostEqual(mirror_bbox.YMin, link_bbox.YMin, delta=1.0)
+        self.assertAlmostEqual(mirror_bbox.YMax, link_bbox.YMax, delta=1.0)
+        self.assertAlmostEqual(mirror_bbox.ZMin, link_bbox.ZMin, delta=1.0)
+        self.assertAlmostEqual(mirror_bbox.ZMax, link_bbox.ZMax, delta=1.0)
 
 
 # for standalone execution

--- a/src/Mod/Test/TestTreeSelection.py
+++ b/src/Mod/Test/TestTreeSelection.py
@@ -108,8 +108,6 @@ class TestSelectAllInstances(unittest.TestCase):
         self.doc.recompute()
         FreeCADGui.updateGui()
 
-        self._debug_print_document_structure()
-
         # Get tree widget
         tree = self._get_tree_widget()
         self.assertIsNotNone(tree, "Could not find tree widget")
@@ -184,8 +182,6 @@ class TestSelectAllInstances(unittest.TestCase):
         self.doc.recompute()
         FreeCADGui.updateGui()
 
-        self._debug_print_document_structure()
-
         # Get tree widget
         tree = self._get_tree_widget()
         self.assertIsNotNone(tree, "Could not find tree widget")
@@ -204,8 +200,6 @@ class TestSelectAllInstances(unittest.TestCase):
 
         # Count selected Cube items in tree
         count = self._count_tree_selections_by_name("Cube")
-
-        self._debug_print_tree_selection(tree, count)
 
         # We expect 3 instances:
         # 1. Cube under Cut


### PR DESCRIPTION
this PR addresses the issue in the below linked github issue.

fixes #28133

also i removed the verbose 12 argument SetValues block with,

```cpp
TopoShape::convertTogpTrsf(placement.toMatrix(), trsf);
```

per the following comment, https://github.com/FreeCAD/FreeCAD/pull/27370#discussion_r2810103433

without the fix to `FeatureMirroring.cpp` the two added unit tests from this PR will fail.

<details>
<summary>failing tests output</summary>

```
FAILED: testMirroringWithAppLinkPlacement (parttests.TestPartMirror.TestPartMirroringRegression.testMirroringWithAppLinkPlacement)
Traceback (most recent call last):
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/Part/parttests/TestPartMirror.py", line 159, in testMirroringWithAppLinkPlacement
    self.assertAlmostEqual(
    ~~~~~~~~~~~~~~~~~~~~~~^
        mirror_center_x,
        ^^^^^^^^^^^^^^^^
    ...<3 lines>...
        f"but is at X={mirror_center_x:.2f}",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: -5.0 != -25.0 within 2.0 delta (20.0 difference) : mirror should be centered at X=-25 (opposite of link at X=25), but is at X=-5.00

FAILED: testMirroringWithAppLinkRotation (parttests.TestPartMirror.TestPartMirroringRegression.testMirroringWithAppLinkRotation)
Traceback (most recent call last):
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 651, in run
    self._callTestMethod(testMethod)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/capin/homebrew/Cellar/python@3.13/3.13.12_1/lib/python3.13/unittest/case.py", line 606, in _callTestMethod
    if method() is not None:
       ~~~~~~^^
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/Part/parttests/TestPartMirror.py", line 216, in testMirroringWithAppLinkRotation
    self.assertAlmostEqual(
    ~~~~~~~~~~~~~~~~~~~~~~^
        mirror_bbox.XMin,
        ^^^^^^^^^^^^^^^^^
    ...<2 lines>...
        msg=f"mirror XMin should be -{link_bbox.XMax:.2f}, got {mirror_bbox.XMin:.2f}",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: -10.0 != -30.000000000000004 within 1.0 delta (20.000000000000004 difference) : mirror XMin should be -30.00, got -10.00

TopoShapeListTest - setting up
TopoShapeListTest: setUp complete
running TopoShapeListTest
TopoShapeListTest finished

----------------------------------------------------------------------
Ran 131 tests in 42.4s

FAILED (failures=2)
System exit
```

</details>

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/28133

## Before and After Images

see linked issue for before image(s).

