### PR TITLE
App: Always use a versioned cache directory

### DIFF
--- a/src/App/ApplicationDirectories.cpp
+++ b/src/App/ApplicationDirectories.cpp
@@ -157,7 +157,9 @@ fs::path ApplicationDirectories::findPath(const fs::path& stdHome, const fs::pat
     return appData;
 }
 
-void ApplicationDirectories::appendVersionIfPossible(const fs::path& basePath, std::vector<std::string> &subdirs) const
+void ApplicationDirectories::appendVersionIfPossible(const fs::path& basePath,
+                                                     std::vector<std::string> &subdirs,
+                                                     MissingDirectoryBehavior behavior) const
 {
     fs::path pathToCheck = basePath;
     for (const auto& it : subdirs) {
@@ -166,7 +168,16 @@ void ApplicationDirectories::appendVersionIfPossible(const fs::path& basePath, s
     if (isVersionedPath(pathToCheck)) {
         return; // Bail out if it's already versioned
     }
-    if (fs::exists(pathToCheck)) {
+    if (behavior == MissingDirectoryBehavior::create) {
+        // Always use the current version, creating the directory if needed
+        auto [major, minor] = _currentVersion;
+        auto versionString = versionStringForPath(major, minor);
+        subdirs.emplace_back(versionString);
+        auto versionedDir = pathToCheck / versionString;
+        if (!fs::exists(versionedDir)) {
+            fs::create_directories(versionedDir);
+        }
+    } else if (fs::exists(pathToCheck)) {
         std::string version = mostRecentAvailableConfigVersion(pathToCheck);
         if (!version.empty()) {
             subdirs.emplace_back(std::move(version));
@@ -223,7 +234,7 @@ void ApplicationDirectories::configurePaths(std::map<std::string,std::string>& m
     // User data path
     //
     auto dataSubdirs = subdirs;
-    appendVersionIfPossible(dataHome, dataSubdirs);
+    appendVersionIfPossible(dataHome, dataSubdirs, MissingDirectoryBehavior::doNotAppend);
     fs::path data = findPath(dataHome, customData, dataSubdirs, true);
     _userAppData = data;
     mConfig["UserAppData"] = Base::FileInfo::pathToString(data) + PATHSEP;
@@ -232,7 +243,7 @@ void ApplicationDirectories::configurePaths(std::map<std::string,std::string>& m
     // User config path
     //
     auto configSubdirs = subdirs;
-    appendVersionIfPossible(configHome, configSubdirs);
+    appendVersionIfPossible(configHome, configSubdirs, MissingDirectoryBehavior::doNotAppend);
     fs::path config = findPath(configHome, customHome, configSubdirs, true);
     _userConfig = config;
     mConfig["UserConfigPath"] = Base::FileInfo::pathToString(config) + PATHSEP;
@@ -240,9 +251,10 @@ void ApplicationDirectories::configurePaths(std::map<std::string,std::string>& m
 
     // User cache path
     //
-    std::vector<std::string> cachedirs = subdirs;
-    cachedirs.emplace_back("Cache");
-    fs::path cache = findPath(cacheHome, customTemp, cachedirs, true);
+    std::vector<std::string> cacheDirs = subdirs;
+    appendVersionIfPossible(cacheHome, cacheDirs, MissingDirectoryBehavior::create);
+    cacheDirs.emplace_back("Cache");
+    fs::path cache = findPath(cacheHome, customTemp, cacheDirs, true);
     _userCache = cache;
     mConfig["UserCachePath"] = Base::FileInfo::pathToString(cache) + PATHSEP;
 

--- a/src/App/ApplicationDirectories.h
+++ b/src/App/ApplicationDirectories.h
@@ -187,12 +187,19 @@ namespace App {
         /// false if the temp directory creation failed.
         bool startSafeMode(std::map<std::string,std::string>& mConfig);
 
-        /// Take a path and add a version to it, if it's possible to do so. A version can be
-        /// appended only if a) the versioned subdirectory already exists, or b) pathToCheck/subdirs
-        /// does NOT yet exist. This does not actually create any directories, just determines
-        /// if we can append the versioned directory name to subdirs.
+        enum class MissingDirectoryBehavior : uint8_t {
+            create,
+            doNotAppend
+        };
+
+        /// Take a path and add a version to it, if it's possible to do so. When \a behavior is
+        /// `doNotAppend`, no directories are created: the most recent existing versioned
+        /// subdirectory is appended if one is found, or the current version is appended if the
+        /// base path does not yet exist. When \a behavior is `create`, the current version is
+        /// always appended and the directory is created on disk if it does not already exist.
         void appendVersionIfPossible(const std::filesystem::path& basePath,
-                                     std::vector<std::string> &subdirs) const;
+                                     std::vector<std::string> &subdirs,
+                                     MissingDirectoryBehavior behavior) const;
 
         static std::filesystem::path findPath(
             const std::filesystem::path& stdHome,

--- a/tests/src/App/ApplicationDirectories.cpp
+++ b/tests/src/App/ApplicationDirectories.cpp
@@ -45,7 +45,12 @@ class ApplicationDirectoriesTestClass: public App::ApplicationDirectories
 public:
     void wrapAppendVersionIfPossible(const fs::path& basePath, std::vector<std::string>& subdirs) const
     {
-        appendVersionIfPossible(basePath, subdirs);
+        appendVersionIfPossible(basePath, subdirs, MissingDirectoryBehavior::doNotAppend);
+    }
+
+    void wrapAppendVersionIfPossibleCreate(const fs::path& basePath, std::vector<std::string>& subdirs) const
+    {
+        appendVersionIfPossible(basePath, subdirs, MissingDirectoryBehavior::create);
     }
 
     std::tuple<int, int> wrapExtractVersionFromConfigMap(
@@ -791,6 +796,102 @@ TEST_F(ApplicationDirectoriesTest, sanitizeReturnsUnchangedIfNoNullCharacter)
 
     EXPECT_EQ(result.string(), input);
     EXPECT_EQ(result.string().find('\0'), std::string::npos);
+}
+
+// --- Tests for MissingDirectoryBehavior::create ---
+
+// Base exists, current version dir already present -> append current, no extra creation needed
+TEST_F(ApplicationDirectoriesTest, appendCreateBaseExistsAppendsCurrentWhenAlreadyPresent)
+{
+    auto appDirs = makeAppDirsForVersion(5, 4);
+
+    fs::path base = tempDir() / "create_current";
+    std::vector<std::string> sub {"configs"};
+    fs::create_directories(base / "configs");
+    fs::create_directories(versionedPath(base / "configs", 5, 4));
+
+    appDirs->wrapAppendVersionIfPossibleCreate(base, sub);
+
+    ASSERT_EQ(sub.size(), 2u);
+    EXPECT_EQ(sub.back(), App::ApplicationDirectories::versionStringForPath(5, 4));
+    EXPECT_TRUE(fs::is_directory(versionedPath(base / "configs", 5, 4)));
+}
+
+// Base exists, older version dir present -> create behavior still uses current version
+TEST_F(ApplicationDirectoriesTest, appendCreateBaseExistsUsesCurrentEvenWhenOlderVersionPresent)
+{
+    auto appDirs = makeAppDirsForVersion(5, 4);
+
+    fs::path base = tempDir() / "create_older";
+    std::vector<std::string> sub {"configs"};
+    fs::create_directories(versionedPath(base / "configs", 5, 2));
+
+    appDirs->wrapAppendVersionIfPossibleCreate(base, sub);
+
+    ASSERT_EQ(sub.size(), 2u);
+    EXPECT_EQ(sub.back(), App::ApplicationDirectories::versionStringForPath(5, 4));
+    EXPECT_TRUE(fs::is_directory(versionedPath(base / "configs", 5, 4)));
+}
+
+// Base exists but no versioned children -> create behavior appends current AND creates the directory
+TEST_F(ApplicationDirectoriesTest, appendCreateBaseExistsNoVersionsAppendsAndCreatesDir)
+{
+    auto appDirs = makeAppDirsForVersion(5, 4);
+
+    fs::path base = tempDir() / "create_noversions";
+    std::vector<std::string> sub {"configs"};
+    fs::create_directories(base / "configs");
+
+    appDirs->wrapAppendVersionIfPossibleCreate(base, sub);
+
+    ASSERT_EQ(sub.size(), 2u);
+    EXPECT_EQ(sub.back(), App::ApplicationDirectories::versionStringForPath(5, 4));
+    // The directory should have been created on disk
+    EXPECT_TRUE(fs::is_directory(versionedPath(base / "configs", 5, 4)));
+}
+
+// Contrast: doNotAppend does NOT append or create when base exists with no versioned children
+TEST_F(ApplicationDirectoriesTest, appendDoNotAppendBaseExistsNoVersionsLeavesUnchanged)
+{
+    auto appDirs = makeAppDirsForVersion(5, 4);
+
+    fs::path base = tempDir() / "donotappend_noversions";
+    std::vector<std::string> sub {"configs"};
+    fs::create_directories(base / "configs");
+
+    auto before = sub;
+    appDirs->wrapAppendVersionIfPossible(base, sub);
+
+    EXPECT_EQ(sub, before);
+    EXPECT_FALSE(fs::exists(versionedPath(base / "configs", 5, 4)));
+}
+
+// Base does not exist -> both behaviors append current version (no directory creation needed)
+TEST_F(ApplicationDirectoriesTest, appendCreateBaseMissingAppendsCurrentSuffix)
+{
+    auto appDirs = makeAppDirsForVersion(5, 4);
+
+    fs::path base = tempDir() / "create_missing";
+    std::vector<std::string> sub {"configs"};
+
+    appDirs->wrapAppendVersionIfPossibleCreate(base, sub);
+
+    ASSERT_EQ(sub.size(), 2u);
+    EXPECT_EQ(sub.back(), App::ApplicationDirectories::versionStringForPath(5, 4));
+}
+
+// Already versioned -> create behavior still bails out (no change)
+TEST_F(ApplicationDirectoriesTest, appendCreateAlreadyVersionedBails)
+{
+    auto appDirs = makeAppDirsForVersion(5, 4);
+
+    fs::path base = tempDir() / "create_bail";
+    std::vector<std::string> sub {"configs", App::ApplicationDirectories::versionStringForPath(5, 2)};
+    fs::create_directories(base / sub[0] / sub[1]);
+
+    auto before = sub;
+    appDirs->wrapAppendVersionIfPossibleCreate(base, sub);
+    EXPECT_EQ(sub, before);
 }
 
 /* NOLINTEND(


### PR DESCRIPTION
Right now, the cache directory is unversioned, the theory being that cache isn't important, and it can always just be cleared. That's a dumb theory, because no code exists to do that clearing. No version of FreeCAD should ever attempt to share cache with any other version.