### PR TITLE
Fix InputHint: show proper key labels instead of "???" in Std Measure

### DIFF
--- a/src/Gui/InputHintWidget.cpp
+++ b/src/Gui/InputHintWidget.cpp
@@ -303,6 +303,16 @@ QString Gui::InputHintWidget::inputRepresentation(const InputHint::UserInput key
         /*: Keyboard key for Scroll Lock */
         case KeyScrollLock: return tr("Scroll Lock");
 
+        // Modifier variants (same Qt values as Key* but stored as KeyboardModifier)
+        case ModifierShift: return tr("⇧ Shift");
+        case ModifierCtrl: return tr("Ctrl");
+#ifdef FC_OS_WIN32
+        case ModifierMeta: return QStringLiteral("⊞ Win");
+#else
+        case ModifierMeta: return QStringLiteral("❖ Meta");
+#endif
+        case ModifierAlt: return tr("Alt");
+
         // function
         case KeyF1: return QStringLiteral("F1");
         case KeyF2: return QStringLiteral("F2");


### PR DESCRIPTION
## Fix: InputHint shows "???" instead of proper key labels

### Problem
The input hints in Std Measure showed "???" instead of proper key labels like "Ctrl" and "⇧ Shift".

### Root Cause
The `inputRepresentation()` function in `InputHintWidget.cpp` was missing cases for `ModifierCtrl`, `ModifierShift`, `ModifierAlt`, and `ModifierMeta` enum values (which are used by `TaskMeasure.cpp`). When these values were passed to `inputRepresentation()`, they fell through to the default case which returns "???".

### Fix
Added explicit cases for `ModifierShift`, `ModifierCtrl`, `ModifierAlt`, and `ModifierMeta` in `inputRepresentation()` that return the same values as their `Key*` counterparts:

```cpp
// Modifier variants (same Qt values as Key* but stored as KeyboardModifier)
case ModifierShift: return tr("⇧ Shift");
case ModifierCtrl: return tr("Ctrl");
#ifdef FC_OS_WIN32
case ModifierMeta: return QStringLiteral("⊞ Win");
#else
case ModifierMeta: return QStringLiteral("❖ Meta");
#endif
case ModifierAlt: return tr("Alt");
```

### Issue
Fixes https://github.com/FreeCAD/FreeCAD/issues/28819

### Testing
This is a FreeCAD C++ bugfix. The fix ensures that when users use Std Measure tool, the input hints properly display Ctrl and Shift key labels instead of "???".

---

Claiming bounty. Payment address: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9