### PR TITLE
Part Design/Part: Improved the error messages 

### DIFF
--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -115,7 +115,13 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         return Part::FilletBase::execute();
     }
     catch (Standard_Failure& e) {
-        return new App::DocumentObjectExecReturn(e.GetMessageString());
+        std::string msg = e.GetMessageString();
+        if (msg.find("command not done") != std::string::npos) {
+            return new App::DocumentObjectExecReturn(
+                "Chamfer size too large: would consume an adjacent face. "
+                "Reduce the size or select fewer edges.");
+        }
+        return new App::DocumentObjectExecReturn(msg.c_str());
     }
     catch (...) {
         return new App::DocumentObjectExecReturn(

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -108,9 +108,11 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         Part::SignalException sig;
         mkChamfer.Build();
         if (!mkChamfer.IsDone()) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                "Exception",
                 "Chamfer failed: size is incompatible with the shape geometry. "
-                "Reduce the size, select fewer edges, or ensure edges have sufficient width."));
+                "Reduce the size, select fewer edges, or ensure edges have sufficient width."
+            ));
         }
         TopoDS_Shape shape = mkChamfer.Shape();
         if (shape.IsNull()) {

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -119,7 +119,8 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         if (msg.find("command not done") != std::string::npos) {
             return new App::DocumentObjectExecReturn(
                 "Chamfer size too large: would consume an adjacent face. "
-                "Reduce the size or select fewer edges.");
+                "Reduce the size or select fewer edges."
+            );
         }
         return new App::DocumentObjectExecReturn(msg.c_str());
     }

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -32,6 +32,7 @@
 
 
 #include <SignalException.h>
+#include <Base/Exception.h>
 #include "FeatureChamfer.h"
 #include "TopoShapeOpCode.h"
 
@@ -123,9 +124,13 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         }
         return new App::DocumentObjectExecReturn(msg.c_str());
     }
+    catch (Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
     catch (...) {
         return new App::DocumentObjectExecReturn(
-            "Chamfer failed: OCC kernel error in chamfer computation"
+            "Chamfer failed: size may be too large for adjacent edges sharing a vertex. "
+            "Reduce the size or chamfer edges individually."
         );
     }
 }

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -121,18 +121,11 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         this->Shape.setValue(res.makeElementShape(mkChamfer, baseTopoShape, Part::OpCodes::Chamfer));
         return Part::FilletBase::execute();
     }
-    catch (Standard_Failure& e) {
-        std::string msg = e.GetMessageString();
-        if (msg.find("command not done") != std::string::npos) {
-            return new App::DocumentObjectExecReturn(
-                "Chamfer size too large: would consume an adjacent face. "
-                "Reduce the size or select fewer edges."
-            );
-        }
-        return new App::DocumentObjectExecReturn(msg.c_str());
-    }
     catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
