### PR TITLE
CAM: Fixes precision error with math.ceil()

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathRotaryParallel.py
+++ b/src/Mod/CAM/CAMTests/TestPathRotaryParallel.py
@@ -140,7 +140,7 @@ class TestPathRotaryParallel(PathTestBase):
         )
         # Expected: angular_step = axial_stepover / radius
         expected_angular_step = axial_stepover / radius
-        expected_passes = int(math.ceil(abs(theta_end - theta_start) / expected_angular_step)) + 1
+        expected_passes = Path.Geom.ceil(abs(theta_end - theta_start) / expected_angular_step) + 1
 
         a_values = [c.Parameters["A"] for c in commands if c.Name == "G1" and "A" in c.Parameters]
         # Distinct A values within float tolerance.

--- a/src/Mod/CAM/CAMTests/TestPathRotaryRings.py
+++ b/src/Mod/CAM/CAMTests/TestPathRotaryRings.py
@@ -99,7 +99,7 @@ class TestPathRotaryRings(PathTestBase):
 
         x_min, x_max = 0.0, 8.0
         axial_stepover = 2.0
-        expected_rings = int(math.ceil((x_max - x_min) / axial_stepover)) + 1
+        expected_rings = Path.Geom.ceil((x_max - x_min) / axial_stepover) + 1
 
         cmds = rotary_rings.generate(
             **_default_args(

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -186,7 +186,7 @@ def generate(
     else:
         Path.Log.debug("(annulus mode)\n")
         work_distance = outer_radius - inner_radius
-        nr = math.ceil(round(work_distance / step, 6)) + 1
+        nr = Path.Geom.ceil(work_distance / step) + 1
         radii = linspace(outer_radius, inner_radius, nr)
 
     if startAt == "Inside":
@@ -202,7 +202,7 @@ def generate(
 
         lengthOneTurn = math.tau * r
         depthPerOneCircle = min(lengthOneTurn * math.tan(ramp_angle_rad), pitch)
-        turncount = math.ceil(round(helixHeight / depthPerOneCircle, 6))
+        turncount = Path.Geom.ceil(helixHeight / depthPerOneCircle)
         zsteps = linspace(topCenterPoint.z, bottomCenterPoint.z, 2 * turncount + 1)
 
         arc_cmd = "G2" if direction == "CW" else "G3"
@@ -286,7 +286,7 @@ def generate(
 
         lengthOneTurn = math.tau * bottomRadius
         depthPerOneCircle = min(lengthOneTurn * math.tan(ramp_angle_rad), pitch)
-        turncount = math.ceil(round(helixHeight / depthPerOneCircle, 6))
+        turncount = Path.Geom.ceil(helixHeight / depthPerOneCircle)
         stepsPerRev = 6
         stepRotate = math.tau / stepsPerRev  # step angle for rotate
         stepRotate = -stepRotate if direction == "CCW" else stepRotate

--- a/src/Mod/CAM/Path/Base/Generator/rotary_parallel.py
+++ b/src/Mod/CAM/Path/Base/Generator/rotary_parallel.py
@@ -190,12 +190,12 @@ def generate(
     # Axial sample density: same convention as the Spiral pattern's
     # grid x-step. Approximately 4 samples per axial_stepover.
     x_sample_step = max(axial_stepover * 0.25, 1e-3)
-    n_x_samples = max(2, int(math.ceil((x_max - x_min) / x_sample_step)) + 1)
+    n_x_samples = max(2, Path.Geom.ceil((x_max - x_min) / x_sample_step) + 1)
 
     # Angular pass count. Always include the start; the end is included
     # if it falls (within tolerance) on a stepover boundary.
     total_theta_span = direction * abs(theta_end - theta_start)
-    n_passes = max(1, int(math.ceil(abs(total_theta_span) / angular_step)) + 1)
+    n_passes = max(1, Path.Geom.ceil(abs(total_theta_span) / angular_step) + 1)
 
     commands = []
     feed_clamp = _FeedClamp()

--- a/src/Mod/CAM/Path/Base/Generator/rotary_rings.py
+++ b/src/Mod/CAM/Path/Base/Generator/rotary_rings.py
@@ -147,7 +147,7 @@ def generate(
     -----
     Ring count formula::
 
-        n_rings = int(math.ceil((x_max - x_min) / axial_stepover)) + 1
+        n_rings = math.ceil((x_max - x_min) / axial_stepover) + 1
 
     The +1 ensures both endpoints (x_min and x_max) get a ring; rings
     are evenly distributed between the two via interpolation by `t` in
@@ -179,7 +179,7 @@ def generate(
                 grid[i][j] = max_r
 
     # Ring count: include both endpoints.
-    n_rings = int(math.ceil((x_max - x_min) / axial_stepover)) + 1
+    n_rings = Path.Geom.ceil((x_max - x_min) / axial_stepover) + 1
     if n_rings < 2:
         n_rings = 2
 
@@ -187,7 +187,7 @@ def generate(
     direction = 1.0 if cut_mode == "Climb" else -1.0
     theta_span = theta_end - theta_start  # typically 2*pi
     # Number of angular sub-steps within a ring.
-    n_steps_per_ring = max(1, int(math.ceil(abs(theta_span) / angular_resolution)))
+    n_steps_per_ring = max(1, Path.Geom.ceil(abs(theta_span) / angular_resolution))
 
     commands = []
     feed_clamp = _FeedClamp()

--- a/src/Mod/CAM/Path/Base/Generator/rotary_spiral.py
+++ b/src/Mod/CAM/Path/Base/Generator/rotary_spiral.py
@@ -290,7 +290,7 @@ def generate(
     direction = 1.0 if cut_mode == "Climb" else -1.0
     n_revs = (x_max - x_min) / axial_stepover
     total_theta_span = direction * n_revs * 2.0 * math.pi
-    n_steps = max(1, int(math.ceil(abs(total_theta_span) / angular_resolution)))
+    n_steps = max(1, Path.Geom.ceil(abs(total_theta_span) / angular_resolution))
 
     commands = []
 

--- a/src/Mod/CAM/Path/Base/Generator/rotation.py
+++ b/src/Mod/CAM/Path/Base/Generator/rotation.py
@@ -578,7 +578,7 @@ def _expand_solution_space(
 
             # Generate k*360° equivalents
             k_min = math.floor((axis.min_limit - base_angle) / 360)
-            k_max = math.ceil((axis.max_limit - base_angle) / 360)
+            k_max = Path.Geom.ceil((axis.max_limit - base_angle) / 360)
 
             for k in range(int(k_min) - 1, int(k_max) + 2):
                 angle = base_angle + k * 360
@@ -589,7 +589,7 @@ def _expand_solution_space(
             if axis.allow_flip:
                 flip_angle = base_angle + 180
                 k_min = math.floor((axis.min_limit - flip_angle) / 360)
-                k_max = math.ceil((axis.max_limit - flip_angle) / 360)
+                k_max = Path.Geom.ceil((axis.max_limit - flip_angle) / 360)
 
                 for k in range(int(k_min) - 1, int(k_max) + 2):
                     angle = flip_angle + k * 360

--- a/src/Mod/CAM/Path/Base/Generator/spiral.py
+++ b/src/Mod/CAM/Path/Base/Generator/spiral.py
@@ -166,7 +166,7 @@ def generate(
     turnDivider = n * CIRCLE_POINTS  # should be n*6 (e.g. 6, 12, ...)
     stepAngle = math.tau / turnDivider  # step angle for rotate
     stepAngle = -stepAngle if direction == "CCW" else stepAngle
-    turns = math.ceil(round((outer_radius - inner_radius) / step, 6))  # amount of spiral turns
+    turns = Path.Geom.ceil((outer_radius - inner_radius) / step)  # amount of spiral turns
     iters = turns * turnDivider
     stepRadius = (outer_radius - inner_radius) / iters  # changes spiral radius on each step
     stepRadius = -stepRadius if startAt == "Outside" else stepRadius

--- a/src/Mod/CAM/Path/Base/Generator/spiral_facing.py
+++ b/src/Mod/CAM/Path/Base/Generator/spiral_facing.py
@@ -187,7 +187,6 @@ def spiral(
     in the limiting direction. This eliminates any uncleared areas in the center regardless of stepover% value.
     First engagement is preserved exactly at the requested percentage.
     """
-    import math
     import Path
     import FreeCAD
     from . import facing_common
@@ -220,7 +219,7 @@ def spiral(
     if total_radial_distance <= 0:
         actual_stepover = stepover_dist
     else:
-        number_of_intervals = math.ceil(total_radial_distance / stepover_dist)
+        number_of_intervals = Path.Geom.ceil(total_radial_distance / stepover_dist)
         actual_stepover = total_radial_distance / number_of_intervals
 
     Path.Log.debug(

--- a/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/LeadInOut.py
@@ -692,7 +692,7 @@ class ObjectDressup:
         else:
             stepLength = self.tolerance * 10
             stepAngle = stepLength / radius
-        stepAngle = angle / math.ceil(round(angle / stepAngle, 6))
+        stepAngle = angle / Path.Geom.ceil(angle / stepAngle)
 
         return stepAngle
 

--- a/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/RampEntry.py
@@ -527,7 +527,7 @@ class ObjectDressup:
         rampheight = abs(startZ - rampedges[-1].end_point[2])
 
         max_rise_over_run = 1 / math.tan(math.radians(self.angle))
-        num_loops = math.ceil(round(rampheight / ramplen / max_rise_over_run, 6))
+        num_loops = Path.Geom.ceil(rampheight / ramplen / max_rise_over_run)
         rampedges *= num_loops
         ramplen *= num_loops
 

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -736,7 +736,7 @@ class PathData:
         tags = []
         maxLength = max(w.Length for w in self.baseWires)
         for wire in self.baseWires:
-            optimalCount = math.ceil(round(wire.Length / maxLength * maxCount, 6))
+            optimalCount = Path.Geom.ceil(wire.Length / maxLength * maxCount)
             numberTags = max(minCount, optimalCount)
 
             # copy edge list into python array for (much) faster random access
@@ -861,7 +861,7 @@ class PathData:
         tagCount = 0
         currentLength += edge.Length
         if edge.Length >= minLength:
-            steps = max(0, math.ceil((currentLength - lastTagLength) / tagDistance) - 1)
+            steps = max(0, Path.Geom.ceil((currentLength - lastTagLength) / tagDistance) - 1)
             tagCount += steps
             lastTagLength += steps * tagDistance
             if tagCount > 0:

--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -40,6 +40,7 @@ __url__ = "https://www.freecad.org"
 __doc__ = "Functions to extract and convert between Path.Command and Part.Edge and utility functions to reason about them."
 
 Tolerance = 0.000001
+Decimal = 6
 
 translate = FreeCAD.Qt.translate
 
@@ -95,6 +96,12 @@ CmdMove = Constants.GCODE_MOVE
 CmdMoveAll = Constants.GCODE_MOVE_ALL
 
 
+def ceil(value, decimal=Decimal):
+    """ceil(value, [decimal=Decimal])
+    Rounding value to exclude precision error and returns ceiling result"""
+    return math.ceil(round(value, decimal))
+
+
 def isRoughly(float1, float2, error=Tolerance):
     """isRoughly(float1, float2, [error=Tolerance])
     Returns true if the two values are the same within a given error."""
@@ -108,7 +115,7 @@ def pointsCoincide(p1, p2, error=Tolerance):
 
 
 def edgesMatch(e0, e1, error=Tolerance):
-    """edgesMatch(e0, e1, [error=Tolerance]
+    """edgesMatch(e0, e1, [error=Tolerance])
     Return true if the edges start and end at the same point and have the same type of curve."""
     if type(e0.Curve) is not type(e1.Curve) or len(e0.Vertexes) != len(e1.Vertexes):
         return False
@@ -853,7 +860,7 @@ def combineHorizontalFaces(faces, keepOrder=False):
             horizontal = outer
 
     # restore order
-    if keepOrder:
+    if keepOrder and len(horizontal) > 1:
         ordered = [None] * len(faces)
         for face in horizontal:
             for i, f in enumerate(faces):

--- a/src/Mod/CAM/Path/Main/Gui/Simulator.py
+++ b/src/Mod/CAM/Path/Main/Gui/Simulator.py
@@ -336,7 +336,7 @@ class PathSimulation:
                 else:
                     da = -((-da) % (2 * math.pi))
                 r = math.sqrt((cmd.i or 0) ** 2 + (cmd.j or 0) ** 2)
-                n = math.ceil(math.sqrt(r / self.resolution * da * da))
+                n = Path.Geom.ceil(math.sqrt(r / self.resolution * da * da))
                 da = da / n
                 dz = (cmd.z - self.curpos.Base.z) / n
                 cmd.Name = "G1"

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -711,7 +711,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
             # Split depth by step down
             work_distance = obj.StartDepth.Value - obj.FinalDepth.Value
-            iters = math.ceil(round(work_distance / obj.StepDown.Value, 6))
+            iters = Path.Geom.ceil(work_distance / obj.StepDown.Value)
             centerTop = FreeCAD.Vector(hole["x"], hole["y"], obj.StartDepth.Value)
             centerBottom = FreeCAD.Vector(centerTop.x, centerTop.y, centerTop.z)
             retractDistance = safeHeight - obj.StartDepth.Value

--- a/src/Mod/CAM/Path/Op/Profile.py
+++ b/src/Mod/CAM/Path/Op/Profile.py
@@ -1306,7 +1306,8 @@ class ObjectProfile(PathAreaOp.ObjectOp):
             E = useWire.Edges[e]
             LE = E.Length
             if LE > (self.radius * 2):
-                nt = math.ceil(LE / (tagRad * math.pi))  # (tagRad * 2 * math.pi) is circumference
+                nt = Path.Geom.ceil(LE / (tagRad * math.pi))
+                # (tagRad * 2 * math.pi) is circumference
             else:
                 nt = 4  # desired + 1
             mid = LE / nt

--- a/src/Mod/CAM/Path/Op/RotarySurface.py
+++ b/src/Mod/CAM/Path/Op/RotarySurface.py
@@ -615,11 +615,11 @@ class ObjectRotarySurface(PathOp.ObjectOp):
         # x grid: dense enough to interpolate well across the spiral.
         x_step = min(step_over * 0.25, (x_max - x_min) / 8.0)
         x_step = max(x_step, 1e-3)
-        n_x = max(2, int(math.ceil((x_max - x_min) / x_step)) + 1)
+        n_x = max(2, Path.Geom.ceil((x_max - x_min) / x_step) + 1)
         xs = [x_min + (x_max - x_min) * i / (n_x - 1) for i in range(n_x)]
 
         # theta grid: full revolution at AngularResolution.
-        n_t = max(8, int(math.ceil(2.0 * math.pi / ang_res_rad)) + 1)
+        n_t = max(8, Path.Geom.ceil(2.0 * math.pi / ang_res_rad) + 1)
         thetas = [2.0 * math.pi * j / (n_t - 1) for j in range(n_t)]
 
         axis_vec = (rot_vec.x, rot_vec.y, rot_vec.z)
@@ -651,7 +651,7 @@ class ObjectRotarySurface(PathOp.ObjectOp):
         min_surface_r = min(valid_radii) if valid_radii else 0.0
         gap = max(0.0, stock_radius - (min_surface_r + stock_to_leave))
         if step_down > 0.0 and gap > 0.0:
-            n_layers = int(math.ceil(gap / step_down))
+            n_layers = Path.Geom.ceil(gap / step_down)
         else:
             n_layers = 1
 

--- a/src/Mod/CAM/Path/Op/Surface.py
+++ b/src/Mod/CAM/Path/Op/Surface.py
@@ -1608,7 +1608,7 @@ class ObjectSurface(PathOp.ObjectOp):
         ALL = []
         PTS = []
         optLinTrans = obj.OptimizeStepOverTransitions
-        safe = math.ceil(obj.SafeHeight.Value)
+        safe = Path.Geom.ceil(obj.SafeHeight.Value)
 
         if optLinTrans is True:
             for P in LN:
@@ -1667,7 +1667,7 @@ class ObjectSurface(PathOp.ObjectOp):
     def _planarMultipassProcess(self, obj, PNTS, lMax):
         output = []
         optimize = obj.OptimizeLinearPaths
-        safe = math.ceil(obj.SafeHeight.Value)
+        safe = Path.Geom.ceil(obj.SafeHeight.Value)
         lenPNTS = len(PNTS)
         prcs = True
         onHold = False

--- a/src/Mod/CAM/Path/Op/SurfaceSupport.py
+++ b/src/Mod/CAM/Path/Op/SurfaceSupport.py
@@ -134,17 +134,13 @@ class PathGeometryGenerator:
         # get X, Y, Z spans; Compute center of rotation
         self.deltaX = self.shape.BoundBox.XLength
         self.deltaY = self.shape.BoundBox.YLength
-        self.deltaC = (
-            self.shape.BoundBox.DiagonalLength
-        )  # math.sqrt(self.deltaX**2 + self.deltaY**2)
-        lineLen = self.deltaC + (
-            2.0 * self.toolDiam
-        )  # Line length to span boundbox diag with 2x cutter diameter extra on each end
-        self.halfDiag = math.ceil(lineLen / 2.0)
-        cutPasses = (
-            math.ceil(lineLen / self.cutOut) + 1
-        )  # Number of lines(passes) required to cover boundbox diagonal
-        self.halfPasses = math.ceil(cutPasses / 2.0)
+        self.deltaC = self.shape.BoundBox.DiagonalLength
+        # Line length to span boundbox diag with 2x cutter diameter extra on each end
+        lineLen = self.deltaC + 2.0 * self.toolDiam
+        self.halfDiag = Path.Geom.ceil(lineLen / 2.0)
+        # Number of lines(passes) required to cover boundbox diagonal
+        cutPasses = Path.Geom.ceil(lineLen / self.cutOut) + 1
+        self.halfPasses = Path.Geom.ceil(cutPasses / 2.0)
 
     # Public methods
     def setDebugObjectsGroup(self, tmpGrpObject):
@@ -266,7 +262,7 @@ class PathGeometryGenerator:
         loopCnt = 0
         segCnt = 0
         twoPi = 2.0 * math.pi
-        maxDist = math.ceil(self.cutOut * self._getRadialPasses())  # self.halfDiag
+        maxDist = Path.Geom.ceil(self.cutOut * self._getRadialPasses())  # self.halfDiag
         move = self.centerOfPattern  # Use to translate the center of the spiral
         lastPoint = FreeCAD.Vector(0.0, 0.0, 0.0)
 
@@ -378,12 +374,10 @@ class PathGeometryGenerator:
                 dist = CORNERS[c].sub(self.centerOfPattern).Length
                 if dist > dMax:
                     dMax = dist
-            diag = dMax + (
-                2.0 * self.toolDiam
-            )  # Line length to span boundbox diag with 2x cutter diameter extra on each end
-            radialPasses = (
-                math.ceil(diag / self.cutOut) + 1
-            )  # Number of lines(passes) required to cover boundbox diagonal
+            # Line length to span boundbox diag with 2x cutter diameter extra on each end
+            diag = dMax + 2.0 * self.toolDiam
+            # Number of lines(passes) required to cover boundbox diagonal
+            radialPasses = Path.Geom.ceil(diag / self.cutOut) + 1
 
         return radialPasses
 

--- a/src/Mod/CAM/Path/Op/Waterline.py
+++ b/src/Mod/CAM/Path/Op/Waterline.py
@@ -1317,7 +1317,7 @@ class ObjectWaterline(PathOp.ObjectOp):
 
             # Determine bounding box length for the OCL scan
             bbLength = math.fabs(ymax - ymin)
-            numScanLines = int(math.ceil(bbLength / smplInt) + 1)
+            numScanLines = Path.Geom.ceil(bbLength / smplInt) + 1
 
             # Run Scan (Grid  based)
             fd = depthparams[-1]

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -888,7 +888,7 @@ class depth_params(object):
         all steps are of equal size, which is as big as possible but not bigger
         than max_size."""
 
-        steps_needed = math.ceil((start - stop) / max_size)
+        steps_needed = Path.Geom.ceil((start - stop) / max_size)
         depths = list(linspace(stop, start, steps_needed, endpoint=False))
 
         return depths


### PR DESCRIPTION
### Description

I found that method `math.ceil()` should always be used with `round()` to exclude precision error
`math.ceil(expr)` should be replaced by `math.ceil(round(expr, 6))`

```
var = (5*3 + 5.1 - 5.1) / 5

var >>> 3.0000000000000004
math.ceil(var) >>> 4
```
we really need return 3, but not 4

```
math.ceil(round(var, 6)) >>> 3
```

### Changes

- Added method `Path.Geom.ceil()`
https://github.com/FreeCAD/FreeCAD/blob/b3250c0cf3bd2529b69d72d6088944fbac915d4a/src/Mod/CAM/Path/Geom.py#L99-L102

- Replaced all `math.ceil()` by `Path.Geom.ceil()` in **CAM** workbench