### PR TITLE
Core: change properties only if new value is different

### DIFF
--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -85,6 +85,10 @@ PropertyInteger::~PropertyInteger() = default;
 
 void PropertyInteger::setValue(long lValue)
 {
+    if (lValue == _lValue) {
+        return;
+    }
+
     aboutToSetValue();
     _lValue = lValue;
     hasSetValue();
@@ -103,9 +107,7 @@ PyObject* PropertyInteger::getPyObject()
 void PropertyInteger::setPyObject(PyObject* value)
 {
     if (PyLong_Check(value)) {
-        aboutToSetValue();
-        _lValue = PyLong_AsLong(value);
-        hasSetValue();
+        setValue(PyLong_AsLong(value));
     }
     else {
         std::string error = std::string("type must be int, not ");
@@ -130,15 +132,13 @@ void PropertyInteger::Restore(Base::XMLReader& reader)
 Property* PropertyInteger::Copy() const
 {
     PropertyInteger* p = new PropertyInteger();
-    p->_lValue = _lValue;
+    p->setValue(_lValue);
     return p;
 }
 
 void PropertyInteger::Paste(const Property& from)
 {
-    aboutToSetValue();
-    _lValue = dynamic_cast<const PropertyInteger&>(from)._lValue;
-    hasSetValue();
+    setValue(dynamic_cast<const PropertyInteger&>(from)._lValue);
 }
 
 void PropertyInteger::setPathValue(const ObjectIdentifier& path, const boost::any& value)
@@ -318,6 +318,10 @@ void PropertyEnumeration::setEnums(const std::vector<std::string>& Enums)
 
 void PropertyEnumeration::setValue(const char* value)
 {
+    if (_enum == value) {
+        return;
+    }
+
     aboutToSetValue();
     _enum.setValue(value);
     hasSetValue();
@@ -325,6 +329,10 @@ void PropertyEnumeration::setValue(const char* value)
 
 void PropertyEnumeration::setValue(long value)
 {
+    if (value == _enum.getInt()) {
+        return;
+    }
+
     aboutToSetValue();
     _enum.setValue(value);
     hasSetValue();
@@ -332,6 +340,10 @@ void PropertyEnumeration::setValue(long value)
 
 void PropertyEnumeration::setValue(const Enumeration& source)
 {
+    if (source == _enum) {
+        return;
+    }
+
     aboutToSetValue();
     _enum = source;
     hasSetValue();
@@ -423,8 +435,6 @@ void PropertyEnumeration::Restore(Base::XMLReader& reader)
     // get the value of my Attribute
     long val = reader.getAttribute<long>("value");
 
-    aboutToSetValue();
-
     if (reader.hasAttribute("CustomEnum")) {
         reader.readElement("CustomEnumList");
         int count = reader.getAttribute<long>("count");
@@ -443,15 +453,16 @@ void PropertyEnumeration::Restore(Base::XMLReader& reader)
     if (val < 0) {
         // If the enum is empty at this stage do not print a warning
         if (_enum.hasEnums()) {
-            Base::Console().developerWarning(std::string("PropertyEnumeration"),
-                                             "Enumeration index %d is out of range, ignore it\n",
-                                             val);
+            Base::Console().developerWarning(
+                std::string("PropertyEnumeration"),
+                "Enumeration index %d is out of range, ignore it\n",
+                val
+            );
         }
         val = getValue();
     }
 
-    _enum.setValue(val);
-    hasSetValue();
+    setValue(val);
 }
 
 PyObject* PropertyEnumeration::getPyObject()
@@ -468,22 +479,20 @@ void PropertyEnumeration::setPyObject(PyObject* value)
     if (PyLong_Check(value)) {
         long val = PyLong_AsLong(value);
         if (_enum.isValid()) {
-            aboutToSetValue();
-            _enum.setValue(val, true);
-            hasSetValue();
+            setValue(val);
         }
         return;
     }
     else if (PyUnicode_Check(value)) {
         std::string str = PyUnicode_AsUTF8(value);
         if (_enum.contains(str.c_str())) {
-            aboutToSetValue();
-            _enum.setValue(str);
-            hasSetValue();
+            setValue(str.c_str());
         }
         else {
-            FC_THROWM(Base::ValueError,
-                      "'" << str << "' is not part of the enumeration in " << getFullName());
+            FC_THROWM(
+                Base::ValueError,
+                "'" << str << "' is not part of the enumeration in " << getFullName()
+            );
         }
         return;
     }
@@ -509,12 +518,10 @@ void PropertyEnumeration::setPyObject(PyObject* value)
                 values[i] = Py::Object(seq[i].ptr()).as_string();
             }
 
-            aboutToSetValue();
             _enum.setEnums(values);
             if (idx >= 0) {
-                _enum.setValue(idx, true);
+                setValue(idx);
             }
-            hasSetValue();
             return;
         }
         catch (Py::Exception&) {
@@ -523,10 +530,11 @@ void PropertyEnumeration::setPyObject(PyObject* value)
         }
     }
 
-    FC_THROWM(Base::TypeError,
-              "PropertyEnumeration "
-                  << getFullName()
-                  << " expects type to be int, string, or list(string), or list(list, int)");
+    FC_THROWM(
+        Base::TypeError,
+        "PropertyEnumeration "
+            << getFullName() << " expects type to be int, string, or list(string), or list(list, int)"
+    );
 }
 
 Property* PropertyEnumeration::Copy() const
@@ -653,6 +661,26 @@ PropertyIntegerConstraint::~PropertyIntegerConstraint()
     }
 }
 
