### PR TITLE
Gui: scale FPS counter with device pixel ratio on HiDPI displays

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1424,7 +1424,18 @@ void View3DInventorViewer::setGradientBackgroundColor(
 void View3DInventorViewer::setEnabledFPSCounter(bool on)
 {
     fpsEnabled = on;
+    if (on) {
+        if (!fpsCounter) {
+            fpsCounter = new QLabel(this);
+            fpsCounter->setAttribute(Qt::WA_TransparentForMouseEvents);
+        }
+        fpsCounter->show();
+    }
+    else if (fpsCounter) {
+        fpsCounter->hide();
+    }
 }
+
 
 void View3DInventorViewer::setEnabledVBO(bool on)
 {
@@ -2626,27 +2637,35 @@ void View3DInventorViewer::renderScene()
         }
     }
 
-    // fps rendering
-    if (fpsEnabled) {
+    if (fpsEnabled && fpsCounter) {
         std::stringstream stream;
         stream.precision(1);
         stream.setf(std::ios::fixed | std::ios::showpoint);
         stream << framesPerSecond[0] << " ms / " << framesPerSecond[1] << " fps";
-        ParameterGrp::handle hGrpOverlayL = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        );
-        std::string overlayLeftWidgets = hGrpOverlayL->GetASCII("Widgets", "");
+
         ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/View"
         );
-        unsigned long axisLetterColor
-            = hGrpView->GetUnsigned("AxisLetterColor", 4294902015);  // default FPS color (yellow)
-        draw2DString(
-            stream.str().c_str(),
-            SbVec2s(10, 10),
-            SbVec2f((overlayLeftWidgets.empty() ? 0.1f : 1.1f), 0.1f),
-            Base::Color(static_cast<uint32_t>(axisLetterColor))
-        );  // NOLINT
+        unsigned long axisLetterColor = hGrpView->GetUnsigned("AxisLetterColor", 4294902015);
+        if (axisLetterColor != previousAxisLetterColor) {
+            previousAxisLetterColor = axisLetterColor;
+            Base::Color c(static_cast<uint32_t>(axisLetterColor));
+            fpsCounter->setStyleSheet(
+                QString::fromLatin1("color: rgb(%1,%2,%3); background: transparent;")
+                    .arg(int(c.r * 255))
+                    .arg(int(c.g * 255))
+                    .arg(int(c.b * 255))
+            );
+        }
+
+        fpsCounter->setText(QString::fromStdString(stream.str()));
+        fpsCounter->adjustSize();
+
+        ParameterGrp::handle hGrpOverlayL = App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+        );
+        int xOffset = hGrpOverlayL->GetASCII("Widgets", "").empty() ? 10 : fpsCounter->width() + 20;
+        fpsCounter->move(xOffset, height() - fpsCounter->height() - 5);
     }
 
     // Workaround for inconsistent QT behavior related to handling custom OpenGL widgets that

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -31,6 +31,7 @@
 
 #include <QCursor>
 #include <QImage>
+#include <QLabel>
 
 #include <Inventor/SbRotation.h>
 #include <Inventor/nodes/SoEnvironment.h>
@@ -605,6 +606,8 @@ private:
 
     // stuff needed to draw the fps counter
     bool fpsEnabled;
+    QLabel* fpsCounter = nullptr;
+    unsigned long previousAxisLetterColor = 0;
     bool vboEnabled;
     bool naviCubeEnabled;
 


### PR DESCRIPTION
Fixes #28642. The FPS bitmap font is rendered at a fixed physical pixel size, making it unreadably small on HiDPI displays. Pass `devicePixelRatio()` to the renderer and scale via `glPixelZoom` and character advance accordingly.