### PR TITLE
BIM: add insertion point cycling for column and beam placement

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -48,6 +48,7 @@ import DraftVecUtils
 from FreeCAD import Vector
 from draftutils import params
 from draftutils import gui_utils
+from draftutils import todo
 
 
 class StructureMode(enum.Enum):
@@ -67,6 +68,7 @@ if FreeCAD.GuiUp:
     import FreeCADGui
     import ArchPrecast
     import draftguitools.gui_trackers as DraftTrackers
+    import draftguitools.gui_tool_utils as DraftToolUtils
     from draftutils.translate import translate
 else:
     # \cond
@@ -320,6 +322,7 @@ class _CommandStructure:
         )
         FreeCADGui.draftToolBar.continueCmd.show()
         self._install_insertion_point_filter()
+        todo.delay(self.update_hints, None)
 
     def getPoint(self, point=None, obj=None):
         "this function is called by the snapper when it has a 3D point"
@@ -330,6 +333,7 @@ class _CommandStructure:
             FreeCADGui.Snapper.off()
             self.tracker.finalize()
             self._remove_insertion_point_filter()
+            todo.delay(FreeCADGui.HintManager.hide, None)
             return
         if self.mode == StructureMode.BEAM and (self.bpoint is None):
             self.bpoint = point
@@ -447,6 +451,7 @@ class _CommandStructure:
         # gui_utils.end_all_events()  # Causes a crash on Linux.
         self.tracker.finalize()
         self._remove_insertion_point_filter()
+        todo.delay(FreeCADGui.HintManager.hide, None)
         if FreeCADGui.draftToolBar.continueMode:
             self.Activated()
 
@@ -482,6 +487,7 @@ class _CommandStructure:
         grid.addWidget(labelmode, 0, 0, 1, 2)
         grid.addWidget(self.modeb, 1, 0, 1, 1)
         grid.addWidget(self.modec, 1, 1, 1, 1)
+        self.modec.toggled.connect(lambda checked: self.update_hints())
 
         # categories box
         labelc = QtGui.QLabel(translate("Arch", "Category"))
@@ -613,6 +619,32 @@ class _CommandStructure:
         if hasattr(self, "_insertion_point_filter"):
             QtGui.QApplication.instance().removeEventFilter(self._insertion_point_filter)
             del self._insertion_point_filter
+
+    def get_hints(self):
+        xyz = (
+            DraftToolUtils._get_hint_xyz_constrain()
+            + DraftToolUtils._get_hint_mod_constrain()
+            + DraftToolUtils._get_hint_mod_snap()
+        )
+        if hasattr(self, "modec") and self.modec.isChecked():
+            return [
+                FreeCADGui.InputHint(
+                    translate("Arch", "%1 insert column"),
+                    FreeCADGui.UserInput.MouseLeft,
+                ),
+                FreeCADGui.InputHint(
+                    translate("Arch", "%1 next insertion point / %2+%1 previous"),
+                    FreeCADGui.UserInput.KeyI,
+                    FreeCADGui.UserInput.KeyShift,
+                ),
+            ] + xyz
+
+    def update_hints(self):
+        hints = self.get_hints()
+        if hints:
+            FreeCADGui.HintManager.show(*hints)
+        else:
+            todo.delay(FreeCADGui.HintManager.hide, None)
 
     def update(self, point, info):
         "this function is called by the Snapper when the mouse is moved"

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -207,8 +207,42 @@ class CommandStructuralSystem:
                 )
 
 
+if FreeCAD.GuiUp:
+
+    class _CycleInsertionPointFilter(QtCore.QObject):
+        """Application-level Qt event filter that intercepts 'I' keypresses during
+        interactive column/beam placement to cycle the cross-section anchor point."""
+
+        def __init__(self, command):
+            super().__init__()
+            self._command = command
+
+        def eventFilter(self, watched, event):
+            if event.type() == QtCore.QEvent.KeyPress:
+                if event.text().upper() == "I":
+                    shift = bool(event.modifiers() & QtCore.Qt.ShiftModifier)
+                    self._command._cycle_insertion_point(shift)
+                    return True
+            return False
+
+
 class _CommandStructure:
     "the Arch Structure command definition"
