### PR TITLE
Core: mark Rotation.isSame as const

### DIFF
--- a/src/Base/Rotation.pyi
+++ b/src/Base/Rotation.pyi
@@ -142,6 +142,7 @@ class Rotation(PyObjectBase):
         """
         ...
 
+    @constmethod
     def isSame(self, rotation: "Rotation", tol: float = 0, /) -> bool:
         """
         Checks if `rotation` perform the same transformation as this rotation.

--- a/src/Base/RotationPyImp.cpp
+++ b/src/Base/RotationPyImp.cpp
@@ -424,7 +424,7 @@ PyObject* RotationPy::toMatrix(PyObject* args) const
     return new MatrixPy(new Matrix4D(mat));
 }
 
-PyObject* RotationPy::isSame(PyObject* args)
+PyObject* RotationPy::isSame(PyObject* args) const
 {
     PyObject* rot {};
     double tol = 0.0;


### PR DESCRIPTION
The recent PR for the CAM workbench #27507 started using `Rotation.isSame` in PostList.py. The function was not marked as const and caused all operations to recompute after every post.

e.g. here:

https://github.com/FreeCAD/FreeCAD/blob/7886ebae105b99f176cddbfc62a106ab06a6d021/src/Mod/CAM/Path/Post/PostList.py#L141