### PR TITLE
Let setupTitleBar replace existing title bar, to avoid need to first remove any existing (#14650)

### DIFF
--- a/src/Gui/DockWindowManager.cpp
+++ b/src/Gui/DockWindowManager.cpp
@@ -542,7 +542,7 @@ void DockWindowManager::setup(DockWindowItems* items)
             docked.removeAt(index);
         }
 
-        if (d->overlayManager && dw && visible) {
+        if (d->overlayManager && dw && visible && !dw->titleBarWidget()) {
             d->overlayManager->setupDockWidget(dw);
         }
     }

--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -999,8 +999,10 @@ public:
 
     void setupTitleBar(QDockWidget* dock)
     {
-        if (!dock->titleBarWidget()) {
-            dock->setTitleBarWidget(createTitleBar(dock));
+        auto* oldWidget = dock->titleBarWidget();
+        dock->setTitleBarWidget(createTitleBar(dock));
+        if (oldWidget) {
+            oldWidget->deleteLater();
         }
     }
 
@@ -1674,11 +1676,6 @@ void OverlayManager::onDockFeaturesChange(QDockWidget::DockWidgetFeatures featur
     }
 
     // Rebuild the title widget as it may have a different set of buttons shown.
-    if (auto* titleBarWidget = qobject_cast<OverlayTitleBar*>(dw->titleBarWidget())) {
-        dw->setTitleBarWidget(nullptr);
-        delete titleBarWidget;
-    }
-
     setupTitleBar(dw);
 }
 

--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -1843,12 +1843,10 @@ void OverlayTabWidget::removeWidget(QDockWidget* dock, QDockWidget* lastDock)
         hide();
     }
 
-    w = dock->titleBarWidget();
-    if (w && w->objectName() == QStringLiteral("OverlayTitle")) {
-        dock->setTitleBarWidget(nullptr);
-        w->deleteLater();
+    auto tw = dock->titleBarWidget();
+    if (!tw || tw->objectName() == QStringLiteral("OverlayTitle")) {
+        OverlayManager::instance()->setupTitleBar(dock);
     }
-    OverlayManager::instance()->setupTitleBar(dock);
 
     dock->setFeatures(dock->features() | QDockWidget::DockWidgetFloatable);
 


### PR DESCRIPTION
Fixes #14650

To update the title bar in the QDockWidget, the existing code, in OverlayManager::onDockFeaturesChange, first removed the title bar by setting it to null and then called setupTitleBar to have an updated title bar setup. It appears that removing the title bar would move the QDockWidget 31 pixels downward, while setting the new title bar would not move the widget.

This change changes the semantics of setupTitleBar to always set a new title bar, and delete any existing, instead of only setup a new if no title bar existed. This avoids the need to remove the old title bar first,

Other call sites are updated as well. It seemed that one other call site had the same remove-then-setup code and therefore benefited, one used a just-created and therefore was unaffected, and one call site had to be guarded. So it was chosen not to add e.g. a "forceOverwrite" flag to the method.