### PR TITLE
Draft: make polar and circular arrays aware of the active working plane

### DIFF
--- a/src/Mod/Draft/draftmake/make_circulararray.py
+++ b/src/Mod/Draft/draftmake/make_circulararray.py
@@ -30,6 +30,7 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
+import WorkingPlane
 import draftmake.make_array as make_array
 import draftutils.utils as utils
 
@@ -43,7 +44,7 @@ def make_circular_array(
     tan_distance=50,
     number=3,
     symmetry=1,
-    axis=App.Vector(0, 0, 1),
+    axis=None,
     center=App.Vector(0, 0, 0),
     use_link=True,
 ):
@@ -88,7 +89,8 @@ def make_circular_array(
         Et cetera.
 
     axis: Base::Vector3, optional
-        It defaults to `App.Vector(0, 0, 1)` or the `+Z` axis.
+        It defaults to the active Draft working plane axis if available,
+        otherwise to `App.Vector(0, 0, 1)` or the `+Z` axis.
         The unit vector indicating the axis of rotation.
 
     center: Base::Vector3, optional
@@ -149,6 +151,12 @@ def make_circular_array(
     except TypeError:
         _err(translate("draft", "Wrong input: must be an integer number."))
         return None
+
+    if axis is None:
+        if App.GuiUp:
+            axis = WorkingPlane.get_working_plane(update=False).axis
+        else:
+            axis = App.Vector(0, 0, 1)
 
     try:
         utils.type_check([(axis, App.Vector), (center, App.Vector)], name=_name)

--- a/src/Mod/Draft/draftmake/make_polararray.py
+++ b/src/Mod/Draft/draftmake/make_polararray.py
@@ -30,6 +30,7 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
+import WorkingPlane
 import draftutils.utils as utils
 import draftmake.make_array as make_array
 
@@ -37,7 +38,14 @@ from draftutils.messages import _err
 from draftutils.translate import translate
 
 
-def make_polar_array(base_object, number=5, angle=360, center=App.Vector(0, 0, 0), use_link=True):
+def make_polar_array(
+    base_object,
+    number=5,
+    angle=360,
+    center=App.Vector(0, 0, 0),
+    axis=None,
+    use_link=True,
+):
     """Create a polar array from the given object.
 
     Parameters
@@ -60,6 +68,11 @@ def make_polar_array(base_object, number=5, angle=360, center=App.Vector(0, 0, 0
     center: Base::Vector3, optional
         It defaults to the origin `App.Vector(0, 0, 0)`.
         The vector indicating the center of rotation of the array.
+
+    axis: Base::Vector3, optional
+        It defaults to the active Draft working plane axis if available,
+        otherwise to `App.Vector(0, 0, 1)` or the `+Z` axis.
+        The unit vector indicating the axis of rotation.
 
     use_link: bool, optional
         It defaults to `True`.
@@ -109,8 +122,14 @@ def make_polar_array(base_object, number=5, angle=360, center=App.Vector(0, 0, 0
         _err(translate("draft", "Wrong input: must be a number."))
         return None
 
+    if axis is None:
+        if App.GuiUp:
+            axis = WorkingPlane.get_working_plane(update=False).axis
+        else:
+            axis = App.Vector(0, 0, 1)
+
     try:
-        utils.type_check([(center, App.Vector)], name=_name)
+        utils.type_check([(center, App.Vector), (axis, App.Vector)], name=_name)
     except TypeError:
         _err(translate("draft", "Wrong input: must be a vector."))
         return None
@@ -119,6 +138,7 @@ def make_polar_array(base_object, number=5, angle=360, center=App.Vector(0, 0, 0
     new_obj = make_array.make_array(
         base_object, arg1=center, arg2=angle, arg3=number, use_link=use_link
     )
+    new_obj.Axis = axis
     return new_obj
 
 

--- a/src/Mod/Draft/drafttaskpanels/task_circulararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_circulararray.py
@@ -34,6 +34,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
+import WorkingPlane
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
 from FreeCAD import Units as U
@@ -97,7 +98,7 @@ class TaskPanelCircularArray:
         self.center = App.Vector()
         # TODO: the axis is currently fixed, it should be editable
         # or selectable from the task panel
-        self.axis = App.Vector(0, 0, 1)
+        self.axis = WorkingPlane.get_working_plane(update=False).axis
         self.r_distance = 100
         self.tan_distance = 50
         self.number = 3

--- a/src/Mod/Draft/drafttaskpanels/task_polararray.py
+++ b/src/Mod/Draft/drafttaskpanels/task_polararray.py
@@ -34,6 +34,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import FreeCADGui as Gui
+import WorkingPlane
 import Draft_rc  # include resources, icons, ui files
 import DraftVecUtils
 from FreeCAD import Units as U
@@ -95,6 +96,9 @@ class TaskPanelPolarArray:
         # -------------------------------------------------------------------
         # Default values for the internal function, and for the task panel interface
         self.center = App.Vector()
+        # TODO: the axis is currently fixed, it should be editable
+        # or selectable from the task panel
+        self.axis = WorkingPlane.get_working_plane(update=False).axis
         self.angle = 360
         self.number = 5
         self.fuse = params.get_param("Draft_array_fuse")
@@ -144,16 +148,19 @@ class TaskPanelPolarArray:
 
         (self.number, self.angle) = self.get_number_angle()
 
+        self.axis = self.get_axis()
         self.center = self.get_center()
 
-        self.valid_input = self.validate_input(self.selection, self.number, self.angle, self.center)
+        self.valid_input = self.validate_input(
+            self.selection, self.number, self.angle, self.axis, self.center
+        )
         if self.valid_input:
             self.create_object()
             # The internal function already displays messages
             # self.print_messages()
             self.finish()
 
-    def validate_input(self, selection, number, angle, center):
+    def validate_input(self, selection, number, angle, axis, center):
         """Check that the input is valid.
 
         Some values may not need to be checked because
@@ -191,7 +198,7 @@ class TaskPanelPolarArray:
             self.angle = -360
 
         # The other arguments are not tested but they should be present.
-        if center:
+        if axis and center:
             pass
 
         self.fuse = self.form.checkbox_fuse.isChecked()
@@ -216,7 +223,7 @@ class TaskPanelPolarArray:
         # This creates the object immediately
         # obj = Draft.make_polar_array(sel_obj,
         #                              self.number, self.angle, self.center,
-        #                              self.use_link)
+        #                              self.axis, self.use_link)
 
         # Instead, we build the commands to execute through the caller
         # of this class, the GuiCommand.
@@ -228,6 +235,7 @@ class TaskPanelPolarArray:
         _cmd += "number=" + str(self.number) + ", "
         _cmd += "angle=" + str(self.angle) + ", "
         _cmd += "center=" + DraftVecUtils.toString(self.center) + ", "
+        _cmd += "axis=" + DraftVecUtils.toString(self.axis) + ", "
         _cmd += "use_link=" + str(self.use_link)
         _cmd += ")"
 
@@ -258,6 +266,14 @@ class TaskPanelPolarArray:
         c_z_str = self.form.input_c_z.text()
         center = App.Vector(_quantity(c_x_str), _quantity(c_y_str), _quantity(c_z_str))
         return center
+
+    def get_axis(self):
+        """Get the axis that will be used for the array. NOT IMPLEMENTED.
+
+        It should consider a second selection of an edge or wire to use
+        as an axis.
+        """
+        return self.axis
 
     def reset_point(self):
         """Reset the center point to the original distance."""


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
fixes #27739
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
<img width="1919" height="1023" alt="resim" src="https://github.com/user-attachments/assets/f365c9ae-7c87-448e-8d88-1bdc6182dd56" />

<img width="1920" height="1080" alt="resim" src="https://github.com/user-attachments/assets/53acb032-b267-49ab-8acc-fcb8cc64b646" />

While talking to @sedatkrn, he said that the issue was a bug, not a feature, and a very critical one at that. I agreed with him and had a solution in mind, but when I looked at the code, I saw that the array functions were unaware of the working planes. Also, there were differences between Polar and Circular. Therefore, I made Polar similar to Circular and ensured they had aware working planes. I also added something in case another axis was entered, since I wasn't entirely sure. I tested it and it worked as intended. Thanks to @ErtugrulEge for submitting such a good issue.


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
