### PR TITLE
Actions: Switch CrowdIn push back to main branch

### DIFF
--- a/.github/workflows/push_crowdin_translations.yml
+++ b/.github/workflows/push_crowdin_translations.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-          ref: releases/FreeCAD-1-1
+          ref: main
 
       - name: Install Qt ≥ 6.8
         uses: jurplel/install-qt-action@d325aaf2a8baeeda41ad0b5d39f84a6af9bcf005


### PR DESCRIPTION
In the lead-up to the 1.1 release we configured our CrowdIn push script to use the strings from the releases/FreeCAD-1-1 branch for stability. Now that 1.1 is released, we need to switch back to main so that translators can begin work for the next release.