### PR TITLE
CI: Run expensive CI only after initial PR approval

### DIFF
--- a/.github/workflows/CI_master.yml
+++ b/.github/workflows/CI_master.yml
@@ -32,7 +32,8 @@ on:
     branches:
       - main
       - releases/**
-  pull_request: ~
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
   merge_group: ~
 
 
@@ -48,6 +49,9 @@ jobs:
 
   Pixi:
     needs: [Prepare]
+    if: >-
+      github.event_name != 'pull_request'
+      || contains(toJSON(github.event.pull_request.labels.*.name), 'Approved:')
     uses: ./.github/workflows/sub_buildPixi.yml
     with:
       artifactBasename: Pixi-${{ github.run_id }}
@@ -61,14 +65,20 @@ jobs:
 
   Windows:
     needs: [Prepare]
-    if: "!startsWith(github.head_ref, 'refs/heads/backport-')"
+    if: >-
+      !startsWith(github.head_ref, 'refs/heads/backport-')
+      && (github.event_name != 'pull_request'
+          || contains(toJSON(github.event.pull_request.labels.*.name), 'Approved:'))
     uses: ./.github/workflows/sub_buildWindows.yml
     with:
       artifactBasename: Windows-${{ github.run_id }}
 
   Lint:
     needs: [Prepare]
-    if: "!startsWith(github.head_ref, 'refs/heads/backport-')"
+    if: >-
+      !startsWith(github.head_ref, 'refs/heads/backport-')
+      && (github.event_name != 'pull_request'
+          || contains(toJSON(github.event.pull_request.labels.*.name), 'Approved:'))
     uses: ./.github/workflows/sub_lint.yml
     with:
       artifactBasename: Lint-${{ github.run_id }}


### PR DESCRIPTION
With our ever-increasing PR submission cadence, we are reaching the limit of how many Windows CI runs we can actually fit into a day. This CI change runs the full Ubuntu test suite as normal, but only runs the more expensive CI if the PR has at least one of the various "Approved" tags on it. Adding that tag triggers the complete run, and all subsequent pushes will get a full run.