### PR TITLE
Build: Version and App Name single source of truth

### DIFF
--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -195,6 +195,10 @@ jobs:
         name: ${{ inputs.artifactBasename }}-${{ matrix.os }}-CoinNodeSnapshots
         path: /tmp/FreeCADTesting/CoinNodeSnapshots
 
+    - name: src/Tools tests
+      if: always()
+      run: python3 -m unittest discover -s src/Tools/tests -p "test_*.py"
+
     - name: C++ tests
       timeout-minutes: 10
       if: runner.os != 'Windows'

--- a/.github/workflows/sub_lint.yml
+++ b/.github/workflows/sub_lint.yml
@@ -215,6 +215,11 @@ jobs:
           mkdir -p ${{ env.reportdir }}
           echo "reportFile=${{ env.reportfilename }}" >> $GITHUB_OUTPUT
 
+    # Version consistency check
+      - name: Check version sync
+        if: always()
+        run: python3 src/Tools/sync_version.py --check
+
     # Generic lints steps
       - name: Check File Case Sensitivity
         uses: credfeto/action-case-checker@cb652aeab29ed363bbdb7d9ee1bfcc010c46cac5 # v1.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,8 +82,14 @@ repos:
 -   repo: local
     hooks:
     -   id: version-sync
+        name: Push version changes to other necessary files
+        entry: python src/Tools/sync_version.py --update
+        language: python
+        files: '(version\.json)'
+        pass_filenames: false
+    -   id: version-sync
         name: Verify version consistency
         entry: python src/Tools/sync_version.py --check
         language: python
-        files: '(version\.json|pixi\.toml|recipe\.yaml|declarations\.nsh|freecad\.spec)'
+        files: '(pixi\.toml|recipe\.yaml|declarations\.nsh|freecad\.spec)'
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,3 +79,11 @@ repos:
     rev: 07a0f7667439f60724899f6ae288e4a4f572e0e1  # frozen: v22.1.2
     hooks:
         -   id: clang-format
+-   repo: local
+    hooks:
+    -   id: version-sync
+        name: Verify version consistency
+        entry: python src/Tools/sync_version.py --check
+        language: python
+        files: '(version\.json|pixi\.toml|recipe\.yaml|declarations\.nsh|freecad\.spec)'
+        pass_filenames: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,19 @@ if(FREECAD_USE_CCACHE)
     endif()
 endif()
 
-project(FreeCAD)
+# Version and Package Name are set in the version.json file and propagate to all other
+# files with version information in them either via CMake or via the sync_version.py
+# script (in src/Tools/)
+file(READ "${CMAKE_SOURCE_DIR}/version.json" VERSION_JSON)
+string(JSON _PROJECT_NAME GET ${VERSION_JSON} "name")
+string(JSON PACKAGE_VERSION_MAJOR GET ${VERSION_JSON} "version_major")
+string(JSON PACKAGE_VERSION_MINOR GET ${VERSION_JSON} "version_minor")
+string(JSON PACKAGE_VERSION_PATCH GET ${VERSION_JSON} "version_patch")
+string(JSON PACKAGE_VERSION_SUFFIX GET ${VERSION_JSON} "version_suffix")
+string(JSON PACKAGE_BUILD_VERSION GET ${VERSION_JSON} "build_version")
 
 # Sanitizer support
-option(FREECAD_USE_SANITIZER_ASAN "Enable AddressSanitizer ie. (ASan)" OFF) 
+option(FREECAD_USE_SANITIZER_ASAN "Enable AddressSanitizer ie. (ASan)" OFF)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     option(FREECAD_USE_SANITIZER_LSAN "Enable LeakSanitizer (LSan)" OFF)
     option(FREECAD_USE_SANITIZER_TSAN "Enable ThreadSanitizer (TSan)" OFF)
@@ -72,6 +81,7 @@ set(PACKAGE_VERSION_MINOR "2")
 set(PACKAGE_VERSION_PATCH "0") # number of patch release (e.g. "4" for the 0.18.4 release)
 set(PACKAGE_VERSION_SUFFIX "dev") # either "dev" for development snapshot or "" (empty string)
 set(PACKAGE_BUILD_VERSION "0") # used when the same FreeCAD version will be re-released (for example using an updated LibPack)
