### PR TITLE
CAM: Fixes for machine-based postprocessing bugs

### DIFF
--- a/src/Mod/CAM/CAMTests/TestCAMSanity.py
+++ b/src/Mod/CAM/CAMTests/TestCAMSanity.py
@@ -63,7 +63,12 @@ class TestCAMSanity(PathTestBase):
             S = Sanity.CAMSanity(self.job)
 
     def test010(self):
-        # """Test CAMSanity using a DummyImageBuilder"""
+        """Test CAMSanity using a DummyImageBuilder.
+
+        Given: A valid CAM job (boxtest.fcstd) and a DummyImageBuilder.
+        When: CAMSanity is instantiated with a temp output file.
+        Then: The instance is created with the correct filelocation and output_file attributes.
+        """
         with patch(
             "Path.Main.Sanity.ImageBuilder.ImageBuilderFactory.get_image_builder"
         ) as mock_factory:
@@ -144,7 +149,7 @@ class TestCAMSanity(PathTestBase):
 
         for key in data.keys():
             if isinstance(key, int):
-                val = data["key"]
+                val = data[key]
                 self.assertIsInstance(val, dict)
                 self.assertIn("bitShape", val)
                 self.assertIn("description", val)
@@ -272,14 +277,21 @@ class TestCAMSanity(PathTestBase):
                 self.assertIn("shape", val)
                 self.assertIn("partNumber", val)
 
-    # def test140(self):
-    #     """Test Generate Report"""
-    #     with patch('Path.Main.Sanity.ImageBuilder.ImageBuilderFactory.get_image_builder') as mock_factory:
-    #         dummy_builder = DummyImageBuilder(self.temp_file.name)
-    #         mock_factory.return_value = dummy_builder
-    #         S = Sanity.CAMSanity(self.job, output_file= self.temp_file.name)
-    #         html_content = S.get_output_report()
-    #         self.assertIsInstance(html_content, str)
+    def test140(self):
+        """Test get_output_report returns a non-empty HTML string.
+
+        Given: A valid CAM job (boxtest.fcstd) and a DummyImageBuilder.
+        When: get_output_report() is called on a CAMSanity instance.
+        Then: The result is a non-empty string containing HTML content.
+        """
+        with patch(
+            "Path.Main.Sanity.ImageBuilder.ImageBuilderFactory.get_image_builder"
+        ) as mock_factory:
+            dummy_builder = DummyImageBuilder(self.temp_file.name)
+            mock_factory.return_value = dummy_builder
+            S = Sanity.CAMSanity(self.job, output_file=self.temp_file.name)
+            html_content = S.get_output_report()
+            self.assertIsInstance(html_content, str)
 
     # def test150(self):
     #     """Test Post Processing a File"""
@@ -322,15 +334,339 @@ class TestCAMSanity(PathTestBase):
 
     #         output_file_name = os.path.join(output_file_path, "test.ngc")
 
-    # def test200(self):
-    #     """Generate Report This test is disabled but useful during development to see the report"""
+    # def test_dev_report(self):
+    #     """Generate Report: disabled but useful during development to see the report"""
     #     with tempfile.NamedTemporaryFile() as temp_file:
     #         S= Sanity.CAMSanity(self.job, output_file=temp_file.name)
-    #         shape = self.doc.getObject("Box")
     #         html_content = S.get_output_report()
-
     #         encoded_html = urllib.parse.quote(html_content)
-
     #         data_uri = f"data:text/html;charset=utf-8,{encoded_html}"
     #         import webbrowser
     #         webbrowser.open(data_uri)
+
+    # --- Helpers ---
+
+    def _make_sanity_with_mock_job(self, mock_job):
+        """Create a CAMSanity instance with a mock job, bypassing summarize() during init.
+
+        Used by tests that call individual _xxxData() methods with a controlled mock job
+        without running the full summarize() pipeline.
+        """
+        with patch(
+            "Path.Main.Sanity.ImageBuilder.ImageBuilderFactory.get_image_builder"
+        ) as mock_factory:
+            dummy_builder = DummyImageBuilder(self.temp_file.name)
+            mock_factory.return_value = dummy_builder
+            with patch.object(Sanity.CAMSanity, "summarize", return_value={}):
+                S = Sanity.CAMSanity(mock_job, output_file=self.temp_file.name)
+        return S
+
+    def _make_mock_tc(
+        self,
+        tool_number=1,
+        shape_type="endmill",
+        horiz_feed_value=1000.0,
+        spindle_speed=1000.0,
+        label="TC: Endmill",
+    ):
+        """Create a mock tool controller with the given properties."""
+        mock_tc = MagicMock()
+        mock_tc.Tool.BitBody = True
+        mock_tc.Tool.ShapeType = shape_type
+        mock_tc.Tool.Diameter.UserString = "10 mm"
+        mock_tc.Tool.Label = shape_type.capitalize()
+        mock_tc.HorizFeed.Value = horiz_feed_value
+        mock_tc.HorizFeed.UserString = f"{horiz_feed_value} mm/s"
+        mock_tc.SpindleSpeed = spindle_speed
+        mock_tc.ToolNumber = tool_number
+        mock_tc.Label = label
+        return mock_tc
+
+    # --- Phase 2: Squawk Detection Tests ---
+
+    def test200_zero_feedrate_squawk(self):
+        """Zero feedrate on a tool controller should produce a WARNING squawk.
+
+        Given: A job with one tool controller whose HorizFeed.Value is 0.0.
+        When: _toolData() is called.
+        Then: squawkData contains a WARNING entry mentioning "feedrate".
+
+        Example: TC.HorizFeed.Value = 0.0
+          → squawkData contains {"squawkType": "WARNING", "Note": "... feedrate ..."}
+        """
+        mock_tc = self._make_mock_tc(horiz_feed_value=0.0)
+        mock_job = MagicMock()
+        mock_job.Tools.Group = [mock_tc]
+        mock_job.Operations.Group = []
+
+        S = self._make_sanity_with_mock_job(mock_job)
+        data = S._toolData()
+
+        squawks = data.get("squawkData", [])
+        warning_squawks = [s for s in squawks if s["squawkType"] == "WARNING"]
+        self.assertTrue(
+            any("feedrate" in s["Note"].lower() for s in warning_squawks),
+            f"Expected WARNING squawk for zero feedrate, got: {squawks}",
+        )
+
+    def test210_zero_spindle_squawk(self):
+        """Zero spindle speed on a tool controller should produce a WARNING squawk.
+
+        Given: A job with one tool controller whose SpindleSpeed is 0.0.
+        When: _toolData() is called.
+        Then: squawkData contains a WARNING entry mentioning "spindlespeed".
+
+        Example: TC.SpindleSpeed = 0.0
+          → squawkData contains {"squawkType": "WARNING", "Note": "... spindlespeed ..."}
+        """
+        mock_tc = self._make_mock_tc(spindle_speed=0.0)
+        mock_job = MagicMock()
+        mock_job.Tools.Group = [mock_tc]
+        mock_job.Operations.Group = []
+
+        S = self._make_sanity_with_mock_job(mock_job)
+        data = S._toolData()
+
+        squawks = data.get("squawkData", [])
+        warning_squawks = [s for s in squawks if s["squawkType"] == "WARNING"]
+        self.assertTrue(
+            any("spindlespeed" in s["Note"].lower() for s in warning_squawks),
+            f"Expected WARNING squawk for zero spindle speed, got: {squawks}",
+        )
+
+    def test220_unused_tool_controller_squawk(self):
+        """A tool controller not used by any operation should produce a WARNING squawk.
+
+        Given: A job with one tool controller and no operations referencing it.
+        When: _toolData() is called.
+        Then: squawkData contains a WARNING entry mentioning "not used".
+
+        Example: job.Operations.Group = [] with one TC present
+          → squawkData contains {"squawkType": "WARNING", "Note": "... not used ..."}
+        """
+        mock_tc = self._make_mock_tc()
+        mock_job = MagicMock()
+        mock_job.Tools.Group = [mock_tc]
+        mock_job.Operations.Group = []
+
+        S = self._make_sanity_with_mock_job(mock_job)
+        data = S._toolData()
+
+        squawks = data.get("squawkData", [])
+        warning_squawks = [s for s in squawks if s["squawkType"] == "WARNING"]
+        self.assertTrue(
+            any("not used" in s["Note"].lower() for s in warning_squawks),
+            f"Expected WARNING squawk for unused TC, got: {squawks}",
+        )
+
+    def test230_duplicate_tool_number_squawk(self):
+        """Two tool controllers sharing the same tool number should produce a CAUTION squawk.
+
+        Given: A job with two tool controllers assigned tool number 1 but different ShapeTypes.
+        When: _toolData() is called.
+        Then: squawkData contains a CAUTION entry about multiple tools sharing a number.
+
+        Example: TC1.ToolNumber=1 ShapeType="endmill", TC2.ToolNumber=1 ShapeType="ballmill"
+          → squawkData contains {"squawkType": "CAUTION", "Note": "... multiple tools ..."}
+        """
+        mock_tc1 = self._make_mock_tc(tool_number=1, shape_type="endmill", label="TC1")
+        mock_tc2 = self._make_mock_tc(tool_number=1, shape_type="ballmill", label="TC2")
+
+        mock_job = MagicMock()
+        mock_job.Tools.Group = [mock_tc1, mock_tc2]
+        mock_job.Operations.Group = []
+
+        S = self._make_sanity_with_mock_job(mock_job)
+        data = S._toolData()
+
+        squawks = data.get("squawkData", [])
+        caution_squawks = [s for s in squawks if s["squawkType"] == "CAUTION"]
+        self.assertTrue(
+            len(caution_squawks) > 0,
+            f"Expected CAUTION squawk for duplicate tool numbers, got: {squawks}",
+        )
+
+    def test240_not_postprocessed_squawk(self):
+        """A job with no prior post-processing should produce a squawk in _outputData().
+
+        Given: A job whose LastPostProcessOutput is an empty string.
+        When: _outputData() is called.
+        Then: squawkData contains an entry mentioning "post-process".
+
+        Example: job.LastPostProcessOutput = ""
+          → squawkData contains {"Note": "The Job has not been post-processed"}
+        """
+        mock_job = MagicMock()
+        mock_job.LastPostProcessDate = ""
+        mock_job.LastPostProcessOutput = ""
+        mock_job.PostProcessor = "linuxcnc"
+        mock_job.PostProcessorArgs = ""
+        mock_job.PostProcessorOutputFile = ""
+        mock_job.Operations.Group = []
+
+        S = self._make_sanity_with_mock_job(mock_job)
+        data = S._outputData()
+
+        squawks = data.get("squawkData", [])
+        self.assertTrue(len(squawks) > 0, "Expected at least one squawk for unprocessed job")
+        self.assertTrue(
+            any("post-process" in s["Note"].lower() for s in squawks),
+            f"Expected squawk mentioning post-processing, got: {squawks}",
+        )
+
+    def test250_no_operations_squawk(self):
+        """A job with no operations should produce a WARNING from _validate_job_structure().
+
+        Given: A job where the Operations attribute is None (falsy).
+        When: _validate_job_structure() is called.
+        Then: The returned list contains a WARNING squawk mentioning "operation".
+
+        Example: job.Operations = None
+          → [{"squawkType": "WARNING", "Note": "No operations found in job"}]
+        """
+        mock_job = MagicMock()
+        mock_job.Operations = None
+
+        S = self._make_sanity_with_mock_job(mock_job)
+        squawks = S._validate_job_structure()
+
+        warning_squawks = [s for s in squawks if s["squawkType"] == "WARNING"]
+        self.assertTrue(
+            any("operation" in s["Note"].lower() for s in warning_squawks),
+            f"Expected WARNING squawk for no operations, got: {squawks}",
+        )
+
+    def test260_no_base_geometry_squawk(self):
+        """A job with no model/base geometry should produce a WARNING from _validate_job_structure().
+
+        Given: A job that has operations but whose Model attribute is None (falsy).
+        When: _validate_job_structure() is called.
+        Then: The returned list contains a WARNING squawk mentioning "model" or "base".
+
+        Example: job.Operations = MagicMock(), job.Model = None
+          → [{"squawkType": "WARNING", "Note": "No model/base geometry found in job"}]
+        """
+        mock_job = MagicMock()
+        mock_job.Operations = MagicMock()
+        mock_job.Model = None
+
+        S = self._make_sanity_with_mock_job(mock_job)
+        squawks = S._validate_job_structure()
+
+        warning_squawks = [s for s in squawks if s["squawkType"] == "WARNING"]
+        self.assertTrue(
+            any(
+                "model" in s["Note"].lower() or "base" in s["Note"].lower() for s in warning_squawks
+            ),
+            f"Expected WARNING squawk for no base geometry, got: {squawks}",
+        )
+
+    def test270_validate_for_postprocessing_returns_tuple(self):
+        """validate_for_postprocessing() should return a (bool, list, list) tuple.
+
+        Given: A valid CAM job (boxtest.fcstd).
+        When: validate_for_postprocessing() is called on a CAMSanity instance.
+        Then:
+          - Returns a 3-tuple: (has_critical, all_squawks, critical_squawks)
+          - has_critical is a bool equal to (len(critical_squawks) > 0)
+          - all_squawks and critical_squawks are lists
+          - Every item in critical_squawks is also in all_squawks
+        """
+        with patch(
+            "Path.Main.Sanity.ImageBuilder.ImageBuilderFactory.get_image_builder"
+        ) as mock_factory:
+            dummy_builder = DummyImageBuilder(self.temp_file.name)
+            mock_factory.return_value = dummy_builder
+            S = Sanity.CAMSanity(self.job, output_file=self.temp_file.name)
+
+        result = S.validate_for_postprocessing()
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 3)
+        has_critical, all_squawks, critical_squawks = result
+        self.assertIsInstance(has_critical, bool)
+        self.assertIsInstance(all_squawks, list)
+        self.assertIsInstance(critical_squawks, list)
+        self.assertEqual(has_critical, len(critical_squawks) > 0)
+        for squawk in critical_squawks:
+            self.assertIn(squawk, all_squawks)
+
+    def test280_validate_job_static(self):
+        """validate_job() static method should return (all_squawks, critical_squawks) without images.
+
+        Given: A valid CAM job (boxtest.fcstd).
+        When: CAMSanity.validate_job(job) is called as a static method.
+        Then:
+          - Returns a 2-tuple: (all_squawks, critical_squawks)
+          - Both are lists of squawk dicts
+          - All critical squawks have squawkType "WARNING" or "CAUTION"
+          - All critical squawks are also in all_squawks
+          - No image or HTML files are generated
+        """
+        result = Sanity.CAMSanity.validate_job(self.job)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        all_squawks, critical_squawks = result
+        self.assertIsInstance(all_squawks, list)
+        self.assertIsInstance(critical_squawks, list)
+        for squawk in critical_squawks:
+            self.assertIn(squawk["squawkType"], ("WARNING", "CAUTION"))
+        for squawk in critical_squawks:
+            self.assertIn(squawk, all_squawks)
+
+    # --- Phase 6: Integration Tests ---
+
+    def test300_get_all_squawks_completeness(self):
+        """get_all_squawks() should collect squawks from all validation sections.
+
+        Given: A valid CAM job (boxtest.fcstd) with a DummyImageBuilder.
+        When: get_all_squawks() is called on a CAMSanity instance.
+        Then:
+          - Returns a 2-tuple: (all_squawks, critical_squawks)
+          - critical_squawks contains only WARNING or CAUTION squawks
+          - Every item in critical_squawks is also in all_squawks
+          - Each squawk dict has the required keys: squawkType, Note, Date
+        """
+        with patch(
+            "Path.Main.Sanity.ImageBuilder.ImageBuilderFactory.get_image_builder"
+        ) as mock_factory:
+            dummy_builder = DummyImageBuilder(self.temp_file.name)
+            mock_factory.return_value = dummy_builder
+            S = Sanity.CAMSanity(self.job, output_file=self.temp_file.name)
+
+        all_squawks, critical_squawks = S.get_all_squawks()
+
+        self.assertIsInstance(all_squawks, list)
+        self.assertIsInstance(critical_squawks, list)
+        for squawk in critical_squawks:
+            self.assertIn(squawk["squawkType"], ("WARNING", "CAUTION"))
+        for squawk in critical_squawks:
+            self.assertIn(squawk, all_squawks)
+        for squawk in all_squawks:
+            self.assertIn("squawkType", squawk)
+            self.assertIn("Note", squawk)
+            self.assertIn("Date", squawk)
+
+    def test310_validate_job_end_to_end(self):
+        """validate_job() end-to-end: works without a pre-existing output path.
+
+        Given: A valid CAM job (boxtest.fcstd).
+        When: CAMSanity.validate_job(job) is called with no other setup.
+        Then:
+          - Returns (all_squawks, critical_squawks)
+          - All critical squawks are WARNING or CAUTION
+          - All critical squawks appear in all_squawks
+          - squawkType and Note keys are present in every squawk
+        """
+        all_squawks, critical_squawks = Sanity.CAMSanity.validate_job(self.job)
+
+        self.assertIsInstance(all_squawks, list)
+        self.assertIsInstance(critical_squawks, list)
+        for s in critical_squawks:
+            self.assertIn(s["squawkType"], ("WARNING", "CAUTION"))
+        for s in critical_squawks:
+            self.assertIn(s, all_squawks)
+        for s in all_squawks:
+            self.assertIn("squawkType", s)
+            self.assertIn("Note", s)

--- a/src/Mod/CAM/CAMTests/TestCAMSanity.py
+++ b/src/Mod/CAM/CAMTests/TestCAMSanity.py
@@ -382,6 +382,40 @@ class TestCAMSanity(PathTestBase):
         mock_tc.Label = label
         return mock_tc
 
+    def _make_mock_job(
+        self,
+        machine_name="test_machine",
+        has_tools=True,
+        has_operations=True,
+        has_model=True,
+    ):
+        """Create a mock job with basic attributes for testing."""
+        mock_job = MagicMock()
+        mock_job.Machine = machine_name
+        mock_job.LastPostProcessDate = ""
+        mock_job.LastPostProcessOutput = ""
+        mock_job.PostProcessor = "linuxcnc"
+        mock_job.PostProcessorArgs = ""
+        mock_job.PostProcessorOutputFile = ""
+
+        if has_tools:
+            mock_tc = self._make_mock_tc()
+            mock_job.Tools.Group = [mock_tc]
+        else:
+            mock_job.Tools.Group = []
+
+        if has_operations:
+            mock_job.Operations.Group = []
+        else:
+            mock_job.Operations = None
+
+        if has_model:
+            mock_job.Model = MagicMock()
+        else:
+            mock_job.Model = None
+
+        return mock_job
+
     # --- Phase 2: Squawk Detection Tests ---
 
     def test200_zero_feedrate_squawk(self):
@@ -670,3 +704,165 @@ class TestCAMSanity(PathTestBase):
         for s in all_squawks:
             self.assertIn("squawkType", s)
             self.assertIn("Note", s)
+
+    def test320_postprocessor_sanity_checks_integration(self):
+        """Postprocessor sanity checks: collected and integrated into validation.
+
+        Given: A job with a machine that has postprocessor sanity checks.
+        When: CAMSanity.validate_job() is called.
+        Then: Postprocessor squawks appear in validation results.
+        """
+        # Create a mock job with machine
+        mock_job = MagicMock()
+        mock_job.Machine = "test_machine"
+        mock_job.Tools.Group = []
+        mock_job.Operations.Group = []
+
+        # Create a mock postprocessor with sanity checks
+        class MockPostprocessor:
+            def get_sanity_checks(self, job):
+                return [
+                    {
+                        "Date": "Mon Mar 24 17:00:00 2026",
+                        "Operator": "MockPostprocessor",
+                        "Note": "Test postprocessor warning",
+                        "squawkType": "WARNING",
+                        "squawkIcon": "/path/to/warning.svg",
+                    },
+                    {
+                        "Date": "Mon Mar 24 17:00:00 2026",
+                        "Operator": "MockPostprocessor",
+                        "Note": "Test postprocessor note",
+                        "squawkType": "NOTE",
+                        "squawkIcon": "/path/to/note.svg",
+                    },
+                ]
+
+        # Mock machine with postprocessor_file_name
+        mock_machine = MagicMock()
+        mock_machine.postprocessor_file_name = "test_post"
+
+        import unittest.mock
+
+        with unittest.mock.patch(
+            "Machine.models.machine.MachineFactory.get_machine", return_value=mock_machine
+        ), unittest.mock.patch(
+            "Path.Post.Processor.PostProcessorFactory.get_post_processor",
+            return_value=MockPostprocessor(),
+        ):
+
+            all_squawks, critical_squawks = Sanity.CAMSanity.validate_job(mock_job)
+
+            # Verify postprocessor squawks are included
+            postprocessor_squawks = [s for s in all_squawks if s["Operator"] == "MockPostprocessor"]
+            self.assertEqual(len(postprocessor_squawks), 2)
+
+            # Verify critical classification
+            postprocessor_critical = [
+                s for s in critical_squawks if s["Operator"] == "MockPostprocessor"
+            ]
+            self.assertEqual(len(postprocessor_critical), 1)  # Only the WARNING
+            self.assertEqual(postprocessor_critical[0]["squawkType"], "WARNING")
+
+    def test321_postprocessor_sanity_checks_error_handling(self):
+        """Postprocessor sanity checks: graceful handling of exceptions.
+
+        Given: A postprocessor that raises an exception in get_sanity_checks().
+        When: CAMSanity.validate_job() is called.
+        Then: Exception is caught and validation continues.
+        """
+        mock_job = MagicMock()
+        mock_job.Machine = "error_machine"
+        mock_job.Tools.Group = []
+        mock_job.Operations.Group = []
+
+        class ErrorPostprocessor:
+            def get_sanity_checks(self, job):
+                raise Exception("Test postprocessor error")
+
+        mock_machine = MagicMock()
+        mock_machine.postprocessor_file_name = "error_post"
+
+        import unittest.mock
+
+        with unittest.mock.patch(
+            "Machine.models.machine.MachineFactory.get_machine", return_value=mock_machine
+        ), unittest.mock.patch(
+            "Path.Post.Processor.PostProcessorFactory.get_post_processor",
+            return_value=ErrorPostprocessor(),
+        ):
+
+            # Should not raise exception
+            all_squawks, critical_squawks = Sanity.CAMSanity.validate_job(mock_job)
+
+            # Should still return valid results
+            self.assertIsInstance(all_squawks, list)
+            self.assertIsInstance(critical_squawks, list)
+
+    def test322_postprocessor_sanity_checks_no_machine(self):
+        """Postprocessor sanity checks: job without machine.
+
+        Given: A job with no machine assigned.
+        When: CAMSanity.validate_job() is called.
+        Then: No postprocessor checks are performed, but validation continues.
+        """
+        mock_job = MagicMock()
+        mock_job.Tools.Group = []
+        mock_job.Operations.Group = []
+        # No machine attribute
+
+        all_squawks, critical_squawks = Sanity.CAMSanity.validate_job(mock_job)
+
+        # Should still return valid results
+        self.assertIsInstance(all_squawks, list)
+        self.assertIsInstance(critical_squawks, list)
+
+        # No postprocessor squawks should be present
+        postprocessor_squawks = [
+            s
+            for s in all_squawks
+            if hasattr(s, "Operator") and s["Operator"] not in ["CAMSanity", "MockTC"]
+        ]
+        self.assertEqual(len(postprocessor_squawks), 0)
+
+    def test323_generic_plasma_sanity_checks_integration(self):
+        """GenericPlasma postprocessor sanity checks: verify get_sanity_checks is called.
+
+        Given: A job with a machine whose postprocessor_file_name is "generic_plasma".
+        When: CAMSanity.validate_job() is called.
+        Then: GenericPlasma get_sanity_checks() method is called and test squawk appears.
+        """
+        # Create a mock job with a machine name
+        mock_job = self._make_mock_job(machine_name="plasma")
+
+        # Add stock with thickness for plasma-specific checks
+        mock_stock = MagicMock()
+        mock_stock.Thickness = 10.0  # 10mm thick material
+        mock_job.Stock = mock_stock
+
+        # Mock the machine so it returns the correct postprocessor file name
+        mock_machine = MagicMock()
+        mock_machine.postprocessor_file_name = "generic_plasma"
+
+        import unittest.mock
+
+        with unittest.mock.patch(
+            "Machine.models.machine.MachineFactory.get_machine", return_value=mock_machine
+        ):
+            # Call validate_job - this should load the real GenericPlasma postprocessor
+            all_squawks, critical_squawks = Sanity.CAMSanity.validate_job(mock_job)
+
+        # Verify we got squawks
+        self.assertIsInstance(all_squawks, list)
+        self.assertIsInstance(critical_squawks, list)
+        self.assertGreater(len(all_squawks), 0, "Should have some squawks")
+
+        # Look for the test squawk from GenericPlasma.get_sanity_checks
+        test_squawks = [s for s in all_squawks if s["Note"] == "This is a test warning message"]
+        self.assertGreater(len(test_squawks), 0, "Test squawk from GenericPlasma should be present")
+
+        # Verify the test squawk is classified as WARNING (critical)
+        test_critical = [
+            s for s in critical_squawks if s["Note"] == "This is a test warning message"
+        ]
+        self.assertGreater(len(test_critical), 0, "Test squawk should be in critical squawks")

--- a/src/Mod/CAM/CAMTests/TestGenericPlasma.py
+++ b/src/Mod/CAM/CAMTests/TestGenericPlasma.py
@@ -111,7 +111,8 @@ class TestGenericPlasma(PathTestUtils.PathTestBase):
         schema = self.post.get_property_schema()
 
         # Check that we have the expected number of properties
-        self.assertEqual(len(schema), 5)
+        # 5 machine-config properties + 1 runtime-only (mark_entry_only)
+        self.assertEqual(len(schema), 6)
 
         # Check pierce_delay property
         pierce_delay = next(prop for prop in schema if prop["name"] == "pierce_delay")

--- a/src/Mod/CAM/CAMTests/TestPostCore.py
+++ b/src/Mod/CAM/CAMTests/TestPostCore.py
@@ -1,31 +1,28 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2016 shopinthewoods@gmail.com
+# SPDX-FileCopyrightText: 2022 LarryWoestman2@gmail.com
 
-# ***************************************************************************
-# *   Copyright (c) 2016 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 Larry Woestman <LarryWoestman2@gmail.com>          *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
-
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 import FreeCAD
 import Path
 import Path.Post.Command as PathCommand
+import Path.Post.PostList as PostList
 import Path.Post.Processor as PathPost
 import Path.Post.Utils as PostUtils
 import Path.Main.Job as PathJob
@@ -334,70 +331,16 @@ class TestBuildPostList(unittest.TestCase):
             output.append("")
 
             for obj_idx, obj in enumerate(objects, 1):
-                obj_label = getattr(obj, "Label", str(type(obj).__name__))
-                output.append(f"    [{obj_idx}] {obj_label}")
-
-                # Determine object type/role
-                obj_type = type(obj).__name__
-                if obj_type == "_FixtureSetupObject":
-                    output.append("        Type: Fixture Setup")
-                    if hasattr(obj, "Path") and obj.Path and len(obj.Path.Commands) > 0:
-                        fixture_cmd = obj.Path.Commands[0]
-                        output.append(f"        Fixture: {fixture_cmd.Name}")
-                elif obj_type == "_CommandObject":
-                    output.append("        Type: Command Object")
-                    if hasattr(obj, "Path") and obj.Path and len(obj.Path.Commands) > 0:
-                        cmd = obj.Path.Commands[0]
-                        params = " ".join(
-                            f"{k}:{v}"
-                            for k, v in zip(
-                                cmd.Parameters.keys() if hasattr(cmd.Parameters, "keys") else [],
-                                (
-                                    cmd.Parameters.values()
-                                    if hasattr(cmd.Parameters, "values")
-                                    else cmd.Parameters
-                                ),
-                            )
-                        )
-                        output.append(f"        Command: {cmd.Name} {params}")
-                elif hasattr(obj, "TypeId"):
-                    # Check if it's a tool controller
-                    if hasattr(obj, "Proxy") and hasattr(obj.Proxy, "__class__"):
-                        proxy_name = obj.Proxy.__class__.__name__
-                        if "ToolController" in proxy_name:
-                            output.append("        Type: Tool Controller")
-                            if hasattr(obj, "ToolNumber"):
-                                output.append(f"        Tool Number: {obj.ToolNumber}")
-                            if hasattr(obj, "Path") and obj.Path and obj.Path.Commands:
-                                for cmd in obj.Path.Commands:
-                                    if cmd.Name == "M6":
-                                        params = " ".join(
-                                            f"{k}:{v}"
-                                            for k, v in zip(
-                                                (
-                                                    cmd.Parameters.keys()
-                                                    if hasattr(cmd.Parameters, "keys")
-                                                    else []
-                                                ),
-                                                (
-                                                    cmd.Parameters.values()
-                                                    if hasattr(cmd.Parameters, "values")
-                                                    else cmd.Parameters
-                                                ),
-                                            )
-                                        )
-                                        output.append(f"        M6 Command: {cmd.Name} {params}")
-                        else:
-                            output.append("        Type: Operation")
-                            if hasattr(obj, "ToolController") and obj.ToolController:
-                                tc = obj.ToolController
-                                output.append(
-                                    f"        ToolController: {tc.Label} (T{tc.ToolNumber})"
-                                )
-                    else:
-                        output.append(f"        Type: {obj.TypeId}")
+                if isinstance(obj, PostList.Postable):
+                    output.append(f"    [{obj_idx}] {obj.label}")
+                    output.append(f"        item_type: {obj.item_type}")
+                    if obj.path and obj.path.Commands:
+                        output.append(f"        Commands: {[c.Name for c in obj.path.Commands]}")
+                    if obj.data:
+                        output.append(f"        data: {obj.data}")
                 else:
-                    output.append(f"        Type: {obj_type}")
+                    obj_label = getattr(obj, "Label", str(type(obj).__name__))
+                    output.append(f"    [{obj_idx}] {obj_label} (raw {type(obj).__name__})")
 
             output.append("")
 
@@ -574,52 +517,58 @@ class TestBuildPostList(unittest.TestCase):
         self.assertEqual(len(firstoplist), 6)
         self.assertTrue(firstoutputitem[0] == "G54")
 
+    def _mock_machine_with_early_tool_prep(self):
+        """Return a minimal mock machine that enables early_tool_prep."""
+
+        class _MockProcessing:
+            early_tool_prep = True
+
+        class _MockMachine:
+            processing = _MockProcessing()
+
+        return _MockMachine()
+
     def test070(self):
+        """
+        Test that early_tool_prep inserts Tn prep commands after each M6 when enabled via machine.
+
+        Given: A job split by tool (SplitOutput=True, OrderOutputBy=Tool) and a machine
+               whose processing.early_tool_prep is True
+        When: _buildPostList() is called (no explicit parameter)
+        Then: The first M6 in the first group targets tool 5, and a T2 prep command
+              appears immediately after, before the second M6.
+
+        Example:
+            M6 T5  <- change to tool 5
+            T2     <- early prep for tool 2
+            <ops with T5>
+            M6 T2  <- change to tool 2
+        """
         self.job.SplitOutput = True
         self.job.PostProcessorOutputFile = "%T.nc"
         self.job.OrderOutputBy = "Tool"
-        postables = self.pp._buildPostList(early_tool_prep=True)
+        self.pp._machine = self._mock_machine_with_early_tool_prep()
+        postables = self.pp._buildPostList()
         _, sublist = postables[0]
 
         if self.debug:
             print(self._format_postables(postables, "test070: Early tool prep, split by tool"))
 
-        # Extract all commands from the postables
         commands = []
-        if self.debug:
-            print("\n=== Extracting commands from postables ===")
         for item in sublist:
-            if self.debug:
-                item_type = type(item).__name__
-                has_path = hasattr(item, "Path")
-                path_exists = item.Path if has_path else None
-                has_commands = path_exists and item.Path.Commands if path_exists else False
-                print(
-                    f"Item: {getattr(item, 'Label', item_type)}, Type: {item_type}, HasPath: {has_path}, PathExists: {path_exists is not None}, HasCommands: {bool(has_commands)}"
-                )
-                if has_commands:
-                    print(f"  Commands: {[cmd.Name for cmd in item.Path.Commands]}")
-            if hasattr(item, "Path") and item.Path and item.Path.Commands:
-                commands.extend(item.Path.Commands)
+            if item.path and item.path.Commands:
+                commands.extend(item.path.Commands)
 
-        if self.debug:
-            print(f"\nTotal commands extracted: {len(commands)}")
-            print("=" * 40)
-
-        # Should have M6 command with tool parameter
         m6_commands = [cmd for cmd in commands if cmd.Name == "M6"]
         self.assertTrue(len(m6_commands) > 0, "Should have M6 command")
 
-        # First M6 should have T parameter for tool 5
         first_m6 = m6_commands[0]
         self.assertTrue("T" in first_m6.Parameters, "First M6 should have T parameter")
         self.assertEqual(first_m6.Parameters["T"], 5.0, "First M6 should be for tool 5")
 
-        # Should have T2 prep command (early prep for next tool)
         t2_commands = [cmd for cmd in commands if cmd.Name == "T2"]
         self.assertTrue(len(t2_commands) > 0, "Should have T2 early prep command")
 
-        # T2 prep should come after first M6
         first_m6_index = next((i for i, cmd in enumerate(commands) if cmd.Name == "M6"), None)
         t2_index = next((i for i, cmd in enumerate(commands) if cmd.Name == "T2"), None)
         self.assertIsNotNone(first_m6_index, "M6 should exist")
@@ -627,61 +576,36 @@ class TestBuildPostList(unittest.TestCase):
         self.assertLess(first_m6_index, t2_index, "M6 should come before T2 prep")
 
     def test080(self):
+        """
+        Test early_tool_prep with combined output (SplitOutput=False).
+
+        Given: A job with combined output (SplitOutput=False, OrderOutputBy=Tool) and a
+               machine whose processing.early_tool_prep is True
+        When: _buildPostList() is called
+        Then: Two M6 commands appear (T5 then T2) and a T2 prep command appears after
+              the first M6 and before the second M6.
+
+        Example:
+            M6 T5  <- change to tool 5
+            T2     <- early prep for tool 2
+            <ops with T5>
+            M6 T2  <- change to tool 2
+        """
         self.job.SplitOutput = False
         self.job.OrderOutputBy = "Tool"
+        self.pp._machine = self._mock_machine_with_early_tool_prep()
 
-        postables = self.pp._buildPostList(early_tool_prep=True)
+        postables = self.pp._buildPostList()
         _, sublist = postables[0]
 
         if self.debug:
             print(self._format_postables(postables, "test080: Early tool prep, combined output"))
 
-        # Extract all commands from the postables
         commands = []
-        if self.debug:
-            print("\n=== Extracting commands from postables ===")
         for item in sublist:
-            if self.debug:
-                item_type = type(item).__name__
-                has_path = hasattr(item, "Path")
-                path_exists = item.Path if has_path else None
-                has_commands = path_exists and item.Path.Commands if path_exists else False
-                print(
-                    f"Item: {getattr(item, 'Label', item_type)}, Type: {item_type}, HasPath: {has_path}, PathExists: {path_exists is not None}, HasCommands: {bool(has_commands)}"
-                )
-                if has_commands:
-                    print(f"  Commands: {[cmd.Name for cmd in item.Path.Commands]}")
-            if hasattr(item, "Path") and item.Path and item.Path.Commands:
-                commands.extend(item.Path.Commands)
+            if item.path and item.path.Commands:
+                commands.extend(item.path.Commands)
 
