### PR TITLE
Sketcher: Create symmetry constraint is checked by default

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
@@ -77,7 +77,7 @@ public:
         , refGeoId(Sketcher::GeoEnum::GeoUndef)
         , refPosId(Sketcher::PointPos::none)
         , deleteOriginal(false)
-        , createSymConstraints(false)
+        , createSymConstraints(true)
     {}
 
     DrawSketchHandlerSymmetry(const DrawSketchHandlerSymmetry&) = delete;
@@ -300,6 +300,8 @@ void DSHSymmetryController::configureToolWidget()
             )
         );
     }
+
+    syncCheckboxToHandler(WCheckbox::SecondBox, handler->createSymConstraints);
 }
 
 template<>


### PR DESCRIPTION
Fixes: #28267

After the changes:-


https://github.com/user-attachments/assets/3d0ebc68-6ef6-43b4-a04b-4c147fcb8a70

