### PR TITLE
Gui/App: Add error checking to config migration

### DIFF
--- a/src/App/ApplicationDirectories.cpp
+++ b/src/App/ApplicationDirectories.cpp
@@ -558,10 +558,11 @@ bool ApplicationDirectories::usingCurrentVersionConfig(fs::path config) const {
     return version == versionStringForPath(std::get<0>(_currentVersion), std::get<1>(_currentVersion));
 }
 
-std::vector<std::string> ApplicationDirectories::migrateConfig(const fs::path& oldPath,
-                                                                const fs::path& newPath)
+ApplicationDirectories::MigrationResult ApplicationDirectories::migrateConfig(
+    const fs::path& oldPath,
+    const fs::path& newPath)
 {
-    std::vector<std::string> skippedPaths;
+    MigrationResult result;
     fs::create_directories(newPath);
     std::error_code errorCode;
     for (auto& file : fs::directory_iterator(oldPath, errorCode)) {
@@ -577,7 +578,7 @@ std::vector<std::string> ApplicationDirectories::migrateConfig(const fs::path& o
             if (errorCode || !fs::exists(target, errorCode)) {
                 Base::Console().warning("Migration: skipping broken symlink '%s'\n",
                                         pathString.c_str());
-                skippedPaths.push_back(pathString);
+                result.failedPaths.push_back(sourcePath);
                 continue;
             }
         }
@@ -591,7 +592,7 @@ std::vector<std::string> ApplicationDirectories::migrateConfig(const fs::path& o
             Base::Console().warning("Migration: failed to copy '%s': %s\n",
                                     pathString.c_str(),
                                     error.what());
-            skippedPaths.push_back(pathString);
+            result.failedPaths.push_back(sourcePath);
         }
     }
     if (errorCode) {
@@ -599,13 +600,13 @@ std::vector<std::string> ApplicationDirectories::migrateConfig(const fs::path& o
                                 Base::FileInfo::pathToString(oldPath).c_str(),
                                 errorCode.message().c_str());
     }
-    return skippedPaths;
+    return result;
 }
 
-std::vector<std::string> ApplicationDirectories::migrateAllPaths(
+ApplicationDirectories::MigrationResult ApplicationDirectories::migrateAllPaths(
     const std::vector<fs::path>& paths) const
 {
-    std::vector<std::string> allSkipped;
+    MigrationResult allResult;
     auto [major, minor] = _currentVersion;
     std::set<fs::path> uniquePaths(paths.begin(), paths.end());
     for (auto path : uniquePaths) {
@@ -627,15 +628,18 @@ std::vector<std::string> ApplicationDirectories::migrateAllPaths(
             continue;  // Ignore an existing path: not an error, just a migration that was already done
         }
         fs::create_directories(newPath);
-        auto skipped = migrateConfig(path, newPath);
-        allSkipped.insert(allSkipped.end(), skipped.begin(), skipped.end());
+        auto result = migrateConfig(path, newPath);
+        allResult.migratedPaths.emplace_back(path, newPath);
+        allResult.failedPaths.insert(allResult.failedPaths.end(),
+                                     result.failedPaths.begin(),
+                                     result.failedPaths.end());
     }
-    if (!allSkipped.empty()) {
+    if (!allResult.failedPaths.empty()) {
         Base::Console().warning("Migration completed with %d skipped file(s). "
                                 "See warnings above for details.\n",
-                                static_cast<int>(allSkipped.size()));
+                                static_cast<int>(allResult.failedPaths.size()));
     }
-    return allSkipped;
+    return allResult;
 }
 
 // TODO: Consider using this for all UNIX-like OSes

--- a/src/App/ApplicationDirectories.h
+++ b/src/App/ApplicationDirectories.h
@@ -128,13 +128,19 @@ namespace App {
         /// \param config The path to check
         bool usingCurrentVersionConfig(std::filesystem::path config) const;
 
+        struct MigrationResult
+        {
+            std::vector<std::filesystem::path> failedPaths;
+            std::vector<std::pair<std::filesystem::path, std::filesystem::path>> migratedPaths;
+        };
+
         /// Migrate a set of versionable configuration directories from the given path to a new
         /// version. The new version's directories cannot exist yet, and the old ones *must* exist.
         /// If the old paths are themselves versioned, then the new paths will be placed at the same
         /// level in the directory structure (e.g., they will be siblings of each entry in paths).
         /// If paths are NOT versioned, the new (versioned) copies will be placed *inside* the
         /// original paths. Returns the paths of entries that could not be copied.
-        std::vector<std::string> migrateAllPaths(const std::vector<std::filesystem::path>& paths) const;
+        MigrationResult migrateAllPaths(const std::vector<std::filesystem::path>& paths) const;
 
         /// A utility method to generate the versioned directory name for a given version. This only
         /// returns the version string, not an entire path. As of FreeCAD 1.1, the string is of the
@@ -164,8 +170,8 @@ namespace App {
         /// A utility method to copy all files and directories from oldPath to newPath, handling the
         /// case where newPath might itself be a subdirectory of oldPath (and *not* attempting that
         /// otherwise-recursive copy). Returns the paths of entries that could not be copied.
-        static std::vector<std::string> migrateConfig(const std::filesystem::path& oldPath,
-                                                       const std::filesystem::path& newPath);
+        static MigrationResult migrateConfig(const std::filesystem::path& oldPath,
+                                              const std::filesystem::path& newPath);
 
 #ifdef FC_OS_WIN32
         /// On Windows, gets the location of the user's "AppData" directory. Invalid on other OSes.

--- a/src/App/ApplicationDirectories.pyi
+++ b/src/App/ApplicationDirectories.pyi
@@ -24,7 +24,7 @@ class ApplicationDirectories(PyObjectBase):
         ...
 
     @staticmethod
-    def migrateAllPaths(paths: list[str], /) -> None:
+    def migrateAllPaths(paths: list[str], /) -> list[str]:
         """
         Migrate a set of versionable configuration directories from the given paths to a new version.
 
@@ -114,7 +114,7 @@ class ApplicationDirectories(PyObjectBase):
         ...
 
     @staticmethod
-    def migrateConfig(oldPath: str, newPath: str, /) -> None:
+    def migrateConfig(oldPath: str, newPath: str, /) -> list[str]:
         """
         A utility method to copy all files and directories from oldPath to newPath, handling the
         case where newPath might itself be a subdirectory of oldPath (and *not* attempting that

--- a/src/App/ApplicationDirectoriesPyImp.cpp
+++ b/src/App/ApplicationDirectoriesPyImp.cpp
@@ -79,7 +79,12 @@ std::string ApplicationDirectoriesPy::representation() const
             }
             paths[i] = Base::FileInfo::stringToPath(s);
         }
-        App::Application::directories()->migrateAllPaths(paths);
+        auto result = App::Application::directories()->migrateAllPaths(paths);
+        Py::List failedList;
+        for (const auto& path : result.failedPaths) {
+            failedList.append(Py::String(Base::FileInfo::pathToString(path)));
+        }
+        return Py::new_reference_to(failedList);
     }
     Py_Return;
 }
