### PR TITLE
BIM: fix MakeBlocks not working for baseless walls

### DIFF
--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -658,7 +658,7 @@ class _Wall(ArchComponent.Component):
                     obj.CountBroken = 0
 
         # set the length property
-        if self.connectEdges:
+        if hasattr(self, "connectEdges") and self.connectEdges:
             l = float(0)
             for e in self.connectEdges:
                 l += e.Length

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -605,105 +605,6 @@ class _Wall(ArchComponent.Component):
                         return
                 elif obj.Base.Shape.Solids:
                     base = Part.Shape(obj.Base.Shape)
-                # blocks calculation
-                elif hasattr(obj, "MakeBlocks") and hasattr(self, "basewires"):
-                    if obj.MakeBlocks and self.basewires and extdata and obj.Width and obj.Height:
-                        # print "calculating blocks"
-                        if len(self.basewires) == 1:
-                            blocks = []
-                            n = FreeCAD.Vector(extv)
-                            n.normalize()
-                            cuts1 = []
-                            cuts2 = []
-                            if obj.BlockLength.Value:
-                                for i in range(2):
-                                    if i == 0:
-                                        offset = obj.OffsetFirst.Value
-                                    else:
-                                        offset = obj.OffsetSecond.Value
-
-                                    # only 1 wire (first) is supported
-                                    # TODO - Can support multiple wires?
-
-                                    # self.basewires was list of list of edges,
-                                    # no matter Base is DWire, Sketch or else
-                                    # See discussion - https://forum.freecad.org/viewtopic.php?t=86365
-                                    baseEdges = self.basewires[0]
-
-                                    for edge in baseEdges:
-                                        while offset < (edge.Length - obj.Joint.Value):
-                                            if offset:
-                                                t = edge.tangentAt(offset)
-                                                p = t.cross(n)
-                                                p.multiply(1.1 * obj.Width.Value + obj.Offset.Value)
-                                                p1 = edge.valueAt(offset).add(p)
-                                                p2 = edge.valueAt(offset).add(p.negative())
-                                                sh = Part.LineSegment(p1, p2).toShape()
-                                                if obj.Joint.Value:
-                                                    sh = sh.extrude(-t.multiply(obj.Joint.Value))
-                                                sh = sh.extrude(n)
-                                                if i == 0:
-                                                    cuts1.append(sh)
-                                                else:
-                                                    cuts2.append(sh)
-                                            offset += obj.BlockLength.Value + obj.Joint.Value
-                                        offset -= edge.Length
-
-                            base_face = base_faces[0]
-                            if obj.BlockHeight.Value:
-                                fsize = obj.BlockHeight.Value + obj.Joint.Value
-                                bh = obj.BlockHeight.Value
-                            else:
-                                fsize = obj.Height.Value
-                                bh = obj.Height.Value
-                            bvec = FreeCAD.Vector(n)
-                            bvec.multiply(bh)
-                            svec = FreeCAD.Vector(n)
-                            svec.multiply(fsize)
-                            if cuts1:
-                                faces1 = base_face.cut(cuts1).Faces
-                            else:
-                                faces1 = base_face.Faces
-                            blocks1 = Part.makeCompound([f.extrude(bvec) for f in faces1])
-                            if cuts2:
-                                faces2 = base_face.cut(cuts2).Faces
-                            else:
-                                faces2 = base_face.Faces
-                            blocks2 = Part.makeCompound([f.extrude(bvec) for f in faces2])
-                            interval = extv.Length / (fsize)
-                            entire = int(interval)
-                            rest = interval - entire
-                            for i in range(entire):
-                                if i % 2:  # odd
-                                    b = Part.Shape(blocks2)
-                                else:
-                                    b = Part.Shape(blocks1)
-                                if i:
-                                    t = FreeCAD.Vector(svec)
-                                    t.multiply(i)
-                                    b.translate(t)
-                                blocks.append(b)
-                            if rest:
-                                rest = extv.Length - (entire * fsize)
-                                rvec = FreeCAD.Vector(n)
-                                rvec.multiply(rest)
-                                if entire % 2:
-                                    b = Part.makeCompound([f.extrude(rvec) for f in faces2])
-                                else:
-                                    b = Part.makeCompound([f.extrude(rvec) for f in faces1])
-                                t = FreeCAD.Vector(svec)
-                                t.multiply(entire)
-                                b.translate(t)
-                                blocks.append(b)
-                            if blocks:
-                                base = Part.makeCompound(blocks)
-
-                        else:
-                            FreeCAD.Console.PrintWarning(
-                                translate("Arch", "Cannot compute blocks for wall")
-                                + obj.Label
-                                + "\n"
-                            )
 
             elif obj.Base.isDerivedFrom("Mesh::Feature"):
                 if obj.Base.Mesh.isSolid():
