### PR TITLE
Gui: Command groups should not enforce a etype

### DIFF
--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1105,7 +1105,9 @@ void Command::updateAction(int)
 
 GroupCommand::GroupCommand(const char* name)
     : Command(name)
-{}
+{
+    eType = 0;
+}
 
 bool GroupCommand::isCheckable() const
 {


### PR DESCRIPTION
Group commands should have etype = 0.
Because the activation state of a group should not depend on the group but on the commands inside.

Currently `GroupCommand `defaults to `Command `default, which is `AlterDoc | Alter3DView | AlterSelection`. So even if all the commands of a group are etype = 0, they will not be active during an edit.

While it does not fix a particular bug in FreeCAD, I do encounter this issue in AstoCAD and it might be a problem in FreeCAD in the future. Fix https://github.com/AstoCAD/FreeCAD/issues/100