### PR TITLE
CAM: Discretize wires as needed before offsetting to make Deburr succeed

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathOpUtil.py
+++ b/src/Mod/CAM/CAMTests/TestPathOpUtil.py
@@ -873,7 +873,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         # Test that offsetting the ellipse requires the tolerance parameter (i.e. requires discretization)
         with self.assertRaises(ValueError) as context:
             PathOpUtil.offsetWire(ellipse_wire, base_shape, 2, True)
-        self.assertIn("tolerance parameter is required", str(context.exception))
+        self.assertIn("tolerance", str(context.exception))
 
         # Test offsetting with tolerance
         tolerance = 0.01

--- a/src/Mod/CAM/CAMTests/TestPathOpUtil.py
+++ b/src/Mod/CAM/CAMTests/TestPathOpUtil.py
@@ -862,6 +862,29 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
             total_length += e.Length
         self.assertGreater(total_length, 0)
 
+    def test48(self):
+        """Check offsetting an ellipse discretizes it into line segments."""
+        # Create an ellipse
+        ellipse = Part.Ellipse(Vector(0, 0, 0), 20, 10)
+        ellipse_edge = ellipse.toShape()
+        ellipse_wire = Part.Wire([ellipse_edge])
+        base_shape = Part.Face(ellipse_wire)
+
+        # Test that offsetting the ellipse requires the tolerance parameter (i.e. requires discretization)
+        with self.assertRaises(ValueError) as context:
+            PathOpUtil.offsetWire(ellipse_wire, base_shape, 2, True)
+        self.assertIn("tolerance parameter is required", str(context.exception))
+
+        # Test offsetting with tolerance
+        tolerance = 0.01
+        offset_wire = PathOpUtil.offsetWire(ellipse_wire, base_shape, 2, True, tolerance=tolerance)
+
+        # Verify the result exists and is discretized into multiple edges
+        self.assertIsNotNone(offset_wire)
+        self.assertGreater(
+            len(offset_wire.Edges), 1, "Ellipse should be discretized into multiple edges"
+        )
+
     def test50(self):
         """Orient an already oriented wire"""
         p0 = Vector()

--- a/src/Mod/CAM/CAMTests/TestPathOpUtil.py
+++ b/src/Mod/CAM/CAMTests/TestPathOpUtil.py
@@ -149,13 +149,13 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         small = getWireInside(obj)
         self.assertRoughly(10, small.Edges[0].Curve.Radius)
 
-        wire = PathOpUtil.offsetWire(small, obj.Shape, 3, True)
+        wire = PathOpUtil.offsetWire(small, obj.Shape, 3, True, tolerance=0)
         self.assertIsNotNone(wire)
         self.assertEqual(1, len(wire.Edges))
         self.assertRoughly(7, wire.Edges[0].Curve.Radius)
         self.assertCoincide(Vector(0, 0, 1), wire.Edges[0].Curve.Axis)
 
-        wire = PathOpUtil.offsetWire(small, obj.Shape, 9.9, True)
+        wire = PathOpUtil.offsetWire(small, obj.Shape, 9.9, True, tolerance=0)
         self.assertIsNotNone(wire)
         self.assertEqual(1, len(wire.Edges))
         self.assertRoughly(0.1, wire.Edges[0].Curve.Radius)
@@ -167,10 +167,10 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         small = getWireInside(obj)
         self.assertRoughly(10, small.Edges[0].Curve.Radius)
-        wire = PathOpUtil.offsetWire(small, obj.Shape, 10, True)
+        wire = PathOpUtil.offsetWire(small, obj.Shape, 10, True, tolerance=0)
         self.assertIsNone(wire)
 
-        wire = PathOpUtil.offsetWire(small, obj.Shape, 15, True)
+        wire = PathOpUtil.offsetWire(small, obj.Shape, 15, True, tolerance=0)
         self.assertIsNone(wire)
 
     def test13(self):
