### PR TITLE
CAM: DressupTag - Approximation

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -949,6 +949,16 @@ class ObjectTagDressup:
             "Tag",
             QT_TRANSLATE_NOOP("App::Property", "IDs of disabled holding tags"),
         )
+        obj.addProperty(
+            "App::PropertyBool",
+            "Approximation",
+            "Path",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Split B-Spline by arcs and ignore not vertical arcs axis (experimental).",
+            ),
+        )
+        obj.setEditorMode("Approximation", 2)  # hide
 
         self.obj = obj
         self.solids = []
@@ -978,6 +988,17 @@ class ObjectTagDressup:
 
     def onDocumentRestored(self, obj):
         self.obj = obj
+        if not hasattr(obj, "Approximation"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "Approximation",
+                "Path",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Split B-Spline by arcs and ignore not vertical arcs axis (experimental).",
+                ),
+            )
+            obj.setEditorMode("Approximation", 2)  # hide
 
     def supportsTagGeneration(self, obj):
         if not self.pathData:
@@ -1105,7 +1126,13 @@ class ObjectTagDressup:
                             )
                     else:
                         commands.extend(
-                            Path.Geom.cmdsForEdge(edge, hSpeed=horizFeed, vSpeed=vertFeed, tol=tol)
+                            Path.Geom.cmdsForEdge(
+                                edge,
+                                approximation=obj.Approximation,
+                                hSpeed=horizFeed,
+                                vSpeed=vertFeed,
+                                tol=tol,
+                            )
                         )
                 edge = None
                 t = 0


### PR DESCRIPTION
Added hidden property `Approximation`, which uses feature in method `Path.Geom.cmdsForEdge()` (#22080)
This allows to decrease amount of commands if path contains not horizontal arc moves, e.g. helix path

[helix_tag.zip](https://github.com/user-attachments/files/26155981/helix_tag.zip)

Amount commands:
- approximation **Off** - 618
- approximation **On** - 175

<img width="941" height="309" alt="Screenshot_20260321_084118_lossy" src="https://github.com/user-attachments/assets/5a52f872-5c67-4cca-aea1-3f9ae24fefc5" />

---

> [!NOTE]
> **DressupTag** itself not so stable and in some cases return incorrect result
> Suggest to keep `Approximation` property hidden and disabled by default 
> So user should use this only if needed, and must have ability to disable this feature to exclude extra factor in case problems