### PR TITLE
Part: Fixed the transformShape

### DIFF
--- a/src/Mod/Part/App/TopoShape.pyi
+++ b/src/Mod/Part/App/TopoShape.pyi
@@ -454,11 +454,13 @@ class TopoShape(ComplexGeoData):
 
     def transformShape(
         self, matrix: Matrix, copy: bool = False, checkScale: bool = False, /
-    ) -> None:
+    ) -> TopoShape:
         """
         Apply transformation on a shape without changing the underlying geometry.
-        transformShape(Matrix, [boolean copy=False, checkScale=False]) -> None
+        transformShape(Matrix, [boolean copy=False, checkScale=False]) -> shape
         --
+        If copy is True, returns a transformed copy and leaves the original unchanged.
+        If copy is False, transforms this shape in place and returns itself.
         If checkScale is True, it will use transformGeometry if non-uniform
         scaling is detected.
         """

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -1041,9 +1041,17 @@ PyObject* TopoShapePy::transformShape(PyObject* args)
     }
 
     Base::Matrix4D mat = static_cast<Base::MatrixPy*>(obj)->value();
+    bool doCopy = Base::asBoolean(copy);
+    bool doCheckScale = Base::asBoolean(checkScale);
     PY_TRY
     {
-        this->getTopoShapePtr()->transformShape(mat, Base::asBoolean(copy), Base::asBoolean(checkScale));
+        if (doCopy) {
+            TopoShape s(*getTopoShapePtr());
+            s.transformShape(mat, false, doCheckScale);
+            return Py::new_reference_to(shape2pyshape(s));
+        }
+
+        this->getTopoShapePtr()->transformShape(mat, false, doCheckScale);
         return IncRef();
     }
     PY_CATCH_OCC

--- a/src/Mod/Part/parttests/regression_tests.py
+++ b/src/Mod/Part/parttests/regression_tests.py
@@ -185,6 +185,23 @@ class RegressionTests(unittest.TestCase):
         for name, pos, normal, xaxis in expected_planes:
             check_plane(name, pos, normal, xaxis)
 
+    def test_transformShape_copy_returns_independent_shape(self):
+        shp = Part.makeBox(1, 2, 3)
+
+        # Regression: copy=True must return an independent shape object, even for identity transform.
+        cloned = shp.transformShape(FreeCAD.Matrix(), True)
+        self.assertIsNot(cloned, shp)
+        self.assertFalse(cloned.isEqual(shp))
+        self.assertAlmostEqual(shp.BoundBox.XMin, 0.0)
+
+        # Transforming the returned copy must not affect the original.
+        moved = cloned.transformShape(
+            FreeCAD.Placement(FreeCAD.Vector(5, 0, 0), FreeCAD.Rotation()).toMatrix(), False
+        )
+        self.assertIs(moved, cloned)
+        self.assertAlmostEqual(shp.BoundBox.XMin, 0.0)
+        self.assertAlmostEqual(cloned.BoundBox.XMin, 5.0)
+
     def test_issue_15716_AttacherEngine_sync(self):
         """
         15716: AttacherType and AttacherEngine property conflict


### PR DESCRIPTION
Fixes: #28249

Fixed `TopoShape.transformShape(matrix, copy=True)` to actually return an independent `TopoShape` instead of always returning self.
Root cause: Python binding `(TopoShapePy::transformShape)` always transformed `self` and returned `IncRef()`, so copy=True was ignored at API level.
Fix: when `copy=True`, clone the current `TopoShape`, apply transform to the clone, and return the new Python shape object; keep `copy=False` behavior as in-place transform returning self.
Corrected `transformShape` return type and docstring in `TopoShape.pyi`from ->` None` to returning a shape.

After the fix:-
```

>>> import Part
>>> import FreeCAD as App
>>> 
>>> shp = Part.makeBox(1,2,3)
>>> print("shp:", shp)
shp: <Solid object at 0000020108BCD8A0>
>>> 
>>> new = shp.transformShape(App.Matrix(), True)
>>> print("new:", new)
new: <Solid object at 0000020108BCE190>
>>> print("same python object:", new is shp)
same python object: False
>>> print("same internal shape:", new.isEqual(shp))
same internal shape: False
>>> 
>>> cop = shp.copy()
>>> print("copy is independent:", cop.isEqual(shp))
copy is independent: False
>>> 
>>> help(shp.transformShape)
Help on built-in function transformShape:

transformShape(matrix, copy=False, checkScale=False, /) method of Part.Solid instance
    transformShape(matrix: Matrix, copy: bool=False, checkScale: bool=False, /) -> TopoShape
    
    If copy is True, returns a transformed copy and leaves the original unchanged.
    If copy is False, transforms this shape in place and returns itself.
    If checkScale is True, it will use transformGeometry if non-uniform
    scaling is detected.

>>> 
```