### PR TITLE
BIM: Resolve link properties to Label in Report SQL queries

### DIFF
--- a/src/Mod/BIM/ArchSql.py
+++ b/src/Mod/BIM/ArchSql.py
@@ -118,14 +118,25 @@ _CUSTOM_FRIENDLY_TOKEN_NAMES = {
 
 
 def _get_property(obj, prop_name):
-    """Gets a property from a FreeCAD object, including sub-properties."""
+    """Gets a property from a FreeCAD object, including sub-properties.
+
+    Link properties (e.g. Material) are resolved to the linked object's Label
+    so that queries like ``WHERE Material = 'Brick'`` work intuitively.
+    Nested access (e.g. ``Material.Color``) bypasses this and traverses
+    the linked object directly.
+    """
     # The property name implies sub-property access (e.g., 'Placement.Base.x')
     is_nested_property = lambda prop_name: "." in prop_name
 
     if not is_nested_property(prop_name):
         # Handle simple, direct properties first, which is the most common case.
         if hasattr(obj, prop_name):
-            return getattr(obj, prop_name)
+            value = getattr(obj, prop_name)
+            # Resolve link properties to the linked object's Label so that
+            # comparisons and SELECT columns show a human-readable name.
+            if isinstance(value, FreeCAD.DocumentObject):
+                return value.Label
+            return value
         return None
     else:
         # Handle nested properties (e.g., Placement.Base.x)


### PR DESCRIPTION
Properties that link to another object (e.g. `Material`) returned the raw DocumentObject, making queries like `WHERE Material = 'Brick'` and `SELECT Material` produce unusable results. Resolve them to the linked object's Label instead. Nested access (e.g. `Material.Color`) is unaffected.

Fixes: #26242