### PR TITLE
CAM: MachineState - Allow process list of commands

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelpers.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelpers.py
@@ -124,6 +124,15 @@ class TestPathHelpers(PathTestBase):
         self.assertTrue(state["Y"] == 50)
         self.assertTrue(state["Z"] == 5)
 
+        # Test process list of commands
+        machine = PathMachineState.MachineState()
+        machine.addCommands(self.commandlist[0])
+        machine.addCommands(self.commandlist[1:])
+        state = machine.getState()
+        self.assertEqual(state["X"], 20)
+        self.assertEqual(state["Y"], 20)
+        self.assertEqual(state["Z"], 5)
+
     def test02(self):
         """Test PathUtils filterarcs"""
 

--- a/src/Mod/CAM/Path/Base/MachineState.py
+++ b/src/Mod/CAM/Path/Base/MachineState.py
@@ -28,7 +28,6 @@ __contributors__ = ""
 
 import Path
 import FreeCAD
-import Path
 
 if False:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -72,7 +71,8 @@ class MachineState:
         self.T = None  #: int = field(default=None)
 
     def addCommand(self, command):
-        """Processes a command and updates the internal state of the machine. Returns true if the command has alterned the machine state"""
+        """Processes a command and updates the internal state of the machine.
+        Returns true if the command has alterned the machine state"""
         oldstate = self.getState()
         if command.Name == "M6":
             self.T = int(command.Parameters["T"])
@@ -103,6 +103,16 @@ class MachineState:
             self.__setattr__(p, command.Parameters[p])
 
         return not oldstate == self.getState()
+
+    def addCommands(self, commands):
+        """Processes a command or list of commands and updates the internal state of the machine"""
+        if isinstance(commands, (list, tuple)):
+            for command in commands:
+                self.addCommand(command)
+        else:
+            return self.addCommand(commands)
+
+        return False
 
     def getState(self):
         """

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -359,8 +359,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
                         solids=solids,
                     )
                     self.commandlist.extend(linking_moves)
-                    for move in linking_moves:
-                        machinestate.addCommand(move)
+                    machinestate.addCommands(linking_moves)
                 # else: no collision - G99 cycle continues, tool stays at retract plane
 
             # Perform drilling


### PR DESCRIPTION
We can send only one command in a time to `MachineState`
New method `addCommands()` processes a command or list of commands
No need to use `for` loop inside other code to send list of commands

**Changes in this commit:**
- Add new method `addCommands()`, which process `Path.Command` or list `[Path.Command, ...]`
- Added tests for method `addCommands()`

