### PR TITLE
Sketcher: Enable symmetry constraints by default in Mirror tool

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerSymmetry.h
@@ -77,7 +77,7 @@ public:
         , refGeoId(Sketcher::GeoEnum::GeoUndef)
         , refPosId(Sketcher::PointPos::none)
         , deleteOriginal(false)
-        , createSymConstraints(false)
+        , createSymConstraints(true)
     {}
 
     DrawSketchHandlerSymmetry(const DrawSketchHandlerSymmetry&) = delete;
@@ -299,6 +299,7 @@ void DSHSymmetryController::configureToolWidget()
                 "Create symmetry constraints between the original and mirrored geometries"
             )
         );
+        toolWidget->setCheckboxChecked(WCheckbox::SecondBox, true);
     }
 }
 


### PR DESCRIPTION
Fixes #28267

The Mirror tool's "Create symmetry constraints" checkbox was unchecked by default, producing loose (unconstrained) mirrored geometry. Users typically want the mirrored copy to stay symmetric relative to the reference line/point.

This PR changes the default to checked, matching the expected behavior described in the issue.