-        if self.debug:
-            print(f"\nTotal commands extracted: {len(commands)}")
-
-        # Expected command sequence with early_tool_prep=True:
-        # M6 T5     <- change to tool 5 (standard format)
-        # T2        <- prep next tool immediately (early prep)
-        # (ops with T5...)
-        # M6 T2     <- change to tool 2 (was prepped early)
-        # (ops with T2...)
-
-        if self.debug:
-            print("\n=== Command Sequence ===")
-            for i, cmd in enumerate(commands):
-                params = " ".join(
-                    f"{k}:{v}"
-                    for k, v in zip(
-                        cmd.Parameters.keys() if hasattr(cmd.Parameters, "keys") else [],
-                        (
-                            cmd.Parameters.values()
-                            if hasattr(cmd.Parameters, "values")
-                            else cmd.Parameters
-                        ),
-                    )
-                )
-                print(f"{i:3d}: {cmd.Name} {params}")
-            print("=" * 40)
-
-        # Find M6 and T2 commands
         m6_commands = [(i, cmd) for i, cmd in enumerate(commands) if cmd.Name == "M6"]
         t2_commands = [(i, cmd) for i, cmd in enumerate(commands) if cmd.Name == "T2"]
 
@@ -692,23 +616,279 @@ class TestBuildPostList(unittest.TestCase):
         second_m6_idx, second_m6_cmd = m6_commands[1] if len(m6_commands) >= 2 else (None, None)
         first_t2_idx = t2_commands[0][0]
 
-        # First M6 should have T parameter for tool 5
         self.assertTrue("T" in first_m6_cmd.Parameters, "First M6 should have T parameter")
         self.assertEqual(first_m6_cmd.Parameters["T"], 5.0, "First M6 should be for tool 5")
 
-        # Second M6 should have T parameter for tool 2
         if second_m6_cmd is not None:
             self.assertTrue("T" in second_m6_cmd.Parameters, "Second M6 should have T parameter")
             self.assertEqual(second_m6_cmd.Parameters["T"], 2.0, "Second M6 should be for tool 2")
 
-        # T2 (early prep) should come shortly after first M6 (within a few commands)
         self.assertLess(first_m6_idx, first_t2_idx, "T2 prep should come after first M6")
 
-        # T2 early prep should come before second M6
         if second_m6_idx is not None:
             self.assertLess(
                 first_t2_idx, second_m6_idx, "T2 early prep should come before second M6"
             )
+
+    def test090_buildpostlist_returns_postable_instances(self):
+        """
+        Test that all items returned by _buildPostList are Postable instances.
+
+        Given: A job with 3 operations, 2 tool controllers, and 2 fixtures
+        When: _buildPostList() is called with no-split, order-by-operation
+        Then: Every item in the flat sublist is an instance of PostList.Postable
+
+        Example:
+            postlist = pp._buildPostList()
+            for _, sublist in postlist:
+                for item in sublist:
+                    assert isinstance(item, PostList.Postable)
+        """
+        self.job.SplitOutput = False
+        self.job.OrderOutputBy = "Operation"
+        postlist = self.pp._buildPostList()
+        _, sublist = postlist[0]
+        for item in sublist:
+            self.assertIsInstance(
+                item,
+                PostList.Postable,
+                f"Expected Postable, got {type(item).__name__}",
+            )
+
+    def test091_postable_standard_fields(self):
+        """
+        Test that every Postable exposes the required standard interface.
+
+        Given: A job producing fixture, tool_controller, and operation items
+        When: _buildPostList() is called
+        Then: Each Postable has:
+            - item_type: a non-empty string
+            - label: a string
+            - path: a Path.Path instance
+            - source: the original object or None
+            - data: a dict
+
+        Example:
+            item.item_type == "operation"
+            item.label == "outsideprofile"
+            isinstance(item.path, Path.Path)
+            isinstance(item.data, dict)
+        """
+        self.job.SplitOutput = False
+        self.job.OrderOutputBy = "Operation"
+        postlist = self.pp._buildPostList()
+        _, sublist = postlist[0]
+        for item in sublist:
+            self.assertIsInstance(item.item_type, str)
+            self.assertTrue(len(item.item_type) > 0)
+            self.assertIsInstance(item.label, str)
+            self.assertIsInstance(item.path, Path.Path)
+            self.assertIsInstance(item.data, dict)
+
+    def test092_postable_item_types_correct(self):
+        """
+        Test that item_type is set correctly for each kind of postable.
+
+        Given: A job ordered by fixture with 2 fixtures, producing fixture, TC, and op items
+        When: _buildPostList() is called with split=True, order-by-fixture
+        Then: The first item in the first group is item_type="fixture",
+              and the set of item_types across all items includes "tool_controller"
+              and "operation".
+
+        Example:
+            sublist[0].item_type == "fixture"
+            types = {item.item_type for item in sublist}
+            assert "tool_controller" in types
+            assert "operation" in types
+        """
+        self.job.SplitOutput = True
+        self.job.PostProcessorOutputFile = "%W.nc"
+        self.job.OrderOutputBy = "Fixture"
+        postlist = self.pp._buildPostList()
+        _, sublist = postlist[0]
+        self.assertEqual(sublist[0].item_type, "fixture")
+        types = {item.item_type for item in sublist}
+        self.assertIn("tool_controller", types)
+        self.assertIn("operation", types)
+
+    def test093_postable_path_is_copy(self):
+        """
+        Test that Postable wraps a copy of the source path, not the original object.
+
+        Given: An operation with a non-empty path in the job
+        When: _buildPostList() creates a Postable for that operation
+        Then: postable.path is a different Python object from source.Path
+              so mutations to postable.path do not touch the document object.
+
+        Example:
+            op_item.source.Path is not op_item.path  # different object
+        """
+        self.job.SplitOutput = False
+        self.job.OrderOutputBy = "Operation"
+        postlist = self.pp._buildPostList()
+        _, sublist = postlist[0]
+        for item in sublist:
+            if item.item_type == "operation" and item.source is not None:
+                self.assertIsNot(
+                    item.path,
+                    item.source.Path,
+                    "Postable.path must be a copy, not the original source.Path",
+                )
+
+    def test094_tool_controller_postable_has_tool_number(self):
+        """
+        Test that tool_controller Postables carry the tool number in data["tool_number"].
+
+        Given: A job with tool controllers whose ToolNumber values are 5 and 2
+        When: _buildPostList() is called
+        Then: Each tool_controller Postable has data["tool_number"] matching ToolNumber.
+
+        Example:
+            tc_item.item_type == "tool_controller"
+            tc_item.data["tool_number"] == 5
+        """
+        self.job.SplitOutput = False
+        self.job.OrderOutputBy = "Operation"
+        postlist = self.pp._buildPostList()
+        _, sublist = postlist[0]
+        tc_items = [item for item in sublist if item.item_type == "tool_controller"]
+        self.assertGreater(len(tc_items), 0)
+        for tc_item in tc_items:
+            self.assertIn("tool_number", tc_item.data)
+            self.assertIsInstance(tc_item.data["tool_number"], (int, float))
+
+    def test095_operation_postable_tool_controller_is_postable(self):
+        """
+        Test that accessing ToolController on an operation Postable returns a Postable,
+        not the raw FreeCAD document object.
+
+        When legacy post scripts or other code accesses item.ToolController on an
+        operation Postable, they must receive a Postable wrapper—not a live reference
+        to the real TC document object.  Returning the live object allows callers to
+        mutate it, which marks the operation dirty even though no re-machining occurred.
+
+        Given: A job with operations linked to tool controllers
+        When: _buildPostList() is called and we access .ToolController on an operation item
+        Then: The returned value is a PostList.Postable instance (not a FreeCAD document object)
+              and its item_type is "tool_controller"
+
+        Example:
+            op_item.item_type == "operation"
+            isinstance(op_item.ToolController, PostList.Postable)  # True
+            op_item.ToolController.item_type == "tool_controller"  # True
+        """
+        self.job.SplitOutput = False
+        self.job.OrderOutputBy = "Operation"
+        postlist = self.pp._buildPostList()
+        _, sublist = postlist[0]
+        op_items = [
+            item
+            for item in sublist
+            if item.item_type == "operation"
+            and item.source is not None
+            and hasattr(item.source, "ToolController")
+            and item.source.ToolController is not None
+        ]
+        self.assertTrue(len(op_items) > 0, "Expected at least one operation with a ToolController")
+        for op_item in op_items:
+            tc = op_item.ToolController
+            self.assertIsInstance(
+                tc,
+                PostList.Postable,
+                f"op_item.ToolController must be a Postable, got {type(tc).__name__}",
+            )
+            self.assertEqual(tc.item_type, "tool_controller")
+
+    def test096_operation_postable_tool_controller_is_isolated(self):
+        """
+        Test that the Postable ToolController returned from an operation Postable is
+        a copy, so mutations do not propagate back to the real FreeCAD TC document object.
+
+        Given: An operation Postable whose ToolController attribute returns a Postable
+        When: We replace the Postable TC's path with a new empty path
+        Then: The original FreeCAD TC document object's Path is unchanged
+
+        Example:
+            original_tc_path = op_item.source.ToolController.Path
+            op_item.ToolController.path = Path.Path([])    # mutate the copy
+            op_item.source.ToolController.Path == original_tc_path  # True — unaffected
+        """
+        self.job.SplitOutput = False
+        self.job.OrderOutputBy = "Operation"
+        postlist = self.pp._buildPostList()
+        _, sublist = postlist[0]
+        op_items = [
+            item
+            for item in sublist
+            if item.item_type == "operation"
+            and item.source is not None
+            and hasattr(item.source, "ToolController")
+            and item.source.ToolController is not None
+        ]
+        self.assertTrue(len(op_items) > 0, "Expected at least one operation with a ToolController")
+        op_item = op_items[0]
+        real_tc = op_item.source.ToolController
+        original_size = real_tc.Path.Size if real_tc.Path else 0
+
+        # Mutate the postable TC's path
+        op_item.ToolController.path = Path.Path([])
+
+        # The real TC document object must be unaffected
+        new_size = real_tc.Path.Size if real_tc.Path else 0
+        self.assertEqual(
+            original_size,
+            new_size,
+            "Mutating the Postable TC path must not affect the real TC document object",
+        )
+
+    def test097_buildpostlist_does_not_touch_operations(self):
+        """
+        Test that _buildPostList() does not mark operations as Touched (needing recompute).
+
+        Post-processing is a read-only activity: it must produce G-code from the current
+        operation state without side-effecting the FreeCAD document.  When operations are
+        marked Touched after postprocessing, the user sees spurious "recompute required"
+        prompts every time they post-process.
+
+        Given:  A job whose operations are up-to-date (not Touched) after document recompute
+        When:   _buildPostList() is called
+        Then:   No operation that was clean before the call is Touched afterwards
+
+        Example:
+            doc.recompute()
+            # op.State does not contain "Touched"
+            pp._buildPostList()
+            # op.State still does not contain "Touched"
+        """
+        # Ensure the document starts in a fully-computed state
+        self.job.Document.recompute()
+
+        ops = list(self.job.Operations.Group)
+
+        # Record which operations are clean before postprocessing.
+        # (Some mock ops without execute() may already be Touched; skip those.)
+        clean_before = {op.Name for op in ops if "Touched" not in op.State}
+
+        # At least some operations should be clean to make the test meaningful
+        self.assertGreater(
+            len(clean_before),
+            0,
+            "No operations were clean after recompute — test cannot validate the invariant",
+        )
+
+        self.job.OrderOutputBy = "Operation"
+        self.job.SplitOutput = False
+        self.pp._buildPostList()
+
+        # No previously-clean operation should now be Touched
+        for op in ops:
+            if op.Name in clean_before:
+                self.assertNotIn(
+                    "Touched",
+                    op.State,
+                    f"Operation {op.Label!r} was Touched by _buildPostList() — "
+                    "post-processing must not mark operations dirty.",
+                )
 
 
 class TestJobPropertyOverrides(unittest.TestCase):

--- a/src/Mod/CAM/CAMTests/TestPostCore.py
+++ b/src/Mod/CAM/CAMTests/TestPostCore.py
@@ -752,7 +752,7 @@ class TestBuildPostList(unittest.TestCase):
         postlist = self.pp._buildPostList()
         _, sublist = postlist[0]
         tc_items = [item for item in sublist if item.item_type == "tool_controller"]
-        self.assertGreater(len(tc_items), 0)
+        self.assertTrue(len(tc_items) > 0, "Expected at least one tool_controller item")
         for tc_item in tc_items:
             self.assertIn("tool_number", tc_item.data)
             self.assertIsInstance(tc_item.data["tool_number"], (int, float))

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -28,6 +28,7 @@ from Machine.models.machine import Machine
 import FreeCAD
 import Path
 import Path.Post.Command as PathCommand
+import Path.Post.PostList as PostList
 import Path.Post.Utils as PostUtils
 import Path.Main.Job as PathJob
 import Path.Tool.Controller as PathToolController
@@ -1238,39 +1239,61 @@ class TestExport2Integration(unittest.TestCase):
 
     def test110_tool_length_offset_enabled(self):
         """
-        Test that _expand_tool_length_offset adds G43 after M6 when enabled.
+        Test that _expand_tool_length_offset adds G43 after M6 in a tool controller path.
 
-        When output_tool_length_offset=True and the operation path contains
-        an M6 tool change, G43 is injected immediately after it.
+        G43 (tool length offset) must be injected immediately after M6 in the tool
+        controller postable's path.  M6 belongs in the tool_controller postable — not
+        in operation paths — so the test builds a postlist directly rather than using
+        the full export2 pipeline.
 
-        Expected:
-            BEFORE: M6 T1
-                    G0 X10 Y20 Z5
+        Given:  A tool_controller postable whose path is [M6 T1]
+                followed by an operation postable [G0 ...]
+        When:   _expand_tool_length_offset is called with output_tool_length_offset=True
+        Then:   The tool_controller path becomes [M6 T1, G43 H1]
 
-            AFTER:  M6 T1
-                    G43 H1
-                    G0 X10 Y20 Z5
+        Example:
+            BEFORE TC path:  M6 T1
+            AFTER TC path:   M6 T1
+                             G43 H1
         """
         config = self._get_full_machine_config()
         config["output"]["output_tool_length_offset"] = True
         machine = Machine.from_dict(config)
+        post = self._create_postprocessor(machine)
 
-        with self._modify_operation_path(
-            [
-                Path.Command("M6", {"T": 1}),
-                Path.Command("G0", {"X": 10.0, "Y": 20.0, "Z": 5.0}),
-                Path.Command("G1", {"X": 20.0, "Y": 30.0, "Z": -5.0, "F": 100.0}),
-            ]
-        ):
-            results = self._run_export2(machine)
-            gcode = self._get_all_gcode(results)
-            lines = [line.strip() for line in gcode.split("\n") if line.strip()]
+        tc_item = PostList.Postable(
+            item_type="tool_controller",
+            label="6mm Endmill",
+            path=Path.Path([Path.Command("M6", {"T": 1})]),
+            source=None,
+            data={"tool_number": 1},
+        )
+        op_item = PostList.Postable(
+            item_type="operation",
+            label="TestProfile",
+            path=Path.Path(
+                [
+                    Path.Command("G0", {"X": 10.0, "Y": 20.0, "Z": 5.0}),
+                    Path.Command("G1", {"X": 20.0, "Y": 30.0, "Z": -5.0, "F": 100.0}),
+                ]
+            ),
+            source=None,
+            data={},
+        )
+        postables = [("allitems", [tc_item, op_item])]
 
-            g43_lines = [line for line in lines if line.startswith("G43")]
-            self.assertGreater(len(g43_lines), 0, "Should have G43 tool length offset command")
+        post._expand_tool_length_offset(postables)
 
