### PR TITLE
Mesh: fix testPrimitiveCount

### DIFF
--- a/src/Mod/Mesh/App/MeshTestsApp.py
+++ b/src/Mod/Mesh/App/MeshTestsApp.py
@@ -514,6 +514,7 @@ class PivyTestCases(unittest.TestCase):
 
     def testPrimitiveCount(self):
         if not FreeCAD.GuiUp:
+            self.skipTest("GUI not running, skipping coin3d primitive count test")
             return
         self.planarMesh.append([-16.097176, -29.891157, 15.987688])
         self.planarMesh.append([-16.176304, -29.859991, 15.947966])
@@ -526,13 +527,15 @@ class PivyTestCases(unittest.TestCase):
         from pivy import coin
         import FreeCADGui
 
-        Mesh.show(planarMeshObject)
         view = FreeCADGui.ActiveDocument.ActiveView
         view.setAxisCross(False)
         pc = coin.SoGetPrimitiveCountAction()
         pc.apply(view.getSceneGraph())
-        self.assertTrue(pc.getTriangleCount() == 2)
-        # self.assertTrue(pc.getPointCount() == 6)
+        pre_mesh_tc = pc.getTriangleCount()
+        Mesh.show(planarMeshObject)
+        pc.apply(view.getSceneGraph())
+        mesh_tc = pc.getTriangleCount() - pre_mesh_tc
+        self.assertTrue(mesh_tc == 2)
 
     def tearDown(self):
         # closing doc


### PR DESCRIPTION
test broke after 3f49f3f05958c4a8f4c5b470adfebbc1503b3f45 which added an invisible cube to the scene, changing the triangle count. The test now checks the difference before and after showing the mesh so it shouldn't break even if the invisible cube is changed/removed in the future