### PR TITLE
CAM: Linking - Consider tool shape

### DIFF
--- a/src/Mod/CAM/CAMTests/TestLinkingGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestLinkingGenerator.py
@@ -88,7 +88,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 target_position=self.target,
                 local_clearance=5,
                 global_clearance=11,
-                tolerance=1.1,
+                safety_margin=1.1,
                 solids=[blocking_box],
                 tool_diameter=0,
             )
@@ -162,7 +162,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
             tool_diameter=self.tooldiameter,
-            tolerance=0.001,
+            safety_margin=0.001,
             solids=[blocking_box1, blocking_box2],
         )
         self.assertGreater(len(cmds), 0)
@@ -177,7 +177,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 local_clearance=self.local_clearance,
                 global_clearance=self.global_clearance,
                 tool_diameter=self.tooldiameter,
-                tolerance=0.001,
+                safety_margin=0.001,
                 solids=[blocking_box1, blocking_box2],
             )
 
@@ -195,7 +195,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
             tool_diameter=self.tooldiameter,
-            tolerance=0.001,
+            safety_margin=0.001,
             solids=[blocking_box1, blocking_box2],
         )
         self.assertGreater(len(cmds), 0)
@@ -210,7 +210,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 local_clearance=self.local_clearance,
                 global_clearance=self.global_clearance,
                 tool_shape=self.tool,
-                tolerance=0.001,
+                safety_margin=0.001,
                 solids=[blocking_box1, blocking_box2],
             )
 
@@ -222,7 +222,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
             tool_shape=Part.Shape(),
-            tolerance=0.001,
+            safety_margin=0.001,
             solids=[Part.Shape()],
         )
         self.assertGreater(len(cmds), 0)

--- a/src/Mod/CAM/CAMTests/TestLinkingGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestLinkingGenerator.py
@@ -23,7 +23,8 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
         self.target = FreeCAD.Vector(10, 0, 0)
         self.local_clearance = 2.0
         self.global_clearance = 5.0
-        self.tool = Part.makeCylinder(1, 5)
+        self.tooldiameter = 2
+        self.tool = Part.makeCylinder(self.tooldiameter / 2, 5)
 
     def test_simple_move(self):
         cmds = generator.get_linking_moves(
@@ -31,7 +32,6 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             target_position=self.target,
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
-            tool_shape=self.tool,
             solids=[],
         )
         self.assertGreater(len(cmds), 0)
@@ -43,7 +43,6 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             target_position=self.start,
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
-            tool_shape=self.tool,
             solids=[],
         )
         self.assertEqual(len(cmds), 0)
@@ -55,7 +54,6 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 target_position=self.target,
                 local_clearance=self.local_clearance,
                 global_clearance=self.global_clearance,
-                tool_shape=self.tool,
                 retract_height_offset=-1,
             )
 
@@ -66,7 +64,6 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 target_position=self.target,
                 local_clearance=10.0,
                 global_clearance=5.0,
-                tool_shape=self.tool,
             )
 
     def test_path_blocked_by_solid(self):
@@ -78,8 +75,8 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 target_position=self.target,
                 local_clearance=self.local_clearance,
                 global_clearance=self.global_clearance,
-                tool_shape=self.tool,
                 solids=[blocking_box],
+                tool_diameter=0,
             )
 
     def test_path_blocked_by_solid_with_tolerance(self):
@@ -91,9 +88,9 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 target_position=self.target,
                 local_clearance=5,
                 global_clearance=11,
-                tool_shape=self.tool,
                 tolerance=1.1,
                 solids=[blocking_box],
+                tool_diameter=0,
             )
 
     def test_plunge_to_zero_depth(self):
@@ -106,7 +103,6 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             target_position=target,
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
-            tool_shape=self.tool,
             solids=[],
         )
 
@@ -140,7 +136,6 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             target_position=target,
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
-            tool_shape=self.tool,
             solids=[],
         )
 
