### PR TITLE
Gui: Fix UB/ASAN crash in SoFCUnifiedSelection

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -2147,7 +2147,7 @@ int SelectionSingleton::checkSelection(
 std::string SelectionSingleton::getSelectedElement(App::DocumentObject* obj, const char* pSubName) const
 {
     if (!obj) {
-        return nullptr;
+        return {};
     }
     auto context = getSelectionContext(obj->getDocument()->getName());
 

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -790,8 +790,9 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
         // We need to convert the short name in the selection to a full element path to look it up
         // Ex:  Body.Pad.Face9  to Body.Pad.;g3;SKT;:H12dc,E;FAC;:H12dc:4,F;:G0;XTR;:H12dc:8,F.Face9
         getFullSubElementName(subName);
-        const char* subSelected
-            = Gui::Selection().getSelectedElement(vpd->getObject(), subName.c_str()).c_str();
+        std::string selectedElement
+            = Gui::Selection().getSelectedElement(vpd->getObject(), subName.c_str());
+        const char* subSelected = selectedElement.empty() ? nullptr : selectedElement.c_str();
 
         FC_TRACE(
             "select " << (subSelected ? subSelected : "'null'") << ", " << objectName << ", " << subName


### PR DESCRIPTION
PR #21978 changed `getSelectedElement()` to return a `std::string`, but a piece of calling code was not updated. This resulted in it calling `.c_str()` on a temporary and hanging onto the pointer. When run with ASAN on, the end result was that a Sketch plane could not be selected by clicking in the 3D view, which would crash. Also fixes a bit of related UB in Selection.cpp which was returning a `nullptr`-initialized std::string.