### PR TITLE
Draft: fix Split creating a copy when clicking at wire endpoint

### DIFF
--- a/src/Mod/Draft/draftfunctions/split.py
+++ b/src/Mod/Draft/draftfunctions/split.py
@@ -59,15 +59,17 @@ splitClosedWire = split_closed_wire
 
 
 def split_open_wire(wire, newPoint, edgeIndex):
+    edge = wire.getSubObject("Edge" + str(edgeIndex))
+    splitPoint = wire.Placement.inverse().multVec(edge.Curve.projectPoint(newPoint))
+    if splitPoint.isEqual(wire.Points[0], 1e-7) or splitPoint.isEqual(wire.Points[-1], 1e-7):
+        return None
     new = make_copy.make_copy(wire)
     wire1Points = []
     wire2Points = []
     for index, point in enumerate(wire.Points):
         if index == edgeIndex:
-            edge = wire.getSubObject("Edge" + str(edgeIndex))
-            newPoint = wire.Placement.inverse().multVec(edge.Curve.projectPoint(newPoint))
-            wire1Points.append(newPoint)
-            wire2Points.append(newPoint)
+            wire1Points.append(splitPoint)
+            wire2Points.append(splitPoint)
             wire2Points.append(point)
         elif index < edgeIndex:
             wire1Points.append(point)

--- a/src/Mod/Draft/draftguitools/gui_split.py
+++ b/src/Mod/Draft/draftguitools/gui_split.py
@@ -104,7 +104,7 @@ class Split(gui_base_original.Modifier):
         cmd_list = [
             "obj = FreeCAD.ActiveDocument." + wire,
             "new = Draft.split(obj, " + point + ", " + index + ")",
-            "FreeCAD.ActiveDocument.recompute()",
+            "if new is not None: FreeCAD.ActiveDocument.recompute()",
         ]
 
         self.commit(translate("draft", "Split Line"), cmd_list)

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -245,6 +245,40 @@ class DraftModification(test_base.DraftTestCaseDoc):
             obj = True
         self.assertTrue(obj, "'{}' failed".format(operation))
 
+    def test_split_at_endpoint(self):
+        """Split a Draft Wire at its endpoints should be a no-op."""
+        operation = "Draft_Split endpoint"
+        _msg("  Test '{}'".format(operation))
+        a = Vector(0, 0, 0)
+        b = Vector(2, 2, 0)
+        c = Vector(4, 0, 0)
+        wire = Draft.make_wire([a, b, c])
+        self.doc.recompute()
+        original_points = list(wire.Points)
+        obj_count = len(self.doc.Objects)
+
+        result = Draft.split(wire, a, 1)
+        self.assertIsNone(result, "'{}' first endpoint should return None".format(operation))
+        self.assertEqual(
+            wire.Points, original_points, "'{}' wire should be unchanged".format(operation)
+        )
+        self.assertEqual(
+            len(self.doc.Objects),
+            obj_count,
+            "'{}' no new object should be created".format(operation),
+        )
+
+        result = Draft.split(wire, c, 2)
+        self.assertIsNone(result, "'{}' last endpoint should return None".format(operation))
+        self.assertEqual(
+            wire.Points, original_points, "'{}' wire should be unchanged".format(operation)
+        )
+        self.assertEqual(
+            len(self.doc.Objects),
+            obj_count,
+            "'{}' no new object should be created".format(operation),
+        )
+
     def test_upgrade(self):
         """Upgrade two Lines into a closed Wire, then draftify it."""
         operation = "Draft Upgrade"


### PR DESCRIPTION
Fixes #27498

## Summary
- `split_open_wire` now projects the click point onto the edge before creating a copy, and returns `None` early if the projected point lands on the first or last vertex of the wire
- GUI skips `recompute()` when `split()` returns `None`
- Regression test added for both endpoint cases