### PR TITLE
CAM: fix red ink bug with kineticNCBeamicon2 legacy post

### DIFF
--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -332,6 +332,7 @@ SET(PathPythonPostScripts_SRCS
     Path/Post/scripts/generic_plasma_post.py
     Path/Post/scripts/grbl_post.py
     Path/Post/scripts/heidenhain_legacy_post.py
+    Path/Post/scripts/KineticNCBeamicon2_legacy_post.py
     Path/Post/scripts/linuxcnc_post.py
     Path/Post/scripts/linuxcnc_legacy_post.py
     Path/Post/scripts/jtech_legacy_post.py

--- a/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_legacy_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/KineticNCBeamicon2_legacy_post.py
@@ -88,17 +88,9 @@ parser.add_argument(
 )
 parser.add_argument("--precision", default="3", help="number of digits of precision, default=3")
 parser.add_argument(
-    "--preamble",
-    help='set commands to be issued before the first command, default="'
-    + PREAMBLE.replace("\n", "\\n")
-    + '"',
+    "--preamble", help="set commands to be issued before the first command", default=""
 )
-parser.add_argument(
-    "--postamble",
-    help='set commands to be issued after the last command, default="'
-    + POSTAMBLE.replace("\n", "\\n")
-    + '"',
-)
+parser.add_argument("--postamble", default="")
 parser.add_argument(
     "--inches", action="store_true", help="Convert output for US imperial mode (G20)"
 )


### PR DESCRIPTION
Fixes #27687 

legacy post pre/postamble arg flags included illegal characters.  Argparse was puking on this.

I've set the default values to the empty string.

This post is legacy and authors should consider porting to new machine-based postprocessing as soon as possible.


