### PR TITLE
Fix SpaceBall button assignment and command dispatch

### DIFF
--- a/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
@@ -167,8 +167,12 @@ long NavlibInterface::SetActiveCommand(std::string commandId)
             }
         }
     }
-    else
-        commandManager.runCommandByName(parsedData.commandName.c_str());
+    else {
+        Gui::Command* cmd = commandManager.getCommandByName(parsedData.commandName.c_str());
+        if (cmd) {
+            cmd->invoke(1);
+        }
+    }
 
     return 0;
 }

--- a/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
+++ b/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
@@ -54,8 +54,10 @@ ButtonView::ButtonView(QWidget* parent)
 
 void ButtonView::selectButton(int number)
 {
-    this->selectionModel()->select(this->model()->index(number, 0), QItemSelectionModel::ClearAndSelect);
-    this->scrollTo(this->model()->index(number, 0), QAbstractItemView::EnsureVisible);
+    QModelIndex idx = this->model()->index(number, 0);
+    this->selectionModel()->select(idx, QItemSelectionModel::ClearAndSelect);
+    this->setCurrentIndex(idx);
+    this->scrollTo(idx, QAbstractItemView::EnsureVisible);
 }
 
 void ButtonView::goSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected)

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1150,7 +1150,11 @@ bool MainWindow::event(QEvent* e)
                 return true;
             }
             else {
-                Application::Instance->commandManager().runCommandByName(commandName.c_str());
+                Command* cmd = Application::Instance->commandManager().getCommandByName(
+                    commandName.c_str());
+                if (cmd) {
+                    cmd->invoke(1);
+                }
             }
         }
         else {

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1151,7 +1151,8 @@ bool MainWindow::event(QEvent* e)
             }
             else {
                 Command* cmd = Application::Instance->commandManager().getCommandByName(
-                    commandName.c_str());
+                    commandName.c_str()
+                );
                 if (cmd) {
                     cmd->invoke(1);
                 }


### PR DESCRIPTION
## Summary

Two bugs in the SpaceBall button system that affect all platforms and drivers:

1. **Button assignment goes to wrong button** — pressing a SpaceMouse button in the Spaceball Buttons dialog highlights the correct button visually, but assigning a command applies it to the previously selected button instead.

2. **Checkable commands do nothing via SpaceBall button** — commands like `Std_OrthographicCamera` and `Std_PerspectiveCamera` silently fail when triggered from a SpaceBall button, while working fine from the toolbar or keyboard shortcut.

## Changes

### Commit 1: Fix button assignment (#17812)

**DlgCustomizeSpaceball.cpp** — `ButtonView::selectButton()` called `selectionModel()->select()` to update the visual highlight, but did not call `setCurrentIndex()`. When `goChangedCommand()` later read `currentIndex()` to determine which button row to assign the command to, it still pointed to the previous button.

Fix: store the `QModelIndex` once and call `setCurrentIndex(idx)` in addition to `select()`.

### Commit 2: Fix command dispatch (#10073)

**MainWindow.cpp** / **NavlibCmds.cpp** — The SpaceBall button handlers dispatched commands via `runCommandByName()` which calls `invoke(0)`. Checkable actions like `Std_OrthographicCamera` guard their execution with `if (iMsg == 1)` to prevent feedback loops from `isActive()` → `setChecked()` → `activated()`. Since `invoke(0)` never satisfies this guard, these commands silently did nothing.

Fix: use `invoke(1)` directly in the spnav and navlib SpaceBall button handlers instead of changing `runCommandByName()` globally, to avoid affecting its ~60 other call sites where `invoke(0)` is correct.

## Testing

Tested on Arch Linux (KDE Plasma Wayland) with SpaceNavigator (046d:c626) via spacenavd:

**Button assignment (#17812):**
- Open Tools → Customize → Spaceball Buttons
- Press SpaceMouse button 1 → assign "Fit All"
- Press SpaceMouse button 2 → assign "View Top"
- Verified: Button 1 shows "Fit All", Button 2 shows "View Top" (before fix: both on button 1)

**Command dispatch (#10073):**
- Assign `Std_OrthographicCamera` to button 1, `Std_PerspectiveCamera` to button 2
- Press buttons → camera switches correctly between orthographic and perspective
- Before fix: both buttons did nothing

**Regression:**
- Toolbar buttons for Orthographic/Perspective still work
- Keyboard shortcuts V,O and V,P still work
- ViewCube perspective toggle still works
- Other SpaceBall button assignments (Fit All, View Top, etc.) unaffected

## Fixes

Fixes #17812 (SpaceBall button assignment to wrong button)
Fixes #10073 (SpaceBall button does nothing for camera commands)