### PR TITLE
App: Add property alias support to PropertyContainer

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2336,6 +2336,14 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
         }
     }
 
+    // Must run before onDocumentRestored() below (Python's chance to register runtime
+    // aliases) and before the dependency loop's final `if (!d->touchedObjs.contains(obj))
+    // obj->purgeTouched();`. The rewrite itself touches objects (ExpressionModifier::
+    // aboutToChange -> Property::hasSetValue -> DocumentObject::onChanged), so that purge
+    // is what keeps merely opening a document from marking it modified. Moving this call
+    // later without compensating for that purge would break that invariant; see
+    // core-app.dox's PropertyRenamingLimits section for why Python aliases are not covered
+    // by this rewrite either way.
     canonicalizeAliasedExpressions(objArray.empty() ? d->objectArray : objArray);
 
     if (checkPartial && !d->touchedObjs.empty()) {

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2220,6 +2220,81 @@ void Document::restore(const char* filename,
     }
 }
 
+void Document::canonicalizeAliasedExpressions(const std::vector<DocumentObject*>& objArray)
+{
+    // Accumulate every alias-to-canonical-name rewrite across all objects into a single
+    // combined map first, so the document is scanned exactly once below. ObjectIdentifier
+    // keys are owner-scoped, so entries from different owning objects cannot collide.
+    std::map<ObjectIdentifier, ObjectIdentifier> paths;
+    for (auto obj : objArray) {
+        auto aliases = obj->getPropertyAliases();
+        if (aliases.empty()) {
+            continue;
+        }
+
+        try {
+            for (const auto& [alias, entry] : aliases) {
+                // Skip aliases shadowed by a real property of the same name; those are not
+                // stale references.
+                if (obj->getPropertyByName(alias.c_str(), PropertyLookupMode::WithoutAliases)) {
+                    continue;
+                }
+                // A dangling alias (typo, or an add-on registering a bad canonical name) must
+                // not rewrite anything: if the canonical name does not resolve to a real
+                // property, rewriting would permanently corrupt user expressions that reference
+                // the alias, since the rewrite gets written back to the file on next save.
+                if (!obj->getPropertyByName(entry.canonicalName.c_str(),
+                                             PropertyLookupMode::WithoutAliases)) {
+                    continue;
+                }
+                paths.emplace(ObjectIdentifier(obj, std::string(alias)),
+                              ObjectIdentifier(obj, entry.canonicalName));
+            }
+        }
+        catch (const Base::Exception& e) {
+            FC_ERR("Failed to canonicalize aliased expressions of " << obj->getFullName() << ": "
+                                                                     << e.what());
+        }
+    }
+
+    if (paths.empty()) {
+        return;
+    }
+
+    for (auto target : d->objectArray) {
+        try {
+            int renamed = target->ExpressionEngine.renameObjectIdentifiers(paths);
+            if (renamed > 0) {
+                FC_MSG(target->getFullName()
+                       << ".ExpressionEngine: canonicalized " << renamed
+                       << " expression reference(s) to renamed properties");
+            }
+        }
+        catch (const Base::Exception& e) {
+            FC_ERR("Failed to canonicalize aliased expressions of " << target->getFullName()
+                                                                     << ": " << e.what());
+        }
+        catch (std::exception& e) {
+            FC_ERR("Failed to canonicalize aliased expressions of " << target->getFullName()
+                                                                     << ": " << e.what());
+        }
+        catch (...) {
+
+            // If a Python exception occurred, it must be cleared immediately.
+            // Otherwise, the interpreter remains in a dirty state, causing
+            // Segfaults later when FreeCAD interacts with Python.
+            if (PyErr_Occurred()) {
+                Base::Console().error("Python error while canonicalizing aliased expressions:\n");
+                PyErr_Print(); // Print the traceback to stderr/Console
+                PyErr_Clear(); // Reset the interpreter state
+            }
+
+            FC_ERR("Failed to canonicalize aliased expressions of "
+                   << target->getFullName() << ": " << "unknown exception");
+        }
+    }
+}
+
 bool Document::afterRestore(const bool checkPartial)
 {
     Base::FlagToggler<> flag(globalIsRestoring, false);
@@ -2260,6 +2335,8 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
             }
         }
     }
+
+    canonicalizeAliasedExpressions(objArray.empty() ? d->objectArray : objArray);
 
     if (checkPartial && !d->touchedObjs.empty()) {
         // partial document touched, signal full reload

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -1472,6 +1472,16 @@ private:
                                 const std::function<void()>& changeFunc);
     [[nodiscard]] Base::ScopeGuard setDefiningTransaction();
 
+    /**
+     * @brief Rewrite expression references that use a property alias to the canonical name.
+     *
+     * Static aliases are not visible to Restore()'s expression text, so a document saved
+     * against an old property name keeps that name in its expressions. This heals them on
+     * load. The document is deliberately not marked as touched; the file heals on the next
+     * save the user makes for their own reasons.
+     */
+    void canonicalizeAliasedExpressions(const std::vector<DocumentObject*>& objArray);
+
 private:
     // # Data Member of the document
     // +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -855,7 +855,8 @@ bool DocumentObject::removeDynamicProperty(const char* name)
     return TransactionalObject::removeDynamicProperty(name);
 }
 
-bool DocumentObject::renameDynamicProperty(Property* prop, const char* name)
+bool DocumentObject::renameDynamicProperty(Property* prop, const char* name,
+                                           RenameLockedPolicy policy)
 {
     std::string oldName = prop->getName();
 
@@ -874,15 +875,17 @@ bool DocumentObject::renameDynamicProperty(Property* prop, const char* name)
         ExpressionEngine.setValue(it, std::shared_ptr<Expression>());
     }
 
-    bool renamed = TransactionalObject::renameDynamicProperty(prop, name);
+    bool renamed = TransactionalObject::renameDynamicProperty(prop, name, policy);
     if (renamed && _pDoc) {
         _pDoc->renamePropertyOfObject(this, prop, oldName.c_str());
     }
 
-
-    App::ObjectIdentifier idNewProp(prop->getContainer(), std::string(name));
+    // If the base rename declined (e.g. RenameLockedPolicy::Skip on a locked property),
+    // the property is still named oldName: re-bind the expressions there rather than under
+    // a name that was never actually taken, which would otherwise destroy the binding.
+    App::ObjectIdentifier idProp(prop->getContainer(), renamed ? std::string(name) : oldName);
     for (auto& exprToMove : expressionsToMove) {
-        ExpressionEngine.setValue(idNewProp, exprToMove);
+        ExpressionEngine.setValue(idProp, exprToMove);
     }
 
     return renamed;

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -1155,7 +1155,8 @@ public:
 
     bool removeDynamicProperty(const char* prop) override;
 
-    bool renameDynamicProperty(Property *prop, const char *name) override;
+    bool renameDynamicProperty(Property *prop, const char *name,
+                               RenameLockedPolicy policy = RenameLockedPolicy::Throw) override;
 
     /**
      * @brief Move the dynamic property to a document object.

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -248,10 +248,24 @@ Property* DynamicProperty::addDynamicProperty(
         name = "<null>";  // setting a bad name to trigger exception
     }
 
-    auto prop = pc.getPropertyByName(name.c_str());
-    if (prop && prop->getContainer() == &pc) {
+    // A real property under this name is always a collision.
+    auto existing = pc.getPropertyByName(name.c_str(), PropertyLookupMode::WithoutAliases);
+    if (existing && existing->getContainer() == &pc) {
         FC_THROWM(Base::NameError,
                   "Property " << pc.getFullName() << '.' << name << " already exists");
+    }
+
+    // The name may still be a registered alias. Add-ons guarded on PropertiesList membership
+    // will call this with the old name, so return the canonical property instead of failing.
+    auto aliased = pc.getPropertyByName(name.c_str());
+    if (aliased && aliased->getContainer() == &pc) {
+        if (aliased->getTypeId().getName() != type) {
+            FC_THROWM(Base::TypeError,
+                      "Property " << pc.getFullName() << '.' << name << " is an alias of "
+                                  << aliased->getName() << " which has type "
+                                  << aliased->getTypeId().getName() << ", not " << type);
+        }
+        return aliased;
     }
 
     if (Base::Tools::getIdentifier(name) != name) {

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -459,7 +459,8 @@ bool DynamicProperty::changeDynamicProperty(const Property* prop,
 }
 
 bool DynamicProperty::renameDynamicProperty(Property* prop,
-                                            const char* newName)
+                                            const char* newName,
+                                            RenameLockedPolicy policy)
 {
     auto& propIndex = impl->props.get<1>();
     auto propIt = propIndex.find(prop);
@@ -469,7 +470,14 @@ bool DynamicProperty::renameDynamicProperty(Property* prop,
     const PropData& data = *propIt;
 
     if (propIt->property->testStatus(Property::LockDynamic)) {
-        FC_THROWM(Base::RuntimeError, "Property " << prop->getName() << " is locked");
+        switch (policy) {
+            case RenameLockedPolicy::Throw:
+                FC_THROWM(Base::RuntimeError, "Property " << prop->getName() << " is locked");
+            case RenameLockedPolicy::Skip:
+                return false;
+            case RenameLockedPolicy::Force:
+                break;
+        }
     }
 
     PropertyContainer* container = prop->getContainer();

--- a/src/App/DynamicProperty.h
+++ b/src/App/DynamicProperty.h
@@ -47,6 +47,20 @@ namespace App
 class Property;
 class PropertyContainer;
 
+/**
+ * @brief Controls how renameDynamicProperty() handles a property locked with
+ * Property::LockDynamic.
+ */
+enum class RenameLockedPolicy {
+    /// Throw Base::RuntimeError if the property is locked. Default; preserves prior behaviour.
+    Throw,
+    /// Rename despite the lock. Used by the alias machinery, where the declaring class is
+    /// renaming its own property.
+    Force,
+    /// Do not rename and do not throw; return `false`.
+    Skip,
+};
+
 struct AppExport CStringHasher
 {
     std::size_t operator()(const char* s) const;
@@ -190,7 +204,17 @@ public:
 
     bool changeDynamicProperty(const Property* prop, const char* group, const char* doc);
 
-    bool renameDynamicProperty(Property* prop, const char* newName);
+    /**
+     * @brief Rename a dynamic property.
+     *
+     * @param[in] prop The property to rename.
+     * @param[in] newName The new name.
+     * @param[in] policy How to handle a property locked with Property::LockDynamic.
+     * @return True if the property was renamed.
+     */
+    bool renameDynamicProperty(Property* prop,
+                                const char* newName,
+                                RenameLockedPolicy policy = RenameLockedPolicy::Throw);
 
 private:
     std::string getUniquePropertyName(const PropertyContainer& pc, const char* Name) const;

--- a/src/App/Extension.cpp
+++ b/src/App/Extension.cpp
@@ -130,8 +130,12 @@ std::string Extension::name() const
     return {};
 }
 
-Property* Extension::extensionGetPropertyByName(const char* name) const
+Property* Extension::extensionGetPropertyByName(const char* name, PropertyLookupMode mode) const
 {
+    // extensionGetPropertyData() only ever returns canonical, statically-declared properties, so
+    // there is no alias branch here to guard; the mode is only meaningful to overrides (e.g.
+    // LinkBaseExtension) that delegate to a container's own getPropertyByName().
+    (void)mode;
     return extensionGetPropertyData().getPropertyByName(this, name);
 }
 

--- a/src/App/Extension.h
+++ b/src/App/Extension.h
@@ -206,7 +206,9 @@ public:
     /**
      * @copydoc PropertyContainer::getPropertyByName()
      */
-    virtual Property *extensionGetPropertyByName(const char* name) const;
+    virtual Property* extensionGetPropertyByName(
+        const char* name,
+        PropertyLookupMode mode = PropertyLookupMode::WithAliases) const;
 
     /**
      * @copydoc PropertyContainer::getPropertyName()

--- a/src/App/ExtensionContainer.cpp
+++ b/src/App/ExtensionContainer.cpp
@@ -187,9 +187,9 @@ void ExtensionContainer::visitProperties(const std::function<void(Property*)>& v
     };
 }
 
-Property* ExtensionContainer::getPropertyByName(const char* name) const
+Property* ExtensionContainer::getPropertyByName(const char* name, PropertyLookupMode mode) const
 {
-    auto prop = App::PropertyContainer::getPropertyByName(name);
+    auto prop = App::PropertyContainer::getPropertyByName(name, mode);
     if (prop) {
         return prop;
     }

--- a/src/App/ExtensionContainer.cpp
+++ b/src/App/ExtensionContainer.cpp
@@ -187,15 +187,15 @@ void ExtensionContainer::visitProperties(const std::function<void(Property*)>& v
     };
 }
 
-Property* ExtensionContainer::getPropertyByName(const char* name) const
+Property* ExtensionContainer::getPropertyByName(const char* name, PropertyLookupMode mode) const
 {
-    auto prop = App::PropertyContainer::getPropertyByName(name);
+    auto prop = App::PropertyContainer::getPropertyByName(name, mode);
     if (prop) {
         return prop;
     }
 
     for (const auto& entry : _extensions) {
-        auto prop = entry.second->extensionGetPropertyByName(name);
+        auto prop = entry.second->extensionGetPropertyByName(name, mode);
         if (prop) {
             return prop;
         }

--- a/src/App/ExtensionContainer.h
+++ b/src/App/ExtensionContainer.h
@@ -225,7 +225,8 @@ public:
      * @{
      */
 
