### PR TITLE
CI: Only call it a weekly if it is build from main

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -42,7 +42,15 @@ jobs:
           if [ "${{ github.event_name }}" = "release" ]; then
             export BUILD_TAG="${{ github.event.release.tag_name }}"
           else
-            export BUILD_TAG=weekly-$(date "+%Y.%m.%d")
+            BRANCH="${{ github.ref_name }}"
+            DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+            if [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+              export BUILD_TAG=weekly-$(date "+%Y.%m.%d")
+            else
+              # Sanitize branch name for use in a tag (replace non-alphanumeric with -)
+              SAFE_BRANCH=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+              export BUILD_TAG=${SAFE_BRANCH}-$(date "+%Y.%m.%d")
+            fi
             gh release create ${BUILD_TAG} --title "Development Build ${BUILD_TAG}" \
                                            -F .github/workflows/weekly-build-notes.md \
                                            --prerelease || \


### PR DESCRIPTION
This doesn't come up often here at the main repo, but when I am trying to provide a release build of a PR for people to test, the build is always called a "weekly". This PR changes it to only be called a weekly if it's based on main (really, the default branch), and to name it after the branch otherwise.