@@ -132,10 +137,14 @@ std::string ApplicationDirectoriesPy::representation() const
     if (!PyArg_ParseTuple(args, "ss", &oldPath, &newPath)) {
         return nullptr;
     }
-    App::ApplicationDirectories::migrateConfig(
+    auto result = App::ApplicationDirectories::migrateConfig(
         Base::FileInfo::stringToPath(oldPath),
         Base::FileInfo::stringToPath(newPath));
-    Py_Return;
+    Py::List failedList;
+    for (const auto& path : result.failedPaths) {
+        failedList.append(Py::String(Base::FileInfo::pathToString(path)));
+    }
+    return Py::new_reference_to(failedList);
 }
 
 PyObject* ApplicationDirectoriesPy::getCustomAttributes([[maybe_unused]] const char* attr) const

--- a/src/Gui/Dialogs/DlgVersionMigrator.cpp
+++ b/src/Gui/Dialogs/DlgVersionMigrator.cpp
@@ -256,13 +256,13 @@ void PathMigrationWorker::run()
 {
     try {
         App::GetApplication().GetUserParameter().SaveDocument();
-        auto skipped = App::Application::directories()->migrateAllPaths({_userAppDir, _configDir});
+        auto result = App::Application::directories()->migrateAllPaths({_userAppDir, _configDir});
         replaceOccurrencesInPreferences();
-        if (!skipped.empty()) {
-            writeMigrationLog(skipped);
+        if (!result.failedPaths.empty()) {
+            writeMigrationLog(result.failedPaths);
             QStringList skippedList;
-            for (const auto& path : skipped) {
-                skippedList.append(QString::fromStdString(path));
+            for (const auto& path : result.failedPaths) {
+                skippedList.append(QString::fromStdString(Base::FileInfo::pathToString(path)));
             }
             Q_EMIT(completedWithWarnings(skippedList));
         }
@@ -362,7 +362,7 @@ void PathMigrationWorker::replaceInContents(
     }
 }
 
-void PathMigrationWorker::writeMigrationLog(const std::vector<std::string>& skippedPaths)
+void PathMigrationWorker::writeMigrationLog(const std::vector<std::filesystem::path>& skippedPaths)
 {
     auto logName = "migration-to-"
         + App::ApplicationDirectories::versionStringForPath(_major, _minor) + ".log";
@@ -371,7 +371,7 @@ void PathMigrationWorker::writeMigrationLog(const std::vector<std::string>& skip
         std::ofstream log(logPath);
         log << "Migration completed with " << skippedPaths.size() << " skipped file(s):\n\n";
         for (const auto& path : skippedPaths) {
-            log << "  " << path << "\n";
+            log << "  " << Base::FileInfo::pathToString(path) << "\n";
         }
         log << "\nSee the FreeCAD Report View for additional details.\n";
     }

--- a/src/Gui/Dialogs/DlgVersionMigrator.h
+++ b/src/Gui/Dialogs/DlgVersionMigrator.h
@@ -119,7 +119,7 @@ protected:
         const std::string& newString
     );
 
-    void writeMigrationLog(const std::vector<std::string>& skippedPaths);
+    void writeMigrationLog(const std::vector<std::filesystem::path>& skippedPaths);
 
 private:
     std::string _configDir;

--- a/tests/src/App/ApplicationDirectories.cpp
+++ b/tests/src/App/ApplicationDirectories.cpp
@@ -434,10 +434,10 @@ TEST_F(ApplicationDirectoriesTest, migrateConfigCreatesDestinationAndCopiesFiles
     writeFile(oldPath / "b.ini", "bravo");
 
     // Act
-    auto skipped = App::ApplicationDirectories::migrateConfig(oldPath, newPath);
+    auto result = App::ApplicationDirectories::migrateConfig(oldPath, newPath);
 
     // Assert
-    EXPECT_TRUE(skipped.empty());
+    EXPECT_TRUE(result.failedPaths.empty());
     ASSERT_TRUE(fs::exists(newPath));
     ASSERT_TRUE(fs::is_directory(newPath));
 
@@ -597,9 +597,9 @@ TEST_F(ApplicationDirectoriesTest, migrateConfigSkipsBrokenSymlink)
     writeFile(oldPath / "good.txt", "ok");
     fs::create_symlink(oldPath / "nonexistent_target", oldPath / "bad_link");
 
-    auto skipped = App::ApplicationDirectories::migrateConfig(oldPath, newPath);
+    auto result = App::ApplicationDirectories::migrateConfig(oldPath, newPath);
 
-    EXPECT_FALSE(skipped.empty());
+    EXPECT_FALSE(result.failedPaths.empty());
     EXPECT_TRUE(fs::exists(newPath / "good.txt"));
     EXPECT_EQ(readFile(newPath / "good.txt"), "ok");
 }
@@ -612,9 +612,9 @@ TEST_F(ApplicationDirectoriesTest, migrateConfigCopiesValidSymlink)
     writeFile(oldPath / "target.txt", "content");
     fs::create_symlink(oldPath / "target.txt", oldPath / "good_link");
 
-    auto skipped = App::ApplicationDirectories::migrateConfig(oldPath, newPath);
+    auto result = App::ApplicationDirectories::migrateConfig(oldPath, newPath);
 
-    EXPECT_TRUE(skipped.empty());
+    EXPECT_TRUE(result.failedPaths.empty());
     EXPECT_TRUE(fs::exists(newPath / "target.txt"));
     EXPECT_TRUE(fs::exists(newPath / "good_link"));
 }
@@ -630,9 +630,9 @@ TEST_F(ApplicationDirectoriesTest, migrateAllPathsReturnsSkippedPaths)
     fs::create_symlink(base / "no_such_file", base / "broken");
 
     std::vector<fs::path> inputs {base};
-    auto skipped = appDirs->migrateAllPaths(inputs);
+    auto result = appDirs->migrateAllPaths(inputs);
 
-    EXPECT_FALSE(skipped.empty());
+    EXPECT_FALSE(result.failedPaths.empty());
     fs::path dest = versionedPath(base, 5, 4);
     EXPECT_TRUE(fs::exists(dest / "good.txt"));
 }


### PR DESCRIPTION
Fixes #28627 (and backported for 1.1.1). The code that handles the migration of one config directory to a new one lacks error handling. If there are broken symlinks, permissions problems, etc. with files in `userAppDataDir` or `configDir`, unhandled exceptions could propagate out, go into Qt code, and crash FreeCAD during startup. This PR adds relatively aggressive error handling and logging to the migration code to prevent the crash, as well as tell the user exactly which files were causing problems. Includes tests for the non-GUI changes.

ETA: test builds of this PR are available here -- https://github.com/chennes/FreeCAD/releases/tag/test-for-issue-28627