### PR TITLE
Gui: Detect spnav daemon disconnect to prevent 100% CPU

### DIFF
--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -35,6 +35,9 @@
 
 #include <QSocketNotifier>
 
+#include <cerrno>
+#include <sys/socket.h>
+
 #include <spnav.h>
 
 // Cached per-axis deadzone values, auto-updated via Observer when user.cfg changes.
@@ -91,11 +94,13 @@ Gui::GuiNativeEvent::GuiNativeEvent(Gui::GUIApplicationNativeEventAware* app)
 
 Gui::GuiNativeEvent::~GuiNativeEvent()
 {
-    if (spnav_close()) {
-        Base::Console().log("Couldn't disconnect from spacenav daemon\n");
-    }
-    else {
-        Base::Console().log("Disconnected from spacenav daemon\n");
+    if (spnavNotifier) {
+        if (spnav_close()) {
+            Base::Console().log("Couldn't disconnect from spacenav daemon\n");
+        }
+        else {
+            Base::Console().log("Disconnected from spacenav daemon\n");
+        }
     }
 }
 
@@ -110,9 +115,8 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
     else {
         spnav_client_name("FreeCAD");
         Base::Console().log("Connected to spacenav daemon\n");
-        QSocketNotifier* SpacenavNotifier
-            = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
-        connect(SpacenavNotifier, SIGNAL(activated(int)), this, SLOT(pollSpacenav()));
+        spnavNotifier = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
+        connect(spnavNotifier, SIGNAL(activated(int)), this, SLOT(pollSpacenav()));
         dzCache = std::make_unique<DeadzoneCache>(
             App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Spaceball/Motion")
         );
@@ -124,7 +128,10 @@ void Gui::GuiNativeEvent::pollSpacenav()
 {
     spnav_event ev;
     bool hasMotion = false;
+    bool gotEvent = false;
+
     while (spnav_poll_event(&ev)) {
+        gotEvent = true;
         switch (ev.type) {
             case SPNAV_EVENT_MOTION: {
                 motionDataArray[0] = -ev.motion.x;
@@ -154,6 +161,24 @@ void Gui::GuiNativeEvent::pollSpacenav()
             }
         }
         mainApp->postMotionEvent(motionDataArray);
+    }
+
+    if (!gotEvent) {
+        // QSocketNotifier fired but no events were available.
+        // Verify the connection is still alive using a non-consuming peek.
+        int fd = spnav_fd();
+        if (fd >= 0) {
+            char buf;
+            ssize_t ret = recv(fd, &buf, 1, MSG_PEEK | MSG_DONTWAIT);
+            if (ret == 0 || (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+                // EOF or socket error — spacenavd disconnected
+                Base::Console().warning(
+                    "Lost connection to spacenav daemon. Restart FreeCAD to reconnect.\n");
+                spnavNotifier->setEnabled(false);
+                spnav_close();
+                spnavNotifier = nullptr;
+            }
+        }
     }
 }
 

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -173,7 +173,8 @@ void Gui::GuiNativeEvent::pollSpacenav()
             if (ret == 0 || (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
                 // EOF or socket error — spacenavd disconnected
                 Base::Console().warning(
-                    "Lost connection to spacenav daemon. Restart FreeCAD to reconnect.\n");
+                    "Lost connection to spacenav daemon. Restart FreeCAD to reconnect.\n"
+                );
                 spnavNotifier->setEnabled(false);
                 spnav_close();
                 spnavNotifier = nullptr;

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.h
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.h
@@ -26,6 +26,7 @@
 #include <memory>
 
 class QMainWindow;
+class QSocketNotifier;
 
 namespace Gui
 {
@@ -46,6 +47,7 @@ private:
     GuiNativeEvent& operator=(const GuiNativeEvent&);
 
     std::unique_ptr<DeadzoneCache> dzCache;
+    QSocketNotifier* spnavNotifier {nullptr};
 
 private Q_SLOTS:
     void pollSpacenav();


### PR DESCRIPTION
When spacenavd stops or crashes while FreeCAD is running, one CPU core goes to 100% and stays there. The only recovery is killing FreeCAD. This happens on any spacenavd exit — USB disconnect, `systemctl stop spacenavd`, daemon crash.

The problem sits in `pollSpacenav()`. When the spnav socket enters EOF state, the kernel keeps reporting it as "readable" (that's how EOF works on Unix sockets). QSocketNotifier fires, `spnav_poll_event()` returns 0 — but 0 means "no events" and also "dead connection", libspnav doesn't tell them apart. So the cycle repeats in a tight loop.

The fix adds a check after an empty poll cycle: `recv(fd, &buf, 1, MSG_PEEK | MSG_DONTWAIT)`. MSG_PEEK doesn't consume data so it won't interfere with libspnav, and it returns 0 on EOF — which is the one thing `spnav_poll_event()` can't tell us. When EOF is detected, the QSocketNotifier gets disabled and the spnav connection is closed.

To make this possible, the QSocketNotifier is stored as a class member instead of a local variable in `initSpaceball()`. The destructor guards `spnav_close()` so it doesn't try to close an already-closed connection.

I verified this independently with a socketpair() reproducer (no hardware needed) — a dead socket produces ~40 million select() wakeups in 10 seconds, and `recv(MSG_PEEK)` detects the EOF immediately with no false positives on healthy sockets.

Tested on Arch Linux / KDE Plasma Wayland with SpaceNavigator (046d:c626) via spacenavd 1.3.1. Without the fix, `sudo systemctl stop spacenavd` pegs a core at 100% instantly. With the fix, CPU stays normal and FreeCAD logs "Lost connection to spacenav daemon. Restart FreeCAD to reconnect." No reconnect — restarting spacenavd still requires a FreeCAD restart, same as before, just without the CPU spike.

Fixes #17809