### PR TITLE
BIM: fix SectionPlane Toggle Cut View icon and label in context menu

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -1514,7 +1514,7 @@ class _ViewProviderSectionPlane:
         menu.addAction(actionEdit)
 
         actionToggleCutview = QtGui.QAction(
-            QtGui.QIcon(":/icons/Draft_Edit.svg"), translate("Arch", "Toggle Cutview"), menu
+            QtGui.QIcon(":/icons/Arch_CutPlane.svg"), translate("Arch", "Toggle Cut View"), menu
         )
         actionToggleCutview.triggered.connect(lambda: self.toggleCutview(vobj))
         menu.addAction(actionToggleCutview)


### PR DESCRIPTION
## Summary
- Fix wrong icon (`Draft_Edit.svg` → `Arch_CutPlane.svg`) in the Section Plane right-click context menu
- Fix inconsistent label (`Toggle Cutview` → `Toggle Cut View`) to match the task panel

Fixes #28907