### PR TITLE
fix: properties input cursor jumping around

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -453,10 +453,10 @@ void QuantitySpinBox::resizeEvent(QResizeEvent* event)
 {
     QAbstractSpinBox::resizeEvent(event);
     resizeWidget();
-    moveCursor();
+    clampCursorBeforeUnit();
 }
 
-void QuantitySpinBox::moveCursor()
+void QuantitySpinBox::clampCursorBeforeUnit()
 {
     Q_D(QuantitySpinBox);
     if (!d->adjustableWidth) {
@@ -493,7 +493,7 @@ void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent* event)
         returnPressed();
     }
     else {
-        moveCursor();
+        clampCursorBeforeUnit();
     }
 }
 
@@ -532,7 +532,7 @@ void QuantitySpinBox::updateEdit(const QString& text)
         edit->setSelection(0, cursor);
     }
     else {
-        moveCursor();
+        clampCursorBeforeUnit();
     }
 }
 

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -198,7 +198,7 @@ protected:
     void paintEvent(QPaintEvent* event) override;
 
 private:
-    void moveCursor();
+    void clampCursorBeforeUnit();
     void validateInput() override;
     void updateText(const Base::Quantity&);
     void updateEdit(const QString& text);


### PR DESCRIPTION
should fix #28387

basically cursor reposition is needed adjustable inputs, which grow as you type (currently only the OVP)

it should not be active on property input