### PR TITLE
Gui: Respect unit schema when applying implied units in expression editor

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -605,15 +605,12 @@ void DlgExpressionInput::applyImpliedUnit()
         Base::Quantity(factor, impliedUnit),
         unitString
     );
-    auto wrapped = std::make_shared<App::OperatorExpression>(
+    expression = std::make_shared<App::OperatorExpression>(
         path.getDocumentObject(),
-        left.get(),
+        left.release(),
         App::OperatorExpression::Operator::UNIT,
-        right.get()
+        right.release()
     );
-    left.release();
-    right.release();
-    expression = wrapped;
 }
 
 void DlgExpressionInput::createBindingVarSet(App::Property* propVarSet, App::DocumentObject* varSet)

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -878,7 +878,7 @@ void DlgExpressionInput::setupVarSets()
 
 std::string DlgExpressionInput::getType()
 {
-    return std::string{determineTypeVarSet().getName()};
+    return std::string {determineTypeVarSet().getName()};
 }
 
 void DlgExpressionInput::onCheckVarSets(int state)

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -30,8 +30,6 @@
 #include <QTreeWidget>
 #include <QStyledItemDelegate>
 
-#include <fmt/format.h>
-
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
@@ -582,6 +580,42 @@ static const App::OperatorExpression* toUnitNumberExpr(const App::Expression* ex
     return nullptr;
 }
 
