### PR TITLE
Subject: Fix armhf build failure: OpenGL macro conflict with Coin3D headers

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -25,8 +25,8 @@
 
 #include "DlgCAMSimulator.h"
 #include "ViewCAMSimulator.h"
-#include "MillSimulation.h"
 #include "Gui/View3DInventorViewer.h"
+#include "MillSimulation.h"
 #include <Mod/Part/App/BRepMesh.h>
 #include <QDateTime>
 #include <QSurfaceFormat>

--- a/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/DlgCAMSimulator.cpp
@@ -26,7 +26,7 @@
 #include "DlgCAMSimulator.h"
 #include "ViewCAMSimulator.h"
 #include "Gui/View3DInventorViewer.h"
-#include "MillSimulation.h"
+#include "MillSimulation.h"  // Must be *after* View3DInventorViewer.h -- See PR #28950
 #include <Mod/Part/App/BRepMesh.h>
 #include <QDateTime>
 #include <QSurfaceFormat>


### PR DESCRIPTION
This build failure was seen on Debian for armhf, Bastian debugged the issue and proposed the patch contained in this MR.
The error can be seen in this buildd log: https://buildd.debian.org/status/fetch.php?pkg=freecad&arch=armhf&ver=1.1.0%2Bdfsg-1&stamp=1774788552&raw=0 

I'm quoting Bastian's explanation/rationale as given in the patch they submitted to the Debian BTS:

Bug-Debian: https://bugs.debian.org/1132247
Patch from: Bastian Germann <bage@debian.org>

On armhf, Qt5 uses GLES2 headers (<GLES2/gl2.h>) rather than desktop <GL/gl.h>. As a consequence, the desktop GL include guard (__gl_h_) is never set when <QOpenGLExtraFunctions> is processed.

OpenGlWrapper.h redefines standard GL function names as macros:
  #define glClearColor gSimWindow->glClearColor

When Gui/View3DInventorViewer.h is included *after* MillSimulation.h (which pulls in OpenGlWrapper.h), the Coin3D headers it depends on include <GL/gl.h> for the first time on armhf. The macro substitution then corrupts the C function declarations inside <GL/gl.h>, e.g.:
  extern void glClearColor(GLfloat, ...)
becomes
  extern void CAMSimulator::DlgCAMSimulator::GetInstance()->glClearColor(...)
which is invalid C++, producing "expected type-specifier before 'glClearColor'".

On x86/amd64, Qt5 desktop includes <GL/gl.h> via <QOpenGLExtraFunctions>, so its include guard is set before Coin3D's include attempt, which then becomes a no-op.

Fix: include Gui/View3DInventorViewer.h before MillSimulation.h so that <GL/gl.h> (and its function declarations) is processed and guarded before the gl* macros are defined.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
