### PR TITLE
Fix: task panel hides when switching workbenches (#28821)

### DIFF
--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -842,7 +842,11 @@ void TaskView::addTaskWatcher()
     }
 
     TaskWatcherPanel->actionPanel->setScheme(QSint::ActionPanelScheme::defaultScheme());
-    setShownTaskInfo(-1);
+    // Don't hide active task dialog when switching workbenches
+    // Only switch to watcher panel if there's no active task dialog
+    if (!currentTaskInfo()) {
+        setShownTaskInfo(-1);
+    }
 }
 
 void TaskView::saveCurrentWidth()


### PR DESCRIPTION
Fix: Task panel hides when switching workbenches

## Issues
Fixes #28821

## Before and After

After the fix:

https://github.com/user-attachments/assets/4ab88c99-b845-452e-bd42-f7c8a4442665