+    }
+    catch (Standard_Failure& e) {
+        return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
     catch (...) {
         return new App::DocumentObjectExecReturn(

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -106,6 +106,12 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         Edges.setValues(edges);
 
         Part::SignalException sig;
+        mkChamfer.Build();
+        if (!mkChamfer.IsDone()) {
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                "Chamfer failed: size is incompatible with the shape geometry. "
+                "Reduce the size, select fewer edges, or ensure edges have sufficient width."));
+        }
         TopoDS_Shape shape = mkChamfer.Shape();
         if (shape.IsNull()) {
             return new App::DocumentObjectExecReturn("Resulting shape is null");

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -123,31 +123,42 @@ App::DocumentObjectExecReturn* Fillet::execute()
                 switch (mkFillet.StripeStatus(ic)) {
                     case ChFiDS_WalkingFailure:
                         return new App::DocumentObjectExecReturn(
-                            "Fillet radius too large: cannot trace surface along edge. Reduce the radius.");
+                            "Fillet radius too large: cannot trace surface along edge. Reduce the "
+                            "radius."
+                        );
                     case ChFiDS_StartsolFailure:
                         return new App::DocumentObjectExecReturn(
                             "Fillet conflict at shared vertex: adjacent radii overlap. "
-                            "Reduce the radius or fillet edges separately.");
+                            "Reduce the radius or fillet edges separately."
+                        );
                     case ChFiDS_TwistedSurface:
                         return new App::DocumentObjectExecReturn(
-                            "Fillet radius too large: surface would self-intersect. Reduce the radius.");
+                            "Fillet radius too large: surface would self-intersect. Reduce the "
+                            "radius."
+                        );
                     default:
                         break;
                 }
                 return new App::DocumentObjectExecReturn(
-                    "Fillet failed on selected edge(s). Reduce the radius or fillet edges individually.");
+                    "Fillet failed on selected edge(s). Reduce the radius or fillet edges "
+                    "individually."
+                );
             }
             if (mkFillet.NbFaultyVertices() > 0) {
                 return new App::DocumentObjectExecReturn(
-                    "Fillet failed at shared corner: adjacent radii overlap. Reduce the radius.");
+                    "Fillet failed at shared corner: adjacent radii overlap. Reduce the radius."
+                );
             }
             if (mkFillet.HasResult()) {
                 return new App::DocumentObjectExecReturn(
-                    "Fillet partially applied: some edges failed. Reduce the radius or fillet individually.");
+                    "Fillet partially applied: some edges failed. Reduce the radius or fillet "
+                    "individually."
+                );
             }
             return new App::DocumentObjectExecReturn(
                 "Fillet failed: radius exceeds adjacent face width. "
-                "Reduce the radius or select fewer edges.");
+                "Reduce the radius or select fewer edges."
+            );
         }
 
         TopoDS_Shape shape = mkFillet.Shape();
@@ -164,7 +175,8 @@ App::DocumentObjectExecReturn* Fillet::execute()
         if (msg.find("command not done") != std::string::npos) {
             return new App::DocumentObjectExecReturn(
                 "Fillet failed: radius too large for selected edge(s). "
-                "Reduce the radius or select fewer edges.");
+                "Reduce the radius or select fewer edges."
+            );
         }
         return new App::DocumentObjectExecReturn(msg.c_str());
     }

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -25,6 +25,7 @@
 #include <FCConfig.h>
 
 #include <BRepFilletAPI_MakeFillet.hxx>
+#include <ChFiDS_ErrorStatus.hxx>
 #include <Precision.hxx>
 #include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
@@ -113,6 +114,42 @@ App::DocumentObjectExecReturn* Fillet::execute()
         }
         Edges.setValues(edges);
 
