### PR TITLE
Part/PD: Error handling for failed preview generation

### DIFF
--- a/src/Mod/Part/Gui/PreviewUpdateScheduler.cpp
+++ b/src/Mod/Part/Gui/PreviewUpdateScheduler.cpp
@@ -23,6 +23,13 @@
 
 #include "PreviewUpdateScheduler.h"
 
+#include <Base/Console.h>
+#include <Base/Exception.h>
+
+#include <Standard_Failure.hxx>
+
+FC_LOG_LEVEL_INIT("Part", true, true);
+
 using namespace PartGui;
 
 QtPreviewUpdateScheduler::QtPreviewUpdateScheduler(QObject* parent)
@@ -56,7 +63,15 @@ void QtPreviewUpdateScheduler::flush()
         }
 
         if (auto* previewExtension = object->getExtensionByType<Part::PreviewExtension>(true)) {
-            previewExtension->updatePreview();
+            try {
+                previewExtension->updatePreview();
+            }
+            catch (Standard_Failure& e) {
+                FC_ERR("Preview update failed: " << e.GetMessageString());
+            }
+            catch (Base::Exception& e) {
+                FC_ERR("Preview update failed: " << e.what());
+            }
         }
     }
 }

--- a/src/Mod/PartDesign/App/FeatureBoolean.cpp
+++ b/src/Mod/PartDesign/App/FeatureBoolean.cpp
@@ -175,7 +175,17 @@ void Boolean::updatePreviewShape()
         TopoShape base = getBaseTopoShape(true).moved(getLocation().Inverted());
         TopoShape result = Shape.getShape();
 
-        PreviewShape.setValue(base.makeElementCut(result.getShape()));
+        try {
+            PreviewShape.setValue(base.makeElementCut(result.getShape()));
+        }
+        catch (Standard_Failure& e) {
+            FC_ERR("Boolean preview failed: " << e.GetMessageString());
+            PreviewShape.setValue(base);
+        }
+        catch (Base::Exception& e) {
+            FC_ERR("Boolean preview failed: " << e.what());
+            PreviewShape.setValue(base);
+        }
         return;
     }
 


### PR DESCRIPTION
Prevent preview exceptions from propagating into Qt code. Adds top-level generic handling in the `flush()` method as a catch-all safety net, but also more targeted handling for the specific case that's causing Issue #28779. Fixes #28779. The underlying error is simply that there is no geometry selected yet, so there's nothing to do a boolean operation on. So basically an "expected" exception.