### PR TITLE
Measurement: Fix Part WB parts in Mass Properties

### DIFF
--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -259,13 +259,15 @@ TaskMassProperties::TaskMassProperties()
     unitsSchemaIndex
         = getUnitsSchemaIndex(panel->ui.unitsComboBox->currentIndex(), preferredSchemaIndex);
 
-    connect(panel->ui.unitsComboBox,
-            &QComboBox::currentIndexChanged,
-            this,
-            [this, preferredSchemaIndex](int index) {
-        unitsSchemaIndex = getUnitsSchemaIndex(index, preferredSchemaIndex);
-        update(Gui::SelectionChanges());
-    });
+    connect(
+        panel->ui.unitsComboBox,
+        &QComboBox::currentIndexChanged,
+        this,
+        [this, preferredSchemaIndex](int index) {
+            unitsSchemaIndex = getUnitsSchemaIndex(index, preferredSchemaIndex);
+            update(Gui::SelectionChanges());
+        }
+    );
 
     auto addTaskBox = [this](const char* icon, const QString& title, QWidget* page) {
         auto* box = new Gui::TaskView::TaskBox(Gui::BitmapFactory().pixmap(icon), title, true, nullptr);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
The Mass Properties module got added yesterday, but a small regression was found in the UI. Specifically for parts in the Part WB. This has been fixed here where the selection correctly gets changed. 

Also fixed some build warnings hyarion found


## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Previously it did not promote the selection when clicking on a part from Part WB

<img width="1357" height="770" alt="image" src="https://github.com/user-attachments/assets/137bf4e9-c463-4556-81cf-338f11bcea48" />

Super sorry for the oversight

