### PR TITLE
Draft: Exclude selected groups/layers from AddToGroup target list

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_groups.py
+++ b/src/Mod/Draft/draftguitools/gui_groups.py
@@ -89,8 +89,7 @@ class AddToGroup(gui_base.GuiCommandNeedsSelection):
 
         self.ui = Gui.draftToolBar
         sel = Gui.Selection.getSelection()
-        objs = [obj for obj in self.doc.Objects
-                if groups.is_group(obj) and obj not in sel]
+        objs = [obj for obj in self.doc.Objects if groups.is_group(obj) and obj not in sel]
         objs.sort(key=lambda obj: obj.Label)
         self.objects = [None] + [None] + objs
         self.labels = (


### PR DESCRIPTION
Fixes #28476

Draft_AddToGroup currently lists all groups in the document as potential targets, including groups that are themselves selected. This allows a group to be added to itself.

Fix: filter out selected objects from the target group list in AddToGroup.Activated().