### PR TITLE
BIM: fix double-click visibility behavior of views in Views Manager

### DIFF
--- a/src/Mod/BIM/bimcommands/BimViews.py
+++ b/src/Mod/BIM/bimcommands/BimViews.py
@@ -675,7 +675,7 @@ def show(item, column=None):
         elif isView(obj):
 
             # case 2: the object is a 2D view
-            ssel = [obj] + obj.OutListRecursive
+            ssel = [obj] + obj.Group
             FreeCADGui.Selection.clearSelection()
             for o in ssel:
                 o.ViewObject.Visibility = True


### PR DESCRIPTION
Fixes #28473.

Instead of making the objects in the view's `OutListRecursive` visible, process the objects in its `Group`. As a result, when double-clicking a view in the Views Manager, only the view and its direct content (Shape2DViews) will become visible and the 3D View will zoom to just those objects.