### PR TITLE
Spreadsheet: Use locale-aware formatting for non-fractional numeric cells

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -545,7 +545,7 @@ QVariant SheetModel::data(const QModelIndex& index, int role) const
                     // v = QString::number(d);
                 }
                 else {
-                    v = QString::number(l);
+                    v = QLocale::system().toString(d, 'f', Base::UnitsApi::getDecimals());
                 }
                 return formatCellDisplay(v, cell);
             }


### PR DESCRIPTION
Fixes an inconsistency in how numbers with fractional vs. non-fractional part were displayed in spreadsheets:

- No fractional part: displayed with `QString::number()`. Produces plain unformatted output (e.g."1000"),
- Fractional: displayed with `QLocale::system().toString()` with fixed decimals and group separators (e.g. "1,000.00").

This affected both plain integers and unitless Quantity values

The fix uses the same QLocale formatting for both cases. In addition, the user's decimal precision preference is now respected for these cells.

The [test file](https://github.com/user-attachments/files/24217224/testing-reporting-walls.FCStd.zip) from #26250 can be used for testing the before/after result.

## Issues

Fixes: #26250