### PR TITLE
Sketcher: Add grid transparency preference

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -29,9 +29,9 @@
 #include <Inventor/nodes/SoLineSet.h>
 #include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoTransparencyType.h>
 #include <Inventor/nodes/SoVertexProperty.h>
 #include <Inventor/nodes/SoSeparator.h>
-#include <Inventor/nodes/SoBaseColor.h>
 #include <Inventor/SbVec3f.h>
 
 #include <QApplication>
@@ -91,6 +91,7 @@ public:
     int GridDivLineWidth = 2;
     unsigned int GridLineColor;
     unsigned int GridDivLineColor;
+    float GridTransparency = 0.6f;
 
 private:
     void computeGridSize(const Gui::View3DInventorViewer* viewer);
@@ -100,7 +101,7 @@ private:
         bool divLines,
         bool subDivLines,
         int pattern,
-        SoBaseColor* color,
+        SoMaterial* material,
         int lineWidth = 1
     );
 
@@ -264,13 +265,14 @@ void GridExtensionP::createGrid(bool cameraUpdate)
 
     computeGridSize(viewer);
 
-    auto getColor = [](auto unpackedcolor) {
-        SoBaseColor* lineColor = new SoBaseColor;
-        float transparency;
+    auto getMaterial = [this](auto unpackedcolor) {
+        SoMaterial* mat = new SoMaterial;
+        float unused;
         SbColor lineCol(0.7f, 0.7f, 0.7f);
-        lineCol.setPackedValue(unpackedcolor, transparency);
-        lineColor->rgb.setValue(lineCol);
-        return lineColor;
+        lineCol.setPackedValue(unpackedcolor, unused);
+        mat->diffuseColor.setValue(lineCol);
+        mat->transparency.setValue(GridTransparency);
+        return mat;
     };
 
     // First we create the subdivision lines
@@ -279,7 +281,7 @@ void GridExtensionP::createGrid(bool cameraUpdate)
         true,
         (GridNumberSubdivision == 1),
         GridLinePattern,
-        getColor(GridLineColor),
+        getMaterial(GridLineColor),
         GridLineWidth
     );
 
@@ -290,7 +292,7 @@ void GridExtensionP::createGrid(bool cameraUpdate)
             false,
             true,
             GridDivLinePattern,
-            getColor(GridDivLineColor),
+            getMaterial(GridDivLineColor),
             GridDivLineWidth
         );
     }