@@ -180,13 +180,13 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         big = getWireOutside(obj)
         self.assertRoughly(20, big.Edges[0].Curve.Radius)
 
-        wire = PathOpUtil.offsetWire(big, obj.Shape, 10, True)
+        wire = PathOpUtil.offsetWire(big, obj.Shape, 10, True, tolerance=0)
         self.assertIsNotNone(wire)
         self.assertEqual(1, len(wire.Edges))
         self.assertRoughly(30, wire.Edges[0].Curve.Radius)
         self.assertCoincide(Vector(0, 0, -1), wire.Edges[0].Curve.Axis)
 
-        wire = PathOpUtil.offsetWire(big, obj.Shape, 20, True)
+        wire = PathOpUtil.offsetWire(big, obj.Shape, 20, True, tolerance=0)
         self.assertIsNotNone(wire)
         self.assertEqual(1, len(wire.Edges))
         self.assertRoughly(40, wire.Edges[0].Curve.Radius)
@@ -208,7 +208,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         # make sure there is a placement and I didn't mess up the model
         self.assertFalse(Path.Geom.pointsCoincide(Vector(), w.Edges[0].Placement.Base))
 
-        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True, tolerance=0)
         self.assertIsNotNone(wire)
         self.assertEqual(1, len(wire.Edges))
         self.assertRoughly(8, wire.Edges[0].Curve.Radius)
@@ -231,7 +231,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         # make sure there is a placement and I didn't mess up the model
         self.assertFalse(Path.Geom.pointsCoincide(Vector(), w.Edges[0].Placement.Base))
 
-        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True, tolerance=0)
         self.assertIsNotNone(wire)
         self.assertEqual(1, len(wire.Edges))
         self.assertRoughly(22, wire.Edges[0].Curve.Radius)
@@ -257,7 +257,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
             ],
         )
 
-        wire = PathOpUtil.offsetWire(small, obj.Shape, 3, True)
+        wire = PathOpUtil.offsetWire(small, obj.Shape, 3, True, tolerance=0)
         self.assertIsNotNone(wire)
         self.assertEqual(3, len(wire.Edges))
         self.assertTrue(wire.isClosed())
@@ -289,7 +289,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
                 Vector(0, y, 0),
             ],
         )
-        wire = PathOpUtil.offsetWire(small, obj.Shape, 5, True)
+        wire = PathOpUtil.offsetWire(small, obj.Shape, 5, True, tolerance=0)
         self.assertIsNone(wire)
 
     def test22(self):
@@ -311,7 +311,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
             ],
         )
 
-        wire = PathOpUtil.offsetWire(big, obj.Shape, 5, True)
+        wire = PathOpUtil.offsetWire(big, obj.Shape, 5, True, tolerance=0)
         self.assertIsNotNone(wire)
         self.assertEqual(6, len(wire.Edges))
         lastAngle = None
@@ -344,7 +344,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         """Check offsetting a cylinder."""
         obj = self.doc.getObjectsByLabel("circle-cut")[0]
 
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True)
+        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
         edge = wire.Edges[0]
         self.assertCoincide(Vector(), edge.Curve.Center)
@@ -352,7 +352,9 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertRoughly(33, edge.Curve.Radius)
 
         # the other way around everything's the same except the axis is negative
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, False)
+        wire = PathOpUtil.offsetWire(
+            getWire(obj.Tool), getPositiveShape(obj), 3, False, tolerance=0
+        )
         self.assertEqual(1, len(wire.Edges))
         edge = wire.Edges[0]
         self.assertCoincide(Vector(), edge.Curve.Center)
@@ -363,7 +365,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         """Check offsetting a box."""
         obj = self.doc.getObjectsByLabel("square-cut")[0]
 
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True)
+        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True, tolerance=0)
         self.assertEqual(8, len(wire.Edges))
         self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
