### PR TITLE
CAM: Clarify PassExtension sign convention in Facing tooltip

### DIFF
--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -172,7 +172,8 @@ class ObjectMillFacing(PathOp.ObjectOp):
                 "Facing",
                 QtCore.QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "Distance to extend cuts beyond polygon boundary for tool disengagement.",
+                    "Distance to extend cuts beyond the boundary shape."
+                    " Positive values contract inward; negative values expand outward.",
                 ),
             ),
             (


### PR DESCRIPTION
Fixes #28386

The PassExtension property tooltip in the Facing operation said "Distance to extend cuts beyond polygon boundary for tool disengagement" which implied the value always extends outward. In practice, the sign convention is inverted:
- **Positive** values contract inward
- **Negative** values expand outward

Update the tooltip to document this convention, matching the option (a) suggested in the issue: keep current math, update the UI text.