-    Property* getPropertyByName(const char* name) const override;
+    Property* getPropertyByName(const char* name,
+                                PropertyLookupMode mode = PropertyLookupMode::WithAliases) const override;
 
     /**
      * @brief Find a property by its name and cast it to the specified type.

--- a/src/App/FeatureTest.cpp
+++ b/src/App/FeatureTest.cpp
@@ -123,6 +123,9 @@ FeatureTest::FeatureTest()
     ADD_PROPERTY_TYPE(Source2, (nullptr), group, Prop_None, "Source for testing links");
     ADD_PROPERTY_TYPE(SourceN, (nullptr), group, Prop_None, "Source for testing links");
     ADD_PROPERTY_TYPE(ExecResult, ("empty"), group, Prop_None, "Result of the execution");
+    ADD_PROPERTY_TYPE(AliasTarget, (0), group, Prop_None, "Property exercising property aliases");
+    ADD_PROPERTY_ALIAS(AliasTarget, "AliasPlain", "1.1");
+    ADD_PROPERTY_DEPRECATED_ALIAS(AliasTarget, "AliasDeprecated", "1.1");
     ADD_PROPERTY_TYPE(ExceptionType,
                       (0),
                       group,

--- a/src/App/FeatureTest.h
+++ b/src/App/FeatureTest.h
@@ -101,6 +101,9 @@ public:
     App::PropertyInteger TypeTransient;
     App::PropertyInteger TypeNoRecompute;
 
+    /// Property used by the test suite to exercise the property alias mechanism.
+    App::PropertyInteger AliasTarget;
+
     App::PropertyQuantity QuantityLength;
     App::PropertyQuantity QuantityOther;
     // App::PropertyQuantity  QuantityMass;

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -2532,10 +2532,10 @@ static bool isExcludedProperties(const char* name)
     return false;
 }
 
-Property* LinkBaseExtension::extensionGetPropertyByName(const char* name) const
+Property* LinkBaseExtension::extensionGetPropertyByName(const char* name, PropertyLookupMode mode) const
 {
     if (checkingProperty) {
-        return inherited::extensionGetPropertyByName(name);
+        return inherited::extensionGetPropertyByName(name, mode);
     }
     Base::StateLocker guard(checkingProperty);
     if (isExcludedProperties(name)) {
@@ -2543,14 +2543,14 @@ Property* LinkBaseExtension::extensionGetPropertyByName(const char* name) const
     }
     auto owner = getContainer();
     if (owner) {
-        App::Property* prop = owner->getPropertyByName(name);
+        App::Property* prop = owner->getPropertyByName(name, mode);
         if (prop) {
             return prop;
         }
         if (owner->canLinkProperties()) {
             auto linked = getTrueLinkedObject(true);
             if (linked) {
-                return linked->getPropertyByName(name);
+                return linked->getPropertyByName(name, mode);
             }
         }
     }

--- a/src/App/Link.h
+++ b/src/App/Link.h
@@ -502,7 +502,9 @@ public:
 
     PyObject* getExtensionPyObject() override;
 
-    Property* extensionGetPropertyByName(const char* name) const override;
+    Property* extensionGetPropertyByName(
+        const char* name,
+        PropertyLookupMode mode = PropertyLookupMode::WithAliases) const override;
 
     /**
      * @brief Get the array index from a subname.

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -75,13 +75,44 @@ App::Property* PropertyContainer::addDynamicProperty(
     return dynamicProps.addDynamicProperty(*this,type,name,group,doc,attr,ro,hidden);
 }
 
-Property *PropertyContainer::getPropertyByName(const char* name) const
+void PropertyContainer::addPropertyAlias(
+    const char* canonicalName, const char* alias, PropertyAliasType aliasType)
+{
+    if (!canonicalName || !alias || canonicalName[0] == '\0' || alias[0] == '\0') {
+        return;
+    }
+    _propertyAliases[alias] = {.canonicalName = canonicalName, .type = aliasType};
+}
+
+Property *PropertyContainer::getPropertyByName(const char* name, PropertyLookupMode mode) const
 {
     auto prop = dynamicProps.getDynamicPropertyByName(name);
     if (prop) {
         return prop;
     }
-    return getPropertyData().getPropertyByName(this,name);
+    prop = getPropertyData().getPropertyByName(this, name);
+    if (prop) {
+        return prop;
+    }
+    // Alias fallback — only reached when normal lookup finds nothing.
+    if (mode == PropertyLookupMode::WithoutAliases || _propertyAliases.empty()) {
+        return nullptr;
+    }
+    if (auto it = _propertyAliases.find(name); it != _propertyAliases.end()) {
+        const auto& entry = it->second;
+        if (entry.type == PropertyAliasType::Deprecated) {
+            FC_WARN("Property '" << name << "' in '" << getFullName()
+                    << "' is deprecated, use '" << entry.canonicalName << "' instead.");
+        }
+        // Resolve the canonical name directly without going through the alias map again,
+        // which prevents infinite loops if aliases are accidentally chained or cyclic.
+        auto resolved = dynamicProps.getDynamicPropertyByName(entry.canonicalName.c_str());
+        if (!resolved) {
+            resolved = getPropertyData().getPropertyByName(this, entry.canonicalName.c_str());
+        }
+        return resolved;
+    }
+    return nullptr;
 }
 
 void PropertyContainer::getPropertyMap(std::map<std::string,Property*> &Map) const
@@ -327,7 +358,8 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
 
     for (int i=0;i<transientCount; ++i) {
         reader.readElement("_Property");
-        Property* prop = getPropertyByName(reader.getAttribute<const char*>("name"));
+        Property* prop = getPropertyByName(reader.getAttribute<const char*>("name"),
+                                           PropertyLookupMode::WithoutAliases);
         if(prop)
             FC_TRACE("restore transient '" << prop->getName() << "'");
         if(prop && reader.hasAttribute("status"))
@@ -343,7 +375,7 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
         // not its name. In this case we would force to read-in a wrong property
         // type and the behaviour would be undefined.
         try {
-            auto prop = getPropertyByName(PropName.c_str());
+            auto prop = getPropertyByName(PropName.c_str(), PropertyLookupMode::WithoutAliases);
             if (!prop || prop->getContainer() != this) {
                 prop = dynamicProps.restore(*this,PropName.c_str(),TypeName.c_str(),reader);
             }

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -35,6 +35,7 @@
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Reader.h>
+#include <Base/Tools.h>
 #include <Base/Writer.h>
 
 #include "Property.h"
@@ -81,13 +82,105 @@ App::Property* PropertyContainer::addDynamicProperty(
     return dynamicProps.addDynamicProperty(*this, type, name, group, doc, attr, ro, hidden);
 }
 
-Property *PropertyContainer::getPropertyByName(const char* name) const
+void PropertyContainer::addPropertyAlias(
+    const char* canonicalName, const char* alias, PropertyAliasType aliasType, const char* since)
+{
+    if (Base::Tools::isNullOrEmpty(canonicalName) || Base::Tools::isNullOrEmpty(alias)) {
+        FC_ERR("Ignoring property alias with an empty canonical name or alias");
+        return;
+    }
+
+    _propertyAliases[alias] = {.canonicalName = canonicalName,
+                               .since = Base::Tools::isNullOrEmpty(since) ? "" : since,
+                               .type = aliasType};
+
+    // Aliases cannot be registered before Restore() for Python-backed objects, because the
+    // Proxy is not loaded yet. Registration is therefore the point at which an old document's
+    // property is migrated to the canonical name. This also rewrites any expressions
+    // referencing it, via signalRenameDynamicProperty.
+    auto legacy = dynamicProps.getDynamicPropertyByName(alias);
+    if (!legacy) {
+        return;
+    }
+    if (getPropertyByName(canonicalName, PropertyLookupMode::WithoutAliases)) {
+        FC_WARN("Not migrating '" << alias << "' in '" << getFullName() << "': '"
+                                  << canonicalName << "' already exists.");
+        return;
+    }
+
+    renameDynamicProperty(legacy, canonicalName, RenameLockedPolicy::Force);
+}
+
+std::map<std::string, PropertyAliasEntry> PropertyContainer::getPropertyAliases() const
+{
+    std::map<std::string, PropertyAliasEntry> aliases;
+    getPropertyData().getAliasMap(aliases);
+
+    for (const auto& [alias, entry] : _propertyAliases) {
+        aliases.insert_or_assign(alias, entry);
+    }
+
+    return aliases;
+}
+
+void PropertyContainer::warnDeprecatedAlias(const char* alias, const char* canonicalName,
+                                            const char* since) const
+{
+    if (!_warnedAliases.insert(alias).second) {
+        return;
+    }
+
+    if (!Base::Tools::isNullOrEmpty(since)) {
+        FC_WARN("Property '" << alias << "' in '" << getFullName() << "' is deprecated since "
+                             << since << ", use '" << canonicalName << "' instead.");
+    }
+    else {
+        FC_WARN("Property '" << alias << "' in '" << getFullName() << "' is deprecated, use '"
+                             << canonicalName << "' instead.");
+    }
+}
+
+Property* PropertyContainer::resolveAlias(const char* name, AliasWarningPolicy warning) const
+{
+    const PropertyAliasEntry* entry = nullptr;
+
+    if (auto it = _propertyAliases.find(name); it != _propertyAliases.end()) {
+        entry = &it->second;
+    }
+    else {
+        entry = getPropertyData().findAlias(name);
+    }
+
+    if (!entry) {
+        return nullptr;
+    }
+
+    if (warning == AliasWarningPolicy::Emit && entry->type == PropertyAliasType::Deprecated) {
+        warnDeprecatedAlias(name, entry->canonicalName.c_str(), entry->since.c_str());
+    }
+
+    // Resolve through the virtual entry point so subclasses that host properties elsewhere —
+    // ExtensionContainer, which keeps extension properties outside PropertyData — can find the
+    // canonical property. WithoutAliases makes the alias branch unreachable, so a chained or
+    // cyclic alias still cannot recurse.
+    return getPropertyByName(entry->canonicalName.c_str(), PropertyLookupMode::WithoutAliases);
+}
+
+Property* PropertyContainer::getPropertyByName(const char* name, PropertyLookupMode mode) const
 {
     auto prop = dynamicProps.getDynamicPropertyByName(name);
     if (prop) {
         return prop;
     }
-    return getPropertyData().getPropertyByName(this,name);
+    prop = getPropertyData().getPropertyByName(this, name);
+    if (prop) {
+        return prop;
+    }
+    // Alias fallback — only reached when normal lookup finds nothing.
+    if (mode == PropertyLookupMode::WithoutAliases) {
+        return nullptr;
+    }
+    return resolveAlias(name, AliasWarningPolicy::Emit);
 }
 
 void PropertyContainer::getPropertyMap(std::map<std::string,Property*> &Map) const
@@ -333,7 +426,8 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
 
     for (int i=0;i<transientCount; ++i) {
         reader.readElement("_Property");
-        Property* prop = getPropertyByName(reader.getAttribute<const char*>("name"));
+        Property* prop = getPropertyByName(reader.getAttribute<const char*>("name"),
+                                           PropertyLookupMode::WithoutAliases);
         if(prop)
             FC_TRACE("restore transient '" << prop->getName() << "'");
         if(prop && reader.hasAttribute("status"))
@@ -349,9 +443,14 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
         // not its name. In this case we would force to read-in a wrong property
         // type and the behaviour would be undefined.
         try {
-            auto prop = getPropertyByName(PropName.c_str());
+            auto prop = getPropertyByName(PropName.c_str(), PropertyLookupMode::WithoutAliases);
             if (!prop || prop->getContainer() != this) {
                 prop = dynamicProps.restore(*this,PropName.c_str(),TypeName.c_str(),reader);
+            }
+            if (!prop) {
+                // Resolve directly rather than through getPropertyByName, so restoring an old
+                // document does not emit deprecation warnings the user cannot act on.
+                prop = resolveAlias(PropName.c_str(), AliasWarningPolicy::Suppress);
             }
 
             decltype(Property::StatusBits) status;
@@ -448,6 +547,9 @@ struct PropertyData::Impl
     >
     > propertyData;
      // clang-format on
+
+    /// Alias name to entry. Not merged with the parent; findAlias walks the chain.
+    std::map<std::string, PropertyAliasEntry> aliasData;
 };
 
 PropertyData::PropertyData(): impl(std::make_unique<Impl>()) {};
@@ -479,6 +581,49 @@ void PropertyData::addProperty(OffsetBase offsetBase,const char* PropName, Prope
 
     Prop->syncType(Type);
     Prop->myName = PropName;
+}
+
+void PropertyData::addAlias(const char* canonicalName, const char* alias, PropertyAliasType type,
+                            const char* since)
+{
+    if (Base::Tools::isNullOrEmpty(canonicalName) || Base::Tools::isNullOrEmpty(alias)) {
+        FC_ERR("Ignoring property alias with an empty canonical name or alias");
+        return;
+    }
+
+    // aliasData is shared per-class state: every instance of the class re-registers the
+    // same alias in its constructor. Unlike insert_or_assign, try_emplace only writes the
+    // entry once, on the first construction, matching addProperty()'s find-then-emplace
+    // shape above -- an assignment here would race with findAlias() readers on other
+    // threads concurrently constructing instances of the same class.
+    impl->aliasData.try_emplace(
+        alias,
+        PropertyAliasEntry {.canonicalName = canonicalName,
+                            .since = Base::Tools::isNullOrEmpty(since) ? "" : since,
+                            .type = type}
+    );
+}
+
+const PropertyAliasEntry* PropertyData::findAlias(const char* alias) const
+{
+    for (const PropertyData* data = this; data; data = data->parentPropertyData) {
+        auto it = data->impl->aliasData.find(alias);
+        if (it != data->impl->aliasData.end()) {
+            return &it->second;
+        }
+    }
+    return nullptr;
+}
+
+void PropertyData::getAliasMap(std::map<std::string, PropertyAliasEntry>& map) const
+{
+    // Walk parents first so that entries declared on this class overwrite inherited ones.
+    if (parentPropertyData) {
+        parentPropertyData->getAliasMap(map);
+    }
+    for (const auto& entry : impl->aliasData) {
+        map.insert_or_assign(entry.first, entry.second);
+    }
 }
 
 void PropertyData::merge(PropertyData *other) const {

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <map>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include <memory>
@@ -70,6 +71,36 @@ enum PropertyType
     Prop_NoRecompute = 16,
     /// The property won't be saved to file at all.
     Prop_NoPersist   = 32,
+};
+
+/**
+ * @brief Specifies whether a property alias is deprecated.
+ *
+ * Pass this to addPropertyAlias() or the ADD_PROPERTY_ALIAS /
+ * ADD_PROPERTY_DEPRECATED_ALIAS macros to control whether using the alias
+ * emits a developer warning.
+ */
+enum class PropertyAliasType {
+    /// The alias resolves silently with no warning.
+    Normal,
+    /// The alias resolves but emits a developer warning to encourage migration to the canonical name.
+    Deprecated,
+};
+
+/// Entry in the property alias map.
+struct PropertyAliasEntry {
+    std::string canonicalName;
+    PropertyAliasType type;
+};
+
+/**
+ * @brief Controls whether property alias resolution is applied in getPropertyByName().
+ */
+enum class PropertyLookupMode {
+    /// Resolve aliases when the canonical name is not found (default).
+    WithAliases,
+    /// Skip alias resolution; only canonical property names are matched.
+    WithoutAliases,
 };
 // clang-format on
 
