### PR TITLE
CAM: allow applying RampEntryDressup to LeadInOutDressup

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
@@ -750,9 +750,10 @@ class CommandPathDressupRampEntry:
         }
 
     def IsActive(self):
-        op = PathDressup.selection()
-        if op:
-            return not PathDressup.hasEntryMethod(op)
+        if FreeCAD.ActiveDocument is not None:
+            for o in FreeCAD.ActiveDocument.Objects:
+                if o.Name[:3] == "Job":
+                    return True
         return False
 
     def Activated(self):

--- a/src/Mod/CAM/Path/Dressup/Utils.py
+++ b/src/Mod/CAM/Path/Dressup/Utils.py
@@ -35,15 +35,6 @@ def selection():
     return None
 
 
-def hasEntryMethod(path):
-    """hasEntryDressup(path) ... returns true if the given object already has an entry method attached."""
-    if "RampEntry" in path.Name or "LeadInOut" in path.Name:
-        return True
-    if "Dressup" in path.Name and hasattr(path, "Base"):
-        return hasEntryMethod(path.Base)
-    return False
-
-
 def baseOp(path):
     """baseOp(path) ... return the base operation underlying the given path"""
     if "Dressup" in path.Name:


### PR DESCRIPTION
This brings RampEntry in line with most of the other dressups, i.e. now it checks if the currently active document contains a "Job".

Previously the RampEntry dressup checked `hasEntryMethod` and disabled the command if the operation already has a entry method applied. Entry method ment either having a RampEntry or a LeadInOut dressup applied. The RampEntry dressup was the only dressup that checked if it should be active in that way. In particular, LeadInOut dressup does not check if RampEntry dressup exists.

Also, see the following image for an example where applying a RampEntry after a LeadInOut makes perfect sense (came up in this [comment](https://github.com/FreeCAD/FreeCAD/issues/28484#issuecomment-4101217129)):

<img width="1926" height="1055" alt="grafik" src="https://github.com/user-attachments/assets/10027867-21e4-4ff0-9205-e1663f6eb983" />

There currently is a workaround for this: apply the RampEntry and the LeadInOut separately to e.g. a Profile and then set the Base property in the RampEntry dressup to be the LeadInOut dressup. This is how the given example was created.
