### PR TITLE
CAM: Pocket_Shape - ExtrusionFace from bspline

### DIFF
--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -291,17 +291,6 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
 
         return self.removalshapes
 
-    # Support methods
-    def isVerticalExtrusionFace(self, face):
-        fBB = face.BoundBox
-        if Path.Geom.isRoughly(fBB.ZLength, 0.0):
-            return False
-        extr = face.extrude(FreeCAD.Vector(0.0, 0.0, fBB.ZLength))
-        if hasattr(extr, "Volume"):
-            if Path.Geom.isRoughly(extr.Volume, 0.0):
-                return True
-        return False
-
     def classifySub(self, bs, sub):
         """classifySub(bs, sub)...
         Given a base and a sub-feature name, returns True
@@ -352,8 +341,8 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
         elif isinstance(face.Surface, Part.SurfaceOfExtrusion):
             # extrusion wall
             Path.Log.debug("type() == Part.SurfaceOfExtrusion")
-            # Save face to self.horiz for processing or display error
-            if self.isVerticalExtrusionFace(face):
+            if Path.Geom.isRoughly(abs(face.Surface.Direction.z), 1.0):
+                # it's a vertical face
                 self.vert.append(face)
                 return True
             else:


### PR DESCRIPTION
Method `isVerticalExtrusionFace()` works incorrect for face created from bspline curve
Also it is looks overcomplicated

---

https://github.com/FreeCAD/FreeCAD/blob/49d7d77274dd516e8f24c82277fe60e3ff10450e/src/Mod/CAM/Path/Op/PocketShape.py#L295-L298

Probably we can not select face with 0 height
So this checks looks useless

---

https://github.com/FreeCAD/FreeCAD/blob/49d7d77274dd516e8f24c82277fe60e3ff10450e/src/Mod/CAM/Path/Op/PocketShape.py#L299-L302

`ExtrsionFace` has attribute `Direction`
So extruding the face and checking volume, looks overcomplicated
Also it give incorrect result for face created from bspline curve

---

[JM_Routing_Template1.zip](https://github.com/user-attachments/files/26044288/JM_Routing_Template1.zip)

<img width="1038" height="367" alt="Screenshot_20260317_081025_lossy" src="https://github.com/user-attachments/assets/cac86f40-75c2-4a6b-bac8-6279b3c12476" />
