### PR TITLE
Part/Gui: Add configurable gizmo coarse snap and fine modifier

### DIFF
--- a/src/Gui/Inventor/Draggers/Gizmo.cpp
+++ b/src/Gui/Inventor/Draggers/Gizmo.cpp
@@ -24,6 +24,7 @@
 #include "Gizmo.h"
 
 #include <cmath>
+#include <QApplication>
 
 #include <Inventor/nodes/SoOrthographicCamera.h>
 #include <Inventor/nodes/SoPerspectiveCamera.h>
@@ -52,6 +53,78 @@
 
 using namespace Gui;
 
+namespace
+{
+enum class DefaultDragBehavior
+{
+    Coarse = 0,
+    Fine = 1,
+};
+
+Base::Reference<ParameterGrp> getGizmoParameterGroup()
+{
+    static Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup(
+        "BaseApp/Preferences/Gui/Gizmos"
+    );
+
+    return hGrp;
+}
+
+Qt::KeyboardModifiers getFineSnapModifier()
+{
+    auto modifier = static_cast<int>(
+        getGizmoParameterGroup()->GetInt("FineSnapModifier", static_cast<int>(Qt::ShiftModifier))
+    );
+    auto result = static_cast<Qt::KeyboardModifiers>(modifier);
+    switch (result.toInt()) {
+        case Qt::ShiftModifier:
+        case Qt::ControlModifier:
+            return result;
+        default:
+            return Qt::ShiftModifier;
+    }
+}
+
+bool isCoarseSnapEnabled()
+{
+    return getGizmoParameterGroup()->GetBool("EnableCoarseSnap", true);
+}
+
+int getCoarseLinearSnapMultiplier()
+{
+    int multiplier = static_cast<int>(
+        getGizmoParameterGroup()->GetInt("CoarseLinearSnapMultiplier", 5)
+    );
+    return std::max(1, multiplier);
+}
+
+int getCoarseRotationSnapMultiplier()
+{
+    int multiplier = static_cast<int>(
+        getGizmoParameterGroup()->GetInt("CoarseRotationSnapMultiplier", 5)
+    );
+    return std::max(1, multiplier);
+}
+
+DefaultDragBehavior getDefaultDragBehavior()
+{
+    int behavior = getGizmoParameterGroup()->GetInt(
+        "DefaultCoarseDragBehavior",
+        static_cast<int>(DefaultDragBehavior::Coarse)
+    );
+    return static_cast<DefaultDragBehavior>(behavior);
+}
+
+double snapToStep(double value, double step)
+{
+    if (step <= 0.0) {
+        return value;
+    }
+
+    return std::round(value / step) * step;
+}
+}  // namespace
+
 void Gizmo::setDraggerPlacement(const Base::Vector3d& pos, const Base::Vector3d& dir)
 {
     setDraggerPlacement(Base::convertTo<SbVec3f>(pos), Base::convertTo<SbVec3f>(dir));
@@ -59,11 +132,7 @@ void Gizmo::setDraggerPlacement(const Base::Vector3d& pos, const Base::Vector3d&
 
 bool Gizmo::isDelayedUpdateEnabled()
 {
-    static Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup(
-        "BaseApp/Preferences/Gui/Gizmos"
-    );
-
-    return hGrp->GetBool("DelayedGizmoUpdate", false);
+    return getGizmoParameterGroup()->GetBool("DelayedGizmoUpdate", false);
 }
 
 double Gizmo::getMultFactor()
@@ -255,6 +324,18 @@ void LinearGizmo::draggingFinished()
 void LinearGizmo::draggingContinued()
 {
     double value = initialValue + getDragLength();
+
+    auto fineModifier = getFineSnapModifier();
+    auto modifiers = QApplication::queryKeyboardModifiers();
+    bool fineModifierPressed = (modifiers & fineModifier) == fineModifier;
+    bool coarseByDefault = getDefaultDragBehavior() == DefaultDragBehavior::Coarse;
+    bool useCoarseSnap = coarseByDefault != fineModifierPressed;
+
+    if (isCoarseSnapEnabled() && useCoarseSnap) {
+        double baseStep = std::abs(dragger->translationIncrement.getValue() / multFactor);
+        value = snapToStep(value, baseStep * getCoarseLinearSnapMultiplier());
+    }
+
     // TODO: Need to change the lower limit to sudoThis->property->minimum() once the
     // two direction extrude work gets merged
     value = std::clamp(value, dragger->translationIncrement.getValue(), property->maximum());
@@ -283,7 +364,7 @@ SoInteractionKit* RotationGizmo::initDragger()
 
     draggerContainer->color.setValue(1, 0, 0);
     dragger = draggerContainer->getDragger();
-    dragger->rotationIncrement = std::numbers::pi / 90.0;
+    dragger->rotationIncrement = std::numbers::pi / 180.0;
 
     auto rotator = new SoRotatorGeometry;
     rotator->arcAngle = std::numbers::pi_v<float> / 6.0f;
@@ -448,6 +529,17 @@ void RotationGizmo::draggingFinished()
 void RotationGizmo::draggingContinued()
 {
     double value = initialValue + getRotAngle();
+
+    auto fineModifier = getFineSnapModifier();
+    auto modifiers = QApplication::queryKeyboardModifiers();
+    bool fineModifierPressed = (modifiers & fineModifier) == fineModifier;
+    bool coarseByDefault = getDefaultDragBehavior() == DefaultDragBehavior::Coarse;
+    bool useCoarseSnap = coarseByDefault != fineModifierPressed;
+
+    if (isCoarseSnapEnabled() && useCoarseSnap) {
+        value = snapToStep(value, getCoarseRotationSnapMultiplier());
+    }
+
     value = Base::clampAngle(
         value,
         property->minimum(),
@@ -765,9 +857,7 @@ void GizmoContainer::cameraPositionChangeCallback(void* data, SoSensor*)
 
 bool GizmoContainer::isEnabled()
 {
-    static Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup(
-        "BaseApp/Preferences/Gui/Gizmos"
-    );
+    static auto hGrp = getGizmoParameterGroup();
 
     return hGrp->GetBool("EnableGizmos", true);
 }

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
@@ -49,6 +49,13 @@ DlgSettingsGeneral::DlgSettingsGeneral(QWidget* parent)
     , ui(new Ui_DlgSettingsGeneral)
 {
     ui->setupUi(this);
+
+    ui->fineSnapModifier->addItem(tr("Shift"), static_cast<int>(Qt::ShiftModifier));
+    ui->fineSnapModifier->addItem(tr("Ctrl"), static_cast<int>(Qt::ControlModifier));
+
+    //: Part/PartDesign settings: drag behavior mode when not holding the snap modifier key
+    ui->defaultCoarseDragBehavior->addItem(tr("Coarse"), 0);
+    ui->defaultCoarseDragBehavior->addItem(tr("Fine"), 1);
 }
 
 /**
@@ -65,6 +72,11 @@ void DlgSettingsGeneral::saveSettings()
     ui->checkAllowCompoundBody->onSave();
     ui->enableGizmos->onSave();
     ui->delayedGizmoUpdate->onSave();
+    ui->enableCoarseSnap->onSave();
+    ui->fineSnapModifier->onSave();
+    ui->defaultCoarseDragBehavior->onSave();
+    ui->coarseLinearSnapMultiplier->onSave();
+    ui->coarseRotationSnapMultiplier->onSave();
     ui->comboDefaultProfileTypeForHole->onSave();
     ui->checkShowFinalPreview->onSave();
     ui->checkShowTransparentPreview->onSave();
@@ -81,6 +93,11 @@ void DlgSettingsGeneral::loadSettings()
     ui->checkAllowCompoundBody->onRestore();
     ui->enableGizmos->onRestore();
     ui->delayedGizmoUpdate->onRestore();
+    ui->enableCoarseSnap->onRestore();
+    ui->fineSnapModifier->onRestore();
+    ui->defaultCoarseDragBehavior->onRestore();
+    ui->coarseLinearSnapMultiplier->onRestore();
+    ui->coarseRotationSnapMultiplier->onRestore();
     ui->comboDefaultProfileTypeForHole->onRestore();
     ui->checkShowFinalPreview->onRestore();
     ui->checkShowTransparentPreview->onRestore();

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -299,6 +299,133 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="enableCoarseSnap">
+        <property name="text">
+         <string>Enable coarse snapping while dragging</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EnableCoarseSnap</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Gui/Gizmos</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayoutFineSnapModifier">
+        <item>
+         <widget class="QLabel" name="labelFineSnapModifier">
+          <property name="text">
+           <string>Fine snap modifier</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="fineSnapModifier">
+          <property name="prefEntry" stdset="0">
+           <cstring>FineSnapModifier</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Gui/Gizmos</cstring>
+          </property>
+          <property name="prefType" stdset="0">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayoutDefaultCoarseDragBehavior">
+        <item>
+         <widget class="QLabel" name="labelDefaultCoarseDragBehavior">
+          <property name="text">
+           <string>Default coarse drag behavior</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefComboBox" name="defaultCoarseDragBehavior">
+          <property name="toolTip">
+           <string>Determines whether the drag is coarse or fine without holding the modifier key</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>DefaultCoarseDragBehavior</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Gui/Gizmos</cstring>
+          </property>
+          <property name="prefType" stdset="0">
+           <number>0</number>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayoutCoarseLinearSnapMultiplier">
+        <item>
+         <widget class="QLabel" name="labelCoarseLinearSnapMultiplier">
+          <property name="text">
+           <string>Coarse movement multiplier</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefSpinBox" name="coarseLinearSnapMultiplier">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>5</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>CoarseLinearSnapMultiplier</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Gui/Gizmos</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayoutCoarseRotationSnapMultiplier">
+        <item>
+         <widget class="QLabel" name="labelCoarseRotationSnapMultiplier">
+          <property name="text">
+           <string>Coarse rotation step (degrees)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="Gui::PrefSpinBox" name="coarseRotationSnapMultiplier">
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="value">
+           <number>5</number>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>CoarseRotationSnapMultiplier</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Gui/Gizmos</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>
@@ -326,6 +453,11 @@
   <customwidget>
    <class>Gui::PrefComboBox</class>
    <extends>QComboBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
This PR adds snapping for gizmos. Those can be quite useful for features like Pad for getting quicker to a precise value without making microscoping mouse movements.

This feature is configurable through the "Part/Part Design" preferences, under the experimental section. These are the values that can be configured:

- Enable coarse snapping while dragging: A checkbox to enable the feature or not
- Fine snap modifier: A ComboBox for which modifier to switch to fine movement while held
- Coarse movement multiplier: How much to multiply the linear gizmo value by
- Coarse rotation step (deg): The amount of degrees a rotation should be snapped to.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

Before:

<img width="695" height="139" alt="Screenshot 2026-03-16 at 22 20 47" src="https://github.com/user-attachments/assets/3ee396ef-e2dd-4ab0-86b3-7bedd6bad4e7" />

<img width="696" height="345" alt="Screenshot 2026-03-16 at 22 21 02" src="https://github.com/user-attachments/assets/e0a356ba-392e-416e-90e8-f50cc2c51970" />

After:

<img width="685" height="241" alt="Screenshot 2026-03-16 at 22 19 18" src="https://github.com/user-attachments/assets/d49f3829-be1a-4288-9168-24b920ccdb11" />

<img width="730" height="343" alt="Screenshot 2026-03-16 at 22 19 43" src="https://github.com/user-attachments/assets/f276025d-6faa-4f9b-99d0-eed8cda55124" />

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
