### PR TITLE
#27800: Disable editing of Escape Character in Preferences

### DIFF
--- a/src/Mod/Spreadsheet/Gui/DlgSettings.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgSettings.ui
@@ -229,6 +229,9 @@ Defaults to: %V = %A
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Escape character, typically the backslash (\), used to indicate special unprintable characters, e.g. \t = tab. Must be a single character.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string notr="true">\</string>
         </property>


### PR DESCRIPTION
# Disable Editing of Escape Character in Preferences

## Issue
The **Escape character** input field was editable in the Spreadsheet preferences, even though:

- It must always be a **single character**
- It is typically expected to remain `\`
- Changing it could lead to **incorrect parsing of special characters** during import/export

Allowing users to edit this field could therefore result in inconsistent or unintended behavior.

---

## Solution
This change **disables the Escape character input field**, preventing manual modification while still displaying the value to the user.

This ensures that:

- The UI reflects that the value is **not intended to be user-editable**
- Users cannot accidentally configure **invalid escape characters**
- **Import/export behavior remains consistent**

The fix was implemented by **disabling the input widget in the UI**.

---

## Before
<img width="1470" height="956" alt="Before change" src="https://github.com/user-attachments/assets/fa396934-06a4-450d-8748-9e72747033d2" />

---

## After
<img width="1470" height="956" alt="After change" src="https://github.com/user-attachments/assets/7f7b8045-4b6a-48a6-ad80-a197e8eea56d" />

---

## Testing
- Built **FreeCAD** locally
- Verified that the **Escape character field is no longer editable**
- Confirmed the value **still displays correctly in the UI**