### PR TITLE
Core: Improve FreeCAD file format for versioning

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1184,9 +1184,7 @@ void Document::Restore(Base::XMLReader& reader)
     // value could be invalid.
     FileName.setValue(FilePath.c_str());
     Label.setValue(DocLabel.c_str());
-    if (auto* docCacheDirProp = freecad_cast<PropertyPath*>(getPropertyByName("DocumentCacheDir"))) {
-        reader.setDocumentCacheDir(docCacheDirProp->getValue().string());
-    }
+    reader.setDocumentCacheDir(resolveDocumentCacheDir(FileName.getValue()));
 
     // SchemeVersion "2"
     if (scheme == 2) {
@@ -1945,6 +1943,31 @@ bool Document::save()
     return false;
 }
 
+std::string Document::resolveDocumentCacheDir(std::string_view filename) const
+{
+    auto* cacheDirProp = freecad_cast<PropertyPath*>(getPropertyByName("DocumentCacheDir"));
+
+    if (!cacheDirProp) {
+        return {};
+    }
+
+    fs::path cacheDir = cacheDirProp->getValue();
+
+    if (cacheDir.empty()) {
+        return {};
+    }
+
+    if (cacheDir.is_relative()) {
+        fs::path filePath = fs::path(filename);
+        fs::path dirFile = filePath.parent_path();
+        fs::path cacheInDirFile = dirFile / cacheDir;
+        return cacheInDirFile.string();
+    }
+
+    return cacheDir.string();
+}
+
+
 bool Document::saveToFile(const char* filename) const
 {
     signalStartSave(*this, filename);
@@ -2013,11 +2036,7 @@ bool Document::saveToFile(const char* filename) const
         Base::ofstream file(tmp, std::ios::out | std::ios::binary);
 
         Base::ZipWriter writer(file);
-        if (auto* cacheDirProp =
-            freecad_cast<PropertyPath*>(getPropertyByName("DocumentCacheDir"))) {
-
-            writer.setDocumentCacheDir(cacheDirProp->getValue().string());
-        }
+        writer.setDocumentCacheDir(resolveDocumentCacheDir(fn));
         if (!file.is_open()) {
             throw Base::FileException("Failed to open file", tmp);
         }

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1021,6 +1021,11 @@ Document::Document(const char* documentName)
                       0,
                       PropertyType(Prop_Transient | Prop_ReadOnly),
                       "Transient directory, where the files live while the document is open");
