### PR TITLE
On 32bit archs, E57Format fails to build, misses include to <limits>

### DIFF
--- a/src/3rdParty/libE57Format/src/ReaderImpl.cpp
+++ b/src/3rdParty/libE57Format/src/ReaderImpl.cpp
@@ -30,6 +30,8 @@
 #include "Common.h"
 #include "StringFunctions.h"
 
+#include <limits>
+
 namespace e57
 {
    /*!


### PR DESCRIPTION
When packaging for Debian, I've encountered this build issue on armhf, for the e57 library caused by a missing include:

(complete build log: https://debusine.debian.net/debian/developers/artifact/3493175/raw/freecad_1.1.0+dfsg-1_armhf-2026-03-28T07:55:49Z.build)

```
/build/reproducible-path/freecad-1.1.0+dfsg/src/3rdParty/libE57Format/src/ReaderImpl.cpp: In member function ‘bool e57::ReaderImpl::ReadData3D(int64_t, e57::Data3D&) const’:
/build/reproducible-path/freecad-1.1.0+dfsg/src/3rdParty/libE57Format/src/ReaderImpl.cpp:633:85: error: incomplete type ‘std::numeric_limits<unsigned int>’ used in nested name specifier
  633 |       if ( points.childCount() > static_cast<int64_t>( std::numeric_limits<size_t>::max() ) )
      |                                                                                     ^~~
/build/reproducible-path/freecad-1.1.0+dfsg/src/3rdParty/libE57Format/src/ReaderImpl.cpp:635:65: error: incomplete type ‘std::numeric_limits<unsigned int>’ used in nested name specifier
  635 |          data3DHeader.pointCount = std::numeric_limits<size_t>::max();
      |                                                                 ^~~
/build/reproducible-path/freecad-1.1.0+dfsg/src/3rdParty/libE57Format/src/ReaderImpl.cpp:638:86: error: incomplete type ‘std::numeric_limits<unsigned int>’ used in nested name specifier
  638 |                    << ") exceeds storage capacity (" << std::numeric_limits<size_t>::max()
      |                                                                                      ^~~
/build/reproducible-path/freecad-1.1.0+dfsg/src/3rdParty/libE57Format/src/ReaderImpl.cpp:639:92: error: incomplete type ‘std::numeric_limits<unsigned int>’ used in nested name specifier
  639 |                    << "). Dropping " << points.childCount() - std::numeric_limits<size_t>::max()
      |                                                                                            ^~~
make[3]: *** [src/3rdParty/libE57Format/CMakeFiles/E57Format.dir/build.make:411: src/3rdParty/libE57Format/CMakeFiles/E57Format.dir/src/ReaderImpl.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
```

including "limits" fixes the "incomplete type" error.

 Submitted upstream as well: https://github.com/asmaloney/libE57Format/pull/340