@@ -379,7 +381,9 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertTrue(PathOpUtil.isWireClockwise(wire))
 
         # change offset orientation
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, False)
+        wire = PathOpUtil.offsetWire(
+            getWire(obj.Tool), getPositiveShape(obj), 3, False, tolerance=0
+        )
         self.assertEqual(8, len(wire.Edges))
         self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
@@ -398,7 +402,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         """Check offsetting a triangle."""
         obj = self.doc.getObjectsByLabel("triangle-cut")[0]
 
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True)
+        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True, tolerance=0)
         self.assertEqual(6, len(wire.Edges))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
@@ -411,7 +415,9 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
                 self.assertCoincide(Vector(0, 0, -1), e.Curve.Axis)
 
         # change offset orientation
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, False)
+        wire = PathOpUtil.offsetWire(
+            getWire(obj.Tool), getPositiveShape(obj), 3, False, tolerance=0
+        )
         self.assertEqual(6, len(wire.Edges))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
@@ -426,7 +432,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         """Check offsetting a shape."""
         obj = self.doc.getObjectsByLabel("shape-cut")[0]
 
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True)
+        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, True, tolerance=0)
         self.assertEqual(6, len(wire.Edges))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
@@ -440,7 +446,9 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
                 self.assertCoincide(Vector(0, 0, -1), e.Curve.Axis)
 
         # change offset orientation
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getPositiveShape(obj), 3, False)
+        wire = PathOpUtil.offsetWire(
+            getWire(obj.Tool), getPositiveShape(obj), 3, False, tolerance=0
+        )
         self.assertEqual(6, len(wire.Edges))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
@@ -455,7 +463,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         """Check offsetting a cylindrical hole."""
         obj = self.doc.getObjectsByLabel("circle-cut")[0]
 
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True)
+        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
         edge = wire.Edges[0]
         self.assertCoincide(Vector(), edge.Curve.Center)
@@ -463,7 +471,9 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertRoughly(27, edge.Curve.Radius)
 
         # the other way around everything's the same except the axis is negative
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, False)
+        wire = PathOpUtil.offsetWire(
+            getWire(obj.Tool), getNegativeShape(obj), 3, False, tolerance=0
+        )
         self.assertEqual(1, len(wire.Edges))
         edge = wire.Edges[0]
         self.assertCoincide(Vector(), edge.Curve.Center)
@@ -474,7 +484,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         """Check offsetting a square hole."""
         obj = self.doc.getObjectsByLabel("square-cut")[0]
 
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True)
+        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True, tolerance=0)
         self.assertEqual(4, len(wire.Edges))
         self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         for e in wire.Edges:
@@ -485,7 +495,9 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertFalse(PathOpUtil.isWireClockwise(wire))
 
         # change offset orientation
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, False)
+        wire = PathOpUtil.offsetWire(
+            getWire(obj.Tool), getNegativeShape(obj), 3, False, tolerance=0
+        )
         self.assertEqual(4, len(wire.Edges))
         self.assertEqual(4, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         for e in wire.Edges:
@@ -499,7 +511,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         """Check offsetting a triangular holee."""
         obj = self.doc.getObjectsByLabel("triangle-cut")[0]
 
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True)
+        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True, tolerance=0)
         self.assertEqual(3, len(wire.Edges))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         length = 48 * math.sin(math.radians(60))
@@ -508,7 +520,9 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertFalse(PathOpUtil.isWireClockwise(wire))
 
         # change offset orientation
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, False)
+        wire = PathOpUtil.offsetWire(
+            getWire(obj.Tool), getNegativeShape(obj), 3, False, tolerance=0
+        )
         self.assertEqual(3, len(wire.Edges))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         for e in wire.Edges:
@@ -519,7 +533,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         """Check offsetting a shape hole."""
         obj = self.doc.getObjectsByLabel("shape-cut")[0]
 
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True)
+        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, True, tolerance=0)
         self.assertEqual(6, len(wire.Edges))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
@@ -533,7 +547,9 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
                 self.assertCoincide(Vector(0, 0, +1), e.Curve.Axis)
 
         # change offset orientation
