### PR TITLE
Fix Sketcher split edge dropping coincident and dimensional constrain…

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -3969,10 +3969,18 @@ int SketchObject::split(int GeoId, const Base::Vector3d& point)
 
     std::erase_if(idsOfOldConstraints, [&GeoId, &allConstraints](const auto& i) {
         const auto* con = allConstraints[i];
-        if (con->Type == InternalAlignment) { return true; }
-        if (con->involvesGeoIdAndPosId(GeoId, PointPos::start)) { return true; }
-        if (con->involvesGeoIdAndPosId(GeoId, PointPos::end)) { return true; }
-        if (con->involvesGeoIdAndPosId(GeoId, PointPos::mid)) { return true; }
+        if (con->Type == InternalAlignment) {
+            return true;
+        }
+        if (con->involvesGeoIdAndPosId(GeoId, PointPos::start)) {
+            return true;
+        }
+        if (con->involvesGeoIdAndPosId(GeoId, PointPos::end)) {
+            return true;
+        }
+        if (con->involvesGeoIdAndPosId(GeoId, PointPos::mid)) {
+            return true;
+        }
         return false;
     });
 


### PR DESCRIPTION
Fixes #28240

The Sketcher Split Edge tool drops coincident and dimensional constraints 
when splitting a line. Parallel constraints survive correctly. This is a 
regression from 1.0.2.

Root cause: In SketchObject::split(), the erase_if filter before calling 
deriveConstraintsForPieces() keeps only PointPos::none constraints, silently 
discarding anything referencing PointPos::start, PointPos::end, or 
PointPos::mid, which includes coincident and dimensional constraints.

Fix: Only exclude InternalAlignment constraints and start/end/mid constraints 
(which are handled separately by transferConstraints()). All other constraints 
including dimensional ones are correctly passed to deriveConstraintsForPieces() 
for remapping.

Tested against 1.1rc2, constraints now survive the split correctly.

Example from 1.1rc2

<img width="624" height="597" alt="image" src="https://github.com/user-attachments/assets/85146abe-7ab4-44ab-a4e6-c1c5d559b1fd" />

<img width="562" height="583" alt="image" src="https://github.com/user-attachments/assets/a0b5b86d-026e-448c-bff4-6fa164b4c6ea" />
