### PR TITLE
Test: make CLI GUI runners headless-safe

### DIFF
--- a/src/App/FreeCADTest.py
+++ b/src/App/FreeCADTest.py
@@ -55,9 +55,7 @@ Log("░░░▀▀▀░▀░▀░▀▀▀░░▀░░░░░▀░░
 import sys
 import TestApp
 
-testCase = FreeCAD.ConfigGet("TestCase")
-
-testResult = TestApp.TestText(testCase)
+testResult = TestApp.RunConfiguredTextTest()
 
 Log("FreeCAD test done\n")
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -79,6 +79,7 @@
 #include "FileDialog.h"
 #include "GuiApplication.h"
 #include "GuiInitScript.h"
+#include "GuiTestScript.h"
 #include "InputHintPy.h"
 #include "LinkViewPy.h"
 #include "MainWindow.h"
@@ -2329,6 +2330,7 @@ void Application::initApplication()
     try {
         initTypes();
         new Base::ScriptProducer("FreeCADGuiInit", FreeCADGuiInit);
+        new Base::ScriptProducer("FreeCADGuiTest", FreeCADGuiTest);
         init_resources();
         setCategoryFilterRules();
         old_qtmsg_handler = qInstallMessageHandler(messageHandler);

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -340,6 +340,7 @@ generate_from_py(Command)
 generate_from_py(Navigation/NavigationStyle)
 
 generate_embed_from_py(FreeCADGuiInit GuiInitScript.h)
+generate_embed_from_py(FreeCADGuiTest GuiTestScript.h)
 
 # The Pyi files
 SET(FreeCADGui_Pyi_SRCS
@@ -1423,6 +1424,7 @@ SET(FreeCADGui_SRCS
     ExpressionBindingPy.h
     ExpressionCompleter.h
     FreeCADGuiInit.py
+    FreeCADGuiTest.py
     FreeCADStyle.h
     GraphicsViewZoom.h
     GuiApplication.h

--- a/src/Gui/FreeCADGuiTest.py
+++ b/src/Gui/FreeCADGuiTest.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2026 FreeCAD contributors                               *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Lesser General Public License for more details.                   *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+"""Run command-line GUI tests after the GUI startup path has completed."""
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from __main__ import Log
+
+
+Log("Init: starting Gui::FreeCADGuiTest.py\n")
+
+import TestApp
+
+test_result = TestApp.RunConfiguredTextTest()

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1727,30 +1727,30 @@ void MainWindow::delayedStartup()
 {
     // automatically run unit tests in Gui
     if (App::Application::Config()["RunMode"] == "Internal") {
-        QTimer::singleShot(1000, this, [] {
-            try {
-                string command = "import sys\n"
-                                 "import FreeCAD\n"
-                                 "import QtUnitGui\n\n"
-                                 "testCase = FreeCAD.ConfigGet(\"TestCase\")\n"
-                                 "QtUnitGui.addTest(testCase)\n"
-                                 "QtUnitGui.setTest(testCase)\n"
-                                 "result = QtUnitGui.runTest()\n"
-                                 "sys.stdout.flush()\n";
-                if (App::Application::Config()["ExitTests"] == "yes") {
-                    command += "sys.exit(0 if result else 1)";
-                }
-                Base::Interpreter().runString(command.c_str());
+        try {
+            // Command-line GUI tests should not depend on the interactive QtUnitGui
+            // dialog. In headless runs such as QT_QPA_PLATFORM=offscreen/minimal,
+            // that dialog path can hang before the test body executes. Run the
+            // embedded text-based GUI test script directly once startup reaches
+            // delayedStartup().
+            Base::Interpreter().runString(Base::ScriptFactory().ProduceScript("FreeCADGuiTest"));
+            if (App::Application::Config()["ExitTests"] == "yes") {
+                Base::Interpreter().runString(
+                    "import sys\n"
+                    "sys.exit(0 if test_result.wasSuccessful() else 1)\n"
+                );
             }
-            catch (const Base::SystemExitException&) {
-                // Properly quit the Qt event loop before propagating the exception
-                QApplication::quit();
-                throw;
-            }
-            catch (const Base::Exception& e) {
-                e.reportException();
-            }
-        });
+        }
+        catch (const Base::SystemExitException&) {
+            // Properly quit the Qt event loop before propagating the exception
+            QApplication::quit();
+            throw;
+        }
+        catch (const Base::Exception& e) {
+            e.reportException();
+            QApplication::quit();
+            throw;
+        }
         return;
     }
 

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -27,6 +27,10 @@ if(BUILD_GUI)
 
     add_executable(FreeCADMain WIN32 ${FreeCAD_SRCS})
     target_link_libraries(FreeCADMain ${FreeCAD_LIBS})
+    if(BUILD_TEST)
+        add_dependencies(FreeCADMain TestSources)
+        add_dependencies(FreeCADMain TestGuiSources)
+    endif()
     if (FREECAD_WARN_ERROR)
         target_compile_warn_error(FreeCADMain)
     endif()
@@ -58,6 +62,9 @@ SET(FreeCADMainCmd_SRCS
 )
 
 add_executable(FreeCADMainCmd ${FreeCADMainCmd_SRCS})
+if(BUILD_TEST)
+    add_dependencies(FreeCADMainCmd TestSources)
+endif()
 
 SET(FreeCADMainCmd_LIBS
     FreeCADApp

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -36,7 +36,18 @@ if(BUILD_GUI)
     list (APPEND Test_SRCS InitGui.py)
 endif(BUILD_GUI)
 
+set(Test_COPY_OUTPUTS)
+foreach(test_src ${Test_SRCS})
+    list(APPEND Test_COPY_OUTPUTS "${CMAKE_BINARY_DIR}/Mod/Test/${test_src}")
+endforeach()
+foreach(test_data_src ${TestData_SRCS})
+    list(APPEND Test_COPY_OUTPUTS "${CMAKE_BINARY_DIR}/Mod/Test/${test_data_src}")
+endforeach()
+
+add_custom_target(TestSources DEPENDS ${Test_COPY_OUTPUTS})
+
 ADD_CUSTOM_TARGET(Test ALL
+    DEPENDS TestSources
     SOURCES ${Test_SRCS} ${TestData_SRCS}
 )
 

--- a/src/Mod/Test/Gui/CMakeLists.txt
+++ b/src/Mod/Test/Gui/CMakeLists.txt
@@ -42,6 +42,12 @@ SET(TestGuiIcon_SVG
     Resources/icons/TestWorkbench.svg
 )
 
+set(TestGui_COPY_OUTPUTS
+    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Test/Resources/icons/TestWorkbench.svg"
+)
+
+add_custom_target(TestGuiSources DEPENDS ${TestGui_COPY_OUTPUTS})
+
 add_library(QtUnitGui SHARED ${TestGui_SRCS} ${TestGuiPy_SRCS} ${TestGuiIcon_SVG})
 
 if(FREECAD_USE_PCH)
@@ -58,7 +64,7 @@ target_include_directories(
 )
 
 target_link_libraries(QtUnitGui ${TestGui_LIBS})
-add_dependencies(QtUnitGui Test)
+add_dependencies(QtUnitGui TestSources TestGuiSources)
 
 if (MSVC)
     target_compile_options(QtUnitGui PRIVATE /wd4251)

--- a/src/Mod/Test/TestApp.py
+++ b/src/Mod/Test/TestApp.py
@@ -93,6 +93,11 @@ def TestText(s):
     return retval
 
 
+def RunConfiguredTextTest():
+    test_case = FreeCAD.ConfigGet("TestCase")
+    return TestText(test_case)
+
+
 def Test(s):
     TestText(s)
 


### PR DESCRIPTION
## Summary

Make the command-line test runners use a shared non-interactive backend, and make the GUI `-t` path work reliably in headless environments.

## Why

The GUI command-line test path should not depend on the interactive `QtUnitGui` dialog. That path is not appropriate for headless runs and was blocking `FreeCAD -t ...` GUI tests.

The App and Gui command-line test paths were also carrying separate runner logic, and partial/dev builds did not guarantee that the `Mod/Test` sources and GUI test resources were present when the executables were rebuilt.

## Changes

- add an embedded GUI CLI test runner in `src/Gui/FreeCADGuiTest.py`
- run GUI command-line tests through that embedded runner instead of `QtUnitGui`
- move shared configured-test execution into `src/Mod/Test/TestApp.py`
- make both `src/App/FreeCADTest.py` and `src/Gui/FreeCADGuiTest.py` use the same backend entrypoint
- add `TestSources` / `TestGuiSources` build targets so `FreeCADCmd` and `FreeCAD` have the required `Mod/Test` files and GUI test resources available in build trees
