### PR TITLE
Sketcher: Text position OVP fix

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerText.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerText.h
@@ -591,7 +591,7 @@ void DSHTextController::computeNextDrawSketchHandlerMode()
             auto& firstParam = onViewParameters[OnViewParameter::First];
             auto& secondParam = onViewParameters[OnViewParameter::Second];
 
-            if (firstParam->isSet && secondParam->isSet) {
+            if (firstParam->hasFinishedEditing && secondParam->hasFinishedEditing) {
                 handler->setNextState(SelectMode::SeekSecond);
             }
         } break;


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/28363

Text tool has not been updated after tetektoza changes to OVP.
This PR updates to use the hasFinishedEditing.