### PR TITLE
NavLib: Fix DLL import vulnerability

### DIFF
--- a/src/3rdParty/3Dconnexion/src/navlib_stub.c
+++ b/src/3rdParty/3Dconnexion/src/navlib_stub.c
@@ -76,7 +76,7 @@ extern const long NlErrorCode;
 
 long NlLoadLibrary() {
   long error = 0;
-  HMODULE h = LoadLibraryA(TheLibrary);
+  HMODULE h = LoadLibraryExA(TheLibrary, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
   if (!h) {
     error = HRESULT_FROM_WIN32(GetLastError());
   }


### PR DESCRIPTION
Fixes the vulnerability reported in [GHSA-2mfq-2h69-c873](https://github.com/FreeCAD/FreeCAD/security/advisories/GHSA-2mfq-2h69-c873) (admin-only link until published). For details on the problem see the writeup about [cve-2022-32223](https://www.aquasec.com/blog/cve-2022-32223-dll-hijacking/).

See also: https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-security
