### PR TITLE
Build: Fix macOS CFBundleVersion generation

### DIFF
--- a/package/rattler-build/osx/create_bundle.sh
+++ b/package/rattler-build/osx/create_bundle.sh
@@ -56,7 +56,7 @@ echo -e "version_name:  ${version_name}"
 echo -e "################"
 
 cp Info.plist.template ${conda_env}/../Info.plist
-sed -i "s/FREECAD_VERSION/${version_name}/" ${conda_env}/../Info.plist
+sed -i "s/FREECAD_VERSION/${BUILD_TAG}/" ${conda_env}/../Info.plist
 sed -i "s/APPLICATION_MENU_NAME/${application_menu_name}/" ${conda_env}/../Info.plist
 
 pixi list -e default > FreeCAD.app/Contents/packages.txt


### PR DESCRIPTION
Dedicated 1.1-branch fix. The variable must be strictly numbers and dots. Fixes #28678 on the release branch. Fix for main branch is the SST PR #28414.