### PR TITLE
Materials: Correct missing or incorrect licenses and authors

### DIFF
--- a/src/Mod/Material/Resources/Materials/Appearance/Aluminum.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Aluminum.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "d1f317f0-5ffa-4798-8ab3-af2ff0b5182c"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Aluminum"
   Description: "Defines the Aluminum appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Brass.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Brass.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "4151e19c-fd6a-4ca4-83d4-d5e17d76cb9c"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Brass"
   Description: "Defines the Brass appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Bronze.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Bronze.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "ae194589-02d4-4e9b-98a7-f523f660d510"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Bronze"
   Description: "Defines the Bronze appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Chrome.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Chrome.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "a9544b88-dde7-4d05-9bdb-c008a4e88dc1"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Chrome"
   Description: "Defines the Chrome appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Copper.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Copper.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "524cad9b-b841-4037-9851-badeca7dcee2"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Copper"
   Description: "Defines the Copper appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Default.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Default.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "5dbb7be6-8b63-479b-ab4c-87be02ead973"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Default"
   Description: "Defines the default appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Emerald.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Emerald.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "54def35f-a6bf-472e-8410-dc9fb4b143cf"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Emerald"
   Description: "Defines the Emerald appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Gold.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Gold.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "85257e2c-be3f-40a1-b03f-0bd4ba58ca08"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Gold"
   Description: "Defines the Gold appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Jade.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Jade.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "cddfa21f-0715-49dd-b35b-951c076fa52c"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Jade"
   Description: "Defines the Jade appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Metalized.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Metalized.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "d149a177-07f1-4e53-9bad-0b5bf0663600"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Metalized"
   Description: "Defines the Metalized appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Neon GNC.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Neon GNC.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "c0341eef-0897-4fcf-a7f7-eddf1a2600a5"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Neon GNC"
   Description: "Defines the Neon GNC appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Neon PHC.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Neon PHC.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "add2d6b2-c8fb-4777-a80a-52bae97300ae"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Neon PHC"
   Description: "Defines the Neon PHC appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Obsidian.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Obsidian.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "a004c270-7d2c-4898-bec6-b1120edacea9"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Obsidian"
   Description: "Defines the Obsidian appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Pewter.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Pewter.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "a61853b9-ec9f-403e-9726-0a938731aecd"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Pewter"
   Description: "Defines the Pewter appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Plaster.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Plaster.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "569dccb6-c64b-4dd0-9d3c-1b78f40ad1a5"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Plaster"
   Description: "Defines the Plaster appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Plastic.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Plastic.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "a74622cd-0e2d-4a96-b8c4-fefcc82ac694"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Plastic"
   Description: "Defines the Plastic appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Ruby.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Ruby.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "953261a0-cc48-41f8-a3f9-7b20ae3f9b56"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Ruby"
   Description: "Defines the Ruby appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Satin.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Satin.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "951b54ae-86b6-46d2-b452-60bd6a3ba1bb"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Satin"
   Description: "Defines the Satin appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Shiny Plastic.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Shiny Plastic.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "591c4c4a-22ba-4a9a-869d-e5610107d69a"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Shiny Plastic"
   Description: "Defines the Shiny Plastic appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Silver.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Silver.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "62839fb0-d854-4b44-92df-b7249213de49"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Silver"
   Description: "Defines the Silver appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Steel.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Steel.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "4b849c55-6b3a-4f75-a055-40c0d0324596"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Steel"
   Description: "Defines the Steel appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Appearance/Stone.FCMat
+++ b/src/Mod/Material/Resources/Materials/Appearance/Stone.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "a9f54d61-cc98-46df-8734-b0543ceb4e45"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Stone"
   Description: "Defines the Stone appearance properties"
 AppearanceModels:

--- a/src/Mod/Material/Resources/Materials/Fluid/Air.FCMat
+++ b/src/Mod/Material/Resources/Materials/Fluid/Air.FCMat
@@ -2,7 +2,8 @@
 # File created by ConvertFCMat.py
 General:
   UUID: "94370b96-c97e-4a3f-83b2-11d7461f7da7"
-  License: "GPL-2.0-or-later"
+  Author: "Qingfeng Xia"
+  License: "LGPL-2.1-or-later"
   Name: "Air"
   Description: "Dry air properties at 20 Degrees Celsius and 1 atm"
 Models:

