### PR TITLE
Build: Make macOS CI builds more resilient to net failure

### DIFF
--- a/package/rattler-build/osx/create_bundle.sh
+++ b/package/rattler-build/osx/create_bundle.sh
@@ -105,5 +105,15 @@ fi
 sha256sum ${version_name}.dmg > ${version_name}.dmg-SHA256.txt
 
 if [[ "${UPLOAD_RELEASE}" == "true" ]]; then
-    gh release upload --clobber ${BUILD_TAG} "${version_name}.dmg" "${version_name}.dmg-SHA256.txt"
+    for attempt in 1 2 3 4 5; do
+        if gh release upload --clobber ${BUILD_TAG} "${version_name}.dmg" "${version_name}.dmg-SHA256.txt"; then
+            break
+        fi
+        if [[ $attempt -eq 5 ]]; then
+            echo "Failed to upload release after 5 attempts" >&2
+            exit 1
+        fi
+        echo "Upload attempt $attempt failed, retrying in $((attempt * 10))s..."
+        sleep $((attempt * 10))
+    done
 fi

--- a/package/scripts/macos_sign_and_notarize.zsh
+++ b/package/scripts/macos_sign_and_notarize.zsh
@@ -247,7 +247,16 @@ print "Notarization submission ID: $id"
 
 if wait_for_notarization_result "$id"; then
   print "✅ Notarization succeeded. Stapling..."
-  xcrun stapler staple "${DMG_NAME}"
+  local staple_attempt=0
+  while ! xcrun stapler staple "${DMG_NAME}"; do
+    (( staple_attempt++ ))
+    if [[ $staple_attempt -ge 5 ]]; then
+      print "❌ Failed to staple after 5 attempts" >&2
+      exit 1
+    fi
+    print "Staple attempt $staple_attempt failed, retrying in $((staple_attempt * 10))s..."
+    sleep $((staple_attempt * 10))
+  done
   print "Stapled: ${DMG_NAME}"
   rm -f "${ID_FILE}"
 else


### PR DESCRIPTION
Fixes #26439 -- there are a couple of different macOS CI/build failures that we've encountered over the last several months. This PR mitigates those issues by adding retry-loops around the things that have failed (generally network accesses). I used a simple linear back-off here, which seemed adequate to me. We don't really know what's causing these failures, exactly, but this will give us a couple of minutes worth of retry.