### PR TITLE
Measurement: Change name from COM to Geometric Center

### DIFF
--- a/src/Mod/Measure/App/MeasureBase.cpp
+++ b/src/Mod/Measure/App/MeasureBase.cpp
@@ -215,7 +215,8 @@ const char* Measure::MeasurePython::getViewProviderName(void) const
     if (objName.starts_with("Center_of_mass")
 
         || objName.find("CenterOfMass") != std::string::npos
-        || objName.find("centerofmass") != std::string::npos) {
+        || objName.find("centerofmass") != std::string::npos
+        || objName.find("Geometric_Center") != std::string::npos) {
         return "MeasureGui::ViewProviderMeasureCOM";
     }
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -405,7 +405,20 @@ void ViewProviderMeasureBase::updateData(const App::Property* prop)
         // Update label
         std::string userLabel(obj->Label.getValue());
         std::string name = userLabel.substr(0, userLabel.find(":"));
-        obj->Label.setValue((name + ": ") + obj->getResultString().toStdString());
+        std::string resultString = obj->getResultString().toStdString();
+
+        // Small UI fix. Since the name Geometric Center is already in the result string
+        // we need to remove it first to not have duplicate name
+        if (name == "Geometric_Center") {
+            std::string label = "Geometric Center";
+            size_t position = resultString.find(label);
+
+            if (position != std::string::npos) {
+                resultString.erase(position, label.size());
+            }
+        }
+
+        obj->Label.setValue((name + ": ") + resultString);
     }
 
     ViewProviderDocumentObject::updateData(prop);

--- a/src/Mod/Measure/InitGui.py
+++ b/src/Mod/Measure/InitGui.py
@@ -43,6 +43,6 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 FreeCAD.MeasureManager.addMeasureType(
     "CENTEROFMASS",
-    QT_TRANSLATE_NOOP("TaskMeasure", "Center of mass"),
+    QT_TRANSLATE_NOOP("TaskMeasure", "Geometric Center"),
     MeasureCOM,
 )

--- a/src/Mod/Measure/MeasureCOM.py
+++ b/src/Mod/Measure/MeasureCOM.py
@@ -119,7 +119,7 @@ class MeasureCOM(MeasureBasePython):
 
     def getResultString(self, obj):
         values = [Units.Quantity(v, Units.Length).getUserPreferred()[0] for v in obj.Result]
-        return "COM\nX: {}\nY: {}\nZ: {}".format(*values)
+        return "Geometric Center\nX: {}\nY: {}\nZ: {}".format(*values)
 
     def execute(self, obj):
         element = obj.Element


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Since Mass Properties was added there is now 2 ways to get the Center Of Mass. Therefore it was decided that COM should be renamed to Geometric Center. 

Out of causion for any regressions the changes are mostly for the UI, so this should not break any Macros or Workbenches. 

A small UI change was also made. When it was called COM the object label was "Center_of_Mass: COM etc.". This would be a problem for Geometric Center, since the label would become "Geometric_Center: Geometric Center etc.". So this has been removed so it is just "Geometric_Center: etc."

Note: If this is tested before another PR has been merged. Then you will see a syntax error in the report view when using the command. This is **not** caused by this change.

## Before and After Images
<img width="912" height="433" alt="image" src="https://github.com/user-attachments/assets/4d615759-a2fd-4c9b-b692-288e91bb2e24" />

<img width="882" height="372" alt="image" src="https://github.com/user-attachments/assets/6cb9a3e2-294f-4446-98db-b174e4660e97" />




