### PR TITLE
Sketcher: Default 'Create symmetry constraints' to checked in Mirror tool

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
@@ -77,7 +77,7 @@ public:
         , refGeoId(Sketcher::GeoEnum::GeoUndef)
         , refPosId(Sketcher::PointPos::none)
         , deleteOriginal(false)
-        , createSymConstraints(false)
+        , createSymConstraints(true)
     {}
 
     DrawSketchHandlerSymmetry(const DrawSketchHandlerSymmetry&) = delete;
@@ -299,6 +299,7 @@ void DSHSymmetryController::configureToolWidget()
                 "Create symmetry constraints between the original and mirrored geometries"
             )
         );
+        toolWidget->setCheckboxChecked(WCheckbox::SecondBox, true);
     }
 }
 


### PR DESCRIPTION
Fixes #28267

The Mirror/Symmetry tool's 'Create symmetry constraints' checkbox now defaults to checked, so mirrored geometry is constrained symmetrically by default.

Previously, mirrored geometry was loose by default — users had to manually enable the constraint checkbox every time. As noted in the issue, constraining the mirrored geometry is almost always the desired behavior.

**Changes:**
- Set `createSymConstraints` member default to `true` (was `false`)
- Set `SecondBox` checkbox to checked on tool widget initialization

**Testing:**
- Open Sketcher, draw geometry, select it, invoke Mirror/Symmetry tool
- Verify 'Create symmetry constraints (J)' checkbox is now checked by default
- Verify toggling still works correctly (J key or clicking)
- Verify mutual exclusion with 'Delete original geometries' still works