### PR TITLE
Gui: Fix Spaceball button list not updating on device reset

### DIFF
--- a/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
+++ b/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
@@ -301,11 +301,12 @@ QString ButtonModel::getLabel(const int& number) const
 
 void ButtonModel::loadConfig(const char* RequiredDeviceName)
 {
-    goClear();
-    if (!RequiredDeviceName) {
-        return;
+    beginResetModel();
+    spaceballButtonGroup()->Clear();
+    if (RequiredDeviceName) {
+        load3DConnexionButtons(RequiredDeviceName);
     }
-    load3DConnexionButtons(RequiredDeviceName);
+    endResetModel();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When you select a device from the dropdown in the Spaceball Buttons dialog and press Reset, the button list doesn't update. It keeps showing the old entries until you close and reopen the dialog.

The problem is in ButtonModel::loadConfig(). It calls goClear() which does beginRemoveRows/endRemoveRows, then load3DConnexionButtons() writes new button entries to user.cfg — but without calling beginInsertRows/endInsertRows. The view never learns about the new rows.

The fix wraps the whole operation in beginResetModel/endResetModel so the view refreshes in one go.

Tested on Arch Linux / KDE Plasma Wayland with SpaceNavigator (046d:c626). Selected "SpaceNavigator" from the dropdown, pressed Reset — the list now immediately updates from 31 entries to 2. Before the fix, the list stayed at 31 until the dialog was reopened.

Fixes #19366