### PR TITLE
BIM: handle IfcLogical material layer import

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_selftest.py
+++ b/src/Mod/BIM/nativeifc/ifc_selftest.py
@@ -341,6 +341,60 @@ class NativeIFCTest(unittest.TestCase):
         mats_after = ifcfile.by_type("IfcMaterialDefinition")
         self.assertTrue(len(mats_after) == len(mats_before) + 1, "Materials failed")
 
+    def test13b_MaterialLayerLogical(self):
+        FreeCAD.Console.PrintMessage("NativeIFC 13b: Material layer logical values...")
+        clearObjects()
+        proj = ifc_tools.create_document(FreeCAD.getDocument("IfcTest"), silent=True)
+        ifcfile = ifc_tools.get_ifcfile(proj)
+        material_set = ifc_tools.api_run(
+            "material.add_material_set",
+            ifcfile,
+            name="Layer Set",
+            set_type="IfcMaterialLayerSet",
+        )
+        material = ifc_tools.api_run("material.add_material", ifcfile, name="Layer Material")
+        layer_unknown = ifc_tools.api_run(
+            "material.add_layer",
+            ifcfile,
+            layer_set=material_set,
+            material=material,
+            name="Unknown Layer",
+        )
+        ifc_tools.api_run(
+            "material.edit_layer",
+            ifcfile,
+            layer=layer_unknown,
+            attributes={"LayerThickness": 42, "IsVentilated": "UNKNOWN"},
+        )
+        layer_true = ifc_tools.api_run(
+            "material.add_layer",
+            ifcfile,
+            layer_set=material_set,
+            material=material,
+            name="True Layer",
+        )
+        ifc_tools.api_run(
+            "material.edit_layer",
+            ifcfile,
+            layer=layer_true,
+            attributes={"LayerThickness": 21, "IsVentilated": True},
+        )
+        ifc_materials.create_material(material_set, proj, recursive=True)
+        layer_unknown_obj = ifc_tools.get_object(layer_unknown, FreeCAD.getDocument("IfcTest"))
+        layer_true_obj = ifc_tools.get_object(layer_true, FreeCAD.getDocument("IfcTest"))
+        self.assertTrue(layer_unknown_obj is not None, "Logical UNKNOWN layer import failed")
+        self.assertTrue(layer_true_obj is not None, "Logical TRUE layer import failed")
+        self.assertTrue(
+            layer_unknown_obj.getTypeIdOfProperty("IsVentilated") == "App::PropertyBool",
+            "Logical UNKNOWN type failed",
+        )
+        self.assertTrue(
+            layer_true_obj.getTypeIdOfProperty("IsVentilated") == "App::PropertyBool",
+            "Logical TRUE type failed",
+        )
+        self.assertTrue(layer_unknown_obj.IsVentilated is False, "Logical UNKNOWN value failed")
+        self.assertTrue(layer_true_obj.IsVentilated is True, "Logical TRUE value failed")
+
     def test14_Layers(self):
         FreeCAD.Console.PrintMessage("NativeIFC 14: Layers...")
         clearObjects()

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -643,7 +643,9 @@ def add_properties(obj, ifcfile=None, ifcentity=None, links=False, shapemode=0, 
         if short and attr not in ("Class", "StepId"):
             continue
         attr_def = next((a for a in attr_defs if a.name() == attr), None)
+        attr_type = str(attr_def.type_of_attribute()).lower() if attr_def else ""
         data_type = ifcopenshell.util.attribute.get_primitive_type(attr_def) if attr_def else None
+        is_logical = "<logical>" in attr_type
         if attr == "Class":
             # main enum property, not saved to file
             if attr not in obj.PropertiesList:
@@ -663,6 +665,18 @@ def add_properties(obj, ifcfile=None, ifcentity=None, links=False, shapemode=0, 
             obj.addProperty("App::PropertyDistance", attr, "IFC")
             if value:
                 setattr(obj, attr, value * (1 / get_scale(ifcfile)))
+        elif data_type == "boolean" or is_logical:
+            if attr not in obj.PropertiesList:
+                obj.addProperty("App::PropertyBool", attr, "IFC", locked=True)
+            if isinstance(value, str):
+                value = value.upper()
+            if value in (None, "", False, 0, "0", "FALSE", ".F.", "UNKNOWN"):
+                value = False
+            elif value in (True, 1, "1", "TRUE", ".T."):
+                value = True
+            else:
+                value = bool(value)
+            setattr(obj, attr, value)
         elif isinstance(value, int):
             if attr not in obj.PropertiesList:
                 obj.addProperty("App::PropertyInteger", attr, "IFC", locked=True)
@@ -673,15 +687,6 @@ def add_properties(obj, ifcfile=None, ifcentity=None, links=False, shapemode=0, 
             if attr not in obj.PropertiesList:
                 obj.addProperty("App::PropertyFloat", attr, "IFC", locked=True)
             setattr(obj, attr, value)
-        elif data_type == "boolean":
-            if attr not in obj.PropertiesList:
-                obj.addProperty("App::PropertyBool", attr, "IFC", locked=True)
-            if not value or value in ["UNKNOWN", "FALSE"]:
-                value = False
-            elif not isinstance(value, bool):
-                print("DEBUG: attempting to set boolean value:", attr, value)
-                value = bool(value)
-            setattr(obj, attr, value)  # will trigger error. TODO: Fix this
         elif isinstance(value, ifcopenshell.entity_instance):
             if links:
                 if attr not in obj.PropertiesList:


### PR DESCRIPTION
## Issues

Closes #28532

## Before and After Images

N/A

## Summary

- treat `IfcLogical` NativeIFC attributes as boolean-like before integer and enum handling
- fix the `IfcMaterialLayer.IsVentilated` import path that currently crashes through `get_enum_items()`
- add a NativeIFC self-test covering `UNKNOWN` and `True` `IsVentilated` values on material layers

## Verification

- `python3 -m py_compile src/Mod/BIM/nativeifc/ifc_tools.py src/Mod/BIM/nativeifc/ifc_selftest.py`
- `git diff --check`
- local `ifcopenshell==0.8.2` probe confirmed:
  - `IfcMaterialLayer.IsVentilated` reports `primitive_type == "enum"`
  - `get_enum_items()` raises `AttributeError`
  - `get_info()["IsVentilated"]` returns `"UNKNOWN"` and `True` for the two regression cases
- EC2 validation on `FreeCAD_weekly-2026.03.11-Linux-x86_64-py311.AppImage` with the reporter's `bonsai-wall_layers.ifc`:
  - baseline bundle reproduced the exact `get_enum_items()` traceback from #28532
  - baseline import loaded only `1` `IfcMaterialLayerSet`
  - patched bundle imported successfully with no exception
  - patched import loaded `3` `IfcMaterialLayerSet` objects and `9` `IfcMaterialLayer` objects
- confirmed the `3` loaded layer sets are the reachable wall-type-backed sets in the sample IFC (`#94`, `#1816`, `#2247`)
- ran focused NativeIFC regression `test13b_MaterialLayerLogical` successfully in the patched AppImage runtime
