### PR TITLE
Part: Fix dangling pointer in getElementSource()

### DIFF
--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -582,6 +582,8 @@ static std::vector<std::pair<long, Data::MappedName>> getElementSource(
             }
             break;
         }
+        // "Compact" makes an owned copy to ensure we don't have a dangling point later on
+        original.compact();
         ret.emplace_back(tag, original);
     }
     return ret;


### PR DESCRIPTION
During my digging into #25720 I ran across this dangling pointer (caught with ASAN, a normal debug build probably won't experience it). It is a sort of convoluted chain of reference/dereference that causes it, but simply ensuring we have an owned copy prevents it entirely.

ETA: This does not actually fix 25720 by itself, but it will be _required_ to fix it. So this will need a backport to 1.1.0. Basically, the copy constructor of a `MappedName` doesn't actually make a copy of the underlying data because `QByteArray` strives to be as opaque and difficult-to-use as possible 😭. `compact()` manually forces the copy.