### PR TITLE
CAM: Fix pocket cut depth by setting OCC tolerance

### DIFF
--- a/src/Mod/CAM/App/Area.cpp
+++ b/src/Mod/CAM/App/Area.cpp
@@ -73,7 +73,6 @@
 #include <Base/Tools.h>
 #include <Mod/Part/App/CrossSection.h>
 #include <Mod/Part/App/FaceMakerBullseye.h>
-#include <Mod/Part/App/FCBRepAlgoAPI_Cut.h>
 #include <Mod/Part/App/FuzzyHelper.h>
 #include <Mod/Part/App/PartFeature.h>
 #include <Mod/CAM/App/PathSegmentWalker.h>
@@ -1722,7 +1721,6 @@ std::vector<shared_ptr<Area>> Area::makeSections(
     const TopoDS_Shape& section_plane
 )
 {
-    FC_LOG_INSTANCE.lvl = 5;
     TopoDS_Shape plane;
     gp_Trsf trsf;
 
@@ -1943,28 +1941,7 @@ std::vector<shared_ptr<Area>> Area::makeSections(
                         // This fix might be better to move into Part::CrossSection but it is kept
                         // here for now to be on the safe side.
                         wires = section.slice(-d);
-
-                        {
-                            AREA_TRACE("a " << a << " b " << b << " c " << c << " d " << d);
-                            gp_Pln slicePlane(a, b, c, d);
-                            BRepBuilderAPI_MakeFace mkFace(slicePlane);
-                            TopoDS_Face face = mkFace.Face();
-                            showShape(face, nullptr, "section_%zu_plane", i);
-
-                            gp_Vec tempVector(a, b, c);
-                            tempVector.Normalize();  // just in case.
-                            tempVector *= (d + 1.0);
-                            gp_Pnt refPoint(0.0, 0.0, 0.0);
-                            refPoint.Translate(tempVector);
-                            AREA_TRACE("ref z " << refPoint.Z());
-
-                            BRepPrimAPI_MakeHalfSpace mkSolid(face, refPoint);
-                            TopoDS_Solid solid = mkSolid.Solid();
-                            FCBRepAlgoAPI_Cut mkCut(shape, solid);
-                            showShape(mkCut.Shape(), nullptr, "section_%zu_aftercut", i);
-                        }
                     });
-
                     showShapes(wires, nullptr, "section_%zu_wire", i);
                     if (wires.empty()) {
                         AREA_LOG("Section returns no wires");
@@ -2044,7 +2021,6 @@ std::vector<shared_ptr<Area>> Area::makeSections(
         }
     }
     FC_TIME_LOG(t, "makeSection count: " << sections.size() << ", total");
-    FC_LOG_INSTANCE.lvl = -1;
     return sections;
 }
 

--- a/src/Mod/CAM/Path/Op/Area.py
+++ b/src/Mod/CAM/Path/Op/Area.py
@@ -284,11 +284,6 @@ class ObjectOp(PathOp.ObjectOp):
         sections = area.makeSections(mode=0, project=self.areaOpUseProjection(obj), heights=heights)
         Path.Log.debug("sections = %s" % sections)
 
-        print()
-        for o in obj.Document.Objects:
-            if o.Name.startswith("section_"):
-                print("{:20} \t {}".format(o.Name, o.Shape.BoundBox))
-
         # Rest machining
         self.sectionShapes = self.sectionShapes + [section.toTopoShape() for section in sections]
         if hasattr(obj, "UseRestMachining") and obj.UseRestMachining:
@@ -366,10 +361,7 @@ class ObjectOp(PathOp.ObjectOp):
         obj.PathParams = str({key: value for key, value in pathParams.items() if key != "shapes"})
         Path.Log.debug("Path with params: {}".format(obj.PathParams))
 
-        print(FreeCAD.getLogLevel("Path.Area"))
-        FreeCAD.setLogLevel("Path.Area", 5)
         (pp, end_vector) = Path.fromShapes(**pathParams)
-        FreeCAD.setLogLevel("Path.Area", -1)
         Path.Log.debug("pp: {}, end vector: {}".format(pp, end_vector))
 
         # Keep track of this segment's end only if it has movement (otherwise end_vector is 0,0,0 and the next segment will unnecessarily start there)


### PR DESCRIPTION
Fixes #28534 
Fixes #10022 

@tarman3 

The final stepdown of pockets sometimes fails to generate because OCC doesn't return any wires for that slice. This PR fixes the tolerance settings on the inputs to OCC to make it return the expected slice.

Tested against #28534 "truncated pocket" model and #10022 "discard empty selection" model.

That was a full day of work to produce a 4 line patch :joy:. But I learned some OCC along the way. Tl;dr:

- OCC has tolerance parameters set on vertices, edges, and faces
- The familiar Precision::Confusion() is the standard tolerance for points
- Edges typically have a fuzzier tolerance, and faces even more so
- Algorithms operating on geometry may update the tolerance. This is why this bug only hits us sometimes, (presumably) when the tolerance on our input geometry is unusually bad
- Boolean operations return a different result based on the tolerance of their inputs. This is an intended feature ([blog post](https://dev.opencascade.org/content/fuzzy-boolean-operations) on related "fuzziness" feature), designed to remove thin features/make the output nice. But it also breaks our slicer
- You can update the tolerance of OCC geometry to prevent this; see this PR's diff