### PR TITLE
Part: Attacher: set hasPlacement flag correctly

### DIFF
--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -983,7 +983,8 @@ void AttachEngine::readLinks(
         // considered later, when the need arises.
         types[i] = getShapeType(shapes[i]->getShape());
 
-        if (subs[i].length() == 0) {
+        std::string elementName = Data::findElementName(subs[i].c_str());
+        if (elementName.length() == 0) {
             types[i] = eRefType(types[i] | rtFlagHasPlacement);
         }
     }


### PR DESCRIPTION
fix https://github.com/FreeCAD/FreeCAD/issues/28672

Currently the rtFlagHasPlacement is set only if the subname is totally empty. Which used to work before because we stored only the direct object.

Example : User select XY_Plane of the origin.
Before attacher saved : 
Object = XY_Plane
subname = empty

So the rtFlagHasPlacement was set correctly.

Now attacher saves : 
Object = Origin
subname = 'XY_plane.'

Because the subname is not empty it fails.
The detection is not good. It should check if the element name is empty.

This PR fix that