### PR TITLE
TechDraw: Use label font family for Rich Text Annotation default

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
+++ b/src/Mod/TechDraw/Gui/QGIRichAnno.cpp
@@ -564,6 +564,7 @@ void QGIRichAnno::setEditMode(bool enable)
             QFont font = PreferencesGui::labelFontQFont();
 
             QTextCharFormat defaultFormat;
+            defaultFormat.setFontFamilies({font.family()});
             defaultFormat.setFontPointSize(font.pointSizeF());
             cursor.setCharFormat(defaultFormat);
         }


### PR DESCRIPTION
## Problem
When creating a new Rich Text Annotation, the default character format only sets the font point size from preferences but not the font family. This causes the annotation to use the system default font instead of osifont (or whatever the user configured as the label font).

## Fix
In `QGIRichAnno::setEditable()`, when initializing an empty document's default format, also set `setFontFamilies()` from the preference font alongside the existing `setFontPointSize()` call.

One-line addition:
```cpp
defaultFormat.setFontFamilies({font.family()});
```

## Testing
1. Create a new TechDraw page with a view
2. Insert a Rich Text Annotation
3. The default font should now be osifont (matching other TechDraw labels)

Fixes #28129