### PR TITLE
CAM: Fix postprocessor dialog which hangs tests running in GUI mode. 

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPostCore.py
+++ b/src/Mod/CAM/CAMTests/TestPostCore.py
@@ -786,6 +786,7 @@ class TestJobPropertyOverrides(unittest.TestCase):
             "pierce_delay": 1000,
             "cooling_delay": 500,
             "force_rapid_feeds": False,
+            "show_dialog": False,  # Disable dialogs for automated tests
             **properties,
         }
 
@@ -909,13 +910,15 @@ class TestJobPropertyOverrides(unittest.TestCase):
         profile_op.Path = Path.Path(plasma_commands)
 
         try:
-            # Mock MachineFactory
+            # Mock MachineFactory to return our test machine with dialog disabled
             original_get_machine = MachineFactory.get_machine
             MachineFactory.get_machine = lambda name: machine
 
             # Test with no overrides (machine defaults)
             self.job.PostProcessorPropertyOverrides = "{}"
             processor = GenericPlasma(self.job, "", "", "mm")
+            # Ensure the processor uses our test machine with dialog disabled
+            processor._machine = machine
             results = processor.export2()
             gcode_no_override = ""
             for section_name, gcode in results:
@@ -924,6 +927,8 @@ class TestJobPropertyOverrides(unittest.TestCase):
             # Test with pierce_delay override
             self.job.PostProcessorPropertyOverrides = '{"pierce_delay": 2500}'  # 2.5 seconds
             processor = GenericPlasma(self.job, "", "", "mm")
+            # Ensure the processor uses our test machine with dialog disabled
+            processor._machine = machine
             results = processor.export2()
             gcode_with_override = ""
             for section_name, gcode in results:

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -285,6 +285,30 @@ def needsTcOp(oldTc, newTc):
 class PostProcessor:
     """Base Class.  All non-legacy postprocessors should inherit from this class."""
 
+    def __init_subclass__(cls, **kwargs):
+        """Automatically wrap pre_processing_dialog methods to check show_dialog setting."""
+        super().__init_subclass__(**kwargs)
+
+        # Auto-wrap pre_processing_dialog in subclasses
+        if hasattr(cls, "pre_processing_dialog"):
+            original = cls.pre_processing_dialog
+
+            def wrapped(self, *args, **kwargs):
+                # Base class logic - runs BEFORE subclass method
+                if hasattr(self, "_machine") and hasattr(self._machine, "postprocessor_properties"):
+                    show_dialog = self._machine.postprocessor_properties.get("show_dialog", True)
+                    if not show_dialog:
+                        Path.Log.debug(
+                            "Pre-processing dialog skipped (show_dialog=False in machine config)"
+                        )
+                        return True
+
+                # Call the original subclass method
+                return original(self, *args, **kwargs)
+
+            # Replace the subclass method with our wrapped version
+            cls.pre_processing_dialog = wrapped
+
     @classmethod
     def get_common_property_schema(cls) -> List[Dict[str, Any]]:
         """
@@ -401,6 +425,17 @@ class PostProcessor:
                 "label": translate("CAM", "Post-Tool Change"),
                 "default": "",
                 "help": translate("CAM", "G-code commands inserted after tool changes."),
+            },
+            {
+                "name": "show_dialog",
+                "type": "bool",
+                "label": translate("CAM", "Show Pre-processing Dialogs"),
+                "default": True,
+                "help": translate(
+                    "CAM",
+                    "Show interactive dialogs during post-processing. "
+                    "Disable for automated operation or testing.",
+                ),
             },
         ]
 


### PR DESCRIPTION
Fixes #28410 

Introduces     def __init_subclass__(cls, **kwargs) to do method injection in the base class.

If the machine definition includes show_dialog == false, the dialog will be suppressed. 