-        wire = PathOpUtil.offsetWire(getWire(obj.Tool), getNegativeShape(obj), 3, False)
+        wire = PathOpUtil.offsetWire(
+            getWire(obj.Tool), getNegativeShape(obj), 3, False, tolerance=0
+        )
         self.assertEqual(6, len(wire.Edges))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Line)]))
         self.assertEqual(3, len([e for e in wire.Edges if isinstance(e.Curve, Part.Circle)]))
@@ -566,7 +582,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(-x, y, 0), edge.Vertexes[0].Point)
         self.assertCoincide(Vector(+x, y, 0), edge.Vertexes[1].Point)
 
-        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 5, True)
+        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 5, True, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
 
         y = y - 5
@@ -575,7 +591,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         # make sure we get the same result even if the edge is oriented the other way
         edge = Path.Geom.flipEdge(edge)
-        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 5, True)
+        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 5, True, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
 
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[0].Vertexes[0].Point)
@@ -602,7 +618,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(-x, y, 0), edge.Vertexes[0].Point)
         self.assertCoincide(Vector(+x, y, 0), edge.Vertexes[1].Point)
 
-        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 5, False)
+        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 5, False, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
 
         y = y - 5
@@ -611,7 +627,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         # make sure we get the same result on a reversed edge
         edge = Path.Geom.flipEdge(edge)
-        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 5, False)
+        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 5, False, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
 
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[0].Vertexes[0].Point)
@@ -634,7 +650,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         ]
         self.assertEqual(2, len(lEdges))
 
-        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, True, tolerance=0)
 
         x = length / 2 + 2 * math.cos(math.pi / 6)
         y = -10 + 2 * math.sin(math.pi / 6)
@@ -649,7 +665,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(0, 0, -1), rEdges[0].Curve.Axis)
 
         # offset the other way
-        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False)
+        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False, tolerance=0)
 
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[0].Vertexes[0].Point)
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[-1].Vertexes[1].Point)
@@ -678,7 +694,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertEqual(2, len(lEdges))
 
         w = Path.Geom.flipWire(Part.Wire(lEdges))
-        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True, tolerance=0)
 
         x = length / 2 + 2 * math.cos(math.pi / 6)
         y = -10 + 2 * math.sin(math.pi / 6)
@@ -693,7 +709,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(0, 0, -1), rEdges[0].Curve.Axis)
 
         # offset the other way
-        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False)
+        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False, tolerance=0)
 
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[0].Vertexes[0].Point)
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[-1].Vertexes[1].Point)
@@ -726,7 +742,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(-x, y, 0), edge.Vertexes[0].Point)
         self.assertCoincide(Vector(+x, y, 0), edge.Vertexes[1].Point)
 
-        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 2, True, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
 
         y = y + 2
@@ -735,7 +751,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         # make sure we get the same result even if the edge is oriented the other way
         edge = Path.Geom.flipEdge(edge)
-        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 2, True, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
 
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[0].Vertexes[0].Point)
@@ -763,7 +779,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertCoincide(Vector(-x, y, 0), edge.Vertexes[0].Point)
         self.assertCoincide(Vector(+x, y, 0), edge.Vertexes[1].Point)
 
-        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 2, False)
+        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 2, False, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
 
         y = y + 2
@@ -772,7 +788,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         # make sure we get the same result even if the edge is oriented the other way
         edge = Path.Geom.flipEdge(edge)
-        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 2, False)
+        wire = PathOpUtil.offsetWire(Part.Wire([edge]), obj.Shape, 2, False, tolerance=0)
         self.assertEqual(1, len(wire.Edges))
 
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[0].Vertexes[0].Point)
@@ -793,7 +809,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         ]
         self.assertEqual(2, len(lEdges))
 
-        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, True, tolerance=0)
 
         x = length / 2 - 2 * math.cos(math.pi / 6)
         y = -5 - 2 * math.sin(math.pi / 6)
