### PR TITLE
Core: macos filename : remove duplicate 'MacOS'

### DIFF
--- a/package/rattler-build/osx/create_bundle.sh
+++ b/package/rattler-build/osx/create_bundle.sh
@@ -49,8 +49,7 @@ cp build/FreeCAD FreeCAD.app/Contents/MacOS/FreeCAD
 
 # Add deployment target suffix to artifact name (e.g., "-macOS11" or "-macOS15")
 deploy_target="${MACOS_DEPLOYMENT_TARGET:-11.0}"
-deploy_suffix="-macOS${deploy_target%%.*}"
-version_name="FreeCAD_${BUILD_TAG}-macOS-$(uname -m)${deploy_suffix}"
+version_name="FreeCAD_${BUILD_TAG}-macOS${deploy_target%%.*}-$(uname -m)"
 application_menu_name="FreeCAD_${BUILD_TAG}"
 
 echo -e "\################"


### PR DESCRIPTION
Currently macos archives are named 

FreeCAD_weekly-2026.03.25-macOS-x86_64-macOS10

With duplicate macOS which doesn't serve any purpose.
This PR changes to : 

FreeCAD_weekly-2026.03.25-macOS10-x86_64