### PR TITLE
Part Design: This fixes the unit switch

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -127,7 +127,9 @@ bool tryUpdateDisplayContextFromText(
     }
 
     try {
-        const auto unitQuantity = Base::Quantity::parse(QStringLiteral("1%1").arg(candidateUnit).toStdString());
+        const auto unitQuantity = Base::Quantity::parse(
+            QStringLiteral("1%1").arg(candidateUnit).toStdString()
+        );
         if (!quantity.isDimensionlessOrUnit(unitQuantity.getUnit())) {
             return false;
         }

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -99,7 +99,7 @@ bool tryUpdateDisplayContextFromText(
     const QString& text,
     const Base::Quantity& quantity,
     double& unitFactor,
-    double& unitValue,
+    double* unitValue,
     QString& unitStr
 )
 {
@@ -132,7 +132,9 @@ bool tryUpdateDisplayContextFromText(
             return false;
         }
         unitFactor = unitQuantity.getValue();
-        unitValue = candidateValue;
+        if (unitValue) {
+            *unitValue = candidateValue;
+        }
         unitStr = candidateUnit;
         return unitFactor != 0.0 || quantity.getValue() == 0.0;
     }
@@ -682,14 +684,13 @@ void QuantitySpinBox::setValue(double value)
     }
 
     double displayFactor = d->unitFactor;
