### PR TITLE
Fix: Dark theme no longer overrides tree view font size

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Dark/FreeCAD Dark.cfg
@@ -106,7 +106,6 @@
           <FCUInt Name="ThemeAccentColor3" Value="1434171135"/>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
-          <FCInt Name="FontSize" Value="11"/>
           <FCInt Name="ItemBackgroundPadding" Value="11"/>
           <FCUInt Name="TreeActiveColor" Value="899696639"/>
           <FCUInt Name="TreeEditColor" Value="1434171135"/>


### PR DESCRIPTION
##Summary
Removes the hardcoded FontSize value from the FreeCAD Dark theme 
preference pack. This value was overriding the user's tree view font 
size preference when switching to the dark theme.

## Issues
Fixes #28487

##Notes
I was unable to verify this fix on the unreleased dev build 
locally. The fix is based on the root cause identified in the issue 
comments by Syres916. The hardcoded FontSize line in the cfg file 
directly explains the reported behavior.