### PR TITLE
CAM: Fix test050 OCCT error

### DIFF
--- a/src/Mod/CAM/Path/Post/Utils.py
+++ b/src/Mod/CAM/Path/Post/Utils.py
@@ -388,7 +388,7 @@ def splitArcs(path, deflection=None):
 
     if not deflection:
         prefGrp = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/CAM")
-        deflection = prefGrp.GetFloat("LibAreaCurveAccuracy", 0.01)
+        deflection = prefGrp.GetFloat("LibAreaCurveAccuracy", 0.01) or 0.01
 
     results = []
     machine = MachineState()


### PR DESCRIPTION
Fixes #28637 

The bug is that the code designed to prevent using a deflection of 0 misses the case where the stored preference is 0. This results in asking OCCT to discretize an arc at deflection 0, which produces the error (discretization of edge failed)

```
[david@rover build]$ ninja && ./bin/FreeCAD --console -t TestCAMApp.TestExport2Integration.test050_split_arcs
...
test050_split_arcs (CAMTests.TestPostOutput.TestExport2Integration.test050_split_arcs)
Test that _expand_split_arcs splits arc moves into linear segments. ... Processor.WARNING: Machine 'Millstone' not found: Machine 'Millstone' not found. Available machines: []. Machine can be set manually.
ok

----------------------------------------------------------------------
Ran 1 test in 0.100s

OK
```