@@ -805,7 +821,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertEqual(0, len(rEdges))
 
         # offset the other way
-        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False)
+        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False, tolerance=0)
 
         self.assertCoincide(Vector(-x, y, 0), wire.Edges[0].Vertexes[0].Point)
         self.assertCoincide(Vector(+x, y, 0), wire.Edges[-1].Vertexes[1].Point)
@@ -831,7 +847,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
 
         # Test with flipped wire - the algorithm should handle it
         w = Path.Geom.flipWire(Part.Wire(lEdges))
-        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True)
+        wire = PathOpUtil.offsetWire(w, obj.Shape, 2, True, tolerance=0)
 
         # Check structural properties rather than exact coordinates
         # Verify the wire is valid and has geometry
@@ -849,7 +865,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertGreater(total_length, 0)
 
         # offset the other way - this should also work
-        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False)
+        wire = PathOpUtil.offsetWire(Part.Wire(lEdges), obj.Shape, 2, False, tolerance=0)
 
         # Check the same structural properties
         self.assertIsNotNone(wire)
@@ -870,14 +886,15 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         ellipse_wire = Part.Wire([ellipse_edge])
         base_shape = Part.Face(ellipse_wire)
 
-        # Test that offsetting the ellipse requires the tolerance parameter (i.e. requires discretization)
+        # Test that offsetting the ellipse requires positive tolerance (i.e. requires discretization)
         with self.assertRaises(ValueError) as context:
-            PathOpUtil.offsetWire(ellipse_wire, base_shape, 2, True)
-        self.assertIn("tolerance", str(context.exception))
+            PathOpUtil.offsetWire(ellipse_wire, base_shape, 2, True, tolerance=0)
+        self.assertIn(
+            "tolerance parameter is required to be a positive value", str(context.exception)
+        )
 
-        # Test offsetting with tolerance
-        tolerance = 0.01
-        offset_wire = PathOpUtil.offsetWire(ellipse_wire, base_shape, 2, True, tolerance=tolerance)
+        # Test offsetting with default (positive) tolerance
+        offset_wire = PathOpUtil.offsetWire(ellipse_wire, base_shape, 2, True)
 
         # Verify the result exists and is discretized into multiple edges
         self.assertIsNotNone(offset_wire)

--- a/src/Mod/CAM/CAMTests/TestPathOpUtil.py
+++ b/src/Mod/CAM/CAMTests/TestPathOpUtil.py
@@ -879,7 +879,7 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         self.assertGreater(total_length, 0)
 
     def test48(self):
-        """Check offsetting an ellipse discretizes it into line segments."""
+        """Check offsetting an ellipse converts it to circular arcs."""
         # Create an ellipse
         ellipse = Part.Ellipse(Vector(0, 0, 0), 20, 10)
         ellipse_edge = ellipse.toShape()
@@ -896,11 +896,19 @@ class TestPathOpUtil(PathTestUtils.PathTestBase):
         # Test offsetting with default (positive) tolerance
         offset_wire = PathOpUtil.offsetWire(ellipse_wire, base_shape, 2, True)
 
-        # Verify the result exists and is discretized into multiple edges
+        # Verify the result exists and is converted into multiple edges
         self.assertIsNotNone(offset_wire)
         self.assertGreater(
-            len(offset_wire.Edges), 1, "Ellipse should be discretized into multiple edges"
+            len(offset_wire.Edges), 1, "Ellipse should be converted to multiple edges"
         )
+
+        # Verify that all edges are circular arcs from the biarc conversion
+        for edge in offset_wire.Edges:
+            self.assertIsInstance(
+                edge.Curve,
+                (Part.Circle, Part.ArcOfCircle),
+                "All edges should be circular arcs, no line segments",
+            )
 
     def test50(self):
         """Orient an already oriented wire"""