+
+    # Nine (u, v) unit offsets for the cross-section insertion grid: center, four
+    # corners, four edge midpoints. Scale by the appropriate half-dimensions per
+    # element type. Cycling order: center first, then clockwise from bottom-right.
+    _INSERTION_POINT_OFFSETS = [
+        (0, 0),  # 0: center (default)
+        (1, -1),  # 1: bottom-right
+        (0, -1),  # 2: bottom-center
+        (-1, -1),  # 3: bottom-left
+        (-1, 0),  # 4: left-center
+        (-1, 1),  # 5: top-left
+        (0, 1),  # 6: top-center
+        (1, 1),  # 7: top-right
+        (1, 0),  # 8: right-center
+    ]
 
     def __init__(self):
 
@@ -269,6 +303,8 @@ class _CommandStructure:
         self.tracker.length(self.Length)
         self.tracker.setRotation(self.wp.get_placement().Rotation)
         self.tracker.on()
+        self._insertion_point_index = 0
+        self.last_point = None
         self.precast = ArchPrecast._PrecastTaskPanel()
         self.dents = ArchPrecast._DentsTaskPanel()
         self.precast.Dents = self.dents
@@ -283,6 +319,7 @@ class _CommandStructure:
             title=title,
         )
         FreeCADGui.draftToolBar.continueCmd.show()
+        self._install_insertion_point_filter()
 
     def getPoint(self, point=None, obj=None):
         "this function is called by the snapper when it has a 3D point"
@@ -292,6 +329,7 @@ class _CommandStructure:
             FreeCAD.activeDraftCommand = None
             FreeCADGui.Snapper.off()
             self.tracker.finalize()
+            self._remove_insertion_point_filter()
             return
         if self.mode == StructureMode.BEAM and (self.bpoint is None):
             self.bpoint = point
@@ -319,12 +357,14 @@ class _CommandStructure:
         if self.mode == StructureMode.BEAM:
             self.Length = point.sub(self.bpoint).Length
             params.set_param_arch("BeamLength", self.Length)
+        precast_used = False  # gates insertion point adjustment in the placement section below
         if self.Profile is not None:
             try:  # try to update latest precast values - fails if dialog has been destroyed already
                 self.precastvalues = self.precast.getValues()
             except Exception:
                 pass
             if ("Precast" in self.Profile) and self.precastvalues:
+                precast_used = True
                 # precast concrete
                 self.precastvalues["PrecastType"] = self.Profile.split("_")[1]
                 self.precastvalues["Length"] = self.Length
@@ -334,12 +374,16 @@ class _CommandStructure:
                 # fix for precast placement, since their (0,0) point is the lower left corner
                 if self.mode == StructureMode.BEAM:
                     delta = FreeCAD.Vector(0, 0 - self.Width / 2, 0)
+                    delta = self.wp.get_global_coords(delta, as_vector=True)
+                    point = point.add(delta)
+                    if self.bpoint:
+                        self.bpoint = self.bpoint.add(delta)
                 else:
-                    delta = FreeCAD.Vector(-self.Length / 2, -self.Width / 2, 0)
-                delta = self.wp.get_global_coords(delta, as_vector=True)
-                point = point.add(delta)
-                if self.bpoint:
-                    self.bpoint = self.bpoint.add(delta)
+                    # Precast origin is the lower-left corner, not the center
+                    anchor_world = self._get_column_insertion_anchor_world(
+                        Vector(-self.Length / 2, -self.Width / 2, 0)
+                    )
+                    point = point.sub(anchor_world)
                 # build the string definition
                 for pair in self.precastvalues.items():
                     argstring += pair[0].lower() + "="
@@ -387,6 +431,9 @@ class _CommandStructure:
                 + ")"
             )
         else:
