### PR TITLE
Gui: Add undo transaction for suppression state toggle

### DIFF
--- a/src/Gui/ViewProviderSuppressibleExtension.cpp
+++ b/src/Gui/ViewProviderSuppressibleExtension.cpp
@@ -22,6 +22,7 @@
 
 
 #include <App/Document.h>
+#include <App/AutoTransaction.h>
 #include <App/SuppressibleExtension.h>
 
 #include "ActionFunction.h"
@@ -90,17 +91,19 @@ QIcon ViewProviderSuppressibleExtension::extensionMergeColorfullOverlayIcons(con
 void ViewProviderSuppressibleExtension::extensionSetupContextMenu(QMenu* menu, QObject*, const char*)
 {
     auto vp = getExtendedViewProvider();
-    auto obj = vp->getObject();
-    auto sObj = obj->getExtensionByType<App::SuppressibleExtension>();
+    auto obj = vp->getObject()->getExtensionByType<App::SuppressibleExtension>();
     // Show Suppressed toggle action if the Suppressed property is visible
-    if (sObj && !sObj->Suppressed.testStatus(App::Property::Hidden)) {
-        auto* func = new Gui::ActionFunction(menu);
+    if (obj && !obj->Suppressed.testStatus(App::Property::Hidden)) {
+        Gui::ActionFunction* func = new Gui::ActionFunction(menu);
         QAction* act = menu->addAction(QObject::tr("Suppressed"));
         act->setCheckable(true);
-        act->setChecked(sObj->Suppressed.getValue());
-        func->trigger(act, [obj, sObj]() {
-            sObj->Suppressed.setValue(!sObj->Suppressed.getValue());
-            obj->getDocument()->recompute();
+        act->setChecked(obj->Suppressed.getValue());
+        func->trigger(act, [obj]() {
+            auto* doc = obj->getExtendedObject()->getDocument();
+            App::AutoTransaction trans(
+                doc->openTransaction("Edit " + obj->Suppressed.getFullName()));
+            obj->Suppressed.setValue(!obj->Suppressed.getValue());
+            doc->recompute();
         });
     }
 }

--- a/src/Gui/ViewProviderSuppressibleExtension.cpp
+++ b/src/Gui/ViewProviderSuppressibleExtension.cpp
@@ -100,8 +100,7 @@ void ViewProviderSuppressibleExtension::extensionSetupContextMenu(QMenu* menu, Q
         act->setChecked(obj->Suppressed.getValue());
         func->trigger(act, [obj]() {
             auto* doc = obj->getExtendedObject()->getDocument();
-            App::AutoTransaction trans(
-                doc->openTransaction("Edit " + obj->Suppressed.getFullName()));
+            App::AutoTransaction trans(doc->openTransaction("Edit " + obj->Suppressed.getFullName()));
             obj->Suppressed.setValue(!obj->Suppressed.getValue());
             doc->recompute();
         });


### PR DESCRIPTION
## Problem

Toggling the suppression state of a PartDesign feature via the context menu does not create an undo entry. Pressing Ctrl+Z after changing suppression does nothing.

Fixes #28594

## Root Cause

In `ViewProviderSuppressibleExtension::extensionSetupContextMenu`, the `Suppressed` property was toggled directly without wrapping it in a transaction:

```cpp
func->trigger(act, [obj]() { obj->Suppressed.setValue(!obj->Suppressed.getValue()); });
```

## Fix

Wrap the toggle in an `App::AutoTransaction` with `openTransaction()`, following the same pattern used in `ViewProviderLink.cpp` for similar context menu actions:

```cpp
func->trigger(act, [obj]() {
    App::AutoTransaction trans(
        obj->getExtendedObject()->getDocument()->openTransaction("Toggle suppression"));
    obj->Suppressed.setValue(!obj->Suppressed.getValue());
});
```

## Testing

1. Open the Part Design example file
2. Right-click a feature → toggle "Suppressed"
3. Press Ctrl+Z → suppression state should be undone
4. Press Ctrl+Y → suppression state should be redone