### PR TITLE
Part: fix Create button accelerator conflict with Close in Primitives task panel

### DIFF
--- a/src/Mod/Part/Gui/DlgPrimitives.cpp
+++ b/src/Mod/Part/Gui/DlgPrimitives.cpp
@@ -2648,7 +2648,7 @@ QDialogButtonBox::StandardButtons TaskPrimitives::getStandardButtons() const
 void TaskPrimitives::modifyStandardButtons(QDialogButtonBox* box)
 {
     QPushButton* btn = box->button(QDialogButtonBox::Ok);
-    btn->setText(QApplication::translate("PartGui::DlgPrimitives", "&Create"));
+    btn->setText(QApplication::translate("PartGui::DlgPrimitives", "C&reate"));
 }
 
 bool TaskPrimitives::accept()


### PR DESCRIPTION
The &Create and &Close buttons both claimed Alt+C, so neither accelerator worked.
Changed &Create to C&reate (Alt+R) to resolve the conflict.

Fixes #28453