+            if not precast_used:
+                anchor_world = self._get_column_insertion_anchor_world()
+                point = point.sub(anchor_world)
             FreeCADGui.doCommand("s.Placement.Base = " + DraftVecUtils.toString(point))
             FreeCADGui.doCommand("wp = WorkingPlane.get_working_plane()")
             FreeCADGui.doCommand(
@@ -399,6 +446,7 @@ class _CommandStructure:
         self.doc.recompute()
         # gui_utils.end_all_events()  # Causes a crash on Linux.
         self.tracker.finalize()
+        self._remove_insertion_point_filter()
         if FreeCADGui.draftToolBar.continueMode:
             self.Activated()
 
@@ -510,6 +558,62 @@ class _CommandStructure:
                             self.vPresets.setCurrentIndex(ps.index(stored[2]))
         return w
 
+    def _get_column_insertion_anchor_local(self):
+        """Return the current insertion-point anchor as a Vector in working plane local
+        frame, relative to the box tracker center. Nine candidates on the
+        insertion (bottom) face: center, four corners, four edge midpoints."""
+        half_length = self.Length / 2
+        half_width = self.Width / 2
+        bottom_face_z = -self.Height / 2
+        u, v = self._INSERTION_POINT_OFFSETS[
+            self._insertion_point_index % len(self._INSERTION_POINT_OFFSETS)
+        ]
+        return Vector(u * half_length, v * half_width, bottom_face_z)
+
+    def _get_column_insertion_anchor_world(self, element_origin_local=None):
+        """Return the current insertion point anchor for a column as a world-space offset.
+
+        Computes the offset between the anchor and the element's geometric origin, so that
+        subtracting the result from the cursor point places the element with the anchor aligned to
+        the cursor.
+
+        Parameters
+        ----------
+        element_origin_local : FreeCAD.Vector, optional
+            The element's geometric origin in working plane local coordinates, relative to the
+            cross-section center. Defaults to the center (0, 0, 0). Pass Vector(-Length/2, -Width/2,
+            0) for precast elements, whose geometry is built from the lower-left corner rather than
+            the center.
+
+        Returns
+        -------
+        FreeCAD.Vector
+            Anchor offset in world coordinates, to be subtracted from the cursor point to align the
+            selected cross-section point with the cursor.
+        """
+        anchor_local = self._get_column_insertion_anchor_local()
+        origin_x = element_origin_local.x if element_origin_local else 0
+        origin_y = element_origin_local.y if element_origin_local else 0
+        net_offset_local = Vector(anchor_local.x - origin_x, anchor_local.y - origin_y, 0)
+        return self.wp.get_global_coords(net_offset_local, as_vector=True)
+
+    def _cycle_insertion_point(self, reverse=False):
+        """Advance (or reverse) the insertion-point index and refresh the tracker."""
+        self._insertion_point_index += -1 if reverse else 1
+        if self.last_point is not None:
+            self.update(self.last_point, None)
+
+    def _install_insertion_point_filter(self):
+        """Install the application-level keyboard filter for insertion-point cycling."""
+        self._insertion_point_filter = _CycleInsertionPointFilter(self)
+        QtGui.QApplication.instance().installEventFilter(self._insertion_point_filter)
+
+    def _remove_insertion_point_filter(self):
+        """Remove the insertion-point keyboard filter (idempotent)."""
+        if hasattr(self, "_insertion_point_filter"):
+            QtGui.QApplication.instance().removeEventFilter(self._insertion_point_filter)
+            del self._insertion_point_filter
+
     def update(self, point, info):
         "this function is called by the Snapper when the mouse is moved"
 
@@ -518,13 +622,12 @@ class _CommandStructure:
                 self.precastvalues = self.precast.getValues()
             except Exception:
                 pass
-            if self.Height >= self.Length:
-                delta = Vector(0, 0, self.Height / 2)
-            else:
-                delta = Vector(self.Length / 2, 0, 0)
-            delta = self.wp.get_global_coords(delta, as_vector=True)
-            if self.mode == StructureMode.COLUMN:
-                self.tracker.pos(point.add(delta))
+            self.last_point = point
+            if self.modec.isChecked():
+                anchor = self.wp.get_global_coords(
+                    self._get_column_insertion_anchor_local(), as_vector=True
+                )
+                self.tracker.pos(point.sub(anchor))
                 self.tracker.on()
             else:
                 if self.bpoint:

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -342,6 +342,7 @@ class _CommandStructure:
             self.precast = ArchPrecast._PrecastTaskPanel()
             self.dents = ArchPrecast._DentsTaskPanel()
             self.precast.Dents = self.dents
+            todo.delay(self.update_hints, None)
             FreeCADGui.Snapper.getPoint(
                 last=point,
                 callback=self.getPoint,
@@ -492,6 +493,7 @@ class _CommandStructure:
         grid.addWidget(self.modeb, 1, 0, 1, 1)
         grid.addWidget(self.modec, 1, 1, 1, 1)
         self.modec.toggled.connect(lambda checked: self.update_hints())
+        self.modeb.toggled.connect(lambda checked: self.update_hints())
 
         # categories box
         labelc = QtGui.QLabel(translate("Arch", "Category"))
@@ -689,6 +691,24 @@ class _CommandStructure:
                     FreeCADGui.UserInput.KeyShift,
                 ),
             ] + xyz
