### PR TITLE
Gui: Fix Qt 5 compilation error in CommandView.cpp

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -410,7 +410,12 @@ void StdCmdFreezeViews::activated(int iMsg)
                 savedViews++;
                 QString viewnr = QString(QObject::tr("Restore View &%1")).arg(index);
                 (*it)->setText(viewnr);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
                 (*it)->setToolTip(QString::fromLatin1(camera));
+#else
+                (*it)->setToolTip(QString::fromLatin1(camera.c_str()));
+#endif
+
                 (*it)->setVisible(true);
                 if (index < 10) {
                     (*it)->setShortcut(QKeySequence(QStringLiteral("CTRL+%1").arg(index)));


### PR DESCRIPTION
Replaced Qt 6 specific `QString::fromLatin1(std::string)` shortcut with a preprocessor macro to restore compatibility with Qt 5 by using `.c_str()`. And without `.c_str()` for Qt 6

**Summary of the changes:**
During a recent update to `src/Gui/CommandView.cpp` (specifically around line 413), `QString::fromLatin1(camera)` was used. While Qt 6 allows implicit conversion from `std::string` to `QString` using this method, Qt 5 strictly requires a raw `const char*`. This caused a fatal `make` error (Error 2) when compiling FreeCAD against Qt 5 / PySide2 on Ubuntu 24.04.

I wrapped the line in a standard `#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)` block to allow Qt 6 users to retain the modern shortcut while explicitly casting `.c_str()` for Qt 5 builders.

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
None open, encountered during local source build.

## Before and After Images
N/A - compilation fix only, no GUI changes.

- [x] I have tested this code locally compiling with Qt 5.15.
- [x] Code Quality (Is code well-written and maintainable?)
- [x] Is the PR rebased on the current main branch with unnecessary commits squashed?