@@ -153,6 +148,85 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             msg="Final plunge should go to target Z=-2",
         )
 
+    def test_path_collision_by_tooldiameter(self):
+        """Test collision using tool diameter"""
+        blocking_box1 = Part.makeBox(1, 10, 10)
+        blocking_box2 = Part.makeBox(1, 10, 10)
+        blocking_box1.translate(FreeCAD.Vector(5, -12, 0))
+        blocking_box2.translate(FreeCAD.Vector(5, 2, 0))
+
+        # Enough space for linking
+        cmds = generator.get_linking_moves(
+            start_position=self.start,
+            target_position=self.target,
+            local_clearance=self.local_clearance,
+            global_clearance=self.global_clearance,
+            tool_diameter=self.tooldiameter,
+            tolerance=0.001,
+            solids=[blocking_box1, blocking_box2],
+        )
+        self.assertGreater(len(cmds), 0)
+
+        # Not enough space for linking
+        blocking_box1.translate(FreeCAD.Vector(0, -1, 0))
+        blocking_box2.translate(FreeCAD.Vector(0, -1, 0))
+        with self.assertRaises(RuntimeError):
+            generator.get_linking_moves(
+                start_position=self.start,
+                target_position=self.target,
+                local_clearance=self.local_clearance,
+                global_clearance=self.global_clearance,
+                tool_diameter=self.tooldiameter,
+                tolerance=0.001,
+                solids=[blocking_box1, blocking_box2],
+            )
+
+    def test_path_collision_by_toolshape(self):
+        """Test collision using tool shape"""
+        blocking_box1 = Part.makeBox(1, 10, 10)
+        blocking_box2 = Part.makeBox(1, 10, 10)
+        blocking_box1.translate(FreeCAD.Vector(5, -12, 0))
+        blocking_box2.translate(FreeCAD.Vector(5, 2, 0))
+
+        # Enough space for linking
+        cmds = generator.get_linking_moves(
+            start_position=self.start,
+            target_position=self.target,
+            local_clearance=self.local_clearance,
+            global_clearance=self.global_clearance,
+            tool_diameter=self.tooldiameter,
+            tolerance=0.001,
+            solids=[blocking_box1, blocking_box2],
+        )
+        self.assertGreater(len(cmds), 0)
+
+        # Not enough space for linking
+        blocking_box1.translate(FreeCAD.Vector(0, -1, 0))
+        blocking_box2.translate(FreeCAD.Vector(0, -1, 0))
+        with self.assertRaises(RuntimeError):
+            generator.get_linking_moves(
+                start_position=self.start,
+                target_position=self.target,
+                local_clearance=self.local_clearance,
+                global_clearance=self.global_clearance,
+                tool_shape=self.tool,
+                tolerance=0.001,
+                solids=[blocking_box1, blocking_box2],
+            )
+
+    def test_null_toolshape(self):
+        """Test toolshape method with null tool shape"""
+        cmds = generator.get_linking_moves(
+            start_position=self.start,
+            target_position=self.target,
+            local_clearance=self.local_clearance,
+            global_clearance=self.global_clearance,
+            tool_shape=Part.Shape(),
+            tolerance=0.001,
+            solids=[Part.Shape()],
+        )
+        self.assertGreater(len(cmds), 0)
+
     @unittest.skip("not yet implemented")
     def test_zero_retract_offset_uses_local_clearance(self):
         cmds = generator.get_linking_moves(
@@ -160,7 +234,6 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             target_position=FreeCAD.Vector(10, 0, 5),
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
-            tool_shape=self.tool,
             retract_height_offset=0,
         )
         self.assertTrue(any(cmd for cmd in cmds if cmd.Parameters.get("Z") == self.local_clearance))

