### PR TITLE
Base: Corrected delete() call in XMLTools.

### DIFF
--- a/src/Base/XMLTools.cpp
+++ b/src/Base/XMLTools.cpp
@@ -175,5 +175,5 @@ void* XStrMemoryManager::allocate(XMLSize_t size)
 
 void XStrMemoryManager::deallocate(void* p)
 {
-    ::operator delete(p);
+    ::operator delete(p, static_cast<std::align_val_t>(alignof(XMLCh)));
 }


### PR DESCRIPTION
The memory is allocated using new() with alignment requirements, and should be deleted using the same alignment requirement.  See issue #27781 for the valgrind error.