### PR TITLE
BIM: Fix pipeline status count and hosted element discovery in Reports

### DIFF
--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -1357,11 +1357,10 @@ class ReportTaskPanel:
 
         # After populating all rows, trigger a validation for all statements.
         # This ensures the counts and statuses are up-to-date when the panel opens.
-        for statement in self.obj.Proxy.live_statements:
-            statement.validate_and_update_status()
-            self._update_table_row_status(
-                self.obj.Proxy.live_statements.index(statement), statement
-            )
+        statements = self.obj.Proxy.live_statements
+        for index, statement in enumerate(statements):
+            statement.validate_and_update_status(statements, index)
+            self._update_table_row_status(index, statement)
 
         # Re-enable signals after population so user edits are handled
         self.table_statements.blockSignals(False)
@@ -1549,7 +1548,9 @@ class ReportTaskPanel:
             statement.include_column_names = self.chk_include_column_names.isChecked()
             statement.add_empty_row_after = self.chk_add_empty_row_after.isChecked()
             statement.print_results_in_bold = self.chk_print_results_in_bold.isChecked()
-            statement.validate_and_update_status()  # Update status in the statement object
+            statement.validate_and_update_status(
+                self.obj.Proxy.live_statements, self.current_edited_statement_index
+            )
             self._update_table_row_status(
                 self.current_edited_statement_index, statement
             )  # Refresh table status
@@ -1966,7 +1967,9 @@ class ReportTaskPanel:
         statement.add_empty_row_after = self.chk_add_empty_row_after.isChecked()
         statement.print_results_in_bold = self.chk_print_results_in_bold.isChecked()
 
-        statement.validate_and_update_status()
+        statement.validate_and_update_status(
+            self.obj.Proxy.live_statements, self.current_edited_statement_index
+        )
         self._update_table_row_status(self.current_edited_statement_index, statement)
         self._set_dirty(True)
 

--- a/src/Mod/BIM/ArchSql.py
+++ b/src/Mod/BIM/ArchSql.py
@@ -341,16 +341,9 @@ def _get_direct_children(obj, discover_hosted_elements, include_components_from_
                     if linked:
                         element_to_check = linked
 
-                element_type = _get_bim_type(element_to_check)
-                is_confirmed_hosted = False
-                if element_type == "Window":
-                    if hasattr(element_to_check, "Hosts") and obj in element_to_check.Hosts:
-                        is_confirmed_hosted = True
-                elif element_type == "Rebar":
-                    if hasattr(element_to_check, "Host") and obj == element_to_check.Host:
-                        is_confirmed_hosted = True
-
-                if is_confirmed_hosted:
+                if hasattr(element_to_check, "Hosts") and obj in element_to_check.Hosts:
+                    children.append(element_to_check)
+                elif hasattr(element_to_check, "Host") and obj == element_to_check.Host:
                     children.append(element_to_check)
 
     # 3. Geometric components from .Additions list

--- a/src/Mod/BIM/ArchSql.py
+++ b/src/Mod/BIM/ArchSql.py
@@ -2288,17 +2288,30 @@ class ReportStatement:
         self._validation_message = translate("Arch", "Ready")
         self._validation_count = 0
 
-    def validate_and_update_status(self):
-        """Runs validation for this statement's query and updates its internal status."""
+    def validate_and_update_status(self, all_statements=None, index=None):
+        """Runs validation for this statement's query and updates its internal status.
+
+        When ``all_statements`` and ``index`` are provided, the pipeline source objects are computed
+        automatically for pipelined statements.
+
+        Parameters
+        ----------
+        all_statements : list of ReportStatement, optional
+            The full ordered list of statements in the report.
+        index : int, optional
+            The position of this statement within ``all_statements``.
+        """
+        source_objects = None
+        if all_statements is not None and index is not None and index > 0 and self.is_pipelined:
+            source_objects = _execute_pipeline_for_objects(all_statements[:index])
+
         if not self.query_string.strip():
             self._validation_status = "OK"  # Empty query is valid, no error
             self._validation_message = translate("Arch", "Ready")
             self._validation_count = 0
             return
 
-        # Avoid shadowing the module-level `count` function by using a
-        # different local name for the numeric result.
-        count_result, error = count(self.query_string)
+        count_result, error = count(self.query_string, source_objects=source_objects)
 
         if error == "INCOMPLETE":
             self._validation_status = "INCOMPLETE"


### PR DESCRIPTION
This PR fixes two issues:

- The Status column now provides the correct count and icon for pipelined queries. Before, the results from a previous statement were not taken into account when the statement was marked as pipelined. The full pipeline was still correctly processed and the final query was correct, but the intermediate status visualization was wrong. The implementation for the fix involves passing the previous statements to the validation method and, if pipelined, run the pipeline and extract the previous statements' results as the source for the validation (and count).  => 82de74f0ae5cca8231b783d003769c04dca3b1c7
- Doors were not considered as direct children of walls, thus in queries such as `SELECT Label, Width, Height FROM CHILDREN(SELECT * FROM document) WHERE IfcType = 'Door'` the `CHILDREN()` function did not consider doors being hosted by a wall. Rather than checking the type of an object, now the `Hosts` and `Host` properties are determined to return the `CHILDREN()` sql function results. => 2ae489c561fc5501079c84c5f3733fa326ceedb8

## Issues

Fixes: #26241