--- a/src/Mod/CAM/Path/Base/Generator/linking.py
+++ b/src/Mod/CAM/Path/Base/Generator/linking.py
@@ -40,7 +40,7 @@ def check_collision(
     solids: Optional[List[Part.Shape]] = None,
     tool_shape: Optional[Part.Shape] = None,
     tool_diameter: Optional[float] = None,
-    tolerance: float = 0.001,
+    safety_margin: float = 1,
 ) -> bool:
     """
     Check if a direct move from start to target would collide with solids.
@@ -67,13 +67,13 @@ def check_collision(
     if not collision_model:
         return False
 
-    tolerance = max(tolerance, 0) or 0.001
+    safety_margin = max(safety_margin, 0) or 1
 
     # Create direct path wire
     wire = Part.Wire([Part.makeLine(start_position, target_position)])
 
     bbDistance = wire.BoundBox.ZMin - collision_model.BoundBox.ZMax
-    if bbDistance >= tolerance or Path.Geom.isRoughly(bbDistance, tolerance):
+    if bbDistance >= safety_margin or Path.Geom.isRoughly(bbDistance, safety_margin):
         # attempt to skip long time computation for simple model
         return False
 
@@ -86,7 +86,7 @@ def check_collision(
         distance = shape.distToShape(collision_model)[0]
     else:
         distance = wire.distToShape(collision_model)[0]
-    return distance < tolerance and not Path.Geom.isRoughly(distance, tolerance)
+    return distance < safety_margin and not Path.Geom.isRoughly(distance, safety_margin)
 
 
 def get_linking_moves(
@@ -99,7 +99,7 @@ def get_linking_moves(
     solids: Optional[List[Part.Shape]] = None,
     retract_height_offset: Optional[float] = None,
     skip_if_no_collision: bool = False,
-    tolerance: float = 0.001,
+    safety_margin: float = 1,
 ) -> list:
     """
     Generate linking moves from start to target position.
