### PR TITLE
Tools: Add language code mapping for Swedish (sv-SE -> sv)

### DIFF
--- a/src/Tools/updatecrowdin.py
+++ b/src/Tools/updatecrowdin.py
@@ -93,6 +93,14 @@ TsFile = namedtuple("TsFile", ["filename", "src_path"])
 
 LEGACY_NAMING_MAP = {"Draft.ts": "draft.ts"}
 
+# Map Crowdin language codes to standard ISO 639-1 codes for filenames.
+# Crowdin uses "sv-SE" for Swedish but per ISO 639-1, "sv" is the correct
+# generic code (covers sv-SE, sv-FI, sv-AX).
+# See: https://github.com/FreeCAD/FreeCAD-translations/issues/359
+LANGUAGE_CODE_MAP = {
+    "sv-SE": "sv",
+}
+
 # Locations that require QM file generation (predominantly Python workbenches)
 GENERATE_QM = {
     "AddonManager",
@@ -349,6 +357,9 @@ def load_token():
 def updateqrc(qrcpath, lncode):
     "updates a qrc file with the given translation entry"
 
+    # Apply language code mapping for filenames
+    filecode = LANGUAGE_CODE_MAP.get(lncode, lncode)
+
     # print("opening " + qrcpath + "...")
 
     # getting qrc file contents
@@ -362,7 +373,7 @@ def updateqrc(qrcpath, lncode):
     f.close()
 
     # checking for existing entry
-    name = "_" + lncode + ".qm"
+    name = "_" + filecode + ".qm"
     for r in resources:
         if name in r:
             # print("language already exists in qrc file")
@@ -385,10 +396,10 @@ def updateqrc(qrcpath, lncode):
     # inserting new entry just after the last one
     line = resources[pos]
     if ".qm" in line:
-        line = re.sub(r"_.*\.qm", "_" + lncode + ".qm", line)
+        line = re.sub(r"_.*\.qm", "_" + filecode + ".qm", line)
     else:
         modname = os.path.splitext(os.path.basename(qrcpath))[0]
-        line = "        <file>translations/" + modname + "_" + lncode + ".qm</file>\n"
+        line = "        <file>translations/" + modname + "_" + filecode + ".qm</file>\n"
         # print "ERROR: no existing qm entry in this resource: Please add one manually " + qrcpath
         # sys.exit()
     # print("inserting line: ",line)
@@ -421,7 +432,8 @@ def updateTranslatorCpp(lncode):
     for i, l in enumerate(cppcode):
         if l.startswith("    d->mapLanguageTopLevelDomain[QT_TR_NOOP("):
             lastentry = i
-            if '"' + lncode + '"' in l:
+            _filecode = LANGUAGE_CODE_MAP.get(lncode, lncode)
+            if '"' + lncode + '"' in l or '"' + _filecode + '"' in l:
                 # print(lnname+" ("+lncode+") already exists in Translator.cpp")
                 return
 
@@ -432,9 +444,11 @@ def updateTranslatorCpp(lncode):
         sys.exit()
 
     # inserting new entry just before the above line
-    line = '    d->mapLanguageTopLevelDomain[QT_TR_NOOP("' + lnname + '")] = "' + lncode + '";\n'
+    # Use mapped language code for the domain (e.g. sv-SE -> sv)
+    filecode = LANGUAGE_CODE_MAP.get(lncode, lncode)
+    line = '    d->mapLanguageTopLevelDomain[QT_TR_NOOP("' + lnname + '")] = "' + filecode + '";\n'
     cppcode.insert(pos, line)
-    print(lnname + " (" + lncode + ") added Translator.cpp")
+    print(lnname + " (" + filecode + ") added Translator.cpp")
 
     # writing the file
     f = open(cppfile, "w")
@@ -452,7 +466,9 @@ def doFile(tsfilepath, targetpath, lncode, qrcpath):
         basename = list(LEGACY_NAMING_MAP)[
             list(LEGACY_NAMING_MAP.values()).index(basename + ".ts")
         ][:-3]
-    newname = basename + "_" + lncode + ".ts"
+    # Apply language code mapping (e.g. sv-SE -> sv)
+    filecode = LANGUAGE_CODE_MAP.get(lncode, lncode)
+    newname = basename + "_" + filecode + ".ts"
     newpath = targetpath + os.sep + newname
     if not os.path.exists(tsfilepath):
         # If this language code does not exist for the given TS file, bail out
@@ -470,7 +486,7 @@ def doFile(tsfilepath, targetpath, lncode, qrcpath):
             )
         except Exception as e:
             print(e)
-        newqm = targetpath + os.sep + basename + "_" + lncode + ".qm"
+        newqm = targetpath + os.sep + basename + "_" + filecode + ".qm"
         if not os.path.exists(newqm):
             print("ERROR: failed to create " + newqm + ", aborting")
             sys.exit()


### PR DESCRIPTION
## Summary

Add `LANGUAGE_CODE_MAP` to `updatecrowdin.py` that maps Crowdin's `sv-SE` language code to the standard ISO 639-1 `sv` code.

### What this changes

- `LANGUAGE_CODE_MAP = {"sv-SE": "sv"}` — maps Crowdin language IDs to standard codes
- Generated `.ts` filenames: `*_sv.ts` instead of `*_sv-SE.ts`
- Generated `.qm` filenames: `*_sv.qm` instead of `*_sv-SE.qm`
- `.qrc` resource file entries updated accordingly
- `Translator.cpp` language domain mapping uses `sv`

### Why

Per ISO 639-1, `sv` is the correct generic code for Swedish (covers sv-SE, sv-FI, sv-AX). Using `sv-SE` is overly specific and inconsistent with how other languages are handled in FreeCAD.

### Approach

Instead of modifying the autogenerated `.ts` files directly (as in #23928), this PR modifies the tool that generates them. The mapping is extensible for any future language code corrections.

### Related

- Fixes https://github.com/FreeCAD/FreeCAD-translations/issues/359
- Supersedes #23928 (which modified autogenerated files directly, as noted by @chennes)
- The Crowdin project should also update its target language from `sv-SE` to `sv`

### Testing

The change is additive — only affects Swedish (`sv-SE`) files. Other languages are unaffected since they pass through the map unchanged.

cc @chennes @hyarion @luzpaz