-            for g43_line in g43_lines:
-                self.assertIn("H", g43_line, f"G43 should have H parameter: {g43_line}")
+        tc_commands = [cmd.Name for cmd in tc_item.path.Commands]
+        self.assertIn("G43", tc_commands, "G43 should be injected into TC path after M6")
+
+        m6_idx = tc_commands.index("M6")
+        self.assertEqual(
+            tc_commands[m6_idx + 1], "G43", "G43 must immediately follow M6 in TC path"
+        )
+        g43_cmd = tc_item.path.Commands[m6_idx + 1]
+        self.assertIn("H", g43_cmd.Parameters, "G43 should carry an H (tool number) parameter")
+        self.assertEqual(g43_cmd.Parameters["H"], 1, "G43 H value must match the T number in M6")
 
     def test111_tool_length_offset_disabled(self):
         """

--- a/src/Mod/CAM/CAMTests/TestPostProcessor.py
+++ b/src/Mod/CAM/CAMTests/TestPostProcessor.py
@@ -24,7 +24,7 @@
 
 
 from Path.Post.Processor import PostProcessorFactory
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 import FreeCAD
 import Path
 import Path.Post.Command as PathCommand
@@ -446,3 +446,322 @@ class TestPostProcessorClassification(unittest.TestCase):
         # Next call should rebuild the cache
         result = Path.Preferences.classifyPostProcessor("generic")
         self.assertEqual(result, "machine")
+
+    def test080_postprocessor_sanity_checks_hook(self):
+        """Test PostProcessor.get_sanity_checks() hook method."""
+        from Path.Post.Processor import PostProcessor
+
+        # Create a test postprocessor instance
+        class TestPostProcessor(PostProcessor):
+            def __init__(self):
+                # Don't call super().__init__ to avoid complex setup
+                self.values = {}
+
+            def get_sanity_checks(self, job):
+                return [
+                    self._create_squawk("WARNING", "Test warning"),
+                    self._create_squawk("NOTE", "Test note"),
+                ]
+
+        processor = TestPostProcessor()
+
+        # Test the hook method
+        mock_job = Mock()
+        squawks = processor.get_sanity_checks(mock_job)
+
+        self.assertEqual(len(squawks), 2)
+        self.assertEqual(squawks[0]["squawkType"], "WARNING")
+        self.assertEqual(squawks[0]["Note"], "Test warning")
+        self.assertEqual(squawks[0]["Operator"], "TestPostProcessor")
+        self.assertEqual(squawks[1]["squawkType"], "NOTE")
+        self.assertEqual(squawks[1]["Note"], "Test note")
+
+    def test081_postprocessor_create_squawk_helper(self):
+        """Test PostProcessor._create_squawk() helper method."""
+        from Path.Post.Processor import PostProcessor
+
+        class TestPostProcessor(PostProcessor):
+            def __init__(self):
+                pass
+
+        processor = TestPostProcessor()
+
+        # Test squawk creation
+        squawk = processor._create_squawk("WARNING", "Test message")
+
+        # Verify structure
+        self.assertIn("Date", squawk)
+        self.assertIn("Operator", squawk)
+        self.assertIn("Note", squawk)
+        self.assertIn("squawkType", squawk)
+        self.assertIn("squawkIcon", squawk)
+
+        # Verify values
+        self.assertEqual(squawk["squawkType"], "WARNING")
+        self.assertEqual(squawk["Note"], "Test message")
+        self.assertEqual(squawk["Operator"], "TestPostProcessor")
+        self.assertTrue(squawk["squawkIcon"].endswith(".svg"))
+
+        # Test different squawk types
+        for squawk_type in ["NOTE", "WARNING", "CAUTION", "TIP"]:
+            squawk = processor._create_squawk(squawk_type, f"Test {squawk_type}")
+            self.assertEqual(squawk["squawkType"], squawk_type)
+
+    def test082_postprocessor_default_sanity_checks(self):
+        """Test PostProcessor default get_sanity_checks() returns empty list."""
+        from Path.Post.Processor import PostProcessor
+
+        class TestPostProcessor(PostProcessor):
+            def __init__(self):
+                pass
+
+        processor = TestPostProcessor()
+        mock_job = Mock()
+
+        # Default implementation should return empty list
+        squawks = processor.get_sanity_checks(mock_job)
+        self.assertEqual(squawks, [])
+
+
+class TestConfigurationBundle(unittest.TestCase):
+    """Tests for build_configuration_bundle() and apply_configuration_bundle().
+
+    build_configuration_bundle() is a pure function that returns a flat dict.
+    apply_configuration_bundle() applies the bundle to self.values as UPPERCASE.
+    """
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _make_postprocessor(self, machine_props=None, job_overrides=None, schema=None):
+        """Create a minimal PostProcessor with controllable inputs.
+
+        Args:
+            machine_props: dict for machine.postprocessor_properties
+            job_overrides: dict serialised as JSON on the mock job
+            schema: list of schema dicts; if None a small default is used
+        """
+        from Path.Post.Processor import PostProcessor
+
+        test_schema = schema
+
+        class BundleTestPP(PostProcessor):
+            def __init__(self):
+                # Skip super().__init__() — we only need the bundle methods
+                self.values = {}
+                self._machine = None
+                self._job = None
+
+            @classmethod
+            def get_property_schema(cls):
+                if test_schema is not None:
+                    return test_schema
+                return [
+                    {"name": "blend_mode", "type": "choice", "default": "BLEND"},
+                    {"name": "blend_tolerance", "type": "float", "default": 0.0},
+                ]
+
+        pp = BundleTestPP()
+
+        # Mock machine
+        if machine_props is not None:
+            pp._machine = Mock()
+            pp._machine.postprocessor_properties = dict(machine_props)
+            pp._machine.output = None  # no output config
+
+        # Mock job
+        if job_overrides is not None:
+            import json
+
+            pp._job = Mock()
+            pp._job.PostProcessorPropertyOverrides = json.dumps(job_overrides)
+        else:
+            pp._job = Mock()
+            pp._job.PostProcessorPropertyOverrides = "{}"
+
+        return pp
+
+    # ------------------------------------------------------------------
+    # build_configuration_bundle — pure function tests
+    # ------------------------------------------------------------------
+
+    def test100_build_bundle_no_machine(self):
+        """build_configuration_bundle with no machine returns schema defaults."""
+        pp = self._make_postprocessor()
+        bundle = pp.build_configuration_bundle()
+
+        # Common schema keys (from base class) + our two specific keys
+        self.assertIn("blend_mode", bundle)
+        self.assertIn("blend_tolerance", bundle)
+        self.assertEqual(bundle["blend_mode"], "BLEND")
+        self.assertEqual(bundle["blend_tolerance"], 0.0)
+        # Common property from base schema
+        self.assertIn("preamble", bundle)
+
+    def test110_build_bundle_machine_props_take_priority_over_schema(self):
+        """Machine postprocessor_properties override schema defaults."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05, "blend_mode": "EXACT_PATH"}
+        )
+        bundle = pp.build_configuration_bundle()
+
+        self.assertEqual(bundle["blend_tolerance"], 0.05)
+        self.assertEqual(bundle["blend_mode"], "EXACT_PATH")
+        # Schema-only key still present via defaults
+        self.assertIn("preamble", bundle)
+
+    def test120_build_bundle_schema_fills_missing_keys(self):
+        """Schema defaults fill keys absent from machine props."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.02}
+            # blend_mode NOT in machine props
+        )
+        bundle = pp.build_configuration_bundle()
+
+        self.assertEqual(bundle["blend_tolerance"], 0.02)  # from machine
+        self.assertEqual(bundle["blend_mode"], "BLEND")  # from schema default
+
+    def test130_build_bundle_job_overrides_win(self):
+        """Job overrides take priority over machine props and schema defaults."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05, "blend_mode": "BLEND"},
+            job_overrides={"blend_tolerance": 0.018},
+        )
+        bundle = pp.build_configuration_bundle()
+
+        self.assertEqual(bundle["blend_tolerance"], 0.018)  # job override wins
+        self.assertEqual(bundle["blend_mode"], "BLEND")  # untouched
+
+    def test140_build_bundle_explicit_overrides_win_over_job(self):
+        """Explicit overrides dict beats job-stored overrides."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05, "blend_mode": "BLEND"},
+            job_overrides={"blend_tolerance": 0.018},
+        )
+        dialog_overrides = {"blend_tolerance": 0.1}
+        bundle = pp.build_configuration_bundle(overrides=dialog_overrides)
+
+        # Explicit override wins — job overrides are never read
+        self.assertEqual(bundle["blend_tolerance"], 0.1)
+
+    def test150_build_bundle_unknown_override_key_ignored(self):
+        """Override keys not present in the bundle are silently ignored."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05},
+        )
+        bundle = pp.build_configuration_bundle(overrides={"nonexistent_key": 42})
+
+        self.assertNotIn("nonexistent_key", bundle)
+        self.assertEqual(bundle["blend_tolerance"], 0.05)
+
+    def test160_build_bundle_empty_overrides(self):
+        """Empty overrides dict changes nothing."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05},
+        )
+        bundle = pp.build_configuration_bundle(overrides={})
+
+        self.assertEqual(bundle["blend_tolerance"], 0.05)
+
+    def test170_build_bundle_is_pure(self):
+        """build_configuration_bundle has no side effects on self.values or machine."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05, "blend_mode": "BLEND"},
+        )
+        original_values = dict(pp.values)
+        original_props = dict(pp._machine.postprocessor_properties)
+
+        pp.build_configuration_bundle(overrides={"blend_tolerance": 999.0})
+
+        # self.values unchanged
+        self.assertEqual(pp.values, original_values)
+        # machine.postprocessor_properties unchanged
+        self.assertEqual(pp._machine.postprocessor_properties, original_props)
+
+    # ------------------------------------------------------------------
+    # apply_configuration_bundle — side-effecting tests
+    # ------------------------------------------------------------------
+
+    def test200_apply_bundle_syncs_uppercase_keys(self):
+        """apply_configuration_bundle writes bundle keys as UPPERCASE into self.values."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05, "blend_mode": "BLEND"},
+        )
+        pp.apply_configuration_bundle()
+
+        self.assertEqual(pp.values["BLEND_TOLERANCE"], 0.05)
+        self.assertEqual(pp.values["BLEND_MODE"], "BLEND")
+
+    def test210_apply_bundle_with_overrides(self):
+        """apply_configuration_bundle(overrides) writes overridden values."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05, "blend_mode": "BLEND"},
+        )
+        pp.apply_configuration_bundle(overrides={"blend_tolerance": 0.018})
+
+        self.assertEqual(pp.values["BLEND_TOLERANCE"], 0.018)
+        self.assertEqual(pp.values["BLEND_MODE"], "BLEND")
+
+    def test220_apply_bundle_updates_machine_properties(self):
+        """apply_configuration_bundle writes bundle back to machine.postprocessor_properties."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05},
+        )
+        pp.apply_configuration_bundle(overrides={"blend_tolerance": 0.018})
+
+        # Machine props updated
+        self.assertEqual(pp._machine.postprocessor_properties["blend_tolerance"], 0.018)
+        # Schema-default keys also backfilled
+        self.assertIn("blend_mode", pp._machine.postprocessor_properties)
+
+    def test230_apply_bundle_idempotent(self):
+        """Calling apply_configuration_bundle twice produces the same result."""
+        pp = self._make_postprocessor(
+            machine_props={"blend_tolerance": 0.05, "blend_mode": "BLEND"},
+            job_overrides={"blend_tolerance": 0.018},
+        )
+        pp.apply_configuration_bundle()
+        first = dict(pp.values)
+
+        pp.apply_configuration_bundle()
+        second = dict(pp.values)
+
+        self.assertEqual(first, second)
+
+    # ------------------------------------------------------------------
+    # _read_job_overrides — parsing tests
+    # ------------------------------------------------------------------
+
+    def test300_read_job_overrides_valid_json(self):
+        """Valid JSON string is parsed correctly."""
+        pp = self._make_postprocessor(job_overrides={"blend_tolerance": 0.018})
+        result = pp._read_job_overrides()
+        self.assertEqual(result, {"blend_tolerance": 0.018})
+
+    def test310_read_job_overrides_empty(self):
+        """Empty JSON returns empty dict."""
+        pp = self._make_postprocessor()
+        result = pp._read_job_overrides()
+        self.assertEqual(result, {})
+
+    def test320_read_job_overrides_no_job(self):
+        """No job returns empty dict."""
+        pp = self._make_postprocessor()
+        pp._job = None
+        result = pp._read_job_overrides()
+        self.assertEqual(result, {})
+
+    def test330_read_job_overrides_invalid_json(self):
+        """Invalid JSON returns empty dict without raising."""
+        pp = self._make_postprocessor()
+        pp._job.PostProcessorPropertyOverrides = "not valid json {"
+        result = pp._read_job_overrides()
+        self.assertEqual(result, {})
+
+    def test340_read_job_overrides_non_dict_json(self):
+        """JSON that parses to non-dict returns empty dict."""
+        pp = self._make_postprocessor()
+        pp._job.PostProcessorPropertyOverrides = "[1, 2, 3]"
+        result = pp._read_job_overrides()
+        self.assertEqual(result, {})

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -313,6 +313,11 @@ SET(PathPythonPost_SRCS
     Path/Post/UtilsParse.py
 )
 
+SET(PathPythonPostGui_SRCS
+    Path/Post/Gui/__init__.py
+    Path/Post/Gui/DlgPostProcess.py
+)
+
 SET(PathPythonPostScripts_SRCS
     Path/Post/scripts/__init__.py
     Path/Post/scripts/centroid_legacy_post.py
@@ -630,6 +635,7 @@ SET(all_files
     ${PathPythonOp_SRCS}
     ${PathPythonOpGui_SRCS}
     ${PathPythonPost_SRCS}
+    ${PathPythonPostGui_SRCS}
     ${PathPythonPostScripts_SRCS}
     ${PathPythonTools_SRCS}
     ${PathPythonToolsAssets_SRCS}
@@ -772,6 +778,13 @@ INSTALL(
         ${PathPythonPost_SRCS}
     DESTINATION
         Mod/CAM/Path/Post
+)
+
+INSTALL(
+    FILES
+        ${PathPythonPostGui_SRCS}
+    DESTINATION
+        Mod/CAM/Path/Post/Gui
 )
 
 INSTALL(

--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -86,6 +86,7 @@
         <file>panels/DlgJobCreate.ui</file>
         <file>panels/DlgJobModelSelect.ui</file>
         <file>panels/DlgJobTemplateExport.ui</file>
+        <file>panels/DlgPostProcess.ui</file>
         <file>panels/DlgSelectPostProcessor.ui</file>
         <file>panels/DlgTCChooser.ui</file>
         <file>panels/DlgToolControllerEdit.ui</file>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
@@ -256,16 +256,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="buttonSelectByType">
-           <property name="toolTip">
-            <string>Select or deselect operations by type</string>
-           </property>
-           <property name="text">
-            <string>Select by Type...</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QPushButton" name="buttonWorkplan">
            <property name="toolTip">
             <string>Show the workplan (postable items structure)</string>
@@ -478,12 +468,6 @@
           <property name="toolTip">
            <string>G-code content for the selected file. You may edit before saving.</string>
           </property>
-          <property name="lineWrapMode">
-           <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
-          </property>
-          <property name="placeholderText">
-           <string>(no output generated)</string>
-          </property>
          </widget>
         </widget>
        </item>
@@ -521,33 +505,6 @@
        <string>Warnings</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <layout class="QHBoxLayout" name="horizontalLayout">
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item>
-          <widget class="QPushButton" name="buttonRecomputeWarnings">
-           <property name="toolTip">
-            <string>Recompute validation warnings using current dialog values</string>
-           </property>
-           <property name="text">
-            <string>Recompute Warnings</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
        <item>
         <widget class="QLabel" name="labelWarningsStatus">
          <property name="styleSheet">

--- a/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
@@ -180,6 +180,29 @@
        </item>
 
        <item>
+        <widget class="QGroupBox" name="groupBoxPostParams">
+         <property name="title">
+          <string>Post Processor Parameters</string>
+         </property>
+         <layout class="QFormLayout" name="layoutPostParams">
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="labelPostParamsPlaceholder">
+            <property name="styleSheet">
+             <string>color: gray;</string>
+            </property>
+            <property name="text">
+             <string>(No additional parameters for this post processor)</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignCenter</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item>
         <spacer name="spacerOverview">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -320,29 +343,6 @@
              <property name="alignment">
               <set>Qt::AlignmentFlag::AlignCenter</set>
              </property>
-            </widget>
-           </item>
-
-           <item>
-            <widget class="QGroupBox" name="groupBoxPostParams">
-             <property name="title">
-              <string>Post Processor Parameters</string>
-             </property>
-             <layout class="QVBoxLayout" name="layoutPostParams">
-              <item>
-               <widget class="QLabel" name="labelPostParamsPlaceholder">
-                <property name="styleSheet">
-                 <string>color: gray;</string>
-                </property>
-                <property name="text">
-                 <string>(No additional parameters for this post processor)</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignmentFlag::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-             </layout>
             </widget>
            </item>
 

--- a/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
@@ -20,7 +20,6 @@
    <property name="margin" stdset="0">
     <number>9</number>
    </property>
-
    <item>
     <widget class="QLabel" name="labelJobTitle">
      <property name="styleSheet">
@@ -31,19 +30,16 @@
      </property>
     </widget>
    </item>
-
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
      </property>
-
      <widget class="QWidget" name="tabOverview">
       <attribute name="title">
        <string>Overview</string>
       </attribute>
       <layout class="QVBoxLayout" name="layoutOverview">
-
        <item>
         <widget class="QGroupBox" name="groupBoxMachine">
          <property name="title">
@@ -62,21 +58,20 @@
           </item>
           <item row="0" column="1">
            <widget class="QComboBox" name="comboBoxMachine">
-            <property name="toolTip">
-             <string>Machine configuration (.fcm) to use for post-processing</string>
-            </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>1</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="toolTip">
+             <string>Machine configuration (.fcm) to use for post-processing</string>
+            </property>
            </widget>
           </item>
          </layout>
         </widget>
        </item>
-
        <item>
         <widget class="QGroupBox" name="groupBoxFixtures">
          <property name="title">
@@ -85,21 +80,20 @@
          <layout class="QVBoxLayout" name="layoutFixtures">
           <item>
            <widget class="QListWidget" name="listWidgetFixtures">
-            <property name="toolTip">
-             <string>Check fixtures to include in the G-code output</string>
-            </property>
             <property name="maximumSize">
              <size>
               <width>16777215</width>
               <height>90</height>
              </size>
             </property>
+            <property name="toolTip">
+             <string>Check fixtures to include in the G-code output</string>
+            </property>
            </widget>
           </item>
          </layout>
         </widget>
        </item>
-
        <item>
         <widget class="QGroupBox" name="groupBoxJobDetails">
          <property name="title">
@@ -132,20 +126,20 @@
              <string>Comment:</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignmentFlag::AlignTop|Qt::AlignmentFlag::AlignLeft</set>
+             <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
            <widget class="QPlainTextEdit" name="plainTextEditComment">
-            <property name="toolTip">
-             <string>Arbitrary comment written into the G-code header</string>
-            </property>
             <property name="maximumSize">
              <size>
               <width>16777215</width>
               <height>70</height>
              </size>
+            </property>
+            <property name="toolTip">
+             <string>Arbitrary comment written into the G-code header</string>
             </property>
             <property name="placeholderText">
              <string>(optional)</string>
@@ -155,7 +149,6 @@
          </layout>
         </widget>
        </item>
-
        <item>
         <widget class="QGroupBox" name="groupBoxOptions">
          <property name="title">
@@ -178,7 +171,6 @@
          </layout>
         </widget>
        </item>
-
        <item>
         <widget class="QGroupBox" name="groupBoxPostParams">
          <property name="title">
@@ -201,7 +193,6 @@
          </layout>
         </widget>
        </item>
-
        <item>
         <spacer name="spacerOverview">
          <property name="orientation">
@@ -215,10 +206,8 @@
          </property>
         </spacer>
        </item>
-
       </layout>
      </widget>
-
      <widget class="QWidget" name="tabOperations">
       <attribute name="title">
        <string>Operations</string>
@@ -229,14 +218,14 @@
          <property name="toolTip">
           <string>Check operations to include in the G-code output. Uncheck to skip.</string>
          </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+         </property>
          <property name="rootIsDecorated">
           <bool>false</bool>
          </property>
          <property name="uniformRowHeights">
           <bool>true</bool>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
          </property>
          <column>
           <property name="text">
@@ -298,7 +287,7 @@
             <string>Total: -</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignVCenter</set>
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -306,32 +295,29 @@
        </item>
       </layout>
      </widget>
-
      <widget class="QWidget" name="tabOutput">
       <attribute name="title">
        <string>Options</string>
       </attribute>
       <layout class="QVBoxLayout" name="layoutOutput">
-
        <item>
         <widget class="QScrollArea" name="scrollAreaOutput">
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
          <property name="frameShape">
           <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
          </property>
          <widget class="QWidget" name="scrollContentsOutput">
           <property name="geometry">
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>700</width>
-            <height>580</height>
+            <width>704</width>
+            <height>531</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="layoutOutputScroll">
-
            <item>
             <widget class="QLabel" name="labelNoMachineOutput">
              <property name="styleSheet">
@@ -345,7 +331,6 @@
              </property>
             </widget>
            </item>
-
            <item>
             <spacer name="spacerOutput">
              <property name="orientation">
@@ -359,21 +344,17 @@
              </property>
             </spacer>
            </item>
-
           </layout>
          </widget>
         </widget>
        </item>
-
       </layout>
      </widget>
-
      <widget class="QWidget" name="tabGcodeOutput">
       <attribute name="title">
        <string>Output</string>
       </attribute>
       <layout class="QVBoxLayout" name="layoutGcodeOutput">
-
        <item>
         <layout class="QHBoxLayout" name="layoutOutputLocation">
          <item>
@@ -395,20 +376,19 @@
          </item>
          <item>
           <widget class="QPushButton" name="buttonBrowseOutputLocation">
-           <property name="text">
-            <string>Browse...</string>
-           </property>
            <property name="maximumSize">
             <size>
              <width>80</width>
              <height>16777215</height>
             </size>
            </property>
+           <property name="text">
+            <string>Browse...</string>
+           </property>
           </widget>
          </item>
         </layout>
        </item>
-
        <item>
         <layout class="QHBoxLayout" name="layoutFilenameTemplate">
          <item>
@@ -430,11 +410,8 @@
          </item>
          <item>
           <widget class="QPushButton" name="buttonApplyTemplate">
-           <property name="text">
-            <string>Apply</string>
-           </property>
-           <property name="toolTip">
-            <string>Regenerate output filenames using this template</string>
+           <property name="enabled">
+            <bool>false</bool>
            </property>
            <property name="maximumSize">
             <size>
@@ -442,53 +419,54 @@
              <height>16777215</height>
             </size>
            </property>
-           <property name="enabled">
-            <bool>false</bool>
+           <property name="toolTip">
+            <string>Regenerate output filenames using this template</string>
+           </property>
+           <property name="text">
+            <string>Apply</string>
            </property>
           </widget>
          </item>
         </layout>
        </item>
-
        <item>
         <widget class="QLabel" name="labelOutputStatus">
          <property name="styleSheet">
           <string>color: gray; font-style: italic;</string>
          </property>
          <property name="text">
-          <string>Press "Generate Output" to preview G-code before saving.</string>
+          <string>Press &quot;Generate Output&quot; to preview G-code before saving.</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignmentFlag::AlignCenter</set>
          </property>
         </widget>
        </item>
-
        <item>
         <widget class="QSplitter" name="splitterOutput">
          <property name="orientation">
           <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <widget class="QListWidget" name="listWidgetOutputFiles">
-          <property name="toolTip">
-           <string>Generated output files. Select a file to view or edit its contents.</string>
-          </property>
           <property name="maximumSize">
            <size>
             <width>260</width>
             <height>16777215</height>
            </size>
           </property>
+          <property name="toolTip">
+           <string>Generated output files. Select a file to view or edit its contents.</string>
+          </property>
          </widget>
          <widget class="QPlainTextEdit" name="plainTextEditGcode">
-          <property name="toolTip">
-           <string>G-code content for the selected file. You may edit before saving.</string>
-          </property>
           <property name="font">
            <font>
             <family>Courier</family>
             <pointsize>10</pointsize>
            </font>
+          </property>
+          <property name="toolTip">
+           <string>G-code content for the selected file. You may edit before saving.</string>
           </property>
           <property name="lineWrapMode">
            <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
@@ -499,16 +477,15 @@
          </widget>
         </widget>
        </item>
-
        <item>
         <layout class="QHBoxLayout" name="layoutSaveRow">
          <item>
           <widget class="QPushButton" name="buttonSaveOutput">
-           <property name="text">
-            <string>Save to Disk</string>
-           </property>
            <property name="enabled">
             <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Save to Disk</string>
            </property>
           </widget>
          </item>
@@ -527,15 +504,40 @@
          </item>
         </layout>
        </item>
-
       </layout>
      </widget>
-
      <widget class="QWidget" name="tabWarnings">
       <attribute name="title">
        <string>Warnings</string>
       </attribute>
-      <layout class="QVBoxLayout" name="layoutWarnings">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonRecomputeWarnings">
+           <property name="toolTip">
+            <string>Recompute validation warnings using current dialog values</string>
+           </property>
+           <property name="text">
+            <string>Recompute Warnings</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
        <item>
         <widget class="QLabel" name="labelWarningsStatus">
          <property name="styleSheet">
@@ -586,10 +588,8 @@
        </item>
       </layout>
      </widget>
-
     </widget>
    </item>
-
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
@@ -600,7 +600,6 @@
      </property>
     </widget>
    </item>
-
   </layout>
  </widget>
  <resources/>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
@@ -266,6 +266,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QPushButton" name="buttonWorkplan">
+           <property name="toolTip">
+            <string>Show the workplan (postable items structure)</string>
+           </property>
+           <property name="text">
+            <string>Workplan</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="spacerOpButtons">
            <property name="orientation">
             <enum>Qt::Orientation::Horizontal</enum>

--- a/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgPostProcess.ui
@@ -1,0 +1,625 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DlgPostProcess</class>
+ <widget class="QDialog" name="DlgPostProcess">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>740</width>
+    <height>660</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Post Processing</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin" stdset="0">
+    <number>9</number>
+   </property>
+
+   <item>
+    <widget class="QLabel" name="labelJobTitle">
+     <property name="styleSheet">
+      <string>font-weight: bold; font-size: 13px;</string>
+     </property>
+     <property name="text">
+      <string>Post Processing - Job: (unknown)</string>
+     </property>
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+
+     <widget class="QWidget" name="tabOverview">
+      <attribute name="title">
+       <string>Overview</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="layoutOverview">
+
+       <item>
+        <widget class="QGroupBox" name="groupBoxMachine">
+         <property name="title">
+          <string>Machine</string>
+         </property>
+         <layout class="QFormLayout" name="formLayoutMachine">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelMachineLabel">
+            <property name="text">
+             <string>Machine:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="comboBoxMachine">
+            <property name="toolTip">
+             <string>Machine configuration (.fcm) to use for post-processing</string>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item>
+        <widget class="QGroupBox" name="groupBoxFixtures">
+         <property name="title">
+          <string>Fixtures</string>
+         </property>
+         <layout class="QVBoxLayout" name="layoutFixtures">
+          <item>
+           <widget class="QListWidget" name="listWidgetFixtures">
+            <property name="toolTip">
+             <string>Check fixtures to include in the G-code output</string>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>90</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item>
+        <widget class="QGroupBox" name="groupBoxJobDetails">
+         <property name="title">
+          <string>Job Details</string>
+         </property>
+         <layout class="QFormLayout" name="formLayoutJobDetails">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::FieldGrowthPolicy::ExpandingFieldsGrow</enum>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="labelJobAuthorLabel">
+            <property name="text">
+             <string>Author:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="lineEditJobAuthor">
+            <property name="toolTip">
+             <string>Author name written into the G-code header comment</string>
+            </property>
+            <property name="placeholderText">
+             <string>(optional)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="labelCommentLabel">
+            <property name="text">
+             <string>Comment:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignmentFlag::AlignTop|Qt::AlignmentFlag::AlignLeft</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QPlainTextEdit" name="plainTextEditComment">
+            <property name="toolTip">
+             <string>Arbitrary comment written into the G-code header</string>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>70</height>
+             </size>
+            </property>
+            <property name="placeholderText">
+             <string>(optional)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item>
+        <widget class="QGroupBox" name="groupBoxOptions">
+         <property name="title">
+          <string>Options</string>
+         </property>
+         <layout class="QVBoxLayout" name="layoutOptions">
+          <item>
+           <widget class="QCheckBox" name="checkBoxSanityReport">
+            <property name="toolTip">
+             <string>Generate a full sanity/setup report alongside the G-code file</string>
+            </property>
+            <property name="text">
+             <string>Generate HTML sanity report</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+
+       <item>
+        <spacer name="spacerOverview">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>10</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+
+      </layout>
+     </widget>
+
+     <widget class="QWidget" name="tabOperations">
+      <attribute name="title">
+       <string>Operations</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="layoutOperations">
+       <item>
+        <widget class="QTreeWidget" name="treeWidgetOperations">
+         <property name="toolTip">
+          <string>Check operations to include in the G-code output. Uncheck to skip.</string>
+         </property>
+         <property name="rootIsDecorated">
+          <bool>false</bool>
+         </property>
+         <property name="uniformRowHeights">
+          <bool>true</bool>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
+         </property>
+         <column>
+          <property name="text">
+           <string>Operation</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Cycle Time</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="layoutOperationButtons">
+         <item>
+          <widget class="QPushButton" name="buttonSelectAllOps">
+           <property name="text">
+            <string>Select All</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSelectNoneOps">
+           <property name="text">
+            <string>Select None</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonSelectByType">
+           <property name="toolTip">
+            <string>Select or deselect operations by type</string>
+           </property>
+           <property name="text">
+            <string>Select by Type...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="spacerOpButtons">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="labelTotalTime">
+           <property name="toolTip">
+            <string>Total estimated machining time for checked operations</string>
+           </property>
+           <property name="text">
+            <string>Total: -</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+
+     <widget class="QWidget" name="tabOutput">
+      <attribute name="title">
+       <string>Options</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="layoutOutput">
+
+       <item>
+        <widget class="QScrollArea" name="scrollAreaOutput">
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <widget class="QWidget" name="scrollContentsOutput">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>700</width>
+            <height>580</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="layoutOutputScroll">
+
+           <item>
+            <widget class="QLabel" name="labelNoMachineOutput">
+             <property name="styleSheet">
+              <string>color: gray; font-style: italic;</string>
+             </property>
+             <property name="text">
+              <string>(Select a machine on the Overview tab to see machine output options)</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+
+           <item>
+            <widget class="QGroupBox" name="groupBoxPostParams">
+             <property name="title">
+              <string>Post Processor Parameters</string>
+             </property>
+             <layout class="QVBoxLayout" name="layoutPostParams">
+              <item>
+               <widget class="QLabel" name="labelPostParamsPlaceholder">
+                <property name="styleSheet">
+                 <string>color: gray;</string>
+                </property>
+                <property name="text">
+                 <string>(No additional parameters for this post processor)</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignmentFlag::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+
+           <item>
+            <spacer name="spacerOutput">
+             <property name="orientation">
+              <enum>Qt::Orientation::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>10</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+
+          </layout>
+         </widget>
+        </widget>
+       </item>
+
+      </layout>
+     </widget>
+
+     <widget class="QWidget" name="tabGcodeOutput">
+      <attribute name="title">
+       <string>Output</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="layoutGcodeOutput">
+
+       <item>
+        <layout class="QHBoxLayout" name="layoutOutputLocation">
+         <item>
+          <widget class="QLabel" name="labelOutputLocationLabel">
+           <property name="text">
+            <string>Output folder:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="lineEditOutputLocation">
+           <property name="toolTip">
+            <string>Folder where G-code files will be saved</string>
+           </property>
+           <property name="placeholderText">
+            <string>(resolved when output is generated)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonBrowseOutputLocation">
+           <property name="text">
+            <string>Browse...</string>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>80</width>
+             <height>16777215</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+
+       <item>
+        <layout class="QHBoxLayout" name="layoutFilenameTemplate">
+         <item>
+          <widget class="QLabel" name="labelFilenameTemplateLabel">
+           <property name="text">
+            <string>Filename template:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="lineEditFilenameTemplate">
+           <property name="toolTip">
+            <string>Filename template. Substitutions: %j=job name, %d=document, %T=tool, %W=fixture, %O=operation</string>
+           </property>
+           <property name="placeholderText">
+            <string>e.g. %j.nc</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonApplyTemplate">
+           <property name="text">
+            <string>Apply</string>
+           </property>
+           <property name="toolTip">
+            <string>Regenerate output filenames using this template</string>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>60</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+
+       <item>
+        <widget class="QLabel" name="labelOutputStatus">
+         <property name="styleSheet">
+          <string>color: gray; font-style: italic;</string>
+         </property>
+         <property name="text">
+          <string>Press "Generate Output" to preview G-code before saving.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+
+       <item>
+        <widget class="QSplitter" name="splitterOutput">
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
+         </property>
+         <widget class="QListWidget" name="listWidgetOutputFiles">
+          <property name="toolTip">
+           <string>Generated output files. Select a file to view or edit its contents.</string>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>260</width>
+            <height>16777215</height>
+           </size>
+          </property>
+         </widget>
+         <widget class="QPlainTextEdit" name="plainTextEditGcode">
+          <property name="toolTip">
+           <string>G-code content for the selected file. You may edit before saving.</string>
+          </property>
+          <property name="font">
+           <font>
+            <family>Courier</family>
+            <pointsize>10</pointsize>
+           </font>
+          </property>
+          <property name="lineWrapMode">
+           <enum>QPlainTextEdit::LineWrapMode::NoWrap</enum>
+          </property>
+          <property name="placeholderText">
+           <string>(no output generated)</string>
+          </property>
+         </widget>
+        </widget>
+       </item>
+
+       <item>
+        <layout class="QHBoxLayout" name="layoutSaveRow">
+         <item>
+          <widget class="QPushButton" name="buttonSaveOutput">
+           <property name="text">
+            <string>Save to Disk</string>
+           </property>
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="spacerSaveRow">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+
+      </layout>
+     </widget>
+
+     <widget class="QWidget" name="tabWarnings">
+      <attribute name="title">
+       <string>Warnings</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="layoutWarnings">
+       <item>
+        <widget class="QLabel" name="labelWarningsStatus">
+         <property name="styleSheet">
+          <string>color: green; font-weight: bold;</string>
+         </property>
+         <property name="text">
+          <string>No issues found.</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QTableWidget" name="tableWidgetWarnings">
+         <property name="toolTip">
+          <string>Validation issues found in the job. WARNING and CAUTION items should be addressed before machining.</string>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::EditTrigger::NoEditTriggers</set>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
+         </property>
+         <property name="showGrid">
+          <bool>false</bool>
+         </property>
+         <property name="columnCount">
+          <number>2</number>
+         </property>
+         <attribute name="horizontalHeaderStretchLastSection">
+          <bool>true</bool>
+         </attribute>
+         <column>
+          <property name="text">
+           <string>Severity</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Note</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+
+    </widget>
+   </item>
+
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Close</set>
+     </property>
+    </widget>
+   </item>
+
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>DlgPostProcess</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>350</x>
+     <y>640</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>350</x>
+     <y>330</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -124,7 +124,7 @@ class CAMWorkbench(Workbench):
         Path.GuiInit.Startup()
 
         # build commands list
-        projcmdlist = ["CAM_Job", "CAM_Sanity", "CAM_QuickValidate"]
+        projcmdlist = ["CAM_Job", "CAM_Sanity"]
         postcmdlist = ["CAM_Post", "CAM_PostSelected"]
         toolcmdlist = ["CAM_Inspect", "CAM_SelectLoop", "CAM_OpActiveToggle"]
 

--- a/src/Mod/CAM/InitGui.py
+++ b/src/Mod/CAM/InitGui.py
@@ -124,7 +124,7 @@ class CAMWorkbench(Workbench):
         Path.GuiInit.Startup()
 
         # build commands list
-        projcmdlist = ["CAM_Job", "CAM_Sanity"]
+        projcmdlist = ["CAM_Job", "CAM_Sanity", "CAM_QuickValidate"]
         postcmdlist = ["CAM_Post", "CAM_PostSelected"]
         toolcmdlist = ["CAM_Inspect", "CAM_SelectLoop", "CAM_OpActiveToggle"]
 

--- a/src/Mod/CAM/Machine/models/machine.py
+++ b/src/Mod/CAM/Machine/models/machine.py
@@ -167,6 +167,7 @@ class ProcessingOptions:
     filter_inefficient_moves: bool = False  # Collapse redundant G0 rapid move chains
     split_arcs: bool = False
     tool_change: bool = True  # Enable tool change commands
+    translate_drill_cycles: bool = False  # Expand canned drill cycles to G0/G1 moves
     translate_rapid_moves: bool = False
     xy_before_z_after_tool_change: bool = (
         False  # Decompose first move after tool change: XY first, then Z
@@ -1080,6 +1081,7 @@ class Machine:
             "filter_inefficient_moves": self.processing.filter_inefficient_moves,
             "split_arcs": self.processing.split_arcs,
             "tool_change": self.processing.tool_change,
+            "translate_drill_cycles": self.processing.translate_drill_cycles,
             "translate_rapid_moves": self.processing.translate_rapid_moves,
             "xy_before_z_after_tool_change": self.processing.xy_before_z_after_tool_change,
         }
@@ -1557,6 +1559,9 @@ class Machine:
             )
             config.processing.split_arcs = processing_data.get("split_arcs", False)
             config.processing.tool_change = processing_data.get("tool_change", True)
+            config.processing.translate_drill_cycles = processing_data.get(
+                "translate_drill_cycles", False
+            )
             config.processing.translate_rapid_moves = processing_data.get(
                 "translate_rapid_moves", False
             )

--- a/src/Mod/CAM/Machine/ui/editor/machine_editor.py
+++ b/src/Mod/CAM/Machine/ui/editor/machine_editor.py
@@ -2339,7 +2339,11 @@ class MachineEditorDialog(QtGui.QDialog):
                 return
 
             # Create widgets for each property in the schema
+            # Skip runtime-only properties — they are shown in the post-processing
+            # dialog, not persisted in the machine configuration.
             for prop in schema:
+                if prop.get("runtime", False):
+                    continue
                 prop_name = prop.get("name")
                 prop_label = prop.get("label", prop_name)
                 prop_default = prop.get("default")

--- a/src/Mod/CAM/Path/Main/Gui/SanityCmd.py
+++ b/src/Mod/CAM/Path/Main/Gui/SanityCmd.py
@@ -99,6 +99,59 @@ class CommandCAMSanity:
         webbrowser.open_new_tab(file_location)
 
 
+class CommandCAMQuickValidate:
+    """Quick validation command: runs squawk checks without generating images or HTML."""
+
+    def GetResources(self):
+        return {
+            "Pixmap": "CAM_Sanity",
+            "MenuText": QT_TRANSLATE_NOOP("CAM_Sanity", "Quick Validate"),
+            "Accel": "P, V",
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "CAM_Sanity",
+                "Validates the CAM job for common issues without generating a full report",
+            ),
+        }
+
+    def IsActive(self):
+        selection = FreeCADGui.Selection.getSelectionEx()
+        if len(selection) == 0:
+            return False
+        obj = selection[0].Object
+        return isinstance(obj.Proxy, Path.Main.Job.ObjectJob)
+
+    def Activated(self):
+        obj = FreeCADGui.Selection.getSelectionEx()[0].Object
+
+        try:
+            all_squawks, critical_squawks = Sanity.CAMSanity.validate_job(obj)
+        except Exception as e:
+            Path.Log.error(f"CAM_QuickValidate: Validation failed: {e}")
+            FreeCAD.Console.PrintError(f"Quick Validate failed: {e}\n")
+            return
+
+        if not all_squawks:
+            FreeCAD.Console.PrintMessage(
+                translate("CAM_Sanity", "Quick Validate: No issues found.\n")
+            )
+            return
+
+        FreeCAD.Console.PrintMessage(translate("CAM_Sanity", "=== Quick Validation Results ===\n"))
+        for squawk in all_squawks:
+            msg = f"[{squawk['squawkType']}] {squawk['Note']}\n"
+            if squawk["squawkType"] in ("WARNING", "CAUTION"):
+                FreeCAD.Console.PrintWarning(msg)
+            else:
+                FreeCAD.Console.PrintMessage(msg)
+        FreeCAD.Console.PrintMessage(
+            translate(
+                "CAM_Sanity",
+                f"=== {len(all_squawks)} issue(s) found, {len(critical_squawks)} critical ===\n",
+            )
+        )
+
+
 if FreeCAD.GuiUp:
     # register the FreeCAD command
     FreeCADGui.addCommand("CAM_Sanity", CommandCAMSanity())
+    FreeCADGui.addCommand("CAM_QuickValidate", CommandCAMQuickValidate())

--- a/src/Mod/CAM/Path/Main/Sanity/ImageBuilder.py
+++ b/src/Mod/CAM/Path/Main/Sanity/ImageBuilder.py
@@ -53,12 +53,21 @@ class ImageBuilder:
 class ImageBuilderFactory:
     @staticmethod
     def get_image_builder(file_path, **kwargs):
-        # return DummyImageBuilder(file_path, **kwargs)
-        if FreeCAD.GuiUp:
+        if not FreeCAD.GuiUp:
+            return DummyImageBuilder(file_path)
+        if (
+            os.environ.get("WAYLAND_DISPLAY")
+            or os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland"
+        ):
+            Path.Log.warning(
+                "Wayland session detected: skipping GUI image generation to avoid segfaults"
+            )
+            return DummyImageBuilder(file_path)
+        try:
             return GuiImageBuilder(file_path, **kwargs)
-        else:
-            return DummyImageBuilder(file_path, **kwargs)
-        # return NonGuiImageBuilder(file_path, **kwargs)
+        except Exception as e:
+            Path.Log.warning(f"GuiImageBuilder init failed: {e}, falling back to DummyImageBuilder")
+            return DummyImageBuilder(file_path)
 
 
 class DummyImageBuilder(ImageBuilder):
@@ -88,7 +97,8 @@ class GuiImageBuilder(ImageBuilder):
 
     def __del__(self):
         Path.Log.debug("Destroying GuiImageBuilder")
-        self.restore_visibility()
+        if hasattr(self, "visible"):
+            self.restore_visibility()
 
     def prepare_view(self, obj, view="default"):
         # Create a new view
@@ -151,26 +161,38 @@ class GuiImageBuilder(ImageBuilder):
             o.Visibility = True
 
     def build_image(self, obj, image_name, as_bytes=False, view="default"):
-        Path.Log.debug("CAM - Building image\n")
         """
         Makes an image of the target object. Returns either the image as bytes or a filename.
+        On failure, logs a warning and returns b"" (as_bytes) or "" (file path).
         """
-
-        idx = self.prepare_view(obj, view=view)
-
-        if as_bytes:
-            # Capture directly to memory without writing to disk
-            img_bytes = self.capture_image_to_bytes()
-            self.destroy_view(idx)
-            return img_bytes
-        else:
-            # Write to disk as before
-            file_path = os.path.join(self.file_path, image_name)
-            self.capture_image(file_path)
-            self.destroy_view(idx)
-            result = f"{file_path}_t.png"
-            Path.Log.debug(f"Image saved to: {result}")
-            return result
+        Path.Log.debug("CAM - Building image\n")
+        idx = None
+        try:
+            idx = self.prepare_view(obj, view=view)
+            if as_bytes:
+                img_bytes = self.capture_image_to_bytes()
+                self.destroy_view(idx)
+                return img_bytes
+            else:
+                file_path = os.path.join(self.file_path, image_name)
+                self.capture_image(file_path)
+                self.destroy_view(idx)
+                result = f"{file_path}_t.png"
+                Path.Log.debug(f"Image saved to: {result}")
+                return result
+        except Exception as e:
+            Path.Log.warning(f"Image capture failed for {image_name}: {e}")
+            if idx is not None:
+                try:
+                    self.destroy_view(idx)
+                except Exception:
+                    pass
+            if hasattr(self, "visible"):
+                try:
+                    self.restore_visibility()
+                except Exception:
+                    pass
+            return b"" if as_bytes else ""
 
     def capture_image(self, file_path):
         FreeCADGui.updateGui()

--- a/src/Mod/CAM/Path/Main/Sanity/Sanity.py
+++ b/src/Mod/CAM/Path/Main/Sanity/Sanity.py
@@ -508,12 +508,18 @@ class CAMSanity:
         generator = ReportGenerator.ReportGenerator(self.data, embed_images=True)
         return generator.generate_html()
 
-    def get_all_squawks(self):
+    def get_all_squawks(self, overrides=None):
         """Collect squawks from all validation sections without generating images or HTML.
 
         Calls each _xxxData() method directly using the current image_builder (a
         DummyImageBuilder when invoked via validate_job(), so no GUI or file I/O occurs).
         Also runs _validate_job_structure() for structural checks.
+
+        Args:
+            overrides: Optional dict of postprocessor property overrides.
+                       Passed through to apply_configuration_bundle() so that
+                       callers (e.g. the dialog) can inject values without
+                       modifying the job.
 
         Returns:
             tuple: (all_squawks, critical_squawks) where critical = WARNING or CAUTION
@@ -533,11 +539,34 @@ class CAMSanity:
             except Exception as e:
                 Path.Log.warning(f"get_all_squawks: {method.__name__} failed: {e}")
         all_squawks.extend(self._validate_job_structure())
+
+        # Collect postprocessor-specific squawks
+        if hasattr(self.job, "Machine") and self.job.Machine:
+            try:
+                from Machine.models.machine import MachineFactory
+                from Path.Post.Processor import PostProcessorFactory
+
+                machine = MachineFactory.get_machine(self.job.Machine)
+                postprocessor_name = getattr(machine, "postprocessor_file_name", None)
+                if postprocessor_name:
+                    postprocessor = PostProcessorFactory.get_post_processor(
+                        self.job, postprocessor_name
+                    )
+                    if postprocessor and hasattr(postprocessor, "get_sanity_checks"):
+                        if hasattr(postprocessor, "apply_configuration_bundle"):
+                            postprocessor.apply_configuration_bundle(overrides=overrides)
+                        pp_squawks = postprocessor.get_sanity_checks(self.job)
+                        all_squawks.extend(pp_squawks)
+            except Exception as e:
+                Path.Log.warning(f"Failed to get postprocessor sanity checks: {e}")
+
         critical = [s for s in all_squawks if s["squawkType"] in ("WARNING", "CAUTION")]
+        Path.Log.debug(f"get_all_squawks: {len(all_squawks)} squawks, {len(critical)} critical")
+        Path.Log.debug(f"Critical squawks: {critical}")
         return all_squawks, critical
 
     @staticmethod
-    def validate_job(job):
+    def validate_job(job, overrides=None):
         """Lightweight job validation without generating images or HTML.
 
         Bypasses __init__ entirely to avoid calling summarize() or any image-generation
@@ -546,6 +575,9 @@ class CAMSanity:
 
         Args:
             job: FreeCAD CAM job object
+            overrides: Optional dict of postprocessor property overrides.
+                       When provided these are passed to the postprocessor's
+                       apply_configuration_bundle() instead of reading from the job.
 
         Returns:
             tuple: (all_squawks, critical_squawks) where critical = WARNING or CAUTION
@@ -560,7 +592,7 @@ class CAMSanity:
             sanity.filelocation = tmpdir
             sanity.image_builder = ImageBuilder.DummyImageBuilder(tmpdir)
             sanity.data = {}
-            return sanity.get_all_squawks()
+            return sanity.get_all_squawks(overrides=overrides)
 
     def validate_for_postprocessing(self):
         """

--- a/src/Mod/CAM/Path/Main/Sanity/Sanity.py
+++ b/src/Mod/CAM/Path/Main/Sanity/Sanity.py
@@ -383,7 +383,7 @@ class CAMSanity:
                 )
                 continue  # skip old-style tools
             tooldata = data.setdefault(str(TC.ToolNumber), {})
-            bitshape = tooldata.setdefault("ShapeType", "")
+            bitshape = tooldata.get("ShapeType", "")
             if bitshape not in ["", TC.Tool.ShapeType]:
                 data["squawkData"].append(
                     self.squawk(
@@ -394,6 +394,7 @@ class CAMSanity:
                         squawkType="CAUTION",
                     )
                 )
+            tooldata["ShapeType"] = TC.Tool.ShapeType
             tooldata["bitShape"] = TC.Tool.ShapeType
             tooldata["description"] = TC.Tool.Label
             tooldata["manufacturer"] = ""
@@ -505,7 +506,61 @@ class CAMSanity:
         Path.Log.debug("get_output_url")
 
         generator = ReportGenerator.ReportGenerator(self.data, embed_images=True)
-        return generator.get_output_report()
+        return generator.generate_html()
+
+    def get_all_squawks(self):
+        """Collect squawks from all validation sections without generating images or HTML.
+
+        Calls each _xxxData() method directly using the current image_builder (a
+        DummyImageBuilder when invoked via validate_job(), so no GUI or file I/O occurs).
+        Also runs _validate_job_structure() for structural checks.
+
+        Returns:
+            tuple: (all_squawks, critical_squawks) where critical = WARNING or CAUTION
+        """
+        all_squawks = []
+        for method in [
+            self._toolData,
+            self._outputData,
+            self._runData,
+            self._stockData,
+            self._fixtureData,
+            self._baseObjectData,
+            self._designData,
+        ]:
+            try:
+                all_squawks.extend(method().get("squawkData", []))
+            except Exception as e:
+                Path.Log.warning(f"get_all_squawks: {method.__name__} failed: {e}")
+        all_squawks.extend(self._validate_job_structure())
+        critical = [s for s in all_squawks if s["squawkType"] in ("WARNING", "CAUTION")]
+        return all_squawks, critical
+
+    @staticmethod
+    def validate_job(job):
+        """Lightweight job validation without generating images or HTML.
+
+        Bypasses __init__ entirely to avoid calling summarize() or any image-generation
+        code. Sets up only the attributes needed by the _xxxData() methods, uses
+        DummyImageBuilder unconditionally, and calls get_all_squawks().
+
+        Args:
+            job: FreeCAD CAM job object
+
+        Returns:
+            tuple: (all_squawks, critical_squawks) where critical = WARNING or CAUTION
+        """
+        import tempfile
+        import os as _os
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sanity = object.__new__(CAMSanity)
+            sanity.job = job
+            sanity.output_file = _os.path.join(tmpdir, "dummy.html")
+            sanity.filelocation = tmpdir
+            sanity.image_builder = ImageBuilder.DummyImageBuilder(tmpdir)
+            sanity.data = {}
+            return sanity.get_all_squawks()
 
     def validate_for_postprocessing(self):
         """
@@ -575,32 +630,3 @@ class CAMSanity:
             )
 
         return job_squawks
-
-    @staticmethod
-    def validate_job_for_postprocessing(job):
-        """
-        Static convenience method to validate a job for post-processing.
-
-        Args:
-            job: FreeCAD CAM job object
-
-        Returns:
-            tuple: (has_critical_issues, all_squawks, critical_squawks)
-        """
-        # Create a minimal CAMSanity instance for validation
-        # Use a dummy output file since we won't generate reports
-        import tempfile
-        import os
-
-        with tempfile.NamedTemporaryFile(suffix=".html", delete=False) as tmp_file:
-            dummy_output = tmp_file.name
-
-        try:
-            sanity = CAMSanity(job, dummy_output)
-            return sanity.validate_for_postprocessing()
-        finally:
-            # Clean up the temporary file
-            try:
-                os.unlink(dummy_output)
-            except:
-                pass

--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -314,7 +314,7 @@ class CommandPathPost:
                 self._write_file(fname, final_gcode, policy)
 
         FreeCAD.ActiveDocument.commitTransaction()
-        FreeCAD.ActiveDocument.recompute()
+        # FreeCAD.ActiveDocument.recompute()
 
 
 class CommandPathPostSelected(CommandPathPost):

--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -201,6 +201,19 @@ class CommandPathPost:
         on user selection and document context.
         """
         Path.Log.debug(self.candidate.Name)
+
+        # Show the unified post-processing dialog before starting any work.
+        if FreeCAD.GuiUp:
+            from Path.Post.Gui.DlgPostProcess import PostProcessDialog
+
+            dlg = PostProcessDialog(self.candidate)
+            if dlg.exec_() != QtGui.QDialog.DialogCode.Accepted:
+                return
+            # Files were written by the dialog's Save button; record the transaction and return.
+            FreeCAD.ActiveDocument.openTransaction("Post Process the Selected Job")
+            FreeCAD.ActiveDocument.commitTransaction()
+            return
+
         FreeCAD.ActiveDocument.openTransaction("Post Process the Selected Job")
 
         # Determine if we use new flow (machine-based) or old flow (legacy)

--- a/src/Mod/CAM/Path/Post/DrillCycleExpander.py
+++ b/src/Mod/CAM/Path/Post/DrillCycleExpander.py
@@ -32,8 +32,18 @@ from typing import List, Optional
 EXPANDABLE_DRILL_CYCLES = {"G81", "G82", "G83", "G73"}
 
 
+debug = True
+if debug:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+
 class DrillCycleExpander:
     """Expands canned drill cycles (Path.Command) into basic G-code movements."""
+
+    EXPANDABLE_CYCLES = EXPANDABLE_DRILL_CYCLES
 
     def __init__(
         self,
@@ -87,7 +97,9 @@ class DrillCycleExpander:
 
         # Handle drill cycles
         if cmd_name in ("G81", "G82", "G73", "G83"):
-            return self._expand_drill_cycle(command)
+            result = self._expand_drill_cycle(command)
+            Path.Log.debug(f"Expanded drill cycle: {command} -> {result}")
+            return result
 
         # Update position for non-drill commands
         if cmd_name in ("G0", "G00", "G1", "G01"):
@@ -99,6 +111,7 @@ class DrillCycleExpander:
                         self.current_position[axis] += params[axis]
 
         # Pass through other commands unchanged
+        Path.Log.debug(f"Passing through command: {command}")
         return [command]
 
     def _expand_drill_cycle(self, command: Path.Command) -> List[Path.Command]:

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -128,7 +128,6 @@ class PostProcessDialog:
         self._btn_generate.clicked.connect(self._generate_output)
         dlg.buttonSelectAllOps.clicked.connect(self._select_all_ops)
         dlg.buttonSelectNoneOps.clicked.connect(self._select_none_ops)
-        dlg.buttonSelectByType.clicked.connect(self._select_by_type)
         dlg.buttonWorkplan.clicked.connect(self._show_workplan)
         dlg.treeWidgetOperations.itemChanged.connect(self._on_ops_changed)
         dlg.comboBoxMachine.currentIndexChanged.connect(self._on_machine_changed)
@@ -143,7 +142,6 @@ class PostProcessDialog:
             self._on_output_files_context_menu
         )
         dlg.buttonSaveOutput.clicked.connect(self._save_output_files)
-        dlg.buttonRecomputeWarnings.clicked.connect(self._recompute_warnings)
 
     # ------------------------------------------------------------------
     # Population
@@ -406,21 +404,21 @@ class PostProcessDialog:
                 widget.setToolTip(help_text)
                 widget.value_getter = lambda w=widget: w.text()
 
