### PR TITLE
BIM: BIM_Slab does not need to set FreeCAD.activeDraftCommand

### DIFF
--- a/src/Mod/BIM/bimcommands/BimSlab.py
+++ b/src/Mod/BIM/bimcommands/BimSlab.py
@@ -60,7 +60,6 @@ class BIM_Slab:
             if hasattr(FreeCADGui, "draftToolBar"):
                 FreeCADGui.draftToolBar.selectUi()
             FreeCAD.Console.PrintMessage(translate("BIM", "Select a planar object") + "\n")
-            FreeCAD.activeDraftCommand = self
             self.view = FreeCADGui.ActiveDocument.ActiveView
             self.callback = self.view.addEventCallback("SoEvent", DraftTools.selectObject)
 


### PR DESCRIPTION
This is only required for commands that use the grid. `FreeCAD.activeDraftCommand` was never reset to `None` by the command.
