### PR TITLE
CAM: Profile - Fix for bspline

### DIFF
--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -686,7 +686,7 @@ class ObjectProfile(PathAreaOp.ObjectOp):
         Path.Log.debug("_flattenWire()")
         wBB = wire.BoundBox
 
-        if wBB.ZLength > 0.0:
+        if not Path.Geom.isRoughly(wBB.ZLength, 0):
             Path.Log.debug("Wire is not horizontally co-planar. Flattening it.")
 
             # Extrude non-horizontal wire


### PR DESCRIPTION
Get error while creating **Profile** for top wire, created from bspline
[ForumExample.zip](https://github.com/user-attachments/files/26113335/ForumExample.zip)

<img width="474" height="291" alt="Screenshot_20260319_132506_lossy" src="https://github.com/user-attachments/assets/e6768206-a27e-440a-9f78-31c0216bb5d9" />


```
File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Profile.py", line 640, in _processSubs
    shapeTups.extend(self._processEdges(obj, basewires, edgelist))
  File "/home/user/projects/FreeCAD_build/Mod/CAM/Path/Op/Profile.py", line 658, in _processEdges
    shapeEnv = PathUtils.getEnvelope(Part.Face(f), depthparams=self.depthparams)
  File "/home/user/projects/FreeCAD_build/Mod/CAM/PathScripts/PathUtils.py", line 428, in getEnvelope
    sec = area.makeSections(heights=[0.0], project=True)[0].getShape()
<class 'IndexError'>: list index out of range
```

---

The reason in incorrect result of method `slice()`

https://github.com/FreeCAD/FreeCAD/blob/8718bc28feeb6e6caa7cb6b99230dd1875b6f963/src/Mod/CAM/Path/Op/Profile.py#L1248

<img width="837" height="419" alt="Screenshot_20260319_131542_lossy" src="https://github.com/user-attachments/assets/45008b22-5695-48aa-82c7-a6bad0e538f6" />

---

There is still present a chance to get result,
if exclude precision error while horizontal checks and skip `_makeCrossSection()` and `slice()`

https://github.com/FreeCAD/FreeCAD/blob/8718bc28feeb6e6caa7cb6b99230dd1875b6f963/src/Mod/CAM/Path/Op/Profile.py#L689