@@ -327,7 +358,8 @@ public:
    * @param[in] name The name of the property to find.
    * @return The property if found or `nullptr` when not found.
    */
-  virtual Property *getPropertyByName(const char* name) const;
+  virtual Property *getPropertyByName(const char* name,
+                                      PropertyLookupMode mode = PropertyLookupMode::WithAliases) const;
 
   /**
    * @brief Get the name of a property.
@@ -535,6 +567,21 @@ public:
   }
 
   /**
+   * @brief Register an alias for a property name.
+   *
+   * After this call, getPropertyByName(alias) and Python attribute access via
+   * the alias name will transparently return the same property as
+   * getPropertyByName(canonicalName). This allows renaming properties in C++
+   * without breaking Python add-ons and macros that use the old name.
+   *
+   * @param[in] canonicalName The current, authoritative name of the property.
+   * @param[in] alias         The old or alternative name to also accept.
+   * @param[in] aliasType     Whether to emit a warning when the alias is used.
+   */
+  void addPropertyAlias(const char* canonicalName, const char* alias,
+                        PropertyAliasType aliasType = PropertyAliasType::Normal);
+
+  /**
    * @brief Remove a dynamic property.
    *
    * @param[in] name The name of the property to remove.
@@ -731,6 +778,8 @@ protected:
 
 private:
   std::string _propertyPrefix;
+  /// Maps alias names to their canonical property name and deprecation status.
+  std::unordered_map<std::string, PropertyAliasEntry> _propertyAliases;
   static PropertyData propertyData;
 };
 
@@ -755,6 +804,16 @@ private:
 
 #define ADD_PROPERTY_TYPE(_prop_, _defaultval_, _group_,_type_,_Docu_) \
     _ADD_PROPERTY_TYPE(#_prop_,_prop_,_defaultval_,_group_,_type_,_Docu_)
+
+/// Register a non-deprecated alias for a property. The old alias name will resolve to the same
+/// property as the canonical name given by _prop_ (a bare C++ member name, stringified).
+#define ADD_PROPERTY_ALIAS(_prop_, _alias_) \
+    this->addPropertyAlias(#_prop_, _alias_, App::PropertyAliasType::Normal)
+
+/// Register a deprecated alias for a property. Like ADD_PROPERTY_ALIAS but emits a developer
+/// warning each time the alias is accessed, encouraging migration to the canonical name.
+#define ADD_PROPERTY_DEPRECATED_ALIAS(_prop_, _alias_) \
+    this->addPropertyAlias(#_prop_, _alias_, App::PropertyAliasType::Deprecated)
 
 
 #define PROPERTY_HEADER(_class_) \

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include <map>
+#include <set>
+#include <unordered_map>
 #include <vector>
 #include <string>
 #include <memory>
@@ -72,6 +74,47 @@ enum PropertyType
     Prop_NoPersist   = 32,
     /// The property is a true input property.
     Prop_Input   = 64,
+};
+
+/**
+ * @brief Specifies whether a property alias is deprecated.
+ *
+ * Pass this to addPropertyAlias() or the ADD_PROPERTY_ALIAS /
+ * ADD_PROPERTY_DEPRECATED_ALIAS macros to control whether using the alias
+ * emits a developer warning.
+ */
+enum class PropertyAliasType {
+    /// The alias resolves silently with no warning.
+    Normal,
+    /// The alias resolves but emits a developer warning to encourage migration to the canonical name.
+    Deprecated,
+};
+
+/// Entry in the per-instance property alias map.
+struct PropertyAliasEntry {
+    std::string canonicalName;
+    std::string since;
+    PropertyAliasType type;
+};
+
+/**
+ * @brief Controls whether property alias resolution is applied in getPropertyByName().
+ */
+enum class PropertyLookupMode {
+    /// Resolve aliases when the canonical name is not found (default).
+    WithAliases,
+    /// Skip alias resolution; only canonical property names are matched.
+    WithoutAliases,
+};
+
+/**
+ * @brief Controls whether resolveAlias() emits a deprecation warning for a deprecated alias.
+ */
+enum class AliasWarningPolicy {
+    /// Emit the deprecation warning, if the alias is deprecated.
+    Emit,
+    /// Never emit the deprecation warning.
+    Suppress,
 };
 // clang-format on
 
@@ -196,6 +239,33 @@ struct AppExport PropertyData
    * @return The property specification if found; `nullptr` otherwise.
    */
   const PropertySpec *findProperty(OffsetBase offsetBase,const Property* prop) const;
+
+  /**
+   * @brief Register an alias for a static property name.
+   *
+   * @param[in] canonicalName The current name of the property.
+   * @param[in] alias The old or alternative name to also accept.
+   * @param[in] type Whether resolving through the alias warns.
+   * @param[in] since The FreeCAD version introducing the alias, e.g. "1.1".
+   */
+  void addAlias(const char* canonicalName, const char* alias, PropertyAliasType type,
+                const char* since);
+
+  /**
+   * @brief Find an alias by name, searching this class then its parents.
+   *
+   * @param[in] alias The alias name to look up.
+   * @return The alias entry if found; `nullptr` otherwise.
+   */
+  const PropertyAliasEntry* findAlias(const char* alias) const;
+
+  /**
+   * @brief Collect every alias visible on this class, including inherited ones.
+   *
+   * @param[out] map Alias name to entry. Entries declared on this class take
+   * precedence over identically named entries inherited from a parent.
+   */
+  void getAliasMap(std::map<std::string, PropertyAliasEntry>& map) const;
 
   /**
    * @name PropertyData accessors
@@ -327,9 +397,12 @@ public:
    * @brief Find a property by its name.
    *
    * @param[in] name The name of the property to find.
+   * @param[in] mode Whether to fall back to alias resolution when no property carries
+   * the given name. Pass PropertyLookupMode::WithoutAliases to match canonical names only.
    * @return The property if found or `nullptr` when not found.
    */
-  virtual Property *getPropertyByName(const char* name) const;
+  virtual Property *getPropertyByName(const char* name,
+                                      PropertyLookupMode mode = PropertyLookupMode::WithAliases) const;
 
   /**
    * @brief Get the name of a property.
@@ -539,6 +612,45 @@ public:
   }
 
   /**
+   * @brief Register an alias for a property name.
+   *
+   * After this call, getPropertyByName(alias) and Python attribute access via
+   * the alias name will transparently return the same property as
+   * getPropertyByName(canonicalName). This allows renaming properties in C++
+   * without breaking Python add-ons and macros that use the old name.
+   *
+   * @param[in] canonicalName The current, authoritative name of the property.
+   * @param[in] alias         The old or alternative name to also accept.
+   * @param[in] aliasType     Whether to emit a warning when the alias is used.
+   * @param[in] since         The FreeCAD version in which the alias was introduced.
+   */
+  void addPropertyAlias(const char* canonicalName, const char* alias,
+                        PropertyAliasType aliasType = PropertyAliasType::Normal,
+                        const char* since = "");
+
+  /**
+   * @brief Check whether this instance has ever registered a runtime alias.
+   *
+   * Exists so tests can confirm that resolving a class-level alias never populates the
+   * per-instance overlay.
+   *
+   * @return `true` if addPropertyAlias() has been called on this instance.
+   */
+  bool hasInstanceAliases() const {
+      return !_propertyAliases.empty();
+  }
+
+  /**
+   * @brief Get every property alias visible on this container.
+   *
+   * Merges aliases declared on the class (and its parents) with aliases registered on this
+   * instance. Instance entries take precedence.
+   *
+   * @return Alias name to its canonical name, introduction version, and deprecation status.
+   */
+  std::map<std::string, PropertyAliasEntry> getPropertyAliases() const;
+
+  /**
    * @brief Remove a dynamic property.
    *
    * @param[in] name The name of the property to remove.
@@ -690,6 +802,23 @@ protected:
   virtual const PropertyData& getPropertyData() const;
 
   /**
+   * @brief Resolve a name through the alias registries.
+   *
+   * Consults the per-instance overlay, then the class registry. Emits at most one
+   * deprecation warning per alias per container, unless suppressed.
+   *
+   * @param[in] name The alias name to resolve.
+   * @param[in] warning Whether to emit the deprecation warning for a deprecated alias.
+   * @return The property the alias refers to, or `nullptr` if the name is not an alias or
+   * the canonical property does not exist.
+   */
+  Property* resolveAlias(const char* name, AliasWarningPolicy warning) const;
+
+  /// Emit the deprecation warning for an alias, at most once per alias per container.
+  void warnDeprecatedAlias(const char* alias, const char* canonicalName,
+                           const char* since) const;
+
+  /**
    * @brief Handle a changed property name during restore.
    *
    * This method is called during restore to possibly fix reading of older
@@ -735,6 +864,11 @@ protected:
 
 private:
   std::string _propertyPrefix;
+  /// Alias names registered on this instance. Static aliases live in PropertyData instead, so
+  /// this stays empty for the vast majority of containers.
+  std::unordered_map<std::string, PropertyAliasEntry> _propertyAliases;
+  /// Alias names already warned about on this instance.
+  mutable std::set<std::string> _warnedAliases;
   static PropertyData propertyData;
 };
 
@@ -759,6 +893,25 @@ private:
 
 #define ADD_PROPERTY_TYPE(_prop_, _defaultval_, _group_,_type_,_Docu_) \
     _ADD_PROPERTY_TYPE(#_prop_,_prop_,_defaultval_,_group_,_type_,_Docu_)
+
+/// Register a non-deprecated alias for a static property. The alias name resolves to the same
+/// property as the canonical name given by _prop_ (a bare C++ member name, stringified).
+/// _since_ is the FreeCAD version introducing the alias, e.g. "1.1".
+/// The `(void)&this->_prop_` reference forces the compiler to reject a misspelled _prop_, the
+/// same way _ADD_PROPERTY_TYPE does above.
+#define ADD_PROPERTY_ALIAS(_prop_, _alias_, _since_) \
+    do { \
+        (void)&this->_prop_; \
+        propertyData.addAlias(#_prop_, _alias_, App::PropertyAliasType::Normal, _since_); \
+    } while (0)
+
+/// Register a deprecated alias for a static property. Like ADD_PROPERTY_ALIAS but emits a
+/// developer warning when the alias is resolved, encouraging migration to the canonical name.
+#define ADD_PROPERTY_DEPRECATED_ALIAS(_prop_, _alias_, _since_) \
+    do { \
+        (void)&this->_prop_; \
+        propertyData.addAlias(#_prop_, _alias_, App::PropertyAliasType::Deprecated, _since_); \
+    } while (0)
 
 
 #define PROPERTY_HEADER(_class_) \

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -528,12 +528,14 @@ public:
    *
    * @param[in] prop The property to rename.
    * @param[in] name The new name for the property.
+   * @param[in] policy How to handle a property locked with Property::LockDynamic.
    *
    * @return `true` if the property was renamed; `false` otherwise.
    * @throw Base::NameError If the new name is invalid or already exists.
    */