--- a/src/Mod/Material/Resources/Materials/Fluid/Argon.FCMat
+++ b/src/Mod/Material/Resources/Materials/Fluid/Argon.FCMat
@@ -2,7 +2,8 @@
 # File created by ConvertFCMat.py
 General:
   UUID: "e359c5b5-eae2-42b1-9ef6-edde21d706ee"
-  License: "GPL-2.0-or-later"
+  Author: "Uwe Stoehr"
+  License: "LGPL-2.1-or-later"
   Name: "Argon"
   Description: "Argon properties at 20 Degrees Celsius and 1 atm"
 Models:

--- a/src/Mod/Material/Resources/Materials/Fluid/Carbon Dioxide.FCMat
+++ b/src/Mod/Material/Resources/Materials/Fluid/Carbon Dioxide.FCMat
@@ -2,7 +2,8 @@
 # File created by ConvertFCMat.py
 General:
   UUID: "ef0e4040-a498-48c3-a87b-e996bfd89195"
-  License: "GPL-2.0-or-later"
+  Author: "Uwe Stoehr"
+  License: "LGPL-2.1-or-later"
   Name: "Carbon Dioxide"
   Description: "Carbon dioxide properties at 20 Degrees Celsius and 1 atm"
 Models:

--- a/src/Mod/Material/Resources/Materials/Fluid/Nitrogen.FCMat
+++ b/src/Mod/Material/Resources/Materials/Fluid/Nitrogen.FCMat
@@ -2,7 +2,8 @@
 # File created by ConvertFCMat.py
 General:
   UUID: "8d02a797-5e0a-4e40-803a-75fc66de8de6"
-  License: "GPL-2.0-or-later"
+  Author: "Uwe Stoehr"
+  License: "LGPL-2.1-or-later"
   Name: "Nitrogen"
   Description: "Nitrogen properties at 20 Degrees Celsius and 1 atm"
 Models:

--- a/src/Mod/Material/Resources/Materials/Fluid/None.FCMat
+++ b/src/Mod/Material/Resources/Materials/Fluid/None.FCMat
@@ -2,7 +2,8 @@
 # File created by ConvertFCMat.py
 General:
   UUID: "944a8018-09bf-48f6-a7b3-aa8f6a00a310"
-  License: "GPL-2.0-or-later"
+  Author: "Qingfeng Xia"
+  License: "LGPL-2.1-or-later"
   Name: "None"
   Description: "None"
 Models:

--- a/src/Mod/Material/Resources/Materials/Fluid/Water.FCMat
+++ b/src/Mod/Material/Resources/Materials/Fluid/Water.FCMat
@@ -2,7 +2,8 @@
 # File created by ConvertFCMat.py
 General:
   UUID: "7e5559d5-be15-4571-a72f-20c39edd41cf"
-  License: "GPL-2.0-or-later"
+  Author: "Qingfeng Xia"
+  License: "LGPL-2.1-or-later"
   Name: "Water"
   Description: "Standard distilled water properties at 20 Degrees Celsius and 1 atm"
   ReferenceSource: "''"

--- a/src/Mod/Material/Resources/Materials/Patterns/PAT/Diagonal4.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/PAT/Diagonal4.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "c8bb743d-0f50-4109-b452-725037c3e3ec"
   Name: "Diagonal4"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   PAT:
     UUID: "0326c759-4e3d-46ca-bb7d-146ebebea65e"

--- a/src/Mod/Material/Resources/Materials/Patterns/PAT/Diagonal5.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/PAT/Diagonal5.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "bf7789e6-227d-4859-a75b-18008723fb51"
   Name: "Diagonal5"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   PAT:
     UUID: "0326c759-4e3d-46ca-bb7d-146ebebea65e"

--- a/src/Mod/Material/Resources/Materials/Patterns/PAT/Diamond.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/PAT/Diamond.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "7cc39c57-f49c-400d-a985-8f8d141f5478"
   Name: "Diamond"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   PAT:
     UUID: "0326c759-4e3d-46ca-bb7d-146ebebea65e"

