### PR TITLE
CAM: Dressup.Utils.baseOp() - Fix for None

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Utils.py
+++ b/src/Mod/CAM/Path/Dressup/Utils.py
@@ -67,7 +67,7 @@ def isOp(obj):
 
 def baseOp(path):
     """baseOp(path) ... return the base operation underlying the given path"""
-    if "Dressup" in path.Name:
+    if hasattr(path, "Name") and "Dressup" in path.Name:
         return baseOp(path.Base)
     return path
 


### PR DESCRIPTION
[CAM : erreur au démarrage](https://forum.freecad.org/viewtopic.php?t=104310)

Get a lot of Python errors, If remove base operation from dress-up

<img width="356" height="259" alt="Screenshot_20260331_142017_lossy" src="https://github.com/user-attachments/assets/b9d87d63-b503-47d1-874f-18f2c141940e" />

```
pyException: Traceback (most recent call last):
  File "D:\utilitaires\freecad\FreeCAD_1.1.0\Mod\CAM\Path\Dressup\Gui\LeadInOut.py", line 1385, in getIcon
    if getattr(PathDressup.baseOp(self.obj), "Active", True):
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "D:\utilitaires\freecad\FreeCAD_1.1.0\Mod\CAM\Path\Dressup\Utils.py", line 51, in baseOp
    return baseOp(path.Base)
           ^^^^^^^^^^^^^^^^^
  File "D:\utilitaires\freecad\FreeCAD_1.1.0\Mod\CAM\Path\Dressup\Utils.py", line 50, in baseOp
    if "Dressup" in path.Name:
                    ^^^^^^^^^
<class 'AttributeError'>: 'NoneType' object has no attribute 'Name'
```

---

This commit changed `Dressup.Utils.baseOp()` to process `None` without errors