-  virtual bool renameDynamicProperty(Property *prop, const char *name) {
-      return dynamicProps.renameDynamicProperty(prop, name);
+  virtual bool renameDynamicProperty(Property *prop, const char *name,
+                                     RenameLockedPolicy policy = RenameLockedPolicy::Throw) {
+      return dynamicProps.renameDynamicProperty(prop, name, policy);
   }
 
   /**

--- a/src/App/PropertyContainer.pyi
+++ b/src/App/PropertyContainer.pyi
@@ -193,3 +193,22 @@ class PropertyContainer(Persistence):
             New property name.
         """
         ...
+
+    def addPropertyAlias(self, canonicalName: str, alias: str, deprecated: bool = False, /) -> None:
+        """
+        Register an alias for a property name.
+
+        After this call, getPropertyByName(alias) and Python attribute access via
+        the alias name will transparently return the same property as the canonical name.
+        This allows renaming a property in C++ without breaking Python add-ons and macros
+        that still use the old name.
+
+        canonicalName : str
+            The current, authoritative name of the property.
+        alias : str
+            The old or alternative name to also accept.
+        deprecated : bool
+            If True, a developer warning is emitted each time the alias is resolved,
+            encouraging migration to the canonical name.
+        """
+        ...

--- a/src/App/PropertyContainer.pyi
+++ b/src/App/PropertyContainer.pyi
@@ -193,3 +193,49 @@ class PropertyContainer(Persistence):
             New property name.
         """
         ...
+
+    def addPropertyAlias(
+        self, property: str, alias: str, deprecated: bool = False, since: str = ""
+    ) -> None:
+        """
+        Register an alias for a property name.
+
+        After this call, getPropertyByName(alias) and Python attribute access via
+        the alias name will transparently return the same property as the canonical name.
+        This allows renaming a property without breaking add-ons and macros that still
+        use the old name.
+
+        If a dynamic property named `alias` exists and no property named `property`
+        does, it is renamed to `property` in place, preserving its value. This is how
+        documents saved under the old name are migrated, so the call is safe to make
+        unconditionally on every load.
+
+        property : str
+            The current, authoritative name of the property.
+        alias : str
+            The old or alternative name to also accept.
+        deprecated : bool
+            If True, a developer warning is emitted the first time the alias is resolved
+            on each object, encouraging migration to the canonical name.
+        since : str
+            The FreeCAD version in which the alias was introduced, e.g. "1.1". Included in
+            the deprecation warning.
+        """
+        ...
+
+    @no_args
+    @constmethod
+    def getPropertyAliases(self) -> dict[str, dict[str, object]]:
+        """
+        Get every property alias visible on this object.
+
+        Merges aliases declared by the C++ class with aliases registered at runtime on this
+        object. Aliases are deliberately absent from PropertiesList, so that deprecated names
+        do not appear in the property editor or in dir().
+
+        Returns a dict mapping each alias name to a dict with keys:
+            canonical  : str  -- the current name of the property
+            deprecated : bool -- whether using the alias emits a warning
+            since      : str  -- the FreeCAD version introducing the alias, may be empty
+        """
+        ...

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -696,3 +696,21 @@ PyObject* PropertyContainerPy::renameProperty(PyObject* args) const
     PY_CATCH
 }
 
+PyObject* PropertyContainerPy::addPropertyAlias(PyObject* args)
+{
+    const char* canonicalName {};
+    const char* alias {};
+    PyObject* pyDeprecated = Py_False;
+    if (!PyArg_ParseTuple(args, "ss|O!", &canonicalName, &alias, &PyBool_Type, &pyDeprecated)) {
+        return nullptr;
+    }
+    PY_TRY
+    {
+        auto aliasType = PyObject_IsTrue(pyDeprecated) ? App::PropertyAliasType::Deprecated
+                                                     : App::PropertyAliasType::Normal;
+        getPropertyContainerPtr()->addPropertyAlias(canonicalName, alias, aliasType);
+        Py_Return;
+    }
+    PY_CATCH
+}
+

--- a/src/App/PropertyContainerPyImp.cpp
+++ b/src/App/PropertyContainerPyImp.cpp
@@ -700,3 +700,53 @@ PyObject* PropertyContainerPy::renameProperty(PyObject* args) const
     PY_CATCH
 }
 
+PyObject* PropertyContainerPy::addPropertyAlias(PyObject* args, PyObject* kwds)
+{
+    const char* canonicalName {};
+    const char* alias {};
+    PyObject* pyDeprecated = Py_False;
+    const char* since = "";
+    static const std::array<const char*, 5> kwlist {"property",
+                                                     "alias",
+                                                     "deprecated",
+                                                     "since",
+                                                     nullptr};
+    if (!Base::Wrapped_ParseTupleAndKeywords(args,
+                                             kwds,
+                                             "ss|O!s",
+                                             kwlist,
+                                             &canonicalName,
+                                             &alias,
+                                             &PyBool_Type,
+                                             &pyDeprecated,
+                                             &since)) {
+        return nullptr;
+    }
+    PY_TRY
+    {
+        auto aliasType = PyObject_IsTrue(pyDeprecated) ? App::PropertyAliasType::Deprecated
+                                                       : App::PropertyAliasType::Normal;
+        getPropertyContainerPtr()->addPropertyAlias(canonicalName, alias, aliasType, since);
+        Py_Return;
+    }
+    PY_CATCH
+}
+
+PyObject* PropertyContainerPy::getPropertyAliases() const
+{
+    PY_TRY
+    {
+        Py::Dict dict;
+        for (const auto& [alias, entry] : getPropertyContainerPtr()->getPropertyAliases()) {
+            Py::Dict info;
+            info.setItem("canonical", Py::String(entry.canonicalName));
+            info.setItem("deprecated",
+                         Py::Boolean(entry.type == App::PropertyAliasType::Deprecated));
+            info.setItem("since", Py::String(entry.since));
+            dict.setItem(alias, info);
+        }
+        return Py::new_reference_to(dict);
+    }
+    PY_CATCH
+}
+

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -917,13 +917,16 @@ void PropertyExpressionEngine::renameExpressions(
     hasSetValue();
 }
 
-void PropertyExpressionEngine::renameObjectIdentifiers(
+int PropertyExpressionEngine::renameObjectIdentifiers(
     const std::map<ObjectIdentifier, ObjectIdentifier>& paths)
 {
+    int renamed = 0;
     for (const auto& it : expressions) {
         RenameObjectIdentifierExpressionVisitor<PropertyExpressionEngine> v(*this, paths, it.first);
         it.second.expression->visit(v);
+        renamed += v.changed();
     }
+    return renamed;
 }
 
 PyObject* PropertyExpressionEngine::getPyObject()

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -289,12 +289,12 @@ public:
     void renameExpressions(const std::map<App::ObjectIdentifier, App::ObjectIdentifier>& paths);
 
     /**
-     * @brief Rename object identifiers in the registered expressions.
+     * @brief Rewrite object identifiers in every stored expression.
      *
-     * @param[in] paths A map with the current and new object identifiers.
+     * @param[in] paths Map of current to new identifiers.
+     * @return The number of references rewritten.
      */
-    void
-    renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App::ObjectIdentifier>& paths);
+    int renameObjectIdentifiers(const std::map<App::ObjectIdentifier, App::ObjectIdentifier>& paths);
 
     /**
      * @brief Create a canonical object identifier of the given object \a p.

--- a/src/App/core-app.dox
+++ b/src/App/core-app.dox
@@ -473,6 +473,88 @@
  *   reader.readEndElement("Properties");
  * }
  * @endcode
+ *
+ * @section PropertyRenaming Renaming a property
+ *
+ * Renaming a property breaks every Python add-on and macro that referenced the old
+ * name. The property alias mechanism keeps the old name working so the rename can be
+ * made without a coordinated flag day.
+ *
+ * @subsection PropertyRenamingCpp Renaming a static C++ property
+ *
+ * Rename the member, then declare an alias for the old name in the constructor:
+ *
+ * @code
+ * // in the header
+ * App::PropertyString Description;
+ *
+ * // in the constructor
+ * ADD_PROPERTY_TYPE(Description, (""), group, App::Prop_None, "Object description");
+ * ADD_PROPERTY_DEPRECATED_ALIAS(Description, "Label2", "1.1");
+ * @endcode
+ *
+ * The third argument is the FreeCAD version introducing the alias. It appears in the
+ * deprecation warning and makes it possible to audit which aliases are old enough to
+ * retire.
+ *
+ * No handleChangedPropertyName() override is needed. Restore() resolves aliases, so a
+ * document saved under the old name restores into the renamed property, silently.
+ *
+ * @subsection PropertyRenamingPython Renaming a Python property
+ *
+ * Python objects have no static properties, so both steps happen at runtime:
+ *
+ * @code{.py}
+ * obj.addPropertyAlias("SurfaceArea", "Area", deprecated=True, since="1.1")
+ * obj.addProperty("App::PropertyArea", "SurfaceArea", "Geometry")
+ * @endcode
+ *
+ * The order matters: addPropertyAlias() must run first, while "SurfaceArea" does not yet
+ * exist, so it can find the leftover "Area" from an older document and migrate it. Calling
+ * addProperty() first creates a fresh "SurfaceArea" with a default value, so
+ * addPropertyAlias() then finds the canonical name already taken and declines to migrate,
+ * silently orphaning the user's value under the old name.
+ *
+ * Both calls are safe to make unconditionally on every load. addProperty() returns the
+ * existing property rather than raising if the name is already taken, and
+ * addPropertyAlias() renames a leftover "Area" from an older document to "SurfaceArea",
+ * preserving its value.
+ *
+ * Aliases are runtime state and are not saved, so registration must run every time the
+ * object is created — from the Proxy constructor and from onDocumentRestored().
+ *
+ * @subsection PropertyRenamingLimits What aliases do not do
+ *
+ * @li <b>Forward compatibility is broken.</b> A renamed static property is written to
+ *     the file under its new name, so an older FreeCAD cannot read it. This is a
+ *     deliberate trade: the alternative is never being able to rename anything.
+ *
+ * @li <b>Aliases can reach documents.</b> An expression referring to an alias persists
+ *     that name into the .FCStd, because the expression stores the text the user typed.
+ *     For a static (C++) alias, Document::afterRestore() rewrites such references to the
+ *     canonical name, so files heal on the next save. A runtime alias registered from
+ *     Python is not covered by that rewrite, because it runs before Python gets a chance
+ *     to register anything: it heals only the properties it migrates at registration time,
+ *     not expressions written against the alias afterwards. An alias cannot be retired
+ *     until the documents in circulation have been through the applicable healing cycle.
+ *
+ * @li <b>Aliases are not properties.</b> They are absent from PropertiesList, from the
+ *     property editor, and from dir(). Use getPropertyAliases() to enumerate them.
+ *
+ * @li <b>Declaring an alias claims that name.</b> If a dynamic property already exists
+ *     under the alias name, registration renames it to the canonical name, whether or not
+ *     the property is locked. This matches what renameProperty() already does for
+ *     unlocked properties, and additionally unblocks locked ones, which renameProperty()
+ *     refuses.
+ *
+ * @subsection PropertyRenamingDesign Why the new name is canonical
+ *
+ * An alternative would be to keep the original name canonical and treat the new name as
+ * the preferred alias, so that a second rename would replace the alias rather than adding
+ * another. That was considered and rejected: it means the name in the file, in the
+ * property editor, and in the code never converges on the one developers actually use,
+ * and every reader must learn the historical name to understand the class. Carrying a
+ * second name for a deprecation window is the cheaper cost.
  */
 
 /**

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -4007,14 +4007,14 @@ static bool isExcludedProperties(const char* name)
     return false;
 }
 
-App::Property* ViewProviderLink::getPropertyByName(const char* name) const
+App::Property* ViewProviderLink::getPropertyByName(const char* name, App::PropertyLookupMode mode) const
 {
-    auto prop = inherited::getPropertyByName(name);
+    auto prop = inherited::getPropertyByName(name, mode);
     if (prop || isExcludedProperties(name)) {
         return prop;
     }
     if (childVp) {
-        prop = childVp->getPropertyByName(name);
+        prop = childVp->getPropertyByName(name, mode);
         if (prop && !prop->testStatus(App::Property::Hidden)) {
             return prop;
         }
@@ -4023,7 +4023,7 @@ App::Property* ViewProviderLink::getPropertyByName(const char* name) const
     if (pcObject && pcObject->canLinkProperties()) {
         auto linked = getLinkedViewProvider(nullptr, true);
         if (linked && linked != this) {
-            prop = linked->getPropertyByName(name);
+            prop = linked->getPropertyByName(name, mode);
         }
     }
     return prop;

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -3900,14 +3900,14 @@ static bool isExcludedProperties(const char* name)
     return false;
 }
 
-App::Property* ViewProviderLink::getPropertyByName(const char* name) const
+App::Property* ViewProviderLink::getPropertyByName(const char* name, App::PropertyLookupMode mode) const
 {
-    auto prop = inherited::getPropertyByName(name);
+    auto prop = inherited::getPropertyByName(name, mode);
     if (prop || isExcludedProperties(name)) {
         return prop;
     }
     if (childVp) {
-        prop = childVp->getPropertyByName(name);
+        prop = childVp->getPropertyByName(name, mode);
         if (prop && !prop->testStatus(App::Property::Hidden)) {
             return prop;
         }
@@ -3916,7 +3916,7 @@ App::Property* ViewProviderLink::getPropertyByName(const char* name) const
     if (pcObject && pcObject->canLinkProperties()) {
         auto linked = getLinkedViewProvider(nullptr, true);
         if (linked && linked != this) {
-            prop = linked->getPropertyByName(name);
+            prop = linked->getPropertyByName(name, mode);
         }
     }
     return prop;

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -326,7 +326,10 @@ public:
         return childVp;
     }
 
-    App::Property* getPropertyByName(const char* name) const override;
+    App::Property* getPropertyByName(
+        const char* name,
+        App::PropertyLookupMode mode = App::PropertyLookupMode::WithAliases
+    ) const override;
     void getPropertyMap(std::map<std::string, App::Property*>& Map) const override;
     /// See PropertyContainer::visitProperties for semantics
     void visitProperties(const std::function<void(App::Property*)>& visitor) const override;

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -304,7 +304,10 @@ public:
         return childVp;
     }
 
-    App::Property* getPropertyByName(const char* name) const override;
+    App::Property* getPropertyByName(
+        const char* name,
+        App::PropertyLookupMode mode = App::PropertyLookupMode::WithAliases
+    ) const override;
     void getPropertyMap(std::map<std::string, App::Property*>& Map) const override;
     /// See PropertyContainer::visitProperties for semantics
     void visitProperties(const std::function<void(App::Property*)>& visitor) const override;

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -858,7 +858,7 @@ void Sheet::updateProperty(CellAddress key)
  *
  */
 
-Property* Sheet::getPropertyByName(const char* name) const
+Property* Sheet::getPropertyByName(const char* name, App::PropertyLookupMode mode) const
 {
     CellAddress addr = getCellAddress(name, true);
     Property* prop = nullptr;
@@ -869,7 +869,7 @@ Property* Sheet::getPropertyByName(const char* name) const
         return prop;
     }
     else {
-        return DocumentObject::getPropertyByName(name);
+        return DocumentObject::getPropertyByName(name, mode);
     }
 }
 

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -859,7 +859,7 @@ void Sheet::updateProperty(CellAddress key)
  *
  */
 
-Property* Sheet::getPropertyByName(const char* name) const
+Property* Sheet::getPropertyByName(const char* name, App::PropertyLookupMode mode) const
 {
     CellAddress addr = getCellAddress(name, true);
     Property* prop = nullptr;
@@ -870,7 +870,7 @@ Property* Sheet::getPropertyByName(const char* name) const
         return prop;
     }
     else {
-        return DocumentObject::getPropertyByName(name);
+        return DocumentObject::getPropertyByName(name, mode);
     }
 }
 

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -206,7 +206,10 @@ public:
         return &cells;
     }
 
-    App::Property* getPropertyByName(const char* name) const override;
+    App::Property* getPropertyByName(
+        const char* name,
+        App::PropertyLookupMode mode = App::PropertyLookupMode::WithAliases
+    ) const override;
 
     App::Property* getDynamicPropertyByName(const char* name) const override;
 

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -196,7 +196,10 @@ public:
         return &cells;
     }
 