--- a/src/Mod/CAM/Path/Op/Deburr.py
+++ b/src/Mod/CAM/Path/Op/Deburr.py
@@ -378,7 +378,9 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
 
             for w in basewires:
                 self.adjusted_basewires.append(w)
-                wire = PathOpUtil.offsetWire(w, base.Shape, offset, True, side)
+                wire = PathOpUtil.offsetWire(
+                    w, base.Shape, offset, True, side, self.job.GeometryTolerance.Value
+                )
                 if wire:
                     wires.append(wire)
 

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -175,15 +175,13 @@ def orientWire(w, forward=True):
     return wire
 
 
-def offsetWire(wire, base, offset, forward, Side=None, tolerance=None):
-    """offsetWire ... offsets the wire away from base and orients the wire accordingly.
-    The function tries to avoid most of the pitfalls of Part.makeOffset2D which is possible because all offsetting
-    happens in the XY plane.
-    tolerance: Deflection tolerance for discretizing non-line/arc edges. Required if wire contains non-line/arc edges.
+def discretizeWire(wire, tolerance):
+    """discretizeWire discretizes any non-line/arc edges in the wire.
+    Edges that are lines or circular arcs are kept as-is.
+    Other edge types (ellipses, splines, etc.) are discretized into line segments.
+    tolerance: Deflection tolerance for discretization. Required if wire contains non-line/arc edges.
+    Returns the wire with non-line/arc edges replaced by line segments.
     """
-    Path.Log.track("offsetWire")
-
-    # Pre-process the wire: discretize any edges that are not lines or circular arcs
     processed_edges = []
     modified = False
     for edge in wire.Edges:
@@ -193,9 +191,9 @@ def offsetWire(wire, base, offset, forward, Side=None, tolerance=None):
             processed_edges.append(edge)
         else:
             # Discretize and replace with line segments
-            if tolerance is None:
+            if tolerance <= 0:
                 raise ValueError(
-                    "tolerance parameter is required when wire contains non-line/arc edges"
+                    "tolerance parameter is required to be a positive value to discritize non-line/arc edges"
                 )
             vertices = edge.discretize(Deflection=tolerance)
             line_edges = [
@@ -206,7 +204,20 @@ def offsetWire(wire, base, offset, forward, Side=None, tolerance=None):
 
     # Reassemble the wire if any edges were replaced
     if modified:
-        wire = Part.Wire(processed_edges)
+        return Part.Wire(processed_edges)
+    return wire
+
+
+def offsetWire(wire, base, offset, forward, Side=None, tolerance=0):
+    """offsetWire ... offsets the wire away from base and orients the wire accordingly.
+    The function tries to avoid most of the pitfalls of Part.makeOffset2D which is possible because all offsetting
+    happens in the XY plane.
+    tolerance: Deflection tolerance for discretizing non-line/arc edges. Required if wire contains non-line/arc edges.
+    """
+    Path.Log.track("offsetWire")
+
+    # Pre-process the wire: discretize any non-line/arc edges
+    wire = discretizeWire(wire, tolerance)
 
     if len(wire.Edges) == 1:
         edge = wire.Edges[0]

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -175,11 +175,10 @@ def orientWire(w, forward=True):
     return wire
 
 
-def discretizeWire(wire, tolerance=0.01):
-    """discretizeWire discretizes any non-line/arc edges in the wire.
+def approximateWire(wire, tolerance=0.01):
+    """approximateWire approximates any non-line/arc edges with lines or arcs.
     Edges that are lines or circular arcs are kept as-is.
-    Other edge types (ellipses, splines, beziers, etc.) are converted to arcs and lines.
-    tolerance: Deflection tolerance for discretization. Must be positive if wire contains non-line/arc edges.
+    tolerance: Deflection tolerance for approximation. Must be positive if wire contains non-line/arc edges.
     Returns the wire with non-line/arc edges replaced by arcs and line segments.
     """
     processed_edges = []
@@ -190,10 +189,10 @@ def discretizeWire(wire, tolerance=0.01):
             # Keep lines and arcs as-is
             processed_edges.append(edge)
         else:
