### PR TITLE
Sketcher: Remove the use of First/Second/Third for Constraints

### DIFF
--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -580,6 +580,14 @@ void Constraint::swapElements(int index1, int index2)
         return;
     }
     if (ensureElementExists(index1) && ensureElementExists(index2)) {
+#if SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
+        if (index1 < 3 || index2 < 3) {
+            GeoElementId temp = getElement(index1);
+            setElement(index1, getElement(index2));
+            setElement(index2, temp);
+            return;
+        }
+#endif
         std::swap(elements[index1], elements[index2]);
     }
 }

--- a/src/Mod/Sketcher/App/Constraint.cpp
+++ b/src/Mod/Sketcher/App/Constraint.cpp
@@ -96,12 +96,12 @@ Constraint* Constraint::copy() const
     temp->MetaData = this->MetaData;
 
 #if SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
-    temp->First = this->First;
-    temp->FirstPos = this->FirstPos;
-    temp->Second = this->Second;
-    temp->SecondPos = this->SecondPos;
-    temp->Third = this->Third;
-    temp->ThirdPos = this->ThirdPos;
+    temp->First_Deprecated = this->First_Deprecated;
+    temp->FirstPos_Deprecated = this->FirstPos_Deprecated;
+    temp->Second_Deprecated = this->Second_Deprecated;
+    temp->SecondPos_Deprecated = this->SecondPos_Deprecated;
+    temp->Third_Deprecated = this->Third_Deprecated;
+    temp->ThirdPos_Deprecated = this->ThirdPos_Deprecated;
 #endif
 
     return temp;
@@ -388,11 +388,11 @@ GeoElementId Constraint::getElement(size_t index) const
     if (index < 3) {
         switch (index) {
             case 0:
-                return GeoElementId(First, FirstPos);
+                return GeoElementId(First_Deprecated, FirstPos_Deprecated);
             case 1:
-                return GeoElementId(Second, SecondPos);
+                return GeoElementId(Second_Deprecated, SecondPos_Deprecated);
             case 2:
-                return GeoElementId(Third, ThirdPos);
+                return GeoElementId(Third_Deprecated, ThirdPos_Deprecated);
         }
     }
 #endif
@@ -408,16 +408,16 @@ void Constraint::setElement(size_t index, GeoElementId element)
         if (index < 3) {
             switch (index) {
                 case 0:
-                    First = element.GeoId;
-                    FirstPos = element.Pos;
+                    First_Deprecated = element.GeoId;
+                    FirstPos_Deprecated = element.Pos;
                     break;
                 case 1:
-                    Second = element.GeoId;
-                    SecondPos = element.Pos;
+                    Second_Deprecated = element.GeoId;
+                    SecondPos_Deprecated = element.Pos;
                     break;
                 case 2:
-                    Third = element.GeoId;
-                    ThirdPos = element.Pos;
+                    Third_Deprecated = element.GeoId;
+                    ThirdPos_Deprecated = element.Pos;
                     break;
             }
         }
@@ -447,11 +447,11 @@ int Constraint::getGeoId(int index) const
     if (index < 3) {
         switch (index) {
             case 0:
-                return First;
+                return First_Deprecated;
             case 1:
-                return Second;
+                return Second_Deprecated;
             case 2:
-                return Third;
+                return Third_Deprecated;
         }
     }
 #endif
@@ -464,11 +464,11 @@ PointPos Constraint::getPosId(int index) const
     if (index < 3) {
         switch (index) {
             case 0:
-                return FirstPos;
+                return FirstPos_Deprecated;
             case 1:
-                return SecondPos;
+                return SecondPos_Deprecated;
             case 2:
-                return ThirdPos;
+                return ThirdPos_Deprecated;
         }
     }
 #endif
@@ -481,11 +481,11 @@ int Constraint::getPosIdAsInt(int index) const
     if (index < 3) {
         switch (index) {
             case 0:
-                return (int)FirstPos;
+                return (int)FirstPos_Deprecated;
             case 1:
-                return (int)SecondPos;
+                return (int)SecondPos_Deprecated;
             case 2:
-                return (int)ThirdPos;
+                return (int)ThirdPos_Deprecated;
         }
     }
 #endif
@@ -503,13 +503,13 @@ void Constraint::setGeoId(int index, int geoId)
     if (index < 3) {
         switch (index) {
             case 0:
-                First = geoId;
+                First_Deprecated = geoId;
                 break;
             case 1:
-                Second = geoId;
+                Second_Deprecated = geoId;
                 break;
             case 2:
-                Third = geoId;
+                Third_Deprecated = geoId;
                 break;
         }
     }
@@ -525,13 +525,13 @@ void Constraint::setPosId(int index, PointPos pos)
     if (index < 3) {
         switch (index) {
             case 0:
-                FirstPos = pos;
+                FirstPos_Deprecated = pos;
                 break;
             case 1:
-                SecondPos = pos;
+                SecondPos_Deprecated = pos;
                 break;
             case 2:
-                ThirdPos = pos;
+                ThirdPos_Deprecated = pos;
                 break;
         }
     }
@@ -547,13 +547,13 @@ void Constraint::setPosId(int index, int pos)
     if (index < 3) {
         switch (index) {
             case 0:
-                FirstPos = static_cast<PointPos>(pos);
+                FirstPos_Deprecated = static_cast<PointPos>(pos);
                 break;
             case 1:
-                SecondPos = static_cast<PointPos>(pos);
+                SecondPos_Deprecated = static_cast<PointPos>(pos);
                 break;
             case 2:
-                ThirdPos = static_cast<PointPos>(pos);
+                ThirdPos_Deprecated = static_cast<PointPos>(pos);
                 break;
         }
     }

--- a/src/Mod/Sketcher/App/Constraint.h
+++ b/src/Mod/Sketcher/App/Constraint.h
@@ -253,12 +253,12 @@ public:
 
 #ifdef SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
     // Deprecated, use getElement/setElement instead
-    int First {GeoEnum::GeoUndef};
-    int Second {GeoEnum::GeoUndef};
-    int Third {GeoEnum::GeoUndef};
-    PointPos FirstPos {PointPos::none};
-    PointPos SecondPos {PointPos::none};
-    PointPos ThirdPos {PointPos::none};
+    int First_Deprecated {GeoEnum::GeoUndef};
+    int Second_Deprecated {GeoEnum::GeoUndef};
+    int Third_Deprecated {GeoEnum::GeoUndef};
+    PointPos FirstPos_Deprecated {PointPos::none};
+    PointPos SecondPos_Deprecated {PointPos::none};
+    PointPos ThirdPos_Deprecated {PointPos::none};
 #endif
 
 private:

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -208,7 +208,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         else {
             return false;
         }
-        constraint->First_Deprecated = FirstIndex;
+        constraint->setGeoId(0, FirstIndex);
         return true;
     };
 
@@ -279,8 +279,8 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             }
 
             if (valid) {
-                constraint->First_Deprecated = FirstIndex;
-                constraint->Second_Deprecated = SecondIndex;
+                constraint->setGeoId(0, FirstIndex);
+                constraint->setGeoId(1, SecondIndex);
                 return true;
             }
         }
@@ -329,7 +329,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return false;
             }
 
-            constraint->First_Deprecated = FirstIndex;
+            constraint->setGeoId(0, FirstIndex);
             constraint->setValue(Value);
             return true;
         }
@@ -413,7 +413,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     0,
                     GeoElementId(FirstIndex, static_cast<Sketcher::PointPos>(FirstPos))
                 );
-                constraint->Second_Deprecated = SecondIndex;
+                constraint->setGeoId(1, SecondIndex);
                 return true;
             }
         }
@@ -432,11 +432,11 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     }
                 }
                 constraint->Type = Angle;
-                constraint->Second_Deprecated = SecondIndex;
+                constraint->setGeoId(1, SecondIndex);
             }
             else if (strcmp("Distance", ConstraintType) == 0) {
                 constraint->Type = Distance;
-                constraint->Second_Deprecated = SecondIndex;
+                constraint->setGeoId(1, SecondIndex);
             }
             else if (strcmp("DistanceX", ConstraintType) == 0) {
                 FirstPos = SecondIndex;
@@ -454,7 +454,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return false;
             }
 
-            constraint->First_Deprecated = FirstIndex;
+            constraint->setGeoId(0, FirstIndex);
             constraint->setValue(Value);
             return true;
         }
@@ -574,7 +574,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                         0,
                         GeoElementId(intArg1, static_cast<Sketcher::PointPos>(intArg2))
                     );
-                    constraint->Second_Deprecated = intArg3;
+                    constraint->setGeoId(1, intArg3);
                     constraint->InternalAlignmentIndex = intArg4;
                     return true;
                 }
@@ -600,7 +600,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     0,
                     GeoElementId(intArg1, static_cast<Sketcher::PointPos>(intArg2))
                 );
-                constraint->Second_Deprecated = intArg3;
+                constraint->setGeoId(1, intArg3);
                 constraint->setValue(Value);
                 return true;
             }
@@ -663,7 +663,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     1,
                     GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
                 );
-                constraint->Third_Deprecated = intArg5;
+                constraint->setGeoId(2, intArg5);
                 return true;
             }
             if (strcmp("Perpendicular", ConstraintType) == 0) {
@@ -676,7 +676,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     1,
                     GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
                 );
-                constraint->Third_Deprecated = intArg5;
+                constraint->setGeoId(2, intArg5);
                 return true;
             }
         }
@@ -711,7 +711,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 constraint->Type = Angle;
                 // valid = true;//non-standard assignment
                 constraint->setElement(0, GeoElementId(intArg1, Sketcher::PointPos::none));
-                constraint->Second_Deprecated = intArg2;  // let's goof up all the terminology =)
+                constraint->setGeoId(1, intArg2);  // let's goof up all the terminology =)
                 constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
                 constraint->setElement(
                     2,
@@ -1116,7 +1116,7 @@ Py::Long ConstraintPy::getFirst() const
 
 void ConstraintPy::setFirst(Py::Long arg)
 {
-    this->getConstraintPtr()->First_Deprecated = arg;
+    this->getConstraintPtr()->setGeoId(0, arg);
 }
 
 Py::Long ConstraintPy::getFirstPos() const
@@ -1147,7 +1147,7 @@ Py::Long ConstraintPy::getSecond() const
 
 void ConstraintPy::setSecond(Py::Long arg)
 {
-    this->getConstraintPtr()->Second_Deprecated = arg;
+    this->getConstraintPtr()->setGeoId(1, arg);
 }
 
 Py::Long ConstraintPy::getSecondPos() const
@@ -1178,7 +1178,7 @@ Py::Long ConstraintPy::getThird() const
 
 void ConstraintPy::setThird(Py::Long arg)
 {
-    this->getConstraintPtr()->Third_Deprecated = arg;
+    this->getConstraintPtr()->setGeoId(2, arg);
 }
 
 Py::Long ConstraintPy::getThirdPos() const

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -409,8 +409,10 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             }
 
             if (valid) {
-                constraint->First_Deprecated = FirstIndex;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->setElement(
+                    0,
+                    GeoElementId(FirstIndex, static_cast<Sketcher::PointPos>(FirstPos))
+                );
                 constraint->Second_Deprecated = SecondIndex;
                 return true;
             }
@@ -528,23 +530,23 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             else if (strcmp("TangentViaPoint", ConstraintType) == 0) {
                 constraint->Type = Tangent;
                 // valid = true;//non-standard assignment
-                constraint->First_Deprecated = intArg1;
-                constraint->FirstPos_Deprecated = Sketcher::PointPos::none;
-                constraint->Second_Deprecated = intArg2;
-                constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
-                constraint->Third_Deprecated = intArg3;
-                constraint->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->setElement(0, GeoElementId(intArg1, Sketcher::PointPos::none));
+                constraint->setElement(1, GeoElementId(intArg2, Sketcher::PointPos::none));
+                constraint->setElement(
+                    2,
+                    GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
+                );
                 return true;
             }
             else if (strcmp("PerpendicularViaPoint", ConstraintType) == 0) {
                 constraint->Type = Perpendicular;
                 // valid = true;//non-standard assignment
-                constraint->First_Deprecated = intArg1;
-                constraint->FirstPos_Deprecated = Sketcher::PointPos::none;
-                constraint->Second_Deprecated = intArg2;
-                constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
-                constraint->Third_Deprecated = intArg3;
-                constraint->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->setElement(0, GeoElementId(intArg1, Sketcher::PointPos::none));
+                constraint->setElement(1, GeoElementId(intArg2, Sketcher::PointPos::none));
+                constraint->setElement(
+                    2,
+                    GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
+                );
                 return true;
             }
             else if (strstr(
@@ -568,18 +570,24 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 }
 
                 if (valid) {
-                    constraint->First_Deprecated = intArg1;
-                    constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
+                    constraint->setElement(
+                        0,
+                        GeoElementId(intArg1, static_cast<Sketcher::PointPos>(intArg2))
+                    );
                     constraint->Second_Deprecated = intArg3;
                     constraint->InternalAlignmentIndex = intArg4;
                     return true;
                 }
             }
             if (valid) {
-                constraint->First_Deprecated = intArg1;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
-                constraint->Second_Deprecated = intArg3;
-                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->setElement(
+                    0,
+                    GeoElementId(intArg1, static_cast<Sketcher::PointPos>(intArg2))
+                );
+                constraint->setElement(
+                    1,
+                    GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
+                );
                 return true;
             }
         }
@@ -588,8 +596,10 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             Value = PyFloat_AsDouble(oNumArg4);
             if (strcmp("Distance", ConstraintType) == 0) {
                 constraint->Type = Distance;
-                constraint->First_Deprecated = intArg1;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
+                constraint->setElement(
+                    0,
+                    GeoElementId(intArg1, static_cast<Sketcher::PointPos>(intArg2))
+                );
                 constraint->Second_Deprecated = intArg3;
                 constraint->setValue(Value);
                 return true;
@@ -645,19 +655,27 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             intArg5 = PyLong_AsLong(oNumArg5);
             if (strcmp("Symmetric", ConstraintType) == 0) {
                 constraint->Type = Symmetric;
-                constraint->First_Deprecated = intArg1;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
-                constraint->Second_Deprecated = intArg3;
-                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->setElement(
+                    0,
+                    GeoElementId(intArg1, static_cast<Sketcher::PointPos>(intArg2))
+                );
+                constraint->setElement(
+                    1,
+                    GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
+                );
                 constraint->Third_Deprecated = intArg5;
                 return true;
             }
             if (strcmp("Perpendicular", ConstraintType) == 0) {
                 constraint->Type = Perpendicular;
-                constraint->First_Deprecated = intArg1;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
-                constraint->Second_Deprecated = intArg3;
-                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->setElement(
+                    0,
+                    GeoElementId(intArg1, static_cast<Sketcher::PointPos>(intArg2))
+                );
+                constraint->setElement(
+                    1,
+                    GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
+                );
                 constraint->Third_Deprecated = intArg5;
                 return true;
             }
@@ -692,12 +710,13 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 }
                 constraint->Type = Angle;
                 // valid = true;//non-standard assignment
-                constraint->First_Deprecated = intArg1;
-                constraint->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constraint->setElement(0, GeoElementId(intArg1, Sketcher::PointPos::none));
                 constraint->Second_Deprecated = intArg2;  // let's goof up all the terminology =)
                 constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
-                constraint->Third_Deprecated = intArg3;
-                constraint->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->setElement(
+                    2,
+                    GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
+                );
                 constraint->setValue(Value);
                 return true;
             }
@@ -705,10 +724,8 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return false;
             }
 
-            constraint->First_Deprecated = intArg1;
-            constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
-            constraint->Second_Deprecated = intArg3;
-            constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+            constraint->setElement(0, GeoElementId(intArg1, static_cast<Sketcher::PointPos>(intArg2)));
+            constraint->setElement(1, GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4)));
             constraint->setValue(Value);
             return true;
         }
@@ -772,12 +789,18 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2, GeoIndex3, PosIndex3
             if (strcmp("Symmetric", ConstraintType) == 0) {
                 constraint->Type = Symmetric;
-                constraint->First_Deprecated = FirstIndex;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
-                constraint->Second_Deprecated = SecondIndex;
-                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(SecondPos);
-                constraint->Third_Deprecated = ThirdIndex;
-                constraint->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(ThirdPos);
+                constraint->setElement(
+                    0,
+                    GeoElementId(FirstIndex, static_cast<Sketcher::PointPos>(FirstPos))
+                );
+                constraint->setElement(
+                    1,
+                    GeoElementId(SecondIndex, static_cast<Sketcher::PointPos>(SecondPos))
+                );
+                constraint->setElement(
+                    2,
+                    GeoElementId(ThirdIndex, static_cast<Sketcher::PointPos>(ThirdPos))
+                );
                 return true;
             }
         }
@@ -785,12 +808,15 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             Value = PyFloat_AsDouble(index_or_value);
             if (strcmp("SnellsLaw", ConstraintType) == 0) {
                 constraint->Type = SnellsLaw;
-                constraint->First_Deprecated = FirstIndex;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
-                constraint->Second_Deprecated = SecondIndex;
-                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(SecondPos);
-                constraint->Third_Deprecated = ThirdIndex;
-                constraint->ThirdPos_Deprecated = Sketcher::PointPos::none;
+                constraint->setElement(
+                    0,
+                    GeoElementId(FirstIndex, static_cast<Sketcher::PointPos>(FirstPos))
+                );
+                constraint->setElement(
+                    1,
+                    GeoElementId(SecondIndex, static_cast<Sketcher::PointPos>(SecondPos))
+                );
+                constraint->setElement(2, GeoElementId(ThirdIndex, Sketcher::PointPos::none));
                 constraint->setValue(Value);
                 return true;
             }

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -208,7 +208,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
         else {
             return false;
         }
-        constraint->First = FirstIndex;
+        constraint->First_Deprecated = FirstIndex;
         return true;
     };
 
@@ -279,8 +279,8 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             }
 
             if (valid) {
-                constraint->First = FirstIndex;
-                constraint->Second = SecondIndex;
+                constraint->First_Deprecated = FirstIndex;
+                constraint->Second_Deprecated = SecondIndex;
                 return true;
             }
         }
@@ -329,7 +329,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return false;
             }
 
-            constraint->First = FirstIndex;
+            constraint->First_Deprecated = FirstIndex;
             constraint->setValue(Value);
             return true;
         }
@@ -409,9 +409,9 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             }
 
             if (valid) {
-                constraint->First = FirstIndex;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                constraint->Second = SecondIndex;
+                constraint->First_Deprecated = FirstIndex;
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->Second_Deprecated = SecondIndex;
                 return true;
             }
         }
@@ -430,29 +430,29 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                     }
                 }
                 constraint->Type = Angle;
-                constraint->Second = SecondIndex;
+                constraint->Second_Deprecated = SecondIndex;
             }
             else if (strcmp("Distance", ConstraintType) == 0) {
                 constraint->Type = Distance;
-                constraint->Second = SecondIndex;
+                constraint->Second_Deprecated = SecondIndex;
             }
             else if (strcmp("DistanceX", ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
                 constraint->Type = DistanceX;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
             }
             else if (strcmp("DistanceY", ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
                 constraint->Type = DistanceY;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
             }
             else {
                 return false;
             }
 
-            constraint->First = FirstIndex;
+            constraint->First_Deprecated = FirstIndex;
             constraint->setValue(Value);
             return true;
         }
@@ -528,23 +528,23 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             else if (strcmp("TangentViaPoint", ConstraintType) == 0) {
                 constraint->Type = Tangent;
                 // valid = true;//non-standard assignment
-                constraint->First = intArg1;
-                constraint->FirstPos = Sketcher::PointPos::none;
-                constraint->Second = intArg2;
-                constraint->SecondPos = Sketcher::PointPos::none;
-                constraint->Third = intArg3;
-                constraint->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->First_Deprecated = intArg1;
+                constraint->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constraint->Second_Deprecated = intArg2;
+                constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constraint->Third_Deprecated = intArg3;
+                constraint->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
                 return true;
             }
             else if (strcmp("PerpendicularViaPoint", ConstraintType) == 0) {
                 constraint->Type = Perpendicular;
                 // valid = true;//non-standard assignment
-                constraint->First = intArg1;
-                constraint->FirstPos = Sketcher::PointPos::none;
-                constraint->Second = intArg2;
-                constraint->SecondPos = Sketcher::PointPos::none;
-                constraint->Third = intArg3;
-                constraint->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->First_Deprecated = intArg1;
+                constraint->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constraint->Second_Deprecated = intArg2;
+                constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constraint->Third_Deprecated = intArg3;
+                constraint->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
                 return true;
             }
             else if (strstr(
@@ -568,18 +568,18 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 }
 
                 if (valid) {
-                    constraint->First = intArg1;
-                    constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                    constraint->Second = intArg3;
+                    constraint->First_Deprecated = intArg1;
+                    constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
+                    constraint->Second_Deprecated = intArg3;
                     constraint->InternalAlignmentIndex = intArg4;
                     return true;
                 }
             }
             if (valid) {
-                constraint->First = intArg1;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                constraint->Second = intArg3;
-                constraint->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->First_Deprecated = intArg1;
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
+                constraint->Second_Deprecated = intArg3;
+                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
                 return true;
             }
         }
@@ -588,9 +588,9 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             Value = PyFloat_AsDouble(oNumArg4);
             if (strcmp("Distance", ConstraintType) == 0) {
                 constraint->Type = Distance;
-                constraint->First = intArg1;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                constraint->Second = intArg3;
+                constraint->First_Deprecated = intArg1;
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
+                constraint->Second_Deprecated = intArg3;
                 constraint->setValue(Value);
                 return true;
             }
@@ -645,20 +645,20 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             intArg5 = PyLong_AsLong(oNumArg5);
             if (strcmp("Symmetric", ConstraintType) == 0) {
                 constraint->Type = Symmetric;
-                constraint->First = intArg1;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                constraint->Second = intArg3;
-                constraint->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
-                constraint->Third = intArg5;
+                constraint->First_Deprecated = intArg1;
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
+                constraint->Second_Deprecated = intArg3;
+                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->Third_Deprecated = intArg5;
                 return true;
             }
             if (strcmp("Perpendicular", ConstraintType) == 0) {
                 constraint->Type = Perpendicular;
-                constraint->First = intArg1;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-                constraint->Second = intArg3;
-                constraint->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
-                constraint->Third = intArg5;
+                constraint->First_Deprecated = intArg1;
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
+                constraint->Second_Deprecated = intArg3;
+                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->Third_Deprecated = intArg5;
                 return true;
             }
         }
@@ -692,12 +692,12 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 }
                 constraint->Type = Angle;
                 // valid = true;//non-standard assignment
-                constraint->First = intArg1;
-                constraint->FirstPos = Sketcher::PointPos::none;
-                constraint->Second = intArg2;  // let's goof up all the terminology =)
-                constraint->SecondPos = Sketcher::PointPos::none;
-                constraint->Third = intArg3;
-                constraint->ThirdPos = static_cast<Sketcher::PointPos>(intArg4);
+                constraint->First_Deprecated = intArg1;
+                constraint->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constraint->Second_Deprecated = intArg2;  // let's goof up all the terminology =)
+                constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constraint->Third_Deprecated = intArg3;
+                constraint->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
                 constraint->setValue(Value);
                 return true;
             }
@@ -705,10 +705,10 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 return false;
             }
 
-            constraint->First = intArg1;
-            constraint->FirstPos = static_cast<Sketcher::PointPos>(intArg2);
-            constraint->Second = intArg3;
-            constraint->SecondPos = static_cast<Sketcher::PointPos>(intArg4);
+            constraint->First_Deprecated = intArg1;
+            constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(intArg2);
+            constraint->Second_Deprecated = intArg3;
+            constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(intArg4);
             constraint->setValue(Value);
             return true;
         }
@@ -772,12 +772,12 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             // ConstraintType, GeoIndex1, PosIndex1, GeoIndex2, PosIndex2, GeoIndex3, PosIndex3
             if (strcmp("Symmetric", ConstraintType) == 0) {
                 constraint->Type = Symmetric;
-                constraint->First = FirstIndex;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                constraint->Second = SecondIndex;
-                constraint->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
-                constraint->Third = ThirdIndex;
-                constraint->ThirdPos = static_cast<Sketcher::PointPos>(ThirdPos);
+                constraint->First_Deprecated = FirstIndex;
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->Second_Deprecated = SecondIndex;
+                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(SecondPos);
+                constraint->Third_Deprecated = ThirdIndex;
+                constraint->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(ThirdPos);
                 return true;
             }
         }
@@ -785,12 +785,12 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
             Value = PyFloat_AsDouble(index_or_value);
             if (strcmp("SnellsLaw", ConstraintType) == 0) {
                 constraint->Type = SnellsLaw;
-                constraint->First = FirstIndex;
-                constraint->FirstPos = static_cast<Sketcher::PointPos>(FirstPos);
-                constraint->Second = SecondIndex;
-                constraint->SecondPos = static_cast<Sketcher::PointPos>(SecondPos);
-                constraint->Third = ThirdIndex;
-                constraint->ThirdPos = Sketcher::PointPos::none;
+                constraint->First_Deprecated = FirstIndex;
+                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->Second_Deprecated = SecondIndex;
+                constraint->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(SecondPos);
+                constraint->Third_Deprecated = ThirdIndex;
+                constraint->ThirdPos_Deprecated = Sketcher::PointPos::none;
                 constraint->setValue(Value);
                 return true;
             }
@@ -891,13 +891,13 @@ std::string ConstraintPy::representation() const
             result << "'Coincident'>";
             break;
         case Horizontal:
-            result << "'Horizontal' (" << getConstraintPtr()->First << ")>";
+            result << "'Horizontal' (" << getConstraintPtr()->First_Deprecated << ")>";
             break;
         case Vertical:
-            result << "'Vertical' (" << getConstraintPtr()->First << ")>";
+            result << "'Vertical' (" << getConstraintPtr()->First_Deprecated << ")>";
             break;
         case Block:
-            result << "'Block' (" << getConstraintPtr()->First << ")>";
+            result << "'Block' (" << getConstraintPtr()->First_Deprecated << ")>";
             break;
         case Radius:
             result << "'Radius'>";
@@ -912,7 +912,7 @@ std::string ConstraintPy::representation() const
             result << "'Parallel'>";
             break;
         case Tangent:
-            if (this->getConstraintPtr()->Third == GeoEnum::GeoUndef) {
+            if (this->getConstraintPtr()->Third_Deprecated == GeoEnum::GeoUndef) {
                 result << "'Tangent'>";
             }
             else {
@@ -920,7 +920,7 @@ std::string ConstraintPy::representation() const
             }
             break;
         case Perpendicular:
-            if (this->getConstraintPtr()->Third == GeoEnum::GeoUndef) {
+            if (this->getConstraintPtr()->Third_Deprecated == GeoEnum::GeoUndef) {
                 result << "'Perpendicular'>";
             }
             else {
@@ -931,7 +931,7 @@ std::string ConstraintPy::representation() const
             result << "'Distance'>";
             break;
         case Angle:
-            if (this->getConstraintPtr()->Third == GeoEnum::GeoUndef) {
+            if (this->getConstraintPtr()->Third_Deprecated == GeoEnum::GeoUndef) {
                 result << "'Angle'>";
             }
             else {
@@ -988,12 +988,12 @@ std::string ConstraintPy::representation() const
             }
             break;
         case Equal:
-            result << "'Equal' (" << getConstraintPtr()->First << "," << getConstraintPtr()->Second
-                   << ")>";
+            result << "'Equal' (" << getConstraintPtr()->First_Deprecated << ","
+                   << getConstraintPtr()->Second_Deprecated << ")>";
             break;
         case PointOnObject:
-            result << "'PointOnObject' (" << getConstraintPtr()->First << ","
-                   << getConstraintPtr()->Second << ")>";
+            result << "'PointOnObject' (" << getConstraintPtr()->First_Deprecated << ","
+                   << getConstraintPtr()->Second_Deprecated << ")>";
             break;
         case Group:
             result << "'Group'>";
@@ -1085,17 +1085,17 @@ Py::String ConstraintPy::getType() const
 
 Py::Long ConstraintPy::getFirst() const
 {
-    return Py::Long(this->getConstraintPtr()->First);
+    return Py::Long(this->getConstraintPtr()->First_Deprecated);
 }
 
 void ConstraintPy::setFirst(Py::Long arg)
 {
-    this->getConstraintPtr()->First = arg;
+    this->getConstraintPtr()->First_Deprecated = arg;
 }
 
 Py::Long ConstraintPy::getFirstPos() const
 {
-    return Py::Long(static_cast<int>(this->getConstraintPtr()->FirstPos));
+    return Py::Long(static_cast<int>(this->getConstraintPtr()->FirstPos_Deprecated));
 }
 
 void ConstraintPy::setFirstPos(Py::Long arg)
@@ -1104,7 +1104,7 @@ void ConstraintPy::setFirstPos(Py::Long arg)
 
     if (pos >= static_cast<int>(Sketcher::PointPos::none)
         && pos <= static_cast<int>(Sketcher::PointPos::mid)) {
-        this->getConstraintPtr()->FirstPos = static_cast<Sketcher::PointPos>(pos);
+        this->getConstraintPtr()->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(pos);
     }
     else {
         std::stringstream str;
@@ -1116,17 +1116,17 @@ void ConstraintPy::setFirstPos(Py::Long arg)
 
 Py::Long ConstraintPy::getSecond() const
 {
-    return Py::Long(this->getConstraintPtr()->Second);
+    return Py::Long(this->getConstraintPtr()->Second_Deprecated);
 }
 
 void ConstraintPy::setSecond(Py::Long arg)
 {
-    this->getConstraintPtr()->Second = arg;
+    this->getConstraintPtr()->Second_Deprecated = arg;
 }
 
 Py::Long ConstraintPy::getSecondPos() const
 {
-    return Py::Long(static_cast<int>(this->getConstraintPtr()->SecondPos));
+    return Py::Long(static_cast<int>(this->getConstraintPtr()->SecondPos_Deprecated));
 }
 
 void ConstraintPy::setSecondPos(Py::Long arg)
@@ -1135,7 +1135,7 @@ void ConstraintPy::setSecondPos(Py::Long arg)
 
     if (pos >= static_cast<int>(Sketcher::PointPos::none)
         && pos <= static_cast<int>(Sketcher::PointPos::mid)) {
-        this->getConstraintPtr()->SecondPos = static_cast<Sketcher::PointPos>(pos);
+        this->getConstraintPtr()->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(pos);
     }
     else {
         std::stringstream str;
@@ -1147,17 +1147,17 @@ void ConstraintPy::setSecondPos(Py::Long arg)
 
 Py::Long ConstraintPy::getThird() const
 {
-    return Py::Long(this->getConstraintPtr()->Third);
+    return Py::Long(this->getConstraintPtr()->Third_Deprecated);
 }
 
 void ConstraintPy::setThird(Py::Long arg)
 {
-    this->getConstraintPtr()->Third = arg;
+    this->getConstraintPtr()->Third_Deprecated = arg;
 }
 
 Py::Long ConstraintPy::getThirdPos() const
 {
-    return Py::Long(static_cast<int>(this->getConstraintPtr()->ThirdPos));
+    return Py::Long(static_cast<int>(this->getConstraintPtr()->ThirdPos_Deprecated));
 }
 
 void ConstraintPy::setThirdPos(Py::Long arg)
@@ -1166,7 +1166,7 @@ void ConstraintPy::setThirdPos(Py::Long arg)
 
     if (pos >= static_cast<int>(Sketcher::PointPos::none)
         && pos <= static_cast<int>(Sketcher::PointPos::mid)) {
-        this->getConstraintPtr()->ThirdPos = static_cast<Sketcher::PointPos>(pos);
+        this->getConstraintPtr()->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(pos);
     }
     else {
         std::stringstream str;

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -442,13 +442,13 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
                 constraint->Type = DistanceX;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->setPosId(0, static_cast<Sketcher::PointPos>(FirstPos));
             }
             else if (strcmp("DistanceY", ConstraintType) == 0) {
                 FirstPos = SecondIndex;
                 SecondIndex = -1;
                 constraint->Type = DistanceY;
-                constraint->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(FirstPos);
+                constraint->setPosId(0, static_cast<Sketcher::PointPos>(FirstPos));
             }
             else {
                 return false;
@@ -712,7 +712,7 @@ int ConstraintPy::PyInit(PyObject* args, PyObject* /*kwd*/)
                 // valid = true;//non-standard assignment
                 constraint->setElement(0, GeoElementId(intArg1, Sketcher::PointPos::none));
                 constraint->setGeoId(1, intArg2);  // let's goof up all the terminology =)
-                constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constraint->setPosId(1, Sketcher::PointPos::none);
                 constraint->setElement(
                     2,
                     GeoElementId(intArg3, static_cast<Sketcher::PointPos>(intArg4))
@@ -1130,7 +1130,7 @@ void ConstraintPy::setFirstPos(Py::Long arg)
 
     if (pos >= static_cast<int>(Sketcher::PointPos::none)
         && pos <= static_cast<int>(Sketcher::PointPos::mid)) {
-        this->getConstraintPtr()->FirstPos_Deprecated = static_cast<Sketcher::PointPos>(pos);
+        this->getConstraintPtr()->setPosId(0, static_cast<Sketcher::PointPos>(pos));
     }
     else {
         std::stringstream str;
@@ -1161,7 +1161,7 @@ void ConstraintPy::setSecondPos(Py::Long arg)
 
     if (pos >= static_cast<int>(Sketcher::PointPos::none)
         && pos <= static_cast<int>(Sketcher::PointPos::mid)) {
-        this->getConstraintPtr()->SecondPos_Deprecated = static_cast<Sketcher::PointPos>(pos);
+        this->getConstraintPtr()->setPosId(1, static_cast<Sketcher::PointPos>(pos));
     }
     else {
         std::stringstream str;
@@ -1192,7 +1192,7 @@ void ConstraintPy::setThirdPos(Py::Long arg)
 
     if (pos >= static_cast<int>(Sketcher::PointPos::none)
         && pos <= static_cast<int>(Sketcher::PointPos::mid)) {
-        this->getConstraintPtr()->ThirdPos_Deprecated = static_cast<Sketcher::PointPos>(pos);
+        this->getConstraintPtr()->setPosId(2, static_cast<Sketcher::PointPos>(pos));
     }
     else {
         std::stringstream str;

--- a/src/Mod/Sketcher/App/ConstraintPyImp.cpp
+++ b/src/Mod/Sketcher/App/ConstraintPyImp.cpp
@@ -917,13 +917,13 @@ std::string ConstraintPy::representation() const
             result << "'Coincident'>";
             break;
         case Horizontal:
-            result << "'Horizontal' (" << getConstraintPtr()->First_Deprecated << ")>";
+            result << "'Horizontal' (" << getConstraintPtr()->getGeoId(0) << ")>";
             break;
         case Vertical:
-            result << "'Vertical' (" << getConstraintPtr()->First_Deprecated << ")>";
+            result << "'Vertical' (" << getConstraintPtr()->getGeoId(0) << ")>";
             break;
         case Block:
-            result << "'Block' (" << getConstraintPtr()->First_Deprecated << ")>";
+            result << "'Block' (" << getConstraintPtr()->getGeoId(0) << ")>";
             break;
         case Radius:
             result << "'Radius'>";
@@ -938,7 +938,7 @@ std::string ConstraintPy::representation() const
             result << "'Parallel'>";
             break;
         case Tangent:
-            if (this->getConstraintPtr()->Third_Deprecated == GeoEnum::GeoUndef) {
+            if (this->getConstraintPtr()->getGeoId(2) == GeoEnum::GeoUndef) {
                 result << "'Tangent'>";
             }
             else {
@@ -946,7 +946,7 @@ std::string ConstraintPy::representation() const
             }
             break;
         case Perpendicular:
-            if (this->getConstraintPtr()->Third_Deprecated == GeoEnum::GeoUndef) {
+            if (this->getConstraintPtr()->getGeoId(2) == GeoEnum::GeoUndef) {
                 result << "'Perpendicular'>";
             }
             else {
@@ -957,7 +957,7 @@ std::string ConstraintPy::representation() const
             result << "'Distance'>";
             break;
         case Angle:
-            if (this->getConstraintPtr()->Third_Deprecated == GeoEnum::GeoUndef) {
+            if (this->getConstraintPtr()->getGeoId(2) == GeoEnum::GeoUndef) {
                 result << "'Angle'>";
             }
             else {
@@ -1014,12 +1014,12 @@ std::string ConstraintPy::representation() const
             }
             break;
         case Equal:
-            result << "'Equal' (" << getConstraintPtr()->First_Deprecated << ","
-                   << getConstraintPtr()->Second_Deprecated << ")>";
+            result << "'Equal' (" << getConstraintPtr()->getGeoId(0) << ","
+                   << getConstraintPtr()->getGeoId(1) << ")>";
             break;
         case PointOnObject:
-            result << "'PointOnObject' (" << getConstraintPtr()->First_Deprecated << ","
-                   << getConstraintPtr()->Second_Deprecated << ")>";
+            result << "'PointOnObject' (" << getConstraintPtr()->getGeoId(0) << ","
+                   << getConstraintPtr()->getGeoId(1) << ")>";
             break;
         case Group:
             result << "'Group'>";
@@ -1111,7 +1111,7 @@ Py::String ConstraintPy::getType() const
 
 Py::Long ConstraintPy::getFirst() const
 {
-    return Py::Long(this->getConstraintPtr()->First_Deprecated);
+    return Py::Long(this->getConstraintPtr()->getGeoId(0));
 }
 
 void ConstraintPy::setFirst(Py::Long arg)
@@ -1121,7 +1121,7 @@ void ConstraintPy::setFirst(Py::Long arg)
 
 Py::Long ConstraintPy::getFirstPos() const
 {
-    return Py::Long(static_cast<int>(this->getConstraintPtr()->FirstPos_Deprecated));
+    return Py::Long(static_cast<int>(this->getConstraintPtr()->getPosId(0)));
 }
 
 void ConstraintPy::setFirstPos(Py::Long arg)
@@ -1142,7 +1142,7 @@ void ConstraintPy::setFirstPos(Py::Long arg)
 
 Py::Long ConstraintPy::getSecond() const
 {
-    return Py::Long(this->getConstraintPtr()->Second_Deprecated);
+    return Py::Long(this->getConstraintPtr()->getGeoId(1));
 }
 
 void ConstraintPy::setSecond(Py::Long arg)
@@ -1152,7 +1152,7 @@ void ConstraintPy::setSecond(Py::Long arg)
 
 Py::Long ConstraintPy::getSecondPos() const
 {
-    return Py::Long(static_cast<int>(this->getConstraintPtr()->SecondPos_Deprecated));
+    return Py::Long(static_cast<int>(this->getConstraintPtr()->getPosId(1)));
 }
 
 void ConstraintPy::setSecondPos(Py::Long arg)
@@ -1173,7 +1173,7 @@ void ConstraintPy::setSecondPos(Py::Long arg)
 
 Py::Long ConstraintPy::getThird() const
 {
-    return Py::Long(this->getConstraintPtr()->Third_Deprecated);
+    return Py::Long(this->getConstraintPtr()->getGeoId(2));
 }
 
 void ConstraintPy::setThird(Py::Long arg)
@@ -1183,7 +1183,7 @@ void ConstraintPy::setThird(Py::Long arg)
 
 Py::Long ConstraintPy::getThirdPos() const
 {
-    return Py::Long(static_cast<int>(this->getConstraintPtr()->ThirdPos_Deprecated));
+    return Py::Long(static_cast<int>(this->getConstraintPtr()->getPosId(2)));
 }
 
 void ConstraintPy::setThirdPos(Py::Long arg)

--- a/src/Mod/Sketcher/App/PropertyConstraintList.cpp
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.cpp
@@ -439,13 +439,13 @@ bool PropertyConstraintList::checkConstraintIndices(int geomax, int geomin)
 
     for (const auto& v : _lValueList) {
 
-        mininternalgeoid = cmin(mininternalgeoid, v->First_Deprecated);
-        mininternalgeoid = cmin(mininternalgeoid, v->Second_Deprecated);
-        mininternalgeoid = cmin(mininternalgeoid, v->Third_Deprecated);
+        mininternalgeoid = cmin(mininternalgeoid, v->getGeoId(0));
+        mininternalgeoid = cmin(mininternalgeoid, v->getGeoId(1));
+        mininternalgeoid = cmin(mininternalgeoid, v->getGeoId(2));
 
-        maxinternalgeoid = cmax(maxinternalgeoid, v->First_Deprecated);
-        maxinternalgeoid = cmax(maxinternalgeoid, v->Second_Deprecated);
-        maxinternalgeoid = cmax(maxinternalgeoid, v->Third_Deprecated);
+        maxinternalgeoid = cmax(maxinternalgeoid, v->getGeoId(0));
+        maxinternalgeoid = cmax(maxinternalgeoid, v->getGeoId(1));
+        maxinternalgeoid = cmax(maxinternalgeoid, v->getGeoId(2));
     }
 
     if (maxinternalgeoid > geomax || mininternalgeoid < geomin) {

--- a/src/Mod/Sketcher/App/PropertyConstraintList.cpp
+++ b/src/Mod/Sketcher/App/PropertyConstraintList.cpp
@@ -439,13 +439,13 @@ bool PropertyConstraintList::checkConstraintIndices(int geomax, int geomin)
 
     for (const auto& v : _lValueList) {
 
-        mininternalgeoid = cmin(mininternalgeoid, v->First);
-        mininternalgeoid = cmin(mininternalgeoid, v->Second);
-        mininternalgeoid = cmin(mininternalgeoid, v->Third);
+        mininternalgeoid = cmin(mininternalgeoid, v->First_Deprecated);
+        mininternalgeoid = cmin(mininternalgeoid, v->Second_Deprecated);
+        mininternalgeoid = cmin(mininternalgeoid, v->Third_Deprecated);
 
-        maxinternalgeoid = cmax(maxinternalgeoid, v->First);
-        maxinternalgeoid = cmax(maxinternalgeoid, v->Second);
-        maxinternalgeoid = cmax(maxinternalgeoid, v->Third);
+        maxinternalgeoid = cmax(maxinternalgeoid, v->First_Deprecated);
+        maxinternalgeoid = cmax(maxinternalgeoid, v->Second_Deprecated);
+        maxinternalgeoid = cmax(maxinternalgeoid, v->Third_Deprecated);
     }
 
     if (maxinternalgeoid > geomax || mininternalgeoid < geomin) {

--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -397,16 +397,16 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
 std::string PythonConverter::process(const Sketcher::Constraint* constraint, GeoIdMode geoIdMode)
 {
     bool addLastIdVar = geoIdMode == GeoIdMode::AddLastGeoIdToGeoIds;
-    bool addLastIdVar1 = constraint->First_Deprecated >= 0 && addLastIdVar;
-    bool addLastIdVar2 = constraint->Second_Deprecated >= 0 && addLastIdVar;
-    bool addLastIdVar3 = constraint->Third_Deprecated >= 0 && addLastIdVar;
+    bool addLastIdVar1 = constraint->getGeoId(0) >= 0 && addLastIdVar;
+    bool addLastIdVar2 = constraint->getGeoId(1) >= 0 && addLastIdVar;
+    bool addLastIdVar3 = constraint->getGeoId(2) >= 0 && addLastIdVar;
 
     std::string geoId1 = (addLastIdVar1 ? "lastGeoId + " : "")
-        + std::to_string(constraint->First_Deprecated);
+        + std::to_string(constraint->getGeoId(0));
     std::string geoId2 = (addLastIdVar2 ? "lastGeoId + " : "")
-        + std::to_string(constraint->Second_Deprecated);
+        + std::to_string(constraint->getGeoId(1));
     std::string geoId3 = (addLastIdVar3 ? "lastGeoId + " : "")
-        + std::to_string(constraint->Third_Deprecated);
+        + std::to_string(constraint->getGeoId(2));
 
 
     static std::map<
@@ -420,8 +420,8 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 [[maybe_unused]] std::string& geoId3) {
                  return boost::str(
                      boost::format("Sketcher.Constraint('Coincident', %s, %i, %s, %i") % geoId1
-                     % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                     % static_cast<int>(constr->SecondPos_Deprecated)
+                     % static_cast<int>(constr->getPosId(0)) % geoId2
+                     % static_cast<int>(constr->getPosId(1))
                  );
              }},
             {Sketcher::Horizontal,
@@ -429,14 +429,14 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->Second_Deprecated == GeoEnum::GeoUndef) {
+                 if (constr->getGeoId(1) == GeoEnum::GeoUndef) {
                      return boost::str(boost::format("Sketcher.Constraint('Horizontal', %s") % geoId1);
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Horizontal', %s, %i, %s, %i") % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated)
+                         % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1))
                      );
                  }
              }},
@@ -445,14 +445,14 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->Second_Deprecated == GeoEnum::GeoUndef) {
+                 if (constr->getGeoId(1) == GeoEnum::GeoUndef) {
                      return boost::str(boost::format("Sketcher.Constraint('Vertical', %s") % geoId1);
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Vertical', %s, %i, %s, %i") % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated)
+                         % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1))
                      );
                  }
              }},
@@ -468,22 +468,22 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
+                 if (constr->getPosId(0) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Tangent', %s, %s") % geoId1 % geoId2
                      );
                  }
-                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+                 else if (constr->getPosId(1) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Tangent', %s, %i, %s") % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->getPosId(0)) % geoId2
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Tangent', %s, %i, %s, %i") % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated)
+                         % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1))
                      );
                  }
              }},
@@ -501,22 +501,22 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
+                 if (constr->getPosId(0) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Perpendicular', %s, %s") % geoId1 % geoId2
                      );
                  }
-                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+                 else if (constr->getPosId(1) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Perpendicular', %s, %i, %s") % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->getPosId(0)) % geoId2
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Perpendicular', %s, %i, %s, %i")
-                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated)
+                         % geoId1 % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1))
                      );
                  }
              }},
@@ -551,14 +551,14 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                      return boost::str(
                          boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %i, %s")
                          % constr->internalAlignmentTypeToString() % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->getPosId(0)) % geoId2
                      );
                  }
                  else if (constr->AlignmentType == BSplineControlPoint) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %i, %s, %i")
                          % constr->internalAlignmentTypeToString() % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->getPosId(0)) % geoId2
                          % constr->InternalAlignmentIndex
                      );
                  }
@@ -577,29 +577,29 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->Second_Deprecated == GeoEnum::GeoUndef) {
+                 if (constr->getGeoId(1) == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Distance', %s, %f") % geoId1
                          % constr->getValue()
                      );
                  }
-                 else if (constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
+                 else if (constr->getPosId(0) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Distance', %s, %s, %f") % geoId1
                          % geoId2 % constr->getValue()
                      );
                  }
-                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+                 else if (constr->getPosId(1) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Distance', %s, %i, %s, %f") % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2 % constr->getValue()
+                         % static_cast<int>(constr->getPosId(0)) % geoId2 % constr->getValue()
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Distance', %s, %i, %s, %i, %f")
-                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated) % constr->getValue()
+                         % geoId1 % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1)) % constr->getValue()
                      );
                  }
              }},
@@ -608,14 +608,14 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 std::string& geoId3) {
-                 if (constr->Second_Deprecated == GeoEnum::GeoUndef) {
+                 if (constr->getGeoId(1) == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Angle', %s, %f") % geoId1
                          % constr->getValue()
                      );
                  }
-                 else if (constr->Third_Deprecated == GeoEnum::GeoUndef) {
-                     if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+                 else if (constr->getGeoId(2) == GeoEnum::GeoUndef) {
+                     if (constr->getPosId(1) == Sketcher::PointPos::none) {
                          return boost::str(
                              boost::format("Sketcher.Constraint('Angle', %s, %s, %f") % geoId1
                              % geoId2 % constr->getValue()
@@ -624,15 +624,15 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                      else {
                          return boost::str(
                              boost::format("Sketcher.Constraint('Angle', %s, %i, %s, %i, %f")
-                             % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                             % static_cast<int>(constr->SecondPos_Deprecated) % constr->getValue()
+                             % geoId1 % static_cast<int>(constr->getPosId(0)) % geoId2
+                             % static_cast<int>(constr->getPosId(1)) % constr->getValue()
                          );
                      }
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('AngleViaPoint', %s, %s, %s, %i, %f")
-                         % geoId1 % geoId2 % geoId3 % static_cast<int>(constr->ThirdPos_Deprecated)
+                         % geoId1 % geoId2 % geoId3 % static_cast<int>(constr->getPosId(2))
                          % constr->getValue()
                      );
                  }
@@ -642,24 +642,24 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos_Deprecated == Sketcher::PointPos::none
-                     && constr->Second_Deprecated == GeoEnum::GeoUndef) {
+                 if (constr->getPosId(0) == Sketcher::PointPos::none
+                     && constr->getGeoId(1) == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceX', %s, %f") % geoId1
                          % constr->getValue()
                      );
                  }
-                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+                 else if (constr->getPosId(1) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceX', %s, %i, %f") % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % constr->getValue()
+                         % static_cast<int>(constr->getPosId(0)) % constr->getValue()
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceX', %s, %i, %s, %i, %f")
-                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated) % constr->getValue()
+                         % geoId1 % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1)) % constr->getValue()
                      );
                  }
              }},
@@ -668,24 +668,24 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos_Deprecated == Sketcher::PointPos::none
-                     && constr->Second_Deprecated == GeoEnum::GeoUndef) {
+                 if (constr->getPosId(0) == Sketcher::PointPos::none
+                     && constr->getGeoId(1) == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceY', %s, %f") % geoId1
                          % constr->getValue()
                      );
                  }
-                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+                 else if (constr->getPosId(1) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceY', %s, %i, %f") % geoId1
-                         % static_cast<int>(constr->FirstPos_Deprecated) % constr->getValue()
+                         % static_cast<int>(constr->getPosId(0)) % constr->getValue()
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceY', %s, %i, %s, %i, %f")
-                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated) % constr->getValue()
+                         % geoId1 % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1)) % constr->getValue()
                      );
                  }
              }},
@@ -726,7 +726,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 [[maybe_unused]] std::string& geoId3) {
                  return boost::str(
                      boost::format("Sketcher.Constraint('PointOnObject', %s, %i, %s") % geoId1
-                     % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                     % static_cast<int>(constr->getPosId(0)) % geoId2
                  );
              }},
             {Sketcher::Symmetric,
@@ -734,19 +734,19 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 std::string& geoId3) {
-                 if (constr->ThirdPos_Deprecated == Sketcher::PointPos::none) {
+                 if (constr->getPosId(2) == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Symmetric', %s, %i, %s, %i, %s")
-                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated) % geoId3
+                         % geoId1 % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1)) % geoId3
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Symmetric', %s, %i, %s, %i, %s, %i")
-                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                         % static_cast<int>(constr->SecondPos_Deprecated) % geoId3
-                         % static_cast<int>(constr->ThirdPos_Deprecated)
+                         % geoId1 % static_cast<int>(constr->getPosId(0)) % geoId2
+                         % static_cast<int>(constr->getPosId(1)) % geoId3
+                         % static_cast<int>(constr->getPosId(2))
                      );
                  }
              }},
@@ -757,8 +757,8 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId3) {
                  return boost::str(
                      boost::format("Sketcher.Constraint('SnellsLaw', %s, %i, %s, %i, %s, %f")
-                     % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
-                     % static_cast<int>(constr->SecondPos_Deprecated) % geoId3 % constr->getValue()
+                     % geoId1 % static_cast<int>(constr->getPosId(0)) % geoId2
+                     % static_cast<int>(constr->getPosId(1)) % geoId3 % constr->getValue()
                  );
              }},
         };

--- a/src/Mod/Sketcher/App/PythonConverter.cpp
+++ b/src/Mod/Sketcher/App/PythonConverter.cpp
@@ -397,13 +397,16 @@ PythonConverter::SingleGeometry PythonConverter::process(const Part::Geometry* g
 std::string PythonConverter::process(const Sketcher::Constraint* constraint, GeoIdMode geoIdMode)
 {
     bool addLastIdVar = geoIdMode == GeoIdMode::AddLastGeoIdToGeoIds;
-    bool addLastIdVar1 = constraint->First >= 0 && addLastIdVar;
-    bool addLastIdVar2 = constraint->Second >= 0 && addLastIdVar;
-    bool addLastIdVar3 = constraint->Third >= 0 && addLastIdVar;
+    bool addLastIdVar1 = constraint->First_Deprecated >= 0 && addLastIdVar;
+    bool addLastIdVar2 = constraint->Second_Deprecated >= 0 && addLastIdVar;
+    bool addLastIdVar3 = constraint->Third_Deprecated >= 0 && addLastIdVar;
 
-    std::string geoId1 = (addLastIdVar1 ? "lastGeoId + " : "") + std::to_string(constraint->First);
-    std::string geoId2 = (addLastIdVar2 ? "lastGeoId + " : "") + std::to_string(constraint->Second);
-    std::string geoId3 = (addLastIdVar3 ? "lastGeoId + " : "") + std::to_string(constraint->Third);
+    std::string geoId1 = (addLastIdVar1 ? "lastGeoId + " : "")
+        + std::to_string(constraint->First_Deprecated);
+    std::string geoId2 = (addLastIdVar2 ? "lastGeoId + " : "")
+        + std::to_string(constraint->Second_Deprecated);
+    std::string geoId3 = (addLastIdVar3 ? "lastGeoId + " : "")
+        + std::to_string(constraint->Third_Deprecated);
 
 
     static std::map<
@@ -417,8 +420,8 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 [[maybe_unused]] std::string& geoId3) {
                  return boost::str(
                      boost::format("Sketcher.Constraint('Coincident', %s, %i, %s, %i") % geoId1
-                     % static_cast<int>(constr->FirstPos) % geoId2
-                     % static_cast<int>(constr->SecondPos)
+                     % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                     % static_cast<int>(constr->SecondPos_Deprecated)
                  );
              }},
             {Sketcher::Horizontal,
@@ -426,14 +429,14 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->Second == GeoEnum::GeoUndef) {
+                 if (constr->Second_Deprecated == GeoEnum::GeoUndef) {
                      return boost::str(boost::format("Sketcher.Constraint('Horizontal', %s") % geoId1);
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Horizontal', %s, %i, %s, %i") % geoId1
-                         % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos)
+                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated)
                      );
                  }
              }},
@@ -442,14 +445,14 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->Second == GeoEnum::GeoUndef) {
+                 if (constr->Second_Deprecated == GeoEnum::GeoUndef) {
                      return boost::str(boost::format("Sketcher.Constraint('Vertical', %s") % geoId1);
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Vertical', %s, %i, %s, %i") % geoId1
-                         % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos)
+                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated)
                      );
                  }
              }},
@@ -465,22 +468,22 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos == Sketcher::PointPos::none) {
+                 if (constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Tangent', %s, %s") % geoId1 % geoId2
                      );
                  }
-                 else if (constr->SecondPos == Sketcher::PointPos::none) {
+                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Tangent', %s, %i, %s") % geoId1
-                         % static_cast<int>(constr->FirstPos) % geoId2
+                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Tangent', %s, %i, %s, %i") % geoId1
-                         % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos)
+                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated)
                      );
                  }
              }},
@@ -498,22 +501,22 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos == Sketcher::PointPos::none) {
+                 if (constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Perpendicular', %s, %s") % geoId1 % geoId2
                      );
                  }
-                 else if (constr->SecondPos == Sketcher::PointPos::none) {
+                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Perpendicular', %s, %i, %s") % geoId1
-                         % static_cast<int>(constr->FirstPos) % geoId2
+                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Perpendicular', %s, %i, %s, %i")
-                         % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos)
+                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated)
                      );
                  }
              }},
@@ -548,14 +551,15 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                      return boost::str(
                          boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %i, %s")
                          % constr->internalAlignmentTypeToString() % geoId1
-                         % static_cast<int>(constr->FirstPos) % geoId2
+                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
                      );
                  }
                  else if (constr->AlignmentType == BSplineControlPoint) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('InternalAlignment:%s', %s, %i, %s, %i")
                          % constr->internalAlignmentTypeToString() % geoId1
-                         % static_cast<int>(constr->FirstPos) % geoId2 % constr->InternalAlignmentIndex
+                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % constr->InternalAlignmentIndex
                      );
                  }
                  else if (constr->AlignmentType == BSplineKnotPoint) {
@@ -573,29 +577,29 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->Second == GeoEnum::GeoUndef) {
+                 if (constr->Second_Deprecated == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Distance', %s, %f") % geoId1
                          % constr->getValue()
                      );
                  }
-                 else if (constr->FirstPos == Sketcher::PointPos::none) {
+                 else if (constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Distance', %s, %s, %f") % geoId1
                          % geoId2 % constr->getValue()
                      );
                  }
-                 else if (constr->SecondPos == Sketcher::PointPos::none) {
+                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Distance', %s, %i, %s, %f") % geoId1
-                         % static_cast<int>(constr->FirstPos) % geoId2 % constr->getValue()
+                         % static_cast<int>(constr->FirstPos_Deprecated) % geoId2 % constr->getValue()
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Distance', %s, %i, %s, %i, %f")
-                         % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos) % constr->getValue()
+                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated) % constr->getValue()
                      );
                  }
              }},
@@ -604,14 +608,14 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 std::string& geoId3) {
-                 if (constr->Second == GeoEnum::GeoUndef) {
+                 if (constr->Second_Deprecated == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Angle', %s, %f") % geoId1
                          % constr->getValue()
                      );
                  }
-                 else if (constr->Third == GeoEnum::GeoUndef) {
-                     if (constr->SecondPos == Sketcher::PointPos::none) {
+                 else if (constr->Third_Deprecated == GeoEnum::GeoUndef) {
+                     if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
                          return boost::str(
                              boost::format("Sketcher.Constraint('Angle', %s, %s, %f") % geoId1
                              % geoId2 % constr->getValue()
@@ -620,15 +624,15 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                      else {
                          return boost::str(
                              boost::format("Sketcher.Constraint('Angle', %s, %i, %s, %i, %f")
-                             % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
-                             % static_cast<int>(constr->SecondPos) % constr->getValue()
+                             % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                             % static_cast<int>(constr->SecondPos_Deprecated) % constr->getValue()
                          );
                      }
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('AngleViaPoint', %s, %s, %s, %i, %f")
-                         % geoId1 % geoId2 % geoId3 % static_cast<int>(constr->ThirdPos)
+                         % geoId1 % geoId2 % geoId3 % static_cast<int>(constr->ThirdPos_Deprecated)
                          % constr->getValue()
                      );
                  }
@@ -638,24 +642,24 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos == Sketcher::PointPos::none
-                     && constr->Second == GeoEnum::GeoUndef) {
+                 if (constr->FirstPos_Deprecated == Sketcher::PointPos::none
+                     && constr->Second_Deprecated == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceX', %s, %f") % geoId1
                          % constr->getValue()
                      );
                  }
-                 else if (constr->SecondPos == Sketcher::PointPos::none) {
+                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceX', %s, %i, %f") % geoId1
-                         % static_cast<int>(constr->FirstPos) % constr->getValue()
+                         % static_cast<int>(constr->FirstPos_Deprecated) % constr->getValue()
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceX', %s, %i, %s, %i, %f")
-                         % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos) % constr->getValue()
+                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated) % constr->getValue()
                      );
                  }
              }},
@@ -664,24 +668,24 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 [[maybe_unused]] std::string& geoId3) {
-                 if (constr->FirstPos == Sketcher::PointPos::none
-                     && constr->Second == GeoEnum::GeoUndef) {
+                 if (constr->FirstPos_Deprecated == Sketcher::PointPos::none
+                     && constr->Second_Deprecated == GeoEnum::GeoUndef) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceY', %s, %f") % geoId1
                          % constr->getValue()
                      );
                  }
-                 else if (constr->SecondPos == Sketcher::PointPos::none) {
+                 else if (constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceY', %s, %i, %f") % geoId1
-                         % static_cast<int>(constr->FirstPos) % constr->getValue()
+                         % static_cast<int>(constr->FirstPos_Deprecated) % constr->getValue()
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('DistanceY', %s, %i, %s, %i, %f")
-                         % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos) % constr->getValue()
+                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated) % constr->getValue()
                      );
                  }
              }},
@@ -722,7 +726,7 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 [[maybe_unused]] std::string& geoId3) {
                  return boost::str(
                      boost::format("Sketcher.Constraint('PointOnObject', %s, %i, %s") % geoId1
-                     % static_cast<int>(constr->FirstPos) % geoId2
+                     % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
                  );
              }},
             {Sketcher::Symmetric,
@@ -730,19 +734,19 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId1,
                 std::string& geoId2,
                 std::string& geoId3) {
-                 if (constr->ThirdPos == Sketcher::PointPos::none) {
+                 if (constr->ThirdPos_Deprecated == Sketcher::PointPos::none) {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Symmetric', %s, %i, %s, %i, %s")
-                         % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos) % geoId3
+                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated) % geoId3
                      );
                  }
                  else {
                      return boost::str(
                          boost::format("Sketcher.Constraint('Symmetric', %s, %i, %s, %i, %s, %i")
-                         % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
-                         % static_cast<int>(constr->SecondPos) % geoId3
-                         % static_cast<int>(constr->ThirdPos)
+                         % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                         % static_cast<int>(constr->SecondPos_Deprecated) % geoId3
+                         % static_cast<int>(constr->ThirdPos_Deprecated)
                      );
                  }
              }},
@@ -753,8 +757,8 @@ std::string PythonConverter::process(const Sketcher::Constraint* constraint, Geo
                 std::string& geoId3) {
                  return boost::str(
                      boost::format("Sketcher.Constraint('SnellsLaw', %s, %i, %s, %i, %s, %f")
-                     % geoId1 % static_cast<int>(constr->FirstPos) % geoId2
-                     % static_cast<int>(constr->SecondPos) % geoId3 % constr->getValue()
+                     % geoId1 % static_cast<int>(constr->FirstPos_Deprecated) % geoId2
+                     % static_cast<int>(constr->SecondPos_Deprecated) % geoId3 % constr->getValue()
                  );
              }},
         };

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -159,12 +159,13 @@ bool Sketch::analyseBlockedGeometry(
 
             for (auto c : constraintList) {
                 // is block driving
-                if (c->Type == Sketcher::Block && c->isActive && c->First == geoindex) {
+                if (c->Type == Sketcher::Block && c->isActive && c->First_Deprecated == geoindex) {
                     blockisDriving = true;
                 }
                 // We have another driving constraint (which may be InternalAlignment)
                 if (c->Type != Sketcher::Block && c->isDriving
-                    && (c->First == geoindex || c->Second == geoindex || c->Third == geoindex)) {
+                    && (c->First_Deprecated == geoindex || c->Second_Deprecated == geoindex
+                        || c->Third_Deprecated == geoindex)) {
                     blockOnly = false;
                 }
             }
@@ -373,7 +374,7 @@ void Sketch::buildInternalAlignmentGeometryMap(const std::vector<Constraint*>& c
 {
     for (auto* c : constraintList) {
         if (c->Type == InternalAlignment) {
-            internalAlignmentGeometryMap[c->First] = c->Second;
+            internalAlignmentGeometryMap[c->First_Deprecated] = c->Second_Deprecated;
         }
     }
 }
@@ -1971,7 +1972,7 @@ int Sketch::addConstraint(const Constraint* constraint)
 
     switch (constraint->Type) {
         case DistanceX:
-            if (constraint->FirstPos == PointPos::none) {  // horizontal length of a line
+            if (constraint->FirstPos_Deprecated == PointPos::none) {  // horizontal length of a line
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -1981,9 +1982,10 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addDistanceXConstraint(constraint->First, c.value, c.driving);
+                rtn = addDistanceXConstraint(constraint->First_Deprecated, c.value, c.driving);
             }
-            else if (constraint->Second == GeoEnum::GeoUndef) {  // point on fixed x-coordinate
+            else if (constraint->Second_Deprecated == GeoEnum::GeoUndef) {  // point on fixed
+                                                                            // x-coordinate
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -1993,9 +1995,15 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addCoordinateXConstraint(constraint->First, constraint->FirstPos, c.value, c.driving);
+                rtn = addCoordinateXConstraint(
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    c.value,
+                    c.driving
+                );
             }
-            else if (constraint->SecondPos != PointPos::none) {  // point to point horizontal distance
+            else if (constraint->SecondPos_Deprecated != PointPos::none) {  // point to point
+                                                                            // horizontal distance
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2006,17 +2014,17 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addDistanceXConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
                     c.value,
                     c.driving
                 );
             }
             break;
         case DistanceY:
-            if (constraint->FirstPos == PointPos::none) {  // vertical length of a line
+            if (constraint->FirstPos_Deprecated == PointPos::none) {  // vertical length of a line
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2026,9 +2034,10 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addDistanceYConstraint(constraint->First, c.value, c.driving);
+                rtn = addDistanceYConstraint(constraint->First_Deprecated, c.value, c.driving);
             }
-            else if (constraint->Second == GeoEnum::GeoUndef) {  // point on fixed y-coordinate
+            else if (constraint->Second_Deprecated == GeoEnum::GeoUndef) {  // point on fixed
+                                                                            // y-coordinate
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2038,9 +2047,15 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addCoordinateYConstraint(constraint->First, constraint->FirstPos, c.value, c.driving);
+                rtn = addCoordinateYConstraint(
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    c.value,
+                    c.driving
+                );
             }
-            else if (constraint->SecondPos != PointPos::none) {  // point to point vertical distance
+            else if (constraint->SecondPos_Deprecated != PointPos::none) {  // point to point
+                                                                            // vertical distance
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2051,89 +2066,94 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addDistanceYConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
                     c.value,
                     c.driving
                 );
             }
             break;
         case Horizontal:
-            if (constraint->Second == GeoEnum::GeoUndef) {  // horizontal line
-                rtn = addHorizontalConstraint(constraint->First);
+            if (constraint->Second_Deprecated == GeoEnum::GeoUndef) {  // horizontal line
+                rtn = addHorizontalConstraint(constraint->First_Deprecated);
             }
             else {  // two points on the same horizontal line
                 rtn = addHorizontalConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated
                 );
             }
             break;
         case Vertical:
-            if (constraint->Second == GeoEnum::GeoUndef) {  // vertical line
-                rtn = addVerticalConstraint(constraint->First);
+            if (constraint->Second_Deprecated == GeoEnum::GeoUndef) {  // vertical line
+                rtn = addVerticalConstraint(constraint->First_Deprecated);
             }
             else {  // two points on the same vertical line
                 rtn = addVerticalConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated
                 );
             }
             break;
         case Coincident:
             rtn = addPointCoincidentConstraint(
-                constraint->First,
-                constraint->FirstPos,
-                constraint->Second,
-                constraint->SecondPos
+                constraint->First_Deprecated,
+                constraint->FirstPos_Deprecated,
+                constraint->Second_Deprecated,
+                constraint->SecondPos_Deprecated
             );
             break;
         case PointOnObject:
-            if (Geoms[checkGeoId(constraint->Second)].type == BSpline) {
+            if (Geoms[checkGeoId(constraint->Second_Deprecated)].type == BSpline) {
                 c.value = new double(constraint->getValue());
                 // Driving doesn't make sense here
                 Parameters.push_back(c.value);
 
                 rtn = addPointOnObjectConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
                     c.value
                 );
             }
             else {
                 rtn = addPointOnObjectConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated
                 );
             }
             break;
         case Parallel:
-            rtn = addParallelConstraint(constraint->First, constraint->Second);
+            rtn = addParallelConstraint(constraint->First_Deprecated, constraint->Second_Deprecated);
             break;
         case Perpendicular:
-            if (constraint->FirstPos != PointPos::none && constraint->SecondPos != PointPos::none
-                && constraint->Third != GeoEnum::GeoUndef) {
+            if (constraint->FirstPos_Deprecated != PointPos::none
+                && constraint->SecondPos_Deprecated != PointPos::none
+                && constraint->Third_Deprecated != GeoEnum::GeoUndef) {
                 // point point line perpendicularity
                 rtn = addPerpendicularConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
-                    constraint->Third
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
+                    constraint->Third_Deprecated
                 );
             }
-            else if (constraint->FirstPos == PointPos::none && constraint->SecondPos == PointPos::none
-                     && constraint->Third == GeoEnum::GeoUndef) {
+            else if (constraint->FirstPos_Deprecated == PointPos::none
+                     && constraint->SecondPos_Deprecated == PointPos::none
+                     && constraint->Third_Deprecated == GeoEnum::GeoUndef) {
                 // simple perpendicularity
-                rtn = addPerpendicularConstraint(constraint->First, constraint->Second);
+                rtn = addPerpendicularConstraint(
+                    constraint->First_Deprecated,
+                    constraint->Second_Deprecated
+                );
             }
             else {
                 // any other point-wise perpendicularity
@@ -2147,12 +2167,12 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleAtPointConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
-                    constraint->Third,
-                    constraint->ThirdPos,
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
+                    constraint->Third_Deprecated,
+                    constraint->ThirdPos_Deprecated,
                     c.value,
                     constraint->Type,
                     c.driving
@@ -2162,29 +2182,32 @@ int Sketch::addConstraint(const Constraint* constraint)
         case Tangent: {
             bool isSpecialCase = false;
 
-            if (constraint->FirstPos == PointPos::none && constraint->SecondPos == PointPos::none
-                && constraint->Third == GeoEnum::GeoUndef) {
+            if (constraint->FirstPos_Deprecated == PointPos::none
+                && constraint->SecondPos_Deprecated == PointPos::none
+                && constraint->Third_Deprecated == GeoEnum::GeoUndef) {
                 // simple tangency
-                rtn = addTangentConstraint(constraint->First, constraint->Second);
+                rtn = addTangentConstraint(constraint->First_Deprecated, constraint->Second_Deprecated);
 
                 isSpecialCase = true;
             }
-            else if (constraint->FirstPos == PointPos::start
-                     && constraint->Third == GeoEnum::GeoUndef) {
+            else if (constraint->FirstPos_Deprecated == PointPos::start
+                     && constraint->Third_Deprecated == GeoEnum::GeoUndef) {
                 // check for B-Spline Knot to curve tangency
-                auto knotgeoId = checkGeoId(constraint->First);
+                auto knotgeoId = checkGeoId(constraint->First_Deprecated);
                 if (Geoms[knotgeoId].type == Point) {
                     auto* point = static_cast<const GeomPoint*>(Geoms[knotgeoId].geo);
 
                     if (GeometryFacade::isInternalType(point, InternalType::BSplineKnotPoint)) {
-                        auto bsplinegeoid = internalAlignmentGeometryMap.at(constraint->First);
+                        auto bsplinegeoid = internalAlignmentGeometryMap.at(
+                            constraint->First_Deprecated
+                        );
 
                         bsplinegeoid = checkGeoId(bsplinegeoid);
 
-                        auto linegeoid = checkGeoId(constraint->Second);
+                        auto linegeoid = checkGeoId(constraint->Second_Deprecated);
 
                         if (Geoms[linegeoid].type == Line) {
-                            if (constraint->SecondPos == PointPos::none) {
+                            if (constraint->SecondPos_Deprecated == PointPos::none) {
                                 rtn = addTangentLineAtBSplineKnotConstraint(
                                     linegeoid,
                                     bsplinegeoid,
@@ -2193,11 +2216,11 @@ int Sketch::addConstraint(const Constraint* constraint)
 
                                 isSpecialCase = true;
                             }
-                            else if (constraint->SecondPos == PointPos::start
-                                     || constraint->SecondPos == PointPos::end) {
+                            else if (constraint->SecondPos_Deprecated == PointPos::start
+                                     || constraint->SecondPos_Deprecated == PointPos::end) {
                                 rtn = addTangentLineEndpointAtBSplineKnotConstraint(
                                     linegeoid,
-                                    constraint->SecondPos,
+                                    constraint->SecondPos_Deprecated,
                                     bsplinegeoid,
                                     knotgeoId
                                 );
@@ -2221,12 +2244,12 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleAtPointConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
-                    constraint->Third,
-                    constraint->ThirdPos,
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
+                    constraint->Third_Deprecated,
+                    constraint->ThirdPos_Deprecated,
                     c.value,
                     constraint->Type,
                     c.driving
@@ -2235,7 +2258,7 @@ int Sketch::addConstraint(const Constraint* constraint)
             break;
         }
         case Distance:
-            if (constraint->SecondPos != PointPos::none) {  // point to point distance
+            if (constraint->SecondPos_Deprecated != PointPos::none) {  // point to point distance
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2245,18 +2268,20 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
                 rtn = addDistanceConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
                     c.value,
                     c.driving
                 );
             }
-            else if (constraint->FirstPos == PointPos::none && constraint->SecondPos == PointPos::none
-                     && constraint->Second != GeoEnum::GeoUndef
-                     && constraint->Third == GeoEnum::GeoUndef) {  // circle to circle, circle to
-                                                                   // arc, etc.
+            else if (constraint->FirstPos_Deprecated == PointPos::none
+                     && constraint->SecondPos_Deprecated == PointPos::none
+                     && constraint->Second_Deprecated != GeoEnum::GeoUndef
+                     && constraint->Third_Deprecated == GeoEnum::GeoUndef) {  // circle to circle,
+                                                                              // circle to
+                                                                              // arc, etc.
 
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
@@ -2266,10 +2291,15 @@ int Sketch::addConstraint(const Constraint* constraint)
                     Parameters.push_back(c.value);
                     DrivenParameters.push_back(c.value);
                 }
-                rtn = addDistanceConstraint(constraint->First, constraint->Second, c.value, c.driving);
+                rtn = addDistanceConstraint(
+                    constraint->First_Deprecated,
+                    constraint->Second_Deprecated,
+                    c.value,
+                    c.driving
+                );
             }
-            else if (constraint->Second != GeoEnum::GeoUndef) {
-                if (constraint->FirstPos != PointPos::none) {  // point to line distance
+            else if (constraint->Second_Deprecated != GeoEnum::GeoUndef) {
+                if (constraint->FirstPos_Deprecated != PointPos::none) {  // point to line distance
                     c.value = new double(constraint->getValue());
                     if (c.driving) {
                         FixParameters.push_back(c.value);
@@ -2279,9 +2309,9 @@ int Sketch::addConstraint(const Constraint* constraint)
                         DrivenParameters.push_back(c.value);
                     }
                     rtn = addDistanceConstraint(
-                        constraint->First,
-                        constraint->FirstPos,
-                        constraint->Second,
+                        constraint->First_Deprecated,
+                        constraint->FirstPos_Deprecated,
+                        constraint->Second_Deprecated,
                         c.value,
                         c.driving
                     );
@@ -2297,11 +2327,11 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addDistanceConstraint(constraint->First, c.value, c.driving);
+                rtn = addDistanceConstraint(constraint->First_Deprecated, c.value, c.driving);
             }
             break;
         case Angle:
-            if (constraint->Third != GeoEnum::GeoUndef) {
+            if (constraint->Third_Deprecated != GeoEnum::GeoUndef) {
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2312,19 +2342,19 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleAtPointConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
-                    constraint->Third,
-                    constraint->ThirdPos,
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
+                    constraint->Third_Deprecated,
+                    constraint->ThirdPos_Deprecated,
                     c.value,
                     constraint->Type,
                     c.driving
                 );
             }
             // angle between two lines (with explicit start points)
-            else if (constraint->SecondPos != PointPos::none) {
+            else if (constraint->SecondPos_Deprecated != PointPos::none) {
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2335,15 +2365,15 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
                     c.value,
                     c.driving
                 );
             }
-            else if (constraint->Second != GeoEnum::GeoUndef) {  // angle between two lines
+            else if (constraint->Second_Deprecated != GeoEnum::GeoUndef) {  // angle between two lines
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2353,9 +2383,15 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addAngleConstraint(constraint->First, constraint->Second, c.value, c.driving);
+                rtn = addAngleConstraint(
+                    constraint->First_Deprecated,
+                    constraint->Second_Deprecated,
+                    c.value,
+                    c.driving
+                );
             }
-            else if (constraint->First != GeoEnum::GeoUndef) {  // orientation angle of a line
+            else if (constraint->First_Deprecated
+                     != GeoEnum::GeoUndef) {  // orientation angle of a line
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2365,7 +2401,7 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addAngleConstraint(constraint->First, c.value, c.driving);
+                rtn = addAngleConstraint(constraint->First_Deprecated, c.value, c.driving);
             }
             break;
         case Radius: {
@@ -2378,7 +2414,7 @@ int Sketch::addConstraint(const Constraint* constraint)
                 DrivenParameters.push_back(c.value);
             }
 
-            rtn = addRadiusConstraint(constraint->First, c.value, c.driving);
+            rtn = addRadiusConstraint(constraint->First_Deprecated, c.value, c.driving);
             break;
         }
         case Diameter: {
@@ -2391,7 +2427,7 @@ int Sketch::addConstraint(const Constraint* constraint)
                 DrivenParameters.push_back(c.value);
             }
 
-            rtn = addDiameterConstraint(constraint->First, c.value, c.driving);
+            rtn = addDiameterConstraint(constraint->First_Deprecated, c.value, c.driving);
             break;
         }
         case Weight: {
@@ -2404,83 +2440,101 @@ int Sketch::addConstraint(const Constraint* constraint)
                 DrivenParameters.push_back(c.value);
             }
 
-            rtn = addRadiusConstraint(constraint->First, c.value, c.driving);
+            rtn = addRadiusConstraint(constraint->First_Deprecated, c.value, c.driving);
             break;
         }
         case Equal:
-            rtn = addEqualConstraint(constraint->First, constraint->Second);
+            rtn = addEqualConstraint(constraint->First_Deprecated, constraint->Second_Deprecated);
             break;
         case Symmetric:
-            if (constraint->ThirdPos != PointPos::none) {
+            if (constraint->ThirdPos_Deprecated != PointPos::none) {
                 rtn = addSymmetricConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
-                    constraint->Third,
-                    constraint->ThirdPos
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
+                    constraint->Third_Deprecated,
+                    constraint->ThirdPos_Deprecated
                 );
             }
             else {
                 rtn = addSymmetricConstraint(
-                    constraint->First,
-                    constraint->FirstPos,
-                    constraint->Second,
-                    constraint->SecondPos,
-                    constraint->Third
+                    constraint->First_Deprecated,
+                    constraint->FirstPos_Deprecated,
+                    constraint->Second_Deprecated,
+                    constraint->SecondPos_Deprecated,
+                    constraint->Third_Deprecated
                 );
             }
             break;
         case InternalAlignment:
             switch (constraint->AlignmentType) {
                 case EllipseMajorDiameter:
-                    rtn = addInternalAlignmentEllipseMajorDiameter(constraint->First, constraint->Second);
+                    rtn = addInternalAlignmentEllipseMajorDiameter(
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
+                    );
                     break;
                 case EllipseMinorDiameter:
-                    rtn = addInternalAlignmentEllipseMinorDiameter(constraint->First, constraint->Second);
+                    rtn = addInternalAlignmentEllipseMinorDiameter(
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
+                    );
                     break;
                 case EllipseFocus1:
-                    rtn = addInternalAlignmentEllipseFocus1(constraint->First, constraint->Second);
+                    rtn = addInternalAlignmentEllipseFocus1(
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
+                    );
                     break;
                 case EllipseFocus2:
-                    rtn = addInternalAlignmentEllipseFocus2(constraint->First, constraint->Second);
+                    rtn = addInternalAlignmentEllipseFocus2(
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
+                    );
                     break;
                 case HyperbolaMajor:
                     rtn = addInternalAlignmentHyperbolaMajorDiameter(
-                        constraint->First,
-                        constraint->Second
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
                     );
                     break;
                 case HyperbolaMinor:
                     rtn = addInternalAlignmentHyperbolaMinorDiameter(
-                        constraint->First,
-                        constraint->Second
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
                     );
                     break;
                 case HyperbolaFocus:
-                    rtn = addInternalAlignmentHyperbolaFocus(constraint->First, constraint->Second);
+                    rtn = addInternalAlignmentHyperbolaFocus(
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
+                    );
                     break;
                 case ParabolaFocus:
-                    rtn = addInternalAlignmentParabolaFocus(constraint->First, constraint->Second);
+                    rtn = addInternalAlignmentParabolaFocus(
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
+                    );
                     break;
                 case BSplineControlPoint:
                     rtn = addInternalAlignmentBSplineControlPoint(
-                        constraint->First,
-                        constraint->Second,
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated,
                         constraint->InternalAlignmentIndex
                     );
                     break;
                 case BSplineKnotPoint:
                     rtn = addInternalAlignmentKnotPoint(
-                        constraint->First,
-                        constraint->Second,
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated,
                         constraint->InternalAlignmentIndex
                     );
                     break;
                 case ParabolaFocalAxis:
                     rtn = addInternalAlignmentParabolaFocalDistance(
-                        constraint->First,
-                        constraint->Second
+                        constraint->First_Deprecated,
+                        constraint->Second_Deprecated
                     );
                     break;
                 default:
@@ -2504,11 +2558,11 @@ int Sketch::addConstraint(const Constraint* constraint)
 
             // assert(constraint->ThirdPos==none); //will work anyway...
             rtn = addSnellsLawConstraint(
-                constraint->First,
-                constraint->FirstPos,
-                constraint->Second,
-                constraint->SecondPos,
-                constraint->Third,
+                constraint->First_Deprecated,
+                constraint->FirstPos_Deprecated,
+                constraint->Second_Deprecated,
+                constraint->SecondPos_Deprecated,
+                constraint->Third_Deprecated,
                 c.value,
                 c.secondvalue,
                 c.driving
@@ -2623,7 +2677,7 @@ void Sketch::getBlockedGeometry(
     for (auto it = ConstraintList.cbegin(); it != ConstraintList.cend(); ++it, ++i) {
         switch ((*it)->Type) {
             case Block: {
-                int geoid = (*it)->First;
+                int geoid = (*it)->First_Deprecated;
 
                 if (geoid >= 0 && geoid < int(blockedGeometry.size())) {
                     blockedGeometry[geoid] = true;
@@ -2641,12 +2695,12 @@ void Sketch::getBlockedGeometry(
     // if a GeoId is blocked and it is linked to Internal Alignment, then GeoIds linked via Internal
     // Alignment are also to be blocked
     for (auto idx : internalAlignmentConstraintIndex) {
-        if (blockedGeometry[ConstraintList[idx]->Second]) {
-            blockedGeometry[ConstraintList[idx]->First] = true;
+        if (blockedGeometry[ConstraintList[idx]->Second_Deprecated]) {
+            blockedGeometry[ConstraintList[idx]->First_Deprecated] = true;
             // associated geometry gets the same blocking constraint index as the blocked element
-            geo2blockingconstraintindex[ConstraintList[idx]->First]
-                = geo2blockingconstraintindex[ConstraintList[idx]->Second];
-            internalAlignmentgeo.push_back(ConstraintList[idx]->First);
+            geo2blockingconstraintindex[ConstraintList[idx]->First_Deprecated]
+                = geo2blockingconstraintindex[ConstraintList[idx]->Second_Deprecated];
+            internalAlignmentgeo.push_back(ConstraintList[idx]->First_Deprecated);
             unenforceableConstraints[idx] = true;
         }
     }
@@ -2657,7 +2711,8 @@ void Sketch::getBlockedGeometry(
             // additionally any further constraint on auxiliary elements linked via Internal
             // Alignment are also unenforceable.
             for (auto& iag : internalAlignmentgeo) {
-                if ((*it)->First == iag || (*it)->Second == iag || (*it)->Third == iag) {
+                if ((*it)->First_Deprecated == iag || (*it)->Second_Deprecated == iag
+                    || (*it)->Third_Deprecated == iag) {
                     unenforceableConstraints[i] = true;
                 }
             }
@@ -2669,24 +2724,28 @@ void Sketch::getBlockedGeometry(
 
             // further, any constraint taking only one element, which is blocked is also
             // unenforceable
-            if ((*it)->Second == GeoEnum::GeoUndef && (*it)->Third == GeoEnum::GeoUndef
-                && (*it)->First >= 0) {
-                if (blockedGeometry[(*it)->First] && i < geo2blockingconstraintindex[(*it)->First]) {
+            if ((*it)->Second_Deprecated == GeoEnum::GeoUndef
+                && (*it)->Third_Deprecated == GeoEnum::GeoUndef && (*it)->First_Deprecated >= 0) {
+                if (blockedGeometry[(*it)->First_Deprecated]
+                    && i < geo2blockingconstraintindex[(*it)->First_Deprecated]) {
                     unenforceableConstraints[i] = true;
                 }
             }
             // further any constraint on only two elements where both elements are blocked or one is
             // blocked and the other is an axis or external provided that the constraints precede
             // the last block constraint.
-            else if ((*it)->Third == GeoEnum::GeoUndef) {
-                if (((*it)->First >= 0 && (*it)->Second >= 0 && blockedGeometry[(*it)->First]
-                     && blockedGeometry[(*it)->Second]
-                     && (i < geo2blockingconstraintindex[(*it)->First]
-                         || i < geo2blockingconstraintindex[(*it)->Second]))
-                    || ((*it)->First < 0 && (*it)->Second >= 0 && blockedGeometry[(*it)->Second]
-                        && i < geo2blockingconstraintindex[(*it)->Second])
-                    || ((*it)->First >= 0 && (*it)->Second < 0 && blockedGeometry[(*it)->First]
-                        && i < geo2blockingconstraintindex[(*it)->First])) {
+            else if ((*it)->Third_Deprecated == GeoEnum::GeoUndef) {
+                if (((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated >= 0
+                     && blockedGeometry[(*it)->First_Deprecated]
+                     && blockedGeometry[(*it)->Second_Deprecated]
+                     && (i < geo2blockingconstraintindex[(*it)->First_Deprecated]
+                         || i < geo2blockingconstraintindex[(*it)->Second_Deprecated]))
+                    || ((*it)->First_Deprecated < 0 && (*it)->Second_Deprecated >= 0
+                        && blockedGeometry[(*it)->Second_Deprecated]
+                        && i < geo2blockingconstraintindex[(*it)->Second_Deprecated])
+                    || ((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated < 0
+                        && blockedGeometry[(*it)->First_Deprecated]
+                        && i < geo2blockingconstraintindex[(*it)->First_Deprecated])) {
                     unenforceableConstraints[i] = true;
                 }
             }
@@ -2695,33 +2754,37 @@ void Sketch::getBlockedGeometry(
             // elements where one is blocked and the other two are axis or external geo, provided
             // that the constraints precede the last block constraint.
             else {
-                if (((*it)->First >= 0 && (*it)->Second >= 0 && (*it)->Third >= 0
-                     && blockedGeometry[(*it)->First] && blockedGeometry[(*it)->Second]
-                     && blockedGeometry[(*it)->Third]
-                     && (i < geo2blockingconstraintindex[(*it)->First]
-                         || i < geo2blockingconstraintindex[(*it)->Second]
-                         || i < geo2blockingconstraintindex[(*it)->Third]))
-                    || ((*it)->First < 0 && (*it)->Second >= 0 && (*it)->Third >= 0
-                        && blockedGeometry[(*it)->Second] && blockedGeometry[(*it)->Third]
-                        && (i < geo2blockingconstraintindex[(*it)->Second]
-                            || i < geo2blockingconstraintindex[(*it)->Third]))
-                    || ((*it)->First >= 0 && (*it)->Second < 0 && (*it)->Third >= 0
-                        && blockedGeometry[(*it)->First] && blockedGeometry[(*it)->Third]
-                        && (i < geo2blockingconstraintindex[(*it)->First]
-                            || i < geo2blockingconstraintindex[(*it)->Third]))
-                    || ((*it)->First >= 0 && (*it)->Second >= 0 && (*it)->Third < 0
-                        && blockedGeometry[(*it)->First] && blockedGeometry[(*it)->Second]
-                        && (i < geo2blockingconstraintindex[(*it)->First]
-                            || i < geo2blockingconstraintindex[(*it)->Second]))
-                    || ((*it)->First >= 0 && (*it)->Second < 0 && (*it)->Third < 0
-                        && blockedGeometry[(*it)->First]
-                        && i < geo2blockingconstraintindex[(*it)->First])
-                    || ((*it)->First < 0 && (*it)->Second >= 0 && (*it)->Third < 0
-                        && blockedGeometry[(*it)->Second]
-                        && i < geo2blockingconstraintindex[(*it)->Second])
-                    || ((*it)->First < 0 && (*it)->Second < 0 && (*it)->Third >= 0
-                        && blockedGeometry[(*it)->Third]
-                        && i < geo2blockingconstraintindex[(*it)->Third])) {
+                if (((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated >= 0
+                     && (*it)->Third_Deprecated >= 0 && blockedGeometry[(*it)->First_Deprecated]
+                     && blockedGeometry[(*it)->Second_Deprecated]
+                     && blockedGeometry[(*it)->Third_Deprecated]
+                     && (i < geo2blockingconstraintindex[(*it)->First_Deprecated]
+                         || i < geo2blockingconstraintindex[(*it)->Second_Deprecated]
+                         || i < geo2blockingconstraintindex[(*it)->Third_Deprecated]))
+                    || ((*it)->First_Deprecated < 0 && (*it)->Second_Deprecated >= 0
+                        && (*it)->Third_Deprecated >= 0 && blockedGeometry[(*it)->Second_Deprecated]
+                        && blockedGeometry[(*it)->Third_Deprecated]
+                        && (i < geo2blockingconstraintindex[(*it)->Second_Deprecated]
+                            || i < geo2blockingconstraintindex[(*it)->Third_Deprecated]))
+                    || ((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated < 0
+                        && (*it)->Third_Deprecated >= 0 && blockedGeometry[(*it)->First_Deprecated]
+                        && blockedGeometry[(*it)->Third_Deprecated]
+                        && (i < geo2blockingconstraintindex[(*it)->First_Deprecated]
+                            || i < geo2blockingconstraintindex[(*it)->Third_Deprecated]))
+                    || ((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated >= 0
+                        && (*it)->Third_Deprecated < 0 && blockedGeometry[(*it)->First_Deprecated]
+                        && blockedGeometry[(*it)->Second_Deprecated]
+                        && (i < geo2blockingconstraintindex[(*it)->First_Deprecated]
+                            || i < geo2blockingconstraintindex[(*it)->Second_Deprecated]))
+                    || ((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated < 0
+                        && (*it)->Third_Deprecated < 0 && blockedGeometry[(*it)->First_Deprecated]
+                        && i < geo2blockingconstraintindex[(*it)->First_Deprecated])
+                    || ((*it)->First_Deprecated < 0 && (*it)->Second_Deprecated >= 0
+                        && (*it)->Third_Deprecated < 0 && blockedGeometry[(*it)->Second_Deprecated]
+                        && i < geo2blockingconstraintindex[(*it)->Second_Deprecated])
+                    || ((*it)->First_Deprecated < 0 && (*it)->Second_Deprecated < 0
+                        && (*it)->Third_Deprecated >= 0 && blockedGeometry[(*it)->Third_Deprecated]
+                        && i < geo2blockingconstraintindex[(*it)->Third_Deprecated])) {
 
                     unenforceableConstraints[i] = true;
                 }

--- a/src/Mod/Sketcher/App/Sketch.cpp
+++ b/src/Mod/Sketcher/App/Sketch.cpp
@@ -159,13 +159,13 @@ bool Sketch::analyseBlockedGeometry(
 
             for (auto c : constraintList) {
                 // is block driving
-                if (c->Type == Sketcher::Block && c->isActive && c->First_Deprecated == geoindex) {
+                if (c->Type == Sketcher::Block && c->isActive && c->getGeoId(0) == geoindex) {
                     blockisDriving = true;
                 }
                 // We have another driving constraint (which may be InternalAlignment)
                 if (c->Type != Sketcher::Block && c->isDriving
-                    && (c->First_Deprecated == geoindex || c->Second_Deprecated == geoindex
-                        || c->Third_Deprecated == geoindex)) {
+                    && (c->getGeoId(0) == geoindex || c->getGeoId(1) == geoindex
+                        || c->getGeoId(2) == geoindex)) {
                     blockOnly = false;
                 }
             }
@@ -374,7 +374,7 @@ void Sketch::buildInternalAlignmentGeometryMap(const std::vector<Constraint*>& c
 {
     for (auto* c : constraintList) {
         if (c->Type == InternalAlignment) {
-            internalAlignmentGeometryMap[c->First_Deprecated] = c->Second_Deprecated;
+            internalAlignmentGeometryMap[c->getGeoId(0)] = c->getGeoId(1);
         }
     }
 }
@@ -1972,7 +1972,7 @@ int Sketch::addConstraint(const Constraint* constraint)
 
     switch (constraint->Type) {
         case DistanceX:
-            if (constraint->FirstPos_Deprecated == PointPos::none) {  // horizontal length of a line
+            if (constraint->getPosId(0) == PointPos::none) {  // horizontal length of a line
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -1982,10 +1982,10 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addDistanceXConstraint(constraint->First_Deprecated, c.value, c.driving);
+                rtn = addDistanceXConstraint(constraint->getGeoId(0), c.value, c.driving);
             }
-            else if (constraint->Second_Deprecated == GeoEnum::GeoUndef) {  // point on fixed
-                                                                            // x-coordinate
+            else if (constraint->getGeoId(1) == GeoEnum::GeoUndef) {  // point on fixed
+                                                                      // x-coordinate
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -1996,14 +1996,14 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addCoordinateXConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
                     c.value,
                     c.driving
                 );
             }
-            else if (constraint->SecondPos_Deprecated != PointPos::none) {  // point to point
-                                                                            // horizontal distance
+            else if (constraint->getPosId(1) != PointPos::none) {  // point to point
+                                                                   // horizontal distance
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2014,17 +2014,17 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addDistanceXConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
                     c.value,
                     c.driving
                 );
             }
             break;
         case DistanceY:
-            if (constraint->FirstPos_Deprecated == PointPos::none) {  // vertical length of a line
+            if (constraint->getPosId(0) == PointPos::none) {  // vertical length of a line
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2034,10 +2034,10 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addDistanceYConstraint(constraint->First_Deprecated, c.value, c.driving);
+                rtn = addDistanceYConstraint(constraint->getGeoId(0), c.value, c.driving);
             }
-            else if (constraint->Second_Deprecated == GeoEnum::GeoUndef) {  // point on fixed
-                                                                            // y-coordinate
+            else if (constraint->getGeoId(1) == GeoEnum::GeoUndef) {  // point on fixed
+                                                                      // y-coordinate
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2048,14 +2048,14 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addCoordinateYConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
                     c.value,
                     c.driving
                 );
             }
-            else if (constraint->SecondPos_Deprecated != PointPos::none) {  // point to point
-                                                                            // vertical distance
+            else if (constraint->getPosId(1) != PointPos::none) {  // point to point
+                                                                   // vertical distance
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2066,94 +2066,90 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addDistanceYConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
                     c.value,
                     c.driving
                 );
             }
             break;
         case Horizontal:
-            if (constraint->Second_Deprecated == GeoEnum::GeoUndef) {  // horizontal line
-                rtn = addHorizontalConstraint(constraint->First_Deprecated);
+            if (constraint->getGeoId(1) == GeoEnum::GeoUndef) {  // horizontal line
+                rtn = addHorizontalConstraint(constraint->getGeoId(0));
             }
             else {  // two points on the same horizontal line
                 rtn = addHorizontalConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1)
                 );
             }
             break;
         case Vertical:
-            if (constraint->Second_Deprecated == GeoEnum::GeoUndef) {  // vertical line
-                rtn = addVerticalConstraint(constraint->First_Deprecated);
+            if (constraint->getGeoId(1) == GeoEnum::GeoUndef) {  // vertical line
+                rtn = addVerticalConstraint(constraint->getGeoId(0));
             }
             else {  // two points on the same vertical line
                 rtn = addVerticalConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1)
                 );
             }
             break;
         case Coincident:
             rtn = addPointCoincidentConstraint(
-                constraint->First_Deprecated,
-                constraint->FirstPos_Deprecated,
-                constraint->Second_Deprecated,
-                constraint->SecondPos_Deprecated
+                constraint->getGeoId(0),
+                constraint->getPosId(0),
+                constraint->getGeoId(1),
+                constraint->getPosId(1)
             );
             break;
         case PointOnObject:
-            if (Geoms[checkGeoId(constraint->Second_Deprecated)].type == BSpline) {
+            if (Geoms[checkGeoId(constraint->getGeoId(1))].type == BSpline) {
                 c.value = new double(constraint->getValue());
                 // Driving doesn't make sense here
                 Parameters.push_back(c.value);
 
                 rtn = addPointOnObjectConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
                     c.value
                 );
             }
             else {
                 rtn = addPointOnObjectConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1)
                 );
             }
             break;
         case Parallel:
-            rtn = addParallelConstraint(constraint->First_Deprecated, constraint->Second_Deprecated);
+            rtn = addParallelConstraint(constraint->getGeoId(0), constraint->getGeoId(1));
             break;
         case Perpendicular:
-            if (constraint->FirstPos_Deprecated != PointPos::none
-                && constraint->SecondPos_Deprecated != PointPos::none
-                && constraint->Third_Deprecated != GeoEnum::GeoUndef) {
+            if (constraint->getPosId(0) != PointPos::none && constraint->getPosId(1) != PointPos::none
+                && constraint->getGeoId(2) != GeoEnum::GeoUndef) {
                 // point point line perpendicularity
                 rtn = addPerpendicularConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
-                    constraint->Third_Deprecated
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
+                    constraint->getGeoId(2)
                 );
             }
-            else if (constraint->FirstPos_Deprecated == PointPos::none
-                     && constraint->SecondPos_Deprecated == PointPos::none
-                     && constraint->Third_Deprecated == GeoEnum::GeoUndef) {
+            else if (constraint->getPosId(0) == PointPos::none
+                     && constraint->getPosId(1) == PointPos::none
+                     && constraint->getGeoId(2) == GeoEnum::GeoUndef) {
                 // simple perpendicularity
-                rtn = addPerpendicularConstraint(
-                    constraint->First_Deprecated,
-                    constraint->Second_Deprecated
-                );
+                rtn = addPerpendicularConstraint(constraint->getGeoId(0), constraint->getGeoId(1));
             }
             else {
                 // any other point-wise perpendicularity
@@ -2167,12 +2163,12 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleAtPointConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
-                    constraint->Third_Deprecated,
-                    constraint->ThirdPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
+                    constraint->getGeoId(2),
+                    constraint->getPosId(2),
                     c.value,
                     constraint->Type,
                     c.driving
@@ -2182,32 +2178,29 @@ int Sketch::addConstraint(const Constraint* constraint)
         case Tangent: {
             bool isSpecialCase = false;
 
-            if (constraint->FirstPos_Deprecated == PointPos::none
-                && constraint->SecondPos_Deprecated == PointPos::none
-                && constraint->Third_Deprecated == GeoEnum::GeoUndef) {
+            if (constraint->getPosId(0) == PointPos::none && constraint->getPosId(1) == PointPos::none
+                && constraint->getGeoId(2) == GeoEnum::GeoUndef) {
                 // simple tangency
-                rtn = addTangentConstraint(constraint->First_Deprecated, constraint->Second_Deprecated);
+                rtn = addTangentConstraint(constraint->getGeoId(0), constraint->getGeoId(1));
 
                 isSpecialCase = true;
             }
-            else if (constraint->FirstPos_Deprecated == PointPos::start
-                     && constraint->Third_Deprecated == GeoEnum::GeoUndef) {
+            else if (constraint->getPosId(0) == PointPos::start
+                     && constraint->getGeoId(2) == GeoEnum::GeoUndef) {
                 // check for B-Spline Knot to curve tangency
-                auto knotgeoId = checkGeoId(constraint->First_Deprecated);
+                auto knotgeoId = checkGeoId(constraint->getGeoId(0));
                 if (Geoms[knotgeoId].type == Point) {
                     auto* point = static_cast<const GeomPoint*>(Geoms[knotgeoId].geo);
 
                     if (GeometryFacade::isInternalType(point, InternalType::BSplineKnotPoint)) {
-                        auto bsplinegeoid = internalAlignmentGeometryMap.at(
-                            constraint->First_Deprecated
-                        );
+                        auto bsplinegeoid = internalAlignmentGeometryMap.at(constraint->getGeoId(0));
 
                         bsplinegeoid = checkGeoId(bsplinegeoid);
 
-                        auto linegeoid = checkGeoId(constraint->Second_Deprecated);
+                        auto linegeoid = checkGeoId(constraint->getGeoId(1));
 
                         if (Geoms[linegeoid].type == Line) {
-                            if (constraint->SecondPos_Deprecated == PointPos::none) {
+                            if (constraint->getPosId(1) == PointPos::none) {
                                 rtn = addTangentLineAtBSplineKnotConstraint(
                                     linegeoid,
                                     bsplinegeoid,
@@ -2216,11 +2209,11 @@ int Sketch::addConstraint(const Constraint* constraint)
 
                                 isSpecialCase = true;
                             }
-                            else if (constraint->SecondPos_Deprecated == PointPos::start
-                                     || constraint->SecondPos_Deprecated == PointPos::end) {
+                            else if (constraint->getPosId(1) == PointPos::start
+                                     || constraint->getPosId(1) == PointPos::end) {
                                 rtn = addTangentLineEndpointAtBSplineKnotConstraint(
                                     linegeoid,
-                                    constraint->SecondPos_Deprecated,
+                                    constraint->getPosId(1),
                                     bsplinegeoid,
                                     knotgeoId
                                 );
@@ -2244,12 +2237,12 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleAtPointConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
-                    constraint->Third_Deprecated,
-                    constraint->ThirdPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
+                    constraint->getGeoId(2),
+                    constraint->getPosId(2),
                     c.value,
                     constraint->Type,
                     c.driving
@@ -2258,7 +2251,7 @@ int Sketch::addConstraint(const Constraint* constraint)
             break;
         }
         case Distance:
-            if (constraint->SecondPos_Deprecated != PointPos::none) {  // point to point distance
+            if (constraint->getPosId(1) != PointPos::none) {  // point to point distance
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2268,20 +2261,20 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
                 rtn = addDistanceConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
                     c.value,
                     c.driving
                 );
             }
-            else if (constraint->FirstPos_Deprecated == PointPos::none
-                     && constraint->SecondPos_Deprecated == PointPos::none
-                     && constraint->Second_Deprecated != GeoEnum::GeoUndef
-                     && constraint->Third_Deprecated == GeoEnum::GeoUndef) {  // circle to circle,
-                                                                              // circle to
-                                                                              // arc, etc.
+            else if (constraint->getPosId(0) == PointPos::none
+                     && constraint->getPosId(1) == PointPos::none
+                     && constraint->getGeoId(1) != GeoEnum::GeoUndef
+                     && constraint->getGeoId(2) == GeoEnum::GeoUndef) {  // circle to circle,
+                                                                         // circle to
+                                                                         // arc, etc.
 
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
@@ -2292,14 +2285,14 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
                 rtn = addDistanceConstraint(
-                    constraint->First_Deprecated,
-                    constraint->Second_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getGeoId(1),
                     c.value,
                     c.driving
                 );
             }
-            else if (constraint->Second_Deprecated != GeoEnum::GeoUndef) {
-                if (constraint->FirstPos_Deprecated != PointPos::none) {  // point to line distance
+            else if (constraint->getGeoId(1) != GeoEnum::GeoUndef) {
+                if (constraint->getPosId(0) != PointPos::none) {  // point to line distance
                     c.value = new double(constraint->getValue());
                     if (c.driving) {
                         FixParameters.push_back(c.value);
@@ -2309,9 +2302,9 @@ int Sketch::addConstraint(const Constraint* constraint)
                         DrivenParameters.push_back(c.value);
                     }
                     rtn = addDistanceConstraint(
-                        constraint->First_Deprecated,
-                        constraint->FirstPos_Deprecated,
-                        constraint->Second_Deprecated,
+                        constraint->getGeoId(0),
+                        constraint->getPosId(0),
+                        constraint->getGeoId(1),
                         c.value,
                         c.driving
                     );
@@ -2327,11 +2320,11 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addDistanceConstraint(constraint->First_Deprecated, c.value, c.driving);
+                rtn = addDistanceConstraint(constraint->getGeoId(0), c.value, c.driving);
             }
             break;
         case Angle:
-            if (constraint->Third_Deprecated != GeoEnum::GeoUndef) {
+            if (constraint->getGeoId(2) != GeoEnum::GeoUndef) {
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2342,19 +2335,19 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleAtPointConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
-                    constraint->Third_Deprecated,
-                    constraint->ThirdPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
+                    constraint->getGeoId(2),
+                    constraint->getPosId(2),
                     c.value,
                     constraint->Type,
                     c.driving
                 );
             }
             // angle between two lines (with explicit start points)
-            else if (constraint->SecondPos_Deprecated != PointPos::none) {
+            else if (constraint->getPosId(1) != PointPos::none) {
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2365,15 +2358,15 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
                     c.value,
                     c.driving
                 );
             }
-            else if (constraint->Second_Deprecated != GeoEnum::GeoUndef) {  // angle between two lines
+            else if (constraint->getGeoId(1) != GeoEnum::GeoUndef) {  // angle between two lines
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2384,14 +2377,13 @@ int Sketch::addConstraint(const Constraint* constraint)
                 }
 
                 rtn = addAngleConstraint(
-                    constraint->First_Deprecated,
-                    constraint->Second_Deprecated,
+                    constraint->getGeoId(0),
+                    constraint->getGeoId(1),
                     c.value,
                     c.driving
                 );
             }
-            else if (constraint->First_Deprecated
-                     != GeoEnum::GeoUndef) {  // orientation angle of a line
+            else if (constraint->getGeoId(0) != GeoEnum::GeoUndef) {  // orientation angle of a line
                 c.value = new double(constraint->getValue());
                 if (c.driving) {
                     FixParameters.push_back(c.value);
@@ -2401,7 +2393,7 @@ int Sketch::addConstraint(const Constraint* constraint)
                     DrivenParameters.push_back(c.value);
                 }
 
-                rtn = addAngleConstraint(constraint->First_Deprecated, c.value, c.driving);
+                rtn = addAngleConstraint(constraint->getGeoId(0), c.value, c.driving);
             }
             break;
         case Radius: {
@@ -2414,7 +2406,7 @@ int Sketch::addConstraint(const Constraint* constraint)
                 DrivenParameters.push_back(c.value);
             }
 
-            rtn = addRadiusConstraint(constraint->First_Deprecated, c.value, c.driving);
+            rtn = addRadiusConstraint(constraint->getGeoId(0), c.value, c.driving);
             break;
         }
         case Diameter: {
@@ -2427,7 +2419,7 @@ int Sketch::addConstraint(const Constraint* constraint)
                 DrivenParameters.push_back(c.value);
             }
 
-            rtn = addDiameterConstraint(constraint->First_Deprecated, c.value, c.driving);
+            rtn = addDiameterConstraint(constraint->getGeoId(0), c.value, c.driving);
             break;
         }
         case Weight: {
@@ -2440,30 +2432,30 @@ int Sketch::addConstraint(const Constraint* constraint)
                 DrivenParameters.push_back(c.value);
             }
 
-            rtn = addRadiusConstraint(constraint->First_Deprecated, c.value, c.driving);
+            rtn = addRadiusConstraint(constraint->getGeoId(0), c.value, c.driving);
             break;
         }
         case Equal:
-            rtn = addEqualConstraint(constraint->First_Deprecated, constraint->Second_Deprecated);
+            rtn = addEqualConstraint(constraint->getGeoId(0), constraint->getGeoId(1));
             break;
         case Symmetric:
-            if (constraint->ThirdPos_Deprecated != PointPos::none) {
+            if (constraint->getPosId(2) != PointPos::none) {
                 rtn = addSymmetricConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
-                    constraint->Third_Deprecated,
-                    constraint->ThirdPos_Deprecated
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
+                    constraint->getGeoId(2),
+                    constraint->getPosId(2)
                 );
             }
             else {
                 rtn = addSymmetricConstraint(
-                    constraint->First_Deprecated,
-                    constraint->FirstPos_Deprecated,
-                    constraint->Second_Deprecated,
-                    constraint->SecondPos_Deprecated,
-                    constraint->Third_Deprecated
+                    constraint->getGeoId(0),
+                    constraint->getPosId(0),
+                    constraint->getGeoId(1),
+                    constraint->getPosId(1),
+                    constraint->getGeoId(2)
                 );
             }
             break;
@@ -2471,70 +2463,70 @@ int Sketch::addConstraint(const Constraint* constraint)
             switch (constraint->AlignmentType) {
                 case EllipseMajorDiameter:
                     rtn = addInternalAlignmentEllipseMajorDiameter(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 case EllipseMinorDiameter:
                     rtn = addInternalAlignmentEllipseMinorDiameter(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 case EllipseFocus1:
                     rtn = addInternalAlignmentEllipseFocus1(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 case EllipseFocus2:
                     rtn = addInternalAlignmentEllipseFocus2(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 case HyperbolaMajor:
                     rtn = addInternalAlignmentHyperbolaMajorDiameter(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 case HyperbolaMinor:
                     rtn = addInternalAlignmentHyperbolaMinorDiameter(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 case HyperbolaFocus:
                     rtn = addInternalAlignmentHyperbolaFocus(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 case ParabolaFocus:
                     rtn = addInternalAlignmentParabolaFocus(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 case BSplineControlPoint:
                     rtn = addInternalAlignmentBSplineControlPoint(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated,
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1),
                         constraint->InternalAlignmentIndex
                     );
                     break;
                 case BSplineKnotPoint:
                     rtn = addInternalAlignmentKnotPoint(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated,
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1),
                         constraint->InternalAlignmentIndex
                     );
                     break;
                 case ParabolaFocalAxis:
                     rtn = addInternalAlignmentParabolaFocalDistance(
-                        constraint->First_Deprecated,
-                        constraint->Second_Deprecated
+                        constraint->getGeoId(0),
+                        constraint->getGeoId(1)
                     );
                     break;
                 default:
@@ -2558,11 +2550,11 @@ int Sketch::addConstraint(const Constraint* constraint)
 
             // assert(constraint->ThirdPos==none); //will work anyway...
             rtn = addSnellsLawConstraint(
-                constraint->First_Deprecated,
-                constraint->FirstPos_Deprecated,
-                constraint->Second_Deprecated,
-                constraint->SecondPos_Deprecated,
-                constraint->Third_Deprecated,
+                constraint->getGeoId(0),
+                constraint->getPosId(0),
+                constraint->getGeoId(1),
+                constraint->getPosId(1),
+                constraint->getGeoId(2),
                 c.value,
                 c.secondvalue,
                 c.driving
@@ -2677,7 +2669,7 @@ void Sketch::getBlockedGeometry(
     for (auto it = ConstraintList.cbegin(); it != ConstraintList.cend(); ++it, ++i) {
         switch ((*it)->Type) {
             case Block: {
-                int geoid = (*it)->First_Deprecated;
+                int geoid = (*it)->getGeoId(0);
 
                 if (geoid >= 0 && geoid < int(blockedGeometry.size())) {
                     blockedGeometry[geoid] = true;
@@ -2695,12 +2687,12 @@ void Sketch::getBlockedGeometry(
     // if a GeoId is blocked and it is linked to Internal Alignment, then GeoIds linked via Internal
     // Alignment are also to be blocked
     for (auto idx : internalAlignmentConstraintIndex) {
-        if (blockedGeometry[ConstraintList[idx]->Second_Deprecated]) {
-            blockedGeometry[ConstraintList[idx]->First_Deprecated] = true;
+        if (blockedGeometry[ConstraintList[idx]->getGeoId(1)]) {
+            blockedGeometry[ConstraintList[idx]->getGeoId(0)] = true;
             // associated geometry gets the same blocking constraint index as the blocked element
-            geo2blockingconstraintindex[ConstraintList[idx]->First_Deprecated]
-                = geo2blockingconstraintindex[ConstraintList[idx]->Second_Deprecated];
-            internalAlignmentgeo.push_back(ConstraintList[idx]->First_Deprecated);
+            geo2blockingconstraintindex[ConstraintList[idx]->getGeoId(0)]
+                = geo2blockingconstraintindex[ConstraintList[idx]->getGeoId(1)];
+            internalAlignmentgeo.push_back(ConstraintList[idx]->getGeoId(0));
             unenforceableConstraints[idx] = true;
         }
     }
@@ -2711,8 +2703,8 @@ void Sketch::getBlockedGeometry(
             // additionally any further constraint on auxiliary elements linked via Internal
             // Alignment are also unenforceable.
             for (auto& iag : internalAlignmentgeo) {
-                if ((*it)->First_Deprecated == iag || (*it)->Second_Deprecated == iag
-                    || (*it)->Third_Deprecated == iag) {
+                if ((*it)->getGeoId(0) == iag || (*it)->getGeoId(1) == iag
+                    || (*it)->getGeoId(2) == iag) {
                     unenforceableConstraints[i] = true;
                 }
             }
@@ -2724,28 +2716,27 @@ void Sketch::getBlockedGeometry(
 
             // further, any constraint taking only one element, which is blocked is also
             // unenforceable
-            if ((*it)->Second_Deprecated == GeoEnum::GeoUndef
-                && (*it)->Third_Deprecated == GeoEnum::GeoUndef && (*it)->First_Deprecated >= 0) {
-                if (blockedGeometry[(*it)->First_Deprecated]
-                    && i < geo2blockingconstraintindex[(*it)->First_Deprecated]) {
+            if ((*it)->getGeoId(1) == GeoEnum::GeoUndef && (*it)->getGeoId(2) == GeoEnum::GeoUndef
+                && (*it)->getGeoId(0) >= 0) {
+                if (blockedGeometry[(*it)->getGeoId(0)]
+                    && i < geo2blockingconstraintindex[(*it)->getGeoId(0)]) {
                     unenforceableConstraints[i] = true;
                 }
             }
             // further any constraint on only two elements where both elements are blocked or one is
             // blocked and the other is an axis or external provided that the constraints precede
             // the last block constraint.
-            else if ((*it)->Third_Deprecated == GeoEnum::GeoUndef) {
-                if (((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated >= 0
-                     && blockedGeometry[(*it)->First_Deprecated]
-                     && blockedGeometry[(*it)->Second_Deprecated]
-                     && (i < geo2blockingconstraintindex[(*it)->First_Deprecated]
-                         || i < geo2blockingconstraintindex[(*it)->Second_Deprecated]))
-                    || ((*it)->First_Deprecated < 0 && (*it)->Second_Deprecated >= 0
-                        && blockedGeometry[(*it)->Second_Deprecated]
-                        && i < geo2blockingconstraintindex[(*it)->Second_Deprecated])
-                    || ((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated < 0
-                        && blockedGeometry[(*it)->First_Deprecated]
-                        && i < geo2blockingconstraintindex[(*it)->First_Deprecated])) {
+            else if ((*it)->getGeoId(2) == GeoEnum::GeoUndef) {
+                if (((*it)->getGeoId(0) >= 0 && (*it)->getGeoId(1) >= 0
+                     && blockedGeometry[(*it)->getGeoId(0)] && blockedGeometry[(*it)->getGeoId(1)]
+                     && (i < geo2blockingconstraintindex[(*it)->getGeoId(0)]
+                         || i < geo2blockingconstraintindex[(*it)->getGeoId(1)]))
+                    || ((*it)->getGeoId(0) < 0 && (*it)->getGeoId(1) >= 0
+                        && blockedGeometry[(*it)->getGeoId(1)]
+                        && i < geo2blockingconstraintindex[(*it)->getGeoId(1)])
+                    || ((*it)->getGeoId(0) >= 0 && (*it)->getGeoId(1) < 0
+                        && blockedGeometry[(*it)->getGeoId(0)]
+                        && i < geo2blockingconstraintindex[(*it)->getGeoId(0)])) {
                     unenforceableConstraints[i] = true;
                 }
             }
@@ -2754,37 +2745,33 @@ void Sketch::getBlockedGeometry(
             // elements where one is blocked and the other two are axis or external geo, provided
             // that the constraints precede the last block constraint.
             else {
-                if (((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated >= 0
-                     && (*it)->Third_Deprecated >= 0 && blockedGeometry[(*it)->First_Deprecated]
-                     && blockedGeometry[(*it)->Second_Deprecated]
-                     && blockedGeometry[(*it)->Third_Deprecated]
-                     && (i < geo2blockingconstraintindex[(*it)->First_Deprecated]
-                         || i < geo2blockingconstraintindex[(*it)->Second_Deprecated]
-                         || i < geo2blockingconstraintindex[(*it)->Third_Deprecated]))
-                    || ((*it)->First_Deprecated < 0 && (*it)->Second_Deprecated >= 0
-                        && (*it)->Third_Deprecated >= 0 && blockedGeometry[(*it)->Second_Deprecated]
-                        && blockedGeometry[(*it)->Third_Deprecated]
-                        && (i < geo2blockingconstraintindex[(*it)->Second_Deprecated]
-                            || i < geo2blockingconstraintindex[(*it)->Third_Deprecated]))
-                    || ((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated < 0
-                        && (*it)->Third_Deprecated >= 0 && blockedGeometry[(*it)->First_Deprecated]
-                        && blockedGeometry[(*it)->Third_Deprecated]
-                        && (i < geo2blockingconstraintindex[(*it)->First_Deprecated]
-                            || i < geo2blockingconstraintindex[(*it)->Third_Deprecated]))
-                    || ((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated >= 0
-                        && (*it)->Third_Deprecated < 0 && blockedGeometry[(*it)->First_Deprecated]
-                        && blockedGeometry[(*it)->Second_Deprecated]
-                        && (i < geo2blockingconstraintindex[(*it)->First_Deprecated]
-                            || i < geo2blockingconstraintindex[(*it)->Second_Deprecated]))
-                    || ((*it)->First_Deprecated >= 0 && (*it)->Second_Deprecated < 0
-                        && (*it)->Third_Deprecated < 0 && blockedGeometry[(*it)->First_Deprecated]
-                        && i < geo2blockingconstraintindex[(*it)->First_Deprecated])
-                    || ((*it)->First_Deprecated < 0 && (*it)->Second_Deprecated >= 0
-                        && (*it)->Third_Deprecated < 0 && blockedGeometry[(*it)->Second_Deprecated]
-                        && i < geo2blockingconstraintindex[(*it)->Second_Deprecated])
-                    || ((*it)->First_Deprecated < 0 && (*it)->Second_Deprecated < 0
-                        && (*it)->Third_Deprecated >= 0 && blockedGeometry[(*it)->Third_Deprecated]
-                        && i < geo2blockingconstraintindex[(*it)->Third_Deprecated])) {
+                if (((*it)->getGeoId(0) >= 0 && (*it)->getGeoId(1) >= 0 && (*it)->getGeoId(2) >= 0
+                     && blockedGeometry[(*it)->getGeoId(0)] && blockedGeometry[(*it)->getGeoId(1)]
+                     && blockedGeometry[(*it)->getGeoId(2)]
+                     && (i < geo2blockingconstraintindex[(*it)->getGeoId(0)]
+                         || i < geo2blockingconstraintindex[(*it)->getGeoId(1)]
+                         || i < geo2blockingconstraintindex[(*it)->getGeoId(2)]))
+                    || ((*it)->getGeoId(0) < 0 && (*it)->getGeoId(1) >= 0 && (*it)->getGeoId(2) >= 0
+                        && blockedGeometry[(*it)->getGeoId(1)] && blockedGeometry[(*it)->getGeoId(2)]
+                        && (i < geo2blockingconstraintindex[(*it)->getGeoId(1)]
+                            || i < geo2blockingconstraintindex[(*it)->getGeoId(2)]))
+                    || ((*it)->getGeoId(0) >= 0 && (*it)->getGeoId(1) < 0 && (*it)->getGeoId(2) >= 0
+                        && blockedGeometry[(*it)->getGeoId(0)] && blockedGeometry[(*it)->getGeoId(2)]
+                        && (i < geo2blockingconstraintindex[(*it)->getGeoId(0)]
+                            || i < geo2blockingconstraintindex[(*it)->getGeoId(2)]))
+                    || ((*it)->getGeoId(0) >= 0 && (*it)->getGeoId(1) >= 0 && (*it)->getGeoId(2) < 0
+                        && blockedGeometry[(*it)->getGeoId(0)] && blockedGeometry[(*it)->getGeoId(1)]
+                        && (i < geo2blockingconstraintindex[(*it)->getGeoId(0)]
+                            || i < geo2blockingconstraintindex[(*it)->getGeoId(1)]))
+                    || ((*it)->getGeoId(0) >= 0 && (*it)->getGeoId(1) < 0 && (*it)->getGeoId(2) < 0
+                        && blockedGeometry[(*it)->getGeoId(0)]
+                        && i < geo2blockingconstraintindex[(*it)->getGeoId(0)])
+                    || ((*it)->getGeoId(0) < 0 && (*it)->getGeoId(1) >= 0 && (*it)->getGeoId(2) < 0
+                        && blockedGeometry[(*it)->getGeoId(1)]
+                        && i < geo2blockingconstraintindex[(*it)->getGeoId(1)])
+                    || ((*it)->getGeoId(0) < 0 && (*it)->getGeoId(1) < 0 && (*it)->getGeoId(2) >= 0
+                        && blockedGeometry[(*it)->getGeoId(2)]
+                        && i < geo2blockingconstraintindex[(*it)->getGeoId(2)])) {
 
                     unenforceableConstraints[i] = true;
                 }

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -291,10 +291,10 @@ struct PointConstraints
                 for (auto& coincidence : allcoincid) {
                     VertexIds v1;
                     VertexIds v2;
-                    v1.GeoId = coincidence->First_Deprecated;
-                    v1.PosId = coincidence->FirstPos_Deprecated;
-                    v2.GeoId = coincidence->Second_Deprecated;
-                    v2.PosId = coincidence->SecondPos_Deprecated;
+                    v1.GeoId = coincidence->getGeoId(0);
+                    v1.PosId = coincidence->getPosId(0);
+                    v2.GeoId = coincidence->getGeoId(1);
+                    v2.PosId = coincidence->getPosId(1);
 
                     // Look if coincident vertices are in the group of adjacent ones we are
                     // processing
@@ -765,10 +765,10 @@ int SketchAnalysis::detectMissingEqualityConstraints(double precision)
         if (it->Type == Sketcher::Equal) {
             ConstraintIds id {
                 Base::Vector3d {},
-                it->First_Deprecated,
-                it->Second_Deprecated,
-                it->FirstPos_Deprecated,
-                it->SecondPos_Deprecated,
+                it->getGeoId(0),
+                it->getGeoId(1),
+                it->getPosId(0),
+                it->getPosId(1),
                 it->Type
             };
 

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -291,10 +291,10 @@ struct PointConstraints
                 for (auto& coincidence : allcoincid) {
                     VertexIds v1;
                     VertexIds v2;
-                    v1.GeoId = coincidence->First;
-                    v1.PosId = coincidence->FirstPos;
-                    v2.GeoId = coincidence->Second;
-                    v2.PosId = coincidence->SecondPos;
+                    v1.GeoId = coincidence->First_Deprecated;
+                    v1.PosId = coincidence->FirstPos_Deprecated;
+                    v2.GeoId = coincidence->Second_Deprecated;
+                    v2.PosId = coincidence->SecondPos_Deprecated;
 
                     // Look if coincident vertices are in the group of adjacent ones we are
                     // processing
@@ -609,10 +609,10 @@ Sketcher::Constraint* SketchAnalysis::create(const ConstraintIds& id)
 {
     auto c = new Sketcher::Constraint();
     c->Type = id.Type;
-    c->First = id.First;
-    c->Second = id.Second;
-    c->FirstPos = id.FirstPos;
-    c->SecondPos = id.SecondPos;
+    c->First_Deprecated = id.First;
+    c->Second_Deprecated = id.Second;
+    c->FirstPos_Deprecated = id.FirstPos;
+    c->SecondPos_Deprecated = id.SecondPos;
     return c;
 }
 
@@ -763,8 +763,14 @@ int SketchAnalysis::detectMissingEqualityConstraints(double precision)
     std::vector<Sketcher::Constraint*> constraint = sketch->Constraints.getValues();
     for (auto it : constraint) {
         if (it->Type == Sketcher::Equal) {
-            ConstraintIds
-                id {Base::Vector3d {}, it->First, it->Second, it->FirstPos, it->SecondPos, it->Type};
+            ConstraintIds id {
+                Base::Vector3d {},
+                it->First_Deprecated,
+                it->Second_Deprecated,
+                it->FirstPos_Deprecated,
+                it->SecondPos_Deprecated,
+                it->Type
+            };
 
             auto pos = std::find_if(equallines.begin(), equallines.end(), Constraint_Equal(id));
 

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -609,8 +609,8 @@ Sketcher::Constraint* SketchAnalysis::create(const ConstraintIds& id)
 {
     auto c = new Sketcher::Constraint();
     c->Type = id.Type;
-    c->First_Deprecated = id.First;
-    c->Second_Deprecated = id.Second;
+    c->setGeoId(0, id.First);
+    c->setGeoId(1, id.Second);
     c->FirstPos_Deprecated = id.FirstPos;
     c->SecondPos_Deprecated = id.SecondPos;
     return c;

--- a/src/Mod/Sketcher/App/SketchAnalysis.cpp
+++ b/src/Mod/Sketcher/App/SketchAnalysis.cpp
@@ -611,8 +611,8 @@ Sketcher::Constraint* SketchAnalysis::create(const ConstraintIds& id)
     c->Type = id.Type;
     c->setGeoId(0, id.First);
     c->setGeoId(1, id.Second);
-    c->FirstPos_Deprecated = id.FirstPos;
-    c->SecondPos_Deprecated = id.SecondPos;
+    c->setPosId(0, id.FirstPos);
+    c->setPosId(1, id.SecondPos);
     return c;
 }
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1301,7 +1301,7 @@ void SketchObject::synchroniseGeometryState()
         bool constraintBlockedState = false;
 
         for (auto cstr : Constraints.getValues()) {
-            if (cstr->First == int(i)) {
+            if (cstr->First_Deprecated == int(i)) {
                 getInternalTypeState(cstr, constraintInternalAlignment);
                 getBlockedState(cstr, constraintBlockedState);
             }
@@ -1407,8 +1407,8 @@ void SketchObject::migrateSketch()
                 continue;
             }
 
-            int circleGeoId = c->First;
-            int bSplineGeoId = c->Second;
+            int circleGeoId = c->First_Deprecated;
+            int bSplineGeoId = c->Second_Deprecated;
 
             auto bsp = static_cast<const Part::GeomBSplineCurve*>(getGeometry(bSplineGeoId));
 
@@ -1419,7 +1419,8 @@ void SketchObject::migrateSketch()
             }
 
             for (auto& ccp : Constraints.getValues()) {
-                if ((ccp->Type == Radius || ccp->Type == Diameter) && ccp->First == circleGeoId) {
+                if ((ccp->Type == Radius || ccp->Type == Diameter)
+                    && ccp->First_Deprecated == circleGeoId) {
                     ccp->Type = Weight;
                     ccp->setValue(weights[c->InternalAlignmentIndex]);
                 }
@@ -1478,7 +1479,7 @@ void SketchObject::migrateSketch()
     // populate parabola and focus geoids
     for (const auto& c : constraints) {
         if (c->Type == InternalAlignment && c->AlignmentType == ParabolaFocus) {
-            parabolaGeoId2FocusGeoId[c->Second] = {c->First};
+            parabolaGeoId2FocusGeoId[c->Second_Deprecated] = {c->First_Deprecated};
         }
     }
 
@@ -1527,10 +1528,10 @@ void SketchObject::migrateSketch()
             = std::ranges::any_of(axisGeoId2ParabolaGeoId, [&](const auto& pair) {
                   auto parabolaGeoId = pair.second;
                   auto axisgeoid = pair.first;
-                  return (c->First == axisgeoid && c->Second == parabolaGeoId
-                          && c->SecondPos == PointPos::mid)
-                      || (c->Second == axisgeoid && c->First == parabolaGeoId
-                          && c->FirstPos == PointPos::mid);
+                  return (c->First_Deprecated == axisgeoid && c->Second_Deprecated == parabolaGeoId
+                          && c->SecondPos_Deprecated == PointPos::mid)
+                      || (c->Second_Deprecated == axisgeoid && c->First_Deprecated == parabolaGeoId
+                          && c->FirstPos_Deprecated == PointPos::mid);
               });
 
         if (axisMajorCoincidentFound) {
@@ -1543,20 +1544,20 @@ void SketchObject::migrateSketch()
             auto parabolaGeoId = pair.second;
             auto axisgeoid = pair.first;
             auto focusGeoId = parabolaGeoId2FocusGeoId[parabolaGeoId];
-            return (c->First == axisgeoid && c->Second == focusGeoId
-                    && c->SecondPos == PointPos::start)
-                || (c->Second == axisgeoid && c->First == focusGeoId
-                    && c->FirstPos == PointPos::start);
+            return (c->First_Deprecated == axisgeoid && c->Second_Deprecated == focusGeoId
+                    && c->SecondPos_Deprecated == PointPos::start)
+                || (c->Second_Deprecated == axisgeoid && c->First_Deprecated == focusGeoId
+                    && c->FirstPos_Deprecated == PointPos::start);
         });
 
         if (focusCoincidentFound != axisGeoId2ParabolaGeoId.end()) {
             auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = Sketcher::ParabolaFocalAxis;
-            newConstr->First = focusCoincidentFound->first;  // axis geoid
-            newConstr->FirstPos = Sketcher::PointPos::none;
-            newConstr->Second = focusCoincidentFound->second;  // parabola geoid
-            newConstr->SecondPos = Sketcher::PointPos::none;
+            newConstr->First_Deprecated = focusCoincidentFound->first;  // axis geoid
+            newConstr->FirstPos_Deprecated = Sketcher::PointPos::none;
+            newConstr->Second_Deprecated = focusCoincidentFound->second;  // parabola geoid
+            newConstr->SecondPos_Deprecated = Sketcher::PointPos::none;
             newConstraints.push_back(newConstr);
 
             addGeometryState(newConstr);
@@ -1738,8 +1739,8 @@ SketchObject::getHigherElements(const char *element, bool silent) const
                     continue;
                 }
                 for (int i=0; i<2; ++i) {
-                    int geoid = i ? cstr->Second : cstr->First;
-                    const Sketcher::PointPos &pos = i ? cstr->SecondPos : cstr->FirstPos;
+                    int geoid = i ? cstr->Second_Deprecated : cstr->First_Deprecated;
+                    const Sketcher::PointPos &pos = i ? cstr->SecondPos_Deprecated : cstr->FirstPos_Deprecated;
                     if(geoid >= 0 && index == getSolvedSketch().getPointId(geoid, pos) + 1)
                         res.push_back(Data::IndexedName::fromConst("Constraint", n));
                 };

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1554,9 +1554,9 @@ void SketchObject::migrateSketch()
             auto* newConstr = new Sketcher::Constraint();
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = Sketcher::ParabolaFocalAxis;
-            newConstr->First_Deprecated = focusCoincidentFound->first;  // axis geoid
+            newConstr->setGeoId(0, focusCoincidentFound->first);  // axis geoid
             newConstr->FirstPos_Deprecated = Sketcher::PointPos::none;
-            newConstr->Second_Deprecated = focusCoincidentFound->second;  // parabola geoid
+            newConstr->setGeoId(1, focusCoincidentFound->second);  // parabola geoid
             newConstr->SecondPos_Deprecated = Sketcher::PointPos::none;
             newConstraints.push_back(newConstr);
 

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1301,7 +1301,7 @@ void SketchObject::synchroniseGeometryState()
         bool constraintBlockedState = false;
 
         for (auto cstr : Constraints.getValues()) {
-            if (cstr->First_Deprecated == int(i)) {
+            if (cstr->getGeoId(0) == int(i)) {
                 getInternalTypeState(cstr, constraintInternalAlignment);
                 getBlockedState(cstr, constraintBlockedState);
             }
@@ -1407,8 +1407,8 @@ void SketchObject::migrateSketch()
                 continue;
             }
 
-            int circleGeoId = c->First_Deprecated;
-            int bSplineGeoId = c->Second_Deprecated;
+            int circleGeoId = c->getGeoId(0);
+            int bSplineGeoId = c->getGeoId(1);
 
             auto bsp = static_cast<const Part::GeomBSplineCurve*>(getGeometry(bSplineGeoId));
 
@@ -1420,7 +1420,7 @@ void SketchObject::migrateSketch()
 
             for (auto& ccp : Constraints.getValues()) {
                 if ((ccp->Type == Radius || ccp->Type == Diameter)
-                    && ccp->First_Deprecated == circleGeoId) {
+                    && ccp->getGeoId(0) == circleGeoId) {
                     ccp->Type = Weight;
                     ccp->setValue(weights[c->InternalAlignmentIndex]);
                 }
@@ -1479,7 +1479,7 @@ void SketchObject::migrateSketch()
     // populate parabola and focus geoids
     for (const auto& c : constraints) {
         if (c->Type == InternalAlignment && c->AlignmentType == ParabolaFocus) {
-            parabolaGeoId2FocusGeoId[c->Second_Deprecated] = {c->First_Deprecated};
+            parabolaGeoId2FocusGeoId[c->getGeoId(1)] = {c->getGeoId(0)};
         }
     }
 
@@ -1528,10 +1528,10 @@ void SketchObject::migrateSketch()
             = std::ranges::any_of(axisGeoId2ParabolaGeoId, [&](const auto& pair) {
                   auto parabolaGeoId = pair.second;
                   auto axisgeoid = pair.first;
-                  return (c->First_Deprecated == axisgeoid && c->Second_Deprecated == parabolaGeoId
-                          && c->SecondPos_Deprecated == PointPos::mid)
-                      || (c->Second_Deprecated == axisgeoid && c->First_Deprecated == parabolaGeoId
-                          && c->FirstPos_Deprecated == PointPos::mid);
+                  return (c->getGeoId(0) == axisgeoid && c->getGeoId(1) == parabolaGeoId
+                          && c->getPosId(1) == PointPos::mid)
+                      || (c->getGeoId(1) == axisgeoid && c->getGeoId(0) == parabolaGeoId
+                          && c->getPosId(0) == PointPos::mid);
               });
 
         if (axisMajorCoincidentFound) {
@@ -1544,10 +1544,10 @@ void SketchObject::migrateSketch()
             auto parabolaGeoId = pair.second;
             auto axisgeoid = pair.first;
             auto focusGeoId = parabolaGeoId2FocusGeoId[parabolaGeoId];
-            return (c->First_Deprecated == axisgeoid && c->Second_Deprecated == focusGeoId
-                    && c->SecondPos_Deprecated == PointPos::start)
-                || (c->Second_Deprecated == axisgeoid && c->First_Deprecated == focusGeoId
-                    && c->FirstPos_Deprecated == PointPos::start);
+            return (c->getGeoId(0) == axisgeoid && c->getGeoId(1) == focusGeoId
+                    && c->getPosId(1) == PointPos::start)
+                || (c->getGeoId(1) == axisgeoid && c->getGeoId(0) == focusGeoId
+                    && c->getPosId(0) == PointPos::start);
         });
 
         if (focusCoincidentFound != axisGeoId2ParabolaGeoId.end()) {
@@ -1739,8 +1739,8 @@ SketchObject::getHigherElements(const char *element, bool silent) const
                     continue;
                 }
                 for (int i=0; i<2; ++i) {
-                    int geoid = i ? cstr->Second_Deprecated : cstr->First_Deprecated;
-                    const Sketcher::PointPos &pos = i ? cstr->SecondPos_Deprecated : cstr->FirstPos_Deprecated;
+                    int geoid = i ? cstr->getGeoId(1) : cstr->getGeoId(0);
+                    const Sketcher::PointPos &pos = i ? cstr->getPosId(1) : cstr->getPosId(0);
                     if(geoid >= 0 && index == getSolvedSketch().getPointId(geoid, pos) + 1)
                         res.push_back(Data::IndexedName::fromConst("Constraint", n));
                 };

--- a/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/src/Mod/Sketcher/App/SketchObject.cpp
@@ -1555,9 +1555,9 @@ void SketchObject::migrateSketch()
             newConstr->Type = Sketcher::InternalAlignment;
             newConstr->AlignmentType = Sketcher::ParabolaFocalAxis;
             newConstr->setGeoId(0, focusCoincidentFound->first);  // axis geoid
-            newConstr->FirstPos_Deprecated = Sketcher::PointPos::none;
+            newConstr->setPosId(0, Sketcher::PointPos::none);
             newConstr->setGeoId(1, focusCoincidentFound->second);  // parabola geoid
-            newConstr->SecondPos_Deprecated = Sketcher::PointPos::none;
+            newConstr->setPosId(1, Sketcher::PointPos::none);
             newConstraints.push_back(newConstr);
 
             addGeometryState(newConstr);

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -1058,15 +1058,15 @@ int SketchObject::delConstraintOnPoint(int geoId, PointPos posId, bool onlyCoinc
     };
 
     auto transferToReplacement =
-        [&geoId, &posId, &replaceGeoId, &replacePosId](int& constrGeoId, PointPos& constrPosId) {
+        [&geoId, &posId, &replaceGeoId, &replacePosId](Constraint* constr, size_t index) {
             if (replaceGeoId == GeoEnum::GeoUndef) {
                 return false;
             }
-            if (geoId != constrGeoId || posId != constrPosId) {
+            auto element = constr->getElement(index);
+            if (element.GeoId != geoId || element.Pos != posId) {
                 return false;
             }
-            constrGeoId = replaceGeoId;
-            constrPosId = replacePosId;
+            constr->setElement(index, GeoElementId(replaceGeoId, replacePosId));
             return true;
         };
 
@@ -1094,13 +1094,10 @@ int SketchObject::delConstraintOnPoint(int geoId, PointPos posId, bool onlyCoinc
             case Sketcher::Distance:
             case Sketcher::DistanceX:
             case Sketcher::DistanceY: {
-                return (
-                    transferToReplacement(constr->First_Deprecated, constr->FirstPos_Deprecated)
-                    || transferToReplacement(constr->Second_Deprecated, constr->SecondPos_Deprecated)
-                );
+                return (transferToReplacement(constr, 0) || transferToReplacement(constr, 1));
             }
             case Sketcher::PointOnObject: {
-                return transferToReplacement(constr->First_Deprecated, constr->FirstPos_Deprecated);
+                return transferToReplacement(constr, 0);
             }
             case Sketcher::Tangent:
             case Sketcher::Perpendicular: {

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -1199,18 +1199,14 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
     // Constrain the vertex to the two lines
     auto* cornerToLine1 = new Sketcher::Constraint();
     cornerToLine1->Type = Sketcher::PointOnObject;
-    cornerToLine1->First_Deprecated = originalCornerId;
-    cornerToLine1->FirstPos_Deprecated = PointPos::start;
-    cornerToLine1->Second_Deprecated = geoId1;
-    cornerToLine1->SecondPos_Deprecated = PointPos::none;
+    cornerToLine1->setElement(0, GeoElementId(originalCornerId, PointPos::start));
+    cornerToLine1->setElement(1, GeoElementId(geoId1, PointPos::none));
     addConstraint(cornerToLine1);
     delete cornerToLine1;
     auto* cornerToLine2 = new Sketcher::Constraint();
     cornerToLine2->Type = Sketcher::PointOnObject;
-    cornerToLine2->First_Deprecated = originalCornerId;
-    cornerToLine2->FirstPos_Deprecated = PointPos::start;
-    cornerToLine2->Second_Deprecated = geoId2;
-    cornerToLine2->SecondPos_Deprecated = PointPos::none;
+    cornerToLine2->setElement(0, GeoElementId(originalCornerId, PointPos::start));
+    cornerToLine2->setElement(1, GeoElementId(geoId2, PointPos::none));
     addConstraint(cornerToLine2);
     delete cornerToLine2;
 
@@ -1250,13 +1246,11 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
             // of the line and the new corner
             if (line1First) {
                 c->FirstPos_Deprecated = (posId1 == PointPos::start) ? PointPos::end : PointPos::start;
-                c->Second_Deprecated = originalCornerId;
-                c->SecondPos_Deprecated = PointPos::start;
+                c->setElement(1, GeoElementId(originalCornerId, PointPos::start));
             }
             if (line2First) {
                 c->FirstPos_Deprecated = (posId2 == PointPos::start) ? PointPos::end : PointPos::start;
-                c->Second_Deprecated = originalCornerId;
-                c->SecondPos_Deprecated = PointPos::start;
+                c->setElement(1, GeoElementId(originalCornerId, PointPos::start));
             }
         }
         else if (c->Type == Sketcher::PointOnObject) {
@@ -1285,16 +1279,13 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
 
         // For any constraint not passing previous conditions, transfer to the new point if relevant
         if (point1First || point2First) {
-            c->First_Deprecated = originalCornerId;
-            c->FirstPos_Deprecated = PointPos::start;
+            c->setElement(0, GeoElementId(originalCornerId, PointPos::start));
         }
         else if (point1Second || point2Second) {
-            c->Second_Deprecated = originalCornerId;
-            c->SecondPos_Deprecated = PointPos::start;
+            c->setElement(1, GeoElementId(originalCornerId, PointPos::start));
         }
         else if (point1Third || point2Third) {
-            c->Third_Deprecated = originalCornerId;
-            c->ThirdPos_Deprecated = PointPos::start;
+            c->setElement(2, GeoElementId(originalCornerId, PointPos::start));
         }
 
         // Default: keep all other constraints
@@ -1381,12 +1372,9 @@ std::unique_ptr<Constraint> SketchObject::createConstraint(
     auto newConstr = std::make_unique<Sketcher::Constraint>();
 
     newConstr->Type = constrType;
-    newConstr->First_Deprecated = firstGeoId;
-    newConstr->FirstPos_Deprecated = firstPos;
-    newConstr->Second_Deprecated = secondGeoId;
-    newConstr->SecondPos_Deprecated = secondPos;
-    newConstr->Third_Deprecated = thirdGeoId;
-    newConstr->ThirdPos_Deprecated = thirdPos;
+    newConstr->setElement(0, GeoElementId(firstGeoId, firstPos));
+    newConstr->setElement(1, GeoElementId(secondGeoId, secondPos));
+    newConstr->setElement(2, GeoElementId(thirdGeoId, thirdPos));
     return newConstr;
 }
 
@@ -1625,10 +1613,8 @@ bool SketchObject::deriveConstraintsForPieces(
             if (con->FirstPos_Deprecated == PointPos::none
                 && con->SecondPos_Deprecated == PointPos::none && newIds.size() > 1) {
                 Constraint* dist = con->copy();
-                dist->First_Deprecated = newIds.front();
-                dist->FirstPos_Deprecated = PointPos::start;
-                dist->Second_Deprecated = newIds.back();
-                dist->SecondPos_Deprecated = PointPos::end;
+                dist->setElement(0, GeoElementId(newIds.front(), PointPos::start));
+                dist->setElement(1, GeoElementId(newIds.back(), PointPos::end));
                 newConstraints.push_back(dist);
                 return true;
             }
@@ -1657,10 +1643,8 @@ bool SketchObject::deriveConstraintsForPieces(
                 if ((newGeoFirstParam - conParam) <= Precision::PApproximation()
                     && (conParam - newGeoLastParam) <= Precision::PApproximation()) {
                     Constraint* trans = con->copy();
-                    trans->First_Deprecated = conId;
-                    trans->FirstPos_Deprecated = conPos;
-                    trans->Second_Deprecated = newIds[i];
-                    trans->SecondPos_Deprecated = PointPos::none;
+                    trans->setElement(0, GeoElementId(conId, conPos));
+                    trans->setElement(1, GeoElementId(newIds[i], PointPos::none));
                     newConstraints.push_back(trans);
                     return true;
                 }
@@ -2543,16 +2527,13 @@ int SketchObject::port_reversedExternalArcs(bool justAnalyze)
             // Propagate the fix made on temp vars to the constraint
             switch (ig) {
                 case 1:
-                    constNew->First_Deprecated = geoId;
-                    constNew->FirstPos_Deprecated = posId;
+                    constNew->setElement(0, GeoElementId(geoId, posId));
                     break;
                 case 2:
-                    constNew->Second_Deprecated = geoId;
-                    constNew->SecondPos_Deprecated = posId;
+                    constNew->setElement(1, GeoElementId(geoId, posId));
                     break;
                 case 3:
-                    constNew->Third_Deprecated = geoId;
-                    constNew->ThirdPos_Deprecated = posId;
+                    constNew->setElement(2, GeoElementId(geoId, posId));
                     break;
             }
         }

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -281,7 +281,7 @@ int SketchObject::testDrivingChange(int ConstrId, bool isdriving)
     if (!vals[ConstrId]->isDimensional())
         return -2;
 
-    if (!(vals[ConstrId]->First_Deprecated >= 0 || vals[ConstrId]->Second_Deprecated >= 0 || vals[ConstrId]->Third_Deprecated >= 0)
+    if (!(vals[ConstrId]->getGeoId(0) >= 0 || vals[ConstrId]->getGeoId(1) >= 0 || vals[ConstrId]->getGeoId(2) >= 0)
         && isdriving) {
         // a constraint that does not have at least one element as not-external-geometry can never
         // be driving.
@@ -516,9 +516,9 @@ int SketchObject::moveDatumsToEnd()
 
 void SketchObject::reverseAngleConstraintToSupplementary(Constraint* constr, int constNum)
 {
-    std::swap(constr->First_Deprecated, constr->Second_Deprecated);
-    std::swap(constr->FirstPos_Deprecated, constr->SecondPos_Deprecated);
-    constr->setPosId(0, (constr->FirstPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
+    std::swap(constr->getGeoId(0), constr->getGeoId(1));
+    std::swap(constr->getPosId(0), constr->getPosId(1));
+    constr->setPosId(0, (constr->getPosId(0) == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
 
     // Edit the expression if any, else modify constraint value directly
     if (constraintHasExpression(constNum)) {
@@ -533,8 +533,8 @@ void SketchObject::reverseAngleConstraintToSupplementary(Constraint* constr, int
 
 void SketchObject::inverseAngleConstraint(Constraint* constr)
 {
-    constr->setPosId(0, (constr->FirstPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
-    constr->setPosId(1, (constr->SecondPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
+    constr->setPosId(0, (constr->getPosId(0) == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
+    constr->setPosId(1, (constr->getPosId(1) == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
 }
 
 bool SketchObject::constraintHasExpression(int constNum) const
@@ -824,11 +824,11 @@ void SketchObject::addGeometryState(const Constraint* cstr) const
     bool constraintBlockedState = false;
 
     if (getInternalTypeState(cstr, constraintInternalAlignment)) {
-        auto gf = GeometryFacade::getFacade(vals[cstr->First_Deprecated]);
+        auto gf = GeometryFacade::getFacade(vals[cstr->getGeoId(0)]);
         gf->setInternalType(constraintInternalAlignment);
     }
     else if (getBlockedState(cstr, constraintBlockedState)) {
-        auto gf = GeometryFacade::getFacade(vals[cstr->First_Deprecated]);
+        auto gf = GeometryFacade::getFacade(vals[cstr->getGeoId(0)]);
         gf->setBlocked(constraintBlockedState);
     }
 }
@@ -839,13 +839,13 @@ void SketchObject::removeGeometryState(const Constraint* cstr) const
 
     // Assign correct Internal Geometry Type (see SketchGeometryExtension)
     if (cstr->Type == InternalAlignment) {
-        auto gf = GeometryFacade::getFacade(vals[cstr->First_Deprecated]);
+        auto gf = GeometryFacade::getFacade(vals[cstr->getGeoId(0)]);
         gf->setInternalType(InternalType::None);
     }
 
     // Assign Blocked geometry mode (see SketchGeometryExtension)
     if (cstr->Type == Block) {
-        auto gf = GeometryFacade::getFacade(vals[cstr->First_Deprecated]);
+        auto gf = GeometryFacade::getFacade(vals[cstr->getGeoId(0)]);
         gf->setBlocked(false);
     }
 }
@@ -1047,13 +1047,13 @@ int SketchObject::delConstraintOnPoint(int geoId, PointPos posId, bool onlyCoinc
             return;
         }
 
-        if ((*it)->First_Deprecated == geoId && (*it)->FirstPos_Deprecated == posId) {
-            replaceGeoId = (*it)->Second_Deprecated;
-            replacePosId = (*it)->SecondPos_Deprecated;
+        if ((*it)->getGeoId(0) == geoId && (*it)->getPosId(0) == posId) {
+            replaceGeoId = (*it)->getGeoId(1);
+            replacePosId = (*it)->getPosId(1);
         }
         else {
-            replaceGeoId = (*it)->First_Deprecated;
-            replacePosId = (*it)->FirstPos_Deprecated;
+            replaceGeoId = (*it)->getGeoId(0);
+            replacePosId = (*it)->getPosId(0);
         }
     };
 
@@ -1124,8 +1124,8 @@ int SketchObject::delConstraintOnPoint(int geoId, PointPos posId, bool onlyCoinc
             // with the given point
             const bool isOneOfDistanceTypes = constr->Type == Sketcher::Distance
                 || constr->Type == Sketcher::DistanceX || constr->Type == Sketcher::DistanceY;
-            const bool involvesEntireCurve = constr->First_Deprecated == geoId
-                && constr->FirstPos_Deprecated == PointPos::none;
+            const bool involvesEntireCurve = constr->getGeoId(0) == geoId
+                && constr->getPosId(0) == PointPos::none;
             const bool isPosAnEndpoint = posId == PointPos::start || posId == PointPos::end;
             if (isOneOfDistanceTypes && involvesEntireCurve && isPosAnEndpoint) {
                 continue;
@@ -1168,8 +1168,8 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
             if (c->Type != Sketcher::Distance && c->Type != Sketcher::Equal) {
                 continue;
             }
-            bool line1 = c->First_Deprecated == geoId1 && c->FirstPos_Deprecated == PointPos::none;
-            bool line2 = c->First_Deprecated == geoId2 && c->FirstPos_Deprecated == PointPos::none;
+            bool line1 = c->getGeoId(0) == geoId1 && c->getPosId(0) == PointPos::none;
+            bool line2 = c->getGeoId(0) == geoId2 && c->getPosId(0) == PointPos::none;
             if (line1 || line2) {
                 deleteme.push_back(i);
             }
@@ -1213,16 +1213,16 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
     std::vector<Constraint*> newConstraints;
     for (auto c : this->Constraints.getValues()) {
         // Keep track of whether the affected lines and endpoints appear in this constraint
-        bool point1First = c->First_Deprecated == geoId1 && c->FirstPos_Deprecated == posId1;
-        bool point2First = c->First_Deprecated == geoId2 && c->FirstPos_Deprecated == posId2;
-        bool point1Second = c->Second_Deprecated == geoId1 && c->SecondPos_Deprecated == posId1;
-        bool point2Second = c->Second_Deprecated == geoId2 && c->SecondPos_Deprecated == posId2;
-        bool point1Third = c->Third_Deprecated == geoId1 && c->ThirdPos_Deprecated == posId1;
-        bool point2Third = c->Third_Deprecated == geoId2 && c->ThirdPos_Deprecated == posId2;
-        bool line1First = c->First_Deprecated == geoId1 && c->FirstPos_Deprecated == PointPos::none;
-        bool line2First = c->First_Deprecated == geoId2 && c->FirstPos_Deprecated == PointPos::none;
-        bool line1Second = c->Second_Deprecated == geoId1 && c->SecondPos_Deprecated == PointPos::none;
-        bool line2Second = c->Second_Deprecated == geoId2 && c->SecondPos_Deprecated == PointPos::none;
+        bool point1First = c->getGeoId(0) == geoId1 && c->getPosId(0) == posId1;
+        bool point2First = c->getGeoId(0) == geoId2 && c->getPosId(0) == posId2;
+        bool point1Second = c->getGeoId(1) == geoId1 && c->getPosId(1) == posId1;
+        bool point2Second = c->getGeoId(1) == geoId2 && c->getPosId(1) == posId2;
+        bool point1Third = c->getGeoId(2) == geoId1 && c->getPosId(2) == posId1;
+        bool point2Third = c->getGeoId(2) == geoId2 && c->getPosId(2) == posId2;
+        bool line1First = c->getGeoId(0) == geoId1 && c->getPosId(0) == PointPos::none;
+        bool line2First = c->getGeoId(0) == geoId2 && c->getPosId(0) == PointPos::none;
+        bool line1Second = c->getGeoId(1) == geoId1 && c->getPosId(1) == PointPos::none;
+        bool line2Second = c->getGeoId(1) == geoId2 && c->getPosId(1) == PointPos::none;
 
         if (c->Type == Sketcher::Coincident) {
             if ((point1First && point2Second) || (point2First && point1Second)) {
@@ -1316,7 +1316,7 @@ int SketchObject::transferConstraints(
                  && !vals[i]->involvesGeoIdAndPosId(toGeoId, toPosId)) {
             std::unique_ptr<Constraint> constNew(newVals[i]->clone());
             constNew->substituteIndexAndPos(fromGeoId, fromPosId, toGeoId, toPosId);
-            if (vals[i]->First_Deprecated < 0 && vals[i]->Second_Deprecated < 0) {
+            if (vals[i]->getGeoId(0) < 0 && vals[i]->getGeoId(1) < 0) {
                 // TODO: Can `vals[i]->Third` be involved as well?
                 // If it is, we need to be sure at most ONE of these is external
                 continue;
@@ -1497,11 +1497,11 @@ bool SketchObject::deriveConstraintsForPieces(
 ) const
 {
     const Part::Geometry* geo = getGeometry(oldId);
-    int conId = con->First_Deprecated;
-    PointPos conPos = con->FirstPos_Deprecated;
+    int conId = con->getGeoId(0);
+    PointPos conPos = con->getPosId(0);
     if (conId == oldId) {
-        conId = con->Second_Deprecated;
-        conPos = con->SecondPos_Deprecated;
+        conId = con->getGeoId(1);
+        conPos = con->getPosId(1);
     }
 
     bool newGeosLikelyNotCreated = std::ranges::find(newGeos, nullptr) != newGeos.end();
@@ -1607,8 +1607,8 @@ bool SketchObject::deriveConstraintsForPieces(
         case DistanceX:
         case DistanceY:
         case PointOnObject: {
-            if (con->FirstPos_Deprecated == PointPos::none
-                && con->SecondPos_Deprecated == PointPos::none && newIds.size() > 1) {
+            if (con->getPosId(0) == PointPos::none && con->getPosId(1) == PointPos::none
+                && newIds.size() > 1) {
                 Constraint* dist = con->copy();
                 dist->setElement(0, GeoElementId(newIds.front(), PointPos::start));
                 dist->setElement(1, GeoElementId(newIds.back(), PointPos::end));
@@ -1721,15 +1721,15 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
         case Sketcher::Horizontal:
         case Sketcher::Vertical: {
             // Only remove alignment for Lines (PointPos::none), not individual points
-            if (constr->FirstPos_Deprecated == Sketcher::PointPos::none &&
-                constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+            if (constr->getPosId(0) == Sketcher::PointPos::none &&
+                constr->getPosId(1) == Sketcher::PointPos::none) {
 
                 changed = true;
 
                 // The first H/V constraint found acts as the "reference" and is effectively removed.
                 // Subsequent H/V constraints are converted to be 'Parallel' to that first reference.
                 if (referenceGeoIds[constr->Type] == GeoEnum::GeoUndef) {
-                    referenceGeoIds[constr->Type] = constr->First_Deprecated;
+                    referenceGeoIds[constr->Type] = constr->getGeoId(0);
                     // We do NOT add the constraint to newConstraints, effectively deleting it.
                 }
                 else {
@@ -1737,7 +1737,7 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
                     Constraint* newConstr = new Constraint();
                     newConstr->Type = Sketcher::Parallel;
                     newConstr->setGeoId(0, referenceGeoIds[constr->Type]);
-                    newConstr->setGeoId(1, constr->First_Deprecated);
+                    newConstr->setGeoId(1, constr->getGeoId(0));
                     newConstraints.push_back(newConstr);
                 }
             }
@@ -1749,8 +1749,8 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
         }
         case Sketcher::Symmetric: {
             // Remove symmetry only if it is constrained relative to an Axis (H or V)
-            bool isAxisSymmetry = (constr->Third_Deprecated == GeoEnum::HAxis || constr->Third_Deprecated == GeoEnum::VAxis);
-            if (isAxisSymmetry && constr->ThirdPos_Deprecated == Sketcher::PointPos::none) {
+            bool isAxisSymmetry = (constr->getGeoId(2) == GeoEnum::HAxis || constr->getGeoId(2) == GeoEnum::VAxis);
+            if (isAxisSymmetry && constr->getPosId(2) == Sketcher::PointPos::none) {
                 changed = true;
                 // Delete constraint by not adding it to newConstraints
             }
@@ -1761,8 +1761,8 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
         }
         case Sketcher::PointOnObject: {
             // Remove Point-on-Object only if constrained onto an Axis
-            bool isOnAxis = (constr->Second_Deprecated == GeoEnum::HAxis || constr->Second_Deprecated == GeoEnum::VAxis);
-            if (isOnAxis && constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+            bool isOnAxis = (constr->getGeoId(1) == GeoEnum::HAxis || constr->getGeoId(1) == GeoEnum::VAxis);
+            if (isOnAxis && constr->getPosId(1) == Sketcher::PointPos::none) {
                 changed = true;
                 // Delete constraint
             }
@@ -1840,13 +1840,13 @@ const std::vector<std::map<int, Sketcher::PointPos>> SketchObject::getCoincidenc
         for (auto iti = coincidenttree.begin(); iti != coincidenttree.end(); ++iti, ++i) {
             // First
             std::map<int, Sketcher::PointPos>::const_iterator filiterator;
-            filiterator = (*iti).find(constr->First_Deprecated);
-            if (filiterator != (*iti).end() && constr->FirstPos_Deprecated == (*filiterator).second) {
+            filiterator = (*iti).find(constr->getGeoId(0));
+            if (filiterator != (*iti).end() && constr->getPosId(0) == (*filiterator).second) {
                 firstpresentin = i;
             }
             // Second
-            filiterator = (*iti).find(constr->Second_Deprecated);
-            if (filiterator != (*iti).end() && constr->SecondPos_Deprecated == (*filiterator).second) {
+            filiterator = (*iti).find(constr->getGeoId(1));
+            if (filiterator != (*iti).end() && constr->getPosId(1) == (*filiterator).second) {
                 secondpresentin = i;
             }
         }
@@ -1860,19 +1860,19 @@ const std::vector<std::map<int, Sketcher::PointPos>> SketchObject::getCoincidenc
         else if (firstpresentin == -1 && secondpresentin == -1) {
             // we do not have any of the values, so create a setCursor
             std::map<int, Sketcher::PointPos> tmp;
-            tmp.insert(std::pair<int, Sketcher::PointPos>(constr->First_Deprecated, constr->FirstPos_Deprecated));
-            tmp.insert(std::pair<int, Sketcher::PointPos>(constr->Second_Deprecated, constr->SecondPos_Deprecated));
+            tmp.insert(std::pair<int, Sketcher::PointPos>(constr->getGeoId(0), constr->getPosId(0)));
+            tmp.insert(std::pair<int, Sketcher::PointPos>(constr->getGeoId(1), constr->getPosId(1)));
             coincidenttree.push_back(std::move(tmp));
         }
         else if (firstpresentin != -1) {
             // add to existing group
             coincidenttree[firstpresentin].insert(
-                std::pair<int, Sketcher::PointPos>(constr->Second_Deprecated, constr->SecondPos_Deprecated));
+                std::pair<int, Sketcher::PointPos>(constr->getGeoId(1), constr->getPosId(1)));
         }
         else {// secondpresentin != -1
             // add to existing group
             coincidenttree[secondpresentin].insert(
-                std::pair<int, Sketcher::PointPos>(constr->First_Deprecated, constr->FirstPos_Deprecated));
+                std::pair<int, Sketcher::PointPos>(constr->getGeoId(0), constr->getPosId(0)));
         }
     }
 
@@ -1944,27 +1944,27 @@ void SketchObject::getDirectlyCoincidentPoints(int GeoId, PointPos PosId,
     PosIdList.push_back(PosId);
     for (const auto& constr : constraints) {
         if (constr->Type == Sketcher::Coincident) {
-            if (constr->First_Deprecated == GeoId && constr->FirstPos_Deprecated == PosId) {
-                GeoIdList.push_back(constr->Second_Deprecated);
-                PosIdList.push_back(constr->SecondPos_Deprecated);
+            if (constr->getGeoId(0) == GeoId && constr->getPosId(0) == PosId) {
+                GeoIdList.push_back(constr->getGeoId(1));
+                PosIdList.push_back(constr->getPosId(1));
             }
-            else if (constr->Second_Deprecated == GeoId && constr->SecondPos_Deprecated == PosId) {
-                GeoIdList.push_back(constr->First_Deprecated);
-                PosIdList.push_back(constr->FirstPos_Deprecated);
+            else if (constr->getGeoId(1) == GeoId && constr->getPosId(1) == PosId) {
+                GeoIdList.push_back(constr->getGeoId(0));
+                PosIdList.push_back(constr->getPosId(0));
             }
         }
         if (constr->Type == Sketcher::Tangent) {
-            if (constr->First_Deprecated == GeoId && constr->FirstPos_Deprecated == PosId &&
-                (constr->SecondPos_Deprecated == Sketcher::PointPos::start ||
-                 constr->SecondPos_Deprecated == Sketcher::PointPos::end)) {
-                GeoIdList.push_back(constr->Second_Deprecated);
-                PosIdList.push_back(constr->SecondPos_Deprecated);
+            if (constr->getGeoId(0) == GeoId && constr->getPosId(0) == PosId &&
+                (constr->getPosId(1) == Sketcher::PointPos::start ||
+                 constr->getPosId(1) == Sketcher::PointPos::end)) {
+                GeoIdList.push_back(constr->getGeoId(1));
+                PosIdList.push_back(constr->getPosId(1));
             }
-            if (constr->Second_Deprecated == GeoId && constr->SecondPos_Deprecated == PosId &&
-                (constr->FirstPos_Deprecated == Sketcher::PointPos::start ||
-                 constr->FirstPos_Deprecated == Sketcher::PointPos::end)) {
-                GeoIdList.push_back(constr->First_Deprecated);
-                PosIdList.push_back(constr->FirstPos_Deprecated);
+            if (constr->getGeoId(1) == GeoId && constr->getPosId(1) == PosId &&
+                (constr->getPosId(0) == Sketcher::PointPos::start ||
+                 constr->getPosId(0) == Sketcher::PointPos::end)) {
+                GeoIdList.push_back(constr->getGeoId(0));
+                PosIdList.push_back(constr->getPosId(0));
             }
         }
     }
@@ -2119,15 +2119,15 @@ bool SketchObject::evaluateConstraint(const Constraint* constraint) const
     int geoId;
 
     // First is always required and GeoId must be within range
-    geoId = constraint->First_Deprecated;
+    geoId = constraint->getGeoId(0);
     ret = ret && (geoId >= -extGeoCount && geoId < intGeoCount);
 
-    geoId = constraint->Second_Deprecated;
+    geoId = constraint->getGeoId(1);
     ret = ret
         && ((geoId == GeoEnum::GeoUndef && !requireSecond)
             || (geoId >= -extGeoCount && geoId < intGeoCount));
 
-    geoId = constraint->Third_Deprecated;
+    geoId = constraint->getGeoId(2);
     ret = ret
         && ((geoId == GeoEnum::GeoUndef && !requireThird)
             || (geoId >= -extGeoCount && geoId < intGeoCount));
@@ -2329,9 +2329,9 @@ double SketchObject::calculateConstraintError(int ConstrId)
     try {
         std::vector<int> GeoIdList;
         int g;
-        GeoIdList.push_back(cstr->First_Deprecated);
-        GeoIdList.push_back(cstr->Second_Deprecated);
-        GeoIdList.push_back(cstr->Third_Deprecated);
+        GeoIdList.push_back(cstr->getGeoId(0));
+        GeoIdList.push_back(cstr->getGeoId(1));
+        GeoIdList.push_back(cstr->getGeoId(2));
 
         // add only necessary geometry to the sketch
         for (std::size_t i = 0; i < GeoIdList.size(); i++) {
@@ -2486,16 +2486,16 @@ int SketchObject::port_reversedExternalArcs(bool justAnalyze)
             Sketcher::PointPos posId = PointPos::none;
             switch (ig) {
                 case 1:
-                    geoId = newVals[ic]->First_Deprecated;
-                    posId = newVals[ic]->FirstPos_Deprecated;
+                    geoId = newVals[ic]->getGeoId(0);
+                    posId = newVals[ic]->getPosId(0);
                     break;
                 case 2:
-                    geoId = newVals[ic]->Second_Deprecated;
-                    posId = newVals[ic]->SecondPos_Deprecated;
+                    geoId = newVals[ic]->getGeoId(1);
+                    posId = newVals[ic]->getPosId(1);
                     break;
                 case 3:
-                    geoId = newVals[ic]->Third_Deprecated;
-                    posId = newVals[ic]->ThirdPos_Deprecated;
+                    geoId = newVals[ic]->getGeoId(2);
+                    posId = newVals[ic]->getPosId(2);
                     break;
             }
 
@@ -2585,25 +2585,25 @@ bool SketchObject::AutoLockTangencyAndPerpty(Constraint* cstr, bool bForce, bool
             // constraint.
             int geoId1, geoId2, geoIdPt;
             PointPos posPt;
-            geoId1 = cstr->First_Deprecated;
-            geoId2 = cstr->Second_Deprecated;
-            geoIdPt = cstr->Third_Deprecated;
-            posPt = cstr->ThirdPos_Deprecated;
+            geoId1 = cstr->getGeoId(0);
+            geoId2 = cstr->getGeoId(1);
+            geoIdPt = cstr->getGeoId(2);
+            posPt = cstr->getPosId(2);
             if (geoIdPt == GeoEnum::GeoUndef) {// not tangent-via-point, try endpoint-to-endpoint...
 
                 // First check if it is a tangency at knot constraint, if not continue with checking
                 // for endpoints. Endpoint constraints make use of the AngleViaPoint framework at
                 // solver level, so they need locking angle calculation, tangency at knot constraint
                 // does not.
-                auto geof = getGeometryFacade(cstr->First_Deprecated);
+                auto geof = getGeometryFacade(cstr->getGeoId(0));
                 if (geof->isInternalType(InternalType::BSplineKnotPoint)) {
                     // there is point that is a B-Spline knot in a two element constraint
                     // this is not implement using AngleViaPoint (TangencyViaPoint)
                     return false;
                 }
 
-                geoIdPt = cstr->First_Deprecated;
-                posPt = cstr->FirstPos_Deprecated;
+                geoIdPt = cstr->getGeoId(0);
+                posPt = cstr->getPosId(0);
             }
             if (posPt == PointPos::none) {
                 // not endpoint-to-curve and not endpoint-to-endpoint tangent (is simple tangency)

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -1739,8 +1739,8 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
                     // Convert to Parallel
                     Constraint* newConstr = new Constraint();
                     newConstr->Type = Sketcher::Parallel;
-                    newConstr->First_Deprecated = referenceGeoIds[constr->Type];
-                    newConstr->Second_Deprecated = constr->First_Deprecated;
+                    newConstr->setGeoId(0, referenceGeoIds[constr->Type]);
+                    newConstr->setGeoId(1, constr->First_Deprecated);
                     newConstraints.push_back(newConstr);
                 }
             }
@@ -2344,9 +2344,9 @@ double SketchObject::calculateConstraintError(int ConstrId)
             }
         }
 
-        cstr->First_Deprecated = GeoIdList[0];
-        cstr->Second_Deprecated = GeoIdList[1];
-        cstr->Third_Deprecated = GeoIdList[2];
+        cstr->setGeoId(0, GeoIdList[0]);
+        cstr->setGeoId(1, GeoIdList[1]);
+        cstr->setGeoId(2, GeoIdList[2]);
         int icstr = sk.addConstraint(cstr);
         result = sk.calculateConstraintError(icstr);
     }

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -516,8 +516,7 @@ int SketchObject::moveDatumsToEnd()
 
 void SketchObject::reverseAngleConstraintToSupplementary(Constraint* constr, int constNum)
 {
-    std::swap(constr->getGeoId(0), constr->getGeoId(1));
-    std::swap(constr->getPosId(0), constr->getPosId(1));
+    constr->swapElements(0, 1);
     constr->setPosId(0, (constr->getPosId(0) == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
 
     // Edit the expression if any, else modify constraint value directly

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -281,7 +281,7 @@ int SketchObject::testDrivingChange(int ConstrId, bool isdriving)
     if (!vals[ConstrId]->isDimensional())
         return -2;
 
-    if (!(vals[ConstrId]->First >= 0 || vals[ConstrId]->Second >= 0 || vals[ConstrId]->Third >= 0)
+    if (!(vals[ConstrId]->First_Deprecated >= 0 || vals[ConstrId]->Second_Deprecated >= 0 || vals[ConstrId]->Third_Deprecated >= 0)
         && isdriving) {
         // a constraint that does not have at least one element as not-external-geometry can never
         // be driving.
@@ -516,9 +516,9 @@ int SketchObject::moveDatumsToEnd()
 
 void SketchObject::reverseAngleConstraintToSupplementary(Constraint* constr, int constNum)
 {
-    std::swap(constr->First, constr->Second);
-    std::swap(constr->FirstPos, constr->SecondPos);
-    constr->FirstPos = (constr->FirstPos == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
+    std::swap(constr->First_Deprecated, constr->Second_Deprecated);
+    std::swap(constr->FirstPos_Deprecated, constr->SecondPos_Deprecated);
+    constr->FirstPos_Deprecated = (constr->FirstPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
 
     // Edit the expression if any, else modify constraint value directly
     if (constraintHasExpression(constNum)) {
@@ -533,8 +533,8 @@ void SketchObject::reverseAngleConstraintToSupplementary(Constraint* constr, int
 
 void SketchObject::inverseAngleConstraint(Constraint* constr)
 {
-    constr->FirstPos = (constr->FirstPos == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
-    constr->SecondPos = (constr->SecondPos == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
+    constr->FirstPos_Deprecated = (constr->FirstPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
+    constr->SecondPos_Deprecated = (constr->SecondPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
 }
 
 bool SketchObject::constraintHasExpression(int constNum) const
@@ -824,11 +824,11 @@ void SketchObject::addGeometryState(const Constraint* cstr) const
     bool constraintBlockedState = false;
 
     if (getInternalTypeState(cstr, constraintInternalAlignment)) {
-        auto gf = GeometryFacade::getFacade(vals[cstr->First]);
+        auto gf = GeometryFacade::getFacade(vals[cstr->First_Deprecated]);
         gf->setInternalType(constraintInternalAlignment);
     }
     else if (getBlockedState(cstr, constraintBlockedState)) {
-        auto gf = GeometryFacade::getFacade(vals[cstr->First]);
+        auto gf = GeometryFacade::getFacade(vals[cstr->First_Deprecated]);
         gf->setBlocked(constraintBlockedState);
     }
 }
@@ -839,13 +839,13 @@ void SketchObject::removeGeometryState(const Constraint* cstr) const
 
     // Assign correct Internal Geometry Type (see SketchGeometryExtension)
     if (cstr->Type == InternalAlignment) {
-        auto gf = GeometryFacade::getFacade(vals[cstr->First]);
+        auto gf = GeometryFacade::getFacade(vals[cstr->First_Deprecated]);
         gf->setInternalType(InternalType::None);
     }
 
     // Assign Blocked geometry mode (see SketchGeometryExtension)
     if (cstr->Type == Block) {
-        auto gf = GeometryFacade::getFacade(vals[cstr->First]);
+        auto gf = GeometryFacade::getFacade(vals[cstr->First_Deprecated]);
         gf->setBlocked(false);
     }
 }
@@ -1047,13 +1047,13 @@ int SketchObject::delConstraintOnPoint(int geoId, PointPos posId, bool onlyCoinc
             return;
         }
 
-        if ((*it)->First == geoId && (*it)->FirstPos == posId) {
-            replaceGeoId = (*it)->Second;
-            replacePosId = (*it)->SecondPos;
+        if ((*it)->First_Deprecated == geoId && (*it)->FirstPos_Deprecated == posId) {
+            replaceGeoId = (*it)->Second_Deprecated;
+            replacePosId = (*it)->SecondPos_Deprecated;
         }
         else {
-            replaceGeoId = (*it)->First;
-            replacePosId = (*it)->FirstPos;
+            replaceGeoId = (*it)->First_Deprecated;
+            replacePosId = (*it)->FirstPos_Deprecated;
         }
     };
 
@@ -1095,12 +1095,12 @@ int SketchObject::delConstraintOnPoint(int geoId, PointPos posId, bool onlyCoinc
             case Sketcher::DistanceX:
             case Sketcher::DistanceY: {
                 return (
-                    transferToReplacement(constr->First, constr->FirstPos)
-                    || transferToReplacement(constr->Second, constr->SecondPos)
+                    transferToReplacement(constr->First_Deprecated, constr->FirstPos_Deprecated)
+                    || transferToReplacement(constr->Second_Deprecated, constr->SecondPos_Deprecated)
                 );
             }
             case Sketcher::PointOnObject: {
-                return transferToReplacement(constr->First, constr->FirstPos);
+                return transferToReplacement(constr->First_Deprecated, constr->FirstPos_Deprecated);
             }
             case Sketcher::Tangent:
             case Sketcher::Perpendicular: {
@@ -1127,8 +1127,8 @@ int SketchObject::delConstraintOnPoint(int geoId, PointPos posId, bool onlyCoinc
             // with the given point
             const bool isOneOfDistanceTypes = constr->Type == Sketcher::Distance
                 || constr->Type == Sketcher::DistanceX || constr->Type == Sketcher::DistanceY;
-            const bool involvesEntireCurve = constr->First == geoId
-                && constr->FirstPos == PointPos::none;
+            const bool involvesEntireCurve = constr->First_Deprecated == geoId
+                && constr->FirstPos_Deprecated == PointPos::none;
             const bool isPosAnEndpoint = posId == PointPos::start || posId == PointPos::end;
             if (isOneOfDistanceTypes && involvesEntireCurve && isPosAnEndpoint) {
                 continue;
@@ -1171,8 +1171,8 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
             if (c->Type != Sketcher::Distance && c->Type != Sketcher::Equal) {
                 continue;
             }
-            bool line1 = c->First == geoId1 && c->FirstPos == PointPos::none;
-            bool line2 = c->First == geoId2 && c->FirstPos == PointPos::none;
+            bool line1 = c->First_Deprecated == geoId1 && c->FirstPos_Deprecated == PointPos::none;
+            bool line2 = c->First_Deprecated == geoId2 && c->FirstPos_Deprecated == PointPos::none;
             if (line1 || line2) {
                 deleteme.push_back(i);
             }
@@ -1199,18 +1199,18 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
     // Constrain the vertex to the two lines
     auto* cornerToLine1 = new Sketcher::Constraint();
     cornerToLine1->Type = Sketcher::PointOnObject;
-    cornerToLine1->First = originalCornerId;
-    cornerToLine1->FirstPos = PointPos::start;
-    cornerToLine1->Second = geoId1;
-    cornerToLine1->SecondPos = PointPos::none;
+    cornerToLine1->First_Deprecated = originalCornerId;
+    cornerToLine1->FirstPos_Deprecated = PointPos::start;
+    cornerToLine1->Second_Deprecated = geoId1;
+    cornerToLine1->SecondPos_Deprecated = PointPos::none;
     addConstraint(cornerToLine1);
     delete cornerToLine1;
     auto* cornerToLine2 = new Sketcher::Constraint();
     cornerToLine2->Type = Sketcher::PointOnObject;
-    cornerToLine2->First = originalCornerId;
-    cornerToLine2->FirstPos = PointPos::start;
-    cornerToLine2->Second = geoId2;
-    cornerToLine2->SecondPos = PointPos::none;
+    cornerToLine2->First_Deprecated = originalCornerId;
+    cornerToLine2->FirstPos_Deprecated = PointPos::start;
+    cornerToLine2->Second_Deprecated = geoId2;
+    cornerToLine2->SecondPos_Deprecated = PointPos::none;
     addConstraint(cornerToLine2);
     delete cornerToLine2;
 
@@ -1220,16 +1220,16 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
     std::vector<Constraint*> newConstraints;
     for (auto c : this->Constraints.getValues()) {
         // Keep track of whether the affected lines and endpoints appear in this constraint
-        bool point1First = c->First == geoId1 && c->FirstPos == posId1;
-        bool point2First = c->First == geoId2 && c->FirstPos == posId2;
-        bool point1Second = c->Second == geoId1 && c->SecondPos == posId1;
-        bool point2Second = c->Second == geoId2 && c->SecondPos == posId2;
-        bool point1Third = c->Third == geoId1 && c->ThirdPos == posId1;
-        bool point2Third = c->Third == geoId2 && c->ThirdPos == posId2;
-        bool line1First = c->First == geoId1 && c->FirstPos == PointPos::none;
-        bool line2First = c->First == geoId2 && c->FirstPos == PointPos::none;
-        bool line1Second = c->Second == geoId1 && c->SecondPos == PointPos::none;
-        bool line2Second = c->Second == geoId2 && c->SecondPos == PointPos::none;
+        bool point1First = c->First_Deprecated == geoId1 && c->FirstPos_Deprecated == posId1;
+        bool point2First = c->First_Deprecated == geoId2 && c->FirstPos_Deprecated == posId2;
+        bool point1Second = c->Second_Deprecated == geoId1 && c->SecondPos_Deprecated == posId1;
+        bool point2Second = c->Second_Deprecated == geoId2 && c->SecondPos_Deprecated == posId2;
+        bool point1Third = c->Third_Deprecated == geoId1 && c->ThirdPos_Deprecated == posId1;
+        bool point2Third = c->Third_Deprecated == geoId2 && c->ThirdPos_Deprecated == posId2;
+        bool line1First = c->First_Deprecated == geoId1 && c->FirstPos_Deprecated == PointPos::none;
+        bool line2First = c->First_Deprecated == geoId2 && c->FirstPos_Deprecated == PointPos::none;
+        bool line1Second = c->Second_Deprecated == geoId1 && c->SecondPos_Deprecated == PointPos::none;
+        bool line2Second = c->Second_Deprecated == geoId2 && c->SecondPos_Deprecated == PointPos::none;
 
         if (c->Type == Sketcher::Coincident) {
             if ((point1First && point2Second) || (point2First && point1Second)) {
@@ -1249,14 +1249,14 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
             // Distance constraint on the line itself. Change it to point-point between the far end
             // of the line and the new corner
             if (line1First) {
-                c->FirstPos = (posId1 == PointPos::start) ? PointPos::end : PointPos::start;
-                c->Second = originalCornerId;
-                c->SecondPos = PointPos::start;
+                c->FirstPos_Deprecated = (posId1 == PointPos::start) ? PointPos::end : PointPos::start;
+                c->Second_Deprecated = originalCornerId;
+                c->SecondPos_Deprecated = PointPos::start;
             }
             if (line2First) {
-                c->FirstPos = (posId2 == PointPos::start) ? PointPos::end : PointPos::start;
-                c->Second = originalCornerId;
-                c->SecondPos = PointPos::start;
+                c->FirstPos_Deprecated = (posId2 == PointPos::start) ? PointPos::end : PointPos::start;
+                c->Second_Deprecated = originalCornerId;
+                c->SecondPos_Deprecated = PointPos::start;
             }
         }
         else if (c->Type == Sketcher::PointOnObject) {
@@ -1285,16 +1285,16 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
 
         // For any constraint not passing previous conditions, transfer to the new point if relevant
         if (point1First || point2First) {
-            c->First = originalCornerId;
-            c->FirstPos = PointPos::start;
+            c->First_Deprecated = originalCornerId;
+            c->FirstPos_Deprecated = PointPos::start;
         }
         else if (point1Second || point2Second) {
-            c->Second = originalCornerId;
-            c->SecondPos = PointPos::start;
+            c->Second_Deprecated = originalCornerId;
+            c->SecondPos_Deprecated = PointPos::start;
         }
         else if (point1Third || point2Third) {
-            c->Third = originalCornerId;
-            c->ThirdPos = PointPos::start;
+            c->Third_Deprecated = originalCornerId;
+            c->ThirdPos_Deprecated = PointPos::start;
         }
 
         // Default: keep all other constraints
@@ -1328,7 +1328,7 @@ int SketchObject::transferConstraints(
                  && !vals[i]->involvesGeoIdAndPosId(toGeoId, toPosId)) {
             std::unique_ptr<Constraint> constNew(newVals[i]->clone());
             constNew->substituteIndexAndPos(fromGeoId, fromPosId, toGeoId, toPosId);
-            if (vals[i]->First < 0 && vals[i]->Second < 0) {
+            if (vals[i]->First_Deprecated < 0 && vals[i]->Second_Deprecated < 0) {
                 // TODO: Can `vals[i]->Third` be involved as well?
                 // If it is, we need to be sure at most ONE of these is external
                 continue;
@@ -1381,12 +1381,12 @@ std::unique_ptr<Constraint> SketchObject::createConstraint(
     auto newConstr = std::make_unique<Sketcher::Constraint>();
 
     newConstr->Type = constrType;
-    newConstr->First = firstGeoId;
-    newConstr->FirstPos = firstPos;
-    newConstr->Second = secondGeoId;
-    newConstr->SecondPos = secondPos;
-    newConstr->Third = thirdGeoId;
-    newConstr->ThirdPos = thirdPos;
+    newConstr->First_Deprecated = firstGeoId;
+    newConstr->FirstPos_Deprecated = firstPos;
+    newConstr->Second_Deprecated = secondGeoId;
+    newConstr->SecondPos_Deprecated = secondPos;
+    newConstr->Third_Deprecated = thirdGeoId;
+    newConstr->ThirdPos_Deprecated = thirdPos;
     return newConstr;
 }
 
@@ -1512,11 +1512,11 @@ bool SketchObject::deriveConstraintsForPieces(
 ) const
 {
     const Part::Geometry* geo = getGeometry(oldId);
-    int conId = con->First;
-    PointPos conPos = con->FirstPos;
+    int conId = con->First_Deprecated;
+    PointPos conPos = con->FirstPos_Deprecated;
     if (conId == oldId) {
-        conId = con->Second;
-        conPos = con->SecondPos;
+        conId = con->Second_Deprecated;
+        conPos = con->SecondPos_Deprecated;
     }
 
     bool newGeosLikelyNotCreated = std::ranges::find(newGeos, nullptr) != newGeos.end();
@@ -1622,13 +1622,13 @@ bool SketchObject::deriveConstraintsForPieces(
         case DistanceX:
         case DistanceY:
         case PointOnObject: {
-            if (con->FirstPos == PointPos::none && con->SecondPos == PointPos::none
-                && newIds.size() > 1) {
+            if (con->FirstPos_Deprecated == PointPos::none
+                && con->SecondPos_Deprecated == PointPos::none && newIds.size() > 1) {
                 Constraint* dist = con->copy();
-                dist->First = newIds.front();
-                dist->FirstPos = PointPos::start;
-                dist->Second = newIds.back();
-                dist->SecondPos = PointPos::end;
+                dist->First_Deprecated = newIds.front();
+                dist->FirstPos_Deprecated = PointPos::start;
+                dist->Second_Deprecated = newIds.back();
+                dist->SecondPos_Deprecated = PointPos::end;
                 newConstraints.push_back(dist);
                 return true;
             }
@@ -1657,10 +1657,10 @@ bool SketchObject::deriveConstraintsForPieces(
                 if ((newGeoFirstParam - conParam) <= Precision::PApproximation()
                     && (conParam - newGeoLastParam) <= Precision::PApproximation()) {
                     Constraint* trans = con->copy();
-                    trans->First = conId;
-                    trans->FirstPos = conPos;
-                    trans->Second = newIds[i];
-                    trans->SecondPos = PointPos::none;
+                    trans->First_Deprecated = conId;
+                    trans->FirstPos_Deprecated = conPos;
+                    trans->Second_Deprecated = newIds[i];
+                    trans->SecondPos_Deprecated = PointPos::none;
                     newConstraints.push_back(trans);
                     return true;
                 }
@@ -1740,23 +1740,23 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
         case Sketcher::Horizontal:
         case Sketcher::Vertical: {
             // Only remove alignment for Lines (PointPos::none), not individual points
-            if (constr->FirstPos == Sketcher::PointPos::none &&
-                constr->SecondPos == Sketcher::PointPos::none) {
+            if (constr->FirstPos_Deprecated == Sketcher::PointPos::none &&
+                constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
 
                 changed = true;
 
                 // The first H/V constraint found acts as the "reference" and is effectively removed.
                 // Subsequent H/V constraints are converted to be 'Parallel' to that first reference.
                 if (referenceGeoIds[constr->Type] == GeoEnum::GeoUndef) {
-                    referenceGeoIds[constr->Type] = constr->First;
+                    referenceGeoIds[constr->Type] = constr->First_Deprecated;
                     // We do NOT add the constraint to newConstraints, effectively deleting it.
                 }
                 else {
                     // Convert to Parallel
                     Constraint* newConstr = new Constraint();
                     newConstr->Type = Sketcher::Parallel;
-                    newConstr->First = referenceGeoIds[constr->Type];
-                    newConstr->Second = constr->First;
+                    newConstr->First_Deprecated = referenceGeoIds[constr->Type];
+                    newConstr->Second_Deprecated = constr->First_Deprecated;
                     newConstraints.push_back(newConstr);
                 }
             }
@@ -1768,8 +1768,8 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
         }
         case Sketcher::Symmetric: {
             // Remove symmetry only if it is constrained relative to an Axis (H or V)
-            bool isAxisSymmetry = (constr->Third == GeoEnum::HAxis || constr->Third == GeoEnum::VAxis);
-            if (isAxisSymmetry && constr->ThirdPos == Sketcher::PointPos::none) {
+            bool isAxisSymmetry = (constr->Third_Deprecated == GeoEnum::HAxis || constr->Third_Deprecated == GeoEnum::VAxis);
+            if (isAxisSymmetry && constr->ThirdPos_Deprecated == Sketcher::PointPos::none) {
                 changed = true;
                 // Delete constraint by not adding it to newConstraints
             }
@@ -1780,8 +1780,8 @@ int SketchObject::removeAxesAlignment(const std::vector<int>& geoIdList)
         }
         case Sketcher::PointOnObject: {
             // Remove Point-on-Object only if constrained onto an Axis
-            bool isOnAxis = (constr->Second == GeoEnum::HAxis || constr->Second == GeoEnum::VAxis);
-            if (isOnAxis && constr->SecondPos == Sketcher::PointPos::none) {
+            bool isOnAxis = (constr->Second_Deprecated == GeoEnum::HAxis || constr->Second_Deprecated == GeoEnum::VAxis);
+            if (isOnAxis && constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
                 changed = true;
                 // Delete constraint
             }
@@ -1859,13 +1859,13 @@ const std::vector<std::map<int, Sketcher::PointPos>> SketchObject::getCoincidenc
         for (auto iti = coincidenttree.begin(); iti != coincidenttree.end(); ++iti, ++i) {
             // First
             std::map<int, Sketcher::PointPos>::const_iterator filiterator;
-            filiterator = (*iti).find(constr->First);
-            if (filiterator != (*iti).end() && constr->FirstPos == (*filiterator).second) {
+            filiterator = (*iti).find(constr->First_Deprecated);
+            if (filiterator != (*iti).end() && constr->FirstPos_Deprecated == (*filiterator).second) {
                 firstpresentin = i;
             }
             // Second
-            filiterator = (*iti).find(constr->Second);
-            if (filiterator != (*iti).end() && constr->SecondPos == (*filiterator).second) {
+            filiterator = (*iti).find(constr->Second_Deprecated);
+            if (filiterator != (*iti).end() && constr->SecondPos_Deprecated == (*filiterator).second) {
                 secondpresentin = i;
             }
         }
@@ -1879,19 +1879,19 @@ const std::vector<std::map<int, Sketcher::PointPos>> SketchObject::getCoincidenc
         else if (firstpresentin == -1 && secondpresentin == -1) {
             // we do not have any of the values, so create a setCursor
             std::map<int, Sketcher::PointPos> tmp;
-            tmp.insert(std::pair<int, Sketcher::PointPos>(constr->First, constr->FirstPos));
-            tmp.insert(std::pair<int, Sketcher::PointPos>(constr->Second, constr->SecondPos));
+            tmp.insert(std::pair<int, Sketcher::PointPos>(constr->First_Deprecated, constr->FirstPos_Deprecated));
+            tmp.insert(std::pair<int, Sketcher::PointPos>(constr->Second_Deprecated, constr->SecondPos_Deprecated));
             coincidenttree.push_back(std::move(tmp));
         }
         else if (firstpresentin != -1) {
             // add to existing group
             coincidenttree[firstpresentin].insert(
-                std::pair<int, Sketcher::PointPos>(constr->Second, constr->SecondPos));
+                std::pair<int, Sketcher::PointPos>(constr->Second_Deprecated, constr->SecondPos_Deprecated));
         }
         else {// secondpresentin != -1
             // add to existing group
             coincidenttree[secondpresentin].insert(
-                std::pair<int, Sketcher::PointPos>(constr->First, constr->FirstPos));
+                std::pair<int, Sketcher::PointPos>(constr->First_Deprecated, constr->FirstPos_Deprecated));
         }
     }
 
@@ -1963,27 +1963,27 @@ void SketchObject::getDirectlyCoincidentPoints(int GeoId, PointPos PosId,
     PosIdList.push_back(PosId);
     for (const auto& constr : constraints) {
         if (constr->Type == Sketcher::Coincident) {
-            if (constr->First == GeoId && constr->FirstPos == PosId) {
-                GeoIdList.push_back(constr->Second);
-                PosIdList.push_back(constr->SecondPos);
+            if (constr->First_Deprecated == GeoId && constr->FirstPos_Deprecated == PosId) {
+                GeoIdList.push_back(constr->Second_Deprecated);
+                PosIdList.push_back(constr->SecondPos_Deprecated);
             }
-            else if (constr->Second == GeoId && constr->SecondPos == PosId) {
-                GeoIdList.push_back(constr->First);
-                PosIdList.push_back(constr->FirstPos);
+            else if (constr->Second_Deprecated == GeoId && constr->SecondPos_Deprecated == PosId) {
+                GeoIdList.push_back(constr->First_Deprecated);
+                PosIdList.push_back(constr->FirstPos_Deprecated);
             }
         }
         if (constr->Type == Sketcher::Tangent) {
-            if (constr->First == GeoId && constr->FirstPos == PosId &&
-                (constr->SecondPos == Sketcher::PointPos::start ||
-                 constr->SecondPos == Sketcher::PointPos::end)) {
-                GeoIdList.push_back(constr->Second);
-                PosIdList.push_back(constr->SecondPos);
+            if (constr->First_Deprecated == GeoId && constr->FirstPos_Deprecated == PosId &&
+                (constr->SecondPos_Deprecated == Sketcher::PointPos::start ||
+                 constr->SecondPos_Deprecated == Sketcher::PointPos::end)) {
+                GeoIdList.push_back(constr->Second_Deprecated);
+                PosIdList.push_back(constr->SecondPos_Deprecated);
             }
-            if (constr->Second == GeoId && constr->SecondPos == PosId &&
-                (constr->FirstPos == Sketcher::PointPos::start ||
-                 constr->FirstPos == Sketcher::PointPos::end)) {
-                GeoIdList.push_back(constr->First);
-                PosIdList.push_back(constr->FirstPos);
+            if (constr->Second_Deprecated == GeoId && constr->SecondPos_Deprecated == PosId &&
+                (constr->FirstPos_Deprecated == Sketcher::PointPos::start ||
+                 constr->FirstPos_Deprecated == Sketcher::PointPos::end)) {
+                GeoIdList.push_back(constr->First_Deprecated);
+                PosIdList.push_back(constr->FirstPos_Deprecated);
             }
         }
     }
@@ -2138,15 +2138,15 @@ bool SketchObject::evaluateConstraint(const Constraint* constraint) const
     int geoId;
 
     // First is always required and GeoId must be within range
-    geoId = constraint->First;
+    geoId = constraint->First_Deprecated;
     ret = ret && (geoId >= -extGeoCount && geoId < intGeoCount);
 
-    geoId = constraint->Second;
+    geoId = constraint->Second_Deprecated;
     ret = ret
         && ((geoId == GeoEnum::GeoUndef && !requireSecond)
             || (geoId >= -extGeoCount && geoId < intGeoCount));
 
-    geoId = constraint->Third;
+    geoId = constraint->Third_Deprecated;
     ret = ret
         && ((geoId == GeoEnum::GeoUndef && !requireThird)
             || (geoId >= -extGeoCount && geoId < intGeoCount));
@@ -2348,9 +2348,9 @@ double SketchObject::calculateConstraintError(int ConstrId)
     try {
         std::vector<int> GeoIdList;
         int g;
-        GeoIdList.push_back(cstr->First);
-        GeoIdList.push_back(cstr->Second);
-        GeoIdList.push_back(cstr->Third);
+        GeoIdList.push_back(cstr->First_Deprecated);
+        GeoIdList.push_back(cstr->Second_Deprecated);
+        GeoIdList.push_back(cstr->Third_Deprecated);
 
         // add only necessary geometry to the sketch
         for (std::size_t i = 0; i < GeoIdList.size(); i++) {
@@ -2360,9 +2360,9 @@ double SketchObject::calculateConstraintError(int ConstrId)
             }
         }
 
-        cstr->First = GeoIdList[0];
-        cstr->Second = GeoIdList[1];
-        cstr->Third = GeoIdList[2];
+        cstr->First_Deprecated = GeoIdList[0];
+        cstr->Second_Deprecated = GeoIdList[1];
+        cstr->Third_Deprecated = GeoIdList[2];
         int icstr = sk.addConstraint(cstr);
         result = sk.calculateConstraintError(icstr);
     }
@@ -2505,16 +2505,16 @@ int SketchObject::port_reversedExternalArcs(bool justAnalyze)
             Sketcher::PointPos posId = PointPos::none;
             switch (ig) {
                 case 1:
-                    geoId = newVals[ic]->First;
-                    posId = newVals[ic]->FirstPos;
+                    geoId = newVals[ic]->First_Deprecated;
+                    posId = newVals[ic]->FirstPos_Deprecated;
                     break;
                 case 2:
-                    geoId = newVals[ic]->Second;
-                    posId = newVals[ic]->SecondPos;
+                    geoId = newVals[ic]->Second_Deprecated;
+                    posId = newVals[ic]->SecondPos_Deprecated;
                     break;
                 case 3:
-                    geoId = newVals[ic]->Third;
-                    posId = newVals[ic]->ThirdPos;
+                    geoId = newVals[ic]->Third_Deprecated;
+                    posId = newVals[ic]->ThirdPos_Deprecated;
                     break;
             }
 
@@ -2543,16 +2543,16 @@ int SketchObject::port_reversedExternalArcs(bool justAnalyze)
             // Propagate the fix made on temp vars to the constraint
             switch (ig) {
                 case 1:
-                    constNew->First = geoId;
-                    constNew->FirstPos = posId;
+                    constNew->First_Deprecated = geoId;
+                    constNew->FirstPos_Deprecated = posId;
                     break;
                 case 2:
-                    constNew->Second = geoId;
-                    constNew->SecondPos = posId;
+                    constNew->Second_Deprecated = geoId;
+                    constNew->SecondPos_Deprecated = posId;
                     break;
                 case 3:
-                    constNew->Third = geoId;
-                    constNew->ThirdPos = posId;
+                    constNew->Third_Deprecated = geoId;
+                    constNew->ThirdPos_Deprecated = posId;
                     break;
             }
         }
@@ -2607,25 +2607,25 @@ bool SketchObject::AutoLockTangencyAndPerpty(Constraint* cstr, bool bForce, bool
             // constraint.
             int geoId1, geoId2, geoIdPt;
             PointPos posPt;
-            geoId1 = cstr->First;
-            geoId2 = cstr->Second;
-            geoIdPt = cstr->Third;
-            posPt = cstr->ThirdPos;
+            geoId1 = cstr->First_Deprecated;
+            geoId2 = cstr->Second_Deprecated;
+            geoIdPt = cstr->Third_Deprecated;
+            posPt = cstr->ThirdPos_Deprecated;
             if (geoIdPt == GeoEnum::GeoUndef) {// not tangent-via-point, try endpoint-to-endpoint...
 
                 // First check if it is a tangency at knot constraint, if not continue with checking
                 // for endpoints. Endpoint constraints make use of the AngleViaPoint framework at
                 // solver level, so they need locking angle calculation, tangency at knot constraint
                 // does not.
-                auto geof = getGeometryFacade(cstr->First);
+                auto geof = getGeometryFacade(cstr->First_Deprecated);
                 if (geof->isInternalType(InternalType::BSplineKnotPoint)) {
                     // there is point that is a B-Spline knot in a two element constraint
                     // this is not implement using AngleViaPoint (TangencyViaPoint)
                     return false;
                 }
 
-                geoIdPt = cstr->First;
-                posPt = cstr->FirstPos;
+                geoIdPt = cstr->First_Deprecated;
+                posPt = cstr->FirstPos_Deprecated;
             }
             if (posPt == PointPos::none) {
                 // not endpoint-to-curve and not endpoint-to-endpoint tangent (is simple tangency)

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -518,7 +518,7 @@ void SketchObject::reverseAngleConstraintToSupplementary(Constraint* constr, int
 {
     std::swap(constr->First_Deprecated, constr->Second_Deprecated);
     std::swap(constr->FirstPos_Deprecated, constr->SecondPos_Deprecated);
-    constr->FirstPos_Deprecated = (constr->FirstPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
+    constr->setPosId(0, (constr->FirstPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
 
     // Edit the expression if any, else modify constraint value directly
     if (constraintHasExpression(constNum)) {
@@ -533,8 +533,8 @@ void SketchObject::reverseAngleConstraintToSupplementary(Constraint* constr, int
 
 void SketchObject::inverseAngleConstraint(Constraint* constr)
 {
-    constr->FirstPos_Deprecated = (constr->FirstPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
-    constr->SecondPos_Deprecated = (constr->SecondPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
+    constr->setPosId(0, (constr->FirstPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
+    constr->setPosId(1, (constr->SecondPos_Deprecated == Sketcher::PointPos::start) ? Sketcher::PointPos::end : Sketcher::PointPos::start);
 }
 
 bool SketchObject::constraintHasExpression(int constNum) const
@@ -1245,11 +1245,11 @@ void SketchObject::transferFilletConstraints(int geoId1, PointPos posId1, int ge
             // Distance constraint on the line itself. Change it to point-point between the far end
             // of the line and the new corner
             if (line1First) {
-                c->FirstPos_Deprecated = (posId1 == PointPos::start) ? PointPos::end : PointPos::start;
+                c->setPosId(0, (posId1 == PointPos::start) ? PointPos::end : PointPos::start);
                 c->setElement(1, GeoElementId(originalCornerId, PointPos::start));
             }
             if (line2First) {
-                c->FirstPos_Deprecated = (posId2 == PointPos::start) ? PointPos::end : PointPos::start;
+                c->setPosId(0, (posId2 == PointPos::start) ? PointPos::end : PointPos::start);
                 c->setElement(1, GeoElementId(originalCornerId, PointPos::start));
             }
         }

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -542,8 +542,8 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
         // DistanceX, DistanceY
         if ((xinv && newConstr->Type == Sketcher::DistanceX)
             || (yinv && newConstr->Type == Sketcher::DistanceY)) {
-            if (newConstr->First == newConstr->Second) {
-                std::swap(newConstr->FirstPos, newConstr->SecondPos);
+            if (newConstr->First_Deprecated == newConstr->Second_Deprecated) {
+                std::swap(newConstr->FirstPos_Deprecated, newConstr->SecondPos_Deprecated);
             }
             else {
                 newConstr->setValue(-newConstr->getValue());
@@ -563,8 +563,9 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
             };
 
             if (xinv && yinv) {  // rotation 180 degrees around normal axis
-                if (newConstr->First == -1 || newConstr->Second == -1 || newConstr->First == -2
-                    || newConstr->Second == -2 || newConstr->Second == GeoEnum::GeoUndef) {
+                if (newConstr->First_Deprecated == -1 || newConstr->Second_Deprecated == -1
+                    || newConstr->First_Deprecated == -2 || newConstr->Second_Deprecated == -2
+                    || newConstr->Second_Deprecated == GeoEnum::GeoUndef) {
                     // angle to horizontal or vertical axis
                     newConstr->setValue(normalizeAngle(newConstr->getValue() + pi));
                 }
@@ -574,8 +575,8 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
                 }
             }
             else if (xinv) {  // rotation 180 degrees around vertical axis
-                if (newConstr->First == -1 || newConstr->Second == -1
-                    || newConstr->Second == GeoEnum::GeoUndef) {
+                if (newConstr->First_Deprecated == -1 || newConstr->Second_Deprecated == -1
+                    || newConstr->Second_Deprecated == GeoEnum::GeoUndef) {
                     // angle to horizontal axis
                     newConstr->setValue(normalizeAngle(pi - newConstr->getValue()));
                 }
@@ -585,7 +586,7 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
                 }
             }
             else if (yinv) {  // rotation 180 degrees around horizontal axis
-                if (newConstr->First == -2 || newConstr->Second == -2) {
+                if (newConstr->First_Deprecated == -2 || newConstr->Second_Deprecated == -2) {
                     // angle to vertical axis
                     newConstr->setValue(normalizeAngle(pi - newConstr->getValue()));
                 }
@@ -599,24 +600,24 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
 
     for (const auto& constr : scvals) {
         Sketcher::Constraint* newConstr = constr->copy();
-        if (constr->First >= 0) {
-            newConstr->First += nextgeoid;
+        if (constr->First_Deprecated >= 0) {
+            newConstr->First_Deprecated += nextgeoid;
         }
-        if (constr->Second >= 0) {
-            newConstr->Second += nextgeoid;
+        if (constr->Second_Deprecated >= 0) {
+            newConstr->Second_Deprecated += nextgeoid;
         }
-        if (constr->Third >= 0) {
-            newConstr->Third += nextgeoid;
+        if (constr->Third_Deprecated >= 0) {
+            newConstr->Third_Deprecated += nextgeoid;
         }
 
-        if (constr->First < -2 && constr->First != GeoEnum::GeoUndef) {
-            newConstr->First -= (nextextgeoid - 2);
+        if (constr->First_Deprecated < -2 && constr->First_Deprecated != GeoEnum::GeoUndef) {
+            newConstr->First_Deprecated -= (nextextgeoid - 2);
         }
-        if (constr->Second < -2 && constr->Second != GeoEnum::GeoUndef) {
-            newConstr->Second -= (nextextgeoid - 2);
+        if (constr->Second_Deprecated < -2 && constr->Second_Deprecated != GeoEnum::GeoUndef) {
+            newConstr->Second_Deprecated -= (nextextgeoid - 2);
         }
-        if (constr->Third < -2 && constr->Third != GeoEnum::GeoUndef) {
-            newConstr->Third -= (nextextgeoid - 2);
+        if (constr->Third_Deprecated < -2 && constr->Third_Deprecated != GeoEnum::GeoUndef) {
+            newConstr->Third_Deprecated -= (nextextgeoid - 2);
         }
 
         if (xinv || yinv) {
@@ -647,7 +648,7 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
         // DistanceX, DistanceY
         if ((xinv && constr->Type == Sketcher::DistanceX)
             || (yinv && constr->Type == Sketcher::DistanceY)) {
-            if (constr->First == constr->Second) {
+            if (constr->First_Deprecated == constr->Second_Deprecated) {
                 return expr;
             }
             else {
@@ -658,8 +659,9 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
         // Angle
         if (constr->Type == Sketcher::Angle) {
             if (xinv && yinv) {  // rotation 180 degrees around normal axis
-                if (constr->First == -1 || constr->Second == -1 || constr->First == -2
-                    || constr->Second == -2 || constr->Second == GeoEnum::GeoUndef) {
+                if (constr->First_Deprecated == -1 || constr->Second_Deprecated == -1
+                    || constr->First_Deprecated == -2 || constr->Second_Deprecated == -2
+                    || constr->Second_Deprecated == GeoEnum::GeoUndef) {
                     // angle to horizontal or vertical axis
                     return "(" + expr + ") + 180 deg";
                 }
@@ -670,8 +672,8 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
                 }
             }
             else if (xinv) {  // rotation 180 degrees around vertical axis
-                if (constr->First == -1 || constr->Second == -1
-                    || constr->Second == GeoEnum::GeoUndef) {
+                if (constr->First_Deprecated == -1 || constr->Second_Deprecated == -1
+                    || constr->Second_Deprecated == GeoEnum::GeoUndef) {
                     // angle to horizontal axis
                     return "180 deg - (" + expr + ")";
                 }
@@ -681,7 +683,7 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
                 }
             }
             else if (yinv) {  // rotation 180 degrees around horizontal axis
-                if (constr->First == -2 || constr->Second == -2) {
+                if (constr->First_Deprecated == -2 || constr->Second_Deprecated == -2) {
                     // angle to vertical axis
                     return "180 deg - (" + expr + ")";
                 }
@@ -933,16 +935,17 @@ void SketchObject::delExternalPrivate(const std::set<long>& ids, bool removeRef)
 
     std::vector<Constraint*> newConstraints;
     for (const auto& cstr : Constraints.getValues()) {
-        if (geoIds.count(cstr->First)
-            || (cstr->Second != GeoEnum::GeoUndef && geoIds.count(cstr->Second))
-            || (cstr->Third != GeoEnum::GeoUndef && geoIds.count(cstr->Third))) {
+        if (geoIds.count(cstr->First_Deprecated)
+            || (cstr->Second_Deprecated != GeoEnum::GeoUndef && geoIds.count(cstr->Second_Deprecated))
+            || (cstr->Third_Deprecated != GeoEnum::GeoUndef && geoIds.count(cstr->Third_Deprecated))) {
             continue;
         }
         int offset = 0;
         std::unique_ptr<Constraint> newCstr(cstr->clone());
         for (auto GeoId : geoIds) {
             GeoId += offset++;
-            if (newCstr->First >= GeoId && newCstr->Second >= GeoId && newCstr->Third >= GeoId) {
+            if (newCstr->First_Deprecated >= GeoId && newCstr->Second_Deprecated >= GeoId
+                && newCstr->Third_Deprecated >= GeoId) {
                 break;
             }
             changeConstraintAfterDeletingGeo(newCstr.get(), GeoId);
@@ -1020,9 +1023,11 @@ int SketchObject::delAllExternal()
     std::vector<Constraint*> newConstraints(0);
 
     for (const auto& constr : constraints) {
-        if (constr->First > GeoEnum::RefExt
-            && (constr->Second > GeoEnum::RefExt || constr->Second == GeoEnum::GeoUndef)
-            && (constr->Third > GeoEnum::RefExt || constr->Third == GeoEnum::GeoUndef)) {
+        if (constr->First_Deprecated > GeoEnum::RefExt
+            && (constr->Second_Deprecated > GeoEnum::RefExt
+                || constr->Second_Deprecated == GeoEnum::GeoUndef)
+            && (constr->Third_Deprecated > GeoEnum::RefExt
+                || constr->Third_Deprecated == GeoEnum::GeoUndef)) {
             Constraint* copiedConstr = constr->clone();
 
             newConstraints.push_back(copiedConstr);
@@ -1061,8 +1066,8 @@ int SketchObject::delConstraintsToExternal(DeleteOptions options)
     std::vector<Constraint*> newConstraints(0);
     int GeoId = GeoEnum::RefExt, NullId = GeoEnum::GeoUndef;
     for (const auto& constr : constraints) {
-        if (constr->First > GeoId && (constr->Second > GeoId || constr->Second == NullId)
-            && (constr->Third > GeoId || constr->Third == NullId)) {
+        if (constr->First_Deprecated > GeoId && (constr->Second_Deprecated > GeoId || constr->Second_Deprecated == NullId)
+            && (constr->Third_Deprecated > GeoId || constr->Third_Deprecated == NullId)) {
             newConstraints.push_back(constr);
         }
     }

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -542,8 +542,8 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
         // DistanceX, DistanceY
         if ((xinv && newConstr->Type == Sketcher::DistanceX)
             || (yinv && newConstr->Type == Sketcher::DistanceY)) {
-            if (newConstr->First_Deprecated == newConstr->Second_Deprecated) {
-                std::swap(newConstr->FirstPos_Deprecated, newConstr->SecondPos_Deprecated);
+            if (newConstr->getGeoId(0) == newConstr->getGeoId(1)) {
+                std::swap(newConstr->getPosId(0), newConstr->getPosId(1));
             }
             else {
                 newConstr->setValue(-newConstr->getValue());
@@ -563,9 +563,9 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
             };
 
             if (xinv && yinv) {  // rotation 180 degrees around normal axis
-                if (newConstr->First_Deprecated == -1 || newConstr->Second_Deprecated == -1
-                    || newConstr->First_Deprecated == -2 || newConstr->Second_Deprecated == -2
-                    || newConstr->Second_Deprecated == GeoEnum::GeoUndef) {
+                if (newConstr->getGeoId(0) == -1 || newConstr->getGeoId(1) == -1
+                    || newConstr->getGeoId(0) == -2 || newConstr->getGeoId(1) == -2
+                    || newConstr->getGeoId(1) == GeoEnum::GeoUndef) {
                     // angle to horizontal or vertical axis
                     newConstr->setValue(normalizeAngle(newConstr->getValue() + pi));
                 }
@@ -575,8 +575,8 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
                 }
             }
             else if (xinv) {  // rotation 180 degrees around vertical axis
-                if (newConstr->First_Deprecated == -1 || newConstr->Second_Deprecated == -1
-                    || newConstr->Second_Deprecated == GeoEnum::GeoUndef) {
+                if (newConstr->getGeoId(0) == -1 || newConstr->getGeoId(1) == -1
+                    || newConstr->getGeoId(1) == GeoEnum::GeoUndef) {
                     // angle to horizontal axis
                     newConstr->setValue(normalizeAngle(pi - newConstr->getValue()));
                 }
@@ -586,7 +586,7 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
                 }
             }
             else if (yinv) {  // rotation 180 degrees around horizontal axis
-                if (newConstr->First_Deprecated == -2 || newConstr->Second_Deprecated == -2) {
+                if (newConstr->getGeoId(0) == -2 || newConstr->getGeoId(1) == -2) {
                     // angle to vertical axis
                     newConstr->setValue(normalizeAngle(pi - newConstr->getValue()));
                 }
@@ -648,7 +648,7 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
         // DistanceX, DistanceY
         if ((xinv && constr->Type == Sketcher::DistanceX)
             || (yinv && constr->Type == Sketcher::DistanceY)) {
-            if (constr->First_Deprecated == constr->Second_Deprecated) {
+            if (constr->getGeoId(0) == constr->getGeoId(1)) {
                 return expr;
             }
             else {
@@ -659,9 +659,9 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
         // Angle
         if (constr->Type == Sketcher::Angle) {
             if (xinv && yinv) {  // rotation 180 degrees around normal axis
-                if (constr->First_Deprecated == -1 || constr->Second_Deprecated == -1
-                    || constr->First_Deprecated == -2 || constr->Second_Deprecated == -2
-                    || constr->Second_Deprecated == GeoEnum::GeoUndef) {
+                if (constr->getGeoId(0) == -1 || constr->getGeoId(1) == -1
+                    || constr->getGeoId(0) == -2 || constr->getGeoId(1) == -2
+                    || constr->getGeoId(1) == GeoEnum::GeoUndef) {
                     // angle to horizontal or vertical axis
                     return "(" + expr + ") + 180 deg";
                 }
@@ -672,8 +672,8 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
                 }
             }
             else if (xinv) {  // rotation 180 degrees around vertical axis
-                if (constr->First_Deprecated == -1 || constr->Second_Deprecated == -1
-                    || constr->Second_Deprecated == GeoEnum::GeoUndef) {
+                if (constr->getGeoId(0) == -1 || constr->getGeoId(1) == -1
+                    || constr->getGeoId(1) == GeoEnum::GeoUndef) {
                     // angle to horizontal axis
                     return "180 deg - (" + expr + ")";
                 }
@@ -683,7 +683,7 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
                 }
             }
             else if (yinv) {  // rotation 180 degrees around horizontal axis
-                if (constr->First_Deprecated == -2 || constr->Second_Deprecated == -2) {
+                if (constr->getGeoId(0) == -2 || constr->getGeoId(1) == -2) {
                     // angle to vertical axis
                     return "180 deg - (" + expr + ")";
                 }
@@ -935,17 +935,17 @@ void SketchObject::delExternalPrivate(const std::set<long>& ids, bool removeRef)
 
     std::vector<Constraint*> newConstraints;
     for (const auto& cstr : Constraints.getValues()) {
-        if (geoIds.count(cstr->First_Deprecated)
-            || (cstr->Second_Deprecated != GeoEnum::GeoUndef && geoIds.count(cstr->Second_Deprecated))
-            || (cstr->Third_Deprecated != GeoEnum::GeoUndef && geoIds.count(cstr->Third_Deprecated))) {
+        if (geoIds.count(cstr->getGeoId(0))
+            || (cstr->getGeoId(1) != GeoEnum::GeoUndef && geoIds.count(cstr->getGeoId(1)))
+            || (cstr->getGeoId(2) != GeoEnum::GeoUndef && geoIds.count(cstr->getGeoId(2)))) {
             continue;
         }
         int offset = 0;
         std::unique_ptr<Constraint> newCstr(cstr->clone());
         for (auto GeoId : geoIds) {
             GeoId += offset++;
-            if (newCstr->First_Deprecated >= GeoId && newCstr->Second_Deprecated >= GeoId
-                && newCstr->Third_Deprecated >= GeoId) {
+            if (newCstr->getGeoId(0) >= GeoId && newCstr->getGeoId(1) >= GeoId
+                && newCstr->getGeoId(2) >= GeoId) {
                 break;
             }
             changeConstraintAfterDeletingGeo(newCstr.get(), GeoId);
@@ -1023,11 +1023,9 @@ int SketchObject::delAllExternal()
     std::vector<Constraint*> newConstraints(0);
 
     for (const auto& constr : constraints) {
-        if (constr->First_Deprecated > GeoEnum::RefExt
-            && (constr->Second_Deprecated > GeoEnum::RefExt
-                || constr->Second_Deprecated == GeoEnum::GeoUndef)
-            && (constr->Third_Deprecated > GeoEnum::RefExt
-                || constr->Third_Deprecated == GeoEnum::GeoUndef)) {
+        if (constr->getGeoId(0) > GeoEnum::RefExt
+            && (constr->getGeoId(1) > GeoEnum::RefExt || constr->getGeoId(1) == GeoEnum::GeoUndef)
+            && (constr->getGeoId(2) > GeoEnum::RefExt || constr->getGeoId(2) == GeoEnum::GeoUndef)) {
             Constraint* copiedConstr = constr->clone();
 
             newConstraints.push_back(copiedConstr);
@@ -1066,8 +1064,8 @@ int SketchObject::delConstraintsToExternal(DeleteOptions options)
     std::vector<Constraint*> newConstraints(0);
     int GeoId = GeoEnum::RefExt, NullId = GeoEnum::GeoUndef;
     for (const auto& constr : constraints) {
-        if (constr->First_Deprecated > GeoId && (constr->Second_Deprecated > GeoId || constr->Second_Deprecated == NullId)
-            && (constr->Third_Deprecated > GeoId || constr->Third_Deprecated == NullId)) {
+        if (constr->getGeoId(0) > GeoId && (constr->getGeoId(1) > GeoId || constr->getGeoId(1) == NullId)
+            && (constr->getGeoId(2) > GeoId || constr->getGeoId(2) == NullId)) {
             newConstraints.push_back(constr);
         }
     }

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -543,7 +543,7 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
         if ((xinv && newConstr->Type == Sketcher::DistanceX)
             || (yinv && newConstr->Type == Sketcher::DistanceY)) {
             if (newConstr->getGeoId(0) == newConstr->getGeoId(1)) {
-                std::swap(newConstr->getPosId(0), newConstr->getPosId(1));
+                newConstr->swapElements(0, 1);
             }
             else {
                 newConstr->setValue(-newConstr->getValue());

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -600,24 +600,24 @@ int SketchObject::carbonCopy(App::DocumentObject* pObj, bool construction)
 
     for (const auto& constr : scvals) {
         Sketcher::Constraint* newConstr = constr->copy();
-        if (constr->First_Deprecated >= 0) {
-            newConstr->First_Deprecated += nextgeoid;
+        if (constr->getGeoId(0) >= 0) {
+            newConstr->setGeoId(0, newConstr->getGeoId(0) + nextgeoid);
         }
-        if (constr->Second_Deprecated >= 0) {
-            newConstr->Second_Deprecated += nextgeoid;
+        if (constr->getGeoId(1) >= 0) {
+            newConstr->setGeoId(1, newConstr->getGeoId(1) + nextgeoid);
         }
-        if (constr->Third_Deprecated >= 0) {
-            newConstr->Third_Deprecated += nextgeoid;
+        if (constr->getGeoId(2) >= 0) {
+            newConstr->setGeoId(2, newConstr->getGeoId(2) + nextgeoid);
         }
 
-        if (constr->First_Deprecated < -2 && constr->First_Deprecated != GeoEnum::GeoUndef) {
-            newConstr->First_Deprecated -= (nextextgeoid - 2);
+        if (constr->getGeoId(0) < -2 && constr->getGeoId(0) != GeoEnum::GeoUndef) {
+            newConstr->setGeoId(0, newConstr->getGeoId(0) - (nextextgeoid - 2));
         }
-        if (constr->Second_Deprecated < -2 && constr->Second_Deprecated != GeoEnum::GeoUndef) {
-            newConstr->Second_Deprecated -= (nextextgeoid - 2);
+        if (constr->getGeoId(1) < -2 && constr->getGeoId(1) != GeoEnum::GeoUndef) {
+            newConstr->setGeoId(1, newConstr->getGeoId(1) - (nextextgeoid - 2));
         }
-        if (constr->Third_Deprecated < -2 && constr->Third_Deprecated != GeoEnum::GeoUndef) {
-            newConstr->Third_Deprecated -= (nextextgeoid - 2);
+        if (constr->getGeoId(2) < -2 && constr->getGeoId(2) != GeoEnum::GeoUndef) {
+            newConstr->setGeoId(2, newConstr->getGeoId(2) - (nextextgeoid - 2));
         }
 
         if (xinv || yinv) {

--- a/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
@@ -533,8 +533,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseMajorDiameter;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(0, currentgeoid + incrgeo + 1);
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -548,8 +548,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseMinorDiameter;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(0, currentgeoid + incrgeo + 1);
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -564,7 +564,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus1;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -578,7 +578,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus2;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
     }
@@ -671,8 +671,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseMajorDiameter;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(0, currentgeoid + incrgeo + 1);
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -686,8 +686,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseMinorDiameter;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(0, currentgeoid + incrgeo + 1);
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -702,7 +702,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus1;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -716,7 +716,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus2;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
     }
@@ -789,8 +789,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::HyperbolaMajor;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(0, currentgeoid + incrgeo + 1);
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -804,8 +804,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::HyperbolaMinor;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(0, currentgeoid + incrgeo + 1);
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
 
@@ -821,7 +821,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::HyperbolaFocus;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -879,7 +879,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfParabola>(const i
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::ParabolaFocus;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -895,7 +895,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfParabola>(const i
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::ParabolaFocalAxis;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::none));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
 
         icon.push_back(newConstr);
 
@@ -976,7 +976,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::BSplineControlPoint;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo, Sketcher::PointPos::mid));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
         newConstr->InternalAlignmentIndex = index;
 
         icon.push_back(newConstr);
@@ -987,7 +987,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
                 // if the first weight is 1.0 it's probably going to be non-rational
                 auto* newConstr3 = new Sketcher::Constraint();
                 newConstr3->Type = Sketcher::Weight;
-                newConstr3->First_Deprecated = controlpointgeoids[0];
+                newConstr3->setGeoId(0, controlpointgeoids[0]);
                 newConstr3->setValue(weights[0]);
 
                 icon.push_back(newConstr3);
@@ -1028,7 +1028,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::BSplineKnotPoint;
         newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo, Sketcher::PointPos::start));
-        newConstr->Second_Deprecated = GeoId;
+        newConstr->setGeoId(1, GeoId);
         newConstr->InternalAlignmentIndex = index;
 
         icon.push_back(newConstr);

--- a/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
@@ -477,7 +477,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (const auto& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->getGeoId(1) != GeoId) {
             continue;
         }
 
@@ -615,7 +615,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (const auto& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->getGeoId(1) != GeoId) {
             continue;
         }
 
@@ -737,7 +737,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->getGeoId(1) != GeoId) {
             continue;
         }
 
@@ -842,7 +842,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfParabola>(const i
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->getGeoId(1) != GeoId) {
             continue;
         }
 
@@ -923,16 +923,16 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
 
     // search for existing poles
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->getGeoId(1) != GeoId) {
             continue;
         }
 
         switch (constr->AlignmentType) {
         case Sketcher::BSplineControlPoint:
-            controlpointgeoids[constr->InternalAlignmentIndex] = constr->First_Deprecated;
+            controlpointgeoids[constr->InternalAlignmentIndex] = constr->getGeoId(0);
             break;
         case Sketcher::BSplineKnotPoint:
-            knotgeoids[constr->InternalAlignmentIndex] = constr->First_Deprecated;
+            knotgeoids[constr->InternalAlignmentIndex] = constr->getGeoId(0);
             break;
         default:
             return -1;
@@ -942,7 +942,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
     if (controlpointgeoids[0] != GeoEnum::GeoUndef) {
         isfirstweightconstrained =
             std::ranges::any_of(vals, [&controlpointgeoids](const auto& constr) {
-                return (constr->Type == Sketcher::Weight && constr->First_Deprecated == controlpointgeoids[0]);
+                return (constr->Type == Sketcher::Weight && constr->getGeoId(0) == controlpointgeoids[0]);
             });
     }
 
@@ -1101,25 +1101,25 @@ int SketchObject::deleteUnusedInternalGeometryWhenTwoFoci(int GeoId, bool delgeo
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->getGeoId(1) != GeoId) {
             continue;
         }
 
         switch (constr->AlignmentType) {
         case Sketcher::EllipseMajorDiameter:
         case Sketcher::HyperbolaMajor:
-            majorelementindex = constr->First_Deprecated;
+            majorelementindex = constr->getGeoId(0);
             break;
         case Sketcher::EllipseMinorDiameter:
         case Sketcher::HyperbolaMinor:
-            minorelementindex = constr->First_Deprecated;
+            minorelementindex = constr->getGeoId(0);
             break;
         case Sketcher::EllipseFocus1:
         case Sketcher::HyperbolaFocus:
-            focus1elementindex = constr->First_Deprecated;
+            focus1elementindex = constr->getGeoId(0);
             break;
         case Sketcher::EllipseFocus2:
-            focus2elementindex = constr->First_Deprecated;
+            focus2elementindex = constr->getGeoId(0);
             break;
         default:
             return -1;
@@ -1184,16 +1184,16 @@ int SketchObject::deleteUnusedInternalGeometryWhenOneFocus(int GeoId, bool delge
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->getGeoId(1) != GeoId) {
             continue;
         }
 
         switch (constr->AlignmentType) {
         case Sketcher::ParabolaFocus:
-            focus1elementindex = constr->First_Deprecated;
+            focus1elementindex = constr->getGeoId(0);
             break;
         case Sketcher::ParabolaFocalAxis:
-            majorelementindex = constr->First_Deprecated;
+            majorelementindex = constr->getGeoId(0);
             break;
         default:
             return -1;
@@ -1252,16 +1252,16 @@ int SketchObject::deleteUnusedInternalGeometryWhenBSpline(int GeoId, bool delgeo
 
     // search for existing poles
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->getGeoId(1) != GeoId) {
             continue;
         }
 
         switch (constr->AlignmentType) {
         case Sketcher::BSplineControlPoint:
-            poleGeoIdsAndConstraints[constr->First_Deprecated] = 0;
+            poleGeoIdsAndConstraints[constr->getGeoId(0)] = 0;
             break;
         case Sketcher::BSplineKnotPoint:
-            knotGeoIdsAndConstraints[constr->First_Deprecated] = 0;
+            knotGeoIdsAndConstraints[constr->getGeoId(0)] = 0;
             break;
         default:
             return -1;
@@ -1279,17 +1279,17 @@ int SketchObject::deleteUnusedInternalGeometryWhenBSpline(int GeoId, bool delgeo
             || constr->Type == Sketcher::Weight) {
             continue;
         }
-        bool firstIsInCPGeoIds = poleGeoIdsAndConstraints.count(constr->First_Deprecated) == 1;
-        bool secondIsInCPGeoIds = poleGeoIdsAndConstraints.count(constr->Second_Deprecated) == 1;
+        bool firstIsInCPGeoIds = poleGeoIdsAndConstraints.count(constr->getGeoId(0)) == 1;
+        bool secondIsInCPGeoIds = poleGeoIdsAndConstraints.count(constr->getGeoId(1)) == 1;
         if (constr->Type == Sketcher::Equal && firstIsInCPGeoIds == secondIsInCPGeoIds) {
             continue;
         }
         // any equality constraint constraining a pole is not interpole
         if (firstIsInCPGeoIds) {
-            ++poleGeoIdsAndConstraints[constr->First_Deprecated];
+            ++poleGeoIdsAndConstraints[constr->getGeoId(0)];
         }
         if (secondIsInCPGeoIds) {
-            ++poleGeoIdsAndConstraints[constr->Second_Deprecated];
+            ++poleGeoIdsAndConstraints[constr->getGeoId(1)];
         }
     }
 

--- a/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
@@ -563,8 +563,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus1;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
         newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
@@ -578,8 +577,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus2;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
         newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
@@ -703,8 +701,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus1;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
         newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
@@ -718,8 +715,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus2;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
         newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
@@ -824,8 +820,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::HyperbolaFocus;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
         newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
@@ -883,8 +878,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfParabola>(const i
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::ParabolaFocus;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::start));
         newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
@@ -900,8 +894,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfParabola>(const i
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::ParabolaFocalAxis;
-        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::none;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo + 1, Sketcher::PointPos::none));
         newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
@@ -982,8 +975,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::BSplineControlPoint;
-        newConstr->First_Deprecated = currentgeoid + incrgeo;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::mid;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo, Sketcher::PointPos::mid));
         newConstr->Second_Deprecated = GeoId;
         newConstr->InternalAlignmentIndex = index;
 
@@ -1011,10 +1003,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
             // AND these weights are equal, constrain them to be equal
             auto* newConstr2 = new Sketcher::Constraint();
             newConstr2->Type = Sketcher::Equal;
-            newConstr2->First_Deprecated = currentgeoid + incrgeo;
-            newConstr2->FirstPos_Deprecated = Sketcher::PointPos::none;
-            newConstr2->Second_Deprecated = controlpointgeoids[0];
-            newConstr2->SecondPos_Deprecated = Sketcher::PointPos::none;
+            newConstr2->setElement(0, GeoElementId(currentgeoid + incrgeo, Sketcher::PointPos::none));
+            newConstr2->setElement(1, GeoElementId(controlpointgeoids[0], Sketcher::PointPos::none));
 
             icon.push_back(newConstr2);
         }
@@ -1037,8 +1027,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::BSplineKnotPoint;
-        newConstr->First_Deprecated = currentgeoid + incrgeo;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->setElement(0, GeoElementId(currentgeoid + incrgeo, Sketcher::PointPos::start));
         newConstr->Second_Deprecated = GeoId;
         newConstr->InternalAlignmentIndex = index;
 

--- a/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectGeometry.cpp
@@ -477,7 +477,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (const auto& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
             continue;
         }
 
@@ -533,8 +533,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseMajorDiameter;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -548,8 +548,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseMinorDiameter;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -563,9 +563,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus1;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos = Sketcher::PointPos::start;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -578,9 +578,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomEllipse>(const int Geo
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus2;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos = Sketcher::PointPos::start;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
     }
@@ -617,7 +617,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (const auto& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
             continue;
         }
 
@@ -673,8 +673,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseMajorDiameter;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -688,8 +688,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseMinorDiameter;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -703,9 +703,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus1;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos = Sketcher::PointPos::start;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -718,9 +718,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfEllipse>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = EllipseFocus2;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos = Sketcher::PointPos::start;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
     }
@@ -741,7 +741,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
             continue;
         }
 
@@ -793,8 +793,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::HyperbolaMajor;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -808,8 +808,8 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::HyperbolaMinor;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
 
@@ -824,9 +824,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfHyperbola>(const 
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::HyperbolaFocus;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos = Sketcher::PointPos::start;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -847,7 +847,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfParabola>(const i
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
             continue;
         }
 
@@ -883,9 +883,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfParabola>(const i
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::ParabolaFocus;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos = Sketcher::PointPos::start;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
         incrgeo++;
@@ -900,9 +900,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomArcOfParabola>(const i
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::ParabolaFocalAxis;
-        newConstr->First = currentgeoid + incrgeo + 1;
-        newConstr->FirstPos = Sketcher::PointPos::none;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo + 1;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::none;
+        newConstr->Second_Deprecated = GeoId;
 
         icon.push_back(newConstr);
 
@@ -930,16 +930,16 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
 
     // search for existing poles
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
             continue;
         }
 
         switch (constr->AlignmentType) {
         case Sketcher::BSplineControlPoint:
-            controlpointgeoids[constr->InternalAlignmentIndex] = constr->First;
+            controlpointgeoids[constr->InternalAlignmentIndex] = constr->First_Deprecated;
             break;
         case Sketcher::BSplineKnotPoint:
-            knotgeoids[constr->InternalAlignmentIndex] = constr->First;
+            knotgeoids[constr->InternalAlignmentIndex] = constr->First_Deprecated;
             break;
         default:
             return -1;
@@ -949,7 +949,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
     if (controlpointgeoids[0] != GeoEnum::GeoUndef) {
         isfirstweightconstrained =
             std::ranges::any_of(vals, [&controlpointgeoids](const auto& constr) {
-                return (constr->Type == Sketcher::Weight && constr->First == controlpointgeoids[0]);
+                return (constr->Type == Sketcher::Weight && constr->First_Deprecated == controlpointgeoids[0]);
             });
     }
 
@@ -982,9 +982,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::BSplineControlPoint;
-        newConstr->First = currentgeoid + incrgeo;
-        newConstr->FirstPos = Sketcher::PointPos::mid;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::mid;
+        newConstr->Second_Deprecated = GeoId;
         newConstr->InternalAlignmentIndex = index;
 
         icon.push_back(newConstr);
@@ -995,7 +995,7 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
                 // if the first weight is 1.0 it's probably going to be non-rational
                 auto* newConstr3 = new Sketcher::Constraint();
                 newConstr3->Type = Sketcher::Weight;
-                newConstr3->First = controlpointgeoids[0];
+                newConstr3->First_Deprecated = controlpointgeoids[0];
                 newConstr3->setValue(weights[0]);
 
                 icon.push_back(newConstr3);
@@ -1011,10 +1011,10 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
             // AND these weights are equal, constrain them to be equal
             auto* newConstr2 = new Sketcher::Constraint();
             newConstr2->Type = Sketcher::Equal;
-            newConstr2->First = currentgeoid + incrgeo;
-            newConstr2->FirstPos = Sketcher::PointPos::none;
-            newConstr2->Second = controlpointgeoids[0];
-            newConstr2->SecondPos = Sketcher::PointPos::none;
+            newConstr2->First_Deprecated = currentgeoid + incrgeo;
+            newConstr2->FirstPos_Deprecated = Sketcher::PointPos::none;
+            newConstr2->Second_Deprecated = controlpointgeoids[0];
+            newConstr2->SecondPos_Deprecated = Sketcher::PointPos::none;
 
             icon.push_back(newConstr2);
         }
@@ -1037,9 +1037,9 @@ int SketchObject::exposeInternalGeometryForType<Part::GeomBSplineCurve>(const in
         auto* newConstr = new Sketcher::Constraint();
         newConstr->Type = Sketcher::InternalAlignment;
         newConstr->AlignmentType = Sketcher::BSplineKnotPoint;
-        newConstr->First = currentgeoid + incrgeo;
-        newConstr->FirstPos = Sketcher::PointPos::start;
-        newConstr->Second = GeoId;
+        newConstr->First_Deprecated = currentgeoid + incrgeo;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::start;
+        newConstr->Second_Deprecated = GeoId;
         newConstr->InternalAlignmentIndex = index;
 
         icon.push_back(newConstr);
@@ -1112,25 +1112,25 @@ int SketchObject::deleteUnusedInternalGeometryWhenTwoFoci(int GeoId, bool delgeo
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
             continue;
         }
 
         switch (constr->AlignmentType) {
         case Sketcher::EllipseMajorDiameter:
         case Sketcher::HyperbolaMajor:
-            majorelementindex = constr->First;
+            majorelementindex = constr->First_Deprecated;
             break;
         case Sketcher::EllipseMinorDiameter:
         case Sketcher::HyperbolaMinor:
-            minorelementindex = constr->First;
+            minorelementindex = constr->First_Deprecated;
             break;
         case Sketcher::EllipseFocus1:
         case Sketcher::HyperbolaFocus:
-            focus1elementindex = constr->First;
+            focus1elementindex = constr->First_Deprecated;
             break;
         case Sketcher::EllipseFocus2:
-            focus2elementindex = constr->First;
+            focus2elementindex = constr->First_Deprecated;
             break;
         default:
             return -1;
@@ -1195,16 +1195,16 @@ int SketchObject::deleteUnusedInternalGeometryWhenOneFocus(int GeoId, bool delge
     const std::vector<Sketcher::Constraint*>& vals = Constraints.getValues();
 
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
             continue;
         }
 
         switch (constr->AlignmentType) {
         case Sketcher::ParabolaFocus:
-            focus1elementindex = constr->First;
+            focus1elementindex = constr->First_Deprecated;
             break;
         case Sketcher::ParabolaFocalAxis:
-            majorelementindex = constr->First;
+            majorelementindex = constr->First_Deprecated;
             break;
         default:
             return -1;
@@ -1263,16 +1263,16 @@ int SketchObject::deleteUnusedInternalGeometryWhenBSpline(int GeoId, bool delgeo
 
     // search for existing poles
     for (auto const& constr : vals) {
-        if (constr->Type != Sketcher::InternalAlignment || constr->Second != GeoId) {
+        if (constr->Type != Sketcher::InternalAlignment || constr->Second_Deprecated != GeoId) {
             continue;
         }
 
         switch (constr->AlignmentType) {
         case Sketcher::BSplineControlPoint:
-            poleGeoIdsAndConstraints[constr->First] = 0;
+            poleGeoIdsAndConstraints[constr->First_Deprecated] = 0;
             break;
         case Sketcher::BSplineKnotPoint:
-            knotGeoIdsAndConstraints[constr->First] = 0;
+            knotGeoIdsAndConstraints[constr->First_Deprecated] = 0;
             break;
         default:
             return -1;
@@ -1290,17 +1290,17 @@ int SketchObject::deleteUnusedInternalGeometryWhenBSpline(int GeoId, bool delgeo
             || constr->Type == Sketcher::Weight) {
             continue;
         }
-        bool firstIsInCPGeoIds = poleGeoIdsAndConstraints.count(constr->First) == 1;
-        bool secondIsInCPGeoIds = poleGeoIdsAndConstraints.count(constr->Second) == 1;
+        bool firstIsInCPGeoIds = poleGeoIdsAndConstraints.count(constr->First_Deprecated) == 1;
+        bool secondIsInCPGeoIds = poleGeoIdsAndConstraints.count(constr->Second_Deprecated) == 1;
         if (constr->Type == Sketcher::Equal && firstIsInCPGeoIds == secondIsInCPGeoIds) {
             continue;
         }
         // any equality constraint constraining a pole is not interpole
         if (firstIsInCPGeoIds) {
-            ++poleGeoIdsAndConstraints[constr->First];
+            ++poleGeoIdsAndConstraints[constr->First_Deprecated];
         }
         if (secondIsInCPGeoIds) {
-            ++poleGeoIdsAndConstraints[constr->Second];
+            ++poleGeoIdsAndConstraints[constr->Second_Deprecated];
         }
     }
 

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -137,10 +137,10 @@ int SketchObject::delGeometries(InputIt first, InputIt last, DeleteOptions optio
     // if a GeoId has internal geometry, it must delete internal geometries too
     for (auto c : Constraints.getValues()) {
         if (c->Type == InternalAlignment) {
-            auto pos = std::ranges::find(sGeoIds, c->Second);
+            auto pos = std::ranges::find(sGeoIds, c->Second_Deprecated);
 
             if (pos != sGeoIds.end()) {
-                sGeoIds.push_back(c->First);
+                sGeoIds.push_back(c->First_Deprecated);
             }
         }
     }
@@ -296,16 +296,16 @@ int SketchObject::fillet(int GeoId1, int GeoId2, const Base::Vector3d& refPnt1,
         auto tangent2 = std::make_unique<Sketcher::Constraint>();
 
         tangent1->Type = Sketcher::Tangent;
-        tangent1->First = GeoId1;
-        tangent1->FirstPos = PosId1;
-        tangent1->Second = filletId;
-        tangent1->SecondPos = filletPosId1;
+        tangent1->First_Deprecated = GeoId1;
+        tangent1->FirstPos_Deprecated = PosId1;
+        tangent1->Second_Deprecated = filletId;
+        tangent1->SecondPos_Deprecated = filletPosId1;
 
         tangent2->Type = Sketcher::Tangent;
-        tangent2->First = GeoId2;
-        tangent2->FirstPos = PosId2;
-        tangent2->Second = filletId;
-        tangent2->SecondPos = filletPosId2;
+        tangent2->First_Deprecated = GeoId2;
+        tangent2->FirstPos_Deprecated = PosId2;
+        tangent2->Second_Deprecated = filletId;
+        tangent2->SecondPos_Deprecated = filletPosId2;
 
         addConstraint(std::move(tangent1));
         addConstraint(std::move(tangent2));
@@ -321,24 +321,24 @@ int SketchObject::fillet(int GeoId1, int GeoId2, const Base::Vector3d& refPnt1,
         auto coinc2 = std::make_unique<Sketcher::Constraint>();
 
         coinc1->Type = Sketcher::Coincident;
-        coinc1->First = lineGeoId;
-        coinc1->FirstPos = filletPosId1;
+        coinc1->First_Deprecated = lineGeoId;
+        coinc1->FirstPos_Deprecated = filletPosId1;
 
         coinc2->Type = Sketcher::Coincident;
-        coinc2->First = lineGeoId;
-        coinc2->FirstPos = filletPosId2;
+        coinc2->First_Deprecated = lineGeoId;
+        coinc2->FirstPos_Deprecated = filletPosId2;
 
         if (trim) {
-            coinc1->Second = GeoId1;
-            coinc1->SecondPos = PosId1;
-            coinc2->Second = GeoId2;
-            coinc2->SecondPos = PosId2;
+            coinc1->Second_Deprecated = GeoId1;
+            coinc1->SecondPos_Deprecated = PosId1;
+            coinc2->Second_Deprecated = GeoId2;
+            coinc2->SecondPos_Deprecated = PosId2;
         }
         else {
-            coinc1->Second = filletId;
-            coinc1->SecondPos = PointPos::start;
-            coinc2->Second = filletId;
-            coinc2->SecondPos = PointPos::end;
+            coinc1->Second_Deprecated = filletId;
+            coinc1->SecondPos_Deprecated = PointPos::start;
+            coinc2->Second_Deprecated = filletId;
+            coinc2->SecondPos_Deprecated = PointPos::end;
         }
 
         addConstraint(std::move(coinc1));
@@ -509,12 +509,12 @@ std::unique_ptr<Constraint> transformPreexistingConstraintForTrim(
             // we might want to transform this (and the new point-on-object constraints) into a
             // coincidence At this stage of the check the point has to be an end of `cuttingGeoId`
             // on the edge of `GeoId`.
-            if (isPointAtPosition(obj, constr->First, constr->FirstPos, cutPointVec)) {
+            if (isPointAtPosition(obj, constr->First_Deprecated, constr->FirstPos_Deprecated, cutPointVec)) {
                 // We already know the point-on-object is on the whole of GeoId
                 newConstr.reset(constr->copy());
                 newConstr->Type = Sketcher::Coincident;
-                newConstr->Second = newGeoId;
-                newConstr->SecondPos = newPosId;
+                newConstr->Second_Deprecated = newGeoId;
+                newConstr->SecondPos_Deprecated = newPosId;
             }
             break;
         }
@@ -526,13 +526,13 @@ std::unique_ptr<Constraint> transformPreexistingConstraintForTrim(
             newConstr.reset(constr->copy());
             newConstr->substituteIndexAndPos(GeoId, PointPos::none, newGeoId, newPosId);
             // make sure the first position is a point
-            if (newConstr->FirstPos == PointPos::none) {
-                std::swap(newConstr->First, newConstr->Second);
-                std::swap(newConstr->FirstPos, newConstr->SecondPos);
+            if (newConstr->FirstPos_Deprecated == PointPos::none) {
+                std::swap(newConstr->First_Deprecated, newConstr->Second_Deprecated);
+                std::swap(newConstr->FirstPos_Deprecated, newConstr->SecondPos_Deprecated);
             }
             // there is no need for the third point if it exists
-            newConstr->Third = GeoEnum::GeoUndef;
-            newConstr->ThirdPos = PointPos::none;
+            newConstr->Third_Deprecated = GeoEnum::GeoUndef;
+            newConstr->ThirdPos_Deprecated = PointPos::none;
             break;
         }
         default:
@@ -550,21 +550,21 @@ std::unique_ptr<Constraint> getNewConstraintAtTrimCut(
 )
 {
     auto newConstr = std::make_unique<Sketcher::Constraint>();
-    newConstr->First = cutGeoId;
-    newConstr->FirstPos = cutPosId;
-    newConstr->Second = cuttingGeoId;
+    newConstr->First_Deprecated = cutGeoId;
+    newConstr->FirstPos_Deprecated = cutPosId;
+    newConstr->Second_Deprecated = cuttingGeoId;
     if (isPointAtPosition(obj, cuttingGeoId, PointPos::start, cutPointVec)) {
         newConstr->Type = Sketcher::Coincident;
-        newConstr->SecondPos = PointPos::start;
+        newConstr->SecondPos_Deprecated = PointPos::start;
     }
     else if (isPointAtPosition(obj, cuttingGeoId, PointPos::end, cutPointVec)) {
         newConstr->Type = Sketcher::Coincident;
-        newConstr->SecondPos = PointPos::end;
+        newConstr->SecondPos_Deprecated = PointPos::end;
     }
     else {
         // Points are sufficiently far apart: use point-on-object
         newConstr->Type = Sketcher::PointOnObject;
-        newConstr->SecondPos = PointPos::none;
+        newConstr->SecondPos_Deprecated = PointPos::none;
     }
     return newConstr;
 }
@@ -667,7 +667,7 @@ void createNewConstraintsForTrim(
         // trim-specific changes first
         const Constraint* con = allConstraints[oldConstrId];
         if (con->Type == InternalAlignment) {
-            geoIdsToBeDeleted.insert(con->First);
+            geoIdsToBeDeleted.insert(con->First_Deprecated);
             continue;
         }
         if (auto newConstr = transformPreexistingConstraintForTrim(
@@ -867,10 +867,10 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
 
         // Build Constraints associated with new pair of arcs
         newConstr->Type = Sketcher::Equal;
-        newConstr->First = GeoId1;
-        newConstr->FirstPos = Sketcher::PointPos::none;
-        newConstr->Second = GeoId2;
-        newConstr->SecondPos = Sketcher::PointPos::none;
+        newConstr->First_Deprecated = GeoId1;
+        newConstr->FirstPos_Deprecated = Sketcher::PointPos::none;
+        newConstr->Second_Deprecated = GeoId2;
+        newConstr->SecondPos_Deprecated = Sketcher::PointPos::none;
         addConstraint(std::move(newConstr));
     };
 
@@ -898,10 +898,10 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
         if (newIds.size() > 1) {
             auto* joint = new Constraint();
             joint->Type = Coincident;
-            joint->First = newIds.front();
-            joint->FirstPos = PointPos::mid;
-            joint->Second = newIds.back();
-            joint->SecondPos = PointPos::mid;
+            joint->First_Deprecated = newIds.front();
+            joint->FirstPos_Deprecated = PointPos::mid;
+            joint->Second_Deprecated = newIds.back();
+            joint->SecondPos_Deprecated = PointPos::mid;
             newConstraints.push_back(joint);
 
             // Any radius etc. equality constraints here
@@ -1038,10 +1038,10 @@ int SketchObject::split(int GeoId, const Base::Vector3d& point)
     if (!isOriginalCurvePeriodic) {
         auto* joint = new Constraint();
         joint->Type = Coincident;
-        joint->First = newIds.front();
-        joint->FirstPos = PointPos::end;
-        joint->Second = newIds.back();
-        joint->SecondPos = PointPos::start;
+        joint->First_Deprecated = newIds.front();
+        joint->FirstPos_Deprecated = PointPos::end;
+        joint->Second_Deprecated = newIds.back();
+        joint->SecondPos_Deprecated = PointPos::start;
         newConstraints.push_back(joint);
 
         transferConstraints(GeoId, PointPos::start, newIds.front(), PointPos::start);
@@ -1053,10 +1053,10 @@ int SketchObject::split(int GeoId, const Base::Vector3d& point)
     if (geoAsCurve->is<Part::GeomArcOfCircle>()) {
         auto* joint = new Constraint();
         joint->Type = Coincident;
-        joint->First = newIds.front();
-        joint->FirstPos = PointPos::mid;
-        joint->Second = newIds.back();
-        joint->SecondPos = PointPos::mid;
+        joint->First_Deprecated = newIds.front();
+        joint->FirstPos_Deprecated = PointPos::mid;
+        joint->Second_Deprecated = newIds.back();
+        joint->SecondPos_Deprecated = PointPos::mid;
         newConstraints.push_back(joint);
     }
 
@@ -1999,11 +1999,12 @@ int SketchObject::addCopy(
 
                 auto constrIt = std::ranges::find_if(constrvals, [&newgeoIdList](auto c) {
                     return (
-                        c->Type == Sketcher::InternalAlignment && c->First == *(newgeoIdList.begin())
+                        c->Type == Sketcher::InternalAlignment
+                        && c->First_Deprecated == *(newgeoIdList.begin())
                     );
                 });
 
-                int definedGeo = (constrIt != constrvals.end()) ? (*constrIt)->Second
+                int definedGeo = (constrIt != constrvals.end()) ? (*constrIt)->Second_Deprecated
                                                                 : GeoEnum::GeoUndef;
 
                 if (std::ranges::find(newgeoIdList, definedGeo) == newgeoIdList.end()) {
@@ -2054,10 +2055,10 @@ int SketchObject::addCopy(
                 int definedGeo = GeoEnum::GeoUndef;
 
                 auto constrIt = std::ranges::find_if(constrvals, [&it](auto c) {
-                    return (c->Type == Sketcher::InternalAlignment && c->First == *it);
+                    return (c->Type == Sketcher::InternalAlignment && c->First_Deprecated == *it);
                 });
                 if (constrIt != constrvals.end()) {
-                    definedGeo = (*constrIt)->Second;
+                    definedGeo = (*constrIt)->Second_Deprecated;
                 }
 
                 if (std::ranges::find(newgeoIdList, definedGeo) == newgeoIdList.end()) {
@@ -2209,16 +2210,17 @@ int SketchObject::addCopy(
 
         // handle geometry constraints
         for (const auto& constr : constrvals) {
-            auto fit = geoIdMap.find(constr->First);
+            auto fit = geoIdMap.find(constr->First_Deprecated);
 
             if (fit == geoIdMap.end()) {
                 continue;
             }
 
             // First of constraint is in geoIdList
-            if (constr->Second == GeoEnum::GeoUndef /*&& constr->Third == GeoEnum::GeoUndef*/) {
+            if (constr->Second_Deprecated
+                == GeoEnum::GeoUndef /*&& constr->Third == GeoEnum::GeoUndef*/) {
                 if ((constr->Type == Sketcher::DistanceX || constr->Type == Sketcher::DistanceY)
-                    && constr->FirstPos != Sketcher::PointPos::none) {
+                    && constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
                     continue;
                 }
                 // if it is not a point locking DistanceX/Y
@@ -2232,63 +2234,63 @@ int SketchObject::addCopy(
                     constNew->Type = Sketcher::Equal;
                     constNew->isDriving = true;
                     // first is already (constr->First)
-                    constNew->Second = fit->second;
+                    constNew->Second_Deprecated = fit->second;
                     newconstrVals.push_back(constNew);
                     continue;
                 }
                 if (!(constr->Type == Sketcher::Angle && clone)) {
                     Constraint* constNew = constr->copy();
-                    constNew->First = fit->second;
+                    constNew->First_Deprecated = fit->second;
                     newconstrVals.push_back(constNew);
                     continue;
                 }
-                if (getGeometry(constr->First)->is<Part::GeomLineSegment>()) {
+                if (getGeometry(constr->First_Deprecated)->is<Part::GeomLineSegment>()) {
                     // Angles on a single Element are mapped to parallel
                     // constraints in clone mode
                     Constraint* constNew = constr->copy();
                     constNew->Type = Sketcher::Parallel;
                     constNew->isDriving = true;
                     // first is already (constr->First)
-                    constNew->Second = fit->second;
+                    constNew->Second_Deprecated = fit->second;
                     newconstrVals.push_back(constNew);
                 }
                 continue;
             }
 
             // other geoids intervene in this constraint
-            auto sit = geoIdMap.find(constr->Second);
+            auto sit = geoIdMap.find(constr->Second_Deprecated);
 
             if (sit == geoIdMap.end()) {
                 continue;
             }
 
             // Second is also in the list
-            if (constr->Third == GeoEnum::GeoUndef) {
+            if (constr->Third_Deprecated == GeoEnum::GeoUndef) {
                 if ((constr->Type == Sketcher::DistanceX || constr->Type == Sketcher::DistanceY
                      || constr->Type == Sketcher::Distance)
-                    && (constr->First == constr->Second) && clone) {
+                    && (constr->First_Deprecated == constr->Second_Deprecated) && clone) {
                     // Distances on a two Elements, which must be points of the
                     // same line are mapped to equality constraints in clone
                     // mode
                     Constraint* constNew = constr->copy();
                     constNew->Type = Sketcher::Equal;
                     constNew->isDriving = true;
-                    constNew->FirstPos = Sketcher::PointPos::none;
+                    constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
                     // first is already (constr->First)
-                    constNew->Second = fit->second;
-                    constNew->SecondPos = Sketcher::PointPos::none;
+                    constNew->Second_Deprecated = fit->second;
+                    constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
                     newconstrVals.push_back(constNew);
                     continue;
                 }
                 // remaining, this includes InternalAlignment constraints
                 Constraint* constNew = constr->copy();
-                constNew->First = fit->second;
-                constNew->Second = sit->second;
+                constNew->First_Deprecated = fit->second;
+                constNew->Second_Deprecated = sit->second;
                 newconstrVals.push_back(constNew);
                 continue;
             }
 
-            auto tit = geoIdMap.find(constr->Third);
+            auto tit = geoIdMap.find(constr->Third_Deprecated);
 
             if (tit != geoIdMap.end()) {
                 continue;
@@ -2296,9 +2298,9 @@ int SketchObject::addCopy(
 
             // Third is also in the list
             Constraint* constNew = constr->copy();
-            constNew->First = fit->second;
-            constNew->Second = sit->second;
-            constNew->Third = tit->second;
+            constNew->First_Deprecated = fit->second;
+            constNew->Second_Deprecated = sit->second;
+            constNew->Third_Deprecated = tit->second;
 
             newconstrVals.push_back(constNew);
         }
@@ -2334,18 +2336,18 @@ int SketchObject::addCopy(
             // add coincidents for construction line
             constNew = new Constraint();
             constNew->Type = Sketcher::Coincident;
-            constNew->First = prevrowstartfirstgeoid;
-            constNew->FirstPos = refposId;
-            constNew->Second = cgeoid;
-            constNew->SecondPos = Sketcher::PointPos::start;
+            constNew->First_Deprecated = prevrowstartfirstgeoid;
+            constNew->FirstPos_Deprecated = refposId;
+            constNew->Second_Deprecated = cgeoid;
+            constNew->SecondPos_Deprecated = Sketcher::PointPos::start;
             newconstrVals.push_back(constNew);
 
             constNew = new Constraint();
             constNew->Type = Sketcher::Coincident;
-            constNew->First = iterfirstgeoid;
-            constNew->FirstPos = refposId;
-            constNew->Second = cgeoid;
-            constNew->SecondPos = Sketcher::PointPos::end;
+            constNew->First_Deprecated = iterfirstgeoid;
+            constNew->FirstPos_Deprecated = refposId;
+            constNew->Second_Deprecated = cgeoid;
+            constNew->SecondPos_Deprecated = Sketcher::PointPos::end;
             newconstrVals.push_back(constNew);
 
             // it is the first added element of this row in the perpendicular to
@@ -2358,27 +2360,27 @@ int SketchObject::addCopy(
                 if (perpscale == 1.0) {
                     constNew = new Constraint();
                     constNew->Type = Sketcher::Equal;
-                    constNew->First = rowrefgeoid;
-                    constNew->FirstPos = Sketcher::PointPos::none;
-                    constNew->Second = colrefgeoid;
-                    constNew->SecondPos = Sketcher::PointPos::none;
+                    constNew->First_Deprecated = rowrefgeoid;
+                    constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                    constNew->Second_Deprecated = colrefgeoid;
+                    constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
                     newconstrVals.push_back(constNew);
                 }
                 else {
                     constNew = new Constraint();
                     constNew->Type = Sketcher::Distance;
-                    constNew->First = rowrefgeoid;
-                    constNew->FirstPos = Sketcher::PointPos::none;
+                    constNew->First_Deprecated = rowrefgeoid;
+                    constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
                     constNew->setValue(perpendicularDisplacement.Length());
                     newconstrVals.push_back(constNew);
                 }
 
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Perpendicular;
-                constNew->First = rowrefgeoid;
-                constNew->FirstPos = Sketcher::PointPos::none;
-                constNew->Second = colrefgeoid;
-                constNew->SecondPos = Sketcher::PointPos::none;
+                constNew->First_Deprecated = rowrefgeoid;
+                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constNew->Second_Deprecated = colrefgeoid;
+                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
                 newconstrVals.push_back(constNew);
             }
             else {
@@ -2388,18 +2390,18 @@ int SketchObject::addCopy(
                 // all other first rowers get an equality and perpendicular constraint
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Equal;
-                constNew->First = rowrefgeoid;
-                constNew->FirstPos = Sketcher::PointPos::none;
-                constNew->Second = cgeoid - 1;
-                constNew->SecondPos = Sketcher::PointPos::none;
+                constNew->First_Deprecated = rowrefgeoid;
+                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constNew->Second_Deprecated = cgeoid - 1;
+                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
                 newconstrVals.push_back(constNew);
 
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Perpendicular;
-                constNew->First = cgeoid - 1;
-                constNew->FirstPos = Sketcher::PointPos::none;
-                constNew->Second = colrefgeoid;
-                constNew->SecondPos = Sketcher::PointPos::none;
+                constNew->First_Deprecated = cgeoid - 1;
+                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constNew->Second_Deprecated = colrefgeoid;
+                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
                 newconstrVals.push_back(constNew);
             }
         }
@@ -2409,18 +2411,18 @@ int SketchObject::addCopy(
             // add coincidents for construction line
             constNew = new Constraint();
             constNew->Type = Sketcher::Coincident;
-            constNew->First = prevfirstgeoid;
-            constNew->FirstPos = refposId;
-            constNew->Second = cgeoid;
-            constNew->SecondPos = Sketcher::PointPos::start;
+            constNew->First_Deprecated = prevfirstgeoid;
+            constNew->FirstPos_Deprecated = refposId;
+            constNew->Second_Deprecated = cgeoid;
+            constNew->SecondPos_Deprecated = Sketcher::PointPos::start;
             newconstrVals.push_back(constNew);
 
             constNew = new Constraint();
             constNew->Type = Sketcher::Coincident;
-            constNew->First = iterfirstgeoid;
-            constNew->FirstPos = refposId;
-            constNew->Second = cgeoid;
-            constNew->SecondPos = Sketcher::PointPos::end;
+            constNew->First_Deprecated = iterfirstgeoid;
+            constNew->FirstPos_Deprecated = refposId;
+            constNew->Second_Deprecated = cgeoid;
+            constNew->SecondPos_Deprecated = Sketcher::PointPos::end;
             newconstrVals.push_back(constNew);
 
             if (y == 0 && x == 1) {
@@ -2431,15 +2433,15 @@ int SketchObject::addCopy(
                 // add length and Angle
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Distance;
-                constNew->First = colrefgeoid;
-                constNew->FirstPos = Sketcher::PointPos::none;
+                constNew->First_Deprecated = colrefgeoid;
+                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
                 constNew->setValue(displacement.Length());
                 newconstrVals.push_back(constNew);
 
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Angle;
-                constNew->First = colrefgeoid;
-                constNew->FirstPos = Sketcher::PointPos::none;
+                constNew->First_Deprecated = colrefgeoid;
+                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
                 constNew->setValue(atan2(displacement.y, displacement.x));
                 newconstrVals.push_back(constNew);
             }
@@ -2450,18 +2452,18 @@ int SketchObject::addCopy(
                 // all other elements get an equality and parallel constraint
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Equal;
-                constNew->First = colrefgeoid;
-                constNew->FirstPos = Sketcher::PointPos::none;
-                constNew->Second = cgeoid - 1;
-                constNew->SecondPos = Sketcher::PointPos::none;
+                constNew->First_Deprecated = colrefgeoid;
+                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constNew->Second_Deprecated = cgeoid - 1;
+                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
                 newconstrVals.push_back(constNew);
 
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Parallel;
-                constNew->First = cgeoid - 1;
-                constNew->FirstPos = Sketcher::PointPos::none;
-                constNew->Second = colrefgeoid;
-                constNew->SecondPos = Sketcher::PointPos::none;
+                constNew->First_Deprecated = cgeoid - 1;
+                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constNew->Second_Deprecated = colrefgeoid;
+                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
                 newconstrVals.push_back(constNew);
             }
         }
@@ -2809,7 +2811,7 @@ bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int m
 
     // modify pole and knot constraints
     for (const auto& constr : cvals) {
-        if (!(constr->Type == Sketcher::InternalAlignment && constr->Second == GeoId)) {
+        if (!(constr->Type == Sketcher::InternalAlignment && constr->Second_Deprecated == GeoId)) {
             newcVals.push_back(constr);
             continue;
         }
@@ -2819,7 +2821,7 @@ bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int m
         if (index == -1) {
             // it is an internal alignment geometry that is no longer valid
             // => delete it and the geometry
-            delGeoId.push_back(constr->First);
+            delGeoId.push_back(constr->First_Deprecated);
             continue;
         }
 
@@ -2950,7 +2952,7 @@ bool SketchObject::insertBSplineKnot(int GeoId, double param, int multiplicity)
 
     // modify pole and knot constraints
     for (const auto& constr : cvals) {
-        if (!(constr->Type == Sketcher::InternalAlignment && constr->Second == GeoId)) {
+        if (!(constr->Type == Sketcher::InternalAlignment && constr->Second_Deprecated == GeoId)) {
             newcVals.push_back(constr);
             continue;
         }
@@ -2972,7 +2974,7 @@ bool SketchObject::insertBSplineKnot(int GeoId, double param, int multiplicity)
         if (indexInNew && indexInNew->at(constr->InternalAlignmentIndex) == -1) {
             // it is an internal alignment geometry that is no longer valid
             // => delete it and the pole circle
-            delGeoId.push_back(constr->First);
+            delGeoId.push_back(constr->First_Deprecated);
             continue;
         }
 

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -542,16 +542,16 @@ std::unique_ptr<Constraint> getNewConstraintAtTrimCut(
     newConstr->setGeoId(1, cuttingGeoId);
     if (isPointAtPosition(obj, cuttingGeoId, PointPos::start, cutPointVec)) {
         newConstr->Type = Sketcher::Coincident;
-        newConstr->SecondPos_Deprecated = PointPos::start;
+        newConstr->setPosId(1, PointPos::start);
     }
     else if (isPointAtPosition(obj, cuttingGeoId, PointPos::end, cutPointVec)) {
         newConstr->Type = Sketcher::Coincident;
-        newConstr->SecondPos_Deprecated = PointPos::end;
+        newConstr->setPosId(1, PointPos::end);
     }
     else {
         // Points are sufficiently far apart: use point-on-object
         newConstr->Type = Sketcher::PointOnObject;
-        newConstr->SecondPos_Deprecated = PointPos::none;
+        newConstr->setPosId(1, PointPos::none);
     }
     return newConstr;
 }
@@ -2254,7 +2254,7 @@ int SketchObject::addCopy(
                     Constraint* constNew = constr->copy();
                     constNew->Type = Sketcher::Equal;
                     constNew->isDriving = true;
-                    constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                    constNew->setPosId(0, Sketcher::PointPos::none);
                     // first is already (constr->First)
                     constNew->setElement(1, GeoElementId(fit->second, Sketcher::PointPos::none));
                     newconstrVals.push_back(constNew);

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -296,16 +296,12 @@ int SketchObject::fillet(int GeoId1, int GeoId2, const Base::Vector3d& refPnt1,
         auto tangent2 = std::make_unique<Sketcher::Constraint>();
 
         tangent1->Type = Sketcher::Tangent;
-        tangent1->First_Deprecated = GeoId1;
-        tangent1->FirstPos_Deprecated = PosId1;
-        tangent1->Second_Deprecated = filletId;
-        tangent1->SecondPos_Deprecated = filletPosId1;
+        tangent1->setElement(0, GeoElementId(GeoId1, PosId1));
+        tangent1->setElement(1, GeoElementId(filletId, filletPosId1));
 
         tangent2->Type = Sketcher::Tangent;
-        tangent2->First_Deprecated = GeoId2;
-        tangent2->FirstPos_Deprecated = PosId2;
-        tangent2->Second_Deprecated = filletId;
-        tangent2->SecondPos_Deprecated = filletPosId2;
+        tangent2->setElement(0, GeoElementId(GeoId2, PosId2));
+        tangent2->setElement(1, GeoElementId(filletId, filletPosId2));
 
         addConstraint(std::move(tangent1));
         addConstraint(std::move(tangent2));
@@ -321,24 +317,18 @@ int SketchObject::fillet(int GeoId1, int GeoId2, const Base::Vector3d& refPnt1,
         auto coinc2 = std::make_unique<Sketcher::Constraint>();
 
         coinc1->Type = Sketcher::Coincident;
-        coinc1->First_Deprecated = lineGeoId;
-        coinc1->FirstPos_Deprecated = filletPosId1;
+        coinc1->setElement(0, GeoElementId(lineGeoId, filletPosId1));
 
         coinc2->Type = Sketcher::Coincident;
-        coinc2->First_Deprecated = lineGeoId;
-        coinc2->FirstPos_Deprecated = filletPosId2;
+        coinc2->setElement(0, GeoElementId(lineGeoId, filletPosId2));
 
         if (trim) {
-            coinc1->Second_Deprecated = GeoId1;
-            coinc1->SecondPos_Deprecated = PosId1;
-            coinc2->Second_Deprecated = GeoId2;
-            coinc2->SecondPos_Deprecated = PosId2;
+            coinc1->setElement(1, GeoElementId(GeoId1, PosId1));
+            coinc2->setElement(1, GeoElementId(GeoId2, PosId2));
         }
         else {
-            coinc1->Second_Deprecated = filletId;
-            coinc1->SecondPos_Deprecated = PointPos::start;
-            coinc2->Second_Deprecated = filletId;
-            coinc2->SecondPos_Deprecated = PointPos::end;
+            coinc1->setElement(1, GeoElementId(filletId, PointPos::start));
+            coinc2->setElement(1, GeoElementId(filletId, PointPos::end));
         }
 
         addConstraint(std::move(coinc1));
@@ -513,8 +503,7 @@ std::unique_ptr<Constraint> transformPreexistingConstraintForTrim(
                 // We already know the point-on-object is on the whole of GeoId
                 newConstr.reset(constr->copy());
                 newConstr->Type = Sketcher::Coincident;
-                newConstr->Second_Deprecated = newGeoId;
-                newConstr->SecondPos_Deprecated = newPosId;
+                newConstr->setElement(1, GeoElementId(newGeoId, newPosId));
             }
             break;
         }
@@ -531,8 +520,7 @@ std::unique_ptr<Constraint> transformPreexistingConstraintForTrim(
                 std::swap(newConstr->FirstPos_Deprecated, newConstr->SecondPos_Deprecated);
             }
             // there is no need for the third point if it exists
-            newConstr->Third_Deprecated = GeoEnum::GeoUndef;
-            newConstr->ThirdPos_Deprecated = PointPos::none;
+            newConstr->setElement(2, GeoElementId(GeoEnum::GeoUndef, PointPos::none));
             break;
         }
         default:
@@ -550,8 +538,7 @@ std::unique_ptr<Constraint> getNewConstraintAtTrimCut(
 )
 {
     auto newConstr = std::make_unique<Sketcher::Constraint>();
-    newConstr->First_Deprecated = cutGeoId;
-    newConstr->FirstPos_Deprecated = cutPosId;
+    newConstr->setElement(0, GeoElementId(cutGeoId, cutPosId));
     newConstr->Second_Deprecated = cuttingGeoId;
     if (isPointAtPosition(obj, cuttingGeoId, PointPos::start, cutPointVec)) {
         newConstr->Type = Sketcher::Coincident;
@@ -867,10 +854,8 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
 
         // Build Constraints associated with new pair of arcs
         newConstr->Type = Sketcher::Equal;
-        newConstr->First_Deprecated = GeoId1;
-        newConstr->FirstPos_Deprecated = Sketcher::PointPos::none;
-        newConstr->Second_Deprecated = GeoId2;
-        newConstr->SecondPos_Deprecated = Sketcher::PointPos::none;
+        newConstr->setElement(0, GeoElementId(GeoId1, Sketcher::PointPos::none));
+        newConstr->setElement(1, GeoElementId(GeoId2, Sketcher::PointPos::none));
         addConstraint(std::move(newConstr));
     };
 
@@ -898,10 +883,8 @@ int SketchObject::trim(int GeoId, const Base::Vector3d& point)
         if (newIds.size() > 1) {
             auto* joint = new Constraint();
             joint->Type = Coincident;
-            joint->First_Deprecated = newIds.front();
-            joint->FirstPos_Deprecated = PointPos::mid;
-            joint->Second_Deprecated = newIds.back();
-            joint->SecondPos_Deprecated = PointPos::mid;
+            joint->setElement(0, GeoElementId(newIds.front(), PointPos::mid));
+            joint->setElement(1, GeoElementId(newIds.back(), PointPos::mid));
             newConstraints.push_back(joint);
 
             // Any radius etc. equality constraints here
@@ -1038,10 +1021,8 @@ int SketchObject::split(int GeoId, const Base::Vector3d& point)
     if (!isOriginalCurvePeriodic) {
         auto* joint = new Constraint();
         joint->Type = Coincident;
-        joint->First_Deprecated = newIds.front();
-        joint->FirstPos_Deprecated = PointPos::end;
-        joint->Second_Deprecated = newIds.back();
-        joint->SecondPos_Deprecated = PointPos::start;
+        joint->setElement(0, GeoElementId(newIds.front(), PointPos::end));
+        joint->setElement(1, GeoElementId(newIds.back(), PointPos::start));
         newConstraints.push_back(joint);
 
         transferConstraints(GeoId, PointPos::start, newIds.front(), PointPos::start);
@@ -1053,10 +1034,8 @@ int SketchObject::split(int GeoId, const Base::Vector3d& point)
     if (geoAsCurve->is<Part::GeomArcOfCircle>()) {
         auto* joint = new Constraint();
         joint->Type = Coincident;
-        joint->First_Deprecated = newIds.front();
-        joint->FirstPos_Deprecated = PointPos::mid;
-        joint->Second_Deprecated = newIds.back();
-        joint->SecondPos_Deprecated = PointPos::mid;
+        joint->setElement(0, GeoElementId(newIds.front(), PointPos::mid));
+        joint->setElement(1, GeoElementId(newIds.back(), PointPos::mid));
         newConstraints.push_back(joint);
     }
 
@@ -2277,8 +2256,7 @@ int SketchObject::addCopy(
                     constNew->isDriving = true;
                     constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
                     // first is already (constr->First)
-                    constNew->Second_Deprecated = fit->second;
-                    constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
+                    constNew->setElement(1, GeoElementId(fit->second, Sketcher::PointPos::none));
                     newconstrVals.push_back(constNew);
                     continue;
                 }
@@ -2336,18 +2314,14 @@ int SketchObject::addCopy(
             // add coincidents for construction line
             constNew = new Constraint();
             constNew->Type = Sketcher::Coincident;
-            constNew->First_Deprecated = prevrowstartfirstgeoid;
-            constNew->FirstPos_Deprecated = refposId;
-            constNew->Second_Deprecated = cgeoid;
-            constNew->SecondPos_Deprecated = Sketcher::PointPos::start;
+            constNew->setElement(0, GeoElementId(prevrowstartfirstgeoid, refposId));
+            constNew->setElement(1, GeoElementId(cgeoid, Sketcher::PointPos::start));
             newconstrVals.push_back(constNew);
 
             constNew = new Constraint();
             constNew->Type = Sketcher::Coincident;
-            constNew->First_Deprecated = iterfirstgeoid;
-            constNew->FirstPos_Deprecated = refposId;
-            constNew->Second_Deprecated = cgeoid;
-            constNew->SecondPos_Deprecated = Sketcher::PointPos::end;
+            constNew->setElement(0, GeoElementId(iterfirstgeoid, refposId));
+            constNew->setElement(1, GeoElementId(cgeoid, Sketcher::PointPos::end));
             newconstrVals.push_back(constNew);
 
             // it is the first added element of this row in the perpendicular to
@@ -2360,27 +2334,22 @@ int SketchObject::addCopy(
                 if (perpscale == 1.0) {
                     constNew = new Constraint();
                     constNew->Type = Sketcher::Equal;
-                    constNew->First_Deprecated = rowrefgeoid;
-                    constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
-                    constNew->Second_Deprecated = colrefgeoid;
-                    constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
+                    constNew->setElement(0, GeoElementId(rowrefgeoid, Sketcher::PointPos::none));
+                    constNew->setElement(1, GeoElementId(colrefgeoid, Sketcher::PointPos::none));
                     newconstrVals.push_back(constNew);
                 }
                 else {
                     constNew = new Constraint();
                     constNew->Type = Sketcher::Distance;
-                    constNew->First_Deprecated = rowrefgeoid;
-                    constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                    constNew->setElement(0, GeoElementId(rowrefgeoid, Sketcher::PointPos::none));
                     constNew->setValue(perpendicularDisplacement.Length());
                     newconstrVals.push_back(constNew);
                 }
 
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Perpendicular;
-                constNew->First_Deprecated = rowrefgeoid;
-                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
-                constNew->Second_Deprecated = colrefgeoid;
-                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constNew->setElement(0, GeoElementId(rowrefgeoid, Sketcher::PointPos::none));
+                constNew->setElement(1, GeoElementId(colrefgeoid, Sketcher::PointPos::none));
                 newconstrVals.push_back(constNew);
             }
             else {
@@ -2390,18 +2359,14 @@ int SketchObject::addCopy(
                 // all other first rowers get an equality and perpendicular constraint
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Equal;
-                constNew->First_Deprecated = rowrefgeoid;
-                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
-                constNew->Second_Deprecated = cgeoid - 1;
-                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constNew->setElement(0, GeoElementId(rowrefgeoid, Sketcher::PointPos::none));
+                constNew->setElement(1, GeoElementId(cgeoid - 1, Sketcher::PointPos::none));
                 newconstrVals.push_back(constNew);
 
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Perpendicular;
-                constNew->First_Deprecated = cgeoid - 1;
-                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
-                constNew->Second_Deprecated = colrefgeoid;
-                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constNew->setElement(0, GeoElementId(cgeoid - 1, Sketcher::PointPos::none));
+                constNew->setElement(1, GeoElementId(colrefgeoid, Sketcher::PointPos::none));
                 newconstrVals.push_back(constNew);
             }
         }
@@ -2411,18 +2376,14 @@ int SketchObject::addCopy(
             // add coincidents for construction line
             constNew = new Constraint();
             constNew->Type = Sketcher::Coincident;
-            constNew->First_Deprecated = prevfirstgeoid;
-            constNew->FirstPos_Deprecated = refposId;
-            constNew->Second_Deprecated = cgeoid;
-            constNew->SecondPos_Deprecated = Sketcher::PointPos::start;
+            constNew->setElement(0, GeoElementId(prevfirstgeoid, refposId));
+            constNew->setElement(1, GeoElementId(cgeoid, Sketcher::PointPos::start));
             newconstrVals.push_back(constNew);
 
             constNew = new Constraint();
             constNew->Type = Sketcher::Coincident;
-            constNew->First_Deprecated = iterfirstgeoid;
-            constNew->FirstPos_Deprecated = refposId;
-            constNew->Second_Deprecated = cgeoid;
-            constNew->SecondPos_Deprecated = Sketcher::PointPos::end;
+            constNew->setElement(0, GeoElementId(iterfirstgeoid, refposId));
+            constNew->setElement(1, GeoElementId(cgeoid, Sketcher::PointPos::end));
             newconstrVals.push_back(constNew);
 
             if (y == 0 && x == 1) {
@@ -2433,15 +2394,13 @@ int SketchObject::addCopy(
                 // add length and Angle
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Distance;
-                constNew->First_Deprecated = colrefgeoid;
-                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constNew->setElement(0, GeoElementId(colrefgeoid, Sketcher::PointPos::none));
                 constNew->setValue(displacement.Length());
                 newconstrVals.push_back(constNew);
 
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Angle;
-                constNew->First_Deprecated = colrefgeoid;
-                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
+                constNew->setElement(0, GeoElementId(colrefgeoid, Sketcher::PointPos::none));
                 constNew->setValue(atan2(displacement.y, displacement.x));
                 newconstrVals.push_back(constNew);
             }
@@ -2452,18 +2411,14 @@ int SketchObject::addCopy(
                 // all other elements get an equality and parallel constraint
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Equal;
-                constNew->First_Deprecated = colrefgeoid;
-                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
-                constNew->Second_Deprecated = cgeoid - 1;
-                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constNew->setElement(0, GeoElementId(colrefgeoid, Sketcher::PointPos::none));
+                constNew->setElement(1, GeoElementId(cgeoid - 1, Sketcher::PointPos::none));
                 newconstrVals.push_back(constNew);
 
                 constNew = new Constraint();
                 constNew->Type = Sketcher::Parallel;
-                constNew->First_Deprecated = cgeoid - 1;
-                constNew->FirstPos_Deprecated = Sketcher::PointPos::none;
-                constNew->Second_Deprecated = colrefgeoid;
-                constNew->SecondPos_Deprecated = Sketcher::PointPos::none;
+                constNew->setElement(0, GeoElementId(cgeoid - 1, Sketcher::PointPos::none));
+                constNew->setElement(1, GeoElementId(colrefgeoid, Sketcher::PointPos::none));
                 newconstrVals.push_back(constNew);
             }
         }

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -137,10 +137,10 @@ int SketchObject::delGeometries(InputIt first, InputIt last, DeleteOptions optio
     // if a GeoId has internal geometry, it must delete internal geometries too
     for (auto c : Constraints.getValues()) {
         if (c->Type == InternalAlignment) {
-            auto pos = std::ranges::find(sGeoIds, c->Second_Deprecated);
+            auto pos = std::ranges::find(sGeoIds, c->getGeoId(1));
 
             if (pos != sGeoIds.end()) {
-                sGeoIds.push_back(c->First_Deprecated);
+                sGeoIds.push_back(c->getGeoId(0));
             }
         }
     }
@@ -499,7 +499,7 @@ std::unique_ptr<Constraint> transformPreexistingConstraintForTrim(
             // we might want to transform this (and the new point-on-object constraints) into a
             // coincidence At this stage of the check the point has to be an end of `cuttingGeoId`
             // on the edge of `GeoId`.
-            if (isPointAtPosition(obj, constr->First_Deprecated, constr->FirstPos_Deprecated, cutPointVec)) {
+            if (isPointAtPosition(obj, constr->getGeoId(0), constr->getPosId(0), cutPointVec)) {
                 // We already know the point-on-object is on the whole of GeoId
                 newConstr.reset(constr->copy());
                 newConstr->Type = Sketcher::Coincident;
@@ -515,9 +515,9 @@ std::unique_ptr<Constraint> transformPreexistingConstraintForTrim(
             newConstr.reset(constr->copy());
             newConstr->substituteIndexAndPos(GeoId, PointPos::none, newGeoId, newPosId);
             // make sure the first position is a point
-            if (newConstr->FirstPos_Deprecated == PointPos::none) {
-                std::swap(newConstr->First_Deprecated, newConstr->Second_Deprecated);
-                std::swap(newConstr->FirstPos_Deprecated, newConstr->SecondPos_Deprecated);
+            if (newConstr->getPosId(0) == PointPos::none) {
+                std::swap(newConstr->getGeoId(0), newConstr->getGeoId(1));
+                std::swap(newConstr->getPosId(0), newConstr->getPosId(1));
             }
             // there is no need for the third point if it exists
             newConstr->setElement(2, GeoElementId(GeoEnum::GeoUndef, PointPos::none));
@@ -654,7 +654,7 @@ void createNewConstraintsForTrim(
         // trim-specific changes first
         const Constraint* con = allConstraints[oldConstrId];
         if (con->Type == InternalAlignment) {
-            geoIdsToBeDeleted.insert(con->First_Deprecated);
+            geoIdsToBeDeleted.insert(con->getGeoId(0));
             continue;
         }
         if (auto newConstr = transformPreexistingConstraintForTrim(
@@ -1979,11 +1979,11 @@ int SketchObject::addCopy(
                 auto constrIt = std::ranges::find_if(constrvals, [&newgeoIdList](auto c) {
                     return (
                         c->Type == Sketcher::InternalAlignment
-                        && c->First_Deprecated == *(newgeoIdList.begin())
+                        && c->getGeoId(0) == *(newgeoIdList.begin())
                     );
                 });
 
-                int definedGeo = (constrIt != constrvals.end()) ? (*constrIt)->Second_Deprecated
+                int definedGeo = (constrIt != constrvals.end()) ? (*constrIt)->getGeoId(1)
                                                                 : GeoEnum::GeoUndef;
 
                 if (std::ranges::find(newgeoIdList, definedGeo) == newgeoIdList.end()) {
@@ -2034,10 +2034,10 @@ int SketchObject::addCopy(
                 int definedGeo = GeoEnum::GeoUndef;
 
                 auto constrIt = std::ranges::find_if(constrvals, [&it](auto c) {
-                    return (c->Type == Sketcher::InternalAlignment && c->First_Deprecated == *it);
+                    return (c->Type == Sketcher::InternalAlignment && c->getGeoId(0) == *it);
                 });
                 if (constrIt != constrvals.end()) {
-                    definedGeo = (*constrIt)->Second_Deprecated;
+                    definedGeo = (*constrIt)->getGeoId(1);
                 }
 
                 if (std::ranges::find(newgeoIdList, definedGeo) == newgeoIdList.end()) {
@@ -2189,17 +2189,16 @@ int SketchObject::addCopy(
 
         // handle geometry constraints
         for (const auto& constr : constrvals) {
-            auto fit = geoIdMap.find(constr->First_Deprecated);
+            auto fit = geoIdMap.find(constr->getGeoId(0));
 
             if (fit == geoIdMap.end()) {
                 continue;
             }
 
             // First of constraint is in geoIdList
-            if (constr->Second_Deprecated
-                == GeoEnum::GeoUndef /*&& constr->Third == GeoEnum::GeoUndef*/) {
+            if (constr->getGeoId(1) == GeoEnum::GeoUndef /*&& constr->Third == GeoEnum::GeoUndef*/) {
                 if ((constr->Type == Sketcher::DistanceX || constr->Type == Sketcher::DistanceY)
-                    && constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
+                    && constr->getPosId(0) != Sketcher::PointPos::none) {
                     continue;
                 }
                 // if it is not a point locking DistanceX/Y
@@ -2223,7 +2222,7 @@ int SketchObject::addCopy(
                     newconstrVals.push_back(constNew);
                     continue;
                 }
-                if (getGeometry(constr->First_Deprecated)->is<Part::GeomLineSegment>()) {
+                if (getGeometry(constr->getGeoId(0))->is<Part::GeomLineSegment>()) {
                     // Angles on a single Element are mapped to parallel
                     // constraints in clone mode
                     Constraint* constNew = constr->copy();
@@ -2237,17 +2236,17 @@ int SketchObject::addCopy(
             }
 
             // other geoids intervene in this constraint
-            auto sit = geoIdMap.find(constr->Second_Deprecated);
+            auto sit = geoIdMap.find(constr->getGeoId(1));
 
             if (sit == geoIdMap.end()) {
                 continue;
             }
 
             // Second is also in the list
-            if (constr->Third_Deprecated == GeoEnum::GeoUndef) {
+            if (constr->getGeoId(2) == GeoEnum::GeoUndef) {
                 if ((constr->Type == Sketcher::DistanceX || constr->Type == Sketcher::DistanceY
                      || constr->Type == Sketcher::Distance)
-                    && (constr->First_Deprecated == constr->Second_Deprecated) && clone) {
+                    && (constr->getGeoId(0) == constr->getGeoId(1)) && clone) {
                     // Distances on a two Elements, which must be points of the
                     // same line are mapped to equality constraints in clone
                     // mode
@@ -2268,7 +2267,7 @@ int SketchObject::addCopy(
                 continue;
             }
 
-            auto tit = geoIdMap.find(constr->Third_Deprecated);
+            auto tit = geoIdMap.find(constr->getGeoId(2));
 
             if (tit != geoIdMap.end()) {
                 continue;
@@ -2766,7 +2765,7 @@ bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int m
 
     // modify pole and knot constraints
     for (const auto& constr : cvals) {
-        if (!(constr->Type == Sketcher::InternalAlignment && constr->Second_Deprecated == GeoId)) {
+        if (!(constr->Type == Sketcher::InternalAlignment && constr->getGeoId(1) == GeoId)) {
             newcVals.push_back(constr);
             continue;
         }
@@ -2776,7 +2775,7 @@ bool SketchObject::modifyBSplineKnotMultiplicity(int GeoId, int knotIndex, int m
         if (index == -1) {
             // it is an internal alignment geometry that is no longer valid
             // => delete it and the geometry
-            delGeoId.push_back(constr->First_Deprecated);
+            delGeoId.push_back(constr->getGeoId(0));
             continue;
         }
 
@@ -2907,7 +2906,7 @@ bool SketchObject::insertBSplineKnot(int GeoId, double param, int multiplicity)
 
     // modify pole and knot constraints
     for (const auto& constr : cvals) {
-        if (!(constr->Type == Sketcher::InternalAlignment && constr->Second_Deprecated == GeoId)) {
+        if (!(constr->Type == Sketcher::InternalAlignment && constr->getGeoId(1) == GeoId)) {
             newcVals.push_back(constr);
             continue;
         }
@@ -2929,7 +2928,7 @@ bool SketchObject::insertBSplineKnot(int GeoId, double param, int multiplicity)
         if (indexInNew && indexInNew->at(constr->InternalAlignmentIndex) == -1) {
             // it is an internal alignment geometry that is no longer valid
             // => delete it and the pole circle
-            delGeoId.push_back(constr->First_Deprecated);
+            delGeoId.push_back(constr->getGeoId(0));
             continue;
         }
 

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -539,7 +539,7 @@ std::unique_ptr<Constraint> getNewConstraintAtTrimCut(
 {
     auto newConstr = std::make_unique<Sketcher::Constraint>();
     newConstr->setElement(0, GeoElementId(cutGeoId, cutPosId));
-    newConstr->Second_Deprecated = cuttingGeoId;
+    newConstr->setGeoId(1, cuttingGeoId);
     if (isPointAtPosition(obj, cuttingGeoId, PointPos::start, cutPointVec)) {
         newConstr->Type = Sketcher::Coincident;
         newConstr->SecondPos_Deprecated = PointPos::start;
@@ -2213,13 +2213,13 @@ int SketchObject::addCopy(
                     constNew->Type = Sketcher::Equal;
                     constNew->isDriving = true;
                     // first is already (constr->First)
-                    constNew->Second_Deprecated = fit->second;
+                    constNew->setGeoId(1, fit->second);
                     newconstrVals.push_back(constNew);
                     continue;
                 }
                 if (!(constr->Type == Sketcher::Angle && clone)) {
                     Constraint* constNew = constr->copy();
-                    constNew->First_Deprecated = fit->second;
+                    constNew->setGeoId(0, fit->second);
                     newconstrVals.push_back(constNew);
                     continue;
                 }
@@ -2230,7 +2230,7 @@ int SketchObject::addCopy(
                     constNew->Type = Sketcher::Parallel;
                     constNew->isDriving = true;
                     // first is already (constr->First)
-                    constNew->Second_Deprecated = fit->second;
+                    constNew->setGeoId(1, fit->second);
                     newconstrVals.push_back(constNew);
                 }
                 continue;
@@ -2262,8 +2262,8 @@ int SketchObject::addCopy(
                 }
                 // remaining, this includes InternalAlignment constraints
                 Constraint* constNew = constr->copy();
-                constNew->First_Deprecated = fit->second;
-                constNew->Second_Deprecated = sit->second;
+                constNew->setGeoId(0, fit->second);
+                constNew->setGeoId(1, sit->second);
                 newconstrVals.push_back(constNew);
                 continue;
             }
@@ -2276,9 +2276,9 @@ int SketchObject::addCopy(
 
             // Third is also in the list
             Constraint* constNew = constr->copy();
-            constNew->First_Deprecated = fit->second;
-            constNew->Second_Deprecated = sit->second;
-            constNew->Third_Deprecated = tit->second;
+            constNew->setGeoId(0, fit->second);
+            constNew->setGeoId(1, sit->second);
+            constNew->setGeoId(2, tit->second);
 
             newconstrVals.push_back(constNew);
         }

--- a/src/Mod/Sketcher/App/SketchObjectOperations.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectOperations.cpp
@@ -516,8 +516,7 @@ std::unique_ptr<Constraint> transformPreexistingConstraintForTrim(
             newConstr->substituteIndexAndPos(GeoId, PointPos::none, newGeoId, newPosId);
             // make sure the first position is a point
             if (newConstr->getPosId(0) == PointPos::none) {
-                std::swap(newConstr->getGeoId(0), newConstr->getGeoId(1));
-                std::swap(newConstr->getPosId(0), newConstr->getPosId(1));
+                newConstr->swapElements(0, 1);
             }
             // there is no need for the third point if it exists
             newConstr->setElement(2, GeoElementId(GeoEnum::GeoUndef, PointPos::none));

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -962,21 +962,21 @@ void CmdSketcherMirrorSketch::activated(int iMsg)
              itc != mirrorconstr.end();
              ++itc) {
 
-            if ((*itc)->First != Sketcher::GeoEnum::GeoUndef
-                || (*itc)->First == Sketcher::GeoEnum::HAxis
-                || (*itc)->First == Sketcher::GeoEnum::VAxis)
+            if ((*itc)->First_Deprecated != Sketcher::GeoEnum::GeoUndef
+                || (*itc)->First_Deprecated == Sketcher::GeoEnum::HAxis
+                || (*itc)->First_Deprecated == Sketcher::GeoEnum::VAxis)
                 // not x, y axes or origin
-                (*itc)->First -= (addedGeometries + 1);
-            if ((*itc)->Second != Sketcher::GeoEnum::GeoUndef
-                || (*itc)->Second == Sketcher::GeoEnum::HAxis
-                || (*itc)->Second == Sketcher::GeoEnum::VAxis)
+                (*itc)->First_Deprecated -= (addedGeometries + 1);
+            if ((*itc)->Second_Deprecated != Sketcher::GeoEnum::GeoUndef
+                || (*itc)->Second_Deprecated == Sketcher::GeoEnum::HAxis
+                || (*itc)->Second_Deprecated == Sketcher::GeoEnum::VAxis)
                 // not x, y axes or origin
-                (*itc)->Second -= (addedGeometries + 1);
-            if ((*itc)->Third != Sketcher::GeoEnum::GeoUndef
-                || (*itc)->Third == Sketcher::GeoEnum::HAxis
-                || (*itc)->Third == Sketcher::GeoEnum::VAxis)
+                (*itc)->Second_Deprecated -= (addedGeometries + 1);
+            if ((*itc)->Third_Deprecated != Sketcher::GeoEnum::GeoUndef
+                || (*itc)->Third_Deprecated == Sketcher::GeoEnum::HAxis
+                || (*itc)->Third_Deprecated == Sketcher::GeoEnum::VAxis)
                 // not x, y axes or origin
-                (*itc)->Third -= (addedGeometries + 1);
+                (*itc)->Third_Deprecated -= (addedGeometries + 1);
         }
 
         mirrorsketch->addGeometry(mirrorgeo);
@@ -1057,21 +1057,21 @@ void CmdSketcherMergeSketches::activated(int iMsg)
             Sketcher::Constraint* constraint =
                 mergesketch->Constraints.getValues()[i + baseConstraints];
 
-            if (constraint->First != Sketcher::GeoEnum::GeoUndef
-                && constraint->First != Sketcher::GeoEnum::HAxis
-                && constraint->First != Sketcher::GeoEnum::VAxis)
+            if (constraint->First_Deprecated != Sketcher::GeoEnum::GeoUndef
+                && constraint->First_Deprecated != Sketcher::GeoEnum::HAxis
+                && constraint->First_Deprecated != Sketcher::GeoEnum::VAxis)
                 // not x, y axes or origin
-                constraint->First += baseGeometry;
-            if (constraint->Second != Sketcher::GeoEnum::GeoUndef
-                && constraint->Second != Sketcher::GeoEnum::HAxis
-                && constraint->Second != Sketcher::GeoEnum::VAxis)
+                constraint->First_Deprecated += baseGeometry;
+            if (constraint->Second_Deprecated != Sketcher::GeoEnum::GeoUndef
+                && constraint->Second_Deprecated != Sketcher::GeoEnum::HAxis
+                && constraint->Second_Deprecated != Sketcher::GeoEnum::VAxis)
                 // not x, y axes or origin
-                constraint->Second += baseGeometry;
-            if (constraint->Third != Sketcher::GeoEnum::GeoUndef
-                && constraint->Third != Sketcher::GeoEnum::HAxis
-                && constraint->Third != Sketcher::GeoEnum::VAxis)
+                constraint->Second_Deprecated += baseGeometry;
+            if (constraint->Third_Deprecated != Sketcher::GeoEnum::GeoUndef
+                && constraint->Third_Deprecated != Sketcher::GeoEnum::HAxis
+                && constraint->Third_Deprecated != Sketcher::GeoEnum::VAxis)
                 // not x, y axes or origin
-                constraint->Third += baseGeometry;
+                constraint->Third_Deprecated += baseGeometry;
         }
 
         baseGeometry = addedGeometries + 1;

--- a/src/Mod/Sketcher/Gui/Command.cpp
+++ b/src/Mod/Sketcher/Gui/Command.cpp
@@ -962,21 +962,24 @@ void CmdSketcherMirrorSketch::activated(int iMsg)
              itc != mirrorconstr.end();
              ++itc) {
 
-            if ((*itc)->First_Deprecated != Sketcher::GeoEnum::GeoUndef
-                || (*itc)->First_Deprecated == Sketcher::GeoEnum::HAxis
-                || (*itc)->First_Deprecated == Sketcher::GeoEnum::VAxis)
+            if ((*itc)->getGeoId(0) != Sketcher::GeoEnum::GeoUndef
+                || (*itc)->getGeoId(0) == Sketcher::GeoEnum::HAxis
+                || (*itc)->getGeoId(0) == Sketcher::GeoEnum::VAxis) {
                 // not x, y axes or origin
-                (*itc)->First_Deprecated -= (addedGeometries + 1);
-            if ((*itc)->Second_Deprecated != Sketcher::GeoEnum::GeoUndef
-                || (*itc)->Second_Deprecated == Sketcher::GeoEnum::HAxis
-                || (*itc)->Second_Deprecated == Sketcher::GeoEnum::VAxis)
+                (*itc)->setGeoId(0, (*itc)->getGeoId(0) - (addedGeometries + 1));
+            }
+            if ((*itc)->getGeoId(1) != Sketcher::GeoEnum::GeoUndef
+                || (*itc)->getGeoId(1) == Sketcher::GeoEnum::HAxis
+                || (*itc)->getGeoId(1) == Sketcher::GeoEnum::VAxis) {
                 // not x, y axes or origin
-                (*itc)->Second_Deprecated -= (addedGeometries + 1);
-            if ((*itc)->Third_Deprecated != Sketcher::GeoEnum::GeoUndef
-                || (*itc)->Third_Deprecated == Sketcher::GeoEnum::HAxis
-                || (*itc)->Third_Deprecated == Sketcher::GeoEnum::VAxis)
+                (*itc)->setGeoId(1, (*itc)->getGeoId(1) - (addedGeometries + 1));
+            }
+            if ((*itc)->getGeoId(2) != Sketcher::GeoEnum::GeoUndef
+                || (*itc)->getGeoId(2) == Sketcher::GeoEnum::HAxis
+                || (*itc)->getGeoId(2) == Sketcher::GeoEnum::VAxis) {
                 // not x, y axes or origin
-                (*itc)->Third_Deprecated -= (addedGeometries + 1);
+                (*itc)->setGeoId(2, (*itc)->getGeoId(2) - (addedGeometries + 1));
+            }
         }
 
         mirrorsketch->addGeometry(mirrorgeo);
@@ -1057,21 +1060,24 @@ void CmdSketcherMergeSketches::activated(int iMsg)
             Sketcher::Constraint* constraint =
                 mergesketch->Constraints.getValues()[i + baseConstraints];
 
-            if (constraint->First_Deprecated != Sketcher::GeoEnum::GeoUndef
-                && constraint->First_Deprecated != Sketcher::GeoEnum::HAxis
-                && constraint->First_Deprecated != Sketcher::GeoEnum::VAxis)
+            if (constraint->getGeoId(0) != Sketcher::GeoEnum::GeoUndef
+                && constraint->getGeoId(0) != Sketcher::GeoEnum::HAxis
+                && constraint->getGeoId(0) != Sketcher::GeoEnum::VAxis) {
                 // not x, y axes or origin
-                constraint->First_Deprecated += baseGeometry;
-            if (constraint->Second_Deprecated != Sketcher::GeoEnum::GeoUndef
-                && constraint->Second_Deprecated != Sketcher::GeoEnum::HAxis
-                && constraint->Second_Deprecated != Sketcher::GeoEnum::VAxis)
+                constraint->setGeoId(0, constraint->getGeoId(0) + baseGeometry);
+            }
+            if (constraint->getGeoId(1) != Sketcher::GeoEnum::GeoUndef
+                && constraint->getGeoId(1) != Sketcher::GeoEnum::HAxis
+                && constraint->getGeoId(1) != Sketcher::GeoEnum::VAxis) {
                 // not x, y axes or origin
-                constraint->Second_Deprecated += baseGeometry;
-            if (constraint->Third_Deprecated != Sketcher::GeoEnum::GeoUndef
-                && constraint->Third_Deprecated != Sketcher::GeoEnum::HAxis
-                && constraint->Third_Deprecated != Sketcher::GeoEnum::VAxis)
+                constraint->setGeoId(1, constraint->getGeoId(1) + baseGeometry);
+            }
+            if (constraint->getGeoId(2) != Sketcher::GeoEnum::GeoUndef
+                && constraint->getGeoId(2) != Sketcher::GeoEnum::HAxis
+                && constraint->getGeoId(2) != Sketcher::GeoEnum::VAxis) {
                 // not x, y axes or origin
-                constraint->Third_Deprecated += baseGeometry;
+                constraint->setGeoId(2, constraint->getGeoId(2) + baseGeometry);
+            }
         }
 
         baseGeometry = addedGeometries + 1;

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -140,7 +140,7 @@ void finishDatumConstraint(Gui::Command* cmd,
 
         for (int i = lastConstraintIndex; i >= firstConstraintIndex; i--) {
             if (lastConstraintType == Radius || lastConstraintType == Diameter) {
-                const Part::Geometry* geo = sketch->getGeometry(ConStr[i]->First);
+                const Part::Geometry* geo = sketch->getGeometry(ConStr[i]->First_Deprecated);
 
                 if (geo && isCircle(*geo)) {
                     ConStr[i]->LabelPosition = labelPosition;
@@ -204,12 +204,12 @@ bool removeRedundantPointOnObject(SketchObject* Obj, int GeoId1, int GeoId2, int
     int cid = 0;
     for (auto it = cvals.begin(); it != cvals.end(); ++it, ++cid) {
         if ((*it)->Type == Sketcher::PointOnObject &&
-            (((*it)->First == GeoId3 && (*it)->Second == GeoId1) ||
-             ((*it)->First == GeoId3 && (*it)->Second == GeoId2))) {
+            (((*it)->First_Deprecated == GeoId3 && (*it)->Second_Deprecated == GeoId1) ||
+             ((*it)->First_Deprecated == GeoId3 && (*it)->Second_Deprecated == GeoId2))) {
 
             // ONLY do this if it is a B-spline (or any other where point
             // on object is implied).
-            const Part::Geometry* geom = Obj->getGeometry((*it)->Second);
+            const Part::Geometry* geom = Obj->getGeometry((*it)->Second_Deprecated);
             if (isBSplineCurve(*geom))
                 cidsToBeRemoved.push_back(cid);
         }
@@ -2956,7 +2956,7 @@ protected:
         // check if the edge already has a Horizontal/Vertical/Block constraint
         for (const auto& constraint : vals) {
             if ((constraint->Type == Sketcher::Horizontal || constraint->Type == Sketcher::Vertical || constraint->Type == Sketcher::Block)
-                && constraint->First == GeoId) {
+                && constraint->First_Deprecated == GeoId) {
                 return true;
             }
         }
@@ -3265,16 +3265,16 @@ bool canHorVerBlock(Sketcher::SketchObject* Obj, int geoId)
 
     // check if the edge already has a Horizontal/Vertical/Block constraint
     for (auto& constr : vals) {
-        if (constr->Type == Sketcher::Horizontal && constr->First == geoId
-            && constr->FirstPos == Sketcher::PointPos::none) {
+        if (constr->Type == Sketcher::Horizontal && constr->First_Deprecated == geoId
+            && constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
             Gui::TranslatedUserWarning(
                 Obj,
                 QObject::tr("Double constraint"),
                 QObject::tr("The selected edge already has a horizontal constraint!"));
             return false;
         }
-        if (constr->Type == Sketcher::Vertical && constr->First == geoId
-            && constr->FirstPos == Sketcher::PointPos::none) {
+        if (constr->Type == Sketcher::Vertical && constr->First_Deprecated == geoId
+            && constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
             Gui::TranslatedUserWarning(
                 Obj,
                 QObject::tr("Impossible constraint"),
@@ -3282,8 +3282,8 @@ bool canHorVerBlock(Sketcher::SketchObject* Obj, int geoId)
             return false;
         }
         // check if the edge already has a Block constraint
-        if (constr->Type == Sketcher::Block && constr->First == geoId
-            && constr->FirstPos == Sketcher::PointPos::none) {
+        if (constr->Type == Sketcher::Block && constr->First_Deprecated == geoId
+            && constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
             Gui::TranslatedUserWarning(
                 Obj,
                 QObject::tr("Impossible constraint"),
@@ -4207,10 +4207,10 @@ bool CmdSketcherConstrainCoincidentUnified::substituteConstraintCombinationsPoin
     int cid = 0;
     for (std::vector<Constraint*>::const_iterator it = cvals.begin(); it != cvals.end();
         ++it, ++cid) {
-        if ((*it)->Type == Sketcher::Tangent && (*it)->FirstPos == Sketcher::PointPos::none
-            && (*it)->SecondPos == Sketcher::PointPos::none && (*it)->Third == GeoEnum::GeoUndef
-            && (((*it)->First == GeoId1 && (*it)->Second == GeoId2)
-                || ((*it)->Second == GeoId1 && (*it)->First == GeoId2))
+        if ((*it)->Type == Sketcher::Tangent && (*it)->FirstPos_Deprecated == Sketcher::PointPos::none
+            && (*it)->SecondPos_Deprecated == Sketcher::PointPos::none && (*it)->Third_Deprecated == GeoEnum::GeoUndef
+            && (((*it)->First_Deprecated == GeoId1 && (*it)->Second_Deprecated == GeoId2)
+                || ((*it)->Second_Deprecated == GeoId1 && (*it)->First_Deprecated == GeoId2))
             && (PosId1 == Sketcher::PointPos::start
                 || PosId1 == Sketcher::PointPos::end)) {
 
@@ -4245,17 +4245,17 @@ bool CmdSketcherConstrainCoincidentUnified::substituteConstraintCombinationsCoin
     int j = 0;
     for (std::vector<Constraint*>::const_iterator it = cvals.begin(); it != cvals.end();
         ++it, ++j) {
-        if ((*it)->Type == Sketcher::Tangent && (*it)->Third == GeoEnum::GeoUndef
-            && (((*it)->First == GeoId1 && (*it)->Second == GeoId2)
-                || ((*it)->Second == GeoId1 && (*it)->First == GeoId2))) {
+        if ((*it)->Type == Sketcher::Tangent && (*it)->Third_Deprecated == GeoEnum::GeoUndef
+            && (((*it)->First_Deprecated == GeoId1 && (*it)->Second_Deprecated == GeoId2)
+                || ((*it)->Second_Deprecated == GeoId1 && (*it)->First_Deprecated == GeoId2))) {
             if (!(PosId1 == Sketcher::PointPos::start
                   || PosId1 == Sketcher::PointPos::end)
                 || !(PosId2 == Sketcher::PointPos::start
                      || PosId2 == Sketcher::PointPos::end)) {
                 continue;
             }
-            if ((*it)->FirstPos == Sketcher::PointPos::none
-                && (*it)->SecondPos == Sketcher::PointPos::none) {
+            if ((*it)->FirstPos_Deprecated == Sketcher::PointPos::none
+                && (*it)->SecondPos_Deprecated == Sketcher::PointPos::none) {
 
                 if (constraintExists) {
                     // try to remove any pre-existing direct coincident constraints
@@ -4284,7 +4284,7 @@ bool CmdSketcherConstrainCoincidentUnified::substituteConstraintCombinationsCoin
                 }
 
                 // if a similar tangency already exists this must result in bad constraints
-                if ((*it)->SecondPos == Sketcher::PointPos::none) {
+                if ((*it)->SecondPos_Deprecated == Sketcher::PointPos::none) {
                     Gui::cmdAppObjectArgs(Obj, "delConstraint(%d)", j);
 
                     doEndpointTangency(Obj, GeoId1, GeoId2, PosId1, PosId2);
@@ -7023,21 +7023,21 @@ bool CmdSketcherConstrainTangent::substituteConstraintCombinations(SketchObject*
     for (std::vector<Constraint*>::const_iterator it = cvals.begin(); it != cvals.end();
          ++it, ++cid) {
         if ((*it)->Type == Sketcher::Coincident
-            && (((*it)->First == GeoId1 && (*it)->Second == GeoId2)
-                || ((*it)->Second == GeoId1 && (*it)->First == GeoId2))
-            && ((*it)->FirstPos == Sketcher::PointPos::start
-                || (*it)->FirstPos == Sketcher::PointPos::end)
-            && ((*it)->SecondPos == Sketcher::PointPos::start
-                || (*it)->SecondPos == Sketcher::PointPos::end)) {
+            && (((*it)->First_Deprecated == GeoId1 && (*it)->Second_Deprecated == GeoId2)
+                || ((*it)->Second_Deprecated == GeoId1 && (*it)->First_Deprecated == GeoId2))
+            && ((*it)->FirstPos_Deprecated == Sketcher::PointPos::start
+                || (*it)->FirstPos_Deprecated == Sketcher::PointPos::end)
+            && ((*it)->SecondPos_Deprecated == Sketcher::PointPos::start
+                || (*it)->SecondPos_Deprecated == Sketcher::PointPos::end)) {
             // save values because 'doEndpointTangency' changes the
             // constraint property and thus invalidates this iterator
-            int first = (*it)->First;
-            int firstpos = static_cast<int>((*it)->FirstPos);
+            int first = (*it)->First_Deprecated;
+            int firstpos = static_cast<int>((*it)->FirstPos_Deprecated);
 
             openCommand(
                 QT_TRANSLATE_NOOP("Command", "Swap coincident+tangency with ptp tangency"));
 
-            doEndpointTangency(Obj, (*it)->First, (*it)->Second, (*it)->FirstPos, (*it)->SecondPos);
+            doEndpointTangency(Obj, (*it)->First_Deprecated, (*it)->Second_Deprecated, (*it)->FirstPos_Deprecated, (*it)->SecondPos_Deprecated);
 
             Gui::cmdAppObjectArgs(Obj, "delConstraintOnPoint(%d,%d)", first, firstpos);
 
@@ -7053,15 +7053,15 @@ bool CmdSketcherConstrainTangent::substituteConstraintCombinations(SketchObject*
             return true;
         }
         else if ((*it)->Type == Sketcher::PointOnObject
-                 && (((*it)->First == GeoId1 && (*it)->Second == GeoId2)
-                     || ((*it)->Second == GeoId1 && (*it)->First == GeoId2))
-                 && ((*it)->FirstPos == Sketcher::PointPos::start
-                     || (*it)->FirstPos == Sketcher::PointPos::end)) {
+                 && (((*it)->First_Deprecated == GeoId1 && (*it)->Second_Deprecated == GeoId2)
+                     || ((*it)->Second_Deprecated == GeoId1 && (*it)->First_Deprecated == GeoId2))
+                 && ((*it)->FirstPos_Deprecated == Sketcher::PointPos::start
+                     || (*it)->FirstPos_Deprecated == Sketcher::PointPos::end)) {
             openCommand(
                 QT_TRANSLATE_NOOP("Command",
                                   "Swap point on object and tangency with point to curve tangency"));
 
-            doEndpointToEdgeTangency(Obj, (*it)->First, (*it)->FirstPos, (*it)->Second);
+            doEndpointToEdgeTangency(Obj, (*it)->First_Deprecated, (*it)->FirstPos_Deprecated, (*it)->Second_Deprecated);
 
             Gui::cmdAppObjectArgs(Obj,
                                   "delConstraint(%d)",

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -140,7 +140,7 @@ void finishDatumConstraint(Gui::Command* cmd,
 
         for (int i = lastConstraintIndex; i >= firstConstraintIndex; i--) {
             if (lastConstraintType == Radius || lastConstraintType == Diameter) {
-                const Part::Geometry* geo = sketch->getGeometry(ConStr[i]->First_Deprecated);
+                const Part::Geometry* geo = sketch->getGeometry(ConStr[i]->getGeoId(0));
 
                 if (geo && isCircle(*geo)) {
                     ConStr[i]->LabelPosition = labelPosition;
@@ -204,12 +204,12 @@ bool removeRedundantPointOnObject(SketchObject* Obj, int GeoId1, int GeoId2, int
     int cid = 0;
     for (auto it = cvals.begin(); it != cvals.end(); ++it, ++cid) {
         if ((*it)->Type == Sketcher::PointOnObject &&
-            (((*it)->First_Deprecated == GeoId3 && (*it)->Second_Deprecated == GeoId1) ||
-             ((*it)->First_Deprecated == GeoId3 && (*it)->Second_Deprecated == GeoId2))) {
+            (((*it)->getGeoId(0) == GeoId3 && (*it)->getGeoId(1) == GeoId1) ||
+             ((*it)->getGeoId(0) == GeoId3 && (*it)->getGeoId(1) == GeoId2))) {
 
             // ONLY do this if it is a B-spline (or any other where point
             // on object is implied).
-            const Part::Geometry* geom = Obj->getGeometry((*it)->Second_Deprecated);
+            const Part::Geometry* geom = Obj->getGeometry((*it)->getGeoId(1));
             if (isBSplineCurve(*geom))
                 cidsToBeRemoved.push_back(cid);
         }
@@ -2956,7 +2956,7 @@ protected:
         // check if the edge already has a Horizontal/Vertical/Block constraint
         for (const auto& constraint : vals) {
             if ((constraint->Type == Sketcher::Horizontal || constraint->Type == Sketcher::Vertical || constraint->Type == Sketcher::Block)
-                && constraint->First_Deprecated == GeoId) {
+                && constraint->getGeoId(0) == GeoId) {
                 return true;
             }
         }
@@ -3265,16 +3265,16 @@ bool canHorVerBlock(Sketcher::SketchObject* Obj, int geoId)
 
     // check if the edge already has a Horizontal/Vertical/Block constraint
     for (auto& constr : vals) {
-        if (constr->Type == Sketcher::Horizontal && constr->First_Deprecated == geoId
-            && constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
+        if (constr->Type == Sketcher::Horizontal && constr->getGeoId(0) == geoId
+            && constr->getPosId(0) == Sketcher::PointPos::none) {
             Gui::TranslatedUserWarning(
                 Obj,
                 QObject::tr("Double constraint"),
                 QObject::tr("The selected edge already has a horizontal constraint!"));
             return false;
         }
-        if (constr->Type == Sketcher::Vertical && constr->First_Deprecated == geoId
-            && constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
+        if (constr->Type == Sketcher::Vertical && constr->getGeoId(0) == geoId
+            && constr->getPosId(0) == Sketcher::PointPos::none) {
             Gui::TranslatedUserWarning(
                 Obj,
                 QObject::tr("Impossible constraint"),
@@ -3282,8 +3282,8 @@ bool canHorVerBlock(Sketcher::SketchObject* Obj, int geoId)
             return false;
         }
         // check if the edge already has a Block constraint
-        if (constr->Type == Sketcher::Block && constr->First_Deprecated == geoId
-            && constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
+        if (constr->Type == Sketcher::Block && constr->getGeoId(0) == geoId
+            && constr->getPosId(0) == Sketcher::PointPos::none) {
             Gui::TranslatedUserWarning(
                 Obj,
                 QObject::tr("Impossible constraint"),
@@ -4207,10 +4207,10 @@ bool CmdSketcherConstrainCoincidentUnified::substituteConstraintCombinationsPoin
     int cid = 0;
     for (std::vector<Constraint*>::const_iterator it = cvals.begin(); it != cvals.end();
         ++it, ++cid) {
-        if ((*it)->Type == Sketcher::Tangent && (*it)->FirstPos_Deprecated == Sketcher::PointPos::none
-            && (*it)->SecondPos_Deprecated == Sketcher::PointPos::none && (*it)->Third_Deprecated == GeoEnum::GeoUndef
-            && (((*it)->First_Deprecated == GeoId1 && (*it)->Second_Deprecated == GeoId2)
-                || ((*it)->Second_Deprecated == GeoId1 && (*it)->First_Deprecated == GeoId2))
+        if ((*it)->Type == Sketcher::Tangent && (*it)->getPosId(0) == Sketcher::PointPos::none
+            && (*it)->getPosId(1) == Sketcher::PointPos::none && (*it)->getGeoId(2) == GeoEnum::GeoUndef
+            && (((*it)->getGeoId(0) == GeoId1 && (*it)->getGeoId(1) == GeoId2)
+                || ((*it)->getGeoId(1) == GeoId1 && (*it)->getGeoId(0) == GeoId2))
             && (PosId1 == Sketcher::PointPos::start
                 || PosId1 == Sketcher::PointPos::end)) {
 
@@ -4245,17 +4245,17 @@ bool CmdSketcherConstrainCoincidentUnified::substituteConstraintCombinationsCoin
     int j = 0;
     for (std::vector<Constraint*>::const_iterator it = cvals.begin(); it != cvals.end();
         ++it, ++j) {
-        if ((*it)->Type == Sketcher::Tangent && (*it)->Third_Deprecated == GeoEnum::GeoUndef
-            && (((*it)->First_Deprecated == GeoId1 && (*it)->Second_Deprecated == GeoId2)
-                || ((*it)->Second_Deprecated == GeoId1 && (*it)->First_Deprecated == GeoId2))) {
+        if ((*it)->Type == Sketcher::Tangent && (*it)->getGeoId(2) == GeoEnum::GeoUndef
+            && (((*it)->getGeoId(0) == GeoId1 && (*it)->getGeoId(1) == GeoId2)
+                || ((*it)->getGeoId(1) == GeoId1 && (*it)->getGeoId(0) == GeoId2))) {
             if (!(PosId1 == Sketcher::PointPos::start
                   || PosId1 == Sketcher::PointPos::end)
                 || !(PosId2 == Sketcher::PointPos::start
                      || PosId2 == Sketcher::PointPos::end)) {
                 continue;
             }
-            if ((*it)->FirstPos_Deprecated == Sketcher::PointPos::none
-                && (*it)->SecondPos_Deprecated == Sketcher::PointPos::none) {
+            if ((*it)->getPosId(0) == Sketcher::PointPos::none
+                && (*it)->getPosId(1) == Sketcher::PointPos::none) {
 
                 if (constraintExists) {
                     // try to remove any pre-existing direct coincident constraints
@@ -4284,7 +4284,7 @@ bool CmdSketcherConstrainCoincidentUnified::substituteConstraintCombinationsCoin
                 }
 
                 // if a similar tangency already exists this must result in bad constraints
-                if ((*it)->SecondPos_Deprecated == Sketcher::PointPos::none) {
+                if ((*it)->getPosId(1) == Sketcher::PointPos::none) {
                     Gui::cmdAppObjectArgs(Obj, "delConstraint(%d)", j);
 
                     doEndpointTangency(Obj, GeoId1, GeoId2, PosId1, PosId2);
@@ -7023,21 +7023,21 @@ bool CmdSketcherConstrainTangent::substituteConstraintCombinations(SketchObject*
     for (std::vector<Constraint*>::const_iterator it = cvals.begin(); it != cvals.end();
          ++it, ++cid) {
         if ((*it)->Type == Sketcher::Coincident
-            && (((*it)->First_Deprecated == GeoId1 && (*it)->Second_Deprecated == GeoId2)
-                || ((*it)->Second_Deprecated == GeoId1 && (*it)->First_Deprecated == GeoId2))
-            && ((*it)->FirstPos_Deprecated == Sketcher::PointPos::start
-                || (*it)->FirstPos_Deprecated == Sketcher::PointPos::end)
-            && ((*it)->SecondPos_Deprecated == Sketcher::PointPos::start
-                || (*it)->SecondPos_Deprecated == Sketcher::PointPos::end)) {
+            && (((*it)->getGeoId(0) == GeoId1 && (*it)->getGeoId(1) == GeoId2)
+                || ((*it)->getGeoId(1) == GeoId1 && (*it)->getGeoId(0) == GeoId2))
+            && ((*it)->getPosId(0) == Sketcher::PointPos::start
+                || (*it)->getPosId(0) == Sketcher::PointPos::end)
+            && ((*it)->getPosId(1) == Sketcher::PointPos::start
+                || (*it)->getPosId(1) == Sketcher::PointPos::end)) {
             // save values because 'doEndpointTangency' changes the
             // constraint property and thus invalidates this iterator
-            int first = (*it)->First_Deprecated;
-            int firstpos = static_cast<int>((*it)->FirstPos_Deprecated);
+            int first = (*it)->getGeoId(0);
+            int firstpos = static_cast<int>((*it)->getPosId(0));
 
             openCommand(
                 QT_TRANSLATE_NOOP("Command", "Swap coincident+tangency with ptp tangency"));
 
-            doEndpointTangency(Obj, (*it)->First_Deprecated, (*it)->Second_Deprecated, (*it)->FirstPos_Deprecated, (*it)->SecondPos_Deprecated);
+            doEndpointTangency(Obj, (*it)->getGeoId(0), (*it)->getGeoId(1), (*it)->getPosId(0), (*it)->getPosId(1));
 
             Gui::cmdAppObjectArgs(Obj, "delConstraintOnPoint(%d,%d)", first, firstpos);
 
@@ -7053,15 +7053,15 @@ bool CmdSketcherConstrainTangent::substituteConstraintCombinations(SketchObject*
             return true;
         }
         else if ((*it)->Type == Sketcher::PointOnObject
-                 && (((*it)->First_Deprecated == GeoId1 && (*it)->Second_Deprecated == GeoId2)
-                     || ((*it)->Second_Deprecated == GeoId1 && (*it)->First_Deprecated == GeoId2))
-                 && ((*it)->FirstPos_Deprecated == Sketcher::PointPos::start
-                     || (*it)->FirstPos_Deprecated == Sketcher::PointPos::end)) {
+                 && (((*it)->getGeoId(0) == GeoId1 && (*it)->getGeoId(1) == GeoId2)
+                     || ((*it)->getGeoId(1) == GeoId1 && (*it)->getGeoId(0) == GeoId2))
+                 && ((*it)->getPosId(0) == Sketcher::PointPos::start
+                     || (*it)->getPosId(0) == Sketcher::PointPos::end)) {
             openCommand(
                 QT_TRANSLATE_NOOP("Command",
                                   "Swap point on object and tangency with point to curve tangency"));
 
-            doEndpointToEdgeTangency(Obj, (*it)->First_Deprecated, (*it)->FirstPos_Deprecated, (*it)->Second_Deprecated);
+            doEndpointToEdgeTangency(Obj, (*it)->getGeoId(0), (*it)->getPosId(0), (*it)->getGeoId(1));
 
             Gui::cmdAppObjectArgs(Obj,
                                   "delConstraint(%d)",

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -75,9 +75,9 @@ bool findBSplineAndKnotIndex(
 )
 {
     for (auto const constraint : Obj->Constraints.getValues()) {
-        if (constraint->Type == Sketcher::InternalAlignment && constraint->First_Deprecated == knotGeoId
+        if (constraint->Type == Sketcher::InternalAlignment && constraint->getGeoId(0) == knotGeoId
             && constraint->AlignmentType == Sketcher::BSplineKnotPoint) {
-            splineGeoId = constraint->Second_Deprecated;
+            splineGeoId = constraint->getGeoId(1);
             knotIndexOCC = constraint->InternalAlignmentIndex + 1;
             return true;  // we have already found our knot.
         }
@@ -1154,12 +1154,10 @@ void CmdSketcherJoinCurves::activated(int iMsg)
     bool tangentConstraintExists = false;
     for (const auto& constr : Obj->Constraints.getValues()) {
         if (constr->Type == Sketcher::ConstraintType::Tangent
-            && ((constr->First_Deprecated == GeoIds[0] && constr->FirstPos_Deprecated == PosIds[0]
-                 && constr->Second_Deprecated == GeoIds[1]
-                 && constr->SecondPos_Deprecated == PosIds[1])
-                || (constr->First_Deprecated == GeoIds[1] && constr->FirstPos_Deprecated == PosIds[1]
-                    && constr->Second_Deprecated == GeoIds[0]
-                    && constr->SecondPos_Deprecated == PosIds[0]))) {
+            && ((constr->getGeoId(0) == GeoIds[0] && constr->getPosId(0) == PosIds[0]
+                 && constr->getGeoId(1) == GeoIds[1] && constr->getPosId(1) == PosIds[1])
+                || (constr->getGeoId(0) == GeoIds[1] && constr->getPosId(0) == PosIds[1]
+                    && constr->getGeoId(1) == GeoIds[0] && constr->getPosId(1) == PosIds[0]))) {
             tangentConstraintExists = true;
         }
     }

--- a/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherBSpline.cpp
@@ -75,9 +75,9 @@ bool findBSplineAndKnotIndex(
 )
 {
     for (auto const constraint : Obj->Constraints.getValues()) {
-        if (constraint->Type == Sketcher::InternalAlignment && constraint->First == knotGeoId
+        if (constraint->Type == Sketcher::InternalAlignment && constraint->First_Deprecated == knotGeoId
             && constraint->AlignmentType == Sketcher::BSplineKnotPoint) {
-            splineGeoId = constraint->Second;
+            splineGeoId = constraint->Second_Deprecated;
             knotIndexOCC = constraint->InternalAlignmentIndex + 1;
             return true;  // we have already found our knot.
         }
@@ -1154,10 +1154,12 @@ void CmdSketcherJoinCurves::activated(int iMsg)
     bool tangentConstraintExists = false;
     for (const auto& constr : Obj->Constraints.getValues()) {
         if (constr->Type == Sketcher::ConstraintType::Tangent
-            && ((constr->First == GeoIds[0] && constr->FirstPos == PosIds[0]
-                 && constr->Second == GeoIds[1] && constr->SecondPos == PosIds[1])
-                || (constr->First == GeoIds[1] && constr->FirstPos == PosIds[1]
-                    && constr->Second == GeoIds[0] && constr->SecondPos == PosIds[0]))) {
+            && ((constr->First_Deprecated == GeoIds[0] && constr->FirstPos_Deprecated == PosIds[0]
+                 && constr->Second_Deprecated == GeoIds[1]
+                 && constr->SecondPos_Deprecated == PosIds[1])
+                || (constr->First_Deprecated == GeoIds[1] && constr->FirstPos_Deprecated == PosIds[1]
+                    && constr->Second_Deprecated == GeoIds[0]
+                    && constr->SecondPos_Deprecated == PosIds[0]))) {
             tangentConstraintExists = true;
         }
     }

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -126,10 +126,10 @@ std::vector<int> getListOfSelectedGeoIds(bool forceInternalSelection)
             if (isEllipse(*geo) || isArcOfEllipse(*geo) || isArcOfHyperbola(*geo) || isArcOfParabola(*geo) || isBSplineCurve(*geo)) {
                 const std::vector<Sketcher::Constraint*>& constraints = Obj->Constraints.getValues();
                 for (const auto constr : constraints) {
-                    if (constr->Type == InternalAlignment && constr->Second == listOfGeoIds[i]) {
-                        if (std::ranges::find(listOfGeoIds, constr->First) == listOfGeoIds.end()) {
+                    if (constr->Type == InternalAlignment && constr->Second_Deprecated == listOfGeoIds[i]) {
+                        if (std::ranges::find(listOfGeoIds, constr->First_Deprecated) == listOfGeoIds.end()) {
                             // If the value is not found, add it to the vector
-                            listOfGeoIds.push_back(constr->First);
+                            listOfGeoIds.push_back(constr->First_Deprecated);
                         }
                     }
                 }
@@ -184,22 +184,22 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj) {
                 || value == GeoEnum::VAxis || value == GeoEnum::HAxis;
         };
 
-        if (!isSelectedGeoOrAxis(listOfGeoId, constr->First)
-            || !isSelectedGeoOrAxis(listOfGeoId, constr->Second)
-            || !isSelectedGeoOrAxis(listOfGeoId, constr->Third)) {
+        if (!isSelectedGeoOrAxis(listOfGeoId, constr->First_Deprecated)
+            || !isSelectedGeoOrAxis(listOfGeoId, constr->Second_Deprecated)
+            || !isSelectedGeoOrAxis(listOfGeoId, constr->Third_Deprecated)) {
             continue;
         }
 
         Constraint* temp = constr->copy();
         for (size_t j = 0; j < listOfGeoId.size(); j++) {
-            if (temp->First == listOfGeoId[j]) {
-                temp->First = j;
+            if (temp->First_Deprecated == listOfGeoId[j]) {
+                temp->First_Deprecated = j;
             }
-            if (temp->Second == listOfGeoId[j]) {
-                temp->Second = j;
+            if (temp->Second_Deprecated == listOfGeoId[j]) {
+                temp->Second_Deprecated = j;
             }
-            if (temp->Third == listOfGeoId[j]) {
-                temp->Third = j;
+            if (temp->Third_Deprecated == listOfGeoId[j]) {
+                temp->Third_Deprecated = j;
             }
         }
         shapeConstraints.push_back(temp);
@@ -813,18 +813,18 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
             int ConstrId = Sketcher::PropertyConstraintList::getIndexFromConstraintName(*it);
 
             if (ConstrId < static_cast<int>(vals.size())) {
-                if (vals[ConstrId]->First != GeoEnum::GeoUndef) {
+                if (vals[ConstrId]->First_Deprecated != GeoEnum::GeoUndef) {
                     ss.str(std::string());
 
-                    switch (vals[ConstrId]->FirstPos) {
+                    switch (vals[ConstrId]->FirstPos_Deprecated) {
                         case Sketcher::PointPos::none:
-                            ss << "Edge" << vals[ConstrId]->First + 1;
+                            ss << "Edge" << vals[ConstrId]->First_Deprecated + 1;
                             break;
                         case Sketcher::PointPos::start:
                         case Sketcher::PointPos::end:
                         case Sketcher::PointPos::mid:
-                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->First,
-                                                                   vals[ConstrId]->FirstPos);
+                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->First_Deprecated,
+                                                                   vals[ConstrId]->FirstPos_Deprecated);
                             if (vertex > -1)
                                 ss << "Vertex" << vertex + 1;
                             break;
@@ -832,18 +832,18 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
                     elementSubNames.push_back(ss.str());
                 }
 
-                if (vals[ConstrId]->Second != GeoEnum::GeoUndef) {
+                if (vals[ConstrId]->Second_Deprecated != GeoEnum::GeoUndef) {
                     ss.str(std::string());
 
-                    switch (vals[ConstrId]->SecondPos) {
+                    switch (vals[ConstrId]->SecondPos_Deprecated) {
                         case Sketcher::PointPos::none:
-                            ss << "Edge" << vals[ConstrId]->Second + 1;
+                            ss << "Edge" << vals[ConstrId]->Second_Deprecated + 1;
                             break;
                         case Sketcher::PointPos::start:
                         case Sketcher::PointPos::end:
                         case Sketcher::PointPos::mid:
-                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->Second,
-                                                                   vals[ConstrId]->SecondPos);
+                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->Second_Deprecated,
+                                                                   vals[ConstrId]->SecondPos_Deprecated);
                             if (vertex > -1)
                                 ss << "Vertex" << vertex + 1;
                             break;
@@ -852,18 +852,18 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
                     elementSubNames.push_back(ss.str());
                 }
 
-                if (vals[ConstrId]->Third != GeoEnum::GeoUndef) {
+                if (vals[ConstrId]->Third_Deprecated != GeoEnum::GeoUndef) {
                     ss.str(std::string());
 
-                    switch (vals[ConstrId]->ThirdPos) {
+                    switch (vals[ConstrId]->ThirdPos_Deprecated) {
                         case Sketcher::PointPos::none:
-                            ss << "Edge" << vals[ConstrId]->Third + 1;
+                            ss << "Edge" << vals[ConstrId]->Third_Deprecated + 1;
                             break;
                         case Sketcher::PointPos::start:
                         case Sketcher::PointPos::end:
                         case Sketcher::PointPos::mid:
-                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->Third,
-                                                                   vals[ConstrId]->ThirdPos);
+                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->Third_Deprecated,
+                                                                   vals[ConstrId]->ThirdPos_Deprecated);
                             if (vertex > -1)
                                 ss << "Vertex" << vertex + 1;
                             break;

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -126,10 +126,10 @@ std::vector<int> getListOfSelectedGeoIds(bool forceInternalSelection)
             if (isEllipse(*geo) || isArcOfEllipse(*geo) || isArcOfHyperbola(*geo) || isArcOfParabola(*geo) || isBSplineCurve(*geo)) {
                 const std::vector<Sketcher::Constraint*>& constraints = Obj->Constraints.getValues();
                 for (const auto constr : constraints) {
-                    if (constr->Type == InternalAlignment && constr->Second_Deprecated == listOfGeoIds[i]) {
-                        if (std::ranges::find(listOfGeoIds, constr->First_Deprecated) == listOfGeoIds.end()) {
+                    if (constr->Type == InternalAlignment && constr->getGeoId(1) == listOfGeoIds[i]) {
+                        if (std::ranges::find(listOfGeoIds, constr->getGeoId(0)) == listOfGeoIds.end()) {
                             // If the value is not found, add it to the vector
-                            listOfGeoIds.push_back(constr->First_Deprecated);
+                            listOfGeoIds.push_back(constr->getGeoId(0));
                         }
                     }
                 }
@@ -184,21 +184,21 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj) {
                 || value == GeoEnum::VAxis || value == GeoEnum::HAxis;
         };
 
-        if (!isSelectedGeoOrAxis(listOfGeoId, constr->First_Deprecated)
-            || !isSelectedGeoOrAxis(listOfGeoId, constr->Second_Deprecated)
-            || !isSelectedGeoOrAxis(listOfGeoId, constr->Third_Deprecated)) {
+        if (!isSelectedGeoOrAxis(listOfGeoId, constr->getGeoId(0))
+            || !isSelectedGeoOrAxis(listOfGeoId, constr->getGeoId(1))
+            || !isSelectedGeoOrAxis(listOfGeoId, constr->getGeoId(2))) {
             continue;
         }
 
         Constraint* temp = constr->copy();
         for (size_t j = 0; j < listOfGeoId.size(); j++) {
-            if (temp->First_Deprecated == listOfGeoId[j]) {
+            if (temp->getGeoId(0) == listOfGeoId[j]) {
                 temp->setGeoId(0, j);
             }
-            if (temp->Second_Deprecated == listOfGeoId[j]) {
+            if (temp->getGeoId(1) == listOfGeoId[j]) {
                 temp->setGeoId(1, j);
             }
-            if (temp->Third_Deprecated == listOfGeoId[j]) {
+            if (temp->getGeoId(2) == listOfGeoId[j]) {
                 temp->setGeoId(2, j);
             }
         }
@@ -813,18 +813,18 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
             int ConstrId = Sketcher::PropertyConstraintList::getIndexFromConstraintName(*it);
 
             if (ConstrId < static_cast<int>(vals.size())) {
-                if (vals[ConstrId]->First_Deprecated != GeoEnum::GeoUndef) {
+                if (vals[ConstrId]->getGeoId(0) != GeoEnum::GeoUndef) {
                     ss.str(std::string());
 
-                    switch (vals[ConstrId]->FirstPos_Deprecated) {
+                    switch (vals[ConstrId]->getPosId(0)) {
                         case Sketcher::PointPos::none:
-                            ss << "Edge" << vals[ConstrId]->First_Deprecated + 1;
+                            ss << "Edge" << vals[ConstrId]->getGeoId(0) + 1;
                             break;
                         case Sketcher::PointPos::start:
                         case Sketcher::PointPos::end:
                         case Sketcher::PointPos::mid:
-                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->First_Deprecated,
-                                                                   vals[ConstrId]->FirstPos_Deprecated);
+                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->getGeoId(0),
+                                                                   vals[ConstrId]->getPosId(0));
                             if (vertex > -1)
                                 ss << "Vertex" << vertex + 1;
                             break;
@@ -832,18 +832,18 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
                     elementSubNames.push_back(ss.str());
                 }
 
-                if (vals[ConstrId]->Second_Deprecated != GeoEnum::GeoUndef) {
+                if (vals[ConstrId]->getGeoId(1) != GeoEnum::GeoUndef) {
                     ss.str(std::string());
 
-                    switch (vals[ConstrId]->SecondPos_Deprecated) {
+                    switch (vals[ConstrId]->getPosId(1)) {
                         case Sketcher::PointPos::none:
-                            ss << "Edge" << vals[ConstrId]->Second_Deprecated + 1;
+                            ss << "Edge" << vals[ConstrId]->getGeoId(1) + 1;
                             break;
                         case Sketcher::PointPos::start:
                         case Sketcher::PointPos::end:
                         case Sketcher::PointPos::mid:
-                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->Second_Deprecated,
-                                                                   vals[ConstrId]->SecondPos_Deprecated);
+                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->getGeoId(1),
+                                                                   vals[ConstrId]->getPosId(1));
                             if (vertex > -1)
                                 ss << "Vertex" << vertex + 1;
                             break;
@@ -852,18 +852,18 @@ void CmdSketcherSelectElementsAssociatedWithConstraints::activated(int iMsg)
                     elementSubNames.push_back(ss.str());
                 }
 
-                if (vals[ConstrId]->Third_Deprecated != GeoEnum::GeoUndef) {
+                if (vals[ConstrId]->getGeoId(2) != GeoEnum::GeoUndef) {
                     ss.str(std::string());
 
-                    switch (vals[ConstrId]->ThirdPos_Deprecated) {
+                    switch (vals[ConstrId]->getPosId(2)) {
                         case Sketcher::PointPos::none:
-                            ss << "Edge" << vals[ConstrId]->Third_Deprecated + 1;
+                            ss << "Edge" << vals[ConstrId]->getGeoId(2) + 1;
                             break;
                         case Sketcher::PointPos::start:
                         case Sketcher::PointPos::end:
                         case Sketcher::PointPos::mid:
-                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->Third_Deprecated,
-                                                                   vals[ConstrId]->ThirdPos_Deprecated);
+                            int vertex = Obj->getVertexIndexGeoPos(vals[ConstrId]->getGeoId(2),
+                                                                   vals[ConstrId]->getPosId(2));
                             if (vertex > -1)
                                 ss << "Vertex" << vertex + 1;
                             break;

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -193,13 +193,13 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj) {
         Constraint* temp = constr->copy();
         for (size_t j = 0; j < listOfGeoId.size(); j++) {
             if (temp->First_Deprecated == listOfGeoId[j]) {
-                temp->First_Deprecated = j;
+                temp->setGeoId(0, j);
             }
             if (temp->Second_Deprecated == listOfGeoId[j]) {
-                temp->Second_Deprecated = j;
+                temp->setGeoId(1, j);
             }
             if (temp->Third_Deprecated == listOfGeoId[j]) {
-                temp->Third_Deprecated = j;
+                temp->setGeoId(2, j);
             }
         }
         shapeConstraints.push_back(temp);

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -720,10 +720,8 @@ protected:
                 else {
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::Coincident;
-                    c->First_Deprecated = geoId1;
-                    c->FirstPos_Deprecated = posId1;
-                    c->Second_Deprecated = geoId2;
-                    c->SecondPos_Deprecated = posId2;
+                    c->setElement(0, Sketcher::GeoElementId(geoId1, posId1));
+                    c->setElement(1, Sketcher::GeoElementId(geoId2, posId2));
                     AutoConstraints.push_back(std::move(c));
                 }
             } break;
@@ -756,8 +754,7 @@ protected:
                 else {
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::PointOnObject;
-                    c->First_Deprecated = geoId1;
-                    c->FirstPos_Deprecated = posId1;
+                    c->setElement(0, Sketcher::GeoElementId(geoId1, posId1));
                     c->Second_Deprecated = geoId2;
                     AutoConstraints.push_back(std::move(c));
                 }
@@ -765,12 +762,9 @@ protected:
             case Sketcher::Symmetric: {
                 auto c = std::make_unique<Sketcher::Constraint>();
                 c->Type = Sketcher::Symmetric;
-                c->First_Deprecated = geoId2;
-                c->FirstPos_Deprecated = Sketcher::PointPos::start;
-                c->Second_Deprecated = geoId2;
-                c->SecondPos_Deprecated = Sketcher::PointPos::end;
-                c->Third_Deprecated = geoId1;
-                c->ThirdPos_Deprecated = posId1;
+                c->setElement(0, Sketcher::GeoElementId(geoId2, Sketcher::PointPos::start));
+                c->setElement(1, Sketcher::GeoElementId(geoId2, Sketcher::PointPos::end));
+                c->setElement(2, Sketcher::GeoElementId(geoId1, posId1));
                 AutoConstraints.push_back(std::move(c));
             } break;
             // In special case of Horizontal/Vertical constraint, geoId2 is normally
@@ -1146,12 +1140,9 @@ protected:
     {
         auto constr = std::make_unique<Sketcher::Constraint>();
         constr->Type = type;
-        constr->First_Deprecated = first;
-        constr->FirstPos_Deprecated = firstPos;
-        constr->Second_Deprecated = second;
-        constr->SecondPos_Deprecated = secondPos;
-        constr->Third_Deprecated = third;
-        constr->ThirdPos_Deprecated = thirdPos;
+        constr->setElement(0, Sketcher::GeoElementId(first, firstPos));
+        constr->setElement(1, Sketcher::GeoElementId(second, secondPos));
+        constr->setElement(2, Sketcher::GeoElementId(third, thirdPos));
         return ShapeConstraints.emplace_back(std::move(constr)).get();
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -755,7 +755,7 @@ protected:
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::PointOnObject;
                     c->setElement(0, Sketcher::GeoElementId(geoId1, posId1));
-                    c->Second_Deprecated = geoId2;
+                    c->setGeoId(1, geoId2);
                     AutoConstraints.push_back(std::move(c));
                 }
             } break;
@@ -776,7 +776,7 @@ protected:
             case Sketcher::Vertical: {
                 auto c = std::make_unique<Sketcher::Constraint>();
                 c->Type = ac.Type;
-                c->First_Deprecated = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
+                c->setGeoId(0, (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1));
                 AutoConstraints.push_back(std::move(c));
             } break;
             case Sketcher::Tangent: {
@@ -865,15 +865,15 @@ protected:
                     // equality
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::Equal;
-                    c->First_Deprecated = geoId1;
-                    c->Second_Deprecated = geoId2;
+                    c->setGeoId(0, geoId1);
+                    c->setGeoId(1, geoId2);
                     AutoConstraints.push_back(std::move(c));
                 }
                 else {  // regular edge to edge tangency
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::Tangent;
-                    c->First_Deprecated = geoId1;
-                    c->Second_Deprecated = geoId2;
+                    c->setGeoId(0, geoId1);
+                    c->setGeoId(1, geoId2);
                     AutoConstraints.push_back(std::move(c));
                 }
             } break;

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -743,10 +743,10 @@ protected:
                 // if tangency, convert to point-to-edge tangency
                 if (itOfTangentConstraint != AutoConstraints.end()) {
                     if ((*itOfTangentConstraint)->getGeoId(0) != geoId1) {
-                        std::swap(
-                            (*itOfTangentConstraint)->getGeoId(1),
-                            (*itOfTangentConstraint)->getGeoId(0)
-                        );
+                        auto tmp0 = (*itOfTangentConstraint)->getGeoId(0);
+                        auto tmp1 = (*itOfTangentConstraint)->getGeoId(1);
+                        (*itOfTangentConstraint)->setGeoId(0, tmp1);
+                        (*itOfTangentConstraint)->setGeoId(1, tmp0);
                     }
 
                     (*itOfTangentConstraint)->setPosId(0, posId1);

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -707,23 +707,23 @@ protected:
                         AutoConstraints,
                         std::tuple {Sketcher::Tangent, geoId1, geoId2},
                         [](const auto& ace) {
-                            return std::tuple {ace->Type, ace->First, ace->Second};
+                            return std::tuple {ace->Type, ace->First_Deprecated, ace->Second_Deprecated};
                         }
                     );
                 }
 
                 if (itOfTangentConstraint != AutoConstraints.end()) {
                     // modify tangency to endpoint-to-endpoint
-                    (*itOfTangentConstraint)->FirstPos = posId1;
-                    (*itOfTangentConstraint)->SecondPos = posId2;
+                    (*itOfTangentConstraint)->FirstPos_Deprecated = posId1;
+                    (*itOfTangentConstraint)->SecondPos_Deprecated = posId2;
                 }
                 else {
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::Coincident;
-                    c->First = geoId1;
-                    c->FirstPos = posId1;
-                    c->Second = geoId2;
-                    c->SecondPos = posId2;
+                    c->First_Deprecated = geoId1;
+                    c->FirstPos_Deprecated = posId1;
+                    c->Second_Deprecated = geoId2;
+                    c->SecondPos_Deprecated = posId2;
                     AutoConstraints.push_back(std::move(c));
                 }
             } break;
@@ -744,30 +744,33 @@ protected:
 
                 // if tangency, convert to point-to-edge tangency
                 if (itOfTangentConstraint != AutoConstraints.end()) {
-                    if ((*itOfTangentConstraint)->First != geoId1) {
-                        std::swap((*itOfTangentConstraint)->Second, (*itOfTangentConstraint)->First);
+                    if ((*itOfTangentConstraint)->First_Deprecated != geoId1) {
+                        std::swap(
+                            (*itOfTangentConstraint)->Second_Deprecated,
+                            (*itOfTangentConstraint)->First_Deprecated
+                        );
                     }
 
-                    (*itOfTangentConstraint)->FirstPos = posId1;
+                    (*itOfTangentConstraint)->FirstPos_Deprecated = posId1;
                 }
                 else {
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::PointOnObject;
-                    c->First = geoId1;
-                    c->FirstPos = posId1;
-                    c->Second = geoId2;
+                    c->First_Deprecated = geoId1;
+                    c->FirstPos_Deprecated = posId1;
+                    c->Second_Deprecated = geoId2;
                     AutoConstraints.push_back(std::move(c));
                 }
             } break;
             case Sketcher::Symmetric: {
                 auto c = std::make_unique<Sketcher::Constraint>();
                 c->Type = Sketcher::Symmetric;
-                c->First = geoId2;
-                c->FirstPos = Sketcher::PointPos::start;
-                c->Second = geoId2;
-                c->SecondPos = Sketcher::PointPos::end;
-                c->Third = geoId1;
-                c->ThirdPos = posId1;
+                c->First_Deprecated = geoId2;
+                c->FirstPos_Deprecated = Sketcher::PointPos::start;
+                c->Second_Deprecated = geoId2;
+                c->SecondPos_Deprecated = Sketcher::PointPos::end;
+                c->Third_Deprecated = geoId1;
+                c->ThirdPos_Deprecated = posId1;
                 AutoConstraints.push_back(std::move(c));
             } break;
             // In special case of Horizontal/Vertical constraint, geoId2 is normally
@@ -779,7 +782,7 @@ protected:
             case Sketcher::Vertical: {
                 auto c = std::make_unique<Sketcher::Constraint>();
                 c->Type = ac.Type;
-                c->First = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
+                c->First_Deprecated = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
                 AutoConstraints.push_back(std::move(c));
             } break;
             case Sketcher::Tangent: {
@@ -839,8 +842,8 @@ protected:
                 }
 
                 auto resultCoincident = std::ranges::find_if(AutoConstraints, [&](const auto& ace) {
-                    return ace->Type == Sketcher::Coincident && ace->First == geoId1
-                        && ace->Second == geoId2;
+                    return ace->Type == Sketcher::Coincident && ace->First_Deprecated == geoId1
+                        && ace->Second_Deprecated == geoId2;
                 });
 
                 auto resultPointOnObject = std::ranges::find_if(AutoConstraints, [&](const auto& ace) {
@@ -849,33 +852,34 @@ protected:
                 });
 
                 if (resultCoincident != AutoConstraints.end()
-                    && isStartOrEnd((*resultCoincident)->FirstPos)
-                    && isStartOrEnd((*resultCoincident)->SecondPos)) {
+                    && isStartOrEnd((*resultCoincident)->FirstPos_Deprecated)
+                    && isStartOrEnd((*resultCoincident)->SecondPos_Deprecated)) {
                     // endpoint-to-endpoint tangency
                     (*resultCoincident)->Type = Sketcher::Tangent;
                 }
                 else if (resultPointOnObject != AutoConstraints.end()
-                         && isStartOrEnd((*resultPointOnObject)->FirstPos)) {
+                         && isStartOrEnd((*resultPointOnObject)->FirstPos_Deprecated)) {
                     // endpoint-to-edge tangency
                     (*resultPointOnObject)->Type = Sketcher::Tangent;
                 }
                 else if (resultCoincident != AutoConstraints.end()
-                         && (*resultCoincident)->FirstPos == Sketcher::PointPos::mid
-                         && (*resultCoincident)->SecondPos == Sketcher::PointPos::mid && geom1 && geom2
+                         && (*resultCoincident)->FirstPos_Deprecated == Sketcher::PointPos::mid
+                         && (*resultCoincident)->SecondPos_Deprecated == Sketcher::PointPos::mid
+                         && geom1 && geom2
                          && (geom1->is<Part::GeomCircle>() || geom1->is<Part::GeomArcOfCircle>())
                          && (geom2->is<Part::GeomCircle>() || geom2->is<Part::GeomArcOfCircle>())) {
                     // equality
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::Equal;
-                    c->First = geoId1;
-                    c->Second = geoId2;
+                    c->First_Deprecated = geoId1;
+                    c->Second_Deprecated = geoId2;
                     AutoConstraints.push_back(std::move(c));
                 }
                 else {  // regular edge to edge tangency
                     auto c = std::make_unique<Sketcher::Constraint>();
                     c->Type = Sketcher::Tangent;
-                    c->First = geoId1;
-                    c->Second = geoId2;
+                    c->First_Deprecated = geoId1;
+                    c->Second_Deprecated = geoId2;
                     AutoConstraints.push_back(std::move(c));
                 }
             } break;
@@ -1142,12 +1146,12 @@ protected:
     {
         auto constr = std::make_unique<Sketcher::Constraint>();
         constr->Type = type;
-        constr->First = first;
-        constr->FirstPos = firstPos;
-        constr->Second = second;
-        constr->SecondPos = secondPos;
-        constr->Third = third;
-        constr->ThirdPos = thirdPos;
+        constr->First_Deprecated = first;
+        constr->FirstPos_Deprecated = firstPos;
+        constr->Second_Deprecated = second;
+        constr->SecondPos_Deprecated = secondPos;
+        constr->Third_Deprecated = third;
+        constr->ThirdPos_Deprecated = thirdPos;
         return ShapeConstraints.emplace_back(std::move(constr)).get();
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -707,7 +707,7 @@ protected:
                         AutoConstraints,
                         std::tuple {Sketcher::Tangent, geoId1, geoId2},
                         [](const auto& ace) {
-                            return std::tuple {ace->Type, ace->First_Deprecated, ace->Second_Deprecated};
+                            return std::tuple {ace->Type, ace->getGeoId(0), ace->getGeoId(1)};
                         }
                     );
                 }
@@ -742,10 +742,10 @@ protected:
 
                 // if tangency, convert to point-to-edge tangency
                 if (itOfTangentConstraint != AutoConstraints.end()) {
-                    if ((*itOfTangentConstraint)->First_Deprecated != geoId1) {
+                    if ((*itOfTangentConstraint)->getGeoId(0) != geoId1) {
                         std::swap(
-                            (*itOfTangentConstraint)->Second_Deprecated,
-                            (*itOfTangentConstraint)->First_Deprecated
+                            (*itOfTangentConstraint)->getGeoId(1),
+                            (*itOfTangentConstraint)->getGeoId(0)
                         );
                     }
 
@@ -836,8 +836,8 @@ protected:
                 }
 
                 auto resultCoincident = std::ranges::find_if(AutoConstraints, [&](const auto& ace) {
-                    return ace->Type == Sketcher::Coincident && ace->First_Deprecated == geoId1
-                        && ace->Second_Deprecated == geoId2;
+                    return ace->Type == Sketcher::Coincident && ace->getGeoId(0) == geoId1
+                        && ace->getGeoId(1) == geoId2;
                 });
 
                 auto resultPointOnObject = std::ranges::find_if(AutoConstraints, [&](const auto& ace) {
@@ -846,20 +846,20 @@ protected:
                 });
 
                 if (resultCoincident != AutoConstraints.end()
-                    && isStartOrEnd((*resultCoincident)->FirstPos_Deprecated)
-                    && isStartOrEnd((*resultCoincident)->SecondPos_Deprecated)) {
+                    && isStartOrEnd((*resultCoincident)->getPosId(0))
+                    && isStartOrEnd((*resultCoincident)->getPosId(1))) {
                     // endpoint-to-endpoint tangency
                     (*resultCoincident)->Type = Sketcher::Tangent;
                 }
                 else if (resultPointOnObject != AutoConstraints.end()
-                         && isStartOrEnd((*resultPointOnObject)->FirstPos_Deprecated)) {
+                         && isStartOrEnd((*resultPointOnObject)->getPosId(0))) {
                     // endpoint-to-edge tangency
                     (*resultPointOnObject)->Type = Sketcher::Tangent;
                 }
                 else if (resultCoincident != AutoConstraints.end()
-                         && (*resultCoincident)->FirstPos_Deprecated == Sketcher::PointPos::mid
-                         && (*resultCoincident)->SecondPos_Deprecated == Sketcher::PointPos::mid
-                         && geom1 && geom2
+                         && (*resultCoincident)->getPosId(0) == Sketcher::PointPos::mid
+                         && (*resultCoincident)->getPosId(1) == Sketcher::PointPos::mid && geom1
+                         && geom2
                          && (geom1->is<Part::GeomCircle>() || geom1->is<Part::GeomArcOfCircle>())
                          && (geom2->is<Part::GeomCircle>() || geom2->is<Part::GeomArcOfCircle>())) {
                     // equality

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -714,8 +714,8 @@ protected:
 
                 if (itOfTangentConstraint != AutoConstraints.end()) {
                     // modify tangency to endpoint-to-endpoint
-                    (*itOfTangentConstraint)->FirstPos_Deprecated = posId1;
-                    (*itOfTangentConstraint)->SecondPos_Deprecated = posId2;
+                    (*itOfTangentConstraint)->setPosId(0, posId1);
+                    (*itOfTangentConstraint)->setPosId(1, posId2);
                 }
                 else {
                     auto c = std::make_unique<Sketcher::Constraint>();
@@ -749,7 +749,7 @@ protected:
                         );
                     }
 
-                    (*itOfTangentConstraint)->FirstPos_Deprecated = posId1;
+                    (*itOfTangentConstraint)->setPosId(0, posId1);
                 }
                 else {
                     auto c = std::make_unique<Sketcher::Constraint>();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -151,15 +151,15 @@ private:
                 // those poles/knots center and mangle it to the endpoint.
                 if (!periodic) {
                     for (auto& constr : sketchgui->getSketchObject()->Constraints.getValues()) {
-                        if (constr->First == geoIds[0]
-                            && constr->FirstPos == Sketcher::PointPos::mid) {
-                            constr->First = currentgeoid;
-                            constr->FirstPos = Sketcher::PointPos::start;
+                        if (constr->First_Deprecated == geoIds[0]
+                            && constr->FirstPos_Deprecated == Sketcher::PointPos::mid) {
+                            constr->First_Deprecated = currentgeoid;
+                            constr->FirstPos_Deprecated = Sketcher::PointPos::start;
                         }
-                        else if (constr->First == geoIds.back()
-                                 && constr->FirstPos == Sketcher::PointPos::mid) {
-                            constr->First = currentgeoid;
-                            constr->FirstPos = Sketcher::PointPos::end;
+                        else if (constr->First_Deprecated == geoIds.back()
+                                 && constr->FirstPos_Deprecated == Sketcher::PointPos::mid) {
+                            constr->First_Deprecated = currentgeoid;
+                            constr->FirstPos_Deprecated = Sketcher::PointPos::end;
                         }
                     }
                 }
@@ -321,15 +321,15 @@ private:
                 // endpoint.
                 if (!periodic) {
                     for (auto& constr : sketchgui->getSketchObject()->Constraints.getValues()) {
-                        if (constr->First == geoIds[0]
-                            && constr->FirstPos == Sketcher::PointPos::start) {
-                            constr->First = currentgeoid;
-                            constr->FirstPos = Sketcher::PointPos::start;
+                        if (constr->First_Deprecated == geoIds[0]
+                            && constr->FirstPos_Deprecated == Sketcher::PointPos::start) {
+                            constr->First_Deprecated = currentgeoid;
+                            constr->FirstPos_Deprecated = Sketcher::PointPos::start;
                         }
-                        else if (constr->First == geoIds.back()
-                                 && constr->FirstPos == Sketcher::PointPos::start) {
-                            constr->First = currentgeoid;
-                            constr->FirstPos = Sketcher::PointPos::end;
+                        else if (constr->First_Deprecated == geoIds.back()
+                                 && constr->FirstPos_Deprecated == Sketcher::PointPos::start) {
+                            constr->First_Deprecated = currentgeoid;
+                            constr->FirstPos_Deprecated = Sketcher::PointPos::end;
                         }
                     }
                 }
@@ -650,8 +650,9 @@ private:
             const int delGeoId = geoIds.back();
             const auto& constraints = sketchgui->getSketchObject()->Constraints.getValues();
             for (int i = constraints.size() - 1; i >= 0; --i) {
-                if (delGeoId == constraints[i]->First || delGeoId == constraints[i]->Second
-                    || delGeoId == constraints[i]->Third) {
+                if (delGeoId == constraints[i]->First_Deprecated
+                    || delGeoId == constraints[i]->Second_Deprecated
+                    || delGeoId == constraints[i]->Third_Deprecated) {
                     Gui::cmdAppObjectArgs(sketchgui->getObject(), "delConstraint(%d)", i);
                 }
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -151,15 +151,15 @@ private:
                 // those poles/knots center and mangle it to the endpoint.
                 if (!periodic) {
                     for (auto& constr : sketchgui->getSketchObject()->Constraints.getValues()) {
-                        if (constr->First_Deprecated == geoIds[0]
-                            && constr->FirstPos_Deprecated == Sketcher::PointPos::mid) {
+                        if (constr->getGeoId(0) == geoIds[0]
+                            && constr->getPosId(0) == Sketcher::PointPos::mid) {
                             constr->setElement(
                                 0,
                                 Sketcher::GeoElementId(currentgeoid, Sketcher::PointPos::start)
                             );
                         }
-                        else if (constr->First_Deprecated == geoIds.back()
-                                 && constr->FirstPos_Deprecated == Sketcher::PointPos::mid) {
+                        else if (constr->getGeoId(0) == geoIds.back()
+                                 && constr->getPosId(0) == Sketcher::PointPos::mid) {
                             constr->setElement(
                                 0,
                                 Sketcher::GeoElementId(currentgeoid, Sketcher::PointPos::end)
@@ -325,15 +325,15 @@ private:
                 // endpoint.
                 if (!periodic) {
                     for (auto& constr : sketchgui->getSketchObject()->Constraints.getValues()) {
-                        if (constr->First_Deprecated == geoIds[0]
-                            && constr->FirstPos_Deprecated == Sketcher::PointPos::start) {
+                        if (constr->getGeoId(0) == geoIds[0]
+                            && constr->getPosId(0) == Sketcher::PointPos::start) {
                             constr->setElement(
                                 0,
                                 Sketcher::GeoElementId(currentgeoid, Sketcher::PointPos::start)
                             );
                         }
-                        else if (constr->First_Deprecated == geoIds.back()
-                                 && constr->FirstPos_Deprecated == Sketcher::PointPos::start) {
+                        else if (constr->getGeoId(0) == geoIds.back()
+                                 && constr->getPosId(0) == Sketcher::PointPos::start) {
                             constr->setElement(
                                 0,
                                 Sketcher::GeoElementId(currentgeoid, Sketcher::PointPos::end)
@@ -658,9 +658,8 @@ private:
             const int delGeoId = geoIds.back();
             const auto& constraints = sketchgui->getSketchObject()->Constraints.getValues();
             for (int i = constraints.size() - 1; i >= 0; --i) {
-                if (delGeoId == constraints[i]->First_Deprecated
-                    || delGeoId == constraints[i]->Second_Deprecated
-                    || delGeoId == constraints[i]->Third_Deprecated) {
+                if (delGeoId == constraints[i]->getGeoId(0) || delGeoId == constraints[i]->getGeoId(1)
+                    || delGeoId == constraints[i]->getGeoId(2)) {
                     Gui::cmdAppObjectArgs(sketchgui->getObject(), "delConstraint(%d)", i);
                 }
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -153,13 +153,17 @@ private:
                     for (auto& constr : sketchgui->getSketchObject()->Constraints.getValues()) {
                         if (constr->First_Deprecated == geoIds[0]
                             && constr->FirstPos_Deprecated == Sketcher::PointPos::mid) {
-                            constr->First_Deprecated = currentgeoid;
-                            constr->FirstPos_Deprecated = Sketcher::PointPos::start;
+                            constr->setElement(
+                                0,
+                                Sketcher::GeoElementId(currentgeoid, Sketcher::PointPos::start)
+                            );
                         }
                         else if (constr->First_Deprecated == geoIds.back()
                                  && constr->FirstPos_Deprecated == Sketcher::PointPos::mid) {
-                            constr->First_Deprecated = currentgeoid;
-                            constr->FirstPos_Deprecated = Sketcher::PointPos::end;
+                            constr->setElement(
+                                0,
+                                Sketcher::GeoElementId(currentgeoid, Sketcher::PointPos::end)
+                            );
                         }
                     }
                 }
@@ -323,13 +327,17 @@ private:
                     for (auto& constr : sketchgui->getSketchObject()->Constraints.getValues()) {
                         if (constr->First_Deprecated == geoIds[0]
                             && constr->FirstPos_Deprecated == Sketcher::PointPos::start) {
-                            constr->First_Deprecated = currentgeoid;
-                            constr->FirstPos_Deprecated = Sketcher::PointPos::start;
+                            constr->setElement(
+                                0,
+                                Sketcher::GeoElementId(currentgeoid, Sketcher::PointPos::start)
+                            );
                         }
                         else if (constr->First_Deprecated == geoIds.back()
                                  && constr->FirstPos_Deprecated == Sketcher::PointPos::start) {
-                            constr->First_Deprecated = currentgeoid;
-                            constr->FirstPos_Deprecated = Sketcher::PointPos::end;
+                            constr->setElement(
+                                0,
+                                Sketcher::GeoElementId(currentgeoid, Sketcher::PointPos::end)
+                            );
                         }
                     }
                 }
@@ -1237,15 +1245,15 @@ void DSHBSplineController::addConstraints()
     using namespace Sketcher;
 
     auto constraintToOrigin = [&]() {
-        ConstraintToAttachment(GeoElementId(firstCurve, pPos), GeoElementId::RtPnt, x0, obj);
+        ConstraintToAttachment(GeoElementId(firstCurve, pPos), Sketcher::GeoElementId::RtPnt, x0, obj);
     };
 
     auto constraintx0 = [&]() {
-        ConstraintToAttachment(GeoElementId(firstCurve, pPos), GeoElementId::VAxis, x0, obj);
+        ConstraintToAttachment(GeoElementId(firstCurve, pPos), Sketcher::GeoElementId::VAxis, x0, obj);
     };
 
     auto constrainty0 = [&]() {
-        ConstraintToAttachment(GeoElementId(firstCurve, pPos), GeoElementId::HAxis, y0, obj);
+        ConstraintToAttachment(GeoElementId(firstCurve, pPos), Sketcher::GeoElementId::HAxis, y0, obj);
     };
 
     auto constraintlengths = [&](bool checkDof) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -1079,21 +1079,31 @@ private:
         bool firstCoincidenceFound = false;
         for (auto* cstr : vals) {
             if (((tangentOnly || cstr->Type != Coincident) && cstr->Type != Tangent)
-                || cstr->FirstPos == PointPos::mid || cstr->FirstPos == PointPos::none
-                || cstr->SecondPos == PointPos::mid || cstr->SecondPos == PointPos::none) {
+                || cstr->FirstPos_Deprecated == PointPos::mid
+                || cstr->FirstPos_Deprecated == PointPos::none
+                || cstr->SecondPos_Deprecated == PointPos::mid
+                || cstr->SecondPos_Deprecated == PointPos::none) {
                 continue;
             }
 
-            if ((cstr->First == geoId1 && cstr->Second == geoId2)
-                || (cstr->First == geoId2 && cstr->Second == geoId1)) {
+            if ((cstr->First_Deprecated == geoId1 && cstr->Second_Deprecated == geoId2)
+                || (cstr->First_Deprecated == geoId2 && cstr->Second_Deprecated == geoId1)) {
                 if (!firstCoincidenceFound) {
-                    positions.firstPos1 = cstr->First == geoId1 ? cstr->FirstPos : cstr->SecondPos;
-                    positions.secondPos1 = cstr->First == geoId2 ? cstr->FirstPos : cstr->SecondPos;
+                    positions.firstPos1 = cstr->First_Deprecated == geoId1
+                        ? cstr->FirstPos_Deprecated
+                        : cstr->SecondPos_Deprecated;
+                    positions.secondPos1 = cstr->First_Deprecated == geoId2
+                        ? cstr->FirstPos_Deprecated
+                        : cstr->SecondPos_Deprecated;
                     firstCoincidenceFound = true;
                 }
                 else {
-                    positions.firstPos2 = cstr->First == geoId1 ? cstr->FirstPos : cstr->SecondPos;
-                    positions.secondPos2 = cstr->First == geoId2 ? cstr->FirstPos : cstr->SecondPos;
+                    positions.firstPos2 = cstr->First_Deprecated == geoId1
+                        ? cstr->FirstPos_Deprecated
+                        : cstr->SecondPos_Deprecated;
+                    positions.secondPos2 = cstr->First_Deprecated == geoId2
+                        ? cstr->FirstPos_Deprecated
+                        : cstr->SecondPos_Deprecated;
                     break;
                 }
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -1079,31 +1079,25 @@ private:
         bool firstCoincidenceFound = false;
         for (auto* cstr : vals) {
             if (((tangentOnly || cstr->Type != Coincident) && cstr->Type != Tangent)
-                || cstr->FirstPos_Deprecated == PointPos::mid
-                || cstr->FirstPos_Deprecated == PointPos::none
-                || cstr->SecondPos_Deprecated == PointPos::mid
-                || cstr->SecondPos_Deprecated == PointPos::none) {
+                || cstr->getPosId(0) == PointPos::mid || cstr->getPosId(0) == PointPos::none
+                || cstr->getPosId(1) == PointPos::mid || cstr->getPosId(1) == PointPos::none) {
                 continue;
             }
 
-            if ((cstr->First_Deprecated == geoId1 && cstr->Second_Deprecated == geoId2)
-                || (cstr->First_Deprecated == geoId2 && cstr->Second_Deprecated == geoId1)) {
+            if ((cstr->getGeoId(0) == geoId1 && cstr->getGeoId(1) == geoId2)
+                || (cstr->getGeoId(0) == geoId2 && cstr->getGeoId(1) == geoId1)) {
                 if (!firstCoincidenceFound) {
-                    positions.firstPos1 = cstr->First_Deprecated == geoId1
-                        ? cstr->FirstPos_Deprecated
-                        : cstr->SecondPos_Deprecated;
-                    positions.secondPos1 = cstr->First_Deprecated == geoId2
-                        ? cstr->FirstPos_Deprecated
-                        : cstr->SecondPos_Deprecated;
+                    positions.firstPos1 = cstr->getGeoId(0) == geoId1 ? cstr->getPosId(0)
+                                                                      : cstr->getPosId(1);
+                    positions.secondPos1 = cstr->getGeoId(0) == geoId2 ? cstr->getPosId(0)
+                                                                       : cstr->getPosId(1);
                     firstCoincidenceFound = true;
                 }
                 else {
-                    positions.firstPos2 = cstr->First_Deprecated == geoId1
-                        ? cstr->FirstPos_Deprecated
-                        : cstr->SecondPos_Deprecated;
-                    positions.secondPos2 = cstr->First_Deprecated == geoId2
-                        ? cstr->FirstPos_Deprecated
-                        : cstr->SecondPos_Deprecated;
+                    positions.firstPos2 = cstr->getGeoId(0) == geoId1 ? cstr->getPosId(0)
+                                                                      : cstr->getPosId(1);
+                    positions.secondPos2 = cstr->getGeoId(0) == geoId2 ? cstr->getPosId(0)
+                                                                       : cstr->getPosId(1);
                     break;
                 }
             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -348,13 +348,13 @@ private:
                     int thirdIndexi = firstCurveCreated + thirdIndex + static_cast<int>(size) * i;
 
                     auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
-                    newConstr->First_Deprecated = firstIndexi;
+                    newConstr->setGeoId(0, firstIndexi);
 
                     if ((cstr->Type == Symmetric || cstr->Type == Tangent
                          || cstr->Type == Perpendicular || cstr->Type == Angle)
                         && firstIndex >= 0 && secondIndex >= 0 && thirdIndex >= 0) {
-                        newConstr->Second_Deprecated = secondIndexi;
-                        newConstr->Third_Deprecated = thirdIndexi;
+                        newConstr->setGeoId(1, secondIndexi);
+                        newConstr->setGeoId(2, thirdIndexi);
                     }
                     else if ((cstr->Type == Coincident || cstr->Type == Tangent
                               || cstr->Type == Symmetric || cstr->Type == Perpendicular
@@ -362,7 +362,7 @@ private:
                               || cstr->Type == PointOnObject || cstr->Type == InternalAlignment)
                              && firstIndex >= 0 && secondIndex >= 0
                              && thirdIndex == GeoEnum::GeoUndef) {
-                        newConstr->Second_Deprecated = secondIndexi;
+                        newConstr->setGeoId(1, secondIndexi);
                     }
                     else if ((cstr->Type == Radius || cstr->Type == Diameter || cstr->Type == Weight)
                              && firstIndex >= 0) {
@@ -371,8 +371,8 @@ private:
                         }
                         else {
                             newConstr->Type = Equal;
-                            newConstr->First_Deprecated = cstr->First_Deprecated;
-                            newConstr->Second_Deprecated = firstIndexi;
+                            newConstr->setGeoId(0, cstr->First_Deprecated);
+                            newConstr->setGeoId(1, firstIndexi);
                         }
                     }
                     else if ((cstr->Type == Distance || cstr->Type == DistanceX
@@ -386,13 +386,13 @@ private:
                                 continue;
                             }
                             newConstr->Type = Equal;
-                            newConstr->First_Deprecated = cstr->First_Deprecated;
-                            newConstr->Second_Deprecated = firstIndexi;
+                            newConstr->setGeoId(0, cstr->First_Deprecated);
+                            newConstr->setGeoId(1, firstIndexi);
                             geoIdsWhoAlreadyHasEqual.push_back(firstIndexi);
                         }
                         else if (cstr->Type == Distance) {
                             if (secondIndex >= 0) {
-                                newConstr->Second_Deprecated = secondIndexi;
+                                newConstr->setGeoId(1, secondIndexi);
                             }
                         }
                         else {
@@ -421,7 +421,7 @@ private:
                         }
                     }
                     else if ((cstr->Type == Block) && firstIndex >= 0) {
-                        newConstr->First_Deprecated = firstIndexi;
+                        newConstr->setGeoId(0, firstIndexi);
                     }
                     else {
                         continue;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -338,9 +338,9 @@ private:
             std::vector<int> geoIdsWhoAlreadyHasEqual = {};
 
             for (auto& cstr : vals) {
-                int firstIndex = indexOfGeoId(listOfGeoIds, cstr->First_Deprecated);
-                int secondIndex = indexOfGeoId(listOfGeoIds, cstr->Second_Deprecated);
-                int thirdIndex = indexOfGeoId(listOfGeoIds, cstr->Third_Deprecated);
+                int firstIndex = indexOfGeoId(listOfGeoIds, cstr->getGeoId(0));
+                int secondIndex = indexOfGeoId(listOfGeoIds, cstr->getGeoId(1));
+                int thirdIndex = indexOfGeoId(listOfGeoIds, cstr->getGeoId(2));
 
                 for (int i = 0; i < numberOfCopiesToMake; i++) {
                     int firstIndexi = firstCurveCreated + firstIndex + static_cast<int>(size) * i;
@@ -371,7 +371,7 @@ private:
                         }
                         else {
                             newConstr->Type = Equal;
-                            newConstr->setGeoId(0, cstr->First_Deprecated);
+                            newConstr->setGeoId(0, cstr->getGeoId(0));
                             newConstr->setGeoId(1, firstIndexi);
                         }
                     }
@@ -379,14 +379,14 @@ private:
                               || cstr->Type == DistanceY)
                              && firstIndex >= 0) {
                         if (!deleteOriginal && cloneConstraints
-                            && (cstr->First_Deprecated == cstr->Second_Deprecated
+                            && (cstr->getGeoId(0) == cstr->getGeoId(1)
                                 || secondIndex < 0)) {  // only line
                                                         // distances
                             if (indexOfGeoId(geoIdsWhoAlreadyHasEqual, firstIndexi) != -1) {
                                 continue;
                             }
                             newConstr->Type = Equal;
-                            newConstr->setGeoId(0, cstr->First_Deprecated);
+                            newConstr->setGeoId(0, cstr->getGeoId(0));
                             newConstr->setGeoId(1, firstIndexi);
                             geoIdsWhoAlreadyHasEqual.push_back(firstIndexi);
                         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerRotate.h
@@ -338,9 +338,9 @@ private:
             std::vector<int> geoIdsWhoAlreadyHasEqual = {};
 
             for (auto& cstr : vals) {
-                int firstIndex = indexOfGeoId(listOfGeoIds, cstr->First);
-                int secondIndex = indexOfGeoId(listOfGeoIds, cstr->Second);
-                int thirdIndex = indexOfGeoId(listOfGeoIds, cstr->Third);
+                int firstIndex = indexOfGeoId(listOfGeoIds, cstr->First_Deprecated);
+                int secondIndex = indexOfGeoId(listOfGeoIds, cstr->Second_Deprecated);
+                int thirdIndex = indexOfGeoId(listOfGeoIds, cstr->Third_Deprecated);
 
                 for (int i = 0; i < numberOfCopiesToMake; i++) {
                     int firstIndexi = firstCurveCreated + firstIndex + static_cast<int>(size) * i;
@@ -348,13 +348,13 @@ private:
                     int thirdIndexi = firstCurveCreated + thirdIndex + static_cast<int>(size) * i;
 
                     auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
-                    newConstr->First = firstIndexi;
+                    newConstr->First_Deprecated = firstIndexi;
 
                     if ((cstr->Type == Symmetric || cstr->Type == Tangent
                          || cstr->Type == Perpendicular || cstr->Type == Angle)
                         && firstIndex >= 0 && secondIndex >= 0 && thirdIndex >= 0) {
-                        newConstr->Second = secondIndexi;
-                        newConstr->Third = thirdIndexi;
+                        newConstr->Second_Deprecated = secondIndexi;
+                        newConstr->Third_Deprecated = thirdIndexi;
                     }
                     else if ((cstr->Type == Coincident || cstr->Type == Tangent
                               || cstr->Type == Symmetric || cstr->Type == Perpendicular
@@ -362,7 +362,7 @@ private:
                               || cstr->Type == PointOnObject || cstr->Type == InternalAlignment)
                              && firstIndex >= 0 && secondIndex >= 0
                              && thirdIndex == GeoEnum::GeoUndef) {
-                        newConstr->Second = secondIndexi;
+                        newConstr->Second_Deprecated = secondIndexi;
                     }
                     else if ((cstr->Type == Radius || cstr->Type == Diameter || cstr->Type == Weight)
                              && firstIndex >= 0) {
@@ -371,27 +371,28 @@ private:
                         }
                         else {
                             newConstr->Type = Equal;
-                            newConstr->First = cstr->First;
-                            newConstr->Second = firstIndexi;
+                            newConstr->First_Deprecated = cstr->First_Deprecated;
+                            newConstr->Second_Deprecated = firstIndexi;
                         }
                     }
                     else if ((cstr->Type == Distance || cstr->Type == DistanceX
                               || cstr->Type == DistanceY)
                              && firstIndex >= 0) {
                         if (!deleteOriginal && cloneConstraints
-                            && (cstr->First == cstr->Second || secondIndex < 0)) {  // only line
-                                                                                    // distances
+                            && (cstr->First_Deprecated == cstr->Second_Deprecated
+                                || secondIndex < 0)) {  // only line
+                                                        // distances
                             if (indexOfGeoId(geoIdsWhoAlreadyHasEqual, firstIndexi) != -1) {
                                 continue;
                             }
                             newConstr->Type = Equal;
-                            newConstr->First = cstr->First;
-                            newConstr->Second = firstIndexi;
+                            newConstr->First_Deprecated = cstr->First_Deprecated;
+                            newConstr->Second_Deprecated = firstIndexi;
                             geoIdsWhoAlreadyHasEqual.push_back(firstIndexi);
                         }
                         else if (cstr->Type == Distance) {
                             if (secondIndex >= 0) {
-                                newConstr->Second = secondIndexi;
+                                newConstr->Second_Deprecated = secondIndexi;
                             }
                         }
                         else {
@@ -420,7 +421,7 @@ private:
                         }
                     }
                     else if ((cstr->Type == Block) && firstIndex >= 0) {
-                        newConstr->First = firstIndexi;
+                        newConstr->First_Deprecated = firstIndexi;
                     }
                     else {
                         continue;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -505,9 +505,9 @@ private:
                     continue;
                 }
 
-                int firstIndex = offsetGeoID(cstr->First, firstCurveCreated);
-                int secondIndex = offsetGeoID(cstr->Second, firstCurveCreated);
-                int thirdIndex = offsetGeoID(cstr->Third, firstCurveCreated);
+                int firstIndex = offsetGeoID(cstr->First_Deprecated, firstCurveCreated);
+                int secondIndex = offsetGeoID(cstr->Second_Deprecated, firstCurveCreated);
+                int thirdIndex = offsetGeoID(cstr->Third_Deprecated, firstCurveCreated);
 
                 auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
 
@@ -525,9 +525,9 @@ private:
                      || cstr->Type == Angle)
                     && firstIndex != GeoEnum::GeoUndef && secondIndex != GeoEnum::GeoUndef
                     && thirdIndex != GeoEnum::GeoUndef) {
-                    newConstr->First = firstIndex;
-                    newConstr->Second = secondIndex;
-                    newConstr->Third = thirdIndex;
+                    newConstr->First_Deprecated = firstIndex;
+                    newConstr->Second_Deprecated = secondIndex;
+                    newConstr->Third_Deprecated = thirdIndex;
                 }
                 else if ((cstr->Type == Coincident || cstr->Type == Tangent
                           || cstr->Type == Symmetric || cstr->Type == Perpendicular
@@ -535,38 +535,40 @@ private:
                           || cstr->Type == PointOnObject || cstr->Type == InternalAlignment)
                          && firstIndex != GeoEnum::GeoUndef && secondIndex != GeoEnum::GeoUndef
                          && thirdIndex == GeoEnum::GeoUndef) {
-                    newConstr->First = firstIndex;
-                    newConstr->Second = secondIndex;
+                    newConstr->First_Deprecated = firstIndex;
+                    newConstr->Second_Deprecated = secondIndex;
                 }
                 else if (cstr->Type == Angle && firstIndex != GeoEnum::GeoUndef
                          && secondIndex == GeoEnum::GeoUndef && thirdIndex == GeoEnum::GeoUndef) {
-                    newConstr->First = firstIndex;
+                    newConstr->First_Deprecated = firstIndex;
                 }
                 else if ((cstr->Type == Radius || cstr->Type == Diameter)
                          && firstIndex != GeoEnum::GeoUndef) {
-                    newConstr->First = firstIndex;
+                    newConstr->First_Deprecated = firstIndex;
                     newConstr->setValue(newConstr->getValue() * scaleFactor);
                 }
                 else if ((cstr->Type == Distance || cstr->Type == DistanceX || cstr->Type == DistanceY)
                          && firstIndex != GeoEnum::GeoUndef && secondIndex != GeoEnum::GeoUndef) {
-                    newConstr->First = firstIndex;
-                    newConstr->Second = secondIndex;
+                    newConstr->First_Deprecated = firstIndex;
+                    newConstr->Second_Deprecated = secondIndex;
                     newConstr->setValue(newConstr->getValue() * scaleFactor);
                 }
                 else if ((cstr->Type == Distance || cstr->Type == DistanceX || cstr->Type == DistanceY)
-                         && firstIndex != GeoEnum::GeoUndef && cstr->Second == GeoEnum::GeoUndef) {
-                    newConstr->First = firstIndex;
+                         && firstIndex != GeoEnum::GeoUndef
+                         && cstr->Second_Deprecated == GeoEnum::GeoUndef) {
+                    newConstr->First_Deprecated = firstIndex;
                     newConstr->setValue(newConstr->getValue() * scaleFactor);
                 }
                 else if ((cstr->Type == Block || cstr->Type == Weight)
                          && firstIndex != GeoEnum::GeoUndef) {
-                    newConstr->First = firstIndex;
+                    newConstr->First_Deprecated = firstIndex;
                 }
                 else if ((cstr->Type == Vertical || cstr->Type == Horizontal)
                          && (firstIndex != GeoEnum::GeoUndef
-                             && (cstr->Second == GeoEnum::GeoUndef || secondIndex != GeoUndef))) {
-                    newConstr->First = firstIndex;
-                    newConstr->Second = secondIndex;
+                             && (cstr->Second_Deprecated == GeoEnum::GeoUndef
+                                 || secondIndex != GeoUndef))) {
+                    newConstr->First_Deprecated = firstIndex;
+                    newConstr->Second_Deprecated = secondIndex;
                 }
                 else {
                     continue;
@@ -582,19 +584,25 @@ private:
         // We might want to skip (remove) a constraint if
         return
             // 1. it's first geometry is undefined => not a valid constraint, should not happen
-            (constr->First == GeoEnum::GeoUndef)
+            (constr->First_Deprecated == GeoEnum::GeoUndef)
 
             // 2. we do not want to have constraints that relate to the origin => it would break if
             // the scale center is not the origin
             || (!allowOriginConstraint
-                && (constr->First == GeoEnum::VAxis || constr->First == GeoEnum::HAxis
-                    || constr->Second == GeoEnum::VAxis || constr->Second == GeoEnum::HAxis
-                    || constr->Third == GeoEnum::VAxis || constr->Third == GeoEnum::HAxis))
+                && (constr->First_Deprecated == GeoEnum::VAxis
+                    || constr->First_Deprecated == GeoEnum::HAxis
+                    || constr->Second_Deprecated == GeoEnum::VAxis
+                    || constr->Second_Deprecated == GeoEnum::HAxis
+                    || constr->Third_Deprecated == GeoEnum::VAxis
+                    || constr->Third_Deprecated == GeoEnum::HAxis))
 
             // 3. it is linked to an external projected geometry => would be unstable
-            || (constr->First != GeoEnum::GeoUndef && constr->First <= GeoEnum::RefExt)
-            || (constr->Second != GeoEnum::GeoUndef && constr->Second <= GeoEnum::RefExt)
-            || (constr->Third != GeoEnum::GeoUndef && constr->Third <= GeoEnum::RefExt);
+            || (constr->First_Deprecated != GeoEnum::GeoUndef
+                && constr->First_Deprecated <= GeoEnum::RefExt)
+            || (constr->Second_Deprecated != GeoEnum::GeoUndef
+                && constr->Second_Deprecated <= GeoEnum::RefExt)
+            || (constr->Third_Deprecated != GeoEnum::GeoUndef
+                && constr->Third_Deprecated <= GeoEnum::RefExt);
     }
 
     // Offset the geom index to match the newly created one

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -525,9 +525,9 @@ private:
                      || cstr->Type == Angle)
                     && firstIndex != GeoEnum::GeoUndef && secondIndex != GeoEnum::GeoUndef
                     && thirdIndex != GeoEnum::GeoUndef) {
-                    newConstr->First_Deprecated = firstIndex;
-                    newConstr->Second_Deprecated = secondIndex;
-                    newConstr->Third_Deprecated = thirdIndex;
+                    newConstr->setGeoId(0, firstIndex);
+                    newConstr->setGeoId(1, secondIndex);
+                    newConstr->setGeoId(2, thirdIndex);
                 }
                 else if ((cstr->Type == Coincident || cstr->Type == Tangent
                           || cstr->Type == Symmetric || cstr->Type == Perpendicular
@@ -535,40 +535,40 @@ private:
                           || cstr->Type == PointOnObject || cstr->Type == InternalAlignment)
                          && firstIndex != GeoEnum::GeoUndef && secondIndex != GeoEnum::GeoUndef
                          && thirdIndex == GeoEnum::GeoUndef) {
-                    newConstr->First_Deprecated = firstIndex;
-                    newConstr->Second_Deprecated = secondIndex;
+                    newConstr->setGeoId(0, firstIndex);
+                    newConstr->setGeoId(1, secondIndex);
                 }
                 else if (cstr->Type == Angle && firstIndex != GeoEnum::GeoUndef
                          && secondIndex == GeoEnum::GeoUndef && thirdIndex == GeoEnum::GeoUndef) {
-                    newConstr->First_Deprecated = firstIndex;
+                    newConstr->setGeoId(0, firstIndex);
                 }
                 else if ((cstr->Type == Radius || cstr->Type == Diameter)
                          && firstIndex != GeoEnum::GeoUndef) {
-                    newConstr->First_Deprecated = firstIndex;
+                    newConstr->setGeoId(0, firstIndex);
                     newConstr->setValue(newConstr->getValue() * scaleFactor);
                 }
                 else if ((cstr->Type == Distance || cstr->Type == DistanceX || cstr->Type == DistanceY)
                          && firstIndex != GeoEnum::GeoUndef && secondIndex != GeoEnum::GeoUndef) {
-                    newConstr->First_Deprecated = firstIndex;
-                    newConstr->Second_Deprecated = secondIndex;
+                    newConstr->setGeoId(0, firstIndex);
+                    newConstr->setGeoId(1, secondIndex);
                     newConstr->setValue(newConstr->getValue() * scaleFactor);
                 }
                 else if ((cstr->Type == Distance || cstr->Type == DistanceX || cstr->Type == DistanceY)
                          && firstIndex != GeoEnum::GeoUndef
                          && cstr->Second_Deprecated == GeoEnum::GeoUndef) {
-                    newConstr->First_Deprecated = firstIndex;
+                    newConstr->setGeoId(0, firstIndex);
                     newConstr->setValue(newConstr->getValue() * scaleFactor);
                 }
                 else if ((cstr->Type == Block || cstr->Type == Weight)
                          && firstIndex != GeoEnum::GeoUndef) {
-                    newConstr->First_Deprecated = firstIndex;
+                    newConstr->setGeoId(0, firstIndex);
                 }
                 else if ((cstr->Type == Vertical || cstr->Type == Horizontal)
                          && (firstIndex != GeoEnum::GeoUndef
                              && (cstr->Second_Deprecated == GeoEnum::GeoUndef
                                  || secondIndex != GeoUndef))) {
-                    newConstr->First_Deprecated = firstIndex;
-                    newConstr->Second_Deprecated = secondIndex;
+                    newConstr->setGeoId(0, firstIndex);
+                    newConstr->setGeoId(1, secondIndex);
                 }
                 else {
                     continue;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerScale.h
@@ -505,9 +505,9 @@ private:
                     continue;
                 }
 
-                int firstIndex = offsetGeoID(cstr->First_Deprecated, firstCurveCreated);
-                int secondIndex = offsetGeoID(cstr->Second_Deprecated, firstCurveCreated);
-                int thirdIndex = offsetGeoID(cstr->Third_Deprecated, firstCurveCreated);
+                int firstIndex = offsetGeoID(cstr->getGeoId(0), firstCurveCreated);
+                int secondIndex = offsetGeoID(cstr->getGeoId(1), firstCurveCreated);
+                int thirdIndex = offsetGeoID(cstr->getGeoId(2), firstCurveCreated);
 
                 auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
 
@@ -555,7 +555,7 @@ private:
                 }
                 else if ((cstr->Type == Distance || cstr->Type == DistanceX || cstr->Type == DistanceY)
                          && firstIndex != GeoEnum::GeoUndef
-                         && cstr->Second_Deprecated == GeoEnum::GeoUndef) {
+                         && cstr->getGeoId(1) == GeoEnum::GeoUndef) {
                     newConstr->setGeoId(0, firstIndex);
                     newConstr->setValue(newConstr->getValue() * scaleFactor);
                 }
@@ -565,8 +565,7 @@ private:
                 }
                 else if ((cstr->Type == Vertical || cstr->Type == Horizontal)
                          && (firstIndex != GeoEnum::GeoUndef
-                             && (cstr->Second_Deprecated == GeoEnum::GeoUndef
-                                 || secondIndex != GeoUndef))) {
+                             && (cstr->getGeoId(1) == GeoEnum::GeoUndef || secondIndex != GeoUndef))) {
                     newConstr->setGeoId(0, firstIndex);
                     newConstr->setGeoId(1, secondIndex);
                 }
@@ -584,25 +583,19 @@ private:
         // We might want to skip (remove) a constraint if
         return
             // 1. it's first geometry is undefined => not a valid constraint, should not happen
-            (constr->First_Deprecated == GeoEnum::GeoUndef)
+            (constr->getGeoId(0) == GeoEnum::GeoUndef)
 
             // 2. we do not want to have constraints that relate to the origin => it would break if
             // the scale center is not the origin
             || (!allowOriginConstraint
-                && (constr->First_Deprecated == GeoEnum::VAxis
-                    || constr->First_Deprecated == GeoEnum::HAxis
-                    || constr->Second_Deprecated == GeoEnum::VAxis
-                    || constr->Second_Deprecated == GeoEnum::HAxis
-                    || constr->Third_Deprecated == GeoEnum::VAxis
-                    || constr->Third_Deprecated == GeoEnum::HAxis))
+                && (constr->getGeoId(0) == GeoEnum::VAxis || constr->getGeoId(0) == GeoEnum::HAxis
+                    || constr->getGeoId(1) == GeoEnum::VAxis || constr->getGeoId(1) == GeoEnum::HAxis
+                    || constr->getGeoId(2) == GeoEnum::VAxis || constr->getGeoId(2) == GeoEnum::HAxis))
 
             // 3. it is linked to an external projected geometry => would be unstable
-            || (constr->First_Deprecated != GeoEnum::GeoUndef
-                && constr->First_Deprecated <= GeoEnum::RefExt)
-            || (constr->Second_Deprecated != GeoEnum::GeoUndef
-                && constr->Second_Deprecated <= GeoEnum::RefExt)
-            || (constr->Third_Deprecated != GeoEnum::GeoUndef
-                && constr->Third_Deprecated <= GeoEnum::RefExt);
+            || (constr->getGeoId(0) != GeoEnum::GeoUndef && constr->getGeoId(0) <= GeoEnum::RefExt)
+            || (constr->getGeoId(1) != GeoEnum::GeoUndef && constr->getGeoId(1) <= GeoEnum::RefExt)
+            || (constr->getGeoId(2) != GeoEnum::GeoUndef && constr->getGeoId(2) <= GeoEnum::RefExt);
     }
 
     // Offset the geom index to match the newly created one

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -145,12 +145,12 @@ public:
                           return (
                               constr->Type == Sketcher::InternalAlignment
                               && constr->AlignmentType == Sketcher::BSplineKnotPoint
-                              && constr->First == pointGeoId
+                              && constr->First_Deprecated == pointGeoId
                           );
                       });
 
                 if (conIt != constraints.end()) {
-                    GeoId = (*conIt)->Second;
+                    GeoId = (*conIt)->Second_Deprecated;
                 }
             }
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSplitting.h
@@ -145,12 +145,12 @@ public:
                           return (
                               constr->Type == Sketcher::InternalAlignment
                               && constr->AlignmentType == Sketcher::BSplineKnotPoint
-                              && constr->First_Deprecated == pointGeoId
+                              && constr->getGeoId(0) == pointGeoId
                           );
                       });
 
                 if (conIt != constraints.end()) {
-                    GeoId = (*conIt)->Second_Deprecated;
+                    GeoId = (*conIt)->getGeoId(1);
                 }
             }
         }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -367,9 +367,9 @@ private:
             std::vector<int> geoIdsWhoAlreadyHasEqual = {};
 
             for (auto& cstr : vals) {
-                int firstIndex = indexOfGeoId(listOfGeoIds, cstr->First_Deprecated);
-                int secondIndex = indexOfGeoId(listOfGeoIds, cstr->Second_Deprecated);
-                int thirdIndex = indexOfGeoId(listOfGeoIds, cstr->Third_Deprecated);
+                int firstIndex = indexOfGeoId(listOfGeoIds, cstr->getGeoId(0));
+                int secondIndex = indexOfGeoId(listOfGeoIds, cstr->getGeoId(1));
+                int thirdIndex = indexOfGeoId(listOfGeoIds, cstr->getGeoId(2));
 
                 for (int k = 0; k < secondNumberOfCopies; k++) {
                     for (int i = 0; i <= numberOfCopiesToMake; i++) {
@@ -410,7 +410,7 @@ private:
                             }
                             else {
                                 newConstr->Type = Equal;
-                                newConstr->setGeoId(0, cstr->First_Deprecated);
+                                newConstr->setGeoId(0, cstr->getGeoId(0));
                                 newConstr->setGeoId(1, firstIndexi);
                             }
                         }
@@ -418,13 +418,12 @@ private:
                                   || cstr->Type == DistanceY)
                                  && firstIndex >= 0 && secondIndex >= 0) {
                             if (!deleteOriginal && cloneConstraints
-                                && cstr->First_Deprecated
-                                    == cstr->Second_Deprecated) {  // only line distances
+                                && cstr->getGeoId(0) == cstr->getGeoId(1)) {  // only line distances
                                 if (indexOfGeoId(geoIdsWhoAlreadyHasEqual, secondIndexi) != -1) {
                                     continue;
                                 }
                                 newConstr->Type = Equal;
-                                newConstr->setGeoId(0, cstr->First_Deprecated);
+                                newConstr->setGeoId(0, cstr->getGeoId(0));
                                 newConstr->setGeoId(1, secondIndexi);
                                 geoIdsWhoAlreadyHasEqual.push_back(secondIndexi);
                             }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -385,13 +385,13 @@ private:
                             + size * (numberOfCopiesToMake + 1) * k;
 
                         auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
-                        newConstr->First_Deprecated = firstIndexi;
+                        newConstr->setGeoId(0, firstIndexi);
 
                         if ((cstr->Type == Symmetric || cstr->Type == Tangent
                              || cstr->Type == Perpendicular || cstr->Type == Angle)
                             && firstIndex >= 0 && secondIndex >= 0 && thirdIndex >= 0) {
-                            newConstr->Second_Deprecated = secondIndexi;
-                            newConstr->Third_Deprecated = thirdIndexi;
+                            newConstr->setGeoId(1, secondIndexi);
+                            newConstr->setGeoId(2, thirdIndexi);
                         }
                         else if ((cstr->Type == Coincident || cstr->Type == Tangent
                                   || cstr->Type == Symmetric || cstr->Type == Perpendicular
@@ -400,7 +400,7 @@ private:
                                   || cstr->Type == Vertical || cstr->Type == InternalAlignment)
                                  && firstIndex >= 0 && secondIndex >= 0
                                  && thirdIndex == GeoEnum::GeoUndef) {
-                            newConstr->Second_Deprecated = secondIndexi;
+                            newConstr->setGeoId(1, secondIndexi);
                         }
                         else if ((cstr->Type == Radius || cstr->Type == Diameter
                                   || cstr->Type == Weight)
@@ -410,8 +410,8 @@ private:
                             }
                             else {
                                 newConstr->Type = Equal;
-                                newConstr->First_Deprecated = cstr->First_Deprecated;
-                                newConstr->Second_Deprecated = firstIndexi;
+                                newConstr->setGeoId(0, cstr->First_Deprecated);
+                                newConstr->setGeoId(1, firstIndexi);
                             }
                         }
                         else if ((cstr->Type == Distance || cstr->Type == DistanceX
@@ -424,18 +424,18 @@ private:
                                     continue;
                                 }
                                 newConstr->Type = Equal;
-                                newConstr->First_Deprecated = cstr->First_Deprecated;
-                                newConstr->Second_Deprecated = secondIndexi;
+                                newConstr->setGeoId(0, cstr->First_Deprecated);
+                                newConstr->setGeoId(1, secondIndexi);
                                 geoIdsWhoAlreadyHasEqual.push_back(secondIndexi);
                             }
                             else {
-                                newConstr->Second_Deprecated = secondIndexi;
+                                newConstr->setGeoId(1, secondIndexi);
                             }
                         }
                         else if ((cstr->Type == Block || cstr->Type == Horizontal
                                   || cstr->Type == Vertical)
                                  && firstIndex >= 0) {
-                            newConstr->First_Deprecated = firstIndexi;
+                            newConstr->setGeoId(0, firstIndexi);
                         }
                         else {
                             continue;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerTranslate.h
@@ -367,9 +367,9 @@ private:
             std::vector<int> geoIdsWhoAlreadyHasEqual = {};
 
             for (auto& cstr : vals) {
-                int firstIndex = indexOfGeoId(listOfGeoIds, cstr->First);
-                int secondIndex = indexOfGeoId(listOfGeoIds, cstr->Second);
-                int thirdIndex = indexOfGeoId(listOfGeoIds, cstr->Third);
+                int firstIndex = indexOfGeoId(listOfGeoIds, cstr->First_Deprecated);
+                int secondIndex = indexOfGeoId(listOfGeoIds, cstr->Second_Deprecated);
+                int thirdIndex = indexOfGeoId(listOfGeoIds, cstr->Third_Deprecated);
 
                 for (int k = 0; k < secondNumberOfCopies; k++) {
                     for (int i = 0; i <= numberOfCopiesToMake; i++) {
@@ -385,13 +385,13 @@ private:
                             + size * (numberOfCopiesToMake + 1) * k;
 
                         auto newConstr = std::unique_ptr<Constraint>(cstr->copy());
-                        newConstr->First = firstIndexi;
+                        newConstr->First_Deprecated = firstIndexi;
 
                         if ((cstr->Type == Symmetric || cstr->Type == Tangent
                              || cstr->Type == Perpendicular || cstr->Type == Angle)
                             && firstIndex >= 0 && secondIndex >= 0 && thirdIndex >= 0) {
-                            newConstr->Second = secondIndexi;
-                            newConstr->Third = thirdIndexi;
+                            newConstr->Second_Deprecated = secondIndexi;
+                            newConstr->Third_Deprecated = thirdIndexi;
                         }
                         else if ((cstr->Type == Coincident || cstr->Type == Tangent
                                   || cstr->Type == Symmetric || cstr->Type == Perpendicular
@@ -400,7 +400,7 @@ private:
                                   || cstr->Type == Vertical || cstr->Type == InternalAlignment)
                                  && firstIndex >= 0 && secondIndex >= 0
                                  && thirdIndex == GeoEnum::GeoUndef) {
-                            newConstr->Second = secondIndexi;
+                            newConstr->Second_Deprecated = secondIndexi;
                         }
                         else if ((cstr->Type == Radius || cstr->Type == Diameter
                                   || cstr->Type == Weight)
@@ -410,31 +410,32 @@ private:
                             }
                             else {
                                 newConstr->Type = Equal;
-                                newConstr->First = cstr->First;
-                                newConstr->Second = firstIndexi;
+                                newConstr->First_Deprecated = cstr->First_Deprecated;
+                                newConstr->Second_Deprecated = firstIndexi;
                             }
                         }
                         else if ((cstr->Type == Distance || cstr->Type == DistanceX
                                   || cstr->Type == DistanceY)
                                  && firstIndex >= 0 && secondIndex >= 0) {
                             if (!deleteOriginal && cloneConstraints
-                                && cstr->First == cstr->Second) {  // only line distances
+                                && cstr->First_Deprecated
+                                    == cstr->Second_Deprecated) {  // only line distances
                                 if (indexOfGeoId(geoIdsWhoAlreadyHasEqual, secondIndexi) != -1) {
                                     continue;
                                 }
                                 newConstr->Type = Equal;
-                                newConstr->First = cstr->First;
-                                newConstr->Second = secondIndexi;
+                                newConstr->First_Deprecated = cstr->First_Deprecated;
+                                newConstr->Second_Deprecated = secondIndexi;
                                 geoIdsWhoAlreadyHasEqual.push_back(secondIndexi);
                             }
                             else {
-                                newConstr->Second = secondIndexi;
+                                newConstr->Second_Deprecated = secondIndexi;
                             }
                         }
                         else if ((cstr->Type == Block || cstr->Type == Horizontal
                                   || cstr->Type == Vertical)
                                  && firstIndex >= 0) {
-                            newConstr->First = firstIndexi;
+                            newConstr->First_Deprecated = firstIndexi;
                         }
                         else {
                             continue;

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -199,11 +199,13 @@ Restart:
             );
             const Constraint* Constr = *it;
 
-            if (Constr->First < -extGeoCount || Constr->First >= intGeoCount
-                || (Constr->Second != GeoEnum::GeoUndef
-                    && (Constr->Second < -extGeoCount || Constr->Second >= intGeoCount))
-                || (Constr->Third != GeoEnum::GeoUndef
-                    && (Constr->Third < -extGeoCount || Constr->Third >= intGeoCount))) {
+            if (Constr->First_Deprecated < -extGeoCount || Constr->First_Deprecated >= intGeoCount
+                || (Constr->Second_Deprecated != GeoEnum::GeoUndef
+                    && (Constr->Second_Deprecated < -extGeoCount
+                        || Constr->Second_Deprecated >= intGeoCount))
+                || (Constr->Third_Deprecated != GeoEnum::GeoUndef
+                    && (Constr->Third_Deprecated < -extGeoCount
+                        || Constr->Third_Deprecated >= intGeoCount))) {
                 // Constraint can refer to non-existent geometry during undo/redo
                 continue;
             }
@@ -216,10 +218,13 @@ Restart:
                 case Vertical:    // write the new position of the Vertical constraint
                 {
                     assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
-                    bool alignment = Constr->Type != Block && Constr->Second != GeoEnum::GeoUndef;
+                    bool alignment = Constr->Type != Block
+                        && Constr->Second_Deprecated != GeoEnum::GeoUndef;
 
                     // get the geometry
-                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(Constr->First);
+                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(
+                        Constr->First_Deprecated
+                    );
 
                     if (!alignment) {
                         // Vertical & Horiz can only be a GeomLineSegment, but Blocked can be
@@ -388,8 +393,14 @@ Restart:
                         Base::Vector3d midpos1, dir1, norm1;
                         Base::Vector3d midpos2, dir2, norm2;
 
-                        midpos1 = geolistfacade.getPoint(Constr->First, Constr->FirstPos);
-                        midpos2 = geolistfacade.getPoint(Constr->Second, Constr->SecondPos);
+                        midpos1 = geolistfacade.getPoint(
+                            Constr->First_Deprecated,
+                            Constr->FirstPos_Deprecated
+                        );
+                        midpos2 = geolistfacade.getPoint(
+                            Constr->Second_Deprecated,
+                            Constr->SecondPos_Deprecated
+                        );
 
                         dir1 = (midpos2 - midpos1).Normalize();
                         dir2 = -dir1;
@@ -421,32 +432,37 @@ Restart:
                     assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                     assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
                     // get the geometry
-                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(Constr->First);
-                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second);
+                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
+                        Constr->First_Deprecated
+                    );
+                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
+                        Constr->Second_Deprecated
+                    );
                     Base::Vector3d midpos1, dir1, norm1;
                     Base::Vector3d midpos2, dir2, norm2;
                     bool twoIcons = false;  // a very local flag. It's set to true to indicate that
                                             // the second dir+norm are valid and should be used
 
-                    if (Constr->Third != GeoEnum::GeoUndef ||            // perpty via point
-                        Constr->FirstPos != Sketcher::PointPos::none) {  // endpoint-to-curve or
-                                                                         // endpoint-to-endpoint perpty
+                    if (Constr->Third_Deprecated != GeoEnum::GeoUndef ||  // perpty via point
+                        Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {  // endpoint-to-curve
+                                                                                    // or
+                        // endpoint-to-endpoint perpty
 
                         int ptGeoId;
                         Sketcher::PointPos ptPosId;
                         do {  // dummy loop to use break =) Maybe goto?
-                            ptGeoId = Constr->First;
-                            ptPosId = Constr->FirstPos;
+                            ptGeoId = Constr->First_Deprecated;
+                            ptPosId = Constr->FirstPos_Deprecated;
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
-                            ptGeoId = Constr->Second;
-                            ptPosId = Constr->SecondPos;
+                            ptGeoId = Constr->Second_Deprecated;
+                            ptPosId = Constr->SecondPos_Deprecated;
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
-                            ptGeoId = Constr->Third;
-                            ptPosId = Constr->ThirdPos;
+                            ptGeoId = Constr->Third_Deprecated;
+                            ptPosId = Constr->ThirdPos_Deprecated;
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
@@ -455,7 +471,7 @@ Restart:
 
                         midpos1 = geolistfacade.getPoint(ptGeoId, ptPosId);
 
-                        norm1 = getNormal(geolistfacade, Constr->Second, midpos1);
+                        norm1 = getNormal(geolistfacade, Constr->Second_Deprecated, midpos1);
 
                         // TODO: Check the method above. This was the old one making use of the
                         // solver.
@@ -466,7 +482,7 @@ Restart:
                         dir1 = norm1;
                         dir1.RotateZ(-pi / 2.0);
                     }
-                    else if (Constr->FirstPos == Sketcher::PointPos::none) {
+                    else if (Constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
 
                         if (geo1->is<Part::GeomLineSegment>()) {
                             const Part::GeomLineSegment* lineSeg1
@@ -550,8 +566,12 @@ Restart:
                     assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                     assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
                     // get the geometry
-                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(Constr->First);
-                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second);
+                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
+                        Constr->First_Deprecated
+                    );
+                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
+                        Constr->Second_Deprecated
+                    );
 
                     Base::Vector3d midpos1, dir1, norm1;
                     Base::Vector3d midpos2, dir2, norm2;
@@ -895,24 +915,30 @@ Restart:
                     int numPoints = 2;
 
                     // pnt1 will be initialized to (0,0,0) if only one point is given
-                    auto pnt1 = geolistfacade.getPoint(Constr->First, Constr->FirstPos);
+                    auto pnt1 = geolistfacade.getPoint(
+                        Constr->First_Deprecated,
+                        Constr->FirstPos_Deprecated
+                    );
 
                     Base::Vector3d pnt2(0., 0., 0.);
 
-                    if (Constr->SecondPos != Sketcher::PointPos::none) {
+                    if (Constr->SecondPos_Deprecated != Sketcher::PointPos::none) {
                         // point to point distance
-                        pnt2 = geolistfacade.getPoint(Constr->Second, Constr->SecondPos);
+                        pnt2 = geolistfacade.getPoint(
+                            Constr->Second_Deprecated,
+                            Constr->SecondPos_Deprecated
+                        );
                     }
-                    else if (Constr->Second != GeoEnum::GeoUndef) {
-                        auto geo1 = geolistfacade.getGeometryFromGeoId(Constr->First);
-                        auto geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second);
+                    else if (Constr->Second_Deprecated != GeoEnum::GeoUndef) {
+                        auto geo1 = geolistfacade.getGeometryFromGeoId(Constr->First_Deprecated);
+                        auto geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second_Deprecated);
                         if (isLineSegment(*geo2)) {
                             // NOLINTNEXTLINE
                             auto lineSeg = static_cast<const Part::GeomLineSegment*>(geo2);
                             Base::Vector3d l2p1 = lineSeg->getStartPoint();
                             Base::Vector3d l2p2 = lineSeg->getEndPoint();
 
-                            if (Constr->FirstPos != Sketcher::PointPos::none) {
+                            if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
                                 // point to line distance
                                 // calculate the projection of p1 onto lineSeg
                                 pnt2.ProjectToLine(pnt1 - l2p1, l2p2 - l2p1);
@@ -930,7 +956,7 @@ Restart:
                             }
                         }
                         else if (isCircleOrArc(*geo2)) {
-                            if (Constr->FirstPos != Sketcher::PointPos::none) {
+                            if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
                                 // point to circular distance
                                 auto [rad, ct] = getRadiusCenterCircleArc(geo2);
 
@@ -947,13 +973,16 @@ Restart:
                             break;
                         }
                     }
-                    else if (Constr->FirstPos != Sketcher::PointPos::none) {
+                    else if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
                         // one point distance
                         pnt1 = Base::Vector3d(0., 0., 0.);
-                        pnt2 = geolistfacade.getPoint(Constr->First, Constr->FirstPos);
+                        pnt2 = geolistfacade.getPoint(
+                            Constr->First_Deprecated,
+                            Constr->FirstPos_Deprecated
+                        );
                     }
-                    else if (Constr->First != GeoEnum::GeoUndef) {
-                        auto geo = geolistfacade.getGeometryFromGeoId(Constr->First);
+                    else if (Constr->First_Deprecated != GeoEnum::GeoUndef) {
+                        auto geo = geolistfacade.getGeometryFromGeoId(Constr->First_Deprecated);
                         if (isLineSegment(*geo)) {
                             // segment distance
                             auto lineSeg = static_cast<const Part::GeomLineSegment*>(geo);
@@ -1013,11 +1042,12 @@ Restart:
                     }
 
                     // Check if arc helpers are needed
-                    if (Constr->Second != GeoEnum::GeoUndef) {
-                        auto geo1 = geolistfacade.getGeometryFromGeoId(Constr->First);
-                        auto geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second);
+                    if (Constr->Second_Deprecated != GeoEnum::GeoUndef) {
+                        auto geo1 = geolistfacade.getGeometryFromGeoId(Constr->First_Deprecated);
+                        auto geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second_Deprecated);
 
-                        if (isArcOfCircle(*geo1) && Constr->FirstPos == Sketcher::PointPos::none) {
+                        if (isArcOfCircle(*geo1)
+                            && Constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
                             auto arc = static_cast<const Part::GeomArcOfCircle*>(geo1);  // NOLINT
                             radius1 = arc->getRadius();
                             center1 = arc->getCenter();
@@ -1041,7 +1071,8 @@ Restart:
                                 numPoints++;
                             }
                         }
-                        if (isArcOfCircle(*geo2) && Constr->SecondPos == Sketcher::PointPos::none) {
+                        if (isArcOfCircle(*geo2)
+                            && Constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
                             auto arc = static_cast<const Part::GeomArcOfCircle*>(geo2);  // NOLINT
                             radius2 = arc->getRadius();
                             center2 = arc->getCenter();
@@ -1114,12 +1145,13 @@ Restart:
                     Base::Vector3d pos, relPos;
                     if (
                         Constr->Type == PointOnObject || Constr->Type == SnellsLaw
-                        || (Constr->Type == Tangent && Constr->Third != GeoEnum::GeoUndef)
+                        || (Constr->Type == Tangent && Constr->Third_Deprecated != GeoEnum::GeoUndef)
                         ||  // Tangency via point
                         (Constr->Type == Tangent
-                         && Constr->FirstPos != Sketcher::PointPos::none)  // endpoint-to-curve or
-                                                                           // endpoint-to-endpoint
-                                                                           // tangency
+                         && Constr->FirstPos_Deprecated
+                             != Sketcher::PointPos::none)  // endpoint-to-curve or
+                                                           // endpoint-to-endpoint
+                                                           // tangency
                     ) {
 
                         // find the point of tangency/point that is on object
@@ -1127,18 +1159,18 @@ Restart:
                         int ptGeoId;
                         Sketcher::PointPos ptPosId;
                         do {  // dummy loop to use break =) Maybe goto?
-                            ptGeoId = Constr->First;
-                            ptPosId = Constr->FirstPos;
+                            ptGeoId = Constr->First_Deprecated;
+                            ptPosId = Constr->FirstPos_Deprecated;
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
-                            ptGeoId = Constr->Second;
-                            ptPosId = Constr->SecondPos;
+                            ptGeoId = Constr->Second_Deprecated;
+                            ptPosId = Constr->SecondPos_Deprecated;
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
-                            ptGeoId = Constr->Third;
-                            ptPosId = Constr->ThirdPos;
+                            ptGeoId = Constr->Third_Deprecated;
+                            ptPosId = Constr->ThirdPos_Deprecated;
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
@@ -1146,7 +1178,7 @@ Restart:
                         } while (false);
 
                         pos = geolistfacade.getPoint(ptGeoId, ptPosId);
-                        auto norm = getNormal(geolistfacade, Constr->Second, pos);
+                        auto norm = getNormal(geolistfacade, Constr->Second_Deprecated, pos);
 
                         // TODO: Check substitution
                         // Base::Vector3d norm =
@@ -1166,8 +1198,12 @@ Restart:
                     }
                     else if (Constr->Type == Tangent) {
                         // get the geometry
-                        const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(Constr->First);
-                        const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second);
+                        const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
+                            Constr->First_Deprecated
+                        );
+                        const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
+                            Constr->Second_Deprecated
+                        );
 
                         if (geo1->is<Part::GeomLineSegment>() && geo2->is<Part::GeomLineSegment>()) {
                             const Part::GeomLineSegment* lineSeg1
@@ -1313,8 +1349,14 @@ Restart:
                     assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                     assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
 
-                    Base::Vector3d pnt1 = geolistfacade.getPoint(Constr->First, Constr->FirstPos);
-                    Base::Vector3d pnt2 = geolistfacade.getPoint(Constr->Second, Constr->SecondPos);
+                    Base::Vector3d pnt1 = geolistfacade.getPoint(
+                        Constr->First_Deprecated,
+                        Constr->FirstPos_Deprecated
+                    );
+                    Base::Vector3d pnt2 = geolistfacade.getPoint(
+                        Constr->Second_Deprecated,
+                        Constr->SecondPos_Deprecated
+                    );
 
                     SbVec3f p1(pnt1.x, pnt1.y, zConstrH);
                     SbVec3f p2(pnt2.x, pnt2.y, zConstrH);
@@ -1353,14 +1395,15 @@ Restart:
                     double startangle, range;
                     double endLineLength1 = 0.0;
                     double endLineLength2 = 0.0;
-                    if (Constr->Second != GeoEnum::GeoUndef) {
+                    if (Constr->Second_Deprecated != GeoEnum::GeoUndef) {
                         Base::Vector3d dir1, dir2;
-                        if (Constr->Third == GeoEnum::GeoUndef) {  // angle between two lines
+                        if (Constr->Third_Deprecated
+                            == GeoEnum::GeoUndef) {  // angle between two lines
                             const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
-                                Constr->First
+                                Constr->First_Deprecated
                             );
                             const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
-                                Constr->Second
+                                Constr->Second_Deprecated
                             );
                             if (!isLineSegment(*geo1) || !isLineSegment(*geo2)) {
                                 break;
@@ -1368,8 +1411,8 @@ Restart:
                             auto* line1 = static_cast<const Part::GeomLineSegment*>(geo1);
                             auto* line2 = static_cast<const Part::GeomLineSegment*>(geo2);
 
-                            bool flip1 = (Constr->FirstPos == PointPos::end);
-                            bool flip2 = (Constr->SecondPos == PointPos::end);
+                            bool flip1 = (Constr->FirstPos_Deprecated == PointPos::end);
+                            bool flip2 = (Constr->SecondPos_Deprecated == PointPos::end);
                             dir1 = (flip1 ? -1. : 1.)
                                 * (line1->getEndPoint() - line1->getStartPoint()).Normalize();
                             dir2 = (flip2 ? -1. : 1.)
@@ -1434,14 +1477,17 @@ Restart:
                                                                 : 0.0;
                         }
                         else {  // angle-via-point
-                            Base::Vector3d p = geolistfacade.getPoint(Constr->Third, Constr->ThirdPos);
+                            Base::Vector3d p = geolistfacade.getPoint(
+                                Constr->Third_Deprecated,
+                                Constr->ThirdPos_Deprecated
+                            );
                             p0 = SbVec3f(p.x, p.y, 0);
-                            dir1 = getNormal(geolistfacade, Constr->First, p);
+                            dir1 = getNormal(geolistfacade, Constr->First_Deprecated, p);
                             // TODO: Check
                             // dir1 = getSolvedSketch().calculateNormalAtPoint(Constr->First,
                             // p.x, p.y);
                             dir1.RotateZ(-pi / 2);  // convert to vector of tangency by rotating
-                            dir2 = getNormal(geolistfacade, Constr->Second, p);
+                            dir2 = getNormal(geolistfacade, Constr->Second_Deprecated, p);
                             // TODO: Check
                             // dir2 = getSolvedSketch().calculateNormalAtPoint(Constr->Second,
                             // p.x, p.y);
@@ -1454,8 +1500,10 @@ Restart:
                             );
                         }
                     }
-                    else if (Constr->First != GeoEnum::GeoUndef) {
-                        const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(Constr->First);
+                    else if (Constr->First_Deprecated != GeoEnum::GeoUndef) {
+                        const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(
+                            Constr->First_Deprecated
+                        );
                         if (geo->is<Part::GeomLineSegment>()) {
                             auto* lineSeg = static_cast<const Part::GeomLineSegment*>(geo);
                             p0 = Base::convertTo<SbVec3f>(
@@ -1518,11 +1566,13 @@ Restart:
                     double endHelperAngle = 0.;
                     double endHelperRange = 0.;
 
-                    if (Constr->First == GeoEnum::GeoUndef) {
+                    if (Constr->First_Deprecated == GeoEnum::GeoUndef) {
                         break;
                     }
 
-                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(Constr->First);
+                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(
+                        Constr->First_Deprecated
+                    );
 
                     if (geo->is<Part::GeomArcOfCircle>()) {
                         auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
@@ -1595,10 +1645,12 @@ Restart:
                     double helperStartAngle = 0.;
                     double helperRange = 0.;
 
-                    if (Constr->First == GeoEnum::GeoUndef) {
+                    if (Constr->First_Deprecated == GeoEnum::GeoUndef) {
                         break;
                     }
-                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(Constr->First);
+                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(
+                        Constr->First_Deprecated
+                    );
 
                     if (geo->is<Part::GeomArcOfCircle>()) {
                         auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
@@ -1843,8 +1895,8 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                 m->diffuseColor = drawingParameters.SelectColor;
             }
             else if (type == Sketcher::Coincident) {
-                selectpoint(constraint->First, constraint->FirstPos);
-                selectpoint(constraint->Second, constraint->SecondPos);
+                selectpoint(constraint->First_Deprecated, constraint->FirstPos_Deprecated);
+                selectpoint(constraint->Second_Deprecated, constraint->SecondPos_Deprecated);
             }
             else if (type == Sketcher::InternalAlignment) {
                 switch (constraint->AlignmentType) {
@@ -1853,7 +1905,7 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                     case HyperbolaMajor:
                     case HyperbolaMinor:
                     case ParabolaFocalAxis: {
-                        selectline(constraint->First);
+                        selectline(constraint->First_Deprecated);
                     } break;
                     case EllipseFocus1:
                     case EllipseFocus2:
@@ -1861,7 +1913,7 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                     case ParabolaFocus:
                     case BSplineControlPoint:
                     case BSplineKnotPoint: {
-                        selectpoint(constraint->First, constraint->FirstPos);
+                        selectpoint(constraint->First_Deprecated, constraint->FirstPos_Deprecated);
                     } break;
                     default:
                         break;
@@ -2090,8 +2142,12 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 sep->addChild(new SoInfo());
 
                 if ((*it)->Type == Tangent) {
-                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId((*it)->First);
-                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId((*it)->Second);
+                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
+                        (*it)->First_Deprecated
+                    );
+                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
+                        (*it)->Second_Deprecated
+                    );
                     if (!geo1 || !geo2) {
                         Base::Console().developerWarning(
                             "EditModeConstraintCoinManager",
@@ -2399,8 +2455,12 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
         switch (constraint->Type) {
 
             case Tangent: {  // second icon is available only for collinear line segments
-                const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(constraint->First);
-                const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(constraint->Second);
+                const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
+                    constraint->First_Deprecated
+                );
+                const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
+                    constraint->Second_Deprecated
+                );
                 if (geo1 && geo1->is<Part::GeomLineSegment>() && geo2
                     && geo2->is<Part::GeomLineSegment>()) {
                     multipleIcons = true;
@@ -2408,9 +2468,9 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
             } break;
             case Horizontal:
             case Vertical: {  // second icon is available only for point alignment
-                if (constraint->Second != GeoEnum::GeoUndef
-                    && constraint->FirstPos != Sketcher::PointPos::none
-                    && constraint->SecondPos != Sketcher::PointPos::none) {
+                if (constraint->Second_Deprecated != GeoEnum::GeoUndef
+                    && constraint->FirstPos_Deprecated != Sketcher::PointPos::none
+                    && constraint->SecondPos_Deprecated != Sketcher::PointPos::none) {
                     multipleIcons = true;
                 }
             } break;
@@ -2419,8 +2479,8 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
                 break;
             case Perpendicular:
                 // second icon is available only when there is no common point
-                if (constraint->FirstPos == Sketcher::PointPos::none
-                    && constraint->Third == GeoEnum::GeoUndef) {
+                if (constraint->FirstPos_Deprecated == Sketcher::PointPos::none
+                    && constraint->Third_Deprecated == GeoEnum::GeoUndef) {
                     multipleIcons = true;
                 }
                 break;
@@ -2478,9 +2538,14 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
             && constraint->isVisible;
 
         if (constraint->Type == Symmetric) {
-            Base::Vector3d startingpoint
-                = geolistfacade.getPoint(constraint->First, constraint->FirstPos);
-            Base::Vector3d endpoint = geolistfacade.getPoint(constraint->Second, constraint->SecondPos);
+            Base::Vector3d startingpoint = geolistfacade.getPoint(
+                constraint->First_Deprecated,
+                constraint->FirstPos_Deprecated
+            );
+            Base::Vector3d endpoint = geolistfacade.getPoint(
+                constraint->Second_Deprecated,
+                constraint->SecondPos_Deprecated
+            );
 
             SbVec3f pos0(startingpoint.x, startingpoint.y, startingpoint.z);
             SbVec3f pos1(endpoint.x, endpoint.y, endpoint.z);

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -199,13 +199,11 @@ Restart:
             );
             const Constraint* Constr = *it;
 
-            if (Constr->First_Deprecated < -extGeoCount || Constr->First_Deprecated >= intGeoCount
-                || (Constr->Second_Deprecated != GeoEnum::GeoUndef
-                    && (Constr->Second_Deprecated < -extGeoCount
-                        || Constr->Second_Deprecated >= intGeoCount))
-                || (Constr->Third_Deprecated != GeoEnum::GeoUndef
-                    && (Constr->Third_Deprecated < -extGeoCount
-                        || Constr->Third_Deprecated >= intGeoCount))) {
+            if (Constr->getGeoId(0) < -extGeoCount || Constr->getGeoId(0) >= intGeoCount
+                || (Constr->getGeoId(1) != GeoEnum::GeoUndef
+                    && (Constr->getGeoId(1) < -extGeoCount || Constr->getGeoId(1) >= intGeoCount))
+                || (Constr->getGeoId(2) != GeoEnum::GeoUndef
+                    && (Constr->getGeoId(2) < -extGeoCount || Constr->getGeoId(2) >= intGeoCount))) {
                 // Constraint can refer to non-existent geometry during undo/redo
                 continue;
             }
@@ -219,12 +217,10 @@ Restart:
                 {
                     assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                     bool alignment = Constr->Type != Block
-                        && Constr->Second_Deprecated != GeoEnum::GeoUndef;
+                        && Constr->getGeoId(1) != GeoEnum::GeoUndef;
 
                     // get the geometry
-                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(
-                        Constr->First_Deprecated
-                    );
+                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(Constr->getGeoId(0));
 
                     if (!alignment) {
                         // Vertical & Horiz can only be a GeomLineSegment, but Blocked can be
@@ -393,14 +389,8 @@ Restart:
                         Base::Vector3d midpos1, dir1, norm1;
                         Base::Vector3d midpos2, dir2, norm2;
 
-                        midpos1 = geolistfacade.getPoint(
-                            Constr->First_Deprecated,
-                            Constr->FirstPos_Deprecated
-                        );
-                        midpos2 = geolistfacade.getPoint(
-                            Constr->Second_Deprecated,
-                            Constr->SecondPos_Deprecated
-                        );
+                        midpos1 = geolistfacade.getPoint(Constr->getGeoId(0), Constr->getPosId(0));
+                        midpos2 = geolistfacade.getPoint(Constr->getGeoId(1), Constr->getPosId(1));
 
                         dir1 = (midpos2 - midpos1).Normalize();
                         dir2 = -dir1;
@@ -433,36 +423,36 @@ Restart:
                     assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
                     // get the geometry
                     const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
-                        Constr->First_Deprecated
+                        Constr->getGeoId(0)
                     );
                     const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
-                        Constr->Second_Deprecated
+                        Constr->getGeoId(1)
                     );
                     Base::Vector3d midpos1, dir1, norm1;
                     Base::Vector3d midpos2, dir2, norm2;
                     bool twoIcons = false;  // a very local flag. It's set to true to indicate that
                                             // the second dir+norm are valid and should be used
 
-                    if (Constr->Third_Deprecated != GeoEnum::GeoUndef ||  // perpty via point
-                        Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {  // endpoint-to-curve
-                                                                                    // or
+                    if (Constr->getGeoId(2) != GeoEnum::GeoUndef ||         // perpty via point
+                        Constr->getPosId(0) != Sketcher::PointPos::none) {  // endpoint-to-curve
+                                                                            // or
                         // endpoint-to-endpoint perpty
 
                         int ptGeoId;
                         Sketcher::PointPos ptPosId;
                         do {  // dummy loop to use break =) Maybe goto?
-                            ptGeoId = Constr->First_Deprecated;
-                            ptPosId = Constr->FirstPos_Deprecated;
+                            ptGeoId = Constr->getGeoId(0);
+                            ptPosId = Constr->getPosId(0);
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
-                            ptGeoId = Constr->Second_Deprecated;
-                            ptPosId = Constr->SecondPos_Deprecated;
+                            ptGeoId = Constr->getGeoId(1);
+                            ptPosId = Constr->getPosId(1);
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
-                            ptGeoId = Constr->Third_Deprecated;
-                            ptPosId = Constr->ThirdPos_Deprecated;
+                            ptGeoId = Constr->getGeoId(2);
+                            ptPosId = Constr->getPosId(2);
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
@@ -471,7 +461,7 @@ Restart:
 
                         midpos1 = geolistfacade.getPoint(ptGeoId, ptPosId);
 
-                        norm1 = getNormal(geolistfacade, Constr->Second_Deprecated, midpos1);
+                        norm1 = getNormal(geolistfacade, Constr->getGeoId(1), midpos1);
 
                         // TODO: Check the method above. This was the old one making use of the
                         // solver.
@@ -482,7 +472,7 @@ Restart:
                         dir1 = norm1;
                         dir1.RotateZ(-pi / 2.0);
                     }
-                    else if (Constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
+                    else if (Constr->getPosId(0) == Sketcher::PointPos::none) {
 
                         if (geo1->is<Part::GeomLineSegment>()) {
                             const Part::GeomLineSegment* lineSeg1
@@ -567,10 +557,10 @@ Restart:
                     assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
                     // get the geometry
                     const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
-                        Constr->First_Deprecated
+                        Constr->getGeoId(0)
                     );
                     const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
-                        Constr->Second_Deprecated
+                        Constr->getGeoId(1)
                     );
 
                     Base::Vector3d midpos1, dir1, norm1;
@@ -915,30 +905,24 @@ Restart:
                     int numPoints = 2;
 
                     // pnt1 will be initialized to (0,0,0) if only one point is given
-                    auto pnt1 = geolistfacade.getPoint(
-                        Constr->First_Deprecated,
-                        Constr->FirstPos_Deprecated
-                    );
+                    auto pnt1 = geolistfacade.getPoint(Constr->getGeoId(0), Constr->getPosId(0));
 
                     Base::Vector3d pnt2(0., 0., 0.);
 
-                    if (Constr->SecondPos_Deprecated != Sketcher::PointPos::none) {
+                    if (Constr->getPosId(1) != Sketcher::PointPos::none) {
                         // point to point distance
-                        pnt2 = geolistfacade.getPoint(
-                            Constr->Second_Deprecated,
-                            Constr->SecondPos_Deprecated
-                        );
+                        pnt2 = geolistfacade.getPoint(Constr->getGeoId(1), Constr->getPosId(1));
                     }
-                    else if (Constr->Second_Deprecated != GeoEnum::GeoUndef) {
-                        auto geo1 = geolistfacade.getGeometryFromGeoId(Constr->First_Deprecated);
-                        auto geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second_Deprecated);
+                    else if (Constr->getGeoId(1) != GeoEnum::GeoUndef) {
+                        auto geo1 = geolistfacade.getGeometryFromGeoId(Constr->getGeoId(0));
+                        auto geo2 = geolistfacade.getGeometryFromGeoId(Constr->getGeoId(1));
                         if (isLineSegment(*geo2)) {
                             // NOLINTNEXTLINE
                             auto lineSeg = static_cast<const Part::GeomLineSegment*>(geo2);
                             Base::Vector3d l2p1 = lineSeg->getStartPoint();
                             Base::Vector3d l2p2 = lineSeg->getEndPoint();
 
-                            if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
+                            if (Constr->getPosId(0) != Sketcher::PointPos::none) {
                                 // point to line distance
                                 // calculate the projection of p1 onto lineSeg
                                 pnt2.ProjectToLine(pnt1 - l2p1, l2p2 - l2p1);
@@ -956,7 +940,7 @@ Restart:
                             }
                         }
                         else if (isCircleOrArc(*geo2)) {
-                            if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
+                            if (Constr->getPosId(0) != Sketcher::PointPos::none) {
                                 // point to circular distance
                                 auto [rad, ct] = getRadiusCenterCircleArc(geo2);
 
@@ -973,16 +957,13 @@ Restart:
                             break;
                         }
                     }
-                    else if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
+                    else if (Constr->getPosId(0) != Sketcher::PointPos::none) {
                         // one point distance
                         pnt1 = Base::Vector3d(0., 0., 0.);
-                        pnt2 = geolistfacade.getPoint(
-                            Constr->First_Deprecated,
-                            Constr->FirstPos_Deprecated
-                        );
+                        pnt2 = geolistfacade.getPoint(Constr->getGeoId(0), Constr->getPosId(0));
                     }
-                    else if (Constr->First_Deprecated != GeoEnum::GeoUndef) {
-                        auto geo = geolistfacade.getGeometryFromGeoId(Constr->First_Deprecated);
+                    else if (Constr->getGeoId(0) != GeoEnum::GeoUndef) {
+                        auto geo = geolistfacade.getGeometryFromGeoId(Constr->getGeoId(0));
                         if (isLineSegment(*geo)) {
                             // segment distance
                             auto lineSeg = static_cast<const Part::GeomLineSegment*>(geo);
@@ -1042,12 +1023,11 @@ Restart:
                     }
 
                     // Check if arc helpers are needed
-                    if (Constr->Second_Deprecated != GeoEnum::GeoUndef) {
-                        auto geo1 = geolistfacade.getGeometryFromGeoId(Constr->First_Deprecated);
-                        auto geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second_Deprecated);
+                    if (Constr->getGeoId(1) != GeoEnum::GeoUndef) {
+                        auto geo1 = geolistfacade.getGeometryFromGeoId(Constr->getGeoId(0));
+                        auto geo2 = geolistfacade.getGeometryFromGeoId(Constr->getGeoId(1));
 
-                        if (isArcOfCircle(*geo1)
-                            && Constr->FirstPos_Deprecated == Sketcher::PointPos::none) {
+                        if (isArcOfCircle(*geo1) && Constr->getPosId(0) == Sketcher::PointPos::none) {
                             auto arc = static_cast<const Part::GeomArcOfCircle*>(geo1);  // NOLINT
                             radius1 = arc->getRadius();
                             center1 = arc->getCenter();
@@ -1071,8 +1051,7 @@ Restart:
                                 numPoints++;
                             }
                         }
-                        if (isArcOfCircle(*geo2)
-                            && Constr->SecondPos_Deprecated == Sketcher::PointPos::none) {
+                        if (isArcOfCircle(*geo2) && Constr->getPosId(1) == Sketcher::PointPos::none) {
                             auto arc = static_cast<const Part::GeomArcOfCircle*>(geo2);  // NOLINT
                             radius2 = arc->getRadius();
                             center2 = arc->getCenter();
@@ -1145,13 +1124,12 @@ Restart:
                     Base::Vector3d pos, relPos;
                     if (
                         Constr->Type == PointOnObject || Constr->Type == SnellsLaw
-                        || (Constr->Type == Tangent && Constr->Third_Deprecated != GeoEnum::GeoUndef)
+                        || (Constr->Type == Tangent && Constr->getGeoId(2) != GeoEnum::GeoUndef)
                         ||  // Tangency via point
                         (Constr->Type == Tangent
-                         && Constr->FirstPos_Deprecated
-                             != Sketcher::PointPos::none)  // endpoint-to-curve or
-                                                           // endpoint-to-endpoint
-                                                           // tangency
+                         && Constr->getPosId(0) != Sketcher::PointPos::none)  // endpoint-to-curve or
+                                                                              // endpoint-to-endpoint
+                                                                              // tangency
                     ) {
 
                         // find the point of tangency/point that is on object
@@ -1159,18 +1137,18 @@ Restart:
                         int ptGeoId;
                         Sketcher::PointPos ptPosId;
                         do {  // dummy loop to use break =) Maybe goto?
-                            ptGeoId = Constr->First_Deprecated;
-                            ptPosId = Constr->FirstPos_Deprecated;
+                            ptGeoId = Constr->getGeoId(0);
+                            ptPosId = Constr->getPosId(0);
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
-                            ptGeoId = Constr->Second_Deprecated;
-                            ptPosId = Constr->SecondPos_Deprecated;
+                            ptGeoId = Constr->getGeoId(1);
+                            ptPosId = Constr->getPosId(1);
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
-                            ptGeoId = Constr->Third_Deprecated;
-                            ptPosId = Constr->ThirdPos_Deprecated;
+                            ptGeoId = Constr->getGeoId(2);
+                            ptPosId = Constr->getPosId(2);
                             if (ptPosId != Sketcher::PointPos::none) {
                                 break;
                             }
@@ -1178,7 +1156,7 @@ Restart:
                         } while (false);
 
                         pos = geolistfacade.getPoint(ptGeoId, ptPosId);
-                        auto norm = getNormal(geolistfacade, Constr->Second_Deprecated, pos);
+                        auto norm = getNormal(geolistfacade, Constr->getGeoId(1), pos);
 
                         // TODO: Check substitution
                         // Base::Vector3d norm =
@@ -1199,10 +1177,10 @@ Restart:
                     else if (Constr->Type == Tangent) {
                         // get the geometry
                         const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
-                            Constr->First_Deprecated
+                            Constr->getGeoId(0)
                         );
                         const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
-                            Constr->Second_Deprecated
+                            Constr->getGeoId(1)
                         );
 
                         if (geo1->is<Part::GeomLineSegment>() && geo2->is<Part::GeomLineSegment>()) {
@@ -1349,14 +1327,10 @@ Restart:
                     assert(Constr->First >= -extGeoCount && Constr->First < intGeoCount);
                     assert(Constr->Second >= -extGeoCount && Constr->Second < intGeoCount);
 
-                    Base::Vector3d pnt1 = geolistfacade.getPoint(
-                        Constr->First_Deprecated,
-                        Constr->FirstPos_Deprecated
-                    );
-                    Base::Vector3d pnt2 = geolistfacade.getPoint(
-                        Constr->Second_Deprecated,
-                        Constr->SecondPos_Deprecated
-                    );
+                    Base::Vector3d pnt1
+                        = geolistfacade.getPoint(Constr->getGeoId(0), Constr->getPosId(0));
+                    Base::Vector3d pnt2
+                        = geolistfacade.getPoint(Constr->getGeoId(1), Constr->getPosId(1));
 
                     SbVec3f p1(pnt1.x, pnt1.y, zConstrH);
                     SbVec3f p2(pnt2.x, pnt2.y, zConstrH);
@@ -1395,15 +1369,14 @@ Restart:
                     double startangle, range;
                     double endLineLength1 = 0.0;
                     double endLineLength2 = 0.0;
-                    if (Constr->Second_Deprecated != GeoEnum::GeoUndef) {
+                    if (Constr->getGeoId(1) != GeoEnum::GeoUndef) {
                         Base::Vector3d dir1, dir2;
-                        if (Constr->Third_Deprecated
-                            == GeoEnum::GeoUndef) {  // angle between two lines
+                        if (Constr->getGeoId(2) == GeoEnum::GeoUndef) {  // angle between two lines
                             const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
-                                Constr->First_Deprecated
+                                Constr->getGeoId(0)
                             );
                             const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
-                                Constr->Second_Deprecated
+                                Constr->getGeoId(1)
                             );
                             if (!isLineSegment(*geo1) || !isLineSegment(*geo2)) {
                                 break;
@@ -1411,8 +1384,8 @@ Restart:
                             auto* line1 = static_cast<const Part::GeomLineSegment*>(geo1);
                             auto* line2 = static_cast<const Part::GeomLineSegment*>(geo2);
 
-                            bool flip1 = (Constr->FirstPos_Deprecated == PointPos::end);
-                            bool flip2 = (Constr->SecondPos_Deprecated == PointPos::end);
+                            bool flip1 = (Constr->getPosId(0) == PointPos::end);
+                            bool flip2 = (Constr->getPosId(1) == PointPos::end);
                             dir1 = (flip1 ? -1. : 1.)
                                 * (line1->getEndPoint() - line1->getStartPoint()).Normalize();
                             dir2 = (flip2 ? -1. : 1.)
@@ -1477,17 +1450,15 @@ Restart:
                                                                 : 0.0;
                         }
                         else {  // angle-via-point
-                            Base::Vector3d p = geolistfacade.getPoint(
-                                Constr->Third_Deprecated,
-                                Constr->ThirdPos_Deprecated
-                            );
+                            Base::Vector3d p
+                                = geolistfacade.getPoint(Constr->getGeoId(2), Constr->getPosId(2));
                             p0 = SbVec3f(p.x, p.y, 0);
-                            dir1 = getNormal(geolistfacade, Constr->First_Deprecated, p);
+                            dir1 = getNormal(geolistfacade, Constr->getGeoId(0), p);
                             // TODO: Check
                             // dir1 = getSolvedSketch().calculateNormalAtPoint(Constr->First,
                             // p.x, p.y);
                             dir1.RotateZ(-pi / 2);  // convert to vector of tangency by rotating
-                            dir2 = getNormal(geolistfacade, Constr->Second_Deprecated, p);
+                            dir2 = getNormal(geolistfacade, Constr->getGeoId(1), p);
                             // TODO: Check
                             // dir2 = getSolvedSketch().calculateNormalAtPoint(Constr->Second,
                             // p.x, p.y);
@@ -1500,9 +1471,9 @@ Restart:
                             );
                         }
                     }
-                    else if (Constr->First_Deprecated != GeoEnum::GeoUndef) {
+                    else if (Constr->getGeoId(0) != GeoEnum::GeoUndef) {
                         const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(
-                            Constr->First_Deprecated
+                            Constr->getGeoId(0)
                         );
                         if (geo->is<Part::GeomLineSegment>()) {
                             auto* lineSeg = static_cast<const Part::GeomLineSegment*>(geo);
@@ -1566,13 +1537,11 @@ Restart:
                     double endHelperAngle = 0.;
                     double endHelperRange = 0.;
 
-                    if (Constr->First_Deprecated == GeoEnum::GeoUndef) {
+                    if (Constr->getGeoId(0) == GeoEnum::GeoUndef) {
                         break;
                     }
 
-                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(
-                        Constr->First_Deprecated
-                    );
+                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(Constr->getGeoId(0));
 
                     if (geo->is<Part::GeomArcOfCircle>()) {
                         auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
@@ -1645,12 +1614,10 @@ Restart:
                     double helperStartAngle = 0.;
                     double helperRange = 0.;
 
-                    if (Constr->First_Deprecated == GeoEnum::GeoUndef) {
+                    if (Constr->getGeoId(0) == GeoEnum::GeoUndef) {
                         break;
                     }
-                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(
-                        Constr->First_Deprecated
-                    );
+                    const Part::Geometry* geo = geolistfacade.getGeometryFromGeoId(Constr->getGeoId(0));
 
                     if (geo->is<Part::GeomArcOfCircle>()) {
                         auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
@@ -1895,8 +1862,8 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                 m->diffuseColor = drawingParameters.SelectColor;
             }
             else if (type == Sketcher::Coincident) {
-                selectpoint(constraint->First_Deprecated, constraint->FirstPos_Deprecated);
-                selectpoint(constraint->Second_Deprecated, constraint->SecondPos_Deprecated);
+                selectpoint(constraint->getGeoId(0), constraint->getPosId(0));
+                selectpoint(constraint->getGeoId(1), constraint->getPosId(1));
             }
             else if (type == Sketcher::InternalAlignment) {
                 switch (constraint->AlignmentType) {
@@ -1905,7 +1872,7 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                     case HyperbolaMajor:
                     case HyperbolaMinor:
                     case ParabolaFocalAxis: {
-                        selectline(constraint->First_Deprecated);
+                        selectline(constraint->getGeoId(0));
                     } break;
                     case EllipseFocus1:
                     case EllipseFocus2:
@@ -1913,7 +1880,7 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                     case ParabolaFocus:
                     case BSplineControlPoint:
                     case BSplineKnotPoint: {
-                        selectpoint(constraint->First_Deprecated, constraint->FirstPos_Deprecated);
+                        selectpoint(constraint->getGeoId(0), constraint->getPosId(0));
                     } break;
                     default:
                         break;
@@ -2142,12 +2109,8 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 sep->addChild(new SoInfo());
 
                 if ((*it)->Type == Tangent) {
-                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
-                        (*it)->First_Deprecated
-                    );
-                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
-                        (*it)->Second_Deprecated
-                    );
+                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId((*it)->getGeoId(0));
+                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId((*it)->getGeoId(1));
                     if (!geo1 || !geo2) {
                         Base::Console().developerWarning(
                             "EditModeConstraintCoinManager",
@@ -2456,10 +2419,10 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
 
             case Tangent: {  // second icon is available only for collinear line segments
                 const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(
-                    constraint->First_Deprecated
+                    constraint->getGeoId(0)
                 );
                 const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(
-                    constraint->Second_Deprecated
+                    constraint->getGeoId(1)
                 );
                 if (geo1 && geo1->is<Part::GeomLineSegment>() && geo2
                     && geo2->is<Part::GeomLineSegment>()) {
@@ -2468,9 +2431,9 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
             } break;
             case Horizontal:
             case Vertical: {  // second icon is available only for point alignment
-                if (constraint->Second_Deprecated != GeoEnum::GeoUndef
-                    && constraint->FirstPos_Deprecated != Sketcher::PointPos::none
-                    && constraint->SecondPos_Deprecated != Sketcher::PointPos::none) {
+                if (constraint->getGeoId(1) != GeoEnum::GeoUndef
+                    && constraint->getPosId(0) != Sketcher::PointPos::none
+                    && constraint->getPosId(1) != Sketcher::PointPos::none) {
                     multipleIcons = true;
                 }
             } break;
@@ -2479,8 +2442,8 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
                 break;
             case Perpendicular:
                 // second icon is available only when there is no common point
-                if (constraint->FirstPos_Deprecated == Sketcher::PointPos::none
-                    && constraint->Third_Deprecated == GeoEnum::GeoUndef) {
+                if (constraint->getPosId(0) == Sketcher::PointPos::none
+                    && constraint->getGeoId(2) == GeoEnum::GeoUndef) {
                     multipleIcons = true;
                 }
                 break;
@@ -2538,14 +2501,10 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
             && constraint->isVisible;
 
         if (constraint->Type == Symmetric) {
-            Base::Vector3d startingpoint = geolistfacade.getPoint(
-                constraint->First_Deprecated,
-                constraint->FirstPos_Deprecated
-            );
-            Base::Vector3d endpoint = geolistfacade.getPoint(
-                constraint->Second_Deprecated,
-                constraint->SecondPos_Deprecated
-            );
+            Base::Vector3d startingpoint
+                = geolistfacade.getPoint(constraint->getGeoId(0), constraint->getPosId(0));
+            Base::Vector3d endpoint
+                = geolistfacade.getPoint(constraint->getGeoId(1), constraint->getPosId(1));
 
             SbVec3f pos0(startingpoint.x, startingpoint.y, startingpoint.z);
             SbVec3f pos1(endpoint.x, endpoint.y, endpoint.z);

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -161,12 +161,11 @@ void EditModeGeometryCoinManager::updateGeometryColor(
             = ViewProviderSketchCoinAttorney::getConstraints(viewProvider);
         for (auto& constr : constraints) {
             if (constr->Type == Coincident
-                || (constr->Type == Tangent && constr->FirstPos_Deprecated != Sketcher::PointPos::none)
-                || (constr->Type == Perpendicular
-                    && constr->FirstPos_Deprecated != Sketcher::PointPos::none
-                    && constr->SecondPos_Deprecated != Sketcher::PointPos::none)) {
-                if ((constr->First_Deprecated == GeoId && constr->FirstPos_Deprecated == PosId)
-                    || (constr->Second_Deprecated == GeoId && constr->SecondPos_Deprecated == PosId)) {
+                || (constr->Type == Tangent && constr->getPosId(0) != Sketcher::PointPos::none)
+                || (constr->Type == Perpendicular && constr->getPosId(0) != Sketcher::PointPos::none
+                    && constr->getPosId(1) != Sketcher::PointPos::none)) {
+                if ((constr->getGeoId(0) == GeoId && constr->getPosId(0) == PosId)
+                    || (constr->getGeoId(1) == GeoId && constr->getPosId(1) == PosId)) {
                     return true;
                 }
             }

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -161,11 +161,12 @@ void EditModeGeometryCoinManager::updateGeometryColor(
             = ViewProviderSketchCoinAttorney::getConstraints(viewProvider);
         for (auto& constr : constraints) {
             if (constr->Type == Coincident
-                || (constr->Type == Tangent && constr->FirstPos != Sketcher::PointPos::none)
-                || (constr->Type == Perpendicular && constr->FirstPos != Sketcher::PointPos::none
-                    && constr->SecondPos != Sketcher::PointPos::none)) {
-                if ((constr->First == GeoId && constr->FirstPos == PosId)
-                    || (constr->Second == GeoId && constr->SecondPos == PosId)) {
+                || (constr->Type == Tangent && constr->FirstPos_Deprecated != Sketcher::PointPos::none)
+                || (constr->Type == Perpendicular
+                    && constr->FirstPos_Deprecated != Sketcher::PointPos::none
+                    && constr->SecondPos_Deprecated != Sketcher::PointPos::none)) {
+                if ((constr->First_Deprecated == GeoId && constr->FirstPos_Deprecated == PosId)
+                    || (constr->Second_Deprecated == GeoId && constr->SecondPos_Deprecated == PosId)) {
                     return true;
                 }
             }

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
@@ -46,8 +46,8 @@ void SketcherTransformationExpressionHelper::storeOriginalExpressions(
         for (size_t i = 0; i < vals.size(); i++) {
             const auto& cstr = vals[i];
             if (cstr->isDriving && cstr->isDimensional()
-                && (cstr->First_Deprecated == geoId
-                    || (cstr->Second_Deprecated == geoId && cstr->Type != Sketcher::Radius
+                && (cstr->getGeoId(0) == geoId
+                    || (cstr->getGeoId(1) == geoId && cstr->Type != Sketcher::Radius
                         && cstr->Type != Sketcher::Diameter && cstr->Type != Sketcher::Weight))) {
 
                 App::ObjectIdentifier spath = sketchObject->Constraints.createPath(static_cast<int>(i));
@@ -177,7 +177,7 @@ bool SketcherTransformationExpressionHelper::constraintReferencesGeometry(
     int geoId
 ) const
 {
-    return cstr->First_Deprecated == geoId
-        || (cstr->Second_Deprecated == geoId && cstr->Type != Sketcher::Radius
+    return cstr->getGeoId(0) == geoId
+        || (cstr->getGeoId(1) == geoId && cstr->Type != Sketcher::Radius
             && cstr->Type != Sketcher::Diameter && cstr->Type != Sketcher::Weight);
 }

--- a/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherTransformationExpressionHelper.cpp
@@ -46,8 +46,8 @@ void SketcherTransformationExpressionHelper::storeOriginalExpressions(
         for (size_t i = 0; i < vals.size(); i++) {
             const auto& cstr = vals[i];
             if (cstr->isDriving && cstr->isDimensional()
-                && (cstr->First == geoId
-                    || (cstr->Second == geoId && cstr->Type != Sketcher::Radius
+                && (cstr->First_Deprecated == geoId
+                    || (cstr->Second_Deprecated == geoId && cstr->Type != Sketcher::Radius
                         && cstr->Type != Sketcher::Diameter && cstr->Type != Sketcher::Weight))) {
 
                 App::ObjectIdentifier spath = sketchObject->Constraints.createPath(static_cast<int>(i));
@@ -177,7 +177,7 @@ bool SketcherTransformationExpressionHelper::constraintReferencesGeometry(
     int geoId
 ) const
 {
-    return cstr->First == geoId
-        || (cstr->Second == geoId && cstr->Type != Sketcher::Radius
+    return cstr->First_Deprecated == geoId
+        || (cstr->Second_Deprecated == geoId && cstr->Type != Sketcher::Radius
             && cstr->Type != Sketcher::Diameter && cstr->Type != Sketcher::Weight);
 }

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -269,29 +269,29 @@ public:
             bool extended = hGrp->GetBool("ExtendedConstraintInformation", false);
 
             if (extended) {
-                if (constraint->Second == Sketcher::GeoEnum::GeoUndef) {
+                if (constraint->Second_Deprecated == Sketcher::GeoEnum::GeoUndef) {
                     name = QStringLiteral("%1 [(%2,%3)]")
                                .arg(name)
-                               .arg(constraint->First)
-                               .arg(static_cast<int>(constraint->FirstPos));
+                               .arg(constraint->First_Deprecated)
+                               .arg(static_cast<int>(constraint->FirstPos_Deprecated));
                 }
-                else if (constraint->Third == Sketcher::GeoEnum::GeoUndef) {
+                else if (constraint->Third_Deprecated == Sketcher::GeoEnum::GeoUndef) {
                     name = QStringLiteral("%1 [(%2,%3),(%4,%5)]")
                                .arg(name)
-                               .arg(constraint->First)
-                               .arg(static_cast<int>(constraint->FirstPos))
-                               .arg(constraint->Second)
-                               .arg(static_cast<int>(constraint->SecondPos));
+                               .arg(constraint->First_Deprecated)
+                               .arg(static_cast<int>(constraint->FirstPos_Deprecated))
+                               .arg(constraint->Second_Deprecated)
+                               .arg(static_cast<int>(constraint->SecondPos_Deprecated));
                 }
                 else {
                     name = QStringLiteral("%1 [(%2,%3),(%4,%5),(%6,%7)]")
                                .arg(name)
-                               .arg(constraint->First)
-                               .arg(static_cast<int>(constraint->FirstPos))
-                               .arg(constraint->Second)
-                               .arg(static_cast<int>(constraint->SecondPos))
-                               .arg(constraint->Third)
-                               .arg(static_cast<int>(constraint->ThirdPos));
+                               .arg(constraint->First_Deprecated)
+                               .arg(static_cast<int>(constraint->FirstPos_Deprecated))
+                               .arg(constraint->Second_Deprecated)
+                               .arg(static_cast<int>(constraint->SecondPos_Deprecated))
+                               .arg(constraint->Third_Deprecated)
+                               .arg(static_cast<int>(constraint->ThirdPos_Deprecated));
                 }
             }
 
@@ -479,8 +479,8 @@ public:
             case Sketcher::Weight:
             case Sketcher::Angle:
             case Sketcher::SnellsLaw:
-                return (constraint->First >= 0 || constraint->Second >= 0
-                        || constraint->Third >= 0);
+                return (constraint->First_Deprecated >= 0 || constraint->Second_Deprecated >= 0
+                        || constraint->Third_Deprecated >= 0);
             case Sketcher::InternalAlignment:
                 return true;
         }
@@ -1381,7 +1381,7 @@ void TaskSketcherConstraints::updateAssociatedConstraintsFilter()
             for (std::vector<Sketcher::Constraint*>::const_iterator it = vals.begin();
                  it != vals.end();
                  ++it, ++i) {
-                if ((*it)->First == GeoId || (*it)->Second == GeoId || (*it)->Third == GeoId) {
+                if ((*it)->First_Deprecated == GeoId || (*it)->Second_Deprecated == GeoId || (*it)->Third_Deprecated == GeoId) {
                     associatedConstraintsFilter.push_back(i);
                 }
             }

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -269,29 +269,29 @@ public:
             bool extended = hGrp->GetBool("ExtendedConstraintInformation", false);
 
             if (extended) {
-                if (constraint->Second_Deprecated == Sketcher::GeoEnum::GeoUndef) {
+                if (constraint->getGeoId(1) == Sketcher::GeoEnum::GeoUndef) {
                     name = QStringLiteral("%1 [(%2,%3)]")
                                .arg(name)
-                               .arg(constraint->First_Deprecated)
-                               .arg(static_cast<int>(constraint->FirstPos_Deprecated));
+                               .arg(constraint->getGeoId(0))
+                               .arg(static_cast<int>(constraint->getPosId(0)));
                 }
-                else if (constraint->Third_Deprecated == Sketcher::GeoEnum::GeoUndef) {
+                else if (constraint->getGeoId(2) == Sketcher::GeoEnum::GeoUndef) {
                     name = QStringLiteral("%1 [(%2,%3),(%4,%5)]")
                                .arg(name)
-                               .arg(constraint->First_Deprecated)
-                               .arg(static_cast<int>(constraint->FirstPos_Deprecated))
-                               .arg(constraint->Second_Deprecated)
-                               .arg(static_cast<int>(constraint->SecondPos_Deprecated));
+                               .arg(constraint->getGeoId(0))
+                               .arg(static_cast<int>(constraint->getPosId(0)))
+                               .arg(constraint->getGeoId(1))
+                               .arg(static_cast<int>(constraint->getPosId(1)));
                 }
                 else {
                     name = QStringLiteral("%1 [(%2,%3),(%4,%5),(%6,%7)]")
                                .arg(name)
-                               .arg(constraint->First_Deprecated)
-                               .arg(static_cast<int>(constraint->FirstPos_Deprecated))
-                               .arg(constraint->Second_Deprecated)
-                               .arg(static_cast<int>(constraint->SecondPos_Deprecated))
-                               .arg(constraint->Third_Deprecated)
-                               .arg(static_cast<int>(constraint->ThirdPos_Deprecated));
+                               .arg(constraint->getGeoId(0))
+                               .arg(static_cast<int>(constraint->getPosId(0)))
+                               .arg(constraint->getGeoId(1))
+                               .arg(static_cast<int>(constraint->getPosId(1)))
+                               .arg(constraint->getGeoId(2))
+                               .arg(static_cast<int>(constraint->getPosId(2)));
                 }
             }
 
@@ -479,8 +479,8 @@ public:
             case Sketcher::Weight:
             case Sketcher::Angle:
             case Sketcher::SnellsLaw:
-                return (constraint->First_Deprecated >= 0 || constraint->Second_Deprecated >= 0
-                        || constraint->Third_Deprecated >= 0);
+                return (constraint->getGeoId(0) >= 0 || constraint->getGeoId(1) >= 0
+                        || constraint->getGeoId(2) >= 0);
             case Sketcher::InternalAlignment:
                 return true;
         }
@@ -1381,7 +1381,7 @@ void TaskSketcherConstraints::updateAssociatedConstraintsFilter()
             for (std::vector<Sketcher::Constraint*>::const_iterator it = vals.begin();
                  it != vals.end();
                  ++it, ++i) {
-                if ((*it)->First_Deprecated == GeoId || (*it)->Second_Deprecated == GeoId || (*it)->Third_Deprecated == GeoId) {
+                if ((*it)->getGeoId(0) == GeoId || (*it)->getGeoId(1) == GeoId || (*it)->getGeoId(2) == GeoId) {
                     associatedConstraintsFilter.push_back(i);
                 }
             }

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -408,7 +408,8 @@ bool SketcherGui::IsPointAlreadyOnCurve(
             const std::vector<Constraint*>& constraints = Obj->Constraints.getValues();
             for (const auto& constraint : constraints) {
                 if (constraint->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constraint->First == GeoIdPoint && constraint->Second == GeoIdCurve) {
+                    && constraint->First_Deprecated == GeoIdPoint
+                    && constraint->Second_Deprecated == GeoIdCurve) {
                     return true;
                 }
             }
@@ -447,7 +448,8 @@ bool SketcherGui::checkConstraint(
 {
     for (std::vector<Sketcher::Constraint*>::const_iterator itc = vals.begin(); itc != vals.end();
          ++itc) {
-        if ((*itc)->Type == type && (*itc)->First == geoid && (*itc)->FirstPos == pos) {
+        if ((*itc)->Type == type && (*itc)->First_Deprecated == geoid
+            && (*itc)->FirstPos_Deprecated == pos) {
             return true;
         }
     }

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -408,8 +408,8 @@ bool SketcherGui::IsPointAlreadyOnCurve(
             const std::vector<Constraint*>& constraints = Obj->Constraints.getValues();
             for (const auto& constraint : constraints) {
                 if (constraint->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constraint->First_Deprecated == GeoIdPoint
-                    && constraint->Second_Deprecated == GeoIdCurve) {
+                    && constraint->getGeoId(0) == GeoIdPoint
+                    && constraint->getGeoId(1) == GeoIdCurve) {
                     return true;
                 }
             }
@@ -448,8 +448,7 @@ bool SketcherGui::checkConstraint(
 {
     for (std::vector<Sketcher::Constraint*>::const_iterator itc = vals.begin(); itc != vals.end();
          ++itc) {
-        if ((*itc)->Type == type && (*itc)->First_Deprecated == geoid
-            && (*itc)->FirstPos_Deprecated == pos) {
+        if ((*itc)->Type == type && (*itc)->getGeoId(0) == geoid && (*itc)->getPosId(0) == pos) {
             return true;
         }
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1786,9 +1786,9 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
                 for (auto c : getSketchObject()->Constraints.getValues()) {
                     if (c->Type == Sketcher::InternalAlignment
                         && c->AlignmentType == BSplineControlPoint
-                        && c->First == geoId) {
+                        && c->First_Deprecated == geoId) {
 
-                        bsplinegeoid = c->Second;
+                        bsplinegeoid = c->Second_Deprecated;
                         break;
                     }
                 }
@@ -1801,9 +1801,9 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
                 for (auto c : getSketchObject()->Constraints.getValues()) {
                     if (c->Type == Sketcher::InternalAlignment
                         && c->AlignmentType == BSplineControlPoint
-                        && c->Second == bsplinegeoid) {
+                        && c->Second_Deprecated == bsplinegeoid) {
 
-                        polegeoids.push_back(c->First);
+                        polegeoids.push_back(c->First_Deprecated);
                     }
                 }
 
@@ -2022,17 +2022,17 @@ void ViewProviderSketch::moveConstraint(Sketcher::Constraint* Constr, int constN
         || Constr->Type == Radius || Constr->Type == Diameter || Constr->Type == Weight) {
 
         Base::Vector3d p1(0., 0., 0.), p2(0., 0., 0.);
-        if (Constr->SecondPos != Sketcher::PointPos::none) {// point to point distance
-            p1 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
-            p2 = getSolvedSketch().getPoint(Constr->Second, Constr->SecondPos);
+        if (Constr->SecondPos_Deprecated != Sketcher::PointPos::none) {// point to point distance
+            p1 = getSolvedSketch().getPoint(Constr->First_Deprecated, Constr->FirstPos_Deprecated);
+            p2 = getSolvedSketch().getPoint(Constr->Second_Deprecated, Constr->SecondPos_Deprecated);
         }
-        else if (Constr->Second != GeoEnum::GeoUndef) {
-            p1 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
-            const Part::Geometry *geo1 = GeoList::getGeometryFromGeoId (geomlist, Constr->First);
-            const Part::Geometry *geo2 = GeoList::getGeometryFromGeoId (geomlist, Constr->Second);
+        else if (Constr->Second_Deprecated != GeoEnum::GeoUndef) {
+            p1 = getSolvedSketch().getPoint(Constr->First_Deprecated, Constr->FirstPos_Deprecated);
+            const Part::Geometry *geo1 = GeoList::getGeometryFromGeoId (geomlist, Constr->First_Deprecated);
+            const Part::Geometry *geo2 = GeoList::getGeometryFromGeoId (geomlist, Constr->Second_Deprecated);
 
             if (isLineSegment(*geo2)) {
-                if (isCircleOrArc(*geo1) && Constr->FirstPos == Sketcher::PointPos::none){
+                if (isCircleOrArc(*geo1) && Constr->FirstPos_Deprecated == Sketcher::PointPos::none){
                     std::swap(geo1, geo2); // see below
                 }
                 else {
@@ -2047,7 +2047,7 @@ void ViewProviderSketch::moveConstraint(Sketcher::Constraint* Constr, int constN
             }
 
             if (isCircleOrArc(*geo2)) {
-                if (Constr->FirstPos != Sketcher::PointPos::none){ // circular to point distance
+                if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none){ // circular to point distance
                     auto [rad, ct] = getRadiusCenterCircleArc(geo2);
 
                     Base::Vector3d v = p1 - ct;
@@ -2072,11 +2072,11 @@ void ViewProviderSketch::moveConstraint(Sketcher::Constraint* Constr, int constN
                 }
             }
         }
-        else if (Constr->FirstPos != Sketcher::PointPos::none) {
-            p2 = getSolvedSketch().getPoint(Constr->First, Constr->FirstPos);
+        else if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
+            p2 = getSolvedSketch().getPoint(Constr->First_Deprecated, Constr->FirstPos_Deprecated);
         }
-        else if (Constr->First != GeoEnum::GeoUndef) {
-            const Part::Geometry* geo = GeoList::getGeometryFromGeoId(geomlist, Constr->First);
+        else if (Constr->First_Deprecated != GeoEnum::GeoUndef) {
+            const Part::Geometry* geo = GeoList::getGeometryFromGeoId(geomlist, Constr->First_Deprecated);
             if (geo->is<Part::GeomLineSegment>()) {
                 const Part::GeomLineSegment* lineSeg =
                     static_cast<const Part::GeomLineSegment*>(geo);
@@ -2089,7 +2089,7 @@ void ViewProviderSketch::moveConstraint(Sketcher::Constraint* Constr, int constN
                 double startangle, endangle;
                 arc->getRange(startangle, endangle, /*emulateCCW=*/true);
 
-                if (Constr->Type == Distance && Constr->Second == GeoEnum::GeoUndef){
+                if (Constr->Type == Distance && Constr->Second_Deprecated == GeoEnum::GeoUndef){
                     double arcAngle = (startangle + endangle) / 2.;
                     Base::Vector2d arcDirection(std::cos(arcAngle), std::sin(arcAngle));
                     Base::Vector2d centerToToPos = toPos - Base::Vector2d(center.x, center.y);
@@ -2209,10 +2209,10 @@ void ViewProviderSketch::moveAngleConstraint(Sketcher::Constraint* constr, int c
     Sketcher::SketchObject* obj = getSketchObject();
     Base::Vector3d p0(0., 0., 0.);
     double factor = 0.5;
-    if (constr->Second != GeoEnum::GeoUndef) {// line to line angle
-        if (constr->Third == GeoEnum::GeoUndef) {// angle between two lines
-            const Part::Geometry* geo1 = obj->getGeometry(constr->First);
-            const Part::Geometry* geo2 = obj->getGeometry(constr->Second);
+    if (constr->Second_Deprecated != GeoEnum::GeoUndef) {// line to line angle
+        if (constr->Third_Deprecated == GeoEnum::GeoUndef) {// angle between two lines
+            const Part::Geometry* geo1 = obj->getGeometry(constr->First_Deprecated);
+            const Part::Geometry* geo2 = obj->getGeometry(constr->Second_Deprecated);
 
             if (!isLineSegment(*geo1) || !isLineSegment(*geo2)) {
                 return;
@@ -2227,8 +2227,8 @@ void ViewProviderSketch::moveAngleConstraint(Sketcher::Constraint* constr, int c
             l2[1] = Base::Vector2d(lineSeg2->getEndPoint().x, lineSeg2->getEndPoint().y);
 
             // First we will check if the angle needs to be reversed to its supplementary
-            bool flip1 = (constr->FirstPos == Sketcher::PointPos::end);
-            bool flip2 = (constr->SecondPos == Sketcher::PointPos::end);
+            bool flip1 = (constr->FirstPos_Deprecated == Sketcher::PointPos::end);
+            bool flip2 = (constr->SecondPos_Deprecated == Sketcher::PointPos::end);
             Base::Vector2d p11 = flip1 ? l1[1] : l1[0];
             Base::Vector2d p12 = flip1 ? l1[0] : l1[1];
             Base::Vector2d p21 = flip2 ? l2[1] : l2[0];
@@ -2275,19 +2275,19 @@ void ViewProviderSketch::moveAngleConstraint(Sketcher::Constraint* constr, int c
             p0 = Base::Vector3d(intersection.x, intersection.y, 0.);
         }
         else {// angle-via-point
-            Base::Vector3d p = getSolvedSketch().getPoint(constr->Third, constr->ThirdPos);
+            Base::Vector3d p = getSolvedSketch().getPoint(constr->Third_Deprecated, constr->ThirdPos_Deprecated);
             p0 = Base::Vector3d(p.x, p.y, 0);
-            Base::Vector3d dir1 = getSolvedSketch().calculateNormalAtPoint(constr->First, p.x, p.y);
+            Base::Vector3d dir1 = getSolvedSketch().calculateNormalAtPoint(constr->First_Deprecated, p.x, p.y);
             dir1.RotateZ(-std::numbers::pi / 2);// convert to vector of tangency by rotating
-            Base::Vector3d dir2 = getSolvedSketch().calculateNormalAtPoint(constr->Second, p.x, p.y);
+            Base::Vector3d dir2 = getSolvedSketch().calculateNormalAtPoint(constr->Second_Deprecated, p.x, p.y);
             dir2.RotateZ(-std::numbers::pi / 2);
 
             Base::Vector3d vec = Base::Vector3d(toPos.x, toPos.y, 0) - p0;
             factor = factor * Base::sgn<double>((dir1 + dir2) * vec);
         }
     }
-    else if (constr->First != GeoEnum::GeoUndef) {// line/arc angle
-        const Part::Geometry* geo = obj->getGeometry(constr->First);
+    else if (constr->First_Deprecated != GeoEnum::GeoUndef) {// line/arc angle
+        const Part::Geometry* geo = obj->getGeometry(constr->First_Deprecated);
 
         if (isLineSegment(*geo)) {
             const auto* lineSeg = static_cast<const Part::GeomLineSegment*>(geo);
@@ -3174,9 +3174,9 @@ void ViewProviderSketch::scaleBSplinePoleCirclesAndUpdateSolverAndSketchObjectGe
             if (gf->getInternalType() == InternalType::BSplineControlPoint) {
                 for (auto c : getSketchObject()->Constraints.getValues()) {
                     if (c->Type == InternalAlignment && c->AlignmentType == BSplineControlPoint
-                        && c->First == GeoId) {
+                        && c->First_Deprecated == GeoId) {
                         auto bspline = dynamic_cast<const Part::GeomBSplineCurve*>(
-                            tempGeo[c->Second]->getGeometry());
+                            tempGeo[c->Second_Deprecated]->getGeometry());
 
                         if (bspline) {
                             auto weights = bspline->getWeights();
@@ -3204,15 +3204,15 @@ void ViewProviderSketch::scaleBSplinePoleCirclesAndUpdateSolverAndSketchObjectGe
                                 for (auto ic : getSketchObject()->Constraints.getValues()) {
                                     if (ic->Type == InternalAlignment
                                         && ic->AlignmentType == BSplineControlPoint
-                                        && ic->Second == c->Second) {
-                                        polegeoids.push_back(ic->First);
+                                        && ic->Second_Deprecated == c->Second_Deprecated) {
+                                        polegeoids.push_back(ic->First_Deprecated);
                                     }
                                 }
 
                                 for (auto ic : getSketchObject()->Constraints.getValues()) {
                                     if (ic->Type == Weight) {
 
-                                        if (auto pos = std::ranges::find(polegeoids, ic->First);
+                                        if (auto pos = std::ranges::find(polegeoids, ic->First_Deprecated);
                                             pos != polegeoids.end()) {
                                             vradius = ic->getValue() * scalefactor;
                                             break;// one is enough, otherwise it would not be
@@ -4358,8 +4358,8 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string>& subList)
                      it != vals.end();
                      ++it) {
                     if (((*it)->Type == Sketcher::Coincident)
-                        && (((*it)->First == GeoId && (*it)->FirstPos == PosId)
-                            || ((*it)->Second == GeoId && (*it)->SecondPos == PosId))) {
+                        && (((*it)->First_Deprecated == GeoId && (*it)->FirstPos_Deprecated == PosId)
+                            || ((*it)->Second_Deprecated == GeoId && (*it)->SecondPos_Deprecated == PosId))) {
                         try {
                             Gui::cmdAppObjectArgs(
                                 getObject(), "delConstraintOnPoint(%d,%d)", GeoId, (int)PosId);

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -1786,9 +1786,9 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
                 for (auto c : getSketchObject()->Constraints.getValues()) {
                     if (c->Type == Sketcher::InternalAlignment
                         && c->AlignmentType == BSplineControlPoint
-                        && c->First_Deprecated == geoId) {
+                        && c->getGeoId(0) == geoId) {
 
-                        bsplinegeoid = c->Second_Deprecated;
+                        bsplinegeoid = c->getGeoId(1);
                         break;
                     }
                 }
@@ -1801,9 +1801,9 @@ void ViewProviderSketch::initDragging(int geoId, Sketcher::PointPos pos, Gui::Vi
                 for (auto c : getSketchObject()->Constraints.getValues()) {
                     if (c->Type == Sketcher::InternalAlignment
                         && c->AlignmentType == BSplineControlPoint
-                        && c->Second_Deprecated == bsplinegeoid) {
+                        && c->getGeoId(1) == bsplinegeoid) {
 
-                        polegeoids.push_back(c->First_Deprecated);
+                        polegeoids.push_back(c->getGeoId(0));
                     }
                 }
 
@@ -2022,17 +2022,17 @@ void ViewProviderSketch::moveConstraint(Sketcher::Constraint* Constr, int constN
         || Constr->Type == Radius || Constr->Type == Diameter || Constr->Type == Weight) {
 
         Base::Vector3d p1(0., 0., 0.), p2(0., 0., 0.);
-        if (Constr->SecondPos_Deprecated != Sketcher::PointPos::none) {// point to point distance
-            p1 = getSolvedSketch().getPoint(Constr->First_Deprecated, Constr->FirstPos_Deprecated);
-            p2 = getSolvedSketch().getPoint(Constr->Second_Deprecated, Constr->SecondPos_Deprecated);
+        if (Constr->getPosId(1) != Sketcher::PointPos::none) {// point to point distance
+            p1 = getSolvedSketch().getPoint(Constr->getGeoId(0), Constr->getPosId(0));
+            p2 = getSolvedSketch().getPoint(Constr->getGeoId(1), Constr->getPosId(1));
         }
-        else if (Constr->Second_Deprecated != GeoEnum::GeoUndef) {
-            p1 = getSolvedSketch().getPoint(Constr->First_Deprecated, Constr->FirstPos_Deprecated);
-            const Part::Geometry *geo1 = GeoList::getGeometryFromGeoId (geomlist, Constr->First_Deprecated);
-            const Part::Geometry *geo2 = GeoList::getGeometryFromGeoId (geomlist, Constr->Second_Deprecated);
+        else if (Constr->getGeoId(1) != GeoEnum::GeoUndef) {
+            p1 = getSolvedSketch().getPoint(Constr->getGeoId(0), Constr->getPosId(0));
+            const Part::Geometry *geo1 = GeoList::getGeometryFromGeoId (geomlist, Constr->getGeoId(0));
+            const Part::Geometry *geo2 = GeoList::getGeometryFromGeoId (geomlist, Constr->getGeoId(1));
 
             if (isLineSegment(*geo2)) {
-                if (isCircleOrArc(*geo1) && Constr->FirstPos_Deprecated == Sketcher::PointPos::none){
+                if (isCircleOrArc(*geo1) && Constr->getPosId(0) == Sketcher::PointPos::none){
                     std::swap(geo1, geo2); // see below
                 }
                 else {
@@ -2047,7 +2047,7 @@ void ViewProviderSketch::moveConstraint(Sketcher::Constraint* Constr, int constN
             }
 
             if (isCircleOrArc(*geo2)) {
-                if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none){ // circular to point distance
+                if (Constr->getPosId(0) != Sketcher::PointPos::none){ // circular to point distance
                     auto [rad, ct] = getRadiusCenterCircleArc(geo2);
 
                     Base::Vector3d v = p1 - ct;
@@ -2072,11 +2072,11 @@ void ViewProviderSketch::moveConstraint(Sketcher::Constraint* Constr, int constN
                 }
             }
         }
-        else if (Constr->FirstPos_Deprecated != Sketcher::PointPos::none) {
-            p2 = getSolvedSketch().getPoint(Constr->First_Deprecated, Constr->FirstPos_Deprecated);
+        else if (Constr->getPosId(0) != Sketcher::PointPos::none) {
+            p2 = getSolvedSketch().getPoint(Constr->getGeoId(0), Constr->getPosId(0));
         }
-        else if (Constr->First_Deprecated != GeoEnum::GeoUndef) {
-            const Part::Geometry* geo = GeoList::getGeometryFromGeoId(geomlist, Constr->First_Deprecated);
+        else if (Constr->getGeoId(0) != GeoEnum::GeoUndef) {
+            const Part::Geometry* geo = GeoList::getGeometryFromGeoId(geomlist, Constr->getGeoId(0));
             if (geo->is<Part::GeomLineSegment>()) {
                 const Part::GeomLineSegment* lineSeg =
                     static_cast<const Part::GeomLineSegment*>(geo);
@@ -2089,7 +2089,7 @@ void ViewProviderSketch::moveConstraint(Sketcher::Constraint* Constr, int constN
                 double startangle, endangle;
                 arc->getRange(startangle, endangle, /*emulateCCW=*/true);
 
-                if (Constr->Type == Distance && Constr->Second_Deprecated == GeoEnum::GeoUndef){
+                if (Constr->Type == Distance && Constr->getGeoId(1) == GeoEnum::GeoUndef){
                     double arcAngle = (startangle + endangle) / 2.;
                     Base::Vector2d arcDirection(std::cos(arcAngle), std::sin(arcAngle));
                     Base::Vector2d centerToToPos = toPos - Base::Vector2d(center.x, center.y);
@@ -2209,10 +2209,10 @@ void ViewProviderSketch::moveAngleConstraint(Sketcher::Constraint* constr, int c
     Sketcher::SketchObject* obj = getSketchObject();
     Base::Vector3d p0(0., 0., 0.);
     double factor = 0.5;
-    if (constr->Second_Deprecated != GeoEnum::GeoUndef) {// line to line angle
-        if (constr->Third_Deprecated == GeoEnum::GeoUndef) {// angle between two lines
-            const Part::Geometry* geo1 = obj->getGeometry(constr->First_Deprecated);
-            const Part::Geometry* geo2 = obj->getGeometry(constr->Second_Deprecated);
+    if (constr->getGeoId(1) != GeoEnum::GeoUndef) {// line to line angle
+        if (constr->getGeoId(2) == GeoEnum::GeoUndef) {// angle between two lines
+            const Part::Geometry* geo1 = obj->getGeometry(constr->getGeoId(0));
+            const Part::Geometry* geo2 = obj->getGeometry(constr->getGeoId(1));
 
             if (!isLineSegment(*geo1) || !isLineSegment(*geo2)) {
                 return;
@@ -2227,8 +2227,8 @@ void ViewProviderSketch::moveAngleConstraint(Sketcher::Constraint* constr, int c
             l2[1] = Base::Vector2d(lineSeg2->getEndPoint().x, lineSeg2->getEndPoint().y);
 
             // First we will check if the angle needs to be reversed to its supplementary
-            bool flip1 = (constr->FirstPos_Deprecated == Sketcher::PointPos::end);
-            bool flip2 = (constr->SecondPos_Deprecated == Sketcher::PointPos::end);
+            bool flip1 = (constr->getPosId(0) == Sketcher::PointPos::end);
+            bool flip2 = (constr->getPosId(1) == Sketcher::PointPos::end);
             Base::Vector2d p11 = flip1 ? l1[1] : l1[0];
             Base::Vector2d p12 = flip1 ? l1[0] : l1[1];
             Base::Vector2d p21 = flip2 ? l2[1] : l2[0];
@@ -2275,19 +2275,19 @@ void ViewProviderSketch::moveAngleConstraint(Sketcher::Constraint* constr, int c
             p0 = Base::Vector3d(intersection.x, intersection.y, 0.);
         }
         else {// angle-via-point
-            Base::Vector3d p = getSolvedSketch().getPoint(constr->Third_Deprecated, constr->ThirdPos_Deprecated);
+            Base::Vector3d p = getSolvedSketch().getPoint(constr->getGeoId(2), constr->getPosId(2));
             p0 = Base::Vector3d(p.x, p.y, 0);
-            Base::Vector3d dir1 = getSolvedSketch().calculateNormalAtPoint(constr->First_Deprecated, p.x, p.y);
+            Base::Vector3d dir1 = getSolvedSketch().calculateNormalAtPoint(constr->getGeoId(0), p.x, p.y);
             dir1.RotateZ(-std::numbers::pi / 2);// convert to vector of tangency by rotating
-            Base::Vector3d dir2 = getSolvedSketch().calculateNormalAtPoint(constr->Second_Deprecated, p.x, p.y);
+            Base::Vector3d dir2 = getSolvedSketch().calculateNormalAtPoint(constr->getGeoId(1), p.x, p.y);
             dir2.RotateZ(-std::numbers::pi / 2);
 
             Base::Vector3d vec = Base::Vector3d(toPos.x, toPos.y, 0) - p0;
             factor = factor * Base::sgn<double>((dir1 + dir2) * vec);
         }
     }
-    else if (constr->First_Deprecated != GeoEnum::GeoUndef) {// line/arc angle
-        const Part::Geometry* geo = obj->getGeometry(constr->First_Deprecated);
+    else if (constr->getGeoId(0) != GeoEnum::GeoUndef) {// line/arc angle
+        const Part::Geometry* geo = obj->getGeometry(constr->getGeoId(0));
 
         if (isLineSegment(*geo)) {
             const auto* lineSeg = static_cast<const Part::GeomLineSegment*>(geo);
@@ -3174,9 +3174,9 @@ void ViewProviderSketch::scaleBSplinePoleCirclesAndUpdateSolverAndSketchObjectGe
             if (gf->getInternalType() == InternalType::BSplineControlPoint) {
                 for (auto c : getSketchObject()->Constraints.getValues()) {
                     if (c->Type == InternalAlignment && c->AlignmentType == BSplineControlPoint
-                        && c->First_Deprecated == GeoId) {
+                        && c->getGeoId(0) == GeoId) {
                         auto bspline = dynamic_cast<const Part::GeomBSplineCurve*>(
-                            tempGeo[c->Second_Deprecated]->getGeometry());
+                            tempGeo[c->getGeoId(1)]->getGeometry());
 
                         if (bspline) {
                             auto weights = bspline->getWeights();
@@ -3204,15 +3204,15 @@ void ViewProviderSketch::scaleBSplinePoleCirclesAndUpdateSolverAndSketchObjectGe
                                 for (auto ic : getSketchObject()->Constraints.getValues()) {
                                     if (ic->Type == InternalAlignment
                                         && ic->AlignmentType == BSplineControlPoint
-                                        && ic->Second_Deprecated == c->Second_Deprecated) {
-                                        polegeoids.push_back(ic->First_Deprecated);
+                                        && ic->getGeoId(1) == c->getGeoId(1)) {
+                                        polegeoids.push_back(ic->getGeoId(0));
                                     }
                                 }
 
                                 for (auto ic : getSketchObject()->Constraints.getValues()) {
                                     if (ic->Type == Weight) {
 
-                                        if (auto pos = std::ranges::find(polegeoids, ic->First_Deprecated);
+                                        if (auto pos = std::ranges::find(polegeoids, ic->getGeoId(0));
                                             pos != polegeoids.end()) {
                                             vradius = ic->getValue() * scalefactor;
                                             break;// one is enough, otherwise it would not be
@@ -4358,8 +4358,8 @@ bool ViewProviderSketch::onDelete(const std::vector<std::string>& subList)
                      it != vals.end();
                      ++it) {
                     if (((*it)->Type == Sketcher::Coincident)
-                        && (((*it)->First_Deprecated == GeoId && (*it)->FirstPos_Deprecated == PosId)
-                            || ((*it)->Second_Deprecated == GeoId && (*it)->SecondPos_Deprecated == PosId))) {
+                        && (((*it)->getGeoId(0) == GeoId && (*it)->getPosId(0) == PosId)
+                            || ((*it)->getGeoId(1) == GeoId && (*it)->getPosId(1) == PosId))) {
                         try {
                             Gui::cmdAppObjectArgs(
                                 getObject(), "delConstraintOnPoint(%d,%d)", GeoId, (int)PosId);

--- a/tests/src/Mod/Sketcher/App/Constraint.cpp
+++ b/tests/src/Mod/Sketcher/App/Constraint.cpp
@@ -54,14 +54,14 @@ TEST_F(ConstraintPointsAccess, testDefaultGeoElementIdsAreSane)  // NOLINT
     // Assert
 #if SKETCHER_CONSTRAINT_USE_LEGACY_ELEMENTS
     // Old way of accessing elements
-    EXPECT_EQ(constraint.First, Sketcher::GeoEnum::GeoUndef);
-    EXPECT_EQ(constraint.FirstPos, Sketcher::PointPos::none);
+    EXPECT_EQ(constraint.First_Deprecated, Sketcher::GeoEnum::GeoUndef);
+    EXPECT_EQ(constraint.FirstPos_Deprecated, Sketcher::PointPos::none);
 
-    EXPECT_EQ(constraint.Second, Sketcher::GeoEnum::GeoUndef);
-    EXPECT_EQ(constraint.SecondPos, Sketcher::PointPos::none);
+    EXPECT_EQ(constraint.Second_Deprecated, Sketcher::GeoEnum::GeoUndef);
+    EXPECT_EQ(constraint.SecondPos_Deprecated, Sketcher::PointPos::none);
 
-    EXPECT_EQ(constraint.Third, Sketcher::GeoEnum::GeoUndef);
-    EXPECT_EQ(constraint.ThirdPos, Sketcher::PointPos::none);
+    EXPECT_EQ(constraint.Third_Deprecated, Sketcher::GeoEnum::GeoUndef);
+    EXPECT_EQ(constraint.ThirdPos_Deprecated, Sketcher::PointPos::none);
 
     // New way of accessing elements
 #endif
@@ -86,12 +86,12 @@ TEST_F(ConstraintPointsAccess, testOldWriteIsReadByNew)  // NOLINT
     auto constraint = Sketcher::Constraint();
 
     // Act
-    constraint.First = 23;
-    constraint.FirstPos = Sketcher::PointPos::start;
-    constraint.Second = 34;
-    constraint.SecondPos = Sketcher::PointPos::end;
-    constraint.Third = 45;
-    constraint.ThirdPos = Sketcher::PointPos::mid;
+    constraint.First_Deprecated = 23;
+    constraint.FirstPos_Deprecated = Sketcher::PointPos::start;
+    constraint.Second_Deprecated = 34;
+    constraint.SecondPos_Deprecated = Sketcher::PointPos::end;
+    constraint.Third_Deprecated = 45;
+    constraint.ThirdPos_Deprecated = Sketcher::PointPos::mid;
 
     // Assert
     EXPECT_EQ(
@@ -119,12 +119,12 @@ TEST_F(ConstraintPointsAccess, testNewWriteIsReadByOld)  // NOLINT
     constraint.setElement(2, Sketcher::GeoElementId(45, Sketcher::PointPos::mid));
 
     // Assert
-    EXPECT_EQ(constraint.First, 23);
-    EXPECT_EQ(constraint.FirstPos, Sketcher::PointPos::start);
-    EXPECT_EQ(constraint.Second, 34);
-    EXPECT_EQ(constraint.SecondPos, Sketcher::PointPos::end);
-    EXPECT_EQ(constraint.Third, 45);
-    EXPECT_EQ(constraint.ThirdPos, Sketcher::PointPos::mid);
+    EXPECT_EQ(constraint.First_Deprecated, 23);
+    EXPECT_EQ(constraint.FirstPos_Deprecated, Sketcher::PointPos::start);
+    EXPECT_EQ(constraint.Second_Deprecated, 34);
+    EXPECT_EQ(constraint.SecondPos_Deprecated, Sketcher::PointPos::end);
+    EXPECT_EQ(constraint.Third_Deprecated, 45);
+    EXPECT_EQ(constraint.ThirdPos_Deprecated, Sketcher::PointPos::mid);
 }
 #endif
 
@@ -158,12 +158,12 @@ TEST_F(ConstraintPointsAccess, testElementSerializationWhenAccessingOldWay)  // 
     auto constraint = Sketcher::Constraint();
 
     // Act
-    constraint.First = 23;
-    constraint.FirstPos = Sketcher::PointPos::start;
-    constraint.Second = 34;
-    constraint.SecondPos = Sketcher::PointPos::end;
-    constraint.Third = 45;
-    constraint.ThirdPos = Sketcher::PointPos::mid;
+    constraint.First_Deprecated = 23;
+    constraint.FirstPos_Deprecated = Sketcher::PointPos::start;
+    constraint.Second_Deprecated = 34;
+    constraint.SecondPos_Deprecated = Sketcher::PointPos::end;
+    constraint.Third_Deprecated = 45;
+    constraint.ThirdPos_Deprecated = Sketcher::PointPos::mid;
 
     Base::StringWriter writer = {};
     constraint.Save(writer);
@@ -215,8 +215,8 @@ TEST_F(ConstraintPointsAccess, testElementSerializationWhenMixingOldAndNew)  // 
     // Act
     constraint.setElement(0, Sketcher::GeoElementId(23, Sketcher::PointPos::start));
     constraint.setElement(1, Sketcher::GeoElementId(34, Sketcher::PointPos::end));
-    constraint.Second = 45;  // Old way
-    constraint.SecondPos = Sketcher::PointPos::mid;
+    constraint.Second_Deprecated = 45;  // Old way
+    constraint.SecondPos_Deprecated = Sketcher::PointPos::mid;
 
     Base::StringWriter writer = {};
     constraint.Save(writer);
@@ -553,10 +553,10 @@ TEST_F(ConstraintPointsAccess, testLegacyWriteReflectedInInvolvesAndSubstitute) 
 {
     // Arrange
     Sketcher::Constraint constraint;
-    constraint.First = 10;
-    constraint.FirstPos = Sketcher::PointPos::start;
-    constraint.Second = 20;
-    constraint.SecondPos = Sketcher::PointPos::end;
+    constraint.First_Deprecated = 10;
+    constraint.FirstPos_Deprecated = Sketcher::PointPos::start;
+    constraint.Second_Deprecated = 20;
+    constraint.SecondPos_Deprecated = Sketcher::PointPos::end;
 
     // Act & Assert
     EXPECT_TRUE(constraint.involvesGeoId(10));
@@ -581,7 +581,7 @@ TEST_F(ConstraintPointsAccess, testSubstituteUpdatesLegacyFieldsToo)  // NOLINT
 
     // Assert
     EXPECT_EQ(constraint.getElement(0), Sketcher::GeoElementId(42, Sketcher::PointPos::start));
-    EXPECT_EQ(constraint.First, 42);
-    EXPECT_EQ(constraint.FirstPos, Sketcher::PointPos::start);
+    EXPECT_EQ(constraint.First_Deprecated, 42);
+    EXPECT_EQ(constraint.FirstPos_Deprecated, Sketcher::PointPos::start);
 }
 #endif

--- a/tests/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObject.cpp
@@ -428,19 +428,14 @@ TEST_F(SketchObjectTest, testConstraintAfterDeletingGeo)
 
     Sketcher::Constraint constr1;
     constr1.Type = Sketcher::ConstraintType::Coincident;
-    constr1.First_Deprecated = geoId1;
-    constr1.FirstPos_Deprecated = Sketcher::PointPos::start;
-    constr1.Second_Deprecated = geoId2;
-    constr1.SecondPos_Deprecated = Sketcher::PointPos::end;
+    constr1.setElement(0, GeoElementId(geoId1, Sketcher::PointPos::start));
+    constr1.setElement(1, GeoElementId(geoId2, Sketcher::PointPos::end));
 
     Sketcher::Constraint constr2;
     constr2.Type = Sketcher::ConstraintType::Tangent;
-    constr2.First_Deprecated = geoId4;
-    constr2.FirstPos_Deprecated = Sketcher::PointPos::none;
-    constr2.Second_Deprecated = geoId3;
-    constr2.SecondPos_Deprecated = Sketcher::PointPos::none;
-    constr2.Third_Deprecated = geoId1;
-    constr2.ThirdPos_Deprecated = Sketcher::PointPos::start;
+    constr2.setElement(0, GeoElementId(geoId4, Sketcher::PointPos::none));
+    constr2.setElement(1, GeoElementId(geoId3, Sketcher::PointPos::none));
+    constr2.setElement(2, GeoElementId(geoId1, Sketcher::PointPos::start));
 
     // Act
     auto nullConstrAfter = getObject()->getConstraintAfterDeletingGeo(nullConstr, 5);
@@ -709,10 +704,8 @@ TEST_F(SketchObjectTest, testDeleteOnlyUnusedInternalGeometryOfBSpline)
     EXPECT_NE(it, constraints.end());
     auto constraint = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constraint->Type = Sketcher::ConstraintType::Coincident;
-    constraint->First_Deprecated = geoIdPnt;
-    constraint->FirstPos_Deprecated = Sketcher::PointPos::start;
-    constraint->Second_Deprecated = (*it)->First_Deprecated;
-    constraint->SecondPos_Deprecated = Sketcher::PointPos::mid;
+    constraint->setElement(0, GeoElementId(geoIdPnt, Sketcher::PointPos::start));
+    constraint->setElement(1, GeoElementId((*it)->First_Deprecated, Sketcher::PointPos::mid));
     getObject()->addConstraint(constraint);
 
     // Act

--- a/tests/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObject.cpp
@@ -459,11 +459,11 @@ TEST_F(SketchObjectTest, testConstraintAfterDeletingGeo)
 
     // Assert
     EXPECT_EQ(constr1.Type, Sketcher::ConstraintType::Coincident);
-    EXPECT_EQ(constr1.First_Deprecated, geoId1);
-    EXPECT_EQ(constr1.Second_Deprecated, geoId2);
-    EXPECT_EQ(constr1PtrAfter1->First_Deprecated, geoId1 - 1);
-    EXPECT_EQ(constr1PtrAfter1->Second_Deprecated, geoId2 - 1);
-    EXPECT_EQ(constr1PtrAfter2->Third_Deprecated, Sketcher::GeoEnum::GeoUndef);
+    EXPECT_EQ(constr1.getGeoId(0), geoId1);
+    EXPECT_EQ(constr1.getGeoId(1), geoId2);
+    EXPECT_EQ(constr1PtrAfter1->getGeoId(0), geoId1 - 1);
+    EXPECT_EQ(constr1PtrAfter1->getGeoId(1), geoId2 - 1);
+    EXPECT_EQ(constr1PtrAfter2->getGeoId(2), Sketcher::GeoEnum::GeoUndef);
     EXPECT_EQ(constr1PtrAfter3.get(), nullptr);
 
     // Act
@@ -471,9 +471,9 @@ TEST_F(SketchObjectTest, testConstraintAfterDeletingGeo)
 
     // Assert
     EXPECT_EQ(constr2.Type, Sketcher::ConstraintType::Tangent);
-    EXPECT_EQ(constr2.First_Deprecated, geoId4 + 1);
-    EXPECT_EQ(constr2.Second_Deprecated, geoId3);
-    EXPECT_EQ(constr2.Third_Deprecated, geoId1);
+    EXPECT_EQ(constr2.getGeoId(0), geoId4 + 1);
+    EXPECT_EQ(constr2.getGeoId(1), geoId3);
+    EXPECT_EQ(constr2.getGeoId(2), geoId1);
 
     // Act
     // Delete a geo involved in the constraint
@@ -516,7 +516,7 @@ TEST_F(SketchObjectTest, testDeleteExposeInternalGeometryOfEllipse)
             constraints.end(),
             [&geoId, &alignmentType](const auto* constr) {
                 return constr->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constr->AlignmentType == alignmentType && constr->Second_Deprecated == geoId;
+                    && constr->AlignmentType == alignmentType && constr->getGeoId(1) == geoId;
             }
         );
         EXPECT_EQ(numConstraintsOfThisType, 1);
@@ -563,7 +563,7 @@ TEST_F(SketchObjectTest, testDeleteExposeInternalGeometryOfHyperbola)
             constraints.end(),
             [&geoId, &alignmentType](const auto* constr) {
                 return constr->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constr->AlignmentType == alignmentType && constr->Second_Deprecated == geoId;
+                    && constr->AlignmentType == alignmentType && constr->getGeoId(1) == geoId;
             }
         );
         EXPECT_EQ(numConstraintsOfThisType, 1);
@@ -609,7 +609,7 @@ TEST_F(SketchObjectTest, testDeleteExposeInternalGeometryOfParabola)
             constraints.end(),
             [&geoId, &alignmentType](const auto* constr) {
                 return constr->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constr->AlignmentType == alignmentType && constr->Second_Deprecated == geoId;
+                    && constr->AlignmentType == alignmentType && constr->getGeoId(1) == geoId;
             }
         );
         EXPECT_EQ(numConstraintsOfThisType, 1);
@@ -658,7 +658,7 @@ TEST_F(SketchObjectTest, testDeleteExposeInternalGeometryOfBSpline)
             constraints.end(),
             [&geoId, &alignmentType](const auto* constr) {
                 return constr->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constr->AlignmentType == alignmentType && constr->Second_Deprecated == geoId;
+                    && constr->AlignmentType == alignmentType && constr->getGeoId(1) == geoId;
             }
         );
     }
@@ -698,14 +698,14 @@ TEST_F(SketchObjectTest, testDeleteOnlyUnusedInternalGeometryOfBSpline)
     auto it = std::find_if(constraints.begin(), constraints.end(), [&geoIdBsp](const auto* constr) {
         return constr->Type == Sketcher::ConstraintType::InternalAlignment
             && constr->AlignmentType == Sketcher::InternalAlignmentType::BSplineControlPoint
-            && constr->Second_Deprecated == geoIdBsp && constr->InternalAlignmentIndex == 1;
+            && constr->getGeoId(1) == geoIdBsp && constr->InternalAlignmentIndex == 1;
     });
     // One Assert to avoid
     EXPECT_NE(it, constraints.end());
     auto constraint = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constraint->Type = Sketcher::ConstraintType::Coincident;
     constraint->setElement(0, GeoElementId(geoIdPnt, Sketcher::PointPos::start));
-    constraint->setElement(1, GeoElementId((*it)->First_Deprecated, Sketcher::PointPos::mid));
+    constraint->setElement(1, GeoElementId((*it)->getGeoId(0), Sketcher::PointPos::mid));
     getObject()->addConstraint(constraint);
 
     // Act

--- a/tests/src/Mod/Sketcher/App/SketchObject.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObject.cpp
@@ -428,19 +428,19 @@ TEST_F(SketchObjectTest, testConstraintAfterDeletingGeo)
 
     Sketcher::Constraint constr1;
     constr1.Type = Sketcher::ConstraintType::Coincident;
-    constr1.First = geoId1;
-    constr1.FirstPos = Sketcher::PointPos::start;
-    constr1.Second = geoId2;
-    constr1.SecondPos = Sketcher::PointPos::end;
+    constr1.First_Deprecated = geoId1;
+    constr1.FirstPos_Deprecated = Sketcher::PointPos::start;
+    constr1.Second_Deprecated = geoId2;
+    constr1.SecondPos_Deprecated = Sketcher::PointPos::end;
 
     Sketcher::Constraint constr2;
     constr2.Type = Sketcher::ConstraintType::Tangent;
-    constr2.First = geoId4;
-    constr2.FirstPos = Sketcher::PointPos::none;
-    constr2.Second = geoId3;
-    constr2.SecondPos = Sketcher::PointPos::none;
-    constr2.Third = geoId1;
-    constr2.ThirdPos = Sketcher::PointPos::start;
+    constr2.First_Deprecated = geoId4;
+    constr2.FirstPos_Deprecated = Sketcher::PointPos::none;
+    constr2.Second_Deprecated = geoId3;
+    constr2.SecondPos_Deprecated = Sketcher::PointPos::none;
+    constr2.Third_Deprecated = geoId1;
+    constr2.ThirdPos_Deprecated = Sketcher::PointPos::start;
 
     // Act
     auto nullConstrAfter = getObject()->getConstraintAfterDeletingGeo(nullConstr, 5);
@@ -464,11 +464,11 @@ TEST_F(SketchObjectTest, testConstraintAfterDeletingGeo)
 
     // Assert
     EXPECT_EQ(constr1.Type, Sketcher::ConstraintType::Coincident);
-    EXPECT_EQ(constr1.First, geoId1);
-    EXPECT_EQ(constr1.Second, geoId2);
-    EXPECT_EQ(constr1PtrAfter1->First, geoId1 - 1);
-    EXPECT_EQ(constr1PtrAfter1->Second, geoId2 - 1);
-    EXPECT_EQ(constr1PtrAfter2->Third, Sketcher::GeoEnum::GeoUndef);
+    EXPECT_EQ(constr1.First_Deprecated, geoId1);
+    EXPECT_EQ(constr1.Second_Deprecated, geoId2);
+    EXPECT_EQ(constr1PtrAfter1->First_Deprecated, geoId1 - 1);
+    EXPECT_EQ(constr1PtrAfter1->Second_Deprecated, geoId2 - 1);
+    EXPECT_EQ(constr1PtrAfter2->Third_Deprecated, Sketcher::GeoEnum::GeoUndef);
     EXPECT_EQ(constr1PtrAfter3.get(), nullptr);
 
     // Act
@@ -476,9 +476,9 @@ TEST_F(SketchObjectTest, testConstraintAfterDeletingGeo)
 
     // Assert
     EXPECT_EQ(constr2.Type, Sketcher::ConstraintType::Tangent);
-    EXPECT_EQ(constr2.First, geoId4 + 1);
-    EXPECT_EQ(constr2.Second, geoId3);
-    EXPECT_EQ(constr2.Third, geoId1);
+    EXPECT_EQ(constr2.First_Deprecated, geoId4 + 1);
+    EXPECT_EQ(constr2.Second_Deprecated, geoId3);
+    EXPECT_EQ(constr2.Third_Deprecated, geoId1);
 
     // Act
     // Delete a geo involved in the constraint
@@ -521,7 +521,7 @@ TEST_F(SketchObjectTest, testDeleteExposeInternalGeometryOfEllipse)
             constraints.end(),
             [&geoId, &alignmentType](const auto* constr) {
                 return constr->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constr->AlignmentType == alignmentType && constr->Second == geoId;
+                    && constr->AlignmentType == alignmentType && constr->Second_Deprecated == geoId;
             }
         );
         EXPECT_EQ(numConstraintsOfThisType, 1);
@@ -568,7 +568,7 @@ TEST_F(SketchObjectTest, testDeleteExposeInternalGeometryOfHyperbola)
             constraints.end(),
             [&geoId, &alignmentType](const auto* constr) {
                 return constr->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constr->AlignmentType == alignmentType && constr->Second == geoId;
+                    && constr->AlignmentType == alignmentType && constr->Second_Deprecated == geoId;
             }
         );
         EXPECT_EQ(numConstraintsOfThisType, 1);
@@ -614,7 +614,7 @@ TEST_F(SketchObjectTest, testDeleteExposeInternalGeometryOfParabola)
             constraints.end(),
             [&geoId, &alignmentType](const auto* constr) {
                 return constr->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constr->AlignmentType == alignmentType && constr->Second == geoId;
+                    && constr->AlignmentType == alignmentType && constr->Second_Deprecated == geoId;
             }
         );
         EXPECT_EQ(numConstraintsOfThisType, 1);
@@ -663,7 +663,7 @@ TEST_F(SketchObjectTest, testDeleteExposeInternalGeometryOfBSpline)
             constraints.end(),
             [&geoId, &alignmentType](const auto* constr) {
                 return constr->Type == Sketcher::ConstraintType::InternalAlignment
-                    && constr->AlignmentType == alignmentType && constr->Second == geoId;
+                    && constr->AlignmentType == alignmentType && constr->Second_Deprecated == geoId;
             }
         );
     }
@@ -703,16 +703,16 @@ TEST_F(SketchObjectTest, testDeleteOnlyUnusedInternalGeometryOfBSpline)
     auto it = std::find_if(constraints.begin(), constraints.end(), [&geoIdBsp](const auto* constr) {
         return constr->Type == Sketcher::ConstraintType::InternalAlignment
             && constr->AlignmentType == Sketcher::InternalAlignmentType::BSplineControlPoint
-            && constr->Second == geoIdBsp && constr->InternalAlignmentIndex == 1;
+            && constr->Second_Deprecated == geoIdBsp && constr->InternalAlignmentIndex == 1;
     });
     // One Assert to avoid
     EXPECT_NE(it, constraints.end());
     auto constraint = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constraint->Type = Sketcher::ConstraintType::Coincident;
-    constraint->First = geoIdPnt;
-    constraint->FirstPos = Sketcher::PointPos::start;
-    constraint->Second = (*it)->First;
-    constraint->SecondPos = Sketcher::PointPos::mid;
+    constraint->First_Deprecated = geoIdPnt;
+    constraint->FirstPos_Deprecated = Sketcher::PointPos::start;
+    constraint->Second_Deprecated = (*it)->First_Deprecated;
+    constraint->SecondPos_Deprecated = Sketcher::PointPos::mid;
     getObject()->addConstraint(constraint);
 
     // Act

--- a/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
@@ -789,8 +789,8 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnFullLengthConstraints)
     int geoId = getObject()->addGeometry(&lineSeg);
     auto constr = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constr->Type = Sketcher::ConstraintType::Distance;
-    constr->First = geoId;
-    constr->FirstPos = Sketcher::PointPos::none;
+    constr->First_Deprecated = geoId;
+    constr->FirstPos_Deprecated = Sketcher::PointPos::none;
     constr->setValue((getObject()->getPoint(geoId, Sketcher::PointPos::end)
                       - getObject()->getPoint(geoId, Sketcher::PointPos::start))
                          .Length());
@@ -824,12 +824,12 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnSymmetricConstraints)
     int geoId = getObject()->addGeometry(&lineSeg);
     auto constr = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constr->Type = Sketcher::ConstraintType::Symmetric;
-    constr->First = geoId;
-    constr->FirstPos = Sketcher::PointPos::start;
-    constr->Second = geoId;
-    constr->SecondPos = Sketcher::PointPos::end;
-    constr->Third = geoIdOfCutting;
-    constr->ThirdPos = Sketcher::PointPos::start;
+    constr->First_Deprecated = geoId;
+    constr->FirstPos_Deprecated = Sketcher::PointPos::start;
+    constr->Second_Deprecated = geoId;
+    constr->SecondPos_Deprecated = Sketcher::PointPos::end;
+    constr->Third_Deprecated = geoIdOfCutting;
+    constr->ThirdPos_Deprecated = Sketcher::PointPos::start;
     getObject()->addConstraint(constr);
 
     // Assert
@@ -863,10 +863,10 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnUnrelatedTangent)
     // TODO: add tangent and confirm
     auto constraint = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constraint->Type = Sketcher::ConstraintType::Tangent;
-    constraint->First = geoId;
-    constraint->FirstPos = Sketcher::PointPos::none;
-    constraint->Second = geoIdInnerCircle;
-    constraint->SecondPos = Sketcher::PointPos::none;
+    constraint->First_Deprecated = geoId;
+    constraint->FirstPos_Deprecated = Sketcher::PointPos::none;
+    constraint->Second_Deprecated = geoIdInnerCircle;
+    constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
     getObject()->addConstraint(constraint);
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Tangent), 1);
 
@@ -883,8 +883,8 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnUnrelatedTangent)
         &Sketcher::Constraint::Type
     );
     EXPECT_NE(tangIt, constraints.end());
-    EXPECT_EQ((*tangIt)->FirstPos, Sketcher::PointPos::none);
-    EXPECT_EQ((*tangIt)->SecondPos, Sketcher::PointPos::none);
+    EXPECT_EQ((*tangIt)->FirstPos_Deprecated, Sketcher::PointPos::none);
+    EXPECT_EQ((*tangIt)->SecondPos_Deprecated, Sketcher::PointPos::none);
 }
 
 // TODO: Ensure endpoint constraints go to the appropriate new geometry
@@ -1187,10 +1187,10 @@ TEST_F(SketchObjectTest, testJoinCurvesWhenTangent)
     // Add end-to-end tangent between these
     auto constraint = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constraint->Type = Sketcher::ConstraintType::Tangent;
-    constraint->First = geoId1;
-    constraint->FirstPos = Sketcher::PointPos::start;
-    constraint->Second = geoId2;
-    constraint->SecondPos = Sketcher::PointPos::start;
+    constraint->First_Deprecated = geoId1;
+    constraint->FirstPos_Deprecated = Sketcher::PointPos::start;
+    constraint->Second_Deprecated = geoId2;
+    constraint->SecondPos_Deprecated = Sketcher::PointPos::start;
     getObject()->addConstraint(constraint);
 
     // Act

--- a/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
@@ -877,8 +877,8 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnUnrelatedTangent)
         &Sketcher::Constraint::Type
     );
     EXPECT_NE(tangIt, constraints.end());
-    EXPECT_EQ((*tangIt)->FirstPos_Deprecated, Sketcher::PointPos::none);
-    EXPECT_EQ((*tangIt)->SecondPos_Deprecated, Sketcher::PointPos::none);
+    EXPECT_EQ((*tangIt)->getPosId(0), Sketcher::PointPos::none);
+    EXPECT_EQ((*tangIt)->getPosId(1), Sketcher::PointPos::none);
 }
 
 // TODO: Ensure endpoint constraints go to the appropriate new geometry

--- a/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
+++ b/tests/src/Mod/Sketcher/App/SketchObjectChanges.cpp
@@ -789,8 +789,7 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnFullLengthConstraints)
     int geoId = getObject()->addGeometry(&lineSeg);
     auto constr = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constr->Type = Sketcher::ConstraintType::Distance;
-    constr->First_Deprecated = geoId;
-    constr->FirstPos_Deprecated = Sketcher::PointPos::none;
+    constr->setElement(0, GeoElementId(geoId, Sketcher::PointPos::none));
     constr->setValue((getObject()->getPoint(geoId, Sketcher::PointPos::end)
                       - getObject()->getPoint(geoId, Sketcher::PointPos::start))
                          .Length());
@@ -824,12 +823,9 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnSymmetricConstraints)
     int geoId = getObject()->addGeometry(&lineSeg);
     auto constr = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constr->Type = Sketcher::ConstraintType::Symmetric;
-    constr->First_Deprecated = geoId;
-    constr->FirstPos_Deprecated = Sketcher::PointPos::start;
-    constr->Second_Deprecated = geoId;
-    constr->SecondPos_Deprecated = Sketcher::PointPos::end;
-    constr->Third_Deprecated = geoIdOfCutting;
-    constr->ThirdPos_Deprecated = Sketcher::PointPos::start;
+    constr->setElement(0, GeoElementId(geoId, Sketcher::PointPos::start));
+    constr->setElement(1, GeoElementId(geoId, Sketcher::PointPos::end));
+    constr->setElement(2, GeoElementId(geoIdOfCutting, Sketcher::PointPos::start));
     getObject()->addConstraint(constr);
 
     // Assert
@@ -863,10 +859,8 @@ TEST_F(SketchObjectTest, testTrimEndEffectOnUnrelatedTangent)
     // TODO: add tangent and confirm
     auto constraint = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constraint->Type = Sketcher::ConstraintType::Tangent;
-    constraint->First_Deprecated = geoId;
-    constraint->FirstPos_Deprecated = Sketcher::PointPos::none;
-    constraint->Second_Deprecated = geoIdInnerCircle;
-    constraint->SecondPos_Deprecated = Sketcher::PointPos::none;
+    constraint->setElement(0, GeoElementId(geoId, Sketcher::PointPos::none));
+    constraint->setElement(1, GeoElementId(geoIdInnerCircle, Sketcher::PointPos::none));
     getObject()->addConstraint(constraint);
     EXPECT_EQ(countConstraintsOfType(getObject(), Sketcher::ConstraintType::Tangent), 1);
 
@@ -1187,10 +1181,8 @@ TEST_F(SketchObjectTest, testJoinCurvesWhenTangent)
     // Add end-to-end tangent between these
     auto constraint = new Sketcher::Constraint();  // Ownership will be transferred to the sketch
     constraint->Type = Sketcher::ConstraintType::Tangent;
-    constraint->First_Deprecated = geoId1;
-    constraint->FirstPos_Deprecated = Sketcher::PointPos::start;
-    constraint->Second_Deprecated = geoId2;
-    constraint->SecondPos_Deprecated = Sketcher::PointPos::start;
+    constraint->setElement(0, GeoElementId(geoId1, Sketcher::PointPos::start));
+    constraint->setElement(1, GeoElementId(geoId2, Sketcher::PointPos::start));
     getObject()->addConstraint(constraint);
 
     // Act


### PR DESCRIPTION
As promised in https://github.com/FreeCAD/FreeCAD/pull/22088#issuecomment-3014337484 (though a bit late), this removes all cases of `First/Second/Third` and `FirstPos/SecondPos/ThirdPos` in favor for using `get/setElement`, `get/setGeoId` etc.

I've renamed the old symbols to have a suffix of `_Deprecated`, as this will:
1. Make it obvious that we will remove this soon
2. Make it easier to rebase work that still uses these symbols (just add `_Deprecated` and I can clean it up again).

The bulk of the work has been done using `clang-rename` and regex to avoid human or ai errors.
There are some fixes that had to be done by hand, but it was quite straight forward and should be easy to review.

The used regex are available in the commit messages.

I recommend reviewing the PR commit-by-commit