-    App::Property* getPropertyByName(const char* name) const override;
+    App::Property* getPropertyByName(
+        const char* name,
+        App::PropertyLookupMode mode = App::PropertyLookupMode::WithAliases
+    ) const override;
 
     App::Property* getDynamicPropertyByName(const char* name) const override;
 

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -11,6 +11,7 @@ SET(Test_SRCS
     Document.py
     GuiDocument.py
     Metadata.py
+    PropertyAlias.py
     StringHasher.py
     Menu.py
     Recompute.py

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -29,6 +29,7 @@ FreeCAD.__unit_test__ += [
     "UnitTests",
     "Document",
     "Metadata",
+    "PropertyAlias",
     "Recompute",
     "StringHasher",
     "UnicodeTests",

--- a/src/Mod/Test/PropertyAlias.py
+++ b/src/Mod/Test/PropertyAlias.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Tests for the property alias mechanism, doubling as usage examples.
+
+Renaming a property breaks add-ons and macros that used the old name. An alias keeps the
+old name working. In Python both steps happen at runtime, and the order matters:
+
+    obj.addPropertyAlias("SurfaceArea", "Area", deprecated=True, since="1.1")
+    obj.addProperty("App::PropertyArea", "SurfaceArea", "Geometry")
+
+addPropertyAlias() must run first, while "SurfaceArea" does not yet exist, so it can find
+and migrate a leftover "Area" from an older document. Calling addProperty() first creates a
+fresh "SurfaceArea" with a default value, so addPropertyAlias() then finds the canonical
+name already taken and declines to migrate, silently orphaning the user's value under the
+old name. Both calls are otherwise safe to make unconditionally on every load. See
+LegacyAreaFeature below for the complete pattern including document restore.
+"""
+
+import os
+import tempfile
+import unittest
+
+import FreeCAD
+
+
+class LegacyAreaFeature:
+    """Renaming a Python property from 'Area' to 'SurfaceArea'.
+
+    Documents saved by an older version stored 'Area'. Registering the alias migrates them
+    in place and keeps 'Area' working for scripts that still use the old name.
+    """
+
+    def __init__(self, obj):
+        obj.Proxy = self
+        # Register the alias before adding the property: on a document saved before the
+        # rename, obj may already carry a dynamic "Area" property, and addPropertyAlias()
+        # only migrates it while "SurfaceArea" does not exist yet. In practice __init__ is
+        # never called on restore (only onDocumentRestored() is, see below), so this
+        # ordering never actually observes a leftover "Area" here -- but it follows the
+        # documented recipe so the class stays a correct example, and so copying this
+        # pattern elsewhere (e.g. into a constructor that *is* reachable on restore)
+        # doesn't silently reintroduce the divergence bug.
+        self.registerAliases(obj)
+        obj.addProperty("App::PropertyArea", "SurfaceArea", "Geometry")
+
+    def onDocumentRestored(self, obj):
+        self.registerAliases(obj)
+
+    def registerAliases(self, obj):
+        # Aliases are runtime state and are not saved, so this must run on every load.
+        obj.addPropertyAlias("SurfaceArea", "Area", deprecated=True, since="1.1")
+
+    @classmethod
+    def attachToLegacyObject(cls, obj):
+        """Attach as Proxy without ever calling __init__, mirroring how FreeCAD actually
+        restores a FeaturePython object: __init__ is not invoked on restore, only
+        onDocumentRestored() is, via registerAliases(). This lets a test exercise the real
+        migration path -- an object still carrying a dynamic "Area" property from before
+        the rename -- without a full save/reload cycle.
+        """
+        self = cls.__new__(cls)
+        obj.Proxy = self
+        self.registerAliases(obj)
+        return self
+
+
+class PropertyAliasBasics(unittest.TestCase):
+    """The alias API as an add-on author sees it."""
+
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PropertyAliasBasics")
+        self.obj = self.Doc.addObject("App::VarSet", "Vars")
+        self.obj.addProperty("App::PropertyInteger", "NewName", "Variables")
+        self.obj.NewName = 42
+        self.obj.addPropertyAlias("NewName", "OldName", True, "1.1")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def testAliasReadsAndWritesCanonical(self):
+        self.assertEqual(self.obj.OldName, 42)
+
+        self.obj.OldName = 7
+
+        self.assertEqual(self.obj.NewName, 7)
+
+    def testHasattrSeesAlias(self):
+        self.assertTrue(hasattr(self.obj, "OldName"))
+
+    def testPropertiesListIsCanonicalOnly(self):
+        # Aliases are deliberately absent, so deprecated names do not appear in the
+        # property editor or in dir().
+        self.assertIn("NewName", self.obj.PropertiesList)
+        self.assertNotIn("OldName", self.obj.PropertiesList)
+
+    def testGetPropertyAliasesReportsCanonicalDeprecatedAndSince(self):
+        aliases = self.obj.getPropertyAliases()
+
+        self.assertIn("OldName", aliases)
+        self.assertEqual(aliases["OldName"]["canonical"], "NewName")
+        self.assertTrue(aliases["OldName"]["deprecated"])
+        self.assertEqual(aliases["OldName"]["since"], "1.1")
+
+    def testAddPropertyOnAliasNameIsNoOp(self):
+        # The idiom add-ons use everywhere. Before aliases were tolerated this raised.
+        if "OldName" not in self.obj.PropertiesList:
+            self.obj.addProperty("App::PropertyInteger", "OldName", "Variables")
+
+        self.assertEqual(self.obj.NewName, 42)
+        self.assertNotIn("OldName", self.obj.PropertiesList)
+
+    def testAddPropertyOnAliasNameWithWrongTypeRaises(self):
+        with self.assertRaises(Exception):
+            self.obj.addProperty("App::PropertyString", "OldName", "Variables")
+
+    def testInstanceAliasOverridesClassAlias(self):
+        # A runtime alias shadows a class-level one of the same name. Nothing tests this
+        # precedence today, so a reversed merge order would go unnoticed.
+        feature = self.Doc.addObject("App::FeatureTest", "Feature")
+        feature.addProperty("App::PropertyInteger", "Other", "Variables")
+
+        feature.addPropertyAlias("Other", "AliasPlain")
+
+        aliases = feature.getPropertyAliases()
+        self.assertEqual(aliases["AliasPlain"]["canonical"], "Other")
+
+
+class PropertyAliasMigration(unittest.TestCase):
+    """The rename recipe, including the document round trip it exists for."""
+
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PropertyAliasMigration")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def testRegisteringAliasMigratesExistingProperty(self):
+        obj = self.Doc.addObject("App::VarSet", "Vars")
+        obj.addProperty("App::PropertyInteger", "Area", "Geometry")
+        obj.Area = 17
+
+        obj.addPropertyAlias("SurfaceArea", "Area", True, "1.1")
+
+        self.assertIn("SurfaceArea", obj.PropertiesList)
+        self.assertNotIn("Area", obj.PropertiesList)
+        self.assertEqual(obj.SurfaceArea, 17)
+        self.assertEqual(obj.Area, 17)
+
+    def testMigrationIsIdempotent(self):
+        obj = self.Doc.addObject("App::VarSet", "Vars")
+        obj.addProperty("App::PropertyInteger", "Area", "Geometry")
+        obj.Area = 17
+
+        obj.addPropertyAlias("SurfaceArea", "Area", True, "1.1")
+        obj.addPropertyAlias("SurfaceArea", "Area", True, "1.1")
+
+        self.assertEqual(obj.SurfaceArea, 17)
+        self.assertIn("SurfaceArea", obj.PropertiesList)
+
+    def testMigrationLeavesUnrelatedUserPropertyAlone(self):
+        obj = self.Doc.addObject("App::VarSet", "Vars")
+        obj.addProperty("App::PropertyInteger", "Area", "Geometry")
+        obj.addProperty("App::PropertyInteger", "MyOwnThing", "Geometry")
+        obj.MyOwnThing = 5
+
+        obj.addPropertyAlias("SurfaceArea", "Area", True, "1.1")
+
+        self.assertIn("MyOwnThing", obj.PropertiesList)
+        self.assertEqual(obj.MyOwnThing, 5)
+
+    def testMigrationSurvivesSaveAndReload(self):
+        obj = self.Doc.addObject("App::FeaturePython", "Legacy")
+        LegacyAreaFeature(obj)
+        obj.SurfaceArea = 250.0
+
+        saveName = os.path.join(tempfile.gettempdir(), "PropertyAliasMigration.FCStd")
+        self.Doc.saveAs(saveName)
+        FreeCAD.closeDocument(self.Doc.Name)
+        self.Doc = FreeCAD.open(saveName)
+
+        restored = self.Doc.Legacy
+        self.assertIn("SurfaceArea", restored.PropertiesList)
+        self.assertAlmostEqual(restored.SurfaceArea.Value, 250.0)
+        # The old name still works for scripts that have not migrated.
+        self.assertAlmostEqual(restored.Area.Value, 250.0)
+
+    def testMigrationFromDocumentSavedUnderOldName(self):
+        # Unlike testMigrationSurvivesSaveAndReload above, this builds a document that
+        # actually contains the pre-rename layout: a dynamic property literally named
+        # "Area", with no "SurfaceArea" anywhere yet. This is what a document saved
+        # before the rename shipped actually looks like on disk, and it is the case the
+        # Python migration path exists for.
+        obj = self.Doc.addObject("App::FeaturePython", "Legacy")
+        obj.addProperty("App::PropertyArea", "Area", "Geometry")
+        obj.Area = 250.0
+
+        # Attach the Proxy the way restore actually does it: via onDocumentRestored(),
+        # never __init__(), so "SurfaceArea" is never created ahead of the migration.
+        LegacyAreaFeature.attachToLegacyObject(obj)
+
+        self.assertIn("SurfaceArea", obj.PropertiesList)
+        self.assertNotIn("Area", obj.PropertiesList)
+        self.assertAlmostEqual(obj.SurfaceArea.Value, 250.0)
+        # The old name still reads through the alias.
+        self.assertAlmostEqual(obj.Area.Value, 250.0)
+
+
+class PropertyAliasStatic(unittest.TestCase):
+    """Aliases declared by a C++ class, seen from Python.
+
+    App::FeatureTest declares AliasTarget with the aliases AliasPlain and AliasDeprecated.
+    """
+
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PropertyAliasStatic")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def testStaticAliasResolves(self):
+        obj = self.Doc.addObject("App::FeatureTest", "Feature")
+        obj.AliasTarget = 11
+
+        self.assertEqual(obj.AliasPlain, 11)
+        self.assertEqual(obj.AliasDeprecated, 11)
+
+    def testStaticAliasAppliesToEveryInstance(self):
+        first = self.Doc.addObject("App::FeatureTest", "First")
+        second = self.Doc.addObject("App::FeatureTest", "Second")
+        first.AliasTarget = 1
+        second.AliasTarget = 2
+
+        self.assertEqual(first.AliasPlain, 1)
+        self.assertEqual(second.AliasPlain, 2)
+
+    def testWriteThroughStaticAliasPersistsUnderCanonicalName(self):
+        # Demonstrates the deliberate forward-compatibility break: the file records the new
+        # name, so an older FreeCAD cannot read this property.
+        obj = self.Doc.addObject("App::FeatureTest", "Feature")
+        obj.AliasPlain = 33
+
+        self.assertIn("AliasTarget", obj.Content)
+        self.assertNotIn("AliasPlain", obj.Content)
+
+    def testStaticAliasSurvivesSaveAndReload(self):
+        obj = self.Doc.addObject("App::FeatureTest", "Feature")
+        obj.AliasPlain = 44
+
+        saveName = os.path.join(tempfile.gettempdir(), "PropertyAliasStatic.FCStd")
+        self.Doc.saveAs(saveName)
+        FreeCAD.closeDocument(self.Doc.Name)
+        self.Doc = FreeCAD.open(saveName)
+
+        self.assertEqual(self.Doc.Feature.AliasTarget, 44)
+        self.assertEqual(self.Doc.Feature.AliasPlain, 44)
+
+
+class PropertyAliasExpressions(unittest.TestCase):
+    """Expressions referencing an alias, and how they are healed on load."""
+
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PropertyAliasExpressions")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def testExpressionUsingAliasEvaluates(self):
+        source = self.Doc.addObject("App::FeatureTest", "Source")
+        target = self.Doc.addObject("App::FeatureTest", "Target")
+        source.AliasTarget = 9
+        target.setExpression("Integer", "Source.AliasDeprecated")
+
+        self.Doc.recompute()
+
+        self.assertEqual(target.Integer, 9)
+
+    def testExpressionIsCanonicalizedOnReload(self):
+        source = self.Doc.addObject("App::FeatureTest", "Source")
+        target = self.Doc.addObject("App::FeatureTest", "Target")
+        source.AliasTarget = 9
+        target.setExpression("Integer", "Source.AliasDeprecated")
+        self.Doc.recompute()
+
+        saveName = os.path.join(tempfile.gettempdir(), "PropertyAliasExpressions.FCStd")
+        self.Doc.saveAs(saveName)
+        FreeCAD.closeDocument(self.Doc.Name)
+        self.Doc = FreeCAD.open(saveName)
+
+        expressions = dict(self.Doc.Target.ExpressionEngine)
+        self.assertIn("AliasTarget", expressions["Integer"])
+        self.assertNotIn("AliasDeprecated", expressions["Integer"])
+
+    def testReloadDoesNotTouchDocument(self):
+        source = self.Doc.addObject("App::FeatureTest", "Source")
+        target = self.Doc.addObject("App::FeatureTest", "Target")
+        source.AliasTarget = 9
+        target.setExpression("Integer", "Source.AliasDeprecated")
+        self.Doc.recompute()
+
+        saveName = os.path.join(tempfile.gettempdir(), "PropertyAliasReload.FCStd")
+        self.Doc.saveAs(saveName)
+        FreeCAD.closeDocument(self.Doc.Name)
+        self.Doc = FreeCAD.open(saveName)
+
+        # Opening a document must never mark it as modified.
+        self.assertFalse(self.Doc.isTouched())
+
+
+class PropertyAliasDocument(unittest.TestCase):
+    """App::Document is a PropertyContainer too."""
+
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("PropertyAliasDocument")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.Doc.Name)
+
+    def testDocumentPropertyAlias(self):
+        self.Doc.Comment = "hello"
+        self.Doc.addPropertyAlias("Comment", "OldComment", True, "1.1")
+
+        self.assertEqual(self.Doc.OldComment, "hello")
+        self.assertIn("OldComment", self.Doc.getPropertyAliases())

--- a/tests/src/App/Property.cpp
+++ b/tests/src/App/Property.cpp
@@ -90,8 +90,110 @@ TEST_F(PropertyFloatTest, testWriteRead)
     EXPECT_DOUBLE_EQ(prop2.getValue(), value);
 }
 
+std::string PropertyAlias::_docName;
+App::Document* PropertyAlias::_doc {nullptr};
+
 std::string RenameProperty::_docName;
 App::Document* RenameProperty::_doc {nullptr};
+
+// Tests that an alias resolves to the same property as the canonical name.
+TEST_F(PropertyAlias, aliasResolvesToCanonicalProperty)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    App::Property* byCanonical = varSet->getPropertyByName("NewName");
+    App::Property* byAlias = varSet->getPropertyByName("OldName");
+
+    ASSERT_NE(byCanonical, nullptr);
+    EXPECT_EQ(byAlias, byCanonical);
+}
+
+// Tests that a non-deprecated alias emits no warning.
+TEST_F(PropertyAlias, nonDeprecatedAliasEmitsNoWarning)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    WarningCapture capture;
+    varSet->getPropertyByName("OldName");
+
+    EXPECT_TRUE(capture.warnings.empty());
+}
+
+// Tests that a deprecated alias still resolves but emits a warning.
+TEST_F(PropertyAlias, deprecatedAliasEmitsWarningAndResolves)
+{
+    varSet->addPropertyAlias("NewName", "OldDeprecated", App::PropertyAliasType::Deprecated);
+
+    WarningCapture capture;
+    App::Property* prop = varSet->getPropertyByName("OldDeprecated");
+
+    ASSERT_NE(prop, nullptr);
+    EXPECT_EQ(prop, varSet->getPropertyByName("NewName"));
+    ASSERT_EQ(capture.warnings.size(), 1u);
+    EXPECT_NE(capture.warnings[0].find("OldDeprecated"), std::string::npos);
+    EXPECT_NE(capture.warnings[0].find("NewName"), std::string::npos);
+}
+
+// Tests that an unknown name still returns nullptr (no regression).
+TEST_F(PropertyAlias, unknownNameReturnsNullptr)
+{
+    App::Property* prop = varSet->getPropertyByName("DoesNotExist");
+
+    EXPECT_EQ(prop, nullptr);
+}
+
+// Tests that an alias works for a static property (Label is inherited from DocumentObject).
+TEST_F(PropertyAlias, aliasForStaticProperty)
+{
+    varSet->addPropertyAlias("Label", "OldLabel");
+
+    App::Property* byCanonical = varSet->getPropertyByName("Label");
+    App::Property* byAlias = varSet->getPropertyByName("OldLabel");
+
+    ASSERT_NE(byCanonical, nullptr);
+    EXPECT_EQ(byAlias, byCanonical);
+}
+
+// Tests that Python attribute access via an alias returns the correct value.
+TEST_F(PropertyAlias, pythonAttributeAccessViaAlias)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    std::string cmd = "vs = App.getDocument('" + _docName + "').getObject('"
+        + varSet->getNameInDocument()
+        + "')\n"
+          "val = vs.OldName\n"
+          "assert val == 42, f'Expected 42, got {val}'";
+    Base::Interpreter().runString(cmd.c_str());
+}
+
+// Tests that Python getPropertyByName() resolves aliases.
+TEST_F(PropertyAlias, pythonGetPropertyByNameViaAlias)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    std::string cmd = "vs = App.getDocument('" + _docName + "').getObject('"
+        + varSet->getNameInDocument()
+        + "')\n"
+          "p1 = vs.getPropertyByName('NewName')\n"
+          "p2 = vs.getPropertyByName('OldName')\n"
+          "assert p1 == p2, f'Alias must resolve to same value, got {p1} vs {p2}'";
+    Base::Interpreter().runString(cmd.c_str());
+}
+
+// Tests that addPropertyAlias is callable from Python.
+TEST_F(PropertyAlias, pythonAddPropertyAlias)
+{
+    std::string cmd = "vs = App.getDocument('" + _docName + "').getObject('"
+        + varSet->getNameInDocument()
+        + "')\n"
+          "vs.addPropertyAlias('NewName', 'PyAlias')\n"
+          "p = vs.getPropertyByName('PyAlias')\n"
+          "assert p is not None, 'Alias registered from Python must resolve'";
+    Base::Interpreter().runString(cmd.c_str());
+
+    EXPECT_EQ(varSet->getPropertyByName("PyAlias"), varSet->getPropertyByName("NewName"));
+}
 
 // Tests whether we can rename a property
 TEST_F(RenameProperty, renameProperty)

--- a/tests/src/App/Property.cpp
+++ b/tests/src/App/Property.cpp
@@ -1425,3 +1425,124 @@ TEST_F(PropertyAlias, registrationRenamesUserAddedPropertyOnCollision)
     EXPECT_STREQ(userAdded->getName(), "ClaimedName");
     EXPECT_EQ(userAdded->getValue(), 5);
 }
+
+// Tests that an expression written against an alias is rewritten to the canonical name when
+// the document is restored, so files stop accumulating alias references.
+TEST_F(PropertyAliasStatic, restoredExpressionIsCanonicalized)
+{
+    second->setExpression(
+        App::ObjectIdentifier(second, std::string("Integer")),
+        App::Expression::parse(second, "First.AliasDeprecated")
+    );
+
+    doc->recompute();
+    doc->afterRestore();
+
+    auto expressions = second->ExpressionEngine.getExpressions();
+    ASSERT_EQ(expressions.size(), 1U);
+    std::string text = expressions.begin()->second->toString();
+    EXPECT_NE(text.find("AliasTarget"), std::string::npos);
+    EXPECT_EQ(text.find("AliasDeprecated"), std::string::npos);
+}
+
+// Tests that healing an expression does not make the document dirty. Opening a file should
+// never mark it as modified.
+TEST_F(PropertyAliasStatic, canonicalizationLeavesDocumentUntouched)
+{
+    second->setExpression(
+        App::ObjectIdentifier(second, std::string("Integer")),
+        App::Expression::parse(second, "First.AliasDeprecated")
+    );
+
+    doc->recompute();
+    doc->purgeTouched();
+    doc->afterRestore();
+
+    EXPECT_FALSE(doc->isTouched());
+}
+
+// Tests that the logged rewrite count is measured rather than assumed.
+TEST_F(PropertyAliasStatic, canonicalizationLogsRewriteCount)
+{
+    second->setExpression(
+        App::ObjectIdentifier(second, std::string("Integer")),
+        App::Expression::parse(second, "First.AliasDeprecated")
+    );
+    doc->recompute();
+
+    LogCapture capture;
+    doc->afterRestore();
+
+    auto matches = [](const std::string& line) {
+        return line.find("canonicalized 1 expression reference(s)") != std::string::npos;
+    };
+    EXPECT_TRUE(std::ranges::any_of(capture.messages, matches));
+}
+
+// Tests that a document with no aliased references is left completely alone.
+TEST_F(PropertyAliasStatic, canonicalizationSkipsDocumentsWithoutAliasedReferences)
+{
+    second->setExpression(
+        App::ObjectIdentifier(second, std::string("Integer")),
+        App::Expression::parse(second, "First.AliasTarget")
+    );
+
+    doc->recompute();
+    doc->afterRestore();
+
+    auto expressions = second->ExpressionEngine.getExpressions();
+    ASSERT_EQ(expressions.size(), 1U);
+    EXPECT_NE(expressions.begin()->second->toString().find("AliasTarget"), std::string::npos);
+}
+
+// Tests that an alias shadowed by a real property of the same name is left alone: it is a
+// genuine property reference, not a stale alias, so canonicalization must not rewrite it.
+TEST_F(PropertyAliasStatic, canonicalizationSkipsShadowedAlias)
+{
+    // "Shadowed" is first added as a real dynamic property, then separately registered as an
+    // alias for AliasTarget. Because AliasTarget already exists, addPropertyAlias() declines to
+    // migrate/rename the dynamic property, leaving "Shadowed" as a genuine property that
+    // happens to share its name with a registered alias.
+    first->addDynamicProperty("App::PropertyInteger", "Shadowed", "Variables");
+    first->addPropertyAlias("AliasTarget", "Shadowed", App::PropertyAliasType::Normal, "1.3");
+    ASSERT_TRUE(first->getPropertyByName("Shadowed", App::PropertyLookupMode::WithoutAliases));
+    ASSERT_TRUE(first->getPropertyAliases().contains("Shadowed"));
+
+    second->setExpression(
+        App::ObjectIdentifier(second, std::string("Integer")),
+        App::Expression::parse(second, "First.Shadowed")
+    );
+
+    doc->recompute();
+    doc->afterRestore();
+
+    auto expressions = second->ExpressionEngine.getExpressions();
+    ASSERT_EQ(expressions.size(), 1U);
+    std::string text = expressions.begin()->second->toString();
+    EXPECT_NE(text.find("Shadowed"), std::string::npos);
+    EXPECT_EQ(text.find("AliasTarget"), std::string::npos);
+}
+
+// Tests that a dangling alias -- one whose canonical name does not resolve to any real
+// property, e.g. a typo or a bad add-on registration -- is left alone by canonicalization.
+// Rewriting an expression to a canonical name that does not exist would permanently corrupt
+// it, since the rewrite gets written back to the file on next save.
+TEST_F(PropertyAliasStatic, canonicalizationLeavesDanglingAliasAlone)
+{
+    first->addPropertyAlias("DoesNotExist", "DanglingAlias", App::PropertyAliasType::Normal, "1.3");
+    ASSERT_FALSE(first->getPropertyByName("DoesNotExist", App::PropertyLookupMode::WithoutAliases));
+    ASSERT_TRUE(first->getPropertyAliases().contains("DanglingAlias"));
+
+    second->setExpression(
+        App::ObjectIdentifier(second, std::string("Integer")),
+        App::Expression::parse(second, "First.DanglingAlias")
+    );
+
+    doc->recompute();
+    doc->afterRestore();
+
+    auto expressions = second->ExpressionEngine.getExpressions();
+    ASSERT_EQ(expressions.size(), 1U);
+    std::string text = expressions.begin()->second->toString();
+    EXPECT_NE(text.find("DanglingAlias"), std::string::npos);
+}

--- a/tests/src/App/Property.cpp
+++ b/tests/src/App/Property.cpp
@@ -195,6 +195,47 @@ TEST_F(RenameProperty, lockedProperty)
     EXPECT_EQ(varSet->getDynamicPropertyByName("NewName"), nullptr);
 }
 
+// Tests that the Skip policy neither renames a locked property nor throws
+TEST_F(RenameProperty, lockedPropertySkipPolicyDoesNotRename)
+{
+    // Arrange
+    prop->setStatus(App::Property::LockDynamic, true);
+
+    // Act
+    bool isRenamed = varSet->renameDynamicProperty(prop, "NewName", App::RenameLockedPolicy::Skip);
+
+    // Assert
+    EXPECT_FALSE(isRenamed);
+    EXPECT_STREQ(varSet->getPropertyName(prop), "Variable");
+    EXPECT_EQ(prop->getValue(), value);
+    EXPECT_EQ(varSet->getDynamicPropertyByName("Variable"), prop);
+    EXPECT_EQ(varSet->getDynamicPropertyByName("NewName"), nullptr);
+}
+
+// Tests that RenameLockedPolicy::Skip on a locked property with a bound expression leaves
+// the binding intact under the original name, rather than destroying it. The rename itself
+// is declined, so a binding re-created under the (never taken) new name would point at
+// nothing.
+TEST_F(RenameProperty, skipPolicyPreservesBoundExpressions)
+{
+    // Arrange
+    prop->setStatus(App::Property::LockDynamic, true);
+    App::ObjectIdentifier path(*prop);
+    std::shared_ptr<App::Expression> expr(App::Expression::parse(varSet, "1 + 1"));
+    varSet->setExpression(path, expr);
+
+    // Act
+    bool isRenamed = varSet->renameDynamicProperty(prop, "NewName", App::RenameLockedPolicy::Skip);
+
+    // Assert
+    EXPECT_FALSE(isRenamed);
+    EXPECT_STREQ(varSet->getPropertyName(prop), "Variable");
+
+    auto expressions = varSet->ExpressionEngine.getExpressions();
+    ASSERT_EQ(expressions.size(), 1U);
+    EXPECT_EQ(expressions.begin()->first.getProperty(), prop);
+}
+
 // Tests whether we can rename to a property that already exists
 TEST_F(RenameProperty, toExistingProperty)
 {

--- a/tests/src/App/Property.cpp
+++ b/tests/src/App/Property.cpp
@@ -34,6 +34,7 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/Expression.h>
+#include <App/Link.h>
 #include <App/ObjectIdentifier.h>
 #include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
@@ -90,7 +91,363 @@ TEST_F(PropertyFloatTest, testWriteRead)
     EXPECT_DOUBLE_EQ(prop2.getValue(), value);
 }
 
+PROPERTY_SOURCE(tests::HookRecordingContainer, App::PropertyContainer)
+
+App::Document* PropertyAliasStatic::doc {nullptr};
+
+App::Document* PropertyAlias::doc {nullptr};
+
 App::Document* RenameProperty::doc {nullptr};
+
+// Tests that a class-level alias is visible on every instance of the class, which is only
+// true if it is stored in PropertyData rather than in a per-instance map.
+TEST_F(PropertyAliasStatic, staticAliasResolvesOnEveryInstance)
+{
+    EXPECT_EQ(first->getPropertyByName("AliasPlain"), &first->AliasTarget);
+    EXPECT_EQ(second->getPropertyByName("AliasPlain"), &second->AliasTarget);
+}
+
+// Tests that an alias declared on a base class is reachable through a derived class, via
+// the parentPropertyData chain. App::FeatureTestException derives from App::FeatureTest.
+TEST_F(PropertyAliasStatic, staticAliasInheritedBySubclass)
+{
+    auto* derived = freecad_cast<App::FeatureTestException*>(
+        doc->addObject("App::FeatureTestException", "Derived")
+    );
+    ASSERT_NE(derived, nullptr);
+    EXPECT_EQ(derived->getPropertyByName("AliasPlain"), &derived->AliasTarget);
+    doc->removeObject(derived->getNameInDocument());
+}
+
+// Tests that an alias resolves to the same property as the canonical name.
+TEST_F(PropertyAlias, aliasResolvesToCanonicalProperty)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    App::Property* byCanonical = varSet->getPropertyByName("NewName");
+    App::Property* byAlias = varSet->getPropertyByName("OldName");
+
+    ASSERT_NE(byCanonical, nullptr);
+    EXPECT_EQ(byAlias, byCanonical);
+}
+
+// Tests that a non-deprecated alias emits no warning.
+TEST_F(PropertyAlias, nonDeprecatedAliasEmitsNoWarning)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    WarningCapture capture;
+    varSet->getPropertyByName("OldName");
+
+    EXPECT_TRUE(capture.warnings.empty());
+}
+
+// Tests that a deprecated alias still resolves but emits a warning.
+TEST_F(PropertyAlias, deprecatedAliasEmitsWarningAndResolves)
+{
+    varSet->addPropertyAlias("NewName", "OldDeprecated", App::PropertyAliasType::Deprecated);
+
+    WarningCapture capture;
+    App::Property* prop = varSet->getPropertyByName("OldDeprecated");
+
+    ASSERT_NE(prop, nullptr);
+    EXPECT_EQ(prop, varSet->getPropertyByName("NewName"));
+    ASSERT_EQ(capture.warnings.size(), 1u);
+    EXPECT_NE(capture.warnings[0].find("OldDeprecated"), std::string::npos);
+    EXPECT_NE(capture.warnings[0].find("NewName"), std::string::npos);
+}
+
+// Tests that an unknown name still returns nullptr (no regression).
+TEST_F(PropertyAlias, unknownNameReturnsNullptr)
+{
+    App::Property* prop = varSet->getPropertyByName("DoesNotExist");
+
+    EXPECT_EQ(prop, nullptr);
+}
+
+// Tests that an alias works for a static property (Label is inherited from DocumentObject).
+TEST_F(PropertyAlias, aliasForStaticProperty)
+{
+    varSet->addPropertyAlias("Label", "OldLabel");
+
+    App::Property* byCanonical = varSet->getPropertyByName("Label");
+    App::Property* byAlias = varSet->getPropertyByName("OldLabel");
+
+    ASSERT_NE(byCanonical, nullptr);
+    EXPECT_EQ(byAlias, byCanonical);
+}
+
+// Tests that Python attribute access via an alias returns the correct value.
+TEST_F(PropertyAlias, pythonAttributeAccessViaAlias)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    std::string cmd = std::string("vs = App.getDocument('") + doc->getName() + "').getObject('"
+        + varSet->getNameInDocument()
+        + "')\n"
+          "val = vs.OldName\n"
+          "assert val == 42, f'Expected 42, got {val}'";
+    Base::Interpreter().runString(cmd.c_str());
+}
+
+// Tests that Python getPropertyByName() resolves aliases.
+TEST_F(PropertyAlias, pythonGetPropertyByNameViaAlias)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    std::string cmd = std::string("vs = App.getDocument('") + doc->getName() + "').getObject('"
+        + varSet->getNameInDocument()
+        + "')\n"
+          "p1 = vs.getPropertyByName('NewName')\n"
+          "p2 = vs.getPropertyByName('OldName')\n"
+          "assert p1 == p2, f'Alias must resolve to same value, got {p1} vs {p2}'";
+    Base::Interpreter().runString(cmd.c_str());
+}
+
+// Tests that addPropertyAlias is callable from Python.
+TEST_F(PropertyAlias, pythonAddPropertyAlias)
+{
+    std::string cmd = std::string("vs = App.getDocument('") + doc->getName() + "').getObject('"
+        + varSet->getNameInDocument()
+        + "')\n"
+          "vs.addPropertyAlias('NewName', 'PyAlias')\n"
+          "p = vs.getPropertyByName('PyAlias')\n"
+          "assert p is not None, 'Alias registered from Python must resolve'";
+    Base::Interpreter().runString(cmd.c_str());
+
+    EXPECT_EQ(varSet->getPropertyByName("PyAlias"), varSet->getPropertyByName("NewName"));
+}
+
+// Tests that a real property is never shadowed by an alias of the same name.
+TEST_F(PropertyAlias, realPropertyTakesPrecedenceOverAlias)
+{
+    varSet->addDynamicProperty("App::PropertyInteger", "OldName", "Variables");
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    App::Property* byName = varSet->getPropertyByName("OldName");
+
+    ASSERT_NE(byName, nullptr);
+    EXPECT_NE(byName, dynProp);
+    EXPECT_STREQ(byName->getName(), "OldName");
+}
+
+// Tests that writing through an alias updates the canonical property.
+TEST_F(PropertyAlias, settingValueThroughAliasUpdatesCanonical)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    auto* viaAlias = freecad_cast<App::PropertyInteger*>(varSet->getPropertyByName("OldName"));
+    ASSERT_NE(viaAlias, nullptr);
+    viaAlias->setValue(99);
+
+    EXPECT_EQ(dynProp->getValue(), 99);
+}
+
+// Tests that a cyclic alias pair terminates instead of recursing forever.
+TEST_F(PropertyAlias, aliasChainDoesNotRecurse)
+{
+    varSet->addPropertyAlias("Missing", "AlsoMissing");
+    varSet->addPropertyAlias("AlsoMissing", "Missing");
+
+    EXPECT_EQ(varSet->getPropertyByName("Missing"), nullptr);
+    EXPECT_EQ(varSet->getPropertyByName("AlsoMissing"), nullptr);
+}
+
+// Tests that a runtime alias shadows a class-level alias of the same name.
+TEST_F(PropertyAliasStatic, instanceAliasOverridesClassAlias)
+{
+    first->addDynamicProperty("App::PropertyInteger", "Other", "Variables");
+    first->addPropertyAlias("Other", "AliasPlain");
+
+    App::Property* resolved = first->getPropertyByName("AliasPlain");
+
+    ASSERT_NE(resolved, nullptr);
+    EXPECT_STREQ(resolved->getName(), "Other");
+    // The other instance is unaffected — the override is per object.
+    EXPECT_EQ(second->getPropertyByName("AliasPlain"), &second->AliasTarget);
+}
+
+// Tests that the deprecation warning names the version the alias was introduced in.
+TEST_F(PropertyAliasStatic, warningIncludesSinceVersion)
+{
+    WarningCapture capture;
+    first->getPropertyByName("AliasDeprecated");
+
+    ASSERT_EQ(capture.warnings.size(), 1U);
+    EXPECT_NE(capture.warnings[0].find("since 1.1"), std::string::npos);
+    EXPECT_NE(capture.warnings[0].find("AliasTarget"), std::string::npos);
+}
+
+// Tests that a deprecated alias warns only once per container, so an alias referenced from an
+// expression does not flood the report view on every recompute.
+TEST_F(PropertyAliasStatic, warningEmittedOncePerContainerPerAlias)
+{
+    WarningCapture capture;
+    first->getPropertyByName("AliasDeprecated");
+    first->getPropertyByName("AliasDeprecated");
+    first->getPropertyByName("AliasDeprecated");
+
+    EXPECT_EQ(capture.warnings.size(), 1U);
+}
+
+// Tests that the once-per-container budget is not shared between objects, so every call site
+// the developer needs to fix is reported.
+TEST_F(PropertyAliasStatic, warningEmittedForEachContainerSeparately)
+{
+    WarningCapture capture;
+    first->getPropertyByName("AliasDeprecated");
+    second->getPropertyByName("AliasDeprecated");
+
+    EXPECT_EQ(capture.warnings.size(), 2U);
+}
+
+// Tests that a non-deprecated alias is silent no matter how often it is used.
+TEST_F(PropertyAliasStatic, nonDeprecatedAliasNeverWarns)
+{
+    WarningCapture capture;
+    first->getPropertyByName("AliasPlain");
+    first->getPropertyByName("AliasPlain");
+
+    EXPECT_TRUE(capture.warnings.empty());
+}
+
+// Tests that the property reports its canonical name even when reached through an alias, so
+// code that round-trips through getName() does not resurrect the old name.
+TEST_F(PropertyAlias, getPropertyNameReturnsCanonicalAfterAliasLookup)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    App::Property* byAlias = varSet->getPropertyByName("OldName");
+
+    ASSERT_NE(byAlias, nullptr);
+    EXPECT_STREQ(byAlias->getName(), "NewName");
+    EXPECT_STREQ(varSet->getPropertyName(byAlias), "NewName");
+}
+
+// Tests that aliases stay out of the property map, so the property editor and dir() are
+// unaffected by them.
+TEST_F(PropertyAlias, getPropertyMapExcludesAliases)
+{
+    varSet->addPropertyAlias("NewName", "OldName");
+
+    std::map<std::string, App::Property*> propertyMap;
+    varSet->getPropertyMap(propertyMap);
+
+    EXPECT_TRUE(propertyMap.contains("NewName"));
+    EXPECT_FALSE(propertyMap.contains("OldName"));
+}
+
+// Tests that resolving a class-level alias leaves the per-instance overlay empty. It must
+// still fail if a regression made class aliases get copied into the per-instance map.
+TEST_F(PropertyAliasStatic, classAliasDoesNotPopulateInstanceOverlay)
+{
+    App::Property* resolved = first->getPropertyByName("AliasPlain");
+
+    ASSERT_EQ(resolved, &first->AliasTarget);
+    EXPECT_FALSE(first->hasInstanceAliases());
+}
+
+// Tests that aliases work on App::Document, which is a PropertyContainer too.
+TEST_F(PropertyAliasDocument, documentContainerSupportsAliases)
+{
+    doc->addPropertyAlias("Comment", "OldComment");
+
+    App::Property* byAlias = doc->getPropertyByName("OldComment");
+
+    ASSERT_NE(byAlias, nullptr);
+    EXPECT_EQ(byAlias, &doc->Comment);
+}
+
+// Tests that an alias can point at a property provided by an extension rather than by the
+// container itself. Support -> AttachmentSupport in AttachExtension is exactly this shape.
+TEST_F(PropertyAliasExtension, aliasResolvesToExtensionProperty)
+{
+    App::Property* canonical = group->getPropertyByName("Group");
+    ASSERT_NE(canonical, nullptr);
+
+    group->addPropertyAlias("Group", "OldGroup");
+
+    EXPECT_EQ(group->getPropertyByName("OldGroup"), canonical);
+}
+
+// Tests that a deprecated alias onto an extension property still warns, so the diagnostic is
+// not silently lost for the case that motivated this fix.
+TEST_F(PropertyAliasExtension, deprecatedAliasToExtensionPropertyWarns)
+{
+    group->addPropertyAlias("Group", "OldGroup", App::PropertyAliasType::Deprecated, "1.1");
+
+    WarningCapture capture;
+    App::Property* resolved = group->getPropertyByName("OldGroup");
+
+    ASSERT_NE(resolved, nullptr);
+    ASSERT_EQ(capture.warnings.size(), 1U);
+    EXPECT_NE(capture.warnings[0].find("since 1.1"), std::string::npos);
+}
+
+// Tests that PropertyLookupMode::WithoutAliases is honoured when the property is provided by an
+// extension (LinkBaseExtension::extensionGetPropertyByName), not just when it lives directly on
+// the container. Alias resolution internally re-looks-up the canonical property using
+// WithoutAliases to guarantee that a chained or cyclic alias cannot recurse forever; if the mode
+// is silently dropped somewhere along the extension chain, that guarantee is lost.
+TEST_F(PropertyAliasExtension, extensionLookupRespectsWithoutAliases)
+{
+    auto* link = freecad_cast<App::Link*>(doc->addObject("App::Link", "LinkObject"));
+    ASSERT_NE(link, nullptr);
+
+    App::Property* canonical = link->addDynamicProperty("App::PropertyInteger", "Canonical", "Base");
+    ASSERT_NE(canonical, nullptr);
+
+    link->addPropertyAlias("Canonical", "Old");
+
+    EXPECT_EQ(link->getPropertyByName("Old", App::PropertyLookupMode::WithAliases), canonical);
+    EXPECT_EQ(link->getPropertyByName("Old", App::PropertyLookupMode::WithoutAliases), nullptr);
+}
+
+// Tests that a property saved under its old name restores into the renamed property with no
+// handleChangedPropertyName override — the central claim of the alias mechanism.
+TEST_F(PropertyAliasRestore, restoresOldNameWithNoHandleChangedPropertyNameOverride)
+{
+    tests::HookRecordingContainer container;
+    restoreInto(container, makeDocument("OldName", "App::PropertyInteger", "<Integer value='7'/>\n"));
+
+    EXPECT_EQ(container.Renamed.getValue(), 7);
+    EXPECT_TRUE(container.nameHookCalls.empty());
+}
+
+// Tests that restoring through an alias emits no deprecation warning. The file was written by
+// an older version; the user did nothing to deprecate.
+TEST_F(PropertyAliasRestore, restoreThroughAliasIsSilent)
+{
+    tests::HookRecordingContainer container;
+
+    WarningCapture capture;
+    restoreInto(container, makeDocument("OldName", "App::PropertyInteger", "<Integer value='7'/>\n"));
+
+    EXPECT_TRUE(capture.warnings.empty());
+}
+
+// Tests that an alias whose saved type disagrees with the canonical property reaches the type
+// hook rather than being force-read into the wrong property.
+TEST_F(PropertyAliasRestore, mismatchedTypeFallsBackToHandleChangedPropertyType)
+{
+    tests::HookRecordingContainer container;
+    restoreInto(container, makeDocument("OldName", "App::PropertyString", "<String value='seven'/>\n"));
+
+    ASSERT_EQ(container.typeHookCalls.size(), 1U);
+    EXPECT_EQ(container.typeHookCalls[0], "App::PropertyString");
+    EXPECT_TRUE(container.nameHookCalls.empty());
+}
+
+// Tests that a name matching no property and no alias still reaches the legacy hook, so
+// subclasses with existing migration logic do not regress.
+TEST_F(PropertyAliasRestore, unmatchedNameStillReachesHandleChangedPropertyName)
+{
+    tests::HookRecordingContainer container;
+    restoreInto(container, makeDocument("Unrelated", "App::PropertyInteger", "<Integer value='7'/>\n"));
+
+    ASSERT_EQ(container.nameHookCalls.size(), 1U);
+    EXPECT_EQ(container.nameHookCalls[0], "Unrelated");
+}
 
 // Tests whether we can rename a property
 TEST_F(RenameProperty, simple)
@@ -947,4 +1304,124 @@ TEST_F(MoveProperty, redoExpressionOriginatingContainerOtherDoc)
 TEST_F(MoveProperty, redoExpressionTargetContainerOtherDoc)
 {
     testRedoMovePropertyExpression(varSetDoc2, varSetDoc2, "Variable", "test#VarSet.Variable");
+}
+
+// Tests the add-on compatibility case: code guarded on PropertiesList membership will call
+// addProperty with the old name, and must get the canonical property back rather than an error.
+TEST_F(PropertyAliasStatic, addOnAliasNameReturnsCanonical)
+{
+    App::Property* added = nullptr;
+    ASSERT_NO_THROW(
+        added = first->addDynamicProperty("App::PropertyInteger", "AliasPlain", "Variables")
+    );
+
+    EXPECT_EQ(added, &first->AliasTarget);
+}
+
+// Tests that a type disagreement is reported rather than silently returning the wrong property.
+TEST_F(PropertyAliasStatic, addOnAliasNameWithWrongTypeThrows)
+{
+    EXPECT_THROW(
+        first->addDynamicProperty("App::PropertyString", "AliasPlain", "Variables"),
+        Base::TypeError
+    );
+}
+
+// Tests that colliding with a real property still throws, unchanged.
+TEST_F(PropertyAliasStatic, addOnRealNameStillThrows)
+{
+    EXPECT_THROW(
+        first->addDynamicProperty("App::PropertyInteger", "AliasTarget", "Variables"),
+        Base::NameError
+    );
+}
+
+// Tests that enumeration reports both class-level and instance-level aliases with their
+// metadata, which is what a retirement audit needs.
+TEST_F(PropertyAliasStatic, getPropertyAliasesMergesClassAndInstance)
+{
+    first->addDynamicProperty("App::PropertyInteger", "Runtime", "Variables");
+    first->addPropertyAlias("Runtime", "RuntimeAlias", App::PropertyAliasType::Normal, "1.2");
+
+    auto aliases = first->getPropertyAliases();
+
+    ASSERT_TRUE(aliases.contains("AliasDeprecated"));
+    EXPECT_EQ(aliases["AliasDeprecated"].canonicalName, "AliasTarget");
+    EXPECT_EQ(aliases["AliasDeprecated"].since, "1.1");
+    EXPECT_EQ(aliases["AliasDeprecated"].type, App::PropertyAliasType::Deprecated);
+
+    ASSERT_TRUE(aliases.contains("RuntimeAlias"));
+    EXPECT_EQ(aliases["RuntimeAlias"].canonicalName, "Runtime");
+    EXPECT_EQ(aliases["RuntimeAlias"].since, "1.2");
+    EXPECT_EQ(aliases["RuntimeAlias"].type, App::PropertyAliasType::Normal);
+}
+
+// Tests the Python migration path: registering an alias renames a dynamic property left over
+// from an older document, preserving its value.
+TEST_F(PropertyAlias, registrationRenamesExistingDynamicProperty)
+{
+    auto* legacy = freecad_cast<App::PropertyInteger*>(
+        varSet->addDynamicProperty("App::PropertyInteger", "LegacyName", "Variables")
+    );
+    ASSERT_NE(legacy, nullptr);
+    legacy->setValue(17);
+
+    varSet->addPropertyAlias("CanonicalName", "LegacyName", App::PropertyAliasType::Deprecated, "1.1");
+
+    auto* migrated = freecad_cast<App::PropertyInteger*>(varSet->getPropertyByName("CanonicalName"));
+    ASSERT_NE(migrated, nullptr);
+    EXPECT_EQ(migrated, legacy);
+    EXPECT_EQ(migrated->getValue(), 17);
+    EXPECT_STREQ(migrated->getName(), "CanonicalName");
+}
+
+// Tests that an already migrated container is left alone, so the recipe is safe to run on
+// every load.
+TEST_F(PropertyAlias, registrationSkipsWhenCanonicalExists)
+{
+    auto* legacy = freecad_cast<App::PropertyInteger*>(
+        varSet->addDynamicProperty("App::PropertyInteger", "LegacyName", "Variables")
+    );
+    legacy->setValue(17);
+    auto* canonical = freecad_cast<App::PropertyInteger*>(
+        varSet->addDynamicProperty("App::PropertyInteger", "CanonicalName", "Variables")
+    );
+    canonical->setValue(23);
+
+    varSet->addPropertyAlias("CanonicalName", "LegacyName");
+
+    EXPECT_EQ(canonical->getValue(), 23);
+    EXPECT_STREQ(legacy->getName(), "LegacyName");
+}
+
+// Tests that a locked property migrates. renameProperty refuses these today, which leaves an
+// add-on that used locked=True permanently stuck with the old name.
+TEST_F(PropertyAlias, registrationRenamesLockedDynamicProperty)
+{
+    auto* legacy = freecad_cast<App::PropertyInteger*>(
+        varSet->addDynamicProperty("App::PropertyInteger", "LegacyName", "Variables")
+    );
+    legacy->setStatus(App::Property::LockDynamic, true);
+    legacy->setValue(17);
+
+    varSet->addPropertyAlias("CanonicalName", "LegacyName");
+
+    EXPECT_STREQ(legacy->getName(), "CanonicalName");
+    EXPECT_EQ(legacy->getValue(), 17);
+}
+
+// Pins the D6 semantics: declaring an alias claims that name, so a colliding user-added
+// property is renamed. This is exactly what obj.renameProperty() already does for unlocked
+// properties, so the design changes nothing here.
+TEST_F(PropertyAlias, registrationRenamesUserAddedPropertyOnCollision)
+{
+    auto* userAdded = freecad_cast<App::PropertyInteger*>(
+        varSet->addDynamicProperty("App::PropertyInteger", "UserChosen", "Variables")
+    );
+    userAdded->setValue(5);
+
+    varSet->addPropertyAlias("ClaimedName", "UserChosen");
+
+    EXPECT_STREQ(userAdded->getName(), "ClaimedName");
+    EXPECT_EQ(userAdded->getValue(), 5);
 }

--- a/tests/src/App/Property.h
+++ b/tests/src/App/Property.h
@@ -29,7 +29,80 @@
 #include <App/PropertyStandard.h>
 #include <App/VarSet.h>
 
+#include <Base/Console.h>
+
 #include <src/App/InitApplication.h>
+
+/// RAII helper that captures developer warnings emitted via Base::Console().
+class WarningCapture: public Base::ILogger
+{
+public:
+    WarningCapture()
+    {
+        Base::Console().attachObserver(this);
+    }
+
+    ~WarningCapture() override
+    {
+        Base::Console().detachObserver(this);
+    }
+
+    const char* name() override
+    {
+        return "WarningCapture";
+    }
+
+    void sendLog(
+        const std::string& /*notifierName*/,
+        const std::string& message,
+        Base::LogStyle level,
+        Base::IntendedRecipient /*recipient*/,
+        Base::ContentType /*content*/
+    ) override
+    {
+        if (level == Base::LogStyle::Warning) {
+            warnings.push_back(message);
+        }
+    }
+
+    std::vector<std::string> warnings;
+};
+
+class PropertyAlias: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+        _docName = App::GetApplication().getUniqueDocumentName("testAlias");
+        _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
+    }
+
+    void SetUp() override
+    {
+        varSet = freecad_cast<App::VarSet*>(_doc->addObject("App::VarSet", "VarSetAlias"));
+        dynProp = freecad_cast<App::PropertyInteger*>(
+            varSet->addDynamicProperty("App::PropertyInteger", "NewName", "Variables")
+        );
+        dynProp->setValue(42);
+    }
+
+    void TearDown() override
+    {
+        _doc->removeObject(varSet->getNameInDocument());
+    }
+
+    static void TearDownTestSuite()
+    {
+        App::GetApplication().closeDocument(_docName.c_str());
+    }
+
+    App::VarSet* varSet {};
+    App::PropertyInteger* dynProp {};
+
+    static std::string _docName;
+    static App::Document* _doc;
+};
 
 class RenameProperty: public ::testing::Test
 {

--- a/tests/src/App/Property.h
+++ b/tests/src/App/Property.h
@@ -25,9 +25,13 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include <App/Document.h>
 #include <App/DocumentObjectGroup.h>
+#include <App/Expression.h>
 #include <App/FeatureTest.h>
+#include <App/ObjectIdentifier.h>
 #include <App/PropertyContainer.h>
 #include <App/PropertyStandard.h>
 #include <App/VarSet.h>
@@ -72,6 +76,41 @@ public:
     }
 
     std::vector<std::string> warnings;
+};
+
+/// RAII helper that captures messages emitted via Base::Console().
+class LogCapture: public Base::ILogger
+{
+public:
+    LogCapture()
+    {
+        Base::Console().attachObserver(this);
+    }
+
+    ~LogCapture() override
+    {
+        Base::Console().detachObserver(this);
+    }
+
+    const char* name() override
+    {
+        return "LogCapture";
+    }
+
+    void sendLog(
+        const std::string& /*notifierName*/,
+        const std::string& message,
+        Base::LogStyle level,
+        Base::IntendedRecipient /*recipient*/,
+        Base::ContentType /*content*/
+    ) override
+    {
+        if (level == Base::LogStyle::Message) {
+            messages.push_back(message);
+        }
+    }
+
+    std::vector<std::string> messages;
 };
 
 class PropertyAliasStatic: public ::testing::Test

--- a/tests/src/App/Property.h
+++ b/tests/src/App/Property.h
@@ -26,10 +26,242 @@
 #include <gtest/gtest.h>
 
 #include <App/Document.h>
+#include <App/DocumentObjectGroup.h>
+#include <App/FeatureTest.h>
+#include <App/PropertyContainer.h>
 #include <App/PropertyStandard.h>
 #include <App/VarSet.h>
 
+#include <Base/Console.h>
+#include <Base/Reader.h>
+
 #include <src/App/InitApplication.h>
+
+#include <xercesc/util/PlatformUtils.hpp>
+
+/// RAII helper that captures developer warnings emitted via Base::Console().
+class WarningCapture: public Base::ILogger
+{
+public:
+    WarningCapture()
+    {
+        Base::Console().attachObserver(this);
+    }
+
+    ~WarningCapture() override
+    {
+        Base::Console().detachObserver(this);
+    }
+
+    const char* name() override
+    {
+        return "WarningCapture";
+    }
+
+    void sendLog(
+        const std::string& /*notifierName*/,
+        const std::string& message,
+        Base::LogStyle level,
+        Base::IntendedRecipient /*recipient*/,
+        Base::ContentType /*content*/
+    ) override
+    {
+        if (level == Base::LogStyle::Warning) {
+            warnings.push_back(message);
+        }
+    }
+
+    std::vector<std::string> warnings;
+};
+
+class PropertyAliasStatic: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+        std::string docName = App::GetApplication().getUniqueDocumentName("testAliasStatic");
+        doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+    }
+
+    void SetUp() override
+    {
+        first = freecad_cast<App::FeatureTest*>(doc->addObject("App::FeatureTest", "First"));
+        second = freecad_cast<App::FeatureTest*>(doc->addObject("App::FeatureTest", "Second"));
+    }
+
+    void TearDown() override
+    {
+        doc->removeObject(first->getNameInDocument());
+        doc->removeObject(second->getNameInDocument());
+    }
+
+    static void TearDownTestSuite()
+    {
+        App::GetApplication().closeDocument(doc->getName());
+    }
+
+    App::FeatureTest* first {};
+    App::FeatureTest* second {};
+
+    static App::Document* doc;
+};
+
+class PropertyAlias: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+        std::string docName = App::GetApplication().getUniqueDocumentName("testAlias");
+        doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+    }
+
+    void SetUp() override
+    {
+        varSet = freecad_cast<App::VarSet*>(doc->addObject("App::VarSet", "VarSetAlias"));
+        dynProp = freecad_cast<App::PropertyInteger*>(
+            varSet->addDynamicProperty("App::PropertyInteger", "NewName", "Variables")
+        );
+        dynProp->setValue(42);
+    }
+
+    void TearDown() override
+    {
+        doc->removeObject(varSet->getNameInDocument());
+    }
+
+    static void TearDownTestSuite()
+    {
+        App::GetApplication().closeDocument(doc->getName());
+    }
+
+    App::VarSet* varSet {};
+    App::PropertyInteger* dynProp {};
+
+    static App::Document* doc;
+};
+
+class PropertyAliasExtension: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        std::string docName = App::GetApplication().getUniqueDocumentName("testAliasExt");
+        doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+        group = freecad_cast<App::DocumentObjectGroup*>(
+            doc->addObject("App::DocumentObjectGroup", "Group")
+        );
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(doc->getName());
+    }
+
+    App::Document* doc {};
+    App::DocumentObjectGroup* group {};
+};
+
+class PropertyAliasDocument: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        std::string docName = App::GetApplication().getUniqueDocumentName("testAliasDoc");
+        doc = App::GetApplication().newDocument(docName.c_str(), "testUser");
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(doc->getName());
+    }
+
+    App::Document* doc {};
+};
+
+namespace tests
+{
+
+/// PropertyContainer that records whether the legacy migration hooks were invoked.
+class HookRecordingContainer: public App::PropertyContainer
+{
+    // PROPERTY_HEADER_WITH_OVERRIDE's getClassName() unconditionally requires a fully
+    // qualified name (see PropertyContainer.h), so the class name must include the
+    // enclosing "tests::" namespace even though this container is not a DocumentObject.
+    PROPERTY_HEADER_WITH_OVERRIDE(tests::HookRecordingContainer);
+
+public:
+    HookRecordingContainer()
+    {
+        ADD_PROPERTY_TYPE(Renamed, (0), "Test", App::Prop_None, "Canonical property");
+        ADD_PROPERTY_DEPRECATED_ALIAS(Renamed, "OldName", "1.1");
+    }
+
+    void handleChangedPropertyName(Base::XMLReader& reader, const char* TypeName, const char* PropName) override
+    {
+        (void)reader;
+        (void)TypeName;
+        nameHookCalls.emplace_back(PropName);
+    }
+
+    void handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop) override
+    {
+        (void)reader;
+        (void)prop;
+        typeHookCalls.emplace_back(TypeName);
+    }
+
+    App::PropertyInteger Renamed;
+    std::vector<std::string> nameHookCalls;
+    std::vector<std::string> typeHookCalls;
+};
+
+}  // namespace tests
+
+class PropertyAliasRestore: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+        XERCES_CPP_NAMESPACE::XMLPlatformUtils::Initialize();
+        tests::HookRecordingContainer::init();
+    }
+
+    /// Build a Properties document containing a single static-style Property element.
+    static std::string makeDocument(const char* propName, const char* typeName, const char* body)
+    {
+        std::string str = "<?xml version='1.0' encoding='utf-8'?>\n";
+        str.append("<Properties Count='1'>\n");
+        str.append("<Property name='");
+        str.append(propName);
+        str.append("' type='");
+        str.append(typeName);
+        str.append("'>\n");
+        str.append(body);
+        str.append("</Property>\n");
+        str.append("</Properties>\n");
+        return str;
+    }
+
+    void restoreInto(tests::HookRecordingContainer& container, const std::string& xml)
+    {
+        std::stringstream data(xml);
+        Base::XMLReader reader("Document.xml", data);
+        container.Restore(reader);
+    }
+};
 
 class RenameProperty: public ::testing::Test
 {


### PR DESCRIPTION
When a static C++ property on a `DocumentObject` is renamed, Python add-ons and macros that reference the old name break silently at runtime. This adds a property alias mechanism to `PropertyContainer` so that old names can be kept working after a rename, with an optional deprecation flag that emits a developer warning to encourage migration without breaking existing scripts.

Aliases are registered via `addPropertyAlias(canonicalName, alias)` in C++ (with convenience macros `ADD_PROPERTY_ALIAS` / `ADD_PROPERTY_DEPRECATED_ALIAS`) or via `obj.addPropertyAlias(canonicalName, alias, deprecated=True)` from Python. Alias resolution is intentionally skipped during document restore so that the existing `handleChangedPropertyName` migration path is unaffected.

## Issues
- closes #28865

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->