+    ADD_PROPERTY_TYPE(DocumentCacheDir,
+                      (""),
+                      0,
+                      Prop_None,
+                      "Cache directory for this document");
     ADD_PROPERTY_TYPE(Tip,
                       (nullptr),
                       0,
@@ -1179,6 +1184,9 @@ void Document::Restore(Base::XMLReader& reader)
     // value could be invalid.
     FileName.setValue(FilePath.c_str());
     Label.setValue(DocLabel.c_str());
+    if (auto* docCacheDirProp = freecad_cast<PropertyPath*>(getPropertyByName("DocumentCacheDir"))) {
+        reader.setDocumentCacheDir(docCacheDirProp->getValue().string());
+    }
 
     // SchemeVersion "2"
     if (scheme == 2) {
@@ -2003,6 +2011,11 @@ bool Document::saveToFile(const char* filename) const
         Base::ofstream file(tmp, std::ios::out | std::ios::binary);
 
         Base::ZipWriter writer(file);
+        if (auto* cacheDirProp =
+            freecad_cast<PropertyPath*>(getPropertyByName("DocumentCacheDir"))) {
+
+            writer.setDocumentCacheDir(cacheDirProp->getValue().string());
+        }
         if (!file.is_open()) {
             throw Base::FileException("Failed to open file", tmp);
         }
@@ -2026,6 +2039,7 @@ bool Document::saveToFile(const char* filename) const
         signalSaveDocument(writer);
 
         // write additional files
+        writer.writeFilesToCacheDir();
         writer.writeFiles();
         if (writer.hasErrors()) {
             // retrieve Writer error strings
@@ -2186,6 +2200,7 @@ void Document::restore(const char* filename,
     // Note: This file doesn't need to be available if the document has been created
     // without GUI. But if available then follow after all data files of the App document.
     signalRestoreDocument(reader);
+    reader.readFilesFromCacheDir();
     reader.readFiles(zipstream);
 
     DocumentP::checkStringHasher(reader);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1744,10 +1744,12 @@ std::vector<DocumentObject*> Document::readObjects(Base::XMLReader& reader)
     return objs;
 }
 
-void Document::addRecomputeObject(DocumentObject* obj) // NOLINT
+void Document::addRecomputeObject(DocumentObject* obj, bool forMigration) // NOLINT
 {
     if (testStatus(Status::Restoring) && obj) {
-        setStatus(Status::RecomputeOnRestore, true);
+        if (forMigration) {
+            setStatus(Status::RecomputeOnRestore, true);
+        }
         d->touchedObjs.insert(obj);
         obj->touch();
     }

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -1244,8 +1244,9 @@ public:
      * Called by objects during restore to ask for recompute.
      *
      * @param[in] obj The object to mark for recompute.
+     * @param[in] forMigration Whether this is for migration purposes or not.
      */
-    void addRecomputeObject(DocumentObject* obj);
+    void addRecomputeObject(DocumentObject* obj, bool forMigration = true);
 
     /// Get the old label of an object before it was changed.
     const std::string& getOldLabel() const

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -184,6 +184,8 @@ public:
     PropertyMap Material;
     /// Read-only name of the temp dir created when the document is opened.
     PropertyString TransientDir;
+    /// Name of the cache dir for this document
+    PropertyPath DocumentCacheDir;
     /// Tip object of the document (if any).
     PropertyLink Tip;
     /// Tip object name of the document (if any).

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -1462,6 +1462,8 @@ private:
     void changePropertyOfObject(TransactionalObject* obj, const Property* prop,
                                 const std::function<void()>& changeFunc);
 
+    std::string resolveDocumentCacheDir(std::string_view filename) const;
+
 private:
     // # Data Member of the document
     // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -58,6 +58,7 @@
 
 using namespace App;
 using namespace XERCES_CPP_NAMESPACE;
+namespace fs = std::filesystem;
 
 namespace
 {
@@ -625,8 +626,14 @@ bool ProjectFile::containsFileInDocumentCache(const std::string& name) const
         return false;
     }
 
-    std::string path = metadata.documentCacheDir + "/" + name;
-    Base::FileInfo fi(path);
+    fs::path pathInCache = fs::path(metadata.documentCacheDir) / name;
+    if (pathInCache.is_relative()) {
+        fs::path filePath = fs::path(stdFile);
+        fs::path dirFile = filePath.parent_path();
+        pathInCache = dirFile / pathInCache;
+    }
+
+    Base::FileInfo fi(pathInCache.string());
     return fi.exists();
 }
 

--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -88,6 +88,7 @@ std::map<std::string, std::string> initMap()
                                                   {"Company", ""},
                                                   {"CreatedBy", ""},
                                                   {"CreationDate", ""},
+                                                  {"DocumentCacheDir", ""},
                                                   {"Label", ""},
                                                   {"LastModifiedBy", ""},
                                                   {"LastModifiedDate", ""},
@@ -168,6 +169,7 @@ private:
         metadata.company = propMap.at("Company");
         metadata.createdBy = propMap.at("CreatedBy");
         metadata.creationDate = propMap.at("CreationDate");
+        metadata.documentCacheDir = propMap.at("DocumentCacheDir");
         metadata.label = propMap.at("Label");
         metadata.lastModifiedBy = propMap.at("LastModifiedBy");
         metadata.lastModifiedDate = propMap.at("LastModifiedDate");
@@ -217,6 +219,7 @@ public:
         metadata.company = propMap.at("Company");
         metadata.createdBy = propMap.at("CreatedBy");
         metadata.creationDate = propMap.at("CreationDate");
+        metadata.documentCacheDir = propMap.at("DocumentCacheDir");
         metadata.label = propMap.at("Label");
         metadata.lastModifiedBy = propMap.at("LastModifiedBy");
         metadata.lastModifiedDate = propMap.at("LastModifiedDate");
@@ -232,22 +235,10 @@ public:
 
     FilterAction startElement(DOMElement* node) override
     {
-        std::array property = {chLatin_P,
-                               chLatin_r,
-                               chLatin_o,
-                               chLatin_p,
-                               chLatin_e,
-                               chLatin_r,
-                               chLatin_t,
-                               chLatin_y,
-                               chNull};
-        if (XMLString::equals(node->getNodeName(), property.data())) {
-            std::array name = {chLatin_n,
-                               chLatin_a,
-                               chLatin_m,
-                               chLatin_e,
-                               chNull};
-            if (DOMAttr* attr = node->getAttributeNode(name.data())) {
+        constexpr auto Property = XMLTools::toXMLCh("Property");
+        if (XMLString::equals(node->getNodeName(), Property.data())) {
+            constexpr auto Name = XMLTools::toXMLCh("name");
+            if (DOMAttr* attr = node->getAttributeNode(Name.data())) {
                 std::string value = StrX(attr->getNodeValue()).c_str();
                 auto it = propMap.find(value);
                 if (it != propMap.end()) {
@@ -259,14 +250,23 @@ public:
             }
         }
 
-        std::array string = {chLatin_S,
-                             chLatin_t,
-                             chLatin_r,
-                             chLatin_i,
-                             chLatin_n,
-                             chLatin_g,
-                             chNull};
-        if (XMLString::equals(node->getNodeName(), string.data())) {
+        // Two metedata properties have type Uuid and Path instead of String.
+        constexpr auto Uuid = XMLTools::toXMLCh("Uuid");
+        constexpr auto Path = XMLTools::toXMLCh("Path");
+        const auto addProperty = [&](const char* property, auto nodeName) {
+            if (XMLString::equals(node->getNodeName(), nodeName.data())) {
+                if (!currentProperty.empty() && currentProperty == property) {
+                    propMap[currentProperty] = readValue(node->getParentNode());
+                    currentProperty.clear();
+                }
+            }
+        };
+        addProperty("Uid", Uuid);
+        addProperty("DocumentCacheDir", Path);
+
+        // other properties have type String.
+        constexpr auto String = XMLTools::toXMLCh("String");
+        if (XMLString::equals(node->getNodeName(), String.data())) {
             if (!currentProperty.empty()) {
                 propMap[currentProperty] = readValue(node->getParentNode());
                 currentProperty.clear();
@@ -274,14 +274,7 @@ public:
         }
 
         // This is the node after the 'Properties' element of the document
-        std::array Objects = {chLatin_O,
-                              chLatin_b,
-                              chLatin_j,
-                              chLatin_e,
-                              chLatin_c,
-                              chLatin_t,
-                              chLatin_s,
-                              chNull};
+        constexpr auto Objects = XMLTools::toXMLCh("Objects");
         if (XMLString::equals(node->getNodeName(), Objects.data())) {
             ThrowXML(ParseException,XMLExcepts::Parser_Parse1);
         }
@@ -625,11 +618,34 @@ bool ProjectFile::containsFile(const std::string& name) const
     return entry != nullptr;
 }
 
+bool ProjectFile::containsFileInDocumentCache(const std::string& name) const
+{
+    ProjectFile::Metadata metadata = getMetadata();
+    if (metadata.documentCacheDir.empty()) {
+        return false;
+    }
+
+    std::string path = metadata.documentCacheDir + "/" + name;
+    Base::FileInfo fi(path);
+    return fi.exists();
+}
+
 uint32_t ProjectFile::sizeOfFile(const std::string& name) const
 {
-    zipios::ZipFile project(stdFile);
-    auto entry = project.getEntry(name);
-    return entry == nullptr ? 0 : entry->getSize();
+    if (containsFile(name)) {
+        zipios::ZipFile project(stdFile);
+        auto entry = project.getEntry(name);
+        return entry == nullptr ? 0 : entry->getSize();
+    }
+
+    if (containsFileInDocumentCache(name)) {
+        ProjectFile::Metadata metadata = getMetadata();
+        std::string path = metadata.documentCacheDir + "/" + name;
+        Base::FileInfo fi(path);
+        return fi.size();
+    }
+
+    return 0;
 }
 
 std::list<std::string> ProjectFile::getInputFiles(const std::string& name) const
@@ -725,6 +741,18 @@ void ProjectFile::readInputFileDirect(const std::string& name, std::ostream& str
     std::unique_ptr<std::istream> istr(project.getInputStream(name));
     if (istr) {
         *istr >> str.rdbuf();
+    }
+}
+
+void ProjectFile::readInputFileFromDocumentCache(const std::string& name, std::ostream& str) const
+{
+    ProjectFile::Metadata metadata = getMetadata();
+    std::string path = metadata.documentCacheDir + "/" + name;
+    Base::FileInfo fi(path);
+    if (fi.exists()) {
+        Base::ifstream file(fi, std::ios::in | std::ios::binary);
+        file >> str.rdbuf();
+        file.close();
     }
 }
 

--- a/src/App/ProjectFile.h
+++ b/src/App/ProjectFile.h
@@ -77,6 +77,7 @@ public:
         std::string company;
         std::string createdBy;
         std::string creationDate;
+        std::string documentCacheDir;
         std::string label;
         std::string lastModifiedBy;
         std::string lastModifiedDate;
@@ -148,6 +149,11 @@ public:
      */
     bool containsFile(const std::string& name) const;
     /**
+     * If the project file contains the file \a name in the document cache true
+     * is returned and false otherwise
+     */
+    bool containsFileInDocumentCache(const std::string& name) const;
+    /**
      * Retrieves the (uncompressed) file size of @a name, or 0 if it does not
      * exist in the project file.
      */
@@ -171,6 +177,10 @@ public:
      * Directly extracts the content of an input file of @a name.
      */
     void readInputFileDirect(const std::string& name, std::ostream& str) const;
+    /**
+     * Reads the content of an input file in the document cache of @a name.
+     */
+    void readInputFileFromDocumentCache(const std::string& name, std::ostream& str) const;
     /**
      * Replaces the input file @a name with the content of the given @a stream.
      * The method returns the file name of the newly created project file.

--- a/src/Base/Persistence.h
+++ b/src/Base/Persistence.h
@@ -157,6 +157,16 @@ public:
     // restore the binary persistence data from a stream. Must have the format used by dumpToStream
     void restoreFromStream(std::istream& stream);
 
+    bool canBeCachedForDocument() const
+    {
+        return cachedForDocument;
+    }
+
+    void setCanBeCachedForDocument(bool canBeCached)
+    {
+        cachedForDocument = canBeCached;
+    }
+
 private:
     /** This method is used at the end of restoreFromStream()
      * after all data files have been read in.
@@ -165,6 +175,8 @@ private:
      */
     virtual void restoreFinished()
     {}
+
+    bool cachedForDocument = false;
 };
 
 }  // namespace Base

--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -436,6 +436,45 @@ void Base::XMLReader::readBinFile(const char* filename)
     to.close();
 }
 
+void Base::XMLReader::readFileFromCacheDir(const FileEntry& entry) const
+{
+    try {
+        Base::FileInfo fi(documentCacheDir + "/" + entry.FileName);
+        if (fi.exists()) {
+            Base::ifstream from(fi, std::ios::in | std::ios::binary);
+            if (!from) {
+                throw Base::FileException("XMLReader::readFilesFromCacheDir() Could not open file!");
+            }
+            Base::Reader reader(from, entry.FileName, FileVersion);
+            entry.Object->RestoreDocFile(reader);
+            if (reader.getLocalReader()) {
+                reader.getLocalReader()->readFilesFromCacheDir();
+            }
+        }
+    }
+    catch (...) {
+        // For any exception we just continue with the next file.
+        // All what we need to do is to notify the user about the
+        // failure.
+        Base::Console().error(
+            "Reading failed from cache file: %s\n",
+            (documentCacheDir + "/" + entry.FileName).c_str()
+        );
+        FailedFiles.push_back(entry.FileName);
+    }
+}
+
+void Base::XMLReader::readFilesFromCacheDir() const
+{
+    if (documentCacheDir.empty()) {
+        return;
+    }
+
+    for (const auto& entry : FileList) {
+        readFileFromCacheDir(entry);
+    }
+}
+
 void Base::XMLReader::readFiles(zipios::ZipInputStream& zipstream) const
 {
     // It's possible that not all objects inside the document could be created, e.g. if a module

--- a/src/Base/Reader.h
+++ b/src/Base/Reader.h
@@ -219,6 +219,10 @@ public:
     unsigned int getAttributeCount() const;
     /// check if the read element has a special attribute
     bool hasAttribute(const char* AttrName) const;
+    void setDocumentCacheDir(const std::string& dir)
+    {
+        documentCacheDir = dir;
+    }
 
 private:
     // all explicit template instantiations - this is for getting
@@ -276,6 +280,7 @@ public:
     /// add a read request of a persistent object
     const char* addFile(const char* Name, Base::Persistence* Object);
     /// process the requested file writes
+    void readFilesFromCacheDir() const;
     void readFiles(zipios::ZipInputStream& zipstream) const;
     /// Returns whether reader has any registered filenames
     bool hasFilenames() const;
@@ -390,11 +395,16 @@ public:
     std::vector<FileEntry> FileList;
 
 private:
+    void readFileFromCacheDir(const FileEntry& entry) const;
+
+private:
     mutable std::vector<std::string> FailedFiles;
 
     std::bitset<32> StatusBits;
 
     std::unique_ptr<std::istream> CharStream;
+
+    std::string documentCacheDir;
 };
 
 class BaseExport Reader: public std::istream

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -434,8 +434,11 @@ void FileWriter::putNextEntry(const char* file, const char* obj)
 {
     Writer::putNextEntry(file, obj);
 
-    std::string fileName = DirName + "/" + file;
-    this->FileStream.open(fileName.c_str(), std::ios::out | std::ios::binary);
+    namespace fs = std::filesystem;
+    fs::path path = DirName + "/" + file;
+    fs::create_directories(path.parent_path());
+
+    this->FileStream.open(path, std::ios::out | std::ios::binary);
 
     Writer::checkErrNo();
 }

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -311,6 +311,35 @@ std::string Writer::addFile(const char* Name, const Base::Persistence* Object)
     return temp.FileName;
 }
 
+void Writer::writeFileToCacheDir(const FileEntry& entry)
+{
+    try {
+        Base::FileWriter writer(documentCacheDir.c_str());
+        writer.putNextEntry(entry.FileName.c_str());
+        entry.Object->SaveDocFile(writer);
+        writer.close();
+    }
+    catch (...) {
+        addError(
+            "Writer::writeFileToCacheDir() Could not write file: " + documentCacheDir + "/"
+            + entry.FileName
+        );
+    }
+}
+
+void Writer::writeFilesToCacheDir()
+{
+    if (documentCacheDir.empty()) {
+        return;
+    }
+
+    for (const auto& entry : FileList) {
+        if (entry.Object->canBeCachedForDocument()) {
+            writeFileToCacheDir(entry);
+        }
+    }
+}
+
 void Writer::incInd()
 {
     if (indent < 1020) {
@@ -366,6 +395,11 @@ void ZipWriter::putNextEntry(const char* file, const char* obj)
     Writer::checkErrNo();
 }
 
+bool ZipWriter::shouldWrite(FileEntry& entry)
+{
+    return documentCacheDir.empty() || !entry.Object->canBeCachedForDocument();
+}
+
 void ZipWriter::writeFiles()
 {
     // use a while loop because it is possible that while
@@ -373,10 +407,12 @@ void ZipWriter::writeFiles()
     size_t index = 0;
     while (index < FileList.size()) {
         FileEntry entry = FileList[index];
-        putNextEntry(entry.FileName.c_str());
-        indent = 0;
-        indBuf[0] = 0;
-        entry.Object->SaveDocFile(*this);
+        if (shouldWrite(entry)) {
+            putNextEntry(entry.FileName.c_str());
+            indent = 0;
+            indBuf[0] = 0;
+            entry.Object->SaveDocFile(*this);
+        }
         index++;
     }
 }

--- a/src/Base/Writer.h
+++ b/src/Base/Writer.h
@@ -99,6 +99,13 @@ public:
     std::string addFile(const char* Name, const Base::Persistence* Object);
     /// process the requested file storing
     virtual void writeFiles() = 0;
+    /// write files to the document cache dir
+    virtual void writeFilesToCacheDir();
+
+    void setDocumentCacheDir(const std::string& dir)
+    {
+        documentCacheDir = dir;
+    }
     /// Set mode
     void setMode(const std::string& mode);
     /// Set modes
@@ -195,13 +202,19 @@ protected:
 
     bool forceXML {false};
     int fileVersion {1};
+    std::string documentCacheDir;
     // NOLINTEND
+
 
 public:
     Writer(const Writer&) = delete;
     Writer(Writer&&) = delete;
     Writer& operator=(const Writer&) = delete;
     Writer& operator=(Writer&&) = delete;
+
+private:
+    void writeFileToCacheDir(const FileEntry& entry);
+
 
 private:
     std::unique_ptr<std::ostream> CharStream;
@@ -248,6 +261,9 @@ public:
     ZipWriter(ZipWriter&&) = delete;
     ZipWriter& operator=(const ZipWriter&) = delete;
     ZipWriter& operator=(ZipWriter&&) = delete;
+
+private:
+    bool shouldWrite(FileEntry& entry);
 
 private:
     zipios::ZipOutputStream ZipStream;

--- a/src/Base/XMLTools.h
+++ b/src/Base/XMLTools.h
@@ -46,6 +46,19 @@ class BaseExport XMLTools
 public:
     static std::string toStdString(const XMLCh* const toTranscode);
     static std::basic_string<XMLCh> toXMLString(const char* const fromTranscode);
+
+    // NOLINTBEGIN(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    template<std::size_t N>
+    static constexpr std::array<XMLCh, N> toXMLCh(const char (&str)[N])
+    {
+
+        std::array<XMLCh, N> result {};
+        for (std::size_t i = 0; i < N; ++i) {
+            result[i] = static_cast<XMLCh>(str[i]);
+        }
+        return result;
+    }
+    // NOLINTEND(modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
     static std::string escapeXml(const std::string& input);
     static void initialize();
     static void terminate();

--- a/src/Gui/Thumbnail.cpp
+++ b/src/Gui/Thumbnail.cpp
@@ -46,7 +46,9 @@ using namespace Gui;
 
 Thumbnail::Thumbnail(int s)
     : size(s)
-{}
+{
+    setCanBeCachedForDocument(true);
+}
 
 Thumbnail::~Thumbnail() = default;
 

--- a/src/Mod/Part/App/FeaturePartBox.cpp
+++ b/src/Mod/Part/App/FeaturePartBox.cpp
@@ -41,6 +41,7 @@ Box::Box()
     ADD_PROPERTY_TYPE(Length, (10.0f), "Box", App::Prop_None, "The length of the box");
     ADD_PROPERTY_TYPE(Width, (10.0f), "Box", App::Prop_None, "The width of the box");
     ADD_PROPERTY_TYPE(Height, (10.0f), "Box", App::Prop_None, "The height of the box");
+    CanComputeShape.setValue(true);
 }
 
 short Box::mustExecute() const

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -1657,8 +1657,13 @@ Feature* Feature::create(const TopoShape& shape, const char* name, App::Document
 
 void Feature::onDocumentRestored()
 {
-    // expandShapeContents();
-    App::GeoFeature::onDocumentRestored();
+    if (CanComputeShape.getValue() && Shape.getShape().isNull()) {
+        // A normal touch does not work because that is cleared in the
+        // recompute phase.
+        App::Document* doc = getDocument();
+        doc->addRecomputeObject(this, /*forMigration = */ false);
+    }
+    GeoFeature::onDocumentRestored();
 }
 
 ShapeHistory Feature::buildHistory(

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -97,9 +97,26 @@ Feature::Feature()
     ADD_PROPERTY(Shape, (TopoDS_Shape()));
     auto mat = Materials::MaterialManager::defaultMaterial();
     ADD_PROPERTY(ShapeMaterial, (*mat));
+    ADD_PROPERTY_TYPE(
+        CanComputeShape,
+        (false),
+        nullptr,
+        App::PropertyType::Prop_Hidden,
+        "Whether the shape can be computed by this document object"
+    );
+
+    startSaveDocumentConnection = App::GetApplication().signalStartSaveDocument.connect(
+        [this](const App::Document& /*doc*/, const std::string& /*filename*/) {
+            Shape.setCanBeCachedForDocument(CanComputeShape.getValue());
+        }
+    );
 }
 
-Feature::~Feature() = default;
+Feature::~Feature()
+{
+    startSaveDocumentConnection.disconnect();
+}
+
 
 short Feature::mustExecute() const
 {

--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -26,6 +26,7 @@
 
 #include <App/FeaturePython.h>
 #include <App/GeoFeature.h>
+#include <App/PropertyStandard.h>
 #include <Mod/Material/App/PropertyMaterial.h>
 #include <Mod/Part/PartGlobal.h>
 #include <Base/Bitmask.h>
@@ -74,6 +75,7 @@ public:
     ~Feature() override;
 
     PropertyPartShape Shape;
+    App::PropertyBool CanComputeShape;
     Materials::PropertyMaterial ShapeMaterial;
 
     /** @name methods override feature */
@@ -257,6 +259,7 @@ private:
     struct ElementCache;
     std::map<std::string, ElementCache> _elementCache;
     std::vector<std::pair<std::string, PropertyPartShape*>> _elementCachePrefixMap;
+    fastsignals::connection startSaveDocumentConnection;
 };
 
 class PartExport FilletBase: public Part::Feature

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -451,7 +451,7 @@ void PropertyPartShape::Restore(Base::XMLReader& reader)
     if (reader.hasAttribute("file")) {
         std::string file = reader.getAttribute<const char*>("file");
         if (!file.empty()) {
-            // initiate a file read
+            // record a file read
             reader.addFile(file.c_str(), this);
         }
     }

--- a/src/Mod/PartDesign/App/Feature.cpp
+++ b/src/Mod/PartDesign/App/Feature.cpp
@@ -129,6 +129,14 @@ Feature::Feature()
 
     App::SuppressibleExtension::initExtension(this);
     Part::PreviewExtension::initExtension(this);
+
+    CanComputeShape.setValue(true);
+
+    startSaveDocumentConnection = App::GetApplication().signalStartSaveDocument.connect(
+        [this](const App::Document& /*doc*/, const std::string& /*filename*/) {
+            SuppressedShape.setCanBeCachedForDocument(CanComputeShape.getValue());
+        }
+    );
 }
 
 App::DocumentObjectExecReturn* Feature::recompute()

--- a/src/Mod/PartDesign/App/Feature.h
+++ b/src/Mod/PartDesign/App/Feature.h
@@ -166,6 +166,9 @@ protected:
     // TODO: Toponaming April 2024 Deprecated in favor of TopoShape method.  Remove when possible.
     static TopoDS_Shape makeShapeFromPlane(const App::DocumentObject* obj);
     static TopoShape makeTopoShapeFromPlane(const App::DocumentObject* obj);
+
+private:
+    fastsignals::scoped_connection startSaveDocumentConnection;
 };
 
 using FeaturePython = App::FeaturePythonT<Feature>;

--- a/src/Mod/PartDesign/App/FeatureAddSub.cpp
+++ b/src/Mod/PartDesign/App/FeatureAddSub.cpp
@@ -50,6 +50,11 @@ PROPERTY_SOURCE(PartDesign::FeatureAddSub, PartDesign::FeatureRefine)
 FeatureAddSub::FeatureAddSub()
 {
     ADD_PROPERTY(AddSubShape, (TopoDS_Shape()));
+    startSaveDocumentConnection = App::GetApplication().signalStartSaveDocument.connect(
+        [this](const App::Document& /*doc*/, const std::string& /*filename*/) {
+            AddSubShape.setCanBeCachedForDocument(CanComputeShape.getValue());
+        }
+    );
 }
 
 void FeatureAddSub::onChanged(const App::Property* property)

--- a/src/Mod/PartDesign/App/FeatureAddSub.h
+++ b/src/Mod/PartDesign/App/FeatureAddSub.h
@@ -61,6 +61,9 @@ public:
 
 protected:
     Type addSubType {Additive};
+
+private:
+    fastsignals::scoped_connection startSaveDocumentConnection;
 };
 
 using FeatureAddSubPython = App::FeaturePythonT<FeatureAddSub>;

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -127,6 +127,8 @@ SketchObject::SketchObject() : geoLastId(0)
                       (App::PropertyType)(App::Prop_Hidden | App::Prop_ReadOnly),
                       "");
 
+    CanComputeShape.setValue(true);
+
     Geometry.setOrderRelevant(true);
 
     allowOtherBody = true;
@@ -157,6 +159,11 @@ SketchObject::SketchObject() : geoLastId(0)
     constraintsRenamedConn = Constraints.signalConstraintsRenamed.connect(
         std::bind(&Sketcher::SketchObject::constraintsRenamed, this, sp::_1));
     //NOLINTEND
+
+    startSaveDocumentConnection = App::GetApplication().signalStartSaveDocument.connect(
+            [this](const App::Document& /*doc*/, const std::string& /*filename*/) {
+                InternalShape.setCanBeCachedForDocument(CanComputeShape.getValue());
+            });
 
     analyser = new SketchAnalysis(this);
 

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1194,6 +1194,7 @@ private:
 
     fastsignals::scoped_connection constraintsRenamedConn;
     fastsignals::scoped_connection constraintsRemovedConn;
+    fastsignals::scoped_connection startSaveDocumentConnection;
 
     bool AutoLockTangencyAndPerpty(Constraint* cstr, bool bForce = false, bool bLock = true);
 

--- a/src/Mod/Start/App/FcstdInfoSource.cpp
+++ b/src/Mod/Start/App/FcstdInfoSource.cpp
@@ -53,7 +53,10 @@ static QByteArray loadFCStdThumbnail(const App::ProjectFile& proj, const QString
         }
         else {
             const auto pathToThumbnail = QString(defaultThumbnailPath).toStdString();
-            if (proj.containsFile(pathToThumbnail)) {
+            bool fileContainsThumbnail = proj.containsFile(pathToThumbnail);
+            bool docCacheContainsThumbnail = proj.containsFileInDocumentCache(pathToThumbnail);
+
+            if (fileContainsThumbnail || docCacheContainsThumbnail) {
                 createThumbnailsDir();
 
                 // Read the thumbnail into a buffer
@@ -65,7 +68,12 @@ static QByteArray loadFCStdThumbnail(const App::ProjectFile& proj, const QString
                 Base::BufferStreambuf dataStreambuf({data.data(), size_t(data.size())});
                 std::ostream dataStream(&dataStreambuf);
 #endif
-                proj.readInputFileDirect(pathToThumbnail, dataStream);
+                if (fileContainsThumbnail) {
+                    proj.readInputFileDirect(pathToThumbnail, dataStream);
+                }
+                else if (docCacheContainsThumbnail) {
+                    proj.readInputFileFromDocumentCache(pathToThumbnail, dataStream);
+                }
 
                 // Save that buffer to the thumbnail cache
                 const Base::FileInfo thumbnailFileInfo(pathToCachedThumbnail.toStdString());

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(Test_SRCS
     TestGui.py
     UnicodeTests.py
     UnitTests.py
+    Versioning.py
     Workbench.py
     unittestgui.py
     testmakeWireString.py

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -33,4 +33,5 @@ FreeCAD.__unit_test__ += [
     "StringHasher",
     "UnicodeTests",
     "TestPythonSyntax",
+    "Versioning",
 ]

--- a/src/Mod/Test/Versioning.py
+++ b/src/Mod/Test/Versioning.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# /****************************************************************************
+#  *                                                                          *
+#  *   Copyright (c) 2026 Pieter Hijma <info@pieterhijma.net>                 *
+#  *                                                                          *
+#  *   This file is part of FreeCAD.                                          *
+#  *                                                                          *
+#  *   FreeCAD is free software: you can redistribute it and/or modify it     *
+#  *   under the terms of the GNU Lesser General Public License as            *
+#  *   published by the Free Software Foundation, either version 2.1 of the   *
+#  *   License, or (at your option) any later version.                        *
+#  *                                                                          *
+#  *   FreeCAD is distributed in the hope that it will be useful, but         *
+#  *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+#  *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+#  *   Lesser General Public License for more details.                        *
+#  *                                                                          *
+#  *   You should have received a copy of the GNU Lesser General Public       *
+#  *   License along with FreeCAD. If not, see                                *
+#  *   <https://www.gnu.org/licenses/>.                                       *
+#  *                                                                          *
+#  ***************************************************************************/
+
+import os
+import time
+import tempfile
+
+import unittest
+
+import zipfile
+import shutil
+import difflib
+
+import FreeCAD
+
+THUMBNAIL_FILE = "thumbnails/Thumbnail.png"
+GUI_DOCUMENT_FILE = "GuiDocument.xml"
+DOCUMENT_FILE = "Document.xml"
+LINE_COLOR_ARRAY_FILE = "LineColorArray"
+POINT_COLOR_ARRAY_FILE = "PointColorArray"
+SHAPE_APPEARANCE_FILE = "ShapeAppearance"
+
+
+def get_document_cache_files_from_file(filepath: str) -> set[str]:
+    """Get the files that potentially target the document cache from a FreeCAD file.
+
+    If there are files in the FreeCAD file that can potentially be cached (for
+    example BRep files or thumbnails), then this function returns these.
+
+    @param[in] filepath The file path of the FreeCAD document.
+    @return The set of file names
+    """
+
+    with zipfile.ZipFile(filepath, "r") as zip_file:
+        all_files = zip_file.namelist()
+        return {f for f in all_files if f.endswith(".brp") or f == THUMBNAIL_FILE}
+
+
+def get_document_cache_files_from_cache_dir(doc_cache_dir: str) -> set[str]:
+    """Get the files from the document cache directory.
+
+    The way this function returns the file names should be similar to how
+    zip_file.namelist() returns them.
+
+    @param[in] doc_cache_dir The document cache directory.
+    @return The set of file names
+    """
+    base = os.fspath(doc_cache_dir)
+    cache_files = set()
+    for root, _, files in os.walk(base):
+        rel_root = os.path.relpath(root, base)
+        prefix = "" if rel_root == "." else rel_root.replace(os.sep, "/") + "/"
+        for file in files:
+            cache_files.add(prefix + file)
+    return cache_files
+
+
+def get_default_files() -> set[str]:
+    """Get the default files that are expected to be in the document cache.
+
+    @return The set of default file names
+    """
+    return {THUMBNAIL_FILE} if FreeCAD.GuiUp else set()
+
+
+def get_bytes_zip_file(zipfile_path: str, filename: str) -> bytes:
+    """Get the contents of a file from a zip file.
+
+    @param[in] filepath The file path of the zip file.
+    @param[in] filename The name of the file in the zip file.
+    @return The content of the file.
+    """
+    with zipfile.ZipFile(zipfile_path, "r") as zip_file:
+        with zip_file.open(filename) as f:
+            return f.read()
+
+
+def get_text_zip_file(zipfile_path: str, filename: str) -> str:
+    """Get the content of a text file from a zip file.
+
+    @param[in] filepath The file path of the zip file.
+    @param[in] filename The name of the file in the zip file.
+    @return The content of the text file.
+    """
+    return get_bytes_zip_file(zipfile_path, filename).decode("utf-8")
+
+
+def get_diff(zipfile1_path: str, zipfile2_path: str, filename: str) -> str:
+    """Get the diff of a file in two zip files.
+
+    The result is a list of tuples, where each tuple contains the removed line
+    and the added line.
+
+    @param[in] zipfile1_path The file path of the first zip file.
+    @param[in] zipfile2_path The file path of the second zip file.
+    @return The diff of the file in the two zip files.
+
+    """
+    text_file1 = get_text_zip_file(zipfile1_path, filename)
+    text_file2 = get_text_zip_file(zipfile2_path, filename)
+    lines1 = text_file1.splitlines(keepends=True)
+    lines2 = text_file2.splitlines(keepends=True)
+
+    diff_output = list(
+        difflib.unified_diff(lines1, lines2, fromfile=zipfile1_path, tofile=zipfile2_path, n=1)
+    )
+    added_lines = [line for line in diff_output if line.startswith("+ ")]
+    removed_lines = [line for line in diff_output if line.startswith("- ")]
+
+    def strip_diff_line(line):
+        return line[2:].strip()
+
+    return list(zip(map(strip_diff_line, removed_lines), map(strip_diff_line, added_lines)))
+
+
+class VersioningTest(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_no_cache_dir(self):
+        """Test whether the expected files are stored in the FreeCAD file.
+
+        Test that when no cache directory is used, the files that are expected
+        to be cached are actually stored in the FreeCAD file.
+        """
+
+        doc = FreeCAD.newDocument("VersioningTest")
+        box = doc.addObject("Part::Box", "Box")
+        doc.recompute()
+
+        self.assertTrue(hasattr(box, "CanComputeShape"))
+        self.assertTrue(box.CanComputeShape)
+        self.assertTrue(hasattr(doc, "DocumentCacheDir"))
+        self.assertEqual(doc.DocumentCacheDir, "")
+
+        temp_dir = tempfile.mkdtemp()
+        temp_file = os.path.join(temp_dir, "VersioningTest.FCStd")
+        doc.saveAs(temp_file)
+        FreeCAD.closeDocument(doc.Name)
+
+        self.assertSetEqual(
+            get_document_cache_files_from_file(temp_file),
+            get_default_files().union({"Box.Shape.brp"}),
+        )
+
+        shutil.rmtree(temp_dir)
+
+    def test_with_cache_dir(self):
+        """Test whether the expected files are stored in the document cache.
+
+        Test that when the document cache is used, the files that are expected
+        to be cached are stored in the cache and not in the FreeCAD file.
+        """
+        doc = FreeCAD.newDocument("VersioningTest")
+        box = doc.addObject("Part::Box", "Box")
+        doc.recompute()
+
+        self.assertTrue(hasattr(box, "CanComputeShape"))
+        self.assertTrue(box.CanComputeShape)
+        self.assertTrue(hasattr(doc, "DocumentCacheDir"))
+
+        temp_dir = tempfile.mkdtemp()
+        doc_cache_dir = os.path.join(temp_dir, "document-cache")
+        os.mkdir(doc_cache_dir)
+
+        doc.DocumentCacheDir = doc_cache_dir
+
+        temp_file = os.path.join(temp_dir, "VersioningTest.FCStd")
+        doc.saveAs(temp_file)
+        FreeCAD.closeDocument(doc.Name)
+
+        # Expected files not in the FreeCAD file.
+        self.assertSetEqual(get_document_cache_files_from_file(temp_file), set())
+
+        # Expected files in the document cache directory.
+        self.assertSetEqual(
+            get_document_cache_files_from_cache_dir(doc_cache_dir),
+            get_default_files().union({"Box.Shape.brp"}),
+        )
+
+        shutil.rmtree(temp_dir)
+
+    def test_diff(self):
+        """Test whether the diff contains the expected differences.
+
+        Test that when the document cache is used, the diff is minimal and only
+        contains the expected differences.  In this case we only expect the
+        change of the box length and the file name of the FreeCAD document.
+        """
+        doc = FreeCAD.newDocument("VersioningTest")
+        box = doc.addObject("Part::Box", "Box")
+        doc.recompute()
+
+        self.assertTrue(hasattr(box, "CanComputeShape"))
+        self.assertTrue(box.CanComputeShape)
+        self.assertTrue(hasattr(doc, "DocumentCacheDir"))
+
+        temp_dir = tempfile.mkdtemp()
+        doc_cache_dir = os.path.join(temp_dir, "document-cache")
+        os.mkdir(doc_cache_dir)
+
+        # Prepare for precise diffs
+        doc.DocumentCacheDir = doc_cache_dir
+        doc.setPropertyStatus("LastModifiedDate", "Transient")
+
+        temp_file_v1 = os.path.join(temp_dir, "VersioningTest1.FCStd")
+        doc.saveAs(temp_file_v1)
+
+        box.Length = 20
+        doc.recompute()
+        time.sleep(1)
+
+        temp_file_v2 = os.path.join(temp_dir, "VersioningTest2.FCStd")
+        doc.saveAs(temp_file_v2)
+        FreeCAD.closeDocument(doc.Name)
+
+        # Expected files not in the FreeCAD file.
+        self.assertSetEqual(get_document_cache_files_from_file(temp_file_v1), set())
+        self.assertSetEqual(get_document_cache_files_from_file(temp_file_v2), set())
+
+        # Expected files in the document cache directory.
+        self.assertSetEqual(
+            get_document_cache_files_from_cache_dir(doc_cache_dir),
+            get_default_files().union({"Box.Shape.brp"}),
+        )
+
+        if FreeCAD.GuiUp:
+            self.assertEqual(
+                get_text_zip_file(temp_file_v1, GUI_DOCUMENT_FILE),
+                get_text_zip_file(temp_file_v2, GUI_DOCUMENT_FILE),
+            )
+            self.assertEqual(
+                get_bytes_zip_file(temp_file_v1, LINE_COLOR_ARRAY_FILE),
+                get_bytes_zip_file(temp_file_v2, LINE_COLOR_ARRAY_FILE),
+            )
+            self.assertEqual(
+                get_bytes_zip_file(temp_file_v1, POINT_COLOR_ARRAY_FILE),
+                get_bytes_zip_file(temp_file_v2, POINT_COLOR_ARRAY_FILE),
+            )
+            self.assertEqual(
+                get_bytes_zip_file(temp_file_v1, SHAPE_APPEARANCE_FILE),
+                get_bytes_zip_file(temp_file_v2, SHAPE_APPEARANCE_FILE),
+            )
+
+        diff = get_diff(temp_file_v1, temp_file_v2, DOCUMENT_FILE)
+        expected_diff = [
+            ('<String value="VersioningTest1"/>', '<String value="VersioningTest2"/>'),
+            ('<Float value="10.0000000000000000"/>', '<Float value="20.0000000000000000"/>'),
+        ]
+        self.assertListEqual(diff, expected_diff)
+
+        shutil.rmtree(temp_dir)
+
+    def test_mark_to_recompute(self):
+        """Tests whether objects without shapes are marked to be recomputed.
+
+        When the document cache is used for a file, but shapes of objects are
+        missing (for example if the file is opened on a different computer),
+        then on opening the file, the objects that have missing shapes should
+        be marked to be recomputed.
+        """
+        doc = FreeCAD.newDocument("VersioningTest")
+        box = doc.addObject("Part::Box", "Box")
+        doc.recompute()
+
+        self.assertTrue(hasattr(box, "CanComputeShape"))
+        self.assertTrue(box.CanComputeShape)
+        self.assertTrue(hasattr(doc, "DocumentCacheDir"))
+
+        temp_dir = tempfile.mkdtemp()
+        doc_cache_dir = os.path.join(temp_dir, "document-cache")
+        os.mkdir(doc_cache_dir)
+
+        doc.DocumentCacheDir = doc_cache_dir
+
+        temp_file = os.path.join(temp_dir, "VersioningTest.FCStd")
+        doc.saveAs(temp_file)
+        FreeCAD.closeDocument(doc.Name)
+
+        os.remove(os.path.join(doc_cache_dir, "Box.Shape.brp"))
+
+        doc = FreeCAD.open(temp_file)
+        self.assertIn("Touched", doc.Box.State)
+        FreeCAD.closeDocument(doc.Name)

--- a/src/Tools/fcinfo
+++ b/src/Tools/fcinfo
@@ -54,6 +54,7 @@ Options:
                      show details of what has changed.
     -p  --partinfo:  Print size and hash of internal BREP part files
     -g  --gui:       Adds visual properties too (if not using -s or -vs)
+    -nd --nodoc:     Do not print document and hash
 
 Git usage:
 
@@ -259,6 +260,11 @@ if __name__ == "__main__":
     else:
         gui = False
 
+    if ("-nd" in sys.argv[1:]) or ("--nodoc" in sys.argv[1:]):
+        nodoc = True
+    else:
+        nodoc = False
+
     zfile = zipfile.ZipFile(sys.argv[-1])
 
     if not "Document.xml" in zfile.namelist():
@@ -279,6 +285,7 @@ if __name__ == "__main__":
         s = str(s / 1048576) + "M"
     else:
         s = str(s / 1024) + "K"
-    print("Document: " + sys.argv[-1] + " (" + s + ")")
-    print("   SHA1: " + str(hashlib.sha1(open(sys.argv[-1], "rb").read()).hexdigest()))
+    if not nodoc:
+        print("Document: " + sys.argv[-1] + " (" + s + ")")
+        print("   SHA1: " + str(hashlib.sha1(open(sys.argv[-1], "rb").read()).hexdigest()))
     xml.sax.parseString(doc, FreeCADFileHandler(zfile, short))


### PR DESCRIPTION
This PR is a potential solution to improve FreeCAD's file format for versioning, for example with Git.

Concretely, this PR solves the following subset of versioning-related problems:
- Redundant BRep files (that can be computed) are stored in the FreeCAD file.
- Removing redundant BRep files comes at the cost of expensive recomputes.
- A recompute of the FreeCAD file without any modifications to the model changes the FreeCAD file.

The underlying principle is a **document cache**. With a **document cache**, each file can have its own, user-defined cache for files that can be recomputed, for example BRep files. With this PR, FreeCAD documents obtain a new path property `DocumentCacheDir` that a user can set to a specific directory. This can be a local directory on the computer, a directory within a versioned project that the versioning system ignores, or simply a temporary directory. When the document cache directory is empty (not set by the user), FreeCAD acts as always and BRep files and thumbnails are stored in the zip file. 

However, if the document cache directory is set, thumbnails and BRep files of document objects that can be recomputed, will be stored in the document cache directory and not in the FreeCAD zip file. A crucial aspect is whether a document object can compute its shape (and hence the BRep file).

To indicate this, `Part::Feature` has a new hidden property `CanComputeShape` that is false by default. However, if we know that a document object can compute its shape, then it is not strictly necessary to store the BRep file of the shape (only for performance reasons). Currently in this PR, only `Part::Box` has this property explicitly set to true. Typically all the Part features and PartDesign features can be set to true.

Suppose we load a FreeCAD file with the document cache set by the user, but the BRep files are not available, then certain document objects may have an empty shape. This will be detected by the system and those document objects will be marked as touched to give the user the opportunity to do a full or partial recompute.

So, with this feature, users can ensure that FreeCAD files have almost no brep files and thumbnails in their files. As such, the files are easier to diff. 

In addition, since the BRep files are not stored in the file, saving a file after a recompute will leave the FreeCAD file unmodified except for the `LastModifiedDate` property. To make FreeCAD files even more suited for versioning, I suggest to mark this property as `Transient`. Changing a property in a git repository will lead then to the following diff:

<img width="1036" height="373" alt="screenshot" src="https://github.com/user-attachments/assets/8320d886-2542-49fc-a516-e9916ccecbcb" />

This diff uses the following `.gitattributes` and `.gitconfig`:

```
*.fcstd diff=fcinfo
*.FCStd diff=fcinfo
```
This PR also added the `-nd` (no document info, no document name, no SHA1 hash) to `fcinfo`.

```
[diff "fcinfo"]
    textconv = freecad-improve-file-format-for-versioning/src/Tools/fcinfo -nd
```

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

May solve https://github.com/FreeCAD/FreeCAD/issues/11936.
May solve https://github.com/FreeCAD/FreeCAD/issues/9432.


## Video
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

A video of how this feature works:


https://github.com/user-attachments/assets/019f1f08-e06f-4887-a1ec-d8a8dbbc3224



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