+        if self.bpoint:
+            return [
+                FreeCADGui.InputHint(
+                    translate("Arch", "%1 insert beam"),
+                    FreeCADGui.UserInput.MouseLeft,
+                ),
+                FreeCADGui.InputHint(
+                    translate("Arch", "%1 next insertion point / %2+%1 previous"),
+                    FreeCADGui.UserInput.KeyI,
+                    FreeCADGui.UserInput.KeyShift,
+                ),
+            ] + xyz
+        return [
+            FreeCADGui.InputHint(
+                translate("Arch", "%1 pick first point of beam"),
+                FreeCADGui.UserInput.MouseLeft,
+            ),
+        ] + xyz
 
     def update_hints(self):
         hints = self.get_hints()

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -375,15 +375,13 @@ class _CommandStructure:
                 self.precastvalues["Width"] = self.Width
                 self.precastvalues["Height"] = self.Height
                 argstring = ""
-                # fix for precast placement, since their (0,0) point is the lower left corner
-                if self.mode == StructureMode.BEAM:
-                    delta = FreeCAD.Vector(0, 0 - self.Width / 2, 0)
-                    delta = self.wp.get_global_coords(delta, as_vector=True)
-                    point = point.add(delta)
+                # Precast beams/columns have a lower-left corner origin, not center.
+                if self.modeb.isChecked():
+                    anchor_world = self._get_beam_insertion_anchor_world(self.bpoint, point)
+                    point = point.sub(anchor_world)
                     if self.bpoint:
-                        self.bpoint = self.bpoint.add(delta)
+                        self.bpoint = self.bpoint.sub(anchor_world)
                 else:
-                    # Precast origin is the lower-left corner, not the center
                     anchor_world = self._get_column_insertion_anchor_world(
                         Vector(-self.Length / 2, -self.Width / 2, 0)
                     )
@@ -424,12 +422,18 @@ class _CommandStructure:
             )
 
         # calculate rotation
