### PR TITLE
Gui: Apply suppressed strikethrough label on file load

### DIFF
--- a/src/Gui/ViewProviderSuppressibleExtension.cpp
+++ b/src/Gui/ViewProviderSuppressibleExtension.cpp
@@ -66,6 +66,21 @@ void ViewProviderSuppressibleExtension::extensionUpdateData(const App::Property*
     }
 }
 
+void ViewProviderSuppressibleExtension::extensionFinishRestoring()
+{
+    auto vp = getExtendedViewProvider();
+    auto owner = vp->getObject();
+    if (!owner || !owner->isValid()) {
+        return;
+    }
+
+    auto ext = owner->getExtensionByType<App::SuppressibleExtension>();
+    if (ext && ext->Suppressed.getValue()) {
+        setSuppressedIcon(true);
+        vp->signalChangeHighlight(true, Gui::HighlightMode::StrikeOut);
+    }
+}
+
 void ViewProviderSuppressibleExtension::setSuppressedIcon(bool onoff)
 {
     isSetSuppressedIcon = onoff;

--- a/src/Gui/ViewProviderSuppressibleExtension.h
+++ b/src/Gui/ViewProviderSuppressibleExtension.h
@@ -37,6 +37,7 @@ public:
     ~ViewProviderSuppressibleExtension() override;
 
     void extensionUpdateData(const App::Property* prop) override;
+    void extensionFinishRestoring() override;
 
     void setSuppressedIcon(bool onoff);
     QIcon extensionMergeColorfullOverlayIcons(const QIcon& orig) const override;


### PR DESCRIPTION
## Problem
When opening a document containing suppressed features, the tree item labels do not show the strikethrough styling. The suppressed icon overlay is also missing. This happens because `extensionUpdateData()` fires during document restoration before the tree item signal connections (`signalChangeHighlight`) are established.

Fixes #24587

## Solution
Override `extensionFinishRestoring()` in `ViewProviderSuppressibleExtension` to re-apply both the suppressed icon overlay and the strikethrough highlight after the document is fully restored and tree items are connected.

## Changes
- `ViewProviderSuppressibleExtension.h`: Added `extensionFinishRestoring()` override declaration
- `ViewProviderSuppressibleExtension.cpp`: Implemented `extensionFinishRestoring()` that checks `Suppressed` property value and re-applies icon + strikethrough if true