### PR TITLE
Assembly: Compiler warning cleanup

### DIFF
--- a/src/Mod/Assembly/App/AssemblyLink.cpp
+++ b/src/Mod/Assembly/App/AssemblyLink.cpp
@@ -513,7 +513,7 @@ void copyPropertyIfDifferent(
     }
 }
 
-std::string removeUpToName(const std::string& sub, const std::string& name)
+[[maybe_unused]] std::string removeUpToName(const std::string& sub, const std::string& name)
 {
     size_t pos = sub.find(name);
     if (pos != std::string::npos) {
@@ -527,7 +527,7 @@ std::string removeUpToName(const std::string& sub, const std::string& name)
     return sub;
 }
 
-std::string replaceLastOccurrence(
+[[maybe_unused]] std::string replaceLastOccurrence(
     const std::string& str,
     const std::string& oldStr,
     const std::string& newStr

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -717,7 +717,7 @@ ViewGroup* AssemblyObject::getExplodedViewGroup() const
     return nullptr;
 }
 
-std::vector<App::DocumentObject*> AssemblyObject::getJoints(bool updateJCS, bool delBadJoints, bool subJoints)
+std::vector<App::DocumentObject*> AssemblyObject::getJoints([[maybe_unused]] bool updateJCS, bool delBadJoints, bool subJoints)
 {
     std::vector<App::DocumentObject*> joints = {};
 

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -717,7 +717,11 @@ ViewGroup* AssemblyObject::getExplodedViewGroup() const
     return nullptr;
 }
 
-std::vector<App::DocumentObject*> AssemblyObject::getJoints([[maybe_unused]] bool updateJCS, bool delBadJoints, bool subJoints)
+std::vector<App::DocumentObject*> AssemblyObject::getJoints(
+    [[maybe_unused]] bool updateJCS,
+    bool delBadJoints,
+    bool subJoints
+)
 {
     std::vector<App::DocumentObject*> joints = {};
 

--- a/src/Mod/Assembly/Gui/Commands.cpp
+++ b/src/Mod/Assembly/Gui/Commands.cpp
@@ -334,7 +334,6 @@ void CmdAssemblySelectJointsOfComponent::activated(int iMsg)
     }
 
     std::set<App::DocumentObject*> components;
-    App::Document* doc = assembly->getDocument();
 
     for (auto& sel : selection) {
         const std::vector<std::string> subs = sel.getSubNames();

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -978,7 +978,6 @@ ViewProviderAssembly::DragMode ViewProviderAssembly::findDragMode()
         if (!ref) {
             return DragMode::Translation;
         }
-        auto* obj = getObjFromJointRef(movingJoint, pName.c_str());
         Base::Placement global_plc = App::GeoFeature::getGlobalPlacement(nullptr, ref);
         jcsGlobalPlc = global_plc * jcsPlc;
 
@@ -1792,9 +1791,7 @@ void ViewProviderAssembly::UpdateSolverInformation()
     auto* assembly = getObject<AssemblyObject>();
 
     int dofs = assembly->getLastDoF();
-    bool hasConflicts = assembly->getLastHasConflicts();
     bool hasRedundancies = assembly->getLastHasRedundancies();
-    bool hasPartiallyRedundant = assembly->getLastHasPartialRedundancies();
     bool hasMalformed = assembly->getLastHasMalformedConstraints();
 
     if (assembly->isEmpty()) {


### PR DESCRIPTION
There are quite a few unused variables in Assembly right now, and it's not clear if these are intentional and intended for future use, accidental inclusions, or are things that *should* be getting used and are not. For the unused functions I've marked them as `[[maybe_unused]]` in case they are being kept for future use, but for the variables I've removed them. If some of these should be left let's mark them so the compiler quiets down.