### PR TITLE
CAM: unit test with ASAN enabled, attempt to resolve crash ie. fixes #27781

### DIFF
--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -182,7 +182,7 @@ void GroupExtension::removeObjectFromDocument(DocumentObject* obj)
 
     // remove all children
     if (obj->hasExtension(GroupExtension::getExtensionClassTypeId())) {
-        GroupExtension* grp = static_cast<GroupExtension*>(
+        auto* grp = static_cast<GroupExtension*>(
             obj->getExtension(GroupExtension::getExtensionClassTypeId()));
 
         // recursive call to remove all subgroups

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -637,7 +637,7 @@ QWidget* TreeWidgetItemDelegate::createEditor(
 
     DynamicQLineEdit* editor;
     if (TreeParams::getLabelExpression()) {
-        DynamicQLineEdit* le = new DynamicQLineEdit(parent);
+        auto* le = new DynamicQLineEdit(parent);
         le->setAutoApply(true);
         le->setFrame(false);
         le->bind(App::ObjectIdentifier(prop));
@@ -1281,8 +1281,8 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
     contextMenu.addSeparator();
     contextMenu.addMenu(&settingsMenu);
 
-    QAction* action = new QAction(tr("Show Description"), this);
-    QAction* internalNameAction = new QAction(tr("Show Internal Name"), this);
+    auto* action = new QAction(tr("Show Description"), this);
+    auto* internalNameAction = new QAction(tr("Show Internal Name"), this);
     action->setStatusTip(
         tr("Shows a description column for items. An item's description can be set by editing the "
            "'label2' property.")
@@ -4343,7 +4343,7 @@ void DocumentItem::slotInEdit(const Gui::ViewProviderDocumentObject& v)
         "User parameter:BaseApp/Preferences/TreeView"
     );
     unsigned long col = hGrp->GetUnsigned("TreeEditColor", 563609599);
-    QColor color(Base::Color::fromPackedRGB<QColor>(col));
+    auto color(Base::Color::fromPackedRGB<QColor>(col));
 
     if (!getTree()->editingItem) {
         auto doc = Application::Instance->editDocument();
@@ -4949,7 +4949,7 @@ void DocumentItem::sortObjectItems()
             updateItemsVisibility(sortedItem, false);
         }
 
-        std::vector<bool>::const_iterator expFrom = expansion.cbegin();
+        auto expFrom = expansion.cbegin();
         sortedItem->applyExpandedSnapshot(expansion, expFrom);
     }
 }
@@ -5349,11 +5349,14 @@ void DocumentItem::slotRecomputedObject(const App::DocumentObject& obj)
     slotRecomputed(*obj.getDocument(), {const_cast<App::DocumentObject*>(&obj)});
 }
 
-void DocumentItem::slotRecomputed(const App::Document&, const std::vector<App::DocumentObject*>& objs)
+void DocumentItem::slotRecomputed(const App::Document& doc, const std::vector<App::DocumentObject*>& objs)
 {
+    const auto& allObjs = doc.getObjects();
+    std::unordered_set<App::DocumentObject*> validObjs(allObjs.begin(), allObjs.end());
+
     auto tree = getTree();
     for (auto obj : objs) {
-        if (!obj->isValid()) {
+        if (validObjs.contains(obj) && !obj->isValid()) {
             tree->ChangedObjects[obj].set(TreeWidget::CS_Error);
         }
     }


### PR DESCRIPTION
this PR aims at addressing the crashing test cam workbench specifically the `CAMTests.TestPathHelix`

when building freecad with ASAN support enabled and running the test suite freecad would crash during the above mentioned test due to a "dangling pointer". ASAN was picking up a "heap-use-after-free" error when recomputing the document.

`isValid` was being called on pointers to objects that already been "freed"

## Issues

- https://github.com/freecad/freecad/issues/27781

## Before and After Images

