### PR TITLE
Techdraw: Prevent changing of line style with the extend/shorten tool

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -2278,7 +2278,7 @@ void _setLineAttributes(TechDraw::CosmeticEdge* cosEdge, int style, float weight
     cosEdge->m_format.setWidth(weight);
     cosEdge->m_format.setColor(color);
     cosEdge->m_format.setVisible(_getActiveLineAttributes().getVisible());
-    cosEdge->m_format.setLineNumber(LineGenerator::fromQtStyle((Qt::PenStyle)style));
+    cosEdge->m_format.setLineNumber(style);
 }
 
 void _setLineAttributes(TechDraw::CenterLine* cosEdge, int style, float weight, Base::Color color)


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/28545

I am not sure why previously `LineGenerator::fromQtStyle((Qt::PenStyle)style)` was used instead of just `style` but there is only one reference of this overload of `_setLineAttributes` function in the whole source and that is from `execExtendShortenLine` so if the extend tool behaves as expected then this change should be safe.

After:

https://github.com/user-attachments/assets/4a313f28-9710-4673-8654-51be49d6c0e4