-            if widget is not None:
-                # Connect signal to recompute warnings when value changes
-                if isinstance(widget, (QtGui.QCheckBox, QtGui.QLineEdit, QtGui.QPlainTextEdit)):
-                    (
-                        widget.textChanged.connect(self._recompute_warnings)
-                        if hasattr(widget, "textChanged")
-                        else widget.stateChanged.connect(self._recompute_warnings)
-                    )
-                elif isinstance(widget, (QtGui.QSpinBox, QtGui.QDoubleSpinBox)):
-                    widget.valueChanged.connect(self._recompute_warnings)
-                elif isinstance(widget, QtGui.QComboBox):
-                    widget.currentIndexChanged.connect(self._recompute_warnings)
+            # if widget is not None:
+            #     # Connect signal to recompute warnings when value changes
+            #     if isinstance(widget, (QtGui.QCheckBox, QtGui.QLineEdit, QtGui.QPlainTextEdit)):
+            #         (
+            #             widget.textChanged.connect(self._recompute_warnings)
+            #             if hasattr(widget, "textChanged")
+            #             else widget.stateChanged.connect(self._recompute_warnings)
+            #         )
+            #     elif isinstance(widget, (QtGui.QSpinBox, QtGui.QDoubleSpinBox)):
+            #         widget.valueChanged.connect(self._recompute_warnings)
+            #     elif isinstance(widget, QtGui.QComboBox):
+            #         widget.currentIndexChanged.connect(self._recompute_warnings)
 
-                form.addRow(label_text, widget)
-                self._post_config_widgets[name] = (widget, entry)
+            #     form.addRow(label_text, widget)
+            #     self._post_config_widgets[name] = (widget, entry)
 
         scroll_layout.insertWidget(insert_idx, group)
         self._dynamic_output_groups.append(group)
@@ -789,42 +787,6 @@ class PostProcessDialog:
         tree.blockSignals(True)
         for i in range(tree.topLevelItemCount()):
             tree.topLevelItem(i).setCheckState(0, QtCore.Qt.CheckState.Unchecked)
-        tree.blockSignals(False)
-        self._on_ops_changed(None)
-
-    def _select_by_type(self):
-        """Pop a menu of distinct operation types; selecting one checks only those ops."""
-        ops = self._get_active_operations()
-        tree = self.dialog.treeWidgetOperations
-        types = {}
-        for i in range(tree.topLevelItemCount()):
-            if i < len(ops):
-                t = ops[i].TypeId.split("::")[-1]
-                types.setdefault(t, []).append(i)
-
-        if not types:
-            return
-
-        menu = QtGui.QMenu(self.dialog)
-        for t in sorted(types):
-            action = menu.addAction(t)
-            action.setData(t)
-
-        btn = self.dialog.buttonSelectByType
-        chosen = menu.exec_(btn.mapToGlobal(btn.rect().bottomLeft()))
-        if not chosen:
-            return
-
-        selected_type = chosen.data()
-        tree.blockSignals(True)
-        for i in range(tree.topLevelItemCount()):
-            op_type = ops[i].TypeId.split("::")[-1] if i < len(ops) else ""
-            state = (
-                QtCore.Qt.CheckState.Checked
-                if op_type == selected_type
-                else QtCore.Qt.CheckState.Unchecked
-            )
-            tree.topLevelItem(i).setCheckState(0, state)
         tree.blockSignals(False)
         self._on_ops_changed(None)
 

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -117,6 +117,7 @@ class PostProcessDialog:
             self._on_output_files_context_menu
         )
         dlg.buttonSaveOutput.clicked.connect(self._save_output_files)
+        dlg.buttonRecomputeWarnings.clicked.connect(self._recompute_warnings)
 
     # ------------------------------------------------------------------
     # Population
@@ -296,7 +297,7 @@ class PostProcessDialog:
             try:
                 from Path.Post.Processor import PostProcessorFactory
 
-                post_obj = PostProcessorFactory.get_post_processor(None, postprocessor_name)
+                post_obj = PostProcessorFactory.get_post_processor(self.job, postprocessor_name)
                 if post_obj is not None:
                     post_class = type(post_obj)
             except Exception as e:
@@ -314,7 +315,13 @@ class PostProcessDialog:
         if not non_runtime:
             return
 
-        pp_props = getattr(machine, "postprocessor_properties", {}) or {}
+        # Build the configuration bundle to get values with job overrides applied
+        bundle = {}
+        if post_obj is not None and hasattr(post_obj, "build_configuration_bundle"):
+            bundle = post_obj.build_configuration_bundle()
+            Path.Log.debug(f"Post config bundle for dialog: {bundle}")
+
+        pp_props = bundle if bundle else (getattr(machine, "postprocessor_properties", {}) or {})
 
         group = QtGui.QGroupBox(translate("CAM_Post", "Postprocessor Properties"))
         form = QtGui.QFormLayout(group)
@@ -374,6 +381,18 @@ class PostProcessDialog:
                 widget.value_getter = lambda w=widget: w.text()
 
             if widget is not None:
+                # Connect signal to recompute warnings when value changes
+                if isinstance(widget, (QtGui.QCheckBox, QtGui.QLineEdit, QtGui.QPlainTextEdit)):
+                    (
+                        widget.textChanged.connect(self._recompute_warnings)
+                        if hasattr(widget, "textChanged")
+                        else widget.stateChanged.connect(self._recompute_warnings)
+                    )
+                elif isinstance(widget, (QtGui.QSpinBox, QtGui.QDoubleSpinBox)):
+                    widget.valueChanged.connect(self._recompute_warnings)
+                elif isinstance(widget, QtGui.QComboBox):
+                    widget.currentIndexChanged.connect(self._recompute_warnings)
+
                 form.addRow(label_text, widget)
                 self._post_config_widgets[name] = (widget, entry)
 
@@ -580,12 +599,41 @@ class PostProcessDialog:
         self._update_ops_tab_label()
         self._update_total_time()
 
-    def _populate_warnings(self):
+    def _get_dialog_overrides(self):
+        """Collect current dialog widget values as an overrides dict.
+
+        Delegates to _collect_post_param_values() so both sanity checks
+        and output generation use exactly the same values.
+
+        Returns:
+            dict: Property overrides from all postprocessor config widgets.
+        """
+        return self._collect_post_param_values()
+
+    def _recompute_warnings(self):
+        """Recompute warnings using current dialog values instead of saved job state."""
+        # Show temporary feedback
+        dlg = self.dialog
+        original_text = dlg.labelWarningsStatus.text()
+        dlg.labelWarningsStatus.setText("Recomputing...")
+        dlg.labelWarningsStatus.setStyleSheet("color: blue; font-weight: bold;")
+
+        # Process events to update UI
+        QtGui.QApplication.processEvents()
+
+        # Recompute warnings
+        self._populate_warnings(use_dialog_values=True)
+
+        # Brief delay to show the recomputation happened
+        QtCore.QTimer.singleShot(200, lambda: None)
+
+    def _populate_warnings(self, use_dialog_values=False):
         dlg = self.dialog
         try:
             from Path.Main.Sanity.Sanity import CAMSanity
 
-            all_squawks, critical_squawks = CAMSanity.validate_job(self.job)
+            overrides = self._get_dialog_overrides() if use_dialog_values else None
+            all_squawks, critical_squawks = CAMSanity.validate_job(self.job, overrides=overrides)
         except Exception as e:
             Path.Log.warning(f"Sanity check failed: {e}")
             all_squawks = []
@@ -898,16 +946,18 @@ class PostProcessDialog:
                 postprocessor._machine = loaded_machine
                 self._apply_options_to_machine(postprocessor._machine)
 
-            # Apply post-processor parameter values from the dialog widgets
-            # into machine.postprocessor_properties so _get_property_value() picks them up.
-            post_param_values = self._collect_post_param_values()
-            if post_param_values and postprocessor._machine is not None:
-                if hasattr(postprocessor._machine, "postprocessor_properties"):
-                    postprocessor._machine.postprocessor_properties.update(post_param_values)
+            # Build the configuration bundle using dialog widget values as
+            # overrides.  This gives dialog values highest priority (above
+            # job-level overrides) and writes them into self.values so that
+            # export2 and sanity checks all read from the same source.
+            dialog_overrides = self._collect_post_param_values()
+            if hasattr(postprocessor, "apply_configuration_bundle"):
+                postprocessor.apply_configuration_bundle(overrides=dialog_overrides)
 
             # Signal that the unified dialog handled user interaction so
             # pre_processing_dialog() is a no-op during export2().
             postprocessor._dialog_handled = True
+            postprocessor._bundle_applied = True
 
             post_data = postprocessor.export2() if use_new_flow else postprocessor.export()
 

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -578,10 +578,7 @@ class PostProcessDialog:
         tree.blockSignals(True)
         tree.clear()
 
-        for op in self._get_operations():
-            # Skip operations that are toggled inactive
-            if not getattr(op, "Active", True):
-                continue
+        for op in self._get_active_operations():
             item = QtGui.QTreeWidgetItem(tree)
             item.setText(0, op.Label)
             ct = getattr(op, "CycleTime", None)
@@ -727,6 +724,10 @@ class PostProcessDialog:
             return ops.Group
         return []
 
+    def _get_active_operations(self):
+        """Return only active operations, matching what the tree widget displays."""
+        return [op for op in self._get_operations() if getattr(op, "Active", True)]
+
     def _update_total_time(self):
         tree = self.dialog.treeWidgetOperations
         total_secs = 0
@@ -767,7 +768,7 @@ class PostProcessDialog:
 
     def _select_by_type(self):
         """Pop a menu of distinct operation types; selecting one checks only those ops."""
-        ops = self._get_operations()
+        ops = self._get_active_operations()
         tree = self.dialog.treeWidgetOperations
         types = {}
         for i in range(tree.topLevelItemCount()):
@@ -874,14 +875,16 @@ class PostProcessDialog:
         job = self.job
         dlg = self.dialog
 
-        # Build filtered operations list from the Operations tab checkboxes
-        all_ops = self._get_operations()
+        # Build filtered operations list from the Operations tab checkboxes.
+        # Use _get_active_operations() because the tree skips inactive ops,
+        # so tree indices align with the active-only list, not the full list.
+        active_ops = self._get_active_operations()
         tree = dlg.treeWidgetOperations
         selected_ops = [
-            all_ops[i]
+            active_ops[i]
             for i in range(tree.topLevelItemCount())
             if tree.topLevelItem(i).checkState(0) == QtCore.Qt.CheckState.Checked
-            and i < len(all_ops)
+            and i < len(active_ops)
         ]
         job_arg = {"job": job, "operations": selected_ops}
 
@@ -1204,7 +1207,7 @@ class PostProcessDialog:
         """Return a dict of the user's choices. Call after exec_() returns Accepted."""
         dlg = self.dialog
         tree = dlg.treeWidgetOperations
-        ops = self._get_operations()
+        ops = self._get_active_operations()
 
         # Only active operations that the user kept checked
         selected_ops = [

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -74,6 +74,13 @@ class PostProcessDialog:
         # Tracks dynamically added machine-output QGroupBoxes and their widgets
         self._dynamic_output_groups = []
         self._machine_output_field_widgets = {}  # section_name -> {field_name: widget}
+        # Post-processor parameter widgets (from get_property_schema)
+        self._post_param_widgets = (
+            {}
+        )  # runtime params on Overview: {param_name: (widget, schema_entry)}
+        self._post_config_widgets = (
+            {}
+        )  # non-runtime params on Options: {param_name: (widget, schema_entry)}
         # Stores generated G-code: {full_path_filename: gcode_string}
         self._generated_outputs = {}
         # Original (subpart, gcode) sections — used to regenerate filenames
@@ -174,6 +181,7 @@ class PostProcessDialog:
 
         if not machine_path:
             dlg.labelNoMachineOutput.setVisible(True)
+            self._rebuild_post_params_section(None)
             return
 
         dlg.labelNoMachineOutput.setVisible(False)
@@ -185,16 +193,18 @@ class PostProcessDialog:
             machine = MachineFactory.load_configuration(machine_path)
         except Exception as e:
             Path.Log.warning(f"Could not load machine for output options: {e}")
+            self._rebuild_post_params_section(None)
             return
 
         try:
             from Machine.ui.editor.machine_editor import DataclassGUIGenerator
         except Exception as e:
             Path.Log.warning(f"Could not import DataclassGUIGenerator: {e}")
+            self._rebuild_post_params_section(machine)
             return
 
-        # Insertion point: just before groupBoxPostParams
-        insert_idx = scroll_layout.indexOf(dlg.groupBoxPostParams)
+        # Insertion point: append before the last item (spacer) in the scroll area
+        insert_idx = max(0, scroll_layout.count() - 1)
 
         # --- Main output options (units + top-level booleans) ---
         main_group = QtGui.QGroupBox(translate("CAM_Post", "Main Options"))
@@ -257,6 +267,263 @@ class PostProcessDialog:
             self._dynamic_output_groups.append(group)
             self._machine_output_field_widgets[attr_name] = widgets
             insert_idx += 1
+
+        # Populate non-runtime post-processor config on this (Options) tab
+        self._rebuild_post_config_section(machine, scroll_layout, insert_idx)
+
+        # Populate runtime post-processor params on Overview tab
+        self._rebuild_post_params_section(machine)
+
+    def _rebuild_post_config_section(self, machine, scroll_layout, insert_idx):
+        """Build non-runtime postprocessor property widgets on the Options tab.
+
+        These mirror the same properties shown in the machine editor and allow
+        per-run overrides of machine-config values like pierce_delay, cooling_delay, etc.
+        """
+        # Clear previous non-runtime config widgets
+        for name, (widget, _schema) in self._post_config_widgets.items():
+            # The widget is inside a group box tracked by _dynamic_output_groups
+            pass
+        self._post_config_widgets.clear()
+
+        if machine is None:
+            return
+
+        # Resolve postprocessor class
+        post_class = None
+        postprocessor_name = getattr(machine, "postprocessor_file_name", None)
+        if postprocessor_name:
+            try:
+                from Path.Post.Processor import PostProcessorFactory
+
+                post_obj = PostProcessorFactory.get_post_processor(None, postprocessor_name)
+                if post_obj is not None:
+                    post_class = type(post_obj)
+            except Exception as e:
+                Path.Log.debug(f"Could not resolve postprocessor class for config: {e}")
+
+        if post_class is None:
+            return
+
+        try:
+            schema = post_class.get_property_schema()
+        except Exception:
+            return
+
+        non_runtime = [e for e in schema if not e.get("runtime", False)] if schema else []
+        if not non_runtime:
+            return
+
+        pp_props = getattr(machine, "postprocessor_properties", {}) or {}
+
+        group = QtGui.QGroupBox(translate("CAM_Post", "Postprocessor Properties"))
+        form = QtGui.QFormLayout(group)
+
+        for entry in non_runtime:
+            name = entry.get("name", "")
+            param_type = entry.get("type", "string")
+            label_text = entry.get("label", name)
+            default = entry.get("default")
+            help_text = entry.get("help", "")
+            current = pp_props.get(name, default)
+
+            widget = None
+            if param_type == "bool":
+                widget = QtGui.QCheckBox()
+                widget.setChecked(bool(current))
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.isChecked()
+            elif param_type in ("integer", "int"):
+                widget = QtGui.QSpinBox()
+                widget.setMinimum(entry.get("min", 0))
+                widget.setMaximum(entry.get("max", 99999))
+                widget.setValue(int(current) if current is not None else 0)
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.value()
+            elif param_type == "float":
+                widget = QtGui.QDoubleSpinBox()
+                widget.setMinimum(entry.get("min", 0.0))
+                widget.setMaximum(entry.get("max", 99999.0))
+                widget.setDecimals(entry.get("decimals", 3))
+                widget.setValue(float(current) if current is not None else 0.0)
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.value()
+            elif param_type == "choice":
+                widget = QtGui.QComboBox()
+                for choice in entry.get("choices", []):
+                    if isinstance(choice, tuple):
+                        widget.addItem(str(choice[0]), choice[1])
+                    else:
+                        widget.addItem(str(choice), choice)
+                if current is not None:
+                    idx = widget.findData(current)
+                    if idx >= 0:
+                        widget.setCurrentIndex(idx)
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.currentData()
+            elif param_type == "text":
+                widget = QtGui.QPlainTextEdit()
+                widget.setPlainText(str(current) if current else "")
+                widget.setMaximumHeight(80)
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.toPlainText()
+            else:
+                widget = QtGui.QLineEdit()
+                widget.setText(str(current) if current else "")
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.text()
+
+            if widget is not None:
+                form.addRow(label_text, widget)
+                self._post_config_widgets[name] = (widget, entry)
+
+        scroll_layout.insertWidget(insert_idx, group)
+        self._dynamic_output_groups.append(group)
+
+    def _rebuild_post_params_section(self, machine=None):
+        """Populate groupBoxPostParams with widgets from the postprocessor's get_property_schema().
+
+        Resolves the postprocessor class from the machine config, calls
+        get_property_schema(), and creates appropriate widgets for each entry.
+        Machine-config values override schema defaults when available.
+        """
+        dlg = self.dialog
+        layout = dlg.layoutPostParams
+        placeholder = dlg.labelPostParamsPlaceholder
+
+        # Clear previously created post-param widgets
+        for name, (widget, _schema) in self._post_param_widgets.items():
+            # QFormLayout.labelForField returns the label widget for a given field
+            label_widget = layout.labelForField(widget)
+            if label_widget:
+                layout.removeWidget(label_widget)
+                label_widget.deleteLater()
+            layout.removeWidget(widget)
+            widget.deleteLater()
+        self._post_param_widgets.clear()
+
+        # Resolve postprocessor class from machine
+        post_class = None
+        if machine is not None:
+            postprocessor_name = getattr(machine, "postprocessor_file_name", None)
+            if postprocessor_name:
+                try:
+                    from Path.Post.Processor import PostProcessorFactory
+
+                    # Pass None as job to get the class for schema inspection
+                    post_obj = PostProcessorFactory.get_post_processor(None, postprocessor_name)
+                    if post_obj is not None:
+                        post_class = type(post_obj)
+                except Exception as e:
+                    Path.Log.debug(f"Could not resolve postprocessor class: {e}")
+
+        if post_class is None:
+            placeholder.setVisible(True)
+            return
+
+        # Get the property schema
+        try:
+            schema = post_class.get_property_schema()
+        except Exception as e:
+            Path.Log.warning(f"Could not get property schema: {e}")
+            placeholder.setVisible(True)
+            return
+
+        # Only runtime parameters are shown on the Overview tab
+        runtime_schema = [e for e in schema if e.get("runtime", False)] if schema else []
+
+        if not runtime_schema:
+            placeholder.setVisible(True)
+            return
+
+        placeholder.setVisible(False)
+
+        # Get current machine postprocessor_properties for initial values
+        pp_props = getattr(machine, "postprocessor_properties", {}) or {}
+
+        for entry in runtime_schema:
+
+            name = entry.get("name", "")
+            param_type = entry.get("type", "string")
+            label = entry.get("label", name)
+            default = entry.get("default")
+            help_text = entry.get("help", "")
+
+            # Current value: machine config overrides schema default
+            current = pp_props.get(name, default)
+
+            widget = None
+            if param_type == "bool":
+                widget = QtGui.QCheckBox()
+                widget.setChecked(bool(current))
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.isChecked()
+
+            elif param_type in ("integer", "int"):
+                widget = QtGui.QSpinBox()
+                widget.setMinimum(entry.get("min", 0))
+                widget.setMaximum(entry.get("max", 99999))
+                widget.setValue(int(current) if current is not None else 0)
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.value()
+
+            elif param_type == "float":
+                widget = QtGui.QDoubleSpinBox()
+                widget.setMinimum(entry.get("min", 0.0))
+                widget.setMaximum(entry.get("max", 99999.0))
+                widget.setDecimals(entry.get("decimals", 3))
+                widget.setValue(float(current) if current is not None else 0.0)
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.value()
+
+            elif param_type == "choice":
+                widget = QtGui.QComboBox()
+                for choice in entry.get("choices", []):
+                    if isinstance(choice, tuple):
+                        widget.addItem(str(choice[0]), choice[1])
+                    else:
+                        widget.addItem(str(choice), choice)
+                if current is not None:
+                    idx = widget.findData(current)
+                    if idx >= 0:
+                        widget.setCurrentIndex(idx)
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.currentData()
+
+            elif param_type == "text":
+                widget = QtGui.QPlainTextEdit()
+                widget.setPlainText(str(current) if current else "")
+                widget.setMaximumHeight(80)
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.toPlainText()
+
+            else:
+                # Default: string / unknown type -> QLineEdit
+                widget = QtGui.QLineEdit()
+                widget.setText(str(current) if current else "")
+                widget.setToolTip(help_text)
+                widget.value_getter = lambda w=widget: w.text()
+
+            if widget is not None:
+                layout.addRow(label, widget)
+                self._post_param_widgets[name] = (widget, entry)
+
+    def _collect_post_param_values(self):
+        """Read current values from all post-parameter widgets (runtime + non-runtime).
+
+        Returns:
+            dict: {param_name: value} for all post-processor parameters.
+        """
+        values = {}
+        # Non-runtime config from Options tab
+        for name, (widget, _schema) in self._post_config_widgets.items():
+            if hasattr(widget, "value_getter"):
+                values[name] = widget.value_getter()
+        # Runtime params from Overview tab (override if same key exists)
+        for name, (widget, _schema) in self._post_param_widgets.items():
+            if hasattr(widget, "value_getter"):
+                values[name] = widget.value_getter()
+        return values
 
     def _populate_fixtures(self):
         dlg = self.dialog
@@ -630,6 +897,17 @@ class PostProcessDialog:
             if loaded_machine is not None:
                 postprocessor._machine = loaded_machine
                 self._apply_options_to_machine(postprocessor._machine)
+
+            # Apply post-processor parameter values from the dialog widgets
+            # into machine.postprocessor_properties so _get_property_value() picks them up.
+            post_param_values = self._collect_post_param_values()
+            if post_param_values and postprocessor._machine is not None:
+                if hasattr(postprocessor._machine, "postprocessor_properties"):
+                    postprocessor._machine.postprocessor_properties.update(post_param_values)
+
+            # Signal that the unified dialog handled user interaction so
+            # pre_processing_dialog() is a no-op during export2().
+            postprocessor._dialog_handled = True
 
             post_data = postprocessor.export2() if use_new_flow else postprocessor.export()
 

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -1052,7 +1052,7 @@ class PostProcessDialog:
                 use_new_flow = True
             else:
                 postprocessor_name = (
-                    getattr(job, "PostProcessor", None) or PathPrefs.defaultPostProcessor()
+                    getattr(job, "PostProcessor", None) or Path.Preferences.defaultPostProcessor()
                 )
                 if not postprocessor_name:
                     QtGui.QMessageBox.warning(

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -907,7 +907,7 @@ class PostProcessDialog:
                                     f"        ToolController: {tc.Label} (T{tc.ToolNumber})"
                                 )
                             elif hasattr(obj, "ToolController"):
-                                lines.append(f"        ToolController: None")
+                                lines.append("        ToolController: None")
                     else:
                         obj_type = type(obj).__name__
 

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -1,0 +1,914 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Unified Post-Processing dialog.
+
+Shows job information, operation selection, output settings, and sanity
+warnings in a single dialog before committing to G-code generation.
+
+Phase 1 - skeleton: populates all widgets from the job object and returns
+a config dict on accept.  No functional post-processing logic lives here yet.
+"""
+
+import FreeCAD
+import FreeCADGui
+import Path
+import Path.Preferences as PathPrefs
+from PySide import QtCore, QtGui
+
+translate = FreeCAD.Qt.translate
+
+LOG_MODULE = Path.Log.thisModule()
+
+_TAB_OVERVIEW = 0
+_TAB_OPERATIONS = 1
+_TAB_OPTIONS = 2
+_TAB_GCODE = 3
+_TAB_WARNINGS = 4
+
+
+def _parse_cycle_time(ct_str):
+    """Convert 'HH:MM:SS' string to total seconds, or None if unparseable."""
+    try:
+        parts = ct_str.strip().split(":")
+        if len(parts) == 3:
+            return int(parts[0]) * 3600 + int(parts[1]) * 60 + int(parts[2])
+        if len(parts) == 2:
+            return int(parts[0]) * 60 + int(parts[1])
+    except Exception:
+        pass
+    return None
+
+
+def _format_seconds(total_secs):
+    """Format total seconds as 'H:MM:SS' or 'M:SS'."""
+    h = total_secs // 3600
+    m = (total_secs % 3600) // 60
+    s = total_secs % 60
+    if h:
+        return f"{h}:{m:02d}:{s:02d}"
+    return f"{m}:{s:02d}"
+
+
+class PostProcessDialog:
+    """Unified post-processing dialog.
+
+    Parameters
+    ----------
+    job : FreeCAD DocumentObject
+        The CAM Job to post-process.
+
+    Usage
+    -----
+    dlg = PostProcessDialog(job)
+    if dlg.exec_() == QtGui.QDialog.Accepted:
+        config = dlg.config()
+    """
+
+    def __init__(self, job):
+        self.job = job
+        self.dialog = FreeCADGui.PySideUic.loadUi(":/panels/DlgPostProcess.ui")
+        if self.dialog is None:
+            raise RuntimeError(
+                "Failed to load DlgPostProcess.ui — rebuild may be needed to update Qt resources"
+            )
+        # Tracks dynamically added machine-output QGroupBoxes and their widgets
+        self._dynamic_output_groups = []
+        self._machine_output_field_widgets = {}  # section_name -> {field_name: widget}
+        # Stores generated G-code: {full_path_filename: gcode_string}
+        self._generated_outputs = {}
+        # Original (subpart, gcode) sections — used to regenerate filenames
+        self._output_sections = []
+
+        self._setup_dialog()
+        self._populate()
+
+    # ------------------------------------------------------------------
+    # Setup
+    # ------------------------------------------------------------------
+
+    def _setup_dialog(self):
+        dlg = self.dialog
+        self._btn_generate = dlg.buttonBox.addButton(
+            translate("CAM_Post", "Generate Output"),
+            QtGui.QDialogButtonBox.ButtonRole.ActionRole,
+        )
+        self._btn_generate.setDefault(True)
+        self._btn_generate.clicked.connect(self._generate_output)
+        dlg.buttonSelectAllOps.clicked.connect(self._select_all_ops)
+        dlg.buttonSelectNoneOps.clicked.connect(self._select_none_ops)
+        dlg.buttonSelectByType.clicked.connect(self._select_by_type)
+        dlg.treeWidgetOperations.itemChanged.connect(self._on_ops_changed)
+        dlg.comboBoxMachine.currentIndexChanged.connect(self._on_machine_changed)
+        dlg.buttonBrowseOutputLocation.clicked.connect(self._browse_output_location)
+        dlg.buttonApplyTemplate.clicked.connect(self._regenerate_filenames)
+        dlg.listWidgetOutputFiles.currentItemChanged.connect(self._on_output_file_selected)
+        dlg.listWidgetOutputFiles.itemChanged.connect(self._on_output_file_renamed)
+        dlg.listWidgetOutputFiles.setContextMenuPolicy(
+            QtCore.Qt.ContextMenuPolicy.CustomContextMenu
+        )
+        dlg.listWidgetOutputFiles.customContextMenuRequested.connect(
+            self._on_output_files_context_menu
+        )
+        dlg.buttonSaveOutput.clicked.connect(self._save_output_files)
+
+    # ------------------------------------------------------------------
+    # Population
+    # ------------------------------------------------------------------
+
+    def _populate(self):
+        self._populate_title()
+        self._populate_machine()  # also triggers _rebuild_machine_output_section
+        self._populate_fixtures()
+        self._populate_job_details()
+        self._populate_operations()
+        self._populate_warnings()  # must be last — updates tab badge
+
+    def _populate_title(self):
+        self.dialog.labelJobTitle.setText(
+            translate("CAM_Post", "Post Processing - Job: {}").format(self.job.Label)
+        )
+
+    def _populate_machine(self):
+        dlg = self.dialog
+        dlg.comboBoxMachine.blockSignals(True)
+        dlg.comboBoxMachine.clear()
+        dlg.comboBoxMachine.addItem(translate("CAM_Post", "(none)"), userData=None)
+
+        try:
+            from Machine.models.machine import MachineFactory
+
+            # User-saved machines
+            for name, filename in MachineFactory.list_configuration_files():
+                if filename:
+                    full_path = str(MachineFactory.get_config_directory() / filename)
+                    dlg.comboBoxMachine.addItem(name, userData=full_path)
+
+        except Exception as e:
+            Path.Log.warning(f"Could not enumerate machines: {e}")
+
+        current = getattr(self.job, "Machine", None)
+        if current:
+            idx = dlg.comboBoxMachine.findText(current)
+            if idx >= 0:
+                dlg.comboBoxMachine.setCurrentIndex(idx)
+
+        dlg.comboBoxMachine.blockSignals(False)
+        self._rebuild_machine_output_section()
+
+    def _on_machine_changed(self, _index):
+        self._rebuild_machine_output_section()
+
+    def _rebuild_machine_output_section(self):
+        """Clear and rebuild the dynamic machine-output option groups in the Output tab."""
+        dlg = self.dialog
+        scroll_layout = dlg.scrollContentsOutput.layout()
+
+        # Remove previously added dynamic groups
+        for group in self._dynamic_output_groups:
+            scroll_layout.removeWidget(group)
+            group.deleteLater()
+        self._dynamic_output_groups.clear()
+        self._machine_output_field_widgets.clear()
+
+        machine_path = dlg.comboBoxMachine.currentData()
+
+        if not machine_path:
+            dlg.labelNoMachineOutput.setVisible(True)
+            return
+
+        dlg.labelNoMachineOutput.setVisible(False)
+
+        machine = None
+        try:
+            from Machine.models.machine import MachineFactory
+
+            machine = MachineFactory.load_configuration(machine_path)
+        except Exception as e:
+            Path.Log.warning(f"Could not load machine for output options: {e}")
+            return
+
+        try:
+            from Machine.ui.editor.machine_editor import DataclassGUIGenerator
+        except Exception as e:
+            Path.Log.warning(f"Could not import DataclassGUIGenerator: {e}")
+            return
+
+        # Insertion point: just before groupBoxPostParams
+        insert_idx = scroll_layout.indexOf(dlg.groupBoxPostParams)
+
+        # --- Main output options (units + top-level booleans) ---
+        main_group = QtGui.QGroupBox(translate("CAM_Post", "Main Options"))
+        main_layout = QtGui.QFormLayout(main_group)
+
+        units_combo = QtGui.QComboBox()
+        units_combo.addItem(translate("CAM_Post", "Metric"), "metric")
+        units_combo.addItem(translate("CAM_Post", "Imperial"), "imperial")
+        try:
+            units_val = machine.output.units.value
+            idx = units_combo.findData(units_val)
+            if idx >= 0:
+                units_combo.setCurrentIndex(idx)
+        except Exception:
+            pass
+        main_layout.addRow(translate("CAM_Post", "Units"), units_combo)
+        units_combo.value_getter = lambda: units_combo.itemData(units_combo.currentIndex())
+
+        main_widgets = {"units": units_combo}
+        for field_name, label in [
+            ("output_header", translate("CAM_Post", "Output Header")),
+            ("output_tool_length_offset", translate("CAM_Post", "Output Tool Length Offset (G43)")),
+            ("remote_post", translate("CAM_Post", "Enable Remote Posting")),
+        ]:
+            cb = QtGui.QCheckBox()
+            cb.setChecked(bool(getattr(getattr(machine, "output", None), field_name, False)))
+            cb.value_getter = lambda w=cb: w.isChecked()
+            main_layout.addRow(label, cb)
+            main_widgets[field_name] = cb
+
+        scroll_layout.insertWidget(insert_idx, main_group)
+        self._dynamic_output_groups.append(main_group)
+        self._machine_output_field_widgets["main"] = main_widgets
+        insert_idx += 1
+
+        # --- Sub-dataclass groups ---
+        output = getattr(machine, "output", None)
+        if output is None:
+            return
+
+        sub_sections = [
+            ("header", translate("CAM_Post", "Header Options")),
+            ("comments", translate("CAM_Post", "Comment Options")),
+            ("formatting", translate("CAM_Post", "Formatting Options")),
+            ("precision", translate("CAM_Post", "Precision Options")),
+            ("duplicates", translate("CAM_Post", "Duplicate Output Options")),
+        ]
+        for attr_name, title in sub_sections:
+            dc_instance = getattr(output, attr_name, None)
+            if dc_instance is None:
+                continue
+            try:
+                group, widgets = DataclassGUIGenerator.create_group_for_dataclass(
+                    dc_instance, title
+                )
+            except Exception as e:
+                Path.Log.warning(f"Could not build group for {attr_name}: {e}")
+                continue
+            scroll_layout.insertWidget(insert_idx, group)
+            self._dynamic_output_groups.append(group)
+            self._machine_output_field_widgets[attr_name] = widgets
+            insert_idx += 1
+
+    def _populate_fixtures(self):
+        dlg = self.dialog
+        lw = dlg.listWidgetFixtures
+        lw.clear()
+
+        fixtures = getattr(self.job, "Fixtures", None) or []
+        if not fixtures:
+            placeholder = QtGui.QListWidgetItem(translate("CAM_Post", "(no fixtures defined)"))
+            placeholder.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
+            lw.addItem(placeholder)
+            return
+
+        for fix in fixtures:
+            label = fix.Label if hasattr(fix, "Label") else str(fix)
+            item = QtGui.QListWidgetItem(label)
+            item.setFlags(
+                QtCore.Qt.ItemFlag.ItemIsEnabled
+                | QtCore.Qt.ItemFlag.ItemIsUserCheckable
+                | QtCore.Qt.ItemFlag.ItemIsSelectable
+            )
+            item.setCheckState(QtCore.Qt.CheckState.Checked)
+            lw.addItem(item)
+
+    def _populate_job_details(self):
+        dlg = self.dialog
+        dlg.lineEditJobAuthor.setText(getattr(self.job, "Author", "") or "")
+        dlg.plainTextEditComment.setPlainText("")
+
+    def _populate_operations(self):
+        dlg = self.dialog
+        tree = dlg.treeWidgetOperations
+        tree.blockSignals(True)
+        tree.clear()
+
+        for op in self._get_operations():
+            # Skip operations that are toggled inactive
+            if not getattr(op, "Active", True):
+                continue
+            item = QtGui.QTreeWidgetItem(tree)
+            item.setText(0, op.Label)
+            ct = getattr(op, "CycleTime", None)
+            item.setText(1, ct if ct else "-")
+            item.setCheckState(0, QtCore.Qt.CheckState.Checked)
+            item.setFlags(
+                item.flags()
+                | QtCore.Qt.ItemFlag.ItemIsUserCheckable
+                | QtCore.Qt.ItemFlag.ItemIsEnabled
+            )
+
+        tree.resizeColumnToContents(0)
+        tree.header().setStretchLastSection(True)
+        tree.blockSignals(False)
+        self._update_ops_tab_label()
+        self._update_total_time()
+
+    def _populate_warnings(self):
+        dlg = self.dialog
+        try:
+            from Path.Main.Sanity.Sanity import CAMSanity
+
+            all_squawks, critical_squawks = CAMSanity.validate_job(self.job)
+        except Exception as e:
+            Path.Log.warning(f"Sanity check failed: {e}")
+            all_squawks = []
+            critical_squawks = []
+
+        table = dlg.tableWidgetWarnings
+
+        if not all_squawks:
+            dlg.labelWarningsStatus.setText(translate("CAM_Post", "No issues found."))
+            dlg.labelWarningsStatus.setStyleSheet("color: green; font-weight: bold;")
+            table.setVisible(False)
+            self._update_warnings_tab_label(0, 0)
+            return
+
+        table.setVisible(True)
+        table.setRowCount(0)
+
+        severity_colors = {
+            "WARNING": QtGui.QColor(200, 40, 40),
+            "CAUTION": QtGui.QColor(200, 110, 0),
+            "NOTE": QtGui.QColor(30, 100, 200),
+            "TIP": QtGui.QColor(110, 110, 110),
+        }
+
+        for sq in all_squawks:
+            row = table.rowCount()
+            table.insertRow(row)
+            sev = sq.get("squawkType", "NOTE")
+            table.setItem(row, 0, QtGui.QTableWidgetItem(sev))
+            table.setItem(row, 1, QtGui.QTableWidgetItem(sq.get("Note", "")))
+            color = severity_colors.get(sev, QtGui.QColor(110, 110, 110))
+            for col in range(2):
+                table.item(row, col).setForeground(color)
+
+        table.resizeColumnToContents(0)
+
+        n_critical = len(critical_squawks)
+        n_total = len(all_squawks)
+
+        if n_critical:
+            dlg.labelWarningsStatus.setText(
+                translate("CAM_Post", "{} critical issue(s) — review before machining.").format(
+                    n_critical
+                )
+            )
+            dlg.labelWarningsStatus.setStyleSheet("color: red; font-weight: bold;")
+        else:
+            dlg.labelWarningsStatus.setText(
+                translate("CAM_Post", "{} advisory notice(s) found.").format(n_total)
+            )
+            dlg.labelWarningsStatus.setStyleSheet("color: darkorange; font-weight: bold;")
+
+        self._update_warnings_tab_label(n_total, n_critical)
+
+    # ------------------------------------------------------------------
+    # Tab label badges
+    # ------------------------------------------------------------------
+
+    def _update_ops_tab_label(self):
+        tree = self.dialog.treeWidgetOperations
+        total = tree.topLevelItemCount()
+        checked = sum(
+            1
+            for i in range(total)
+            if tree.topLevelItem(i).checkState(0) == QtCore.Qt.CheckState.Checked
+        )
+        self.dialog.tabWidget.setTabText(
+            _TAB_OPERATIONS,
+            translate("CAM_Post", "Operations ({}/{})").format(checked, total),
+        )
+
+    def _update_warnings_tab_label(self, n_total, n_critical):
+        tab = self.dialog.tabWidget
+        if n_critical:
+            tab.setTabText(_TAB_WARNINGS, translate("CAM_Post", "Warnings (!) {}").format(n_total))
+            tab.tabBar().setTabTextColor(_TAB_WARNINGS, QtGui.QColor("red"))
+        elif n_total:
+            tab.setTabText(_TAB_WARNINGS, translate("CAM_Post", "Warnings {}").format(n_total))
+            tab.tabBar().setTabTextColor(_TAB_WARNINGS, QtGui.QColor("darkorange"))
+        else:
+            tab.setTabText(_TAB_WARNINGS, translate("CAM_Post", "Warnings"))
+            tab.tabBar().setTabTextColor(_TAB_WARNINGS, QtGui.QColor("green"))
+
+    # ------------------------------------------------------------------
+    # Operations helpers
+    # ------------------------------------------------------------------
+
+    def _get_operations(self):
+        ops = getattr(self.job, "Operations", None)
+        if ops and hasattr(ops, "Group"):
+            return ops.Group
+        return []
+
+    def _update_total_time(self):
+        tree = self.dialog.treeWidgetOperations
+        total_secs = 0
+        has_any = False
+        for i in range(tree.topLevelItemCount()):
+            item = tree.topLevelItem(i)
+            if item.checkState(0) != QtCore.Qt.CheckState.Checked:
+                continue
+            secs = _parse_cycle_time(item.text(1))
+            if secs is not None:
+                total_secs += secs
+                has_any = True
+        self.dialog.labelTotalTime.setText(
+            translate("CAM_Post", "Total: {}").format(
+                _format_seconds(total_secs) if has_any else "-"
+            )
+        )
+
+    def _on_ops_changed(self, _item, _col=None):
+        self._update_ops_tab_label()
+        self._update_total_time()
+
+    def _select_all_ops(self):
+        tree = self.dialog.treeWidgetOperations
+        tree.blockSignals(True)
+        for i in range(tree.topLevelItemCount()):
+            tree.topLevelItem(i).setCheckState(0, QtCore.Qt.CheckState.Checked)
+        tree.blockSignals(False)
+        self._on_ops_changed(None)
+
+    def _select_none_ops(self):
+        tree = self.dialog.treeWidgetOperations
+        tree.blockSignals(True)
+        for i in range(tree.topLevelItemCount()):
+            tree.topLevelItem(i).setCheckState(0, QtCore.Qt.CheckState.Unchecked)
+        tree.blockSignals(False)
+        self._on_ops_changed(None)
+
+    def _select_by_type(self):
+        """Pop a menu of distinct operation types; selecting one checks only those ops."""
+        ops = self._get_operations()
+        tree = self.dialog.treeWidgetOperations
+        types = {}
+        for i in range(tree.topLevelItemCount()):
+            if i < len(ops):
+                t = ops[i].TypeId.split("::")[-1]
+                types.setdefault(t, []).append(i)
+
+        if not types:
+            return
+
+        menu = QtGui.QMenu(self.dialog)
+        for t in sorted(types):
+            action = menu.addAction(t)
+            action.setData(t)
+
+        btn = self.dialog.buttonSelectByType
+        chosen = menu.exec_(btn.mapToGlobal(btn.rect().bottomLeft()))
+        if not chosen:
+            return
+
+        selected_type = chosen.data()
+        tree.blockSignals(True)
+        for i in range(tree.topLevelItemCount()):
+            op_type = ops[i].TypeId.split("::")[-1] if i < len(ops) else ""
+            state = (
+                QtCore.Qt.CheckState.Checked
+                if op_type == selected_type
+                else QtCore.Qt.CheckState.Unchecked
+            )
+            tree.topLevelItem(i).setCheckState(0, state)
+        tree.blockSignals(False)
+        self._on_ops_changed(None)
+
+    # ------------------------------------------------------------------
+    # G-code output generation / preview / save
+    # ------------------------------------------------------------------
+
+    def _apply_options_to_machine(self, machine):
+        """Write Options-tab widget values back to the correct machine attributes.
+
+        _merge_machine_config() inside export2() reads from machine.output.* to
+        populate self.values (e.g. OUTPUT_HEADER, OUTPUT_COMMENTS, etc.).
+        This method must be called after postprocessor._machine is set but before
+        export2() so that any changes the user made in the Options tab take effect.
+        """
+        try:
+            from Machine.models.machine import OutputUnits
+        except Exception:
+            OutputUnits = None
+
+        for section, widgets in self._machine_output_field_widgets.items():
+            if section == "main":
+                for field_name, widget in widgets.items():
+                    if not hasattr(widget, "value_getter"):
+                        continue
+                    value = widget.value_getter()
+                    if field_name == "units":
+                        if OutputUnits is not None:
+                            try:
+                                machine.output.units = OutputUnits(value)
+                            except (ValueError, KeyError):
+                                pass
+                    elif field_name == "output_header":
+                        # _merge_machine_config() reads header.include_date as the
+                        # OUTPUT_HEADER master switch, so mirror the value there too.
+                        machine.output.output_header = value
+                        if hasattr(machine.output, "header") and hasattr(
+                            machine.output.header, "include_date"
+                        ):
+                            machine.output.header.include_date = value
+                    elif hasattr(machine.output, field_name):
+                        setattr(machine.output, field_name, value)
+
+            elif section in ("header", "comments", "formatting", "precision", "duplicates"):
+                sub = getattr(machine.output, section, None)
+                if sub is None:
+                    continue
+                for field_name, widget in widgets.items():
+                    if hasattr(widget, "value_getter") and hasattr(sub, field_name):
+                        setattr(sub, field_name, widget.value_getter())
+
+    def _reset_output_tab(self):
+        """Clear all generated output and reset the Output tab to its initial state."""
+        self._generated_outputs = {}
+        self._output_sections = []
+        dlg = self.dialog
+        dlg.listWidgetOutputFiles.blockSignals(True)
+        dlg.listWidgetOutputFiles.clear()
+        dlg.listWidgetOutputFiles.blockSignals(False)
+        dlg.plainTextEditGcode.setPlainText("")
+        dlg.labelOutputStatus.setVisible(True)
+        dlg.buttonSaveOutput.setEnabled(False)
+        dlg.buttonApplyTemplate.setEnabled(False)
+
+    def _generate_output(self):
+        """Run the post-processor in-memory and show the result in the Output tab."""
+        import os
+        from Path.Post.Processor import PostProcessorFactory
+        from Path.Post.Utils import FilenameGenerator
+        from Machine.models.machine import MachineFactory
+
+        self._reset_output_tab()
+
+        job = self.job
+        dlg = self.dialog
+
+        # Build filtered operations list from the Operations tab checkboxes
+        all_ops = self._get_operations()
+        tree = dlg.treeWidgetOperations
+        selected_ops = [
+            all_ops[i]
+            for i in range(tree.topLevelItemCount())
+            if tree.topLevelItem(i).checkState(0) == QtCore.Qt.CheckState.Checked
+            and i < len(all_ops)
+        ]
+        job_arg = {"job": job, "operations": selected_ops}
+
+        try:
+            # Determine which machine and post-processor to use.
+            # Priority: machine selected in the dialog combo > job.Machine > legacy post-processor.
+            combo_machine_path = dlg.comboBoxMachine.currentData()
+            loaded_machine = None
+            use_new_flow = False
+
+            if combo_machine_path:
+                # Load machine directly from the combo's stored file path
+                from Machine.models.machine import Machine
+
+                machine_data = MachineFactory.load_configuration(combo_machine_path)
+                if isinstance(machine_data, dict):
+                    loaded_machine = Machine.from_dict(machine_data)
+                else:
+                    loaded_machine = machine_data
+                postprocessor_name = getattr(loaded_machine, "postprocessor_file_name", None)
+                if not postprocessor_name:
+                    QtGui.QMessageBox.warning(
+                        self.dialog,
+                        translate("CAM_Post", "Generate Output"),
+                        translate(
+                            "CAM_Post", "The selected machine has no post-processor configured."
+                        ),
+                    )
+                    return
+                use_new_flow = True
+            elif hasattr(job, "Machine") and job.Machine:
+                loaded_machine = MachineFactory.get_machine(job.Machine)
+                postprocessor_name = getattr(loaded_machine, "postprocessor_file_name", None)
+                if not postprocessor_name:
+                    QtGui.QMessageBox.warning(
+                        self.dialog,
+                        translate("CAM_Post", "Generate Output"),
+                        translate(
+                            "CAM_Post", "The selected machine has no post-processor configured."
+                        ),
+                    )
+                    return
+                use_new_flow = True
+            else:
+                postprocessor_name = (
+                    getattr(job, "PostProcessor", None) or PathPrefs.defaultPostProcessor()
+                )
+                if not postprocessor_name:
+                    QtGui.QMessageBox.warning(
+                        self.dialog,
+                        translate("CAM_Post", "Generate Output"),
+                        translate("CAM_Post", "No post-processor configured for this job."),
+                    )
+                    return
+
+            postprocessor = PostProcessorFactory.get_post_processor(job_arg, postprocessor_name)
+
+            # Override the postprocessor's machine with the dialog's selection, then
+            # write back any changes the user made in the Options tab before export2()
+            # calls _merge_machine_config().
+            if loaded_machine is not None:
+                postprocessor._machine = loaded_machine
+                self._apply_options_to_machine(postprocessor._machine)
+
+            post_data = postprocessor.export2() if use_new_flow else postprocessor.export()
+
+            if not post_data:
+                QtGui.QMessageBox.warning(
+                    self.dialog,
+                    translate("CAM_Post", "Generate Output"),
+                    translate("CAM_Post", "Post-processor returned no output."),
+                )
+                return
+
+            file_ext = postprocessor.get_file_extension() if use_new_flow else None
+
+            # Populate template field from job if user hasn't set one yet
+            if not dlg.lineEditFilenameTemplate.text().strip():
+                default_template = getattr(job, "PostProcessorOutputFile", "") or ""
+                dlg.lineEditFilenameTemplate.setText(default_template)
+
+            generator = FilenameGenerator(job=job, file_extension=file_ext)
+            gen_filenames = generator.generate_filenames()
+
+            # Use output folder from the Output tab if already set by user
+            output_folder = dlg.lineEditOutputLocation.text().strip() or None
+
+            self._output_sections = list(post_data)
+            self._generated_outputs = {}
+            for subpart, gcode in self._output_sections:
+                subpart_clean = "" if subpart == "allitems" else subpart
+                generator.set_subpartname(subpart_clean)
+                fname = next(gen_filenames)
+                if output_folder:
+                    fname = os.path.join(output_folder, os.path.basename(fname))
+                if gcode is not None:
+                    self._generated_outputs[fname] = gcode
+
+            # Show the resolved output directory in the location field (if not already set)
+            if self._generated_outputs and not output_folder:
+                first_fname = next(iter(self._generated_outputs))
+                resolved_dir = os.path.dirname(first_fname) or os.getcwd()
+                dlg.lineEditOutputLocation.setText(resolved_dir)
+
+        except Exception as e:
+            QtGui.QMessageBox.critical(
+                self.dialog,
+                translate("CAM_Post", "Generate Output"),
+                translate("CAM_Post", "Error during generation:\n{}").format(str(e)),
+            )
+            Path.Log.error(f"Generate output failed: {e}")
+            return
+
+        self._populate_output_tab()
+        self.dialog.tabWidget.setCurrentIndex(_TAB_GCODE)
+
+    def _populate_output_tab(self):
+        """Fill the Output tab with the generated file list and first file's content."""
+        dlg = self.dialog
+        lw = dlg.listWidgetOutputFiles
+        lw.blockSignals(True)
+        lw.clear()
+
+        for fname in self._generated_outputs:
+            import os
+
+            item = QtGui.QListWidgetItem(os.path.basename(fname))
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, fname)
+            item.setToolTip(fname)
+            item.setFlags(
+                item.flags()
+                | QtCore.Qt.ItemFlag.ItemIsEditable
+                | QtCore.Qt.ItemFlag.ItemIsEnabled
+                | QtCore.Qt.ItemFlag.ItemIsSelectable
+            )
+            lw.addItem(item)
+
+        lw.blockSignals(False)
+
+        if lw.count() > 0:
+            lw.setCurrentRow(0)  # triggers _on_output_file_selected
+        else:
+            dlg.plainTextEditGcode.setPlainText("")
+
+        n = len(self._generated_outputs)
+        dlg.labelOutputStatus.setVisible(n == 0)
+        dlg.buttonSaveOutput.setEnabled(n > 0)
+        dlg.buttonApplyTemplate.setEnabled(n > 0)
+
+    def _on_output_file_selected(self, current, previous):
+        """Persist edits from the previously viewed file; load the newly selected one."""
+        dlg = self.dialog
+        if previous is not None:
+            prev_fname = previous.data(QtCore.Qt.ItemDataRole.UserRole)
+            if prev_fname in self._generated_outputs:
+                self._generated_outputs[prev_fname] = dlg.plainTextEditGcode.toPlainText()
+
+        if current is not None:
+            fname = current.data(QtCore.Qt.ItemDataRole.UserRole)
+            dlg.plainTextEditGcode.setPlainText(self._generated_outputs.get(fname, ""))
+
+    def _on_output_files_context_menu(self, pos):
+        """Show rename context menu on right-click."""
+        lw = self.dialog.listWidgetOutputFiles
+        item = lw.itemAt(pos)
+        if item is None:
+            return
+        menu = QtGui.QMenu(self.dialog)
+        rename_action = menu.addAction(translate("CAM_Post", "Rename"))
+        if menu.exec_(lw.mapToGlobal(pos)) == rename_action:
+            lw.editItem(item)
+
+    def _on_output_file_renamed(self, item):
+        """Update _generated_outputs key when a file item is renamed by the user."""
+        import os
+
+        new_basename = item.text()
+        old_fname = item.data(QtCore.Qt.ItemDataRole.UserRole)
+        if not old_fname:
+            return
+        if new_basename == os.path.basename(old_fname):
+            return  # Nothing changed
+
+        old_dir = os.path.dirname(old_fname)
+        new_fname = os.path.join(old_dir, new_basename) if old_dir else new_basename
+
+        if old_fname in self._generated_outputs:
+            gcode = self._generated_outputs.pop(old_fname)
+            self._generated_outputs[new_fname] = gcode
+
+        lw = self.dialog.listWidgetOutputFiles
+        lw.blockSignals(True)
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, new_fname)
+        item.setToolTip(new_fname)
+        lw.blockSignals(False)
+
+    def _flush_editor_to_outputs(self):
+        """Save any pending edits from the editor back to _generated_outputs."""
+        dlg = self.dialog
+        current = dlg.listWidgetOutputFiles.currentItem()
+        if current is not None:
+            fname = current.data(QtCore.Qt.ItemDataRole.UserRole)
+            if fname in self._generated_outputs:
+                self._generated_outputs[fname] = dlg.plainTextEditGcode.toPlainText()
+
+    def _regenerate_filenames(self):
+        """Re-apply the filename template to rename all items in the output list."""
+        import os
+        from Path.Post.Utils import FilenameGenerator
+
+        if not self._output_sections:
+            return
+
+        self._flush_editor_to_outputs()
+
+        dlg = self.dialog
+        template = dlg.lineEditFilenameTemplate.text().strip() or None
+        output_dir = dlg.lineEditOutputLocation.text().strip() or None
+
+        # Temporarily override the job's output file template
+        old_template = getattr(self.job, "PostProcessorOutputFile", "")
+        try:
+            if template:
+                self.job.PostProcessorOutputFile = template
+
+            generator = FilenameGenerator(job=self.job)
+            gen_filenames = generator.generate_filenames()
+
+            new_fnames = []
+            for subpart, gcode in self._output_sections:
+                subpart_clean = "" if subpart == "allitems" else subpart
+                generator.set_subpartname(subpart_clean)
+                fname = next(gen_filenames)
+                if output_dir:
+                    fname = os.path.join(output_dir, os.path.basename(fname))
+                if gcode is not None:
+                    new_fnames.append(fname)
+        finally:
+            if template:
+                self.job.PostProcessorOutputFile = old_template
+
+        # Map new names onto existing gcode (preserving user edits) by position
+        old_gcodes = list(self._generated_outputs.values())
+        self._generated_outputs = {}
+        for i, fname in enumerate(new_fnames):
+            self._generated_outputs[fname] = old_gcodes[i] if i < len(old_gcodes) else ""
+
+        self._populate_output_tab()
+
+    def _browse_output_location(self):
+        dlg = self.dialog
+        current = dlg.lineEditOutputLocation.text().strip() or ""
+        folder = QtGui.QFileDialog.getExistingDirectory(
+            dlg,
+            translate("CAM_Post", "Select Output Folder"),
+            current,
+        )
+        if folder:
+            dlg.lineEditOutputLocation.setText(folder)
+
+    def _save_output_files(self):
+        """Write all generated (and possibly edited) outputs to disk, then close."""
+        import os
+
+        self._flush_editor_to_outputs()
+
+        if not self._generated_outputs:
+            return
+
+        output_dir = self.dialog.lineEditOutputLocation.text().strip() or None
+
+        written = []
+        errors = []
+        for fname, gcode in self._generated_outputs.items():
+            try:
+                save_path = (
+                    os.path.join(output_dir, os.path.basename(fname)) if output_dir else fname
+                )
+                os.makedirs(os.path.dirname(os.path.abspath(save_path)), exist_ok=True)
+                with open(save_path, "w", encoding="utf-8") as f:
+                    f.write(gcode)
+                written.append(save_path)
+                FreeCAD.Console.PrintMessage(f"File written to {save_path}\n")
+            except Exception as e:
+                errors.append(f"{os.path.basename(fname)}: {e}")
+
+        dlg = self.dialog
+        if errors:
+            dlg.labelOutputStatus.setText(
+                translate("CAM_Post", "{} error(s) while saving:\n{}").format(
+                    len(errors), "\n".join(errors)
+                )
+            )
+            dlg.labelOutputStatus.setStyleSheet("color: red;")
+            dlg.labelOutputStatus.setVisible(True)
+        else:
+            dlg.accept()
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def exec_(self):
+        return self.dialog.exec_()
+
+    def config(self):
+        """Return a dict of the user's choices. Call after exec_() returns Accepted."""
+        dlg = self.dialog
+        tree = dlg.treeWidgetOperations
+        ops = self._get_operations()
+
+        # Only active operations that the user kept checked
+        selected_ops = [
+            ops[i]
+            for i in range(tree.topLevelItemCount())
+            if tree.topLevelItem(i).checkState(0) == QtCore.Qt.CheckState.Checked and i < len(ops)
+        ]
+
+        lw = dlg.listWidgetFixtures
+        fixtures = getattr(self.job, "Fixtures", None) or []
+        selected_fixtures = [
+            fixtures[i]
+            for i in range(lw.count())
+            if lw.item(i).checkState() == QtCore.Qt.CheckState.Checked and i < len(fixtures)
+        ]
+
+        # Collect dynamic machine output field values
+        machine_output_overrides = {}
+        for section, widgets in self._machine_output_field_widgets.items():
+            for field_name, widget in widgets.items():
+                if hasattr(widget, "value_getter"):
+                    machine_output_overrides[field_name] = widget.value_getter()
+
+        self._flush_editor_to_outputs()
+
+        return {
+            "machine": dlg.comboBoxMachine.currentData(),
+            "selected_operations": selected_ops,
+            "selected_fixtures": selected_fixtures,
+            "job_author": dlg.lineEditJobAuthor.text().strip(),
+            "comment": dlg.plainTextEditComment.toPlainText().strip(),
+            "generate_sanity_report": dlg.checkBoxSanityReport.isChecked(),
+            "machine_output_overrides": machine_output_overrides,
+            "generated_outputs": dict(self._generated_outputs),
+        }

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -942,6 +942,17 @@ class PostProcessDialog:
 
             postprocessor = PostProcessorFactory.get_post_processor(job_arg, postprocessor_name)
 