@@ -149,12 +149,14 @@ def get_linking_moves(
 
     heights = sorted(candidate_heights)
 
-    tolerance = max(tolerance, 0) or 0.001
+    safety_margin = max(safety_margin, 0) or 1
 
     # Try each height
     for height in heights:
         wire = make_linking_wire(start_position, target_position, height)
-        if is_travel_collision_free(wire, collision_model, tool_shape, tool_diameter, tolerance):
+        if is_travel_collision_free(
+            wire, collision_model, tool_shape, tool_diameter, safety_margin
+        ):
             cmds = Path.fromShape(wire).Commands
             # Ensure all commands have complete XYZ coordinates
             # Path.fromShape() may omit coordinates that don't change
@@ -202,7 +204,7 @@ def is_travel_collision_free(
     solid: Optional[Part.Shape],
     tool_shape: Optional[Part.Shape] = None,
     tool_diameter: Optional[float] = None,
-    tolerance: float = 0.001,
+    safety_margin: float = 1,
 ) -> bool:
     """
     Check if a horizontal edge of wire would not collide with solids.
@@ -211,10 +213,10 @@ def is_travel_collision_free(
     if not solid:
         return True
 
-    tolerance = max(tolerance, 0) or 0.001
+    safety_margin = max(safety_margin, 0) or 1
 
     bbDistance = wire.BoundBox.ZMax - solid.BoundBox.ZMax
-    if bbDistance >= tolerance or Path.Geom.isRoughly(bbDistance, tolerance):
+    if bbDistance >= safety_margin or Path.Geom.isRoughly(bbDistance, safety_margin):
         # attempt to skip long time computation for simple model
         return True
 
@@ -227,7 +229,7 @@ def is_travel_collision_free(
         distance = shape.distToShape(solid)[0]
     else:
         distance = wire.distToShape(solid)[0]
-    return distance >= tolerance or Path.Geom.isRoughly(distance, tolerance)
+    return distance >= safety_margin or Path.Geom.isRoughly(distance, safety_margin)
 
 
 def _create_horizontal_face(wire, width):

--- a/src/Mod/CAM/Path/Base/Generator/linking.py
+++ b/src/Mod/CAM/Path/Base/Generator/linking.py
@@ -38,12 +38,20 @@ def check_collision(
     start_position: Vector,
     target_position: Vector,
     solids: Optional[List[Part.Shape]] = None,
+    tool_shape: Optional[Part.Shape] = None,
+    tool_diameter: Optional[float] = None,
     tolerance: float = 0.001,
 ) -> bool:
     """
     Check if a direct move from start to target would collide with solids.
     Returns True if collision detected, False if path is clear.
+
+    For collision detection uses one of the methods below:
+    - tool_shape: cross-section of the tool shape (most long computation)
+    - tool_diameter: uses horizontal face with width of the tool diameter (middle computation)
+    - if no tool_shape and tool_diameter uses simple wire (fast computation)
     """
+
     if start_position == target_position:
         return False
 
@@ -59,6 +67,8 @@ def check_collision(
     if not collision_model:
         return False
 
+    tolerance = max(tolerance, 0) or 0.001
+
     # Create direct path wire
     wire = Part.Wire([Part.makeLine(start_position, target_position)])
 
@@ -67,7 +77,15 @@ def check_collision(
         # attempt to skip long time computation for simple model
         return False
 
-    distance = wire.distToShape(collision_model)[0]
+    shape = None
+    if tool_shape:
+        shape = _create_tool_path_shape(wire, tool_shape)
+    elif tool_diameter:
+        shape = _create_horizontal_face(wire, tool_diameter)
+    if shape:
+        distance = shape.distToShape(collision_model)[0]
+    else:
+        distance = wire.distToShape(collision_model)[0]
     return distance < tolerance and not Path.Geom.isRoughly(distance, tolerance)
 
 
@@ -76,7 +94,8 @@ def get_linking_moves(
     target_position: Vector,
     local_clearance: float,
     global_clearance: float,
-    tool_shape: Part.Shape,  # required placeholder
+    tool_shape: Optional[Part.Shape] = None,
+    tool_diameter: Optional[float] = None,
     solids: Optional[List[Part.Shape]] = None,
     retract_height_offset: Optional[float] = None,
     skip_if_no_collision: bool = False,
@@ -88,6 +107,11 @@ def get_linking_moves(
     If skip_if_no_collision is True and the direct path at the current height
     is collision-free, returns empty list (useful for canned drill cycles that
     handle their own retraction).
+
+    For collision detection uses one of the methods below:
+    - tool_shape: cross-section of the tool shape (most long computation)
+    - tool_diameter: uses horizontal face with width of the tool diameter (middle computation)
+    - if no tool_shape and tool_diameter uses simple wire (fast computation)
     """
     if start_position == target_position:
         return []
@@ -125,10 +149,12 @@ def get_linking_moves(
 
     heights = sorted(candidate_heights)
 
+    tolerance = max(tolerance, 0) or 0.001
+
     # Try each height
     for height in heights:
         wire = make_linking_wire(start_position, target_position, height)
-        if is_wire_collision_free(wire, collision_model, tolerance):
+        if is_travel_collision_free(wire, collision_model, tool_shape, tool_diameter, tolerance):
             cmds = Path.fromShape(wire).Commands
             # Ensure all commands have complete XYZ coordinates
             # Path.fromShape() may omit coordinates that don't change
@@ -171,8 +197,12 @@ def make_linking_wire(start: Vector, target: Vector, z: float) -> Part.Wire:
     return Part.Wire(edges) if edges else Part.Wire([Part.makeLine(start, target)])
 
 
-def is_wire_collision_free(
-    wire: Part.Wire, solid: Optional[Part.Shape], tolerance: float = 0.001
+def is_travel_collision_free(
+    wire: Part.Wire,
+    solid: Optional[Part.Shape],
+    tool_shape: Optional[Part.Shape] = None,
+    tool_diameter: Optional[float] = None,
+    tolerance: float = 0.001,
 ) -> bool:
     """
     Check if a horizontal edge of wire would not collide with solids.
@@ -181,10 +211,66 @@ def is_wire_collision_free(
     if not solid:
         return True
 
+    tolerance = max(tolerance, 0) or 0.001
+
     bbDistance = wire.BoundBox.ZMax - solid.BoundBox.ZMax
     if bbDistance >= tolerance or Path.Geom.isRoughly(bbDistance, tolerance):
         # attempt to skip long time computation for simple model
         return True
 
-    distance = wire.distToShape(solid)[0]
+    shape = None
+    if tool_shape:
+        shape = _create_tool_path_shape(wire, tool_shape)
+    elif tool_diameter:
+        shape = _create_horizontal_face(wire, tool_diameter)
+    if shape:
+        distance = shape.distToShape(solid)[0]
+    else:
+        distance = wire.distToShape(solid)[0]
     return distance >= tolerance or Path.Geom.isRoughly(distance, tolerance)
+
+
+def _create_horizontal_face(wire, width):
+    """Return a rectangular horizontal face sweeping the wire's horizontal
+    edge laterally by `width` (tool diameter). Used for tool-diameter
+    collision checks. Returns None if the wire has no horizontal edge."""
+    edge = None
+    for e in wire.Edges:
+        if Path.Geom.isHorizontal(e):
+            edge = e
+            break
+    if not edge:
+        return None
+    direction = edge.Vertexes[1].Point - edge.Vertexes[0].Point
+    normal = direction.cross(Vector(0, 0, 1))
+    offset = normal.normalize() * width / 2
+    e1 = edge.translated(offset)
+    e2 = edge.translated(-offset)
+    e3 = Part.makeLine(e1.Vertexes[0].Point, e2.Vertexes[0].Point)
+    e4 = Part.makeLine(e1.Vertexes[1].Point, e2.Vertexes[1].Point)
+    wire = Part.Wire(Part.__sortEdges__([e1, e2, e3, e4]))
+
+    return Part.makeFace(wire)
+
+
+def _create_tool_path_shape(wire, tool_shape):
+    """Return a solid representing the volume swept by the tool's
+    cross-section along the wire's horizontal edge. Used for full
+    tool-shape collision checks. Returns None if there is no
+    horizontal edge or the slice is empty."""
+    edge = None
+    for e in wire.Edges:
+        if Path.Geom.isHorizontal(e):
+            edge = e
+            break
+    if not edge:
+        return None
+    p0 = edge.Vertexes[0].Point
+    p1 = edge.Vertexes[1].Point
+    direction = p1 - p0
+    section = tool_shape.slice(direction, 0)
+    if not section:
+        return None
+    section[0].translate(p0)
+
+    return section[0].extrude(direction)

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -57,6 +57,7 @@ FeatureStartPoint = 0x0008  # StartPoint
 FeatureFinishDepth = 0x0010  # FinishDepth
 FeatureStepDown = 0x0020  # StepDown
 FeatureNoFinalDepth = 0x0040  # edit or not edit FinalDepth
+FeatureLinking = 0x0080  # Linking
 FeatureBaseVertexes = 0x0100  # Base
 FeatureBaseEdges = 0x0200  # Base
 FeatureBaseFaces = 0x0400  # Base
@@ -156,6 +157,26 @@ class ObjectOp(object):
                 QT_TRANSLATE_NOOP("App::Property", "Holds the min Z value of Stock"),
             )
             obj.setEditorMode("OpStockZMin", 1)  # read-only
+
+    def addLinking(self, obj):
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "LinkingMode",
+            "Linking",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Method collision detection to create optimal path between areas"
+                "\n\nCompromise: uses tool diameter (middle long time computation)"
+                "\nFastest: not related from tool size (fast computation)"
+                "\nSafest: uses cross section of tool shape (most long time computation)",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyLength",
+            "LinkingSafetyMargin",
+            "Linking",
+            QT_TRANSLATE_NOOP("App::Property", "Distance for collision detection"),
+        )
 
     def __init__(self, obj, name, parentJob=None):
         Path.Log.track()
@@ -327,6 +348,9 @@ class ObjectOp(object):
                 QT_TRANSLATE_NOOP("App::Property", "Upper limit of the turning diameter."),
             )
 
+        if FeatureLinking & features:
+            self.addLinking(obj)
+
         # members being set later
         self.commandlist = None
         self.horizFeed = None
@@ -376,6 +400,11 @@ class ObjectOp(object):
                 (translate("CAM_Operation", "None"), "None"),
                 (translate("CAM_Operation", "Flood"), "Flood"),
                 (translate("CAM_Operation", "Mist"), "Mist"),
+            ],
+            "LinkingMode": [
+                (translate("CAM_Operation", "Fastest"), "Fastest"),
+                (translate("CAM_Operation", "Compromise"), "Compromise"),
+                (translate("CAM_Operation", "Safest"), "Safest"),
             ],
         }
 
@@ -475,6 +504,14 @@ class ObjectOp(object):
                 QT_TRANSLATE_NOOP("App::Property", "Incremental Step Down of Tool"),
             )
             obj.StepDown = 0
+
+        if FeatureLinking & features and not hasattr(obj, "LinkingMode"):
+            self.addLinking(obj)
+            for n in self.opPropertyEnumerations():
+                if hasattr(obj, n[0]):
+                    setattr(obj, n[0], n[1])
+            obj.LinkingMode = "Fastest"
+            self.applyExpression(obj, "LinkingSafetyMargin", "OpToolDiameter")
 
         self.setEditorModes(obj, features)
         self.opOnDocumentRestored(obj)
@@ -634,6 +671,10 @@ class ObjectOp(object):
 
         if FeatureStartPoint & features:
             obj.UseStartPoint = False
+
+        if FeatureLinking & features:
+            obj.LinkingMode = "Fastest"
+            self.applyExpression(obj, "LinkingSafetyMargin", "OpToolDiameter")
 
         self.opSetDefaultValues(obj, job)
         return job

--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -66,6 +66,7 @@ class ObjectOp(PathOp.ObjectOp):
             | PathOp.FeatureBaseFaces
             | self.circularHoleFeatures(obj)
             | PathOp.FeatureCoolant
+            | PathOp.FeatureLinking
         )
 
     def circularHoleFeatures(self, obj):

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -300,9 +300,14 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
             "local_clearance": safe_height,
             "global_clearance": obj.ClearanceHeight.Value,
             "solids": solids,
-            "tool_diameter": self.tool.Diameter.Value,
-            "safety_margin": 10,
+            "tool_shape": None,
+            "tool_diameter": None,
+            "safety_margin": obj.LinkingSafetyMargin.Value,
         }
+        if obj.LinkingMode == "Safest":
+            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
+        elif obj.LinkingMode == "Compromise":
+            linkingArgs["tool_diameter"] = obj.ToolController.Tool.Diameter.Value
 
         # http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g98-g99
 

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -292,12 +292,17 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
             v2 = FreeCAD.Vector(hole["x"], hole["y"], obj.FinalDepth.Value - endoffset)
             edgelist.append(Part.makeLine(v1, v2))
 
-        # build list of solids for collision detection.
-        # Include base objects from job
-        solids = []
-        for base in self.job.Model.Group:
-            solids.append(base.Shape)
-        tolerance = abs(safe_height - obj.StartDepth.Value)
+        # Prepare linking parameters
+        solids = [base.Shape for base in self.job.Model.Group]
+        linkingArgs = {
+            "start_position": None,
+            "target_position": None,
+            "local_clearance": safe_height,
+            "global_clearance": obj.ClearanceHeight.Value,
+            "solids": solids,
+            "tool_diameter": self.tool.Diameter.Value,
+            "safety_margin": 10,
+        }
 
         # http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g98-g99
 
@@ -339,15 +344,10 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
                 # Check if direct move at retract plane would collide with model
                 current_pos = machinestate.getPosition()
                 target_at_safe_height = FreeCAD.Vector(startPoint.x, startPoint.y, safe_height)
-                linking_moves = linking.get_linking_moves(
-                    start_position=current_pos,
-                    target_position=target_at_safe_height,
-                    local_clearance=safe_height,
-                    global_clearance=obj.ClearanceHeight.Value,
-                    solids=solids,
-                    tool_diameter=self.tool.Diameter,
-                    tolerance=tolerance,
-                )
+                linkingArgs["start_position"] = current_pos
+                linkingArgs["target_position"] = target_at_safe_height
+                linking_moves = linking.get_linking_moves(**linkingArgs)
+
                 """if linking_moves contains only 2 commands this means
                 it not contains vertical moves to clearance height
                 and this commands should be skipped"""

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -297,6 +297,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
         solids = []
         for base in self.job.Model.Group:
             solids.append(base.Shape)
+        tolerance = abs(safe_height - obj.StartDepth.Value)
 
         # http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g98-g99
 
@@ -343,8 +344,9 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
                     target_position=target_at_safe_height,
                     local_clearance=safe_height,
                     global_clearance=obj.ClearanceHeight.Value,
-                    tool_shape=self.tool.Shape,
                     solids=solids,
+                    tool_diameter=self.tool.Diameter,
+                    tolerance=tolerance,
                 )
                 """if linking_moves contains only 2 commands this means
                 it not contains vertical moves to clearance height

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -597,9 +597,14 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "local_clearance": safeHeight,
             "global_clearance": clearanceHeight,
             "solids": solids,
-            "tool_diameter": tooldiameter,
-            "safety_margin": 10,
+            "tool_shape": None,
+            "tool_diameter": None,
+            "safety_margin": obj.LinkingSafetyMargin.Value,
         }
+        if obj.LinkingMode == "Safest":
+            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
+        elif obj.LinkingMode == "Compromise":
+            linkingArgs["tool_diameter"] = tooldiameter
 
         obj.Direction = _caclulatePathDirection(obj)
 

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -598,7 +598,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "global_clearance": clearanceHeight,
             "solids": solids,
             "tool_diameter": tooldiameter,
-            "tolerance": abs(safeHeight - obj.StartDepth.Value),
+            "safety_margin": 10,
         }
 
         obj.Direction = _caclulatePathDirection(obj)

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -597,7 +597,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "local_clearance": safeHeight,
             "global_clearance": clearanceHeight,
             "solids": solids,
-            "tool_shape": self.tool.Shape,
+            "tool_diameter": tooldiameter,
             "tolerance": abs(safeHeight - obj.StartDepth.Value),
         }
 

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -71,6 +71,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
             | PathOp.FeatureHeights
             | PathOp.FeatureStepDown
             | PathOp.FeatureCoolant
