### PR TITLE
Sketcher: Fix Text tool shortcut conflicting with Trim Edge (G,T)

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1377,7 +1377,7 @@ CmdSketcherCreateText::CmdSketcherCreateText()
     sWhatsThis = "Sketcher_CreateText";
     sStatusTip = sToolTipText;
     sPixmap = "Sketcher_CreateText";
-    sAccel = "G, T";
+    sAccel = "G, D";
     eType = ForEdit;
 }
 


### PR DESCRIPTION
## Problem
The newly added `Sketcher_CreateText` tool was assigned the shortcut `G, T`, which conflicts with the established `Sketcher_Trimming` / `Sketcher_CompCurveEdition` shortcut. This causes the Text tool to hijack the Trim Edge shortcut.

## Fix
Change the Text tool shortcut from `G, T` to `G, D` (mnemonic: **D**raw text). The `G, D` combination is not used by any other Sketcher command.

## Testing
1. Edit a sketch
2. Press `G, T` → Trim Edge tool activates (as expected)
3. Press `G, D` → Text tool activates

Fixes #28599