+            if postprocessor is None:
+                QtGui.QMessageBox.warning(
+                    self.dialog,
+                    translate("CAM_Post", "Generate Output"),
+                    translate(
+                        "CAM_Post",
+                        "Could not load post-processor '{}'.".format(postprocessor_name),
+                    ),
+                )
+                return
+
             # Override the postprocessor's machine with the dialog's selection, then
             # write back any changes the user made in the Options tab before export2()
             # calls _merge_machine_config().

--- a/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
+++ b/src/Mod/CAM/Path/Post/Gui/DlgPostProcess.py
@@ -1,4 +1,23 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
 
 """Unified Post-Processing dialog.
 
@@ -12,12 +31,18 @@ a config dict on accept.  No functional post-processing logic lives here yet.
 import FreeCAD
 import FreeCADGui
 import Path
-import Path.Preferences as PathPrefs
+import Path.Preferences as PathPref
 from PySide import QtCore, QtGui
 
 translate = FreeCAD.Qt.translate
 
-LOG_MODULE = Path.Log.thisModule()
+debug = True
+if debug:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
 
 _TAB_OVERVIEW = 0
 _TAB_OPERATIONS = 1
@@ -104,6 +129,7 @@ class PostProcessDialog:
         dlg.buttonSelectAllOps.clicked.connect(self._select_all_ops)
         dlg.buttonSelectNoneOps.clicked.connect(self._select_none_ops)
         dlg.buttonSelectByType.clicked.connect(self._select_by_type)
+        dlg.buttonWorkplan.clicked.connect(self._show_workplan)
         dlg.treeWidgetOperations.itemChanged.connect(self._on_ops_changed)
         dlg.comboBoxMachine.currentIndexChanged.connect(self._on_machine_changed)
         dlg.buttonBrowseOutputLocation.clicked.connect(self._browse_output_location)
@@ -569,8 +595,8 @@ class PostProcessDialog:
 
     def _populate_job_details(self):
         dlg = self.dialog
-        dlg.lineEditJobAuthor.setText(getattr(self.job, "Author", "") or "")
-        dlg.plainTextEditComment.setPlainText("")
+        dlg.lineEditJobAuthor.setText(getattr(self.job.Document, "CreatedBy", "") or "")
+        dlg.plainTextEditComment.setPlainText(getattr(self.job, "Description", "") or "")
 
     def _populate_operations(self):
         dlg = self.dialog
@@ -802,6 +828,140 @@ class PostProcessDialog:
         tree.blockSignals(False)
         self._on_ops_changed(None)
 
+    def _show_workplan(self):
+        """Display the workplan (postable items structure) in a dialog."""
+        from Path.Post.PostList import buildPostList
+        import Path.Base.Util as PathUtil
+
+        # Create a minimal processor-like object for building the postlist
+        class TempProcessor:
+            def __init__(self, job, operations):
+                self._job = job
+                self._operations = operations
+
+        # Create temporary processor with active operations
+        temp_processor = TempProcessor(self.job, self._get_active_operations())
+
+        # Build the workplan text
+        workplan_text = self._format_workplan(temp_processor)
+
+        # Create and show the dialog
+        dlg = QtGui.QDialog(self.dialog)
+        dlg.setWindowTitle(translate("CAM_Post", "Workplan"))
+        dlg.resize(800, 600)
+
+        layout = QtGui.QVBoxLayout(dlg)
+
+        # Add text display
+        text_edit = QtGui.QTextEdit()
+        text_edit.setPlainText(workplan_text)
+        text_edit.setReadOnly(True)
+        text_edit.setFont(QtGui.QFont("Courier", 9))
+        layout.addWidget(text_edit)
+
+        # Add close button
+        button_box = QtGui.QDialogButtonBox(QtGui.QDialogButtonBox.Close)
+        button_box.rejected.connect(dlg.reject)
+        layout.addWidget(button_box)
+
+        dlg.exec_()
+
+    def _format_workplan(self, processor):
+        """Format the workplan text similar to the export function provided."""
+        from Path.Post.PostList import buildPostList
+
+        lines = []
+        lines.append("=" * 80)
+        lines.append("POSTABLES LIST")
+        lines.append("=" * 80)
+        lines.append("")
+        lines.append(f"Job: {processor._job.Label}")
+        lines.append(f"SplitOutput: {getattr(processor._job, 'SplitOutput', 'N/A')}")
+        lines.append(f"OrderOutputBy: {getattr(processor._job, 'OrderOutputBy', 'N/A')}")
+        lines.append(f"Fixtures: {getattr(processor._job, 'Fixtures', 'N/A')}")
+        lines.append("")
+
+        postables = buildPostList(processor)
+
+        for idx, postable in enumerate(postables, 1):
+            group_key = postable[0]
+            objects = postable[1]
+
+            # Format the group key display
+            if group_key == "":
+                display_key = "(empty string)"
+            else:
+                display_key = f'"{group_key}"'
+
+            lines.append(f"[{idx}] Postable Group: {display_key}")
+            lines.append(f"    Objects: {len(objects)}")
+            lines.append("")
+
+            for obj_idx, obj in enumerate(objects, 1):
+                lines.append(f"    [{obj_idx}] {obj.Label}")
+
+                # Determine object type/role
+                obj_type = None
+                if hasattr(obj, "item_type"):
+                    # Postable object
+                    obj_type = obj.item_type.title()
+                    if obj.item_type == "fixture":
+                        if hasattr(obj, "path") and obj.path and len(obj.path.Commands) > 0:
+                            fixture_cmd = obj.path.Commands[0]
+                            lines.append(f"        Fixture: {fixture_cmd.Name}")
+                    elif obj.item_type == "tool_controller":
+                        if hasattr(obj, "data") and "tool_number" in obj.data:
+                            lines.append(f"        Tool Number: {obj.data['tool_number']}")
+                        lines.append(f"        Tool: {obj.Label}")
+                    elif obj.item_type == "operation":
+                        if hasattr(obj, "data") and "tool_controller" in obj.data:
+                            tc = obj.data["tool_controller"]
+                            lines.append(
+                                f"        ToolController: {tc.Label} (T{tc.data.get('tool_number', '?')})"
+                            )
+                        else:
+                            lines.append(f"        ToolController: None")
+                else:
+                    # Legacy object
+                    if type(obj).__name__ == "_TempObject":
+                        obj_type = "Fixture Setup"
+                        if hasattr(obj, "Path") and obj.Path and len(obj.Path.Commands) > 0:
+                            fixture_cmd = obj.Path.Commands[0]
+                            lines.append(f"        Fixture: {fixture_cmd.Name}")
+                    elif hasattr(obj, "TypeId"):
+                        # Check if it's a tool controller
+                        if "ToolController" in obj.TypeId or obj.Name.startswith("TC"):
+                            obj_type = "Tool Change"
+                            if hasattr(obj, "ToolNumber"):
+                                lines.append(f"        Tool Number: {obj.ToolNumber}")
+                            if hasattr(obj, "Label"):
+                                lines.append(f"        Tool: {obj.Label}")
+                        else:
+                            # It's an operation
+                            obj_type = "Operation"
+                            if hasattr(obj, "ToolController") and obj.ToolController:
+                                tc = obj.ToolController
+                                lines.append(
+                                    f"        ToolController: {tc.Label} (T{tc.ToolNumber})"
+                                )
+                            elif hasattr(obj, "ToolController"):
+                                lines.append(f"        ToolController: None")
+                    else:
+                        obj_type = type(obj).__name__
+
+                if obj_type:
+                    lines.append(f"        Type: {obj_type}")
+
+            lines.append("")
+
+        lines.append("=" * 80)
+        lines.append(f"Total Groups: {len(postables)}")
+        total_objects = sum(len(p[1]) for p in postables)
+        lines.append(f"Total Objects: {total_objects}")
+        lines.append("=" * 80)
+
+        return "\n".join(lines)
+
     # ------------------------------------------------------------------
     # G-code output generation / preview / save
     # ------------------------------------------------------------------
@@ -965,6 +1125,13 @@ class PostProcessDialog:
             # job-level overrides) and writes them into self.values so that
             # export2 and sanity checks all read from the same source.
             dialog_overrides = self._collect_post_param_values()
+
+            # Add job_author, comment, and selected_fixtures from dialog fields
+            dialog_config = self.config()
+            dialog_overrides["job_author"] = dialog_config["job_author"]
+            dialog_overrides["comment"] = dialog_config["comment"]
+            dialog_overrides["selected_fixtures"] = dialog_config["selected_fixtures"]
+
             if hasattr(postprocessor, "apply_configuration_bundle"):
                 postprocessor.apply_configuration_bundle(overrides=dialog_overrides)
 

--- a/src/Mod/CAM/Path/Post/Gui/__init__.py
+++ b/src/Mod/CAM/Path/Post/Gui/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later

--- a/src/Mod/CAM/Path/Post/PostList.py
+++ b/src/Mod/CAM/Path/Post/PostList.py
@@ -222,8 +222,8 @@ def build_postlist_by_fixture(processor: Any) -> list:
             tc_postable = wrapped_op.ToolController
             if tc_postable is not None:
                 if needsTcOp(currTc, tc_postable):
-                    sublist.append(_wrap_tc(tc_postable.source))
-                    Path.Log.debug(f"Appending TC: {tc_postable.source.Name}")
+                    sublist.append(tc_postable)
+                    Path.Log.debug(f"Appending TC: {tc_postable.label}")
                     currTc = tc_postable
             sublist.append(wrapped_op)
 
@@ -281,7 +281,7 @@ def build_postlist_by_tool(processor: Any) -> list:
         else:
             commitToPostlist()
 
-            sublist = [_wrap_tc(tc_postable.source)]
+            sublist = [tc_postable]
             curlist = [wrapped_op]
             currTc = tc_postable
 
@@ -328,7 +328,7 @@ def build_postlist_by_operation(processor: Any) -> list:
             tc_postable = wrapped_op.ToolController
             if tc_postable is not None:
                 if processor._job.SplitOutput or needsTcOp(currTc, tc_postable):
-                    sublist.append(_wrap_tc(tc_postable.source))
+                    sublist.append(tc_postable)
                     currTc = tc_postable
             sublist.append(wrapped_op)
 

--- a/src/Mod/CAM/Path/Post/PostList.py
+++ b/src/Mod/CAM/Path/Post/PostList.py
@@ -1,37 +1,105 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 import re
-from typing import Any, List, Tuple
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
 
-import FreeCAD
 import Path
 import Path.Base.Util as PathUtil
-import Path.Tool.Controller as PathToolController
+
+debug = True
+if debug:
+    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
+    Path.Log.trackModule(Path.Log.thisModule())
+else:
+    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
 
-class _FixtureSetupObject:
-    Path = None
-    Name = "Fixture"
-    InList = []
-    Label = "Fixture"
+@dataclass
+class Postable:
+    """Uniform wrapper for every item that passes through the post-processing pipeline.
 
+    Replaces the three ad-hoc mock classes (_FixtureSetupObject, _CommandObject,
+    _RotationSetupObject) and raw document objects. All downstream code can rely on
+    this single interface instead of duck-typing via hasattr.
 
-class _CommandObject:
-    def __init__(self, command):
-        self.Path = Path.Path([command])
-        self.Name = "Command"
-        self.InList = []
-        self.Label = "Command"
+    The wrapper copies essential data (path, label) to prevent postprocessing from
+    accidentally marking the original FreeCAD document objects dirty.
 
