### PR TITLE
Gui: Add attachment editor button to LinkLabel

### DIFF
--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -51,6 +51,7 @@
 #include <Base/Interpreter.h>
 #include <Base/Tools.h>
 #include <Gui/Command.h>
+#include <Gui/Application.h>
 #include <Gui/Control.h>
 #include <Gui/Dialogs/DlgPropertyLink.h>
 #include <Gui/FileDialog.h>
@@ -4668,6 +4669,7 @@ void LinkSelection::select()
 
 LinkLabel::LinkLabel(QWidget* parent, const App::Property* prop)
     : QWidget(parent)
+    , secondaryButton(nullptr)
     , objProp(prop)
     , dlg(nullptr)
 {
@@ -4682,6 +4684,16 @@ LinkLabel::LinkLabel(QWidget* parent, const App::Property* prop)
     label->setTextInteractionFlags(Qt::TextBrowserInteraction);
     layout->addWidget(label);
 
+    if (objProp.getPropertyName() == "AttachmentSupport") {
+        secondaryButton = new QPushButton(QStringLiteral("E"), this);
+#if defined(Q_OS_MACOS)
+        secondaryButton->setAttribute(Qt::WA_LayoutUsesWidgetRect);  // layout size from QMacStyle
+                                                                     // was not correct
+#endif
+        secondaryButton->setToolTip(tr("Open attachment editor"));
+        layout->addWidget(secondaryButton);
+    }
+
     editButton = new QPushButton(QStringLiteral("…"), this);
 #if defined(Q_OS_MACOS)
     editButton->setAttribute(Qt::WA_LayoutUsesWidgetRect);  // layout size from QMacStyle was not correct
@@ -4695,6 +4707,9 @@ LinkLabel::LinkLabel(QWidget* parent, const App::Property* prop)
     // setLayout(layout);
 
     connect(label, &QLabel::linkActivated, this, &LinkLabel::onLinkActivated);
+    if (secondaryButton) {
+        connect(secondaryButton, &QPushButton::clicked, this, &LinkLabel::onSecondaryActivated);
+    }
     connect(editButton, &QPushButton::clicked, this, &LinkLabel::onEditClicked);
 }
 
@@ -4780,9 +4795,48 @@ void LinkLabel::onLinkChanged()
     }
 }
 
+void LinkLabel::onSecondaryActivated()
+{
+    if (objProp.getPropertyName() != "AttachmentSupport") {
+        return;
+    }
+
+    auto* owner = objProp.getObject();
+    auto* doc = owner ? owner->getDocument() : nullptr;
+    if (!owner || !doc) {
+        return;
+    }
+
+    auto& cmdMgr = Gui::Application::Instance->commandManager();
+    if (!cmdMgr.getCommandByName("Part_EditAttachment")) {
+        return;
+    }
+
+    auto* docName = doc->getName();
+    auto* objName = owner->getNameInDocument();
+
+    const bool restoreSelection = !Gui::Selection().isSelected(docName, objName)
+        || Gui::Selection().getSelection(docName).size() != 1;
+
+    if (restoreSelection) {
+        Gui::Selection().selStackPush(true, false, docName);
+        Gui::Selection().clearSelection(docName);
+        Gui::Selection().addSelection(docName, objName);
+    }
+
+    cmdMgr.runCommandByName("Part_EditAttachment");
+
+    if (restoreSelection) {
+        Gui::Selection().selStackGoBack(1, docName);
+    }
+}
+
 void LinkLabel::resizeEvent(QResizeEvent* e)
 {
     editButton->setFixedWidth(e->size().height());
+    if (secondaryButton) {
+        secondaryButton->setFixedWidth(e->size().height());
+    }
 }
 
 // --------------------------------------------------------------------

--- a/src/Gui/propertyeditor/PropertyItem.cpp
+++ b/src/Gui/propertyeditor/PropertyItem.cpp
@@ -52,6 +52,7 @@
 #include <Base/Tools.h>
 #include <Gui/Command.h>
 #include <Gui/Application.h>
+#include <Gui/BitmapFactory.h>
 #include <Gui/Control.h>
 #include <Gui/Dialogs/DlgPropertyLink.h>
 #include <Gui/FileDialog.h>
@@ -4685,11 +4686,12 @@ LinkLabel::LinkLabel(QWidget* parent, const App::Property* prop)
     layout->addWidget(label);
 
     if (objProp.getPropertyName() == "AttachmentSupport") {
-        secondaryButton = new QPushButton(QStringLiteral("E"), this);
+        secondaryButton = new QPushButton(this);
 #if defined(Q_OS_MACOS)
         secondaryButton->setAttribute(Qt::WA_LayoutUsesWidgetRect);  // layout size from QMacStyle
                                                                      // was not correct
 #endif
+        secondaryButton->setIcon(Gui::BitmapFactory().iconFromTheme("Part_Attachment"));
         secondaryButton->setToolTip(tr("Open attachment editor"));
         layout->addWidget(secondaryButton);
     }
@@ -4833,9 +4835,11 @@ void LinkLabel::onSecondaryActivated()
 
 void LinkLabel::resizeEvent(QResizeEvent* e)
 {
-    editButton->setFixedWidth(e->size().height());
+    const int side = e->size().height();
+    editButton->setFixedWidth(side);
     if (secondaryButton) {
-        secondaryButton->setFixedWidth(e->size().height());
+        secondaryButton->setFixedWidth(side);
+        secondaryButton->setIconSize(QSize(side - 4, side - 4));
     }
 }
 

--- a/src/Gui/propertyeditor/PropertyItem.h
+++ b/src/Gui/propertyeditor/PropertyItem.h
@@ -1359,6 +1359,7 @@ protected:
 protected Q_SLOTS:
     void onLinkActivated(const QString&);
     void onEditClicked();
+    void onSecondaryActivated();
     void onLinkChanged();
 
 Q_SIGNALS:
@@ -1366,6 +1367,7 @@ Q_SIGNALS:
 
 private:
     QLabel* label;
+    QPushButton* secondaryButton;
     QPushButton* editButton;
     QVariant link;
     App::DocumentObjectT objProp;


### PR DESCRIPTION
This PR adds for the `AttachmentSupport` property a button to open the attachment editor, next to the existing link button.

This should remove some confusion I had relating to how to modify the attachment, by putting it here so it doesn't stay "hidden" in the right click menu.

I tested this on macOS.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
Before:
<img width="382" height="145" alt="Screenshot 2026-03-26 at 13 11 15" src="https://github.com/user-attachments/assets/f02bb1ec-5ea8-4aba-85a6-6c2ba5a8754e" />

After:
<img width="399" height="109" alt="Screenshot 2026-03-26 at 13 12 28" src="https://github.com/user-attachments/assets/586aec4e-670a-4d87-81fe-977096e442ca" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
