### PR TITLE
Gui: Add Std_MassProperties to the Tools menu

### DIFF
--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -779,6 +779,7 @@ MenuItem* StdWorkbench::setupMenuBar() const
     }
 #endif
     *tool << "Std_Measure"
+          << "Std_MassProperties"
           << "Std_AnnotationLabel"
           << "Std_UnitsCalculator"
           << "Std_ClarifySelection"


### PR DESCRIPTION
Seems more consistent to also add Std_MassProperties to the Tools menu.