### PR TITLE
BIM: Fix inconsistent decimal precision in Report preview table

### DIFF
--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -2036,7 +2036,11 @@ class ReportTaskPanel:
 
             for row_idx, row_data in enumerate(data_rows):
                 for col_idx, cell_value in enumerate(row_data):
-                    item = QtWidgets.QTableWidgetItem(str(cell_value))
+                    if isinstance(cell_value, FreeCAD.Units.Quantity):
+                        display_text = cell_value.toStr()
+                    else:
+                        display_text = str(cell_value)
+                    item = QtWidgets.QTableWidgetItem(display_text)
                     self.table_preview_results.setItem(row_idx, col_idx, item)
             self.table_preview_results.horizontalHeader().setSectionResizeMode(
                 QtWidgets.QHeaderView.Interactive


### PR DESCRIPTION
In the Report preview table on the Tasks panel, Quantity values were originally displayed with `str()`, which shows full floating-point precision and exposes noise digits (e.g. "6587500.000000001 mm^2").

The fix uses `Quantity.toStr()` instead, which respects the user's decimal precision preference.

|Before | After |
|---|---|
| <img width="809" height="772" alt="Captura de pantalla de 2026-03-28 09-12-43" src="https://github.com/user-attachments/assets/3d898934-4d0e-40a1-ae24-5d9cde620f67" /> |<img width="809" height="772" alt="Captura de pantalla de 2026-03-28 09-14-55" src="https://github.com/user-attachments/assets/baf89201-6953-481f-abce-959adc10af7c" />|

## Issues

Fixes: #26249