### PR TITLE
Assembly: Fix datum typo in isBodySubObject

### DIFF
--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -790,7 +790,7 @@ def getObjMassAndCom(obj, containingPart=None):
         obj = obj.getLinkedObject()
 
     if obj.TypeId == "PartDesign::Body":
-        part = part.Tip
+        obj = obj.Tip
 
     if obj.isDerivedFrom("Part::Feature"):
         mass = obj.Shape.Volume


### PR DESCRIPTION
Fix typo mentioned by @chennes in https://github.com/FreeCAD/FreeCAD/issues/27409#issuecomment-4072313900