@@ -301,7 +303,7 @@ void GridExtensionP::createGridPart(
     bool subDivLines,
     bool divLines,
     int pattern,
-    SoBaseColor* color,
+    SoMaterial* material,
     int lineWidth
 )
 {
@@ -311,7 +313,10 @@ void GridExtensionP::createGridPart(
     GridRoot->addChild(parent);
     SoVertexProperty* vts;
 
-    parent->addChild(color);
+    SoTransparencyType* transparencyType = new SoTransparencyType;
+    transparencyType->value = SoTransparencyType::DELAYED_BLEND;
+    parent->addChild(transparencyType);
+    parent->addChild(material);
 
     SoDrawStyle* DefaultStyle = new SoDrawStyle;
     DefaultStyle->lineWidth = lineWidth;
@@ -585,6 +590,12 @@ void ViewProviderGridExtension::setGridLineColor(const Base::Color& color)
 void ViewProviderGridExtension::setGridDivLineColor(const Base::Color& color)
 {
     pImpl->GridDivLineColor = color.getPackedValue();
+    drawGrid(false);
+}
+
+void ViewProviderGridExtension::setGridTransparency(float transparency)
+{
+    pImpl->GridTransparency = transparency;
     drawGrid(false);
 }
 

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.h
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.h
@@ -80,6 +80,7 @@ protected:
     void setGridDivLineWidth(int width);
     void setGridLineColor(const Base::Color& color);
     void setGridDivLineColor(const Base::Color& color);
+    void setGridTransparency(float transparency);
 
     bool extensionHandleChangedPropertyType(
         Base::XMLReader& reader,

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -357,6 +357,7 @@ void SketcherSettingsGrid::saveSettings()
     ui->gridSize->onSave();
     ui->checkBoxGridAuto->onSave();
     ui->gridSizePixelThreshold->onSave();
+    ui->gridTransparency->onSave();
     ui->gridLineColor->onSave();
     ui->gridDivLineColor->onSave();
     ui->gridLineWidth->onSave();
@@ -381,6 +382,7 @@ void SketcherSettingsGrid::loadSettings()
     ui->gridSize->onRestore();
     ui->checkBoxGridAuto->onRestore();
     ui->gridSizePixelThreshold->onRestore();
+    ui->gridTransparency->onRestore();
     ui->gridLineColor->onRestore();
     ui->gridDivLineColor->onRestore();
     ui->gridLineWidth->onRestore();

--- a/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettingsGrid.ui
@@ -159,8 +159,40 @@ The grid spacing changes if it becomes smaller than the specified pixel size.</s
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="vLayout">
-      <item>
+     <layout class="QGridLayout" name="gridLayoutDisplay">
+    <item row="0" column="0">
+     <widget class="QLabel" name="label_gridTransparency">
+      <property name="text">
+       <string>Grid transparency</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="1">
+     <widget class="Gui::PrefSpinBox" name="gridTransparency">
+      <property name="toolTip">
+       <string>Sets the transparency of the grid lines (0 = opaque, 100 = fully transparent)</string>
+      </property>
+      <property name="suffix">
+       <string notr="true"> %</string>
+      </property>
+      <property name="minimum">
+       <number>0</number>
+      </property>
+      <property name="maximum">
+       <number>100</number>
+      </property>
+      <property name="value">
+       <number>60</number>
+      </property>
+      <property name="prefEntry" stdset="0">
+       <cstring>GridTransparency</cstring>
+      </property>
+      <property name="prefPath" stdset="0">
+       <cstring>Mod/Sketcher/General</cstring>
+      </property>
+     </widget>
+    </item>
+      <item row="1" column="0" colspan="2">
        <widget class="QGroupBox" name="groupBox_3">
         <property name="title">
          <string>Minor Grid Lines</string>
@@ -266,7 +298,7 @@ The grid spacing changes if it becomes smaller than the specified pixel size.</s
         </layout>
        </widget>
       </item>
-      <item>
+      <item row="2" column="0" colspan="2">
        <widget class="QGroupBox" name="groupBox_4">
         <property name="title">
          <string>Major Grid Lines</string>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -386,6 +386,12 @@ void ViewProviderSketch::ParameterObserver::initParameters()
               Client.setGridDivLineColor(color);
           },
           nullptr}},
+        {"GridTransparency",
+         {[this](const std::string& string, [[maybe_unused]] App::Property* property) {
+              auto v = getSketcherGeneralParameter(string, 60);
+              Client.setGridTransparency(static_cast<float>(v) / 100.0f);
+          },
+          nullptr}},
         {"SegmentsPerGeometry",
          {[this](const std::string& string,
                                          [[maybe_unused]] App::Property* property) {


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Adds a preference to set the transparency for the grid in Sketcher. Default value is 60 % as per DWG discussion.
AI helped me with the VP implementation.
<img width="1053" height="1044" alt="grafik" src="https://github.com/user-attachments/assets/92d5445a-4d3c-425e-9335-800377ddc827" />

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #28775 
## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
### Light Theme
#### Before:
<img width="1228" height="693" alt="Bildschirmfoto 2026-03-28 um 17 02 36" src="https://github.com/user-attachments/assets/bb0688c8-9e80-4d4b-b15c-b14652ae410b" />

#### After
<img width="1228" height="685" alt="Bildschirmfoto 2026-03-28 um 17 02 02" src="https://github.com/user-attachments/assets/763cde25-e083-4be3-8f91-19606197f767" />

### Dark Theme
#### Before
<img width="1232" height="700" alt="Bildschirmfoto 2026-03-28 um 17 03 04" src="https://github.com/user-attachments/assets/afffa609-ddf5-4090-b6ea-41e81180bc20" />

#### After:
<img width="1224" height="694" alt="Bildschirmfoto 2026-03-28 um 17 03 23" src="https://github.com/user-attachments/assets/a05be479-0d89-4553-9672-7d0507809127" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
