### PR TITLE
CAM: Clarify StartDepth tooltip to reflect actual behavior

### DIFF
--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -241,7 +241,10 @@ class ObjectOp(object):
                 "App::PropertyDistance",
                 "StartDepth",
                 "Depth",
-                QT_TRANSLATE_NOOP("App::Property", "Starting Depth of Tool- top of the material in Z. The first cut occurs at StartDepth - StepDown."),
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Starting Depth of Tool- top of the material in Z. The first cut occurs at StartDepth - StepDown.",
+                ),
             )
             obj.addProperty(
                 "App::PropertyDistance",


### PR DESCRIPTION
Fixes #26272

The StartDepth tooltip reads "Starting Depth of Tool- first cut depth in Z", implying the tool cuts AT StartDepth. In reality the first machining layer is at StartDepth - StepDown. Updated the tooltip to clarify this.