### PR TITLE
BIM: fix crash caused by grouped commands in TaskWatcher (v1.1)

### DIFF
--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -471,7 +471,7 @@ class BIMWorkbench(Workbench):
                     continue
                 idx = lst.index(itm[0])
                 cmds = list(itm[1].GetCommands(itm[1]))
-                lst = lst[:idx] + cmds + lst[idx+1:]
+                lst = lst[:idx] + cmds + lst[idx + 1 :]
             setattr(self, attr, lst)
 
     def loadPreferences(self):


### PR DESCRIPTION
Fixes #27984.