### PR TITLE
CAM: Pocket_Shape - Fixes depth of the last step down

### DIFF
--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -185,8 +185,6 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
     def areaOpShapes(self, obj):
         """areaOpShapes(obj) ... return shapes representing the solids to be removed."""
         Path.Log.track()
-        self.removalshapes = []
-
         # self.isDebug = True if Path.Log.getLevel(Path.Log.thisModule()) == 4 else False
         self.removalshapes = []
         avoidFeatures = list()
@@ -250,22 +248,13 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             # check all faces and see if they are touching/overlapping and combine and simplify
             self.horizontal = Path.Geom.combineHorizontalFaces(self.horiz)
 
-            # Move all faces to final depth less buffer before extrusion
-            # Small negative buffer is applied to compensate for internal significant digits/rounding issue
-            if self.job.GeometryTolerance.Value == 0.0:
-                buffer = 0.000001
-            else:
-                buffer = self.job.GeometryTolerance.Value / 10.0
+            # removalshapes should be lower than FinalDepth and higher than StartDepth
             for h in self.horizontal:
-                h.translate(
-                    FreeCAD.Vector(0.0, 0.0, obj.FinalDepth.Value - h.BoundBox.ZMin - buffer)
-                )
-
-            # extrude all faces up to StartDepth plus buffer and those are the removal shapes
-            extent = FreeCAD.Vector(0, 0, obj.StartDepth.Value - obj.FinalDepth.Value + buffer)
-            self.removalshapes = [
-                (face.removeSplitter().extrude(extent), False) for face in self.horizontal
-            ]
+                # move each face on height below 1 mm of FinalDepth
+                h.translate(FreeCAD.Vector(0, 0, obj.FinalDepth.Value - h.BoundBox.ZMin - 1))
+                # extrude each face to height 1 mm above StartDepth
+                v = FreeCAD.Vector(0, 0, obj.StartDepth.Value - obj.FinalDepth.Value + 2)
+                self.removalshapes.append((h.removeSplitter().extrude(v), False))
 
         else:  # process the job base object as a whole
             Path.Log.debug("processing the whole job base object")


### PR DESCRIPTION
> [!NOTE]
> There is another PR #28609 which also fix the same issues, but at low level
>
> This PR is also useful, because it makes code shorter and simpler
> With this changes no slice operation in extreme height, which exclude the reason of any precision error, so solution more stable to future changes in OCC

---

Fixes #28534
Fixes #10022
- #28534
- #10022

<img width="1704" height="636" alt="Screenshot_20260322_211654_hor" src="https://github.com/user-attachments/assets/fbf54a66-fcc3-491c-ab72-3ae5c98f06c8" />

---

Shape creates lower than `FinalDepth`, with very small distance `buffer`

https://github.com/FreeCAD/FreeCAD/blob/2a8f35eae90601324b46bfee58540c4c7e9286f8/src/Mod/CAM/Path/Op/PocketShape.py#L255-L262

<img width="990" height="501" alt="Screenshot_20260322_213005_hor" src="https://github.com/user-attachments/assets/0694a68a-f66c-4725-997a-cbf3a083241f" />

Some times this is not enough to exclude precision errors and code below returns empty wire 

https://github.com/FreeCAD/FreeCAD/blob/2a8f35eae90601324b46bfee58540c4c7e9286f8/src/Mod/CAM/App/Area.cpp#L1933-L1939

---

We have no real limitation at which distance move shape and how far to extrude
Important only that all depths should be inside this shape
Suggest to use bigger value, e.g. "magic" 1 mm to exclude any precision errors

<img width="990" height="501" alt="Screenshot_20260322_213057_hor" src="https://github.com/user-attachments/assets/37b8bb0d-bb69-411a-b500-c8a532c934b2" />

---

<img width="844" height="327" alt="Screenshot_20260322_210340_hor_lossy" src="https://github.com/user-attachments/assets/d8c5726e-4ba7-445c-b3e7-d4e5d09e7c03" />