+        // Explicitly build so OCC diagnostics are available on failure.
+        mkFillet.Build();
+        if (!mkFillet.IsDone()) {
+            int nFaulty = mkFillet.NbFaultyContours();
+            if (nFaulty > 0) {
+                int ic = mkFillet.FaultyContour(1);
+                switch (mkFillet.StripeStatus(ic)) {
+                    case ChFiDS_WalkingFailure:
+                        return new App::DocumentObjectExecReturn(
+                            "Fillet radius too large: cannot trace surface along edge. Reduce the radius.");
+                    case ChFiDS_StartsolFailure:
+                        return new App::DocumentObjectExecReturn(
+                            "Fillet conflict at shared vertex: adjacent radii overlap. "
+                            "Reduce the radius or fillet edges separately.");
+                    case ChFiDS_TwistedSurface:
+                        return new App::DocumentObjectExecReturn(
+                            "Fillet radius too large: surface would self-intersect. Reduce the radius.");
+                    default:
+                        break;
+                }
+                return new App::DocumentObjectExecReturn(
+                    "Fillet failed on selected edge(s). Reduce the radius or fillet edges individually.");
+            }
+            if (mkFillet.NbFaultyVertices() > 0) {
+                return new App::DocumentObjectExecReturn(
+                    "Fillet failed at shared corner: adjacent radii overlap. Reduce the radius.");
+            }
+            if (mkFillet.HasResult()) {
+                return new App::DocumentObjectExecReturn(
+                    "Fillet partially applied: some edges failed. Reduce the radius or fillet individually.");
+            }
+            return new App::DocumentObjectExecReturn(
+                "Fillet failed: radius exceeds adjacent face width. "
+                "Reduce the radius or select fewer edges.");
+        }
+
         TopoDS_Shape shape = mkFillet.Shape();
         if (shape.IsNull()) {
             return new App::DocumentObjectExecReturn("Resulting shape is null");
@@ -123,7 +160,13 @@ App::DocumentObjectExecReturn* Fillet::execute()
         return Part::FilletBase::execute();
     }
     catch (Standard_Failure& e) {
-        return new App::DocumentObjectExecReturn(e.GetMessageString());
+        std::string msg = e.GetMessageString();
+        if (msg.find("command not done") != std::string::npos) {
+            return new App::DocumentObjectExecReturn(
+                "Fillet failed: radius too large for selected edge(s). "
+                "Reduce the radius or select fewer edges.");
+        }
+        return new App::DocumentObjectExecReturn(msg.c_str());
     }
     catch (...) {
         return new App::DocumentObjectExecReturn("A fatal error occurred when making fillets");

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -164,7 +164,8 @@ App::DocumentObjectExecReturn* Fillet::execute()
                 );
             }
             return new App::DocumentObjectExecReturn(
-                "Fillet failed: the radius may be too large or incompatible with the selected edges. "
+                "Fillet failed: the radius may be too large or incompatible with the selected "
+                "edges. "
                 "Reduce the radius or select fewer edges."
             );
         }

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -123,18 +123,24 @@ App::DocumentObjectExecReturn* Fillet::execute()
                 switch (mkFillet.StripeStatus(ic)) {
                     case ChFiDS_WalkingFailure:
                         return new App::DocumentObjectExecReturn(
-                            "Fillet radius too large: cannot trace surface along edge. Reduce the "
-                            "radius."
+                            "Fillet failed: could not trace the blending surface along this edge. "
+                            "The radius may be too large or the edge geometry too complex. "
+                            "Try reducing the radius or selecting fewer edges."
                         );
                     case ChFiDS_StartsolFailure:
                         return new App::DocumentObjectExecReturn(
-                            "Fillet conflict at shared vertex: adjacent radii overlap. "
-                            "Reduce the radius or fillet edges separately."
+                            "Fillet failed to start on selected edge: the radius may be too large. "
+                            "Reduce the radius or fillet this edge separately."
                         );
                     case ChFiDS_TwistedSurface:
                         return new App::DocumentObjectExecReturn(
-                            "Fillet radius too large: surface would self-intersect. Reduce the "
-                            "radius."
+                            "Fillet failed: the blending surface would be self-intersecting. "
+                            "Try reducing the radius or selecting a different edge."
+                        );
+                    case ChFiDS_Error:
+                        return new App::DocumentObjectExecReturn(
+                            "Fillet failed: OCC internal geometry error. "
+                            "Check that selected edges are valid and the shape has no defects."
                         );
                     default:
                         break;
@@ -146,7 +152,9 @@ App::DocumentObjectExecReturn* Fillet::execute()
             }
             if (mkFillet.NbFaultyVertices() > 0) {
                 return new App::DocumentObjectExecReturn(
-                    "Fillet failed at shared corner: adjacent radii overlap. Reduce the radius."
+                    "Fillet failed at one or more vertices. "
+                    "The radius may be causing conflicts where edges meet. "
+                    "Try reducing the radius or filleting edges individually."
                 );
             }
             if (mkFillet.HasResult()) {
@@ -156,7 +164,7 @@ App::DocumentObjectExecReturn* Fillet::execute()
                 );
             }
             return new App::DocumentObjectExecReturn(
-                "Fillet failed: radius exceeds adjacent face width. "
+                "Fillet failed: the radius may be too large or incompatible with the selected edges. "
                 "Reduce the radius or select fewer edges."
             );
         }

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -179,14 +179,7 @@ App::DocumentObjectExecReturn* Fillet::execute()
         return Part::FilletBase::execute();
     }
     catch (Standard_Failure& e) {
-        std::string msg = e.GetMessageString();
-        if (msg.find("command not done") != std::string::npos) {
-            return new App::DocumentObjectExecReturn(
-                "Fillet failed: radius too large for selected edge(s). "
-                "Reduce the radius or select fewer edges."
-            );
-        }
-        return new App::DocumentObjectExecReturn(msg.c_str());
+        return new App::DocumentObjectExecReturn(e.GetMessageString());
     }
     catch (...) {
         return new App::DocumentObjectExecReturn("A fatal error occurred when making fillets");

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4116,32 +4116,43 @@ TopoShape& TopoShape::makeElementFillet(
             int ic = mkFillet.FaultyContour(1);
             switch (mkFillet.StripeStatus(ic)) {
                 case ChFiDS_WalkingFailure:
-                    FC_THROWM(Base::CADKernelError,
-                        "Fillet radius too large: cannot trace surface along edge. Reduce the radius.");
+                    FC_THROWM(Base::CADKernelError, "Fillet radius too large: cannot trace surface along edge. Reduce the radius.");
                 case ChFiDS_StartsolFailure:
-                    FC_THROWM(Base::CADKernelError,
+                    FC_THROWM(
+                        Base::CADKernelError,
                         "Fillet conflict at shared vertex: adjacent radii overlap. "
-                        "Reduce the radius or fillet edges separately.");
+                        "Reduce the radius or fillet edges separately."
+                    );
                 case ChFiDS_TwistedSurface:
-                    FC_THROWM(Base::CADKernelError,
-                        "Fillet radius too large: surface would self-intersect. Reduce the radius.");
+                    FC_THROWM(
+                        Base::CADKernelError,
+                        "Fillet radius too large: surface would self-intersect. Reduce the radius."
+                    );
                 default:
                     break;
             }
-            FC_THROWM(Base::CADKernelError,
-                "Fillet failed on " << nFaulty << " edge contour(s). "
-                "Reduce the radius or fillet edges individually.");
+            FC_THROWM(
+                Base::CADKernelError,
+                "Fillet failed on " << nFaulty
+                                    << " edge contour(s). "
+                                       "Reduce the radius or fillet edges individually."
+            );
         }
         int nVerts = mkFillet.NbFaultyVertices();
         if (nVerts > 0) {
-            FC_THROWM(Base::CADKernelError,
-                "Fillet failed at " << nVerts << " shared vertex/vertices: "
-                "adjacent radii overlap. Reduce the radius.");
+            FC_THROWM(
+                Base::CADKernelError,
+                "Fillet failed at " << nVerts
+                                    << " shared vertex/vertices: "
+                                       "adjacent radii overlap. Reduce the radius."
+            );
         }
         if (mkFillet.HasResult()) {
-            FC_THROWM(Base::CADKernelError,
+            FC_THROWM(
+                Base::CADKernelError,
                 "Fillet partially applied: some edges could not be filleted. "
-                "Reduce the radius or fillet edges individually.");
+                "Reduce the radius or fillet edges individually."
+            );
         }
         // No fillet-specific diagnostic matched — rethrow the original OCC exception
         // so real errors (memory, corruption, etc.) are not masked.
@@ -4216,9 +4227,11 @@ TopoShape& TopoShape::makeElementChamfer(
     catch (const Standard_Failure& e) {
         std::string msg = e.GetMessageString();
         if (msg.find("command not done") != std::string::npos) {
-            FC_THROWM(Base::CADKernelError,
+            FC_THROWM(
+                Base::CADKernelError,
                 "Chamfer size too large: would consume or eliminate an adjacent face. "
-                "Reduce the size, select fewer edges, or widen the sketch.");
+                "Reduce the size, select fewer edges, or widen the sketch."
+            );
         }
         throw;
     }

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4116,17 +4116,34 @@ TopoShape& TopoShape::makeElementFillet(
             int ic = mkFillet.FaultyContour(1);
             switch (mkFillet.StripeStatus(ic)) {
                 case ChFiDS_WalkingFailure:
-                    FC_THROWM(Base::CADKernelError, "Fillet radius too large: cannot trace surface along edge. Reduce the radius.");
+                    FC_THROWM(Base::CADKernelError,
+                        "Fillet failed: could not trace the blending surface along edge contour "
+                            << ic
+                            << ". The radius may be too large or the edge geometry too complex. "
+                               "Try reducing the radius or selecting fewer edges.");
                 case ChFiDS_StartsolFailure:
                     FC_THROWM(
                         Base::CADKernelError,
-                        "Fillet conflict at shared vertex: adjacent radii overlap. "
-                        "Reduce the radius or fillet edges separately."
+                        "Fillet failed to start on edge contour "
+                            << ic
+                            << ": the radius may be too large. "
+                               "Reduce the radius or fillet this edge separately."
                     );
                 case ChFiDS_TwistedSurface:
                     FC_THROWM(
                         Base::CADKernelError,
-                        "Fillet radius too large: surface would self-intersect. Reduce the radius."
+                        "Fillet failed on edge contour "
+                            << ic
+                            << ": the blending surface would be self-intersecting. "
+                               "Try reducing the radius or selecting a different edge."
+                    );
+                case ChFiDS_Error:
+                    FC_THROWM(
+                        Base::CADKernelError,
+                        "Fillet failed on edge contour "
+                            << ic
+                            << ": OCC internal geometry error. "
+                               "Check that selected edges are valid and the shape has no defects."
                     );
                 default:
                     break;
@@ -4143,8 +4160,9 @@ TopoShape& TopoShape::makeElementFillet(
             FC_THROWM(
                 Base::CADKernelError,
                 "Fillet failed at " << nVerts
-                                    << " shared vertex/vertices: "
-                                       "adjacent radii overlap. Reduce the radius."
+                                    << " vertex/vertices. "
+                                       "The radius may be causing conflicts where edges meet. "
+                                       "Try reducing the radius or filleting edges individually."
             );
         }
         if (mkFillet.HasResult()) {
@@ -4154,10 +4172,9 @@ TopoShape& TopoShape::makeElementFillet(
                 "Reduce the radius or fillet edges individually."
             );
         }
-        // No fillet-specific diagnostic matched — rethrow the original OCC exception
-        // so real errors (memory, corruption, etc.) are not masked.
-        (void)e;
-        throw;
+        // Diagnostics empty: failure occurred before OCC could track faulty contours.
+        // Surface the raw OCC message without speculative hints — the cause is unknown here.
+        FC_THROWM(Base::CADKernelError, "Fillet failed: " << e.GetMessageString());
     }
 }
 
@@ -4229,8 +4246,9 @@ TopoShape& TopoShape::makeElementChamfer(
         if (msg.find("command not done") != std::string::npos) {
             FC_THROWM(
                 Base::CADKernelError,
-                "Chamfer size too large: would consume or eliminate an adjacent face. "
-                "Reduce the size, select fewer edges, or widen the sketch."
+                "Chamfer failed: the parameters are incompatible with this shape geometry. "
+                "Try reducing the size, selecting fewer edges, "
+                "or ensuring the selected edges have sufficient width."
             );
         }
         throw;

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4116,11 +4116,13 @@ TopoShape& TopoShape::makeElementFillet(
             int ic = mkFillet.FaultyContour(1);
             switch (mkFillet.StripeStatus(ic)) {
                 case ChFiDS_WalkingFailure:
-                    FC_THROWM(Base::CADKernelError,
+                    FC_THROWM(
+                        Base::CADKernelError,
                         "Fillet failed: could not trace the blending surface along edge contour "
                             << ic
                             << ". The radius may be too large or the edge geometry too complex. "
-                               "Try reducing the radius or selecting fewer edges.");
+                               "Try reducing the radius or selecting fewer edges."
+                    );
                 case ChFiDS_StartsolFailure:
                     FC_THROWM(
                         Base::CADKernelError,

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -58,6 +58,7 @@
 #include <BRepBuilderAPI_Transform.hxx>
 #include <BRepFilletAPI_MakeChamfer.hxx>
 #include <BRepFilletAPI_MakeFillet.hxx>
+#include <ChFiDS_ErrorStatus.hxx>
 #include <BRepLib.hxx>
 #include <BRepOffsetAPI_DraftAngle.hxx>
 #include <BRepOffsetAPI_MakeFilling.hxx>
@@ -4105,7 +4106,48 @@ TopoShape& TopoShape::makeElementFillet(
         }
         mkFillet.Add(radius1, radius2, TopoDS::Edge(edge));
     }
-    return makeElementShape(mkFillet, shape, op);
+    try {
+        return makeElementShape(mkFillet, shape, op);
+    }
+    catch (const Standard_Failure& e) {
+        // Build() was called lazily inside Shape(); diagnostics are now populated.
+        int nFaulty = mkFillet.NbFaultyContours();
+        if (nFaulty > 0) {
+            int ic = mkFillet.FaultyContour(1);
+            switch (mkFillet.StripeStatus(ic)) {
+                case ChFiDS_WalkingFailure:
+                    FC_THROWM(Base::CADKernelError,
+                        "Fillet radius too large: cannot trace surface along edge. Reduce the radius.");
+                case ChFiDS_StartsolFailure:
+                    FC_THROWM(Base::CADKernelError,
+                        "Fillet conflict at shared vertex: adjacent radii overlap. "
+                        "Reduce the radius or fillet edges separately.");
+                case ChFiDS_TwistedSurface:
+                    FC_THROWM(Base::CADKernelError,
+                        "Fillet radius too large: surface would self-intersect. Reduce the radius.");
+                default:
+                    break;
+            }
+            FC_THROWM(Base::CADKernelError,
+                "Fillet failed on " << nFaulty << " edge contour(s). "
+                "Reduce the radius or fillet edges individually.");
+        }
+        int nVerts = mkFillet.NbFaultyVertices();
+        if (nVerts > 0) {
+            FC_THROWM(Base::CADKernelError,
+                "Fillet failed at " << nVerts << " shared vertex/vertices: "
+                "adjacent radii overlap. Reduce the radius.");
+        }
+        if (mkFillet.HasResult()) {
+            FC_THROWM(Base::CADKernelError,
+                "Fillet partially applied: some edges could not be filleted. "
+                "Reduce the radius or fillet edges individually.");
+        }
+        // No fillet-specific diagnostic matched — rethrow the original OCC exception
+        // so real errors (memory, corruption, etc.) are not masked.
+        (void)e;
+        throw;
+    }
 }
 
 TopoShape& TopoShape::makeElementChamfer(
@@ -4168,7 +4210,18 @@ TopoShape& TopoShape::makeElementChamfer(
         }
     }
     Part::SignalException sig;
-    return makeElementShape(mkChamfer, shape, op);
+    try {
+        return makeElementShape(mkChamfer, shape, op);
+    }
+    catch (const Standard_Failure& e) {
+        std::string msg = e.GetMessageString();
+        if (msg.find("command not done") != std::string::npos) {
+            FC_THROWM(Base::CADKernelError,
+                "Chamfer size too large: would consume or eliminate an adjacent face. "
+                "Reduce the size, select fewer edges, or widen the sketch.");
+        }
+        throw;
+    }
 }
 
 TopoShape& TopoShape::makeElementGeneralFuse(

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -204,7 +204,13 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         return App::DocumentObject::StdReturn;
     }
     catch (Standard_Failure& e) {
-        return new App::DocumentObjectExecReturn(e.GetMessageString());
+        std::string msg = e.GetMessageString();
+        if (msg.find("command not done") != std::string::npos) {
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                "Chamfer failed: size too large for selected edge(s). "
+                "Reduce the size or select fewer edges."));
+        }
+        return new App::DocumentObjectExecReturn(msg.c_str());
     }
     catch (...) {
         return new App::DocumentObjectExecReturn(

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -203,19 +203,16 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         this->Shape.setValue(shape);
         return App::DocumentObject::StdReturn;
     }
-    catch (Standard_Failure& e) {
-        std::string msg = e.GetMessageString();
-        if (msg.find("command not done") != std::string::npos) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
-                "Exception",
-                "Chamfer failed: size too large for selected edge(s). "
-                "Reduce the size or select fewer edges."
-            ));
-        }
-        return new App::DocumentObjectExecReturn(msg.c_str());
-    }
     catch (Base::Exception& e) {
         return new App::DocumentObjectExecReturn(e.what());
+    }
+    catch (Standard_Failure& e) {
+        // Surface the raw OCC message with context; do not assume a single cause.
+        std::string msg = e.GetMessageString();
+        std::string fullMsg = "Chamfer failed: " + msg
+            + ". Check that the size is not too large, edges are valid, "
+              "and the shape has no degenerate edges.";
+        return new App::DocumentObjectExecReturn(fullMsg.c_str());
     }
     catch (...) {
         return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -206,9 +206,11 @@ App::DocumentObjectExecReturn* Chamfer::execute()
     catch (Standard_Failure& e) {
         std::string msg = e.GetMessageString();
         if (msg.find("command not done") != std::string::npos) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                "Exception",
                 "Chamfer failed: size too large for selected edge(s). "
-                "Reduce the size or select fewer edges."));
+                "Reduce the size or select fewer edges."
+            ));
         }
         return new App::DocumentObjectExecReturn(msg.c_str());
     }

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -218,9 +218,11 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         return new App::DocumentObjectExecReturn(e.what());
     }
     catch (...) {
-        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+            "Exception",
             "Chamfer failed: size may be too large for adjacent edges sharing a vertex. "
-            "Reduce the size or chamfer edges individually."));
+            "Reduce the size or chamfer edges individually."
+        ));
     }
 }
 

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -212,10 +212,13 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         }
         return new App::DocumentObjectExecReturn(msg.c_str());
     }
