### PR TITLE
BIM: fix sun path arc, sphere and ray ignoring Declination rotation

### DIFF
--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -1811,6 +1811,10 @@ class _ViewProviderSite:
         from pivy import coin
 
         obj = vobj.Object
+        declination_rot = FreeCAD.Rotation(
+            FreeCAD.Vector(0, 0, 1),
+            obj.Declination.Value if hasattr(obj, "Declination") else 0.0,
+        )
 
         # During document restore the view provider may be allocated without full runtime
         # initialization (attach()/node creation). If the scenegraph nodes we need are not yet
@@ -1907,7 +1911,7 @@ class _ViewProviderSite:
                 x = math.cos(az_rad) * xy_proj
                 y = math.sin(az_rad) * xy_proj
                 z = math.sin(alt_rad) * vobj.SolarDiagramScale
-                point = FreeCAD.Vector(x, y, z)
+                point = declination_rot * FreeCAD.Vector(x, y, z)
                 if hour_float < 10:
                     morning_points.append(point)
                 elif hour_float <= 14:
@@ -1916,7 +1920,7 @@ class _ViewProviderSite:
                     afternoon_points.append(point)
                 # Check if the current time is a full hour
                 if hour_float % 1 == 0:
-                    marker_coords.append(FreeCAD.Vector(x, y, z))
+                    marker_coords.append(point)
 
                 if hasattr(vobj, "ShowHourLabels") and vobj.ShowHourLabels:
                     if vobj.ShowHourLabels and (hour_float in [9.0, 12.0, 15.0]):
@@ -1926,10 +1930,9 @@ class _ViewProviderSite:
 
                         # Create a transform to position the text slightly offset from the marker
                         text_transform = coin.SoTransform()
-                        offset_vec = FreeCAD.Vector(x, y, z).normalize() * (
-                            vobj.SolarDiagramScale * 0.03
-                        )
-                        text_pos = FreeCAD.Vector(x, y, z).add(offset_vec)
+                        direction = FreeCAD.Vector(point).normalize()
+                        offset_vec = direction * (vobj.SolarDiagramScale * 0.03)
+                        text_pos = point + offset_vec
                         text_transform.translation.setValue(text_pos.x, text_pos.y, text_pos.z)
 
                         # Add a separator for this specific label
@@ -1997,7 +2000,7 @@ class _ViewProviderSite:
         y = math.sin(azimuth_rad) * xy_proj
         z = math.sin(altitude_rad) * vobj.SolarDiagramScale
         sun_pos_3d = vobj.SolarDiagramPosition.add(
-            FreeCAD.Vector(x, y, z)
+            declination_rot * FreeCAD.Vector(x, y, z)
         )  # Final absolute position
 
         self.sunTransform.translation.setValue(sun_pos_3d.x, sun_pos_3d.y, sun_pos_3d.z)

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -1441,6 +1441,8 @@ class _ViewProviderSite:
         elif prop == "Declination":
             self.onChanged(obj.ViewObject, "SolarDiagramPosition")
             self.updateTrueNorthRotation()
+            if hasattr(obj.ViewObject, "ShowSunPosition"):
+                self.updateSunPosition(obj.ViewObject)
         elif prop == "Terrain":
             self.updateCompassLocation(obj.ViewObject)
         elif prop == "Placement":

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -1422,8 +1422,8 @@ class _ViewProviderSite:
     def updateData(self, obj, prop):
         """Method called when the host object has a property changed.
 
-        If the Longitude or Latitude has changed, set the SolarDiagram to
-        update.
+        If Longitude, Latitude or TimeZone has changed, rebuild the solar
+        diagram and update the sun position arc, sphere and ray.
 
         If Terrain or Placement has changed, move the compass to follow it.
 
@@ -1437,6 +1437,7 @@ class _ViewProviderSite:
 
         if prop in ["Longitude", "Latitude", "TimeZone"]:
             self.onChanged(obj.ViewObject, "SolarDiagram")
+            self.updateSunPosition(obj.ViewObject)
         elif prop == "Declination":
             self.onChanged(obj.ViewObject, "SolarDiagramPosition")
             self.updateTrueNorthRotation()
@@ -1805,6 +1806,9 @@ class _ViewProviderSite:
 
     def updateSunPosition(self, vobj):
         """Calculates sun position and updates the sphere, path arc, and ray object."""
+        if not hasattr(vobj, "ShowSunPosition"):
+            return
+
         import math
         import Part
         import datetime


### PR DESCRIPTION
In the Coin3D scene graph, the static solar diagram sits inside `basesep` (a `SoSeparator`), after `self.coords` (a `SoTransform` whose rotation is driven by the Declination property), so it is automatically rotated. The sun path arc, hour markers and sphere are nodes under `sunSwitch`, which is a sibling of `basesep` directly under `vobj.Annotation` and therefore outside `self.coords`'s reach. The sun ray is a Draft document object with absolute world coordinates, also unaffected by any scene graph transform.

Apply a `FreeCAD.Rotation` from `Declination.Value` around Z at the top of `updateSunPosition` and use it for every computed point, including `sun_pos_3d`, from which both the sphere position and the sun ray endpoints are derived.

**Note**: in the long run it might be worth considering whether `sunSwitch` should be simply brought under `basesep`. But for now, the above is the least intrusive fix.

**Update**: this also fixes a pre-existing bugs, whereby the sun position (sphere, arc and ray) was not being updated when,

-  `Latitude`, `Longitude` or `Timezone` were being updated. No specific issue had been filed for this bug.
- `Declination` was being updated. No specific issue had been filed for this bug, either.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes: #28471

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
