### PR TITLE
Gui: fix duplicate container entries in Clarify Selection menu

### DIFF
--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -760,11 +760,23 @@ void SelectionMenu::processSelections(
     for (int i = 0; i < (int)selections.size(); ++i) {
         const auto& sel = selections[i];
 
-        App::DocumentObject* sobj = getSubObject(sel);
+        App::DocumentObject* sobj = sel.obj;
+        bool usedFallback = false;
+        if (!sel.subName.empty()) {
+            App::DocumentObject* resolved = sel.obj->getSubObject(sel.subName.c_str());
+            if (resolved) {
+                sobj = resolved;
+            }
+            else {
+                usedFallback = true;
+            }
+        }
         std::string elementType = extractElementType(sel);
-        std::string objKey = createObjectKey(sel);
+        // When sub-path resolution failed, all picks share the same container object.
+        // Collapse them to a single menu entry so the container does not appear as duplicates.
+        std::string objKey = usedFallback ? std::string(sel.objName) : createObjectKey(sel);
         std::string itemId = elementType + "|" + std::string(sobj->Label.getValue()) + "|"
-            + sel.subName;
+            + (usedFallback ? sel.objName : sel.subName);
 
         if (processedItems.find(itemId) != processedItems.end()) {
             continue;
@@ -902,17 +914,6 @@ void SelectionMenu::leaveEvent(QEvent* e)
     QMenu::leaveEvent(e);
 }
 
-App::DocumentObject* SelectionMenu::getSubObject(const PickData& sel)
-{
-    App::DocumentObject* sobj = sel.obj;
-    if (!sel.subName.empty()) {
-        sobj = sel.obj->getSubObject(sel.subName.c_str());
-        if (!sobj) {
-            sobj = sel.obj;
-        }
-    }
-    return sobj;
-}
 
 std::string SelectionMenu::extractElementType(const PickData& sel)
 {

--- a/src/Gui/Selection/SelectionView.h
+++ b/src/Gui/Selection/SelectionView.h
@@ -169,7 +169,6 @@ private:
         const std::vector<PickData>& selections
     );
 
-    App::DocumentObject* getSubObject(const PickData& sel);
     std::string extractElementType(const PickData& sel);
     std::string createObjectKey(const PickData& sel);
     QIcon getOrCreateIcon(App::DocumentObject* sobj, std::map<App::DocumentObject*, QIcon>& icons);


### PR DESCRIPTION
Fixes #28700

## Problem
When picking overlapping PartDesign bodies inside an Assembly, `getSubObject` fails to resolve through the body hierarchy and falls back to the Assembly itself. Since the deduplication key included `subName` (which differs per pick), each overlapping body produced a separate "Assembly" entry in the Clarify Selection "Other" submenu.

## Fix
Track explicitly whether `getSubObject` returned null. When it did, use a `subName`-independent key so all failed lookups for the same container collapse into a single menu entry.