+void DlgExpressionInput::applyImpliedUnit()
+{
+    if (!expression || impliedUnit == Base::Unit::One) {
+        return;
+    }
+
+    std::unique_ptr<App::Expression> evaluated(expression->eval());
+    const auto* numberExpr = toNumberExpr(evaluated.get());
+    if (!numberExpr || !numberExpr->getQuantity().isDimensionless()) {
+        return;
+    }
+
+    double factor = 1.0;
+    std::string unitString;
+    Base::Quantity(1.0, impliedUnit).getUserString(factor, unitString);
+    if (unitString.empty()) {
+        return;
+    }
+
+    auto left = expression->copy();
+    auto right = std::make_unique<App::UnitExpression>(
+        path.getDocumentObject(),
+        Base::Quantity(factor, impliedUnit),
+        unitString
+    );
+    auto wrapped = std::make_shared<App::OperatorExpression>(
+        path.getDocumentObject(),
+        left.get(),
+        App::OperatorExpression::Operator::UNIT,
+        right.get()
+    );
+    left.release();
+    right.release();
+    expression = wrapped;
+}
+
 void DlgExpressionInput::createBindingVarSet(App::Property* propVarSet, App::DocumentObject* varSet)
 {
     ObjectIdentifier varSetId(*propVarSet);
@@ -621,7 +655,7 @@ void DlgExpressionInput::acceptWithVarSet()
     std::string name = nameProp.toStdString();
     std::string group = nameGroup.toStdString();
     std::string type = getType();
-    auto prop = obj->addDynamicProperty(type, name.c_str(), group.c_str());
+    auto prop = obj->addDynamicProperty(type.c_str(), name.c_str(), group.c_str());
 
     // Set the value of the property in the VarSet
     //
@@ -676,6 +710,8 @@ void DlgExpressionInput::acceptWithVarSet()
 
 void DlgExpressionInput::accept()
 {
+    applyImpliedUnit();
+
     if (varSetsVisible) {
         if (needReportOnVarSet()) {
             return;
@@ -697,7 +733,7 @@ static App::Document* getPreselectedDocument()
     }
 
     App::Document* doc = App::GetApplication().getDocument(lastDoc.c_str());
-    if (!doc) {
+    if (doc == nullptr) {
         return App::GetApplication().getActiveDocument();
     }
 
@@ -728,7 +764,7 @@ int DlgExpressionInput::getVarSetIndex(const App::Document* doc) const
 void DlgExpressionInput::preselectVarSet()
 {
     const App::Document* doc = getPreselectedDocument();
-    if (!doc) {
+    if (doc == nullptr) {
         FC_ERR("No active document found");
     }
     ui->comboBoxVarSet->setCurrentIndex(getVarSetIndex(doc));
@@ -763,7 +799,7 @@ static void addVarSetsVarSetComboBox(
         auto* vp = freecad_cast<Gui::ViewProviderDocumentObject*>(
             Gui::Application::Instance->getViewProvider(varSet)
         );
-        if (!vp) {
+        if (vp == nullptr) {
             FC_ERR("No ViewProvider found for VarSet: " << varSet->getNameInDocument());
             continue;
         }
@@ -842,7 +878,7 @@ void DlgExpressionInput::setupVarSets()
 
 std::string DlgExpressionInput::getType()
 {
-    return std::string {determineTypeVarSet().getName()};
+    return std::string{determineTypeVarSet().getName()};
 }
 
 void DlgExpressionInput::onCheckVarSets(int state)
@@ -889,13 +925,13 @@ void DlgExpressionInput::onVarSetSelected(int /*index*/)
     }
 
     App::Document* doc = App::GetApplication().getDocument(docName.toUtf8());
-    if (!doc) {
+    if (doc == nullptr) {
         FC_ERR("Document not found: " << docName.toStdString());
         return;
     }
 
     App::DocumentObject* varSet = doc->getObject(varSetName.toUtf8());
-    if (!varSet) {
+    if (varSet == nullptr) {
         FC_ERR("Variable set not found: " << varSetName.toStdString());
         return;
     }

--- a/src/Gui/Dialogs/DlgExpressionInput.h
+++ b/src/Gui/Dialogs/DlgExpressionInput.h
@@ -123,6 +123,7 @@ private:
     void updateVarSetInfo(bool checkExpr = true);
     void createBindingVarSet(App::Property* propVarSet, App::DocumentObject* varSet);
     void acceptWithVarSet();
+    void applyImpliedUnit();
     bool isPropertyNameValid(
         const QString& nameProp,
         const App::DocumentObject* obj,

--- a/tests/src/Gui/Dialogs/CMakeLists.txt
+++ b/tests/src/Gui/Dialogs/CMakeLists.txt
@@ -1,1 +1,2 @@
 setup_qt_test(DlgVersionMigrator)
+setup_qt_test(DlgExpressionInput)

--- a/tests/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/tests/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -79,6 +79,42 @@ private Q_SLOTS:
         checkImpliedLengthExpression("1/10", "0.1 in");
     }
 
+    void test_ImpliedUnitIgnoresLengthExpression()
+    {
+        Base::UnitsApi::setSchema("Internal");
+
+        docName = App::GetApplication().getUniqueDocumentName("test");
+        App::Document* doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+        App::DocumentObject* obj = doc->addObject("App::VarSet", "VarSet");
+        QVERIFY(obj != nullptr);
+
+        App::Property* width = obj->addDynamicProperty("App::PropertyLength", "Width");
+        QVERIFY(width != nullptr);
+        App::ObjectIdentifier widthPath(*width);
+        width->setPathValue(widthPath, Base::Quantity::parse("2 mm"));
+
+        App::Property* length = obj->addDynamicProperty("App::PropertyLength", "Length");
+        QVERIFY(length != nullptr);
+        App::ObjectIdentifier lengthPath(*length);
+
+        auto expr = App::Expression::parse(obj, "Width");
+        auto exprShared = std::shared_ptr<const App::Expression>(expr.release());
+
+        Gui::Dialog::DlgExpressionInput dlg(lengthPath, exprShared, Base::Unit::Length);
+        dlg.accept();
+
+        auto accepted = dlg.getExpression();
+        QVERIFY(accepted != nullptr);
+
+        auto evaluated = accepted->eval();
+        auto value = evaluated->getValueAsAny();
+        QVERIFY(value.type() == typeid(Base::Quantity));
+
+        const Base::Quantity quantity = App::any_cast<Base::Quantity>(value);
+        QCOMPARE(quantity.getUnit(), Base::Unit::Length);
+        QVERIFY(std::abs(quantity.getValue() - Base::Quantity::parse("2 mm").getValue()) < 1e-12);
+    }
+
 private:
     std::string docName;
 };

--- a/tests/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/tests/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QDebug>
+#include <QTest>
+
+#include <cmath>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/Expression.h>
+#include <App/ObjectIdentifier.h>
+#include <Base/Quantity.h>
+#include <Base/UnitsApi.h>
+
+#include "Gui/Dialogs/DlgExpressionInput.h"
+#include <src/App/InitApplication.h>
+
+class testDlgExpressionInput: public QObject
+{
+    Q_OBJECT
+
+public:
+    testDlgExpressionInput()
+    {
+        tests::initApplication();
+    }
+
+private:
+    void checkImpliedLengthExpression(const char* source, const char* expectedQuantity)
+    {
+        Base::UnitsApi::setSchema("ImperialDecimal");
+
+        docName = App::GetApplication().getUniqueDocumentName("test");
+        App::Document* doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+        App::DocumentObject* obj = doc->addObject("App::VarSet", "VarSet");
+        QVERIFY(obj != nullptr);
+        App::Property* prop = obj->addDynamicProperty("App::PropertyLength", "Len");
+        QVERIFY(prop != nullptr);
+        App::ObjectIdentifier path(*prop);
+
+        auto expr = App::Expression::parse(obj, source);
+        auto exprShared = std::shared_ptr<const App::Expression>(expr.release());
+
+        Gui::Dialog::DlgExpressionInput dlg(path, exprShared, Base::Unit::Length);
+        dlg.accept();
+
+        auto accepted = dlg.getExpression();
+        QVERIFY(accepted != nullptr);
+
+        auto evaluated = accepted->eval();
+        auto value = evaluated->getValueAsAny();
+        QVERIFY(value.type() == typeid(Base::Quantity));
+
+        const Base::Quantity quantity = App::any_cast<Base::Quantity>(value);
+        QVERIFY(!quantity.isDimensionless());
+        QCOMPARE(quantity.getUnit(), Base::Unit::Length);
+
+        const Base::Quantity expected = Base::Quantity::parse(expectedQuantity);
+        QVERIFY(std::abs(quantity.getValue() - expected.getValue()) < 1e-12);
+    }
+
+private Q_SLOTS:
+
+    void init()
+    {}
+
+    void cleanup()
+    {
+        if (!docName.empty()) {
+            App::GetApplication().closeDocument(docName.c_str());
+            docName.clear();
+        }
+        Base::UnitsApi::setSchema("Internal");
+    }
+
+    void test_ImplicitUnitForDimensionlessExpression()
+    {
+        checkImpliedLengthExpression("1/10", "0.1 in");
+    }
+
+private:
+    std::string docName;
+};
+
+QTEST_MAIN(testDlgExpressionInput)
+
+#include "DlgExpressionInput.moc"


### PR DESCRIPTION
Fixes #16861

When entering a dimensionless expression (e.g. '1/10') in the expression editor for properties with an implied unit (such as Length), the dialog previously interpreted the value using metric units instead of the user's configured unit schema.

This patch ensures that expressions accepted through 'DlgExpressionInput' respect the active unit schema when applying implied units.

### Implementation
- Refactor 'withImpliedUnit' to modify the expression in-place.
- Remove unnecessary 'shared_ptr' copies.
- Use 'std::make_shared' for expression wrapping.

### Tests
- Add a Qt regression test for 'DlgExpressionInput::accept()' verifying that a dimensionless expression under the 'ImperialDecimal' schema evaluates to a quantity with the correct implied length unit.