### PR TITLE
fix lag spikes while rotating

### DIFF
--- a/src/Gui/Navigation/BlenderNavigationStyle.cpp
+++ b/src/Gui/Navigation/BlenderNavigationStyle.cpp
@@ -175,6 +175,7 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent* const ev)
                     this->centerTime = ev->getTime();
                     setupPanningPlane(getCamera());
                     this->lockrecenter = false;
+                    processed = true;
                 }
                 else {
                     SbTime tmp = (ev->getTime() - this->centerTime);

--- a/src/Gui/Navigation/CADNavigationStyle.cpp
+++ b/src/Gui/Navigation/CADNavigationStyle.cpp
@@ -185,6 +185,7 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent* const ev)
                     this->centerTime = ev->getTime();
                     setupPanningPlane(getCamera());
                     this->lockrecenter = false;
+                    processed = true;
                 }
                 else {
                     SbTime tmp = (ev->getTime() - this->centerTime);

--- a/src/Gui/Navigation/OpenCascadeNavigationStyle.cpp
+++ b/src/Gui/Navigation/OpenCascadeNavigationStyle.cpp
@@ -175,6 +175,7 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent* const ev)
                     this->centerTime = ev->getTime();
                     setupPanningPlane(getCamera());
                     this->lockrecenter = false;
+                    processed = true;
                 }
                 else if (this->currentmode == NavigationStyle::PANNING) {
                     newmode = NavigationStyle::IDLE;

--- a/src/Gui/Navigation/OpenSCADNavigationStyle.cpp
+++ b/src/Gui/Navigation/OpenSCADNavigationStyle.cpp
@@ -174,6 +174,7 @@ SbBool OpenSCADNavigationStyle::processSoEvent(const SoEvent* const ev)
                     this->centerTime = ev->getTime();
                     setupPanningPlane(getCamera());
                     this->lockrecenter = false;
+                    processed = true;
                 }
                 else if (curmode == NavigationStyle::PANNING) {
                     newmode = NavigationStyle::IDLE;

--- a/src/Gui/Navigation/RevitNavigationStyle.cpp
+++ b/src/Gui/Navigation/RevitNavigationStyle.cpp
@@ -177,6 +177,7 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent* const ev)
                     this->centerTime = ev->getTime();
                     setupPanningPlane(getCamera());
                     this->lockrecenter = false;
+                    processed = true;
                 }
                 else {
                     SbTime tmp = (ev->getTime() - this->centerTime);

--- a/src/Gui/Navigation/SolidWorksNavigationStyle.cpp
+++ b/src/Gui/Navigation/SolidWorksNavigationStyle.cpp
@@ -175,6 +175,7 @@ SbBool SolidWorksNavigationStyle::processSoEvent(const SoEvent* const ev)
                     this->centerTime = ev->getTime();
                     setupPanningPlane(getCamera());
                     this->lockrecenter = false;
+                    processed = true;
                 }
                 else {
                     SbTime tmp = (ev->getTime() - this->centerTime);


### PR DESCRIPTION
When in rotating mode, we don't want to continue trying to select
geometry. Once the user has rotated the model to the right place, then
they can release and click on the geometry they want to select.

The current behavior is a problem because it creates lag spikes while
rotating the model.

Note, I've only really tested the Blender controls. But the rest seem
like they were originally copy-pastes of each other, so I've paplied the
patch to every reference of `this->lockrecenter = false;`
