### PR TITLE
Core: Sanitize backup date format to avoid illegal filename characters

### DIFF
--- a/src/App/BackupPolicy.cpp
+++ b/src/App/BackupPolicy.cpp
@@ -232,7 +232,16 @@ void BackupPolicy::applyTimeStamp(const std::string& sourcename, const std::stri
                         const auto knownGoodFormat {"%Y-%m-%d_%H-%M-%S"};
                         std::strftime(buffer.data(), bufferLength, knownGoodFormat, &local_tm);
                     }
-                    str << bn << buffer.data();
+                    // Sanitize the formatted date string by replacing characters
+                    // that are illegal in Windows file names (e.g. colons from %T)
+                    std::string dateStr(buffer.data());
+                    const std::string illegalChars = "<>:\"/\\|?*";
+                    for (char& ch : dateStr) {
+                        if (illegalChars.find(ch) != std::string::npos) {
+                            ch = '-';
+                        }
+                    }
+                    str << bn << dateStr;
 
                     fn = str.str();
                     bool done = false;


### PR DESCRIPTION
## Problem
On Windows, the FCBak date format preference (`Edit > Preferences > Document > Storage`) allows format specifiers like `%T` that produce colons (`HH:MM:SS`), which are illegal in Windows filenames. This results in:
> File not saved: Cannot rename project file to backup file

Fixes #25752

## Solution
Sanitize the `strftime` output by replacing characters illegal in Windows filenames (`<>:"/\|?*`) with hyphens before using it in the backup filename. This is applied after formatting so any user-specified date format works safely.

## Changes
- `src/App/BackupPolicy.cpp`: Added sanitization step after `strftime` call to replace illegal filename characters with hyphens