### PR TITLE
fix: TechDraw moveViews - fix undefined variable 'i' in enumerate loop

### DIFF
--- a/src/Mod/TechDraw/moveViews.py
+++ b/src/Mod/TechDraw/moveViews.py
@@ -61,7 +61,7 @@ def moveViews():
         print("Select 1 Drawing page and 1 TechDraw page")
         return
 
-    for o in dPage.OutList:
+    for i, o in enumerate(dPage.OutList):
         newName = "DraftView" + str(i).zfill(3)
         print("moving " + o.Name + " to " + newName)
         svg = svgHead + o.ViewResult + svgTail


### PR DESCRIPTION
## Problem
In `src/Mod/TechDraw/moveViews.py`, the variable `i` was used 
in the for loop without being defined, which would cause a 
`NameError` at runtime.

## Fix
Replaced:
```python
for o in dPage.OutList:
```
With:
```python
for i, o in enumerate(dPage.OutList):
```

## Testing
Manually verified the fix resolves the undefined variable issue.
