### PR TITLE
Core: Check PreSelection in preferences UI to match default in other code

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsSelection.ui
+++ b/src/Gui/PreferencePages/DlgSettingsSelection.ui
@@ -178,6 +178,9 @@ A larger value makes it easier to select elements, but may prevent selection of 
         <property name="text">
          <string>Preselect the object in the 3D view when hovering the cursor over the tree item</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
         <property name="prefEntry" stdset="0">
          <cstring>PreSelection</cstring>
         </property>


### PR DESCRIPTION
Reported on the forum:
https://forum.freecad.org/viewtopic.php?t=104307

The PreSelection preference checkbox (["Preselect the object in 3D View when hovering the cursor over the tree item"](https://wiki.freecad.org/Preferences_Editor#Selection)) was unchecked (`False`) by default in the Preferences Editor. But in the rest of the code the default was `True`. Starting without a CFG file would mean `True` was used, but changing a single (other!) preference would result in `False` unexpectedly becoming the new setting.

We really need to improve how preferences are handled.

This PR only fixes the inconsistency for this preference by checking the checkbox in the UI file.

https://github.com/FreeCAD/FreeCAD/blob/33dcd31f5e2175e7dcdfd3caf1d9d86440919bfc/src/Gui/TreeParams.cpp#L101
https://github.com/FreeCAD/FreeCAD/blob/33dcd31f5e2175e7dcdfd3caf1d9d86440919bfc/src/Gui/TreeParams.py#L51

<img width="400" height="213" alt="afbeelding" src="https://github.com/user-attachments/assets/eed6a526-bd91-409f-beed-e3849825ba86" />