+            | PathOp.FeatureLinking
         )
 
     def initOperation(self, obj):
@@ -280,9 +281,14 @@ class ObjectMillFacing(PathOp.ObjectOp):
             "local_clearance": obj.SafeHeight.Value,
             "global_clearance": obj.ClearanceHeight.Value,
             "solids": solids,
-            "tool_diameter": tool_diameter,
-            "safety_margin": 10,
+            "tool_shape": None,
+            "tool_diameter": None,
+            "safety_margin": obj.LinkingSafetyMargin.Value,
         }
+        if obj.LinkingMode == "Safest":
+            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
+        elif obj.LinkingMode == "Compromise":
+            linkingArgs["tool_diameter"] = tool_diameter
 
         # Determine the step-downs
         finish_step = 0.0  # No finish step for facing

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -272,6 +272,17 @@ class ObjectMillFacing(PathOp.ObjectOp):
         tool_diameter = tool.Diameter.Value
         Path.Log.debug(f"Tool diameter: {tool_diameter}")
 
+        # Prepare linking parameters
+        solids = [base.Shape for base in self.job.Model.Group]
+        linkingArgs = {
+            "start_position": None,
+            "target_position": None,
+            "local_clearance": obj.SafeHeight.Value,
+            "global_clearance": obj.ClearanceHeight.Value,
+            "solids": solids,
+            "tool_diameter": tool_diameter,
+        }
+
         # Determine the step-downs
         finish_step = 0.0  # No finish step for facing
         Path.Log.debug(
@@ -588,13 +599,10 @@ class ObjectMillFacing(PathOp.ObjectOp):
                         first_position = FreeCAD.Vector(target_xy[0], target_xy[1], depth)
 
                         # Generate collision-aware linking moves up to safe/clearance and back down
-                        link_commands = linking.get_linking_moves(
-                            start_position=last_position,
-                            target_position=first_position,
-                            local_clearance=obj.SafeHeight.Value,
-                            global_clearance=obj.ClearanceHeight.Value,
-                            tool_shape=obj.ToolController.Tool.Shape,
-                        )
+                        linkingArgs["start_position"] = last_position
+                        linkingArgs["target_position"] = first_position
+                        link_commands = linking.get_linking_moves(**linkingArgs)
+
                         # Append linking moves, ensuring full XYZ continuity
                         current = last_position
                         for lc in link_commands:
@@ -662,7 +670,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
         # Apply feedrates to the entire commandlist, with debug on failure
         try:
             FeedRate.setFeedRate(self.commandlist, obj.ToolController)
-        except Exception as e:
+        except Exception:
             # Dump last 12 commands for diagnostics
             n = len(self.commandlist)
             start = max(0, n - 12)

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -281,6 +281,7 @@ class ObjectMillFacing(PathOp.ObjectOp):
             "global_clearance": obj.ClearanceHeight.Value,
             "solids": solids,
             "tool_diameter": tool_diameter,
+            "safety_margin": 10,
         }
 
         # Determine the step-downs


