### PR TITLE
CAM: Maneuver - Move instruction_to_command() to class

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathLanguage.py
+++ b/src/Mod/CAM/CAMTests/TestPathLanguage.py
@@ -101,7 +101,6 @@ class TestPathLanguage(PathTestUtils.PathTestBase):
 
     def test50(self):
         """Verify tangents of moves."""
-
         self.assertTangents(INSTR("G1 X0  Y0"), (0, 0))  # by declaration
         self.assertTangents(INSTR("G1 X1  Y0"), (0, 0))
         self.assertTangents(INSTR("G1 X-1 Y0"), (PI, PI))
@@ -119,3 +118,11 @@ class TestPathLanguage(PathTestUtils.PathTestBase):
         self.assertTangents(INSTR("G3 X2  Y0  I1 J0"), (-PI / 2, PI / 2))
         self.assertTangents(INSTR("G3 X2  Y2  I1 J1"), (-PI / 4, 3 * PI / 4))
         self.assertTangents(INSTR("G3 X0  Y-2 I0 J-1"), (PI, 0))
+
+    def test60(self):
+        """Verify convert Maneuver to gcode."""
+        instr = INSTR("G1 X5  Y6")
+        self.assertEqual(instr.toCommand().toGCode(), "G1 X5.000000 Y6.000000")
+
+        mnvr = MNVR("G1 X3 Y4")
+        self.assertEqual(mnvr.toPath().toGCode().strip(), "G1 X3.000000 Y4.000000")

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -19,6 +19,9 @@ GCODE_MOVE_RAPID = ["G0", "G00"]
 # Linear interpolation (feed moves)
 GCODE_MOVE_STRAIGHT = ["G1", "G01"]
 
+# Linear interpolation (rapid and feed moves)
+GCODE_MOVE_LINE = GCODE_MOVE_RAPID + GCODE_MOVE_STRAIGHT
+
 # Circular interpolation - clockwise
 GCODE_MOVE_CW = ["G2", "G02"]
 
@@ -38,7 +41,7 @@ GCODE_MOVE_MILL = GCODE_MOVE_STRAIGHT + GCODE_MOVE_ARC
 GCODE_MOVE = GCODE_MOVE_STRAIGHT + GCODE_MOVE_ARC + GCODE_MOVE_DRILL
 
 # All move commands (cutting moves + rapid)
-GCODE_MOVE_ALL = GCODE_MOVE + GCODE_MOVE_RAPID
+GCODE_MOVE_ALL = GCODE_MOVE_LINE + GCODE_MOVE_ARC + GCODE_MOVE_DRILL
 
 # =============================================================================
 # G-Code Modal Commands

--- a/src/Mod/CAM/Path/Base/Generator/dogboneII.py
+++ b/src/Mod/CAM/Path/Base/Generator/dogboneII.py
@@ -109,7 +109,7 @@ class Bone(object):
 
 
 def kink_to_path(kink, g0=False):
-    return Path.Path([PathLanguage.instruction_to_command(instr) for instr in [kink.m0, kink.m1]])
+    return Path.Path([instr.toCommand() for instr in [kink.m0, kink.m1]])
 
 
 def bone_to_path(bone, g0=False):
@@ -124,7 +124,7 @@ def bone_to_path(bone, g0=False):
             param["Y"] = pos.y
         cmds.append(Path.Command("G0", param))
     for instr in [kink.m0, bone.instr[0], bone.instr[1], kink.m1]:
-        cmds.append(PathLanguage.instruction_to_command(instr))
+        cmds.append(instr.toCommand())
     return Path.Path(cmds)
 
 

--- a/src/Mod/CAM/Path/Base/Language.py
+++ b/src/Mod/CAM/Path/Base/Language.py
@@ -20,6 +20,7 @@
 # *                                                                         *
 # ***************************************************************************
 
+import Constants
 import FreeCAD
 import Path
 import math
@@ -29,8 +30,6 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "https://www.freecad.org"
 __doc__ = "Functions to extract and convert between Path.Command and Part.Edge and utility functions to reason about them."
 
-CmdMoveStraight = Path.Geom.CmdMoveStraight + Path.Geom.CmdMoveRapid
-
 
 class Instruction(object):
     """An Instruction is a pure python replacement of Path.Command which also tracks its begin position."""
