### PR TITLE
BIM: Fix Report object appearing faded in the Tree View

### DIFF
--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -767,6 +767,7 @@ class ViewProviderReport:
     def __init__(self, vobj):
         vobj.Proxy = self
         self.vobj = vobj
+        vobj.ToggleVisibility = "NoToggleVisibility"
 
     def getIcon(self):
         return ":/icons/Arch_Schedule.svg"
@@ -789,7 +790,12 @@ class ViewProviderReport:
 
     def attach(self, vobj):
         """Called by the C++ loader when the view provider is rehydrated."""
-        self.vobj = vobj  # Ensure self.vobj is set for consistent access
+        self.vobj = vobj
+        vobj.ToggleVisibility = "NoToggleVisibility"
+
+    def isShow(self):
+        """Always return True so the Tree View does not fade this object."""
+        return True
 
     def claimChildren(self):
         """


### PR DESCRIPTION
The Report object is a data-only object (like a Spreadsheet) with no geometry to show or hide. However, the Tree View rendered it as faded because the default `isShow()` returns `false` when there is nothing to display, and showed a toggleable eye icon that had no effect. This PR addresses these two issues.

The "faded" issue was made more evident just recently, as before PR (https://github.com/FreeCAD/FreeCAD/pull/28114) hidden objects in the Tree View with overlay mode were (incorrectly) not being faded down.

## Before and After Images

|Before|After|
|---|---|
|<img width="291" height="253" alt="Captura de pantalla de 2026-03-28 09-59-15" src="https://github.com/user-attachments/assets/61b62973-6958-4445-a085-6ca490eddf58" />|<img width="291" height="253" alt="Captura de pantalla de 2026-03-28 09-52-47" src="https://github.com/user-attachments/assets/fcb40338-5b4b-41ba-9837-650c1dbb68ab" />|