### PR TITLE
Sketcher: fix multi-selection highlighting for internal faces

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3560,7 +3560,8 @@ bool ViewProviderSketch::getDetailPath(
             auto len = pPath->getLength();
             if (append) {
                 pPath->append(pcRoot);
-                pPath->append(pcModeSwitch);
+                pPath->append(pcAnnotation);
+                pPath->append(pcSketchFacesToggle);
             }
 
             if (!ViewProvider2DObject::getDetailPath(realName, pPath, false, det)) {


### PR DESCRIPTION
## Summary

Fix Ctrl+click multi-selection not visually highlighting internal faces.

`getDetailPath()` was building the Coin3D path through `pcModeSwitch`, but internal faces live under `pcAnnotation/pcSketchFacesToggle`. This caused `SoSelectionElementAction` to never reach the `SoBrepFaceSet` rendering internal faces.

The selection was registered correctly (Pad worked on all selected faces), only the visual highlight was missing.

### Before
Ctrl+clicking multiple internal faces: only the first face highlights.

### After
All Ctrl+clicked faces highlight correctly.

Fixes #23434

## Test plan
- [x] Single click on internal face — highlights
- [x] Ctrl+click second face — both highlight
- [x] Ctrl+click highlighted face — deselects
- [x] Edit mode selection still works