### PR TITLE
BIM: baseless ArchComponent should not lose shape

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -375,13 +375,12 @@ class Component(ArchIFC.IfcProduct):
 
         if self.clone(obj):
             return
-        if self.ensureBase(obj) is False:
-            # This will fall through if the Component object has no base, allowing the base shapeto
-            # be cleared
+        if getattr(obj, "Base", None) is None:
+            # Do not modify Arch_Components without a Base object.
             return
 
-        # Only proceed if a Base object is linked and contains valid geometry.
-        if obj.Base and hasattr(obj.Base, "Shape") and not obj.Base.Shape.isNull():
+        if hasattr(obj.Base, "Shape") and not obj.Base.Shape.isNull():
+            # The Base object contains valid geometry.
             # Create a standalone shape as a deep copy of the base geometry, to avoid modifying
             # the original source.
             base_shape = Part.Shape(obj.Base.Shape)
@@ -398,8 +397,7 @@ class Component(ArchIFC.IfcProduct):
             final_shape = self.processSubShapes(obj, base_shape, obj.Placement)
             self.applyShape(obj, final_shape, obj.Placement, allownosolid=True)
         else:
-            # Clear the shape if the base has been removed. This avoids leaving a stale shape that
-            # is not updated when the base is removed.
+            # Clear the shape to avoid leaving a stale shape.
             obj.Shape = Part.Shape()
 
     def dumps(self):

--- a/src/Mod/BIM/bimtests/TestArchComponent.py
+++ b/src/Mod/BIM/bimtests/TestArchComponent.py
@@ -701,22 +701,35 @@ class TestArchComponent(TestArchBase.TestArchBase):
                 msg="CSG pieces did not align. Base shape likely retained the offset.",
             )
 
-    def test_component_base_removal_cleanup(self):
-        """Test that removing the Base property clears the component shape."""
-        self.printTestMessage("ArchComponent Base Removal Cleanup...")
+    def test_component_without_base(self):
+        """Test that a component without a base retains its shape."""
+        self.printTestMessage("ArchComponent without Base test...")
 
-        box = self.document.addObject("Part::Box", "StaleTestBox")
-        comp = Arch.makeComponent(box)
+        box1 = self.document.addObject("Part::Box", "TestBox1")
+        box2 = self.document.addObject("Part::Box", "TestBox2")
+        self.document.recompute()
+        volume_box1 = box1.Shape.Volume
+        volume_box2 = box2.Shape.Volume  # Box2 will be deleted.
+        
+        comp1 = Arch.makeComponent(box1)
+        comp2 = Arch.makeComponent(box2, delete=True)
         self.document.recompute()
 
-        self.assertFalse(comp.Shape.isNull(), "Component should have a shape initially.")
-
-        # Trigger the 'else' block
-        comp.Base = None
+        comp1.Base = None
         self.document.recompute()
 
-        self.assertTrue(
-            comp.Shape.isNull(), "Component retained a stale shape after its Base was removed."
+        self.assertAlmostEqual(
+            volume_box1,
+            comp1.Shape.Volume,
+            places=6,
+            msg="Wrong shape for baseless component!",
+        )
+
+        self.assertAlmostEqual(
+            volume_box2,
+            comp2.Shape.Volume,
+            places=6,
+            msg="Wrong shape for baseless component!",
         )
 
     def test_add_window_link_standard(self):

--- a/src/Mod/BIM/bimtests/TestArchComponent.py
+++ b/src/Mod/BIM/bimtests/TestArchComponent.py
@@ -710,7 +710,7 @@ class TestArchComponent(TestArchBase.TestArchBase):
         self.document.recompute()
         volume_box1 = box1.Shape.Volume
         volume_box2 = box2.Shape.Volume  # Box2 will be deleted.
-        
+
         comp1 = Arch.makeComponent(box1)
         comp2 = Arch.makeComponent(box2, delete=True)
         self.document.recompute()


### PR DESCRIPTION
Fixes #28705.

During the v1.1 dev cycle it was wrongly assumed that ArchComponents always need to have a base, and that without a base their shape should be reset.

This is not the case as the `delete` argument of the `makeComponent` function demonstrates:
https://github.com/FreeCAD/FreeCAD/blob/ffb07e2f1a51029697aaac024214e26c6112b48e/src/Mod/BIM/ArchCommands.py#L307