-        if self.mode == StructureMode.BEAM and self.bpoint:
+        if self.modeb.isChecked() and self.bpoint:
+            beam_start = self.bpoint
+            beam_end = point
+            if not precast_used:
+                anchor_world = self._get_beam_insertion_anchor_world(beam_start, beam_end)
+                beam_start = beam_start.sub(anchor_world)
+                beam_end = beam_end.sub(anchor_world)
             FreeCADGui.doCommand(
                 "s.Placement = Arch.placeAlongEdge("
-                + DraftVecUtils.toString(self.bpoint)
+                + DraftVecUtils.toString(beam_start)
                 + ","
-                + DraftVecUtils.toString(point)
+                + DraftVecUtils.toString(beam_end)
                 + ","
                 + str(horiz)
                 + ")"
@@ -603,6 +607,53 @@ class _CommandStructure:
         net_offset_local = Vector(anchor_local.x - origin_x, anchor_local.y - origin_y, 0)
         return self.wp.get_global_coords(net_offset_local, as_vector=True)
 
+    def _get_beam_insertion_anchor_world(self, beam_start, beam_end):
+        """Return the current insertion-point anchor for a beam as a world-space offset.
+
+        The anchor lies in the cross-section plane (perpendicular to the span). The width
+        offset runs along the cross-section's horizontal axis (wp_normal x span); the height
+        offset runs along the cross-section's vertical axis (span x cross-section-horizontal).
+        Both axes tilt with the span, so the anchor stays on an actual edge or corner of the
+        cross-section for tilted beams.
+
+        Parameters
+        ----------
+        beam_start : FreeCAD.Vector
+            Start point of the beam in world coordinates.
+        beam_end : FreeCAD.Vector
+            End point of the beam in world coordinates.
+
+        Returns
+        -------
+        FreeCAD.Vector
+            Anchor offset in world coordinates, to be subtracted from beam
+            endpoints to align the selected cross-section point with the cursor.
+        """
+        span = beam_end.sub(beam_start)
+        if span.Length == 0:
+            return Vector(0, 0, 0)
+        span_dir = Vector(span)
+        span_dir.normalize()
+        cross_section_horizontal = self.wp.axis.cross(span_dir)
+        if cross_section_horizontal.Length == 0:
+            # Span parallel to WP normal: cross-section frame is degenerate.
+            return Vector(0, 0, 0)
+        cross_section_horizontal.normalize()
+        cross_section_vertical = span_dir.cross(cross_section_horizontal)
+
+        half_width = self.Width / 2
+        half_height = self.Height / 2
+        u, v = self._INSERTION_POINT_OFFSETS[
+            self._insertion_point_index % len(self._INSERTION_POINT_OFFSETS)
+        ]
+        width_offset = u * half_width
+        height_offset = v * half_height
+        return Vector(
+            width_offset * cross_section_horizontal.x + height_offset * cross_section_vertical.x,
+            width_offset * cross_section_horizontal.y + height_offset * cross_section_vertical.y,
+            width_offset * cross_section_horizontal.z + height_offset * cross_section_vertical.z,
+        )
+
     def _cycle_insertion_point(self, reverse=False):
         """Advance (or reverse) the insertion-point index and refresh the tracker."""
         self._insertion_point_index += -1 if reverse else 1
@@ -663,12 +714,23 @@ class _CommandStructure:
                 self.tracker.on()
             else:
                 if self.bpoint:
-                    delta = Vector(0, 0, -self.Height / 2)
-                    delta = self.wp.get_global_coords(delta, as_vector=True)
+                    anchor_world = self._get_beam_insertion_anchor_world(self.bpoint, point)
+                    # Tracker cube center lands at midpoint(p1,p2) + (Height/2) * wp_normal.
+                    # We want cube center = midpoint - anchor_world, so shift both endpoints
+                    # by delta = -anchor_world - (Height/2) * wp_normal.
+                    half_height_normal = Vector(self.wp.axis)
+                    half_height_normal.multiply(self.Height / 2)
+                    delta = Vector(
+                        -anchor_world.x - half_height_normal.x,
+                        -anchor_world.y - half_height_normal.y,
+                        -anchor_world.z - half_height_normal.z,
+                    )
                     self.tracker.update([self.bpoint.add(delta), point.add(delta)])
                     self.tracker.on()
-                    l = (point.sub(self.bpoint)).Length
-                    self.vLength.setText(FreeCAD.Units.Quantity(l, FreeCAD.Units.Length).UserString)
+                    beam_span = (point.sub(self.bpoint)).Length
+                    self.vLength.setText(
+                        FreeCAD.Units.Quantity(beam_span, FreeCAD.Units.Length).UserString
+                    )
                 else:
                     self.tracker.off()
 


### PR DESCRIPTION
When placing columns or beams, the cursor previously always snapped to the center of the bottom cross-section. For instance, to align the corner or midpoint of a column with another object, the user had to place the column in two stages: 1) create the column 2) adjust the column's placement. This quickly becomes ineffective, even after a few column and beam insertions.

This PR adds insertion point cycling for a more effective workflow: pressing the <kbd>I</kbd> key during placement cycles through nine candidates on the cross-section (center, four corners, four edge midpoints); <kbd>Shift</kbd>+<kbd>I</kbd> reverses. The preview and final placement shift so the chosen point tracks the cursor, removing the need for post-placement corrections.

https://github.com/user-attachments/assets/a615e2fc-7a63-49e7-8a21-55c5f658c1b0

_The video illustrates how pressing <kbd>I</kbd> to select the next insertion point (or <kbd>Shift</kbd>+<kbd>I</kbd> for previous) offers direct control of the insertion point when clicking. The status bar hints explain this for discoverability._

For beams the anchor candidates rotate with the beam axis, so the cross-section orientation stays consistent regardless of beam direction.

Both standard and precast elements are supported in both modes. The fact that precast elements have a different behavior (their anchor point is the lower left corner instead of the cross-section's center point) predates this PR.

Status bar hints are shown during placement to make the <kbd>I</kbd> and <kbd>Shift</kbd>+<kbd>I</kbd> shortcuts discoverable.

## Known issues

The installed Qt key filter is application-wide for the duration of the column/beam creation session, also intercepting `I`/`Shift`+`I` on the task panel and everywhere else. A further iteration could make the filter more selective.

The initial implementation of this PR touched the `placeAlongEdge` function, but that approach was discarded. During testing, it was found that that method places beam-based profiles flipped 180° degrees from their profile footprint. That does not matter for symmetrical profiles, but it might do (depending on the convention of what is the correct orientation) for symmetrical profiles. This could be fixed by rearranging the rotation arguments, which would also remove the need for an additional corrective 90° post-rotation present in the code. However, this change was not included in the scope of this PR. 

## Additional notes

If extended to window placement, this could be a potential solution for https://github.com/FreeCAD/FreeCAD/issues/19552