### PR TITLE
App: Switch back to MappingStatus::Generated

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -4871,7 +4871,7 @@ public:
             if (it.Key().IsNull()) {
                 continue;
             }
-            mapper.populate(MappingStatus::Modified, it.Key(), it.Value());
+            mapper.populate(MappingStatus::Generated, it.Key(), it.Value());
         }
     }
 };


### PR DESCRIPTION
In d1f7060 PR #17769 made a parity change with LS3, changing the mapping status from Generated to Modified. Bisection revealed that this was one of a sequence of changes that was breaking the file in Issue #25720. Since the original justification for the change was simply to match the element mapping produced by LS3, and not to fix any particular bug, this commit reverts that change. That said, I also think this makes sense from a "theoretical" standpoint, since "refine" is a many-to-one merge of existing geometry, which I think corresponds more closely to the "this is new geometry based on some other geometry" rather than the "this *is* the existing geometry" of the "Modified" flag.

This should be backported to 1.1.0 as part of the sequence of PR's that will eventually fix #25720.