### PR TITLE
Part: Rewrite SignalException for cross-platform signal handling 

### DIFF
--- a/src/Gui/NotificationArea.cpp
+++ b/src/Gui/NotificationArea.cpp
@@ -121,7 +121,10 @@ struct NotificationAreaP
     bool missedNotifications = false;
 
     // Access control
-    std::mutex mutexNotification;
+    // recursive_mutex: Qt warning handlers can re-enter pushNotification()
+    // on the same thread during widget creation. Re-entrancy is safe because
+    // each entry appends to the notification list without invalidating iterators.
+    std::recursive_mutex mutexNotification;
 
     // Pointers to widgets (no ownership)
     QMenu* menu = nullptr;
@@ -911,14 +914,14 @@ NotificationArea::NotificationArea(QWidget* parent)
     // NOLINTBEGIN
     //  Signals for synchronisation of storage before showing/hiding the widget
     QObject::connect(pImp->menu, &QMenu::aboutToHide, [&]() {
-        lock_guard<std::mutex> g(pImp->mutexNotification);
+        lock_guard<std::recursive_mutex> g(pImp->mutexNotification);
         static_cast<NotificationsAction*>(pImp->notificationaction)->clearUnreadFlag();
         static_cast<NotificationsAction*>(pImp->notificationaction)->shiftToCache();
     });
 
     QObject::connect(pImp->menu, &QMenu::aboutToShow, [this]() {
         // guard to avoid modifying the notification list and indices while creating the tooltip
-        lock_guard<std::mutex> g(pImp->mutexNotification);
+        lock_guard<std::recursive_mutex> g(pImp->mutexNotification);
         setText(QString::number(0));  // no unread notifications
         if (pImp->missedNotifications) {
             setIcon(TrayIcon::Normal);
@@ -1003,7 +1006,7 @@ void NotificationArea::mousePressEvent(QMouseEvent* e)
 
         QAction* delnotifications = menu.addAction(tr("Delete User Notifications"), [&]() {
             // guard to avoid modifying the notification list and indices while creating the tooltip
-            lock_guard<std::mutex> g(pImp->mutexNotification);
+            lock_guard<std::recursive_mutex> g(pImp->mutexNotification);
             na->deleteNotifications();
             setText(QString::number(na->getUnreadCount()));
         });
@@ -1012,7 +1015,7 @@ void NotificationArea::mousePressEvent(QMouseEvent* e)
 
         QAction* delall = menu.addAction(tr("Delete All"), [&]() {
             // guard to avoid modifying the notification list and indices while creating the tooltip
-            lock_guard<std::mutex> g(pImp->mutexNotification);
+            lock_guard<std::recursive_mutex> g(pImp->mutexNotification);
             na->deleteAll();
             setText(QString::number(0));
         });
@@ -1049,7 +1052,7 @@ void NotificationArea::pushNotification(
         showConfirmationDialog(notifiername, message);
     }
     // guard to avoid modifying the notification list and indices while creating the tooltip
-    lock_guard<std::mutex> g(pImp->mutexNotification);
+    lock_guard<std::recursive_mutex> g(pImp->mutexNotification);
 
     // NOLINTNEXTLINE
     NotificationsAction* na = static_cast<NotificationsAction*>(pImp->notificationaction);
@@ -1140,7 +1143,7 @@ void NotificationArea::showConfirmationDialog(const QString& notifiername, const
 void NotificationArea::showInNotificationArea()
 {
     // guard to avoid modifying the notification list and indices while creating the tooltip
-    lock_guard<std::mutex> g(pImp->mutexNotification);
+    lock_guard<std::recursive_mutex> g(pImp->mutexNotification);
 
     // NOLINTNEXTLINE
     NotificationsAction* na = static_cast<NotificationsAction*>(pImp->notificationaction);
@@ -1246,7 +1249,7 @@ void NotificationArea::showInNotificationArea()
                         [this, item, repetitions = item->getRepetitions()]() {
                             // guard to avoid modifying the notification
                             // start index while creating the tooltip
-                            lock_guard<std::mutex> g(pImp->mutexNotification);
+                            lock_guard<std::recursive_mutex> g(pImp->mutexNotification);
 
                             // if the item exists and the number of repetitions has not changed in
                             // the meantime

--- a/src/Mod/Part/App/ExtrusionHelper.cpp
+++ b/src/Mod/Part/App/ExtrusionHelper.cpp
@@ -47,6 +47,7 @@
 #include <ShapeFix_Wire.hxx>
 
 #include "ExtrusionHelper.h"
+#include "SignalException.h"
 #include "TopoShape.h"
 #include "BRepOffsetAPI_MakeOffsetFix.h"
 #include "Geometry.h"
@@ -686,21 +687,19 @@ void ExtrusionHelper::makeElementDraft(
         }
 
         try {
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-            Base::SignalException se;
-#endif
+            Part::SignalException::guard([&] {
+                // make loft
+                BRepOffsetAPI_ThruSections mkGenerator(
+                    params.solid ? Standard_True : Standard_False,
+                    /*ruled=*/Standard_True
+                );
+                for (auto& s : list_of_sections) {
+                    mkGenerator.AddWire(TopoDS::Wire(s.getShape()));
+                }
 
-            // make loft
-            BRepOffsetAPI_ThruSections mkGenerator(
-                params.solid ? Standard_True : Standard_False,
-                /*ruled=*/Standard_True
-            );
-            for (auto& s : list_of_sections) {
-                mkGenerator.AddWire(TopoDS::Wire(s.getShape()));
-            }
-
-            mkGenerator.Build();
-            drafts.push_back(TopoShape(0, hasher).makeElementShape(mkGenerator, list_of_sections));
+                mkGenerator.Build();
+                drafts.push_back(TopoShape(0, hasher).makeElementShape(mkGenerator, list_of_sections));
+            });
         }
         catch (Standard_Failure&) {
             throw;

--- a/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.cpp
+++ b/src/Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.cpp
@@ -104,38 +104,39 @@ void FCBRepAlgoAPI_BooleanOperation::Build()
 
 void FCBRepAlgoAPI_BooleanOperation::Build(const Message_ProgressRange& progressRange)
 {
-    Part::SignalException sig;
-    if (progressRange.UserBreak()) {
-        Standard_ConstructionError::Raise("User aborted");
-    }
-    if (myOperation == BOPAlgo_CUT && myArguments.Size() == 1 && myTools.Size() == 1
-        && myTools.First().ShapeType() == TopAbs_COMPOUND) {
-        // cut argument and compound tool
-        TopTools_ListOfShape myOriginalArguments = myArguments;
-        TopTools_ListOfShape myOriginalTools = myTools;
-        RecursiveCutFusedTools(myOriginalArguments, myOriginalTools.First());
-        myArguments = myOriginalArguments;
-        myTools = myOriginalTools;
-    }
-    else if (
-        myOperation == BOPAlgo_CUT && myArguments.Size() == 1
-        && myArguments.First().ShapeType() == TopAbs_COMPOUND
-    ) {
-        // cut compound argument
-        TopTools_ListOfShape myOriginalArguments = myArguments;
-        RecursiveCutCompound(myOriginalArguments.First());
-        myArguments = myOriginalArguments;
-    }
-    else {
+    Part::SignalException::guard([&] {
+        if (progressRange.UserBreak()) {
+            Standard_ConstructionError::Raise("User aborted");
+        }
+        if (myOperation == BOPAlgo_CUT && myArguments.Size() == 1 && myTools.Size() == 1
+            && myTools.First().ShapeType() == TopAbs_COMPOUND) {
+            // cut argument and compound tool
+            TopTools_ListOfShape myOriginalArguments = myArguments;
+            TopTools_ListOfShape myOriginalTools = myTools;
+            RecursiveCutFusedTools(myOriginalArguments, myOriginalTools.First());
+            myArguments = myOriginalArguments;
+            myTools = myOriginalTools;
+        }
+        else if (
+            myOperation == BOPAlgo_CUT && myArguments.Size() == 1
+            && myArguments.First().ShapeType() == TopAbs_COMPOUND
+        ) {
+            // cut compound argument
+            TopTools_ListOfShape myOriginalArguments = myArguments;
+            RecursiveCutCompound(myOriginalArguments.First());
+            myArguments = myOriginalArguments;
+        }
+        else {
 #if OCC_VERSION_HEX >= 0x070600
-        BRepAlgoAPI_BooleanOperation::Build(progressRange);
+            BRepAlgoAPI_BooleanOperation::Build(progressRange);
 #else
-        BRepAlgoAPI_BooleanOperation::Build();
+            BRepAlgoAPI_BooleanOperation::Build();
 #endif
-    }
-    if (progressRange.UserBreak()) {
-        Standard_ConstructionError::Raise("User aborted");
-    }
+        }
+        if (progressRange.UserBreak()) {
+            Standard_ConstructionError::Raise("User aborted");
+        }
+    });
 }
 
 void FCBRepAlgoAPI_BooleanOperation::RecursiveAddTools(const TopoDS_Shape& theTool)

--- a/src/Mod/Part/App/FeatureChamfer.cpp
+++ b/src/Mod/Part/App/FeatureChamfer.cpp
@@ -104,8 +104,8 @@ App::DocumentObjectExecReturn* Chamfer::execute()
         }
         Edges.setValues(edges);
 
-        Part::SignalException sig;
-        TopoDS_Shape shape = mkChamfer.Shape();
+        TopoDS_Shape shape;
+        Part::SignalException::guard([&] { shape = mkChamfer.Shape(); });
         if (shape.IsNull()) {
             return new App::DocumentObjectExecReturn("Resulting shape is null");
         }

--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -46,6 +46,7 @@
 
 #include "FeatureExtrusion.h"
 #include "ExtrusionHelper.h"
+#include "SignalException.h"
 #include "Part2DObject.h"
 
 
@@ -343,11 +344,10 @@ void Extrusion::extrudeShape(TopoShape& result, const TopoShape& source, const E
     if (std::fabs(params.taperAngleFwd) >= Precision::Angular()
         || std::fabs(params.taperAngleRev) >= Precision::Angular()) {
         // Tapered extrusion!
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-        Base::SignalException se;
-#endif
         std::vector<TopoShape> drafts;
-        ExtrusionHelper::makeElementDraft(params, myShape, drafts, result.Hasher);
+        Part::SignalException::guard([&] {
+            ExtrusionHelper::makeElementDraft(params, myShape, drafts, result.Hasher);
+        });
         if (drafts.empty()) {
             Standard_Failure::Raise("Drafting shape failed");
         }

--- a/src/Mod/Part/App/FeatureFillet.cpp
+++ b/src/Mod/Part/App/FeatureFillet.cpp
@@ -36,6 +36,7 @@
 #include <Base/Exception.h>
 
 #include "FeatureFillet.h"
+#include "SignalException.h"
 #include "TopoShapeOpCode.h"
 
 
@@ -54,9 +55,6 @@ App::DocumentObjectExecReturn* Fillet::execute()
 
 
     try {
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-        Base::SignalException se;
-#endif
         TopoShape baseTopoShape
             = Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
         auto baseShape = baseTopoShape.getShape();
@@ -113,7 +111,8 @@ App::DocumentObjectExecReturn* Fillet::execute()
         }
         Edges.setValues(edges);
 
-        TopoDS_Shape shape = mkFillet.Shape();
+        TopoDS_Shape shape;
+        Part::SignalException::guard([&] { shape = mkFillet.Shape(); });
         if (shape.IsNull()) {
             return new App::DocumentObjectExecReturn("Resulting shape is null");
         }

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -119,9 +119,6 @@ const char* Boolean::opCode() const
 App::DocumentObjectExecReturn* Boolean::execute()
 {
     try {
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-        Base::SignalException se;
-#endif
         auto base = Base.getValue();
         auto tool = Tool.getValue();
 

--- a/src/Mod/Part/App/SignalException.cpp
+++ b/src/Mod/Part/App/SignalException.cpp
@@ -26,8 +26,10 @@
 #include <FCConfig.h>
 
 #if defined(__GNUC__) && (defined(FC_OS_LINUX) || defined(FC_OS_MACOSX))
-# include <atomic>
+# include <array>
 # include <csetjmp>
+# include <csignal>
+# include <mutex>
 # include <regex>
 # include <string>
 # include <boost/core/demangle.hpp>
@@ -62,17 +64,41 @@ static std::string demangleStackTrace(const char* trace)
 void SignalException::guard(std::function<void()> fn)
 {
 #if defined(__GNUC__) && (defined(FC_OS_LINUX) || defined(FC_OS_MACOSX))
-    // Process-wide nesting counter. Only the outermost guard() installs/uninstalls
-    // signal handlers. Inner guards just add a setjmp landing pad so OCC's longjmp
-    // reaches the nearest handler on the stack. Atomic because signal handlers are
-    // process-wide, so all threads must share the same counter to avoid one thread
-    // uninstalling handlers while another thread's guard() is still active.
-    static std::atomic<int> guardDepth = 0;
-    static constexpr int stackTraceDepth = 50;
+    // Process-wide nesting counter and mutex. Only the outermost guard()
+    // installs/uninstalls signal handlers. The mutex ensures the depth check
+    // and OSD::SetSignal call are atomic - without it, a second thread could
+    // enter guard() and run fn() before the first thread finishes installing
+    // handlers.
+    // Signals that OSD::SetSignal() installs handlers for.
+    static constexpr std::array guardedSignals = {
+        SIGFPE,
+        SIGHUP,
+        SIGINT,
+        SIGQUIT,
+        SIGILL,
+        SIGBUS,
+# ifdef SIGSYS
+        SIGSYS,
+# endif
+        SIGSEGV
+    };
 
-    if (guardDepth++ == 0) {
-        OSD::SetSignalStackTraceLength(stackTraceDepth);
-        OSD::SetSignal(OSD_SignalMode_Set, Standard_False);
+    static int guardDepth = 0;
+    static std::mutex guardMutex;
+    static constexpr int stackTraceDepth = 50;
+    // Snapshot of signal handlers before the outermost guard() installed
+    // OCC's handlers, so we can restore them when the last guard() exits.
+    static std::array<struct sigaction, guardedSignals.size()> savedHandlers = {};
+
+    {
+        std::lock_guard lock(guardMutex);
+        if (guardDepth++ == 0) {
+            for (size_t i = 0; i < guardedSignals.size(); ++i) {
+                sigaction(guardedSignals[i], nullptr, &savedHandlers[i]);
+            }
+            OSD::SetSignalStackTraceLength(stackTraceDepth);
+            OSD::SetSignal(OSD_SignalMode_Set, Standard_False);
+        }
     }
 
     // setjmp returns 0 on initial call (normal path). If a signal fires
@@ -83,8 +109,13 @@ void SignalException::guard(std::function<void()> fn)
         fn();
     }
     else {
-        if (--guardDepth == 0) {
-            OSD::SetSignal(OSD_SignalMode_Unset, Standard_False);
+        {
+            std::lock_guard lock(guardMutex);
+            if (--guardDepth == 0) {
+                for (size_t i = 0; i < guardedSignals.size(); ++i) {
+                    sigaction(guardedSignals[i], &savedHandlers[i], nullptr);
+                }
+            }
         }
         handler.Catches(STANDARD_TYPE(Standard_Failure));
         auto error = handler.Error();
@@ -94,8 +125,13 @@ void SignalException::guard(std::function<void()> fn)
         error->Reraise();
     }
 
-    if (--guardDepth == 0) {
-        OSD::SetSignal(OSD_SignalMode_Unset, Standard_False);
+    {
+        std::lock_guard lock(guardMutex);
+        if (--guardDepth == 0) {
+            for (size_t i = 0; i < guardedSignals.size(); ++i) {
+                sigaction(guardedSignals[i], &savedHandlers[i], nullptr);
+            }
+        }
     }
 #else
     fn();

--- a/src/Mod/Part/App/SignalException.cpp
+++ b/src/Mod/Part/App/SignalException.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
- *   Copyright (c) 2025 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   Copyright (c) 2026 The FreeCAD project association AISBL              *
  *                                                                         *
  *   This file is part of FreeCAD.                                         *
  *                                                                         *
@@ -23,214 +24,81 @@
 
 #include "SignalException.h"
 #include <FCConfig.h>
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-# include <array>
-# include <boost/stacktrace.hpp>
-# include <stdexcept>
-# include <iostream>
-# include <csignal>
+
+#if defined(__GNUC__) && (defined(FC_OS_LINUX) || defined(FC_OS_MACOSX))
+# include <atomic>
+# include <csetjmp>
+# include <regex>
+# include <string>
+# include <boost/core/demangle.hpp>
 # include <OSD.hxx>
-# include <OSD_WhoAmI.hxx>
-# include <OSD_SIGHUP.hxx>
-# include <OSD_SIGINT.hxx>
-# include <OSD_SIGQUIT.hxx>
-# include <OSD_SIGILL.hxx>
-# include <OSD_SIGKILL.hxx>
-# include <OSD_SIGBUS.hxx>
-# include <OSD_SIGSEGV.hxx>
-# include <OSD_SIGSYS.hxx>
-# include <Standard.hxx>
-# include <Standard_NumericError.hxx>
 # include <Standard_ErrorHandler.hxx>
-# include <Standard_Assert.hxx>
-# include <Standard_Version.hxx>
-// OCCT 8 removed NewInstance/Jump in favor of Standard_ErrorHandler::Abort
-# if OCC_VERSION_HEX >= 0x080000
-#  define OSD_SIGNAL_THROW(Type, msg) Standard_ErrorHandler::Abort(Type(msg))
-# else
-#  define OSD_SIGNAL_THROW(Type, msg) Type::NewInstance(msg)->Jump()
-# endif
+# include <Standard_Failure.hxx>
 #endif
-#include <Base/SystemHandler.h>
 
 using namespace Part;
 
-// NOLINTBEGIN(concurrency-mt-unsafe, cppcoreguidelines-pro-type-member-init)
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-static OSD_SignalMode OSD_WasSetSignal = OSD_SignalMode_AsIs;  // NOLINT
-
-static void SegvHandler(const int theSignal, siginfo_t* theSigInfo, const Standard_Address /*theContext*/)
+// NOLINTBEGIN(concurrency-mt-unsafe)
+#if defined(__GNUC__) && (defined(FC_OS_LINUX) || defined(FC_OS_MACOSX))
+/// Replace mangled C++ symbols (_Z...) in a stack trace with demangled names.
+static std::string demangleStackTrace(const char* trace)
 {
-    std::cerr << "\nStacktrace:" << std::endl;
-    std::cerr << "SIGSEGV signal raised: " << theSignal << std::endl;
-    std::cerr << boost::stacktrace::stacktrace() << std::endl;
-    std::cerr << "\n" << std::endl;
-    if (theSigInfo != nullptr) {
-        sigset_t set;
-        sigemptyset(&set);
-        sigaddset(&set, SIGSEGV);
-        sigprocmask(SIG_UNBLOCK, &set, nullptr);
-        OSD_SIGNAL_THROW(OSD_SIGSEGV, "SIGSEGV 'segmentation violation' detected.");
+    std::string result;
+    // Match mangled symbols: _Z followed by alphanumeric/underscore characters
+    std::regex mangledPattern("(_Z[A-Za-z0-9_]+)");
+    const char* pos = trace;
+    std::cmatch match;
+    while (std::regex_search(pos, match, mangledPattern)) {
+        result.append(pos, match[0].first);
+        std::string demangled = boost::core::demangle(match[0].str().c_str());
+        result.append(demangled);
+        pos = match[0].second;
     }
-    exit(SIGSEGV);
+    result.append(pos);
+    return result;
 }
+#endif
 
-static void throw_exc(const int theSignal, siginfo_t* /*theSigInfo*/, const Standard_Address /*theContext*/)
+void SignalException::guard(std::function<void()> fn)
 {
-    struct sigaction oldact;
-    struct sigaction act;
-    // re-install the signal
-    if (!sigaction(theSignal, nullptr, &oldact)) {
-        if (sigaction(theSignal, &oldact, &act)) {
-            perror("sigaction");
-        }
+#if defined(__GNUC__) && (defined(FC_OS_LINUX) || defined(FC_OS_MACOSX))
+    // Process-wide nesting counter. Only the outermost guard() installs/uninstalls
+    // signal handlers. Inner guards just add a setjmp landing pad so OCC's longjmp
+    // reaches the nearest handler on the stack. Atomic because signal handlers are
+    // process-wide, so all threads must share the same counter to avoid one thread
+    // uninstalling handlers while another thread's guard() is still active.
+    static std::atomic<int> guardDepth = 0;
+    static constexpr int stackTraceDepth = 50;
+
+    if (guardDepth++ == 0) {
+        OSD::SetSignalStackTraceLength(stackTraceDepth);
+        OSD::SetSignal(OSD_SignalMode_Set, Standard_False);
+    }
+
+    // setjmp returns 0 on initial call (normal path). If a signal fires
+    // during fn(), OCC's handler calls longjmp back here with a non-zero
+    // value, entering the else branch to re-raise as a C++ exception.
+    Standard_ErrorHandler handler;
+    if (setjmp(handler.Label()) == 0) {
+        fn();
     }
     else {
-        perror("sigaction");
-    }
-
-    sigset_t set;
-    sigemptyset(&set);
-    switch (theSignal) {
-        case SIGHUP:
-            OSD_SIGNAL_THROW(OSD_SIGHUP, "SIGHUP 'hangup' detected.");
-            exit(SIGHUP);
-            break;
-        case SIGINT:
-            // For safe handling of Control-C as stop event, arm a variable but do not
-            // generate longjump (we are out of context anyway)
-            OSD_SIGNAL_THROW(OSD_SIGINT, "SIGINT 'interrupt' detected.");
-            exit(SIGINT);
-            break;
-        case SIGQUIT:
-            OSD_SIGNAL_THROW(OSD_SIGQUIT, "SIGQUIT 'quit' detected.");
-            exit(SIGQUIT);
-            break;
-        case SIGILL:
-            OSD_SIGNAL_THROW(OSD_SIGILL, "SIGILL 'illegal instruction' detected.");
-            exit(SIGILL);
-            break;
-        case SIGKILL:
-            OSD_SIGNAL_THROW(OSD_SIGKILL, "SIGKILL 'kill' detected.");
-            exit(SIGKILL);
-            break;
-        case SIGBUS:
-            sigaddset(&set, SIGBUS);
-            sigprocmask(SIG_UNBLOCK, &set, nullptr);
-            OSD_SIGNAL_THROW(OSD_SIGBUS, "SIGBUS 'bus error' detected.");
-            exit(SIGBUS);
-            break;
-        case SIGSEGV:
-            OSD_SIGNAL_THROW(OSD_SIGSEGV, "SIGSEGV 'segmentation violation' detected.");
-            exit(SIGSEGV);
-            break;
-# ifdef SIGSYS
-        case SIGSYS:
-            OSD_SIGNAL_THROW(OSD_SIGSYS, "SIGSYS 'bad argument to system call' detected.");
-            exit(SIGSYS);
-            break;
-# endif
-        case SIGFPE:
-            sigaddset(&set, SIGFPE);
-            sigprocmask(SIG_UNBLOCK, &set, nullptr);
-            OSD::SetFloatingSignal(Standard_True);
-            OSD_SIGNAL_THROW(Standard_NumericError, "SIGFPE Arithmetic exception detected");
-            break;
-        default:
-            break;
-    }
-}
-
-static void setSignal(OSD_SignalMode theSignalMode)
-{
-    OSD_WasSetSignal = theSignalMode;
-    if (theSignalMode == OSD_SignalMode_AsIs) {
-        return;  // nothing to be done with signal handlers
-    }
-
-    // Prepare signal descriptors
-    struct sigaction anActSet;
-    struct sigaction anActDfl;
-    struct sigaction anActOld;
-    sigemptyset(&anActSet.sa_mask);
-    sigemptyset(&anActDfl.sa_mask);
-    sigemptyset(&anActOld.sa_mask);
-# ifdef SA_RESTART
-    anActSet.sa_flags = anActDfl.sa_flags = anActOld.sa_flags = SA_RESTART;
-# else
-    anActSet.sa_flags = anActDfl.sa_flags = anActOld.sa_flags = 0;
-# endif
-# ifdef SA_SIGINFO
-    anActSet.sa_flags = anActSet.sa_flags | SA_SIGINFO;
-    anActSet.sa_sigaction = throw_exc;
-# else
-    anActSet.sa_handler = throw_exc;
-# endif
-    anActDfl.sa_handler = SIG_DFL;
-
-    // Set signal handlers; NB: SIGSEGV must be the last one!
-    const int NBSIG = 8;
-    constexpr static std::array<int, NBSIG> aSignalTypes
-        = {SIGFPE, SIGHUP, SIGINT, SIGQUIT, SIGILL, SIGBUS, SIGSYS, SIGSEGV};
-    for (int aSignalType : aSignalTypes) {
-        // SIGSEGV has special handler
-        if (aSignalType == SIGSEGV) {
-# ifdef SA_SIGINFO
-            anActSet.sa_sigaction = /*(void(*)(int, siginfo_t *, void*))*/ SegvHandler;
-# else
-            anActSet.sa_handler = /*(SIG_PFV)*/ SegvHandler;
-# endif
+        if (--guardDepth == 0) {
+            OSD::SetSignal(OSD_SignalMode_Unset, Standard_False);
         }
-
-        // set handler according to specified mode and current handler
-        int retcode = -1;
-        if (theSignalMode == OSD_SignalMode_Set || theSignalMode == OSD_SignalMode_SetUnhandled) {
-            retcode = sigaction(aSignalType, &anActSet, &anActOld);
+        handler.Catches(STANDARD_TYPE(Standard_Failure));
+        auto error = handler.Error();
+        if (const char* stack = error->GetStackString()) {
+            error->SetStackString(demangleStackTrace(stack).c_str());
         }
-        else if (theSignalMode == OSD_SignalMode_Unset) {
-            retcode = sigaction(aSignalType, &anActDfl, &anActOld);
-        }
-        if (theSignalMode == OSD_SignalMode_SetUnhandled && retcode == 0
-            && anActOld.sa_handler != SIG_DFL) {
-            struct sigaction anActOld2;
-            sigemptyset(&anActOld2.sa_mask);
-            retcode = sigaction(aSignalType, &anActOld, &anActOld2);
-        }
-        Standard_ASSERT(
-            retcode == 0,
-            "sigaction() failed",
-            std::cout << "OSD::SetSignal(): sigaction() failed for " << aSignalType << std::endl
-        );
+        error->Reraise();
     }
-}
-#endif
 
-// ----------------------------------------------------------------------------
-
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-static OSD_SignalMode currentSignalMode = OSD_SignalMode_Unset;  // NOLINT
-#endif
-
-SignalException::SignalException()
-{
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-    if (currentSignalMode == OSD_SignalMode_Unset) {
-        currentSignalMode = OSD_SignalMode_Set;
-        setSignal(currentSignalMode);
-        enabled = true;
+    if (--guardDepth == 0) {
+        OSD::SetSignal(OSD_SignalMode_Unset, Standard_False);
     }
+#else
+    fn();
 #endif
 }
-
-SignalException::~SignalException()
-{
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-    if (enabled && currentSignalMode == OSD_SignalMode_Set) {
-        currentSignalMode = OSD_SignalMode_Unset;
-        setSignal(currentSignalMode);
-        // this is the default handler
-        Base::SystemHandler::installSegfaultHandler();
-    }
-#endif
-}
-// NOLINTEND(concurrency-mt-unsafe, cppcoreguidelines-pro-type-member-init)
+// NOLINTEND(concurrency-mt-unsafe)

--- a/src/Mod/Part/App/SignalException.h
+++ b/src/Mod/Part/App/SignalException.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
- *   Copyright (c) 2025 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   Copyright (c) 2026 The FreeCAD project association AISBL              *
  *                                                                         *
  *   This file is part of FreeCAD.                                         *
  *                                                                         *
@@ -23,24 +24,21 @@
 
 #pragma once
 
+#include <functional>
 #include <Mod/Part/PartGlobal.h>
 
 namespace Part
 {
 
+/// Executes a callable with POSIX signal handlers that convert crashes
+/// (SIGSEGV, SIGBUS, SIGFPE, etc.) into C++ exceptions (Standard_Failure).
+/// On Linux/macOS the signal handler does longjmp back into guard(),
+/// which then throws, so no macro (OCC_CATCH_SIGNALS) is needed at the call site.
+/// On other platforms this is a no-op passthrough.
 class PartExport SignalException
 {
 public:
-    SignalException();
-    ~SignalException();
-
-    SignalException(const SignalException&) = default;
-    SignalException(SignalException&&) = default;
-    SignalException& operator=(const SignalException&) = default;
-    SignalException& operator=(SignalException&&) = default;
-
-private:
-    bool enabled {false};
+    static void guard(std::function<void()> fn);
 };
 
 }  // namespace Part

--- a/src/Mod/Part/App/TopoShape.cpp
+++ b/src/Mod/Part/App/TopoShape.cpp
@@ -38,6 +38,7 @@
 #include <BRep_Tool.hxx>
 #include <BRepAdaptor_Surface.hxx>
 #include <Mod/Part/App/FCBRepAlgoAPI_Common.h>
+#include <Mod/Part/App/SignalException.h>
 #include <BRepAdaptor_CompCurve.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <Mod/Part/App/FCBRepAlgoAPI_Cut.h>
@@ -2993,10 +2994,7 @@ TopoDS_Shape TopoShape::makeOffset2D(
 
         if (fabs(offset) > Precision::Confusion()) {
             try {
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-                Base::SignalException se;
-#endif
-                mkOffset.Perform(offset);
+                Part::SignalException::guard([&] { mkOffset.Perform(offset); });
             }
             catch (Standard_Failure&) {
                 throw;

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -2837,10 +2837,7 @@ TopoShape& TopoShape::makeElementOffset2D(
                 mkOffset.AddWire(TopoDS::Wire(w.getShape()));
             }
             try {
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-                Base::SignalException se;
-#endif
-                mkOffset.Perform(offset);
+                Part::SignalException::guard([&] { mkOffset.Perform(offset); });
             }
             catch (Standard_Failure&) {
                 throw;
@@ -4171,8 +4168,8 @@ TopoShape& TopoShape::makeElementChamfer(
                 break;
         }
     }
-    Part::SignalException sig;
-    return makeElementShape(mkChamfer, shape, op);
+    Part::SignalException::guard([&] { makeElementShape(mkChamfer, shape, op); });
+    return *this;
 }
 
 TopoShape& TopoShape::makeElementGeneralFuse(

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -161,16 +161,17 @@ App::DocumentObjectExecReturn* Chamfer::execute()
     }
     try {
         TopoShape shape(0);
-        Part::SignalException sig;
-        shape.makeElementChamfer(
-            TopShape,
-            edges,
-            static_cast<Part::ChamferType>(chamferType),
-            size,
-            size2,
-            nullptr,
-            flipDirection ? Part::Flip::flip : Part::Flip::none
-        );
+        Part::SignalException::guard([&] {
+            shape.makeElementChamfer(
+                TopShape,
+                edges,
+                static_cast<Part::ChamferType>(chamferType),
+                size,
+                size2,
+                nullptr,
+                flipDirection ? Part::Flip::flip : Part::Flip::none
+            );
+        });
         if (shape.isNull()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Failed to create chamfer")

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -37,6 +37,7 @@
 
 #include <Base/Exception.h>
 #include <Base/Reader.h>
+#include <Mod/Part/App/SignalException.h>
 #include <Mod/Part/App/TopoShape.h>
 
 #include "FeatureFillet.h"
@@ -111,12 +112,9 @@ App::DocumentObjectExecReturn* Fillet::execute()
     try {
         TopoShape shape(0);  //,getDocument()->getStringHasher());
 
-        // Add signal handler for segfault protection
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-        Base::SignalException se;
-#endif
-
-        shape.makeElementFillet(baseShape, edges, Radius.getValue(), Radius.getValue());
+        Part::SignalException::guard([&] {
+            shape.makeElementFillet(baseShape, edges, Radius.getValue(), Radius.getValue());
+        });
         if (shape.isNull()) {
             return new App::DocumentObjectExecReturn(
                 QT_TRANSLATE_NOOP("Exception", "Resulting shape is null")

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerOffset.h
@@ -31,6 +31,7 @@
 
 #include <QApplication>
 
+#include <Mod/Part/App/SignalException.h>
 #include <BRep_Tool.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepAdaptor_Surface.hxx>
@@ -253,10 +254,7 @@ private:
             mkOffset.AddWire(wire);
         }
         try {
-#if defined(__GNUC__) && defined(FC_OS_LINUX)
-            Base::SignalException se;
-#endif
-            mkOffset.Perform(offsetLength);
+            Part::SignalException::guard([&] { mkOffset.Perform(offsetLength); });
         }
         catch (Standard_Failure&) {
             throw;

--- a/tests/src/Mod/Part/App/CMakeLists.txt
+++ b/tests/src/Mod/Part/App/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(Part_tests_run
         PartFeature.cpp
         PartFeatures.cpp
         PartTestHelpers.cpp
+        SignalException.cpp
         PropertyTopoShape.cpp
         TopoDS_Shape.cpp
         TopoShape.cpp

--- a/tests/src/Mod/Part/App/SignalException.cpp
+++ b/tests/src/Mod/Part/App/SignalException.cpp
@@ -232,7 +232,7 @@ TEST_F(SignalExceptionTest, threadSafeFirstInFirstOut)
             c.advance();   // phase 1: thread 1 inside guard
             c.waitFor(3);  // wait for thread 2 to also be inside
         });
-        c.advance();       // phase 4: thread 1 has exited guard
+        c.advance();  // phase 4: thread 1 has exited guard
     });
 
     // Thread 2: enter guard, signal thread 1 to exit, then raise SIGSEGV
@@ -284,7 +284,7 @@ TEST_F(SignalExceptionTest, threadSafeFirstInLastOut)
             c.waitFor(1);  // wait for thread 1 to be inside guard
             c.advance();   // phase 2: thread 2 inside guard
         });
-        c.advance();       // phase 3: thread 2 has exited guard
+        c.advance();  // phase 3: thread 2 has exited guard
     });
 
     t1.join();
@@ -305,7 +305,7 @@ TEST_F(SignalExceptionTest, handlersRestoredAfterConcurrentGuards)
             c.advance();   // phase 1: inside
             c.waitFor(2);  // wait for t2 to be inside
         });
-        c.advance();       // phase 3: t1 exited
+        c.advance();  // phase 3: t1 exited
     });
 
     std::thread t2([&] {

--- a/tests/src/Mod/Part/App/SignalException.cpp
+++ b/tests/src/Mod/Part/App/SignalException.cpp
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *                                                                         *
+ *   Copyright (c) 2026 The FreeCAD project association AISBL              *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <FCConfig.h>
+#include <Mod/Part/App/SignalException.h>
+#include <Standard_Failure.hxx>
+
+#include <cmath>
+#include <condition_variable>
+#include <csignal>
+#include <mutex>
+#include <thread>
+
+class SignalExceptionTest: public ::testing::Test
+{
+};
+
+TEST_F(SignalExceptionTest, normalExecution)
+{
+    int result = 0;
+    Part::SignalException::guard([&] { result = 42; });
+    EXPECT_EQ(result, 42);
+}
+
+TEST_F(SignalExceptionTest, cppExceptionPassesThrough)
+{
+    EXPECT_THROW(
+        Part::SignalException::guard([&] { throw std::runtime_error("test"); }),
+        std::runtime_error
+    );
+}
+
+TEST_F(SignalExceptionTest, nestedGuardsWork)
+{
+    int depth = 0;
+    Part::SignalException::guard([&] {
+        depth = 1;
+        Part::SignalException::guard([&] { depth = 2; });
+        EXPECT_EQ(depth, 2);
+    });
+    EXPECT_EQ(depth, 2);
+}
+
+#if defined(__GNUC__) && (defined(FC_OS_LINUX) || defined(FC_OS_MACOSX))
+
+TEST_F(SignalExceptionTest, exceptionContainsStackTrace)
+{
+    try {
+        Part::SignalException::guard([&] { raise(SIGSEGV); });
+        FAIL() << "Expected Standard_Failure";
+    }
+    catch (const Standard_Failure& e) {
+        std::string trace = e.GetStackString();
+        std::cerr << "Stack trace from exception:\n" << trace << std::endl;
+        EXPECT_FALSE(trace.empty()) << "Exception should contain a stack trace";
+        // Check for the demangled function name - this verifies both
+        // that the stack trace captures the right frames and that
+        // demangling works.
+        EXPECT_NE(trace.find("Part::SignalException::guard"), std::string::npos)
+            << "Stack trace should contain demangled Part::SignalException::guard";
+    }
+}
+
+TEST_F(SignalExceptionTest, catchesSIGSEGV)
+{
+    EXPECT_THROW(
+        Part::SignalException::guard([&] {
+            // Raise SIGSEGV explicitly rather than dereferencing null,
+            // which would be undefined behavior even in a test.
+            raise(SIGSEGV);
+        }),
+        Standard_Failure
+    );
+}
+
+TEST_F(SignalExceptionTest, catchesSIGFPE)
+{
+    EXPECT_THROW(Part::SignalException::guard([&] { raise(SIGFPE); }), Standard_Failure);
+}
+
+TEST_F(SignalExceptionTest, catchesSIGHUP)
+{
+    EXPECT_THROW(Part::SignalException::guard([&] { raise(SIGHUP); }), Standard_Failure);
+}
+
+// SIGINT is intentionally not tested - OCC's handler sets a cancellation
+// flag rather than converting it to an exception via longjmp.
+
+TEST_F(SignalExceptionTest, catchesSIGQUIT)
+{
+    EXPECT_THROW(Part::SignalException::guard([&] { raise(SIGQUIT); }), Standard_Failure);
+}
+
+# ifdef SIGSYS
+TEST_F(SignalExceptionTest, catchesSIGSYS)
+{
+    EXPECT_THROW(Part::SignalException::guard([&] { raise(SIGSYS); }), Standard_Failure);
+}
+# endif
+
+TEST_F(SignalExceptionTest, catchesSIGBUS)
+{
+    EXPECT_THROW(Part::SignalException::guard([&] { raise(SIGBUS); }), Standard_Failure);
+}
+
+TEST_F(SignalExceptionTest, catchesSIGILL)
+{
+    EXPECT_THROW(Part::SignalException::guard([&] { raise(SIGILL); }), Standard_Failure);
+}
+
+TEST_F(SignalExceptionTest, fpeNotArmedOutsideGuard)
+{
+    // Run a guard to install/uninstall handlers
+    Part::SignalException::guard([&] {});
+
+    // After guard exits, FPE should NOT be armed.
+    // A floating-point division by zero should produce inf, not SIGFPE.
+    volatile double zero = 0.0;
+    volatile double result = 1.0 / zero;
+    EXPECT_TRUE(std::isinf(result));
+}
+
+TEST_F(SignalExceptionTest, signalHandlersRestoredAfterGuard)
+{
+    // Capture SIGSEGV handler before guard
+    struct sigaction before = {};
+    sigaction(SIGSEGV, nullptr, &before);
+
+    Part::SignalException::guard([&] {});
+
+    // Capture SIGSEGV handler after guard
+    struct sigaction after = {};
+    sigaction(SIGSEGV, nullptr, &after);
+
+    // Handler should be restored to what it was before
+    EXPECT_EQ(before.sa_handler, after.sa_handler);
+    EXPECT_EQ(before.sa_sigaction, after.sa_sigaction);
+}
+
+TEST_F(SignalExceptionTest, signalHandlersRestoredAfterException)
+{
+    struct sigaction before = {};
+    sigaction(SIGSEGV, nullptr, &before);
+
+    try {
+        Part::SignalException::guard([&] { raise(SIGSEGV); });
+    }
+    catch (const Standard_Failure&) {
+        // expected
+    }
+
+    struct sigaction after = {};
+    sigaction(SIGSEGV, nullptr, &after);
+
+    EXPECT_EQ(before.sa_handler, after.sa_handler);
+    EXPECT_EQ(before.sa_sigaction, after.sa_sigaction);
+}
+
+TEST_F(SignalExceptionTest, nestedGuardRestoresCorrectly)
+{
+    struct sigaction before = {};
+    sigaction(SIGSEGV, nullptr, &before);
+
+    Part::SignalException::guard([&] {
+        // Inner guard should save/restore independently
+        Part::SignalException::guard([&] {});
+    });
+
+    struct sigaction after = {};
+    sigaction(SIGSEGV, nullptr, &after);
+
+    EXPECT_EQ(before.sa_handler, after.sa_handler);
+    EXPECT_EQ(before.sa_sigaction, after.sa_sigaction);
+}
+
+// Conductor: the main thread steps through phases, workers wait at each phase.
+struct Conductor
+{
+    std::mutex mtx;
+    std::condition_variable cv;
+    int phase = 0;
+
+    void waitFor(int target)
+    {
+        std::unique_lock lock(mtx);
+        cv.wait(lock, [&] { return phase >= target; });
+    }
+
+    void advance()
+    {
+        {
+            std::lock_guard lock(mtx);
+            ++phase;
+        }
+        cv.notify_all();
+    }
+};
+
+// Thread 1 enters first and exits first (while thread 2 is still inside).
+// This is the bug case: the first entrant's exit must not uninstall handlers.
+TEST_F(SignalExceptionTest, threadSafeFirstInFirstOut)
+{
+    Conductor c;
+    bool thread2Caught = false;
+
+    // Thread 1: enter guard, wait, exit guard while thread 2 is still inside
+    std::thread t1([&] {
+        Part::SignalException::guard([&] {
+            c.advance();   // phase 1: thread 1 inside guard
+            c.waitFor(3);  // wait for thread 2 to also be inside
+        });
+        c.advance();       // phase 4: thread 1 has exited guard
+    });
+
+    // Thread 2: enter guard, signal thread 1 to exit, then raise SIGSEGV
+    std::thread t2([&] {
+        try {
+            Part::SignalException::guard([&] {
+                c.waitFor(1);  // wait for thread 1 to be inside guard
+                c.advance();   // phase 2: thread 2 inside guard
+                // Not used but keeps phase sequence logical
+                c.advance();   // phase 3: tell thread 1 it can exit
+                c.waitFor(4);  // wait for thread 1 to have exited
+                raise(SIGSEGV);
+            });
+        }
+        catch (const Standard_Failure&) {
+            thread2Caught = true;
+        }
+    });
+
+    t1.join();
+    t2.join();
+    EXPECT_TRUE(thread2Caught) << "Thread 2 should catch SIGSEGV after thread 1 exits guard";
+}
+
+// Thread 1 enters first but exits last (thread 2 exits first).
+// This is the natural stack-like ordering.
+TEST_F(SignalExceptionTest, threadSafeFirstInLastOut)
+{
+    Conductor c;
+    bool thread1Caught = false;
+
+    // Thread 1: enter guard, wait for thread 2 to exit, then raise SIGSEGV
+    std::thread t1([&] {
+        try {
+            Part::SignalException::guard([&] {
+                c.advance();   // phase 1: thread 1 inside guard
+                c.waitFor(3);  // wait for thread 2 to have exited
+                raise(SIGSEGV);
+            });
+        }
+        catch (const Standard_Failure&) {
+            thread1Caught = true;
+        }
+    });
+
+    // Thread 2: enter guard, wait, exit guard while thread 1 is still inside
+    std::thread t2([&] {
+        Part::SignalException::guard([&] {
+            c.waitFor(1);  // wait for thread 1 to be inside guard
+            c.advance();   // phase 2: thread 2 inside guard
+        });
+        c.advance();       // phase 3: thread 2 has exited guard
+    });
+
+    t1.join();
+    t2.join();
+    EXPECT_TRUE(thread1Caught) << "Thread 1 should catch SIGSEGV after thread 2 exits guard";
+}
+
+// Verify signal handlers are restored after all threads exit guard.
+TEST_F(SignalExceptionTest, handlersRestoredAfterConcurrentGuards)
+{
+    struct sigaction before = {};
+    sigaction(SIGSEGV, nullptr, &before);
+
+    Conductor c;
+
+    std::thread t1([&] {
+        Part::SignalException::guard([&] {
+            c.advance();   // phase 1: inside
+            c.waitFor(2);  // wait for t2 to be inside
+        });
+        c.advance();       // phase 3: t1 exited
+    });
+
+    std::thread t2([&] {
+        Part::SignalException::guard([&] {
+            c.waitFor(1);  // wait for t1 to be inside
+            c.advance();   // phase 2: inside
+            c.waitFor(3);  // wait for t1 to exit
+        });
+    });
+
+    t1.join();
+    t2.join();
+
+    struct sigaction after = {};
+    sigaction(SIGSEGV, nullptr, &after);
+
+    EXPECT_EQ(before.sa_handler, after.sa_handler);
+    EXPECT_EQ(before.sa_sigaction, after.sa_sigaction);
+}
+
+#endif


### PR DESCRIPTION
The previous `SignalException` (https://github.com/FreeCAD/FreeCAD/pull/27854) installed custom signal handlers that called OCC's `Jump()`, which does throw from inside a signal handler. This is undefined behavior and only works on Linux/GCC by coincidence but crashes on macOS/clang.
The proper fix requires `setjmp` at the call site so `longjmp` has a valid landing pad. OCC provides this via the `OCC_CATCH_SIGNALS` macro, but a macro can't be encapsulated in a class since `setjmp` must live in the caller's stack frame, which is why I had to change it from RAII to an encapsulated lambda.

- Rewrites SignalException as a guard(fn) callback using OCC's native signal handling
- Fixes macOS crash where chamfer/fillet on bad geometry caused EXC_BAD_ACCESS instead of a recoverable error
- Fixes NotificationArea deadlock (re-entrant mutex from Qt warning during notification display causing some places to hang after occt crashing bug was fixed)

Easiest way to check that this works as intended is to follow the steps in https://github.com/FreeCAD/FreeCAD/issues/27221 and see that it doesn't crash.

This has been tested on:
 - [x] macOS
 - [x] Linux