--- a/src/Mod/Material/Resources/Materials/Patterns/PAT/Diamond2.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/PAT/Diamond2.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "b8940cab-1fbb-4ba5-9e32-2179589d6593"
   Name: "Diamond2"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   PAT:
     UUID: "0326c759-4e3d-46ca-bb7d-146ebebea65e"

--- a/src/Mod/Material/Resources/Materials/Patterns/PAT/Diamond4.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/PAT/Diamond4.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "a9146fcf-4168-4065-8a58-ec78735e471d"
   Name: "Diamond4"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   PAT:
     UUID: "0326c759-4e3d-46ca-bb7d-146ebebea65e"

--- a/src/Mod/Material/Resources/Materials/Patterns/PAT/Horizontal5.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/PAT/Horizontal5.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "0902d885-ac66-441e-9c3f-e0086a4817fc"
   Name: "Horizontal5"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   PAT:
     UUID: "0326c759-4e3d-46ca-bb7d-146ebebea65e"

--- a/src/Mod/Material/Resources/Materials/Patterns/PAT/Square.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/PAT/Square.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "7e8510f7-7d87-4782-894d-068b0d3f04b7"
   Name: "Square"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   PAT:
     UUID: "0326c759-4e3d-46ca-bb7d-146ebebea65e"

--- a/src/Mod/Material/Resources/Materials/Patterns/PAT/Vertical5.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/PAT/Vertical5.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "eaa335a5-3bee-4da7-9e26-0ebbdac2e182"
   Name: "Vertical5"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   PAT:
     UUID: "0326c759-4e3d-46ca-bb7d-146ebebea65e"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/aluminum.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/aluminum.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "abab7c4a-464a-40af-bf9e-32f658adf224"
   Name: "aluminum"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/brick01.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/brick01.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "37b63834-928e-444c-a1b7-49a3f3fba3d1"
   Name: "brick01"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/concrete.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/concrete.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "39221178-f9a4-40f5-927f-eed2f17c748d"
   Name: "concrete"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/cross.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/cross.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "e321248b-de79-4573-b68b-53df020052b0"
   Name: "cross"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/cuprous.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/cuprous.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "50e78494-a675-413f-a541-70d1904f0189"
   Name: "cuprous"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/diagonal1.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/diagonal1.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "2b4e5304-13ab-47d1-b530-e438eeda4ed0"
   Name: "diagonal1"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/diagonal2.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/diagonal2.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "91efc25f-a841-4bb3-a4ca-6b4d70fd4e05"
   Name: "diagonal2"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/earth.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/earth.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "94149a01-f4ad-4e6a-a6df-acb3ea97eb0b"
   Name: "earth"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/general_steel.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/general_steel.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "29329280-1e89-4e8f-8e22-4582965654b4"
   Name: "general_steel"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/glass.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/glass.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "0f8f1e63-885e-4940-a562-afed029b172a"
   Name: "glass"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/hatch45L.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/hatch45L.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "f2421e27-1b54-4c6e-8da9-e0be3f1783a5"
   Name: "hatch45L"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/hatch45R.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/hatch45R.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "169e4200-586d-4bde-aae5-4527392012f8"
   Name: "hatch45R"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/hbone.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/hbone.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "92232ced-d96b-4cc8-a052-4e13f7d943ab"
   Name: "hbone"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/line.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/line.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "bf024194-da67-4c3c-a482-08c7efa6dbde"
   Name: "line"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/plastic.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/plastic.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "2fc720b1-19b3-4a30-a0f4-a782135559f5"
   Name: "plastic"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/plus.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/plus.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "90b1bd10-7df1-4338-bb74-f82040570afd"
   Name: "plus"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/simple.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/simple.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "52d16497-4e67-45f0-b366-62fdf93dcbe7"
   Name: "simple"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/solid.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/solid.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "d7c6b577-b41b-4d4b-a2b3-2139a1a9a7af"
   Name: "solid"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/square.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/square.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "836b307f-542d-466b-ba67-d96401b2fa8f"
   Name: "square"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/steel.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/steel.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "e8555d5c-c9ff-458f-9ad3-ecabd02b5327"
   Name: "steel"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/titanium.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/titanium.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "5c66ffe9-6556-4361-9da7-ed3b187e3cfe"
   Name: "titanium"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/wood.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/wood.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "c693952c-5f5a-4f8f-9e6f-714464219a8b"
   Name: "wood"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/woodgrain.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/woodgrain.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "f3ffddec-9468-41c4-b107-035287283e45"
   Name: "woodgrain"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/zinc.FCMat
