### PR TITLE
Gui: Add shortcuts to transform, measure, edit attachment

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1922,7 +1922,6 @@ StdCmdTransform::StdCmdTransform()
     sToolTipText = QT_TR_NOOP("Transforms the selected object");
     sStatusTip = sToolTipText;
     sWhatsThis = "Std_Transform";
-    sAccel = "Ctrl+Shift+T";
 }
 
 void StdCmdTransform::activated(int iMsg)

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1922,6 +1922,7 @@ StdCmdTransform::StdCmdTransform()
     sToolTipText = QT_TR_NOOP("Transforms the selected object");
     sStatusTip = sToolTipText;
     sWhatsThis = "Std_Transform";
+    sAccel = "Ctrl+Shift+T";
 }
 
 void StdCmdTransform::activated(int iMsg)
@@ -2012,6 +2013,7 @@ StdCmdTransformManip::StdCmdTransformManip()
     sStatusTip = sToolTipText;
     sWhatsThis = "Std_TransformManip";
     sPixmap = "Std_TransformManip";
+    sAccel = "Shift+T";
 }
 
 void StdCmdTransformManip::activated(int iMsg)

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -2012,7 +2012,7 @@ StdCmdTransformManip::StdCmdTransformManip()
     sStatusTip = sToolTipText;
     sWhatsThis = "Std_TransformManip";
     sPixmap = "Std_TransformManip";
-    sAccel = "Shift+T";
+    sAccel = "Ctrl+Alt+T";
 }
 
 void StdCmdTransformManip::activated(int iMsg)

--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -53,6 +53,7 @@ StdCmdMeasure::StdCmdMeasure()
     sWhatsThis = "Std_Measure";
     sStatusTip = QT_TR_NOOP("Measures a feature");
     sPixmap = "umf-measurement";
+    sAccel = "Shift+M";
 }
 
 void StdCmdMeasure::activated(int iMsg)

--- a/src/Mod/Measure/Gui/Command.cpp
+++ b/src/Mod/Measure/Gui/Command.cpp
@@ -53,7 +53,7 @@ StdCmdMeasure::StdCmdMeasure()
     sWhatsThis = "Std_Measure";
     sStatusTip = QT_TR_NOOP("Measures a feature");
     sPixmap = "umf-measurement";
-    sAccel = "Shift+M";
+    sAccel = "Ctrl+Alt+M";
 }
 
 void StdCmdMeasure::activated(int iMsg)

--- a/src/Mod/Part/AttachmentEditor/Commands.py
+++ b/src/Mod/Part/AttachmentEditor/Commands.py
@@ -88,7 +88,7 @@ class CommandEditAttachment:
         return {
             "Pixmap": "Part_Attachment",
             "MenuText": QT_TRANSLATE_NOOP("Part_EditAttachment", "Attachment"),
-            "Accel": "Shift+A",
+            "Accel": "Ctrl+Alt+E",
             "ToolTip": QT_TRANSLATE_NOOP(
                 "Part_EditAttachment",
                 "Opens the attachment editor to change the attachment of the selected object",

--- a/src/Mod/Part/AttachmentEditor/Commands.py
+++ b/src/Mod/Part/AttachmentEditor/Commands.py
@@ -88,7 +88,7 @@ class CommandEditAttachment:
         return {
             "Pixmap": "Part_Attachment",
             "MenuText": QT_TRANSLATE_NOOP("Part_EditAttachment", "Attachment"),
-            "Accel": "",
+            "Accel": "Shift+A",
             "ToolTip": QT_TRANSLATE_NOOP(
                 "Part_EditAttachment",
                 "Opens the attachment editor to change the attachment of the selected object",


### PR DESCRIPTION
Fixes: #28150

  Transform (3D interactive)    ->  `Std_TransformManip`    ->` Ctrl+Alt+T` 
Measure ->`Std_Measure `      -> ` Ctrl+Alt+M`
Edit Attachment  ->`Part_EditAttachment`   ->  `Ctrl+Alt+E`
