### PR TITLE
TD: Remove `this` check

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
@@ -476,7 +476,7 @@ void QGIRichAnno::mouseMoveEvent(QGraphicsSceneMouseEvent* event)
         // update.
 
         QTimer::singleShot(0, this, [this]() {
-            if (this && scene()) {
+            if (scene()) {
                 Q_EMIT positionChanged();
             }
         });


### PR DESCRIPTION
The check is not necessary, the timer will not fire if the object has been deleted. If the check was added to address a specific problem, there's probably another problem lurking in here someplace.