### PR TITLE
TechDraw: Fix DraftView and ArchView not respecting page Scale on cre…

### DIFF
--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -349,6 +349,8 @@ void CmdTechDrawView::activated(int iMsg)
                 SpreadName.c_str());
             doCommand(Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)", PageName.c_str(),
                 FeatName.c_str());
+            doCommand(Doc, "if App.activeDocument().%s.Scale: App.activeDocument().%s.Scale = App.activeDocument().%s.Scale",
+                PageName.c_str(), FeatName.c_str(), PageName.c_str());
             updateActive();
             commitCommand();
             viewCreated = true;
@@ -366,6 +368,8 @@ void CmdTechDrawView::activated(int iMsg)
                 SourceName.c_str());
             doCommand(Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)", PageName.c_str(),
                 FeatName.c_str());
+            doCommand(Doc, "if App.activeDocument().%s.Scale: App.activeDocument().%s.Scale = App.activeDocument().%s.Scale",
+                PageName.c_str(), FeatName.c_str(), PageName.c_str());
             updateActive();
             commitCommand();
             viewCreated = true;
@@ -1640,6 +1644,8 @@ void CmdTechDrawDraftView::activated(int iMsg)
                   SourceName.c_str());
         doCommand(Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)", PageName.c_str(),
                   FeatName.c_str());
+        doCommand(Doc, "if App.activeDocument().%s.Scale: App.activeDocument().%s.Scale = App.activeDocument().%s.Scale",
+                  PageName.c_str(), FeatName.c_str(), PageName.c_str());
         doCommand(Doc, "App.activeDocument().%s.Direction = FreeCAD.Vector(%.12f, %.12f, %.12f)",
                   FeatName.c_str(), dirs.first.x, dirs.first.y, dirs.first.z);
         updateActive();

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -1782,6 +1782,8 @@ void CmdTechDrawSpreadsheetView::activated(int iMsg)
 
     doCommand(Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)", PageName.c_str(),
               FeatName.c_str());
+    doCommand(Doc, "if App.activeDocument().%s.Scale: App.activeDocument().%s.Scale = App.activeDocument().%s.Scale",
+        PageName.c_str(), FeatName.c_str(), PageName.c_str());
     updateActive();
     commitCommand();
 }


### PR DESCRIPTION
## Summary

The `TechDraw_View` command (New View button) has inline code paths for creating ArchView and SpreadsheetView that did not copy the page's `Scale` property to newly created views. Similarly, the dedicated `TechDraw_DraftView` command had the same issue. This caused these views to always default to `Scale=1.0` regardless of the page setting.

Note: The dedicated `TechDraw_ArchView` command was already fixed by a prior commit (bf19a8917fa), but the `TechDraw_View` command — which is the primary way users create these views — was missed.

## Issues

Fixes #27698

## Changes

Added page scale inheritance to three previously unfixed code paths in `Command.cpp`:
- `TechDraw_View` → ArchSection (BIM view) creation path
- `TechDraw_View` → Spreadsheet view creation path
- `TechDraw_DraftView` dedicated command

## Test plan

- [ ] Create a TechDraw Page and set its `Scale` to a non-default value (e.g. `0.01`)
- [ ] Select a BIM Section Plane and click **New View** (`TechDraw_View`) → verify the created BIM view inherits the page scale
- [ ] Select a Draft object and run **TechDraw → Draft View** → verify the created DraftView inherits the page scale
- [ ] Select a Spreadsheet and click **New View** → verify the created Spreadsheet view inherits the page scale
- [ ] Verify that `BIM_TDView` (BIM workbench) still works correctly (was not affected)

### Before
https://github.com/user-attachments/assets/c50462fd-0f4e-42d5-a3fe-9ba84cfd7678

### After
https://github.com/user-attachments/assets/b2f4e233-60a9-455d-be26-7807945f30d1