### PR TITLE
BIM: Remove 3D View cut when Arch_SectionPlane is deleted

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -1470,12 +1470,12 @@ class _ViewProviderSectionPlane:
             if hasattr(self, "txtfont") and hasattr(vobj, "FontSize"):
                 self.txtfont.size = vobj.FontSize.Value
         return
-        
+
     def onDelete(self, vobj, subelements):
 
         vobj.CutView = False
         return True
-            
+
     def dumps(self):
 
         return None


### PR DESCRIPTION
Fixes: #19669.

Additonally:
The `updateData` function has been modified to also trigger `self.refreshCutView(vobj)` when the Shape of the plane changes. This has two benefits: The clipped view is now also updated if the Placement of the plane is changed via the Property View, and the `singleShot` delay is no longer necessary.