### PR TITLE
PD: Add migration to handle reversed TwoLengths prism

### DIFF
--- a/src/Mod/PartDesign/App/FeatureExtrude.cpp
+++ b/src/Mod/PartDesign/App/FeatureExtrude.cpp
@@ -966,6 +966,20 @@ void FeatureExtrude::onDocumentRestored()
         Type.setValue("Length");
         Type2.setValue("Length");
         SideType.setValue("Two sides");
+
+        // The old TwoLengths code path (generatePrism) always extruded in +dir:
+        //   offset = -L2 * dir  (Reversed=false) or -L * dir (Reversed=true)
+        //   extrude = (L+L2) * dir
+        // The new "Two sides" code extrudes Side 1 in dir, Side 2 in -dir,
+        // with Reversed toggling the sign of dir. To preserve the same OCC
+        // topology (face/edge ordering), we toggle Reversed so the effective
+        // extrusion direction matches the old +dir, and swap Length/Length2
+        // to keep the correct offset for each side.
+        Reversed.setValue(!Reversed.getValue());
+        double origL = Length.getValue();
+        double origL2 = Length2.getValue();
+        Length.setValue(origL2);
+        Length2.setValue(origL);
     }
     else if (Midplane.getValue()) {
         Midplane.setValue(false);


### PR DESCRIPTION
Commit a346c266 (PR #21794) was a major refactoring of the extrusion code, and one consequence of it was that the 'TwoLengths' extrusion was deprecated and replaced. The code that replaced it generated the same final geometry, but in the opposite direction, changing the face order and breaking the element names. This commit adds a backwards-compatibility branch to the file loading code that flips the direction of the inputs, so the final output matches the original.

This should be backported to 1.1.0 as part of the sequence of PR's that will eventually fix https://github.com/FreeCAD/FreeCAD/issues/25720.