### PR TITLE
BIM: Handle unexpected characters in Report SQL statements

### DIFF
--- a/src/Mod/BIM/ArchSql.py
+++ b/src/Mod/BIM/ArchSql.py
@@ -36,7 +36,7 @@ else:
 
 
 # Import exception types from the generated parser for type-safe handling.
-from generated_sql_parser import UnexpectedEOF, UnexpectedToken, VisitError
+from generated_sql_parser import UnexpectedCharacters, UnexpectedEOF, UnexpectedToken, VisitError
 import generated_sql_parser
 
 from typing import List, Tuple, Any, Optional
@@ -2091,6 +2091,12 @@ def _run_query(query_string: str, mode: str, source_objects: Optional[List] = No
             raise SqlEngineError(str(e))
         except VisitError as e:
             message = f"Transformer Error: Failed to process rule '{e.rule}'. Original error: {e.orig_exc}"
+            raise BimSqlSyntaxError(message) from e
+        except UnexpectedCharacters as e:
+            message = (
+                f"Syntax Error: Unexpected character '{e.char}' at line {e.line},"
+                f" column {e.column}."
+            )
             raise BimSqlSyntaxError(message) from e
         except UnexpectedToken as e:
             # Heuristic for a better typing experience: If the unexpected token's


### PR DESCRIPTION
Characters not in the grammar (e.g. \, [, {, ~, !, @, #, $, %, ^) raised an uncaught `UnexpectedCharacters` exception from the lexer. Catch it alongside the existing `UnexpectedToken` and `UnexpectedEOF` handlers and convert it to a `BimSqlSyntaxError` with a friendlier user message.

We should make this message translatable, but I'd prefer to do this in a separate PR, together with the other user-visible ArchReport messages.

## Issues

Fixes: #26243