### PR TITLE
App: normalize relative command-line document paths

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2823,6 +2823,11 @@ std::list<std::string> Application::processFiles(const std::list<std::string>& f
     for (const auto & it : files) {
 
         Base::FileInfo file(it);
+        if (!QFileInfo(QString::fromUtf8(file.filePath().c_str())).isAbsolute()) {
+            // Keep command-line-opened documents registered to their real filesystem path.
+            const QString absolutePath = QFileInfo(QString::fromUtf8(it.c_str())).absoluteFilePath();
+            file = Base::FileInfo(absolutePath.toUtf8().constData());
+        }
         // Can we safely remove the isSymlink check and directly query the canonical
         // path for every string? The reason for avoiding it currently is that
         // getCannonicalPath will log an error if the file doesn't exist

--- a/tests/src/App/Application.cpp
+++ b/tests/src/App/Application.cpp
@@ -2,6 +2,12 @@
 
 #include <gtest/gtest.h>
 #define FC_OS_MACOSX 1
+#include <filesystem>
+
+#include "App/Application.h"
+#include "App/Document.h"
+#include "App/Link.h"
+#include "Base/FileInfo.h"
 #include "App/ProgramOptionsUtilities.h"
 
 #include <src/App/InitApplication.h>
@@ -18,6 +24,16 @@ protected:
     static void SetUpTestSuite()
     {
         tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        App::GetApplication().closeAllDocuments();
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeAllDocuments();
     }
 };
 
@@ -57,3 +73,65 @@ TEST_F(ApplicationTest, fCustomSyntaxEmptyIn)
     Spr exp {"", ""};
     EXPECT_EQ(res, exp);
 };
+
+TEST_F(ApplicationTest, processFilesNormalizesRelativeDocumentPathsForLinks)
+{
+    namespace fs = std::filesystem;
+
+    struct CurrentPathGuard
+    {
+        explicit CurrentPathGuard(fs::path path)
+            : original(std::move(path))
+        {}
+
+        ~CurrentPathGuard()
+        {
+            fs::current_path(original);
+        }
+
+        fs::path original;
+    };
+
+    const fs::path originalPath = fs::current_path();
+    CurrentPathGuard pathGuard(originalPath);
+
+    const fs::path root = Base::FileInfo::getTempFileName("fc28683");
+    fs::remove(root);
+    fs::create_directories(root / "cwd");
+    fs::create_directories(root / "owner");
+
+    const fs::path sourceFile = root / "cwd" / "box.FCStd";
+    const fs::path ownerFile = root / "owner" / "owner.FCStd";
+
+    auto sourceName = App::GetApplication().getUniqueDocumentName("box_source");
+    auto* sourceDoc = App::GetApplication().newDocument(sourceName.c_str(), "box");
+    ASSERT_NE(sourceDoc, nullptr);
+    ASSERT_NE(sourceDoc->addObject("App::DocumentObjectGroup", "Target"), nullptr);
+    ASSERT_TRUE(sourceDoc->saveAs(sourceFile.string().c_str()));
+    App::GetApplication().closeDocument(sourceDoc->getName());
+
+    fs::current_path(root / "cwd");
+    auto processed = App::Application::processFiles({std::string("box.FCStd")});
+    ASSERT_EQ(processed.size(), 1);
+    EXPECT_EQ(processed.front(), "box.FCStd");
+
+    auto* reopenedDoc = App::GetApplication().getDocument("box");
+    ASSERT_NE(reopenedDoc, nullptr);
+    EXPECT_EQ(fs::path(reopenedDoc->getFileName()), sourceFile);
+
+    auto* target = reopenedDoc->getObject("Target");
+    ASSERT_NE(target, nullptr);
+
+    auto ownerName = App::GetApplication().getUniqueDocumentName("owner_doc");
+    auto* ownerDoc = App::GetApplication().newDocument(ownerName.c_str(), "owner");
+    ASSERT_NE(ownerDoc, nullptr);
+    ASSERT_TRUE(ownerDoc->saveAs(ownerFile.string().c_str()));
+
+    auto* link = freecad_cast<App::Link*>(ownerDoc->addObject("App::Link", "Link"));
+    ASSERT_NE(link, nullptr);
+    EXPECT_NO_THROW(link->setLink(-1, target));
+    EXPECT_EQ(link->getLinkedObject(), target);
+
+    fs::current_path(originalPath);
+    fs::remove_all(root);
+}


### PR DESCRIPTION
## Issues

Closes #28683

## Before and After Images

N/A

When a file is opened from the command line with a relative path, FreeCAD keeps that relative name on the document. Later, link resolution can treat it as relative to the owner document and end up looking for the already opened file under the wrong path, such as `/tmp/box.FCStd`.

This change normalizes command-line document paths before opening the document, so the document keeps an absolute filename. It also adds a regression test for reopening a document from a relative CLI path and creating an `App::Link` from another saved document.

Validation:
- reproduced the assertion from #28683 in a Linux debug run before the change
- reran the same steps after the change and the link is created successfully
- added an App regression test for this case