+++ b/src/Mod/Material/Resources/Materials/Patterns/Pattern Files/zinc.FCMat
@@ -4,7 +4,7 @@ General:
   UUID: "957f8af7-7a3f-4086-9aaa-2bc7aa07a54f"
   Name: "zinc"
   Author: "David Carter"
-  License: "All rights reserved"
+  License: "CC-BY-4.0"
 AppearanceModels:
   Pattern File:
     UUID: "c6596294-e97d-4812-87db-28e1d66521a3"

--- a/src/Mod/Material/Resources/Materials/Standard/Default.FCMat
+++ b/src/Mod/Material/Resources/Materials/Standard/Default.FCMat
@@ -3,7 +3,7 @@
 General:
   UUID: "7f9fd73b-50c9-41d8-b7b2-575a030c1eeb"
   Author: "David Carter"
-  License: "GPL-2.0-or-later"
+  License: "CC-BY-4.0"
   Name: "Default"
   Description: "Generic material with density of 1"
 Inherits:

--- a/src/Mod/Material/Resources/Materials/Standard/Metal/Alloys/Invar-Generic.FCMat
+++ b/src/Mod/Material/Resources/Materials/Standard/Metal/Alloys/Invar-Generic.FCMat
@@ -3,6 +3,7 @@
 General:
   UUID: "27745e16-2a10-4c8e-bd22-59971806909c"
   Author: "Uwe Stöhr"
+  License: "LGPL-2.1-or-later"
   Name: "Invar Generic"
 Models:
   Father:

--- a/src/Mod/Material/Resources/Materials/Standard/Metal/Aluminum/Aluminum-Generic.FCMat
+++ b/src/Mod/Material/Resources/Materials/Standard/Metal/Aluminum/Aluminum-Generic.FCMat
@@ -3,6 +3,7 @@
 General:
   UUID: "9bf060e9-1663-44a2-88e2-2ff6ee858efe"
   Author: "Uwe Stöhr"
+  License: "LGPL-2.1-or-later"
   Name: "Aluminum Generic"
 Inherits:
   Aluminum:

--- a/src/Mod/Material/Resources/Materials/Standard/Metal/Copper/Copper-Generic.FCMat
+++ b/src/Mod/Material/Resources/Materials/Standard/Metal/Copper/Copper-Generic.FCMat
@@ -3,6 +3,7 @@
 General:
   UUID: "6c03899d-496e-4c60-a41b-3d66f2337fb9"
   Author: "Uwe Stöhr"
+  License: "LGPL-2.1-or-later"
   Name: "Copper Generic"
 Inherits:
   Copper:

--- a/src/Mod/Material/Resources/Materials/Standard/Metal/Iron/Iron-Generic.FCMat
+++ b/src/Mod/Material/Resources/Materials/Standard/Metal/Iron/Iron-Generic.FCMat
@@ -3,6 +3,7 @@
 General:
   UUID: "1826c364-d26a-43fb-8f61-288281236836"
   Author: "Uwe Stöhr"
+  License: "LGPL-2.1-or-later"
   Name: "Iron Generic"
 Inherits:
   Steel:

--- a/src/Mod/Material/Resources/Materials/Standard/Metal/Titanium/Ti-6Al-4V.FCMat
+++ b/src/Mod/Material/Resources/Materials/Standard/Metal/Titanium/Ti-6Al-4V.FCMat
@@ -3,6 +3,7 @@
 General:
   UUID: "f8013463-8008-4063-818c-ab6884cfa015"
   Author: "vlk"
+  License: "LGPL-2.1-or-later"
   Name: "Ti-6Al-4V (Grade 5)"
 Models:
   Father:


### PR DESCRIPTION
During conversion of some materials from the originals, in some cases authorship was lost, or licensing mistaken. In addition, during their creation some files had incorrect licenses applied. Files previously licensed LGPL-2.1.-or-later had that license restored. Other files were re-licensed by agreement of their author.
