### PR TITLE
The zipios bug has been fixed, do not override the zipios build option for Debian builds.

### DIFF
--- a/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
+++ b/cMake/FreeCAD_Helpers/InitializeFreeCADBuildOptions.cmake
@@ -174,10 +174,6 @@ macro(InitializeFreeCADBuildOptions)
 
     # if this is set override some options
     if (FREECAD_BUILD_DEBIAN)
-        # Disable it until the upstream package has been fixed. See
-        # https://github.com/FreeCAD/FreeCAD/issues/13676#issuecomment-2539978468
-        # https://github.com/FreeCAD/FreeCAD/issues/13676#issuecomment-2541513308
-        set(FREECAD_USE_EXTERNAL_ZIPIOS OFF )
         # A Debian package for SMESH doesn't exist
         #set(FREECAD_USE_EXTERNAL_SMESH ON )
     endif (FREECAD_BUILD_DEBIAN)


### PR DESCRIPTION
(Bitten by this when preparing FreeCAD 1.1.0 for Debian)

Debian Bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1089837, the reason for the original change (https://github.com/FreeCAD/FreeCAD/pull/18494) has been fixed. Additionally, the default of FREECAD_USE_EXTERNAL_ZIPIOS is "Off" anyways, so #18494 just made it impossible to override this setting. Therefore I'd suggest to remove that override.

I understand that "FREECAD_BUILD_DEBIAN" is targeted for FreeCAD-provided .deb packages - could the option name be clarified that this is not for "official Debian packages", eg. by renaming it to FREECAD_BUILD_PPA_DEB or like?

Thanks for considering!
