### PR TITLE
TD: Fix Segfault and logic errors during TechDraw object destruction

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -244,7 +244,7 @@ void QGIView::dragFinished()
     }
 
     bool ownTransaction = (viewObj->getDocument()->getTransactionID(true) == 0);
-    
+
     if (ownTransaction) {
         viewObj->getDocument()->openTransaction("Drag view");
     }
@@ -1129,17 +1129,22 @@ bool QGIView::shouldShowFromViewProvider() const
 
 bool QGIView::isExporting() const
 {
-    auto* view{freecad_cast<TechDraw::DrawView*>(getViewObject())};
-    auto vpPage = getViewProviderPage(view);
-    if (!view || !vpPage) {
+    auto* obj = getViewObject();
+    if (!obj || !obj->getDocument()) {
         return false;
     }
-
+    auto* view = freecad_cast<TechDraw::DrawView*>(obj);
+    if (!view) {
+        return false;
+    }
+    auto vpPage = getViewProviderPage(view);
+    if (!vpPage) {
+        return false;
+    }
     QGSPage* scenePage = vpPage->getQGSPage();
     if (!scenePage) {
         return false;
     }
-
     return scenePage->getExportingAny();
 }
 

--- a/src/Mod/TechDraw/Gui/QGIViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewPart.cpp
@@ -123,6 +123,12 @@ QVariant QGIViewPart::itemChange(GraphicsItemChange change, const QVariant& valu
         // we are selected, don't change anything?
     }
     else if (change == ItemSceneChange && scene()) {
+        // Disconnect the signal to prevent callbacks during teardown
+        if (m_selectionChangedConnection) {
+            QObject::disconnect(m_selectionChangedConnection);
+            // Reset the connection handle so it's not holding a stale reference
+            m_selectionChangedConnection = QMetaObject::Connection();
+        }
         // This means we are finished?
         tidy();
     }
@@ -130,6 +136,9 @@ QVariant QGIViewPart::itemChange(GraphicsItemChange change, const QVariant& valu
         if (scene()) {
             // added to scene
             m_selectionChangedConnection = connect(scene(), &QGraphicsScene::selectionChanged, this, [this]() {
+                if (!scene()) {
+                    return;
+                }
                 // When selection changes, if the mouse is not over the view,
                 // hide any non-selected vertices.
                 if (!isUnderMouse()) {
@@ -268,7 +277,7 @@ void QGIViewPart::draw()
     //this is old C/L
     drawCenterLines(true);//have to draw centerlines after border to get size correct.
     drawAllSectionLines();//same for section lines
-    
+
     prepareGeometryChange();
 }
 


### PR DESCRIPTION
Fixed a Segfault occurring during TechDraw Page destruction (notably in Safe Mode). 

i've tracked this using gdb


```
 Thread 1 "FreeCAD" received signal SIGSEGV, Segmentation fault.
0x0000000000000040 in ?? ()
(gdb) bt
#0  0x0000000000000040 in ?? ()
#1  0x00007ffff4ef2559 in Base::BaseClass::isDerivedFrom () at /home/alfre/git/freecad/src/Base/BaseClass.h:146
#2  0x00007fff11b7f1e4 in Base::freecad_cast<TechDraw::DrawView*, TechDraw::DrawView> () at /home/alfre/git/freecad/src/Base/BaseClass.h:211
#3  0x00007fff11b7def8 in TechDrawGui::QGIView::isExporting () at /home/alfre/git/freecad/src/Mod/TechDraw/Gui/QGIView.cpp:1132
#4  0x00007fff11bfcd82 in TechDrawGui::QGIViewPart::hideCenterMarks () at /home/alfre/git/freecad/src/Mod/TechDraw/Gui/QGIViewPart.cpp:1430
#5  0x00007fff11bf4945 in operator() () at /home/alfre/git/freecad/src/Mod/TechDraw/Gui/QGIViewPart.cpp:136 
```

this should fix #28583 TechDraw: Access violation (crash) when undoing centerline deletion attempt


seems that both issues are connected somehow, because i cannot reproduce the other anymore