### PR DESCRIPTION
`linking` taking argument `tool_shape`, but not use it
`linking` in **Helix** and **Drilling** operations uses wire for check collisions

Wire have zero thickness, so diameter of the tool is not taken into account
Result of `Linking` can be incorrect in some cases

[linking_test1.zip](https://github.com/user-attachments/files/26333484/linking_test1.zip)
[linking_test2.zip](https://github.com/user-attachments/files/26333495/linking_test2.zip)
[linking_test3.zip](https://github.com/user-attachments/files/26333536/linking_test3.zip)

<img width="922" height="556" alt="Screenshot_20260307_235751_lossy" src="https://github.com/user-attachments/assets/df0c6ff2-276f-4b93-8844-8ded2440bc59" />

---

### Changes:

Added two methods: **tool_diameter** and **tool_shape**

- **tool_diameter**
For simple tool shape like EndMill for `Helix` and `Drilling` operations 
Creates `Face` from horizontal wire. The width of the `Face` is tool diameter
Middle picture

- **tool_shape**
For complicated tool shape. Not implemented in operations
Creates extruded shell from tool shape section
Right picture

For both methods added tests

<img width="1454" height="611" alt="1_hor" src="https://github.com/user-attachments/assets/b78b108c-1b00-4741-9345-6fde7cc9d314" />

---

The reason to create several methods is a time calculation

In example below 100 holes

- **wire** method - 6 seconds
- **tool_diameter** method - 10 seconds
- **tool_shape** (simple cylinder) method - 20 second
With complicated tool shape time calculation will be increased

Face method is a compromise between safety and performance

<img width="972" height="583" alt="Screenshot_20260316_074529_lossy" src="https://github.com/user-attachments/assets/28d6097b-2efb-4133-9a67-93d55d518115" />

---

Maybe it make sense to add ability to select linking method to Path group of properties:
- No linking (old behavior)
- Wire
- Tool diameter
- Tool shape