+    catch (Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
+    }
     catch (...) {
-        return new App::DocumentObjectExecReturn(
-            QT_TRANSLATE_NOOP("Exception", "Chamfer failed: OCC kernel error in chamfer computation")
-        );
+        return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+            "Chamfer failed: size may be too large for adjacent edges sharing a vertex. "
+            "Reduce the size or chamfer edges individually."));
     }
 }
 

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -153,15 +153,14 @@ App::DocumentObjectExecReturn* Fillet::execute()
         return new App::DocumentObjectExecReturn(e.what());
     }
     catch (Standard_Failure& e) {
+        // Surface the raw OCC message with context; do not assume a single cause
+        // since Standard_Failure here can come from edge Add(), post-processing, or
+        // any OCC operation in this block.
         std::string msg = e.GetMessageString();
-        if (msg.find("command not done") != std::string::npos) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
-                "Exception",
-                "Fillet failed: radius too large for selected edge(s). "
-                "Reduce the radius or select fewer edges."
-            ));
-        }
-        return new App::DocumentObjectExecReturn(msg.c_str());
+        std::string fullMsg = "Fillet failed: " + msg
+            + ". Check that the radius is not too large, edges are valid, "
+              "and the shape has no zero-length or degenerate edges.";
+        return new App::DocumentObjectExecReturn(fullMsg.c_str());
     }
     catch (...) {
         return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -155,9 +155,11 @@ App::DocumentObjectExecReturn* Fillet::execute()
     catch (Standard_Failure& e) {
         std::string msg = e.GetMessageString();
         if (msg.find("command not done") != std::string::npos) {
-            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                "Exception",
                 "Fillet failed: radius too large for selected edge(s). "
-                "Reduce the radius or select fewer edges."));
+                "Reduce the radius or select fewer edges."
+            ));
         }
         return new App::DocumentObjectExecReturn(msg.c_str());
     }

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -153,14 +153,18 @@ App::DocumentObjectExecReturn* Fillet::execute()
         return new App::DocumentObjectExecReturn(e.what());
     }
     catch (Standard_Failure& e) {
-        return new App::DocumentObjectExecReturn(e.GetMessageString());
+        std::string msg = e.GetMessageString();
+        if (msg.find("command not done") != std::string::npos) {
+            return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP("Exception",
+                "Fillet failed: radius too large for selected edge(s). "
+                "Reduce the radius or select fewer edges."));
+        }
+        return new App::DocumentObjectExecReturn(msg.c_str());
     }
     catch (...) {
         return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
             "Exception",
-            "Fillet operation failed. The selected edges may contain geometry that cannot be "
-            "filleted together. "
-            "Try filleting edges individually or with a smaller radius."
+            "Fillet operation failed. Try a smaller radius or fillet edges individually."
         ));
     }
 }


### PR DESCRIPTION

Fixes: #28189
Replace the cryptic "`BRep_API: command not done`" error with actionable messages when Fillet or Chamfer operations fail due to oversized radius/size. For Fillet, the fix  uses OCC's `NbFaultyContours()`, `StripeStatus()`,` NbFaultyVertices()`, and `HasResult() `diagnostic APIs to pinpoint the exact cause `(WalkingFailure, StartsolFailure,TwistedSurface) `and report it precisely. 
For Chamfer — which exposes no diagnostic API — the known "command not done" exception is intercepted and replaced with a helpful message.

**Local Testing:-**

https://github.com/user-attachments/assets/bfd0297e-46e6-4b91-80c6-1113af45b815



