### PR TITLE
Gui: Don't add redundant == or != to nullptr conditions

### DIFF
--- a/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibCmds.cpp
@@ -157,7 +157,7 @@ long NavlibInterface::SetActiveCommand(std::string commandId)
             if (!std::string(command->getName()).compare(parsedData.commandName)) {
                 if (parsedData.actionIndex == -1) {
                     Gui::Action* pAction = command->getAction();
-                    if (pAction != nullptr) {
+                    if (pAction) {
                         pAction->action()->trigger();
                     }
                 }
@@ -177,7 +177,7 @@ void NavlibInterface::unpackCommands(Gui::Command& command,
                                      TDxCategory& category,
                                      std::vector<TDx::CImage>& images)
 {
-    if (command.getAction() == nullptr)
+    if (!command.getAction())
         return;
 
     QList<QAction*> pQActions;
@@ -185,7 +185,7 @@ void NavlibInterface::unpackCommands(Gui::Command& command,
     int32_t index = -1;
     auto actionGroup = qobject_cast<Gui::ActionGroup*>(command.getAction());
 
-    if (actionGroup != nullptr) {
+    if (actionGroup) {
         pQActions = actionGroup->actions();
         std::string subCategoryName = actionGroup->text().toStdString();
         subCategory = TDxCategory(subCategoryName, subCategoryName);

--- a/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
@@ -58,7 +58,7 @@ NavlibInterface::~NavlibInterface()
 {
     disableNavigation();
 
-    if (pivot.pVisibility != nullptr)
+    if (pivot.pVisibility)
         pivot.pVisibility->unref();
 }
 
@@ -97,7 +97,7 @@ long NavlibInterface::GetPointerPosition(navlib::point_t& position) const
 
     if (is3DView()) {
         const Gui::View3DInventorViewer* const inventorViewer = currentView.pView3d->getViewer();
-        if (inventorViewer == nullptr)
+        if (!inventorViewer)
             return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
         QPoint viewPoint = currentView.pView3d->mapFromGlobal(QCursor::pos());
@@ -122,7 +122,7 @@ CameraType NavlibInterface::getCamera() const
 {
     if (is3DView()) {
         const Gui::View3DInventorViewer* inventorViewer = currentView.pView3d->getViewer();
-        if (inventorViewer != nullptr)
+        if (inventorViewer)
             return dynamic_cast<CameraType>(inventorViewer->getCamera());
     }
     return nullptr;
@@ -132,18 +132,18 @@ template SoCamera* NavlibInterface::getCamera<SoCamera*>() const;
 
 void NavlibInterface::onViewChanged(const Gui::MDIView* view)
 {
-    if (view == nullptr)
+    if (!view)
         return;
 
     currentView.pView3d = dynamic_cast<const Gui::View3DInventor*>(view);
     currentView.pView2d = nullptr;
-    if (currentView.pView3d != nullptr) {
+    if (currentView.pView3d) {
         const Gui::View3DInventorViewer* const inventorViewer = currentView.pView3d->getViewer();
-        if (inventorViewer == nullptr)
+        if (!inventorViewer)
             return;
 
         auto pGroup = dynamic_cast<SoGroup* const>(inventorViewer->getSceneGraph());
-        if (pGroup == nullptr)
+        if (!pGroup)
             return;
 
         if (pGroup->findChild(pivot.pVisibility) == -1)
@@ -198,11 +198,11 @@ void NavlibInterface::enableNavigation()
 void NavlibInterface::connectActiveTab()
 {
     auto pQMdiArea = Gui::MainWindow::getInstance()->findChild<QMdiArea*>();
-    if (pQMdiArea == nullptr)
+    if (!pQMdiArea)
         return;
 
     auto pQTabBar = pQMdiArea->findChild<QTabBar*>();
-    if (pQTabBar == nullptr)
+    if (!pQTabBar)
         return;
 
     pQTabBar->connect(pQTabBar, &QTabBar::currentChanged, [this, pQTabBar](int idx) {
@@ -222,7 +222,7 @@ long NavlibInterface::GetCameraMatrix(navlib::matrix_t& matrix) const
 
     if (is3DView()) {
         auto pCamera = getCamera<SoCamera*>();
-        if (pCamera == nullptr)
+        if (!pCamera)
             return navlib::make_result_code(navlib::navlib_errc::function_not_supported);
 
         SbMatrix cameraMatrix;
@@ -268,7 +268,7 @@ long NavlibInterface::SetCameraMatrix(const navlib::matrix_t& matrix)
 
     if (is3DView()) {
         auto pCamera = getCamera<SoCamera*>();
-        if (pCamera == nullptr)
+        if (!pCamera)
             return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
         SbMatrix cameraMatrix(matrix(0, 0), matrix(0, 1), matrix(0, 2), matrix(0, 3),
@@ -288,7 +288,7 @@ long NavlibInterface::SetCameraMatrix(const navlib::matrix_t& matrix)
 long NavlibInterface::GetViewFrustum(navlib::frustum_t& frustum) const
 {
     const auto pCamera = getCamera<SoPerspectiveCamera* const>();
-    if (pCamera == nullptr)
+    if (!pCamera)
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     const SbViewVolume viewVolume = pCamera->getViewVolume(pCamera->aspectRatio.getValue());
@@ -327,7 +327,7 @@ long NavlibInterface::GetViewExtents(navlib::box_t& extents) const
     }
 
     const auto pCamera = getCamera<SoOrthographicCamera* const>();
-    if (pCamera == nullptr)
+    if (!pCamera)
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     const SbViewVolume viewVolume = pCamera->getViewVolume(pCamera->aspectRatio.getValue());
@@ -371,7 +371,7 @@ long NavlibInterface::SetViewExtents(const navlib::box_t& extents)
 
     if (is3DView()) {
         auto pCamera = getCamera<SoOrthographicCamera* const>();
-        if (pCamera == nullptr)
+        if (!pCamera)
             return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
         navlib::box_t oldExtents;
@@ -399,13 +399,13 @@ long NavlibInterface::SetViewFOV(double)
 long NavlibInterface::GetIsViewPerspective(navlib::bool_t& perspective) const
 {
     auto pPerspectiveCamera = getCamera<SoPerspectiveCamera* const>();
-    if (pPerspectiveCamera != nullptr) {
+    if (pPerspectiveCamera) {
         perspective = true;
         return 0;
     }
 
     auto pOrthographicCamera = getCamera<SoOrthographicCamera* const>();
-    if (pOrthographicCamera != nullptr || is2DView()) {
+    if (pOrthographicCamera || is2DView()) {
         perspective = false;
         return 0;
     }
@@ -417,7 +417,7 @@ long NavlibInterface::GetModelExtents(navlib::box_t& extents) const
 {
     if (is3DView()) {
         const Gui::View3DInventorViewer* const inventorViewer = currentView.pView3d->getViewer();
-        if (inventorViewer == nullptr)
+        if (!inventorViewer)
             return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
         SoGetBoundingBoxAction action(inventorViewer->getSoRenderManager()->getViewportRegion());

--- a/src/Gui/3Dconnexion/navlib/NavlibPivot.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibPivot.cpp
@@ -71,7 +71,7 @@ long NavlibInterface::GetPivotPosition(navlib::point_t&) const
 
 long NavlibInterface::SetPivotPosition(const navlib::point_t& position)
 {
-    if (pivot.pTransform == nullptr)
+    if (!pivot.pTransform)
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     pivot.pTransform->translation.setValue(position.x, position.y, position.z);
@@ -86,7 +86,7 @@ long NavlibInterface::IsUserPivot(navlib::bool_t& userPivot) const
 
 long NavlibInterface::GetPivotVisible(navlib::bool_t& visible) const
 {
-    if (pivot.pVisibility == nullptr)
+    if (!pivot.pVisibility)
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     visible = pivot.pVisibility->whichChild.getValue() == SO_SWITCH_ALL;
@@ -96,7 +96,7 @@ long NavlibInterface::GetPivotVisible(navlib::bool_t& visible) const
 
 long NavlibInterface::SetPivotVisible(bool visible)
 {
-    if (pivot.pVisibility == nullptr)
+    if (!pivot.pVisibility)
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     if (visible)
@@ -115,11 +115,11 @@ long NavlibInterface::GetHitLookAt(navlib::point_t& position) const
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     const Gui::View3DInventorViewer* const inventorViewer = currentView.pView3d->getViewer();
-    if (inventorViewer == nullptr)
+    if (!inventorViewer)
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     SoNode* pSceneGraph = inventorViewer->getSceneGraph();
-    if (pSceneGraph == nullptr)
+    if (!pSceneGraph)
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     // Prepare the ray-picking object
@@ -131,7 +131,7 @@ long NavlibInterface::GetHitLookAt(navlib::point_t& position) const
     // Get the camera rotation
     SoCamera* pCamera = getCamera<SoCamera*>();
 
-    if (pCamera == nullptr)
+    if (!pCamera)
         return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
     pCamera->orientation.getValue().getValue(cameraMatrix);
@@ -177,7 +177,7 @@ long NavlibInterface::GetHitLookAt(navlib::point_t& position) const
         SoPickedPoint* pickedPoint = rayPickAction.getPickedPoint();
 
         // Check if there was a hit
-        if (pickedPoint != nullptr) {
+        if (pickedPoint) {
             SbVec3f hitPoint = pickedPoint->getPoint();
             float distance = (origin - hitPoint).length();
 
@@ -213,7 +213,7 @@ long NavlibInterface::GetSelectionExtents(navlib::box_t& extents) const
                       Gui::ViewProvider* pViewProvider =
                           Gui::Application::Instance->getViewProvider(selection.pObject);
 
-                      if (pViewProvider == nullptr)
+                      if (!pViewProvider)
                           return navlib::make_result_code(navlib::navlib_errc::no_data_available);
 
                       boundingBox.Add(pViewProvider->getBoundingBox(selection.SubName, true));
@@ -254,7 +254,7 @@ long NavlibInterface::SetHitLookFrom(const navlib::point_t& eye)
     }
     else {
         auto pCamera = getCamera<SoCamera*>();
-        if (pCamera == nullptr) {
+        if (!pCamera) {
             return navlib::make_result_code(navlib::navlib_errc::no_data_available);
         }
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -631,7 +631,7 @@ Application::Application(bool GUIenabled)
     PyObject* module = PyImport_AddModule("FreeCADGui");
     PyMethodDef* meth = FreeCADGui_methods;
     PyObject* dict = PyModule_GetDict(module);
-    for (; meth->ml_name != nullptr; meth++) {
+    for (; meth->ml_name; meth++) {
         PyObject* descr;
         descr = PyCFunction_NewEx(meth, nullptr, nullptr);
         if (!descr) {
@@ -2790,7 +2790,7 @@ void Application::setStyle(const QString& name)
         return qobject_cast<FreeCADStyle*>(style) != nullptr;
     };
 
-    if (auto* current = qApp->style(); current != nullptr && requiresEventFilter(current)) {
+    if (auto* current = qApp->style(); current && requiresEventFilter(current)) {
         qApp->removeEventFilter(current);
     }
 

--- a/src/Gui/CallTips.cpp
+++ b/src/Gui/CallTips.cpp
@@ -226,7 +226,7 @@ QMap<QString, CallTip> CallTipsList::extractTips(const QString& context) const
     try {
         PyErr_Clear();
         Py::Module module("__main__");
-        if (module.ptr() == nullptr) {
+        if (!module.ptr()) {
             return tips;
         }
         Py::Dict dict = module.getDict();

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1480,7 +1480,7 @@ void StdCmdDelete::activated(int iMsg)
             bool autoDeletion = true;
             for (auto& sel : sels) {
                 auto obj = sel.getObject();
-                if (obj == nullptr) {
+                if (!obj) {
                     Base::Console().developerWarning(
                         "StdCmdDelete::activated",
                         "App::DocumentObject pointer is nullptr\n"

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -330,7 +330,7 @@ Gui::Action* StdCmdToggleSkipRecompute::createAction()
 void StdCmdToggleSkipRecompute::activated(int iMsg)
 {
     const auto doc = this->getDocument();
-    if (doc == nullptr) {
+    if (!doc) {
         return;
     }
 
@@ -345,7 +345,7 @@ void StdCmdToggleSkipRecompute::activated(int iMsg)
 bool StdCmdToggleSkipRecompute::isActive()
 {
     const auto doc = this->getDocument();
-    if (doc == nullptr) {
+    if (!doc) {
         return false;
     }
 

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -394,7 +394,7 @@ void StdCmdFreezeViews::activated(int iMsg)
     else if (iMsg == 3) {
         // Create a new view
         auto* view3d = freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
-        if (view3d == nullptr) {
+        if (!view3d) {
             Base::Console().developerError(
                 "StdCmdFreezeViews",
                 "Expected the active view to be View3DInventor\n"
@@ -2639,7 +2639,7 @@ void StdCmdViewIvIssueCamPos::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     auto* view3d = freecad_cast<View3DInventor*>(getGuiApplication()->activeView());
-    if (view3d == nullptr) {
+    if (!view3d) {
         Base::Console().developerError(
             "StdCmdViewIvIssueCameraPos",
             "Expected the active view to be View3DInventor\n"

--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -177,7 +177,7 @@ int DlgAddProperty::findLabelRow(const char* labelName, QFormLayout* layout)
 {
     for (int row = 0; row < layout->rowCount(); ++row) {
         QLayoutItem* labelItem = layout->itemAt(row, QFormLayout::LabelRole);
-        if (labelItem == nullptr) {
+        if (!labelItem) {
             continue;
         }
 
@@ -204,7 +204,7 @@ void DlgAddProperty::removeExistingWidget(QFormLayout* formLayout, int labelRow)
 void DlgAddProperty::setWidgetForLabel(const char* labelName, QWidget* widget, QLayout* layout)
 {
     auto formLayout = qobject_cast<QFormLayout*>(layout);
-    if (formLayout == nullptr) {
+    if (!formLayout) {
         FC_ERR("Form layout not found");
         return;
     }
@@ -403,7 +403,7 @@ void DlgAddProperty::addEditor(PropertyItem* propertyItem)
     else {
         addNormalEditor(propertyItem);
     }
-    if (editor == nullptr) {
+    if (!editor) {
         return;
     }
 
@@ -451,12 +451,12 @@ bool DlgAddProperty::isExcluded(const Base::Type& type) const
 
 bool DlgAddProperty::isTypeWithEditor(PropertyItem* propertyItem) const
 {
-    if (propertyItem == nullptr) {
+    if (!propertyItem) {
         return false;
     }
 
     App::Property* prop = propertyItem->getFirstProperty();
-    if (prop == nullptr) {
+    if (!prop) {
         return false;
     }
 
@@ -689,7 +689,7 @@ void DlgAddProperty::showStatusMessage()
 
 void DlgAddProperty::removeEditor()
 {
-    if (editor == nullptr) {
+    if (!editor) {
         return;
     }
 
@@ -713,7 +713,7 @@ QVariant DlgAddProperty::getEditorData() const
 {
     if (isEnumPropertyItem()) {
         PropertyItem* child = propertyItem->child(0);
-        if (child == nullptr) {
+        if (!child) {
             return {};
         }
         return child->editorData(editor.get());
@@ -726,7 +726,7 @@ void DlgAddProperty::setEditorData(const QVariant& data)
 {
     if (isEnumPropertyItem()) {
         PropertyItem* child = propertyItem->child(0);
-        if (child == nullptr) {
+        if (!child) {
             return;
         }
         child->setEditorData(editor.get(), data);
@@ -741,7 +741,7 @@ void DlgAddProperty::setEditor(bool valueNeedsReset)
     if (editor && !valueNeedsReset) {
         QVariant data = getEditorData();
         addEditor(propertyItem.get());
-        if (editor == nullptr) {
+        if (!editor) {
             return;
         }
         setEditorData(data);
@@ -762,15 +762,15 @@ void DlgAddProperty::setEditor(bool valueNeedsReset)
 
 void DlgAddProperty::setPropertyItem(App::Property* prop, bool supportsExpressions)
 {
-    if (prop == nullptr) {
+    if (!prop) {
         return;
     }
 
-    if (propertyItem == nullptr) {
+    if (!propertyItem) {
         propertyItem.reset(createPropertyItem(prop));
     }
 
-    if (propertyItem == nullptr) {
+    if (!propertyItem) {
         return;
     }
 
@@ -816,7 +816,7 @@ bool DlgAddProperty::clearBoundProperty()
 
 bool DlgAddProperty::clear(FieldChange fieldChange)
 {
-    if (propertyItem == nullptr) {
+    if (!propertyItem) {
         return true;
     }
 
@@ -890,7 +890,7 @@ void DlgAddProperty::changeEvent(QEvent* e)
 void DlgAddProperty::valueChangedEnum()
 {
     auto* propEnum = static_cast<App::PropertyEnumeration*>(propertyItem->getFirstProperty());
-    if (propEnum == nullptr || propertyItem->childCount() == 0) {
+    if (!propEnum || propertyItem->childCount() == 0) {
         return;
     }
 
@@ -1019,13 +1019,13 @@ void DlgAddProperty::addDocumentation()
     std::string group = comboBoxGroup.currentText().toStdString();
     std::string doc = ui->lineEditToolTip->text().toStdString();
 
-    if (propertyItem == nullptr) {
+    if (!propertyItem) {
         // If there is no property item, we cannot add documentation.
         return;
     }
 
     App::Property* prop = propertyItem->getFirstProperty();
-    if (prop == nullptr) {
+    if (!prop) {
         return;
     }
 

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -697,7 +697,7 @@ static App::Document* getPreselectedDocument()
     }
 
     App::Document* doc = App::GetApplication().getDocument(lastDoc.c_str());
-    if (doc == nullptr) {
+    if (!doc) {
         return App::GetApplication().getActiveDocument();
     }
 
@@ -728,7 +728,7 @@ int DlgExpressionInput::getVarSetIndex(const App::Document* doc) const
 void DlgExpressionInput::preselectVarSet()
 {
     const App::Document* doc = getPreselectedDocument();
-    if (doc == nullptr) {
+    if (!doc) {
         FC_ERR("No active document found");
     }
     ui->comboBoxVarSet->setCurrentIndex(getVarSetIndex(doc));
@@ -763,7 +763,7 @@ static void addVarSetsVarSetComboBox(
         auto* vp = freecad_cast<Gui::ViewProviderDocumentObject*>(
             Gui::Application::Instance->getViewProvider(varSet)
         );
-        if (vp == nullptr) {
+        if (!vp) {
             FC_ERR("No ViewProvider found for VarSet: " << varSet->getNameInDocument());
             continue;
         }
@@ -889,13 +889,13 @@ void DlgExpressionInput::onVarSetSelected(int /*index*/)
     }
 
     App::Document* doc = App::GetApplication().getDocument(docName.toUtf8());
-    if (doc == nullptr) {
+    if (!doc) {
         FC_ERR("Document not found: " << docName.toStdString());
         return;
     }
 
     App::DocumentObject* varSet = doc->getObject(varSetName.toUtf8());
-    if (varSet == nullptr) {
+    if (!varSet) {
         FC_ERR("Variable set not found: " << varSetName.toStdString());
         return;
     }

--- a/src/Gui/ExpressionBinding.cpp
+++ b/src/Gui/ExpressionBinding.cpp
@@ -97,7 +97,7 @@ void ExpressionBinding::bind(const App::ObjectIdentifier& _path)
 {
     const Property* prop = _path.getProperty();
 
-    Q_ASSERT(prop != nullptr);
+    Q_ASSERT(prop);
 
     path = prop->canonicalPath(_path);
 
@@ -133,7 +133,7 @@ std::shared_ptr<App::Expression> ExpressionBinding::getExpression() const
 {
     DocumentObject* docObj = path.getDocumentObject();
 
-    Q_ASSERT(isBound() && docObj != nullptr);
+    Q_ASSERT(isBound() && docObj);
 
     return docObj->getExpression(path).expression;
 }

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -251,7 +251,7 @@ public:
     void setUserSchema(int userSchema)
     {
         App::Document* doc = App::GetApplication().getActiveDocument();
-        if (doc != nullptr) {
+        if (doc) {
             if (doc->UnitSystem.getValue() != userSchema) {
                 doc->UnitSystem.setValue(userSchema);
             }
@@ -275,7 +275,7 @@ private:
         bool ignore = hGrpu->GetBool("IgnoreProjectSchema", false);
         App::Document* doc = App::GetApplication().getActiveDocument();
         int userSchema = getWindowParameter()->GetInt("UserSchema", 0);
-        if (doc != nullptr && !ignore) {
+        if (doc && !ignore) {
             userSchema = doc->UnitSystem.getValue();
         }
         auto actions = menu()->actions();
@@ -937,7 +937,7 @@ int MainWindow::confirmSave(App::Document* doc, QWidget* parent, bool addCheckbo
         const QList<QWidget*> listOfMDIs = this->windows();
         for (QWidget* widget : listOfMDIs) {
             auto mdiView = qobject_cast<MDIView*>(widget);
-            if (mdiView != nullptr && mdiView->getAppDocument() == doc) {
+            if (mdiView && mdiView->getAppDocument() == doc) {
                 this->setActiveWindow(mdiView);
             }
         }
@@ -974,7 +974,7 @@ bool MainWindow::closeAllDocuments(bool close)
     // moves the active document to the front
     MDIView* activeView = this->activeWindow();
     App::Document* activeDoc = (activeView ? activeView->getAppDocument() : nullptr);
-    if (activeDoc != nullptr) {
+    if (activeDoc) {
         for (auto it = ++docs.begin(); it != docs.end(); it++) {
             if (*it == activeDoc) {
                 docs.erase(it);

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1220,7 +1220,7 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             // If the previous flat button animation is still active then apply the rotation to the
             // previous target orientation, otherwise apply the rotation to the current camera
             // orientation
-            if (m_flatButtonAnimation != nullptr
+            if (m_flatButtonAnimation
                 && m_flatButtonAnimation->state() == QAbstractAnimation::Running) {
                 m_flatButtonTargetOrientation = rotation * m_flatButtonTargetOrientation;
             }

--- a/src/Gui/Navigation/NavigationAnimator.cpp
+++ b/src/Gui/Navigation/NavigationAnimator.cpp
@@ -96,7 +96,7 @@ void NavigationAnimator::stop()
  */
 bool NavigationAnimator::isAnimating() const
 {
-    if (activeAnimation != nullptr) {
+    if (activeAnimation) {
         return activeAnimation->state() == QAbstractAnimation::State::Running;
     }
 

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
@@ -351,7 +351,7 @@ void DlgSettingsLightSources::resetSettingsToDefaults()
 
 void DlgSettingsLightSources::zoomIn() const
 {
-    if (camera == nullptr) {
+    if (!camera) {
         return;
     }
 
@@ -360,7 +360,7 @@ void DlgSettingsLightSources::zoomIn() const
 
 void DlgSettingsLightSources::zoomOut() const
 {
-    if (camera == nullptr) {
+    if (!camera) {
         return;
     }
 

--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -406,7 +406,7 @@ public:
         const auto PyW_uniqueName = QString::number(reinterpret_cast<quintptr>(pyobj));
         auto PyW_invalidator = findChild<QObject*>(PyW_uniqueName, Qt::FindDirectChildrenOnly);
 
-        if (PyW_invalidator == nullptr) {
+        if (!PyW_invalidator) {
             PyW_invalidator = new QObject(this);
             PyW_invalidator->setObjectName(PyW_uniqueName);
 
@@ -420,7 +420,7 @@ public:
         auto destroyedFun = [pyobj]() {
             Base::PyGILStateLocker lock;
 
-            if (auto sbkPtr = reinterpret_cast<SbkObject*>(pyobj); sbkPtr != nullptr) {
+            if (auto sbkPtr = reinterpret_cast<SbkObject*>(pyobj); sbkPtr) {
                 Shiboken::Object::setValidCpp(sbkPtr, false);
             }
             else {

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -1315,7 +1315,7 @@ SoFCSelectionContextBasePtr SoFCSelectionRoot::getNodeContext(
     }
 
     auto front = dynamic_cast<SoFCSelectionRoot*>(stack.front());
-    if (front == nullptr) {
+    if (!front) {
         return SoFCSelectionContextBasePtr();
     }
 
@@ -1341,7 +1341,7 @@ SoFCSelectionContextBasePtr SoFCSelectionRoot::getNodeContext2(
     }
 
     auto* back = dynamic_cast<SoFCSelectionRoot*>(stack.back());
-    if (back == nullptr || back->contextMap2.empty()) {
+    if (!back || back->contextMap2.empty()) {
         return ret;
     }
 
@@ -1387,7 +1387,7 @@ std::pair<bool, SoFCSelectionContextBasePtr*> SoFCSelectionRoot::findActionConte
 
     if (res.first) {
         auto back = dynamic_cast<SoFCSelectionRoot*>(stack.back());
-        if (back != nullptr) {
+        if (back) {
             stack.back() = _node;
             if (create) {
                 res.second = &back->contextMap2[stack];
@@ -1406,7 +1406,7 @@ std::pair<bool, SoFCSelectionContextBasePtr*> SoFCSelectionRoot::findActionConte
     }
     else {
         auto front = dynamic_cast<SoFCSelectionRoot*>(stack.front());
-        if (front != nullptr) {
+        if (front) {
             stack.front() = _node;
             if (create) {
                 res.second = &front->contextMap[stack];
@@ -2027,7 +2027,7 @@ void SoFCPathAnnotation::GLRenderBelowPath(SoGLRenderAction* action)
                         continue;
                     }
                     auto node = dynamic_cast<SoFCSelectionRoot*>(path->getNode(i));
-                    if (node != nullptr && node->selectionStyle.getValue() == SoFCSelectionRoot::Box) {
+                    if (node && node->selectionStyle.getValue() == SoFCSelectionRoot::Box) {
                         bbox = true;
                         break;
                     }

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -1169,8 +1169,7 @@ void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
                 }
             }
             contextMenu.addAction(this->selectDependentsAction);
-            if (doc == App::GetApplication().getActiveDocument()
-                && this->skipRecomputeCommand != nullptr) {
+            if (doc == App::GetApplication().getActiveDocument() && this->skipRecomputeCommand) {
                 // if active document is selected, use Command
                 this->skipRecomputeCommand->addTo(&contextMenu);
             }

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -2341,7 +2341,7 @@ Py::Object View3DInventorPy::getSceneGraph()
 {
     try {
         SoNode* scene = getView3DInventorPtr()->getViewer()->getSceneGraph();
-        if (scene == nullptr) {
+        if (!scene) {
             return Py::None();
         }
         PyObject* proxy = nullptr;

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -593,7 +593,7 @@ void NaviCubeSettings::applySettings()
 
 void NaviCubeSettings::parameterChanged(const char* Name)
 {
-    if (Name == nullptr) {
+    if (!Name) {
         return;
     }
     NaviCube* nc = _viewer->getNaviCube();

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -3934,7 +3934,7 @@ void ViewProviderLink::getPropertyMap(std::map<std::string, App::Property*>& Map
 void ViewProviderLink::visitProperties(const std::function<void(App::Property*)>& visitor) const
 {
     inherited::visitProperties(visitor);
-    if (childVp != nullptr) {
+    if (childVp) {
         childVp->visitProperties(visitor);
     }
 }

--- a/src/Gui/WorkbenchSelector.cpp
+++ b/src/Gui/WorkbenchSelector.cpp
@@ -324,7 +324,7 @@ void WorkbenchTabWidget::updateWorkbenchList()
         addWorkbenchTab(action);
     }
 
-    if (temporaryWorkbenchAction != nullptr) {
+    if (temporaryWorkbenchAction) {
         setTemporaryWorkbenchTab(temporaryWorkbenchAction);
     }
 

--- a/src/Gui/propertyeditor/PropertyEditor.cpp
+++ b/src/Gui/propertyeditor/PropertyEditor.cpp
@@ -828,7 +828,7 @@ void PropertyEditor::setFirstLevelExpanded(bool doExpand)
         }
 
         auto* item = static_cast<PropertyItem*>(index.internalPointer());
-        if (item == nullptr || item->childCount() <= 0) {
+        if (!item || item->childCount() <= 0) {
             return;
         }
 
@@ -1157,7 +1157,7 @@ void PropertyEditor::contextMenuEvent(QContextMenuEvent*)
             break;
         case MA_AddProp: {
             App::PropertyContainer* container = getSelectedPropertyContainer();
-            if (container == nullptr) {
+            if (!container) {
                 return;
             }
             App::AutoTransaction committer("Add property");


### PR DESCRIPTION
Follow C++ Core Guidelines ES.87: Don't add redundant == or != to conditions.

All the work done by @petterreinholdtsen