### PR TITLE
TechDraw: Selection order blocks dimension creation

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -2185,6 +2185,13 @@ void execDim(Gui::Command* cmd, std::string type, StringVector acceptableGeometr
         return;
     }
 
+    if (geometryRefs2d == DimensionGeometry::isViewReference && references3d.empty()) {
+        QMessageBox::warning(Gui::getMainWindow(),
+            QObject::tr("Incorrect Selection"),
+            QObject::tr("Cannot make 3D dimension without 3d references"));
+        return;
+    }
+
     //what 3d geometry configuration did we receive?
     DimensionGeometry geometryRefs3d{DimensionGeometry::isInvalid};
     if (geometryRefs2d == DimensionGeometry::isViewReference && !references3d.empty()) {
@@ -2193,7 +2200,6 @@ void execDim(Gui::Command* cmd, std::string type, StringVector acceptableGeometr
             acceptableGeometry,
             minimumCounts,
             acceptableDimensionGeometrys);
-
         if (geometryRefs3d == DimensionGeometry::isInvalid) {
             QMessageBox::warning(Gui::getMainWindow(),
                 QObject::tr("Incorrect Selection"),

--- a/src/Mod/TechDraw/Gui/DimensionValidators.cpp
+++ b/src/Mod/TechDraw/Gui/DimensionValidators.cpp
@@ -71,7 +71,6 @@ TechDraw::DrawViewPart* TechDraw::getReferencesFromSelection(ReferenceVector& re
             }
             for (auto& sub : selItem.getSubNames()) {
                 // plain ordinary 2d view + geometry reference
-
                 ReferenceEntry ref(dvp, ShapeFinder::getLastTerm(sub));
                 references2d.push_back(ref);
             }
@@ -86,6 +85,10 @@ TechDraw::DrawViewPart* TechDraw::getReferencesFromSelection(ReferenceVector& re
             } else {
                 // this is a regular 3d reference in form obj + long subelement
                 for (auto& sub3d : selItem.getSubNames()) {
+                    if (!isValidSubElement(sub3d)) {
+                        // sub is not a vertex, edge or face.
+                        continue;
+                    }
                     ReferenceEntry ref(obj3d, sub3d);
                     references3d.push_back(ref);
                 }
@@ -99,6 +102,7 @@ TechDraw::DrawViewPart* TechDraw::getReferencesFromSelection(ReferenceVector& re
             return dim->getViewPart();
         }
     }
+
     return dvp;
 }
 
@@ -217,6 +221,8 @@ DimensionGeometry TechDraw::validateDimSelection3d(
 
     return DimensionGeometry::isInvalid;
 }
+
+
 bool TechDraw::validateSubnameList(const StringVector& subNames, const GeometrySet& acceptableGeometrySet)
 {
     for (auto& sub : subNames) {    // NOLINT (std::ranges::all_of())
@@ -483,7 +489,7 @@ DimensionGeometry TechDraw::isValidSingleFace(const ReferenceEntry& ref)
 DimensionGeometry TechDraw::isValidSingleFace3d(DrawViewPart* dvp, const ReferenceEntry& ref)
 {
     (void)dvp;
-    //the Name starts with "Edge"
+    //the Name starts with "Face"
     std::string geomName = DrawUtil::getGeomTypeFromName(ref.getSubName());
     if (geomName != "Face") {
         return DimensionGeometry::isInvalid;
@@ -791,4 +797,27 @@ DimensionGeometry TechDraw::lineOrientation(const Base::Vector3d& point0,
     //        }
 
     return DimensionGeometry::isDiagonal;
+}
+
+
+bool TechDraw::isValidSubElement(const std::string& subElementName)
+{
+    if (subElementName.empty()) {
+        return false;
+    }
+
+    std::string last = ShapeFinder::getLastTerm(subElementName);
+
+    if (last.empty()) {
+        return false;
+    }
+
+    std::string lastGeom = DrawUtil::getGeomTypeFromName(last);
+    if (lastGeom == "Vertex" ||
+        lastGeom == "Edge" ||
+        lastGeom == "Face") {
+        return true;
+    }
+
+    return false;
 }

--- a/src/Mod/TechDraw/Gui/DimensionValidators.h
+++ b/src/Mod/TechDraw/Gui/DimensionValidators.h
@@ -49,12 +49,12 @@ enum class DimensionGeometry {
     isVertical,
     isDiagonal,
     isCircle,
-    isEllipse,
+    isEllipse,          // 5
     isBSplineCircle,
     isBSpline,
     isAngle,
     isAngle3Pt,
-    isMultiEdge,
+    isMultiEdge,        // 10
     isZLimited,
     isHybrid,
     isFace,
@@ -103,5 +103,6 @@ bool  refsMatchToken(const ReferenceVector& refs, const std::string& matchToken)
 DimensionGeometry lineOrientation(const Base::Vector3d& point0,
                                   const Base::Vector3d& point1);
 
+bool isValidSubElement(const std::string& subElementName);
 
 }


### PR DESCRIPTION
This PR corrects a problem discovered while testing PR #28046.

When creating an area dimension with a reference to a 3d face, if the view is selected first, then 
the selection contains 2 items - the view and the face.

If the face is selected first, the selection contains 3 items after selecting the face- the view, 
the face and the pad that owns the face.  Since a pad is not a valid reference for an area dimension,
the attempt to create a dimension fails (Invalid selection - Can not create 3d dimension from this selection).

This PR checks the selection and drops selection items that are not a vertex, edge or face.

Face selected before view:
<img width="1474" height="843" alt="FaceSelectedBeforeView" src="https://github.com/user-attachments/assets/dc9e4e1e-4a51-49c1-b635-1d6a4e24403d" />

View selected before face:
<img width="1297" height="674" alt="ViewSelectedBeforeFace" src="https://github.com/user-attachments/assets/cde173cc-c20f-43ca-82c4-39a91e1defa3" />
