### PR TITLE
App: Fix separator path in safe mode

### DIFF
--- a/src/App/SafeMode.cpp
+++ b/src/App/SafeMode.cpp
@@ -58,10 +58,10 @@ static void _replaceDirs()
     };
 
     for (auto const d : dirs) {
-        auto const path = temp_base + PATHSEP + d + PATHSEP;
-        auto const qpath = QString::fromStdString(path);
+        auto const path = temp_base + "/" + d + "/";
+        auto const qpath = QDir::cleanPath(QString::fromStdString(path));
         QDir().mkpath(qpath);
-        config[d] = path;
+        config[d] = QDir::toNativeSeparators(qpath).toStdString();
     }
 }
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Fix slash-backslash mixing in safe mode paths (the issue is for Windows).
Internally, `QDir` uses `/` as path separator: https://doc.qt.io/qt-6/qdir.html#details.
See comments in https://github.com/FreeCAD/FreeCAD/pull/27942#issuecomment-4048749685.

@hyarion @chennes 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