+project(${_PROJECT_NAME})
 string(TIMESTAMP PACKAGE_COPYRIGHT_YEAR "%Y")
 
 set(PACKAGE_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,13 @@ string(JSON PACKAGE_VERSION_PATCH GET ${VERSION_JSON} "version_patch")
 string(JSON PACKAGE_VERSION_SUFFIX GET ${VERSION_JSON} "version_suffix")
 string(JSON PACKAGE_BUILD_VERSION GET ${VERSION_JSON} "build_version")
 
+project(${_PROJECT_NAME})
+string(TIMESTAMP PACKAGE_COPYRIGHT_YEAR "%Y")
+
+set(PACKAGE_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")
+set(PACKAGE_STRING "${PROJECT_NAME} ${PACKAGE_VERSION}")
+
+
 # Sanitizer support
 option(FREECAD_USE_SANITIZER_ASAN "Enable AddressSanitizer ie. (ASan)" OFF)
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -69,23 +76,12 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
 endif()
 
 mark_as_advanced(
-    FREECAD_USE_SANITIZER_ASAN
-    FREECAD_USE_SANITIZER_LSAN
-    FREECAD_USE_SANITIZER_TSAN
-    FREECAD_USE_SANITIZER_UBSAN
-    FREECAD_USE_SANITIZER_MSAN
+        FREECAD_USE_SANITIZER_ASAN
+        FREECAD_USE_SANITIZER_LSAN
+        FREECAD_USE_SANITIZER_TSAN
+        FREECAD_USE_SANITIZER_UBSAN
+        FREECAD_USE_SANITIZER_MSAN
 )
-
-set(PACKAGE_VERSION_MAJOR "1")
-set(PACKAGE_VERSION_MINOR "2")
-set(PACKAGE_VERSION_PATCH "0") # number of patch release (e.g. "4" for the 0.18.4 release)
-set(PACKAGE_VERSION_SUFFIX "dev") # either "dev" for development snapshot or "" (empty string)
-set(PACKAGE_BUILD_VERSION "0") # used when the same FreeCAD version will be re-released (for example using an updated LibPack)
-project(${_PROJECT_NAME})
-string(TIMESTAMP PACKAGE_COPYRIGHT_YEAR "%Y")
-
-set(PACKAGE_VERSION "${PACKAGE_VERSION_MAJOR}.${PACKAGE_VERSION_MINOR}.${PACKAGE_VERSION_PATCH}")
-set(PACKAGE_STRING "${PROJECT_NAME} ${PACKAGE_VERSION}")
 
 # include local modules
 include(CheckCXXCompilerFlag)

--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -16,7 +16,7 @@
 
 Name:           freecad
 Epoch:          1
-Version:        1.1.0~dev
+Version:        1.2.0~dev
 Release:        1%{?dist}
 
 Summary:        A general purpose 3D CAD modeler

--- a/package/rattler-build/osx/Info.plist.template
+++ b/package/rattler-build/osx/Info.plist.template
@@ -21,11 +21,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string></string>
+	<string>FREECAD_BUNDLE_VERSION</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>FREECAD_VERSION</string>
+	<string>FREECAD_BUNDLE_VERSION</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/package/rattler-build/osx/create_bundle.sh
+++ b/package/rattler-build/osx/create_bundle.sh
@@ -56,8 +56,22 @@ echo -e "\################"
 echo -e "version_name:  ${version_name}"
 echo -e "################"
 
+# Extract Apple-compliant bundle version from version.json
+# For dev/weekly builds, append a "d" + ISO week number suffix (e.g. "1.2.0d12")
+# per Apple's CFBundleVersion spec for development builds
+bundle_version=$(python3 -c "
+import json, datetime
+d = json.load(open('../../../version.json'))
+v = f'{d[\"version_major\"]}.{d[\"version_minor\"]}.{d[\"version_patch\"]}'
+suffix = d.get('version_suffix', '')
+if suffix:
+    week = datetime.date.today().isocalendar()[1]
+    v += f'd{week}'
+print(v)
+")
+
 cp Info.plist.template ${conda_env}/../Info.plist
-sed -i "s/FREECAD_VERSION/${version_name}/" ${conda_env}/../Info.plist
+sed -i "s/FREECAD_BUNDLE_VERSION/${bundle_version}/" ${conda_env}/../Info.plist
 sed -i "s/APPLICATION_MENU_NAME/${application_menu_name}/" ${conda_env}/../Info.plist
 
 pixi list -e default > FreeCAD.app/Contents/packages.txt

--- a/package/rattler-build/pixi.toml
+++ b/package/rattler-build/pixi.toml
@@ -8,7 +8,7 @@ preview = ["pixi-build"]
 
 [package]
 name = "freecad"
-version = "1.1.0dev"
+version = "1.2.0-dev"
 homepage = "https://freecad.org"
 repository = "https://github.com/FreeCAD/FreeCAD"
 description = "FreeCAD"

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.1.0dev"
+  version: "1.2.0-dev"
 
 package:
   name: freecad

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "FreeCAD"
-version = "1.0.0"
+version = "1.2.0"
 description = "pixi instructions for FreeCAD"
 authors = ["looooo <sppedflyer@gmail.com>"]
 channels = ["conda-forge"]

--- a/src/Tools/sync_version.py
+++ b/src/Tools/sync_version.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+#
+# Sync version and project name from version.json to all packaging/build files.
+#
+# Files updated by this script:
+#   - pixi.toml (workspace version)
+#   - package/rattler-build/pixi.toml (package version, name, description)
+#   - package/rattler-build/recipe.yaml (context version, package name)
+#   - package/WindowsInstaller/include/declarations.nsh (APP_NAME)
+#   - package/fedora/freecad.spec (Version, Name)
+#
+# Usage:
+#   python src/Tools/sync_version.py --check    # verify consistency (no changes)
+#   python src/Tools/sync_version.py --update   # update all files
+#
+# This script is intended to be run from the repository root directory.
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class VersionInfo:
+    """Version and project identity parsed from version.json.
+
+    Provides the version in several formats needed by different packaging systems.
+    """
+
+    name: str
+    major: int
+    minor: int
+    patch: int
+    suffix: str
+    build: int
+
+    @classmethod
+    def from_json(cls, repo_root: Path) -> "VersionInfo":
+        """Load and parse the version.json file.
+
+        repo_root: path to the repository root containing version.json.
+        """
+        version_file = repo_root / "version.json"
+        with open(version_file, encoding="utf-8") as f:
+            data = json.load(f)
+        return cls(
+            name=data["name"],
+            major=data["version_major"],
+            minor=data["version_minor"],
+            patch=data["version_patch"],
+            suffix=data["version_suffix"],
+            build=data["build_version"],
+        )
+
+    @property
+    def simple(self) -> str:
+        """Version without suffix, e.g. "1.2.0"."""
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    @property
+    def complete(self) -> str:
+        """Version with suffix after "-" per SemVer convention, e.g. "1.2.0-dev"."""
+        return f"{self.simple}-{self.suffix}" if self.suffix else self.simple
+
+    @property
+    def rpm(self) -> str:
+        """Version with suffix after "~" per RPM convention, e.g. "1.2.0~dev"."""
+        return f"{self.simple}~{self.suffix}" if self.suffix else self.simple
+
+    @property
+    def lowercase_name(self) -> str:
+        """Lowercased project name, e.g. "freecad"."""
+        return self.name.lower()
+
+
+def replace_in_toml_section(content: str, section: str, key: str, value: str) -> str:
+    """Replace a quoted field value within a specific TOML section.
+
+    Finds the given section header (e.g. "[workspace]"), then within that section
+    replaces the value of the given key. Only matches quoted string values.
+
+    content: the full file text.
+    section: the section header to match, e.g. "[workspace]".
+    key: the TOML key name, e.g. "version".
+    value: the new value to set (will be quoted in the output).
+
+    Returns the updated content string (unchanged if no match was found).
+    """
+    section_pattern = re.escape(section)
+    section_match = re.search(section_pattern, content)
+    if not section_match:
+        return content
+
+    section_start = section_match.start()
+    next_section = re.search(r"\n\[", content[section_match.end() :])
+    section_end = section_match.end() + next_section.start() if next_section else len(content)
+
+    section_text = content[section_start:section_end]
+    field_pattern = rf'({re.escape(key)}\s*=\s*)"[^"]*"'
+    new_section = re.sub(field_pattern, rf'\g<1>"{value}"', section_text)
+    return content[:section_start] + new_section + content[section_end:]
+
+
+def sync_workspace_pixi_toml(filepath: Path, version: VersionInfo) -> tuple[str, bool]:
+    """Sync the workspace pixi.toml version field.
+
+    Updates the version under the [workspace] section.
+    """
+    content = filepath.read_text(encoding="utf-8")
+    updated = replace_in_toml_section(content, "[workspace]", "version", version.simple)
+    return updated, updated != content
+
+
+def sync_rattler_build_pixi_toml(filepath: Path, version: VersionInfo) -> tuple[str, bool]:
+    """Sync the rattler-build pixi.toml version, name, and description fields.
+
+    Updates fields under the [package] section.
+    """
+    content = filepath.read_text(encoding="utf-8")
+    updated = content
+    updated = replace_in_toml_section(updated, "[package]", "version", version.complete)
+    updated = replace_in_toml_section(updated, "[package]", "name", version.lowercase_name)
+    updated = replace_in_toml_section(updated, "[package]", "description", version.name)
+    return updated, updated != content
+
+
+def sync_recipe_yaml(filepath: Path, version: VersionInfo) -> tuple[str, bool]:
+    """Sync the rattler-build recipe.yaml version and package name.
+
+    Updates:
+      - context.version (quoted value)
+      - package.name (unquoted value)
+    """
+    content = filepath.read_text(encoding="utf-8")
+    updated = content
+
+    # context:\n  version: "1.2.0dev"
+    updated = re.sub(
+        r'(context:\s*\n\s*version:\s*)"[^"]*"',
+        rf'\g<1>"{version.complete}"',
+        updated,
+    )
+
+    # package:\n  name: freecad
+    updated = re.sub(
+        r"(package:\s*\n\s*name:\s*)\S+",
+        rf"\g<1>{version.lowercase_name}",
+        updated,
+    )
+
+    return updated, updated != content
+
+
+def sync_declarations_nsh(filepath: Path, version: VersionInfo) -> tuple[str, bool]:
+    """Sync the NSIS installer APP_NAME define.
+
+    Updates: !define APP_NAME "FreeCAD"
+    """
+    content = filepath.read_text(encoding="utf-8")
+    updated = re.sub(
+        r'(!define APP_NAME\s+)"[^"]*"',
+        rf'\g<1>"{version.name}"',
+        content,
+    )
+    return updated, updated != content
+
+
+def sync_fedora_spec(filepath: Path, version: VersionInfo) -> tuple[str, bool]:
+    """Sync the Fedora RPM spec file Name and Version fields.
+
+    Updates:
+      - Name: freecad
+      - Version: 1.2.0~dev (using RPM "~" convention for pre-release suffixes)
+    """
+    content = filepath.read_text(encoding="utf-8")
+    updated = content
+
+    # Name:           freecad
+    updated = re.sub(r"(Name:\s+)\S+", rf"\g<1>{version.lowercase_name}", updated)
+
+    # Version:        1.2.0~dev
+    updated = re.sub(r"(Version:\s+)\S+", rf"\g<1>{version.rpm}", updated)
+
+    return updated, updated != content
+
+
+# Each entry is (relative_path, sync_function).
+SYNC_TARGETS = [
+    ("pixi.toml", sync_workspace_pixi_toml),
+    ("package/rattler-build/pixi.toml", sync_rattler_build_pixi_toml),
+    ("package/rattler-build/recipe.yaml", sync_recipe_yaml),
+    ("package/WindowsInstaller/include/declarations.nsh", sync_declarations_nsh),
+    ("package/fedora/freecad.spec", sync_fedora_spec),
+]
+
+
+def run(repo_root: Path, check_only: bool) -> bool:
+    """Process all sync targets, either checking or applying updates.
+
+    repo_root: path to the repository root.
+    check_only: if True, only report out-of-sync files without modifying them;
+        if False, write updated content to each file.
+
+    Returns True if all files were already in sync, False otherwise.
+    """
+    version = VersionInfo.from_json(repo_root)
+    all_synced = True
+
+    for relative_path, sync_function in SYNC_TARGETS:
+        filepath = repo_root / relative_path
+        if not filepath.exists():
+            print(f"  SKIP: {relative_path} (file not found)")
+            continue
+
+        new_content, changed = sync_function(filepath, version)
+
+        if changed:
+            all_synced = False
+            if check_only:
+                print(f"  OUT OF SYNC: {relative_path}")
+            else:
+                filepath.write_text(new_content, encoding="utf-8")
+                print(f"  UPDATED: {relative_path}")
+        else:
+            print(f"  OK: {relative_path}")
+
+    return all_synced
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or sys.argv[1] not in ("--check", "--update"):
+        print(f"Usage: {sys.argv[0]} --check|--update")
+        print("  --check   Verify all files match version.json (no changes)")
+        print("  --update  Update all files to match version.json")
+        sys.exit(2)
+
+    check_only = sys.argv[1] == "--check"
+    repo_root = Path(__file__).resolve().parent.parent.parent
+
+    version = VersionInfo.from_json(repo_root)
+    print(f"version.json: {version.name} {version.complete}")
+    print()
+
+    all_synced = run(repo_root, check_only)
+
+    if not all_synced:
+        if check_only:
+            print()
+            print("Files are out of sync. Run with --update to fix.")
+            sys.exit(1)
+        else:
+            print()
+            print("All files updated.")
+    else:
+        print()
+        print("All files are in sync.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Tools/tests/test_sync_version.py
+++ b/src/Tools/tests/test_sync_version.py
@@ -1,0 +1,433 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from sync_version import (
+    VersionInfo,
+    replace_in_toml_section,
+    sync_workspace_pixi_toml,
+    sync_rattler_build_pixi_toml,
+    sync_recipe_yaml,
+    sync_declarations_nsh,
+    sync_fedora_spec,
+    run,
+)
+
+
+def make_version(
+    name="FreeCAD",
+    major=1,
+    minor=2,
+    patch=0,
+    suffix="dev",
+    build=0,
+) -> VersionInfo:
+    return VersionInfo(name=name, major=major, minor=minor, patch=patch, suffix=suffix, build=build)
+
+
+class TestVersionInfo(unittest.TestCase):
+    def test_simple_version(self):
+        version = make_version(major=1, minor=2, patch=3)
+        self.assertEqual(version.simple, "1.2.3")
+
+    def test_complete_version_with_suffix(self):
+        version = make_version(suffix="dev")
+        self.assertEqual(version.complete, "1.2.0-dev")
+
+    def test_complete_version_without_suffix(self):
+        version = make_version(suffix="")
+        self.assertEqual(version.complete, "1.2.0")
+
+    def test_complete_version_rc(self):
+        version = make_version(suffix="RC1")
+        self.assertEqual(version.complete, "1.2.0-RC1")
+
+    def test_rpm_version_with_suffix(self):
+        version = make_version(suffix="dev")
+        self.assertEqual(version.rpm, "1.2.0~dev")
+
+    def test_rpm_version_without_suffix(self):
+        version = make_version(suffix="")
+        self.assertEqual(version.rpm, "1.2.0")
+
+    def test_rpm_version_rc(self):
+        version = make_version(suffix="RC1")
+        self.assertEqual(version.rpm, "1.2.0~RC1")
+
+    def test_lowercase_name(self):
+        version = make_version(name="FreeCAD")
+        self.assertEqual(version.lowercase_name, "freecad")
+
+    def test_from_json(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "version.json").write_text(
+                json.dumps(
+                    {
+                        "name": "TestApp",
+                        "version_major": 3,
+                        "version_minor": 4,
+                        "version_patch": 5,
+                        "version_suffix": "beta",
+                        "build_version": 2,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            version = VersionInfo.from_json(root)
+            self.assertEqual(version.name, "TestApp")
+            self.assertEqual(version.simple, "3.4.5")
+            self.assertEqual(version.complete, "3.4.5-beta")
+            self.assertEqual(version.build, 2)
+
+
+class TestReplaceInTomlSection(unittest.TestCase):
+    SAMPLE = '[workspace]\nname = "FreeCAD"\nversion = "1.0.0"\n\n' '[dependencies]\nfoo = "*"\n'
+
+    def test_replaces_field_in_correct_section(self):
+        result = replace_in_toml_section(self.SAMPLE, "[workspace]", "version", "2.0.0")
+        self.assertIn('version = "2.0.0"', result)
+        self.assertIn('name = "FreeCAD"', result)
+
+    def test_does_not_modify_other_sections(self):
+        result = replace_in_toml_section(self.SAMPLE, "[workspace]", "version", "2.0.0")
+        self.assertIn('foo = "*"', result)
+
+    def test_no_match_returns_unchanged(self):
+        result = replace_in_toml_section(self.SAMPLE, "[nonexistent]", "version", "2.0.0")
+        self.assertEqual(result, self.SAMPLE)
+
+    def test_key_not_in_section_returns_unchanged(self):
+        result = replace_in_toml_section(self.SAMPLE, "[workspace]", "missing_key", "x")
+        self.assertEqual(result, self.SAMPLE)
+
+    def test_does_not_replace_key_in_wrong_section(self):
+        content = '[section_a]\nversion = "1.0"\n\n' '[section_b]\nversion = "2.0"\n'
+        result = replace_in_toml_section(content, "[section_a]", "version", "9.9")
+        self.assertIn('version = "9.9"', result.split("[section_b]")[0])
+        self.assertIn('version = "2.0"', result.split("[section_b]")[1])
+
+
+def write_temp_file(directory: Path, name: str, content: str) -> Path:
+    filepath = directory / name
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    filepath.write_text(content, encoding="utf-8")
+    return filepath
+
+
+WORKSPACE_PIXI_TOML = """\
+[workspace]
+name = "FreeCAD"
+version = "1.0.0"
+description = "pixi instructions for FreeCAD"
+
+[dependencies]
+cmake = "*"
+"""
+
+RATTLER_PIXI_TOML = """\
+[workspace]
+channels = ["https://prefix.dev/conda-forge"]
+platforms = ["linux-64"]
+
+[package]
+name = "freecad"
+version = "1.1.0dev"
+homepage = "https://freecad.org"
+repository = "https://github.com/FreeCAD/FreeCAD"
+description = "FreeCAD"
+
+[feature.freecad.dependencies]
+freecad = { path = "." }
+"""
+
+RECIPE_YAML = """\
+context:
+  version: "1.1.0dev"
+
+package:
+  name: freecad
+  version: "${{ version }}"
+
+source:
+  path: ../..
+"""
+
+DECLARATIONS_NSH = """\
+!define FILES_LICENSE "license.rtf"
+
+!define APP_NAME "FreeCAD"
+!define APP_VERSION_NUMBER "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}"
+!define APP_DIR "${APP_NAME} ${APP_SERIES_NAME}"
+"""
+
+FEDORA_SPEC = """\
+Name:           freecad
+Epoch:          1
+Version:        1.1.0~dev
+Release:        1%{?dist}
+
+Summary:        A general purpose 3D CAD modeler
+"""
+
+
+class TestSyncWorkspacePixiToml(unittest.TestCase):
+    def test_updates_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "pixi.toml", WORKSPACE_PIXI_TOML)
+            version = make_version()
+            result, changed = sync_workspace_pixi_toml(filepath, version)
+            self.assertTrue(changed)
+            self.assertIn('version = "1.2.0"', result)
+
+    def test_already_in_sync(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "pixi.toml", WORKSPACE_PIXI_TOML)
+            version = make_version(major=1, minor=0, patch=0, suffix="")
+            result, changed = sync_workspace_pixi_toml(filepath, version)
+            self.assertFalse(changed)
+
+    def test_ignores_suffix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "pixi.toml", WORKSPACE_PIXI_TOML)
+            version = make_version(suffix="RC1")
+            result, changed = sync_workspace_pixi_toml(filepath, version)
+            self.assertIn('version = "1.2.0"', result)
+            self.assertNotIn("RC1", result)
+
+
+class TestSyncRattlerBuildPixiToml(unittest.TestCase):
+    def test_updates_version_name_description(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "pixi.toml", RATTLER_PIXI_TOML)
+            version = make_version()
+            result, changed = sync_rattler_build_pixi_toml(filepath, version)
+            self.assertTrue(changed)
+            self.assertIn('version = "1.2.0-dev"', result)
+            self.assertIn('name = "freecad"', result)
+            self.assertIn('description = "FreeCAD"', result)
+
+    def test_updates_with_different_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "pixi.toml", RATTLER_PIXI_TOML)
+            version = make_version(name="MyCAD")
+            result, changed = sync_rattler_build_pixi_toml(filepath, version)
+            self.assertTrue(changed)
+            self.assertIn('name = "mycad"', result)
+            self.assertIn('description = "MyCAD"', result)
+
+    def test_release_version_no_suffix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "pixi.toml", RATTLER_PIXI_TOML)
+            version = make_version(suffix="")
+            result, changed = sync_rattler_build_pixi_toml(filepath, version)
+            self.assertIn('version = "1.2.0"', result)
+
+    def test_does_not_modify_workspace_section(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "pixi.toml", RATTLER_PIXI_TOML)
+            version = make_version()
+            result, changed = sync_rattler_build_pixi_toml(filepath, version)
+            workspace_section = result.split("[package]")[0]
+            self.assertIn("conda-forge", workspace_section)
+
+
+class TestSyncRecipeYaml(unittest.TestCase):
+    def test_updates_version_and_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "recipe.yaml", RECIPE_YAML)
+            version = make_version()
+            result, changed = sync_recipe_yaml(filepath, version)
+            self.assertTrue(changed)
+            self.assertIn('version: "1.2.0-dev"', result)
+            self.assertIn("name: freecad", result)
+
+    def test_preserves_version_template_reference(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "recipe.yaml", RECIPE_YAML)
+            version = make_version()
+            result, changed = sync_recipe_yaml(filepath, version)
+            self.assertIn('version: "${{ version }}"', result)
+
+    def test_updates_with_different_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "recipe.yaml", RECIPE_YAML)
+            version = make_version(name="MyCAD")
+            result, changed = sync_recipe_yaml(filepath, version)
+            self.assertIn("name: mycad", result)
+
+    def test_release_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "recipe.yaml", RECIPE_YAML)
+            version = make_version(suffix="")
+            result, changed = sync_recipe_yaml(filepath, version)
+            self.assertIn('version: "1.2.0"', result)
+
+
+class TestSyncDeclarationsNsh(unittest.TestCase):
+    def test_updates_app_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "declarations.nsh", DECLARATIONS_NSH)
+            version = make_version(name="MyCAD")
+            result, changed = sync_declarations_nsh(filepath, version)
+            self.assertTrue(changed)
+            self.assertIn('!define APP_NAME "MyCAD"', result)
+
+    def test_already_in_sync(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "declarations.nsh", DECLARATIONS_NSH)
+            version = make_version(name="FreeCAD")
+            result, changed = sync_declarations_nsh(filepath, version)
+            self.assertFalse(changed)
+
+    def test_preserves_other_defines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "declarations.nsh", DECLARATIONS_NSH)
+            version = make_version(name="MyCAD")
+            result, changed = sync_declarations_nsh(filepath, version)
+            self.assertIn("APP_VERSION_NUMBER", result)
+            self.assertIn("APP_DIR", result)
+
+
+class TestSyncFedoraSpec(unittest.TestCase):
+    def test_updates_name_and_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "freecad.spec", FEDORA_SPEC)
+            version = make_version()
+            result, changed = sync_fedora_spec(filepath, version)
+            self.assertTrue(changed)
+            self.assertIn("Name:           freecad", result)
+            self.assertIn("Version:        1.2.0~dev", result)
+
+    def test_release_version_no_tilde(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "freecad.spec", FEDORA_SPEC)
+            version = make_version(suffix="")
+            result, changed = sync_fedora_spec(filepath, version)
+            self.assertIn("Version:        1.2.0", result)
+            self.assertNotIn("~", result.split("Version:")[1].split("\n")[0])
+
+    def test_rc_version(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "freecad.spec", FEDORA_SPEC)
+            version = make_version(suffix="RC1")
+            result, changed = sync_fedora_spec(filepath, version)
+            self.assertIn("Version:        1.2.0~RC1", result)
+
+    def test_updates_name_for_fork(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "freecad.spec", FEDORA_SPEC)
+            version = make_version(name="MyCAD")
+            result, changed = sync_fedora_spec(filepath, version)
+            self.assertIn("Name:           mycad", result)
+
+    def test_preserves_other_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            filepath = write_temp_file(Path(tmp), "freecad.spec", FEDORA_SPEC)
+            version = make_version()
+            result, changed = sync_fedora_spec(filepath, version)
+            self.assertIn("Epoch:          1", result)
+            self.assertIn("Release:        1%{?dist}", result)
+
+
+@patch("sys.stdout", new_callable=io.StringIO)
+class TestRun(unittest.TestCase):
+    def _create_repo(self, tmp: str, version: VersionInfo) -> Path:
+        root = Path(tmp)
+        (root / "version.json").write_text(
+            json.dumps(
+                {
+                    "name": version.name,
+                    "version_major": version.major,
+                    "version_minor": version.minor,
+                    "version_patch": version.patch,
+                    "version_suffix": version.suffix,
+                    "build_version": version.build,
+                }
+            ),
+            encoding="utf-8",
+        )
+        write_temp_file(root, "pixi.toml", WORKSPACE_PIXI_TOML)
+        write_temp_file(root, "package/rattler-build/pixi.toml", RATTLER_PIXI_TOML)
+        write_temp_file(root, "package/rattler-build/recipe.yaml", RECIPE_YAML)
+        write_temp_file(
+            root,
+            "package/WindowsInstaller/include/declarations.nsh",
+            DECLARATIONS_NSH,
+        )
+        write_temp_file(root, "package/fedora/freecad.spec", FEDORA_SPEC)
+        return root
+
+    def test_check_detects_out_of_sync(self, _stdout):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._create_repo(tmp, make_version())
+            result = run(root, check_only=True)
+            self.assertFalse(result)
+
+    def test_update_then_check_is_synced(self, _stdout):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._create_repo(tmp, make_version())
+            run(root, check_only=False)
+            result = run(root, check_only=True)
+            self.assertTrue(result)
+
+    def test_check_when_already_synced(self, _stdout):
+        version = make_version(major=1, minor=0, patch=0, suffix="")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._create_repo(tmp, version)
+            result = run(root, check_only=True)
+            # pixi.toml starts with "1.0.0" which matches this version,
+            # but other files have "1.1.0dev" so they will be out of sync
+            self.assertFalse(result)
+
+    def test_skips_missing_files(self, _stdout):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "version.json").write_text(
+                json.dumps(
+                    {
+                        "name": "FreeCAD",
+                        "version_major": 1,
+                        "version_minor": 2,
+                        "version_patch": 0,
+                        "version_suffix": "dev",
+                        "build_version": 0,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            # Only create pixi.toml, skip the rest
+            write_temp_file(root, "pixi.toml", WORKSPACE_PIXI_TOML)
+            result = run(root, check_only=True)
+            # Should not crash, just skip missing files
+            self.assertFalse(result)
+
+    def test_update_does_not_modify_synced_files(self, _stdout):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self._create_repo(tmp, make_version())
+            run(root, check_only=False)
+            # Record file contents after first update
+            contents = {}
+            for child in root.rglob("*"):
+                if child.is_file() and child.name != "version.json":
+                    contents[child] = child.read_text(encoding="utf-8")
+            # Run update again
+            run(root, check_only=False)
+            # Verify nothing changed
+            for filepath, original in contents.items():
+                self.assertEqual(
+                    filepath.read_text(encoding="utf-8"),
+                    original,
+                    f"{filepath.name} was modified on second run",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version.json
+++ b/version.json
@@ -1,0 +1,11 @@
+{
+  "name": "FreeCAD",
+  "version_major": 1,
+  "version_minor": 2,
+  "version_patch": 0,
+  "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
+  "version_suffix": "dev",
+  "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
+  "build_version": 0,
+  "build_version_note": "used when the same FreeCAD version is re-released (for example using an updated LibPack)"
+}


### PR DESCRIPTION
Fixes #25392.

This PR implements a new metadata file for the repo called `version.json` -- that file contains the complete version information as well as the program name. The CMakeLists.txt file reads from it to compile in the correct version with no further changes to the source code. Then five other files in the repo need to be updated from the data in that file:
* `pixi.toml` (workspace version)
* `package/rattler-build/pixi.toml` (package version, name, description)
* `package/rattler-build/recipe.yaml` (context version, package name)
* `package/WindowsInstaller/include/declarations.nsh` (APP_NAME)
* `package/fedora/freecad.spec` (Version, Name)

A pre-commit call is added to ensure that if version.json is updated, those other files also get updated. It works by running a new Python script: `src/Tools/sync_version.py`. That script can be run one of two ways: the `--check` argument will tell whether the files are all in sync with the `version.json` file, and the `--update` option will modify the files so that they all match that source data.

This PR includes comprehensive unit tests for the new code, generated by Anthropic's Claude AI. Those tests have been placed into a new `src/Tools/tests` subdirectory on the theory that eventually all of our tools should have tests. A CI runner was added to find and run those tests, as well as to run the `check` version of our script to verify that the version file never gets updated without also updating all of the other files.

Future work includes a more comprehensive app name change to better-enable forks to release a product with a name other than "FreeCAD" (which is fairly annoying right now, as I suspect @PaddleStroke can tell you 😁 ).

Closes: #25382