### PR TITLE
Gui: fix visibility not restored when opening headless-generated files

### DIFF
--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -97,6 +97,11 @@ void ViewProviderDocumentObject::getTaskViewContent(std::vector<Gui::TaskView::T
 
 void ViewProviderDocumentObject::startRestoring()
 {
+    // Prevent hide() from overwriting the App object's already-restored Visibility.
+    Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
+        App::Property::User1,
+        &Visibility
+    );
     hide();
     auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
     for (Gui::ViewProviderExtension* ext : vector) {
@@ -106,6 +111,14 @@ void ViewProviderDocumentObject::startRestoring()
 
 void ViewProviderDocumentObject::finishRestoring()
 {
+    // Sync VP visibility from App object in case no GuiDocument.xml was present.
+    if (auto* obj = getObject(); obj && Visibility.getValue() != obj->Visibility.getValue()) {
+        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
+            App::Property::User1,
+            &Visibility
+        );
+        Visibility.setValue(obj->Visibility.getValue());
+    }
     auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
     for (Gui::ViewProviderExtension* ext : vector) {
         ext->extensionFinishRestoring();


### PR DESCRIPTION
Fixes #28555

When a ffile is saved headlesly (no GuiDocument.xml), startRestoring()
calls hide() which propagates Visibility=false to the App object via
onChanged(), overwriting the value already restored from Document.xml.

Fix by guarding hide() with User1 in startRestoring() to block the
propagation, and syncing App→VP in finishRestoring() for the case where
no GuiDocument.xml was present.