### PR TITLE
App: Use stored cache in reload of export types

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1568,7 +1568,7 @@ void Application::retranslateExportTypes()
     std::erase_if(_mExportTypes, [](const FileTypeItem& item) {
         return item.translatable;
     });
-    for (const auto &cacheEntry : translatableExportTypeCache.getCache()) {
+    for (const auto &cacheEntry : cache) {
         addTranslatableExportType(cacheEntry.description, cacheEntry.extensions, cacheEntry.moduleName);
     }
 }


### PR DESCRIPTION
Fixes #28284 -- the whole point of line 1566 was to make a copy of the cache before I erased the translatable types. And then when I went to restore them, instead of using the saved copy, I used the now-cleared cache. Doh.