### PR TITLE
BIM: fix duplicate processing in IFC export

### DIFF
--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -390,6 +390,9 @@ def export(exportList, filename, colors=None, preferences=None):
         if Draft.getType(obj)
         not in ["Dimension", "Material", "MaterialContainer", "WorkingPlaneProxy"]
     ]
+
+    # Note that the Draft.get_group_contents() function used later will also find children.
+    # Duplicate processing is avoided with the treated list.
     if preferences["FULL_PARAMETRIC"]:
         objectslist = Arch.getAllChildren(objectslist)
 
@@ -1150,19 +1153,24 @@ def export(exportList, filename, colors=None, preferences=None):
         if (Draft.getType(floor) == "Floor") or (
             hasattr(floor, "IfcType") and floor.IfcType == "Building Storey"
         ):
+            f = products[floor.Name]
+            floors.append(f)
+            defaulthost = f
+            treated.append(floor.Name)
+
+            # objs will include the floor itself, we avoid duplicate processing with the treated list.
             objs = Draft.get_group_contents(floor, walls=True, addgroups=True)
             objs = Arch.pruneIncluded(objs)
-            objs.remove(floor)  # get_group_contents + addgroups will include the floor itself
-            buildingelements, spaces = [], []
+            buildingelements = []
+            spaces = []
             for c in objs:
-                if c.Name in products and c.Name not in treated:
+                if c.Name not in treated and c.Name in products:
                     prod = products[c.Name]
                     if prod.is_a() == "IfcSpace":
                         spaces.append(prod)
                     else:
                         buildingelements.append(prod)
                     treated.append(c.Name)
-            f = products[floor.Name]
             if buildingelements:
                 ifcfile.createIfcRelContainedInSpatialStructure(
                     ifcopenshell.guid.new(), history, "StoreyLink", "", buildingelements, f
@@ -1171,8 +1179,6 @@ def export(exportList, filename, colors=None, preferences=None):
                 ifcfile.createIfcRelAggregates(
                     ifcopenshell.guid.new(), history, "StoreyLink", "", f, spaces
                 )
-            floors.append(f)
-            defaulthost = f
 
     # buildings
 
@@ -1182,23 +1188,25 @@ def export(exportList, filename, colors=None, preferences=None):
         if (Draft.getType(building) == "Building") or (
             hasattr(building, "IfcType") and building.IfcType == "Building"
         ):
+            b = products[building.Name]
+            buildings.append(b)
+            if not defaulthost and not preferences["ADD_DEFAULT_STOREY"]:
+                defaulthost = b
+            treated.append(building.Name)
+
+            # objs will include the building itself, we avoid duplicate processing with the treated list.
             objs = Draft.get_group_contents(building, walls=True, addgroups=True)
             objs = Arch.pruneIncluded(objs)
             children = []
             childfloors = []
             for c in objs:
-                if not (c.Name in treated):
-                    if (
-                        c.Name != building.Name
-                    ):  # get_group_contents + addgroups will include the building itself
-                        if c.Name in products:
-                            if Draft.getType(c) in ["Floor", "BuildingPart", "Space"]:
-                                childfloors.append(products[c.Name])
-                                treated.append(c.Name)
-                            elif not (c.Name in treated):
-                                children.append(products[c.Name])
-                                treated.append(c.Name)
-            b = products[building.Name]
+                if c.Name not in treated and c.Name in products:
+                    if Draft.getType(c) in ["Floor", "BuildingPart", "Space"]:
+                        childfloors.append(products[c.Name])
+                        treated.append(c.Name)
+                    else:
+                        children.append(products[c.Name])
+                        treated.append(c.Name)
             if children:
                 ifcfile.createIfcRelContainedInSpatialStructure(
                     ifcopenshell.guid.new(), history, "BuildingLink", "", children, b
@@ -1207,27 +1215,23 @@ def export(exportList, filename, colors=None, preferences=None):
                 ifcfile.createIfcRelAggregates(
                     ifcopenshell.guid.new(), history, "BuildingLink", "", b, childfloors
                 )
-            buildings.append(b)
-            if not defaulthost and not preferences["ADD_DEFAULT_STOREY"]:
-                defaulthost = b
 
     # sites
 
     for site in exportIFCHelper.getObjectsOfIfcType(objectslist, "Site"):
+        sites.append(products[site.Name])
+        treated.append(site.Name)
+
+        # objs will include the site itself, we avoid duplicate processing with the treated list.
         objs = Draft.get_group_contents(site, walls=True, addgroups=True)
         objs = Arch.pruneIncluded(objs)
         children = []
         childbuildings = []
         for c in objs:
-            if (
-                c.Name != site.Name
-            ):  # get_group_contents + addgroups will include the building itself
-                if c.Name in products:
-                    if not (c.Name in treated):
-                        if Draft.getType(c) == "Building":
-                            childbuildings.append(products[c.Name])
-                            treated.append(c.Name)
-        sites.append(products[site.Name])
+            if c.Name not in treated and c.Name in products:
+                if Draft.getType(c) == "Building":
+                    childbuildings.append(products[c.Name])
+                    treated.append(c.Name)
 
     # add default site, building and storey as required
 


### PR DESCRIPTION
Fixes #28370.

The issue is caused by the use of `Arch.getAllChildren()` and `Draft.get_group_contents()` which can find the same children. The fix makes use of the existing `treated` list.