+void PropertyIntegerConstraint::setValue(long lValue)
+{
+    if (_ConstStruct) {
+        if (lValue > _ConstStruct->UpperBound) {
+            lValue = _ConstStruct->UpperBound;
+        }
+        else if (lValue < _ConstStruct->LowerBound) {
+            lValue = _ConstStruct->LowerBound;
+        }
+    }
+
+    if (lValue == _lValue) {
+        return;
+    }
+
+    aboutToSetValue();
+    _lValue = lValue;
+    hasSetValue();
+}
+
 void PropertyIntegerConstraint::setConstraints(const Constraints* sConstrain)
 {
     if (_ConstStruct != sConstrain) {
@@ -698,52 +726,37 @@ long PropertyIntegerConstraint::getStepSize() const
 void PropertyIntegerConstraint::setPyObject(PyObject* value)
 {
     if (PyLong_Check(value)) {
-        long temp = PyLong_AsLong(value);
-        if (_ConstStruct) {
-            if (temp > _ConstStruct->UpperBound) {
-                temp = _ConstStruct->UpperBound;
-            }
-            else if (temp < _ConstStruct->LowerBound) {
-                temp = _ConstStruct->LowerBound;
-            }
-        }
-
-        aboutToSetValue();
-        _lValue = temp;
-        hasSetValue();
+        setValue(PyLong_AsLong(value));
     }
     else {
-        long valConstr[] = {0,
-                            std::numeric_limits<int>::lowest(),
-                            std::numeric_limits<int>::max(),
-                            1};
+        long valConstr[] = {0, std::numeric_limits<int>::lowest(), std::numeric_limits<int>::max(), 1};
 
         if (PyDict_Check(value)) {
             Py::Tuple dummy;
-            static const std::array<const char*, 5> kw = {"value",
-                                                          "min",
-                                                          "max",
-                                                          "step",
-                                                          nullptr};
+            static const std::array<const char*, 5> kw = {"value", "min", "max", "step", nullptr};
 
-            if (!Base::Wrapped_ParseTupleAndKeywords(dummy.ptr(),
-                                                     value,
-                                                     "l|lll",
-                                                      kw,
-                                                     &(valConstr[0]),
-                                                     &(valConstr[1]),
-                                                     &(valConstr[2]),
-                                                     &(valConstr[3]))) {
+            if (!Base::Wrapped_ParseTupleAndKeywords(
+                    dummy.ptr(),
+                    value,
+                    "l|lll",
+                    kw,
+                    &(valConstr[0]),
+                    &(valConstr[1]),
+                    &(valConstr[2]),
+                    &(valConstr[3])
+                )) {
                 throw Py::Exception();
             }
         }
         else if (PyTuple_Check(value)) {
-            if (!PyArg_ParseTuple(value,
-                                  "llll",
-                                  &(valConstr[0]),
-                                  &(valConstr[1]),
-                                  &(valConstr[2]),
-                                  &(valConstr[3]))) {
+            if (!PyArg_ParseTuple(
+                    value,
+                    "llll",
+                    &(valConstr[0]),
+                    &(valConstr[1]),
+                    &(valConstr[2]),
+                    &(valConstr[3])
+                )) {
                 throw Py::Exception();
             }
         }
@@ -758,24 +771,15 @@ void PropertyIntegerConstraint::setPyObject(PyObject* value)
         c->LowerBound = valConstr[1];
         c->UpperBound = valConstr[2];
         c->StepSize = std::max<long>(1, valConstr[3]);
-        if (valConstr[0] > c->UpperBound) {
-            valConstr[0] = c->UpperBound;
-        }
-        else if (valConstr[0] < c->LowerBound) {
-            valConstr[0] = c->LowerBound;
-        }
         setConstraints(c);
 
-        aboutToSetValue();
-        _lValue = valConstr[0];
-        hasSetValue();
+        setValue(valConstr[0]);
     }
 }
 
 void PropertyIntegerConstraint::Save(Base::Writer& writer) const
 {
-    writer.Stream() << writer.ind()
-                    << "<Integer value=\"" << _lValue << "\"";
+    writer.Stream() << writer.ind() << "<Integer value=\"" << _lValue << "\"";
     if (_ConstStruct && _ConstStruct->isDeletable()) {
         long minimum = _ConstStruct->LowerBound;
         long maximum = _ConstStruct->UpperBound;
@@ -1071,6 +1075,10 @@ PropertyFloat::~PropertyFloat() = default;
 
 void PropertyFloat::setValue(double lValue)
 {
+    if (lValue == _dValue) {
+        return;
+    }
+
     aboutToSetValue();
     _dValue = lValue;
     hasSetValue();
@@ -1089,14 +1097,10 @@ PyObject* PropertyFloat::getPyObject()
 void PropertyFloat::setPyObject(PyObject* value)
 {
     if (PyFloat_Check(value)) {
-        aboutToSetValue();
-        _dValue = PyFloat_AsDouble(value);
-        hasSetValue();
+        setValue(PyFloat_AsDouble(value));
     }
     else if (PyLong_Check(value)) {
-        aboutToSetValue();
-        _dValue = PyLong_AsLong(value);
-        hasSetValue();
+        setValue(PyLong_AsLong(value));
     }
     else {
         std::string error = std::string("type must be float or int, not ");
@@ -1121,15 +1125,13 @@ void PropertyFloat::Restore(Base::XMLReader& reader)
 Property* PropertyFloat::Copy() const
 {
     PropertyFloat* p = new PropertyFloat();
-    p->_dValue = _dValue;
+    p->setValue(_dValue);
     return p;
 }
 
 void PropertyFloat::Paste(const Property& from)
 {
-    aboutToSetValue();
-    _dValue = dynamic_cast<const PropertyFloat&>(from)._dValue;
-    hasSetValue();
+    setValue(dynamic_cast<const PropertyFloat&>(from)._dValue);
 }
 
 void PropertyFloat::setPathValue(const ObjectIdentifier& path, const boost::any& value)
@@ -1185,6 +1187,26 @@ PropertyFloatConstraint::~PropertyFloatConstraint()
     }
 }
 
+void PropertyFloatConstraint::setValue(double lValue)
+{
+    if (_ConstStruct) {
+        if (lValue > _ConstStruct->UpperBound) {
+            lValue = _ConstStruct->UpperBound;
+        }
+        else if (lValue < _ConstStruct->LowerBound) {
+            lValue = _ConstStruct->LowerBound;
+        }
+    }
+
+    if (lValue == _dValue) {
+        return;
+    }
+
+    aboutToSetValue();
+    _dValue = lValue;
+    hasSetValue();
+}
+
 void PropertyFloatConstraint::setConstraints(const Constraints* sConstrain)
 {
     if (_ConstStruct != sConstrain) {
@@ -1227,67 +1249,41 @@ double PropertyFloatConstraint::getStepSize() const
 void PropertyFloatConstraint::setPyObject(PyObject* value)
 {
     if (PyFloat_Check(value)) {
-        double temp = PyFloat_AsDouble(value);
-        if (_ConstStruct) {
-            if (temp > _ConstStruct->UpperBound) {
-                temp = _ConstStruct->UpperBound;
-            }
-            else if (temp < _ConstStruct->LowerBound) {
-                temp = _ConstStruct->LowerBound;
-            }
-        }
-
-        aboutToSetValue();
-        _dValue = temp;
-        hasSetValue();
+        setValue(PyFloat_AsDouble(value));
     }
     else if (PyLong_Check(value)) {
-        double temp = static_cast<double>(PyLong_AsLong(value));
-        if (_ConstStruct) {
-            if (temp > _ConstStruct->UpperBound) {
-                temp = _ConstStruct->UpperBound;
-            }
-            else if (temp < _ConstStruct->LowerBound) {
-                temp = _ConstStruct->LowerBound;
-            }
-        }
-
-        aboutToSetValue();
-        _dValue = temp;
-        hasSetValue();
+        setValue(static_cast<double>(PyLong_AsLong(value)));
     }
     else {
-        double valConstr[] = {0.0,
-                              std::numeric_limits<double>::lowest(),
-                              std::numeric_limits<double>::max(),
-                              1.0};
+        double valConstr[]
+            = {0.0, std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max(), 1.0};
 
         if (PyDict_Check(value)) {
             Py::Tuple dummy;
-            static const std::array<const char*, 5> kw = {"value",
-                                                          "min",
-                                                          "max",
-                                                          "step",
-                                                           nullptr};
+            static const std::array<const char*, 5> kw = {"value", "min", "max", "step", nullptr};
 
-            if (!Base::Wrapped_ParseTupleAndKeywords(dummy.ptr(),
-                                                     value,
-                                                     "d|ddd",
-                                                     kw,
-                                                     &(valConstr[0]),
-                                                     &(valConstr[1]),
-                                                     &(valConstr[2]),
-                                                     &(valConstr[3]))) {
+            if (!Base::Wrapped_ParseTupleAndKeywords(
+                    dummy.ptr(),
+                    value,
+                    "d|ddd",
+                    kw,
+                    &(valConstr[0]),
+                    &(valConstr[1]),
+                    &(valConstr[2]),
+                    &(valConstr[3])
+                )) {
                 throw Py::Exception();
             }
         }
         else if (PyTuple_Check(value)) {
-            if (!PyArg_ParseTuple(value,
-                                  "dddd",
-                                  &(valConstr[0]),
-                                  &(valConstr[1]),
-                                  &(valConstr[2]),
-                                  &(valConstr[3]))) {
+            if (!PyArg_ParseTuple(
+                    value,
+                    "dddd",
+                    &(valConstr[0]),
+                    &(valConstr[1]),
+                    &(valConstr[2]),
+                    &(valConstr[3])
+                )) {
                 throw Py::Exception();
             }
         }
@@ -1308,24 +1304,15 @@ void PropertyFloatConstraint::setPyObject(PyObject* value)
         c->LowerBound = valConstr[1];
         c->UpperBound = valConstr[2];
         c->StepSize = stepSize;
-        if (valConstr[0] > c->UpperBound) {
-            valConstr[0] = c->UpperBound;
-        }
-        else if (valConstr[0] < c->LowerBound) {
-            valConstr[0] = c->LowerBound;
-        }
         setConstraints(c);
 
-        aboutToSetValue();
-        _dValue = valConstr[0];
-        hasSetValue();
+        setValue(valConstr[0]);
     }
 }
 
 void PropertyFloatConstraint::Save(Base::Writer& writer) const
 {
-    writer.Stream() << writer.ind()
-                    << "<Float value=\"" << _dValue << "\"";
+    writer.Stream() << writer.ind() << "<Float value=\"" << _dValue << "\"";
     if (_ConstStruct && _ConstStruct->isDeletable()) {
         double minimum = _ConstStruct->LowerBound;
         double maximum = _ConstStruct->UpperBound;
@@ -1379,8 +1366,8 @@ TYPESYSTEM_SOURCE(App::PropertyPrecision, App::PropertyFloatConstraint)
 //**************************************************************************
 // Construction/Destruction
 //
-const PropertyFloatConstraint::Constraints PrecisionStandard = {
-    0.0, std::numeric_limits<double>::max(), 0.001};
+const PropertyFloatConstraint::Constraints PrecisionStandard
+    = {0.0, std::numeric_limits<double>::max(), 0.001};
 
 PropertyPrecision::PropertyPrecision()
 {
@@ -1444,8 +1431,7 @@ void PropertyFloatList::Save(Base::Writer& writer) const
     }
     else {
         writer.Stream() << writer.ind() << "<FloatList file=\""
-                        << (getSize() ? writer.addFile(getName(), this) : "") << "\"/>"
-                        << std::endl;
+                        << (getSize() ? writer.addFile(getName(), this) : "") << "\"/>" << std::endl;
     }
 }
 
@@ -1609,8 +1595,7 @@ void PropertyString::Save(Base::Writer& writer) const
     auto verifyXMLString = [this](std::string& input) {
         const std::string output = this->validateXMLString(input);
         if (output != input) {
-            Base::Console().warning("XML output: Validate invalid string:\n'%s'\n'%s'\n",
-                                    input, output);
+            Base::Console().warning("XML output: Validate invalid string:\n'%s'\n'%s'\n", input, output);
         }
         return output;
     };
@@ -1692,7 +1677,7 @@ void PropertyString::setPathValue(const ObjectIdentifier& path, const boost::any
 {
     verifyPath(path);
     if (value.type() == typeid(std::string)) {
-        setValue(boost::any_cast<const std::string &>(value));
+        setValue(boost::any_cast<const std::string&>(value));
     }
     else {
         setValue(anyToString(value));
@@ -1848,12 +1833,10 @@ PyObject* PropertyStringList::getPyObject()
     PyObject* list = PyList_New(getSize());
 
     for (int i = 0; i < getSize(); i++) {
-        PyObject* item =
-            PyUnicode_DecodeUTF8(_lValueList[i].c_str(), _lValueList[i].size(), nullptr);
+        PyObject* item = PyUnicode_DecodeUTF8(_lValueList[i].c_str(), _lValueList[i].size(), nullptr);
         if (!item) {
             Py_DECREF(list);
-            throw Base::UnicodeError(
-                "UTF8 conversion failure at PropertyStringList::getPyObject()");
+            throw Base::UnicodeError("UTF8 conversion failure at PropertyStringList::getPyObject()");
         }
         PyList_SetItem(list, i, item);
     }
@@ -2237,6 +2220,10 @@ PropertyBool::~PropertyBool() = default;
 
 void PropertyBool::setValue(bool lValue)
 {
+    if (lValue == _lValue) {
+        return;
+    }
+
     aboutToSetValue();
     _lValue = lValue;
     hasSetValue();
@@ -2289,15 +2276,13 @@ void PropertyBool::Restore(Base::XMLReader& reader)
 Property* PropertyBool::Copy() const
 {
     PropertyBool* p = new PropertyBool();
-    p->_lValue = _lValue;
+    p->setValue(_lValue);
     return p;
 }
 
 void PropertyBool::Paste(const Property& from)
 {
-    aboutToSetValue();
-    _lValue = dynamic_cast<const PropertyBool&>(from)._lValue;
-    hasSetValue();
+    setValue(dynamic_cast<const PropertyBool&>(from)._lValue);
 }
 
 void PropertyBool::setPathValue(const ObjectIdentifier& path, const boost::any& value)
@@ -2441,7 +2426,7 @@ namespace
 {
 /// The definition of "alpha" was corrected in FreeCAD 1.1 -- returns true if the reader is working
 /// on a file that pre-dates that correction.
-bool readerRequiresAlphaConversion(const Base::XMLReader &reader)
+bool readerRequiresAlphaConversion(const Base::XMLReader& reader)
 {
     return Base::getVersion(reader.ProgramVersion) < Base::Version::v1_1;
 }
@@ -2454,7 +2439,7 @@ void convertAlphaInMaterial(App::Material& material)
     material.specularColor.a = 1.0F - material.specularColor.a;
     material.emissiveColor.a = 1.0F - material.emissiveColor.a;
 }
-}
+}  // namespace
 
 TYPESYSTEM_SOURCE(App::PropertyColor, App::Property)
 
@@ -2576,8 +2561,9 @@ void PropertyColor::setPyObject(PyObject* value)
         cCol.setPackedValue(PyLong_AsUnsignedLong(value));
     }
     else {
-        std::string error =
-            std::string("type must be integer or tuple of float or tuple integer, not ");
+        std::string error = std::string(
+            "type must be integer or tuple of float or tuple integer, not "
+        );
         error += value->ob_type->tp_name;
         throw Base::TypeError(error);
     }
@@ -2669,8 +2655,7 @@ void PropertyColorList::Save(Base::Writer& writer) const
 {
     if (!writer.isForceXML()) {
         writer.Stream() << writer.ind() << "<ColorList file=\""
-                        << (getSize() ? writer.addFile(getName(), this) : "") << "\"/>"
-                        << std::endl;
+                        << (getSize() ? writer.addFile(getName(), this) : "") << "\"/>" << std::endl;
     }
 }
 

--- a/src/App/PropertyStandard.cpp
+++ b/src/App/PropertyStandard.cpp
@@ -84,6 +84,10 @@ PropertyInteger::~PropertyInteger() = default;
 
 void PropertyInteger::setValue(long lValue)
 {
+    if (lValue == _lValue) {
+        return;
+    }
+
     aboutToSetValue();
     _lValue = lValue;
     hasSetValue();
@@ -102,9 +106,7 @@ PyObject* PropertyInteger::getPyObject()
 void PropertyInteger::setPyObject(PyObject* value)
 {
     if (PyLong_Check(value)) {
-        aboutToSetValue();
-        _lValue = PyLong_AsLong(value);
-        hasSetValue();
+        setValue(PyLong_AsLong(value));
     }
     else {
         std::string error = std::string("type must be int, not ");
@@ -129,15 +131,13 @@ void PropertyInteger::Restore(Base::XMLReader& reader)
 Property* PropertyInteger::Copy() const
 {
     PropertyInteger* p = new PropertyInteger();
-    p->_lValue = _lValue;
+    p->setValue(_lValue);
     return p;
 }
 
 void PropertyInteger::Paste(const Property& from)
 {
-    aboutToSetValue();
-    _lValue = dynamic_cast<const PropertyInteger&>(from)._lValue;
-    hasSetValue();
+    setValue(dynamic_cast<const PropertyInteger&>(from)._lValue);
 }
 
 void PropertyInteger::setPathValue(const ObjectIdentifier& path, const boost::any& value)
@@ -317,6 +317,10 @@ void PropertyEnumeration::setEnums(const std::vector<std::string>& Enums)
 
 void PropertyEnumeration::setValue(const char* value)
 {
+    if (_enum == value) {
+        return;
+    }
+
     aboutToSetValue();
     _enum.setValue(value);
     hasSetValue();
@@ -324,6 +328,10 @@ void PropertyEnumeration::setValue(const char* value)
 
 void PropertyEnumeration::setValue(long value)
 {
+    if (value == _enum.getInt()) {
+        return;
+    }
+
     aboutToSetValue();
     _enum.setValue(value);
     hasSetValue();
@@ -331,6 +339,10 @@ void PropertyEnumeration::setValue(long value)
 
 void PropertyEnumeration::setValue(const Enumeration& source)
 {
+    if (source == _enum) {
+        return;
+    }
+
     aboutToSetValue();
     _enum = source;
     hasSetValue();
@@ -422,8 +434,6 @@ void PropertyEnumeration::Restore(Base::XMLReader& reader)
     // get the value of my Attribute
     long val = reader.getAttribute<long>("value");
 
-    aboutToSetValue();
-
     if (reader.hasAttribute("CustomEnum")) {
         reader.readElement("CustomEnumList");
         int count = reader.getAttribute<long>("count");
@@ -442,15 +452,16 @@ void PropertyEnumeration::Restore(Base::XMLReader& reader)
     if (val < 0) {
         // If the enum is empty at this stage do not print a warning
         if (_enum.hasEnums()) {
-            Base::Console().developerWarning(std::string("PropertyEnumeration"),
-                                             "Enumeration index %d is out of range, ignore it\n",
-                                             val);
+            Base::Console().developerWarning(
+                std::string("PropertyEnumeration"),
+                "Enumeration index %d is out of range, ignore it\n",
+                val
+            );
         }
         val = getValue();
     }
 
-    _enum.setValue(val);
-    hasSetValue();
+    setValue(val);
 }
 
 PyObject* PropertyEnumeration::getPyObject()
@@ -467,22 +478,20 @@ void PropertyEnumeration::setPyObject(PyObject* value)
     if (PyLong_Check(value)) {
         long val = PyLong_AsLong(value);
         if (_enum.isValid()) {
-            aboutToSetValue();
-            _enum.setValue(val, true);
-            hasSetValue();
+            setValue(val);
         }
         return;
     }
     else if (PyUnicode_Check(value)) {
         std::string str = PyUnicode_AsUTF8(value);
         if (_enum.contains(str.c_str())) {
-            aboutToSetValue();
-            _enum.setValue(str);
-            hasSetValue();
+            setValue(str.c_str());
         }
         else {
-            FC_THROWM(Base::ValueError,
-                      "'" << str << "' is not part of the enumeration in " << getFullName());
+            FC_THROWM(
+                Base::ValueError,
+                "'" << str << "' is not part of the enumeration in " << getFullName()
+            );
         }
         return;
     }
@@ -508,12 +517,10 @@ void PropertyEnumeration::setPyObject(PyObject* value)
                 values[i] = Py::Object(seq[i].ptr()).as_string();
             }
 
-            aboutToSetValue();
             _enum.setEnums(values);
             if (idx >= 0) {
-                _enum.setValue(idx, true);
+                setValue(idx);
             }
-            hasSetValue();
             return;
         }
         catch (Py::Exception&) {
@@ -522,10 +529,11 @@ void PropertyEnumeration::setPyObject(PyObject* value)
         }
     }
 
-    FC_THROWM(Base::TypeError,
-              "PropertyEnumeration "
-                  << getFullName()
-                  << " expects type to be int, string, or list(string), or list(list, int)");
+    FC_THROWM(
+        Base::TypeError,
+        "PropertyEnumeration "
+            << getFullName() << " expects type to be int, string, or list(string), or list(list, int)"
+    );
 }
 
 Property* PropertyEnumeration::Copy() const
@@ -652,6 +660,26 @@ PropertyIntegerConstraint::~PropertyIntegerConstraint()
     }
 }
 
+void PropertyIntegerConstraint::setValue(long lValue)
+{
+    if (_ConstStruct) {
+        if (lValue > _ConstStruct->UpperBound) {
+            lValue = _ConstStruct->UpperBound;
+        }
+        else if (lValue < _ConstStruct->LowerBound) {
+            lValue = _ConstStruct->LowerBound;
+        }
+    }
+
+    if (lValue == _lValue) {
+        return;
+    }
+
+    aboutToSetValue();
+    _lValue = lValue;
+    hasSetValue();
+}
+
 void PropertyIntegerConstraint::setConstraints(const Constraints* sConstrain)
 {
     if (_ConstStruct != sConstrain) {
@@ -697,52 +725,37 @@ long PropertyIntegerConstraint::getStepSize() const
 void PropertyIntegerConstraint::setPyObject(PyObject* value)
 {
     if (PyLong_Check(value)) {
-        long temp = PyLong_AsLong(value);
-        if (_ConstStruct) {
-            if (temp > _ConstStruct->UpperBound) {
-                temp = _ConstStruct->UpperBound;
-            }
-            else if (temp < _ConstStruct->LowerBound) {
-                temp = _ConstStruct->LowerBound;
-            }
-        }
-
-        aboutToSetValue();
-        _lValue = temp;
-        hasSetValue();
+        setValue(PyLong_AsLong(value));
     }
     else {
-        long valConstr[] = {0,
-                            std::numeric_limits<int>::lowest(),
-                            std::numeric_limits<int>::max(),
-                            1};
+        long valConstr[] = {0, std::numeric_limits<int>::lowest(), std::numeric_limits<int>::max(), 1};
 
         if (PyDict_Check(value)) {
             Py::Tuple dummy;
-            static const std::array<const char*, 5> kw = {"value",
-                                                          "min",
-                                                          "max",
-                                                          "step",
-                                                          nullptr};
+            static const std::array<const char*, 5> kw = {"value", "min", "max", "step", nullptr};
 
-            if (!Base::Wrapped_ParseTupleAndKeywords(dummy.ptr(),
-                                                     value,
-                                                     "l|lll",
-                                                      kw,
-                                                     &(valConstr[0]),
-                                                     &(valConstr[1]),
-                                                     &(valConstr[2]),
-                                                     &(valConstr[3]))) {
+            if (!Base::Wrapped_ParseTupleAndKeywords(
+                    dummy.ptr(),
+                    value,
+                    "l|lll",
+                    kw,
+                    &(valConstr[0]),
+                    &(valConstr[1]),
+                    &(valConstr[2]),
+                    &(valConstr[3])
+                )) {
                 throw Py::Exception();
             }
         }
         else if (PyTuple_Check(value)) {
-            if (!PyArg_ParseTuple(value,
-                                  "llll",
-                                  &(valConstr[0]),
-                                  &(valConstr[1]),
-                                  &(valConstr[2]),
-                                  &(valConstr[3]))) {
+            if (!PyArg_ParseTuple(
+                    value,
+                    "llll",
+                    &(valConstr[0]),
+                    &(valConstr[1]),
+                    &(valConstr[2]),
+                    &(valConstr[3])
+                )) {
                 throw Py::Exception();
             }
         }
@@ -757,24 +770,15 @@ void PropertyIntegerConstraint::setPyObject(PyObject* value)
         c->LowerBound = valConstr[1];
         c->UpperBound = valConstr[2];
         c->StepSize = std::max<long>(1, valConstr[3]);
-        if (valConstr[0] > c->UpperBound) {
-            valConstr[0] = c->UpperBound;
-        }
-        else if (valConstr[0] < c->LowerBound) {
-            valConstr[0] = c->LowerBound;
-        }
         setConstraints(c);
 
-        aboutToSetValue();
-        _lValue = valConstr[0];
-        hasSetValue();
+        setValue(valConstr[0]);
     }
 }
 
 void PropertyIntegerConstraint::Save(Base::Writer& writer) const
 {
-    writer.Stream() << writer.ind()
-                    << "<Integer value=\"" << _lValue << "\"";
+    writer.Stream() << writer.ind() << "<Integer value=\"" << _lValue << "\"";
     if (_ConstStruct && _ConstStruct->isDeletable()) {
         long minimum = _ConstStruct->LowerBound;
         long maximum = _ConstStruct->UpperBound;
@@ -1070,6 +1074,10 @@ PropertyFloat::~PropertyFloat() = default;
 
 void PropertyFloat::setValue(double lValue)
 {
+    if (lValue == _dValue) {
+        return;
+    }
+
     aboutToSetValue();
     _dValue = lValue;
     hasSetValue();
@@ -1088,14 +1096,10 @@ PyObject* PropertyFloat::getPyObject()
 void PropertyFloat::setPyObject(PyObject* value)
 {
     if (PyFloat_Check(value)) {
-        aboutToSetValue();
-        _dValue = PyFloat_AsDouble(value);
-        hasSetValue();
+        setValue(PyFloat_AsDouble(value));
     }
     else if (PyLong_Check(value)) {
-        aboutToSetValue();
-        _dValue = PyLong_AsLong(value);
-        hasSetValue();
+        setValue(PyLong_AsLong(value));
     }
     else {
         std::string error = std::string("type must be float or int, not ");
@@ -1120,15 +1124,13 @@ void PropertyFloat::Restore(Base::XMLReader& reader)
 Property* PropertyFloat::Copy() const
 {
     PropertyFloat* p = new PropertyFloat();
-    p->_dValue = _dValue;
+    p->setValue(_dValue);
     return p;
 }
 
 void PropertyFloat::Paste(const Property& from)
 {
-    aboutToSetValue();
-    _dValue = dynamic_cast<const PropertyFloat&>(from)._dValue;
-    hasSetValue();
+    setValue(dynamic_cast<const PropertyFloat&>(from)._dValue);
 }
 
 void PropertyFloat::setPathValue(const ObjectIdentifier& path, const boost::any& value)
@@ -1184,6 +1186,26 @@ PropertyFloatConstraint::~PropertyFloatConstraint()
     }
 }
 
+void PropertyFloatConstraint::setValue(double lValue)
+{
+    if (_ConstStruct) {
+        if (lValue > _ConstStruct->UpperBound) {
+            lValue = _ConstStruct->UpperBound;
+        }
+        else if (lValue < _ConstStruct->LowerBound) {
+            lValue = _ConstStruct->LowerBound;
+        }
+    }
+
+    if (lValue == _dValue) {
+        return;
+    }
+
+    aboutToSetValue();
+    _dValue = lValue;
+    hasSetValue();
+}
+
 void PropertyFloatConstraint::setConstraints(const Constraints* sConstrain)
 {
     if (_ConstStruct != sConstrain) {
@@ -1226,67 +1248,41 @@ double PropertyFloatConstraint::getStepSize() const
 void PropertyFloatConstraint::setPyObject(PyObject* value)
 {
     if (PyFloat_Check(value)) {
-        double temp = PyFloat_AsDouble(value);
-        if (_ConstStruct) {
-            if (temp > _ConstStruct->UpperBound) {
-                temp = _ConstStruct->UpperBound;
-            }
-            else if (temp < _ConstStruct->LowerBound) {
-                temp = _ConstStruct->LowerBound;
-            }
-        }
-
-        aboutToSetValue();
-        _dValue = temp;
-        hasSetValue();
+        setValue(PyFloat_AsDouble(value));
     }
     else if (PyLong_Check(value)) {
-        double temp = static_cast<double>(PyLong_AsLong(value));
-        if (_ConstStruct) {
-            if (temp > _ConstStruct->UpperBound) {
-                temp = _ConstStruct->UpperBound;
-            }
-            else if (temp < _ConstStruct->LowerBound) {
-                temp = _ConstStruct->LowerBound;
-            }
-        }
-
-        aboutToSetValue();
-        _dValue = temp;
-        hasSetValue();
+        setValue(static_cast<double>(PyLong_AsLong(value)));
     }
     else {
-        double valConstr[] = {0.0,
-                              std::numeric_limits<double>::lowest(),
-                              std::numeric_limits<double>::max(),
-                              1.0};
+        double valConstr[]
+            = {0.0, std::numeric_limits<double>::lowest(), std::numeric_limits<double>::max(), 1.0};
 
         if (PyDict_Check(value)) {
             Py::Tuple dummy;
-            static const std::array<const char*, 5> kw = {"value",
-                                                          "min",
-                                                          "max",
-                                                          "step",
-                                                           nullptr};
+            static const std::array<const char*, 5> kw = {"value", "min", "max", "step", nullptr};
 
-            if (!Base::Wrapped_ParseTupleAndKeywords(dummy.ptr(),
-                                                     value,
-                                                     "d|ddd",
-                                                     kw,
-                                                     &(valConstr[0]),
-                                                     &(valConstr[1]),
-                                                     &(valConstr[2]),
-                                                     &(valConstr[3]))) {
+            if (!Base::Wrapped_ParseTupleAndKeywords(
+                    dummy.ptr(),
+                    value,
+                    "d|ddd",
+                    kw,
+                    &(valConstr[0]),
+                    &(valConstr[1]),
+                    &(valConstr[2]),
+                    &(valConstr[3])
+                )) {
                 throw Py::Exception();
             }
         }
         else if (PyTuple_Check(value)) {
-            if (!PyArg_ParseTuple(value,
-                                  "dddd",
-                                  &(valConstr[0]),
-                                  &(valConstr[1]),
-                                  &(valConstr[2]),
-                                  &(valConstr[3]))) {
+            if (!PyArg_ParseTuple(
+                    value,
+                    "dddd",
+                    &(valConstr[0]),
+                    &(valConstr[1]),
+                    &(valConstr[2]),
+                    &(valConstr[3])
+                )) {
                 throw Py::Exception();
             }
         }
@@ -1307,24 +1303,15 @@ void PropertyFloatConstraint::setPyObject(PyObject* value)
         c->LowerBound = valConstr[1];
         c->UpperBound = valConstr[2];
         c->StepSize = stepSize;
-        if (valConstr[0] > c->UpperBound) {
-            valConstr[0] = c->UpperBound;
-        }
-        else if (valConstr[0] < c->LowerBound) {
-            valConstr[0] = c->LowerBound;
-        }
         setConstraints(c);
 
-        aboutToSetValue();
-        _dValue = valConstr[0];
-        hasSetValue();
+        setValue(valConstr[0]);
     }
 }
 
 void PropertyFloatConstraint::Save(Base::Writer& writer) const
 {
-    writer.Stream() << writer.ind()
-                    << "<Float value=\"" << _dValue << "\"";
+    writer.Stream() << writer.ind() << "<Float value=\"" << _dValue << "\"";
     if (_ConstStruct && _ConstStruct->isDeletable()) {
         double minimum = _ConstStruct->LowerBound;
         double maximum = _ConstStruct->UpperBound;
@@ -1378,8 +1365,8 @@ TYPESYSTEM_SOURCE(App::PropertyPrecision, App::PropertyFloatConstraint)
 //**************************************************************************
 // Construction/Destruction
 //
-const PropertyFloatConstraint::Constraints PrecisionStandard = {
-    0.0, std::numeric_limits<double>::max(), 0.001};
+const PropertyFloatConstraint::Constraints PrecisionStandard
+    = {0.0, std::numeric_limits<double>::max(), 0.001};
 
 PropertyPrecision::PropertyPrecision()
 {
@@ -1443,8 +1430,7 @@ void PropertyFloatList::Save(Base::Writer& writer) const
     }
     else {
         writer.Stream() << writer.ind() << "<FloatList file=\""
-                        << (getSize() ? writer.addFile(getName(), this) : "") << "\"/>"
-                        << std::endl;
+                        << (getSize() ? writer.addFile(getName(), this) : "") << "\"/>" << std::endl;
     }
 }
 
@@ -1608,8 +1594,7 @@ void PropertyString::Save(Base::Writer& writer) const
     auto verifyXMLString = [this](std::string& input) {
         const std::string output = this->validateXMLString(input);
         if (output != input) {
-            Base::Console().warning("XML output: Validate invalid string:\n'%s'\n'%s'\n",
-                                    input, output);
+            Base::Console().warning("XML output: Validate invalid string:\n'%s'\n'%s'\n", input, output);
         }
         return output;
     };
@@ -1683,7 +1668,7 @@ void PropertyString::setPathValue(const ObjectIdentifier& path, const boost::any
 {
     verifyPath(path);
     if (value.type() == typeid(std::string)) {
-        setValue(boost::any_cast<const std::string &>(value));
+        setValue(boost::any_cast<const std::string&>(value));
     }
     else {
         setValue(anyToString(value));
@@ -1839,12 +1824,10 @@ PyObject* PropertyStringList::getPyObject()
     PyObject* list = PyList_New(getSize());
 
     for (int i = 0; i < getSize(); i++) {
-        PyObject* item =
-            PyUnicode_DecodeUTF8(_lValueList[i].c_str(), _lValueList[i].size(), nullptr);
+        PyObject* item = PyUnicode_DecodeUTF8(_lValueList[i].c_str(), _lValueList[i].size(), nullptr);
         if (!item) {
             Py_DECREF(list);
-            throw Base::UnicodeError(
-                "UTF8 conversion failure at PropertyStringList::getPyObject()");
+            throw Base::UnicodeError("UTF8 conversion failure at PropertyStringList::getPyObject()");
         }
         PyList_SetItem(list, i, item);
     }
@@ -2228,6 +2211,10 @@ PropertyBool::~PropertyBool() = default;
 
 void PropertyBool::setValue(bool lValue)
 {
+    if (lValue == _lValue) {
+        return;
+    }
+
     aboutToSetValue();
     _lValue = lValue;
     hasSetValue();
@@ -2280,15 +2267,13 @@ void PropertyBool::Restore(Base::XMLReader& reader)
 Property* PropertyBool::Copy() const
 {
     PropertyBool* p = new PropertyBool();
-    p->_lValue = _lValue;
+    p->setValue(_lValue);
     return p;
 }
 
 void PropertyBool::Paste(const Property& from)
 {
-    aboutToSetValue();
-    _lValue = dynamic_cast<const PropertyBool&>(from)._lValue;
-    hasSetValue();
+    setValue(dynamic_cast<const PropertyBool&>(from)._lValue);
 }
 
 void PropertyBool::setPathValue(const ObjectIdentifier& path, const boost::any& value)
@@ -2432,7 +2417,7 @@ namespace
 {
 /// The definition of "alpha" was corrected in FreeCAD 1.1 -- returns true if the reader is working
 /// on a file that pre-dates that correction.
-bool readerRequiresAlphaConversion(const Base::XMLReader &reader)
+bool readerRequiresAlphaConversion(const Base::XMLReader& reader)
 {
     return Base::getVersion(reader.ProgramVersion) < Base::Version::v1_1;
 }
@@ -2445,7 +2430,7 @@ void convertAlphaInMaterial(App::Material& material)
     material.specularColor.a = 1.0F - material.specularColor.a;
     material.emissiveColor.a = 1.0F - material.emissiveColor.a;
 }
-}
+}  // namespace
 
 TYPESYSTEM_SOURCE(App::PropertyColor, App::Property)
 
@@ -2567,8 +2552,9 @@ void PropertyColor::setPyObject(PyObject* value)
         cCol.setPackedValue(PyLong_AsUnsignedLong(value));
     }
     else {
-        std::string error =
-            std::string("type must be integer or tuple of float or tuple integer, not ");
+        std::string error = std::string(
+            "type must be integer or tuple of float or tuple integer, not "
+        );
         error += value->ob_type->tp_name;
         throw Base::TypeError(error);
     }
@@ -2660,8 +2646,7 @@ void PropertyColorList::Save(Base::Writer& writer) const
 {
     if (!writer.isForceXML()) {
         writer.Stream() << writer.ind() << "<ColorList file=\""
-                        << (getSize() ? writer.addFile(getName(), this) : "") << "\"/>"
-                        << std::endl;
+                        << (getSize() ? writer.addFile(getName(), this) : "") << "\"/>" << std::endl;
     }
 }
 

--- a/src/App/PropertyStandard.h
+++ b/src/App/PropertyStandard.h
@@ -284,6 +284,10 @@ public:
     /// destructor
     ~PropertyIntegerConstraint() override;
 
+    /** Sets the property
+     */
+    void setValue(long);
+
     /// Constraint methods
     //@{
     /// the boundary struct
@@ -632,6 +636,9 @@ public:
      */
     ~PropertyFloatConstraint() override;
 
+    /** Sets the property
+     */
+    void setValue(double lValue);
 
     /// Constraint methods
     //@{
@@ -1113,7 +1120,7 @@ protected:
     Base::Color getPyValue(PyObject* py) const override;
 
 private:
-    bool requiresAlphaConversion {false}; // In 1.1 the handling of alpha was inverted
+    bool requiresAlphaConversion {false};  // In 1.1 the handling of alpha was inverted
 };
 
 
@@ -1221,8 +1228,7 @@ public:
     {
         PropertyListsT<Material>::setValue(materials);
     }
-    void
-    setValues(const std::vector<App::Material>& newValues = std::vector<App::Material>()) override;
+    void setValues(const std::vector<App::Material>& newValues = std::vector<App::Material>()) override;
     void setValue(const Material& mat);
     void setValue(int index, const Material& mat);
 


### PR DESCRIPTION
While investigating #28326 I noticed that the core of the issue seems to be the writing of some properties of the ToolController in question. However, the values are overwritten with the same value as the current value. I would have expected this write to simply do nothing. Also, the behaviour is not consistent between property types: e.g. `PropertyString` does not cause a recompute when overwritten with the same value whereas `PropertyInteger` does.

Looking into PropertyStandard.cpp we find a check and an early return in `PropertyString::setValue`:

https://github.com/FreeCAD/FreeCAD/blob/d90c88f0fc4ee2f4aebd14c2e2b5df0e1b479236/src/App/PropertyStandard.cpp#L1534-L1536

A similar check is missing in many other property types.

This PR adds an equivalent check and thus avoids calling `aboutToSetValue` and `hasSetValue` if the new value is the same as the current value. I  implemented this for `PropertyInteger`, `PropertyIntegerConstraint`, `PropertyFloat`, `PropertyFloatConstraint`, `PropertyBoolean` and `PropertyEnumeration`.

fixes #28326
at least partly fixes #17610, i.e. you can now open the task panel for an operation, immediately close it, and the operation will not need to recompute

This PR touches the very core of FreeCAD and probably affects a lot of functionality (hopefully for the better), which is why I'm pinging a few of the last contributors to the affected files. I think this needs some extra sets of eyes.

@chennes @wwmayer @kadet1090 @hyarion @kpemartin 

Let me know if you think this is the correct way to go forward and/or to implement this. If you think this is good I can try and implement this for some of the remaining property types.