-            # Discretize to lines and arcs
+            # Approximate with lines and arcs
             if tolerance <= 0:
                 raise ValueError(
-                    "tolerance parameter is required to be a positive value to discritize non-line/arc edges"
+                    "tolerance parameter is required to be a positive value to approximate non-line/arc edges"
                 )
             modified = True
 
@@ -234,8 +233,8 @@ def offsetWire(wire, base, offset, forward, Side=None, tolerance=0.01):
     """
     Path.Log.track("offsetWire")
 
-    # Pre-process the wire: discretize any non-line/arc edges
-    wire = discretizeWire(wire, tolerance)
+    # Pre-process the wire: approximate any non-line/arc edges with arcs and lines
+    wire = approximateWire(wire, tolerance)
 
     if len(wire.Edges) == 1:
         edge = wire.Edges[0]

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -176,14 +176,14 @@ def orientWire(w, forward=True):
 
 
 def offsetWire(wire, base, offset, forward, Side=None, tolerance=None):
-    """offsetWire(wire, base, offset, forward, Side=None, tolerance=None) ... offsets the wire away from base and orients the wire accordingly.
+    """offsetWire ... offsets the wire away from base and orients the wire accordingly.
     The function tries to avoid most of the pitfalls of Part.makeOffset2D which is possible because all offsetting
     happens in the XY plane.
     tolerance: Deflection tolerance for discretizing non-line/arc edges. Required if wire contains non-line/arc edges.
     """
     Path.Log.track("offsetWire")
 
-    # Pre-process wire: discretize any edges that are not lines or circular arcs
+    # Pre-process the wire: discretize any edges that are not lines or circular arcs
     processed_edges = []
     modified = False
     for edge in wire.Edges:

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -175,12 +175,38 @@ def orientWire(w, forward=True):
     return wire
 
 
-def offsetWire(wire, base, offset, forward, Side=None):
-    """offsetWire(wire, base, offset, forward) ... offsets the wire away from base and orients the wire accordingly.
+def offsetWire(wire, base, offset, forward, Side=None, tolerance=None):
+    """offsetWire(wire, base, offset, forward, Side=None, tolerance=None) ... offsets the wire away from base and orients the wire accordingly.
     The function tries to avoid most of the pitfalls of Part.makeOffset2D which is possible because all offsetting
     happens in the XY plane.
+    tolerance: Deflection tolerance for discretizing non-line/arc edges. Required if wire contains non-line/arc edges.
     """
     Path.Log.track("offsetWire")
+
+    # Pre-process wire: discretize any edges that are not lines or circular arcs
+    processed_edges = []
+    modified = False
+    for edge in wire.Edges:
+        curve = edge.Curve
+        if isinstance(curve, (Part.Line, Part.LineSegment, Part.Circle, Part.ArcOfCircle)):
+            # Keep lines and arcs as-is
+            processed_edges.append(edge)
+        else:
+            # Discretize and replace with line segments
+            if tolerance is None:
+                raise ValueError(
+                    "tolerance parameter is required when wire contains non-line/arc edges"
+                )
+            vertices = edge.discretize(Deflection=tolerance)
+            line_edges = [
+                Part.makeLine(vertices[i], vertices[i + 1]) for i in range(len(vertices) - 1)
+            ]
+            processed_edges.extend(line_edges)
+            modified = True
+
+    # Reassemble the wire if any edges were replaced
+    if modified:
+        wire = Part.Wire(processed_edges)
 
     if len(wire.Edges) == 1:
         edge = wire.Edges[0]

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -178,9 +178,9 @@ def orientWire(w, forward=True):
 def discretizeWire(wire, tolerance=0.01):
     """discretizeWire discretizes any non-line/arc edges in the wire.
     Edges that are lines or circular arcs are kept as-is.
