### PR TITLE
CAM: Fix saving of _shape_type for toolbits

### DIFF
--- a/src/Mod/CAM/Path/Tool/docobject/ui/docobject.py
+++ b/src/Mod/CAM/Path/Tool/docobject/ui/docobject.py
@@ -30,6 +30,8 @@ from .property import BasePropertyEditorWidget
 
 def _get_label_text(prop_name, keep_case=False, preserve_consecutive_caps=False):
     """Generate a human-readable label from a property name."""
+    # First, replace underscores and hyphens with spaces
+    prop_name = prop_name.replace("_", " ").replace("-", " ")
     # Add space before capital letters (CamelCase splitting)
     if preserve_consecutive_caps:
         s1 = re.sub(r"(?<![A-Z])([A-Z][a-z]+)", r" \1", prop_name)
@@ -41,8 +43,8 @@ def _get_label_text(prop_name, keep_case=False, preserve_consecutive_caps=False)
         s2 = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1 \2", s1)
     # Add space before sequences of capitals followed by end of string
     s3 = re.sub(r"([A-Z]+)$", r" \1", s2)
-    # Remove leading/trailing spaces
-    result = s3.strip()
+    # Remove leading/trailing spaces and collapse multiple spaces
+    result = " ".join(s3.split())
     if not keep_case:
         return result.capitalize()
     return result.title()

--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -951,7 +951,12 @@ class ToolBit(Asset, ABC):
         attrs["id"] = self.id
         attrs["name"] = self.obj.Label
         attrs["shape"] = self._tool_bit_shape.get_id() + ".fcstd"
-        attrs["shape-type"] = self._tool_bit_shape.name
+        # Use the _shape_type (subclass) as the shape-type if it differs from the actual shape name, to preserve the alias/subtype information. Otherwise, just use _tool_bit_shape.name (main class name)
+        shape_type = getattr(self, "_shape_type", None) or self._tool_bit_shape.name
+        if shape_type.lower() == self._tool_bit_shape.name.lower():
+            attrs["shape-type"] = self._tool_bit_shape.name
+        else:
+            attrs["shape-type"] = shape_type
         attrs["parameter"] = {}
         attrs["attribute"] = {}
 
@@ -1041,6 +1046,7 @@ class ToolBit(Asset, ABC):
     def get_subtype(self) -> Optional[str]:
         """Returns the alias/subtype used to instantiate this toolbit, if any."""
         # Only return the subtype if it differs from the class name
-        if self._shape_type.lower() != self._tool_bit_shape.name.lower():
-            return self._shape_type.lower()
+        shape_type = getattr(self, "_shape_type", None) or self._tool_bit_shape.name
+        if shape_type.lower() != self._tool_bit_shape.name.lower():
+            return shape_type.lower()
         return None

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/typefilter.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/typefilter.py
@@ -48,17 +48,16 @@ class ToolBitTypeFilterMixin:
         Returns:
             List of tuples: (display_text, actual_value)
         """
-        # Build a mapping: {ParentType: {actual_subtype: display_subtype}}
+        # Build a mapping: {ParentType: {subtype_value}}
         type_map = {}
         for asset in assets:
             parent = asset.get_shape_name()  # Preserve original case (e.g., "Probe")
             subtype = asset.get_subtype()
             if subtype:
-                # Preserve underscores/hyphens but make displayable
-                subtype_disp = subtype.replace("_", " ").replace("-", " ").title()
-                type_map.setdefault(parent, {})[subtype] = subtype_disp
+                # Store the subtype value
+                type_map.setdefault(parent, set()).add(subtype)
             else:
-                type_map.setdefault(parent, {})
+                type_map.setdefault(parent, set())
 
         # Flatten for combo: parent, then indented subtypes
         # Return tuples of (display, value)
@@ -66,7 +65,7 @@ class ToolBitTypeFilterMixin:
         for parent in sorted(type_map):
             parent_display = _get_label_text(parent, keep_case=True, preserve_consecutive_caps=True)
             result.append((parent_display, parent))  # Parent with formatted display
-            for subtype_val, subtype_disp in sorted(type_map[parent].items()):
+            for subtype_val in sorted(type_map[parent]):
                 subtype_display = _get_label_text(
                     subtype_val, keep_case=True, preserve_consecutive_caps=True
                 )


### PR DESCRIPTION
Corrects logic so that the _shape_type is saved properly and not always defaulted to the primary toolbit type. Ensures subclass/alias information is preserved when saving toolbits.

src/Mod/CAM/Path/Tool/toolbit/models/base.py:
- Fix fallback logic for _shape_type to correctly save subclass/alias when present
- Only default to primary type if _shape_type is missing or matches the main class

src/Mod/CAM/Path/Tool/docobject/ui/docobject.py:
- Improve label formatting by handling underscores, hyphens, and extra spaces

src/Mod/CAM/Path/Tool/toolbit/ui/typefilter.py:
- Simplify type filter mapping and display logic for toolbit subtypes