### PR TITLE
Gui: Switched View3DInventor camera to QString for Qt 5 compatibility.

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -401,7 +401,7 @@ void StdCmdFreezeViews::activated(int iMsg)
             );
             return;
         }
-        const std::string& camera = view3d->getCamera();
+        const QString& camera = view3d->getCamera();
 
         QList<QAction*> acts = pcAction->actions();
         int index = 1;
@@ -410,7 +410,7 @@ void StdCmdFreezeViews::activated(int iMsg)
                 savedViews++;
                 QString viewnr = QString(QObject::tr("Restore View &%1")).arg(index);
                 (*it)->setText(viewnr);
-                (*it)->setToolTip(QString::fromLatin1(camera));
+                (*it)->setToolTip(camera);
                 (*it)->setVisible(true);
                 if (index < 10) {
                     (*it)->setShortcut(QKeySequence(QStringLiteral("CTRL+%1").arg(index)));
@@ -2646,24 +2646,25 @@ void StdCmdViewIvIssueCamPos::activated(int iMsg)
         );
         return;
     }
-    std::string camera = view3d->getCamera();
+    QString camera = view3d->getCamera();
 
     // remove the #inventor line...
-    std::string::size_type pos = camera.find_first_of('\n');
-    camera.erase(0, pos);
+    std::string::size_type pos = camera.indexOf('\n');
+    camera.remove(0, pos);
 
     // remove all returns
-    while ((pos = camera.find('\n')) != std::string::npos) {
+    while ((pos = camera.indexOf('\n')) != -1) {
         camera.replace(pos, 1, " ");
     }
 
     // build up the command string
-    std::string command = "Gui.activeView().setCamera(\"";
+    QString command = "Gui.activeView().setCamera(\"";
     command += camera;
     command += "\")";
 
-    Base::Console().message("%s\n", camera.c_str());
-    getGuiApplication()->macroManager()->addLine(MacroManager::Gui, command.c_str());
+    QByteArray latin1camera = camera.toLatin1();
+    Base::Console().message("%s\n", latin1camera.constData());
+    getGuiApplication()->macroManager()->addLine(MacroManager::Gui, command.toLatin1());
 }
 
 bool StdCmdViewIvIssueCamPos::isActive()

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -2023,8 +2023,7 @@ void Document::SaveDocFile(Base::Writer& writer) const
     // save camera settings
     for (const auto& it : getMDIViews()) {
         if (auto* view3D = freecad_cast<View3DInventor*>(it)) {
-            const std::string& camera = view3D->getCamera();
-            if (saveCameraSettings(camera.c_str())) {
+            if (saveCameraSettings(view3D->getCamera().toLatin1())) {
                 break;
             }
         }
@@ -2213,8 +2212,7 @@ MDIView* Document::createView(const Base::Type& typeId, CreateViewMode mode)
             auto firstView = static_cast<View3DInventor*>(theViews.front());
             shareWidget = qobject_cast<QOpenGLWidget*>(firstView->getViewer()->getGLWidget());
 
-            const std::string& camera = firstView->getCamera();
-            saveCameraSettings(camera.c_str());
+            saveCameraSettings(firstView->getCamera().toLatin1());
         }
 
         auto view3D = new View3DInventor(this, getMainWindow(), shareWidget);

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -570,24 +570,27 @@ bool View3DInventor::onHasMsg(const char* pMsg) const
     return false;
 }
 
-const std::string& View3DInventor::getCamera() const
+const QString View3DInventor::getCamera() const
 {
     SoCamera* Cam = _viewer->getSoRenderManager()->getCamera();
     if (!Cam) {
         throw Base::RuntimeError("Could not find reference to 3D View camera");
     }
-    return SoFCDB::writeNodesToString(Cam);
+    QString camera;
+    camera.fromLatin1(SoFCDB::writeNodesToString(Cam).c_str());
+    return camera;
 }
 
-bool View3DInventor::setCamera(const char* pCamera)
+bool View3DInventor::setCamera(QString camera)
 {
     SoCamera* CamViewer = _viewer->getSoRenderManager()->getCamera();
     if (!CamViewer) {
         throw Base::RuntimeError("No camera set so far…");
     }
 
+    QByteArray latin1camera = camera.toLatin1();
     SoInput in;
-    in.setBuffer((void*)pCamera, std::strlen(pCamera));
+    in.setBuffer((void*)latin1camera.constData(), latin1camera.length());
 
     SoNode* Cam;
     SoDB::read(&in, Cam);

--- a/src/Gui/View3DInventor.h
+++ b/src/Gui/View3DInventor.h
@@ -121,8 +121,8 @@ public:
      */
     void setCurrentViewMode(ViewMode b) override;
     RayPickInfo getObjInfoRay(Base::Vector3d* startvec, Base::Vector3d* dirvec);
-    const std::string& getCamera() const;
-    bool setCamera(const char* pCamera);
+    const QString getCamera() const;
+    bool setCamera(const QString camera);
     void toggleClippingPlane();
     bool hasClippingPlane() const;
 


### PR DESCRIPTION
The new code did not build with Qt 5.  Rewrite the code to using QString instead of std::string, and move conversion to/from latin1 closer to where the value is used and fetched from file.  Adjusted handling in Document to make it clear that the string is latin1 encoded.

Perhaps it would be better to use UTF-8 instead of ISO-8859-1 (latin1) here?