### PR TITLE
Gui: Navi Cube - Double click to "home to face"

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1200,8 +1200,7 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
         if (m_Faces[pickId].type == ShapeId::Main || m_Faces[pickId].type == ShapeId::Edge
             || m_Faces[pickId].type == ShapeId::Corner) {
             // Detect double-click: same face clicked twice within the system double-click interval
-            bool isDoubleClick = m_ClickTimer.isValid()
-                && m_LastClickPickId == pickId
+            bool isDoubleClick = m_ClickTimer.isValid() && m_LastClickPickId == pickId
                 && m_ClickTimer.elapsed() < QApplication::doubleClickInterval();
 
             // Handle the cube faces


### PR DESCRIPTION
When clicking on a face, the view will rotate to the face.  However, if not already centered on the part, rotation to the face doesn't do much value.

Double clicking the face now rotates to the face, but also will home your screen to center the view.

This video shows an example of the view offset from the part and double clicking on the face of the navigation cube homing back to that face.
![Screen Recording 2026-03-24 at 1 58 41 PM](https://github.com/user-attachments/assets/2127d072-2201-455b-bf62-b24ab33a2928)