### PR TITLE
BIM: make Report spreadsheet editable after generation

### DIFF
--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -707,9 +707,14 @@ class _ArchReport:
                 f"Report '{getattr(obj, 'Label', '')}': No target spreadsheet found.\n"
             )
             return
-        # clear all the content of the spreadsheet
+        # Save column widths before clearing so user adjustments survive recomputes.
         used_range = sp.getUsedRange()
+        saved_widths = {}
         if used_range:
+            first_col = ord(used_range[0].rstrip("0123456789"))
+            last_col = ord(used_range[1].rstrip("0123456789"))
+            for col in range(first_col, last_col + 1):
+                saved_widths[chr(col)] = sp.getColumnWidth(chr(col))
             sp.clear(f"{used_range[0]}:{used_range[1]}")
         else:
             FreeCAD.Console.PrintError(
@@ -737,6 +742,8 @@ class _ArchReport:
                 print_results_in_bold=statement.print_results_in_bold,
             )
 
+        for col, width in saved_widths.items():
+            sp.setColumnWidth(col, width)
         sp.recompute()
         sp.purgeTouched()
 

--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -696,6 +696,8 @@ class _ArchReport:
 
     def execute(self, obj):
         """Executes all statements and writes the results to the target spreadsheet."""
+        if not getattr(obj, "AutoUpdate", True):
+            return
         if not self.live_statements:
             return
 

--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -716,11 +716,6 @@ class _ArchReport:
             for col in range(first_col, last_col + 1):
                 saved_widths[chr(col)] = sp.getColumnWidth(chr(col))
             sp.clear(f"{used_range[0]}:{used_range[1]}")
-        else:
-            FreeCAD.Console.PrintError(
-                f"Report '{getattr(obj, 'Label', '')}': Invalid cell address found, clearing spreadsheet.\n"
-            )
-            sp.clearAll()
 
         # Reset the row counter for a new report build.
         self.spreadsheet_current_row = 1

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -2111,3 +2111,27 @@ class TestArchReport(TestArchBase.TestArchBase):
         finally:
             # CLEANUP: Always restore the user's original schema.
             FreeCAD.Units.setSchema(original_schema_index)
+
+    def test_autoupdate_controls_spreadsheet_overwrite(self):
+        """AutoUpdate=False preserves user edits on recompute;
+        AutoUpdate=True overwrites them."""
+        report = Arch.makeReport()
+        report.Proxy.live_statements[0].query_string = "SELECT Label FROM document"
+        report.Proxy.commit_statements()
+        self.doc.recompute()
+
+        sp = report.Target
+        self.assertIsNotNone(sp, "Report should have a target spreadsheet.")
+        self.assertTrue(len(sp.getUsedCells()) > 0, "Spreadsheet should have data.")
+
+        with self.subTest(AutoUpdate=False):
+            report.AutoUpdate = False
+            sp.set("Z1", "USER_EDIT")
+            self.doc.recompute()
+            self.assertIn("USER_EDIT", sp.getContents("Z1"))
+
+        with self.subTest(AutoUpdate=True):
+            report.AutoUpdate = True
+            sp.set("Z1", "USER_EDIT")
+            self.doc.recompute()
+            self.assertEqual(sp.getContents("Z1"), "")

--- a/src/Mod/BIM/bimtests/TestArchReport.py
+++ b/src/Mod/BIM/bimtests/TestArchReport.py
@@ -2135,3 +2135,21 @@ class TestArchReport(TestArchBase.TestArchBase):
             sp.set("Z1", "USER_EDIT")
             self.doc.recompute()
             self.assertEqual(sp.getContents("Z1"), "")
+
+    def test_column_widths_preserved_across_recompute(self):
+        """Column widths set by the user should survive a report recompute."""
+        report = Arch.makeReport()
+        report.Proxy.live_statements[0].query_string = "SELECT Label FROM document"
+        report.Proxy.commit_statements()
+        self.doc.recompute()
+
+        sp = report.Target
+        custom_width = 200
+        sp.setColumnWidth("A", custom_width)
+        self.doc.recompute()
+
+        self.assertEqual(
+            sp.getColumnWidth("A"),
+            custom_width,
+            "Column width should be preserved after recompute.",
+        )


### PR DESCRIPTION
The Report's `Target` link creates a dependency that causes to call `execute()` on every document recompute, overwriting the spreadsheet even when AutoUpdate is False. This made the generated spreadsheet effectively read-only: any user edit (cell content, column width, alignment) was immediately lost.

This PR:

- Fixes this by making `execute()` now respect `AutoUpdate=False`, skipping the rewrite.
- Column widths are saved and restored across recomputes so user adjustments persist when `AutoUpdate` is `True`
- Unrelated to the changes above, the misleading "Invalid cell address" error that fired on every first run (empty spreadsheet) was removed. The change is small, the user experience benefit high, and the risk low.
- Expands the test suite to cover the first two points above

## Issues

Note: this PR fixes the issue in the sense that the spreadsheet can now be made editable by skipping recomputes. It is not the exact solution that the OP was asking for though. Making it fully editable or being able to keep the full formatting (or even cell alignment) across recomputes would require major changes and would be brittle: if the row styles/alignments were saved, whenever the query returns more objects, the user formatting would no longer point to the original cells.

That said, a small migitation for better user changes preservation across recomputes has been added: keeping column width. The ArchSchedule tool is also doing this, and column count and definition generally stay constant throughout recomputes, so it's safe to save it.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/26251