@@ -716,6 +617,12 @@ class _Wall(ArchComponent.Component):
                                 translate("Arch", "This mesh is an invalid solid") + "\n"
                             )
                             obj.Base.ViewObject.show()
+        # Blocks calculation
+        if hasattr(obj, "MakeBlocks") and hasattr(self, "basewires"):
+            if obj.MakeBlocks and self.basewires and extdata and obj.Width and obj.Height:
+                blocks = self._make_blocks(obj, base_faces[0], extv)
+                if blocks is not None:
+                    base = blocks
         if not base:
             # FreeCAD.Console.PrintError(translate("Arch","Error: Invalid base object")+"\n")
             # return
@@ -1707,6 +1614,124 @@ class _Wall(ArchComponent.Component):
                             layers.append(varwidth)
         return layers
 
+    def _make_blocks(self, obj, base_face, extv):
+        """Cut a wall's base face into block-sized pieces and stack them.
+
+        Uses self.basewires (a list of lists of edges representing the wall's centerline) to compute
+        vertical cutting planes at block boundaries. The base face is then cut and extruded in
+        alternating rows to produce a brick-like pattern.
+
+        Parameters
+        ----------
+        obj : FreeCAD.DocumentObject
+            The wall object. Its block properties (BlockLength, BlockHeight, Joint, OffsetFirst,
+            OffsetSecond) control the block layout.
+        base_face : Part.Face
+            The 2D cross-section face to be cut into blocks and extruded.
+        extv : FreeCAD.Vector
+            The extrusion vector (direction and magnitude of the wall height).
+
+        Returns
+        -------
+        Part.Compound or None
+            A compound of block solids, or None if blocks could not be computed.
+        """
+        import Part
+
+        if len(self.basewires) != 1:
+            FreeCAD.Console.PrintWarning(
+                translate("Arch", "Cannot compute blocks for wall") + obj.Label + "\n"
+            )
+            return None
+
+        n = FreeCAD.Vector(extv)
+        n.normalize()
+        cuts1 = []
+        cuts2 = []
+        if obj.BlockLength.Value:
+            for i in range(2):
+                if i == 0:
+                    offset = obj.OffsetFirst.Value
+                else:
+                    offset = obj.OffsetSecond.Value
+
+                # only 1 wire (first) is supported
+                # TODO - Can support multiple wires?
+
+                # self.basewires was list of list of edges,
+                # no matter Base is DWire, Sketch or else
+                # See discussion - https://forum.freecad.org/viewtopic.php?t=86365
+                baseEdges = self.basewires[0]
+
+                for edge in baseEdges:
+                    while offset < (edge.Length - obj.Joint.Value):
+                        if offset:
+                            t = edge.tangentAt(offset)
+                            p = t.cross(n)
+                            p.multiply(1.1 * obj.Width.Value + obj.Offset.Value)
+                            p1 = edge.valueAt(offset).add(p)
+                            p2 = edge.valueAt(offset).add(p.negative())
+                            sh = Part.LineSegment(p1, p2).toShape()
+                            if obj.Joint.Value:
+                                sh = sh.extrude(-t.multiply(obj.Joint.Value))
+                            sh = sh.extrude(n)
+                            if i == 0:
+                                cuts1.append(sh)
+                            else:
+                                cuts2.append(sh)
+                        offset += obj.BlockLength.Value + obj.Joint.Value
+                    offset -= edge.Length
+
+        blocks = []
+        if obj.BlockHeight.Value:
+            fsize = obj.BlockHeight.Value + obj.Joint.Value
+            bh = obj.BlockHeight.Value
+        else:
+            fsize = obj.Height.Value
+            bh = obj.Height.Value
+        bvec = FreeCAD.Vector(n)
+        bvec.multiply(bh)
+        svec = FreeCAD.Vector(n)
+        svec.multiply(fsize)
+        if cuts1:
+            faces1 = base_face.cut(cuts1).Faces
+        else:
+            faces1 = base_face.Faces
+        blocks1 = Part.makeCompound([f.extrude(bvec) for f in faces1])
+        if cuts2:
+            faces2 = base_face.cut(cuts2).Faces
+        else:
+            faces2 = base_face.Faces
+        blocks2 = Part.makeCompound([f.extrude(bvec) for f in faces2])
+        interval = extv.Length / (fsize)
+        entire = int(interval)
+        rest = interval - entire
+        for i in range(entire):
+            if i % 2:  # odd
+                b = Part.Shape(blocks2)
+            else:
+                b = Part.Shape(blocks1)
+            if i:
+                t = FreeCAD.Vector(svec)
+                t.multiply(i)
+                b.translate(t)
+            blocks.append(b)
+        if rest:
+            rest = extv.Length - (entire * fsize)
+            rvec = FreeCAD.Vector(n)
+            rvec.multiply(rest)
+            if entire % 2:
+                b = Part.makeCompound([f.extrude(rvec) for f in faces2])
+            else:
+                b = Part.makeCompound([f.extrude(rvec) for f in faces1])
+            t = FreeCAD.Vector(svec)
+            t.multiply(entire)
+            b.translate(t)
+            blocks.append(b)
+        if blocks:
+            return Part.makeCompound(blocks)
+        return None
+
     def build_base_from_scratch(self, obj):
         """Generate the 2D profile for extruding a baseless Arch Wall.
 
@@ -1783,6 +1808,11 @@ class _Wall(ArchComponent.Component):
             offset += abs(layer)
 
         placement = FreeCAD.Placement()
+
+        # Set basewires so blocks calculation can use the centerline edge.
+        p1 = Vector(-safe_length / 2, 0, 0)
+        p2 = Vector(safe_length / 2, 0, 0)
+        self.basewires = [[Part.LineSegment(p1, p2).toShape()]]
 
         return base_faces, placement
 

--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -371,9 +371,10 @@ class TestArchWall(TestArchBase.TestArchBase):
         )
 
     def test_wall_makeblocks(self):
-        """Test the 'MakeBlocks' feature of Arch Wall.
-        This is a regression test for https://github.com/FreeCAD/FreeCAD/issues/26982, and
-        a basic, functional test for the MakeBlocks code path.
+        """Test the 'MakeBlocks' feature for both based and baseless Arch Walls.
+        This is a regression test for https://github.com/FreeCAD/FreeCAD/issues/26982,
+        a unit test for https://github.com/FreeCAD/FreeCAD/issues/27817, and a basic, functional test for the
+        MakeBlocks code path.
         """
         operation = "Checking Arch Wall MakeBlocks functional correctness..."
         self.printTestMessage(operation)
