### PR TITLE
Draft: Lazy-import Mesh in importDXF to fix undeclared dependency

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -1243,6 +1243,7 @@ def drawMesh(mesh, forceShape=False):
                 md.append([p1, p3, p4])
     try:
         import Mesh
+
         m = Mesh.Mesh(md)
         if forceShape:
             s = Part.Shape()


### PR DESCRIPTION
Fixes #27738

`importDXF.py` unconditionally imports `Mesh` at module level, but `Mesh` is not declared as a dependency of `Draft` in `CheckIntermoduleDependencies.cmake`. This means FreeCAD can be built with Draft but without Mesh, and importing a DXF will fail even for non-mesh features.

**Fix:** Move `import Mesh` from module-level (line 62) to a lazy import inside the only function that uses it (the 3dface mesh construction block around line 1246). All other DXF import functionality works without the Mesh module.