-    double displayValue = d->unitValue;
     QString displayUnit = d->unitStr;
     if (!tryUpdateDisplayContextFromText(
             d->locale,
             lineEdit()->text(),
             d->quantity,
             displayFactor,
-            displayValue,
+            nullptr,
             displayUnit
         )) {
         setValue(quantity);
@@ -1012,7 +1013,7 @@ void QuantitySpinBox::stepBy(int steps)
         lineEdit()->text(),
         current,
         d->unitFactor,
-        d->unitValue,
+        &d->unitValue,
         d->unitStr
     );
     if (!preserveDisplay && d->pendingEmit) {

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -58,6 +58,89 @@ using namespace Base;
 namespace Gui
 {
 
+QString formatDisplayValue(
+    const QLocale& locale,
+    const Base::Quantity& quantity,
+    double factor,
+    const QString& unitStr
+)
+{
+    QLocale displayLocale(locale);
+    const auto& format = quantity.getFormat();
+    if (format.option != Base::QuantityFormat::None) {
+        displayLocale.setNumberOptions(static_cast<QLocale::NumberOptions>(format.option));
+    }
+
+    QString number = displayLocale.toString(
+        quantity.getValue() / factor,
+        format.toFormat(),
+        format.getPrecision()
+    );
+    if (qAbs(quantity.getValue()) >= 1000.0) {
+        number.remove(locale.groupSeparator());
+    }
+    if (unitStr.isEmpty()) {
+        return number;
+    }
+
+    static const QStringList compactUnits {
+        QStringLiteral("°"),
+        QStringLiteral("′"),
+        QStringLiteral("″"),
+        QStringLiteral("'"),
+        QStringLiteral("\"")
+    };
+    const QString separator = compactUnits.contains(unitStr) ? QString() : QStringLiteral(" ");
+    return number + separator + unitStr;
+}
+
+bool tryUpdateDisplayContextFromText(
+    const QLocale& locale,
+    const QString& text,
+    const Base::Quantity& quantity,
+    double& unitFactor,
+    double& unitValue,
+    QString& unitStr
+)
+{
+    QString expr = QStringLiteral("^([%1%2]?[0-9\\%3]*)\\%4?([0-9]+(%5[%1%2]?[0-9]+)?)")
+                       .arg(locale.negativeSign())
+                       .arg(locale.positiveSign())
+                       .arg(locale.groupSeparator())
+                       .arg(locale.decimalPoint())
+                       .arg(locale.exponential());
+    auto rmatch = QRegularExpression(expr).match(text.trimmed());
+    if (!rmatch.hasMatch()) {
+        return false;
+    }
+
+    const QString numberText = rmatch.captured(0);
+    const QString candidateUnit = text.trimmed().mid(rmatch.capturedLength()).trimmed();
+    if (candidateUnit.isEmpty()) {
+        return false;
+    }
+
+    bool ok = false;
+    const double candidateValue = locale.toDouble(numberText, &ok);
+    if (!ok) {
+        return false;
+    }
+
+    try {
+        const auto unitQuantity = Base::Quantity::parse(QStringLiteral("1%1").arg(candidateUnit).toStdString());
+        if (!quantity.isDimensionlessOrUnit(unitQuantity.getUnit())) {
+            return false;
+        }
+        unitFactor = unitQuantity.getValue();
+        unitValue = candidateValue;
+        unitStr = candidateUnit;
+        return unitFactor != 0.0 || quantity.getValue() == 0.0;
+    }
+    catch (const Base::ParserError&) {
+        return false;
+    }
+}
+
 class QuantitySpinBoxPrivate
 {
 public:
@@ -66,7 +149,9 @@ public:
         , pendingEmit(false)
         , normalize(true)
         , checkRangeInExpression(false)
+        , preserveDisplayOnNextSetValue(false)
         , unitValue(0)
+        , unitFactor(1.0)
         , maximum(std::numeric_limits<double>::max())
         , minimum(-std::numeric_limits<double>::max())
         , singleStep(1.0)
@@ -306,11 +391,13 @@ public:
     bool pendingEmit;
     bool normalize;
     bool checkRangeInExpression;
+    bool preserveDisplayOnNextSetValue;
     QString validStr;
     Base::Quantity quantity;
     Base::Quantity cached;
     Base::Unit unit;
     double unitValue;
+    double unitFactor;
     QString unitStr;
     double maximum;
     double minimum;
@@ -482,6 +569,7 @@ void QuantitySpinBox::updateText(const Quantity& quant)
 
     double dFactor;
     QString txt = getUserString(quant, dFactor, d->unitStr);
+    d->unitFactor = dFactor;
     d->unitValue = quant.getValue() / dFactor;
     updateEdit(txt);
     handlePendingEmit();
@@ -564,6 +652,7 @@ bool QuantitySpinBox::isNormalized()
 void QuantitySpinBox::setValue(const Base::Quantity& value)
 {
     Q_D(QuantitySpinBox);
+    d->preserveDisplayOnNextSetValue = false;
     d->quantity = value;
     // check limits
     if (d->quantity.getValue() > d->maximum) {
@@ -585,8 +674,44 @@ void QuantitySpinBox::setValue(double value)
     Base::QuantityFormat currentformat = d->quantity.getFormat();
     auto quantity = Base::Quantity(value, d->unit);
     quantity.setFormat(currentformat);
+    const bool preserveDisplay = d->preserveDisplayOnNextSetValue;
+    d->preserveDisplayOnNextSetValue = false;
+    if (!preserveDisplay || d->unitStr.isEmpty()) {
+        setValue(quantity);
+        return;
+    }
 
-    setValue(quantity);
+    double displayFactor = d->unitFactor;
+    double displayValue = d->unitValue;
+    QString displayUnit = d->unitStr;
+    if (!tryUpdateDisplayContextFromText(
+            d->locale,
+            lineEdit()->text(),
+            d->quantity,
+            displayFactor,
+            displayValue,
+            displayUnit
+        )) {
+        setValue(quantity);
+        return;
+    }
+
+    d->quantity = quantity;
+    // check limits
+    if (d->quantity.getValue() > d->maximum) {
+        d->quantity.setValue(d->maximum);
+    }
+    if (d->quantity.getValue() < d->minimum) {
+        d->quantity.setValue(d->minimum);
+    }
+
+    d->unitFactor = displayFactor;
+    d->unitStr = displayUnit;
+    d->cached = d->quantity;
+    d->pendingEmit = true;
+    d->unitValue = d->quantity.getValue() / d->unitFactor;
+    updateEdit(formatDisplayValue(d->locale, d->quantity, d->unitFactor, d->unitStr));
+    updateFromCache(true, false);
 }
 
 bool QuantitySpinBox::autoNormalize() const
@@ -686,11 +811,18 @@ void QuantitySpinBox::updateFromCache(bool notify, bool updateUnit /* = true */)
 {
     Q_D(QuantitySpinBox);
     if (d->pendingEmit) {
-        double factor;
         const Base::Quantity& res = d->cached;
-        auto tmpUnit(d->unitStr);
-        QString text = getUserString(res, factor, updateUnit ? d->unitStr : tmpUnit);
-        d->unitValue = res.getValue() / factor;
+        QString text;
+        if (updateUnit) {
+            double factor;
+            text = getUserString(res, factor, d->unitStr);
+            d->unitFactor = factor;
+            d->unitValue = res.getValue() / factor;
+        }
+        else {
+            text = lineEdit()->text();
+            d->unitValue = res.getValue() / d->unitFactor;
+        }
         d->quantity = res;
 
         // signaling
@@ -874,7 +1006,24 @@ QAbstractSpinBox::StepEnabled QuantitySpinBox::stepEnabled() const
 void QuantitySpinBox::stepBy(int steps)
 {
     Q_D(QuantitySpinBox);
-    updateFromCache(false);
+    const Base::Quantity& current = d->pendingEmit ? d->cached : d->quantity;
+    const bool preserveDisplay = tryUpdateDisplayContextFromText(
+        d->locale,
+        lineEdit()->text(),
+        current,
+        d->unitFactor,
+        d->unitValue,
+        d->unitStr
+    );
+    if (!preserveDisplay && d->pendingEmit) {
+        updateFromCache(false);
+    }
+    else if (preserveDisplay) {
+        updateFromCache(false, false);
+    }
+    else {
+        updateFromCache(false);
+    }
 
     double step = d->singleStep * steps;
     double val = d->unitValue + step;
@@ -885,10 +1034,23 @@ void QuantitySpinBox::stepBy(int steps)
         val = d->minimum;
     }
 
-    Quantity quant(val, d->unitStr.toStdString());
+    Quantity quant(d->quantity);
+    quant.setValue(val * d->unitFactor);
     quant.setFormat(d->quantity.getFormat());
-    updateText(quant);
-    updateFromCache(true);
+    if (!preserveDisplay) {
+        d->preserveDisplayOnNextSetValue = false;
+        updateText(quant);
+        updateFromCache(true);
+    }
+    else {
+        d->preserveDisplayOnNextSetValue = true;
+        d->cached = quant;
+        d->pendingEmit = true;
+        d->unitValue = val;
+        updateEdit(formatDisplayValue(d->locale, quant, d->unitFactor, d->unitStr));
+        updateFromCache(true, false);
+    }
+
     update();
     selectNumber();
 }


### PR DESCRIPTION
Fixes: #28187

This PR fixes a unit-conversion bug in `Gui::QuantitySpinBox` that affected the PartDesign Hole diameter editor when the value was changed using stepping controls such as the mouse wheel, keyboard arrows, or spinbox buttons.                                                                                                                      
                                                                                                                                                                             
 The issue was caused by the step-update path reformatting the quantity from its raw value on every step. Near zero, the unit schema could auto-scale the displayed value from the current editing unit, such as mm, into a smaller unit such as nm.
                                                                                                                         
To fix this, the step logic now preserves the current display unit context during UI-driven stepping. The widget keeps track of the displayed unit string and its conversion factor, and reuses them while stepping instead of re-running automatic unit scaling on every increment or decrement. The refresh path in `setValue(double)` was  also adjusted so that the immediate post-step update keeps the same display unit only for that step flow, while ordinary external updates still use the normal schema-based  formatting path.                                                                                                                                                           
                                                                                                                                                                             
  The patch also validates that any pending unit suffix is compatible with the widget’s quantity type before reusing it, and keeps the existing `QuantityFormat` behavior  intact so precision and formatting remain unchanged.

**Local Testing:-**

https://github.com/user-attachments/assets/357b9bec-8899-44ac-98a1-a05e26706feb

