### PR TITLE
core: fix build with boost v1.90 and newer clang compilers specifically macos 26 llvm / clang

### DIFF
--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -29,6 +29,16 @@
 #include <QIcon>
 #include <fastsignals/signal.h>
 #include <boost/intrusive_ptr.hpp>
+#include <Inventor/misc/SoBase.h>
+
+inline void intrusive_ptr_add_ref(SoBase* obj)
+{
+    obj->ref();
+}
+inline void intrusive_ptr_release(SoBase* obj)
+{
+    obj->unref();
+}
 
 #include <App/Material.h>
 #include <App/TransactionalObject.h>


### PR DESCRIPTION
this PR will fix the below build error when using boost v1.90 and newer llvm / clang compilers specifically the one bundled with Xcode and macos 26.

when preparing to publish a new macos 26 freecad bottle using the v1.1.0 tarball. macos 26 ie. tahoe on the github hosted arm runner the results produce a build failure with the below output, taken from the raw github log from the ci run,

```
2026-03-31T18:47:50.8114650Z In file included from /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/TaskTransform.cpp:43:
2026-03-31T18:47:50.8114920Z In file included from /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/ViewProviderDragger.h:27:
2026-03-31T18:47:50.8115190Z In file included from /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/ViewProviderDocumentObject.h:29:
2026-03-31T18:47:50.8115400Z In file included from /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/ViewProvider.h:32:
2026-03-31T18:47:50.8115590Z In file included from /opt/homebrew/Cellar/boost/1.90.0_1/include/boost/intrusive_ptr.hpp:16:
2026-03-31T18:47:50.8115910Z /opt/homebrew/Cellar/boost/1.90.0_1/include/boost/smart_ptr/intrusive_ptr.hpp:76:23: error: use of undeclared identifier 'intrusive_ptr_release'
2026-03-31T18:47:50.8116030Z    76 |         if( px != 0 ) intrusive_ptr_release( px );
2026-03-31T18:47:50.8116080Z       |                       ^
2026-03-31T18:47:50.8116600Z /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/ViewProvider.h:96:7: note: in instantiation of member function 'boost::intrusive_ptr<Gui::SoTransformDragger>::~intrusive_ptr' requested here
2026-03-31T18:47:50.8116700Z    96 | class CoinPtr: public boost::intrusive_ptr<T>
2026-03-31T18:47:50.8116740Z       |       ^
2026-03-31T18:47:50.8117150Z /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/TaskTransform.cpp:80:16: note: in implicit destructor for 'Gui::CoinPtr<Gui::SoTransformDragger>' first required here
2026-03-31T18:47:50.8117220Z    80 | TaskTransform::TaskTransform(
2026-03-31T18:47:50.8117270Z       |                ^
2026-03-31T18:47:50.8117490Z In file included from /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/TaskTransform.cpp:43:
2026-03-31T18:47:50.8117730Z In file included from /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/ViewProviderDragger.h:27:
2026-03-31T18:47:50.8118010Z In file included from /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/ViewProviderDocumentObject.h:29:
2026-03-31T18:47:50.8118220Z In file included from /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/ViewProvider.h:32:
2026-03-31T18:47:50.8118410Z In file included from /opt/homebrew/Cellar/boost/1.90.0_1/include/boost/intrusive_ptr.hpp:16:
2026-03-31T18:47:50.8118720Z /opt/homebrew/Cellar/boost/1.90.0_1/include/boost/smart_ptr/intrusive_ptr.hpp:59:34: error: use of undeclared identifier 'intrusive_ptr_add_ref'
2026-03-31T18:47:50.8118830Z    59 |         if( px != 0 && add_ref ) intrusive_ptr_add_ref( px );
2026-03-31T18:47:50.8118880Z       |                                  ^
2026-03-31T18:47:50.8119360Z /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/ViewProvider.h:104:11: note: in instantiation of member function 'boost::intrusive_ptr<Gui::SoTransformDragger>::intrusive_ptr' requested here
2026-03-31T18:47:50.8119500Z   104 |         : inherited(p, add_ref)
2026-03-31T18:47:50.8119550Z       |           ^
2026-03-31T18:47:50.8120000Z /private/tmp/freecadA1.1.0_py313_qt6-20260331-64238-638y41/src/Gui/TaskTransform.cpp:91:7: note: in instantiation of member function 'Gui::CoinPtr<Gui::SoTransformDragger>::CoinPtr' requested here
2026-03-31T18:47:50.8120050Z    91 |     , dragger(dragger)
2026-03-31T18:47:50.8120090Z       |       ^
2026-03-31T18:47:50.8120150Z 3 warnings and 2 errors generated.
```

and other error messages can be seen from the below PR for reference.

- https://github.com/FreeCAD/homebrew-freecad/pull/803

quickest i found to reproduce ( i do not have local access to a macos 26 box arm or intel). i can log in to github hosted runners and run commands via a tmux session, but unfortunately i can get logged off at a moments notice.