@@ -38,8 +37,8 @@ class Instruction(object):
     def __init__(self, begin, cmd, param=None):
         self.begin = begin
         if isinstance(cmd, Path.Command):
-            self.cmd = Path.Name
-            self.param = Path.Parameters
+            self.cmd = cmd.Name
+            self.param = cmd.Parameters
         else:
             self.cmd = cmd
             if param is None:
@@ -128,6 +127,10 @@ class Instruction(object):
             s = [fmt.format(k, v) for k, v in self.param.items()]
         return f"{self.cmd}{{{', '.join(s)}}}"
 
+    def toCommand(self):
+        """toCommand(instr) ... return Path.Command object"""
+        return Path.Command(self.cmd, self.param)
+
 
 class MoveStraight(Instruction):
     def anglesOfTangents(self):
@@ -149,7 +152,7 @@ class MoveStraight(Instruction):
         return False
 
     def isRapid(self):
-        return self.cmd in Path.Geom.CmdMoveRapid
+        return self.cmd in Constants.GCODE_MOVE_RAPID
 
     def pathLength(self):
         return (self.positionEnd() - self.positionBegin()).Length
@@ -251,7 +254,7 @@ class Maneuver(object):
         self.instr.extend(coll)
 
     def toPath(self):
-        return Path.Path([instruction_to_command(instr) for instr in self.instr])
+        return Path.Path([instr.toCommand() for instr in self.instr])
 
     def __repr__(self):
         if self.instr:
@@ -263,11 +266,11 @@ class Maneuver(object):
         if not begin:
             begin = FreeCAD.Vector(0, 0, 0)
 
-        if cmd.Name in CmdMoveStraight:
+        if cmd.Name in Constants.GCODE_MOVE_LINE:
             return MoveStraight(begin, cmd.Name, cmd.Parameters)
-        if cmd.Name in Path.Geom.CmdMoveCW:
+        if cmd.Name in Constants.GCODE_MOVE_CW:
             return MoveArcCW(begin, cmd.Name, cmd.Parameters)
-        if cmd.Name in Path.Geom.CmdMoveCCW:
+        if cmd.Name in Constants.GCODE_MOVE_CCW:
             return MoveArcCCW(begin, cmd.Name, cmd.Parameters)
         return Instruction(begin, cmd.Name, cmd.Parameters)
 
@@ -286,7 +289,3 @@ class Maneuver(object):
     @classmethod
     def FromGCode(cls, gcode, begin=None):
         return cls.FromPath(Path.Path(gcode), begin)
-
-
-def instruction_to_command(instr):
-    return Path.Command(instr.cmd, instr.param)


### PR DESCRIPTION
`instruction_to_command()` uses only for objects of `Instruction` class,
but for some reason placed outside the class

https://github.com/FreeCAD/FreeCAD/blob/c263d8f51cc4dc0c378eab6adf58fef2e2571d2a/src/Mod/CAM/Path/Base/Language.py#L291-L292

---

**Changes in this commit:**
- Replaced external function `instruction_to_command()` by class method `toCommand()`
- Added tests for new method `toCommand()`

---

**Also**

https://github.com/FreeCAD/FreeCAD/blob/21ef29bb828f6807b34094ba3a4f143a0ec2b336/src/Mod/CAM/Path/Base/Language.py#L40-L42

Probably this is a mistake
`Path` object not contains attributes `Name` and `Parameters`,
but `Path.Command` contains
Fixes this

---

**Also**

`CmdMoveStraight` created in top of the file and used only once in end of the file
Looks strange
Fixes this

https://github.com/FreeCAD/FreeCAD/blob/21ef29bb828f6807b34094ba3a4f143a0ec2b336/src/Mod/CAM/Path/Base/Language.py#L32

https://github.com/FreeCAD/FreeCAD/blob/21ef29bb828f6807b34094ba3a4f143a0ec2b336/src/Mod/CAM/Path/Base/Language.py#L266

If this is a reason for optimization, lets add new var to `Constants`
Something like `GCODE_MOVE_LINE = GCODE_MOVE_RAPID + GCODE_MOVE_STRAIGHT`
