### PR TITLE
Gui: prepare task panel palette before first show

### DIFF
--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -104,7 +104,7 @@ void applyPreShowTaskPanelPalette(TaskPanel* panel, QWidget* source)
     syncWidgetPalette(panel, palette);
     syncWidgetPalette(panel->actionPanel, palette);
 }
-}
+}  // namespace
 
 
 //**************************************************************************


### PR DESCRIPTION
Fixes the white task dialog background regression from `#21978` by preparing the shared task page before first show instead of repairing it after presentation.

## Issues
Closes #28530

## Before and After Images

### Overlay On

<img width="1474" height="904" alt="image" src="https://github.com/user-attachments/assets/66c84e84-7b09-440b-bf9b-1738ffae2d0c" />

### Overlay Off

<img width="1474" height="904" alt="image" src="https://github.com/user-attachments/assets/6bbab998-a556-48db-af79-a8bed74973d4" />


## Root Cause

The issue in `#28530` is not specific to one PartDesign task and does not depend on overlay mode.

After `#21978`, each fresh task dialog is shown through a new shared page (`TaskPanel` wrapping `QSint::ActionPanel`). On the reproduced path, that shared page was first-painted before the intended dock visual state had been applied. That is why task dialogs could first appear with the wrong light background and then only correct on later repaint, hover, or overlay toggle.

## Fix

Apply the existing dock palette to the fresh dialog page before it becomes visible:

- source: the real host/dock palette
- targets: `TaskPanel` and `QSint::ActionPanel`
- timing: preshow, before the page is inserted and shown

This replaces the earlier post-show repair model.

## Validation

Issue surface covered:

- white first-paint on task dialogs
- background flicker / persistent wrong background until later repaint
- overlay on
- overlay off
- maintainer-reported repeated-open path