```
brew install llvm -v;
brew install boost -v;
brew install coin3d -v;
```

```
brew info llvm
```

```
╰─λ brew info llvm
==> llvm ✔: stable 22.1.2 (bottled), HEAD
Next-gen compiler infrastructure
https://llvm.org/
Installed
/home/capin/homebrew/Cellar/llvm/22.1.1 (9,689 files, 2.8GB)
  Poured from bottle on 2026-03-23 at 14:44:18
/home/capin/homebrew/Cellar/llvm/22.1.2 (9,690 files, 2.8GB) *
  Poured from bottle on 2026-03-28 at 15:33:12
From: /home/capin/homebrew/Library/Taps/homebrew/homebrew-core/Formula/l/llvm.rb
License: Apache-2.0 WITH LLVM-exception
==> Dependencies
Build: cmake ✔, ninja ✔, swig ✔, binutils ✔, pkgconf ✔
Required: python@3.14 ✔, xz ✔, z3 ✔, zstd ✔, libedit ✔, libffi ✔, ncurses ✔, zlib-ng-compat ✔
==> Options
--HEAD
	Install HEAD version
==> Caveats
CLANG_CONFIG_FILE_SYSTEM_DIR: /home/capin/homebrew/etc/clang
CLANG_CONFIG_FILE_USER_DIR:   ~/.config/clang

LLD is now provided in a separate formula:
  brew install lld
```

```cpp
#include <Inventor/misc/SoBase.h>
#include <boost/intrusive_ptr.hpp>

template<class T>
class CoinPtr : public boost::intrusive_ptr<T> {
    typedef boost::intrusive_ptr<T> inherited;
public:
    CoinPtr() {}
    CoinPtr(T* p, bool add_ref = true) : inherited(p, add_ref) {}
};

template class boost::intrusive_ptr<SoBase>;

int main() {
    CoinPtr<SoBase> p;
    return 0;
}
```

compile that cpp program with the provided llvm / clang

some setup commands,

```
export bp=$(brew --prefix)
```

```
$bp/bin/clang++ \
  -std=c++20 \
  -I $bp/opt/coin3d/include \
  -I $bp/opt/boost/include \
  /tmp/test_coinptr_fix.cpp \
  -c -o /dev/null
```

<details>
<summary> build error from above output </summary>

