### PR TITLE
Fix #28077: Fix area unit conversion in Properties panel

### DIFF
--- a/src/Mod/Measure/App/MeasureArea.cpp
+++ b/src/Mod/Measure/App/MeasureArea.cpp
@@ -47,6 +47,7 @@ MeasureArea::MeasureArea()
         App::PropertyType(App::Prop_ReadOnly | App::Prop_Output),
         "Area of element"
     );
+    Area.setUnit(Base::Unit::Area);
 }
 
 MeasureArea::~MeasureArea() = default;

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -70,7 +70,7 @@ constexpr std::array
 
 constexpr std::array angleUnitLabels {"deg", "rad", "gon"};
 
-constexpr std::array areaUnitLabels {"mm^2", "cm^2", "m^2", "km^2", "in^2", "ft^2", "yd^2", "mi^2"};
+constexpr std::array areaUnitLabels {"mm²", "cm²", "m²", "km²", "in²", "ft²", "yd²", "mi²"};
 
 template<std::size_t N>
 QStringList toQStringList(const std::array<const char*, N>& strings)

--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -70,7 +70,7 @@ constexpr std::array
 
 constexpr std::array angleUnitLabels {"deg", "rad", "gon"};
 
-constexpr std::array areaUnitLabels {"mm²", "cm²", "m²", "km²", "in²", "ft²", "yd²", "mi²"};
+constexpr std::array areaUnitLabels {"mm^2", "cm^2", "m^2", "km^2", "in^2", "ft^2", "yd^2", "mi^2"};
 
 template<std::size_t N>
 QStringList toQStringList(const std::array<const char*, N>& strings)


### PR DESCRIPTION
## Issues
Fixes #28077 

## Summary

Fix area unit conversion in Properties panel:

The MeasureArea tool was missing the unit type for the Area property.
Because of this, the properties panel treated it as a length and applied a linear conversion instead of a quadratic one. I fixed this by adding Area.setUnit(Base::Unit::Area) in the constructor.
Also, I changed the Unicode '²' to '^2' in the TaskMeasure GUI.
The Base::Quantity parser wasn't recognizing the unicode character, which broke the unit dropdown menu.

## Before and After Images
Before: The properties panel converted area values incorrectly when changing unit systems.
<img width="1589" height="787" alt="Before" src="https://github.com/user-attachments/assets/4372750b-a0c0-464f-a666-f392ca40d89c" />


After: The properties panel now converts area values quadratically, as expected for area units. The area unit dropdown parses area unit string using ^2.
<img width="1104" height="798" alt="After" src="https://github.com/user-attachments/assets/0e846aa9-bd90-4a57-bba1-c547c5f959fc" />
