### PR TITLE
CAM: Preferences - Default tolerance

### DIFF
--- a/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
@@ -78,6 +78,9 @@ If left empty no template will be preselected.</string>
               <property name="toolTip">
                <string>Default value for new jobs, used for computing Paths. Smaller increases accuracy, but slows down computation</string>
               </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
              </widget>
             </item>
             <item row="1" column="0">
@@ -88,7 +91,14 @@ If left empty no template will be preselected.</string>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="Gui::InputField" name="curveAccuracy"/>
+             <widget class="Gui::InputField" name="curveAccuracy">
+              <property name="toolTip">
+               <string>Uses while calculates arcs. Smaller increases accuracy, but slows down computation</string>
+              </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>

--- a/src/Mod/CAM/Path/Main/Gui/PreferencesJob.py
+++ b/src/Mod/CAM/Path/Main/Gui/PreferencesJob.py
@@ -49,6 +49,15 @@ class JobPreferencesPage:
         jobTemplate = self.form.leDefaultJobTemplate.text()
         geometryTolerance = Units.Quantity(self.form.geometryTolerance.text())
         curveAccuracy = Units.Quantity(self.form.curveAccuracy.text())
+
+        if not geometryTolerance:
+            geomTol = Units.Quantity(Path.Preferences.defaultGeometryTolerance(), Units.Length)
+            self.form.geometryTolerance.setText(geomTol.UserString)
+
+        if not curveAccuracy:
+            curveAcc = Units.Quantity(Path.Preferences.defaultLibAreaCurveAccuracy(), Units.Length)
+            self.form.curveAccuracy.setText(curveAcc.UserString)
+
         Path.Preferences.setJobDefaults(jobTemplate, geometryTolerance, curveAccuracy)
 
         if curveAccuracy:
@@ -167,9 +176,8 @@ class JobPreferencesPage:
 
         geomTol = Units.Quantity(Path.Preferences.defaultGeometryTolerance(), Units.Length)
         self.form.geometryTolerance.setText(geomTol.UserString)
-        self.form.curveAccuracy.setText(
-            Units.Quantity(Path.Preferences.defaultLibAreaCurveAccuracy(), Units.Length).UserString
-        )
+        curveAcc = Units.Quantity(Path.Preferences.defaultLibAreaCurveAccuracy(), Units.Length)
+        self.form.curveAccuracy.setText(curveAcc.UserString)
 
         self.form.leOutputFile.setText(Path.Preferences.defaultOutputFile())
         self.selectComboEntry(self.form.cboOutputPolicy, Path.Preferences.defaultOutputPolicy())

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -161,7 +161,7 @@ class ObjectJob:
         )
         obj.setEditorMode("CycleTime", 1)  # read-only
         obj.addProperty(
-            "App::PropertyDistance",
+            "App::PropertyLength",
             "GeometryTolerance",
             "Geometry",
             QT_TRANSLATE_NOOP(
@@ -723,6 +723,9 @@ class ObjectJob:
         return None
 
     def execute(self, obj):
+        if not obj.GeometryTolerance:
+            obj.GeometryTolerance = Path.Preferences.defaultGeometryTolerance()
+
         if getattr(obj, "Operations", None):
             # obj.Path = obj.Operations.Path
             self.getCycleTime()

--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -308,11 +308,11 @@ def defaultPostProcessorArgs():
 
 
 def defaultGeometryTolerance():
-    return preferences().GetFloat(GeometryTolerance, 0.01)
+    return preferences().GetFloat(GeometryTolerance, 0.01) or 0.01
 
 
 def defaultLibAreaCurveAccuracy():
-    return preferences().GetFloat(LibAreaCurveAccuracy, 0.01)
+    return preferences().GetFloat(LibAreaCurveAccuracy, 0.01) or 0.01
 
 
 def defaultFilePath():


### PR DESCRIPTION
Fixes #28459

- #28459 

- Do not allows to set negative value
- Replace zero by default value

https://github.com/user-attachments/assets/c2a0b561-4e55-47f6-91b2-6fadaa0eb134

---

Also `Job.GeometryTolerance` should not be negative,
so replaced `App::PropertyDistance` by `App::PropertyLength`

<img width="609" height="260" alt="Screenshot_20260320_065757_lossy" src="https://github.com/user-attachments/assets/5efc7987-781d-45d8-9b7b-dba8d2c64daa" />