@@ -383,25 +384,11 @@ class TestArchWall(TestArchBase.TestArchBase):
         BL, BH = 400.0, 200.0  # Block Length and Height
         O1, O2 = 0.0, 200.0  # Row offsets
 
-        # Create base line
-        p1 = App.Vector(0, 0, 0)
-        p2 = App.Vector(L, 0, 0)
-        line = Draft.makeLine(p1, p2)
-        self.document.recompute()
-
-        # Create wall based on line and block parameters
-        wall = Arch.makeWall(line, width=W, height=H)
-        wall.BlockLength = BL
-        wall.BlockHeight = BH
-        wall.Joint = 0  # For test and volume calculation simplicity
-        wall.OffsetFirst = O1
-        wall.OffsetSecond = O2
-
         def calc_row(row_start):
             """
             Simulates the 1D block-segmentation logic for a single horizontal course.
 
-            This helper replicates the "sawing" algorithm found in _Wall.execute:
+            This helper replicates the "sawing" algorithm found in _Wall._make_blocks:
             1. It places the first vertical joint at 'row_start'.
             2. It advances the cutting position by 'BlockLength' (BL).
             3. It measures the resulting segments between joints.
@@ -451,28 +438,43 @@ class TestArchWall(TestArchBase.TestArchBase):
             expected_entire += ent
             expected_broken += brk
 
-        # Enable the feature, triggering the #26982 bug via the code path in _Wall.execute()
-        wall.MakeBlocks = True
+        expected_vol = L * W * H
+
+        # Create both wall variants: one with a base line, one baseless
+        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(L, 0, 0))
+        self.document.recompute()
+        based_wall = Arch.makeWall(line, width=W, height=H)
+        baseless_wall = Arch.makeWall(None, length=L, width=W, height=H)
+
+        walls = {"based": based_wall, "baseless": baseless_wall}
+        for wall in walls.values():
+            wall.BlockLength = BL
+            wall.BlockHeight = BH
+            wall.Joint = 0  # For test and volume calculation simplicity
+            wall.OffsetFirst = O1
+            wall.OffsetSecond = O2
+            wall.MakeBlocks = True
         self.document.recompute()
 
-        # Regression check: did we crash?
-        self.assertFalse(wall.Shape.isNull(), "Wall shape should not be null")
+        for label, wall in walls.items():
+            with self.subTest(wall=label):
+                # Regression check
+                self.assertFalse(wall.Shape.isNull(), "Wall shape should not be null")
 
-        # Functional check: compare dynamic calculation to property values
-        self.assertEqual(
-            wall.CountEntire,
-            expected_entire,
-            f"Mismatch in Entire blocks. Expected {expected_entire}, got {wall.CountEntire}",
-        )
-        self.assertEqual(
-            wall.CountBroken,
-            expected_broken,
-            f"Mismatch in Broken blocks. Expected {expected_broken}, got {wall.CountBroken}",
-        )
+                # Functional check: block counts and volume correctness
+                self.assertEqual(
+                    wall.CountEntire,
+                    expected_entire,
+                    f"Mismatch in Entire blocks. Expected {expected_entire}, got {wall.CountEntire}",
+                )
+                self.assertEqual(
+                    wall.CountBroken,
+                    expected_broken,
+                    f"Mismatch in Broken blocks. Expected {expected_broken}, got {wall.CountBroken}",
+                )
 
-        # Integrity check: volume correctness
-        expected_vol = L * W * H
-        self.assertAlmostEqual(wall.Shape.Volume, expected_vol, places=3)
+                # Integrity check: volume correctness
+                self.assertAlmostEqual(wall.Shape.Volume, expected_vol, places=3)
 
     def test_debase_wall_stationary_children(self):
         """Test that debasing a wall does not shift its children in world space."""


### PR DESCRIPTION
The blocks calculation was nested inside the `if obj.Base:` branch of `ArchWall._Wall.execute()`, so it was skipped entirely for baseless walls. The result for users was that baseless walls could not be tessellated into blocks.

This PR:

- Extracts the logic into a `_make_blocks()` method and call it after the base-specific logic so it runs for all wall types. The creation of a dedicated block was not strictly necessary, but it makes the code more maintainable and readable. Plus, moving the code into a method was something I had already started a few months ago, independently from the associated issue. The logic has been copied verbatim to the new method. The only minor change has been structural: early return on the `len(self.basewires) != 1:` check to remove a code indentation level 
- Creates `self.basewires` in `build_base_from_scratch()` so that baseless walls provide the centerline edge the blocks algorithm needs.
- Adds a test for block creation for baseless walls
- Fixes a pre-existing, not reported bug with an unguarded `connectEdges` access. It would manifest itself when doing a `BIM_Copy` of a baseless wall with blocks: a "has no attribute" error was shown. It was harmless in the sense that it was cleared in the next recompute, but the fix has been added to this PR too for a better user experience.

## Issues

Fixes: https://github.com/FreeCAD/FreeCAD/issues/27817