-    Other edge types (ellipses, splines, etc.) are discretized into line segments.
+    Other edge types (ellipses, splines, beziers, etc.) are converted to arcs and lines.
     tolerance: Deflection tolerance for discretization. Must be positive if wire contains non-line/arc edges.
-    Returns the wire with non-line/arc edges replaced by line segments.
+    Returns the wire with non-line/arc edges replaced by arcs and line segments.
     """
     processed_edges = []
     modified = False
@@ -190,17 +190,35 @@ def discretizeWire(wire, tolerance=0.01):
             # Keep lines and arcs as-is
             processed_edges.append(edge)
         else:
-            # Discretize and replace with line segments
+            # Discretize to lines and arcs
             if tolerance <= 0:
                 raise ValueError(
                     "tolerance parameter is required to be a positive value to discritize non-line/arc edges"
                 )
-            vertices = edge.discretize(Deflection=tolerance)
-            line_edges = [
-                Part.makeLine(vertices[i], vertices[i + 1]) for i in range(len(vertices) - 1)
-            ]
-            processed_edges.extend(line_edges)
             modified = True
+
+            # Convert to BSpline first if appropriate, to enable arc fitting
+            if isinstance(curve, (Part.Ellipse, Part.Hyperbola, Part.Parabola)):
+                # Convert edge to NURBS (BSpline)
+                shape = edge.toNurbs()
+                edge = shape.Edges[0]
+            elif isinstance(curve, Part.BezierCurve):
+                # Convert BezierCurve to BSpline
+                curve = edge.Curve.toBSpline()
+                edge = curve.toShape()
+
+            if isinstance(edge.Curve, Part.BSplineCurve):
+                # Convert BSpline to arcs
+                curves = edge.Curve.toBiArcs(tolerance)
+                for curve in curves:
+                    processed_edges.append(curve.toShape())
+            else:
+                # For other curve types, fall back to discretization to line segments
+                vertices = edge.discretize(Deflection=tolerance)
+                line_edges = [
+                    Part.makeLine(vertices[i], vertices[i + 1]) for i in range(len(vertices) - 1)
+                ]
+                processed_edges.extend(line_edges)
 
     # Reassemble the wire if any edges were replaced
     if modified:

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -175,11 +175,11 @@ def orientWire(w, forward=True):
     return wire
 
 
-def discretizeWire(wire, tolerance):
+def discretizeWire(wire, tolerance=0.01):
     """discretizeWire discretizes any non-line/arc edges in the wire.
     Edges that are lines or circular arcs are kept as-is.
     Other edge types (ellipses, splines, etc.) are discretized into line segments.
-    tolerance: Deflection tolerance for discretization. Required if wire contains non-line/arc edges.
+    tolerance: Deflection tolerance for discretization. Must be positive if wire contains non-line/arc edges.
     Returns the wire with non-line/arc edges replaced by line segments.
     """
     processed_edges = []
@@ -208,11 +208,11 @@ def discretizeWire(wire, tolerance):
     return wire
 
 
-def offsetWire(wire, base, offset, forward, Side=None, tolerance=0):
+def offsetWire(wire, base, offset, forward, Side=None, tolerance=0.01):
     """offsetWire ... offsets the wire away from base and orients the wire accordingly.
     The function tries to avoid most of the pitfalls of Part.makeOffset2D which is possible because all offsetting
     happens in the XY plane.
-    tolerance: Deflection tolerance for discretizing non-line/arc edges. Required if wire contains non-line/arc edges.
+    tolerance: Deflection tolerance for discretization. Must be positive if wire contains non-line/arc edges.
     """
     Path.Log.track("offsetWire")
 


### PR DESCRIPTION
Fixes #16495 
Fixes #16750

OCCT cannot offset all geometry (i.e. ellipses, splines). In any case, we cannot output gcode for shapes other than lines and circular arcs. This PR modifies the offsetWire function to check the input wire for invalid geometry types and discretize to line segments as needed.

Added tests for an ellipse.
Tested against sample models for both issues.