### PR TITLE
BIM: fix BimLibrary web address concatenation on Windows

### DIFF
--- a/src/Mod/BIM/bimcommands/BimLibrary.py
+++ b/src/Mod/BIM/bimcommands/BimLibrary.py
@@ -226,7 +226,7 @@ class BIM_Library_TaskPanel:
         else:
             path = self.filemodel.itemFromIndex(index).toolTip()
         if path.startswith(":github"):
-            path = RAWURL + "/" + path[7:]
+            path = RAWURL + path[7:]
         thumb = self.getThumbnail(path)
         if thumb:
             px = QtGui.QPixmap(thumb)
@@ -387,10 +387,10 @@ class BIM_Library_TaskPanel:
 
         from PySide import QtGui
 
-        def add_line(f, dp):
+        def add_line(f, dp, sep):
             if self.isAllowed(f) and (text.lower() in f.lower()):
                 it = QtGui.QStandardItem(f)
-                it.setToolTip(os.path.join(dp, f))
+                it.setToolTip(dp.rstrip(sep) + sep + f.lstrip(sep))
                 self.filemodel.appendRow(it)
                 if f.lower().endswith(".fcstd"):
                     it.setIcon(QtGui.QIcon(":icons/freecad-doc.png"))
@@ -404,13 +404,13 @@ class BIM_Library_TaskPanel:
         if self.form.checkOnline.isChecked():
             res = self.getOfflineLib(structured=True)
             for i in range(len(res[0])):
-                add_line(res[0][i], res[2][i])
+                add_line(res[0][i], res[2][i], "/")
         else:
             res = os.walk(self.librarypath)
             for dp, dn, fn in res:
                 for f in fn:
                     if not os.path.isdir(os.path.join(dp, f)):
-                        add_line(f, dp)
+                        add_line(f, dp, os.path.sep)
         self.modelmode = 0
 
     def getFilters(self):


### PR DESCRIPTION
Fixes #26139.

On Windows web addresses were joined with a backslash, which resulted in invalid addresses. Web addresses would also contain a double slash.