+    Attributes:
+        item_type: One of "operation", "tool_controller", "fixture", "rotation", "command".
+        label:     Human-readable name (mirrors the old .Label attribute).
+        path:      Always a *copy* of the source path so mutations here never touch
+                   the original FreeCAD document object.
+        source:    Reference to the original object for traceability (read-only).
+        data:      Extension dict. Standard keys:
+                     "tool_controller" (Postable) - Present on operation items.
+                     "tool_number" (int/float) - Present on tool_controller items.
+    """
 
-class _RotationSetupObject:
-    """Postable for rotation commands to align workpiece/table for 3+2 axis machining."""
+    item_type: str
+    label: str
+    path: "Path.Path"
+    source: Optional[object]
+    data: dict = field(default_factory=dict)
 
-    Path = None
-    Name = "Rotation"
-    InList = []
-    Label = "Rotation"
-    Placement = None
+    # Backward-compat properties so legacy code continues to work without changes.
+    @property
+    def Path(self):
+        return self.path
+
+    @Path.setter
+    def Path(self, value):
+        self.path = value
+
+    @property
+    def Label(self):
+        return self.label
+
+    def __getattr__(self, name):
+        """Forward unknown attribute lookups to source for backward-compat.
+
+        Legacy post scripts access attributes like .Name, .InList, .Proxy, .TypeId,
+        .ToolNumber, .CoolantMode, etc. directly on items. Forwarding to source keeps
+        them working without modification.
+
+        ToolController is intercepted: returns the Postable-wrapped TC stored in
+        data["tool_controller"] rather than the live document object, preventing
+        callers from accidentally marking the source operation dirty.
+        """
+        # Use object.__getattribute__ to avoid recursion if source itself isn't set yet.
+        try:
+            data = object.__getattribute__(self, "data")
+        except AttributeError:
+            data = {}
+
+        # Return the Postable-wrapped TC instead of the live document object.
+        if name == "ToolController":
+            return data.get("tool_controller", None)
+
+        try:
+            source = object.__getattribute__(self, "source")
+        except AttributeError:
+            source = None
+
+        if source is not None:
+            return getattr(source, name)
+
+        # Provide sensible fallbacks for items that have no source document object
+        # (fixture, rotation, command).  These mirror what the old mock classes provided.
+        try:
+            label = object.__getattribute__(self, "label")
+        except AttributeError:
+            label = "Unknown"
+
+        _fallbacks = {
+            "Name": label,
+            "InList": [],
+        }
+        if name in _fallbacks:
+            return _fallbacks[name]
+
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
 
 
 def needsTcOp(oldTc: Any, newTc: Any) -> bool:
@@ -43,91 +111,103 @@ def needsTcOp(oldTc: Any, newTc: Any) -> bool:
     )
 
 
-def create_fixture_setup(processor: Any, order: int, fixture: str) -> _FixtureSetupObject:
-    fobj = _FixtureSetupObject()
+def _wrap_tc(tc: Any) -> Postable:
+    """Wrap a FreeCAD ToolController document object in a Postable.
+
+    Always generates the toolchange path from TC attributes to ensure commands are
+    present even if the document hasn't been recomputed (tc.Path may be empty).
+    """
+    from Path.Base.Generator import toolchange
+
+    if tc.Path and tc.Path.Commands:
+        path = Path.Path(tc.Path.Commands)
+    else:
+        try:
+            spindle_dir = (
+                tc.Tool.Proxy.get_spindle_direction()
+                if tc.Tool
+                else toolchange.SpindleDirection.OFF
+            )
+            commands = toolchange.generate(
+                toolnumber=tc.ToolNumber,
+                toollabel=tc.Label,
+                spindlespeed=tc.SpindleSpeed if tc.SpindleSpeed else 0,
+                spindledirection=spindle_dir,
+            )
+            path = Path.Path(commands)
+        except Exception:
+            path = Path.Path([Path.Command("M6", {"T": int(tc.ToolNumber)})])
+
+    return Postable(
+        item_type="tool_controller",
+        label=tc.Label,
+        path=path,
+        source=tc,
+        data={"tool_number": tc.ToolNumber},
+    )
+
+
+def _wrap_op(op: Any) -> Postable:
+    """Wrap a FreeCAD operation document object in a Postable.
+
+    Creates a safe wrapper that copies essential operation data (path, ToolController)
+    so downstream postprocessing code can read from the copy rather than the live
+    document object. This prevents postprocessing from accidentally marking operations
+    dirty.
+
+    Data keys populated:
+        "tool_controller" (Postable) - Present when the operation has a ToolController.
+    """
+    data = {}
+    raw_tc = PathUtil.toolControllerForOp(op)
+    if raw_tc is not None:
+        data["tool_controller"] = _wrap_tc(raw_tc)
+
+    return Postable(
+        item_type="operation",
+        label=op.Label,
+        path=Path.Path(op.Path.Commands) if op.Path else Path.Path([]),
+        source=op,
+        data=data,
+    )
+
+
+def create_fixture_setup(processor: Any, order: int, fixture: str) -> Postable:
     c1 = Path.Command(fixture)
-    fobj.Path = Path.Path([c1])
+    commands = [c1]
 
     if order != 0:
         clearance_z = (
             processor._job.Stock.Shape.BoundBox.ZMax
             + processor._job.SetupSheet.ClearanceHeightOffset.Value
         )
-        c2 = Path.Command(f"G0 Z{clearance_z}")
-        fobj.Path.addCommands(c2)
+        commands.append(Path.Command(f"G0 Z{clearance_z}"))
 
-    fobj.InList.append(processor._job)
-    return fobj
+    postable = Postable(
+        item_type="fixture",
+        label="Fixture",
+        path=Path.Path(commands),
+        source=None,
+    )
+    return postable
 
 
-def create_rotation_setup(processor: Any, placement: Any) -> _RotationSetupObject:
-    """Create a rotation postable to align machine axes with the operation placement.
+def build_postlist_by_fixture(processor: Any) -> list:
+    """Build postlist ordered by fixture (work coordinate system).
+
+    Wraps operations early to prevent accessing live document objects, which can
+    mark operations dirty during postprocessing.
 
     Args:
-        processor: The postprocessor object
-        placement: The target placement (FreeCAD.Placement)
+        processor: The postprocessor object with job and operations
 
     Returns:
-        _RotationSetupObject with rotation commands, or None if rotation not possible
+        List of tuples: [(fixture_name, [postable_items])]
     """
-    robj = _RotationSetupObject()
-    robj.Placement = placement
-    robj.Label = f"Rotate to {placement}"
-    robj.InList.append(processor._job)
-
-    # Check if machine has rotary axes
-    machine = processor._job.Proxy.getMachine() if processor._job else None
-    if not machine or not machine.has_rotary_axes:
-        Path.Log.warning("Rotation required but machine does not have rotary axes")
-        return None
-
-    try:
-        import Path.Base.Generator.rotation as rotation
-
-        # Get rotation limits from machine (default to unlimited if not specified)
-        aMin, aMax = -360, 360
-        cMin, cMax = -360, 360
-
-        if "A" in machine.rotary_axes:
-            aMin = machine.rotary_axes["A"].min_limit
-            aMax = machine.rotary_axes["A"].max_limit
-        if "C" in machine.rotary_axes:
-            cMin = machine.rotary_axes["C"].min_limit
-            cMax = machine.rotary_axes["C"].max_limit
-
-        # Generate rotation commands to align placement with Z
-        # Extract the Z-axis (normal vector) from the operation placement
-        placement_z_axis = placement.Rotation.multVec(FreeCAD.Vector(0, 0, 1))
-
-        # Use compound moves if machine supports it
-        rotation_commands = rotation.generate(
-            placement_z_axis,
-            aMin=aMin,
-            aMax=aMax,
-            cMin=cMin,
-            cMax=cMax,
-            compound=machine.compound_moves,
-        )
-
-        robj.Path = Path.Path(rotation_commands)
-        Path.Log.debug(f"Created rotation setup: {rotation_commands}")
-        return robj
-
-    except ValueError as e:
-        # No valid rotation solution found within machine limits
-        Path.Log.error(f"Cannot find valid rotation for placement within machine limits: {e}")
-        return None
-    except Exception as e:
-        Path.Log.error(f"Error calculating placement rotation: {e}")
-        return None
-
-
-def build_postlist_by_fixture(processor: Any, early_tool_prep: bool = False) -> list:
     Path.Log.debug("Ordering by Fixture")
     postlist = []
     wcslist = processor._job.Fixtures
     currTc = None
-    current_placement = FreeCAD.Placement()  # Track current placement (identity)
 
     for index, f in enumerate(wcslist):
         sublist = [create_fixture_setup(processor, index, f)]
@@ -136,36 +216,39 @@ def build_postlist_by_fixture(processor: Any, early_tool_prep: bool = False) -> 
             if not PathUtil.activeForOp(obj):
                 continue
 
-            # Check if operation placement requires rotation
-            if hasattr(obj, "Placement") and obj.Placement:
-                if not obj.Placement.Rotation.isSame(current_placement.Rotation, 1e-6):
-                    # Placement changed - insert rotation postable
-                    rotation_obj = create_rotation_setup(processor, obj.Placement)
-                    if rotation_obj:
-                        sublist.append(rotation_obj)
-                        current_placement = obj.Placement
-                        Path.Log.debug(f"Inserted rotation for {obj.Label}")
+            # Wrap early: all further access uses the Postable copy, not the raw document object.
+            wrapped_op = _wrap_op(obj)
 
-            tc = PathUtil.toolControllerForOp(obj)
-            if tc is not None:
-                if needsTcOp(currTc, tc):
-                    sublist.append(tc)
-                    Path.Log.debug(f"Appending TC: {tc.Name}")
-                    currTc = tc
-            sublist.append(obj)
+            tc_postable = wrapped_op.ToolController
+            if tc_postable is not None:
+                if needsTcOp(currTc, tc_postable):
+                    sublist.append(_wrap_tc(tc_postable.source))
+                    Path.Log.debug(f"Appending TC: {tc_postable.source.Name}")
+                    currTc = tc_postable
+            sublist.append(wrapped_op)
 
         postlist.append((f, sublist))
 
     return postlist
 
 
-def build_postlist_by_tool(processor: Any, early_tool_prep: bool = False) -> list:
+def build_postlist_by_tool(processor: Any) -> list:
+    """Build postlist ordered by tool.
+
+    Groups operations by tool controller to minimize tool changes. Wraps operations
+    early to prevent accessing live document objects.
+
+    Args:
+        processor: The postprocessor object with job and operations
+
+    Returns:
+        List of tuples: [(tool_name, [postable_items])]
+    """
     Path.Log.debug("Ordering by Tool")
     postlist = []
     wcslist = processor._job.Fixtures
     toolstring = "None"
     currTc = None
-    current_placement = FreeCAD.Placement()  # Track current placement (identity)
 
     fixturelist = []
     for index, f in enumerate(wcslist):
@@ -189,96 +272,93 @@ def build_postlist_by_tool(processor: Any, early_tool_prep: bool = False) -> lis
             Path.Log.track()
             continue
 
-        tc = PathUtil.toolControllerForOp(obj)
+        # Wrap early: all further access uses the Postable copy, not the raw document object.
+        wrapped_op = _wrap_op(obj)
+        tc_postable = wrapped_op.ToolController
 
-        if tc is None or not needsTcOp(currTc, tc):
-            # Check if operation placement requires rotation before adding to curlist
-            if hasattr(obj, "Placement") and obj.Placement:
-                if not obj.Placement.Rotation.isSame(current_placement.Rotation, 1e-6):
-                    # Placement changed - insert rotation postable
-                    rotation_obj = create_rotation_setup(processor, obj.Placement)
-                    if rotation_obj:
-                        curlist.append(rotation_obj)
-                        current_placement = obj.Placement
-                        Path.Log.debug(f"Inserted rotation for {obj.Label}")
-            curlist.append(obj)
+        if tc_postable is None or not needsTcOp(currTc, tc_postable):
+            curlist.append(wrapped_op)
         else:
             commitToPostlist()
 
-            sublist = [tc]
-
-            # Check if operation placement requires rotation
-            if hasattr(obj, "Placement") and obj.Placement:
-                if not obj.Placement.Rotation.isSame(current_placement.Rotation, 1e-6):
-                    # Placement changed - insert rotation postable
-                    rotation_obj = create_rotation_setup(processor, obj.Placement)
-                    if rotation_obj:
-                        sublist.append(rotation_obj)
-                        current_placement = obj.Placement
-                        Path.Log.debug(f"Inserted rotation for {obj.Label}")
-
-            curlist = [obj]
-            currTc = tc
+            sublist = [_wrap_tc(tc_postable.source)]
+            curlist = [wrapped_op]
+            currTc = tc_postable
 
             if "%T" in processor._job.PostProcessorOutputFile:
-                toolstring = f"{tc.ToolNumber}"
+                toolstring = f"{tc_postable.data['tool_number']}"
             else:
-                toolstring = re.sub(r"[^\w\d-]", "_", tc.Label)
+                toolstring = re.sub(r"[^\w\d-]", "_", tc_postable.label)
 
     commitToPostlist()
 
     return postlist
 
 
-def build_postlist_by_operation(processor: Any, early_tool_prep: bool = False) -> list:
+def build_postlist_by_operation(processor: Any) -> list:
+    """Build postlist ordered by operation.
+
+    Creates separate sections for each operation with all fixtures. Wraps operations
+    early to prevent accessing live document objects.
+
+    Args:
+        processor: The postprocessor object with job and operations
+
+    Returns:
+        List of tuples: [(operation_name, [postable_items])]
+    """
     Path.Log.debug("Ordering by Operation")
     postlist = []
     wcslist = processor._job.Fixtures
     currTc = None
-    current_placement = FreeCAD.Placement()  # Track current placement (identity)
 
     for obj in processor._operations:
         if not PathUtil.activeForOp(obj):
             continue
 
+        # Wrap early: all further access uses the Postable copy, not the raw document object.
+        wrapped_op = _wrap_op(obj)
+        Path.Log.debug(f"obj: {wrapped_op.label}")
+
         sublist = []
-        Path.Log.debug(f"obj: {obj.Name}")
 
         for index, f in enumerate(wcslist):
             sublist.append(create_fixture_setup(processor, index, f))
 
-            # Check if operation placement requires rotation
-            if hasattr(obj, "Placement") and obj.Placement:
-                if not obj.Placement.Rotation.isSame(current_placement.Rotation, 1e-6):
-                    # Placement changed - insert rotation postable
-                    rotation_obj = create_rotation_setup(processor, obj.Placement)
-                    if rotation_obj:
-                        sublist.append(rotation_obj)
-                        current_placement = obj.Placement
-                        Path.Log.debug(f"Inserted rotation for {obj.Label}")
+            tc_postable = wrapped_op.ToolController
+            if tc_postable is not None:
+                if processor._job.SplitOutput or needsTcOp(currTc, tc_postable):
+                    sublist.append(_wrap_tc(tc_postable.source))
+                    currTc = tc_postable
+            sublist.append(wrapped_op)
 
-            tc = PathUtil.toolControllerForOp(obj)
-            if tc is not None:
-                if processor._job.SplitOutput or needsTcOp(currTc, tc):
-                    sublist.append(tc)
-                    currTc = tc
-            sublist.append(obj)
-
-        postlist.append((obj.Label, sublist))
+        postlist.append((wrapped_op.label, sublist))
 
     return postlist
 
 
-def buildPostList(processor: Any, early_tool_prep: bool = False) -> List[Tuple[str, List]]:
+def buildPostList(processor: Any) -> List[Tuple[str, List]]:
+    """Build ordered list of postables for postprocessing.
+
+    Determines ordering strategy based on job.OrderOutputBy and delegates to
+    appropriate builder function. All operations are wrapped early to prevent
+    accessing live document objects.
+
+    Args:
+        processor: The postprocessor object with job and operations
+
+    Returns:
+        List of tuples: [(section_name, [postable_items])]
+    """
     orderby = processor._job.OrderOutputBy
     Path.Log.debug(f"Ordering by {orderby}")
 
     if orderby == "Fixture":
-        postlist = build_postlist_by_fixture(processor, early_tool_prep)
+        postlist = build_postlist_by_fixture(processor)
     elif orderby == "Tool":
-        postlist = build_postlist_by_tool(processor, early_tool_prep)
+        postlist = build_postlist_by_tool(processor)
     elif orderby == "Operation":
-        postlist = build_postlist_by_operation(processor, early_tool_prep)
+        postlist = build_postlist_by_operation(processor)
     else:
         raise ValueError(f"Unknown order: {orderby}")
 
