### PR TITLE
CAM: Grbl post inadvertently dropped from cmake.  Fixing

### DIFF
--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -325,6 +325,7 @@ SET(PathPythonPostScripts_SRCS
     Path/Post/scripts/gcode_pre.py
     Path/Post/scripts/generic_post.py
     Path/Post/scripts/generic_plasma_post.py
+    Path/Post/scripts/grbl_post.py
     Path/Post/scripts/heidenhain_legacy_post.py
     Path/Post/scripts/linuxcnc_post.py
     Path/Post/scripts/linuxcnc_legacy_post.py

--- a/src/Mod/CAM/Path/Post/scripts/grbl_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/grbl_post.py
@@ -54,8 +54,6 @@ Defaults = Dict[str, bool]
 Values = Dict[str, Any]
 Visible = Dict[str, bool]
 
-POST_TYPE = "machine"
-
 
 class Grbl(PostProcessor):
     """The Grbl post processor class."""


### PR DESCRIPTION
Restore missing file to cmakelists.txt