### PR TITLE
Release 1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ project(FreeCAD)
 set(PACKAGE_VERSION_MAJOR "1")
 set(PACKAGE_VERSION_MINOR "1")
 set(PACKAGE_VERSION_PATCH "0") # number of patch release (e.g. "4" for the 0.18.4 release)
-set(PACKAGE_VERSION_SUFFIX "rc3") # either "dev" for development snapshot or "" (empty string)
+set(PACKAGE_VERSION_SUFFIX "") # either "dev" for development snapshot or "" (empty string)
 set(PACKAGE_BUILD_VERSION "0") # used when the same FreeCAD version will be re-released (for example using an updated LibPack)
 string(TIMESTAMP PACKAGE_COPYRIGHT_YEAR "%Y")
 

--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -16,7 +16,7 @@
 
 Name:           freecad
 Epoch:          1
-Version:        1.1.0~rc3
+Version:        1.1.0
 Release:        1%{?dist}
 
 Summary:        A general purpose 3D CAD modeler

--- a/package/rattler-build/pixi.lock
+++ b/package/rattler-build/pixi.lock
@@ -4221,7 +4221,7 @@ packages:
   timestamp: 1765632825351
 - conda: .
   name: freecad
-  version: 1.1.0rc3
+  version: 1.1.0
   build: h3c70cbc_0
   subdir: win-64
   variants:
@@ -4282,7 +4282,7 @@ packages:
   - tbb >=2022.3.0
 - conda: .
   name: freecad
-  version: 1.1.0rc3
+  version: 1.1.0
   build: h6d4d2f9_0
   subdir: linux-aarch64
   variants:
@@ -4344,7 +4344,7 @@ packages:
   - yaml-cpp >=0.8.0,<0.9.0a0
 - conda: .
   name: freecad
-  version: 1.1.0rc3
+  version: 1.1.0
   build: h81b34b9_0
   subdir: linux-64
   variants:
@@ -4407,7 +4407,7 @@ packages:
   - yaml-cpp >=0.8.0,<0.9.0a0
 - conda: .
   name: freecad
-  version: 1.1.0rc3
+  version: 1.1.0
   build: he0f4bc8_0
   subdir: osx-64
   variants:
@@ -4466,7 +4466,7 @@ packages:
   - yaml-cpp >=0.8.0,<0.9.0a0
 - conda: .
   name: freecad
-  version: 1.1.0rc3
+  version: 1.1.0
   build: he8ea13f_0
   subdir: osx-arm64
   variants:

--- a/package/rattler-build/pixi.toml
+++ b/package/rattler-build/pixi.toml
@@ -9,7 +9,7 @@ preview = ["pixi-build"]
 
 [package]
 name = "freecad"
-version = "1.1.0rc3"
+version = "1.1.0"
 homepage = "https://freecad.org"
 repository = "https://github.com/FreeCAD/FreeCAD"
 description = "FreeCAD"

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.1.0rc3"
+  version: "1.1.0"
 
 package:
   name: freecad


### PR DESCRIPTION
I am also removing opencv package from the release due to #22570, opencv is not used by freecad itself so for the time being addons that need it are better off requiring the user to install