### PR TITLE
Build: Make Ubunttu package installation more fault-tolerant

### DIFF
--- a/package/ubuntu/install-apt-packages.sh
+++ b/package/ubuntu/install-apt-packages.sh
@@ -3,7 +3,12 @@ set -euo pipefail
 
 # Add the KDE Neon repository for up-to-date and matching Qt6 and PySide packages
 # Ubuntu 24.04 does not have PySide6 packages available
-sudo wget -qO- http://archive.neon.kde.org/public.key | sudo gpg --dearmor -o /usr/share/keyrings/neon-keyring.gpg
+KEY=$(wget --retry-connrefused --waitretry=3 --tries=5 -qO- https://archive.neon.kde.org/public.key)
+if [ -z "$KEY" ]; then
+  echo "Failed to download KDE Neon GPG key" >&2
+  exit 1
+fi
+echo "$KEY" | sudo gpg --dearmor -o /usr/share/keyrings/neon-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/neon-keyring.gpg] http://archive.neon.kde.org/user noble main" | sudo tee /etc/apt/sources.list.d/neon-qt.list
 
 # Update package lists quietly


### PR DESCRIPTION
Today we've had a lot of failures in the CI that seem related to intermittent failure to download from `http://archive.neon.kde.org/` -- add a bit of protection to those calls so they aren't as fragile. I also switch that fetch to https for good measure.