### PR TITLE
Part: Repect 'VisualTouched' flag even if no geometry changed

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -1473,7 +1473,7 @@ void ViewProviderPartExt::updateVisual()
 {
     TopoDS_Shape shape = getRenderedShape().getShape();
 
-    if (lastRenderedShape.IsPartner(shape)) {
+    if (!VisualTouched && lastRenderedShape.IsPartner(shape)) {
         return;
     }
 


### PR DESCRIPTION
In commit 72971d48e5bd55d71163fcf5ea56d3816926359b from PR #26992 we introduced an optimization that didn't recompute the coin scenegraph if no geometry changed. This ignored any code that explicitly set the `VisualTouched` flag on the geometry, and appears to have resulted in Issue #28814 (revealed by bisection). This PR fixes #28814 by checking that flag before deciding the short-circuit.