### PR TITLE
Sketcher: enable two-sided lighting for internal faces

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -32,6 +32,7 @@
 #include <Inventor/details/SoPointDetail.h>
 #include <Inventor/events/SoKeyboardEvent.h>
 #include <Inventor/nodes/SoCamera.h>
+#include <Inventor/nodes/SoShapeHints.h>
 
 #include <QApplication>
 #include <QFontMetricsF>
@@ -510,7 +511,13 @@ SoSketchFaces::SoSketchFaces(){
     material->diffuseColor.connectFrom(&color);
     material->transparency.connectFrom(&transparency);
 
+    // Enable two-sided lighting so faces are visible from both sides
+    auto* shapeHints = new SoShapeHints;
+    shapeHints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+    shapeHints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
+
     SoSeparator::addChild(material);
+    SoSeparator::addChild(shapeHints);
     SoSeparator::addChild(coords);
     SoSeparator::addChild(norm);
     SoSeparator::addChild(faceset);


### PR DESCRIPTION
## Summary

Add `SoShapeHints` with `UNKNOWN_SHAPE_TYPE` to the `SoSketchFaces` node so internal faces are rendered from both sides of the sketch plane. Previously faces were nearly invisible when viewed from behind.

Fixes #23407

## Test plan

- [x] Faces visible from front — no change
- [x] Faces visible from behind — was nearly invisible, now rendered
- [x] Selection highlighting works from both sides
- [x] Ctrl+click multi-select works from both sides
- [x] Transparency unchanged when viewed from front
- [x] Edit mode unaffected — faces hidden in edit, visible outside
- [x] MakeInternals toggle works correctly