```
In file included from /tmp/test_coinptr.cpp:2:
In file included from /home/capin/homebrew/opt/boost/include/boost/intrusive_ptr.hpp:16:
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:59:34: error: use of undeclared identifier
      'intrusive_ptr_add_ref'
   59 |         if( px != 0 && add_ref ) intrusive_ptr_add_ref( px );
      |                                  ^~~~~~~~~~~~~~~~~~~~~
/tmp/test_coinptr.cpp:12:23: note: in instantiation of member function 'boost::intrusive_ptr<SoBase>::intrusive_ptr' requested here
   12 | template class boost::intrusive_ptr<SoBase>;
      |                       ^
In file included from /tmp/test_coinptr.cpp:2:
In file included from /home/capin/homebrew/opt/boost/include/boost/intrusive_ptr.hpp:16:
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:71:23: error: use of undeclared identifier
      'intrusive_ptr_add_ref'
   71 |         if( px != 0 ) intrusive_ptr_add_ref( px );
      |                       ^~~~~~~~~~~~~~~~~~~~~
/tmp/test_coinptr.cpp:12:23: note: in instantiation of member function 'boost::intrusive_ptr<SoBase>::intrusive_ptr' requested here
   12 | template class boost::intrusive_ptr<SoBase>;
      |                       ^
In file included from /tmp/test_coinptr.cpp:2:
In file included from /home/capin/homebrew/opt/boost/include/boost/intrusive_ptr.hpp:16:
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:76:23: error: use of undeclared identifier
      'intrusive_ptr_release'
   76 |         if( px != 0 ) intrusive_ptr_release( px );
      |                       ^~~~~~~~~~~~~~~~~~~~~
/tmp/test_coinptr.cpp:12:23: note: in instantiation of member function 'boost::intrusive_ptr<SoBase>::~intrusive_ptr' requested here
   12 | template class boost::intrusive_ptr<SoBase>;
      |                       ^
In file included from /tmp/test_coinptr.cpp:2:
In file included from /home/capin/homebrew/opt/boost/include/boost/intrusive_ptr.hpp:16:
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:66:23: error: use of undeclared identifier
      'intrusive_ptr_add_ref'
   66 |         if( px != 0 ) intrusive_ptr_add_ref( px );
      |                       ^~~~~~~~~~~~~~~~~~~~~
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:116:9: note: in instantiation of function template
      specialization 'boost::intrusive_ptr<SoBase>::intrusive_ptr<SoBase>' requested here
  116 |         this_type(rhs).swap(*this);
      |         ^
/tmp/test_coinptr.cpp:12:23: note: in instantiation of member function 'boost::intrusive_ptr<SoBase>::operator=' requested here
   12 | template class boost::intrusive_ptr<SoBase>;
      |                       ^
In file included from /tmp/test_coinptr.cpp:2:
In file included from /home/capin/homebrew/opt/boost/include/boost/intrusive_ptr.hpp:16:
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:122:9: error: no matching conversion for functional-style cast
      from 'SoBase *' to 'this_type' (aka 'intrusive_ptr<SoBase>')
  122 |         this_type(rhs).swap(*this);
      |         ^~~~~~~~~~~~~~
/tmp/test_coinptr.cpp:12:23: note: in instantiation of member function 'boost::intrusive_ptr<SoBase>::operator=' requested here
   12 | template class boost::intrusive_ptr<SoBase>;
      |                       ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:87:30: note: candidate constructor not viable: no known
      conversion from 'SoBase *' to 'intrusive_ptr<SoBase>' for 1st argument
   87 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr && rhs) noexcept : px( rhs.px )
      |                              ^             ~~~~~~~~~~~~~~~~~~~~
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:63:30: note: candidate template ignored: could not match
      'intrusive_ptr<U>' against 'SoBase *'
   63 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr( intrusive_ptr<U> const & rhs, typename boost::detail::sp_enable_if_convertib...
      |                              ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:101:30: note: candidate template ignored: could not match
      'intrusive_ptr<U>' against 'SoBase *'
  101 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr<U> && rhs, typename boost::detail::sp_enable_if_convertible<U,T...
      |                              ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:53:15: note: candidate constructor not viable: requires 0
      arguments, but 1 was provided
   53 |     constexpr intrusive_ptr() noexcept : px( 0 )
      |               ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:133:9: error: no matching conversion for functional-style cast
      from 'SoBase *' to 'this_type' (aka 'intrusive_ptr<SoBase>')
  133 |         this_type( rhs ).swap( *this );
      |         ^~~~~~~~~~~~~~~~
/tmp/test_coinptr.cpp:12:23: note: in instantiation of member function 'boost::intrusive_ptr<SoBase>::reset' requested here
   12 | template class boost::intrusive_ptr<SoBase>;
      |                       ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:87:30: note: candidate constructor not viable: no known
      conversion from 'SoBase *' to 'intrusive_ptr<SoBase>' for 1st argument
   87 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr && rhs) noexcept : px( rhs.px )
      |                              ^             ~~~~~~~~~~~~~~~~~~~~
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:63:30: note: candidate template ignored: could not match
      'intrusive_ptr<U>' against 'SoBase *'
   63 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr( intrusive_ptr<U> const & rhs, typename boost::detail::sp_enable_if_convertib...
      |                              ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:101:30: note: candidate template ignored: could not match
      'intrusive_ptr<U>' against 'SoBase *'
  101 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr<U> && rhs, typename boost::detail::sp_enable_if_convertible<U,T...
      |                              ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:53:15: note: candidate constructor not viable: requires 0
      arguments, but 1 was provided
   53 |     constexpr intrusive_ptr() noexcept : px( 0 )
      |               ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:138:9: error: no matching constructor for initialization of
      'this_type' (aka 'intrusive_ptr<SoBase>')
  138 |         this_type( rhs, add_ref ).swap( *this );
      |         ^          ~~~~~~~~~~~~
/tmp/test_coinptr.cpp:12:23: note: in instantiation of member function 'boost::intrusive_ptr<SoBase>::reset' requested here
   12 | template class boost::intrusive_ptr<SoBase>;
      |                       ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:63:30: note: candidate template ignored: could not match
      'intrusive_ptr<U>' against 'SoBase *'
   63 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr( intrusive_ptr<U> const & rhs, typename boost::detail::sp_enable_if_convertib...
      |                              ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:101:30: note: candidate template ignored: could not match
      'intrusive_ptr<U>' against 'SoBase *'
  101 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr<U> && rhs, typename boost::detail::sp_enable_if_convertible<U,T...
      |                              ^
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:87:30: note: candidate constructor not viable: requires single
      argument 'rhs', but 2 arguments were provided
   87 |     BOOST_SP_CXX20_CONSTEXPR intrusive_ptr(intrusive_ptr && rhs) noexcept : px( rhs.px )
      |                              ^             ~~~~~~~~~~~~~~~~~~~~
/home/capin/homebrew/opt/boost/include/boost/smart_ptr/intrusive_ptr.hpp:53:15: note: candidate constructor not viable: requires 0
      arguments, but 2 were provided
   53 |     constexpr intrusive_ptr() noexcept : px( 0 )
      |               ^
7 errors generated.
```

</details>

the above build error can be reproduced with my local asahi linux setup and homebrew.

## Issues

no none issues that i'm aware of, though i did not do an exhaustive search.

## Before and After Images

NA