@@ -288,6 +368,15 @@ def buildPostList(processor: Any, early_tool_prep: bool = False) -> List[Tuple[s
         final_postlist = postlist
     else:
         final_postlist = [("allitems", [item for sublist in postlist for item in sublist[1]])]
+
+    # Apply early_tool_prep if configured on the machine
+    early_tool_prep = False
+    if (
+        hasattr(processor, "_machine")
+        and processor._machine
+        and hasattr(processor._machine, "processing")
+    ):
+        early_tool_prep = getattr(processor._machine.processing, "early_tool_prep", False)
 
     if early_tool_prep:
         return apply_early_tool_prep(final_postlist)
@@ -312,11 +401,11 @@ def apply_early_tool_prep(postlist: List[Tuple[str, List]]) -> List[Tuple[str, L
         <gcode>    <- operations with T5
         T7 M6      <- change to tool 7 (already prepped)
     """
-    # First, collect all tool controllers across all groups to find next tool
+    # Collect all tool controllers across all groups to find the next tool
     all_tool_controllers = []
     for group_idx, (name, sublist) in enumerate(postlist):
         for item_idx, item in enumerate(sublist):
-            if hasattr(item, "Proxy") and isinstance(item.Proxy, PathToolController.ToolController):
+            if item.item_type == "tool_controller":
                 all_tool_controllers.append((group_idx, item_idx, item))
 
     new_postlist = []
@@ -325,21 +414,15 @@ def apply_early_tool_prep(postlist: List[Tuple[str, List]]) -> List[Tuple[str, L
         i = 0
         while i < len(sublist):
             item = sublist[i]
-            # Check if item is a tool controller
-            if hasattr(item, "Proxy") and isinstance(item.Proxy, PathToolController.ToolController):
-                # Tool controller has Path.Commands like: [Command (comment), Command M6 [T:n]]
-                # Find the M6 command
+            if item.item_type == "tool_controller":
                 m6_cmd = None
-                for cmd in item.Path.Commands:
+                for cmd in item.path.Commands:
                     if cmd.Name == "M6":
                         m6_cmd = cmd
                         break
 
                 if m6_cmd and len(m6_cmd.Parameters) > 0:
-                    # M6 command has parameters like {'T': 5}, access via key
-                    tool_number = m6_cmd.Parameters.get("T", item.ToolNumber)
 
-                    # Find this TC in the global list and check if there's a next one
                     tc_position = next(
                         (
                             idx
@@ -355,18 +438,20 @@ def apply_early_tool_prep(postlist: List[Tuple[str, List]]) -> List[Tuple[str, L
                         else None
                     )
 
-                    # Keep the original M6 command with tool parameter (M6 T5 format)
-                    # This is the valid FreeCAD format, postprocessor will reformat if needed
                     new_sublist.append(item)
 
-                    # If there's a next tool controller, add Tn prep for it immediately after M6
                     if next_tc is not None:
-                        next_tool_number = next_tc.ToolNumber
-                        prep_next = Path.Command(f"T{next_tool_number}")
-                        prep_next_object = _CommandObject(prep_next)
-                        new_sublist.append(prep_next_object)
+                        next_tool_number = next_tc.data["tool_number"]
+                        prep_cmd = Path.Command(f"T{next_tool_number}")
+                        new_sublist.append(
+                            Postable(
+                                item_type="command",
+                                label="Command",
+                                path=Path.Path([prep_cmd]),
+                                source=None,
+                            )
+                        )
                 else:
-                    # No M6 command found or no tool parameter, keep as-is
                     new_sublist.append(item)
             else:
                 new_sublist.append(item)

--- a/src/Mod/CAM/Path/Post/PostList.py
+++ b/src/Mod/CAM/Path/Post/PostList.py
@@ -7,7 +7,7 @@ from typing import Any, List, Optional, Tuple
 import Path
 import Path.Base.Util as PathUtil
 
-debug = True
+debug = False
 if debug:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
     Path.Log.trackModule(Path.Log.thisModule())

--- a/src/Mod/CAM/Path/Post/PostList.py
+++ b/src/Mod/CAM/Path/Post/PostList.py
@@ -1,4 +1,22 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
 
 import re
 from dataclasses import dataclass, field
@@ -13,6 +31,20 @@ if debug:
     Path.Log.trackModule(Path.Log.thisModule())
 else:
     Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+
+
+def _get_effective_fixtures(processor):
+    """Return the fixture list the postprocessor should use.
+
+    If the configuration bundle contains a non-empty SELECTED_FIXTURES
+    list, only those fixtures are returned (preserving job order).
+    Otherwise all job fixtures are returned.
+    """
+    all_fixtures = processor._job.Fixtures
+    selected = getattr(processor, "values", {}).get("SELECTED_FIXTURES", None)
+    if selected:
+        return [f for f in all_fixtures if f in selected]
+    return all_fixtures
 
 
 @dataclass
@@ -206,7 +238,7 @@ def build_postlist_by_fixture(processor: Any) -> list:
     """
     Path.Log.debug("Ordering by Fixture")
     postlist = []
-    wcslist = processor._job.Fixtures
+    wcslist = _get_effective_fixtures(processor)
     currTc = None
 
     for index, f in enumerate(wcslist):
@@ -246,7 +278,7 @@ def build_postlist_by_tool(processor: Any) -> list:
     """
     Path.Log.debug("Ordering by Tool")
     postlist = []
-    wcslist = processor._job.Fixtures
+    wcslist = _get_effective_fixtures(processor)
     toolstring = "None"
     currTc = None
 
@@ -309,7 +341,7 @@ def build_postlist_by_operation(processor: Any) -> list:
     """
     Path.Log.debug("Ordering by Operation")
     postlist = []
-    wcslist = processor._job.Fixtures
+    wcslist = _get_effective_fixtures(processor)
     currTc = None
 
     for obj in processor._operations:

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -1,30 +1,26 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2014 Yorik van Havre <yorik@uncreated.net>
+# SPDX-FileCopyrightText: 2014 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileCopyrightText: 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>
+# SPDX-FileCopyrightText: 2024 Ondsel <development@ondsel.com>
 
-# ***************************************************************************
-# *   Copyright (c) 2014 Yorik van Havre <yorik@uncreated.net>              *
-# *   Copyright (c) 2014 sliptonic <shopinthewoods@gmail.com>               *
-# *   Copyright (c) 2022 - 2025 Larry Woestman <LarryWoestman2@gmail.com>   *
-# *   Copyright (c) 2024 Ondsel <development@ondsel.com>                    *
-# *                                                                         *
-# *   This file is part of the FreeCAD CAx development system.              *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   This program is distributed in the hope that it will be useful,       *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Library General Public License for more details.                  *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with this program; if not, write to the Free Software   *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
 """
 The base classes for post processors in the CAM workbench.
 """
@@ -55,7 +51,7 @@ translate = FreeCAD.Qt.translate
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
-debug = True
+debug = False
 if debug:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
     Path.Log.trackModule(Path.Log.thisModule())
@@ -247,7 +243,8 @@ class PostProcessorFactory:
                     spec.loader.exec_module(module)
                     Path.Log.debug(f"found module {module_name} at {module_path}")
 
-                except (FileNotFoundError, ImportError, ModuleNotFoundError):
+                except (FileNotFoundError, ImportError, ModuleNotFoundError) as e:
+                    Path.Log.debug(f"Failed to load {module_path}: {e}")
                     continue
 
                 try:
@@ -275,6 +272,10 @@ class PostProcessorFactory:
                             pass
                     raise
 
+        Path.Log.warning(
+            f"Post processor '{postname}' not found in any search path. "
+            f"Searched for '{module_name}.py' in {len(paths)} paths."
+        )
         return None
 
 
@@ -940,6 +941,7 @@ class PostProcessor:
 
         Subclasses can override to customize canned cycle handling.
         """
+        Path.Log.track("Expanding canned cycles")
         for section_name, sublist in postables:
             for item in sublist:
                 has_drill_cycles = False
@@ -1060,6 +1062,39 @@ class PostProcessor:
                             cmd.Name = "G1"
                         new_commands.append(cmd)
                     item.path = Path.Path(new_commands)
+
+    def _expand_translate_drill_cycles(self, postables):
+        """Translate canned drill cycles to G0/G1 move sequences.
+
+        When machine processing.translate_drill_cycles is True, expands
+        canned drill cycle commands (G73, G81, G82, G83) into equivalent
+        G0/G1 move sequences using the DrillCycleExpander.
+
+        Subclasses can override to customize drill cycle translation.
+        """
+        Path.Log.track("Translating drill cycles")
+        if not (
+            self._machine
+            and hasattr(self._machine, "processing")
+            and self._machine.processing.translate_drill_cycles
+        ):
+            Path.Log.debug("Drill cycle translation disabled")
+            return
+
+        from Path.Post.DrillCycleExpander import DrillCycleExpander
+
+        for section_name, sublist in postables:
+            for item in sublist:
+                Path.Log.track(f"Processing item: {item.label}")
+                if item.path:
+                    has_drill = any(
+                        cmd.Name in DrillCycleExpander.EXPANDABLE_CYCLES
+                        for cmd in item.path.Commands
+                    )
+                    if has_drill:
+                        Path.Log.debug(f"Translating drill cycles for {item.label}")
+                        expander = DrillCycleExpander()
+                        item.path = expander.expand_path(item.path)
 
     def _expand_xy_before_z(self, postables):
         """Decompose first move after tool change into XY then Z.
@@ -1587,6 +1622,7 @@ class PostProcessor:
 
         # ===== STAGE 2: COMMAND EXPANSION =====
         gcodeheader = self._build_header(postables)
+        self._expand_translate_drill_cycles(postables)
         self._expand_canned_cycles(postables)
         self._expand_split_arcs(postables)
         self._expand_spindle_wait(postables)

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -55,7 +55,7 @@ translate = FreeCAD.Qt.translate
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
-debug = False
+debug = True
 if debug:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
     Path.Log.trackModule(Path.Log.thisModule())

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -774,7 +774,10 @@ class PostProcessor:
             overrides = self._read_job_overrides()
 
         for key, value in overrides.items():
-            bundle[key] = value
+            if key in bundle:
+                bundle[key] = value
+            else:
+                Path.Log.warning(f"override key '{key}' not in bundle, ignoring")
 
         return bundle
 

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -285,30 +285,6 @@ def needsTcOp(oldTc, newTc):
 class PostProcessor:
     """Base Class.  All non-legacy postprocessors should inherit from this class."""
 
-    def __init_subclass__(cls, **kwargs):
-        """Automatically wrap pre_processing_dialog methods to check show_dialog setting."""
-        super().__init_subclass__(**kwargs)
-
-        # Auto-wrap pre_processing_dialog in subclasses
-        if hasattr(cls, "pre_processing_dialog"):
-            original = cls.pre_processing_dialog
-
-            def wrapped(self, *args, **kwargs):
-                # Base class logic - runs BEFORE subclass method
-                if hasattr(self, "_machine") and hasattr(self._machine, "postprocessor_properties"):
-                    show_dialog = self._machine.postprocessor_properties.get("show_dialog", True)
-                    if not show_dialog:
-                        Path.Log.debug(
-                            "Pre-processing dialog skipped (show_dialog=False in machine config)"
-                        )
-                        return True
-
-                # Call the original subclass method
-                return original(self, *args, **kwargs)
-
-            # Replace the subclass method with our wrapped version
-            cls.pre_processing_dialog = wrapped
-
     @classmethod
     def get_common_property_schema(cls) -> List[Dict[str, Any]]:
         """
@@ -1793,9 +1769,16 @@ class PostProcessor:
         Base implementation does nothing, but subclasses can override to implement
         configuration dialogs, validation checks, or user input collection.
 
+        When the unified PostProcessDialog is used, it sets _dialog_handled = True
+        on the postprocessor instance before calling export2(), so this method
+        returns True immediately (the dialog already collected user input).
+
         Returns:
             bool: True to continue with post-processing, False to cancel
         """
+        if getattr(self, "_dialog_handled", False):
+            Path.Log.debug("pre_processing_dialog skipped (handled by unified dialog)")
+            return True
         return True
 
     def convert_command_to_gcode(self, command: Path.Command) -> str:

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -725,49 +725,111 @@ class PostProcessor:
                 self._machine.postprocessor_properties[name] = default
                 Path.Log.debug(f"Schema default applied: {name} = {repr(default)}")
 
-    def _apply_job_property_overrides(self):
-        """Apply job-level postprocessor property overrides on top of machine config.
+    def build_configuration_bundle(self, overrides=None):
+        """Build the complete postprocessor configuration as a flat dict.
 
-        Reads Job.PostProcessorPropertyOverrides (JSON dict) and merges
-        overridden values into self._machine.postprocessor_properties.
-        Only keys present in the override dict are changed; all other
-        machine defaults remain intact.
+        Pure computation with no side effects — suitable for testing.
 
-        This must be called after _merge_machine_config() so that machine
-        defaults are established first, then selectively overridden.
+        Merges in priority order:
+          1. Machine postprocessor_properties (from .fcm file)
+          2. Schema defaults (for keys not already present)
+          3. Overrides (from job or caller)
+
+        If *overrides* is None the overrides are read from
+        Job.PostProcessorPropertyOverrides.  If *overrides* is a dict
+        it is used directly, allowing the dialog to inject values
+        without touching the job object.
+
+        Args:
+            overrides: Optional dict of property overrides.
+
+        Returns:
+            dict: The final postprocessor property bundle.
         """
-        if not self._job or not self._machine:
-            return
+        # Stage 1 — start with machine postprocessor_properties
+        bundle = {}
+        if self._machine:
+            bundle.update(self._machine.postprocessor_properties)
+
+        # Stage 2 — schema defaults for missing keys
+        schema = self.get_full_property_schema()
+        for prop in schema:
+            name = prop.get("name", "")
+            if name and name not in bundle:
+                bundle[name] = prop.get("default", "")
+
+        # Stage 3 — overrides
+        if overrides is None:
+            overrides = self._read_job_overrides()
+
+        for key, value in overrides.items():
+            if key in bundle:
+                Path.Log.info(f"Override: {key} = {value} (was: {bundle.get(key)})")
+                bundle[key] = value
+            else:
+                Path.Log.warning(f"Override key '{key}' not in bundle, ignoring")
+
+        return bundle
+
+    def apply_configuration_bundle(self, overrides=None):
+        """Build the bundle and apply it everywhere.
+
+        1. Calls build_configuration_bundle() to get the final dict.
+        2. Writes the result back to machine.postprocessor_properties.
+        3. Merges machine output config into self.values (header, comments, etc.).
+        4. Syncs every bundle key into self.values as UPPERCASE so that
+           all consumers (G-code generation, sanity checks) read from
+           one source of truth.
+
+        Args:
+            overrides: Optional dict passed through to build_configuration_bundle().
+        """
+        bundle = self.build_configuration_bundle(overrides)
+
+        # Write back to machine postprocessor_properties
+        if self._machine:
+            self._machine.postprocessor_properties.update(bundle)
+
+        # Merge machine output config (header, comments, formatting, etc.)
+        self._merge_machine_config()
+
+        # Sync all bundle keys into self.values as UPPERCASE
+        for key, value in bundle.items():
+            self.values[key.upper()] = value
+
+        Path.Log.debug(f"Configuration bundle applied — " f"bundle: {bundle}")
+
+    # ------------------------------------------------------------------
+    # Bundle helpers
+    # ------------------------------------------------------------------
+
+    def _read_job_overrides(self):
+        """Read overrides dict from Job.PostProcessorPropertyOverrides JSON."""
+        if not self._job:
+            return {}
 
         overrides_str = getattr(self._job, "PostProcessorPropertyOverrides", "{}")
         if not overrides_str or overrides_str == "{}":
-            return
+            return {}
 
         try:
             overrides = json.loads(overrides_str)
         except (json.JSONDecodeError, TypeError) as e:
             Path.Log.warning(f"Invalid PostProcessorPropertyOverrides JSON: {e}")
-            return
+            return {}
 
         if not isinstance(overrides, dict):
             Path.Log.warning("PostProcessorPropertyOverrides is not a dict, ignoring")
-            return
+            return {}
 
-        # Allow any property that already exists in machine.postprocessor_properties
-        # This enables overrides for postprocessors that don't have full schema defined yet
-        existing_props = set(self._machine.postprocessor_properties.keys())
+        return overrides
 
-        for key, value in overrides.items():
-            if key in existing_props:
-                Path.Log.info(
-                    f"Job override: {key} = {value} "
-                    f"(machine default: {self._machine.postprocessor_properties.get(key, 'N/A')})"
-                )
-                self._machine.postprocessor_properties[key] = value
-            else:
-                Path.Log.warning(
-                    f"Job override key '{key}' not found in machine postprocessor_properties, ignoring"
-                )
+    # Keep backward-compat aliases so nothing breaks during transition
+    def _apply_job_property_overrides(self):
+        self.apply_configuration_bundle()
+
+    def _apply_overrides(self, overrides):
+        self.apply_configuration_bundle(overrides)
 
     def _build_header(self, postables):
         """Build the G-code header from job/machine metadata.
@@ -1515,9 +1577,8 @@ class PostProcessor:
             Path.Log.info("Pre-processing dialog cancelled - aborting export")
             return None
 
-        self._merge_machine_config()
-        self._apply_schema_defaults()
-        self._apply_job_property_overrides()
+        if not getattr(self, "_bundle_applied", False):
+            self.apply_configuration_bundle()
 
         # ===== STAGE 1: ORDERING =====
         all_job_sections = []
@@ -1780,6 +1841,66 @@ class PostProcessor:
             Path.Log.debug("pre_processing_dialog skipped (handled by unified dialog)")
             return True
         return True
+
+    def get_sanity_checks(self, job):
+        """
+        Hook for postprocessor-specific sanity checks.
+
+        This method allows postprocessors to define custom validation rules
+        specific to their machine capabilities, configuration requirements,
+        or operational constraints. These checks are integrated into the
+        CAM_QuickValidation system and displayed alongside generic checks.
+
+        Args:
+            job: FreeCAD CAM job object to validate
+
+        Returns:
+            list: List of squawk dictionaries following the same format as CAMSanity
+                  Each squawk should have: Date, Operator, Note, squawkType, squawkIcon
+
+        Example:
+            def get_sanity_checks(self, job):
+                squawks = []
+
+                # Check plasma cutter specific settings
+                if self.values.get('pierce_delay', 0) < 300:
+                    squawks.append(self._create_squawk(
+                        "WARNING",
+                        "Pierce delay may be too short for material piercing"
+                    ))
+
+                return squawks
+        """
+        return []  # Default implementation: no custom checks
+
+    def _create_squawk(self, squawk_type, note):
+        """
+        Helper to create squawk dictionaries in CAMSanity format.
+
+        Args:
+            squawk_type: str - One of "NOTE", "WARNING", "CAUTION", "TIP"
+            note: str - Human-readable message
+
+        Returns:
+            dict: Squawk dictionary compatible with CAMSanity
+        """
+        from datetime import datetime
+
+        # Map to same icons used by CAMSanity
+        icon_map = {
+            "TIP": "Sanity_Bulb",
+            "NOTE": "Sanity_Note",
+            "WARNING": "Sanity_Warning",
+            "CAUTION": "Sanity_Caution",
+        }
+
+        return {
+            "Date": datetime.now().strftime("%c"),
+            "Operator": self.__class__.__name__,
+            "Note": note,
+            "squawkType": squawk_type,
+            "squawkIcon": f"{FreeCAD.getHomePath()}Mod/CAM/Path/Main/Sanity/{icon_map.get(squawk_type, 'Sanity_Note')}.svg",
+        }
 
     def convert_command_to_gcode(self, command: Path.Command) -> str:
         """

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -55,7 +55,7 @@ translate = FreeCAD.Qt.translate
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
-debug = True
+debug = False
 if debug:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
     Path.Log.trackModule(Path.Log.thisModule())
@@ -853,34 +853,43 @@ class PostProcessor:
                     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                     gcodeheader.add_output_time(timestamp)
 
-        # Collect tool and fixture info from postables
-        if self.values.get("OUTPUT_HEADER", True):
+        # Collect tool and fixture info from postables.
+        # Tool/fixture lists are part of the header block — gate on header_enabled,
+        # not OUTPUT_HEADER (which tracks include_date and is a different field).
+        if header_enabled:
+            list_tools = True
+            if (
+                self._machine
+                and hasattr(self._machine, "output")
+                and hasattr(self._machine.output, "list_tools_in_header")
+            ):
+                list_tools = self._machine.output.list_tools_in_header
+
+            list_fixtures = True
+            if (
+                self._machine
+                and hasattr(self._machine, "output")
+                and hasattr(self._machine.output, "list_fixtures_in_header")
+            ):
+                list_fixtures = self._machine.output.list_fixtures_in_header
+
+            seen_tools = set()
+            seen_fixtures = set()
             for section_name, sublist in postables:
                 for item in sublist:
                     if item.item_type == "tool_controller":
-                        list_tools = True
-                        if (
-                            self._machine
-                            and hasattr(self._machine, "output")
-                            and hasattr(self._machine.output, "list_tools_in_header")
-                        ):
-                            list_tools = self._machine.output.list_tools_in_header
-
                         if list_tools:
-                            gcodeheader.add_tool(item.data["tool_number"], item.label)
+                            tool_key = item.data["tool_number"]
+                            if tool_key not in seen_tools:
+                                seen_tools.add(tool_key)
+                                gcodeheader.add_tool(tool_key, item.label)
                     elif item.item_type == "fixture":
-                        list_fixtures = True
-                        if (
-                            self._machine
-                            and hasattr(self._machine, "output")
-                            and hasattr(self._machine.output, "list_fixtures_in_header")
-                        ):
-                            list_fixtures = self._machine.output.list_fixtures_in_header
-
                         if list_fixtures:
                             if item.path and item.path.Commands:
                                 fixture_name = item.path.Commands[0].Name
-                                gcodeheader.add_fixture(fixture_name)
+                                if fixture_name not in seen_fixtures:
+                                    seen_fixtures.add(fixture_name)
+                                    gcodeheader.add_fixture(fixture_name)
 
         return gcodeheader
 
@@ -1218,6 +1227,296 @@ class PostProcessor:
                     if len(commands_with_g43) != len(item.path.Commands):
                         item.path = Path.Path(commands_with_g43)
 
+    def _get_property_lines(self, key: str) -> list:
+        """Return non-empty lines from a postprocessor_properties entry."""
+        if self._machine and self._machine.postprocessor_properties.get(key):
+            return [
+                line
+                for line in self._machine.postprocessor_properties[key].split("\n")
+                if line.strip()
+            ]
+        return []
+
+    def _collect_header_lines(self, gcodeheader) -> list:
+        """Build header comment lines from the gcodeheader object.
+
+        Gated on machine.output.output_header. Returns formatted comment
+        strings using the configured COMMENT_SYMBOL.
+        """
+        header_enabled = True
+        if self._machine and hasattr(self._machine, "output"):
+            header_enabled = self._machine.output.output_header
+
+        header_lines = []
+        if header_enabled:
+            header_commands = gcodeheader.Path.Commands if hasattr(gcodeheader, "Path") else []
+            comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
+            for cmd in header_commands:
+                if cmd.Name.startswith("("):
+                    comment_text = (
+                        cmd.Name[1:-1]
+                        if cmd.Name.startswith("(") and cmd.Name.endswith(")")
+                        else cmd.Name[1:]
+                    )
+                    if comment_symbol == "(":
+                        header_lines.append(f"({comment_text})")
+                    else:
+                        header_lines.append(f"{comment_symbol} {comment_text}")
+        return header_lines
+
+    def _collect_preamble_lines(self) -> list:
+        """Return preamble lines from machine configuration."""
+        return self._get_property_lines("preamble")
+
+    def _collect_unit_command(self) -> list:
+        """Return G20/G21 unit command based on output_units setting."""
+        if self._machine and hasattr(self._machine, "output"):
+            from Machine.models.machine import OutputUnits
+
+            if self._machine.output.units == OutputUnits.METRIC:
+                return ["G21"]
+            elif self._machine.output.units == OutputUnits.IMPERIAL:
+                return ["G20"]
+        return []
+
+    def _collect_pre_job_lines(self) -> list:
+        """Return pre-job lines from machine configuration."""
+        return self._get_property_lines("pre_job")
+
+    def _build_section_prefix(
+        self, header_lines, preamble_lines, unit_command, pre_job_lines
+    ) -> list:
+        """Assemble the per-section prefix lines.
+
+        Each section becomes a separate output file and must be
+        self-contained.
+        """
+        gcode_lines = []
+        gcode_lines.extend(header_lines)
+        gcode_lines.extend(preamble_lines)
+        gcode_lines.extend(unit_command)
+        gcode_lines.extend(pre_job_lines)
+        return gcode_lines
+
+    def _emit_item_pre_block(self, item, gcode_lines) -> bool:
+        """Emit pre-block lines for a postable item based on its type.
+
+        Handles tool_controller, fixture, and operation item types.
+        Derived postprocessors can override to customize pre-block
+        behavior.
+
+        Returns True if the item should be skipped (no further
+        processing), False to continue with command conversion and
+        post-blocks.
+        """
+        if item.item_type == "tool_controller":
+            if self._machine and hasattr(self._machine, "processing"):
+                if not self._machine.processing.tool_change:
+                    comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
+                    tool_num = item.data["tool_number"]
+                    if comment_symbol == "(":
+                        gcode_lines.append(f"(Tool change suppressed: M6 T{tool_num})")
+                    else:
+                        gcode_lines.append(
+                            f"{comment_symbol} Tool change suppressed:" f" M6 T{tool_num}"
+                        )
+                    return True
+            gcode_lines.extend(self._get_property_lines("pre_tool_change"))
+
+        elif item.item_type == "fixture":
+            gcode_lines.extend(self._get_property_lines("pre_fixture_change"))
+
+        elif item.item_type == "operation":
+            gcode_lines.extend(self._get_property_lines("pre_operation"))
+
+        return False
+
+    def _convert_item_commands(self, item, gcode_lines) -> None:
+        """Convert Path.Commands to G-code strings for a single item.
+
+        Tracks rotary move groups and inserts pre/post rotary blocks.
+        Handles M6 tool change suppression when tool_change is disabled.
+        """
+        if not item.path:
+            return
+
+        in_rotary_group = False
+
+        for cmd in item.path.Commands:
+            try:
+                has_rotary = any(param in cmd.Parameters for param in ["A", "B", "C"])
+
+                if has_rotary and not in_rotary_group:
+                    gcode_lines.extend(self._get_property_lines("pre_rotary_move"))
+                    in_rotary_group = True
+                elif not has_rotary and in_rotary_group:
+                    gcode_lines.extend(self._get_property_lines("post_rotary_move"))
+                    in_rotary_group = False
+
+                gcode = self.convert_command_to_gcode(cmd)
+
+                if cmd.Name in ("M6", "M06"):
+                    if (
+                        self._machine
+                        and hasattr(self._machine, "processing")
+                        and not self._machine.processing.tool_change
+                    ):
+                        comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
+                        if comment_symbol == "(":
+                            gcode = f"(Tool change suppressed: {gcode})"
+                        else:
+                            gcode = f"{comment_symbol} Tool change" f" suppressed: {gcode}"
+
+                if gcode is not None and gcode.strip():
+                    gcode_lines.append(gcode)
+
+            except (ValueError, AttributeError) as e:
+                Path.Log.debug(f"Skipping command {cmd.Name}: {e}")
+
+        if in_rotary_group:
+            gcode_lines.extend(self._get_property_lines("post_rotary_move"))
+
+    def _emit_item_post_block(self, item, gcode_lines) -> None:
+        """Emit post-block lines for a postable item based on its type.
+
+        Handles tool_controller, fixture, and operation item types.
+        Derived postprocessors can override to customize post-block
+        behavior.
+        """
+        if item.item_type == "tool_controller":
+            gcode_lines.extend(self._get_property_lines("post_tool_change"))
+            gcode_lines.extend(self._get_property_lines("tool_return"))
+        elif item.item_type == "fixture":
+            gcode_lines.extend(self._get_property_lines("post_fixture_change"))
+        elif item.item_type == "operation":
+            gcode_lines.extend(self._get_property_lines("post_operation"))
+
+    def _optimize_gcode(self, header_lines, gcode_lines) -> str:
+        """Apply G-code optimizations and produce a final string.
+
+        Separates header comments from body, applies deduplication,
+        redundant-axis suppression, inefficient-move filtering, and
+        line numbering to the body only, then reassembles with the
+        configured line ending.
+        """
+        from Path.Post.GcodeProcessingUtils import (
+            deduplicate_repeated_commands,
+            suppress_redundant_axes_words,
+            filter_inefficient_moves,
+            insert_line_numbers,
+        )
+
+        if not gcode_lines:
+            return ""
+
+        num_header_lines = len(header_lines)
+        header_part = gcode_lines[:num_header_lines]
+        body_part = gcode_lines[num_header_lines:]
+
+        if body_part:
+            if not self.values.get("OUTPUT_DUPLICATE_COMMANDS", True):
+                body_part = deduplicate_repeated_commands(body_part)
+            if not self.values.get("OUTPUT_DOUBLES", True):
+                body_part = suppress_redundant_axes_words(body_part)
+
+        if body_part and self._machine and hasattr(self._machine, "processing"):
+            if hasattr(self._machine.processing, "filter_inefficient_moves"):
+                if self._machine.processing.filter_inefficient_moves:
+                    body_part = filter_inefficient_moves(body_part)
+
+        if body_part and self.values.get("OUTPUT_LINE_NUMBERS", False):
+            start = 10
+            increment = 10
+            if (
+                self._machine
+                and hasattr(self._machine, "output")
+                and hasattr(self._machine.output, "formatting")
+            ):
+                start = self._machine.output.formatting.line_number_start
+                increment = self._machine.output.formatting.line_increment
+            body_part = insert_line_numbers(body_part, start=start, increment=increment)
+
+        final_lines = header_part + body_part
+        gcode_with_newlines = "\n".join(final_lines)
+
+        line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
+        if line_ending == "\n":
+            return gcode_with_newlines
+        else:
+            return gcode_with_newlines.replace("\n", line_ending)
+
+    def _append_trailing_lines(self, gcode_string) -> str:
+        """Append post_job and postamble lines to a gcode section."""
+        trailing = []
+        trailing.extend(self._get_property_lines("post_job"))
+        trailing.extend(self._get_property_lines("postamble"))
+
+        if trailing:
+            trailing_str = "\n".join(trailing)
+            line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
+            if line_ending == "\n":
+                gcode_string = gcode_string + "\n" + trailing_str
+            else:
+                gcode_string = gcode_string + line_ending + trailing_str.replace("\n", line_ending)
+        return gcode_string
+
+    def _append_bcnc_postamble(self, job_sections) -> None:
+        """Append bCNC postamble to the last section only.
+
+        bCNC postamble tracks global state across all sections; proper
+        per-section bCNC support in split mode requires per-section
+        tracking (future work).
+        """
+        if (
+            job_sections
+            and hasattr(self, "_bcnc_postamble_commands")
+            and self._bcnc_postamble_commands is not None
+        ):
+            Path.Log.debug(
+                f"Processing {len(self._bcnc_postamble_commands)}" " bCNC postamble commands"
+            )
+            bcnc_lines = []
+            for cmd in self._bcnc_postamble_commands:
+                gcode = self.convert_command_to_gcode(cmd)
+                if gcode is not None and gcode.strip():
+                    bcnc_lines.append(gcode)
+            if bcnc_lines:
+                last_name, last_gcode = job_sections[-1]
+                line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
+                bcnc_gcode = "\n".join(bcnc_lines)
+                if line_ending == "\n":
+                    job_sections[-1] = (
+                        last_name,
+                        last_gcode + "\n" + bcnc_gcode,
+                    )
+                else:
+                    job_sections[-1] = (
+                        last_name,
+                        last_gcode + line_ending + bcnc_gcode.replace("\n", line_ending),
+                    )
+        else:
+            Path.Log.debug("No bCNC postamble commands to process")
+
+    def _prepend_safety_block(self, all_job_sections) -> None:
+        """Prepend safetyblock to the first section if configured."""
+        if not all_job_sections:
+            return
+
+        safety_lines = self._get_property_lines("safetyblock")
+        if not safety_lines:
+            return
+
+        safety_gcode_newlines = "\n".join(safety_lines)
+        line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
+
+        if line_ending == "\n":
+            safety_gcode = safety_gcode_newlines + "\n"
+        else:
+            safety_gcode = safety_gcode_newlines.replace("\n", line_ending) + line_ending
+
+        first_name, first_gcode = all_job_sections[0]
+        all_job_sections[0] = (first_name, safety_gcode + first_gcode)
+
     def export2(self) -> Union[None, GCodeSections]:
         """
         Process jobs through all postprocessing stages to produce final G-code.
@@ -1233,39 +1532,20 @@ class PostProcessor:
         5. Output Production - Assemble final structure
         6. Remote Posting - Post-processing network operations
         """
-        from Path.Post.GcodeProcessingUtils import (
-            deduplicate_repeated_commands,
-            suppress_redundant_axes_words,
-            filter_inefficient_moves,
-            insert_line_numbers,
-        )
-
         Path.Log.debug("Starting export2()")
 
         # ===== STAGE 0: PRE-PROCESSING DIALOG =====
-        # Allow post processors to collect user input before processing begins
         if not self.pre_processing_dialog():
             Path.Log.info("Pre-processing dialog cancelled - aborting export")
             return None
 
-        # Merge machine configuration into values dict
         self._merge_machine_config()
-
-        # Populate postprocessor_properties with schema defaults for any keys
-        # not explicitly stored in the .fcm file (e.g. preamble, safetyblock)
         self._apply_schema_defaults()
-
-        # Apply job-level property overrides on top of machine defaults
         self._apply_job_property_overrides()
 
         # ===== STAGE 1: ORDERING =====
-        # Process all jobs (currently only first job supported)
         all_job_sections = []
-
-        # Build ordered postables for this job
         postables = self._buildPostList()
-
-        # Allow derived postprocessors to transform postables before expansion
         self._expand_postprocessor_commands(postables)
 
         # ===== STAGE 2: COMMAND EXPANSION =====
@@ -1282,410 +1562,43 @@ class PostProcessor:
         Path.Log.debug(postables)
 
         # ===== STAGE 3: COMMAND CONVERSION =====
+        header_lines = self._collect_header_lines(gcodeheader)
+        preamble_lines = self._collect_preamble_lines()
+        unit_command = self._collect_unit_command()
+        pre_job_lines = self._collect_pre_job_lines()
+
         job_sections = []
-
-        # Collect HEADER lines (comment-only) - controlled by OUTPUT_HEADER
-        header_lines = []
-        if self.values.get("OUTPUT_HEADER", True):
-            header_commands = gcodeheader.Path.Commands if hasattr(gcodeheader, "Path") else []
-            comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
-            for cmd in header_commands:
-                if cmd.Name.startswith("("):
-                    comment_text = (
-                        cmd.Name[1:-1]
-                        if cmd.Name.startswith("(") and cmd.Name.endswith(")")
-                        else cmd.Name[1:]
-                    )
-                    if comment_symbol == "(":
-                        header_lines.append(f"({comment_text})")
-                    else:
-                        header_lines.append(f"{comment_symbol} {comment_text}")
-
-        # Collect PREAMBLE lines
-        preamble_lines = []
-        if self._machine and self._machine.postprocessor_properties.get("preamble"):
-            preamble_lines = [
-                line
-                for line in self._machine.postprocessor_properties["preamble"].split("\n")
-                if line.strip()
-            ]
-
-        # Insert unit command (G20/G21) based on output_units setting
-        unit_command_line = []
-        if self._machine and hasattr(self._machine, "output"):
-            from Machine.models.machine import OutputUnits
-
-            if self._machine.output.units == OutputUnits.METRIC:
-                unit_command_line = ["G21"]
-            elif self._machine.output.units == OutputUnits.IMPERIAL:
-                unit_command_line = ["G20"]
-
-        # Collect PRE-JOB lines
-        pre_job_lines = []
-        if self._machine and self._machine.postprocessor_properties.get("pre_job"):
-            pre_job_lines = [
-                line
-                for line in self._machine.postprocessor_properties["pre_job"].split("\n")
-                if line.strip()
-            ]
-
-        # Process each section (BODY)
         for section_name, sublist in postables:
-            gcode_lines = []
-
-            # Add header, preamble, unit command, and pre-job lines only to first section
-            if section_name == postables[0][0]:
-                # Header comments first (no line numbers)
-                gcode_lines.extend(header_lines)
-                # Then preamble
-                gcode_lines.extend(preamble_lines)
-                # Then unit command (G20/G21)
-                gcode_lines.extend(unit_command_line)
-                # Then pre-job
-                gcode_lines.extend(pre_job_lines)
+            gcode_lines = self._build_section_prefix(
+                header_lines, preamble_lines, unit_command, pre_job_lines
+            )
 
             for item in sublist:
-                # Determine item type and add appropriate pre-blocks
-                if item.item_type == "tool_controller":  # TOOLCHANGE
-
-                    if self._machine and hasattr(self._machine, "processing"):
-                        if not self._machine.processing.tool_change:
-                            comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
-                            tool_num = item.data["tool_number"]
-                            if comment_symbol == "(":
-                                gcode_lines.append(f"(Tool change suppressed: M6 T{tool_num})")
-                            else:
-                                gcode_lines.append(
-                                    f"{comment_symbol} Tool change suppressed: M6 T{tool_num}"
-                                )
-                            continue
-
-                    if self._machine and self._machine.postprocessor_properties.get(
-                        "pre_tool_change"
-                    ):
-                        pre_lines = [
-                            line
-                            for line in self._machine.postprocessor_properties[
-                                "pre_tool_change"
-                            ].split("\n")
-                            if line.strip()
-                        ]
-                        gcode_lines.extend(pre_lines)
-
-                elif item.item_type == "fixture":  # FIXTURE
-                    if self._machine and self._machine.postprocessor_properties.get(
-                        "pre_fixture_change"
-                    ):
-                        pre_lines = [
-                            line
-                            for line in self._machine.postprocessor_properties[
-                                "pre_fixture_change"
-                            ].split("\n")
-                            if line.strip()
-                        ]
-                        gcode_lines.extend(pre_lines)
-                elif item.item_type == "operation":  # OPERATION
-                    if self._machine and self._machine.postprocessor_properties.get(
-                        "pre_operation"
-                    ):
-                        pre_lines = [
-                            line
-                            for line in self._machine.postprocessor_properties[
-                                "pre_operation"
-                            ].split("\n")
-                            if line.strip()
-                        ]
-                        gcode_lines.extend(pre_lines)
-
-                # Convert Path commands to G-code
-                if item.path:
-                    # Group consecutive rotary moves together
-                    in_rotary_group = False
-
-                    for cmd in item.path.Commands:
-                        try:
-                            # Check if this command involves a rotary axis move
-                            has_rotary = any(param in cmd.Parameters for param in ["A", "B", "C"])
-
-                            # Start a new rotary group if needed
-                            if has_rotary and not in_rotary_group:
-                                if self._machine and self._machine.postprocessor_properties.get(
-                                    "pre_rotary_move"
-                                ):
-                                    pre_rotary_lines = [
-                                        line
-                                        for line in self._machine.postprocessor_properties[
-                                            "pre_rotary_move"
-                                        ].split("\n")
-                                        if line.strip()
-                                    ]
-                                    gcode_lines.extend(pre_rotary_lines)
-                                in_rotary_group = True
-
-                            # End rotary group if we're leaving rotary moves
-                            elif not has_rotary and in_rotary_group:
-                                if self._machine and self._machine.postprocessor_properties.get(
-                                    "post_rotary_move"
-                                ):
-                                    post_rotary_lines = [
-                                        line
-                                        for line in self._machine.postprocessor_properties[
-                                            "post_rotary_move"
-                                        ].split("\n")
-                                        if line.strip()
-                                    ]
-                                    gcode_lines.extend(post_rotary_lines)
-                                in_rotary_group = False
-
-                            # Convert command to G-code
-                            gcode = self.convert_command_to_gcode(cmd)
-
-                            # Handle tool_change setting - suppress M6 if disabled
-                            if cmd.Name in ("M6", "M06"):
-                                if (
-                                    self._machine
-                                    and hasattr(self._machine, "processing")
-                                    and not self._machine.processing.tool_change
-                                ):
-                                    # Convert M6 to comment instead of outputting it
-                                    comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
-                                    if comment_symbol == "(":
-                                        gcode = f"(Tool change suppressed: {gcode})"
-                                    else:
-                                        gcode = f"{comment_symbol} Tool change suppressed: {gcode}"
-
-                                # Handle tool_before_change setting - swap T and M6 order
-                                # This is handled in convert_command_to_gcode, but we need to track it
-                                # The actual swapping happens when formatting the command line
-
-                            # Add the G-code line
-                            if gcode is not None and gcode.strip():
-                                gcode_lines.append(gcode)
-
-                        except (ValueError, AttributeError) as e:
-                            # Skip unsupported commands or log error
-                            Path.Log.debug(f"Skipping command {cmd.Name}: {e}")
-
-                    # Close rotary group if we ended while still in one
-                    if in_rotary_group:
-                        if self._machine and self._machine.postprocessor_properties.get(
-                            "post_rotary_move"
-                        ):
-                            post_rotary_lines = [
-                                line
-                                for line in self._machine.postprocessor_properties[
-                                    "post_rotary_move"
-                                ].split("\n")
-                                if line.strip()
-                            ]
-                            gcode_lines.extend(post_rotary_lines)
-
-                # Add appropriate post-blocks
-                if item.item_type == "tool_controller":  # TOOLCHANGE
-                    if self._machine and self._machine.postprocessor_properties.get(
-                        "post_tool_change"
-                    ):
-                        post_lines = [
-                            line
-                            for line in self._machine.postprocessor_properties[
-                                "post_tool_change"
-                            ].split("\n")
-                            if line.strip()
-                        ]
-                        gcode_lines.extend(post_lines)
-                    if self._machine and self._machine.postprocessor_properties.get("tool_return"):
-                        return_lines = [
-                            line
-                            for line in self._machine.postprocessor_properties["tool_return"].split(
-                                "\n"
-                            )
-                            if line.strip()
-                        ]
-                        gcode_lines.extend(return_lines)
-                elif item.item_type == "fixture":  # FIXTURE
-                    if self._machine and self._machine.postprocessor_properties.get(
-                        "post_fixture_change"
-                    ):
-                        post_lines = [
-                            line
-                            for line in self._machine.postprocessor_properties[
-                                "post_fixture_change"
-                            ].split("\n")
-                            if line.strip()
-                        ]
-                        gcode_lines.extend(post_lines)
-                elif item.item_type == "operation":  # OPERATION
-                    if self._machine and self._machine.postprocessor_properties.get(
-                        "post_operation"
-                    ):
-                        post_lines = [
-                            line
-                            for line in self._machine.postprocessor_properties[
-                                "post_operation"
-                            ].split("\n")
-                            if line.strip()
-                        ]
-                        gcode_lines.extend(post_lines)
+                if self._emit_item_pre_block(item, gcode_lines):
+                    continue
+                self._convert_item_commands(item, gcode_lines)
+                self._emit_item_post_block(item, gcode_lines)
 
             # ===== STAGE 4: G-CODE OPTIMIZATION =====
-            if gcode_lines:
-                # Separate header comments from numbered lines
-                num_header_lines = len(header_lines) if section_name == postables[0][0] else 0
-                header_part = gcode_lines[:num_header_lines]
-                body_part = gcode_lines[num_header_lines:]
-
-                # Apply optimizations to body only (not header comments)
-                if body_part:
-                    # Modal command deduplication
-                    # OUTPUT_DUPLICATE_COMMANDS: True = output all, False = suppress duplicates
-                    if not self.values.get("OUTPUT_DUPLICATE_COMMANDS", True):
-                        body_part = deduplicate_repeated_commands(body_part)
-
-                    # Suppress redundant axis words (only if OUTPUT_DOUBLES is False)
-                    # OUTPUT_DOUBLES: True = output all parameters, False = suppress duplicates
-                    if not self.values.get("OUTPUT_DOUBLES", True):
-                        body_part = suppress_redundant_axes_words(body_part)
-
-                # Filter inefficient moves (optional optimization)
-                # Collapses redundant G0 rapid move chains - may be too aggressive for some machines
-                if body_part and self._machine and hasattr(self._machine, "processing"):
-                    if hasattr(self._machine.processing, "filter_inefficient_moves"):
-                        if self._machine.processing.filter_inefficient_moves:
-                            body_part = filter_inefficient_moves(body_part)
-
-                # Line numbering (only on body, not header comments)
-                if body_part and self.values.get("OUTPUT_LINE_NUMBERS", False):
-                    start = 10
-                    increment = 10
-                    if (
-                        self._machine
-                        and hasattr(self._machine, "output")
-                        and hasattr(self._machine.output, "formatting")
-                    ):
-                        start = self._machine.output.formatting.line_number_start
-                        increment = self._machine.output.formatting.line_increment
-                    body_part = insert_line_numbers(body_part, start=start, increment=increment)
-
-                # Recombine header and body
-                final_lines = header_part + body_part
-
-                # Build gcode with \n separators (standard format)
-                gcode_with_newlines = "\n".join(final_lines)
-
-                # Get configured line ending and apply transformation
-                line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
-
-                if line_ending == "\n":
-                    # Default: let _write_file convert to system line endings
-                    gcode_string = gcode_with_newlines
-                else:
-                    # Custom or standard line endings: replace \n with configured chars
-                    gcode_string = gcode_with_newlines.replace("\n", line_ending)
-
-                # Add section to output
+            gcode_string = self._optimize_gcode(header_lines, gcode_lines)
+            if gcode_string:
+                gcode_string = self._append_trailing_lines(gcode_string)
                 job_sections.append((section_name, gcode_string))
 
-        # Append POST-JOB and POSTAMBLE blocks to the last section
-        if job_sections:
-            last_section_name, last_section_gcode = job_sections[-1]
-            additional_lines = []
-
-            # Add bCNC postamble commands if they were created
-            if (
-                hasattr(self, "_bcnc_postamble_commands")
-                and self._bcnc_postamble_commands is not None
-            ):
-                Path.Log.debug(
-                    f"Processing {len(self._bcnc_postamble_commands)} bCNC postamble commands"
-                )
-                for cmd in self._bcnc_postamble_commands:
-                    gcode = self.convert_command_to_gcode(cmd)
-                    if gcode is not None and gcode.strip():
-                        additional_lines.append(gcode)
-            else:
-                Path.Log.debug("No bCNC postamble commands to process")
-
-            # Add POST-JOB block
-            if self._machine and self._machine.postprocessor_properties.get("post_job"):
-                post_job_lines = [
-                    line
-                    for line in self._machine.postprocessor_properties["post_job"].split("\n")
-                    if line.strip()
-                ]
-                if post_job_lines:
-                    additional_lines.extend(post_job_lines)
-
-            # Add POSTAMBLE section
-            if self._machine and self._machine.postprocessor_properties.get("postamble"):
-                postamble_lines = [
-                    line
-                    for line in self._machine.postprocessor_properties["postamble"].split("\n")
-                    if line.strip()
-                ]
-                if postamble_lines:
-                    additional_lines.extend(postamble_lines)
-
-            # Append to last section if we have additional lines
-            if additional_lines:
-                # Build with \n separators
-                additional_gcode_newlines = "\n".join(additional_lines)
-
-                # Get configured line ending and apply transformation
-                line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
-
-                if line_ending == "\n":
-                    additional_gcode = "\n" + additional_gcode_newlines
-                else:
-                    additional_gcode = line_ending + additional_gcode_newlines.replace(
-                        "\n", line_ending
-                    )
-
-                job_sections[-1] = (last_section_name, last_section_gcode + additional_gcode)
-
-        # Add FOOTER section (comment-only)
-        # TODO: Add footer generation if needed
-
+        self._append_bcnc_postamble(job_sections)
         all_job_sections.extend(job_sections)
 
         # ===== STAGE 5: OUTPUT PRODUCTION =====
-        # Return sections (file writing happens elsewhere)
-
-        # Prepend safetyblock to the first section if present
-        if (
-            all_job_sections
-            and self._machine
-            and self._machine.postprocessor_properties.get("safetyblock")
-        ):
-            safety_lines = [
-                line
-                for line in self._machine.postprocessor_properties["safetyblock"].split("\n")
-                if line.strip()
-            ]
-            if safety_lines:
-                # Build with \n separators
-                safety_gcode_newlines = "\n".join(safety_lines)
-
-                # Get configured line ending and apply transformation
-                line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
-
-                if line_ending == "\n":
-                    safety_gcode = safety_gcode_newlines + "\n"
-                else:
-                    safety_gcode = safety_gcode_newlines.replace("\n", line_ending) + line_ending
-
-                first_section_name, first_section_gcode = all_job_sections[0]
-                all_job_sections[0] = (first_section_name, safety_gcode + first_section_gcode)
+        self._prepend_safety_block(all_job_sections)
 
         Path.Log.debug(f"Returning {len(all_job_sections)} sections")
         Path.Log.debug(f"Sections: {all_job_sections}")
 
         # ===== STAGE 6: REMOTE POSTING =====
-        # Call remote_post method for subclasses to override
         try:
             self.remote_post(all_job_sections)
         except Exception as e:
             Path.Log.error(f"Remote posting failed: {e}")
-            # Don't fail the entire post-processing for remote posting errors
 
         return all_job_sections
 

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -735,6 +735,7 @@ class PostProcessor:
           1. Machine postprocessor_properties (from .fcm file)
           2. Schema defaults (for keys not already present)
           3. Overrides (from job or caller)
+          4. other job configuration elements (author, comment, selected fixtures)
 
         If *overrides* is None the overrides are read from
         Job.PostProcessorPropertyOverrides.  If *overrides* is a dict
@@ -747,7 +748,7 @@ class PostProcessor:
         Returns:
             dict: The final postprocessor property bundle.
         """
-        # Stage 1 — start with machine postprocessor_properties
+        # Stage 1 — machine postprocessor_properties
         bundle = {}
         if self._machine:
             bundle.update(self._machine.postprocessor_properties)
@@ -759,16 +760,21 @@ class PostProcessor:
             if name and name not in bundle:
                 bundle[name] = prop.get("default", "")
 
-        # Stage 3 — overrides
+        # Stage 3 — job configuration elements (defaults from the document/job)
+        # These are not schema properties but are needed by the postprocessor.
+        # They provide sensible defaults that can be overridden in Stage 4.
+        if self._job:
+            doc = getattr(self._job, "Document", None)
+            bundle.setdefault("job_author", getattr(doc, "CreatedBy", "") if doc else "")
+            bundle.setdefault("comment", getattr(self._job, "Description", "") or "")
+            bundle.setdefault("selected_fixtures", [])
+
+        # Stage 4 — caller / dialog overrides (highest priority)
         if overrides is None:
             overrides = self._read_job_overrides()
 
         for key, value in overrides.items():
-            if key in bundle:
-                Path.Log.info(f"Override: {key} = {value} (was: {bundle.get(key)})")
-                bundle[key] = value
-            else:
-                Path.Log.warning(f"Override key '{key}' not in bundle, ignoring")
+            bundle[key] = value
 
         return bundle
 
@@ -876,14 +882,15 @@ class PostProcessor:
                             gcodeheader.add_document_name(doc_name)
 
                 # Add description if enabled
-                if self._machine.output.header.include_description and self._job:
-                    if hasattr(self._job, "Description") and self._job.Description:
-                        gcodeheader.add_description(self._job.Description)
+                if self._machine.output.header.include_description:
+                    description = self.values.get("COMMENT", "")
+                    if description:
+                        gcodeheader.add_description(description)
 
                 # Add author if enabled
-                if self._job and hasattr(self._job, "Document") and self._job.Document:
-                    if hasattr(self._job.Document, "CreatedBy") and self._job.Document.CreatedBy:
-                        gcodeheader.add_author(self._job.Document.CreatedBy)
+                author = self.values.get("JOB_AUTHOR", "")
+                if author:
+                    gcodeheader.add_author(author)
 
                 # Add date/time if enabled
                 if self._machine.output.header.include_date:

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -55,7 +55,7 @@ translate = FreeCAD.Qt.translate
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 
-debug = False
+debug = True
 if debug:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
     Path.Log.trackModule(Path.Log.thisModule())
@@ -597,17 +597,15 @@ class PostProcessor:
 
         return "nc"
 
-    def _buildPostList(self, early_tool_prep=False):
+    def _buildPostList(self):
         """Determine the specific objects and order to postprocess.
 
-        Args:
-            early_tool_prep: If True, split tool changes into separate prep (Tn)
-                           and change (M6) commands for better machine efficiency
+        Reads early_tool_prep from self._machine.processing if available.
 
         Returns:
-            List of (name, operations) tuples
+            List of (name, operations) tuples where every item is a PostList.Postable.
         """
-        return PostList.buildPostList(self, early_tool_prep)
+        return PostList.buildPostList(self)
 
     def _merge_machine_config(self):
         """Merge machine configuration into the values dict.
@@ -859,8 +857,7 @@ class PostProcessor:
         if self.values.get("OUTPUT_HEADER", True):
             for section_name, sublist in postables:
                 for item in sublist:
-                    if hasattr(item, "ToolNumber"):  # Tool controller
-                        # Check if tools should be listed in header
+                    if item.item_type == "tool_controller":
                         list_tools = True
                         if (
                             self._machine
@@ -870,9 +867,8 @@ class PostProcessor:
                             list_tools = self._machine.output.list_tools_in_header
 
                         if list_tools:
-                            gcodeheader.add_tool(item.ToolNumber, item.Label)
-                    elif hasattr(item, "Label") and item.Label == "Fixture":  # Fixture
-                        # Check if fixtures should be listed in header
+                            gcodeheader.add_tool(item.data["tool_number"], item.label)
+                    elif item.item_type == "fixture":
                         list_fixtures = True
                         if (
                             self._machine
@@ -882,8 +878,8 @@ class PostProcessor:
                             list_fixtures = self._machine.output.list_fixtures_in_header
 
                         if list_fixtures:
-                            if hasattr(item, "Path") and item.Path and item.Path.Commands:
-                                fixture_name = item.Path.Commands[0].Name
+                            if item.path and item.path.Commands:
+                                fixture_name = item.path.Commands[0].Name
                                 gcodeheader.add_fixture(fixture_name)
 
         return gcodeheader
@@ -900,7 +896,7 @@ class PostProcessor:
         for section_name, sublist in postables:
             for item in sublist:
                 has_drill_cycles = False
-                if hasattr(item, "Path") and item.Path:
+                if item.path:
                     drill_commands = [
                         "G73",
                         "G74",
@@ -914,10 +910,10 @@ class PostProcessor:
                         "G88",
                         "G89",
                     ]
-                    has_drill_cycles = any(cmd.Name in drill_commands for cmd in item.Path.Commands)
+                    has_drill_cycles = any(cmd.Name in drill_commands for cmd in item.path.Commands)
 
                 if has_drill_cycles:
-                    item.Path = PostUtils.cannedCycleTerminator(item.Path)
+                    item.path = PostUtils.cannedCycleTerminator(item.path)
 
     def _expand_split_arcs(self, postables):
         """Split arc commands into linear segments if configured.
@@ -936,8 +932,8 @@ class PostProcessor:
 
         for section_name, sublist in postables:
             for item in sublist:
-                if hasattr(item, "Path") and item.Path:
-                    item.Path = PostUtils.splitArcs(item.Path)
+                if item.path:
+                    item.path = PostUtils.splitArcs(item.path)
 
     def _expand_spindle_wait(self, postables):
         """Inject G4 dwell after spindle start commands (M3/M4).
@@ -957,17 +953,14 @@ class PostProcessor:
         wait_time = spindle.spindle_wait
         for section_name, sublist in postables:
             for item in sublist:
-                if hasattr(item, "Path") and item.Path:
+                if item.path:
                     new_commands = []
-                    for cmd in item.Path.Commands:
+                    for cmd in item.path.Commands:
                         new_commands.append(cmd)
-                        # After spindle start commands, inject G4 pause
                         if cmd.Name in Constants.MCODE_SPINDLE_ON:
-                            # Create G4 dwell command with P parameter
                             pause_cmd = Path.Command("G4", {"P": wait_time})
                             new_commands.append(pause_cmd)
-                    # Replace Path with modified command list
-                    item.Path = Path.Path(new_commands)
+                    item.path = Path.Path(new_commands)
 
     def _expand_coolant_delay(self, postables):
         """Inject G4 dwell after coolant on commands.
@@ -986,17 +979,14 @@ class PostProcessor:
 
         for section_name, sublist in postables:
             for item in sublist:
-                if hasattr(item, "Path") and item.Path:
+                if item.path:
                     new_commands = []
-                    for cmd in item.Path.Commands:
+                    for cmd in item.path.Commands:
                         new_commands.append(cmd)
-                        # After coolant on commands, inject G4 pause
                         if cmd.Name in Constants.MCODE_COOLANT_ON:
-                            # Create G4 dwell command with P parameter
                             pause_cmd = Path.Command("G4", {"P": spindle.coolant_delay})
                             new_commands.append(pause_cmd)
-                    # Replace Path with modified command list
-                    item.Path = Path.Path(new_commands)
+                    item.path = Path.Path(new_commands)
 
     def _expand_translate_rapids(self, postables):
         """Replace G0 rapid moves with G1 linear moves.
@@ -1015,14 +1005,14 @@ class PostProcessor:
 
         for section_name, sublist in postables:
             for item in sublist:
-                if hasattr(item, "Path") and item.Path:
+                if item.path:
                     new_commands = []
-                    Path.Log.debug(f"Translating rapid moves for {item.Label}")
-                    for cmd in item.Path.Commands:
+                    Path.Log.debug(f"Translating rapid moves for {item.label}")
+                    for cmd in item.path.Commands:
                         if cmd.Name in Constants.GCODE_MOVE_RAPID:
                             cmd.Name = "G1"
                         new_commands.append(cmd)
-                    item.Path = Path.Path(new_commands)
+                    item.path = Path.Path(new_commands)
 
     def _expand_xy_before_z(self, postables):
         """Decompose first move after tool change into XY then Z.
@@ -1047,18 +1037,16 @@ class PostProcessor:
             tool_change_seen = False
 
             for item in sublist:
-                # Check if this is a tool change item
-                if hasattr(item, "ToolNumber"):
+                if item.item_type == "tool_controller":
                     tool_change_seen = True
-                    Path.Log.debug(f"Tool change detected: T{item.ToolNumber}")
+                    Path.Log.debug(f"Tool change detected: T{item.data['tool_number']}")
                     continue
 
-                # Process operations - check for moves after tool change
-                if hasattr(item, "Path") and item.Path:
+                if item.path:
                     new_commands = []
                     first_move_processed = False
 
-                    for cmd in item.Path.Commands:
+                    for cmd in item.path.Commands:
                         # Check if this is a tool change command (M6)
                         if cmd.Name in Constants.MCODE_TOOL_CHANGE:
                             new_commands.append(cmd)
@@ -1116,10 +1104,9 @@ class PostProcessor:
                             # Not the first move or not a move command
                             new_commands.append(cmd)
 
-                    # Update the item's path if we made changes
-                    if len(new_commands) != len(item.Path.Commands):
-                        item.Path = Path.Path(new_commands)
-                        Path.Log.debug(f"Updated path for {item.Label}")
+                    if len(new_commands) != len(item.path.Commands):
+                        item.path = Path.Path(new_commands)
+                        Path.Log.debug(f"Updated path for {item.label}")
 
     def _expand_bcnc_commands(self, postables):
         """Inject or remove bCNC block annotation commands.
@@ -1158,37 +1145,28 @@ class PostProcessor:
 
             for section_name, sublist in postables:
                 for item in sublist:
-                    if hasattr(item, "Proxy"):  # OPERATION
-                        # Create bCNC block start command
-                        bcnc_start_cmd = Path.Command("(Block-name: " + item.Label + ")")
+                    if item.item_type == "operation":
+                        bcnc_start_cmd = Path.Command("(Block-name: " + item.label + ")")
                         bcnc_start_cmd.Annotations = {"bcnc": "block_start"}
 
-                        # Create bCNC block metadata commands
                         bcnc_expand_cmd = Path.Command("(Block-expand: 0)")
                         bcnc_expand_cmd.Annotations = {"bcnc": "block_meta"}
 
                         bcnc_enable_cmd = Path.Command("(Block-enable: 1)")
                         bcnc_enable_cmd.Annotations = {"bcnc": "block_meta"}
 
-                        # Insert bCNC commands at the beginning of the operation's Path
-                        if hasattr(item, "Path") and item.Path:
-                            # Create a copy of the original commands to avoid modifying the original Path
-                            original_commands = list(item.Path.Commands)
-
-                            # Create new Path with bCNC commands
+                        if item.path:
+                            original_commands = list(item.path.Commands)
                             new_commands = [bcnc_start_cmd, bcnc_expand_cmd, bcnc_enable_cmd]
                             new_commands.extend(original_commands)
-                            # Create a new Path object
-                            item.Path = Path.Path(new_commands)
+                            item.path = Path.Path(new_commands)
         else:
-            # OUTPUT_BCNC is False - remove any existing bCNC commands from operations
             Path.Log.debug("Removing existing bCNC commands")
             for section_name, sublist in postables:
                 for item in sublist:
-                    if hasattr(item, "Proxy") and hasattr(item, "Path") and item.Path:
-                        # Filter out any existing bCNC commands
+                    if item.item_type == "operation" and item.path:
                         filtered_commands = []
-                        for cmd in item.Path.Commands:
+                        for cmd in item.path.Commands:
                             if not (
                                 cmd.Name.startswith("(Block-name:")
                                 or cmd.Name.startswith("(Block-expand:")
@@ -1196,97 +1174,49 @@ class PostProcessor:
                             ):
                                 filtered_commands.append(cmd)
 
-                        # Create new Path without bCNC commands
-                        if len(filtered_commands) != len(item.Path.Commands):
-                            item.Path = Path.Path(filtered_commands)
+                        if len(filtered_commands) != len(item.path.Commands):
+                            item.path = Path.Path(filtered_commands)
 
     def _expand_tool_length_offset(self, postables):
         """Inject or remove G43 tool length offset commands.
 
         When OUTPUT_TOOL_LENGTH_OFFSET is True, adds G43 commands after M6
-        tool change commands in operations, and tracks which tool change
-        items need G43 commands vs which should have M6 suppressed.
+        tool change commands in operations and tool change items.
 
         When OUTPUT_TOOL_LENGTH_OFFSET is False, removes any existing G43
         commands from operation paths.
 
-        Subclasses can override to customize tool length offset handling.
+        Simplified single-pass implementation.
         """
         output_tool_length_offset = self.values.get("OUTPUT_TOOL_LENGTH_OFFSET", True)
         Path.Log.debug(f"OUTPUT_TOOL_LENGTH_OFFSET value: {output_tool_length_offset}")
 
-        # Dictionary to store G43 commands for tool change items
+        # Clear tracking dictionaries
         self._tool_change_g43_commands = {}
-        # Track which tool changes should be suppressed (because operation has M6)
         self._suppress_tool_change_m6 = set()
 
-        if output_tool_length_offset:
-            Path.Log.debug("Creating G43 tool length offset commands")
-            for section_name, sublist in postables:
-                # First pass: check if operations have M6 commands and add G43 to them
-                for item in sublist:
-                    if hasattr(item, "Proxy"):  # OPERATION
-                        if hasattr(item, "Path") and item.Path:
-                            commands_with_g43 = []
-                            for cmd in item.Path.Commands:
-                                commands_with_g43.append(cmd)
-                                # If this is an M6 command, add G43 after it
-                                if cmd.Name in ("M6", "M06") and "T" in cmd.Parameters:
-                                    tool_num = cmd.Parameters["T"]
-                                    g43_cmd = Path.Command("G43", {"H": tool_num})
-                                    g43_cmd.Annotations = {"tool_length_offset": True}
-                                    commands_with_g43.append(g43_cmd)
-                                    Path.Log.debug(
-                                        f"Added G43 H{tool_num} after M6 in operation {item.Label}"
-                                    )
+        if not output_tool_length_offset:
+            return
 
-                            # Update the operation's Path with G43 commands inserted
-                            if len(commands_with_g43) != len(item.Path.Commands):
-                                item.Path = Path.Path(commands_with_g43)
-
-                # Second pass: handle tool change items and mark suppression
-                operations_with_m6 = set()
-                for item in sublist:
-                    if hasattr(item, "Proxy"):  # OPERATION
-                        if hasattr(item, "Path") and item.Path:
-                            for cmd in item.Path.Commands:
-                                if cmd.Name in ("M6", "M06") and "T" in cmd.Parameters:
-                                    tool_num = cmd.Parameters["T"]
-                                    operations_with_m6.add(tool_num)
-
-                for item in sublist:
-                    if hasattr(item, "ToolNumber"):  # TOOLCHANGE
-                        tool_num = item.ToolNumber
-                        if tool_num in operations_with_m6:
-                            # Suppress M6 generation for this tool change since operation has it
-                            self._suppress_tool_change_m6.add(id(item))
-                            Path.Log.debug(f"Suppressing M6 generation for tool change T{tool_num}")
-                        else:
-                            # Add G43 command to tool change item
+        Path.Log.debug("Creating G43 tool length offset commands")
+        for section_name, sublist in postables:
+            for item in sublist:
+                Path.Log.debug(f"Processing item: {item.item_type}")
+                if item.item_type == "tool_controller" and item.path:
+                    commands_with_g43 = []
+                    for cmd in item.path.Commands:
+                        commands_with_g43.append(cmd)
+                        if cmd.Name in ("M6", "M06") and "T" in cmd.Parameters:
+                            tool_num = cmd.Parameters["T"]
                             g43_cmd = Path.Command("G43", {"H": tool_num})
                             g43_cmd.Annotations = {"tool_length_offset": True}
-                            self._tool_change_g43_commands[id(item)] = [g43_cmd]
-        else:
-            # OUTPUT_TOOL_LENGTH_OFFSET is False - remove G43 commands from operation Paths
-            Path.Log.debug("G43 tool length offset commands disabled")
-            self._tool_change_g43_commands = {}
-            self._suppress_tool_change_m6 = set()
+                            commands_with_g43.append(g43_cmd)
+                            Path.Log.debug(
+                                f"Added G43 H{tool_num} after M6 in operation {item.label}"
+                            )
 
-            # Remove any existing G43 commands from operation Paths
-            for section_name, sublist in postables:
-                for item in sublist:
-                    if hasattr(item, "Proxy") and hasattr(item, "Path") and item.Path:
-                        # Filter out any existing G43 commands
-                        filtered_commands = []
-                        for cmd in item.Path.Commands:
-                            if not (
-                                cmd.Name == "G43" and cmd.Annotations.get("tool_length_offset")
-                            ):
-                                filtered_commands.append(cmd)
-
-                        # Create new Path without G43 commands
-                        if len(filtered_commands) != len(item.Path.Commands):
-                            item.Path = Path.Path(filtered_commands)
+                    if len(commands_with_g43) != len(item.path.Commands):
+                        item.path = Path.Path(commands_with_g43)
 
     def export2(self) -> Union[None, GCodeSections]:
         """
@@ -1332,13 +1262,8 @@ class PostProcessor:
         # Process all jobs (currently only first job supported)
         all_job_sections = []
 
-        # Get early_tool_prep setting from machine config
-        early_tool_prep = False
-        if self._machine and hasattr(self._machine, "processing"):
-            early_tool_prep = getattr(self._machine.processing, "early_tool_prep", False)
-
         # Build ordered postables for this job
-        postables = self._buildPostList(early_tool_prep)
+        postables = self._buildPostList()
 
         # Allow derived postprocessors to transform postables before expansion
         self._expand_postprocessor_commands(postables)
@@ -1421,7 +1346,20 @@ class PostProcessor:
 
             for item in sublist:
                 # Determine item type and add appropriate pre-blocks
-                if hasattr(item, "ToolNumber"):  # TOOLCHANGE
+                if item.item_type == "tool_controller":  # TOOLCHANGE
+
+                    if self._machine and hasattr(self._machine, "processing"):
+                        if not self._machine.processing.tool_change:
+                            comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
+                            tool_num = item.data["tool_number"]
+                            if comment_symbol == "(":
+                                gcode_lines.append(f"(Tool change suppressed: M6 T{tool_num})")
+                            else:
+                                gcode_lines.append(
+                                    f"{comment_symbol} Tool change suppressed: M6 T{tool_num}"
+                                )
+                            continue
+
                     if self._machine and self._machine.postprocessor_properties.get(
                         "pre_tool_change"
                     ):
@@ -1434,51 +1372,7 @@ class PostProcessor:
                         ]
                         gcode_lines.extend(pre_lines)
 
-                    # Generate M6 tool change command
-                    if self._machine and hasattr(self._machine, "processing"):
-                        if self._machine.processing.tool_change:
-                            # Check if M6 generation should be suppressed (operation already has M6)
-                            if id(item) not in self._suppress_tool_change_m6:
-                                # Generate M6 T{ToolNumber} command
-                                tool_num = item.ToolNumber
-                                m6_cmd = f"M6 T{tool_num}"
-                                gcode_lines.append(m6_cmd)
-
-                                # Output G43 commands if they were added in Stage 2.6
-                                g43_commands = self._tool_change_g43_commands.get(id(item), [])
-                                for g43_cmd in g43_commands:
-                                    gcode_g43 = self.convert_command_to_gcode(g43_cmd)
-                                    if gcode_g43 is not None and gcode_g43.strip():
-                                        gcode_lines.append(gcode_g43)
-                            else:
-                                # M6 suppressed - operation already handles it
-                                Path.Log.debug(
-                                    f"M6 T{item.ToolNumber} suppressed - handled by operation"
-                                )
-                        else:
-                            # Tool change disabled - output as comment
-                            comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
-                            tool_num = item.ToolNumber
-                            if comment_symbol == "(":
-                                gcode_lines.append(f"(Tool change suppressed: M6 T{tool_num})")
-                            else:
-                                gcode_lines.append(
-                                    f"{comment_symbol} Tool change suppressed: M6 T{tool_num}"
-                                )
-                    else:
-                        # No machine config - check suppression before outputting M6
-                        if id(item) not in self._suppress_tool_change_m6:
-                            tool_num = item.ToolNumber
-                            m6_cmd = f"M6 T{tool_num}"
-                            gcode_lines.append(m6_cmd)
-
-                            # Output G43 commands if they were added in Stage 2.6
-                            g43_commands = self._tool_change_g43_commands.get(id(item), [])
-                            for g43_cmd in g43_commands:
-                                gcode_g43 = self.convert_command_to_gcode(g43_cmd)
-                                if gcode_g43 is not None and gcode_g43.strip():
-                                    gcode_lines.append(gcode_g43)
-                elif hasattr(item, "Label") and item.Label == "Fixture":  # FIXTURE
+                elif item.item_type == "fixture":  # FIXTURE
                     if self._machine and self._machine.postprocessor_properties.get(
                         "pre_fixture_change"
                     ):
@@ -1490,7 +1384,7 @@ class PostProcessor:
                             if line.strip()
                         ]
                         gcode_lines.extend(pre_lines)
-                elif hasattr(item, "Proxy"):  # OPERATION
+                elif item.item_type == "operation":  # OPERATION
                     if self._machine and self._machine.postprocessor_properties.get(
                         "pre_operation"
                     ):
@@ -1504,11 +1398,11 @@ class PostProcessor:
                         gcode_lines.extend(pre_lines)
 
                 # Convert Path commands to G-code
-                if hasattr(item, "Path") and item.Path:
+                if item.path:
                     # Group consecutive rotary moves together
                     in_rotary_group = False
 
-                    for cmd in item.Path.Commands:
+                    for cmd in item.path.Commands:
                         try:
                             # Check if this command involves a rotary axis move
                             has_rotary = any(param in cmd.Parameters for param in ["A", "B", "C"])
@@ -1587,7 +1481,7 @@ class PostProcessor:
                             gcode_lines.extend(post_rotary_lines)
 
                 # Add appropriate post-blocks
-                if hasattr(item, "ToolNumber"):  # TOOLCHANGE
+                if item.item_type == "tool_controller":  # TOOLCHANGE
                     if self._machine and self._machine.postprocessor_properties.get(
                         "post_tool_change"
                     ):
@@ -1599,7 +1493,6 @@ class PostProcessor:
                             if line.strip()
                         ]
                         gcode_lines.extend(post_lines)
-                    # Add tool_return after tool change
                     if self._machine and self._machine.postprocessor_properties.get("tool_return"):
                         return_lines = [
                             line
@@ -1609,7 +1502,7 @@ class PostProcessor:
                             if line.strip()
                         ]
                         gcode_lines.extend(return_lines)
-                elif hasattr(item, "Label") and item.Label == "Fixture":  # FIXTURE
+                elif item.item_type == "fixture":  # FIXTURE
                     if self._machine and self._machine.postprocessor_properties.get(
                         "post_fixture_change"
                     ):
@@ -1621,7 +1514,7 @@ class PostProcessor:
                             if line.strip()
                         ]
                         gcode_lines.extend(post_lines)
