### PR TITLE
Core: Add version warning dialog and preference

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -31,6 +31,7 @@
 #include <cctype>
 #include <mutex>
 #include <QApplication>
+#include <QCheckBox>
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QOpenGLWidget>
@@ -1503,10 +1504,103 @@ bool Document::askIfSavingFailed(const QString& error)
     return false;
 }
 
+bool Document::warnIfOlderVersion()
+{
+    // Skip warning if no GUI (headless/scripted mode)
+    if (!getMainWindow()) {
+        return true;
+    }
+
+    // Check if version checking is disabled in preferences
+    if (App::GetApplication()
+            .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
+            ->GetBool("DisableVersionCheckOnSave", false)) {
+        return true;
+    }
+
+    // Get document version info
+    const char* docVersion = d->_pcDocument->getProgramVersion();
+    const bool hasVersionString = !Base::Tools::isNullOrEmpty(docVersion);
+
+    // Parse document version string like "1.0R39319 (Git)" or "0.21R33694 (Git)"
+    // hasVersion is true only if the string is present AND parses as major.minor.
+    // Unrecognised strings like "pre-0.14" still display in the dialog but cannot
+    // be compared numerically, so they are treated as older versions.
+    int docMajor = 0, docMinor = 0;
+    const bool hasVersion = hasVersionString
+        && std::sscanf(docVersion, "%d.%d", &docMajor, &docMinor) == 2;
+
+    // Get current FreeCAD version
+    auto config = App::Application::Config();
+    int currentMajor = 0, currentMinor = 0;
+    if (config.count("BuildVersionMajor") && config.count("BuildVersionMinor")) {
+        currentMajor = std::stoi(config["BuildVersionMajor"]);
+        currentMinor = std::stoi(config["BuildVersionMinor"]);
+    }
+    else {
+        return true;
+    }
+
+    // Warn if the document was created with an older version or has no version info
+    if (!hasVersion || (docMajor < currentMajor)
+        || (docMajor == currentMajor && docMinor < currentMinor)) {
+        QMessageBox msgBox(getMainWindow());
+        msgBox.setWindowTitle(QObject::tr("File Created with Older FreeCAD Version"));
+        msgBox.setIcon(QMessageBox::Warning);
+        msgBox.setText(
+            QObject::tr(
+                "This file was created with %1, but you are using v%2.%3.\n\n"
+                "Saving will upgrade the file format. The file may not be readable "
+                "by older versions of FreeCAD after saving.\n\n"
+                "Use 'Save As…' to preserve the original file."
+                "\n"
+            )
+                .arg(
+                    !hasVersionString
+                        ? QObject::tr("an unknown older version of FreeCAD")
+                        : QObject::tr("FreeCAD version %1").arg(QString::fromUtf8(docVersion))
+                )
+                .arg(currentMajor)
+                .arg(currentMinor)
+        );
+        QPushButton* saveButton = msgBox.addButton(QObject::tr("Save"), QMessageBox::AcceptRole);
+        QPushButton* saveAsButton = msgBox.addButton(QObject::tr("Save As…"), QMessageBox::ActionRole);
+        msgBox.addButton(QMessageBox::Cancel);
+        msgBox.setDefaultButton(QMessageBox::Cancel);
+
+        QCheckBox dontShowCheckBox(QObject::tr("Do not show this warning again"), &msgBox);
+        msgBox.setCheckBox(&dontShowCheckBox);
+
+        int ret = msgBox.exec();
+
+        if (msgBox.clickedButton() == saveButton) {
+            if (dontShowCheckBox.isChecked()) {
+                App::GetApplication()
+                    .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
+                    ->SetBool("DisableVersionCheckOnSave", true);
+            }
+        }
+        else if (msgBox.clickedButton() == saveAsButton) {
+            saveAs();
+            return false;
+        }
+
+        if (ret == QMessageBox::Cancel) {
+            return false;
+        }
+    }
+    return true;
+}
+
 /// Save the document
 bool Document::save()
 {
     if (d->_pcDocument->isSaved()) {
+        // Warn if this document was created with an older FreeCAD version
+        if (!warnIfOlderVersion()) {
+            return false;
+        }
+
         try {
             std::vector<App::Document*> docs;
             std::map<App::Document*, bool> dmap;

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -362,6 +362,8 @@ private:
     bool checkTransactionID(bool undo, int iSteps);
     /// Ask for user interaction if saving has failed
     bool askIfSavingFailed(const QString&);
+    /// Warn if saving a document from an older FreeCAD version (returns false if user cancels)
+    bool warnIfOlderVersion();
 
     struct DocumentP* d;
     static int _iDocCount;

--- a/src/Gui/PreferencePages/DlgSettingsDocument.ui
+++ b/src/Gui/PreferencePages/DlgSettingsDocument.ui
@@ -584,6 +584,25 @@ get date suffix according to the specified format</string>
         </item>
        </layout>
       </item>
+      <item row="10" column="0">
+       <widget class="Gui::PrefCheckBox" name="prefDisableVersionCheckOnSave">
+        <property name="toolTip">
+         <string>Suppresses the version mismatch warning when saving files created with an older FreeCAD version</string>
+        </property>
+        <property name="text">
+         <string>Suppress older version warning on save</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DisableVersionCheckOnSave</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Document</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
@@ -146,6 +146,7 @@ void DlgSettingsDocumentImp::saveSettings()
     ui->prefCountBackupFiles->onSave();
     ui->prefSaveBackupExtension->onSave();
     ui->prefSaveBackupDateFormat->onSave();
+    ui->prefDisableVersionCheckOnSave->onSave();
     ui->prefDuplicateLabel->onSave();
     ui->prefPartialLoading->onSave();
     ui->prefLicenseType->onSave();
@@ -182,6 +183,7 @@ void DlgSettingsDocumentImp::loadSettings()
     ui->prefCountBackupFiles->onRestore();
     ui->prefSaveBackupExtension->onRestore();
     ui->prefSaveBackupDateFormat->onRestore();
+    ui->prefDisableVersionCheckOnSave->onRestore();
     ui->prefDuplicateLabel->onRestore();
     ui->prefPartialLoading->onRestore();
     ui->prefLicenseType->onRestore();


### PR DESCRIPTION
This PR Adds a warning dialog when saving files created with older FreeCAD versions. Introduced a preference to disable this warning.  Only checking Major and Minor version numbers.  No extensive checks beyond the version.   As can be seen in the example below, it works as far back as .20 version files, I can't speak to any older than that (Did files always have a Program Version in them)

pre-0.14
<img width="509" height="244" alt="Screenshot from 2026-04-21 01-31-17" src="https://github.com/user-attachments/assets/70f53e23-d06f-432a-af9b-a5f4e4434bab" />

 v0.14
<img width="509" height="244" alt="Screenshot from 2026-04-21 01-32-40" src="https://github.com/user-attachments/assets/c1fa003c-8ae5-4c15-98de-980479d6d5b9" />

v1.0
<img width="509" height="244" alt="Screenshot from 2026-04-21 01-30-59" src="https://github.com/user-attachments/assets/bcd97b6f-fee4-4ff6-8454-e2fe6033782f" />

Preferences to suppress the warning dialog
<img width="679" height="309" alt="Screenshot from 2026-04-21 01-58-43" src="https://github.com/user-attachments/assets/5b7734fb-eb69-4bb0-87cf-ebf516d279b6" />


Please advise if the text for the title, dialog and buttons is good, as well as the order of the buttons. (My understanding this is platform dependent)  I made Save a Accept Role, Save As a Action Role, and of course, Cancel by default is a Reject Role 