### PR TITLE
CAM: Drilling - Optimize linking

### DIFF
--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -337,27 +337,21 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
                 # For G99 mode, tool is at StartDepth (R-plane) after previous hole
                 # Check if direct move at retract plane would collide with model
                 current_pos = machinestate.getPosition()
-                target_at_retract_plane = FreeCAD.Vector(startPoint.x, startPoint.y, current_pos.z)
-
-                # Check collision at the retract plane (current Z height)
-                collision_detected = linking.check_collision(
+                target_at_safe_height = FreeCAD.Vector(startPoint.x, startPoint.y, safe_height)
+                linking_moves = linking.get_linking_moves(
                     start_position=current_pos,
-                    target_position=target_at_retract_plane,
+                    target_position=target_at_safe_height,
+                    local_clearance=safe_height,
+                    global_clearance=obj.ClearanceHeight.Value,
+                    tool_shape=self.tool.Shape,
                     solids=solids,
                 )
-
-                if collision_detected:
+                """if linking_moves contains only 2 commands this means
+                it not contains vertical moves to clearance height
+                and this commands should be skipped"""
+                if len(linking_moves) > 2:
                     # Cannot traverse at retract plane - need to break cycle group
                     # Retract to safe height, traverse, then plunge to safe height for new cycle
-                    target_at_safe_height = FreeCAD.Vector(startPoint.x, startPoint.y, safe_height)
-                    linking_moves = linking.get_linking_moves(
-                        start_position=current_pos,
-                        target_position=target_at_safe_height,
-                        local_clearance=safe_height,
-                        global_clearance=obj.ClearanceHeight.Value,
-                        tool_shape=self.tool.Shape,
-                        solids=solids,
-                    )
                     self.commandlist.extend(linking_moves)
                     machinestate.addCommands(linking_moves)
                 # else: no collision - G99 cycle continues, tool stays at retract plane


### PR DESCRIPTION
Each call of `linking` spends time for time long method `distToShape()`
Calls `linking` twice (`linking.check_collision()` and `linking.get_linking_moves()`), increases time calculation twice

Calculate `linking` moves and not use them is much faster than call `linking.check_collision()` and `linking.get_linking_moves()`

I suggest to calls only `linking.get_linking_moves()`
If amount commands in linking moves is 2, this mean there is no collision and linking can be skipped

---

Linking commands between holes

**1** - [Command G0 [ X:50 Y:15 Z:55 ], Command G0 [ X:50 Y:65 Z:55 ]]
**2** - [Command G0 [ X:50 Y:65 Z:55 ], Command G0 [ X:50 Y:115 Z:55 ]]
**3** - [Command G0 [ X:50 Y:115 Z:55 ], Command G0 [ X:50 Y:165 Z:55 ]]
**4** - [Command G0 [ X:50 Y:165 Z:55 ], Command G0 [ X:50 Y:165 **Z:111** ], Command G0 [ X:50 Y:355 **Z:111** ], Command G0 [ X:50 Y:355 Z:55 ]]
**5** - [Command G0 [ X:50 Y:355 Z:55 ], Command G0 [ X:50 Y:455 Z:55 ]]

We need to add linking moves only in case **4**
So we can always generate linking moves, but add them only if amount of commands > 2

<img width="681" height="282" alt="Screenshot_20260314_132328_lossy" src="https://github.com/user-attachments/assets/c9407ae9-31f6-4919-b979-0524fe2dc576" />