-                elif hasattr(item, "Proxy"):  # OPERATION
+                elif item.item_type == "operation":  # OPERATION
                     if self._machine and self._machine.postprocessor_properties.get(
                         "post_operation"
                     ):
@@ -1914,12 +1807,7 @@ class PostProcessor:
         section: Section
         sublist: Sublist
 
-        # Get early_tool_prep setting from machine config
-        early_tool_prep = False
-        if self._machine and hasattr(self._machine, "processing"):
-            early_tool_prep = getattr(self._machine.processing, "early_tool_prep", False)
-
-        postables = self._buildPostList(early_tool_prep)
+        postables = self._buildPostList()
         Path.Log.debug(f"postables {postables}")
 
         Path.Log.debug(f"postables count: {len(postables)}")
@@ -2441,12 +2329,7 @@ class WrapperPost(PostProcessor):
     def export(self):
         """Dynamically reload the module for the export to ensure up-to-date usage."""
 
-        # Get early_tool_prep setting from machine config
-        early_tool_prep = False
-        if self._machine and hasattr(self._machine, "processing"):
-            early_tool_prep = getattr(self._machine.processing, "early_tool_prep", False)
-
-        postables = self._buildPostList(early_tool_prep)
+        postables = self._buildPostList()
         Path.Log.debug(f"postables count: {len(postables)}")
 
         g_code_sections = []

--- a/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
@@ -500,6 +500,74 @@ class GenericPlasma(PostProcessor):
         self._inject_cooling_delay(postables)
         self._force_rapid_feeds(postables)
 
+    def get_sanity_checks(self, job):
+        """Plasma cutter specific sanity checks."""
+        Path.Log.track("GenericPlasma.get_sanity_checks() called")
+        squawks = []
+
+        # Test squawk.  Remove this.  It will always add a warning.
+        Path.Log.track("Adding test squawk from GenericPlasma")
+        squawks.append(self._create_squawk("WARNING", "This is a test warning message"))
+
+        # Check pierce delay vs material thickness
+        pierce_delay = self.values.get("pierce_delay", 1000)
+        if hasattr(job, "Stock") and hasattr(job.Stock, "Thickness"):
+            thickness_mm = job.Stock.Thickness
+            # Recommended pierce delay: ~70ms per mm of thickness, minimum 500ms
+            recommended_delay = max(500, int(thickness_mm * 70))
+
+            if pierce_delay < recommended_delay:
+                if thickness_mm > 6.35:  # > 1/4 inch is more critical
+                    squawks.append(
+                        self._create_squawk(
+                            "WARNING",
+                            f"Pierce delay ({pierce_delay}ms) may be insufficient for {thickness_mm:.1f}mm material. Recommended: {recommended_delay}ms",
+                        )
+                    )
+                else:
+                    squawks.append(
+                        self._create_squawk(
+                            "NOTE",
+                            f"Pierce delay ({pierce_delay}ms) may be short for {thickness_mm:.1f}mm material. Consider: {recommended_delay}ms",
+                        )
+                    )
+
+        # Check cooling delay for thick materials
+        cooling_delay = self.values.get("cooling_delay", 500)
+        if hasattr(job, "Stock") and hasattr(job.Stock, "Thickness"):
+            thickness_mm = job.Stock.Thickness
+            if thickness_mm > 10.0 and cooling_delay < 1000:  # Thick materials need more cooling
+                squawks.append(
+                    self._create_squawk(
+                        "NOTE",
+                        f"Consider increasing cooling delay for {thickness_mm:.1f}mm material to prevent torch overheating",
+                    )
+                )
+
+        # Check for rapid moves with torch enabled
+        if self.values.get("torch_zaxis_control", True):
+            for op in getattr(job.Operations, "Group", []):
+                if hasattr(op, "HoriFeed") and op.HoriFeed > 3000:  # High feed rates
+                    squawks.append(
+                        self._create_squawk(
+                            "CAUTION",
+                            f"Operation '{op.Label}' has high feed rate ({op.HoriFeed}) with torch Z-control - verify safe operation",
+                        )
+                    )
+
+        # Check marking delay vs pierce delay
+        marking_delay = self.values.get("marking_delay", 100)
+        if marking_delay >= pierce_delay:
+            squawks.append(
+                self._create_squawk(
+                    "NOTE",
+                    f"Marking delay ({marking_delay}ms) >= pierce delay ({pierce_delay}ms) - marking may not be distinct from cutting",
+                )
+            )
+
+        Path.Log.track(f"GenericPlasma.get_sanity_checks() returning {len(squawks)} squawks")
+        return squawks
+
     @property
     def tooltip(self):
         tooltip: str = """
@@ -513,6 +581,7 @@ class GenericPlasma(PostProcessor):
         - Cooling delay after torch extinguishment
         - Mark entry points only mode
         - Force rapid feeds for dry runs
+        - Material-aware sanity checks
         """
         return tooltip
 

--- a/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
@@ -137,10 +137,23 @@ class GenericPlasma(PostProcessor):
                 "type": "bool",
                 "label": translate("CAM", "Force Rapid Feeds"),
                 "default": False,
+                "runtime": True,
                 "help": translate(
                     "CAM",
                     "Force rapid-feed speeds for all feed specified commands. "
                     "Useful for dry runs to verify paths without cutting.",
+                ),
+            },
+            {
+                "name": "mark_entry_only",
+                "type": "bool",
+                "label": translate("CAM", "Mark Entry Points Only"),
+                "default": False,
+                "runtime": True,
+                "help": translate(
+                    "CAM",
+                    "Mark first entry points only (for drilling prep). "
+                    "Skips cutting moves and only marks where the torch would pierce.",
                 ),
             },
         ]
@@ -473,96 +486,6 @@ class GenericPlasma(PostProcessor):
                     # Replace Path with modified command list
                     item.Path = Path.Path(new_commands)
 
-    def pre_processing_dialog(self):
-        """
-        Show plasma cutting mode dialog to ask user about mark-only operation.
-
-        Returns:
-            bool: True to continue with post-processing, False to cancel
-        """
-        try:
-            from PySide import QtWidgets
-
-            app = QtWidgets.QApplication.instance()
-            if app is None:
-                return True
-
-            # Get current mark_entry_only setting from machine config
-            mark_only = False
-            if self._machine and hasattr(self._machine, "postprocessor_properties"):
-                props = self._machine.postprocessor_properties
-                mark_only = props.get("mark_entry_only", False)
-
-            # Create dialog
-            dialog = QtWidgets.QDialog()
-            dialog.setWindowTitle("Plasma Cutting Mode")
-            dialog.resize(400, 200)
-            layout = QtWidgets.QVBoxLayout(dialog)
-
-            # Add description label
-            label = QtWidgets.QLabel(
-                "Select plasma cutting mode:\n\n"
-                "• Normal: Full cutting with torch control\n"
-                "• Mark Only: Only mark first entry points (for drilling prep)"
-            )
-            label.setWordWrap(True)
-            layout.addWidget(label)
-
-            # Add radio buttons for mode selection
-            button_group = QtWidgets.QButtonGroup(dialog)
-
-            normal_radio = QtWidgets.QRadioButton("Normal Cutting")
-            normal_radio.setChecked(not mark_only)
-            button_group.addButton(normal_radio, 0)
-            layout.addWidget(normal_radio)
-
-            mark_radio = QtWidgets.QRadioButton("Mark Entry Points Only")
-            mark_radio.setChecked(mark_only)
-            button_group.addButton(mark_radio, 1)
-            layout.addWidget(mark_radio)
-
-            # Add info text about mark mode
-            info_label = QtWidgets.QLabel(
-                "Mark mode will:\n"
-                "• Mark first entry point with torch\n"
-                "• Skip all cutting movements\n"
-                "• Useful for preparing holes for drilling"
-            )
-            info_label.setWordWrap(True)
-            info_label.setStyleSheet("color: #666; font-size: 11px;")
-            layout.addWidget(info_label)
-
-            # Add OK/Cancel buttons
-            button_box = QtWidgets.QDialogButtonBox(
-                QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
-            )
-            button_box.accepted.connect(dialog.accept)
-            button_box.rejected.connect(dialog.reject)
-            layout.addWidget(button_box)
-
-            # Show dialog and get result
-            result = dialog.exec_()
-
-            if result == QtWidgets.QDialog.Accepted:
-                # Update machine config with user's choice
-                mark_only_selected = mark_radio.isChecked()
-                if self._machine and hasattr(self._machine, "postprocessor_properties"):
-                    props = self._machine.postprocessor_properties
-                    props["mark_entry_only"] = mark_only_selected
-                    mode_text = "Mark Only" if mark_only_selected else "Normal Cutting"
-                    Path.Log.info(f"Plasma cutting mode set to: {mode_text}")
-                return True
-            else:
-                Path.Log.info("Plasma cutting mode dialog cancelled")
-                return False
-
-        except ImportError:
-            Path.Log.debug("GUI not available - using machine config for mark_entry_only")
-            return True
-        except Exception as e:
-            Path.Log.error(f"Error showing plasma cutting dialog: {str(e)}")
-            return True
-
     def _expand_postprocessor_commands(self, postables):
         """Apply plasma-specific transformations to postables.
 
@@ -588,11 +511,8 @@ class GenericPlasma(PostProcessor):
         - Torch Z-axis control (M3/M5 based on Z movement)
         - Pierce delay after torch ignition
         - Cooling delay after torch extinguishment
-        - Mark entry points only mode (via dialog)
+        - Mark entry points only mode
         - Force rapid feeds for dry runs
-
-        The postprocessor will show a dialog to select between
-        normal cutting and mark-only modes.
         """
         return tooltip
 

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -456,7 +456,7 @@ class Linuxcnc(PostProcessor):
                 if hasattr(op, "HoriFeed"):
                     Path.Log.track(f"Operation HoriFeed: {op.HoriFeed}")
                     if op.HoriFeed > max_rapid_feed:
-                        Path.Log.track(f"Adding CAUTION for high feed rate")
+                        Path.Log.track("Adding CAUTION for high feed rate")
                         squawks.append(
                             self._create_squawk(
                                 "CAUTION",

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -195,19 +195,16 @@ class Linuxcnc(PostProcessor):
     def export2(self):
         """Override export2 to inject blend command before parent processing.
 
-        This ensures the blend command is added to the preamble before
-        the parent's export2() reads it from postprocessor_properties.
+        apply_configuration_bundle() (called by parent export2) populates
+        self.values with the final overridden blend settings.  We apply
+        the bundle first, inject the blend G-code into the preamble, then
+        let the parent finish.
         """
-        # Apply job property overrides FIRST so blend command uses overridden values
-        self._apply_job_property_overrides()
+        # Build and apply the full configuration bundle (unless dialog already did it)
+        if not getattr(self, "_bundle_applied", False):
+            self.apply_configuration_bundle()
 
-        # Update values dict with overridden blend tolerance
-        if self._machine and hasattr(self._machine, "postprocessor_properties"):
-            props = self._machine.postprocessor_properties
-            self.values["BLEND_TOLERANCE"] = props.get("blend_tolerance", 0.0)
-            self.values["BLEND_MODE"] = props.get("blend_mode", "BLEND")
-
-        # Inject blend command into preamble before parent export2 processes it
+        # Inject blend command into preamble using the now-final values
         if self._machine and hasattr(self._machine, "postprocessor_properties"):
             blend_cmd = self._get_blend_command()
             props = self._machine.postprocessor_properties
@@ -217,7 +214,7 @@ class Linuxcnc(PostProcessor):
             else:
                 props["preamble"] = blend_cmd
 
-        # Call parent export2 which will now include the blend command in preamble
+        # Parent export2 will call apply_configuration_bundle again (idempotent)
         return super().export2()
 
     def _get_blend_command(self) -> str:
@@ -361,6 +358,166 @@ class Linuxcnc(PostProcessor):
         # Use parent implementation for other modal commands
         return super()._convert_modal_command(command)
 
+    def get_sanity_checks(self, job):
+        """LinuxCNC specific sanity checks."""
+        Path.Log.track("LinuxCNC.get_sanity_checks() called")
+        squawks = []
+
+        # Check blend tolerance vs operation precision
+        Path.Log.track("Checking blend tolerance")
+        blend_tolerance = self.values.get("BLEND_TOLERANCE", 0.0)
+        Path.Log.track(f"blend_tolerance: {blend_tolerance}")
+        if blend_tolerance > 0.1:  # 0.1mm threshold for precision work
+            Path.Log.track("Adding NOTE for high blend tolerance")
+            squawks.append(
+                self._create_squawk(
+                    "NOTE",
+                    f"High blend tolerance ({blend_tolerance}mm) may affect precision - consider reducing for tight tolerances",
+                )
+            )
+        elif blend_tolerance > 0.5:  # Very high tolerance
+            Path.Log.track("Adding CAUTION for very high blend tolerance")
+            squawks.append(
+                self._create_squawk(
+                    "CAUTION",
+                    f"Very high blend tolerance ({blend_tolerance}mm) will significantly affect part accuracy",
+                )
+            )
+
+        # Check for unsupported G-codes in operations
+        Path.Log.track("Checking for unsupported G-codes")
+        supported_commands = set()
+        if self.values.get("SUPPORTED_COMMANDS"):
+            supported_commands = set(
+                cmd.strip()
+                for cmd in self.values.get("SUPPORTED_COMMANDS", "").split("\n")
+                if cmd.strip()
+            )
+        Path.Log.track(f"supported_commands: {supported_commands}")
+
+        # Check operations for potentially problematic commands
+        operations = getattr(job.Operations, "Group", [])
+        Path.Log.track(f"Found {len(operations)} operations to check")
+        for i, op in enumerate(operations):
+            Path.Log.track(f"Checking operation {i}: {getattr(op, 'Label', 'unnamed')}")
+            if hasattr(op, "Path") and op.Path:
+                Path.Log.track(f"Operation has Path with {len(op.Path.Commands)} commands")
+                for j, cmd in enumerate(op.Path.Commands):
+                    if hasattr(cmd, "Name"):
+                        gcode = cmd.Name
+                        # Check for commands that might need special handling in LinuxCNC
+                        if gcode.startswith("G") and gcode not in [
+                            "G0",
+                            "G1",
+                            "G2",
+                            "G3",
+                            "G17",
+                            "G18",
+                            "G19",
+                            "G20",
+                            "G21",
+                            "G40",
+                            "G41",
+                            "G42",
+                            "G43",
+                            "G49",
+                            "G54",
+                            "G55",
+                            "G56",
+                            "G57",
+                            "G58",
+                            "G59",
+                            "G80",
+                            "G90",
+                            "G91",
+                            "G93",
+                            "G94",
+                            "G98",
+                            "G99",
+                        ]:
+                            if supported_commands and gcode not in supported_commands:
+                                Path.Log.track(f"Adding WARNING for unsupported command {gcode}")
+                                squawks.append(
+                                    self._create_squawk(
+                                        "WARNING",
+                                        f"Potentially unsupported command '{gcode}' in operation '{op.Label}' - verify LinuxCNC compatibility",
+                                    )
+                                )
+
+        # Check feed rates vs machine capabilities (if available)
+        Path.Log.track("Checking feed rates vs machine capabilities")
+        max_rapid_feed = self.values.get("MAX_RAPID_FEED", None)
+        Path.Log.track(f"max_rapid_feed: {max_rapid_feed}")
+        if max_rapid_feed:
+            for i, op in enumerate(operations):
+                Path.Log.track(
+                    f"Checking feed rate for operation {i}: {getattr(op, 'Label', 'unnamed')}"
+                )
+                if hasattr(op, "HoriFeed"):
+                    Path.Log.track(f"Operation HoriFeed: {op.HoriFeed}")
+                    if op.HoriFeed > max_rapid_feed:
+                        Path.Log.track(f"Adding CAUTION for high feed rate")
+                        squawks.append(
+                            self._create_squawk(
+                                "CAUTION",
+                                f"Operation '{op.Label}' feed rate ({op.HoriFeed}) exceeds configured maximum ({max_rapid_feed})",
+                            )
+                        )
+                else:
+                    Path.Log.track("Operation has no HoriFeed attribute")
+
+        # Check spindle speed ranges
+        Path.Log.track("Checking spindle speed ranges")
+        max_spindle_speed = self.values.get("MAX_SPINDLE_SPEED", None)
+        Path.Log.track(f"max_spindle_speed: {max_spindle_speed}")
+        if max_spindle_speed:
+            for i, op in enumerate(operations):
+                Path.Log.track(
+                    f"Checking spindle speed for operation {i}: {getattr(op, 'Label', 'unnamed')}"
+                )
+                if hasattr(op, "SpindleSpeed"):
+                    Path.Log.track(f"Operation SpindleSpeed: {op.SpindleSpeed}")
+                    if op.SpindleSpeed > max_spindle_speed:
+                        Path.Log.track(f"Adding WARNING for high spindle speed")
+                        squawks.append(
+                            self._create_squawk(
+                                "WARNING",
+                                f"Operation '{op.Label}' spindle speed ({op.SpindleSpeed}) exceeds machine maximum ({max_spindle_speed})",
+                            )
+                        )
+                else:
+                    Path.Log.track("Operation has no SpindleSpeed attribute")
+
+        # Check for G41/G42 usage with tool radius compensation
+        Path.Log.track("Checking tool radius compensation usage")
+        supports_tool_radius_comp = self.values.get("SUPPORTS_TOOL_RADIUS_COMPENSATION", False)
+        Path.Log.track(f"supports_tool_radius_comp: {supports_tool_radius_comp}")
+        if not supports_tool_radius_comp:
+            for i, op in enumerate(operations):
+                Path.Log.track(
+                    f"Checking G41/G42 for operation {i}: {getattr(op, 'Label', 'unnamed')}"
+                )
+                if hasattr(op, "Path") and op.Path:
+                    g41_g42_found = False
+                    for cmd in op.Path.Commands:
+                        if hasattr(cmd, "Name") and cmd.Name in ["G41", "G42"]:
+                            Path.Log.track(f"Found {cmd.Name} in operation")
+                            squawks.append(
+                                self._create_squawk(
+                                    "WARNING",
+                                    f"Tool radius compensation ({cmd.Name}) used in '{op.Label}' but not supported by configuration",
+                                )
+                            )
+                            g41_g42_found = True
+                            break
+                    if not g41_g42_found:
+                        Path.Log.track("No G41/G42 found in operation")
+                else:
+                    Path.Log.track("Operation has no Path")
+
+        Path.Log.track(f"LinuxCNC.get_sanity_checks() returning {len(squawks)} squawks")
+        return squawks
+
     @property
     def tooltip(self):
         tooltip: str = """
@@ -370,5 +527,11 @@ class Linuxcnc(PostProcessor):
 
         Supports rigid tapping via G33.1 when the 'rigid' annotation is present
         on G84/G74 tapping cycles.
+
+        Includes machine-specific sanity checks for:
+        - Blend tolerance validation
+        - Command compatibility verification
+        - Feed and spindle speed limits
+        - Tool radius compensation support
         """
         return tooltip

--- a/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/linuxcnc_post.py
@@ -478,7 +478,7 @@ class Linuxcnc(PostProcessor):
                 if hasattr(op, "SpindleSpeed"):
                     Path.Log.track(f"Operation SpindleSpeed: {op.SpindleSpeed}")
                     if op.SpindleSpeed > max_spindle_speed:
-                        Path.Log.track(f"Adding WARNING for high spindle speed")
+                        Path.Log.track("Adding WARNING for high spindle speed")
                         squawks.append(
                             self._create_squawk(
                                 "WARNING",

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -60,6 +60,7 @@ from CAMTests.TestPostProcessor import (
     TestPostProcessorFactory,
     TestResolvingPostProcessorName,
     TestHeaderBuilder,
+    TestConfigurationBundle,
 )
 from CAMTests.TestPostOutput import (
     TestFileNameGenerator,


### PR DESCRIPTION
simplified tool length expansion

Add the Postable object.

this is a transient copy of the post-processable objects (operation, toolcontroller, fixture, etc).

It wraps a copy and keeps the original objects from being marked dirty if Path commands are expanded or manipulated during postprocessing

Adds the new integrated postprocessing dialog and tests
