### PR TITLE
Gui: update CoinPtr to not use boost::intrusive_ptr

### DIFF
--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -597,7 +597,7 @@ bool View3DInventor::setCamera(const char* pCamera)
     }
 
     // this is to make sure to reliably delete the node
-    CoinPtr<SoNode> camPtr{Cam};
+    CoinPtr<SoNode> camPtr {Cam};
 
     // toggle between perspective and orthographic camera
     if (Cam->getTypeId() != CamViewer->getTypeId()) {

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -91,56 +91,80 @@ enum ViewStatus
  * This class is copied from Inventor/misc/SoRefPtr.h and can be removed when the
  * minimum supported coin version provides this header.
  */
-template <typename T>
-class SoRefPtr {
+template<typename T>
+class SoRefPtr
+{
 public:
-    SoRefPtr(void) noexcept : ptr(NULL) { }
+    SoRefPtr(void) noexcept
+        : ptr(NULL)
+    {}
 
-    explicit SoRefPtr(T * p) : ptr(p)
+    explicit SoRefPtr(T* p)
+        : ptr(p)
     {
-        if (this->ptr) this->ptr->ref();
+        if (this->ptr) {
+            this->ptr->ref();
+        }
     }
 
-    SoRefPtr(const SoRefPtr & other) : ptr(other.ptr)
+    SoRefPtr(const SoRefPtr& other)
+        : ptr(other.ptr)
     {
-        if (this->ptr) this->ptr->ref();
+        if (this->ptr) {
+            this->ptr->ref();
+        }
     }
 
-    SoRefPtr(SoRefPtr && other) noexcept : ptr(other.ptr)
+    SoRefPtr(SoRefPtr&& other) noexcept
+        : ptr(other.ptr)
     {
         other.ptr = NULL;
     }
 
     ~SoRefPtr(void)
     {
-        if (this->ptr) this->ptr->unref();
+        if (this->ptr) {
+            this->ptr->unref();
+        }
     }
 
-    SoRefPtr & operator=(SoRefPtr other) noexcept
+    SoRefPtr& operator=(SoRefPtr other) noexcept
     {
         this->swap(other);
         return *this;
     }
 
-    void reset(T * p = NULL)
+    void reset(T* p = NULL)
     {
         SoRefPtr tmp(p);
         this->swap(tmp);
     }
 
-    T * get(void) const noexcept { return this->ptr; }
-    T & operator*(void) const { return *this->ptr; }
-    T * operator->(void) const noexcept { return this->ptr; }
-    explicit operator bool(void) const noexcept { return this->ptr != NULL; }
+    T* get(void) const noexcept
+    {
+        return this->ptr;
+    }
+    T& operator*(void) const
+    {
+        return *this->ptr;
+    }
+    T* operator->(void) const noexcept
+    {
+        return this->ptr;
+    }
+    explicit operator bool(void) const noexcept
+    {
+        return this->ptr != NULL;
+    }
 
-    void swap(SoRefPtr & other) noexcept
+    void swap(SoRefPtr& other) noexcept
     {
         using std::swap;
         swap(this->ptr, other.ptr);
     }
 
 private:
-    T * ptr;
+    T* ptr;
 };
 
 /** Convenience smart pointer to wrap coin node.

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1644,7 +1644,7 @@ void LinkView::updateLink()
 bool LinkView::linkGetElementPicked(const SoPickedPoint* pp, std::string& subname) const
 {
     std::ostringstream ss;
-    CoinPtr<SoPath> path{pp->getPath()};
+    CoinPtr<SoPath> path {pp->getPath()};
     if (!nodeArray.empty()) {
         auto idx = path->findNode(pcLinkRoot);
         if (idx < 0 || idx + 2 >= path->getLength()) {


### PR DESCRIPTION
This PR removes the dependency of CoinPtr on boost::intrusive_ptr because boost support has been removed from coin.