### PR TITLE
[Gui] Fix Segmentation fault on exit, appears to apply to Python 3.14 and above

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -94,6 +94,7 @@
 #include <App/GeoFeatureGroupExtension.h>
 #include <Base/Console.h>
 #include <Base/FileInfo.h>
+#include <Base/Interpreter.h>
 #include <Base/Sequencer.h>
 #include <Base/Profiler.h>
 #include <Base/Tools.h>
@@ -780,6 +781,7 @@ View3DInventorViewer::~View3DInventorViewer()
     delete viewerEventFilter;
 
     if (_viewerPy) {
+        Base::PyGILStateLocker lock;
         static_cast<View3DInventorViewerPy*>(_viewerPy)->_viewer = nullptr;
         Py_DECREF(_viewerPy);
     }


### PR DESCRIPTION
During investigating a different issue from the forum, the following segmentation fault on closing FreeCAD down was triggered, see below, this PR fixes the seg fault.

```
Program received signal SIGSEGV, Segmentation fault.
#0  /usr/lib/libc.so.6(+0x3e2d0) [0x7f260e84d2d0]
#1  /usr/lib/libpython3.14.so.1.0(_Py_Dealloc+0x48) [0x7f26113594b8]
#2  0x7f2614302e65 in Gui::View3DInventorViewer::~View3DInventorViewer() from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x3f5
#3  0x7f2614302ece in Gui::View3DInventorViewer::~View3DInventorViewer() from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xe
#4  0x7f26142e8366 in Gui::View3DInventor::~View3DInventor() from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x116
#5  0x7f26142e83ee in Gui::View3DInventor::~View3DInventor() from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xe
#6  0x7f260efc637c in QObject::event(QEvent*) from /usr/lib/libQt6Core.so.6+0x4c
#7  0x7f2610103380 in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /usr/lib/libQt6Widgets.so.6+0x90
#8  0x7f2613da5a88 in Gui::GUIApplication::notify(QObject*, QEvent*) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xc8
#9  0x7f260ef6bf48 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /usr/lib/libQt6Core.so.6+0x158
#10  0x7f260ef6c320 in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) from /usr/lib/libQt6Core.so.6+0x380
#11  /usr/lib/libQt6Core.so.6(+0x451e78) [0x7f260f251e78]
#12  /usr/lib/libglib-2.0.so.0(+0x5ef4d) [0x7f260b306f4d]
#13  /usr/lib/libglib-2.0.so.0(+0x60617) [0x7f260b308617]
#14  /usr/lib/libglib-2.0.so.0(g_main_context_iteration+0x35) [0x7f260b308825]
#15  0x7f260f24fcb2 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) from /usr/lib/libQt6Core.so.6+0x72
#16  0x7f26144286e4 in Gui::MainWindow::closeEvent(QCloseEvent*) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x484
#17  0x7f261015dbca in QWidget::event(QEvent*) from /usr/lib/libQt6Widgets.so.6+0x4ba
#18  0x7f2610103380 in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /usr/lib/libQt6Widgets.so.6+0x90
#19  0x7f2613da5a88 in Gui::GUIApplication::notify(QObject*, QEvent*) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xc8
#20  0x7f260ef6bf48 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /usr/lib/libQt6Core.so.6+0x158
#21  0x7f2610158c33 in QWidgetPrivate::handleClose(QWidgetPrivate::CloseMode) from /usr/lib/libQt6Widgets.so.6+0x143
#22  /usr/lib/libQt6Widgets.so.6(+0x17f492) [0x7f261017f492]
#23  0x7f260f815a3d in QWindow::event(QEvent*) from /usr/lib/libQt6Gui.so.6+0x48d
#24  0x7f2610103380 in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /usr/lib/libQt6Widgets.so.6+0x90
#25  0x7f2613da5a88 in Gui::GUIApplication::notify(QObject*, QEvent*) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xc8
#26  0x7f260ef6bf48 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /usr/lib/libQt6Core.so.6+0x158
#27  0x7f260f7a12a2 in QGuiApplicationPrivate::processCloseEvent(QWindowSystemInterfacePrivate::CloseEvent*) from /usr/lib/libQt6Gui.so.6+0xc2
#28  0x7f260f7effc3 in QPlatformWindow::close() from /usr/lib/libQt6Gui.so.6+0xc3
#29  0x7f260f812b2b in QWindow::close() from /usr/lib/libQt6Gui.so.6+0x5b
#30  0x7f2613e2cc19 in Gui::Command::_invoke(int, bool) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x259
#31  0x7f2613e2d0c6 in Gui::Command::invoke(int, Gui::Command::TriggerSource) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0x176
#32  /usr/lib/libQt6Core.so.6(+0x1d8f0f) [0x7f260efd8f0f]
#33  0x7f260fc1b165 in QAction::activate(QAction::ActionEvent) from /usr/lib/libQt6Gui.so.6+0x1e5
#34  /usr/lib/libQt6Widgets.so.6(+0x309f2d) [0x7f2610309f2d]
#35  /usr/lib/libQt6Widgets.so.6(+0x30e7e8) [0x7f261030e7e8]
#36  0x7f261015e487 in QWidget::event(QEvent*) from /usr/lib/libQt6Widgets.so.6+0xd77
#37  0x7f2610103380 in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /usr/lib/libQt6Widgets.so.6+0x90
#38  0x7f2610104df7 in QApplication::notify(QObject*, QEvent*) from /usr/lib/libQt6Widgets.so.6+0xfd7
#39  0x7f2613da5a88 in Gui::GUIApplication::notify(QObject*, QEvent*) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xc8
#40  0x7f260ef6bf48 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /usr/lib/libQt6Core.so.6+0x158
#41  0x7f26100f9228 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) from /usr/lib/libQt6Widgets.so.6+0x5c8
#42  /usr/lib/libQt6Widgets.so.6(+0x178d0f) [0x7f2610178d0f]
#43  /usr/lib/libQt6Widgets.so.6(+0x1797db) [0x7f26101797db]
#44  0x7f2610103380 in QApplicationPrivate::notify_helper(QObject*, QEvent*) from /usr/lib/libQt6Widgets.so.6+0x90
#45  0x7f2613da5a88 in Gui::GUIApplication::notify(QObject*, QEvent*) from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xc8
#46  0x7f260ef6bf48 in QCoreApplication::notifyInternal2(QObject*, QEvent*) from /usr/lib/libQt6Core.so.6+0x158
#47  0x7f260f7a7fa8 in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) from /usr/lib/libQt6Gui.so.6+0x758
#48  0x7f260f82c3ac in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) from /usr/lib/libQt6Gui.so.6+0x2fc
#49  /usr/lib/qt6/plugins/platforms/../../../libQt6XcbQpa.so.6(+0x56277) [0x7f2609a6a277]
#50  /usr/lib/libglib-2.0.so.0(+0x5ef4d) [0x7f260b306f4d]
#51  /usr/lib/libglib-2.0.so.0(+0x60617) [0x7f260b308617]
#52  /usr/lib/libglib-2.0.so.0(g_main_context_iteration+0x35) [0x7f260b308825]
#53  0x7f260f24fcb2 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) from /usr/lib/libQt6Core.so.6+0x72
#54  0x7f260ef76cf6 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) from /usr/lib/libQt6Core.so.6+0x206
#55  0x7f260ef709f1 in QCoreApplication::exec() from /usr/lib/libQt6Core.so.6+0xb1
#56  0x7f2613cb19df in Gui::Application::runApplication() from /home/username/freecad-daily-build/lib/libFreeCADGui.so+0xa9f
#57  /home/username/freecad-daily-build/bin/FreeCAD(+0x88a2) [0x55b48a9b98a2]
#58  /usr/lib/libc.so.6(+0x276c1) [0x7f260e8366c1]
#59  /usr/lib/libc.so.6(__libc_start_main+0x89) [0x7f260e8367f9]
#60  /home/username/freecad-daily-build/bin/FreeCAD(+0x8b45) [0x55b48a9b9b45]
```
Fixes https://github.com/FreeCAD/FreeCAD/issues/27562