### PR TITLE
Mesh: Use correct bounds for check

### DIFF
--- a/src/Mod/Mesh/App/Core/MeshIO.cpp
+++ b/src/Mod/Mesh/App/Core/MeshIO.cpp
@@ -1103,8 +1103,8 @@ bool MeshInput::LoadNastran(std::istream& input)
                 // GRID    1               1.2345671.2345671.234567
                 // GRID    112             6.0000000.5000000.00E+00
 
-                // Element type(8), id(8), cp(8), x(8), y(8), z(at least 1)
-                if (line.length() < 41) {
+                // Element type(8), id(8), cp(8), x(8), y(8), z(8)
+                if (line.length() < 48) {
                     badElementCounter++;
                     continue;
                 }


### PR DESCRIPTION
Reported as a security advisory in GHSA-jx4x-9jqv-jq2g, this is a basic buffer overrun. It looks like we were trying to be "flexible" with our bad-length detection, except that down a few lines we then read eight bytes starting at `line[40]`, so the flexibility results in a bad access. Not really a security concern (and labeling it as such basically hid it), but it should be fixed.