### PR TITLE
Gui: Adde more specific tuple types for style parameters

### DIFF
--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -181,6 +181,7 @@ SET(FreeCADBase_CPP_SRCS
     Console.cpp
     ConsoleObserver.cpp
     Color.cpp
+    ColorShading.cpp
     OkLch.cpp
     CoordinateSystem.cpp
     CoordinateSystemPyImp.cpp
@@ -255,6 +256,7 @@ SET(FreeCADBase_HPP_SRCS
     ConsoleObserver.h
     Converter.h
     Color.h
+    ColorShading.h
     OkLch.h
     CoordinateSystem.h
     DualNumber.h

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -181,6 +181,7 @@ SET(FreeCADBase_CPP_SRCS
     Console.cpp
     ConsoleObserver.cpp
     Color.cpp
+    OkLch.cpp
     CoordinateSystem.cpp
     CoordinateSystemPyImp.cpp
     DualQuaternion.cpp
@@ -254,6 +255,7 @@ SET(FreeCADBase_HPP_SRCS
     ConsoleObserver.h
     Converter.h
     Color.h
+    OkLch.h
     CoordinateSystem.h
     DualNumber.h
     DualQuaternion.h

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -210,6 +210,7 @@ SET(FreeCADBase_CPP_SRCS
     ${Console_MODULE_GENERATED_SRCS}
     ConsoleObserver.cpp
     Color.cpp
+    OkLch.cpp
     CoordinateSystem.cpp
     CoordinateSystemPyImp.cpp
     DualQuaternion.cpp
@@ -286,6 +287,7 @@ SET(FreeCADBase_HPP_SRCS
     ConsoleObserver.h
     Converter.h
     Color.h
+    OkLch.h
     CoordinateSystem.h
     DualNumber.h
     DualQuaternion.h

--- a/src/Base/ColorShading.cpp
+++ b/src/Base/ColorShading.cpp
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "ColorShading.h"
+
+#include <algorithm>
+#include <cmath>
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+namespace Base::ColorShading
+{
+
+namespace
+{
+
+constexpr float anchorTolerance = 1e-3F;
+constexpr float minExponent = 0.1F;
+constexpr float maxExponent = 10.0F;
+constexpr float minRangeDelta = 1e-6F;
+
+std::pair<float, float> computeLightnessRange(float anchorLightness, const Parameters& parameters)
+{
+    float halfRange = parameters.range / 2.0F;
+    float high = std::min(parameters.maxLightness, anchorLightness + halfRange);
+    float low = std::max(parameters.minLightness, anchorLightness - halfRange);
+    return {high, low};
+}
+
+float computeExponent(float anchorLightness, float high, float low, float pivot)
+{
+    float totalRange = high - low;
+    if (totalRange < minRangeDelta) {
+        return 1.0F;
+    }
+    float ratio = (high - anchorLightness) / totalRange;
+    ratio = std::clamp(ratio, 0.01F, 0.99F);
+    float exponent = std::log(ratio) / std::log(pivot);
+    return std::clamp(exponent, minExponent, maxExponent);
+}
+
+float lightnessForPosition(float position, float exponent, float high, float low)
+{
+    return high - (high - low) * std::pow(position, exponent);
+}
+
+}  // namespace
+
+OkLch computeShade(float position, const OkLch& anchor, const Parameters& parameters)
+{
+    if (std::abs(position - parameters.pivot) < anchorTolerance) {
+        return anchor;
+    }
+    auto [high, low] = computeLightnessRange(anchor.lightness, parameters);
+    float exponent = computeExponent(anchor.lightness, high, low, parameters.pivot);
+    float targetLightness = lightnessForPosition(position, exponent, high, low);
+    float darkScale = (anchor.lightness > 0.0F) ? targetLightness / anchor.lightness : 0.0F;
+    float lightScale = (anchor.lightness < 1.0F)
+        ? (1.0F - targetLightness) / (1.0F - anchor.lightness)
+        : 0.0F;
+    float chromaScale = std::pow(std::min(darkScale, lightScale), parameters.chromaExponent);
+    return OkLch {
+        .lightness = targetLightness,
+        .chroma = anchor.chroma * chromaScale,
+        .hue = anchor.hue,
+    };
+}
+
+}  // namespace Base::ColorShading
+
+// NOLINTEND(readability-magic-numbers)

--- a/src/Base/ColorShading.h
+++ b/src/Base/ColorShading.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <FCGlobal.h>
+
+#include "OkLch.h"
+
+namespace Base::ColorShading
+{
+
+struct Parameters
+{
+    float range = 0.8F;
+    float minLightness = 0.17F;
+    float maxLightness = 0.97F;
+    float pivot = 0.5F;
+    float chromaExponent = 0.5F;
+};
+
+/**
+ * @brief Returns target OkLch color for a position on the shade curve.
+ *
+ * Position 0 = lightest, 0.5 = anchor (unchanged), 1 = darkest.
+ * Uses a centered power curve so that the anchor lightness maps to
+ * position 0.5, and the output lightness is clamped to [minLightness, maxLightness].
+ * Chroma is scaled proportionally to lightness to avoid oversaturation in dark shades.
+ */
+BaseExport OkLch computeShade(float position, const OkLch& anchor, const Parameters& parameters);
+
+}  // namespace Base::ColorShading

--- a/src/Base/OkLch.cpp
+++ b/src/Base/OkLch.cpp
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+// Conversion matrices and algorithm from Bjorn Ottosson's OKLab color space,
+// published at https://bottosson.github.io/posts/oklab/ (public domain / MIT license).
+
+#include "OkLch.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+namespace Base
+{
+
+namespace
+{
+
+/// sRGB gamma to linear
+float srgbToLinear(float channel)
+{
+    if (channel <= 0.04045f) {
+        return channel / 12.92f;
+    }
+    return std::pow((channel + 0.055f) / 1.055f, 2.4f);
+}
+
+/// Linear to sRGB gamma
+float linearToSrgb(float channel)
+{
+    if (channel <= 0.0031308f) {
+        return channel * 12.92f;
+    }
+    return 1.055f * std::pow(channel, 1.0f / 2.4f) - 0.055f;
+}
+
+struct OkLab
+{
+    float lightness;
+    float a;
+    float b;
+};
+
+/// Linear sRGB to OKLab using Ottosson's combined matrices (no XYZ intermediate).
+OkLab linearSrgbToOkLab(float red, float green, float blue)
+{
+    float lCone = 0.4122214708f * red + 0.5363325363f * green + 0.0514459929f * blue;
+    float mCone = 0.2119034982f * red + 0.6806995451f * green + 0.1073969566f * blue;
+    float sCone = 0.0883024619f * red + 0.2817188376f * green + 0.6299787005f * blue;
+
+    float lRoot = std::cbrt(lCone);
+    float mRoot = std::cbrt(mCone);
+    float sRoot = std::cbrt(sCone);
+
+    return {
+        .lightness = 0.2104542553f * lRoot + 0.7936177850f * mRoot - 0.0040720468f * sRoot,
+        .a = 1.9779984951f * lRoot - 2.4285922050f * mRoot + 0.4505937099f * sRoot,
+        .b = 0.0259040371f * lRoot + 0.7827717662f * mRoot - 0.8086757660f * sRoot,
+    };
+}
+
+struct LinearRgb
+{
+    float red;
+    float green;
+    float blue;
+};
+
+/// OKLab to linear sRGB using Ottosson's inverse matrices.
+LinearRgb okLabToLinearSrgb(const OkLab& lab)
+{
+    float lRoot = lab.lightness + 0.3963377774f * lab.a + 0.2158037573f * lab.b;
+    float mRoot = lab.lightness - 0.1055613458f * lab.a - 0.0638541728f * lab.b;
+    float sRoot = lab.lightness - 0.0894841775f * lab.a - 1.2914855480f * lab.b;
+
+    float lCone = lRoot * lRoot * lRoot;
+    float mCone = mRoot * mRoot * mRoot;
+    float sCone = sRoot * sRoot * sRoot;
+
+    return {
+        .red = +4.0767416621f * lCone - 3.3077115913f * mCone + 0.2309699292f * sCone,
+        .green = -1.2684380046f * lCone + 2.6097574011f * mCone - 0.3413193965f * sCone,
+        .blue = -0.0041960863f * lCone - 0.7034186147f * mCone + 1.7076147010f * sCone,
+    };
+}
+
+
+constexpr float pi = std::numbers::pi_v<float>;
+
+constexpr float degreesPerRadian = 180.0f / pi;
+constexpr float radiansPerDegree = pi / 180.0f;
+constexpr float fullCircleDegrees = 360.0f;
+
+OkLch okLabToOkLch(const OkLab& lab)
+{
+    float chroma = std::sqrt(lab.a * lab.a + lab.b * lab.b);
+    float hueDegrees = std::atan2(lab.b, lab.a) * degreesPerRadian;
+    if (hueDegrees < 0.0f) {
+        hueDegrees += fullCircleDegrees;
+    }
+
+    return {
+        .lightness = lab.lightness,
+        .chroma = chroma,
+        .hue = hueDegrees,
+    };
+}
+
+OkLab okLchToOkLab(const OkLch& lch)
+{
+    float hueRadians = lch.hue * radiansPerDegree;
+
+    return {
+        .lightness = lch.lightness,
+        .a = lch.chroma * std::cos(hueRadians),
+        .b = lch.chroma * std::sin(hueRadians),
+    };
+}
+
+bool isInGamut(const LinearRgb& rgb)
+{
+    constexpr float epsilon = 1e-6f;
+    return rgb.red >= -epsilon && rgb.red <= 1.0f + epsilon && rgb.green >= -epsilon
+        && rgb.green <= 1.0f + epsilon && rgb.blue >= -epsilon && rgb.blue <= 1.0f + epsilon;
+}
+
+}  // namespace
+
+OkLch toOkLch(const Color& color)
+{
+    float linearRed = srgbToLinear(color.r);
+    float linearGreen = srgbToLinear(color.g);
+    float linearBlue = srgbToLinear(color.b);
+
+    OkLab lab = linearSrgbToOkLab(linearRed, linearGreen, linearBlue);
+    return okLabToOkLch(lab);
+}
+
+Color fromOkLch(const OkLch& oklch, float alpha)
+{
+    // Binary search: reduce chroma until the result fits sRGB gamut.
+    constexpr int maxIterations = 20;
+    constexpr float chromaTolerance = 1e-5f;
+
+    float lowChroma = 0.0f;
+    float highChroma = oklch.chroma;
+
+    OkLch candidate = oklch;
+
+    // First check if the full chroma is already in gamut.
+    OkLab lab = okLchToOkLab(candidate);
+    LinearRgb linear = okLabToLinearSrgb(lab);
+
+    if (isInGamut(linear)) {
+        return Color(
+            std::clamp(linearToSrgb(linear.red), 0.0f, 1.0f),
+            std::clamp(linearToSrgb(linear.green), 0.0f, 1.0f),
+            std::clamp(linearToSrgb(linear.blue), 0.0f, 1.0f),
+            alpha
+        );
+    }
+
+    // Binary search for maximum in-gamut chroma.
+    for (int iteration = 0; iteration < maxIterations; ++iteration) {
+        float midChroma = (lowChroma + highChroma) * 0.5f;
+        candidate.chroma = midChroma;
+
+        lab = okLchToOkLab(candidate);
+        linear = okLabToLinearSrgb(lab);
+
+        if (isInGamut(linear)) {
+            lowChroma = midChroma;
+        }
+        else {
+            highChroma = midChroma;
+        }
+
+        if (highChroma - lowChroma < chromaTolerance) {
+            break;
+        }
+    }
+
+    // Use lowChroma (last known in-gamut value).
+    candidate.chroma = lowChroma;
+    lab = okLchToOkLab(candidate);
+    linear = okLabToLinearSrgb(lab);
+
+    return Color(
+        std::clamp(linearToSrgb(linear.red), 0.0f, 1.0f),
+        std::clamp(linearToSrgb(linear.green), 0.0f, 1.0f),
+        std::clamp(linearToSrgb(linear.blue), 0.0f, 1.0f),
+        alpha
+    );
+}
+
+}  // namespace Base
+
+// NOLINTEND(readability-magic-numbers)

--- a/src/Base/OkLch.h
+++ b/src/Base/OkLch.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+// Conversion matrices and algorithm from Bjorn Ottosson's OKLab color space,
+// published at https://bottosson.github.io/posts/oklab/ (public domain / MIT license).
+
+#pragma once
+
+#include <FCGlobal.h>
+
+#include "Color.h"
+
+namespace Base
+{
+
+/**
+ * @brief Color representation in OKLCH Space.
+ *
+ * The OKLCH color space is the best currently known color representation that allows making
+ * changes to color (like changing the hue or lightness) while preserving the "feel" (like how dark
+ * color feels - as the preceived lightness is different per hue) of the color.
+ */
+struct OkLch
+{
+    float lightness;  // [0, 1]
+    float chroma;     // [0, ~0.37]
+    float hue;        // [0, 360) degrees
+};
+
+/**
+ * @brief Converts an sRGB color to OKLCH.
+ *
+ * Pipeline: sRGB -> linear RGB -> OKLab -> OKLCH.
+ * Alpha is not included in the OKLCH representation.
+ */
+BaseExport OkLch toOkLch(const Color& color);
+
+/**
+ * @brief Converts an OKLCH color back to sRGB.
+ *
+ * Pipeline: OKLCH -> OKLab -> linear RGB -> sRGB.
+ * Applies gamut mapping by reducing chroma until the result fits sRGB [0, 1].
+ */
+BaseExport Color fromOkLch(const OkLch& oklch, float alpha = 1.0f);
+
+}  // namespace Base

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1398,6 +1398,7 @@ SET(FreeCADGui_SRCS
     StyleParameters/Value.h
     StyleParameters/Parser.h
     StyleParameters/ParameterManager.h
+    StyleParameters/Insets.h
 )
 
 SET(FreeCADGui_SRCS

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1399,6 +1399,7 @@ SET(FreeCADGui_SRCS
     StyleParameters/Parser.h
     StyleParameters/ParameterManager.h
     StyleParameters/Insets.h
+    StyleParameters/Corners.h
 )
 
 SET(FreeCADGui_SRCS

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1398,6 +1398,7 @@ SET(FreeCADGui_SRCS
     StyleParameters/Value.h
     StyleParameters/Parser.h
     StyleParameters/ParameterManager.h
+    StyleParameters/Edges.h
     StyleParameters/Insets.h
     StyleParameters/Corners.h
     StyleParameters/Gradient.h

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1400,6 +1400,7 @@ SET(FreeCADGui_SRCS
     StyleParameters/ParameterManager.h
     StyleParameters/Insets.h
     StyleParameters/Corners.h
+    StyleParameters/Gradient.h
 )
 
 SET(FreeCADGui_SRCS

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1415,6 +1415,8 @@ SET(FreeCADGui_SRCS
     StyleParameters/Parser.h
     StyleParameters/ParameterManager.h
     StyleParameters/Diagnostics.h
+    StyleParameters/Edges.h
+    StyleParameters/Insets.h
 )
 
 SET(FreeCADGui_SRCS

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1366,6 +1366,7 @@ SET(FreeCADGui_CPP_SRCS
     StyleParameters/Parser.cpp
     StyleParameters/ParameterManager.cpp
     StyleParameters/Diagnostics.cpp
+    StyleParameters/ColorShading.cpp
 )
 SET(FreeCADGui_SRCS
     Application.h
@@ -1419,6 +1420,7 @@ SET(FreeCADGui_SRCS
     StyleParameters/Insets.h
     StyleParameters/Corners.h
     StyleParameters/Gradient.h
+    StyleParameters/ColorShading.h
 )
 
 SET(FreeCADGui_SRCS

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1418,6 +1418,7 @@ SET(FreeCADGui_SRCS
     StyleParameters/Edges.h
     StyleParameters/Insets.h
     StyleParameters/Corners.h
+    StyleParameters/Gradient.h
 )
 
 SET(FreeCADGui_SRCS

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1365,6 +1365,7 @@ SET(FreeCADGui_CPP_SRCS
     StyleParameters/Value.cpp
     StyleParameters/Parser.cpp
     StyleParameters/ParameterManager.cpp
+    StyleParameters/Diagnostics.cpp
 )
 SET(FreeCADGui_SRCS
     Application.h
@@ -1413,6 +1414,7 @@ SET(FreeCADGui_SRCS
     StyleParameters/Value.h
     StyleParameters/Parser.h
     StyleParameters/ParameterManager.h
+    StyleParameters/Diagnostics.h
 )
 
 SET(FreeCADGui_SRCS

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1417,6 +1417,7 @@ SET(FreeCADGui_SRCS
     StyleParameters/Diagnostics.h
     StyleParameters/Edges.h
     StyleParameters/Insets.h
+    StyleParameters/Corners.h
 )
 
 SET(FreeCADGui_SRCS

--- a/src/Gui/Dialogs/DlgThemeEditor.cpp
+++ b/src/Gui/Dialogs/DlgThemeEditor.cpp
@@ -124,6 +124,24 @@ struct StyleParametersModel::ParameterItem: Item
     QFlags<Qt::ItemFlag> flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;
 };
 
+struct StyleParametersModel::ValueItem: Item
+{
+    ValueItem(QString name, QString expression, StyleParameters::Value value)
+        : name(std::move(name))
+        , expression(std::move(expression))
+        , value(std::move(value))
+    {}
+
+    bool isHeader() const override
+    {
+        return false;
+    }
+
+    QString name;
+    QString expression;
+    StyleParameters::Value value;
+};
+
 class StyleParametersModel::Node
 {
 public:
@@ -448,6 +466,11 @@ void StyleParametersModel::reset()
     }
 
     endResetModel();
+
+    // Expand tuples. We need to do this in a separate pass because resolution might require
+    // parameters that are not yet added to the model if we do it in a single pass.
+    manager->reload();
+    QtTools::walkTreeModel(this, [this](const QModelIndex& index) { expandTupleIfNeeded(index); });
 }
 
 void StyleParametersModel::flush()
@@ -473,6 +496,46 @@ void StyleParametersModel::flush()
     }
 
     reset();
+}
+
+void StyleParametersModel::expandTupleIfNeeded(const QModelIndex& index)
+{
+    const QModelIndex parent = index.siblingAtColumn(0);
+    if (auto parameterItem = item<ParameterItem>(parent)) {
+        if (const auto& value = manager->resolve(parameterItem->token.name)) {
+            auto* parameterNode = node(parent);
+
+            // Remove all existing children
+            if (parameterNode->childCount() > 0) {
+                beginRemoveRows(parent, 0, parameterNode->childCount() - 1);
+                while (parameterNode->childCount() > 0) {
+                    parameterNode->removeChild(0);
+                }
+                endRemoveRows();
+            }
+
+            if (value->holds<StyleParameters::Tuple>()) {
+                const auto& tuple = value->get<StyleParameters::Tuple>();
+
+                beginInsertRows(parent, 0, static_cast<int>(tuple.size()) - 1);
+                int i = 0;
+                for (const auto& [name, elementValue] : tuple.elements) {
+                    QString nameOrIndex = name ? QString::fromStdString(*name)
+                                               : QStringLiteral("%1").arg(i++);
+                    parameterNode->appendChild(
+                        std::make_unique<Node>(std::make_unique<ValueItem>(
+                            nameOrIndex,
+                            QStringLiteral("@%1.%2")
+                                .arg(QString::fromStdString(parameterItem->token.name))
+                                .arg(nameOrIndex),
+                            *elementValue
+                        ))
+                    );
+                }
+                endInsertRows();
+            }
+        }
+    }
 }
 
 int StyleParametersModel::rowCount(const QModelIndex& index) const
@@ -553,6 +616,29 @@ QVariant StyleParametersModel::data(const QModelIndex& index, int role) const
         }
     }
 
+    if (auto tupleElementItem = item<ValueItem>(index)) {
+        if (role == Qt::DisplayRole) {
+            if (index.column() == ParameterName) {
+                return tupleElementItem->name;
+            }
+            if (index.column() == ParameterExpression) {
+                return tupleElementItem->expression;
+            }
+            if (index.column() == ParameterType) {
+                return typeOfTokenValue(tupleElementItem->value);
+            }
+            if (index.column() == ParameterPreview) {
+                return QString::fromStdString(tupleElementItem->value.toString());
+            }
+        }
+
+        if (role == Qt::DecorationRole) {
+            if (index.column() == ParameterPreview && tupleElementItem->value.holds<Base::Color>()) {
+                return colorPreview(tupleElementItem->value.get<Base::Color>().asValue<QColor>());
+            }
+        }
+    }
+
     return {};
 }
 
@@ -612,6 +698,8 @@ bool StyleParametersModel::setData(
 
     this->manager->reload();
 
+    expandTupleIfNeeded(index);
+
     QtTools::walkTreeModel(this, [this](const QModelIndex& index) {
         const QModelIndex previewColumnIndex = index.siblingAtColumn(ParameterPreview);
 
@@ -627,6 +715,10 @@ Qt::ItemFlags StyleParametersModel::flags(const QModelIndex& index) const
         if (index.column() == ParameterName || index.column() == ParameterExpression) {
             return parameterItem->flags | QAbstractItemModel::flags(index);
         }
+    }
+
+    if (item<ValueItem>(index)) {
+        return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
     }
 
     if (isAddPlaceholder(index)) {

--- a/src/Gui/Dialogs/DlgThemeEditor.cpp
+++ b/src/Gui/Dialogs/DlgThemeEditor.cpp
@@ -32,25 +32,89 @@
 #include <Base/ServiceProvider.h>
 #include <Base/Tools.h>
 
+#include <StyleParameters/Gradient.h>
+
 #include <ranges>
+#include <QGraphicsEffect>
+#include <QGraphicsItem>
+#include <QGraphicsScene>
 #include <QImageReader>
+#include <QLinearGradient>
 #include <QPainter>
+#include <QRadialGradient>
 #include <QStyledItemDelegate>
 #include <QTimer>
 
+QPixmap applyDropShadow(const QPixmap& source)
+{
+    auto* effect = new QGraphicsDropShadowEffect;
+    effect->setBlurRadius(4);
+    effect->setOffset(QPointF(0.0, 2.0));
+    effect->setColor(QColor(0, 0, 0, 90));
+
+    auto* item = new QGraphicsPixmapItem;
+    item->setPixmap(source);
+    item->setGraphicsEffect(effect);
+
+    QGraphicsScene scene;
+    scene.addItem(item);
+
+    QPixmap result(source.size());
+    result.fill(Qt::transparent);
+    QPainter painter(&result);
+    scene.render(&painter, QRectF(QPointF(), source.size()), QRectF(QPointF(), source.size()));
+    return result;
+}
+
 QPixmap colorPreview(const QColor& color)
 {
-    constexpr qsizetype size = 16;
+    constexpr qsizetype iconSize = 24;
+    constexpr qsizetype shapeSize = 16;
+    constexpr qsizetype shapeX = 4;
+    constexpr qsizetype shapeY = 4;
 
-    QPixmap preview = Gui::BitmapFactory().empty({size, size});
+    QPixmap preview = Gui::BitmapFactory().empty({iconSize, iconSize});
 
-    QPainter painter(&preview);
-    painter.setRenderHint(QPainter::Antialiasing);
-    painter.setPen(Qt::NoPen);
-    painter.setBrush(color);
-    painter.drawEllipse(QRect {0, 0, size, size});
+    {
+        QPainter painter(&preview);
+        painter.setRenderHint(QPainter::Antialiasing);
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(color);
+        painter.drawEllipse(QRect {shapeX, shapeY, shapeSize, shapeSize});
+    }
 
-    return preview;
+    return applyDropShadow(preview);
+}
+
+QPixmap gradientPreview(const Gui::StyleParameters::Tuple& tuple)
+{
+    constexpr qsizetype iconSize = 24;
+    constexpr qsizetype shapeSize = 16;
+    constexpr qsizetype shapeX = 4;
+    constexpr qsizetype shapeY = 4;
+    constexpr int cornerRadius = 3;
+
+    QPixmap preview = Gui::BitmapFactory().empty({iconSize, iconSize});
+
+    // convertTo<QBrush> uses QGradient::ObjectMode so gradient coords [0,1]
+    // map to the bounding rect of the painted shape — equivalent to the
+    // explicit pixel scaling this function previously performed.
+    try {
+        const QBrush brush = Base::convertTo<QBrush>(Gui::StyleParameters::Value(tuple));
+        if (brush.style() == Qt::NoBrush) {
+            return preview;
+        }
+
+        QPainter painter(&preview);
+        painter.setRenderHint(QPainter::Antialiasing);
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(brush);
+        painter.drawRoundedRect(QRect {shapeX, shapeY, shapeSize, shapeSize}, cornerRadius, cornerRadius);
+    }
+    catch (...) {
+    }
+
+    return applyDropShadow(preview);
 }
 
 QString typeOfTokenValue(const Gui::StyleParameters::Value& value)
@@ -67,8 +131,15 @@ QString typeOfTokenValue(const Gui::StyleParameters::Value& value)
             [](const Base::Color&) {
                 return QWidget::tr("Color");
             },
-            [](const Gui::StyleParameters::Tuple&) {
-                return QWidget::tr("Tuple");
+            [](const Gui::StyleParameters::Tuple& tuple) {
+                switch (tuple.kind) {
+                    case Gui::StyleParameters::TupleKind::LinearGradient:
+                        return QWidget::tr("Linear Gradient");
+                    case Gui::StyleParameters::TupleKind::RadialGradient:
+                        return QWidget::tr("Radial Gradient");
+                    default:
+                        return QWidget::tr("Tuple");
+                }
             }
         },
         value
@@ -302,6 +373,27 @@ public:
         painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, tr("New parameter…"));
     }
 
+    void paintGradientPreview(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index
+    ) const
+    {
+        // Draw background and selection highlight, suppressing text and icon.
+        QStyleOptionViewItem bgOnly(option);
+        bgOnly.text.clear();
+        bgOnly.icon = QIcon();
+        bgOnly.features.setFlag(QStyleOptionViewItem::HasDecoration, false);
+        bgOnly.features.setFlag(QStyleOptionViewItem::HasDisplay, false);
+        QStyledItemDelegate::paint(painter, bgOnly, index);
+
+        // Overlay the gradient bar stretched to the cell with a small margin.
+        constexpr int margin = 3;
+        const QRect drawRect = option.rect.adjusted(margin, margin, -margin, -margin);
+        const QPixmap gradientPixmap = index.data(Qt::UserRole).value<QPixmap>();
+        painter->drawPixmap(drawRect, gradientPixmap, gradientPixmap.rect());
+    }
+
     void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
     {
         auto model = dynamic_cast<const StyleParametersModel*>(index.model());
@@ -329,6 +421,10 @@ public:
 
             painter->fillRect(option.rect, headerBackgroundColor);
             QStyledItemDelegate::paint(painter, option, index);
+        }
+        else if (index.column() == StyleParametersModel::ParameterPreview
+                 && !index.data(Qt::UserRole).value<QPixmap>().isNull()) {
+            paintGradientPreview(painter, opt, index);
         }
         else {
             QStyledItemDelegate::paint(painter, option, index);
@@ -405,20 +501,11 @@ std::list<StyleParameters::Parameter> StyleParametersModel::all() const
 
 std::optional<StyleParameters::Parameter> StyleParametersModel::get(const std::string& name) const
 {
-    std::optional<StyleParameters::Parameter> result = std::nullopt;
+    if (auto it = parameterIndex.find(name); it != parameterIndex.end()) {
+        return it->second->token;
+    }
 
-    QtTools::walkTreeModel(this, [this, &name, &result](const QModelIndex& index) {
-        if (auto parameterItem = item<ParameterItem>(index)) {
-            if (parameterItem->token.name == name) {
-                result = parameterItem->token;
-                return true;
-            }
-        }
-
-        return false;
-    });
-
-    return result;
+    return std::nullopt;
 }
 
 void StyleParametersModel::removeItem(const QModelIndex& index)
@@ -431,6 +518,7 @@ void StyleParametersModel::removeItem(const QModelIndex& index)
         }
 
         groupItem->deleted.insert(parameterItem->token.name);
+        parameterIndex.erase(parameterItem->token.name);
 
         beginRemoveRows(index.parent(), index.row(), index.row());
         node(index.parent())->removeChild(index.row());
@@ -469,8 +557,19 @@ void StyleParametersModel::reset()
 
     // Expand tuples. We need to do this in a separate pass because resolution might require
     // parameters that are not yet added to the model if we do it in a single pass.
+    rebuildIndex();
     manager->reload();
     QtTools::walkTreeModel(this, [this](const QModelIndex& index) { expandTupleIfNeeded(index); });
+}
+
+void StyleParametersModel::rebuildIndex()
+{
+    parameterIndex.clear();
+    QtTools::walkTreeModel(this, [this](const QModelIndex& index) {
+        if (auto* parameterItem = item<ParameterItem>(index)) {
+            parameterIndex.emplace(parameterItem->token.name, parameterItem);
+        }
+    });
 }
 
 void StyleParametersModel::flush()
@@ -603,9 +702,16 @@ QVariant StyleParametersModel::data(const QModelIndex& index, int role) const
             }
         }
 
-        if (role == Qt::DecorationRole) {
-            if (index.column() == ParameterPreview && std::holds_alternative<Base::Color>(*value)) {
+        if (role == Qt::DecorationRole && index.column() == ParameterPreview) {
+            if (std::holds_alternative<Base::Color>(*value)) {
                 return colorPreview(std::get<Base::Color>(*value).asValue<QColor>());
+            }
+            if (value->holds<StyleParameters::Tuple>()) {
+                const auto& tuple = value->get<StyleParameters::Tuple>();
+                if (tuple.kind == StyleParameters::TupleKind::LinearGradient
+                    || tuple.kind == StyleParameters::TupleKind::RadialGradient) {
+                    return gradientPreview(tuple);
+                }
             }
         }
     }
@@ -632,9 +738,16 @@ QVariant StyleParametersModel::data(const QModelIndex& index, int role) const
             }
         }
 
-        if (role == Qt::DecorationRole) {
-            if (index.column() == ParameterPreview && tupleElementItem->value.holds<Base::Color>()) {
+        if (role == Qt::DecorationRole && index.column() == ParameterPreview) {
+            if (tupleElementItem->value.holds<Base::Color>()) {
                 return colorPreview(tupleElementItem->value.get<Base::Color>().asValue<QColor>());
+            }
+            if (tupleElementItem->value.holds<StyleParameters::Tuple>()) {
+                const auto& tuple = tupleElementItem->value.get<StyleParameters::Tuple>();
+                if (tuple.kind == StyleParameters::TupleKind::LinearGradient
+                    || tuple.kind == StyleParameters::TupleKind::RadialGradient) {
+                    return gradientPreview(tuple);
+                }
             }
         }
     }
@@ -659,9 +772,13 @@ bool StyleParametersModel::setData(
 
             // there is no rename operation, so we need to mark the previous token as deleted
             groupItem->deleted.insert(parameterItem->token.name);
+            parameterIndex.erase(parameterItem->token.name);
 
             parameterItem->name = newName;
             parameterItem->token = newToken;
+            // Use insert_or_assign so that renaming to a name that already exists in
+            // a lower-priority source correctly updates the index to this entry.
+            parameterIndex.insert_or_assign(newToken.name, parameterItem);
         }
 
         if (index.column() == ParameterExpression) {
@@ -687,9 +804,14 @@ bool StyleParametersModel::setData(
             int start = rowCount(index.parent());
 
             beginInsertRows(index.parent(), start, start + 1);
-            auto item = std::make_unique<Node>(std::make_unique<ParameterItem>(newName, token));
-            node(index.parent())->appendChild(std::move(item));
+            auto newNode = std::make_unique<Node>(std::make_unique<ParameterItem>(newName, token));
+            auto* newParameterItem = newNode->data<ParameterItem>();
+            node(index.parent())->appendChild(std::move(newNode));
             endInsertRows();
+            // Use insert_or_assign so that adding an override for a name that already
+            // exists in a lower-priority source correctly updates the index to point
+            // to this (higher-priority, user-editable) entry.
+            parameterIndex.insert_or_assign(token.name, newParameterItem);
 
             // this must be queued to basically next frame so widget has a chance to update
             QTimer::singleShot(0, [this, index]() { this->newParameterAdded(index); });
@@ -698,7 +820,10 @@ bool StyleParametersModel::setData(
 
     this->manager->reload();
 
-    expandTupleIfNeeded(index);
+    // Re-expand ALL tuples, not just the edited one: any token that references
+    // the changed token may produce a different tuple, so its ValueItem children
+    // need to be rebuilt with fresh resolved values.
+    QtTools::walkTreeModel(this, [this](const QModelIndex& index) { expandTupleIfNeeded(index); });
 
     QtTools::walkTreeModel(this, [this](const QModelIndex& index) {
         const QModelIndex previewColumnIndex = index.siblingAtColumn(ParameterPreview);
@@ -816,7 +941,10 @@ DlgThemeEditor::DlgThemeEditor(QWidget* parent)
     }
 
     ui->tokensTreeView->setColumnWidth(StyleParametersModel::ParameterName, nameColumnWidth);
-    ui->tokensTreeView->expandAll();
+
+    for (int row = 0; row < model->rowCount(QModelIndex()); ++row) {
+        ui->tokensTreeView->expand(model->index(row, 0, QModelIndex()));
+    }
 
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
@@ -831,7 +959,9 @@ DlgThemeEditor::DlgThemeEditor(QWidget* parent)
     );
 
     connect(model.get(), &StyleParametersModel::modelReset, ui->tokensTreeView, [this] {
-        ui->tokensTreeView->expandAll();
+        for (int row = 0; row < model->rowCount(QModelIndex()); ++row) {
+            ui->tokensTreeView->expand(model->index(row, 0, QModelIndex()));
+        }
     });
     connect(model.get(), &StyleParametersModel::newParameterAdded, this, [this](const QModelIndex& index) {
         const auto newParameterExpressionIndex = index.siblingAtColumn(

--- a/src/Gui/Dialogs/DlgThemeEditor.cpp
+++ b/src/Gui/Dialogs/DlgThemeEditor.cpp
@@ -422,8 +422,10 @@ public:
             painter->fillRect(option.rect, headerBackgroundColor);
             QStyledItemDelegate::paint(painter, option, index);
         }
-        else if (index.column() == StyleParametersModel::ParameterPreview
-                 && !index.data(Qt::UserRole).value<QPixmap>().isNull()) {
+        else if (
+            index.column() == StyleParametersModel::ParameterPreview
+            && !index.data(Qt::UserRole).value<QPixmap>().isNull()
+        ) {
             paintGradientPreview(painter, opt, index);
         }
         else {

--- a/src/Gui/Dialogs/DlgThemeEditor.cpp
+++ b/src/Gui/Dialogs/DlgThemeEditor.cpp
@@ -32,25 +32,90 @@
 #include <Base/ServiceProvider.h>
 #include <Base/Tools.h>
 
+#include <StyleParameters/Gradient.h>
+
 #include <ranges>
+#include <QGraphicsEffect>
+#include <QGraphicsItem>
+#include <QGraphicsScene>
+#include <QHash>
 #include <QImageReader>
+#include <QLinearGradient>
 #include <QPainter>
+#include <QRadialGradient>
 #include <QStyledItemDelegate>
 #include <QTimer>
 
+namespace
+{
+
+QPixmap applyDropShadow(const QPixmap& source)
+{
+    auto* effect = new QGraphicsDropShadowEffect;
+    effect->setBlurRadius(4);
+    effect->setOffset(QPointF(0.0, 2.0));
+    effect->setColor(QColor(0, 0, 0, 90));
+
+    auto* item = new QGraphicsPixmapItem;
+    item->setPixmap(source);
+    item->setGraphicsEffect(effect);
+
+    QGraphicsScene scene;
+    scene.addItem(item);
+
+    QPixmap result(source.size());
+    result.fill(Qt::transparent);
+    QPainter painter(&result);
+    scene.render(&painter, QRectF(QPointF(), source.size()), QRectF(QPointF(), source.size()));
+    return result;
+}
+
 QPixmap colorPreview(const QColor& color)
 {
-    constexpr qsizetype size = 16;
+    constexpr qsizetype iconSize = 24;
+    constexpr qsizetype shapeSize = 16;
+    constexpr qsizetype shapeX = 4;
+    constexpr qsizetype shapeY = 4;
 
-    QPixmap preview = Gui::BitmapFactory().empty({size, size});
+    QPixmap preview = Gui::BitmapFactory().empty({iconSize, iconSize});
 
-    QPainter painter(&preview);
-    painter.setRenderHint(QPainter::Antialiasing);
-    painter.setPen(Qt::NoPen);
-    painter.setBrush(color);
-    painter.drawEllipse(QRect {0, 0, size, size});
+    {
+        QPainter painter(&preview);
+        painter.setRenderHint(QPainter::Antialiasing);
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(color);
+        painter.drawEllipse(QRect {shapeX, shapeY, shapeSize, shapeSize});
+    }
 
-    return preview;
+    return applyDropShadow(preview);
+}
+
+QPixmap gradientPreview(const Gui::StyleParameters::Tuple& tuple)
+{
+    constexpr qsizetype iconSize = 24;
+    constexpr qsizetype shapeSize = 16;
+    constexpr qsizetype shapeX = 4;
+    constexpr qsizetype shapeY = 4;
+    constexpr int cornerRadius = 3;
+
+    QPixmap preview = Gui::BitmapFactory().empty({iconSize, iconSize});
+
+    // convertTo<QBrush> uses QGradient::ObjectMode so gradient coords [0,1]
+    // map to the bounding rect of the painted shape.
+    const QBrush brush = Base::convertTo<QBrush>(Gui::StyleParameters::Value(tuple));
+    if (brush.style() == Qt::NoBrush) {
+        return preview;
+    }
+
+    {
+        QPainter painter(&preview);
+        painter.setRenderHint(QPainter::Antialiasing);
+        painter.setPen(Qt::NoPen);
+        painter.setBrush(brush);
+        painter.drawRoundedRect(QRect {shapeX, shapeY, shapeSize, shapeSize}, cornerRadius, cornerRadius);
+    }
+
+    return applyDropShadow(preview);
 }
 
 QString typeOfTokenValue(const Gui::StyleParameters::Value& value)
@@ -67,14 +132,49 @@ QString typeOfTokenValue(const Gui::StyleParameters::Value& value)
             [](const Base::Color&) {
                 return QWidget::tr("Color");
             },
-            [](const Gui::StyleParameters::Tuple&) {
-                return QWidget::tr("Tuple");
+            [](const Gui::StyleParameters::Tuple& tuple) {
+                switch (tuple.kind) {
+                    case Gui::StyleParameters::TupleKind::LinearGradient:
+                        return QWidget::tr("Linear Gradient");
+                    case Gui::StyleParameters::TupleKind::RadialGradient:
+                        return QWidget::tr("Radial Gradient");
+                    default:
+                        return QWidget::tr("Tuple");
+                }
             }
         },
         value
     );
     // clang-format on
 }
+
+QPixmap cachedColorPreview(const QColor& color)
+{
+    static QHash<QRgb, QPixmap> cache;
+
+    const QRgb key = color.rgba();
+    if (const auto found = cache.constFind(key); found != cache.constEnd()) {
+        return *found;
+    }
+
+    return *cache.insert(key, colorPreview(color));
+}
+
+QPixmap cachedGradientPreview(const Gui::StyleParameters::Tuple& tuple)
+{
+    static QHash<QString, QPixmap> cache;
+
+    // Value::toString() spells translucent stops as rgba(...), so gradients differing only in
+    // stop transparency keep distinct cache keys.
+    const QString key = QString::fromStdString(Gui::StyleParameters::Value(tuple).toString());
+    if (const auto found = cache.constFind(key); found != cache.constEnd()) {
+        return *found;
+    }
+
+    return *cache.insert(key, gradientPreview(tuple));
+}
+
+}  // namespace
 
 namespace Gui
 {
@@ -122,6 +222,24 @@ struct StyleParametersModel::ParameterItem: Item
     QString name;
     StyleParameters::Parameter token;
     QFlags<Qt::ItemFlag> flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsEditable;
+};
+
+struct StyleParametersModel::ValueItem: Item
+{
+    ValueItem(QString name, QString expression, StyleParameters::Value value)
+        : name(std::move(name))
+        , expression(std::move(expression))
+        , value(std::move(value))
+    {}
+
+    bool isHeader() const override
+    {
+        return false;
+    }
+
+    QString name;
+    QString expression;
+    StyleParameters::Value value;
 };
 
 class StyleParametersModel::Node
@@ -284,6 +402,27 @@ public:
         painter->drawText(rect, Qt::AlignLeft | Qt::AlignVCenter, tr("New parameter…"));
     }
 
+    void paintGradientPreview(
+        QPainter* painter,
+        const QStyleOptionViewItem& option,
+        const QModelIndex& index
+    ) const
+    {
+        // Draw background and selection highlight, suppressing text and icon.
+        QStyleOptionViewItem bgOnly(option);
+        bgOnly.text.clear();
+        bgOnly.icon = QIcon();
+        bgOnly.features.setFlag(QStyleOptionViewItem::HasDecoration, false);
+        bgOnly.features.setFlag(QStyleOptionViewItem::HasDisplay, false);
+        QStyledItemDelegate::paint(painter, bgOnly, index);
+
+        // Overlay the gradient bar stretched to the cell with a small margin.
+        constexpr int margin = 3;
+        const QRect drawRect = option.rect.adjusted(margin, margin, -margin, -margin);
+        const QPixmap gradientPixmap = index.data(Qt::UserRole).value<QPixmap>();
+        painter->drawPixmap(drawRect, gradientPixmap, gradientPixmap.rect());
+    }
+
     void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override
     {
         auto model = dynamic_cast<const StyleParametersModel*>(index.model());
@@ -311,6 +450,12 @@ public:
 
             painter->fillRect(option.rect, headerBackgroundColor);
             QStyledItemDelegate::paint(painter, option, index);
+        }
+        else if (
+            index.column() == StyleParametersModel::ParameterPreview
+            && !index.data(Qt::UserRole).value<QPixmap>().isNull()
+        ) {
+            paintGradientPreview(painter, opt, index);
         }
         else {
             QStyledItemDelegate::paint(painter, option, index);
@@ -387,20 +532,11 @@ std::list<StyleParameters::Parameter> StyleParametersModel::all() const
 
 std::optional<StyleParameters::Parameter> StyleParametersModel::get(const std::string& name) const
 {
-    std::optional<StyleParameters::Parameter> result = std::nullopt;
+    if (auto it = parameterIndex.find(name); it != parameterIndex.end()) {
+        return it->second->token;
+    }
 
-    QtTools::walkTreeModel(this, [this, &name, &result](const QModelIndex& index) {
-        if (auto parameterItem = item<ParameterItem>(index)) {
-            if (parameterItem->token.name == name) {
-                result = parameterItem->token;
-                return true;
-            }
-        }
-
-        return false;
-    });
-
-    return result;
+    return std::nullopt;
 }
 
 void StyleParametersModel::removeItem(const QModelIndex& index)
@@ -413,6 +549,7 @@ void StyleParametersModel::removeItem(const QModelIndex& index)
         }
 
         groupItem->deleted.insert(parameterItem->token.name);
+        parameterIndex.erase(parameterItem->token.name);
 
         beginRemoveRows(index.parent(), index.row(), index.row());
         node(index.parent())->removeChild(index.row());
@@ -448,6 +585,22 @@ void StyleParametersModel::reset()
     }
 
     endResetModel();
+
+    // Expand tuples. We need to do this in a separate pass because resolution might require
+    // parameters that are not yet added to the model if we do it in a single pass.
+    rebuildIndex();
+    manager->reload();
+    QtTools::walkTreeModel(this, [this](const QModelIndex& index) { expandTupleIfNeeded(index); });
+}
+
+void StyleParametersModel::rebuildIndex()
+{
+    parameterIndex.clear();
+    QtTools::walkTreeModel(this, [this](const QModelIndex& index) {
+        if (auto* parameterItem = item<ParameterItem>(index)) {
+            parameterIndex.emplace(parameterItem->token.name, parameterItem);
+        }
+    });
 }
 
 void StyleParametersModel::flush()
@@ -473,6 +626,46 @@ void StyleParametersModel::flush()
     }
 
     reset();
+}
+
+void StyleParametersModel::expandTupleIfNeeded(const QModelIndex& index)
+{
+    const QModelIndex parent = index.siblingAtColumn(0);
+    if (auto parameterItem = item<ParameterItem>(parent)) {
+        if (const auto& value = manager->resolve(parameterItem->token.name)) {
+            auto* parameterNode = node(parent);
+
+            // Remove all existing children
+            if (parameterNode->childCount() > 0) {
+                beginRemoveRows(parent, 0, parameterNode->childCount() - 1);
+                while (parameterNode->childCount() > 0) {
+                    parameterNode->removeChild(0);
+                }
+                endRemoveRows();
+            }
+
+            if (value->holds<StyleParameters::Tuple>()) {
+                const auto& tuple = value->get<StyleParameters::Tuple>();
+
+                beginInsertRows(parent, 0, static_cast<int>(tuple.size()) - 1);
+                int i = 0;
+                for (const auto& [name, elementValue] : tuple.elements) {
+                    QString nameOrIndex = name ? QString::fromStdString(*name)
+                                               : QStringLiteral("%1").arg(i++);
+                    parameterNode->appendChild(
+                        std::make_unique<Node>(std::make_unique<ValueItem>(
+                            nameOrIndex,
+                            QStringLiteral("@%1.%2")
+                                .arg(QString::fromStdString(parameterItem->token.name))
+                                .arg(nameOrIndex),
+                            *elementValue
+                        ))
+                    );
+                }
+                endInsertRows();
+            }
+        }
+    }
 }
 
 int StyleParametersModel::rowCount(const QModelIndex& index) const
@@ -540,9 +733,27 @@ QVariant StyleParametersModel::data(const QModelIndex& index, int role) const
             }
         }
 
-        if (role == Qt::DecorationRole) {
-            if (index.column() == ParameterPreview && std::holds_alternative<Base::Color>(*value)) {
-                return colorPreview(std::get<Base::Color>(*value).asValue<QColor>());
+        if (role == Qt::DecorationRole && index.column() == ParameterPreview) {
+            if (const auto* color = value->tryGet<Base::Color>()) {
+                return cachedColorPreview(color->asValue<QColor>());
+            }
+            if (const auto* tuple = value->tryGet<StyleParameters::Tuple>()) {
+                if (tuple->kind == StyleParameters::TupleKind::LinearGradient
+                    || tuple->kind == StyleParameters::TupleKind::RadialGradient) {
+                    return cachedGradientPreview(*tuple);
+                }
+            }
+        }
+
+        // The delegate's paintGradientPreview() looks for the gradient bar under UserRole
+        // (see Delegate::paint()); everything else leaves this role unset, so that branch
+        // never fires for non-gradient rows.
+        if (role == Qt::UserRole && index.column() == ParameterPreview) {
+            if (const auto* tuple = value->tryGet<StyleParameters::Tuple>()) {
+                if (tuple->kind == StyleParameters::TupleKind::LinearGradient
+                    || tuple->kind == StyleParameters::TupleKind::RadialGradient) {
+                    return cachedGradientPreview(*tuple);
+                }
             }
         }
     }
@@ -550,6 +761,44 @@ QVariant StyleParametersModel::data(const QModelIndex& index, int role) const
     if (auto groupItem = item<GroupItem>(index)) {
         if (role == Qt::DisplayRole && index.column() == ParameterName) {
             return groupItem->title;
+        }
+    }
+
+    if (auto tupleElementItem = item<ValueItem>(index)) {
+        if (role == Qt::DisplayRole) {
+            if (index.column() == ParameterName) {
+                return tupleElementItem->name;
+            }
+            if (index.column() == ParameterExpression) {
+                return tupleElementItem->expression;
+            }
+            if (index.column() == ParameterType) {
+                return typeOfTokenValue(tupleElementItem->value);
+            }
+            if (index.column() == ParameterPreview) {
+                return QString::fromStdString(tupleElementItem->value.toString());
+            }
+        }
+
+        if (role == Qt::DecorationRole && index.column() == ParameterPreview) {
+            if (const auto* color = tupleElementItem->value.tryGet<Base::Color>()) {
+                return cachedColorPreview(color->asValue<QColor>());
+            }
+            if (const auto* tuple = tupleElementItem->value.tryGet<StyleParameters::Tuple>()) {
+                if (tuple->kind == StyleParameters::TupleKind::LinearGradient
+                    || tuple->kind == StyleParameters::TupleKind::RadialGradient) {
+                    return cachedGradientPreview(*tuple);
+                }
+            }
+        }
+
+        if (role == Qt::UserRole && index.column() == ParameterPreview) {
+            if (const auto* tuple = tupleElementItem->value.tryGet<StyleParameters::Tuple>()) {
+                if (tuple->kind == StyleParameters::TupleKind::LinearGradient
+                    || tuple->kind == StyleParameters::TupleKind::RadialGradient) {
+                    return cachedGradientPreview(*tuple);
+                }
+            }
         }
     }
 
@@ -573,9 +822,13 @@ bool StyleParametersModel::setData(
 
             // there is no rename operation, so we need to mark the previous token as deleted
             groupItem->deleted.insert(parameterItem->token.name);
+            parameterIndex.erase(parameterItem->token.name);
 
             parameterItem->name = newName;
             parameterItem->token = newToken;
+            // Use insert_or_assign so that renaming to a name that already exists in
+            // a lower-priority source correctly updates the index to this entry.
+            parameterIndex.insert_or_assign(newToken.name, parameterItem);
         }
 
         if (index.column() == ParameterExpression) {
@@ -601,9 +854,14 @@ bool StyleParametersModel::setData(
             int start = rowCount(index.parent());
 
             beginInsertRows(index.parent(), start, start + 1);
-            auto item = std::make_unique<Node>(std::make_unique<ParameterItem>(newName, token));
-            node(index.parent())->appendChild(std::move(item));
+            auto newNode = std::make_unique<Node>(std::make_unique<ParameterItem>(newName, token));
+            auto* newParameterItem = newNode->data<ParameterItem>();
+            node(index.parent())->appendChild(std::move(newNode));
             endInsertRows();
+            // Use insert_or_assign so that adding an override for a name that already
+            // exists in a lower-priority source correctly updates the index to point
+            // to this (higher-priority, user-editable) entry.
+            parameterIndex.insert_or_assign(token.name, newParameterItem);
 
             // this must be queued to basically next frame so widget has a chance to update
             QTimer::singleShot(0, [this, index]() { this->newParameterAdded(index); });
@@ -611,6 +869,11 @@ bool StyleParametersModel::setData(
     }
 
     this->manager->reload();
+
+    // Re-expand ALL tuples, not just the edited one: any token that references
+    // the changed token may produce a different tuple, so its ValueItem children
+    // need to be rebuilt with fresh resolved values.
+    QtTools::walkTreeModel(this, [this](const QModelIndex& index) { expandTupleIfNeeded(index); });
 
     QtTools::walkTreeModel(this, [this](const QModelIndex& index) {
         const QModelIndex previewColumnIndex = index.siblingAtColumn(ParameterPreview);
@@ -627,6 +890,10 @@ Qt::ItemFlags StyleParametersModel::flags(const QModelIndex& index) const
         if (index.column() == ParameterName || index.column() == ParameterExpression) {
             return parameterItem->flags | QAbstractItemModel::flags(index);
         }
+    }
+
+    if (item<ValueItem>(index)) {
+        return Qt::ItemIsEnabled | Qt::ItemIsSelectable;
     }
 
     if (isAddPlaceholder(index)) {
@@ -724,7 +991,10 @@ DlgThemeEditor::DlgThemeEditor(QWidget* parent)
     }
 
     ui->tokensTreeView->setColumnWidth(StyleParametersModel::ParameterName, nameColumnWidth);
-    ui->tokensTreeView->expandAll();
+
+    for (int row = 0; row < model->rowCount(QModelIndex()); ++row) {
+        ui->tokensTreeView->expand(model->index(row, 0, QModelIndex()));
+    }
 
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
@@ -739,7 +1009,9 @@ DlgThemeEditor::DlgThemeEditor(QWidget* parent)
     );
 
     connect(model.get(), &StyleParametersModel::modelReset, ui->tokensTreeView, [this] {
-        ui->tokensTreeView->expandAll();
+        for (int row = 0; row < model->rowCount(QModelIndex()); ++row) {
+            ui->tokensTreeView->expand(model->index(row, 0, QModelIndex()));
+        }
     });
     connect(model.get(), &StyleParametersModel::newParameterAdded, this, [this](const QModelIndex& index) {
         const auto newParameterExpressionIndex = index.siblingAtColumn(

--- a/src/Gui/Dialogs/DlgThemeEditor.h
+++ b/src/Gui/Dialogs/DlgThemeEditor.h
@@ -73,6 +73,7 @@ public:
     struct Item;
     struct GroupItem;
     struct ParameterItem;
+    struct ValueItem;
 
     enum Column : std::uint8_t
     {
@@ -94,6 +95,8 @@ public:
 
     void reset();
     void flush() override;
+
+    void expandTupleIfNeeded(const QModelIndex& index);
 
     int rowCount(const QModelIndex& index) const override;
     int columnCount(const QModelIndex& index) const override;

--- a/src/Gui/Dialogs/DlgThemeEditor.h
+++ b/src/Gui/Dialogs/DlgThemeEditor.h
@@ -28,6 +28,7 @@
 
 #include <QDialog>
 #include <QTreeView>
+#include <map>
 #include <optional>
 
 QT_BEGIN_NAMESPACE
@@ -128,9 +129,14 @@ Q_SIGNALS:
     void newParameterAdded(const QModelIndex& index);
 
 private:
+    void rebuildIndex();
+
     std::list<ParameterSource*> sources;
     std::unique_ptr<StyleParameters::ParameterManager> manager;
     std::unique_ptr<Node> root;
+    /// Name-to-ParameterItem index for O(log N) get() lookups.
+    /// First occurrence wins (highest-priority source is at the top of the tree).
+    std::map<std::string, ParameterItem*> parameterIndex;
 };
 
 class GuiExport DlgThemeEditor: public QDialog

--- a/src/Gui/Dialogs/DlgThemeEditor.h
+++ b/src/Gui/Dialogs/DlgThemeEditor.h
@@ -28,6 +28,7 @@
 
 #include <QDialog>
 #include <QTreeView>
+#include <map>
 #include <optional>
 
 QT_BEGIN_NAMESPACE
@@ -73,6 +74,7 @@ public:
     struct Item;
     struct GroupItem;
     struct ParameterItem;
+    struct ValueItem;
 
     enum Column : std::uint8_t
     {
@@ -94,6 +96,8 @@ public:
 
     void reset();
     void flush() override;
+
+    void expandTupleIfNeeded(const QModelIndex& index);
 
     int rowCount(const QModelIndex& index) const override;
     int columnCount(const QModelIndex& index) const override;
@@ -125,9 +129,14 @@ Q_SIGNALS:
     void newParameterAdded(const QModelIndex& index);
 
 private:
+    void rebuildIndex();
+
     std::list<ParameterSource*> sources;
     std::unique_ptr<StyleParameters::ParameterManager> manager;
     std::unique_ptr<Node> root;
+    /// Name-to-ParameterItem index for O(log N) get() lookups.
+    /// First occurrence wins (highest-priority source is at the top of the tree).
+    std::map<std::string, ParameterItem*> parameterIndex;
 };
 
 class GuiExport DlgThemeEditor: public QDialog

--- a/src/Gui/Dialogs/DlgThemeEditor.ui
+++ b/src/Gui/Dialogs/DlgThemeEditor.ui
@@ -23,6 +23,13 @@
       <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="1">
+       <widget class="QPushButton" name="pushButton">
+        <property name="text">
+         <string>PushButton</string>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="1">
        <widget class="QCheckBox" name="checkBox">
         <property name="text">
@@ -30,17 +37,20 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
-       <widget class="QScrollBar" name="horizontalScrollBar">
-        <property name="orientation">
-         <enum>Qt::Orientation::Horizontal</enum>
+      <item row="2" column="1">
+       <widget class="QRadioButton" name="radioButton">
+        <property name="text">
+         <string>RadioButton</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QSpinBox" name="spinBox"/>
+      <item row="5" column="1">
+       <widget class="QLineEdit" name="lineEdit"/>
       </item>
-      <item row="8" column="1">
+      <item row="1" column="1">
+       <widget class="Gui::ColorButton" name="colorButton"/>
+      </item>
+      <item row="11" column="1">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Orientation::Vertical</enum>
@@ -53,14 +63,7 @@
         </property>
        </spacer>
       </item>
-      <item row="2" column="1">
-       <widget class="QRadioButton" name="radioButton">
-        <property name="text">
-         <string>RadioButton</string>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="1">
+      <item row="8" column="1">
        <widget class="QComboBox" name="comboBox">
         <item>
          <property name="text">
@@ -74,14 +77,24 @@
         </item>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="pushButton">
-        <property name="text">
-         <string>PushButton</string>
+      <item row="7" column="1">
+       <widget class="QScrollBar" name="horizontalScrollBar">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="4" column="1">
+       <widget class="QSpinBox" name="spinBox"/>
+      </item>
+      <item row="9" column="1">
+       <widget class="QComboBox" name="comboBox_2">
+        <property name="editable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
        <widget class="QTabWidget" name="tabWidget">
         <widget class="QWidget" name="tab">
          <attribute name="title">
@@ -95,8 +108,8 @@
         </widget>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="Gui::ColorButton" name="colorButton"/>
+      <item row="6" column="1">
+       <widget class="QTextEdit" name="textEdit"/>
       </item>
      </layout>
     </widget>

--- a/src/Gui/StyleParameters/ColorShading.cpp
+++ b/src/Gui/StyleParameters/ColorShading.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "ColorShading.h"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+namespace Gui::StyleParameters::ColorShading
+{
+
+namespace
+{
+
+constexpr float anchorTolerance = 1e-3F;
+constexpr float minExponent = 0.1F;
+constexpr float maxExponent = 10.0F;
+constexpr float minRangeDelta = 1e-6F;
+constexpr float minPivot = 0.01F;
+constexpr float maxPivot = 0.99F;
+
+Parameters normalized(const Parameters& parameters)
+{
+    Parameters result = parameters;
+
+    result.minLightness = std::clamp(parameters.minLightness, 0.0F, 1.0F);
+    result.maxLightness = std::clamp(parameters.maxLightness, 0.0F, 1.0F);
+
+    if (result.minLightness > result.maxLightness) {
+        std::swap(result.minLightness, result.maxLightness);
+    }
+
+    result.range = std::max(parameters.range, 0.0F);
+    result.pivot = std::clamp(parameters.pivot, minPivot, maxPivot);
+    result.chromaExponent = std::clamp(parameters.chromaExponent, 0.0F, maxExponent);
+
+    return result;
+}
+
+std::pair<float, float> computeLightnessRange(float anchorLightness, const Parameters& parameters)
+{
+    float halfRange = parameters.range / 2.0F;
+    float high = std::min(parameters.maxLightness, anchorLightness + halfRange);
+    float low = std::max(parameters.minLightness, anchorLightness - halfRange);
+    return {high, low};
+}
+
+float computeExponent(float anchorLightness, float high, float low, float pivot)
+{
+    float totalRange = high - low;
+    if (totalRange < minRangeDelta) {
+        return 1.0F;
+    }
+    float ratio = (high - anchorLightness) / totalRange;
+    ratio = std::clamp(ratio, 0.01F, 0.99F);
+    float exponent = std::log(ratio) / std::log(pivot);
+    return std::clamp(exponent, minExponent, maxExponent);
+}
+
+float lightnessForPosition(float position, float exponent, float high, float low)
+{
+    return high - (high - low) * std::pow(position, exponent);
+}
+
+}  // namespace
+
+OkLch computeShade(float position, const OkLch& anchor, const Parameters& rawParameters)
+{
+    const Parameters parameters = normalized(rawParameters);
+    const float curvePosition = std::clamp(position, 0.0F, 1.0F);
+
+    if (std::abs(curvePosition - parameters.pivot) < anchorTolerance) {
+        return anchor;
+    }
+
+    auto [high, low] = computeLightnessRange(anchor.lightness, parameters);
+    float exponent = computeExponent(anchor.lightness, high, low, parameters.pivot);
+    float targetLightness = lightnessForPosition(curvePosition, exponent, high, low);
+    float darkScale = (anchor.lightness > 0.0F) ? targetLightness / anchor.lightness : 0.0F;
+    float lightScale = (anchor.lightness < 1.0F)
+        ? (1.0F - targetLightness) / (1.0F - anchor.lightness)
+        : 0.0F;
+    // curvePosition is clamped to [0,1] above, which makes targetLightness a true convex
+    // combination of low and high, so neither scale can go negative and this guard is
+    // currently unreachable. Kept as defence-in-depth in case an unbounded position ever
+    // reaches this line again (e.g. the clamp above is removed or bypassed).
+    float chromaScale
+        = std::pow(std::max(std::min(darkScale, lightScale), 0.0F), parameters.chromaExponent);
+
+    return OkLch {
+        .lightness = std::clamp(targetLightness, 0.0F, 1.0F),
+        .chroma = anchor.chroma * chromaScale,
+        .hue = anchor.hue,
+    };
+}
+
+}  // namespace Gui::StyleParameters::ColorShading
+
+// NOLINTEND(readability-magic-numbers)

--- a/src/Gui/StyleParameters/ColorShading.h
+++ b/src/Gui/StyleParameters/ColorShading.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <FCGlobal.h>
+
+#include <Base/OkLch.h>
+
+namespace Gui::StyleParameters::ColorShading
+{
+
+using Base::OkLch;
+
+struct Parameters
+{
+    float range = 0.8F;
+    float minLightness = 0.17F;
+    float maxLightness = 0.97F;
+    float pivot = 0.5F;
+    float chromaExponent = 0.5F;
+};
+
+/**
+ * @brief Returns target OkLch color for a position on the shade curve.
+ *
+ * Position 0 = lightest, 0.5 = anchor (unchanged), 1 = darkest. Position is clamped to
+ * [0, 1] before use, so a caller passing an out-of-range value (e.g. a theme author writing
+ * "shade(@color, 30)" instead of "shade(@color, 30%)") saturates at one end of the curve
+ * rather than extrapolating past it.
+ * Uses a centered power curve so that the anchor lightness maps to
+ * position 0.5, and the output lightness is clamped to [minLightness, maxLightness].
+ * Chroma is scaled proportionally to lightness to avoid oversaturation in dark shades.
+ * Parameters are sanitized internally, so callers need not pre-validate them.
+ */
+GuiExport OkLch computeShade(float position, const OkLch& anchor, const Parameters& parameters);
+
+}  // namespace Gui::StyleParameters::ColorShading

--- a/src/Gui/StyleParameters/Corners.h
+++ b/src/Gui/StyleParameters/Corners.h
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <array>
+
+#include <Base/Exception.h>
+
+#include "Value.h"
+
+namespace Gui::StyleParameters
+{
+
+/**
+ * @brief C++ wrapper providing ergonomic access to a 4-element corner radii tuple
+ *        (top_left, top_right, bottom_right, bottom_left).
+ *
+ * Unlike Insets (which represent box sides), Corners represent the four corners
+ * of a rectangle. The CSS border-radius shorthand uses diagonal pairing for 2-value
+ * expansion rather than the opposite-side pairing used by margin/padding.
+ */
+class Corners
+{
+public:
+    explicit Corners(Tuple tuple)
+        : tuple_(expand(tuple))
+    {
+        tuple_.kind = TupleKind::Corners;
+    }
+
+    const Numeric& topLeft() const
+    {
+        return tuple_.get<Numeric>("top_left");
+    }
+    const Numeric& topRight() const
+    {
+        return tuple_.get<Numeric>("top_right");
+    }
+    const Numeric& bottomRight() const
+    {
+        return tuple_.get<Numeric>("bottom_right");
+    }
+    const Numeric& bottomLeft() const
+    {
+        return tuple_.get<Numeric>("bottom_left");
+    }
+
+    static constexpr TupleKind kind()
+    {
+        return TupleKind::Corners;
+    }
+
+    /**
+     * @brief Expands a tuple using CSS border-radius shorthand rules.
+     *
+     * Uses diagonal pairing (2 values = top-left/bottom-right paired),
+     * and explicit corner name overrides. Returns a normalized 4-element
+     * tuple with Generic kind — caller sets the target kind.
+     */
+    static Tuple expand(const Tuple& args)
+    {
+        std::vector<const Value*> positional;
+        for (const auto& elem : args.elements) {
+            if (!elem.name) {
+                positional.push_back(elem.value.get());
+            }
+        }
+
+        // Single tuple argument: always expand to normalize shape.
+        if (positional.size() == 1 && positional[0]->holds<Tuple>()) {
+            return expand(positional[0]->get<Tuple>());
+        }
+
+        // CSS border-radius shorthand: diagonal pairing
+        auto [topLeft, topRight, bottomRight, bottomLeft] = [&]() -> std::array<const Value*, 4> {
+            switch (positional.size()) {
+                case 0:
+                    return {nullptr, nullptr, nullptr, nullptr};
+                case 1:
+                    return {positional[0], positional[0], positional[0], positional[0]};
+                case 2:
+                    return {positional[0], positional[1], positional[0], positional[1]};
+                case 3:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[1]};
+                case 4:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[3]};
+                default:
+                    THROWM(Base::ExpressionError, "Corners accept 1-4 positional arguments");
+            }
+        }();
+
+        // Explicit corner names override positional
+        if (const Value* found = args.find("top_left")) {
+            topLeft = found;
+        }
+        if (const Value* found = args.find("top_right")) {
+            topRight = found;
+        }
+        if (const Value* found = args.find("bottom_right")) {
+            bottomRight = found;
+        }
+        if (const Value* found = args.find("bottom_left")) {
+            bottomLeft = found;
+        }
+
+        static const Value zero = Numeric{0.0, ""};
+
+        auto makeElement = [](const char* name, const Value& val) {
+            return Tuple::Element {
+                .name = std::string(name),
+                .value = std::make_shared<const Value>(val)
+            };
+        };
+
+        Tuple result;
+        result.elements.push_back(makeElement("top_left", *topLeft));
+        result.elements.push_back(makeElement("top_right", *topRight));
+        result.elements.push_back(makeElement("bottom_right", *bottomRight));
+        result.elements.push_back(makeElement("bottom_left", *bottomLeft));
+        return result;
+    }
+
+    const Tuple& tuple() const
+    {
+        return tuple_;
+    }
+
+private:
+    Tuple tuple_;
+};
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Corners.h
+++ b/src/Gui/StyleParameters/Corners.h
@@ -126,19 +126,12 @@ public:
 
         static const Value zero = Numeric{0.0, ""};
 
-        auto makeElement = [](const char* name, const Value& val) {
-            return Tuple::Element {
-                .name = std::string(name),
-                .value = std::make_shared<const Value>(val)
-            };
-        };
-
-        Tuple result;
-        result.elements.push_back(makeElement("top_left", *topLeft));
-        result.elements.push_back(makeElement("top_right", *topRight));
-        result.elements.push_back(makeElement("bottom_right", *bottomRight));
-        result.elements.push_back(makeElement("bottom_left", *bottomLeft));
-        return result;
+        return Tuple({
+            Tuple::Element::named("top_left",     topLeft     ? *topLeft     : zero),
+            Tuple::Element::named("top_right",    topRight    ? *topRight    : zero),
+            Tuple::Element::named("bottom_right", bottomRight ? *bottomRight : zero),
+            Tuple::Element::named("bottom_left",  bottomLeft  ? *bottomLeft  : zero),
+        });
     }
 
     const Tuple& tuple() const

--- a/src/Gui/StyleParameters/Corners.h
+++ b/src/Gui/StyleParameters/Corners.h
@@ -128,13 +128,13 @@ public:
             bottomLeft = found;
         }
 
-        static const Value zero = Numeric{0.0, ""};
+        static const Value zero = Numeric {0.0, ""};
 
         return Tuple({
-            Tuple::Element::named("top_left",     topLeft     ? *topLeft     : zero),
-            Tuple::Element::named("top_right",    topRight    ? *topRight    : zero),
+            Tuple::Element::named("top_left", topLeft ? *topLeft : zero),
+            Tuple::Element::named("top_right", topRight ? *topRight : zero),
             Tuple::Element::named("bottom_right", bottomRight ? *bottomRight : zero),
-            Tuple::Element::named("bottom_left",  bottomLeft  ? *bottomLeft  : zero),
+            Tuple::Element::named("bottom_left", bottomLeft ? *bottomLeft : zero),
         });
     }
 

--- a/src/Gui/StyleParameters/Corners.h
+++ b/src/Gui/StyleParameters/Corners.h
@@ -43,6 +43,10 @@ namespace Gui::StyleParameters
 class Corners
 {
 public:
+    explicit Corners(const Value& value)
+        : Corners(asTuple(value))
+    {}
+
     explicit Corners(Tuple tuple)
         : tuple_(expand(tuple))
     {

--- a/src/Gui/StyleParameters/Corners.h
+++ b/src/Gui/StyleParameters/Corners.h
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <optional>
+
+#include "Diagnostics.h"
+#include "Value.h"
+
+namespace Gui::StyleParameters
+{
+
+/**
+ * @brief C++ wrapper providing ergonomic access to a 4-element corner radii tuple
+ *        (top_left, top_right, bottom_right, bottom_left).
+ *
+ * Unlike Insets (which represent box sides), Corners represent the four corners
+ * of a rectangle. The CSS border-radius shorthand uses diagonal pairing for 2-value
+ * expansion rather than the opposite-side pairing used by margin/padding.
+ */
+class Corners
+{
+public:
+    /// Builds corners from a value; a value that is not valid corners yields zero corners.
+    explicit Corners(const Value& value)
+        : tuple_(validated(value).value_or(zeros()))
+    {}
+
+    /// Builds corners from a raw argument tuple; an invalid tuple yields zero corners.
+    explicit Corners(Tuple tuple)
+        : Corners(Value {std::move(tuple)})
+    {}
+
+    /// Builds corners from a value, or nothing when the value is not valid corners.
+    static std::optional<Corners> tryFrom(const Value& value)
+    {
+        if (auto tuple = validated(value)) {
+            return Corners(std::move(*tuple));
+        }
+        return std::nullopt;
+    }
+
+    const Numeric& topLeft() const
+    {
+        return tuple_.get<Numeric>("top_left");
+    }
+    const Numeric& topRight() const
+    {
+        return tuple_.get<Numeric>("top_right");
+    }
+    const Numeric& bottomRight() const
+    {
+        return tuple_.get<Numeric>("bottom_right");
+    }
+    const Numeric& bottomLeft() const
+    {
+        return tuple_.get<Numeric>("bottom_left");
+    }
+
+    static constexpr TupleKind kind()
+    {
+        return TupleKind::Corners;
+    }
+
+    /**
+     * @brief Expands a tuple using CSS border-radius shorthand rules.
+     *
+     * Uses diagonal pairing (2 values = top-left/bottom-right paired) and explicit corner
+     * name overrides. Returns nothing when there are more than four positional arguments.
+     */
+    static std::optional<Tuple> expand(const Tuple& args)
+    {
+        std::vector<const Value*> positional;
+        for (const auto& element : args.elements) {
+            if (!element.name) {
+                positional.push_back(element.value.get());
+            }
+        }
+
+        // A lone tuple argument only supplies the base shape — border_radius((1px, 2px),
+        // top_left: 9px) still has to honour the outer override, so it is expanded, not returned.
+        std::optional<Tuple> nested;
+        if (positional.size() == 1 && positional[0]->holds<Tuple>()) {
+            nested = expand(positional[0]->get<Tuple>());
+            if (!nested) {
+                return std::nullopt;
+            }
+            positional.clear();
+        }
+
+        if (positional.size() > 4) {  // NOLINT(*-magic-numbers)
+            Diagnostics::report("Corners accept 1-4 positional arguments, got {}", positional.size());
+            return std::nullopt;
+        }
+
+        // CSS border-radius shorthand: diagonal pairing
+        auto [topLeft, topRight, bottomRight, bottomLeft] = [&]() -> std::array<const Value*, 4> {
+            if (nested) {
+                return {
+                    nested->find("top_left"),
+                    nested->find("top_right"),
+                    nested->find("bottom_right"),
+                    nested->find("bottom_left"),
+                };
+            }
+
+            switch (positional.size()) {
+                case 1:
+                    return {positional[0], positional[0], positional[0], positional[0]};
+                case 2:
+                    return {positional[0], positional[1], positional[0], positional[1]};
+                case 3:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[1]};
+                case 4:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[3]};
+                default:
+                    return {nullptr, nullptr, nullptr, nullptr};
+            }
+        }();
+
+        // Explicit corner names override positional
+        if (const Value* found = args.find("top_left")) {
+            topLeft = found;
+        }
+        if (const Value* found = args.find("top_right")) {
+            topRight = found;
+        }
+        if (const Value* found = args.find("bottom_right")) {
+            bottomRight = found;
+        }
+        if (const Value* found = args.find("bottom_left")) {
+            bottomLeft = found;
+        }
+
+        static const Value zero {styleDefault<Numeric>()};
+
+        // clang-format off
+        return Tuple({
+            Element::named("top_left",     topLeft     ? *topLeft     : zero),
+            Element::named("top_right",    topRight    ? *topRight    : zero),
+            Element::named("bottom_right", bottomRight ? *bottomRight : zero),
+            Element::named("bottom_left",  bottomLeft  ? *bottomLeft  : zero),
+        });
+        // clang-format on
+    }
+
+    const Tuple& tuple() const
+    {
+        return tuple_;
+    }
+
+private:
+    /**
+     * @brief Normalizes and fully validates a value as corners.
+     *
+     * Accepts a Generic tuple or an existing Corners tuple only — unlike the edge kinds,
+     * Corners has no sibling kinds it coerces with, so anything else (Padding, a gradient,
+     * ...) is rejected outright. Otherwise such a tuple would silently backfill as all-zero
+     * corners with no diagnostic, since expand() fills missing corner names with zeros
+     * regardless of what the tuple actually was. What remains is checking that every corner
+     * resolves to a Numeric, which separately rejects same-shaped-but-mistyped input.
+     */
+    static std::optional<Tuple> validated(const Value& value)
+    {
+        const Tuple source = asTuple(value);
+
+        if (source.kind != TupleKind::Generic && source.kind != TupleKind::Corners) {
+            Diagnostics::report(
+                "Expected {} tuple, got {}",
+                tupleKindName(TupleKind::Corners),
+                tupleKindName(source.kind)
+            );
+            return std::nullopt;
+        }
+
+        auto expanded = expand(source);
+        if (!expanded) {
+            return std::nullopt;
+        }
+
+        for (const char* corner : {"top_left", "top_right", "bottom_right", "bottom_left"}) {
+            if (!expanded->tryGetOrReport<Numeric>(corner)) {
+                return std::nullopt;
+            }
+        }
+
+        expanded->kind = TupleKind::Corners;
+        return expanded;
+    }
+
+    /// All-zero corners, used when a value cannot be interpreted as corners.
+    static Tuple zeros()
+    {
+        Tuple result = *expand(Tuple {});
+        result.kind = TupleKind::Corners;
+        return result;
+    }
+
+    Tuple tuple_;
+};
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Diagnostics.cpp
+++ b/src/Gui/StyleParameters/Diagnostics.cpp
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "Diagnostics.h"
+
+#include <map>
+#include <ranges>
+#include <unordered_set>
+#include <vector>
+
+#include <Base/Console.h>
+
+namespace Gui::StyleParameters
+{
+
+namespace
+{
+
+std::map<std::size_t, Diagnostics::Observer>& observers()
+{
+    static std::map<std::size_t, Diagnostics::Observer> instance;
+    return instance;
+}
+
+std::unordered_set<std::string>& alreadyReported()
+{
+    static std::unordered_set<std::string> instance;
+    return instance;
+}
+
+std::size_t nextObserverId()
+{
+    static std::size_t counter = 0;
+    return ++counter;
+}
+
+/// Names of tokens currently being resolved, innermost last.
+std::vector<std::string>& resolutionScopes()
+{
+    static std::vector<std::string> instance;
+    return instance;
+}
+
+}  // namespace
+
+Diagnostics::ResolutionScope::ResolutionScope(std::string tokenName)
+{
+    resolutionScopes().push_back(std::move(tokenName));
+}
+
+Diagnostics::ResolutionScope::~ResolutionScope()
+{
+    resolutionScopes().pop_back();
+}
+
+void Diagnostics::Subscription::reset()
+{
+    if (id_ != 0) {
+        Diagnostics::remove(id_);
+        id_ = 0;
+    }
+}
+
+Diagnostics::Subscription Diagnostics::observe(Observer observer)
+{
+    const std::size_t id = nextObserverId();
+    observers().emplace(id, std::move(observer));
+    return Subscription(id);
+}
+
+void Diagnostics::remove(std::size_t id)
+{
+    observers().erase(id);
+}
+
+void Diagnostics::clear()
+{
+    alreadyReported().clear();
+}
+
+void Diagnostics::emit(const std::string& message)
+{
+    const auto& scopes = resolutionScopes();
+    const std::string prefixed = scopes.empty() ? message : (scopes.back() + ": " + message);
+
+    if (!alreadyReported().insert(prefixed).second) {
+        return;
+    }
+
+    Base::Console().developerWarning("StyleParameters", "%s\n", prefixed);
+
+    for (const auto& observer : observers() | std::views::values) {
+        try {
+            observer(prefixed);
+        }
+        catch (...) {
+            // An observer must never break the totality of the code that reported.
+        }
+    }
+}
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Diagnostics.h
+++ b/src/Gui/StyleParameters/Diagnostics.h
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <utility>
+
+#include <fmt/format.h>
+
+#include <FCGlobal.h>
+
+namespace Gui::StyleParameters
+{
+
+/**
+ * @brief Reports style parameter values that could not be produced as requested.
+ *
+ * Style parameter access is total: a request that cannot be satisfied yields a default
+ * instead of failing. Every such substitution is reported here so that the mishap stays
+ * visible to whoever authored the theme.
+ */
+class GuiExport Diagnostics
+{
+public:
+    using Observer = std::function<void(const std::string&)>;
+
+    /// Keeps an observer registered until destroyed.
+    class GuiExport Subscription
+    {
+    public:
+        Subscription() = default;
+        explicit Subscription(std::size_t id)
+            : id_(id)
+        {}
+        ~Subscription()
+        {
+            reset();
+        }
+
+        Subscription(const Subscription&) = delete;
+        Subscription& operator=(const Subscription&) = delete;
+
+        Subscription(Subscription&& other) noexcept
+            : id_(std::exchange(other.id_, 0))
+        {}
+
+        Subscription& operator=(Subscription&& other) noexcept
+        {
+            if (this != &other) {
+                reset();
+                id_ = std::exchange(other.id_, 0);
+            }
+            return *this;
+        }
+
+    private:
+        void reset();
+
+        std::size_t id_ = 0;
+    };
+
+    /**
+     * @brief Registers an observer for the lifetime of the returned handle.
+     *
+     * The observer must not call observe() again, nor destroy a live Subscription, from
+     * within its own callback — report() is not reentrant with respect to the observer list.
+     */
+    [[nodiscard]] static Subscription observe(Observer observer);
+
+    /**
+     * @brief Names the token currently being resolved, so reports made while this scope is
+     *        active are prefixed with it.
+     *
+     * Without a diagnostic naming which token produced it, a mishap that degrades silently
+     * (rather than throwing) reports only the element and its type, and identical defects in
+     * two different tokens dedup into a single, anonymous message. Scopes nest — resolving one
+     * token can require resolving another — and a report is prefixed with the innermost active
+     * scope.
+     */
+    class GuiExport ResolutionScope
+    {
+    public:
+        explicit ResolutionScope(std::string tokenName);
+        ~ResolutionScope();
+
+        ResolutionScope(const ResolutionScope&) = delete;
+        ResolutionScope& operator=(const ResolutionScope&) = delete;
+        ResolutionScope(ResolutionScope&&) = delete;
+        ResolutionScope& operator=(ResolutionScope&&) = delete;
+    };
+
+    /// Reports a mishap. Messages already reported since the last clear() are dropped.
+    template<typename... Args>
+    static void report(fmt::format_string<Args...> format, Args&&... args)
+    {
+        emit(fmt::format(format, std::forward<Args>(args)...));
+    }
+
+    /// Forgets which messages have already been reported.
+    static void clear();
+
+private:
+    static void emit(const std::string& message);
+    static void remove(std::size_t id);
+};
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Edges.h
+++ b/src/Gui/StyleParameters/Edges.h
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <concepts>
+
+#include <Base/Exception.h>
+#include <fmt/format.h>
+
+#include "Value.h"
+
+namespace Gui::StyleParameters
+{
+
+/**
+ * @brief Generic 4-side (top, right, bottom, left) CSS box-model wrapper.
+ *
+ * Owns a 4-element Tuple and provides typed accessors for each side.
+ * @p expand() handles CSS 1–4 arg shorthand and named group arguments
+ * (vertical, horizontal, top, right, bottom, left). Subclasses add
+ * kind-specific validation via the protected constructor.
+ */
+template<typename T>
+class Edges
+{
+public:
+    explicit Edges(Tuple tuple)
+        : tuple_(std::move(tuple))
+    {}
+
+    explicit Edges(const Value& value)
+        : tuple_([&value]() -> Tuple {
+            if (value.holds<Tuple>()) {
+                const auto& tuple = value.get<Tuple>();
+                return tuple.kind == TupleKind::Generic ? expand(tuple) : tuple;
+            }
+            return expand(asTuple(value));
+        }())
+    {}
+
+    const T& top() const
+    {
+        return tuple_.get<T>("top");
+    }
+    const T& right() const
+    {
+        return tuple_.get<T>("right");
+    }
+    const T& bottom() const
+    {
+        return tuple_.get<T>("bottom");
+    }
+    const T& left() const
+    {
+        return tuple_.get<T>("left");
+    }
+
+    Numeric horizontal() const
+        requires std::same_as<T, Numeric>
+    {
+        return left() + right();
+    }
+
+    Numeric vertical() const
+        requires std::same_as<T, Numeric>
+    {
+        return top() + bottom();
+    }
+
+    const Tuple& tuple() const
+    {
+        return tuple_;
+    }
+
+    /**
+     * @brief Expands a tuple using CSS box-model shorthand rules.
+     *
+     * Handles positional shorthand (1-4 args), group names (vertical, horizontal),
+     * and explicit side overrides (top, right, bottom, left). Returns a normalized
+     * 4-element tuple with Generic kind — caller sets the target kind.
+     */
+    static Tuple expand(const Tuple& args)
+    {
+        std::vector<const Value*> positional;
+        for (const auto& elem : args.elements) {
+            if (!elem.name) {
+                positional.push_back(elem.value.get());
+            }
+        }
+
+        // Single tuple argument: always expand to normalize shape.
+        if (positional.size() == 1 && positional[0]->holds<Tuple>()) {
+            return expand(positional[0]->get<Tuple>());
+        }
+
+        // CSS box-model shorthand: top, right, bottom, left
+        auto [top, right, bottom, left] = [&]() -> std::array<const Value*, 4> {
+            switch (positional.size()) {
+                case 0:
+                    return {nullptr, nullptr, nullptr, nullptr};
+                case 1:
+                    return {positional[0], positional[0], positional[0], positional[0]};
+                case 2:
+                    return {positional[0], positional[1], positional[0], positional[1]};
+                case 3:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[1]};
+                case 4:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[3]};
+                default:
+                    THROWM(Base::ExpressionError, "Edges accept 1-4 positional arguments");
+            }
+        }();
+
+        // Group names override positional
+        if (const Value* vertical = args.find("vertical")) {
+            top = bottom = vertical;
+        }
+        if (const Value* horizontal = args.find("horizontal")) {
+            right = left = horizontal;
+        }
+
+        // Explicit side names override everything
+        if (const Value* found = args.find("top")) {
+            top = found;
+        }
+        if (const Value* found = args.find("right")) {
+            right = found;
+        }
+        if (const Value* found = args.find("bottom")) {
+            bottom = found;
+        }
+        if (const Value* found = args.find("left")) {
+            left = found;
+        }
+
+        // clang-format off
+        static const Value zero = []() -> Value {
+            if constexpr (std::is_same_v<T, Numeric>) { return Numeric{0.0, ""}; }
+            else                                       { return Base::Color{0.0f, 0.0f, 0.0f, 0.0f}; }
+        }();
+        // clang-format on
+
+        return Tuple({
+            Tuple::Element::named("top",    top    ? *top    : zero),
+            Tuple::Element::named("right",  right  ? *right  : zero),
+            Tuple::Element::named("bottom", bottom ? *bottom : zero),
+            Tuple::Element::named("left",   left   ? *left   : zero),
+        });
+    }
+
+protected:
+    explicit Edges(Tuple tuple, TupleKind expected)
+        : tuple_(expand(tuple))
+    {
+        tuple_.kind = expected;
+    }
+
+private:
+    Tuple tuple_;
+};
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Edges.h
+++ b/src/Gui/StyleParameters/Edges.h
@@ -163,10 +163,10 @@ public:
         // clang-format on
 
         return Tuple({
-            Tuple::Element::named("top",    top    ? *top    : zero),
-            Tuple::Element::named("right",  right  ? *right  : zero),
+            Tuple::Element::named("top", top ? *top : zero),
+            Tuple::Element::named("right", right ? *right : zero),
             Tuple::Element::named("bottom", bottom ? *bottom : zero),
-            Tuple::Element::named("left",   left   ? *left   : zero),
+            Tuple::Element::named("left", left ? *left : zero),
         });
     }
 

--- a/src/Gui/StyleParameters/Edges.h
+++ b/src/Gui/StyleParameters/Edges.h
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <concepts>
+#include <optional>
+
+#include <fmt/format.h>
+
+#include "Diagnostics.h"
+#include "Value.h"
+
+namespace Gui::StyleParameters
+{
+
+/**
+ * @brief Generic 4-side (top, right, bottom, left) CSS box-model wrapper.
+ *
+ * Owns a 4-element Tuple and provides typed accessors for each side.
+ * @p expand() handles CSS 1–4 arg shorthand and named group arguments
+ * (vertical, horizontal, top, right, bottom, left). Subclasses add
+ * kind-specific validation via the protected constructor.
+ */
+template<typename T>
+class Edges
+{
+public:
+    /// Builds edges from any value; a value that is not valid edges yields zero edges.
+    explicit Edges(const Value& value)
+        : tuple_(validated(value, std::nullopt).value_or(zeros(std::nullopt)))
+    {}
+
+    /// Builds edges from a value, or nothing when the value is not valid edges.
+    static std::optional<Edges> tryFrom(const Value& value)
+    {
+        if (auto tuple = validated(value, std::nullopt)) {
+            return Edges(std::move(*tuple));
+        }
+        return std::nullopt;
+    }
+
+    const T& top() const
+    {
+        return tuple_.get<T>("top");
+    }
+    const T& right() const
+    {
+        return tuple_.get<T>("right");
+    }
+    const T& bottom() const
+    {
+        return tuple_.get<T>("bottom");
+    }
+    const T& left() const
+    {
+        return tuple_.get<T>("left");
+    }
+
+    Numeric horizontal() const
+        requires std::same_as<T, Numeric>
+    {
+        return left() + right();
+    }
+
+    Numeric vertical() const
+        requires std::same_as<T, Numeric>
+    {
+        return top() + bottom();
+    }
+
+    const Tuple& tuple() const
+    {
+        return tuple_;
+    }
+
+    /**
+     * @brief Expands a tuple using CSS box-model shorthand rules.
+     *
+     * Handles positional shorthand (1-4 args), group names (vertical, horizontal),
+     * and explicit side overrides. Returns nothing when there are more than four
+     * positional arguments.
+     */
+    static std::optional<Tuple> expand(const Tuple& args)
+    {
+        std::vector<const Value*> positional;
+        for (const auto& element : args.elements) {
+            if (!element.name) {
+                positional.push_back(element.value.get());
+            }
+        }
+
+        // A lone tuple argument only supplies the base shape — padding((1px, 2px), top: 9px)
+        // still has to honour the outer override, so it is expanded, not returned.
+        std::optional<Tuple> nested;
+        if (positional.size() == 1 && positional[0]->holds<Tuple>()) {
+            nested = expand(positional[0]->get<Tuple>());
+            if (!nested) {
+                return std::nullopt;
+            }
+            positional.clear();
+        }
+
+        if (positional.size() > 4) {  // NOLINT(*-magic-numbers)
+            Diagnostics::report("Edges accept 1-4 positional arguments, got {}", positional.size());
+            return std::nullopt;
+        }
+
+        // CSS box-model shorthand: top, right, bottom, left
+        auto [top, right, bottom, left] = [&]() -> std::array<const Value*, 4> {
+            if (nested) {
+                return {
+                    nested->find("top"),
+                    nested->find("right"),
+                    nested->find("bottom"),
+                    nested->find("left"),
+                };
+            }
+
+            switch (positional.size()) {
+                case 1:
+                    return {positional[0], positional[0], positional[0], positional[0]};
+                case 2:
+                    return {positional[0], positional[1], positional[0], positional[1]};
+                case 3:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[1]};
+                case 4:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[3]};
+                default:
+                    return {nullptr, nullptr, nullptr, nullptr};
+            }
+        }();
+
+        // Group names override positional
+        if (const Value* vertical = args.find("vertical")) {
+            top = bottom = vertical;
+        }
+        if (const Value* horizontal = args.find("horizontal")) {
+            right = left = horizontal;
+        }
+
+        // Explicit side names override everything
+        if (const Value* found = args.find("top")) {
+            top = found;
+        }
+        if (const Value* found = args.find("right")) {
+            right = found;
+        }
+        if (const Value* found = args.find("bottom")) {
+            bottom = found;
+        }
+        if (const Value* found = args.find("left")) {
+            left = found;
+        }
+
+        static const Value zero {styleDefault<T>()};
+
+        return Tuple({
+            Element::named("top", top ? *top : zero),
+            Element::named("right", right ? *right : zero),
+            Element::named("bottom", bottom ? *bottom : zero),
+            Element::named("left", left ? *left : zero),
+        });
+    }
+
+protected:
+    /**
+     * @brief Normalizes and fully validates a value as edges of the given kind.
+     *
+     * Accepts a Generic tuple or any of the four edge kinds (Padding, Margins,
+     * BorderThickness, BorderColors) — they share the four-sided box shape and coerce
+     * between each other, e.g. a Margins token reads correctly as Padding. Anything else
+     * (Corners, a gradient, ...) is rejected outright, since such a tuple would otherwise
+     * silently backfill as all-zero edges with no side actually resolved from it. What
+     * remains is checking that every side resolves to a T, which is what separately
+     * rejects same-shaped-but-mistyped input such as border_colors(...) passed where
+     * padding(...) is expected. Passing no expected kind leaves the kind untouched;
+     * otherwise the result is retagged with it.
+     */
+    static std::optional<Tuple> validated(const Value& value, std::optional<TupleKind> expectedKind)
+    {
+        const Tuple source = asTuple(value);
+
+        if (source.kind != TupleKind::Generic && !isEdgeKind(source.kind)) {
+            Diagnostics::report(
+                "Expected {} tuple, got {}",
+                expectedKind ? tupleKindName(*expectedKind) : "edges",
+                tupleKindName(source.kind)
+            );
+            return std::nullopt;
+        }
+
+        auto expanded = expand(source);
+        if (!expanded) {
+            return std::nullopt;
+        }
+
+        for (const char* side : {"top", "right", "bottom", "left"}) {
+            if (!expanded->tryGetOrReport<T>(side)) {
+                return std::nullopt;
+            }
+        }
+
+        if (expectedKind) {
+            expanded->kind = *expectedKind;
+        }
+
+        return expanded;
+    }
+
+    /// All-zero edges, used when a value cannot be interpreted as edges.
+    static Tuple zeros(std::optional<TupleKind> kind)
+    {
+        Tuple result = *expand(Tuple {});
+        if (kind) {
+            result.kind = *kind;
+        }
+        return result;
+    }
+
+    /// Expands and fully validates a raw argument tuple, tagging it with the given kind.
+    explicit Edges(Tuple tuple, TupleKind expected)
+        : tuple_(validated(Value {std::move(tuple)}, expected).value_or(zeros(expected)))
+    {}
+
+    /**
+     * @brief Wraps a tuple that validated() has already accepted.
+     *
+     * Not public: holding an Edges must imply its tuple is well formed, so the only way in
+     * from outside is through a validating entry point — tryFrom, or the Value constructor.
+     */
+    explicit Edges(Tuple tuple)
+        : tuple_(std::move(tuple))
+    {}
+
+private:
+    Tuple tuple_;
+};
+
+/**
+ * @brief Adds kind identity to an Edges specialization.
+ *
+ * A concrete edge type states only which TupleKind it is; construction, validation and
+ * the tryFrom factory come from here.
+ */
+template<typename Derived, typename T, TupleKind Kind>
+class TypedEdges: public Edges<T>
+{
+public:
+    /// Wraps a raw argument tuple, expanding shorthand and tagging it with this kind.
+    explicit TypedEdges(Tuple tuple)
+        : Edges<T>(std::move(tuple), Kind)
+    {
+        assertUsedAsCrtpBase();
+    }
+
+    /// Total: a value that is not valid edges of this kind yields zero edges.
+    explicit TypedEdges(const Value& value)
+        : Edges<T>(Edges<T>::validated(value, Kind).value_or(Edges<T>::zeros(Kind)))
+    {
+        assertUsedAsCrtpBase();
+    }
+
+    /// Builds this kind from a value, or nothing when the value is not that shape.
+    static std::optional<Derived> tryFrom(const Value& value)
+    {
+        if (auto tuple = Edges<T>::validated(value, Kind)) {
+            return Derived(std::move(*tuple));
+        }
+        return std::nullopt;
+    }
+
+    static constexpr TupleKind kind()
+    {
+        return Kind;
+    }
+
+private:
+    /**
+     * @brief Rejects instantiating this template other than as Derived's own base.
+     *
+     * Without it, TypedEdges<Padding, Numeric, TupleKind::Corners> is publicly constructible
+     * and validates a tuple as edges before tagging it Corners — a mislabelled tuple no
+     * accessor would catch. Checked from the constructor bodies, where Derived is complete.
+     */
+    static constexpr void assertUsedAsCrtpBase()
+    {
+        static_assert(
+            std::is_base_of_v<TypedEdges, Derived>,
+            "TypedEdges may only be instantiated as the base of the kind it names"
+        );
+    }
+};
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Gradient.h
+++ b/src/Gui/StyleParameters/Gradient.h
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <algorithm>
+#include <vector>
+
+#include <Base/Exception.h>
+#include <fmt/format.h>
+
+#include "Value.h"
+
+namespace Gui::StyleParameters
+{
+
+/**
+ * @brief Represents a single color stop in a gradient.
+ */
+struct ColorStop
+{
+    Numeric position;
+    Base::Color color;
+};
+
+/**
+ * @brief Base class for gradient tuple wrappers.
+ *
+ * Gradients are stored as typed Tuples with named geometry elements
+ * (e.g. x1, y1, x2, y2 for linear) and a named "stops" element
+ * containing a Tuple of (position, color) sub-tuples.
+ *
+ * Gradients must be created via parser functions (linear_gradient,
+ * radial_gradient) — Generic tuples do NOT auto-expand to gradients
+ * unless explicitly constructed via the wrapper class.
+ */
+class Gradient
+{
+public:
+    /**
+     * @brief Returns the stops sub-tuple.
+     */
+    const Tuple& stops() const
+    {
+        return tuple_.get<Tuple>("stops");
+    }
+
+    /**
+     * @brief Extracts structured color stops from the tuple.
+     */
+    std::vector<ColorStop> colorStops() const
+    {
+        std::vector<ColorStop> result;
+        const auto& stopsTuple = stops();
+        for (size_t index = 0; index < stopsTuple.size(); ++index) {
+            const auto& stopEntry = stopsTuple.at(index).get<Tuple>();
+            result.push_back({
+                .position = stopEntry.at(0).get<Numeric>(),
+                .color = stopEntry.at(1).get<Base::Color>(),
+            });
+        }
+        return result;
+    }
+
+    const Tuple& tuple() const
+    {
+        return tuple_;
+    }
+
+protected:
+    Gradient(Tuple tuple, TupleKind expected)
+        : tuple_(std::move(tuple))
+    {
+        if (tuple_.kind != expected) {
+            THROWM(
+                Base::TypeError,
+                fmt::format(
+                    "Expected {} tuple, got {}",
+                    tupleKindName(expected),
+                    tupleKindName(tuple_.kind)
+                )
+            );
+        }
+    }
+
+    /**
+     * @brief Extracts a numeric value from a found element, using the default when absent.
+     *
+     * @throws Base::ExpressionError if the value is present but not Numeric.
+     */
+    static double numericOrDefault(const Value* found, const char* paramName, double defaultValue)
+    {
+        if (!found) {
+            return defaultValue;
+        }
+        if (!found->holds<Numeric>()) {
+            THROWM(
+                Base::ExpressionError,
+                fmt::format("Gradient geometry parameter '{}' must be a number", paramName)
+            );
+        }
+        return found->get<Numeric>().value;
+    }
+
+    /**
+     * @brief Creates a geometry element with a default value.
+     *
+     * Looks up a named element in the args tuple and uses the provided
+     * default if not found.
+     */
+    static Tuple::Element makeGeometryElement(const char* name, double defaultValue, const Tuple& args)
+    {
+        const Value* found = args.find(name);
+        double value = found ? found->get<Numeric>().value : defaultValue;
+        return Tuple::Element {
+            .name = std::string(name),
+            .value = std::make_shared<const Value>(Numeric {.value = value, .unit = ""}),
+        };
+    }
+
+    /**
+     * @brief Builds the "stops" element from positional arguments.
+     *
+     * Processes positional args from the function call:
+     * - Bare Color values become auto-positioned stops
+     * - Tuple(Numeric, Color) values become explicit stops
+     *
+     * Auto-positioning distributes bare colors evenly from 0 to 1
+     * based on their index in the total stop list.
+     * Stops are sorted by position after processing.
+     *
+     * @throws Base::ExpressionError if fewer than 2 stops or invalid stop format.
+     */
+    static Tuple::Element buildStopsElement(const Tuple& args)
+    {
+        struct RawStop
+        {
+            std::optional<double> position;
+            Base::Color color;
+        };
+
+        std::vector<RawStop> rawStops;
+
+        for (const auto& element : args.elements) {
+            if (element.name) {
+                continue;  // named args are geometry, skip
+            }
+
+            const Value& value = *element.value;
+
+            if (value.holds<Base::Color>()) {
+                rawStops.push_back({
+                    .position = std::nullopt,
+                    .color = value.get<Base::Color>(),
+                });
+            }
+            else if (value.holds<Tuple>()) {
+                const auto& stopTuple = value.get<Tuple>();
+                if (stopTuple.size() != 2 || !stopTuple.at(0).holds<Numeric>()
+                    || !stopTuple.at(1).holds<Base::Color>()) {
+                    THROWM(Base::ExpressionError, "Gradient stop tuple must be (position, color)");
+                }
+                rawStops.push_back({
+                    .position = stopTuple.at(0).get<Numeric>().value,
+                    .color = stopTuple.at(1).get<Base::Color>(),
+                });
+            }
+            else {
+                THROWM(
+                    Base::ExpressionError,
+                    "Gradient arguments must be colors or (position, color) tuples"
+                );
+            }
+        }
+
+        if (rawStops.size() < 2) {
+            THROWM(Base::ExpressionError, "Gradient requires at least 2 color stops");
+        }
+
+        // Auto-distribute positions for bare colors
+        for (size_t index = 0; index < rawStops.size(); ++index) {
+            if (!rawStops[index].position) {
+                rawStops[index].position = static_cast<double>(index)
+                    / static_cast<double>(rawStops.size() - 1);
+            }
+        }
+
+        // Sort stops by position
+        std::ranges::sort(rawStops, [](const RawStop& left, const RawStop& right) {
+            return *left.position < *right.position;
+        });
+
+        // Build stops tuple
+        Tuple stopsTuple;
+        for (const auto& stop : rawStops) {
+            Tuple stopEntry;
+            stopEntry.elements.push_back({
+                .name = std::nullopt,
+                .value = std::make_shared<const Value>(Numeric {.value = *stop.position, .unit = ""}),
+            });
+            stopEntry.elements.push_back({
+                .name = std::nullopt,
+                .value = std::make_shared<const Value>(stop.color),
+            });
+            stopsTuple.elements.push_back({
+                .name = std::nullopt,
+                .value = std::make_shared<const Value>(std::move(stopEntry)),
+            });
+        }
+
+        return Tuple::Element {
+            .name = std::string("stops"),
+            .value = std::make_shared<const Value>(std::move(stopsTuple)),
+        };
+    }
+
+    Tuple tuple_;
+};
+
+/**
+ * @brief Wrapper for LinearGradient tuples.
+ *
+ * Geometry: x1, y1, x2, y2 (defaults: 0, 0, 0, 1 = top to bottom).
+ * Plus a "stops" element containing color stop sub-tuples.
+ */
+class LinearGradient: public Gradient
+{
+public:
+    explicit LinearGradient(Tuple tuple)
+        : Gradient(
+              tuple.kind == TupleKind::Generic ? expand(tuple) : std::move(tuple),
+              TupleKind::LinearGradient
+          )
+    {}
+
+    double x1() const
+    {
+        return tuple_.get<Numeric>("x1").value;
+    }
+    double y1() const
+    {
+        return tuple_.get<Numeric>("y1").value;
+    }
+    double x2() const
+    {
+        return tuple_.get<Numeric>("x2").value;
+    }
+    double y2() const
+    {
+        return tuple_.get<Numeric>("y2").value;
+    }
+
+    static constexpr TupleKind kind()
+    {
+        return TupleKind::LinearGradient;
+    }
+
+private:
+    static Tuple expand(const Tuple& args)
+    {
+        Tuple result;
+        result.kind = TupleKind::LinearGradient;
+        result.elements.push_back(makeGeometryElement("x1", 0.0, args));
+        result.elements.push_back(makeGeometryElement("y1", 0.0, args));
+        result.elements.push_back(makeGeometryElement("x2", 0.0, args));
+        result.elements.push_back(makeGeometryElement("y2", 1.0, args));
+        result.elements.push_back(buildStopsElement(args));
+        return result;
+    }
+};
+
+/**
+ * @brief Wrapper for RadialGradient tuples.
+ *
+ * Geometry: cx, cy, radius, fx, fy (defaults: 0.5, 0.5, 0.5, cx, cy).
+ * fx and fy default to cx and cy respectively when not specified.
+ * Plus a "stops" element containing color stop sub-tuples.
+ */
+class RadialGradient: public Gradient
+{
+public:
+    explicit RadialGradient(Tuple tuple)
+        : Gradient(
+              tuple.kind == TupleKind::Generic ? expand(tuple) : std::move(tuple),
+              TupleKind::RadialGradient
+          )
+    {}
+
+    double cx() const
+    {
+        return tuple_.get<Numeric>("cx").value;
+    }
+    double cy() const
+    {
+        return tuple_.get<Numeric>("cy").value;
+    }
+    double radius() const
+    {
+        return tuple_.get<Numeric>("radius").value;
+    }
+    double fx() const
+    {
+        return tuple_.get<Numeric>("fx").value;
+    }
+    double fy() const
+    {
+        return tuple_.get<Numeric>("fy").value;
+    }
+
+    static constexpr TupleKind kind()
+    {
+        return TupleKind::RadialGradient;
+    }
+
+private:
+    static Tuple expand(const Tuple& args)
+    {
+        // fx defaults to cx, fy defaults to cy
+        constexpr double defaultCenter = 0.5;
+        constexpr double defaultRadius = 0.5;
+
+        double cxValue = numericOrDefault(args.find("cx"), "cx", defaultCenter);
+        double cyValue = numericOrDefault(args.find("cy"), "cy", defaultCenter);
+        double fxValue = numericOrDefault(args.find("fx"), "fx", cxValue);
+        double fyValue = numericOrDefault(args.find("fy"), "fy", cyValue);
+
+        Tuple result;
+        result.kind = TupleKind::RadialGradient;
+        result.elements.push_back(makeGeometryElement("cx", defaultCenter, args));
+        result.elements.push_back(makeGeometryElement("cy", defaultCenter, args));
+        result.elements.push_back(makeGeometryElement("radius", defaultRadius, args));
+        result.elements.push_back({
+            .name = std::string("fx"),
+            .value = std::make_shared<const Value>(Numeric {.value = fxValue, .unit = ""}),
+        });
+        result.elements.push_back({
+            .name = std::string("fy"),
+            .value = std::make_shared<const Value>(Numeric {.value = fyValue, .unit = ""}),
+        });
+        result.elements.push_back(buildStopsElement(args));
+        return result;
+    }
+};
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Gradient.h
+++ b/src/Gui/StyleParameters/Gradient.h
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <ranges>
 #include <vector>
 
 #include <Base/Exception.h>
@@ -73,8 +74,8 @@ public:
     {
         std::vector<ColorStop> result;
         const auto& stopsTuple = stops();
-        for (size_t index = 0; index < stopsTuple.size(); ++index) {
-            const auto& stopEntry = stopsTuple.at(index).get<Tuple>();
+        for (const auto& stop : stopsTuple.elements) {
+            const auto& stopEntry = stop.value->get<Tuple>();
             result.push_back({
                 .position = stopEntry.at(0).get<Numeric>(),
                 .color = stopEntry.at(1).get<Base::Color>(),
@@ -107,31 +108,39 @@ public:
         const std::function<Base::Color(const Base::Color&)>& transform
     )
     {
+        auto makeStopTuple = [](Numeric position, Base::Color color) {
+            return Tuple({
+                Tuple::Element::unnamed(position),
+                Tuple::Element::unnamed(color),
+            });
+        };
+
+        auto transformStop = [&](const Tuple::Element& stop) {
+            const auto& stopEntry = stop.value->get<Tuple>();
+            return Tuple::Element::unnamed(makeStopTuple(
+                stopEntry.at(0).get<Numeric>(),
+                transform(stopEntry.at(1).get<Base::Color>())
+            ));
+        };
+
+        auto transformElement = [&](const Tuple::Element& element) -> Tuple::Element {
+            if (element.name != "stops") {
+                return element;
+            }
+
+            const auto& stopsTuple = element.value->get<Tuple>();
+            Tuple transformedStops;
+            std::ranges::transform(
+                stopsTuple.elements,
+                std::back_inserter(transformedStops.elements),
+                transformStop
+            );
+            return Tuple::Element::named("stops", std::move(transformedStops));
+        };
+
         Tuple result;
         result.kind = gradient.kind;
-
-        for (const auto& element : gradient.elements) {
-            if (element.name == "stops") {
-                const auto& stopsTuple = element.value->get<Tuple>();
-                Tuple transformedStops;
-
-                for (const auto& stop : stopsTuple.elements) {
-                    const auto& stopEntry = stop.value->get<Tuple>();
-                    transformedStops.elements.push_back(
-                        Tuple::Element::unnamed(Tuple({
-                            Tuple::Element::unnamed(stopEntry.at(0).get<Numeric>()),
-                            Tuple::Element::unnamed(transform(stopEntry.at(1).get<Base::Color>())),
-                        }))
-                    );
-                }
-
-                result.elements.push_back(Tuple::Element::named("stops", std::move(transformedStops)));
-            }
-            else {
-                result.elements.push_back(element);  // copy geometry as-is
-            }
-        }
-
+        std::ranges::transform(gradient.elements, std::back_inserter(result.elements), transformElement);
         return result;
     }
 

--- a/src/Gui/StyleParameters/Gradient.h
+++ b/src/Gui/StyleParameters/Gradient.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 #include <vector>
 
 #include <Base/Exception.h>
@@ -87,6 +88,53 @@ public:
         return tuple_;
     }
 
+    /**
+     * @brief Returns true if the tuple holds a linear or radial gradient.
+     */
+    static bool isGradient(const Tuple& tuple)
+    {
+        return tuple.kind == TupleKind::LinearGradient || tuple.kind == TupleKind::RadialGradient;
+    }
+
+    /**
+     * @brief Applies a color transform to every stop in a gradient tuple.
+     *
+     * Returns a copy of the gradient with the same geometry and stop positions,
+     * but with each stop's color replaced by transform(color).
+     */
+    static Tuple mapStopColors(
+        const Tuple& gradient,
+        const std::function<Base::Color(const Base::Color&)>& transform
+    )
+    {
+        Tuple result;
+        result.kind = gradient.kind;
+
+        for (const auto& element : gradient.elements) {
+            if (element.name == "stops") {
+                const auto& stopsTuple = element.value->get<Tuple>();
+                Tuple transformedStops;
+
+                for (const auto& stop : stopsTuple.elements) {
+                    const auto& stopEntry = stop.value->get<Tuple>();
+                    transformedStops.elements.push_back(
+                        Tuple::Element::unnamed(Tuple({
+                            Tuple::Element::unnamed(stopEntry.at(0).get<Numeric>()),
+                            Tuple::Element::unnamed(transform(stopEntry.at(1).get<Base::Color>())),
+                        }))
+                    );
+                }
+
+                result.elements.push_back(Tuple::Element::named("stops", std::move(transformedStops)));
+            }
+            else {
+                result.elements.push_back(element);  // copy geometry as-is
+            }
+        }
+
+        return result;
+    }
+
 protected:
     Gradient(Tuple tuple, TupleKind expected)
         : tuple_(std::move(tuple))
@@ -130,12 +178,8 @@ protected:
      */
     static Tuple::Element makeGeometryElement(const char* name, double defaultValue, const Tuple& args)
     {
-        const Value* found = args.find(name);
-        double value = found ? found->get<Numeric>().value : defaultValue;
-        return Tuple::Element {
-            .name = std::string(name),
-            .value = std::make_shared<const Value>(Numeric {.value = value, .unit = ""}),
-        };
+        double value = numericOrDefault(args.find(name), name, defaultValue);
+        return Tuple::Element::named(name, Numeric {.value = value, .unit = ""});
     }
 
     /**
@@ -213,25 +257,14 @@ protected:
         // Build stops tuple
         Tuple stopsTuple;
         for (const auto& stop : rawStops) {
-            Tuple stopEntry;
-            stopEntry.elements.push_back({
-                .name = std::nullopt,
-                .value = std::make_shared<const Value>(Numeric {.value = *stop.position, .unit = ""}),
+            Tuple stopEntry({
+                Tuple::Element::unnamed(Numeric {.value = *stop.position, .unit = ""}),
+                Tuple::Element::unnamed(stop.color),
             });
-            stopEntry.elements.push_back({
-                .name = std::nullopt,
-                .value = std::make_shared<const Value>(stop.color),
-            });
-            stopsTuple.elements.push_back({
-                .name = std::nullopt,
-                .value = std::make_shared<const Value>(std::move(stopEntry)),
-            });
+            stopsTuple.elements.push_back(Tuple::Element::unnamed(std::move(stopEntry)));
         }
 
-        return Tuple::Element {
-            .name = std::string("stops"),
-            .value = std::make_shared<const Value>(std::move(stopsTuple)),
-        };
+        return Tuple::Element::named("stops", std::move(stopsTuple));
     }
 
     Tuple tuple_;
@@ -278,14 +311,16 @@ public:
 private:
     static Tuple expand(const Tuple& args)
     {
-        Tuple result;
-        result.kind = TupleKind::LinearGradient;
-        result.elements.push_back(makeGeometryElement("x1", 0.0, args));
-        result.elements.push_back(makeGeometryElement("y1", 0.0, args));
-        result.elements.push_back(makeGeometryElement("x2", 0.0, args));
-        result.elements.push_back(makeGeometryElement("y2", 1.0, args));
-        result.elements.push_back(buildStopsElement(args));
-        return result;
+        return Tuple(
+            {
+                makeGeometryElement("x1", 0.0, args),
+                makeGeometryElement("y1", 0.0, args),
+                makeGeometryElement("x2", 0.0, args),
+                makeGeometryElement("y2", 1.0, args),
+                buildStopsElement(args),
+            },
+            TupleKind::LinearGradient
+        );
     }
 };
 
@@ -344,21 +379,17 @@ private:
         double fxValue = numericOrDefault(args.find("fx"), "fx", cxValue);
         double fyValue = numericOrDefault(args.find("fy"), "fy", cyValue);
 
-        Tuple result;
-        result.kind = TupleKind::RadialGradient;
-        result.elements.push_back(makeGeometryElement("cx", defaultCenter, args));
-        result.elements.push_back(makeGeometryElement("cy", defaultCenter, args));
-        result.elements.push_back(makeGeometryElement("radius", defaultRadius, args));
-        result.elements.push_back({
-            .name = std::string("fx"),
-            .value = std::make_shared<const Value>(Numeric {.value = fxValue, .unit = ""}),
-        });
-        result.elements.push_back({
-            .name = std::string("fy"),
-            .value = std::make_shared<const Value>(Numeric {.value = fyValue, .unit = ""}),
-        });
-        result.elements.push_back(buildStopsElement(args));
-        return result;
+        return Tuple(
+            {
+                makeGeometryElement("cx", defaultCenter, args),
+                makeGeometryElement("cy", defaultCenter, args),
+                makeGeometryElement("radius", defaultRadius, args),
+                Tuple::Element::named("fx", Numeric {.value = fxValue, .unit = ""}),
+                Tuple::Element::named("fy", Numeric {.value = fyValue, .unit = ""}),
+                buildStopsElement(args),
+            },
+            TupleKind::RadialGradient
+        );
     }
 };
 

--- a/src/Gui/StyleParameters/Gradient.h
+++ b/src/Gui/StyleParameters/Gradient.h
@@ -288,6 +288,10 @@ protected:
 class LinearGradient: public Gradient
 {
 public:
+    explicit LinearGradient(const Value& value)
+        : LinearGradient(asTuple(value))
+    {}
+
     explicit LinearGradient(Tuple tuple)
         : Gradient(
               tuple.kind == TupleKind::Generic ? expand(tuple) : std::move(tuple),
@@ -343,6 +347,10 @@ private:
 class RadialGradient: public Gradient
 {
 public:
+    explicit RadialGradient(const Value& value)
+        : RadialGradient(asTuple(value))
+    {}
+
     explicit RadialGradient(Tuple tuple)
         : Gradient(
               tuple.kind == TupleKind::Generic ? expand(tuple) : std::move(tuple),

--- a/src/Gui/StyleParameters/Gradient.h
+++ b/src/Gui/StyleParameters/Gradient.h
@@ -1,0 +1,564 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <optional>
+#include <ranges>
+#include <vector>
+
+#include "Diagnostics.h"
+#include "Value.h"
+
+namespace Gui::StyleParameters
+{
+
+/**
+ * @brief Represents a single color stop in a gradient.
+ */
+struct ColorStop
+{
+    Numeric position;
+    Base::Color color;
+};
+
+/**
+ * @brief Base class for gradient tuple wrappers.
+ *
+ * Gradients are stored as typed Tuples with named geometry elements
+ * (e.g. x1, y1, x2, y2 for linear) and a named "stops" element
+ * containing a Tuple of (position, color) sub-tuples.
+ *
+ * Gradients must be created via parser functions (linear_gradient,
+ * radial_gradient) — Generic tuples do NOT auto-expand to gradients
+ * unless explicitly constructed via the wrapper class.
+ */
+class Gradient
+{
+public:
+    /**
+     * @brief Returns the stops sub-tuple.
+     */
+    const Tuple& stops() const
+    {
+        return tuple_.get<Tuple>("stops");
+    }
+
+    /**
+     * @brief Extracts structured color stops.
+     *
+     * tuple_ is only ever populated through validated construction (the Tuple/Value
+     * constructors and tryFrom on TypedGradient), so every stop is already known to be a
+     * well-formed (position, color) pair.
+     */
+    std::vector<ColorStop> colorStops() const
+    {
+        std::vector<ColorStop> result;
+
+        for (const auto& stop : stops().elements) {
+            const Tuple& entry = stop.value->get<Tuple>();
+            result.push_back(
+                {.position = entry.at(0).get<Numeric>(), .color = entry.at(1).get<Base::Color>()}
+            );
+        }
+
+        return result;
+    }
+
+    const Tuple& tuple() const
+    {
+        return tuple_;
+    }
+
+    /**
+     * @brief Applies a color transform to every stop, keeping geometry and positions unchanged.
+     *
+     * Operates on the already-validated tuple_, so every stop is known to be a well-formed
+     * (position, color) pair.
+     */
+    Tuple mapStopColors(const std::function<Base::Color(const Base::Color&)>& transform) const
+    {
+        auto makeStopTuple = [](Numeric position, Base::Color color) {
+            return Tuple({
+                Element::unnamed(position),
+                Element::unnamed(color),
+            });
+        };
+
+        auto transformStop = [&](const Tuple::Element& stop) -> Tuple::Element {
+            const Tuple& entry = stop.value->get<Tuple>();
+            return Element::unnamed(
+                makeStopTuple(entry.at(0).get<Numeric>(), transform(entry.at(1).get<Base::Color>()))
+            );
+        };
+
+        auto transformElement = [&](const Tuple::Element& element) -> Tuple::Element {
+            if (element.name != "stops") {
+                return element;
+            }
+
+            const auto& stopsTuple = element.value->get<Tuple>();
+            Tuple transformedStops;
+            std::ranges::transform(
+                stopsTuple.elements,
+                std::back_inserter(transformedStops.elements),
+                transformStop
+            );
+            return Element::named("stops", std::move(transformedStops));
+        };
+
+        Tuple result;
+        result.kind = tuple_.kind;
+        std::ranges::transform(tuple_.elements, std::back_inserter(result.elements), transformElement);
+        return result;
+    }
+
+protected:
+    explicit Gradient(Tuple tuple)
+        : tuple_(std::move(tuple))
+    {}
+
+    /// True when a value is a gradient coordinate: a number on the normalized 0-1 scale.
+    static bool isNormalized(const Value& value)
+    {
+        const Numeric* numeric = value.tryGet<Numeric>();
+        return numeric && numeric->asFraction().has_value();
+    }
+
+    /// True when the tuple has a stops element holding well-formed (position, color) entries.
+    static bool isWellFormed(const Tuple& tuple)
+    {
+        const Tuple* stops = tuple.tryGet<Tuple>("stops");
+        if (!stops || stops->size() < 2) {
+            return false;
+        }
+
+        for (const auto& stop : stops->elements) {
+            const Tuple* entry = stop.value->tryGet<Tuple>();
+            if (!entry || entry->size() != 2 || !isNormalized(entry->at(0))
+                || !entry->at(1).tryGet<Base::Color>()) {
+                return false;
+            }
+        }
+
+        for (const auto& element : tuple.elements) {
+            if (element.name && *element.name != "stops" && !isNormalized(*element.value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @brief Extracts a gradient coordinate from a found element, using the default when absent
+     *        or reporting and defaulting when present but not a normalized number.
+     */
+    static double numericOrDefault(const Value* found, const char* paramName, double defaultValue)
+    {
+        if (!found) {
+            return defaultValue;
+        }
+
+        if (const Numeric* numeric = found->tryGet<Numeric>()) {
+            if (auto fraction = numeric->asFraction()) {
+                return *fraction;
+            }
+        }
+
+        Diagnostics::report(
+            "Gradient geometry parameter '{}' must be a number or percentage, got {}",
+            paramName,
+            found->toString()
+        );
+        return defaultValue;
+    }
+
+    /**
+     * @brief Creates a geometry element with a default value.
+     *
+     * Looks up a named element in the args tuple and uses the provided
+     * default if not found.
+     */
+    static Tuple::Element makeGeometryElement(const char* name, double defaultValue, const Tuple& args)
+    {
+        double value = numericOrDefault(args.find(name), name, defaultValue);
+        return Element::named(name, Numeric {.value = value, .unit = ""});
+    }
+
+    /**
+     * @brief Builds the "stops" element from positional arguments.
+     *
+     * Processes positional args from the function call:
+     * - Bare Color values become auto-positioned stops
+     * - Tuple(Numeric, Color) values become explicit stops
+     *
+     * Auto-positioning distributes bare colors evenly from 0 to 1
+     * based on their index in the total stop list.
+     * Stops are sorted by position after processing.
+     *
+     * Returns nothing (and reports) when there are fewer than 2 stops or a stop is malformed.
+     */
+    static std::optional<Tuple::Element> buildStopsElement(const Tuple& args)
+    {
+        struct RawStop
+        {
+            std::optional<double> position;
+            Base::Color color;
+        };
+
+        std::vector<RawStop> rawStops;
+
+        for (const auto& element : args.elements) {
+            if (element.name) {
+                continue;  // named args are geometry, skip
+            }
+
+            const Value& value = *element.value;
+
+            if (value.holds<Base::Color>()) {
+                rawStops.push_back({
+                    .position = std::nullopt,
+                    .color = value.get<Base::Color>(),
+                });
+            }
+            else if (value.holds<Tuple>()) {
+                const auto& stopTuple = value.get<Tuple>();
+                if (stopTuple.size() != 2 || !isNormalized(stopTuple.at(0))
+                    || !stopTuple.at(1).holds<Base::Color>()) {
+                    Diagnostics::report(
+                        "Gradient stop tuple must be (position, color), where position is a "
+                        "number or percentage, got {}",
+                        value.toString()
+                    );
+                    return std::nullopt;
+                }
+                rawStops.push_back({
+                    .position = stopTuple.at(0).get<Numeric>().asFraction(),
+                    .color = stopTuple.at(1).get<Base::Color>(),
+                });
+            }
+            else {
+                Diagnostics::report(
+                    "Gradient arguments must be colors or (position, color) tuples, got {}",
+                    value.toString()
+                );
+                return std::nullopt;
+            }
+        }
+
+        if (rawStops.size() < 2) {
+            Diagnostics::report("Gradient requires at least 2 color stops");
+            return std::nullopt;
+        }
+
+        // Auto-distribute positions for bare colors
+        for (size_t index = 0; index < rawStops.size(); ++index) {
+            if (!rawStops[index].position) {
+                rawStops[index].position = static_cast<double>(index)
+                    / static_cast<double>(rawStops.size() - 1);
+            }
+        }
+
+        // Sort stops by position
+        std::ranges::sort(rawStops, [](const RawStop& left, const RawStop& right) {
+            return *left.position < *right.position;
+        });
+
+        // Build stops tuple
+        Tuple stopsTuple;
+        for (const auto& stop : rawStops) {
+            Tuple stopEntry({
+                Element::unnamed(Numeric {.value = *stop.position, .unit = ""}),
+                Element::unnamed(stop.color),
+            });
+            stopsTuple.elements.push_back(Element::unnamed(std::move(stopEntry)));
+        }
+
+        return Element::named("stops", std::move(stopsTuple));
+    }
+
+    /// Two fully transparent stops, used when a value cannot be interpreted as a gradient.
+    static Tuple::Element transparentStops()
+    {
+        const auto stop = [](double position) {
+            return Element::unnamed(Tuple({
+                Element::unnamed(Numeric {.value = position, .unit = ""}),
+                Element::unnamed(Base::Color(0.0F, 0.0F, 0.0F, 0.0F)),
+            }));
+        };
+
+        return Element::named("stops", Tuple({stop(0.0), stop(1.0)}));
+    }
+
+    Tuple tuple_;
+};
+
+/**
+ * @brief Adds kind identity to a Gradient specialization.
+ *
+ * A concrete gradient type states only its kind and supplies its own expand() (Generic-args
+ * shorthand expansion) and zeros() (transparent fallback tagged with its kind) — those
+ * genuinely differ per gradient (different geometry fields, different defaults). Validation,
+ * the tryFrom factory, and both constructors are shape-identical across kinds and come from
+ * here, mirroring TypedEdges in Edges.h.
+ */
+template<typename Derived, TupleKind Kind>
+class TypedGradient: public Gradient
+{
+public:
+    /// Total: a value that is not a valid Kind gradient yields Derived::zeros().
+    explicit TypedGradient(const Value& value)
+        : Gradient(validated(value).value_or(Derived::zeros()))
+    {}
+
+    /// Total: wraps a raw tuple with the same validation as the Value constructor, so this
+    /// can never produce an ill-formed gradient either.
+    explicit TypedGradient(Tuple tuple)
+        : TypedGradient(Value {std::move(tuple)})
+    {}
+
+    /// Builds this kind from a value, or nothing when the value is not that shape.
+    static std::optional<Derived> tryFrom(const Value& value)
+    {
+        if (auto tuple = validated(value)) {
+            return Derived(std::move(*tuple));
+        }
+        return std::nullopt;
+    }
+
+    static constexpr TupleKind kind()
+    {
+        return Kind;
+    }
+
+protected:
+    /**
+     * @brief Normalizes and fully validates a value as a Kind gradient.
+     *
+     * Accepts a Generic tuple (expanded via Derived::expand) or an already-tagged Kind tuple
+     * whose stops and geometry check out. Anything else is rejected outright.
+     */
+    static std::optional<Tuple> validated(const Value& value)
+    {
+        const Tuple source = asTuple(value);
+
+        if (source.kind == Kind) {
+            if (!isWellFormed(source)) {
+                Diagnostics::report("Malformed {} tuple {}", tupleKindName(Kind), Value {source});
+                return std::nullopt;
+            }
+            return source;
+        }
+
+        if (source.kind != TupleKind::Generic) {
+            Diagnostics::report(
+                "Expected {} tuple, got {}",
+                tupleKindName(Kind),
+                tupleKindName(source.kind)
+            );
+            return std::nullopt;
+        }
+
+        return Derived::expand(source);
+    }
+};
+
+/**
+ * @brief Wrapper for LinearGradient tuples.
+ *
+ * Geometry: x1, y1, x2, y2 (defaults: 0, 0, 0, 1 = top to bottom).
+ * Plus a "stops" element containing color stop sub-tuples.
+ */
+class LinearGradient: public TypedGradient<LinearGradient, TupleKind::LinearGradient>
+{
+public:
+    using TypedGradient::TypedGradient;
+
+    double x1() const
+    {
+        return tuple_.get<Numeric>("x1").value;
+    }
+    double y1() const
+    {
+        return tuple_.get<Numeric>("y1").value;
+    }
+    double x2() const
+    {
+        return tuple_.get<Numeric>("x2").value;
+    }
+    double y2() const
+    {
+        return tuple_.get<Numeric>("y2").value;
+    }
+
+private:
+    friend class TypedGradient<LinearGradient, TupleKind::LinearGradient>;
+
+    /// A transparent top-to-bottom gradient, used when a value cannot be interpreted as a
+    /// linear gradient.
+    static Tuple zeros()
+    {
+        return Tuple(
+            {
+                Element::named("x1", Numeric {.value = 0.0, .unit = ""}),
+                Element::named("y1", Numeric {.value = 0.0, .unit = ""}),
+                Element::named("x2", Numeric {.value = 0.0, .unit = ""}),
+                Element::named("y2", Numeric {.value = 1.0, .unit = ""}),
+                transparentStops(),
+            },
+            TupleKind::LinearGradient
+        );
+    }
+
+    static std::optional<Tuple> expand(const Tuple& args)
+    {
+        auto stops = buildStopsElement(args);
+        if (!stops) {
+            return std::nullopt;
+        }
+
+        return Tuple(
+            {
+                makeGeometryElement("x1", 0.0, args),
+                makeGeometryElement("y1", 0.0, args),
+                makeGeometryElement("x2", 0.0, args),
+                makeGeometryElement("y2", 1.0, args),
+                std::move(*stops),
+            },
+            TupleKind::LinearGradient
+        );
+    }
+};
+
+/**
+ * @brief Wrapper for RadialGradient tuples.
+ *
+ * Geometry: cx, cy, radius, fx, fy (defaults: 0.5, 0.5, 0.5, cx, cy).
+ * fx and fy default to cx and cy respectively when not specified.
+ * Plus a "stops" element containing color stop sub-tuples.
+ */
+class RadialGradient: public TypedGradient<RadialGradient, TupleKind::RadialGradient>
+{
+public:
+    using TypedGradient::TypedGradient;
+
+    double cx() const
+    {
+        return tuple_.get<Numeric>("cx").value;
+    }
+    double cy() const
+    {
+        return tuple_.get<Numeric>("cy").value;
+    }
+    double radius() const
+    {
+        return tuple_.get<Numeric>("radius").value;
+    }
+    double fx() const
+    {
+        return tuple_.get<Numeric>("fx").value;
+    }
+    double fy() const
+    {
+        return tuple_.get<Numeric>("fy").value;
+    }
+
+private:
+    friend class TypedGradient<RadialGradient, TupleKind::RadialGradient>;
+
+    /// A transparent centered gradient, used when a value cannot be interpreted as a radial
+    /// gradient.
+    static Tuple zeros()
+    {
+        constexpr double defaultCenter = 0.5;
+        constexpr double defaultRadius = 0.5;
+
+        return Tuple(
+            {
+                Element::named("cx", Numeric {.value = defaultCenter, .unit = ""}),
+                Element::named("cy", Numeric {.value = defaultCenter, .unit = ""}),
+                Element::named("radius", Numeric {.value = defaultRadius, .unit = ""}),
+                Element::named("fx", Numeric {.value = defaultCenter, .unit = ""}),
+                Element::named("fy", Numeric {.value = defaultCenter, .unit = ""}),
+                transparentStops(),
+            },
+            TupleKind::RadialGradient
+        );
+    }
+
+    static std::optional<Tuple> expand(const Tuple& args)
+    {
+        // fx defaults to cx, fy defaults to cy
+        constexpr double defaultCenter = 0.5;
+        constexpr double defaultRadius = 0.5;
+
+        double cxValue = numericOrDefault(args.find("cx"), "cx", defaultCenter);
+        double cyValue = numericOrDefault(args.find("cy"), "cy", defaultCenter);
+        double fxValue = numericOrDefault(args.find("fx"), "fx", cxValue);
+        double fyValue = numericOrDefault(args.find("fy"), "fy", cyValue);
+
+        auto stops = buildStopsElement(args);
+        if (!stops) {
+            return std::nullopt;
+        }
+
+        return Tuple(
+            {
+                makeGeometryElement("cx", defaultCenter, args),
+                makeGeometryElement("cy", defaultCenter, args),
+                makeGeometryElement("radius", defaultRadius, args),
+                Element::named("fx", Numeric {.value = fxValue, .unit = ""}),
+                Element::named("fy", Numeric {.value = fyValue, .unit = ""}),
+                std::move(*stops),
+            },
+            TupleKind::RadialGradient
+        );
+    }
+};
+
+/**
+ * @brief Applies a color transform to a gradient value's stops, or nothing when it is not a
+ *        gradient.
+ *
+ * Tries the value as a LinearGradient, then a RadialGradient; the mapping only ever runs on
+ * a wrapper that has already passed tryFrom's validation, so this is the sole path from a
+ * caller-supplied Value to a stop transform.
+ */
+inline std::optional<Tuple> mapGradientStops(
+    const Value& value,
+    const std::function<Base::Color(const Base::Color&)>& transform
+)
+{
+    if (auto linear = LinearGradient::tryFrom(value)) {
+        return linear->mapStopColors(transform);
+    }
+    if (auto radial = RadialGradient::tryFrom(value)) {
+        return radial->mapStopColors(transform);
+    }
+    return std::nullopt;
+}
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Insets.h
+++ b/src/Gui/StyleParameters/Insets.h
@@ -23,180 +23,26 @@
 
 #pragma once
 
-#include <array>
-
-#include <Base/Exception.h>
-#include <fmt/format.h>
-
-#include "Value.h"
+#include "Edges.h"
 
 namespace Gui::StyleParameters
 {
 
-/**
- * @brief C++ wrapper providing ergonomic access to a 4-element insets tuple
- *        (top, right, bottom, left).
- *
- * Owns the Tuple by value so it can be safely returned from functions.
- * Subclasses add kind-specific validation.
- */
-class Insets
-{
-public:
-    explicit Insets(Tuple tuple)
-        : tuple_(std::move(tuple))
-    {}
-
-    explicit Insets(const Value& value)
-        : tuple_([&value]() -> Tuple {
-            if (value.holds<Tuple>()) {
-                const auto& tuple = value.get<Tuple>();
-                return tuple.kind == TupleKind::Generic ? expand(tuple) : tuple;
-            }
-            return expand(asTuple(value));
-        }())
-    {}
-
-    const Numeric& top() const
-    {
-        return tuple_.get<Numeric>("top");
-    }
-    const Numeric& right() const
-    {
-        return tuple_.get<Numeric>("right");
-    }
-    const Numeric& bottom() const
-    {
-        return tuple_.get<Numeric>("bottom");
-    }
-    const Numeric& left() const
-    {
-        return tuple_.get<Numeric>("left");
-    }
-
-    Numeric horizontal() const
-    {
-        return left() + right();
-    }
-    Numeric vertical() const
-    {
-        return top() + bottom();
-    }
-
-    const Tuple& tuple() const
-    {
-        return tuple_;
-    }
-
-    /**
-     * @brief Expands a tuple using CSS box-model shorthand rules.
-     *
-     * Handles positional shorthand (1-4 args), group names (vertical, horizontal),
-     * and explicit side overrides (top, right, bottom, left). Returns a normalized
-     * 4-element tuple with Generic kind — caller sets the target kind.
-     */
-    static Tuple expand(const Tuple& args)
-    {
-        std::vector<const Value*> positional;
-        for (const auto& elem : args.elements) {
-            if (!elem.name) {
-                positional.push_back(elem.value.get());
-            }
-        }
-
-        // Single tuple argument: pass through for re-tagging (e.g., padding(@existingTuple))
-        if (positional.size() == 1 && positional[0]->holds<Tuple>()) {
-            return positional[0]->get<Tuple>();
-        }
-
-        // CSS box-model shorthand: top, right, bottom, left
-        auto [top, right, bottom, left] = [&]() -> std::array<const Value*, 4> {
-            switch (positional.size()) {
-                case 0:
-                    return {nullptr, nullptr, nullptr, nullptr};
-                case 1:
-                    return {positional[0], positional[0], positional[0], positional[0]};
-                case 2:
-                    return {positional[0], positional[1], positional[0], positional[1]};
-                case 3:  // NOLINT(*-magic-numbers)
-                    return {positional[0], positional[1], positional[2], positional[1]};
-                case 4:  // NOLINT(*-magic-numbers)
-                    return {positional[0], positional[1], positional[2], positional[3]};
-                default:
-                    THROWM(Base::ExpressionError, "Insets accept 1-4 positional arguments");
-            }
-        }();
-
-        // Group names override positional
-        if (const Value* vertical = args.find("vertical")) {
-            top = bottom = vertical;
-        }
-        if (const Value* horizontal = args.find("horizontal")) {
-            right = left = horizontal;
-        }
-
-        // Explicit side names override everything
-        if (const Value* found = args.find("top")) {
-            top = found;
-        }
-        if (const Value* found = args.find("right")) {
-            right = found;
-        }
-        if (const Value* found = args.find("bottom")) {
-            bottom = found;
-        }
-        if (const Value* found = args.find("left")) {
-            left = found;
-        }
-
-        if (!top || !right || !bottom || !left) {
-            THROWM(Base::ExpressionError, "Insets require all four sides to be specified");
-        }
-
-        return Tuple({
-            Tuple::Element::named("top", *top),
-            Tuple::Element::named("right", *right),
-            Tuple::Element::named("bottom", *bottom),
-            Tuple::Element::named("left", *left),
-        });
-    }
-
-protected:
-    Insets(Tuple tuple, TupleKind expected)
-        : tuple_(std::move(tuple))
-    {
-        if (tuple_.kind == TupleKind::Generic) {
-            tuple_ = expand(tuple_);
-            tuple_.kind = expected;
-        }
-        if (tuple_.kind != expected) {
-            THROWM(
-                Base::TypeError,
-                fmt::format(
-                    "Expected {} tuple, got {}",
-                    tupleKindName(expected),
-                    tupleKindName(tuple_.kind)
-                )
-            );
-        }
-    }
-
-private:
-    Tuple tuple_;
-};
+/// @brief 4-side numeric insets (top, right, bottom, left).
+using Insets = Edges<Numeric>;
 
 /**
  * @brief Padding insets — wraps a Tuple with kind == TupleKind::Padding.
  */
-class Padding: public Insets
+class Padding: public Edges<Numeric>
 {
 public:
     explicit Padding(Tuple tuple)
-        : Insets(std::move(tuple), TupleKind::Padding)
+        : Edges<Numeric>(std::move(tuple), TupleKind::Padding)
     {}
 
     explicit Padding(const Value& value)
-        : Insets(asTuple(value), TupleKind::Padding)
+        : Edges<Numeric>(asTuple(value), TupleKind::Padding)
     {}
 
     static constexpr TupleKind kind()
@@ -208,15 +54,15 @@ public:
 /**
  * @brief Margins insets — wraps a Tuple with kind == TupleKind::Margins.
  */
-class Margins: public Insets
+class Margins: public Edges<Numeric>
 {
 public:
     explicit Margins(Tuple tuple)
-        : Insets(std::move(tuple), TupleKind::Margins)
+        : Edges<Numeric>(std::move(tuple), TupleKind::Margins)
     {}
 
     explicit Margins(const Value& value)
-        : Insets(asTuple(value), TupleKind::Margins)
+        : Edges<Numeric>(asTuple(value), TupleKind::Margins)
     {}
 
     static constexpr TupleKind kind()
@@ -228,20 +74,44 @@ public:
 /**
  * @brief Border thickness insets — wraps a Tuple with kind == TupleKind::BorderThickness.
  */
-class BorderThickness: public Insets
+class BorderThickness: public Edges<Numeric>
 {
 public:
     explicit BorderThickness(Tuple tuple)
-        : Insets(std::move(tuple), TupleKind::BorderThickness)
+        : Edges<Numeric>(std::move(tuple), TupleKind::BorderThickness)
     {}
 
     explicit BorderThickness(const Value& value)
-        : Insets(asTuple(value), TupleKind::BorderThickness)
+        : Edges<Numeric>(asTuple(value), TupleKind::BorderThickness)
     {}
 
     static constexpr TupleKind kind()
     {
         return TupleKind::BorderThickness;
+    }
+};
+
+/**
+ * @brief Per-side border colors — wraps a Tuple with kind == TupleKind::BorderColors.
+ *
+ * Accepts the same CSS shorthand as numeric insets: a bare color value expands to
+ * all four sides, two values set vertical and horizontal, and so on. The
+ * border_colors() YAML function produces a typed tuple directly.
+ */
+class BorderColors: public Edges<Base::Color>
+{
+public:
+    explicit BorderColors(Tuple tuple)
+        : Edges<Base::Color>(std::move(tuple), TupleKind::BorderColors)
+    {}
+
+    explicit BorderColors(const Value& value)
+        : Edges<Base::Color>(asTuple(value), TupleKind::BorderColors)
+    {}
+
+    static constexpr TupleKind kind()
+    {
+        return TupleKind::BorderColors;
     }
 };
 

--- a/src/Gui/StyleParameters/Insets.h
+++ b/src/Gui/StyleParameters/Insets.h
@@ -143,19 +143,12 @@ public:
             THROWM(Base::ExpressionError, "Insets require all four sides to be specified");
         }
 
-        auto makeElement = [](const char* name, const Value& val) {
-            return Tuple::Element {
-                .name = std::string(name),
-                .value = std::make_shared<const Value>(val)
-            };
-        };
-
-        Tuple result;
-        result.elements.push_back(makeElement("top", *top));
-        result.elements.push_back(makeElement("right", *right));
-        result.elements.push_back(makeElement("bottom", *bottom));
-        result.elements.push_back(makeElement("left", *left));
-        return result;
+        return Tuple({
+            Tuple::Element::named("top", *top),
+            Tuple::Element::named("right", *right),
+            Tuple::Element::named("bottom", *bottom),
+            Tuple::Element::named("left", *left),
+        });
     }
 
 protected:

--- a/src/Gui/StyleParameters/Insets.h
+++ b/src/Gui/StyleParameters/Insets.h
@@ -49,20 +49,11 @@ public:
 
     explicit Insets(const Value& value)
         : tuple_([&value]() -> Tuple {
-            if (value.holds<Numeric>()) {
-                const auto& numeric = value.get<Numeric>();
-                return Tuple({
-                    Tuple::Element::named("top", numeric),
-                    Tuple::Element::named("right", numeric),
-                    Tuple::Element::named("bottom", numeric),
-                    Tuple::Element::named("left", numeric),
-                });
-            }
             if (value.holds<Tuple>()) {
                 const auto& tuple = value.get<Tuple>();
                 return tuple.kind == TupleKind::Generic ? expand(tuple) : tuple;
             }
-            THROWM(Base::TypeError, "Insets: value must be a Numeric or an inset Tuple");
+            return expand(asTuple(value));
         }())
     {}
 
@@ -204,6 +195,10 @@ public:
         : Insets(std::move(tuple), TupleKind::Padding)
     {}
 
+    explicit Padding(const Value& value)
+        : Insets(asTuple(value), TupleKind::Padding)
+    {}
+
     static constexpr TupleKind kind()
     {
         return TupleKind::Padding;
@@ -220,6 +215,10 @@ public:
         : Insets(std::move(tuple), TupleKind::Margins)
     {}
 
+    explicit Margins(const Value& value)
+        : Insets(asTuple(value), TupleKind::Margins)
+    {}
+
     static constexpr TupleKind kind()
     {
         return TupleKind::Margins;
@@ -234,6 +233,10 @@ class BorderThickness: public Insets
 public:
     explicit BorderThickness(Tuple tuple)
         : Insets(std::move(tuple), TupleKind::BorderThickness)
+    {}
+
+    explicit BorderThickness(const Value& value)
+        : Insets(asTuple(value), TupleKind::BorderThickness)
     {}
 
     static constexpr TupleKind kind()

--- a/src/Gui/StyleParameters/Insets.h
+++ b/src/Gui/StyleParameters/Insets.h
@@ -47,6 +47,25 @@ public:
         : tuple_(std::move(tuple))
     {}
 
+    explicit Insets(const Value& value)
+        : tuple_([&value]() -> Tuple {
+            if (value.holds<Numeric>()) {
+                const auto& numeric = value.get<Numeric>();
+                return Tuple({
+                    Tuple::Element::named("top", numeric),
+                    Tuple::Element::named("right", numeric),
+                    Tuple::Element::named("bottom", numeric),
+                    Tuple::Element::named("left", numeric),
+                });
+            }
+            if (value.holds<Tuple>()) {
+                const auto& tuple = value.get<Tuple>();
+                return tuple.kind == TupleKind::Generic ? expand(tuple) : tuple;
+            }
+            THROWM(Base::TypeError, "Insets: value must be a Numeric or an inset Tuple");
+        }())
+    {}
+
     const Numeric& top() const
     {
         return tuple_.get<Numeric>("top");

--- a/src/Gui/StyleParameters/Insets.h
+++ b/src/Gui/StyleParameters/Insets.h
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include <array>
+
+#include <Base/Exception.h>
+#include <fmt/format.h>
+
+#include "Value.h"
+
+namespace Gui::StyleParameters
+{
+
+/**
+ * @brief C++ wrapper providing ergonomic access to a 4-element insets tuple
+ *        (top, right, bottom, left).
+ *
+ * Owns the Tuple by value so it can be safely returned from functions.
+ * Subclasses add kind-specific validation.
+ */
+class Insets
+{
+public:
+    explicit Insets(Tuple tuple)
+        : tuple_(std::move(tuple))
+    {}
+
+    const Numeric& top() const
+    {
+        return tuple_.get<Numeric>("top");
+    }
+    const Numeric& right() const
+    {
+        return tuple_.get<Numeric>("right");
+    }
+    const Numeric& bottom() const
+    {
+        return tuple_.get<Numeric>("bottom");
+    }
+    const Numeric& left() const
+    {
+        return tuple_.get<Numeric>("left");
+    }
+
+    Numeric horizontal() const
+    {
+        return left() + right();
+    }
+    Numeric vertical() const
+    {
+        return top() + bottom();
+    }
+
+    const Tuple& tuple() const
+    {
+        return tuple_;
+    }
+
+    /**
+     * @brief Expands a tuple using CSS box-model shorthand rules.
+     *
+     * Handles positional shorthand (1-4 args), group names (vertical, horizontal),
+     * and explicit side overrides (top, right, bottom, left). Returns a normalized
+     * 4-element tuple with Generic kind — caller sets the target kind.
+     */
+    static Tuple expand(const Tuple& args)
+    {
+        std::vector<const Value*> positional;
+        for (const auto& elem : args.elements) {
+            if (!elem.name) {
+                positional.push_back(elem.value.get());
+            }
+        }
+
+        // Single tuple argument: pass through for re-tagging (e.g., padding(@existingTuple))
+        if (positional.size() == 1 && positional[0]->holds<Tuple>()) {
+            return positional[0]->get<Tuple>();
+        }
+
+        // CSS box-model shorthand: top, right, bottom, left
+        auto [top, right, bottom, left] = [&]() -> std::array<const Value*, 4> {
+            switch (positional.size()) {
+                case 0:
+                    return {nullptr, nullptr, nullptr, nullptr};
+                case 1:
+                    return {positional[0], positional[0], positional[0], positional[0]};
+                case 2:
+                    return {positional[0], positional[1], positional[0], positional[1]};
+                case 3:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[1]};
+                case 4:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[3]};
+                default:
+                    THROWM(Base::ExpressionError, "Insets accept 1-4 positional arguments");
+            }
+        }();
+
+        // Group names override positional
+        if (const Value* vertical = args.find("vertical")) {
+            top = bottom = vertical;
+        }
+        if (const Value* horizontal = args.find("horizontal")) {
+            right = left = horizontal;
+        }
+
+        // Explicit side names override everything
+        if (const Value* found = args.find("top")) {
+            top = found;
+        }
+        if (const Value* found = args.find("right")) {
+            right = found;
+        }
+        if (const Value* found = args.find("bottom")) {
+            bottom = found;
+        }
+        if (const Value* found = args.find("left")) {
+            left = found;
+        }
+
+        if (!top || !right || !bottom || !left) {
+            THROWM(Base::ExpressionError, "Insets require all four sides to be specified");
+        }
+
+        auto makeElement = [](const char* name, const Value& val) {
+            return Tuple::Element {
+                .name = std::string(name),
+                .value = std::make_shared<const Value>(val)
+            };
+        };
+
+        Tuple result;
+        result.elements.push_back(makeElement("top", *top));
+        result.elements.push_back(makeElement("right", *right));
+        result.elements.push_back(makeElement("bottom", *bottom));
+        result.elements.push_back(makeElement("left", *left));
+        return result;
+    }
+
+protected:
+    Insets(Tuple tuple, TupleKind expected)
+        : tuple_(std::move(tuple))
+    {
+        if (tuple_.kind == TupleKind::Generic) {
+            tuple_ = expand(tuple_);
+            tuple_.kind = expected;
+        }
+        if (tuple_.kind != expected) {
+            THROWM(
+                Base::TypeError,
+                fmt::format(
+                    "Expected {} tuple, got {}",
+                    tupleKindName(expected),
+                    tupleKindName(tuple_.kind)
+                )
+            );
+        }
+    }
+
+private:
+    Tuple tuple_;
+};
+
+/**
+ * @brief Padding insets — wraps a Tuple with kind == TupleKind::Padding.
+ */
+class Padding: public Insets
+{
+public:
+    explicit Padding(Tuple tuple)
+        : Insets(std::move(tuple), TupleKind::Padding)
+    {}
+
+    static constexpr TupleKind kind()
+    {
+        return TupleKind::Padding;
+    }
+};
+
+/**
+ * @brief Margins insets — wraps a Tuple with kind == TupleKind::Margins.
+ */
+class Margins: public Insets
+{
+public:
+    explicit Margins(Tuple tuple)
+        : Insets(std::move(tuple), TupleKind::Margins)
+    {}
+
+    static constexpr TupleKind kind()
+    {
+        return TupleKind::Margins;
+    }
+};
+
+/**
+ * @brief Border thickness insets — wraps a Tuple with kind == TupleKind::BorderThickness.
+ */
+class BorderThickness: public Insets
+{
+public:
+    explicit BorderThickness(Tuple tuple)
+        : Insets(std::move(tuple), TupleKind::BorderThickness)
+    {}
+
+    static constexpr TupleKind kind()
+    {
+        return TupleKind::BorderThickness;
+    }
+};
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/Insets.h
+++ b/src/Gui/StyleParameters/Insets.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#pragma once
+
+#include "Edges.h"
+
+namespace Gui::StyleParameters
+{
+
+/// @brief 4-side numeric insets (top, right, bottom, left).
+using Insets = Edges<Numeric>;
+
+/// @brief Padding insets — wraps a Tuple with kind == TupleKind::Padding.
+class Padding: public TypedEdges<Padding, Numeric, TupleKind::Padding>
+{
+public:
+    using TypedEdges::TypedEdges;
+};
+
+/// @brief Margins insets — wraps a Tuple with kind == TupleKind::Margins.
+class Margins: public TypedEdges<Margins, Numeric, TupleKind::Margins>
+{
+public:
+    using TypedEdges::TypedEdges;
+};
+
+/// @brief Border thickness insets — wraps a Tuple with kind == TupleKind::BorderThickness.
+class BorderThickness: public TypedEdges<BorderThickness, Numeric, TupleKind::BorderThickness>
+{
+public:
+    using TypedEdges::TypedEdges;
+};
+
+/**
+ * @brief Per-side border colors — wraps a Tuple with kind == TupleKind::BorderColors.
+ *
+ * Accepts the same CSS shorthand as numeric insets: a bare color expands to all four
+ * sides, two values set vertical and horizontal, and so on.
+ */
+class BorderColors: public TypedEdges<BorderColors, Base::Color, TupleKind::BorderColors>
+{
+public:
+    using TypedEdges::TypedEdges;
+};
+
+}  // namespace Gui::StyleParameters

--- a/src/Gui/StyleParameters/ParameterManager.cpp
+++ b/src/Gui/StyleParameters/ParameterManager.cpp
@@ -77,13 +77,49 @@ std::string yamlNodeToExpression(const YAML::Node& node)
     return "";
 }
 
+/// Formats a gradient tuple as QSS qlineargradient() or qradialgradient().
+std::string gradientToQss(const Tuple& tuple, const auto& formatValue)
+{
+    const char* functionName = tuple.kind == TupleKind::LinearGradient ? "qlineargradient"
+                                                                       : "qradialgradient";
+
+    std::vector<std::string> parts;
+
+    // Geometry params (all named elements except "stops")
+    for (const auto& [name, value] : tuple.elements) {
+        if (!name || *name == "stops") {
+            continue;
+        }
+        parts.push_back(fmt::format("{}:{}", *name, formatValue(*value)));
+    }
+
+    // Stops
+    const auto* stopsValue = tuple.find("stops");
+    if (stopsValue && stopsValue->holds<Tuple>()) {
+        const auto& stopsTuple = stopsValue->get<Tuple>();
+        for (size_t index = 0; index < stopsTuple.size(); ++index) {
+            const auto& stopEntry = stopsTuple.at(index).get<Tuple>();
+            parts.push_back(
+                fmt::format("stop:{} {}", formatValue(stopEntry.at(0)), formatValue(stopEntry.at(1)))
+            );
+        }
+    }
+
+    return fmt::format("{}({})", functionName, fmt::join(parts, ", "));
+}
+
 /// Formats a Value for QSS output.
-/// Tuples become space-separated values (e.g. "10px 5px 10px 5px"),
-/// all other types delegate to toString().
+/// Gradient tuples use qlineargradient()/qradialgradient() syntax.
+/// Other tuples become space-separated values (e.g. "10px 5px 10px 5px").
+/// All other types delegate to toString().
 std::string toQss(const Value& value)
 {
     if (value.holds<Tuple>()) {
         const auto& tuple = value.get<Tuple>();
+
+        if (tuple.kind == TupleKind::LinearGradient || tuple.kind == TupleKind::RadialGradient) {
+            return gradientToQss(tuple, [](const Value& val) { return toQss(val); });
+        }
 
         std::vector<std::string> parts;
         parts.reserve(tuple.elements.size());

--- a/src/Gui/StyleParameters/ParameterManager.cpp
+++ b/src/Gui/StyleParameters/ParameterManager.cpp
@@ -22,11 +22,13 @@
  ***************************************************************************/
 
 #include "ParameterManager.h"
+#include "Diagnostics.h"
 #include "Parser.h"
 
 #include <QFile>
 #include <fstream>
 #include <yaml-cpp/yaml.h>
+#include <fmt/format.h>
 #include <fmt/ranges.h>
 
 #include <QRegularExpression>
@@ -77,13 +79,49 @@ std::string yamlNodeToExpression(const YAML::Node& node)
     return "";
 }
 
+/// Formats a gradient tuple as QSS qlineargradient() or qradialgradient().
+std::string gradientToQss(const Tuple& tuple, const auto& formatValue)
+{
+    const char* functionName = tuple.kind == TupleKind::LinearGradient ? "qlineargradient"
+                                                                       : "qradialgradient";
+
+    std::vector<std::string> parts;
+
+    // Geometry params (all named elements except "stops")
+    for (const auto& [name, value] : tuple.elements) {
+        if (!name || *name == "stops") {
+            continue;
+        }
+        parts.push_back(fmt::format("{}:{}", *name, formatValue(*value)));
+    }
+
+    // Stops
+    const auto* stopsValue = tuple.find("stops");
+    if (stopsValue && stopsValue->holds<Tuple>()) {
+        const auto& stopsTuple = stopsValue->get<Tuple>();
+        for (size_t index = 0; index < stopsTuple.size(); ++index) {
+            const auto& stopEntry = stopsTuple.at(index).get<Tuple>();
+            parts.push_back(
+                fmt::format("stop:{} {}", formatValue(stopEntry.at(0)), formatValue(stopEntry.at(1)))
+            );
+        }
+    }
+
+    return fmt::format("{}({})", functionName, fmt::join(parts, ", "));
+}
+
 /// Formats a Value for QSS output.
-/// Tuples become space-separated values (e.g. "10px 5px 10px 5px"),
-/// all other types delegate to toString().
+/// Gradient tuples use qlineargradient()/qradialgradient() syntax.
+/// Other tuples become space-separated values (e.g. "10px 5px 10px 5px").
+/// All other types delegate to toString().
 std::string toQss(const Value& value)
 {
     if (value.holds<Tuple>()) {
         const auto& tuple = value.get<Tuple>();
+
+        if (tuple.kind == TupleKind::LinearGradient || tuple.kind == TupleKind::RadialGradient) {
+            return gradientToQss(tuple, [](const Value& val) { return toQss(val); });
+        }
 
         std::vector<std::string> parts;
         parts.reserve(tuple.elements.size());
@@ -304,6 +342,7 @@ ParameterManager::ParameterManager() = default;
 void ParameterManager::reload()
 {
     _resolved.clear();
+    Diagnostics::clear();
 }
 
 std::string ParameterManager::replacePlaceholders(
@@ -311,72 +350,96 @@ std::string ParameterManager::replacePlaceholders(
     ResolveContext context
 ) const
 {
-    // Matches @TokenName (group name) or @{expression} (group expression)
-    static const QRegularExpression regex("@(?:(?P<name>\\w+)|({(?P<expression>(?>[^{}]+|(?2))+)}))");
+    // Structural backstop, mirroring resolve()'s outermost catch: no future edit to this
+    // function, nor to the callback it drives, should be able to let an exception escape into
+    // replacePlaceholders's callers — Application.cpp's QSS substitution is unguarded. On
+    // failure the original expression is returned unchanged rather than an empty string, since
+    // a caller substituting into QSS is better served by the untouched source than by silence.
+    try {
+        // Matches @TokenName (group name) or @{expression} (group expression)
+        static const QRegularExpression regex(
+            "@(?:(?P<name>\\w+)|({(?P<expression>(?>[^{}]+|(?2))+)}))"
+        );
 
-    auto substituteWithCallback =
-        [](const QRegularExpression& regex,
-           const QString& input,
-           const std::function<QString(const QRegularExpressionMatch&)>& callback) {
-            QRegularExpressionMatchIterator it = regex.globalMatch(input);
+        auto substituteWithCallback =
+            [](const QRegularExpression& regex,
+               const QString& input,
+               const std::function<QString(const QRegularExpressionMatch&)>& callback) {
+                QRegularExpressionMatchIterator it = regex.globalMatch(input);
 
-            QString result;
-            qsizetype lastIndex = 0;
+                QString result;
+                qsizetype lastIndex = 0;
 
-            while (it.hasNext()) {
-                QRegularExpressionMatch match = it.next();
+                while (it.hasNext()) {
+                    QRegularExpressionMatch match = it.next();
 
-                qsizetype start = match.capturedStart();
-                qsizetype end = match.capturedEnd();
+                    qsizetype start = match.capturedStart();
+                    qsizetype end = match.capturedEnd();
 
-                result += input.mid(lastIndex, start - lastIndex);
-                result += callback(match);
+                    result += input.mid(lastIndex, start - lastIndex);
+                    result += callback(match);
 
-                lastIndex = end;
-            }
-
-            // Append any remaining text after the last match
-            result += input.mid(lastIndex);
-
-            return result;
-        };
-
-    // clang-format off
-    return substituteWithCallback(
-        regex,
-        QString::fromStdString(expression),
-        [&](const QRegularExpressionMatch& match) -> QString {
-            // Group 1: @TokenName
-            if (!match.captured("name").isEmpty()) {
-                auto tokenName = match.captured(1).toStdString();
-                auto tokenValue = resolve(tokenName, context);
-
-                if (!tokenValue) {
-                    Base::Console().warning("Requested non-existent style parameter token '%s'.\n", tokenName);
-                    return QStringLiteral("");
+                    lastIndex = end;
                 }
 
-                context.visited.erase(tokenName);
-                return QString::fromStdString(toQss(*tokenValue));
-            }
+                // Append any remaining text after the last match
+                result += input.mid(lastIndex);
 
-            // Group 2: @{expression}
-            auto exprBody = match.captured("expression").toStdString();
-            try {
-                Value result = evaluate(exprBody, context);
-                return QString::fromStdString(toQss(result));
-            }
-            catch (Base::Exception& e) {
-                Base::Console().warning(
-                    "Failed to evaluate inline expression '@{%s}': %s\n",
-                    exprBody,
-                    e.what()
-                );
-                return QStringLiteral("");
-            }
+                return result;
+            };
+
+        // clang-format off
+        return substituteWithCallback(
+            regex,
+            QString::fromStdString(expression),
+            [&](const QRegularExpressionMatch& match) -> QString {
+                // Group 1: @TokenName
+                if (!match.captured("name").isEmpty()) {
+                    auto tokenName = match.captured(1).toStdString();
+
+                    try {
+                        auto tokenValue = resolve(tokenName, context);
+
+                        if (!tokenValue) {
+                            Diagnostics::report("Requested non-existent style parameter token '{}'", tokenName);
+                            return QStringLiteral("");
+                        }
+
+                        context.visited.erase(tokenName);
+                        return QString::fromStdString(toQss(*tokenValue));
+                    }
+                    catch (...) {
+                        Diagnostics::report("Failed to resolve style parameter token '{}'", tokenName);
+                        return QStringLiteral("");
+                    }
+                }
+
+                // Group 2: @{expression}
+                auto exprBody = match.captured("expression").toStdString();
+                try {
+                    Value result = evaluate(exprBody, context);
+                    return QString::fromStdString(toQss(result));
+                }
+                catch (const Base::Exception& exception) {
+                    Diagnostics::report(
+                        "Failed to evaluate inline expression '@{{{}}}': {}",
+                        exprBody,
+                        exception.what()
+                    );
+                    return QStringLiteral("");
+                }
+                catch (...) {
+                    Diagnostics::report("Failed to evaluate inline expression '@{{{}}}'", exprBody);
+                    return QStringLiteral("");
+                }
+        }
+        ).toStdString();
+        // clang-format on
     }
-    ).toStdString();
-    // clang-format on
+    catch (...) {
+        Diagnostics::report("Failed to substitute style parameter placeholders in '{}'", expression);
+        return expression;
+    }
 }
 
 std::list<Parameter> ParameterManager::parameters() const
@@ -404,38 +467,80 @@ std::optional<std::string> ParameterManager::expression(const std::string& name)
 
 std::optional<Value> ParameterManager::resolve(const std::string& name, ResolveContext context) const
 {
-    std::optional<Parameter> maybeParameter = this->parameter(name);
+    Diagnostics::ResolutionScope scope(name);
 
-    if (!maybeParameter) {
+    try {
+        std::optional<Parameter> maybeParameter;
+        try {
+            maybeParameter = this->parameter(name);
+        }
+        catch (...) {
+            Diagnostics::report("Failed to retrieve style parameter '{}' from its source", name);
+            return std::nullopt;
+        }
+
+        if (!maybeParameter) {
+            return std::nullopt;
+        }
+
+        if (context.visited.contains(name)) {
+            Diagnostics::report("The style parameter '{}' contains a circular reference", name);
+            return expression(name);
+        }
+
+        const Parameter& token = *maybeParameter;
+
+        if (!_resolved.contains(token.name)) {
+            context.visited.insert(token.name);
+            try {
+                _resolved[token.name] = evaluate(token.value, context);
+            }
+            catch (const Base::Exception& exception) {
+                Diagnostics::report(
+                    "Style parameter '{}' could not be evaluated: {}",
+                    token.name,
+                    exception.what()
+                );
+                // Fall back to treating the value as a generic string.
+                try {
+                    _resolved[token.name] = replacePlaceholders(token.value, context);
+                }
+                catch (...) {
+                    _resolved[token.name] = token.value;
+                }
+            }
+            context.visited.erase(token.name);
+        }
+
+        return _resolved[token.name];
+    }
+    catch (...) {
+        // Structural backstop: no future edit to this function, nor any call site it reaches
+        // (parameter(), expression(), evaluate()) that is not already individually guarded
+        // above, should be able to let an exception escape resolve().
+        Diagnostics::report("Failed to resolve style parameter '{}'", name);
         return std::nullopt;
     }
-
-    if (context.visited.contains(name)) {
-        Base::Console().warning("The style parameter '%s' contains circular-reference.\n", name);
-        return expression(name);
-    }
-
-    const Parameter& token = *maybeParameter;
-
-    if (!_resolved.contains(token.name)) {
-        context.visited.insert(token.name);
-        try {
-            _resolved[token.name] = evaluate(token.value, context);
-        }
-        catch (Base::Exception&) {
-            // in case of being unable to parse it, we need to treat it as a generic value
-            _resolved[token.name] = replacePlaceholders(token.value, context);
-        }
-        context.visited.erase(token.name);
-    }
-
-    return _resolved[token.name];
 }
 
 Value ParameterManager::evaluate(const std::string& expression, ResolveContext context) const
 {
-    Parser parser(expression);
-    return parser.parse()->evaluate({.manager = this, .context = std::move(context)});
+    try {
+        Parser parser(expression);
+        return parser.parse()->evaluate({.manager = this, .context = std::move(context)});
+    }
+    catch (const Base::Exception&) {
+        throw;
+    }
+    catch (const std::exception& exception) {
+        THROWM(
+            Base::ExpressionError,
+            fmt::format("Failed to evaluate '{}': {}", expression, exception.what())
+        );
+    }
+    catch (...) {
+        THROWM(Base::ExpressionError, fmt::format("Failed to evaluate '{}'", expression));
+    }
 }
 
 std::optional<Parameter> ParameterManager::parameter(const std::string& name) const

--- a/src/Gui/StyleParameters/ParameterManager.h
+++ b/src/Gui/StyleParameters/ParameterManager.h
@@ -430,37 +430,9 @@ public:
      * @return The resolved value
      */
     template<typename T>
-        requires std::is_constructible_v<T, const Tuple&>
     T resolve(const ParameterDefinition<T>& definition, ResolveContext context = {}) const
     {
-        auto value = resolve(definition.name, std::move(context));
-
-        if (!value || !value->template holds<Tuple>()) {
-            return definition.defaultValue;
-        }
-
-        const auto& tuple = value->template get<Tuple>();
-
-        // Reject tuples with a different typed kind (e.g., Margins when expecting Padding).
-        // Generic and matching kinds are accepted — the constructor handles expansion.
-        if (tuple.kind != TupleKind::Generic && tuple.kind != T::kind()) {
-            return definition.defaultValue;
-        }
-
-        return T(tuple);
-    }
-
-    template<typename T>
-        requires(!std::is_constructible_v<T, const Tuple&>)
-    T resolve(const ParameterDefinition<T>& definition, ResolveContext context = {}) const
-    {
-        auto value = resolve(definition.name, std::move(context));
-
-        if (!value || !std::holds_alternative<T>(*value)) {
-            return definition.defaultValue;
-        }
-
-        return std::get<T>(*value);
+        return valueAs<T>(resolve(definition.name, std::move(context))).value_or(definition.defaultValue);
     }
 
     /**

--- a/src/Gui/StyleParameters/ParameterManager.h
+++ b/src/Gui/StyleParameters/ParameterManager.h
@@ -432,13 +432,7 @@ public:
     template<typename T>
     T resolve(const ParameterDefinition<T>& definition, ResolveContext context = {}) const
     {
-        auto value = resolve(definition.name, std::move(context));
-
-        if (!value || !std::holds_alternative<T>(*value)) {
-            return definition.defaultValue;
-        }
-
-        return std::get<T>(*value);
+        return valueAs<T>(resolve(definition.name, std::move(context))).value_or(definition.defaultValue);
     }
 
     /**

--- a/src/Gui/StyleParameters/ParameterManager.h
+++ b/src/Gui/StyleParameters/ParameterManager.h
@@ -430,6 +430,28 @@ public:
      * @return The resolved value
      */
     template<typename T>
+        requires std::is_constructible_v<T, const Tuple&>
+    T resolve(const ParameterDefinition<T>& definition, ResolveContext context = {}) const
+    {
+        auto value = resolve(definition.name, std::move(context));
+
+        if (!value || !value->template holds<Tuple>()) {
+            return definition.defaultValue;
+        }
+
+        const auto& tuple = value->template get<Tuple>();
+
+        // Reject tuples with a different typed kind (e.g., Margins when expecting Padding).
+        // Generic and matching kinds are accepted — the constructor handles expansion.
+        if (tuple.kind != TupleKind::Generic && tuple.kind != T::kind()) {
+            return definition.defaultValue;
+        }
+
+        return T(tuple);
+    }
+
+    template<typename T>
+        requires(!std::is_constructible_v<T, const Tuple&>)
     T resolve(const ParameterDefinition<T>& definition, ResolveContext context = {}) const
     {
         auto value = resolve(definition.name, std::move(context));

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -23,6 +23,7 @@
 
 #include "Parser.h"
 #include "Corners.h"
+#include "Gradient.h"
 #include "Insets.h"
 #include "ParameterManager.h"
 
@@ -101,6 +102,8 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
         {"margins", [&args]() -> Value { return Margins(args).tuple(); }},
         {"border_thickness", [&args]() -> Value { return BorderThickness(args).tuple(); }},
         {"border_radius", [&args]() -> Value { return Corners(args).tuple(); }},
+        {"linear_gradient", [&args]() -> Value { return LinearGradient(args).tuple(); }},
+        {"radial_gradient", [&args]() -> Value { return RadialGradient(args).tuple(); }},
     };
 
     if (functions.contains(functionName)) {

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "Parser.h"
+#include "Corners.h"
 #include "Insets.h"
 #include "ParameterManager.h"
 
@@ -92,85 +93,14 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
         );
     };
 
-    const auto makeInsets = [&args](TupleKind kind) -> Value {
-        // If the single positional argument is already a tuple, re-tag it
-        std::vector<const Value*> positional;
-        for (const auto& elem : args.elements) {
-            if (!elem.name) {
-                positional.push_back(elem.value.get());
-            }
-        }
-
-        if (positional.size() == 1 && positional[0]->holds<Tuple>()) {
-            Tuple converted = positional[0]->get<Tuple>();
-            converted.kind = kind;
-            return converted;
-        }
-
-        // Expand CSS-like shorthand from positional args
-        auto [top, right, bottom, left] = [&]() -> std::array<const Value*, 4> {
-            switch (positional.size()) {
-                case 0:
-                    return {nullptr, nullptr, nullptr, nullptr};
-                case 1:
-                    return {positional[0], positional[0], positional[0], positional[0]};
-                case 2:
-                    return {positional[0], positional[1], positional[0], positional[1]};
-                case 3:  // NOLINT(*-magic-numbers)
-                    return {positional[0], positional[1], positional[2], positional[1]};
-                case 4:  // NOLINT(*-magic-numbers)
-                    return {positional[0], positional[1], positional[2], positional[3]};
-                default:
-                    THROWM(Base::ExpressionError, "Insets functions accept 1-4 positional arguments");
-            }
-        }();
-
-        // Group names override positional
-        if (const Value* vertical = args.find("vertical")) {
-            top = bottom = vertical;
-        }
-        if (const Value* horizontal = args.find("horizontal")) {
-            right = left = horizontal;
-        }
-
-        // Explicit side names override everything
-        if (const Value* found = args.find("top")) {
-            top = found;
-        }
-        if (const Value* found = args.find("right")) {
-            right = found;
-        }
-        if (const Value* found = args.find("bottom")) {
-            bottom = found;
-        }
-        if (const Value* found = args.find("left")) {
-            left = found;
-        }
-
-        if (!top || !right || !bottom || !left) {
-            THROWM(Base::ExpressionError, "Insets function requires all four sides to be specified");
-        }
-
-        auto makeElement = [](const char* name, const Value& val) {
-            return Tuple::Element {std::string(name), std::make_shared<const Value>(val)};
-        };
-
-        Tuple result;
-        result.kind = kind;
-        result.elements.push_back(makeElement("top", *top));
-        result.elements.push_back(makeElement("right", *right));
-        result.elements.push_back(makeElement("bottom", *bottom));
-        result.elements.push_back(makeElement("left", *left));
-        return result;
-    };
-
     std::map<std::string, std::function<Value()>> functions = {
         {"lighten", lightenOrDarken},
         {"darken", lightenOrDarken},
         {"blend", blend},
-        {"padding", [&]() { return makeInsets(TupleKind::Padding); }},
-        {"margins", [&]() { return makeInsets(TupleKind::Margins); }},
-        {"border_thickness", [&]() { return makeInsets(TupleKind::BorderThickness); }},
+        {"padding", [&args]() -> Value { return Padding(args).tuple(); }},
+        {"margins", [&args]() -> Value { return Margins(args).tuple(); }},
+        {"border_thickness", [&args]() -> Value { return BorderThickness(args).tuple(); }},
+        {"border_radius", [&args]() -> Value { return Corners(args).tuple(); }},
     };
 
     if (functions.contains(functionName)) {

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -322,6 +322,51 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
         {"border_radius", [&args]() -> Value { return Corners(args).tuple(); }},
         {"linear_gradient", [&args]() -> Value { return LinearGradient(args).tuple(); }},
         {"radial_gradient", [&args]() -> Value { return RadialGradient(args).tuple(); }},
+        {
+            "content_box",
+            [&args]() -> Value {
+                if (args.size() < 2) {
+                    THROWM(Base::ExpressionError, "content_box requires at least 2 arguments: a size tuple and at least one inset");
+                }
+
+                const Value& sizeValue = args.at(0);
+                Numeric width, height;
+
+                if (sizeValue.holds<Tuple>()) {
+                    const auto& sizeTuple = sizeValue.get<Tuple>();
+                    width = sizeTuple.get<Numeric>("width");
+                    height = sizeTuple.get<Numeric>("height");
+                }
+                else if (sizeValue.holds<Numeric>()) {
+                    width = sizeValue.get<Numeric>();
+                    height = sizeValue.get<Numeric>();
+                }
+                else {
+                    THROWM(Base::TypeError, "content_box: first argument must be a (width, height) size tuple or a Numeric");
+                }
+
+                for (size_t index = 1; index < args.size(); ++index) {
+                    const Value& insetValue = args.at(index);
+                    if (!insetValue.holds<Tuple>()) {
+                        THROWM(
+                            Base::TypeError,
+                            fmt::format("content_box: argument {} must be an inset tuple", index)
+                        );
+                    }
+                    const auto& insetTuple = insetValue.get<Tuple>();
+                    const Insets insets(
+                        insetTuple.kind == TupleKind::Generic ? Insets::expand(insetTuple) : insetTuple
+                    );
+                    width = width - insets.horizontal();
+                    height = height - insets.vertical();
+                }
+
+                return Tuple({
+                    Tuple::Element::named("width", width),
+                    Tuple::Element::named("height", height),
+                });
+            },
+        },
     };
 
     if (functions.contains(functionName)) {

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -279,7 +279,10 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
 
     const auto contentBox = [&args]() -> Value {
         if (args.size() < 2) {
-            THROWM(Base::ExpressionError, "content_box requires at least 2 arguments: a size tuple and at least one inset");
+            THROWM(
+                Base::ExpressionError,
+                "content_box requires at least 2 arguments: a size tuple and at least one inset"
+            );
         }
 
         const Value& sizeValue = args.at(0);
@@ -295,7 +298,10 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
             height = sizeValue.get<Numeric>();
         }
         else {
-            THROWM(Base::TypeError, "content_box: first argument must be a (width, height) size tuple or a Numeric");
+            THROWM(
+                Base::TypeError,
+                "content_box: first argument must be a (width, height) size tuple or a Numeric"
+            );
         }
 
         for (size_t index = 1; index < args.size(); ++index) {

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -318,6 +318,7 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
         {"shades", shades},
         {"padding", [&args]() -> Value { return Padding(args).tuple(); }},
         {"margins", [&args]() -> Value { return Margins(args).tuple(); }},
+        {"border_colors", [&args]() -> Value { return BorderColors(args).tuple(); }},
         {"border_thickness", [&args]() -> Value { return BorderThickness(args).tuple(); }},
         {"border_radius", [&args]() -> Value { return Corners(args).tuple(); }},
         {"linear_gradient", [&args]() -> Value { return LinearGradient(args).tuple(); }},

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "Parser.h"
+#include "Insets.h"
 #include "ParameterManager.h"
 
 #include <Utilities.h>
@@ -91,10 +92,85 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
         );
     };
 
+    const auto makeInsets = [&args](TupleKind kind) -> Value {
+        // If the single positional argument is already a tuple, re-tag it
+        std::vector<const Value*> positional;
+        for (const auto& elem : args.elements) {
+            if (!elem.name) {
+                positional.push_back(elem.value.get());
+            }
+        }
+
+        if (positional.size() == 1 && positional[0]->holds<Tuple>()) {
+            Tuple converted = positional[0]->get<Tuple>();
+            converted.kind = kind;
+            return converted;
+        }
+
+        // Expand CSS-like shorthand from positional args
+        auto [top, right, bottom, left] = [&]() -> std::array<const Value*, 4> {
+            switch (positional.size()) {
+                case 0:
+                    return {nullptr, nullptr, nullptr, nullptr};
+                case 1:
+                    return {positional[0], positional[0], positional[0], positional[0]};
+                case 2:
+                    return {positional[0], positional[1], positional[0], positional[1]};
+                case 3:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[1]};
+                case 4:  // NOLINT(*-magic-numbers)
+                    return {positional[0], positional[1], positional[2], positional[3]};
+                default:
+                    THROWM(Base::ExpressionError, "Insets functions accept 1-4 positional arguments");
+            }
+        }();
+
+        // Group names override positional
+        if (const Value* vertical = args.find("vertical")) {
+            top = bottom = vertical;
+        }
+        if (const Value* horizontal = args.find("horizontal")) {
+            right = left = horizontal;
+        }
+
+        // Explicit side names override everything
+        if (const Value* found = args.find("top")) {
+            top = found;
+        }
+        if (const Value* found = args.find("right")) {
+            right = found;
+        }
+        if (const Value* found = args.find("bottom")) {
+            bottom = found;
+        }
+        if (const Value* found = args.find("left")) {
+            left = found;
+        }
+
+        if (!top || !right || !bottom || !left) {
+            THROWM(Base::ExpressionError, "Insets function requires all four sides to be specified");
+        }
+
+        auto makeElement = [](const char* name, const Value& val) {
+            return Tuple::Element {std::string(name), std::make_shared<const Value>(val)};
+        };
+
+        Tuple result;
+        result.kind = kind;
+        result.elements.push_back(makeElement("top", *top));
+        result.elements.push_back(makeElement("right", *right));
+        result.elements.push_back(makeElement("bottom", *bottom));
+        result.elements.push_back(makeElement("left", *left));
+        return result;
+    };
+
     std::map<std::string, std::function<Value()>> functions = {
         {"lighten", lightenOrDarken},
         {"darken", lightenOrDarken},
         {"blend", blend},
+        {"padding", [&]() { return makeInsets(TupleKind::Padding); }},
+        {"margins", [&]() { return makeInsets(TupleKind::Margins); }},
+        {"border_thickness", [&]() { return makeInsets(TupleKind::BorderThickness); }},
     };
 
     if (functions.contains(functionName)) {
@@ -392,7 +468,7 @@ std::unique_ptr<Expr> Parser::parseFunctionCall()
 {
     skipWhitespace();
     size_t start = pos;
-    while (pos < input.size() && isalnum(input[pos])) {
+    while (pos < input.size() && (isalnum(input[pos]) || input[pos] == '_')) {
         ++pos;
     }
     std::string functionName = input.substr(start, pos - start);

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -322,51 +322,7 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
         {"border_radius", [&args]() -> Value { return Corners(args).tuple(); }},
         {"linear_gradient", [&args]() -> Value { return LinearGradient(args).tuple(); }},
         {"radial_gradient", [&args]() -> Value { return RadialGradient(args).tuple(); }},
-        {
-            "content_box",
-            [&args]() -> Value {
-                if (args.size() < 2) {
-                    THROWM(Base::ExpressionError, "content_box requires at least 2 arguments: a size tuple and at least one inset");
-                }
-
-                const Value& sizeValue = args.at(0);
-                Numeric width, height;
-
-                if (sizeValue.holds<Tuple>()) {
-                    const auto& sizeTuple = sizeValue.get<Tuple>();
-                    width = sizeTuple.get<Numeric>("width");
-                    height = sizeTuple.get<Numeric>("height");
-                }
-                else if (sizeValue.holds<Numeric>()) {
-                    width = sizeValue.get<Numeric>();
-                    height = sizeValue.get<Numeric>();
-                }
-                else {
-                    THROWM(Base::TypeError, "content_box: first argument must be a (width, height) size tuple or a Numeric");
-                }
-
-                for (size_t index = 1; index < args.size(); ++index) {
-                    const Value& insetValue = args.at(index);
-                    if (!insetValue.holds<Tuple>()) {
-                        THROWM(
-                            Base::TypeError,
-                            fmt::format("content_box: argument {} must be an inset tuple", index)
-                        );
-                    }
-                    const auto& insetTuple = insetValue.get<Tuple>();
-                    const Insets insets(
-                        insetTuple.kind == TupleKind::Generic ? Insets::expand(insetTuple) : insetTuple
-                    );
-                    width = width - insets.horizontal();
-                    height = height - insets.vertical();
-                }
-
-                return Tuple({
-                    Tuple::Element::named("width", width),
-                    Tuple::Element::named("height", height),
-                });
-            },
-        },
+        {"content_box", contentBox},
     };
 
     if (functions.contains(functionName)) {

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -54,6 +54,19 @@ Value Color::evaluate([[maybe_unused]] const EvaluationContext& context) const
 
 Value FunctionCall::evaluate(const EvaluationContext& context) const
 {
+    if (functionName == "coalesce") {
+        if (arguments.elements.empty()) {
+            THROWM(Base::ExpressionError, "coalesce requires at least one argument");
+        }
+        for (const auto& element : arguments.elements) {
+            Value result = element.expression->evaluate(context);
+            if (!result.holds<std::string>() || !result.get<std::string>().starts_with("@")) {
+                return result;
+            }
+        }
+        return arguments.elements.back().expression->evaluate(context);
+    }
+
     auto argsValue = arguments.evaluate(context);
     const auto& args = argsValue.get<Tuple>();
 

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -60,8 +60,6 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
     const auto lightenOrDarken = [this, &args]() -> Value {
         auto resolved = ArgumentParser {{"color"}, {"amount"}}.resolve(args);
 
-        auto color = resolved.get<Base::Color>("color").asValue<QColor>();
-
         // In Qt if you want to make color 20% darker or lighter, you need to pass 120 as the value
         // we, however, want users to pass only the relative difference, hence we need to add the
         // 100 required by Qt.
@@ -69,29 +67,75 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
         // NOLINTNEXTLINE(*-magic-numbers)
         auto amount = 100 + static_cast<int>(resolved.get<Numeric>("amount").value);
 
-        if (functionName == "lighten") {
-            return Base::Color::fromValue(color.lighter(amount));
+        const auto applyToColor = [&](const Base::Color& color) -> Base::Color {
+            auto qcolor = color.asValue<QColor>();
+            if (functionName == "lighten") {
+                return Base::Color::fromValue(qcolor.lighter(amount));
+            }
+            return Base::Color::fromValue(qcolor.darker(amount));
+        };
+
+        const Value* colorValue = resolved.find("color");
+        if (colorValue->holds<Tuple>()) {
+            const auto& colorTuple = colorValue->get<Tuple>();
+            if (!Gradient::isGradient(colorTuple)) {
+                THROWM(
+                    Base::ExpressionError,
+                    fmt::format("{}: color argument must be a color or gradient", functionName)
+                );
+            }
+            return Gradient::mapStopColors(colorTuple, applyToColor);
         }
 
-        if (functionName == "darken") {
-            return Base::Color::fromValue(color.darker(amount));
-        }
-
-        return {};
+        return applyToColor(resolved.get<Base::Color>("color"));
     };
 
     const auto blend = [&args]() -> Value {
         auto resolved = ArgumentParser {{"from"}, {"to"}, {"amount"}}.resolve(args);
 
-        auto firstColor = resolved.get<Base::Color>("from");
-        auto secondColor = resolved.get<Base::Color>("to");
         auto amount = Base::fromPercent(static_cast<long>(resolved.get<Numeric>("amount").value));
 
-        return Base::Color(
-            (1 - amount) * firstColor.r + amount * secondColor.r,
-            (1 - amount) * firstColor.g + amount * secondColor.g,
-            (1 - amount) * firstColor.b + amount * secondColor.b
-        );
+        const auto blendColors =
+            [amount](const Base::Color& first, const Base::Color& second) -> Base::Color {
+            return Base::Color(
+                (1 - amount) * first.r + amount * second.r,
+                (1 - amount) * first.g + amount * second.g,
+                (1 - amount) * first.b + amount * second.b
+            );
+        };
+
+        const Value* fromValue = resolved.find("from");
+        const Value* toValue = resolved.find("to");
+
+        if (fromValue->holds<Tuple>() && !Gradient::isGradient(fromValue->get<Tuple>())) {
+            THROWM(Base::ExpressionError, "blend: 'from' argument must be a color or gradient");
+        }
+        if (toValue->holds<Tuple>() && !Gradient::isGradient(toValue->get<Tuple>())) {
+            THROWM(Base::ExpressionError, "blend: 'to' argument must be a color or gradient");
+        }
+
+        bool fromIsGradient = fromValue->holds<Tuple>();
+        bool toIsGradient = toValue->holds<Tuple>();
+
+        if (fromIsGradient && toIsGradient) {
+            THROWM(Base::ExpressionError, "Cannot blend two gradients");
+        }
+
+        if (fromIsGradient) {
+            const auto& targetColor = toValue->get<Base::Color>();
+            return Gradient::mapStopColors(fromValue->get<Tuple>(), [&](const Base::Color& stopColor) {
+                return blendColors(stopColor, targetColor);
+            });
+        }
+
+        if (toIsGradient) {
+            const auto& sourceColor = fromValue->get<Base::Color>();
+            return Gradient::mapStopColors(toValue->get<Tuple>(), [&](const Base::Color& stopColor) {
+                return blendColors(sourceColor, stopColor);
+            });
+        }
+
+        return blendColors(fromValue->get<Base::Color>(), toValue->get<Base::Color>());
     };
 
     std::map<std::string, std::function<Value()>> functions = {

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -28,6 +28,8 @@
 #include "ParameterManager.h"
 
 #include <Utilities.h>
+#include <Base/ColorShading.h>
+#include <Base/OkLch.h>
 #include <Base/Tools.h>
 
 #include <QColor>
@@ -148,13 +150,172 @@ Value FunctionCall::evaluate(const EvaluationContext& context) const
             });
         }
 
+        if (!fromValue->holds<Base::Color>()) {
+            THROWM(Base::ExpressionError, "Expected color as from argument");
+        }
+
+        if (!toValue->holds<Base::Color>()) {
+            THROWM(Base::ExpressionError, "Expected color as to argument");
+        }
+
         return blendColors(fromValue->get<Base::Color>(), toValue->get<Base::Color>());
+    };
+
+    const auto asPercent = [](const Numeric& numeric) -> float {
+        if (numeric.unit == "%") {
+            return static_cast<float>(numeric.value / 100.0);
+        }
+        return static_cast<float>(numeric.value);
+    };
+
+    const auto parseShadingParams = [&asPercent](const Tuple& resolved) {
+        return Base::ColorShading::Parameters {
+            .range = asPercent(resolved.get<Numeric>("range")),
+            .minLightness = asPercent(resolved.get<Numeric>("min")),
+            .maxLightness = asPercent(resolved.get<Numeric>("max")),
+            .pivot = asPercent(resolved.get<Numeric>("pivot")),
+            .chromaExponent = asPercent(resolved.get<Numeric>("q")),
+        };
+    };
+
+    const auto applyShade = [](float position,
+                               const Base::Color& color,
+                               const Base::OkLch& oklch,
+                               const Base::ColorShading::Parameters& shadingParams) -> Base::Color {
+        auto shadeOklch = Base::ColorShading::computeShade(position, oklch, shadingParams);
+        if (shadeOklch.lightness == oklch.lightness && shadeOklch.chroma == oklch.chroma) {
+            return color;
+        }
+        return Base::fromOkLch(shadeOklch, color.a);
+    };
+
+    const auto shade = [&args, &asPercent, &parseShadingParams, &applyShade]() -> Value {
+        auto resolved = ArgumentParser {
+            {.name = "color"},
+            {.name = "lightness"},
+            {.name = "range", .defaultValue = Numeric {0.8, ""}},
+            {.name = "min", .defaultValue = Numeric {0.17, ""}},
+            {.name = "max", .defaultValue = Numeric {0.97, ""}},
+            {.name = "pivot", .defaultValue = Numeric {0.5, ""}},
+            {.name = "q", .defaultValue = Numeric {0.1, ""}},
+        }.resolve(args);
+
+        auto position = asPercent(resolved.get<Numeric>("lightness"));
+        auto shadingParams = parseShadingParams(resolved);
+
+        const auto applyToColor = [&](const Base::Color& color) -> Base::Color {
+            auto oklch = Base::toOkLch(color);
+            return applyShade(position, color, oklch, shadingParams);
+        };
+
+        const Value* colorValue = resolved.find("color");
+        if (colorValue->holds<Tuple>()) {
+            const auto& colorTuple = colorValue->get<Tuple>();
+            if (!Gradient::isGradient(colorTuple)) {
+                THROWM(Base::ExpressionError, "shade: color argument must be a color or gradient");
+            }
+            return Gradient::mapStopColors(colorTuple, applyToColor);
+        }
+
+        return applyToColor(resolved.get<Base::Color>("color"));
+    };
+
+    const auto shades = [&args, &asPercent, &parseShadingParams, &applyShade]() -> Value {
+        auto resolved = ArgumentParser {
+            {.name = "color"},
+            {.name = "shades"},
+            {.name = "range", .defaultValue = Numeric {0.8, ""}},
+            {.name = "min", .defaultValue = Numeric {0.17, ""}},
+            {.name = "max", .defaultValue = Numeric {0.97, ""}},
+            {.name = "pivot", .defaultValue = Numeric {0.5, ""}},
+            {.name = "q", .defaultValue = Numeric {0.1, ""}},
+        }.resolve(args);
+
+        const auto& shadesSpec = resolved.get<Tuple>("shades");
+        auto shadingParams = parseShadingParams(resolved);
+
+        const auto appendElement = [](Tuple& result, const Tuple::Element& spec, Value shadeValue) {
+            if (spec.name) {
+                result.elements.push_back(Tuple::Element::named(*spec.name, std::move(shadeValue)));
+            }
+            else {
+                result.elements.push_back(Tuple::Element::unnamed(std::move(shadeValue)));
+            }
+        };
+
+        const Value* colorValue = resolved.find("color");
+        if (colorValue->holds<Tuple>()) {
+            const auto& gradientTuple = colorValue->get<Tuple>();
+            if (!Gradient::isGradient(gradientTuple)) {
+                THROWM(Base::ExpressionError, "shades: color argument must be a color or gradient");
+            }
+
+            Tuple result;
+            for (const auto& element : shadesSpec.elements) {
+                float position = asPercent(element.value->get<Numeric>());
+                auto shadedGradient = Gradient::mapStopColors(
+                    gradientTuple,
+                    [&](const Base::Color& stopColor) -> Base::Color {
+                        auto oklch = Base::toOkLch(stopColor);
+                        return applyShade(position, stopColor, oklch, shadingParams);
+                    }
+                );
+                appendElement(result, element, std::move(shadedGradient));
+            }
+            return result;
+        }
+
+        const auto& baseColor = resolved.get<Base::Color>("color");
+        auto baseOklch = Base::toOkLch(baseColor);
+
+        Tuple result;
+        for (const auto& element : shadesSpec.elements) {
+            float position = asPercent(element.value->get<Numeric>());
+            auto shadeColor = applyShade(position, baseColor, baseOklch, shadingParams);
+            appendElement(result, element, shadeColor);
+        }
+        return result;
+    };
+
+    const auto contentBox = [&args]() -> Value {
+        if (args.size() < 2) {
+            THROWM(Base::ExpressionError, "content_box requires at least 2 arguments: a size tuple and at least one inset");
+        }
+
+        const Value& sizeValue = args.at(0);
+        Numeric width, height;
+
+        if (sizeValue.holds<Tuple>()) {
+            const auto& sizeTuple = sizeValue.get<Tuple>();
+            width = sizeTuple.get<Numeric>("width");
+            height = sizeTuple.get<Numeric>("height");
+        }
+        else if (sizeValue.holds<Numeric>()) {
+            width = sizeValue.get<Numeric>();
+            height = sizeValue.get<Numeric>();
+        }
+        else {
+            THROWM(Base::TypeError, "content_box: first argument must be a (width, height) size tuple or a Numeric");
+        }
+
+        for (size_t index = 1; index < args.size(); ++index) {
+            const Insets insets(args.at(index));
+            width = width - insets.horizontal();
+            height = height - insets.vertical();
+        }
+
+        return Tuple({
+            Tuple::Element::named("width", width),
+            Tuple::Element::named("height", height),
+        });
     };
 
     std::map<std::string, std::function<Value()>> functions = {
         {"lighten", lightenOrDarken},
         {"darken", lightenOrDarken},
         {"blend", blend},
+        {"shade", shade},
+        {"shades", shades},
         {"padding", [&args]() -> Value { return Padding(args).tuple(); }},
         {"margins", [&args]() -> Value { return Margins(args).tuple(); }},
         {"border_thickness", [&args]() -> Value { return BorderThickness(args).tuple(); }},

--- a/src/Gui/StyleParameters/Parser.cpp
+++ b/src/Gui/StyleParameters/Parser.cpp
@@ -22,17 +22,416 @@
  ***************************************************************************/
 
 #include "Parser.h"
+#include "ColorShading.h"
+#include "Corners.h"
+#include "Gradient.h"
+#include "Insets.h"
 #include "ParameterManager.h"
 
 #include <Utilities.h>
+#include <Base/OkLch.h>
 #include <Base/Tools.h>
 
 #include <QColor>
 #include <algorithm>
+#include <cctype>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+#include <unordered_map>
 #include <variant>
 
 namespace Gui::StyleParameters
 {
+
+namespace
+{
+/// Returns the named argument of type T, throwing Base::ExpressionError when it is not.
+template<typename T>
+const T& requireArgument(const Tuple& args, const std::string& name, const char* function)
+{
+    if (const T* value = args.tryGet<T>(name)) {
+        return *value;
+    }
+
+    const Value* found = args.find(name);
+    THROWM(
+        Base::ExpressionError,
+        fmt::format(
+            "{}: '{}' argument must be {}, got {}",
+            function,
+            name,
+            valueTypeName<T>(),
+            found ? found->toString() : "nothing"
+        )
+    );
+}
+
+bool isDigitChar(char character)
+{
+    return std::isdigit(static_cast<unsigned char>(character)) != 0;
+}
+
+bool isAlphaChar(char character)
+{
+    return std::isalpha(static_cast<unsigned char>(character)) != 0;
+}
+
+bool isAlnumChar(char character)
+{
+    return std::isalnum(static_cast<unsigned char>(character)) != 0;
+}
+
+bool isSpaceChar(char character)
+{
+    return std::isspace(static_cast<unsigned char>(character)) != 0;
+}
+
+int parseIntOrThrow(const std::string& text, int base = 10)  // NOLINT(*-magic-numbers)
+{
+    try {
+        return std::stoi(text, nullptr, base);
+    }
+    catch (const std::invalid_argument&) {
+        THROWM(Base::ParserError, fmt::format("Invalid integer: {}", text));
+    }
+    catch (const std::out_of_range&) {
+        THROWM(Base::ParserError, fmt::format("Integer out of range: {}", text));
+    }
+}
+
+double parseDoubleOrThrow(const std::string& text)
+{
+    try {
+        return std::stod(text);
+    }
+    catch (const std::invalid_argument&) {
+        THROWM(Base::ParserError, fmt::format("Invalid number: {}", text));
+    }
+    catch (const std::out_of_range&) {
+        THROWM(Base::ParserError, fmt::format("Number out of range: {}", text));
+    }
+}
+
+std::optional<size_t> parseIndex(const std::string& text)
+{
+    try {
+        return std::stoul(text);
+    }
+    catch (const std::exception&) {
+        return std::nullopt;
+    }
+}
+
+/// Shrinks a (width, height) size by one or more insets.
+Value contentBox(const Tuple& args)
+{
+    if (args.size() < 2) {
+        THROWM(
+            Base::ExpressionError,
+            "content_box requires at least 2 arguments: a size tuple and at least one inset"
+        );
+    }
+
+    const Value& sizeValue = args.at(0);
+    Numeric width, height;
+
+    if (sizeValue.holds<Tuple>()) {
+        const auto& sizeTuple = sizeValue.get<Tuple>();
+        // The Base::TypeError branch below only guards the outer shape of the first argument
+        // (tuple vs. numeric vs. neither); it says nothing about what's inside the tuple, so
+        // "width"/"height" of the wrong type still need their own check.
+        width = requireArgument<Numeric>(sizeTuple, "width", "content_box");
+        height = requireArgument<Numeric>(sizeTuple, "height", "content_box");
+    }
+    else if (sizeValue.holds<Numeric>()) {
+        width = sizeValue.get<Numeric>();
+        height = sizeValue.get<Numeric>();
+    }
+    else {
+        THROWM(
+            Base::TypeError,
+            "content_box: first argument must be a (width, height) size tuple or a Numeric"
+        );
+    }
+
+    for (size_t index = 1; index < args.size(); ++index) {
+        const Insets insets(args.at(index));
+        width = width - insets.horizontal();
+        height = height - insets.vertical();
+    }
+
+    return Tuple({
+        Tuple::Element::named("width", width),
+        Tuple::Element::named("height", height),
+    });
+}
+
+/// True when a value is a valid linear or radial gradient, going through the same tryFrom
+/// validation mapGradientStops uses. Lets callers with more than one gradient argument (e.g.
+/// blend) decide between arguments before committing to a mapping.
+bool isGradientValue(const Value& value)
+{
+    return LinearGradient::tryFrom(value).has_value() || RadialGradient::tryFrom(value).has_value();
+}
+
+/// Converts a Numeric to a plain fraction, treating a "%" unit as out-of-100 and any other
+/// unit as if it were dimensionless.
+float asPercent(const Numeric& numeric)
+{
+    return static_cast<float>(numeric.asFraction().value_or(numeric.value));
+}
+
+// Each of these has an ArgumentParser default, so a slot is always present; requireArgument
+// only ever throws here when the theme author supplied an explicit, wrongly-typed value —
+// a defaulted slot is always a Numeric and passes through untouched.
+ColorShading::Parameters parseShadingParams(const Tuple& resolved, const char* function)
+{
+    return ColorShading::Parameters {
+        .range = asPercent(requireArgument<Numeric>(resolved, "range", function)),
+        .minLightness = asPercent(requireArgument<Numeric>(resolved, "min", function)),
+        .maxLightness = asPercent(requireArgument<Numeric>(resolved, "max", function)),
+        .pivot = asPercent(requireArgument<Numeric>(resolved, "pivot", function)),
+        .chromaExponent = asPercent(requireArgument<Numeric>(resolved, "q", function)),
+    };
+}
+
+Base::Color applyShade(
+    float position,
+    const Base::Color& color,
+    const Base::OkLch& oklch,
+    const ColorShading::Parameters& shadingParams
+)
+{
+    auto shadeOklch = ColorShading::computeShade(position, oklch, shadingParams);
+    if (shadeOklch.lightness == oklch.lightness && shadeOklch.chroma == oklch.chroma) {
+        return color;
+    }
+    return Base::fromOkLch(shadeOklch, color.a);
+}
+
+/// Shared implementation of `lighten`/`darken`, distinguished only by the Qt lighter/darker
+/// call and the function name used in diagnostics.
+Value lightenOrDarken(const Tuple& args, bool lighten)
+{
+    const char* functionName = lighten ? "lighten" : "darken";
+
+    auto resolved = ArgumentParser {{"color"}, {"amount"}}.resolve(args);
+
+    // In Qt if you want to make color 20% darker or lighter, you need to pass 120 as the value
+    // we, however, want users to pass only the relative difference, hence we need to add the
+    // 100 required by Qt.
+    //
+    // NOLINTNEXTLINE(*-magic-numbers)
+    auto amount = 100
+        + static_cast<int>(requireArgument<Numeric>(resolved, "amount", functionName).value);
+
+    const auto applyToColor = [&](const Base::Color& color) -> Base::Color {
+        auto qcolor = color.asValue<QColor>();
+        if (lighten) {
+            return Base::Color::fromValue(qcolor.lighter(amount));
+        }
+        return Base::Color::fromValue(qcolor.darker(amount));
+    };
+
+    const Value* colorValue = resolved.find("color");
+    if (colorValue->holds<Tuple>()) {
+        auto mapped = mapGradientStops(*colorValue, applyToColor);
+        if (!mapped) {
+            THROWM(
+                Base::ExpressionError,
+                fmt::format("{}: color argument must be a color or gradient", functionName)
+            );
+        }
+        return Value {std::move(*mapped)};
+    }
+
+    return applyToColor(requireArgument<Base::Color>(resolved, "color", functionName));
+}
+
+Value lighten(const Tuple& args)
+{
+    return lightenOrDarken(args, true);
+}
+
+Value darken(const Tuple& args)
+{
+    return lightenOrDarken(args, false);
+}
+
+Value blend(const Tuple& args)
+{
+    auto resolved = ArgumentParser {{"from"}, {"to"}, {"amount"}}.resolve(args);
+
+    auto amount = Base::fromPercent(
+        static_cast<long>(requireArgument<Numeric>(resolved, "amount", "blend").value)
+    );
+
+    const auto blendColors =
+        [amount](const Base::Color& first, const Base::Color& second) -> Base::Color {
+        return Base::Color(
+            (1 - amount) * first.r + amount * second.r,
+            (1 - amount) * first.g + amount * second.g,
+            (1 - amount) * first.b + amount * second.b
+        );
+    };
+
+    const Value* fromValue = resolved.find("from");
+    const Value* toValue = resolved.find("to");
+
+    bool fromIsGradient = fromValue->holds<Tuple>() && isGradientValue(*fromValue);
+    bool toIsGradient = toValue->holds<Tuple>() && isGradientValue(*toValue);
+
+    if (fromValue->holds<Tuple>() && !fromIsGradient) {
+        THROWM(Base::ExpressionError, "blend: 'from' argument must be a color or gradient");
+    }
+    if (toValue->holds<Tuple>() && !toIsGradient) {
+        THROWM(Base::ExpressionError, "blend: 'to' argument must be a color or gradient");
+    }
+
+    if (fromIsGradient && toIsGradient) {
+        THROWM(Base::ExpressionError, "Cannot blend two gradients");
+    }
+
+    if (fromIsGradient) {
+        const auto& targetColor = requireArgument<Base::Color>(resolved, "to", "blend");
+        auto mapped = mapGradientStops(*fromValue, [&](const Base::Color& stopColor) {
+            return blendColors(stopColor, targetColor);
+        });
+        return Value {std::move(*mapped)};
+    }
+
+    if (toIsGradient) {
+        const auto& sourceColor = requireArgument<Base::Color>(resolved, "from", "blend");
+        auto mapped = mapGradientStops(*toValue, [&](const Base::Color& stopColor) {
+            return blendColors(sourceColor, stopColor);
+        });
+        return Value {std::move(*mapped)};
+    }
+
+    if (!fromValue->holds<Base::Color>()) {
+        THROWM(Base::ExpressionError, "Expected color as from argument");
+    }
+
+    if (!toValue->holds<Base::Color>()) {
+        THROWM(Base::ExpressionError, "Expected color as to argument");
+    }
+
+    return blendColors(fromValue->get<Base::Color>(), toValue->get<Base::Color>());
+}
+
+Value shade(const Tuple& args)
+{
+    auto resolved = ArgumentParser {
+        {.name = "color"},
+        {.name = "lightness"},
+        {.name = "range", .defaultValue = Numeric {0.8, ""}},
+        {.name = "min", .defaultValue = Numeric {0.17, ""}},
+        {.name = "max", .defaultValue = Numeric {0.97, ""}},
+        {.name = "pivot", .defaultValue = Numeric {0.5, ""}},
+        {.name = "q", .defaultValue = Numeric {0.1, ""}},
+    }.resolve(args);
+
+    auto position = asPercent(requireArgument<Numeric>(resolved, "lightness", "shade"));
+    auto shadingParams = parseShadingParams(resolved, "shade");
+
+    const auto applyToColor = [&](const Base::Color& color) -> Base::Color {
+        auto oklch = Base::toOkLch(color);
+        return applyShade(position, color, oklch, shadingParams);
+    };
+
+    const Value* colorValue = resolved.find("color");
+    if (colorValue->holds<Tuple>()) {
+        auto mapped = mapGradientStops(*colorValue, applyToColor);
+        if (!mapped) {
+            THROWM(Base::ExpressionError, "shade: color argument must be a color or gradient");
+        }
+        return Value {std::move(*mapped)};
+    }
+
+    return applyToColor(requireArgument<Base::Color>(resolved, "color", "shade"));
+}
+
+Value shades(const Tuple& args)
+{
+    auto resolved = ArgumentParser {
+        {.name = "color"},
+        {.name = "shades"},
+        {.name = "range", .defaultValue = Numeric {0.8, ""}},
+        {.name = "min", .defaultValue = Numeric {0.17, ""}},
+        {.name = "max", .defaultValue = Numeric {0.97, ""}},
+        {.name = "pivot", .defaultValue = Numeric {0.5, ""}},
+        {.name = "q", .defaultValue = Numeric {0.1, ""}},
+    }.resolve(args);
+
+    const auto& shadesSpec = requireArgument<Tuple>(resolved, "shades", "shades");
+    auto shadingParams = parseShadingParams(resolved, "shades");
+
+    const auto appendElement = [](Tuple& result, const Tuple::Element& spec, Value shadeValue) {
+        if (spec.name) {
+            result.elements.push_back(Tuple::Element::named(*spec.name, std::move(shadeValue)));
+        }
+        else {
+            result.elements.push_back(Tuple::Element::unnamed(std::move(shadeValue)));
+        }
+    };
+
+    const Value* colorValue = resolved.find("color");
+    if (colorValue->holds<Tuple>()) {
+        if (!isGradientValue(*colorValue)) {
+            THROWM(Base::ExpressionError, "shades: color argument must be a color or gradient");
+        }
+
+        Tuple result;
+        for (const auto& element : shadesSpec.elements) {
+            float position = asPercent(element.value->get<Numeric>());
+            auto shadedGradient
+                = mapGradientStops(*colorValue, [&](const Base::Color& stopColor) -> Base::Color {
+                      auto oklch = Base::toOkLch(stopColor);
+                      return applyShade(position, stopColor, oklch, shadingParams);
+                  });
+            appendElement(result, element, std::move(*shadedGradient));
+        }
+        return result;
+    }
+
+    const auto& baseColor = requireArgument<Base::Color>(resolved, "color", "shades");
+    auto baseOklch = Base::toOkLch(baseColor);
+
+    Tuple result;
+    for (const auto& element : shadesSpec.elements) {
+        float position = asPercent(element.value->get<Numeric>());
+        auto shadeColor = applyShade(position, baseColor, baseOklch, shadingParams);
+        appendElement(result, element, shadeColor);
+    }
+    return result;
+}
+
+using StyleFunction = Value (*)(const Tuple&);
+
+/// Table of all style functions taking a single Tuple argument, built once and reused —
+/// see FunctionCall::evaluate for the "coalesce" special case that bypasses it.
+const std::unordered_map<std::string_view, StyleFunction>& styleFunctions()
+{
+    static const std::unordered_map<std::string_view, StyleFunction> table = {
+        {"lighten", lighten},
+        {"darken", darken},
+        {"blend", blend},
+        {"shade", shade},
+        {"shades", shades},
+        {"content_box", contentBox},
+        {"padding", [](const Tuple& args) -> Value { return Padding(args).tuple(); }},
+        {"margins", [](const Tuple& args) -> Value { return Margins(args).tuple(); }},
+        {"border_colors", [](const Tuple& args) -> Value { return BorderColors(args).tuple(); }},
+        {"border_thickness", [](const Tuple& args) -> Value { return BorderThickness(args).tuple(); }},
+        {"border_radius", [](const Tuple& args) -> Value { return Corners(args).tuple(); }},
+        {"linear_gradient", [](const Tuple& args) -> Value { return LinearGradient(args).tuple(); }},
+        {"radial_gradient", [](const Tuple& args) -> Value { return RadialGradient(args).tuple(); }},
+    };
+    return table;
+}
+
+}  // namespace
 
 Value ParameterReference::evaluate(const EvaluationContext& context) const
 {
@@ -51,54 +450,25 @@ Value Color::evaluate([[maybe_unused]] const EvaluationContext& context) const
 
 Value FunctionCall::evaluate(const EvaluationContext& context) const
 {
+    if (functionName == "coalesce") {
+        if (arguments.elements.empty()) {
+            THROWM(Base::ExpressionError, "coalesce requires at least one argument");
+        }
+        for (const auto& element : arguments.elements) {
+            Value result = element.expression->evaluate(context);
+            if (!result.holds<std::string>() || !result.get<std::string>().starts_with("@")) {
+                return result;
+            }
+        }
+        return arguments.elements.back().expression->evaluate(context);
+    }
+
     auto argsValue = arguments.evaluate(context);
     const auto& args = argsValue.get<Tuple>();
 
-    const auto lightenOrDarken = [this, &args]() -> Value {
-        auto resolved = ArgumentParser {{"color"}, {"amount"}}.resolve(args);
-
-        auto color = resolved.get<Base::Color>("color").asValue<QColor>();
-
-        // In Qt if you want to make color 20% darker or lighter, you need to pass 120 as the value
-        // we, however, want users to pass only the relative difference, hence we need to add the
-        // 100 required by Qt.
-        //
-        // NOLINTNEXTLINE(*-magic-numbers)
-        auto amount = 100 + static_cast<int>(resolved.get<Numeric>("amount").value);
-
-        if (functionName == "lighten") {
-            return Base::Color::fromValue(color.lighter(amount));
-        }
-
-        if (functionName == "darken") {
-            return Base::Color::fromValue(color.darker(amount));
-        }
-
-        return {};
-    };
-
-    const auto blend = [&args]() -> Value {
-        auto resolved = ArgumentParser {{"from"}, {"to"}, {"amount"}}.resolve(args);
-
-        auto firstColor = resolved.get<Base::Color>("from");
-        auto secondColor = resolved.get<Base::Color>("to");
-        auto amount = Base::fromPercent(static_cast<long>(resolved.get<Numeric>("amount").value));
-
-        return Base::Color(
-            (1 - amount) * firstColor.r + amount * secondColor.r,
-            (1 - amount) * firstColor.g + amount * secondColor.g,
-            (1 - amount) * firstColor.b + amount * secondColor.b
-        );
-    };
-
-    std::map<std::string, std::function<Value()>> functions = {
-        {"lighten", lightenOrDarken},
-        {"darken", lightenOrDarken},
-        {"blend", blend},
-    };
-
-    if (functions.contains(functionName)) {
-        return functions.at(functionName)();
+    const auto& table = styleFunctions();
+    if (auto entry = table.find(functionName); entry != table.end()) {
+        return entry->second(args);
     }
 
     THROWM(Base::ExpressionError, fmt::format("Unknown function '{}'", functionName));
@@ -161,8 +531,15 @@ Value MemberAccess::evaluate(const EvaluationContext& context) const
         return *found;
     }
 
-    if (std::ranges::all_of(member, ::isdigit)) {
-        return tuple.at(std::stoul(member));
+    if (std::ranges::all_of(member, isDigitChar)) {
+        const std::optional<size_t> index = parseIndex(member);
+        const Value* element = index ? tuple.tryAt(*index) : nullptr;
+
+        if (!element) {
+            THROWM(Base::ExpressionError, fmt::format("Tuple has no element at index '{}'", member));
+        }
+
+        return *element;
     }
 
     THROWM(Base::ExpressionError, fmt::format("Tuple has no member '{}'", member));
@@ -293,14 +670,24 @@ std::unique_ptr<Expr> Parser::parseColor()
 {
     const auto parseHexadecimalColor = [&]() {
         constexpr int hexadecimalBase = 16;
+        constexpr size_t hexDigitCount = 6;
+
+        const size_t start = pos;
 
         // Format is #RRGGBB
         pos++;
-        int r = std::stoi(input.substr(pos, 2), nullptr, hexadecimalBase);
+        if (input.size() - pos < hexDigitCount) {
+            THROWM(
+                Base::ParserError,
+                fmt::format("Invalid hexadecimal color, expected #RRGGBB, got '{}'", input.substr(start))
+            );
+        }
+
+        int r = parseIntOrThrow(input.substr(pos, 2), hexadecimalBase);
         pos += 2;
-        int g = std::stoi(input.substr(pos, 2), nullptr, hexadecimalBase);
+        int g = parseIntOrThrow(input.substr(pos, 2), hexadecimalBase);
         pos += 2;
-        int b = std::stoi(input.substr(pos, 2), nullptr, hexadecimalBase);
+        int b = parseIntOrThrow(input.substr(pos, 2), hexadecimalBase);
         pos += 2;
 
         return std::make_unique<Color>(Base::Color(r / 255.0, g / 255.0, b / 255.0));
@@ -338,20 +725,12 @@ std::unique_ptr<Expr> Parser::parseColor()
 
     skipWhitespace();
 
-    try {
-        if (input[pos] == '#') {
-            return parseHexadecimalColor();
-        }
-
-        if (peekString(rgbFunction) || peekString(rgbaFunction)) {
-            return parseFunctionStyleColor();
-        }
+    if (input[pos] == '#') {
+        return parseHexadecimalColor();
     }
-    catch (std::invalid_argument&) {
-        THROWM(
-            Base::ParserError,
-            "Invalid color format, expected #RRGGBB or rgb(r,g,b) or rgba(r,g,b,a)"
-        );
+
+    if (peekString(rgbFunction) || peekString(rgbaFunction)) {
+        return parseFunctionStyleColor();
     }
 
     THROWM(Base::ParserError, "Unknown color format");
@@ -370,7 +749,7 @@ std::unique_ptr<Expr> Parser::parseParameter()
         THROWM(Base::ParserError, fmt::format("Expected '@' for parameter, got '{}'", input[pos]));
     }
     size_t start = pos;
-    while (pos < input.size() && (isalnum(input[pos]) || input[pos] == '_')) {
+    while (pos < input.size() && (isAlnumChar(input[pos]) || input[pos] == '_')) {
         ++pos;
     }
     if (start == pos) {
@@ -385,14 +764,14 @@ std::unique_ptr<Expr> Parser::parseParameter()
 bool Parser::peekFunction()
 {
     skipWhitespace();
-    return pos < input.size() && isalpha(input[pos]);
+    return pos < input.size() && isAlphaChar(input[pos]);
 }
 
 std::unique_ptr<Expr> Parser::parseFunctionCall()
 {
     skipWhitespace();
     size_t start = pos;
-    while (pos < input.size() && isalnum(input[pos])) {
+    while (pos < input.size() && (isAlnumChar(input[pos]) || input[pos] == '_')) {
         ++pos;
     }
     std::string functionName = input.substr(start, pos - start);
@@ -411,18 +790,18 @@ bool Parser::peekNamedElement()
     skipWhitespace();
 
     // Check for `identifier :` pattern (identifiers may start with digits, e.g. shade names like 050)
-    if (pos >= input.size() || !isalnum(input[pos])) {
+    if (pos >= input.size() || !isAlnumChar(input[pos])) {
         pos = saved;
         return false;
     }
 
     // Skip identifier characters
-    while (pos < input.size() && (isalnum(input[pos]) || input[pos] == '_')) {
+    while (pos < input.size() && (isAlnumChar(input[pos]) || input[pos] == '_')) {
         ++pos;
     }
 
     // Skip whitespace between identifier and colon
-    while (pos < input.size() && isspace(input[pos])) {
+    while (pos < input.size() && isSpaceChar(input[pos])) {
         ++pos;
     }
 
@@ -443,7 +822,7 @@ std::unique_ptr<TupleLiteral> Parser::parseTuple(std::optional<TupleLiteral::Ele
         if (peekNamedElement()) {
             skipWhitespace();
             size_t start = pos;
-            while (pos < input.size() && (isalnum(input[pos]) || input[pos] == '_')) {
+            while (pos < input.size() && (isAlnumChar(input[pos]) || input[pos] == '_')) {
                 ++pos;
             }
             elem.name = input.substr(start, pos - start);
@@ -485,37 +864,29 @@ int Parser::parseInt()
 {
     skipWhitespace();
     size_t start = pos;
-    while (pos < input.size() && (isdigit(input[pos]) || input[pos] == '.')) {
+    while (pos < input.size() && (isDigitChar(input[pos]) || input[pos] == '.')) {
         ++pos;
     }
-    return std::stoi(input.substr(start, pos - start));
+    return parseIntOrThrow(input.substr(start, pos - start));
 }
 
 std::unique_ptr<Expr> Parser::parseNumber()
 {
     skipWhitespace();
     size_t start = pos;
-    while (pos < input.size() && (isdigit(input[pos]) || input[pos] == '.')) {
+    while (pos < input.size() && (isDigitChar(input[pos]) || input[pos] == '.')) {
         ++pos;
     }
 
-    std::string number = input.substr(start, pos - start);
-
-    try {
-        double value = std::stod(number);
-        std::string unit = parseUnit();
-        return std::make_unique<Number>(value, unit);
-    }
-    catch (std::invalid_argument&) {
-        THROWM(Base::ParserError, fmt::format("Invalid number: {}", number));
-    }
+    const double value = parseDoubleOrThrow(input.substr(start, pos - start));
+    return std::make_unique<Number>(value, parseUnit());
 }
 
 std::string Parser::parseUnit()
 {
     skipWhitespace();
     size_t start = pos;
-    while (pos < input.size() && (isalpha(input[pos]) || input[pos] == '%')) {
+    while (pos < input.size() && (isAlphaChar(input[pos]) || input[pos] == '%')) {
         ++pos;
     }
     if (start == pos) {
@@ -527,7 +898,7 @@ std::string Parser::parseUnit()
 std::string Parser::parseMember()
 {
     size_t start = pos;
-    while (pos < input.size() && (isalnum(input[pos]) || input[pos] == '_')) {
+    while (pos < input.size() && (isAlnumChar(input[pos]) || input[pos] == '_')) {
         ++pos;
     }
     if (start == pos) {
@@ -548,7 +919,7 @@ bool Parser::match(char expected)
 
 void Parser::skipWhitespace()
 {
-    while (pos < input.size() && isspace(input[pos])) {
+    while (pos < input.size() && isSpaceChar(input[pos])) {
         ++pos;
     }
 }

--- a/src/Gui/StyleParameters/Value.cpp
+++ b/src/Gui/StyleParameters/Value.cpp
@@ -121,9 +121,24 @@ std::string Value::toString() const
 namespace
 {
 
+TupleKind resolveKind(TupleKind lhs, TupleKind rhs)
+{
+    if (lhs == rhs || rhs == TupleKind::Generic) {
+        return lhs;
+    }
+    if (lhs == TupleKind::Generic) {
+        return rhs;
+    }
+    THROWM(
+        Base::ExpressionError,
+        fmt::format("Cannot combine {} and {} tuples", tupleKindName(lhs), tupleKindName(rhs))
+    );
+}
+
 Tuple elementWise(const Tuple& lhs, const Tuple& rhs, auto op)
 {
     Tuple result;
+    result.kind = resolveKind(lhs.kind, rhs.kind);
     std::vector<bool> rhsUsed(rhs.size(), false);
 
     // Phase 1: LHS named elements — match by name in RHS
@@ -196,6 +211,7 @@ Tuple elementWise(const Tuple& lhs, const Tuple& rhs, auto op)
 Tuple scalarBroadcast(const Tuple& tuple, const Value& scalar, auto op)
 {
     Tuple result;
+    result.kind = tuple.kind;
     for (size_t i = 0; i < tuple.size(); ++i) {
         result.elements.emplace_back(
             tuple.elements[i].name,
@@ -264,6 +280,7 @@ Value Value::operator-() const
     if (holds<Tuple>()) {
         Tuple result;
         const auto& tuple = get<Tuple>();
+        result.kind = tuple.kind;
         for (size_t i = 0; i < tuple.size(); ++i) {
             result.elements.emplace_back(
                 tuple.elements[i].name,

--- a/src/Gui/StyleParameters/Value.cpp
+++ b/src/Gui/StyleParameters/Value.cpp
@@ -317,6 +317,25 @@ size_t Tuple::size() const
     return elements.size();
 }
 
+Tuple::Element Tuple::Element::named(std::string name, Value val)
+{
+    return {.name = std::move(name), .value = std::make_shared<const Value>(std::move(val))};
+}
+
+Tuple::Element Tuple::Element::unnamed(Value val)
+{
+    return {.name = std::nullopt, .value = std::make_shared<const Value>(std::move(val))};
+}
+
+Tuple::Tuple(std::initializer_list<Element> elements)
+    : elements(elements)
+{}
+
+Tuple::Tuple(std::initializer_list<Element> elements, TupleKind kind)
+    : kind(kind)
+    , elements(elements)
+{}
+
 ArgumentParser::ArgumentParser(std::initializer_list<ParamDef> params)
     : params_(params)
 {}

--- a/src/Gui/StyleParameters/Value.cpp
+++ b/src/Gui/StyleParameters/Value.cpp
@@ -27,6 +27,8 @@
 #include <ranges>
 #include <fmt/ranges.h>
 
+#include <Base/Exception.h>
+
 namespace Gui::StyleParameters
 {
 
@@ -121,6 +123,42 @@ std::string Value::toString() const
 namespace
 {
 
+TupleKind resolveKind(TupleKind lhs, TupleKind rhs)
+{
+    if (lhs == rhs || rhs == TupleKind::Generic) {
+        return lhs;
+    }
+    if (lhs == TupleKind::Generic) {
+        return rhs;
+    }
+    THROWM(
+        Base::ExpressionError,
+        fmt::format("Cannot combine {} and {} tuples", tupleKindName(lhs), tupleKindName(rhs))
+    );
+}
+
+/// True when both tuples carry the same element names, in the same order.
+bool hasSameElementNames(const Tuple& lhs, const Tuple& rhs)
+{
+    return std::ranges::equal(lhs.elements, rhs.elements, {}, &Element::name, &Element::name);
+}
+
+/**
+ * @brief The kind an arithmetic result may keep.
+ *
+ * A typed kind asserts a validated structure, so it only survives while the result still has
+ * the exact elements of the typed operand. Combining with a differently-shaped tuple — say
+ * `padding(10px) + (foo: 5px)`, which leaves the four sides plus a stray fifth element — is
+ * no longer padding, and claiming otherwise would let it serialize as five QSS values.
+ */
+TupleKind survivingKind(TupleKind kind, const Tuple& typedSource, const Tuple& result)
+{
+    if (kind == TupleKind::Generic || hasSameElementNames(typedSource, result)) {
+        return kind;
+    }
+    return TupleKind::Generic;
+}
+
 Tuple elementWise(const Tuple& lhs, const Tuple& rhs, auto op)
 {
     Tuple result;
@@ -196,6 +234,7 @@ Tuple elementWise(const Tuple& lhs, const Tuple& rhs, auto op)
 Tuple scalarBroadcast(const Tuple& tuple, const Value& scalar, auto op)
 {
     Tuple result;
+    result.kind = tuple.kind;
     for (size_t i = 0; i < tuple.size(); ++i) {
         result.elements.emplace_back(
             tuple.elements[i].name,
@@ -264,6 +303,7 @@ Value Value::operator-() const
     if (holds<Tuple>()) {
         Tuple result;
         const auto& tuple = get<Tuple>();
+        result.kind = tuple.kind;
         for (size_t i = 0; i < tuple.size(); ++i) {
             result.elements.emplace_back(
                 tuple.elements[i].name,
@@ -275,15 +315,21 @@ Value Value::operator-() const
     THROWM(Base::ExpressionError, "Unary negation requires a numeric or tuple value");
 }
 
+const Value* Tuple::tryAt(size_t index) const
+{
+    return index < elements.size() ? elements[index].value.get() : nullptr;
+}
+
 const Value& Tuple::at(size_t index) const
 {
-    if (index >= elements.size()) {
-        THROWM(
-            Base::RuntimeError,
-            fmt::format("Tuple index {} out of range (size {})", index, elements.size())
-        );
+    if (const Value* value = tryAt(index)) {
+        return *value;
     }
-    return *elements[index].value;
+
+    Diagnostics::report("Tuple index {} out of range (size {})", index, elements.size());
+
+    static const Value fallback {styleDefault<Numeric>()};
+    return fallback;
 }
 
 const Value* Tuple::find(const std::string& name) const
@@ -299,6 +345,25 @@ size_t Tuple::size() const
 {
     return elements.size();
 }
+
+Tuple::Element Tuple::Element::named(std::string name, Value val)
+{
+    return {.name = std::move(name), .value = std::make_shared<const Value>(std::move(val))};
+}
+
+Tuple::Element Tuple::Element::unnamed(Value val)
+{
+    return {.name = std::nullopt, .value = std::make_shared<const Value>(std::move(val))};
+}
+
+Tuple::Tuple(std::initializer_list<Element> elements)
+    : elements(elements)
+{}
+
+Tuple::Tuple(std::initializer_list<Element> elements, TupleKind kind)
+    : kind(kind)
+    , elements(elements)
+{}
 
 ArgumentParser::ArgumentParser(std::initializer_list<ParamDef> params)
     : params_(params)

--- a/src/Gui/StyleParameters/Value.cpp
+++ b/src/Gui/StyleParameters/Value.cpp
@@ -23,6 +23,7 @@
 
 #include "Value.h"
 
+#include <algorithm>
 #include <functional>
 #include <ranges>
 #include <fmt/ranges.h>
@@ -73,6 +74,19 @@ Numeric Numeric::operator*(const Numeric& rhs) const
     return {value * rhs.value, unit};
 }
 
+std::optional<double> Numeric::asFraction() const
+{
+    constexpr double percentScale = 100.0;
+
+    if (unit.empty()) {
+        return value;
+    }
+    if (unit == "%") {
+        return value / percentScale;
+    }
+    return std::nullopt;
+}
+
 void Numeric::ensureEqualUnits(const Numeric& rhs) const
 {
     if (unit != rhs.unit) {
@@ -83,6 +97,39 @@ void Numeric::ensureEqualUnits(const Numeric& rhs) const
     }
 }
 
+namespace
+{
+
+/**
+ * @brief Renders a color in the form the expression parser reads back.
+ *
+ * Translucent colors need the `rgba()` form: `#rrggbb` has nowhere to put the alpha, and this
+ * rendering is what ends up in generated QSS, where a dropped alpha turns a transparent stop
+ * into an opaque black one.
+ */
+std::string colorToString(const Base::Color& color)
+{
+    constexpr uint32_t channelMask = 0xFF;
+    constexpr uint32_t channelBits = 8;
+
+    const uint32_t packed = color.getPackedValue();
+    const uint32_t alpha = packed & channelMask;
+
+    if (alpha == channelMask) {
+        return fmt::format("#{:0>6x}", color.getPackedRGB() >> channelBits);
+    }
+
+    return fmt::format(
+        "rgba({}, {}, {}, {})",
+        (packed >> (3 * channelBits)) & channelMask,
+        (packed >> (2 * channelBits)) & channelMask,
+        (packed >> channelBits) & channelMask,
+        alpha
+    );
+}
+
+}  // namespace
+
 std::string Value::toString() const
 {
     if (holds<Numeric>()) {
@@ -91,8 +138,7 @@ std::string Value::toString() const
     }
 
     if (holds<Base::Color>()) {
-        auto color = get<Base::Color>();
-        return fmt::format("#{:0>6x}", color.getPackedRGB() >> 8);  // NOLINT(*-magic-numbers)
+        return colorToString(get<Base::Color>());
     }
 
     if (holds<Tuple>()) {
@@ -161,6 +207,8 @@ TupleKind survivingKind(TupleKind kind, const Tuple& typedSource, const Tuple& r
 
 Tuple elementWise(const Tuple& lhs, const Tuple& rhs, auto op)
 {
+    const TupleKind kind = resolveKind(lhs.kind, rhs.kind);
+
     Tuple result;
     std::vector<bool> rhsUsed(rhs.size(), false);
 
@@ -227,6 +275,8 @@ Tuple elementWise(const Tuple& lhs, const Tuple& rhs, auto op)
     for (size_t k = paired; k < rhsUnnamed.size(); ++k) {
         result.elements.push_back(rhs.elements[rhsUnnamed[k]]);
     }
+
+    result.kind = survivingKind(kind, lhs.kind == kind ? lhs : rhs, result);
 
     return result;
 }

--- a/src/Gui/StyleParameters/Value.h
+++ b/src/Gui/StyleParameters/Value.h
@@ -114,6 +114,8 @@ enum class TupleKind : std::uint8_t
     Margins,
     BorderThickness,
     Corners,
+    LinearGradient,
+    RadialGradient,
 };
 
 constexpr const char* tupleKindName(TupleKind kind)
@@ -129,6 +131,10 @@ constexpr const char* tupleKindName(TupleKind kind)
             return "BorderThickness";
         case TupleKind::Corners:
             return "Corners";
+        case TupleKind::LinearGradient:
+            return "LinearGradient";
+        case TupleKind::RadialGradient:
+            return "RadialGradient";
     }
     return "<unknown>";
 }

--- a/src/Gui/StyleParameters/Value.h
+++ b/src/Gui/StyleParameters/Value.h
@@ -151,7 +151,17 @@ struct GuiExport Tuple
     {
         std::optional<std::string> name;
         std::shared_ptr<const Value> value;
+
+        /// Creates a named element, wrapping val in a shared_ptr.
+        static Element named(std::string name, Value val);
+
+        /// Creates an unnamed element, wrapping val in a shared_ptr.
+        static Element unnamed(Value val);
     };
+
+    Tuple() = default;
+    Tuple(std::initializer_list<Element> elements);
+    Tuple(std::initializer_list<Element> elements, TupleKind kind);
 
     TupleKind kind = TupleKind::Generic;
     std::vector<Element> elements;

--- a/src/Gui/StyleParameters/Value.h
+++ b/src/Gui/StyleParameters/Value.h
@@ -113,6 +113,7 @@ enum class TupleKind : std::uint8_t
     Padding,
     Margins,
     BorderThickness,
+    Corners,
 };
 
 constexpr const char* tupleKindName(TupleKind kind)
@@ -126,6 +127,8 @@ constexpr const char* tupleKindName(TupleKind kind)
             return "Margins";
         case TupleKind::BorderThickness:
             return "BorderThickness";
+        case TupleKind::Corners:
+            return "Corners";
     }
     return "<unknown>";
 }

--- a/src/Gui/StyleParameters/Value.h
+++ b/src/Gui/StyleParameters/Value.h
@@ -294,6 +294,20 @@ const T& Tuple::get(const std::string& name) const
 }
 
 /**
+ * @brief Wraps a Value in a 1-element unnamed generic Tuple if it is not already a Tuple.
+ *
+ * This allows scalar values (e.g. a bare Numeric) to be passed into constructors that
+ * expect a Tuple and use CSS-like expansion (1 element → all sides equal).
+ */
+inline Tuple asTuple(const Value& value)
+{
+    if (value.holds<Tuple>()) {
+        return value.get<Tuple>();
+    }
+    return Tuple({Tuple::Element::unnamed(value)});
+}
+
+/**
  * @brief Defines a single parameter in a function signature.
  *
  * Used with ArgumentParser to declare positional/named parameters with optional defaults.
@@ -328,6 +342,46 @@ public:
 private:
     std::vector<ParamDef> params_;
 };
+
+/**
+ * @brief Extracts a typed value from an optional Value without explicit casting.
+ *
+ * Provides a uniform interface for the two common extraction patterns:
+ *
+ * - For domain wrapper types constructible from `const Value&` (Insets, Corners,
+ *   InnerShadow, …): constructs `T` from the value and returns nullopt if the
+ *   constructor throws Base::Exception (i.e. the value has the wrong structure).
+ *
+ * - For variant member types (Numeric, Base::Color, std::string, Tuple): returns
+ *   the value only if it holds exactly `T`, nullopt otherwise.
+ *
+ * This function is the shared building block for ParameterManager::resolve(definition)
+ * and FreeCADStyle::resolve<T>(), ensuring both use identical dispatch logic.
+ */
+template<typename T>
+    requires std::is_constructible_v<T, const Value&>
+std::optional<T> valueAs(const std::optional<Value>& value)
+{
+    if (!value) {
+        return std::nullopt;
+    }
+    try {
+        return T(*value);
+    }
+    catch (const Base::Exception&) {
+        return std::nullopt;
+    }
+}
+
+template<typename T>
+    requires(!std::is_constructible_v<T, const Value&>)
+std::optional<T> valueAs(const std::optional<Value>& value)
+{
+    if (!value || !value->holds<T>()) {
+        return std::nullopt;
+    }
+    return value->get<T>();
+}
 
 }  // namespace Gui::StyleParameters
 

--- a/src/Gui/StyleParameters/Value.h
+++ b/src/Gui/StyleParameters/Value.h
@@ -113,6 +113,7 @@ enum class TupleKind : std::uint8_t
     Padding,
     Margins,
     BorderThickness,
+    BorderColors,
     Corners,
     LinearGradient,
     RadialGradient,
@@ -129,6 +130,8 @@ constexpr const char* tupleKindName(TupleKind kind)
             return "Margins";
         case TupleKind::BorderThickness:
             return "BorderThickness";
+        case TupleKind::BorderColors:
+            return "BorderColors";
         case TupleKind::Corners:
             return "Corners";
         case TupleKind::LinearGradient:

--- a/src/Gui/StyleParameters/Value.h
+++ b/src/Gui/StyleParameters/Value.h
@@ -101,6 +101,36 @@ private:
 struct Value;
 
 /**
+ * @brief Identifies the semantic kind of a tuple.
+ *
+ * Generic tuples have no special meaning. Typed kinds (Padding, Margins, BorderThickness)
+ * carry structural identity: they are always 4-element (top, right, bottom, left) insets
+ * created via CSS-like shorthand functions.
+ */
+enum class TupleKind : std::uint8_t
+{
+    Generic,
+    Padding,
+    Margins,
+    BorderThickness,
+};
+
+constexpr const char* tupleKindName(TupleKind kind)
+{
+    switch (kind) {
+        case TupleKind::Generic:
+            return "Generic";
+        case TupleKind::Padding:
+            return "Padding";
+        case TupleKind::Margins:
+            return "Margins";
+        case TupleKind::BorderThickness:
+            return "BorderThickness";
+    }
+    return "<unknown>";
+}
+
+/**
  * @brief Represents a tuple of named or unnamed values.
  *
  * Tuples group related values into a single parameter using `(key: val1, val2)` syntax.
@@ -114,6 +144,7 @@ struct GuiExport Tuple
         std::shared_ptr<const Value> value;
     };
 
+    TupleKind kind = TupleKind::Generic;
     std::vector<Element> elements;
 
     /**

--- a/src/Gui/StyleParameters/Value.h
+++ b/src/Gui/StyleParameters/Value.h
@@ -93,6 +93,15 @@ struct GuiExport Numeric
     Numeric operator*(const Numeric& rhs) const;
     /// @}
 
+    /**
+     * @brief The value as a plain fraction — dimensionless as-is, `%` out of 100.
+     *
+     * Yields nothing for any other unit, so callers that only accept normalized numbers
+     * (gradient geometry, stop positions) can tell `50%` from `50px` instead of silently
+     * dropping the unit.
+     */
+    std::optional<double> asFraction() const;
+
 private:
     void ensureEqualUnits(const Numeric& rhs) const;
 };

--- a/src/Gui/StyleParameters/Value.h
+++ b/src/Gui/StyleParameters/Value.h
@@ -24,20 +24,21 @@
 #ifndef STYLEPARAMETERS_VALUE_H
 #define STYLEPARAMETERS_VALUE_H
 
+#include <concepts>
 #include <memory>
 #include <optional>
 #include <string>
 #include <type_traits>
 #include <variant>
 #include <vector>
-#include <cassert>
+#include <cstdint>
 
 #include <fmt/format.h>
 
-#include "Base/Console.h"
 #include <Base/Color.h>
-#include <Base/Exception.h>
 #include <FCGlobal.h>
+
+#include "Diagnostics.h"
 
 namespace Gui::StyleParameters
 {
@@ -53,7 +54,7 @@ namespace Gui::StyleParameters
 struct GuiExport Numeric
 {
     /// Numeric value of the length.
-    double value;
+    double value = 0.0;
     /// Unit of the length, empty if the value is dimensionless.
     std::string unit = "";
 
@@ -101,6 +102,63 @@ private:
 struct Value;
 
 /**
+ * @brief Identifies the semantic kind of a tuple.
+ *
+ * Generic tuples have no special meaning. A typed kind carries structural identity, so
+ * consuming code can tell box-model insets from corner radii or a gradient rather than
+ * guessing from shape alone. Each kind is produced by its own construction function and
+ * accepted only after its expected element names and types have been validated.
+ */
+enum class TupleKind : std::uint8_t
+{
+    Generic,
+    Padding,
+    Margins,
+    BorderThickness,
+    BorderColors,
+    Corners,
+    LinearGradient,
+    RadialGradient,
+};
+
+constexpr const char* tupleKindName(TupleKind kind)
+{
+    switch (kind) {
+        case TupleKind::Generic:
+            return "Generic";
+        case TupleKind::Padding:
+            return "Padding";
+        case TupleKind::Margins:
+            return "Margins";
+        case TupleKind::BorderThickness:
+            return "BorderThickness";
+        case TupleKind::BorderColors:
+            return "BorderColors";
+        case TupleKind::Corners:
+            return "Corners";
+        case TupleKind::LinearGradient:
+            return "LinearGradient";
+        case TupleKind::RadialGradient:
+            return "RadialGradient";
+    }
+    return "<unknown>";
+}
+
+/// True for the tuple kinds that share the four-sided box shape and may coerce between each other.
+constexpr bool isEdgeKind(TupleKind kind)
+{
+    switch (kind) {
+        case TupleKind::Padding:
+        case TupleKind::Margins:
+        case TupleKind::BorderThickness:
+        case TupleKind::BorderColors:
+            return true;
+        default:
+            return false;
+    }
+}
+
+/**
  * @brief Represents a tuple of named or unnamed values.
  *
  * Tuples group related values into a single parameter using `(key: val1, val2)` syntax.
@@ -108,17 +166,32 @@ struct Value;
  */
 struct GuiExport Tuple
 {
-    struct Element
+    struct GuiExport Element
     {
         std::optional<std::string> name;
         std::shared_ptr<const Value> value;
+
+        /// Creates a named element, wrapping val in a shared_ptr.
+        static Element named(std::string name, Value val);
+
+        /// Creates an unnamed element, wrapping val in a shared_ptr.
+        static Element unnamed(Value val);
     };
 
+    Tuple() = default;
+    Tuple(std::initializer_list<Element> elements);
+    Tuple(std::initializer_list<Element> elements, TupleKind kind);
+
+    TupleKind kind = TupleKind::Generic;
     std::vector<Element> elements;
 
     /**
-     * @brief Returns the value at the given index (bounds-checked).
-     * @throws Base::RuntimeError if index is out of range.
+     * @brief Returns a pointer to the value at the given index, or nullptr when out of range.
+     */
+    const Value* tryAt(size_t index) const;
+
+    /**
+     * @brief Returns the value at the given index, or an empty value when out of range.
      */
     const Value& at(size_t index) const;
 
@@ -134,13 +207,58 @@ struct GuiExport Tuple
     size_t size() const;
 
     /**
-     * @brief Gets a named element with type checking and user-friendly error messages.
-     *
-     * @throws Base::ExpressionError if the element is not found or has the wrong type.
+     * @brief Returns a pointer to the named element of type T, or nullptr when absent or of
+     *        another type.
+     */
+    template<typename T>
+    const T* tryGet(const std::string& name) const;
+
+    /**
+     * @brief Returns the named element, or the empty value of type T when it cannot be produced.
      */
     template<typename T>
     const T& get(const std::string& name) const;
+
+    /**
+     * @brief Returns the named element, or the given fallback when it cannot be produced.
+     */
+    template<typename T>
+    T get(const std::string& name, const T& fallback) const;
+
+    /**
+     * @brief Returns the named element of type T, reporting when it is absent or of another type.
+     */
+    template<typename T>
+    const T* tryGetOrReport(const std::string& name) const;
 };
+
+/// Convenience alias for Tuple::Element, used pervasively by tuple-shaped wrappers.
+using Element = Tuple::Element;
+
+template<typename T>
+constexpr const char* valueTypeName()
+{
+    if constexpr (std::is_same_v<T, Numeric>) {
+        return "numeric";
+    }
+    else if constexpr (std::is_same_v<T, Base::Color>) {
+        return "color";
+    }
+    else if constexpr (std::is_same_v<T, std::string>) {
+        return "string";
+    }
+    else if constexpr (std::is_same_v<T, Tuple>) {
+        return "tuple";
+    }
+
+    return "<unknown>";
+}
+
+/**
+ * @brief The empty value substituted when a request of type T cannot be satisfied.
+ */
+template<typename T>
+const T& styleDefault();
 
 /**
  * @brief This struct represents any valid value that can be used as the parameter value.
@@ -174,20 +292,40 @@ struct GuiExport Value: std::variant<Numeric, Base::Color, std::string, Tuple>
     }
 
     /**
-     * @brief Gets the value of the given type.
-     *
-     * Throws std::bad_variant_access if the value does not hold the requested type.
+     * @brief Returns a pointer to the held value, or nullptr if it holds another type.
+     */
+    template<typename T>
+    const T* tryGet() const
+    {
+        return std::get_if<T>(this);
+    }
+
+    /**
+     * @brief Returns the held value, or the empty value of type T when it holds another type.
      */
     template<typename T>
     const T& get() const
     {
-        try {
-            return std::get<T>(*this);
+        if (const T* value = tryGet<T>()) {
+            return *value;
         }
-        catch (...) {
-            Base::Console().critical("This should never happen, probably missing holds<T> check.");
-            throw;
+
+        Diagnostics::report("Expected {} value, got {}", valueTypeName<T>(), toString());
+        return styleDefault<T>();
+    }
+
+    /**
+     * @brief Returns the held value, or the given fallback when it holds another type.
+     */
+    template<typename T>
+    T get(const T& fallback) const
+    {
+        if (const T* value = tryGet<T>()) {
+            return *value;
         }
+
+        Diagnostics::report("Expected {} value, got {}", valueTypeName<T>(), toString());
+        return fallback;
     }
 
     /**
@@ -205,42 +343,90 @@ struct GuiExport Value: std::variant<Numeric, Base::Color, std::string, Tuple>
     /// @}
 };
 
-template<typename T>
-constexpr const char* valueTypeName()
+template<>
+inline const Numeric& styleDefault<Numeric>()
 {
-    if constexpr (std::is_same_v<T, Numeric>) {
-        return "numeric";
-    }
-    else if constexpr (std::is_same_v<T, Base::Color>) {
-        return "color";
-    }
-    else if constexpr (std::is_same_v<T, std::string>) {
-        return "string";
-    }
-    else if constexpr (std::is_same_v<T, Tuple>) {
-        return "tuple";
+    static const Numeric value {.value = 0.0, .unit = ""};
+    return value;
+}
+
+template<>
+inline const Base::Color& styleDefault<Base::Color>()
+{
+    static const Base::Color value(0.0F, 0.0F, 0.0F, 0.0F);
+    return value;
+}
+
+template<>
+inline const std::string& styleDefault<std::string>()
+{
+    static const std::string value;
+    return value;
+}
+
+template<>
+inline const Tuple& styleDefault<Tuple>()
+{
+    static const Tuple value;
+    return value;
+}
+
+template<typename T>
+const T* Tuple::tryGetOrReport(const std::string& name) const
+{
+    if (const T* value = tryGet<T>(name)) {
+        return value;
     }
 
-    return "<unknown>";
+    if (const Value* found = find(name)) {
+        Diagnostics::report("Argument '{}' must be {}, got {}", name, valueTypeName<T>(), *found);
+    }
+    else {
+        Diagnostics::report("Missing argument '{}'", name);
+    }
+
+    return nullptr;
+}
+
+template<typename T>
+const T* Tuple::tryGet(const std::string& name) const
+{
+    const Value* value = find(name);
+    return value ? value->tryGet<T>() : nullptr;
 }
 
 template<typename T>
 const T& Tuple::get(const std::string& name) const
 {
-    const Value* value = find(name);
-
-    if (!value) {
-        THROWM(Base::ExpressionError, fmt::format("Missing argument '{}'", name));
+    if (const T* value = tryGetOrReport<T>(name)) {
+        return *value;
     }
 
-    if (!value->holds<T>()) {
-        THROWM(
-            Base::ExpressionError,
-            fmt::format("Argument '{}' must be {}, got {}", name, valueTypeName<T>(), value->toString())
-        );
+    return styleDefault<T>();
+}
+
+template<typename T>
+T Tuple::get(const std::string& name, const T& fallback) const
+{
+    if (const T* value = tryGetOrReport<T>(name)) {
+        return *value;
     }
 
-    return value->get<T>();
+    return fallback;
+}
+
+/**
+ * @brief Wraps a Value in a 1-element unnamed generic Tuple if it is not already a Tuple.
+ *
+ * This allows scalar values (e.g. a bare Numeric) to be passed into constructors that
+ * expect a Tuple and use CSS-like expansion (1 element → all sides equal).
+ */
+inline Tuple asTuple(const Value& value)
+{
+    if (value.holds<Tuple>()) {
+        return value.get<Tuple>();
+    }
+    return Tuple({Tuple::Element::unnamed(value)});
 }
 
 /**
@@ -279,6 +465,51 @@ private:
     std::vector<ParamDef> params_;
 };
 
+/**
+ * @brief Satisfied by domain wrapper types that validate a Value themselves.
+ */
+template<typename T>
+concept HasTryFrom = requires(const Value& value) {
+    { T::tryFrom(value) } -> std::same_as<std::optional<T>>;
+};
+
+/**
+ * @brief Extracts a typed value from an optional Value.
+ *
+ * Domain wrapper types (Insets, Padding, Corners, LinearGradient, …) validate through their
+ * own tryFrom. Variant member types (Numeric, Base::Color, std::string, Tuple) are returned
+ * only when the value holds exactly that type. Either way, a value of the wrong shape yields
+ * nothing, so callers keep their own default.
+ */
+template<HasTryFrom T>
+std::optional<T> valueAs(const std::optional<Value>& value)
+{
+    if (!value) {
+        return std::nullopt;
+    }
+    return T::tryFrom(*value);
+}
+
+template<typename T>
+    requires(!HasTryFrom<T>)
+std::optional<T> valueAs(const std::optional<Value>& value)
+{
+    if (!value) {
+        return std::nullopt;
+    }
+    const T* held = value->tryGet<T>();
+    return held ? std::optional<T>(*held) : std::nullopt;
+}
+
 }  // namespace Gui::StyleParameters
+
+template<>
+struct fmt::formatter<Gui::StyleParameters::Value>: fmt::formatter<std::string>
+{
+    auto format(const Gui::StyleParameters::Value& value, fmt::format_context& ctx) const
+    {
+        return fmt::formatter<std::string>::format(value.toString(), ctx);
+    }
+};
 
 #endif  // STYLEPARAMETERS_VALUE_H

--- a/src/Gui/Utilities.h
+++ b/src/Gui/Utilities.h
@@ -23,9 +23,15 @@
 #pragma once
 
 #include <vector>
+#include <QBrush>
 #include <QColor>
+#include <QLinearGradient>
+#include <QMarginsF>
+#include <QRadialGradient>
 #include <App/Material.h>
+#include <Base/Console.h>
 #include <Base/Converter.h>
+#include <Base/Exception.h>
 #include <Base/ViewProj.h>
 #include <Inventor/SbColor.h>
 #include <Inventor/SbColor4f.h>
@@ -33,6 +39,9 @@
 #include <Inventor/SbRotation.h>
 #include <Inventor/SbVec2f.h>
 #include <Inventor/SbViewVolume.h>
+#include <StyleParameters/Gradient.h>
+#include <StyleParameters/Insets.h>
+#include <StyleParameters/Value.h>
 
 class SbViewVolume;
 class QAbstractItemView;
@@ -440,6 +449,78 @@ inline Base::Matrix4D convertTo<Base::Matrix4D, SbMatrix>(const SbMatrix& vec2)
     }
     return mat;
 }
+
+template<>
+inline QMarginsF convertTo<QMarginsF, Gui::StyleParameters::Insets>(
+    const Gui::StyleParameters::Insets& insets
+)
+{
+    return {
+        insets.left().value,
+        insets.top().value,
+        insets.right().value,
+        insets.bottom().value,
+    };
+}
+
+template<>
+inline QLinearGradient convertTo<QLinearGradient, Gui::StyleParameters::LinearGradient>(
+    const Gui::StyleParameters::LinearGradient& gradient
+)
+{
+    QLinearGradient qGradient(gradient.x1(), gradient.y1(), gradient.x2(), gradient.y2());
+    qGradient.setCoordinateMode(QGradient::ObjectMode);
+    for (const auto& stop : gradient.colorStops()) {
+        qGradient.setColorAt(stop.position.value, stop.color.asValue<QColor>());
+    }
+    return qGradient;
+}
+
+template<>
+inline QRadialGradient convertTo<QRadialGradient, Gui::StyleParameters::RadialGradient>(
+    const Gui::StyleParameters::RadialGradient& gradient
+)
+{
+    QRadialGradient
+        qGradient(gradient.cx(), gradient.cy(), gradient.radius(), gradient.fx(), gradient.fy());
+    qGradient.setCoordinateMode(QGradient::ObjectMode);
+    for (const auto& stop : gradient.colorStops()) {
+        qGradient.setColorAt(stop.position.value, stop.color.asValue<QColor>());
+    }
+    return qGradient;
+}
+
+template<>
+inline QBrush convertTo<QBrush, Gui::StyleParameters::Value>(const Gui::StyleParameters::Value& value)
+{
+    using namespace Gui::StyleParameters;
+
+    if (value.holds<Color>()) {
+        return value.get<Color>().asValue<QColor>();
+    }
+
+    if (!value.holds<Tuple>()) {
+        return Qt::NoBrush;
+    }
+
+    const auto& tuple = value.get<Tuple>();
+
+    try {
+        if (tuple.kind == TupleKind::LinearGradient) {
+            return convertTo<QLinearGradient>(LinearGradient(tuple));
+        }
+        if (tuple.kind == TupleKind::RadialGradient) {
+            return convertTo<QRadialGradient>(RadialGradient(tuple));
+        }
+    }
+    catch (const Exception& exception) {
+        // log and proceed to return NoBrush
+        Console().warning(exception.what());
+    }
+
+    return Qt::NoBrush;
+}
+
 }  // namespace Base
 
 namespace App

--- a/src/Gui/Utilities.h
+++ b/src/Gui/Utilities.h
@@ -23,7 +23,11 @@
 #pragma once
 
 #include <vector>
+#include <QBrush>
 #include <QColor>
+#include <QLinearGradient>
+#include <QMarginsF>
+#include <QRadialGradient>
 #include <App/Material.h>
 #include <Base/Converter.h>
 #include <Base/ViewProj.h>
@@ -33,6 +37,9 @@
 #include <Inventor/SbRotation.h>
 #include <Inventor/SbVec2f.h>
 #include <Inventor/SbViewVolume.h>
+#include <StyleParameters/Gradient.h>
+#include <StyleParameters/Insets.h>
+#include <StyleParameters/Value.h>
 
 class SbViewVolume;
 class QAbstractItemView;
@@ -440,6 +447,76 @@ inline Base::Matrix4D convertTo<Base::Matrix4D, SbMatrix>(const SbMatrix& vec2)
     }
     return mat;
 }
+
+template<>
+inline QMarginsF convertTo<QMarginsF, Gui::StyleParameters::Insets>(
+    const Gui::StyleParameters::Insets& insets
+)
+{
+    return {
+        insets.left().value,
+        insets.top().value,
+        insets.right().value,
+        insets.bottom().value,
+    };
+}
+
+template<>
+inline QLinearGradient convertTo<QLinearGradient, Gui::StyleParameters::LinearGradient>(
+    const Gui::StyleParameters::LinearGradient& gradient
+)
+{
+    QLinearGradient qGradient(gradient.x1(), gradient.y1(), gradient.x2(), gradient.y2());
+    qGradient.setCoordinateMode(QGradient::ObjectMode);
+    for (const auto& stop : gradient.colorStops()) {
+        qGradient.setColorAt(stop.position.value, stop.color.asValue<QColor>());
+    }
+    return qGradient;
+}
+
+template<>
+inline QRadialGradient convertTo<QRadialGradient, Gui::StyleParameters::RadialGradient>(
+    const Gui::StyleParameters::RadialGradient& gradient
+)
+{
+    QRadialGradient
+        qGradient(gradient.cx(), gradient.cy(), gradient.radius(), gradient.fx(), gradient.fy());
+    qGradient.setCoordinateMode(QGradient::ObjectMode);
+    for (const auto& stop : gradient.colorStops()) {
+        qGradient.setColorAt(stop.position.value, stop.color.asValue<QColor>());
+    }
+    return qGradient;
+}
+
+template<>
+inline QBrush convertTo<QBrush, Gui::StyleParameters::Value>(const Gui::StyleParameters::Value& value)
+{
+    using namespace Gui::StyleParameters;
+
+    if (const Color* color = value.tryGet<Color>()) {
+        return color->asValue<QColor>();
+    }
+
+    const Tuple* tuple = value.tryGet<Tuple>();
+    if (!tuple) {
+        return Qt::NoBrush;
+    }
+
+    if (tuple->kind == TupleKind::LinearGradient) {
+        if (const auto gradient = LinearGradient::tryFrom(value)) {
+            return convertTo<QLinearGradient>(*gradient);
+        }
+    }
+
+    if (tuple->kind == TupleKind::RadialGradient) {
+        if (const auto gradient = RadialGradient::tryFrom(value)) {
+            return convertTo<QRadialGradient>(*gradient);
+        }
+    }
+
+    return Qt::NoBrush;
+}
+
 }  // namespace Base
 
 namespace App

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(Base_tests_run
         InputSource.cpp
         Handle.cpp
         Matrix.cpp
+        OkLch.cpp
         Parameter.cpp
         ParameterObserver.cpp
         Placement.cpp

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(Base_tests_run
         BoundBox.cpp
         Builder3D.cpp
         Color.cpp
+        ColorShading.cpp
         Console.cpp
         CoordinateSystem.cpp
         DualNumber.cpp

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(Base_tests_run
         InputSource.cpp
         Handle.cpp
         Matrix.cpp
+        OkLch.cpp
         Parameter.cpp
         ParameterObserver.cpp
         Placement.cpp

--- a/tests/src/Base/ColorShading.cpp
+++ b/tests/src/Base/ColorShading.cpp
@@ -1,0 +1,217 @@
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include "Base/ColorShading.h"
+#include "Base/OkLch.h"
+
+// NOLINTBEGIN
+
+class ColorShadingTest: public ::testing::Test
+{
+protected:
+    Base::ColorShading::Parameters defaultParameters;
+
+    Base::OkLch makeAnchor(float lightness, float chroma = 0.1F, float hue = 240.0F)
+    {
+        return Base::OkLch {
+            .lightness = lightness,
+            .chroma = chroma,
+            .hue = hue,
+        };
+    }
+};
+
+TEST_F(ColorShadingTest, AnchorReturnsUnchanged)
+{
+    // Position 0.5 should return the anchor unchanged
+    auto anchor = makeAnchor(0.55F);
+    auto result = Base::ColorShading::computeShade(0.5F, anchor, defaultParameters);
+    EXPECT_FLOAT_EQ(result.lightness, anchor.lightness);
+    EXPECT_FLOAT_EQ(result.chroma, anchor.chroma);
+    EXPECT_FLOAT_EQ(result.hue, anchor.hue);
+}
+
+TEST_F(ColorShadingTest, MonotonicDecrease)
+{
+    // Lightness must strictly decrease as position increases from 0 to 1
+    auto anchor = makeAnchor(0.55F);
+    float previous = Base::ColorShading::computeShade(0.0F, anchor, defaultParameters).lightness;
+
+    for (int index = 1; index <= 10; ++index) {
+        float position = static_cast<float>(index) / 10.0F;
+        // Skip the anchor position itself
+        if (std::abs(position - 0.5F) < 1e-3F) {
+            continue;
+        }
+        float current = Base::ColorShading::computeShade(position, anchor, defaultParameters).lightness;
+        EXPECT_LT(current, previous) << "position=" << position;
+        previous = current;
+    }
+}
+
+TEST_F(ColorShadingTest, SymmetricRangeIsLinear)
+{
+    // When anchor is exactly centered in the range, the exponent should be ~1 (linear)
+    // This means equal steps in position produce equal steps in lightness
+    auto anchor = makeAnchor(0.57F);  // centered in default [0.17, 0.97] with range 0.8
+
+    float light = Base::ColorShading::computeShade(0.25F, anchor, defaultParameters).lightness;
+    float dark = Base::ColorShading::computeShade(0.75F, anchor, defaultParameters).lightness;
+
+    // Symmetric positions should produce symmetric lightness offsets from anchor
+    float lightDelta = light - anchor.lightness;
+    float darkDelta = anchor.lightness - dark;
+    EXPECT_NEAR(lightDelta, darkDelta, 0.01F);
+}
+
+TEST_F(ColorShadingTest, ClampedRangeRespectsMinMax)
+{
+    // Results should stay within [minLightness, maxLightness]
+    Base::ColorShading::Parameters parameters = {
+        .range = 0.6F,
+        .minLightness = 0.2F,
+        .maxLightness = 0.8F,
+    };
+
+    auto anchor = makeAnchor(0.5F);
+    for (int index = 0; index <= 10; ++index) {
+        float position = static_cast<float>(index) / 10.0F;
+        if (std::abs(position - 0.5F) < 1e-3F) {
+            continue;
+        }
+        float result = Base::ColorShading::computeShade(position, anchor, parameters).lightness;
+        EXPECT_GE(result, parameters.minLightness - 1e-6F) << "position=" << position;
+        EXPECT_LE(result, parameters.maxLightness + 1e-6F) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, NarrowRangeProducesLessVariation)
+{
+    auto anchor = makeAnchor(0.55F);
+
+    Base::ColorShading::Parameters narrowParameters = {
+        .range = 0.2F,
+        .minLightness = 0.17F,
+        .maxLightness = 0.97F,
+    };
+
+    float wideLight = Base::ColorShading::computeShade(0.1F, anchor, defaultParameters).lightness;
+    float wideDark = Base::ColorShading::computeShade(0.9F, anchor, defaultParameters).lightness;
+    float wideSpan = wideLight - wideDark;
+
+    float narrowLight = Base::ColorShading::computeShade(0.1F, anchor, narrowParameters).lightness;
+    float narrowDark = Base::ColorShading::computeShade(0.9F, anchor, narrowParameters).lightness;
+    float narrowSpan = narrowLight - narrowDark;
+
+    EXPECT_LT(narrowSpan, wideSpan);
+}
+
+TEST_F(ColorShadingTest, ExtremeLightnessIsHandled)
+{
+    // Anchor near 0 or 1 should not produce NaN or infinity
+    for (float anchorLightness : {0.0F, 0.01F, 0.99F, 1.0F}) {
+        auto anchor = makeAnchor(anchorLightness);
+        for (int index = 0; index <= 10; ++index) {
+            float position = static_cast<float>(index) / 10.0F;
+            if (std::abs(position - 0.5F) < 1e-3F) {
+                continue;
+            }
+            auto result = Base::ColorShading::computeShade(position, anchor, defaultParameters);
+            EXPECT_FALSE(std::isnan(result.lightness))
+                << "anchor=" << anchorLightness << " position=" << position;
+            EXPECT_FALSE(std::isinf(result.lightness))
+                << "anchor=" << anchorLightness << " position=" << position;
+            EXPECT_FALSE(std::isnan(result.chroma))
+                << "anchor=" << anchorLightness << " position=" << position;
+            EXPECT_FALSE(std::isinf(result.chroma))
+                << "anchor=" << anchorLightness << " position=" << position;
+        }
+    }
+}
+
+TEST_F(ColorShadingTest, ChromaScalesWithGamutBoundary)
+{
+    // Chroma should scale by sqrt(min(targetL/anchorL, (1-targetL)/(1-anchorL)))
+    // so it shrinks toward both black and white, with sqrt softening the effect
+    auto anchor = makeAnchor(0.6F, 0.15F, 260.0F);
+
+    for (float position : {0.1F, 0.3F, 0.7F, 0.9F}) {
+        auto result = Base::ColorShading::computeShade(position, anchor, defaultParameters);
+        float darkScale = result.lightness / anchor.lightness;
+        float lightScale = (1.0F - result.lightness) / (1.0F - anchor.lightness);
+        float expectedChroma = anchor.chroma * std::pow(std::min(darkScale, lightScale), 0.5F);
+        EXPECT_NEAR(result.chroma, expectedChroma, 1e-6F) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, LighterShadesReduceChroma)
+{
+    // For lighter shades, chroma should decrease (not increase) to avoid tinted near-whites
+    auto anchor = makeAnchor(0.74F, 0.014F, 250.0F);  // similar to #ADB5BD
+
+    for (float position : {0.0F, 0.1F, 0.2F, 0.3F}) {
+        auto result = Base::ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_GT(result.lightness, anchor.lightness) << "position=" << position;
+        EXPECT_LT(result.chroma, anchor.chroma) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, BlackAnchorProducesZeroChroma)
+{
+    // Anchor with lightness=0 should not cause division by zero; chroma should be 0
+    auto anchor = Base::OkLch {
+        .lightness = 0.0F,
+        .chroma = 0.1F,
+        .hue = 200.0F,
+    };
+
+    for (float position : {0.0F, 0.3F, 0.7F, 1.0F}) {
+        auto result = Base::ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_FLOAT_EQ(result.chroma, 0.0F) << "position=" << position;
+        EXPECT_FALSE(std::isnan(result.chroma)) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, WhiteAnchorProducesZeroChroma)
+{
+    // Anchor with lightness=1 should not cause division by zero; chroma should be 0
+    auto anchor = Base::OkLch {
+        .lightness = 1.0F,
+        .chroma = 0.1F,
+        .hue = 200.0F,
+    };
+
+    for (float position : {0.0F, 0.3F, 0.7F, 1.0F}) {
+        auto result = Base::ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_FLOAT_EQ(result.chroma, 0.0F) << "position=" << position;
+        EXPECT_FALSE(std::isnan(result.chroma)) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, GrayStaysNeutral)
+{
+    // Near-zero chroma should stay near-zero at all positions
+    auto anchor = makeAnchor(0.5F, 0.001F, 0.0F);
+
+    for (int index = 0; index <= 10; ++index) {
+        float position = static_cast<float>(index) / 10.0F;
+        if (std::abs(position - 0.5F) < 1e-3F) {
+            continue;
+        }
+        auto result = Base::ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_LT(result.chroma, 0.01F) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, HueIsPreserved)
+{
+    // Hue should remain unchanged across all positions
+    auto anchor = makeAnchor(0.55F, 0.12F, 123.0F);
+
+    for (float position : {0.0F, 0.2F, 0.8F, 1.0F}) {
+        auto result = Base::ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_FLOAT_EQ(result.hue, anchor.hue) << "position=" << position;
+    }
+}
+
+// NOLINTEND

--- a/tests/src/Base/OkLch.cpp
+++ b/tests/src/Base/OkLch.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include "Base/Color.h"
+#include "Base/OkLch.h"
+
+// NOLINTBEGIN
+
+class OkLchTest: public ::testing::Test
+{
+};
+
+// Round-trip: fromOkLch(toOkLch(color)) should approximate the original color.
+TEST_F(OkLchTest, RoundTripBlack)
+{
+    Base::Color black(0.0f, 0.0f, 0.0f);
+    auto oklch = Base::toOkLch(black);
+    auto result = Base::fromOkLch(oklch);
+    EXPECT_NEAR(result.r, 0.0f, 0.01f);
+    EXPECT_NEAR(result.g, 0.0f, 0.01f);
+    EXPECT_NEAR(result.b, 0.0f, 0.01f);
+}
+
+TEST_F(OkLchTest, RoundTripWhite)
+{
+    Base::Color white(1.0f, 1.0f, 1.0f);
+    auto oklch = Base::toOkLch(white);
+    auto result = Base::fromOkLch(oklch);
+    EXPECT_NEAR(result.r, 1.0f, 0.01f);
+    EXPECT_NEAR(result.g, 1.0f, 0.01f);
+    EXPECT_NEAR(result.b, 1.0f, 0.01f);
+}
+
+TEST_F(OkLchTest, RoundTripRed)
+{
+    Base::Color red(1.0f, 0.0f, 0.0f);
+    auto oklch = Base::toOkLch(red);
+    auto result = Base::fromOkLch(oklch);
+    EXPECT_NEAR(result.r, 1.0f, 0.01f);
+    EXPECT_NEAR(result.g, 0.0f, 0.01f);
+    EXPECT_NEAR(result.b, 0.0f, 0.01f);
+}
+
+TEST_F(OkLchTest, RoundTripGreen)
+{
+    Base::Color green(0.0f, 1.0f, 0.0f);
+    auto oklch = Base::toOkLch(green);
+    auto result = Base::fromOkLch(oklch);
+    EXPECT_NEAR(result.r, 0.0f, 0.01f);
+    EXPECT_NEAR(result.g, 1.0f, 0.01f);
+    EXPECT_NEAR(result.b, 0.0f, 0.01f);
+}
+
+TEST_F(OkLchTest, RoundTripBlue)
+{
+    Base::Color blue(0.0f, 0.0f, 1.0f);
+    auto oklch = Base::toOkLch(blue);
+    auto result = Base::fromOkLch(oklch);
+    EXPECT_NEAR(result.r, 0.0f, 0.01f);
+    EXPECT_NEAR(result.g, 0.0f, 0.01f);
+    EXPECT_NEAR(result.b, 1.0f, 0.01f);
+}
+
+TEST_F(OkLchTest, RoundTripMidGray)
+{
+    Base::Color gray(0.5f, 0.5f, 0.5f);
+    auto oklch = Base::toOkLch(gray);
+    auto result = Base::fromOkLch(oklch);
+    EXPECT_NEAR(result.r, 0.5f, 0.01f);
+    EXPECT_NEAR(result.g, 0.5f, 0.01f);
+    EXPECT_NEAR(result.b, 0.5f, 0.01f);
+}
+
+// Known values: black has L=0, white has L~1, gray has low chroma.
+TEST_F(OkLchTest, BlackHasZeroLightness)
+{
+    auto oklch = Base::toOkLch(Base::Color(0.0f, 0.0f, 0.0f));
+    EXPECT_FLOAT_EQ(oklch.lightness, 0.0f);
+}
+
+TEST_F(OkLchTest, WhiteHasFullLightness)
+{
+    auto oklch = Base::toOkLch(Base::Color(1.0f, 1.0f, 1.0f));
+    EXPECT_NEAR(oklch.lightness, 1.0f, 0.01f);
+}
+
+TEST_F(OkLchTest, GrayHasLowChroma)
+{
+    auto oklch = Base::toOkLch(Base::Color(0.5f, 0.5f, 0.5f));
+    EXPECT_NEAR(oklch.chroma, 0.0f, 0.01f);
+}
+
+// Gamut mapping: fromOkLch with very high chroma should return valid sRGB.
+TEST_F(OkLchTest, GamutMappingClampsToValidSrgb)
+{
+    Base::OkLch outOfGamut = {.lightness = 0.7f, .chroma = 0.5f, .hue = 120.0f};
+    auto result = Base::fromOkLch(outOfGamut);
+    EXPECT_GE(result.r, 0.0f);
+    EXPECT_LE(result.r, 1.0f);
+    EXPECT_GE(result.g, 0.0f);
+    EXPECT_LE(result.g, 1.0f);
+    EXPECT_GE(result.b, 0.0f);
+    EXPECT_LE(result.b, 1.0f);
+}
+
+// Alpha is preserved through conversion.
+TEST_F(OkLchTest, AlphaPreserved)
+{
+    Base::Color semiTransparent(1.0f, 0.0f, 0.0f, 0.5f);
+    auto oklch = Base::toOkLch(semiTransparent);
+    auto result = Base::fromOkLch(oklch, semiTransparent.a);
+    EXPECT_NEAR(result.a, 0.5f, 0.01f);
+}
+
+// NOLINTEND

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(Gui_tests_run
         StyleParameters/ParameterManagerTest.cpp
         StyleParameters/YamlParameterSourceTest.cpp
         StyleParameters/DiagnosticsTest.cpp
+        StyleParameters/ValueAccessTest.cpp
         InputHintTest.cpp
         SelectionTest.cpp
 )

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(Gui_tests_run
         StyleParameters/ValueAccessTest.cpp
         StyleParameters/EdgesTest.cpp
         StyleParameters/CornersTest.cpp
+        StyleParameters/GradientTest.cpp
         InputHintTest.cpp
         SelectionTest.cpp
 )

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(Gui_tests_run
         StyleParameters/DiagnosticsTest.cpp
         StyleParameters/ValueAccessTest.cpp
         StyleParameters/EdgesTest.cpp
+        StyleParameters/CornersTest.cpp
         InputHintTest.cpp
         SelectionTest.cpp
 )

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(Gui_tests_run
         StyleParameters/YamlParameterSourceTest.cpp
         StyleParameters/DiagnosticsTest.cpp
         StyleParameters/ValueAccessTest.cpp
+        StyleParameters/EdgesTest.cpp
         InputHintTest.cpp
         SelectionTest.cpp
 )

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -9,10 +9,12 @@ add_executable(Gui_tests_run
         Camera.cpp
         ColorScaleOverlayTest.cpp
         FileDialog.cpp
+        StyleParameters/DiagnosticsCapture.h
         StyleParameters/StyleParametersApplicationTest.cpp
         StyleParameters/ParserTest.cpp
         StyleParameters/ParameterManagerTest.cpp
         StyleParameters/YamlParameterSourceTest.cpp
+        StyleParameters/DiagnosticsTest.cpp
         InputHintTest.cpp
         SelectionTest.cpp
 )

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(Gui_tests_run
         StyleParameters/ValueMatchers.cpp
         StyleParameters/StyleParametersApplicationTest.cpp
         StyleParameters/ParserTest.cpp
+        StyleParameters/ParserRobustnessTest.cpp
         StyleParameters/ParameterManagerTest.cpp
         StyleParameters/YamlParameterSourceTest.cpp
         StyleParameters/DiagnosticsTest.cpp

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -10,6 +10,8 @@ add_executable(Gui_tests_run
         ColorScaleOverlayTest.cpp
         FileDialog.cpp
         StyleParameters/DiagnosticsCapture.h
+        StyleParameters/ValueMatchers.h
+        StyleParameters/ValueMatchers.cpp
         StyleParameters/StyleParametersApplicationTest.cpp
         StyleParameters/ParserTest.cpp
         StyleParameters/ParameterManagerTest.cpp

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(Gui_tests_run
         StyleParameters/EdgesTest.cpp
         StyleParameters/CornersTest.cpp
         StyleParameters/GradientTest.cpp
+        StyleParameters/ColorShadingTest.cpp
         InputHintTest.cpp
         SelectionTest.cpp
 )

--- a/tests/src/Gui/StyleParameters/ColorShadingTest.cpp
+++ b/tests/src/Gui/StyleParameters/ColorShadingTest.cpp
@@ -1,0 +1,270 @@
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include <Base/OkLch.h>
+#include <Gui/StyleParameters/ColorShading.h>
+
+using namespace Gui::StyleParameters;
+
+// NOLINTBEGIN
+
+class ColorShadingTest: public ::testing::Test
+{
+protected:
+    ColorShading::Parameters defaultParameters;
+
+    Base::OkLch makeAnchor(float lightness, float chroma = 0.1F, float hue = 240.0F)
+    {
+        return Base::OkLch {
+            .lightness = lightness,
+            .chroma = chroma,
+            .hue = hue,
+        };
+    }
+};
+
+TEST_F(ColorShadingTest, AnchorReturnsUnchanged)
+{
+    auto anchor = makeAnchor(0.55F);
+    auto result = ColorShading::computeShade(0.5F, anchor, defaultParameters);
+    EXPECT_FLOAT_EQ(result.lightness, anchor.lightness);
+    EXPECT_FLOAT_EQ(result.chroma, anchor.chroma);
+    EXPECT_FLOAT_EQ(result.hue, anchor.hue);
+}
+
+TEST_F(ColorShadingTest, MonotonicDecrease)
+{
+    auto anchor = makeAnchor(0.55F);
+    float previous = ColorShading::computeShade(0.0F, anchor, defaultParameters).lightness;
+
+    for (int index = 1; index <= 10; ++index) {
+        float position = static_cast<float>(index) / 10.0F;
+        // Skip the anchor position itself
+        if (std::abs(position - 0.5F) < 1e-3F) {
+            continue;
+        }
+        float current = ColorShading::computeShade(position, anchor, defaultParameters).lightness;
+        EXPECT_LT(current, previous) << "position=" << position;
+        previous = current;
+    }
+}
+
+TEST_F(ColorShadingTest, SymmetricRangeIsLinear)
+{
+    // When anchor is exactly centered in the range, the exponent should be ~1 (linear)
+    // This means equal steps in position produce equal steps in lightness
+    auto anchor = makeAnchor(0.57F);  // centered in default [0.17, 0.97] with range 0.8
+
+    float light = ColorShading::computeShade(0.25F, anchor, defaultParameters).lightness;
+    float dark = ColorShading::computeShade(0.75F, anchor, defaultParameters).lightness;
+
+    // Symmetric positions should produce symmetric lightness offsets from anchor
+    float lightDelta = light - anchor.lightness;
+    float darkDelta = anchor.lightness - dark;
+    EXPECT_NEAR(lightDelta, darkDelta, 0.01F);
+}
+
+TEST_F(ColorShadingTest, ClampedRangeRespectsMinMax)
+{
+    ColorShading::Parameters parameters = {
+        .range = 0.6F,
+        .minLightness = 0.2F,
+        .maxLightness = 0.8F,
+    };
+
+    auto anchor = makeAnchor(0.5F);
+    for (int index = 0; index <= 10; ++index) {
+        float position = static_cast<float>(index) / 10.0F;
+        if (std::abs(position - 0.5F) < 1e-3F) {
+            continue;
+        }
+        float result = ColorShading::computeShade(position, anchor, parameters).lightness;
+        EXPECT_GE(result, parameters.minLightness - 1e-6F) << "position=" << position;
+        EXPECT_LE(result, parameters.maxLightness + 1e-6F) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, NarrowRangeProducesLessVariation)
+{
+    auto anchor = makeAnchor(0.55F);
+
+    ColorShading::Parameters narrowParameters = {
+        .range = 0.2F,
+        .minLightness = 0.17F,
+        .maxLightness = 0.97F,
+    };
+
+    float wideLight = ColorShading::computeShade(0.1F, anchor, defaultParameters).lightness;
+    float wideDark = ColorShading::computeShade(0.9F, anchor, defaultParameters).lightness;
+    float wideSpan = wideLight - wideDark;
+
+    float narrowLight = ColorShading::computeShade(0.1F, anchor, narrowParameters).lightness;
+    float narrowDark = ColorShading::computeShade(0.9F, anchor, narrowParameters).lightness;
+    float narrowSpan = narrowLight - narrowDark;
+
+    EXPECT_LT(narrowSpan, wideSpan);
+}
+
+TEST_F(ColorShadingTest, ExtremeLightnessIsHandled)
+{
+    for (float anchorLightness : {0.0F, 0.01F, 0.99F, 1.0F}) {
+        auto anchor = makeAnchor(anchorLightness);
+        for (int index = 0; index <= 10; ++index) {
+            float position = static_cast<float>(index) / 10.0F;
+            if (std::abs(position - 0.5F) < 1e-3F) {
+                continue;
+            }
+            auto result = ColorShading::computeShade(position, anchor, defaultParameters);
+            EXPECT_FALSE(std::isnan(result.lightness))
+                << "anchor=" << anchorLightness << " position=" << position;
+            EXPECT_FALSE(std::isinf(result.lightness))
+                << "anchor=" << anchorLightness << " position=" << position;
+            EXPECT_FALSE(std::isnan(result.chroma))
+                << "anchor=" << anchorLightness << " position=" << position;
+            EXPECT_FALSE(std::isinf(result.chroma))
+                << "anchor=" << anchorLightness << " position=" << position;
+        }
+    }
+}
+
+TEST_F(ColorShadingTest, ChromaScalesWithGamutBoundary)
+{
+    // Chroma should scale by sqrt(min(targetL/anchorL, (1-targetL)/(1-anchorL)))
+    // so it shrinks toward both black and white, with sqrt softening the effect
+    auto anchor = makeAnchor(0.6F, 0.15F, 260.0F);
+
+    for (float position : {0.1F, 0.3F, 0.7F, 0.9F}) {
+        auto result = ColorShading::computeShade(position, anchor, defaultParameters);
+        float darkScale = result.lightness / anchor.lightness;
+        float lightScale = (1.0F - result.lightness) / (1.0F - anchor.lightness);
+        float expectedChroma = anchor.chroma * std::pow(std::min(darkScale, lightScale), 0.5F);
+        EXPECT_NEAR(result.chroma, expectedChroma, 1e-6F) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, LighterShadesReduceChroma)
+{
+    // For lighter shades, chroma should decrease (not increase) to avoid tinted near-whites
+    auto anchor = makeAnchor(0.74F, 0.014F, 250.0F);  // similar to #ADB5BD
+
+    for (float position : {0.0F, 0.1F, 0.2F, 0.3F}) {
+        auto result = ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_GT(result.lightness, anchor.lightness) << "position=" << position;
+        EXPECT_LT(result.chroma, anchor.chroma) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, BlackAnchorProducesZeroChroma)
+{
+    auto anchor = Base::OkLch {
+        .lightness = 0.0F,
+        .chroma = 0.1F,
+        .hue = 200.0F,
+    };
+
+    for (float position : {0.0F, 0.3F, 0.7F, 1.0F}) {
+        auto result = ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_FLOAT_EQ(result.chroma, 0.0F) << "position=" << position;
+        EXPECT_FALSE(std::isnan(result.chroma)) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, WhiteAnchorProducesZeroChroma)
+{
+    auto anchor = Base::OkLch {
+        .lightness = 1.0F,
+        .chroma = 0.1F,
+        .hue = 200.0F,
+    };
+
+    for (float position : {0.0F, 0.3F, 0.7F, 1.0F}) {
+        auto result = ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_FLOAT_EQ(result.chroma, 0.0F) << "position=" << position;
+        EXPECT_FALSE(std::isnan(result.chroma)) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, GrayStaysNeutral)
+{
+    auto anchor = makeAnchor(0.5F, 0.001F, 0.0F);
+
+    for (int index = 0; index <= 10; ++index) {
+        float position = static_cast<float>(index) / 10.0F;
+        if (std::abs(position - 0.5F) < 1e-3F) {
+            continue;
+        }
+        auto result = ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_LT(result.chroma, 0.01F) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, HueIsPreserved)
+{
+    auto anchor = makeAnchor(0.55F, 0.12F, 123.0F);
+
+    for (float position : {0.0F, 0.2F, 0.8F, 1.0F}) {
+        auto result = ColorShading::computeShade(position, anchor, defaultParameters);
+        EXPECT_FLOAT_EQ(result.hue, anchor.hue) << "position=" << position;
+    }
+}
+
+TEST_F(ColorShadingTest, ExtremePivotsProduceFiniteShades)
+{
+    // log(pivot) is NaN for a negative pivot and infinite at 0, both of which propagate
+    // through computeExponent unless the pivot is clamped first.
+    const Base::OkLch anchor {.lightness = 0.5F, .chroma = 0.1F, .hue = 30.0F};
+
+    for (float pivot : {-1.0F, 0.0F, 1.0F}) {
+        const Base::OkLch shade
+            = ColorShading::computeShade(0.2F, anchor, ColorShading::Parameters {.pivot = pivot});
+
+        EXPECT_TRUE(std::isfinite(shade.lightness)) << "pivot=" << pivot;
+        EXPECT_TRUE(std::isfinite(shade.chroma)) << "pivot=" << pivot;
+    }
+}
+
+TEST_F(ColorShadingTest, MaxLightnessAboveOneIsClamped)
+{
+    const Base::OkLch anchor {.lightness = 0.5F, .chroma = 0.1F, .hue = 30.0F};
+    const ColorShading::Parameters parameters {.maxLightness = 2.0F};
+
+    const Base::OkLch shade = ColorShading::computeShade(0.0F, anchor, parameters);
+
+    EXPECT_TRUE(std::isfinite(shade.chroma));
+    EXPECT_GE(shade.chroma, 0.0F);
+    EXPECT_LE(shade.lightness, 1.0F);
+}
+
+TEST_F(ColorShadingTest, InvertedBoundsPreserveLightToDarkDirection)
+{
+    // Swapping inverted min/max doesn't change boundedness (both endpoints are already
+    // clamped into [0,1], so any interpolation between them stays in [0,1] either way) but it
+    // does change which end of the curve is lighter. Without the swap, position 0 would be
+    // the darker shade and position 1 the lighter one, inverting the documented contract.
+    const Base::OkLch anchor {.lightness = 0.5F, .chroma = 0.1F, .hue = 30.0F};
+    const ColorShading::Parameters parameters {.minLightness = 0.9F, .maxLightness = 0.1F};
+
+    const Base::OkLch lightEnd = ColorShading::computeShade(0.0F, anchor, parameters);
+    const Base::OkLch darkEnd = ColorShading::computeShade(1.0F, anchor, parameters);
+
+    EXPECT_GT(lightEnd.lightness, darkEnd.lightness);
+}
+
+TEST_F(ColorShadingTest, OutOfRangePositionSaturatesAtTheCurveEnds)
+{
+    // A theme author writing shade(@color, 30) instead of 30% must land on the darkest shade
+    // of the curve, not somewhere far outside it.
+    const Base::OkLch anchor {.lightness = 0.5F, .chroma = 0.1F, .hue = 30.0F};
+
+    const Base::OkLch belowRange = ColorShading::computeShade(-30.0F, anchor, {});
+    const Base::OkLch lightest = ColorShading::computeShade(0.0F, anchor, {});
+    EXPECT_FLOAT_EQ(belowRange.lightness, lightest.lightness);
+    EXPECT_FLOAT_EQ(belowRange.chroma, lightest.chroma);
+
+    const Base::OkLch aboveRange = ColorShading::computeShade(30.0F, anchor, {});
+    const Base::OkLch darkest = ColorShading::computeShade(1.0F, anchor, {});
+    EXPECT_FLOAT_EQ(aboveRange.lightness, darkest.lightness);
+    EXPECT_FLOAT_EQ(aboveRange.chroma, darkest.chroma);
+}
+
+// NOLINTEND

--- a/tests/src/Gui/StyleParameters/CornersTest.cpp
+++ b/tests/src/Gui/StyleParameters/CornersTest.cpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <Gui/StyleParameters/Corners.h>
+
+#include "DiagnosticsCapture.h"
+
+using namespace Gui::StyleParameters;
+using ::testing::Contains;
+using ::testing::HasSubstr;
+
+TEST(CornersTest, FromColorDegradesToZeroAndReports)
+{
+    DiagnosticsCapture capture;
+
+    const Corners corners {Value {Base::Color(1.0F, 0.0F, 0.0F)}};
+
+    EXPECT_DOUBLE_EQ(corners.topLeft().value, 0.0);
+    EXPECT_DOUBLE_EQ(corners.bottomRight().value, 0.0);
+    EXPECT_EQ(corners.tuple().kind, TupleKind::Corners);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("must be numeric")));
+}
+
+TEST(CornersTest, TryFromColorReturnsNullopt)
+{
+    EXPECT_FALSE(Corners::tryFrom(Value {Base::Color(1.0F, 0.0F, 0.0F)}).has_value());
+}
+
+TEST(CornersTest, DiagonalPairingForTwoValues)
+{
+    const Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 4.0, .unit = "px"}),
+        Tuple::Element::unnamed(Numeric {.value = 8.0, .unit = "px"}),
+    });
+    const Corners corners {args};
+
+    EXPECT_DOUBLE_EQ(corners.topLeft().value, 4.0);
+    EXPECT_DOUBLE_EQ(corners.topRight().value, 8.0);
+    EXPECT_DOUBLE_EQ(corners.bottomRight().value, 4.0);
+    EXPECT_DOUBLE_EQ(corners.bottomLeft().value, 8.0);
+}
+
+TEST(CornersTest, TooManyPositionalArgumentsDegradesToZero)
+{
+    DiagnosticsCapture capture;
+
+    Tuple args;
+    for (int index = 0; index < 5; ++index) {
+        args.elements.push_back(
+            Tuple::Element::unnamed(Numeric {.value = static_cast<double>(index), .unit = "px"})
+        );
+    }
+
+    const Corners corners {args};
+
+    EXPECT_DOUBLE_EQ(corners.topLeft().value, 0.0);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("1-4 positional arguments")));
+}
+
+TEST(CornersTest, RejectsAPaddingTuple)
+{
+    DiagnosticsCapture capture;
+
+    const Tuple padding(
+        {
+            Tuple::Element::named("top", Numeric {.value = 1.0, .unit = "px"}),
+            Tuple::Element::named("right", Numeric {.value = 1.0, .unit = "px"}),
+            Tuple::Element::named("bottom", Numeric {.value = 1.0, .unit = "px"}),
+            Tuple::Element::named("left", Numeric {.value = 1.0, .unit = "px"}),
+        },
+        TupleKind::Padding
+    );
+
+    EXPECT_FALSE(Corners::tryFrom(Value {padding}).has_value());
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("Expected Corners tuple, got Padding")));
+}
+
+TEST(CornersTest, RawArgumentTupleFromColorDegradesToZeroAndReports)
+{
+    // Mirrors Parser.cpp's border_radius(...) function, which calls Corners(args) with the
+    // raw Generic argument tuple (e.g. border_radius(#ff0000)). The raw-tuple constructor
+    // must validate element types too, not just wrap whatever expand() produces — otherwise
+    // a Color would be stored where a Numeric corner is expected.
+    DiagnosticsCapture capture;
+
+    const Tuple args({Tuple::Element::unnamed(Base::Color(1.0F, 0.0F, 0.0F))});
+    const Corners corners {args};
+
+    const Value* topLeftElement = corners.tuple().find("top_left");
+    ASSERT_NE(topLeftElement, nullptr);
+    EXPECT_TRUE(topLeftElement->holds<Numeric>());
+    EXPECT_DOUBLE_EQ(corners.topLeft().value, 0.0);
+    EXPECT_EQ(corners.tuple().kind, TupleKind::Corners);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("must be numeric")));
+}

--- a/tests/src/Gui/StyleParameters/DiagnosticsCapture.h
+++ b/tests/src/Gui/StyleParameters/DiagnosticsCapture.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Test-only helper. Nothing in shipped code uses this.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <Gui/StyleParameters/Diagnostics.h>
+
+namespace Gui::StyleParameters
+{
+
+/// Captures diagnostics for the lifetime of the object and clears dedup state on both ends.
+class DiagnosticsCapture
+{
+public:
+    DiagnosticsCapture()
+    {
+        Diagnostics::clear();
+        subscription_ = Diagnostics::observe([this](const std::string& message) {
+            messages_.push_back(message);
+        });
+    }
+
+    ~DiagnosticsCapture()
+    {
+        Diagnostics::clear();
+    }
+
+    DiagnosticsCapture(const DiagnosticsCapture&) = delete;
+    DiagnosticsCapture& operator=(const DiagnosticsCapture&) = delete;
+
+    const std::vector<std::string>& messages() const
+    {
+        return messages_;
+    }
+
+private:
+    std::vector<std::string> messages_;
+    Diagnostics::Subscription subscription_;
+};
+
+}  // namespace Gui::StyleParameters

--- a/tests/src/Gui/StyleParameters/DiagnosticsTest.cpp
+++ b/tests/src/Gui/StyleParameters/DiagnosticsTest.cpp
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <stdexcept>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <Gui/StyleParameters/Diagnostics.h>
+
+#include "DiagnosticsCapture.h"
+
+using namespace Gui::StyleParameters;
+using ::testing::ElementsAre;
+
+TEST(DiagnosticsTest, DeliversFormattedMessageToObserver)
+{
+    DiagnosticsCapture capture;
+
+    Diagnostics::report("Argument '{}' must be {}", "width", "numeric");
+
+    EXPECT_THAT(capture.messages(), ElementsAre("Argument 'width' must be numeric"));
+}
+
+TEST(DiagnosticsTest, DropsExactRepeats)
+{
+    DiagnosticsCapture capture;
+
+    Diagnostics::report("same message");
+    Diagnostics::report("same message");
+    Diagnostics::report("different message");
+
+    EXPECT_THAT(capture.messages(), ElementsAre("same message", "different message"));
+}
+
+TEST(DiagnosticsTest, ClearAllowsMessageAgain)
+{
+    DiagnosticsCapture capture;
+
+    Diagnostics::report("repeatable");
+    Diagnostics::clear();
+    Diagnostics::report("repeatable");
+
+    EXPECT_THAT(capture.messages(), ElementsAre("repeatable", "repeatable"));
+}
+
+TEST(DiagnosticsTest, ObserverStopsReceivingAfterSubscriptionEnds)
+{
+    std::vector<std::string> received;
+
+    {
+        auto subscription = Diagnostics::observe([&received](const std::string& message) {
+            received.push_back(message);
+        });
+        Diagnostics::report("while subscribed");
+    }
+
+    Diagnostics::clear();
+    Diagnostics::report("after unsubscribed");
+
+    EXPECT_THAT(received, ElementsAre("while subscribed"));
+}
+
+TEST(DiagnosticsTest, SupportsMultipleSimultaneousObservers)
+{
+    DiagnosticsCapture first;
+    DiagnosticsCapture second;
+
+    Diagnostics::report("broadcast");
+
+    EXPECT_THAT(first.messages(), ElementsAre("broadcast"));
+    EXPECT_THAT(second.messages(), ElementsAre("broadcast"));
+}
+
+TEST(DiagnosticsTest, ThrowingObserverDoesNotPreventOthersFromReceiving)
+{
+    Diagnostics::clear();
+
+    // Registered first, so it runs before `capture` below and would otherwise poison the loop.
+    auto throwing = Diagnostics::observe([](const std::string&) {
+        throw std::runtime_error("misbehaving observer");
+    });
+
+    DiagnosticsCapture capture;
+
+    EXPECT_NO_THROW(Diagnostics::report("boom"));
+    EXPECT_THAT(capture.messages(), ElementsAre("boom"));
+}
+
+TEST(DiagnosticsTest, NoActiveResolutionScopeMeansNoPrefix)
+{
+    DiagnosticsCapture capture;
+
+    Diagnostics::report("bad value");
+
+    EXPECT_THAT(capture.messages(), ElementsAre("bad value"));
+}
+
+TEST(DiagnosticsTest, ResolutionScopePrefixesTheTokenName)
+{
+    DiagnosticsCapture capture;
+
+    {
+        Diagnostics::ResolutionScope scope("MyToken");
+        Diagnostics::report("bad value");
+    }
+
+    EXPECT_THAT(capture.messages(), ElementsAre("MyToken: bad value"));
+}
+
+TEST(DiagnosticsTest, SameDefectUnderTwoScopesProducesTwoDistinctMessages)
+{
+    DiagnosticsCapture capture;
+
+    {
+        Diagnostics::ResolutionScope scope("TokenA");
+        Diagnostics::report("bad value");
+    }
+    {
+        Diagnostics::ResolutionScope scope("TokenB");
+        Diagnostics::report("bad value");
+    }
+
+    EXPECT_THAT(capture.messages(), ElementsAre("TokenA: bad value", "TokenB: bad value"));
+}
+
+TEST(DiagnosticsTest, NestedResolutionScopeReportsTheInnermostToken)
+{
+    DiagnosticsCapture capture;
+
+    {
+        Diagnostics::ResolutionScope outer("Outer");
+        {
+            Diagnostics::ResolutionScope inner("Inner");
+            Diagnostics::report("bad value");
+        }
+        Diagnostics::report("bad value, inner ended");
+    }
+
+    EXPECT_THAT(capture.messages(), ElementsAre("Inner: bad value", "Outer: bad value, inner ended"));
+}

--- a/tests/src/Gui/StyleParameters/EdgesTest.cpp
+++ b/tests/src/Gui/StyleParameters/EdgesTest.cpp
@@ -24,6 +24,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <Gui/StyleParameters/Corners.h>
 #include <Gui/StyleParameters/Insets.h>
 
 #include "DiagnosticsCapture.h"
@@ -155,6 +156,20 @@ TEST(EdgesTest, PaddingOfNestedBorderColorsArgumentDegradesToZero)
     EXPECT_EQ(padding.tuple().kind, TupleKind::Padding);
     EXPECT_THAT(capture.messages(), Contains(HasSubstr("must be numeric")));
 }
+
+TEST(EdgesTest, PaddingTryFromCornersReturnsNulloptWithMessage)
+{
+    // Corners has no top/right/bottom/left elements at all, so expand() would silently
+    // backfill all four sides with zero — a differently-shaped tuple must be rejected
+    // before that happens, not waved through as zero padding with no diagnostic.
+    DiagnosticsCapture capture;
+
+    const Corners corners {Value {Numeric {.value = 4.0, .unit = "px"}}};
+
+    EXPECT_FALSE(Padding::tryFrom(Value {corners.tuple()}).has_value());
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("got Corners")));
+}
+
 TEST(EdgesTest, InsetsTryFromLinearGradientReturnsNullopt)
 {
     const Tuple gradient(
@@ -169,6 +184,19 @@ TEST(EdgesTest, InsetsTryFromLinearGradientReturnsNullopt)
 
     EXPECT_FALSE(Insets::tryFrom(Value {gradient}).has_value());
 }
+
+TEST(EdgesTest, PaddingFromCornersDegradesToZeroAndReports)
+{
+    DiagnosticsCapture capture;
+
+    const Corners corners {Value {Numeric {.value = 4.0, .unit = "px"}}};
+    const Padding padding {Value {corners.tuple()}};
+
+    EXPECT_DOUBLE_EQ(padding.top().value, 0.0);
+    EXPECT_EQ(padding.tuple().kind, TupleKind::Padding);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("got Corners")));
+}
+
 TEST(EdgesTest, PaddingFromMarginsTupleCoerces)
 {
     // The four edge kinds share element type Numeric and are structurally interchangeable, so

--- a/tests/src/Gui/StyleParameters/EdgesTest.cpp
+++ b/tests/src/Gui/StyleParameters/EdgesTest.cpp
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <Gui/StyleParameters/Insets.h>
+
+#include "DiagnosticsCapture.h"
+
+using namespace Gui::StyleParameters;
+using ::testing::Contains;
+using ::testing::HasSubstr;
+
+namespace
+{
+Value colorValue()
+{
+    return Base::Color(1.0F, 0.0F, 0.0F);
+}
+
+Tuple colorEdges()
+{
+    return Tuple(
+        {
+            Tuple::Element::named("top", colorValue()),
+            Tuple::Element::named("right", colorValue()),
+            Tuple::Element::named("bottom", colorValue()),
+            Tuple::Element::named("left", colorValue()),
+        },
+        TupleKind::BorderColors
+    );
+}
+}  // namespace
+
+TEST(EdgesTest, PaddingFromColorDegradesToZeroAndReports)
+{
+    DiagnosticsCapture capture;
+
+    const Padding padding {colorValue()};
+
+    EXPECT_DOUBLE_EQ(padding.top().value, 0.0);
+    EXPECT_DOUBLE_EQ(padding.left().value, 0.0);
+    EXPECT_EQ(padding.tuple().kind, TupleKind::Padding);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("must be numeric")));
+}
+
+TEST(EdgesTest, PaddingTryFromColorReturnsNullopt)
+{
+    EXPECT_FALSE(Padding::tryFrom(colorValue()).has_value());
+}
+
+TEST(EdgesTest, PaddingFromBorderColorsDegradesToZero)
+{
+    const Padding padding {Value {colorEdges()}};
+
+    EXPECT_DOUBLE_EQ(padding.top().value, 0.0);
+    EXPECT_EQ(padding.tuple().kind, TupleKind::Padding);
+    EXPECT_FALSE(Padding::tryFrom(Value {colorEdges()}).has_value());
+}
+
+TEST(EdgesTest, PaddingFromNumericExpandsToAllSides)
+{
+    const Padding padding {Value {Numeric {.value = 10.0, .unit = "px"}}};
+
+    EXPECT_DOUBLE_EQ(padding.top().value, 10.0);
+    EXPECT_DOUBLE_EQ(padding.right().value, 10.0);
+    EXPECT_DOUBLE_EQ(padding.bottom().value, 10.0);
+    EXPECT_DOUBLE_EQ(padding.left().value, 10.0);
+    EXPECT_TRUE(Padding::tryFrom(Value {Numeric {.value = 10.0, .unit = "px"}}).has_value());
+}
+
+TEST(EdgesTest, BorderColorsFromColorExpandsToAllSides)
+{
+    const BorderColors colors {colorValue()};
+
+    EXPECT_FLOAT_EQ(colors.top().r, 1.0F);
+    EXPECT_FLOAT_EQ(colors.left().r, 1.0F);
+    EXPECT_EQ(colors.tuple().kind, TupleKind::BorderColors);
+    EXPECT_TRUE(BorderColors::tryFrom(colorValue()).has_value());
+}
+
+TEST(EdgesTest, TooManyPositionalArgumentsDegradesToZero)
+{
+    DiagnosticsCapture capture;
+
+    const Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1.0, .unit = "px"}),
+        Tuple::Element::unnamed(Numeric {.value = 2.0, .unit = "px"}),
+        Tuple::Element::unnamed(Numeric {.value = 3.0, .unit = "px"}),
+        Tuple::Element::unnamed(Numeric {.value = 4.0, .unit = "px"}),
+        Tuple::Element::unnamed(Numeric {.value = 5.0, .unit = "px"}),
+    });
+
+    const Padding padding {args};
+
+    EXPECT_DOUBLE_EQ(padding.top().value, 0.0);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("1-4 positional arguments")));
+}
+
+TEST(EdgesTest, PaddingAcceptsAnExistingPaddingTuple)
+{
+    const Padding original {Value {Numeric {.value = 7.0, .unit = "px"}}};
+    const Padding copy {Value {original.tuple()}};
+
+    EXPECT_DOUBLE_EQ(copy.top().value, 7.0);
+    EXPECT_EQ(copy.tuple().kind, TupleKind::Padding);
+}
+
+TEST(EdgesTest, InsetsAcceptAnyEdgeKind)
+{
+    const Padding padding {Value {Numeric {.value = 3.0, .unit = "px"}}};
+    const auto insets = Insets::tryFrom(Value {padding.tuple()});
+
+    ASSERT_TRUE(insets.has_value());
+    EXPECT_DOUBLE_EQ(insets->horizontal().value, 6.0);
+}
+
+TEST(EdgesTest, PaddingOfNestedBorderColorsArgumentDegradesToZero)
+{
+    // Regression test for padding(border_colors(#ff0000)): the raw-argument-tuple
+    // constructor (the one Parser.cpp's padding()/margins()/etc. functions use) must
+    // validate element types too, not just the Value constructor. Checking the tuple's
+    // stored element (not just the top() accessor, which degrades on its own regardless
+    // of what was stored) is what actually proves the tuple itself holds numerics.
+    DiagnosticsCapture capture;
+
+    const Tuple args({Tuple::Element::unnamed(colorEdges())});
+    const Padding padding {args};
+
+    const Value* topElement = padding.tuple().find("top");
+    ASSERT_NE(topElement, nullptr);
+    EXPECT_TRUE(topElement->holds<Numeric>());
+    EXPECT_DOUBLE_EQ(padding.top().value, 0.0);
+    EXPECT_EQ(padding.tuple().kind, TupleKind::Padding);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("must be numeric")));
+}
+TEST(EdgesTest, InsetsTryFromLinearGradientReturnsNullopt)
+{
+    const Tuple gradient(
+        {
+            Tuple::Element::named("x1", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("y1", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("x2", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("y2", Numeric {.value = 1.0, .unit = ""}),
+        },
+        TupleKind::LinearGradient
+    );
+
+    EXPECT_FALSE(Insets::tryFrom(Value {gradient}).has_value());
+}
+TEST(EdgesTest, PaddingFromMarginsTupleCoerces)
+{
+    // The four edge kinds share element type Numeric and are structurally interchangeable, so
+    // the kind gate must coerce between them rather than demand an exact match.
+    DiagnosticsCapture capture;
+
+    const Margins margins {Value {Numeric {.value = 8.0, .unit = "px"}}};
+    const auto padding = Padding::tryFrom(Value {margins.tuple()});
+
+    ASSERT_TRUE(padding.has_value());
+    EXPECT_DOUBLE_EQ(padding->top().value, 8.0);
+    EXPECT_EQ(padding->tuple().kind, TupleKind::Padding);
+}

--- a/tests/src/Gui/StyleParameters/GradientTest.cpp
+++ b/tests/src/Gui/StyleParameters/GradientTest.cpp
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <Gui/StyleParameters/Gradient.h>
+
+#include "DiagnosticsCapture.h"
+
+using namespace Gui::StyleParameters;
+using ::testing::Contains;
+using ::testing::HasSubstr;
+
+namespace
+{
+Tuple twoStopGradient()
+{
+    return LinearGradient(Tuple({
+                              Tuple::Element::unnamed(Base::Color(1.0F, 0.0F, 0.0F)),
+                              Tuple::Element::unnamed(Base::Color(0.0F, 0.0F, 1.0F)),
+                          }))
+        .tuple();
+}
+}  // namespace
+
+TEST(GradientTest, TooFewStopsDegradesToTransparentAndReports)
+{
+    DiagnosticsCapture capture;
+
+    const LinearGradient gradient {
+        Value {Tuple({Tuple::Element::unnamed(Base::Color(1.0F, 0.0F, 0.0F))})}
+    };
+
+    const auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2U);
+    EXPECT_FLOAT_EQ(stops[0].color.a, 0.0F);
+    EXPECT_FLOAT_EQ(stops[1].color.a, 0.0F);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("at least 2 color stops")));
+}
+
+TEST(GradientTest, TryFromTooFewStopsReturnsNullopt)
+{
+    EXPECT_FALSE(
+        LinearGradient::tryFrom(Value {Tuple({Tuple::Element::unnamed(Base::Color(1.0F, 0.0F, 0.0F))})})
+            .has_value()
+    );
+}
+
+TEST(GradientTest, KindMismatchDegradesAndReports)
+{
+    DiagnosticsCapture capture;
+
+    const Tuple radial = RadialGradient(Tuple({
+                                            Tuple::Element::unnamed(Base::Color(1.0F, 0.0F, 0.0F)),
+                                            Tuple::Element::unnamed(Base::Color(0.0F, 0.0F, 1.0F)),
+                                        }))
+                             .tuple();
+
+    EXPECT_FALSE(LinearGradient::tryFrom(Value {radial}).has_value());
+
+    const LinearGradient degraded {Value {radial}};
+    EXPECT_EQ(degraded.tuple().kind, TupleKind::LinearGradient);
+    EXPECT_FLOAT_EQ(degraded.colorStops()[0].color.a, 0.0F);
+    EXPECT_THAT(
+        capture.messages(),
+        Contains(HasSubstr("Expected LinearGradient tuple, got RadialGradient"))
+    );
+}
+
+TEST(GradientTest, NonNumericGeometryParameterDegradesAndReports)
+{
+    DiagnosticsCapture capture;
+
+    // Mirrors linear_gradient(x1: #ffffff, #000000, #ffffff): a color supplied where the
+    // numeric x1 geometry parameter is expected, alongside two otherwise-valid stops.
+    const Tuple args({
+        Tuple::Element::named("x1", Base::Color(1.0F, 1.0F, 1.0F)),
+        Tuple::Element::unnamed(Base::Color(0.0F, 0.0F, 0.0F)),
+        Tuple::Element::unnamed(Base::Color(1.0F, 1.0F, 1.0F)),
+    });
+
+    std::optional<LinearGradient> gradient;
+    EXPECT_NO_THROW({ gradient.emplace(Tuple {args}); });
+    ASSERT_TRUE(gradient.has_value());
+
+    EXPECT_DOUBLE_EQ(gradient->x1(), 0.0);
+    EXPECT_EQ(gradient->tuple().kind, TupleKind::LinearGradient);
+
+    const auto stops = gradient->colorStops();
+    ASSERT_EQ(stops.size(), 2U);
+
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("'x1' must be a number")));
+}
+
+TEST(GradientTest, WellFormedGradientRoundTrips)
+{
+    const auto gradient = LinearGradient::tryFrom(Value {twoStopGradient()});
+
+    ASSERT_TRUE(gradient.has_value());
+    EXPECT_DOUBLE_EQ(gradient->x1(), 0.0);
+    EXPECT_DOUBLE_EQ(gradient->y2(), 1.0);
+
+    const auto stops = gradient->colorStops();
+    ASSERT_EQ(stops.size(), 2U);
+    EXPECT_FLOAT_EQ(stops[0].color.r, 1.0F);
+    EXPECT_FLOAT_EQ(stops[1].color.b, 1.0F);
+}
+
+TEST(GradientTest, MalformedKindTaggedTupleNeverProducesIllFormedWrapperThroughAnyRoute)
+{
+    // Already tagged LinearGradient, but with a "stops" element that fails isWellFormed's check
+    // (a single well-formed stop, one short of the required 2). A matching kind must not be
+    // taken as proof the contents are well formed.
+    const Tuple malformed(
+        {
+            Tuple::Element::named("x1", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("y1", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("x2", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("y2", Numeric {.value = 1.0, .unit = ""}),
+            Tuple::Element::named(
+                "stops",
+                Tuple({Tuple::Element::unnamed(Tuple({
+                    Tuple::Element::unnamed(Numeric {.value = 0.0, .unit = ""}),
+                    Tuple::Element::unnamed(Base::Color(1.0F, 0.0F, 0.0F)),
+                }))})
+            ),
+        },
+        TupleKind::LinearGradient
+    );
+
+    // Route 1: tryFrom must reject it outright.
+    {
+        DiagnosticsCapture capture;
+        EXPECT_FALSE(LinearGradient::tryFrom(Value {malformed}).has_value());
+    }
+
+    // Route 2: the Value constructor is total, so it must degrade to a fully transparent,
+    // well-formed gradient rather than keep the malformed stops.
+    {
+        DiagnosticsCapture capture;
+        const LinearGradient viaValue {Value {malformed}};
+        const auto stops = viaValue.colorStops();
+        ASSERT_EQ(stops.size(), 2U);
+        EXPECT_FLOAT_EQ(stops[0].color.a, 0.0F);
+        EXPECT_FLOAT_EQ(stops[1].color.a, 0.0F);
+    }
+
+    // Route 3: the raw-Tuple constructor, the one that can see a matching kind and be tempted
+    // to skip validation. It must degrade exactly like the Value constructor.
+    {
+        DiagnosticsCapture capture;
+        const LinearGradient viaTuple {Tuple {malformed}};
+        const auto stops = viaTuple.colorStops();
+        ASSERT_EQ(stops.size(), 2U);
+        EXPECT_FLOAT_EQ(stops[0].color.a, 0.0F);
+        EXPECT_FLOAT_EQ(stops[1].color.a, 0.0F);
+        EXPECT_THAT(capture.messages(), Contains(HasSubstr("Malformed LinearGradient tuple")));
+    }
+}

--- a/tests/src/Gui/StyleParameters/ParameterManagerTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParameterManagerTest.cpp
@@ -433,3 +433,33 @@ TEST_F(ParameterManagerTest, ExistingTokenUsesToQss)
     auto result = manager.replacePlaceholders("size: @BaseSize; color: @PrimaryColor;");
     EXPECT_EQ(result, "size: 16px; color: #ff0000;");
 }
+
+TEST_F(ParameterManagerTest, QssFormattingLinearGradient)
+{
+    auto result = manager.replacePlaceholders("background: @{linear_gradient(#ff0000, #0000ff)}");
+    EXPECT_EQ(
+        result,
+        "background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #ff0000, stop:1 #0000ff)"
+    );
+}
+
+TEST_F(ParameterManagerTest, QssFormattingLinearGradientCustomGeometry)
+{
+    auto result = manager.replacePlaceholders(
+        "background: @{linear_gradient(x1: 0, y1: 0, x2: 1, y2: 0, #ff0000, #0000ff)}"
+    );
+    EXPECT_EQ(
+        result,
+        "background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #ff0000, stop:1 #0000ff)"
+    );
+}
+
+TEST_F(ParameterManagerTest, QssFormattingRadialGradient)
+{
+    auto result = manager.replacePlaceholders("background: @{radial_gradient(#ff0000, #0000ff)}");
+    EXPECT_EQ(
+        result,
+        "background: qradialgradient(cx:0.5, cy:0.5, radius:0.5, fx:0.5, fy:0.5, "
+        "stop:0 #ff0000, stop:1 #0000ff)"
+    );
+}

--- a/tests/src/Gui/StyleParameters/ParameterManagerTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParameterManagerTest.cpp
@@ -371,6 +371,11 @@ TEST_F(ParameterManagerTest, QssFormattingGenericTuple)
     EXPECT_EQ(manager.replacePlaceholders("@{(1px, 2px)}"), "1px 2px");
 }
 
+TEST_F(ParameterManagerTest, QssFormattingInsetsTuple)
+{
+    EXPECT_EQ(manager.replacePlaceholders("@{padding(10px, 5px)}"), "10px 5px 10px 5px");
+}
+
 // --- @{expression} substitution tests ---
 
 TEST_F(ParameterManagerTest, InlineExpressionSimple)
@@ -379,10 +384,35 @@ TEST_F(ParameterManagerTest, InlineExpressionSimple)
     EXPECT_EQ(result, "padding: 10px");
 }
 
+TEST_F(ParameterManagerTest, InlineExpressionFunctionCall)
+{
+    auto result = manager.replacePlaceholders("padding: @{padding(10px, 5px)}");
+    EXPECT_EQ(result, "padding: 10px 5px 10px 5px");
+}
+
+TEST_F(ParameterManagerTest, InlineExpressionWithParameterReference)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{"InlineBase", "8px"}},
+        ParameterSource::Metadata {"Inline Source"}
+    );
+    manager.addSource(source.get());
+    sources.push_back(std::move(source));
+
+    auto result = manager.replacePlaceholders("padding: @{padding(@InlineBase)}");
+    EXPECT_EQ(result, "padding: 8px 8px 8px 8px");
+}
+
 TEST_F(ParameterManagerTest, InlineExpressionArithmetic)
 {
     auto result = manager.replacePlaceholders("margin: @{@BaseSize * 2}");
     EXPECT_EQ(result, "margin: 32px");
+}
+
+TEST_F(ParameterManagerTest, InlineExpressionMixedWithToken)
+{
+    auto result = manager.replacePlaceholders("padding: @{padding(10px)}; color: @PrimaryColor;");
+    EXPECT_EQ(result, "padding: 10px 10px 10px 10px; color: #ff0000;");
 }
 
 TEST_F(ParameterManagerTest, InlineExpressionInvalidLogsWarning)

--- a/tests/src/Gui/StyleParameters/ParameterManagerTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParameterManagerTest.cpp
@@ -25,6 +25,7 @@
 
 #include <Gui/Application.h>
 #include <Gui/Utilities.h>
+#include <Gui/StyleParameters/Insets.h>
 #include <Gui/StyleParameters/ParameterManager.h>
 
 using namespace Gui::StyleParameters;
@@ -462,4 +463,108 @@ TEST_F(ParameterManagerTest, QssFormattingRadialGradient)
         "background: qradialgradient(cx:0.5, cy:0.5, radius:0.5, fx:0.5, fy:0.5, "
         "stop:0 #ff0000, stop:1 #0000ff)"
     );
+}
+
+// --- Coercive resolve<T> tests ---
+
+// Bare Numeric "5px" should be coerced into a 1-element generic Tuple and expanded to all sides.
+TEST_F(ParameterManagerTest, ResolvePaddingFromBareNumeric)
+{
+    auto coerciveSource = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{"BasePadding", "5px"}},
+        ParameterSource::Metadata {"Coercive Source"}
+    );
+    manager.addSource(coerciveSource.get());
+    sources.push_back(std::move(coerciveSource));
+
+    ParameterDefinition<Padding> definition {
+        .name = "BasePadding",
+        .defaultValue = Padding(Tuple({}, TupleKind::Padding)),
+    };
+
+    // Can't default-construct an empty Padding directly, so use a separate check for the result
+    auto result = manager.resolve(definition);
+    EXPECT_DOUBLE_EQ(result.top().value, 5.0);
+    EXPECT_EQ(result.top().unit, "px");
+    EXPECT_DOUBLE_EQ(result.right().value, 5.0);
+    EXPECT_DOUBLE_EQ(result.bottom().value, 5.0);
+    EXPECT_DOUBLE_EQ(result.left().value, 5.0);
+}
+
+// 1-element generic Tuple "(5px)" should be expanded to all sides equal.
+TEST_F(ParameterManagerTest, ResolvePaddingFromOneElementGenericTuple)
+{
+    auto coerciveSource = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{"BasePadding", "(5px)"}},
+        ParameterSource::Metadata {"Coercive Source"}
+    );
+    manager.addSource(coerciveSource.get());
+    sources.push_back(std::move(coerciveSource));
+
+    ParameterDefinition<Padding> definition {
+        .name = "BasePadding",
+        .defaultValue = Padding(Tuple({}, TupleKind::Padding)),
+    };
+
+    auto result = manager.resolve(definition);
+    EXPECT_DOUBLE_EQ(result.top().value, 5.0);
+    EXPECT_EQ(result.top().unit, "px");
+    EXPECT_DOUBLE_EQ(result.right().value, 5.0);
+    EXPECT_DOUBLE_EQ(result.bottom().value, 5.0);
+    EXPECT_DOUBLE_EQ(result.left().value, 5.0);
+}
+
+// Typed "padding(5px)" Tuple should be passed through and expand to all sides equal.
+TEST_F(ParameterManagerTest, ResolvePaddingFromTypedPaddingTuple)
+{
+    auto coerciveSource = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{"BasePadding", "padding(5px)"}},
+        ParameterSource::Metadata {"Coercive Source"}
+    );
+    manager.addSource(coerciveSource.get());
+    sources.push_back(std::move(coerciveSource));
+
+    ParameterDefinition<Padding> definition {
+        .name = "BasePadding",
+        .defaultValue = Padding(Tuple({}, TupleKind::Padding)),
+    };
+
+    auto result = manager.resolve(definition);
+    EXPECT_DOUBLE_EQ(result.top().value, 5.0);
+    EXPECT_EQ(result.top().unit, "px");
+    EXPECT_DOUBLE_EQ(result.right().value, 5.0);
+    EXPECT_DOUBLE_EQ(result.bottom().value, 5.0);
+    EXPECT_DOUBLE_EQ(result.left().value, 5.0);
+}
+
+// Kind coercion: "margins(5px)" resolved as Padding succeeds by re-expanding named elements.
+TEST_F(ParameterManagerTest, ResolvePaddingFromMarginsTokenCoercesViaNamedElements)
+{
+    auto coerciveSource = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{"BasePadding", "margins(5px)"}},
+        ParameterSource::Metadata {"Coercive Source"}
+    );
+    manager.addSource(coerciveSource.get());
+    sources.push_back(std::move(coerciveSource));
+
+    const Numeric defaultValue {.value = 99, .unit = "px"};
+    Padding defaultPadding(Tuple(
+        {
+            Tuple::Element::named("top", Value(defaultValue)),
+            Tuple::Element::named("right", Value(defaultValue)),
+            Tuple::Element::named("bottom", Value(defaultValue)),
+            Tuple::Element::named("left", Value(defaultValue)),
+        },
+        TupleKind::Padding
+    ));
+
+    ParameterDefinition<Padding> definition {
+        .name = "BasePadding",
+        .defaultValue = std::move(defaultPadding),
+    };
+
+    auto result = manager.resolve(definition);
+    // Coercion succeeds — returns the token's values (5px), not the default (99px).
+    EXPECT_DOUBLE_EQ(result.top().value, 5.0);
+    EXPECT_EQ(result.top().unit, "px");
 }

--- a/tests/src/Gui/StyleParameters/ParameterManagerTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParameterManagerTest.cpp
@@ -21,11 +21,22 @@
  *                                                                          *
  ***************************************************************************/
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <Gui/Application.h>
 #include <Gui/Utilities.h>
+#include <Gui/StyleParameters/Gradient.h>
+#include <Gui/StyleParameters/Insets.h>
 #include <Gui/StyleParameters/ParameterManager.h>
+
+#include "DiagnosticsCapture.h"
+#include "ValueMatchers.h"
+
+using namespace Gui::StyleParameters;
+using namespace Gui::StyleParameters::Matchers;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 
 using namespace Gui::StyleParameters;
 
@@ -69,30 +80,19 @@ TEST_F(ParameterManagerTest, BasicParameterResolution)
     {
         auto result = manager.resolve("BaseSize");
         EXPECT_TRUE(result.has_value());
-        EXPECT_TRUE(std::holds_alternative<Numeric>(*result));
-        auto length = std::get<Numeric>(*result);
-        EXPECT_DOUBLE_EQ(length.value, 16.0);  // Should get value from source2 (later source)
-        EXPECT_EQ(length.unit, "px");
+        EXPECT_THAT(*result, IsNumeric(16.0, "px"));  // Should get value from source2 (later source)
     }
 
     {
         auto result = manager.resolve("PrimaryColor");
         EXPECT_TRUE(result.has_value());
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(*result));
-        auto color = std::get<Base::Color>(*result);
-        EXPECT_EQ(color.r, 1);
-        EXPECT_EQ(color.g, 0);
-        EXPECT_EQ(color.b, 0);
+        EXPECT_THAT(*result, IsColor(Base::Color(1, 0, 0)));
     }
 
     {
         auto result = manager.resolve("SecondaryColor");
         EXPECT_TRUE(result.has_value());
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(*result));
-        auto color = std::get<Base::Color>(*result);
-        EXPECT_EQ(color.r, 0);
-        EXPECT_EQ(color.g, 1);
-        EXPECT_EQ(color.b, 0);
+        EXPECT_THAT(*result, IsColor(Base::Color(0, 1, 0)));
     }
 }
 
@@ -101,18 +101,12 @@ TEST_F(ParameterManagerTest, ParameterReferences)
 {
     {
         auto result = manager.resolve("Margin");
-        EXPECT_TRUE(std::holds_alternative<Numeric>(*result));
-        auto length = std::get<Numeric>(*result);
-        EXPECT_DOUBLE_EQ(length.value, 32.0);  // @BaseSize * 2 = 16 * 2 = 32
-        EXPECT_EQ(length.unit, "px");
+        EXPECT_THAT(*result, IsNumeric(32.0, "px"));  // @BaseSize * 2 = 16 * 2 = 32
     }
 
     {
         auto result = manager.resolve("Padding");
-        EXPECT_TRUE(std::holds_alternative<Numeric>(*result));
-        auto length = std::get<Numeric>(*result);
-        EXPECT_DOUBLE_EQ(length.value, 8.0);  // @BaseSize / 2 = 16 / 2 = 8
-        EXPECT_EQ(length.unit, "px");
+        EXPECT_THAT(*result, IsNumeric(8.0, "px"));  // @BaseSize / 2 = 16 / 2 = 8
     }
 }
 
@@ -139,19 +133,15 @@ TEST_F(ParameterManagerTest, CacheInvalidation)
 {
     // Initial resolution
     auto result1 = manager.resolve("BaseSize");
-    EXPECT_TRUE(std::holds_alternative<Numeric>(*result1));
-    auto length1 = std::get<Numeric>(*result1);
-    EXPECT_DOUBLE_EQ(length1.value, 16.0);
+    EXPECT_THAT(*result1, IsNumeric(16.0));
 
     // Reload should clear cache
     manager.reload();
 
     // Resolution after reload should work the same
     auto result2 = manager.resolve("BaseSize");
-    EXPECT_TRUE(std::holds_alternative<Numeric>(*result2));
-    auto length2 = std::get<Numeric>(*result2);
-    EXPECT_DOUBLE_EQ(length2.value, 16.0);
-    EXPECT_EQ(length1.unit, length2.unit);
+    EXPECT_THAT(*result2, IsNumeric(16.0));
+    EXPECT_EQ(result1->get<Numeric>().unit, result2->get<Numeric>().unit);
 }
 
 // Test source priority
@@ -170,10 +160,7 @@ TEST_F(ParameterManagerTest, SourcePriority)
 
     // Should get value from the latest source (highest priority)
     auto result = manager.resolve("BaseSize");
-    EXPECT_TRUE(std::holds_alternative<Numeric>(*result));
-    auto length = std::get<Numeric>(*result);
-    EXPECT_DOUBLE_EQ(length.value, 24.0);
-    EXPECT_EQ(length.unit, "px");
+    EXPECT_THAT(*result, IsNumeric(24.0, "px"));
 }
 
 // Test parameter listing
@@ -287,18 +274,12 @@ TEST_F(ParameterManagerTest, ComplexExpressions)
 
     {
         auto result = manager.resolve("ComplexMargin");
-        EXPECT_TRUE(std::holds_alternative<Numeric>(*result));
-        auto length = std::get<Numeric>(*result);
-        EXPECT_DOUBLE_EQ(length.value, 40.0);  // (16 + 4) * 2 = 20 * 2 = 40
-        EXPECT_EQ(length.unit, "px");
+        EXPECT_THAT(*result, IsNumeric(40.0, "px"));  // (16 + 4) * 2 = 20 * 2 = 40
     }
 
     {
         auto result = manager.resolve("ComplexPadding");
-        EXPECT_TRUE(std::holds_alternative<Numeric>(*result));
-        auto length = std::get<Numeric>(*result);
-        EXPECT_DOUBLE_EQ(length.value, 7.0);  // (16 - 2) / 2 = 14 / 2 = 7
-        EXPECT_EQ(length.unit, "px");
+        EXPECT_THAT(*result, IsNumeric(7.0, "px"));  // (16 - 2) / 2 = 14 / 2 = 7
     }
 
     {
@@ -371,6 +352,11 @@ TEST_F(ParameterManagerTest, QssFormattingGenericTuple)
     EXPECT_EQ(manager.replacePlaceholders("@{(1px, 2px)}"), "1px 2px");
 }
 
+TEST_F(ParameterManagerTest, QssFormattingInsetsTuple)
+{
+    EXPECT_EQ(manager.replacePlaceholders("@{padding(10px, 5px)}"), "10px 5px 10px 5px");
+}
+
 // --- @{expression} substitution tests ---
 
 TEST_F(ParameterManagerTest, InlineExpressionSimple)
@@ -379,10 +365,35 @@ TEST_F(ParameterManagerTest, InlineExpressionSimple)
     EXPECT_EQ(result, "padding: 10px");
 }
 
+TEST_F(ParameterManagerTest, InlineExpressionFunctionCall)
+{
+    auto result = manager.replacePlaceholders("padding: @{padding(10px, 5px)}");
+    EXPECT_EQ(result, "padding: 10px 5px 10px 5px");
+}
+
+TEST_F(ParameterManagerTest, InlineExpressionWithParameterReference)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{"InlineBase", "8px"}},
+        ParameterSource::Metadata {"Inline Source"}
+    );
+    manager.addSource(source.get());
+    sources.push_back(std::move(source));
+
+    auto result = manager.replacePlaceholders("padding: @{padding(@InlineBase)}");
+    EXPECT_EQ(result, "padding: 8px 8px 8px 8px");
+}
+
 TEST_F(ParameterManagerTest, InlineExpressionArithmetic)
 {
     auto result = manager.replacePlaceholders("margin: @{@BaseSize * 2}");
     EXPECT_EQ(result, "margin: 32px");
+}
+
+TEST_F(ParameterManagerTest, InlineExpressionMixedWithToken)
+{
+    auto result = manager.replacePlaceholders("padding: @{padding(10px)}; color: @PrimaryColor;");
+    EXPECT_EQ(result, "padding: 10px 10px 10px 10px; color: #ff0000;");
 }
 
 TEST_F(ParameterManagerTest, InlineExpressionInvalidLogsWarning)
@@ -402,4 +413,429 @@ TEST_F(ParameterManagerTest, ExistingTokenUsesToQss)
     // @TokenName for non-tuple types should still work identically
     auto result = manager.replacePlaceholders("size: @BaseSize; color: @PrimaryColor;");
     EXPECT_EQ(result, "size: 16px; color: #ff0000;");
+}
+
+TEST_F(ParameterManagerTest, QssFormattingLinearGradient)
+{
+    auto result = manager.replacePlaceholders("background: @{linear_gradient(#ff0000, #0000ff)}");
+    EXPECT_EQ(
+        result,
+        "background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 #ff0000, stop:1 #0000ff)"
+    );
+}
+
+TEST_F(ParameterManagerTest, QssFormattingLinearGradientCustomGeometry)
+{
+    auto result = manager.replacePlaceholders(
+        "background: @{linear_gradient(x1: 0, y1: 0, x2: 1, y2: 0, #ff0000, #0000ff)}"
+    );
+    EXPECT_EQ(
+        result,
+        "background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #ff0000, stop:1 #0000ff)"
+    );
+}
+
+TEST_F(ParameterManagerTest, QssFormattingRadialGradient)
+{
+    auto result = manager.replacePlaceholders("background: @{radial_gradient(#ff0000, #0000ff)}");
+    EXPECT_EQ(
+        result,
+        "background: qradialgradient(cx:0.5, cy:0.5, radius:0.5, fx:0.5, fy:0.5, "
+        "stop:0 #ff0000, stop:1 #0000ff)"
+    );
+}
+
+TEST_F(ParameterManagerTest, QssFormattingKeepsStopAlpha)
+{
+    auto result = manager.replacePlaceholders(
+        "background: @{linear_gradient(rgba(255, 0, 0, 128), rgba(0, 0, 255, 0))}"
+    );
+    EXPECT_EQ(
+        result,
+        "background: qlineargradient(x1:0, y1:0, x2:0, y2:1, "
+        "stop:0 rgba(255, 0, 0, 128), stop:1 rgba(0, 0, 255, 0))"
+    );
+}
+
+TEST_F(ParameterManagerTest, QssFormattingKeepsColorAlpha)
+{
+    auto result = manager.replacePlaceholders("color: @{rgba(255, 0, 0, 128)}");
+    EXPECT_EQ(result, "color: rgba(255, 0, 0, 128)");
+}
+
+TEST_F(ParameterManagerTest, QssFormattingMalformedGradientStaysTransparent)
+{
+    DiagnosticsCapture capture;
+
+    // A gradient that cannot be interpreted degrades to fully transparent stops; serializing
+    // those as #000000 would paint the widget black instead of leaving it invisible.
+    auto result = manager.replacePlaceholders("background: @{linear_gradient(#ff0000)}");
+    EXPECT_EQ(
+        result,
+        "background: qlineargradient(x1:0, y1:0, x2:0, y2:1, "
+        "stop:0 rgba(0, 0, 0, 0), stop:1 rgba(0, 0, 0, 0))"
+    );
+}
+
+// --- Coercive resolve<T> tests ---
+
+// Every way a theme author can write four edges must resolve to the same Padding, whether the
+// token is a bare length, a positional or named generic tuple, or a differently-kinded edge
+// tuple. Only the wrong *shape* may fall back to the caller's default.
+TEST_F(ParameterManagerTest, ResolvePaddingCoercesEveryEquivalentTokenShape)
+{
+    struct TokenShape
+    {
+        std::string expression;
+        double top;
+        double right;
+        double bottom;
+        double left;
+    };
+
+    // clang-format off
+    const std::vector<TokenShape> shapes {
+        {.expression = "5px",                                              .top = 5,  .right = 5,  .bottom = 5,  .left = 5},
+        {.expression = "(5px)",                                            .top = 5,  .right = 5,  .bottom = 5,  .left = 5},
+        {.expression = "(10px, 5px)",                                      .top = 10, .right = 5,  .bottom = 10, .left = 5},
+        {.expression = "(top: 10px, right: 5px, bottom: 10px, left: 20px)",.top = 10, .right = 5,  .bottom = 10, .left = 20},
+        {.expression = "(horizontal: 10px, vertical: 20px)",               .top = 20, .right = 10, .bottom = 20, .left = 10},
+        {.expression = "padding(1px, 2px, 3px, 4px)",                      .top = 1,  .right = 2,  .bottom = 3,  .left = 4},
+        {.expression = "margins(10px)",                                    .top = 10, .right = 10, .bottom = 10, .left = 10},
+    };
+    // clang-format on
+
+    const Padding fallback {Value {Numeric {.value = 99.0, .unit = "px"}}};
+
+    for (const TokenShape& shape : shapes) {
+        InMemoryParameterSource source(
+            std::list<Parameter> {{.name = "BasePadding", .value = shape.expression}},
+            ParameterSource::Metadata {.name = "Coercive Source"}
+        );
+
+        // A fresh manager per shape: resolved values are cached by token name.
+        Gui::StyleParameters::ParameterManager coercive;
+        coercive.addSource(&source);
+
+        const Padding resolved = coercive.resolve(
+            ParameterDefinition<Padding> {.name = "BasePadding", .defaultValue = fallback}
+        );
+
+        EXPECT_DOUBLE_EQ(resolved.top().value, shape.top) << shape.expression;
+        EXPECT_EQ(resolved.top().unit, "px") << shape.expression;
+        EXPECT_DOUBLE_EQ(resolved.right().value, shape.right) << shape.expression;
+        EXPECT_DOUBLE_EQ(resolved.bottom().value, shape.bottom) << shape.expression;
+        EXPECT_DOUBLE_EQ(resolved.left().value, shape.left) << shape.expression;
+    }
+}
+
+TEST_F(ParameterManagerTest, ResolveDefinitionFallsBackWhenTokenHasWrongShape)
+{
+    DiagnosticsCapture capture;
+
+    InMemoryParameterSource source(
+        std::list<Parameter> {
+            {.name = "GradientToken", .value = "linear_gradient(#ff0000, #0000ff)"},
+            {.name = "PaddingToken", .value = "padding(4px, 8px)"},
+        },
+        ParameterSource::Metadata {.name = "Shape Test Source"}
+    );
+    manager.addSource(&source);
+
+    const Insets fallback {Value {Numeric {.value = 12.0, .unit = "px"}}};
+
+    // Wrong shape: the caller's default must win, not a degraded zero.
+    const Insets resolved = manager.resolve(
+        ParameterDefinition<Insets> {.name = "GradientToken", .defaultValue = fallback}
+    );
+    EXPECT_DOUBLE_EQ(resolved.top().value, 12.0);
+
+    // Right shape: the token must win.
+    const Insets fromToken = manager.resolve(
+        ParameterDefinition<Insets> {.name = "PaddingToken", .defaultValue = fallback}
+    );
+    EXPECT_DOUBLE_EQ(fromToken.top().value, 4.0);
+    EXPECT_DOUBLE_EQ(fromToken.right().value, 8.0);
+
+    // Missing token: the caller's default must win.
+    const Insets missing = manager.resolve(
+        ParameterDefinition<Insets> {.name = "NoSuchToken", .defaultValue = fallback}
+    );
+    EXPECT_DOUBLE_EQ(missing.top().value, 12.0);
+}
+
+TEST_F(ParameterManagerTest, ResolveDefinitionOfVariantTypeStillWorks)
+{
+    InMemoryParameterSource source(
+        std::list<Parameter> {{.name = "ColorToken", .value = "#ff0000"}},
+        ParameterSource::Metadata {.name = "Variant Test Source"}
+    );
+    manager.addSource(&source);
+
+    const Base::Color fallback(0.0F, 1.0F, 0.0F);
+
+    const Base::Color resolved = manager.resolve(
+        ParameterDefinition<Base::Color> {.name = "ColorToken", .defaultValue = fallback}
+    );
+    EXPECT_FLOAT_EQ(resolved.r, 1.0F);
+
+    const Base::Color missing = manager.resolve(
+        ParameterDefinition<Base::Color> {.name = "NoSuchToken", .defaultValue = fallback}
+    );
+    EXPECT_FLOAT_EQ(missing.g, 1.0F);
+}
+
+TEST_F(ParameterManagerTest, ReloadClearsDiagnosticState)
+{
+    DiagnosticsCapture capture;
+
+    Diagnostics::report("first");
+    Diagnostics::report("first");
+    manager.reload();
+    Diagnostics::report("first");
+
+    EXPECT_EQ(capture.messages().size(), 2U);
+}
+
+TEST_F(ParameterManagerTest, EvaluateWrapsNonBaseExceptionsAsExpressionError)
+{
+    // A 400-digit literal makes std::stod throw std::out_of_range deep in the parser.
+    EXPECT_THROW(manager.evaluate(std::string(400, '9')), Base::Exception);
+}
+
+// A 400-digit literal makes std::stod throw std::out_of_range, which is neither a
+// Base::Exception nor caught by the parser -- the kind of failure that must still be absorbed
+// placeholder by placeholder.
+TEST_F(ParameterManagerTest, ReplacePlaceholdersAbsorbsNonBaseExceptions)
+{
+    EXPECT_EQ(
+        manager.replacePlaceholders("width: @{" + std::string(400, '9') + "}; height: @BaseSize;"),
+        "width: ; height: 16px;"
+    );
+}
+
+namespace
+{
+
+/// Test double simulating a misbehaving ParameterSource: throws a plain std::exception
+/// (not a Base::Exception) from every get(), regardless of the requested name.
+class ThrowingParameterSource: public ParameterSource
+{
+public:
+    ThrowingParameterSource()
+        : ParameterSource(Metadata {.name = "Throwing Source"})
+    {}
+
+    std::list<Parameter> all() const override
+    {
+        return {};
+    }
+
+    std::optional<Parameter> get(const std::string&) const override
+    {
+        throw std::runtime_error("simulated parameter source failure");
+    }
+};
+
+}  // namespace
+
+// ParameterSource is a public virtual interface; a misbehaving subclass's get() can throw
+// anything. replacePlaceholders's @name branch must still absorb it even though resolve()
+// itself now guards the same call directly (see ResolveAbsorbsThrowingParameterSource below).
+TEST_F(ParameterManagerTest, ReplacePlaceholdersAbsorbsThrowingParameterSource)
+{
+    ThrowingParameterSource source;
+    manager.addSource(&source);
+
+    EXPECT_NO_THROW({
+        const std::string result = manager.replacePlaceholders("color: @AnyToken;");
+        EXPECT_EQ(result, "color: ;");
+    });
+}
+
+// resolve(name) calls ParameterSource::get() (via parameter()) before its own try block
+// around evaluate() begins. Called directly — not through replacePlaceholders, which would
+// catch it secondhand — a throwing source must not escape resolve() itself.
+TEST_F(ParameterManagerTest, ResolveAbsorbsThrowingParameterSource)
+{
+    ThrowingParameterSource source;
+    manager.addSource(&source);
+
+    std::optional<Value> result;
+    EXPECT_NO_THROW({ result = manager.resolve("AnyToken"); });
+    EXPECT_FALSE(result.has_value());
+}
+
+// resolve(definition) delegates to resolve(name); the caller's default must win when the
+// source throws, exactly as when the token is simply missing.
+TEST_F(ParameterManagerTest, ResolveDefinitionAbsorbsThrowingParameterSource)
+{
+    ThrowingParameterSource source;
+    manager.addSource(&source);
+
+    const Numeric fallback {.value = 42.0, .unit = "px"};
+    ParameterDefinition<Numeric> definition {.name = "AnyToken", .defaultValue = fallback};
+
+    Numeric result {};
+    EXPECT_NO_THROW({ result = manager.resolve(definition); });
+    EXPECT_DOUBLE_EQ(result.value, 42.0);
+    EXPECT_EQ(result.unit, "px");
+}
+
+namespace
+{
+
+/// Test double for the circular-reference path: get() succeeds the first time a name is looked
+/// up (returning a self-referential expression), then throws on every subsequent lookup of that
+/// same name.
+class SelfReferentialThenThrowingParameterSource: public ParameterSource
+{
+public:
+    SelfReferentialThenThrowingParameterSource()
+        : ParameterSource(Metadata {.name = "Cyclic Source"})
+    {}
+
+    std::list<Parameter> all() const override
+    {
+        return {};
+    }
+
+    std::optional<Parameter> get(const std::string& name) const override
+    {
+        if (name != "Cyclic") {
+            return std::nullopt;
+        }
+        if (lookupCount++ == 0) {
+            return Parameter {.name = "Cyclic", .value = "@Cyclic"};
+        }
+        throw std::runtime_error("simulated failure on repeated lookup");
+    }
+
+private:
+    mutable int lookupCount = 0;
+};
+
+}  // namespace
+
+// resolve()'s cycle branch falls back to expression(name), a second lookup of the same name
+// that no inner guard covers. The context is seeded as already-visited rather than letting the
+// recursion happen naturally, because natural recursion reaches the branch inside a nested
+// resolve() whose own catch would absorb the throw first -- proving the wrong guard.
+TEST_F(ParameterManagerTest, ResolveAbsorbsThrowFromCyclicFallback)
+{
+    SelfReferentialThenThrowingParameterSource source;
+    manager.addSource(&source);
+
+    Gui::StyleParameters::ParameterManager::ResolveContext context;
+    context.visited.insert("Cyclic");
+
+    std::optional<Value> result;
+    EXPECT_NO_THROW({ result = manager.resolve("Cyclic", context); });
+    EXPECT_FALSE(result.has_value());
+}
+
+// --- Diagnostic token attribution (Diagnostics::ResolutionScope, installed by resolve()) ---
+
+TEST_F(ParameterManagerTest, ResolveReportsAreAttributedToTheToken)
+{
+    DiagnosticsCapture capture;
+
+    InMemoryParameterSource source(
+        std::list<Parameter> {{.name = "BadPadding", .value = "padding(#ff0000)"}},
+        ParameterSource::Metadata {.name = "Bad Padding Source"}
+    );
+    manager.addSource(&source);
+
+    manager.resolve("BadPadding");
+
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("BadPadding: Argument 'top'")));
+}
+
+TEST_F(ParameterManagerTest, SameDefectInTwoTokensProducesTwoDistinctMessages)
+{
+    DiagnosticsCapture capture;
+
+    InMemoryParameterSource source(
+        std::list<Parameter> {
+            {.name = "BadPaddingA", .value = "padding(#ff0000)"},
+            {.name = "BadPaddingB", .value = "padding(#ff0000)"},
+        },
+        ParameterSource::Metadata {.name = "Bad Padding Source"}
+    );
+    manager.addSource(&source);
+
+    manager.resolve("BadPaddingA");
+    manager.resolve("BadPaddingB");
+
+    // Without the token prefix both defects produce the identical message and dedup into a
+    // single report naming neither token.
+    EXPECT_EQ(capture.messages().size(), 2U);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("BadPaddingA: ")));
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("BadPaddingB: ")));
+}
+
+// --- Circular references report through Diagnostics, not to Base::Console directly ---
+
+TEST_F(ParameterManagerTest, CircularReferenceReportsThroughDiagnostics)
+{
+    DiagnosticsCapture capture;
+
+    auto circularSource = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {
+            {"A", "@B"},
+            {"B", "@A"},
+        },
+        ParameterSource::Metadata {"Circular Source"}
+    );
+    manager.addSource(circularSource.get());
+    sources.push_back(std::move(circularSource));
+
+    manager.resolve("A");
+
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("circular reference")));
+}
+
+// --- Failures are contained to the placeholder that caused them ---
+
+TEST_F(ParameterManagerTest, UnknownTokenIsDroppedAndNeighboursStillResolve)
+{
+    DiagnosticsCapture capture;
+
+    // Every placeholder is substituted under its own guard, so one that cannot be resolved
+    // collapses to nothing while its neighbours are unaffected. Only a failure of the
+    // substitution machinery itself -- outside all of those guards -- would echo the whole
+    // input back untouched, and no expression can provoke that.
+    EXPECT_EQ(manager.replacePlaceholders("border: @BaseSize solid @Missing;"), "border: 16px solid ;");
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("Missing")));
+}
+
+TEST_F(ParameterManagerTest, FailingInlineExpressionIsDroppedAndNeighboursStillResolve)
+{
+    DiagnosticsCapture capture;
+
+    EXPECT_EQ(
+        manager.replacePlaceholders("border: @{@BaseSize * 2} solid @{nope(1)};"),
+        "border: 32px solid ;"
+    );
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("nope(1)")));
+}
+
+TEST_F(ParameterManagerTest, TokenThatFailsToEvaluateSubstitutesItsLiteralText)
+{
+    DiagnosticsCapture capture;
+
+    // A token is only dropped when it does not exist. One that exists but cannot be evaluated
+    // keeps its authored text, which QSS is free to reject on its own terms -- guessing a
+    // replacement would be a worse lie than passing the source through.
+    InMemoryParameterSource source(
+        std::list<Parameter> {{.name = "Broken", .value = "nope(1)"}},
+        ParameterSource::Metadata {.name = "Broken Placeholder Source"}
+    );
+    manager.addSource(&source);
+
+    EXPECT_EQ(
+        manager.replacePlaceholders("border: @BaseSize solid @Broken;"),
+        "border: 16px solid nope(1);"
+    );
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("Broken")));
 }

--- a/tests/src/Gui/StyleParameters/ParserRobustnessTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserRobustnessTest.cpp
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <Gui/StyleParameters/ParameterManager.h>
+#include <Gui/StyleParameters/Parser.h>
+
+using namespace Gui::StyleParameters;
+
+class ParserRobustnessTest: public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        source = std::make_unique<InMemoryParameterSource>(
+            std::list<Parameter> {{.name = "Tuple3", .value = "(10, 20, 30)"}},
+            ParameterSource::Metadata {.name = "Robustness Source"}
+        );
+        manager.addSource(source.get());
+    }
+
+    Gui::StyleParameters::ParameterManager manager;
+    std::unique_ptr<InMemoryParameterSource> source;
+};
+
+// Regression: std::stoul threw std::out_of_range past every catch site on the resolve path.
+TEST_F(ParserRobustnessTest, HugeMemberIndexIsAnExpressionError)
+{
+    Parser parser("@Tuple3.99999999999999999999");
+    auto expr = parser.parse();
+
+    EXPECT_THROW(expr->evaluate({.manager = &manager, .context = {}}), Base::ExpressionError);
+}
+
+// Regression: std::stoi in rgb() threw std::out_of_range; only invalid_argument was caught.
+TEST_F(ParserRobustnessTest, HugeColorComponentIsAParserError)
+{
+    EXPECT_THROW(
+        {
+            Parser parser("rgb(99999999999,0,0)");
+            parser.parse();
+        },
+        Base::ParserError
+    );
+}
+
+// Regression: std::stod threw std::out_of_range for an over-long literal.
+TEST_F(ParserRobustnessTest, OverlongNumericLiteralIsAParserError)
+{
+    const std::string literal(400, '9');
+
+    EXPECT_THROW(
+        {
+            Parser parser(literal);
+            parser.parse();
+        },
+        Base::ParserError
+    );
+}
+
+TEST_F(ParserRobustnessTest, NonAsciiInputDoesNotCrash)
+{
+    // Bytes >= 0x80 are negative as char; passing them to isdigit and friends is UB.
+    EXPECT_NO_THROW({
+        try {
+            Parser parser("10px + \xc3\xa9");
+            parser.parse();
+        }
+        catch (const Base::Exception&) {
+            // A parse error is fine; undefined behaviour is not.
+        }
+    });
+}
+
+TEST_F(ParserRobustnessTest, EveryFailureThroughResolveIsContained)
+{
+    InMemoryParameterSource broken(
+        std::list<Parameter> {
+            {.name = "A", .value = "@Tuple3.99999999999999999999"},
+            {.name = "B", .value = "rgb(99999999999,0,0)"},
+            {.name = "C", .value = std::string(400, '9')},
+            {.name = "D", .value = "#fff"},
+        },
+        ParameterSource::Metadata {.name = "Broken Source"}
+    );
+    manager.addSource(&broken);
+
+    for (const char* name : {"A", "B", "C", "D"}) {
+        EXPECT_NO_THROW({
+            const auto resolved = manager.resolve(name);
+            EXPECT_TRUE(resolved.has_value());
+        }) << "resolving "
+           << name;
+    }
+}
+
+// Regression: substr(pos, 2) silently clips once fewer than 2 characters remain, so the third
+// component's substr(pos, 2) call can start past the end of the string. #fff is the shortest
+// input that overshoots: after two clipped reads pos lands one past input.size(), and
+// substr throws std::out_of_range because its precondition is pos <= size(), not pos < size().
+TEST_F(ParserRobustnessTest, ShortHexColorLiteralIsAParserError)
+{
+    EXPECT_THROW(
+        {
+            Parser parser("#fff");
+            parser.parse();
+        },
+        Base::ParserError
+    );
+}
+
+TEST_F(ParserRobustnessTest, TwoDigitHexColorLiteralIsAParserError)
+{
+    EXPECT_THROW(
+        {
+            Parser parser("#ff");
+            parser.parse();
+        },
+        Base::ParserError
+    );
+}
+
+TEST_F(ParserRobustnessTest, BareHashIsAParserError)
+{
+    EXPECT_THROW(
+        {
+            Parser parser("#");
+            parser.parse();
+        },
+        Base::ParserError
+    );
+}
+
+// The length guard must not reject well-formed input.
+TEST_F(ParserRobustnessTest, FullLengthHexColorLiteralStillParses)
+{
+    Parser parser("#ff8000");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Base::Color>());
+    const auto& color = result.get<Base::Color>();
+    EXPECT_DOUBLE_EQ(color.r, 1.0);
+    EXPECT_NEAR(color.g, 128 / 255.0, 1e-6);
+    EXPECT_DOUBLE_EQ(color.b, 0.0);
+}

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -26,6 +26,7 @@
 #include <Gui/Utilities.h>
 
 #include <Gui/StyleParameters/Corners.h>
+#include <Gui/StyleParameters/Gradient.h>
 #include <Gui/StyleParameters/Insets.h>
 #include <Gui/StyleParameters/Parser.h>
 #include <Gui/StyleParameters/ParameterManager.h>
@@ -2066,4 +2067,289 @@ TEST_F(ParserTest, ResolveTypedCorners)
     EXPECT_DOUBLE_EQ(resolved.topRight().value, 2.0);
     EXPECT_DOUBLE_EQ(resolved.bottomRight().value, 3.0);
     EXPECT_DOUBLE_EQ(resolved.bottomLeft().value, 4.0);
+}
+
+// Gradient tests
+
+TEST_F(ParserTest, LinearGradientMinimal)
+{
+    Parser parser("linear_gradient(#ff0000, #0000ff)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    // Default geometry: top to bottom
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("x1").value, 0.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("y1").value, 0.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("x2").value, 0.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("y2").value, 1.0);
+
+    // Stops gathered in named "stops" element
+    const auto* stopsValue = tuple.find("stops");
+    ASSERT_NE(stopsValue, nullptr);
+    ASSERT_TRUE(stopsValue->holds<Tuple>());
+    const auto& stopsTuple = stopsValue->get<Tuple>();
+    EXPECT_EQ(stopsTuple.size(), 2);
+
+    // First stop: position 0, red
+    const auto& firstStop = stopsTuple.at(0).get<Tuple>();
+    EXPECT_DOUBLE_EQ(firstStop.at(0).get<Numeric>().value, 0.0);
+    EXPECT_DOUBLE_EQ(firstStop.at(1).get<Base::Color>().r, 1.0);
+    EXPECT_DOUBLE_EQ(firstStop.at(1).get<Base::Color>().g, 0.0);
+    EXPECT_DOUBLE_EQ(firstStop.at(1).get<Base::Color>().b, 0.0);
+
+    // Second stop: position 1, blue
+    const auto& secondStop = stopsTuple.at(1).get<Tuple>();
+    EXPECT_DOUBLE_EQ(secondStop.at(0).get<Numeric>().value, 1.0);
+    EXPECT_DOUBLE_EQ(secondStop.at(1).get<Base::Color>().r, 0.0);
+    EXPECT_DOUBLE_EQ(secondStop.at(1).get<Base::Color>().g, 0.0);
+    EXPECT_DOUBLE_EQ(secondStop.at(1).get<Base::Color>().b, 1.0);
+}
+
+TEST_F(ParserTest, LinearGradientExplicitStops)
+{
+    Parser parser("linear_gradient((0, #ff0000), (0.5, #00ff00), (1, #0000ff))");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    const auto& stopsTuple = tuple.get<Tuple>("stops");
+    EXPECT_EQ(stopsTuple.size(), 3);
+
+    EXPECT_DOUBLE_EQ(stopsTuple.at(0).get<Tuple>().at(0).get<Numeric>().value, 0.0);
+    EXPECT_DOUBLE_EQ(stopsTuple.at(1).get<Tuple>().at(0).get<Numeric>().value, 0.5);
+    EXPECT_DOUBLE_EQ(stopsTuple.at(2).get<Tuple>().at(0).get<Numeric>().value, 1.0);
+
+    // Middle stop is green
+    EXPECT_DOUBLE_EQ(stopsTuple.at(1).get<Tuple>().at(1).get<Base::Color>().g, 1.0);
+}
+
+TEST_F(ParserTest, LinearGradientCustomGeometry)
+{
+    Parser parser("linear_gradient(x1: 0, y1: 0, x2: 1, y2: 0, #ff0000, #0000ff)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    // Custom geometry: left to right
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("x1").value, 0.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("y1").value, 0.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("x2").value, 1.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("y2").value, 0.0);
+
+    const auto& stopsTuple = tuple.get<Tuple>("stops");
+    EXPECT_EQ(stopsTuple.size(), 2);
+}
+
+TEST_F(ParserTest, LinearGradientMixedStops)
+{
+    // Bare color + explicit (position, color) tuples
+    Parser parser("linear_gradient(#ff0000, (0.5, #00ff00), #0000ff)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    const auto& stopsTuple = result.get<Tuple>().get<Tuple>("stops");
+    EXPECT_EQ(stopsTuple.size(), 3);
+
+    // Bare #ff0000 at index 0 → position 0/2 = 0.0
+    EXPECT_DOUBLE_EQ(stopsTuple.at(0).get<Tuple>().at(0).get<Numeric>().value, 0.0);
+    // Explicit (0.5, #00ff00)
+    EXPECT_DOUBLE_EQ(stopsTuple.at(1).get<Tuple>().at(0).get<Numeric>().value, 0.5);
+    // Bare #0000ff at index 2 → position 2/2 = 1.0
+    EXPECT_DOUBLE_EQ(stopsTuple.at(2).get<Tuple>().at(0).get<Numeric>().value, 1.0);
+}
+
+TEST_F(ParserTest, RadialGradientMinimal)
+{
+    Parser parser("radial_gradient(#ff0000, #0000ff)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::RadialGradient);
+
+    // Default geometry
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("cx").value, 0.5);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("cy").value, 0.5);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("radius").value, 0.5);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("fx").value, 0.5);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("fy").value, 0.5);
+
+    const auto& stopsTuple = tuple.get<Tuple>("stops");
+    EXPECT_EQ(stopsTuple.size(), 2);
+}
+
+TEST_F(ParserTest, RadialGradientCustomGeometry)
+{
+    Parser parser("radial_gradient(cx: 0.3, cy: 0.3, radius: 0.8, (0, #ff0000), (1, #0000ff))");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("cx").value, 0.3);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("cy").value, 0.3);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("radius").value, 0.8);
+    // fx/fy default to cx/cy when not specified
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("fx").value, 0.3);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("fy").value, 0.3);
+}
+
+TEST_F(ParserTest, RadialGradientExplicitFocalPoint)
+{
+    Parser parser("radial_gradient(cx: 0.5, cy: 0.5, fx: 0.2, fy: 0.8, #ff0000, #0000ff)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("fx").value, 0.2);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("fy").value, 0.8);
+}
+
+TEST_F(ParserTest, GradientTooFewStops)
+{
+    EXPECT_THROW(
+        {
+            Parser parser("linear_gradient(#ff0000)");
+            auto expr = parser.parse();
+            expr->evaluate({.manager = &manager, .context = {}});
+        },
+        Base::ExpressionError
+    );
+
+    EXPECT_THROW(
+        {
+            Parser parser("radial_gradient()");
+            auto expr = parser.parse();
+            expr->evaluate({.manager = &manager, .context = {}});
+        },
+        Base::ExpressionError
+    );
+}
+
+TEST_F(ParserTest, GradientKindMismatchThrows)
+{
+    // Build a RadialGradient tuple, then try to wrap it as LinearGradient
+    Parser parser("radial_gradient(#ff0000, #0000ff)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    EXPECT_THROW(LinearGradient(result.get<Tuple>()), Base::TypeError);
+}
+
+TEST_F(ParserTest, GradientWrapper)
+{
+    Parser parser("linear_gradient(x1: 0.1, y1: 0.2, x2: 0.3, y2: 0.4, #ff0000, #0000ff)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    LinearGradient gradient(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(gradient.x1(), 0.1);
+    EXPECT_DOUBLE_EQ(gradient.y1(), 0.2);
+    EXPECT_DOUBLE_EQ(gradient.x2(), 0.3);
+    EXPECT_DOUBLE_EQ(gradient.y2(), 0.4);
+
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[0].color.r, 1.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 1.0);
+    EXPECT_DOUBLE_EQ(stops[1].color.b, 1.0);
+}
+
+TEST_F(ParserTest, RadialGradientWrapper)
+{
+    Parser parser("radial_gradient(cx: 0.3, cy: 0.4, radius: 0.7, fx: 0.1, fy: 0.2, #ff0000, #0000ff)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    RadialGradient gradient(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(gradient.cx(), 0.3);
+    EXPECT_DOUBLE_EQ(gradient.cy(), 0.4);
+    EXPECT_DOUBLE_EQ(gradient.radius(), 0.7);
+    EXPECT_DOUBLE_EQ(gradient.fx(), 0.1);
+    EXPECT_DOUBLE_EQ(gradient.fy(), 0.2);
+
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+}
+
+TEST_F(ParserTest, GradientStopsAccessibleViaMemberAccess)
+{
+    Parser parser("linear_gradient(#ff0000, #0000ff).stops");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().size(), 2);
+}
+
+TEST_F(ParserTest, ResolveTypedLinearGradient)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {
+            {.name = "TestGradient", .value = "linear_gradient(#ff0000, #00ff00, #0000ff)"}
+        },
+        ParameterSource::Metadata {.name = "Gradient Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    // Build a default LinearGradient tuple
+    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = ""});
+    auto one = std::make_shared<const Value>(Numeric {.value = 1, .unit = ""});
+    Tuple defaultStopsTuple;
+    {
+        Tuple stop0;
+        stop0.elements.push_back({.name = std::nullopt, .value = zero});
+        stop0.elements.push_back(
+            {.name = std::nullopt, .value = std::make_shared<const Value>(Base::Color(0, 0, 0))}
+        );
+        Tuple stop1;
+        stop1.elements.push_back({.name = std::nullopt, .value = one});
+        stop1.elements.push_back(
+            {.name = std::nullopt, .value = std::make_shared<const Value>(Base::Color(1, 1, 1))}
+        );
+        defaultStopsTuple.elements.push_back(
+            {.name = std::nullopt, .value = std::make_shared<const Value>(std::move(stop0))}
+        );
+        defaultStopsTuple.elements.push_back(
+            {.name = std::nullopt, .value = std::make_shared<const Value>(std::move(stop1))}
+        );
+    }
+
+    Tuple defaultTuple;
+    defaultTuple.kind = TupleKind::LinearGradient;
+    defaultTuple.elements.push_back({.name = std::string("x1"), .value = zero});
+    defaultTuple.elements.push_back({.name = std::string("y1"), .value = zero});
+    defaultTuple.elements.push_back({.name = std::string("x2"), .value = zero});
+    defaultTuple.elements.push_back({.name = std::string("y2"), .value = one});
+    defaultTuple.elements.push_back(
+        {.name = std::string("stops"),
+         .value = std::make_shared<const Value>(std::move(defaultStopsTuple))}
+    );
+
+    ParameterDefinition<LinearGradient> def {
+        .name = "TestGradient",
+        .defaultValue = LinearGradient(defaultTuple),
+    };
+    auto resolved = mgr.resolve(def);
+
+    auto stops = resolved.colorStops();
+    ASSERT_EQ(stops.size(), 3);
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 0.5);
+    EXPECT_DOUBLE_EQ(stops[2].position.value, 1.0);
+    EXPECT_DOUBLE_EQ(stops[1].color.g, 1.0);  // middle stop is green
 }

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -2771,3 +2771,73 @@ TEST_F(ParserTest, ShadesCustomMinMax)
     EXPECT_LE(lightOklch.lightness, 0.91F);
     EXPECT_GE(darkOklch.lightness, 0.19F);
 }
+
+// content_box() tests
+
+TEST_F(ParserTest, ContentBoxWithSizeTupleAndPadding)
+{
+    Parser parser("content_box((width: 100px, height: 50px), padding(10px))");
+    auto result = parser.parse()->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("width").value, 80.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("height").value, 30.0);
+}
+
+TEST_F(ParserTest, ContentBoxWithAsymmetricPadding)
+{
+    // padding(top, right, bottom, left): horizontal = right + left = 5 + 15 = 20
+    //                                    vertical   = top + bottom = 10 + 20 = 30
+    Parser parser("content_box((width: 200px, height: 100px), padding(10px, 5px, 20px, 15px))");
+    auto result = parser.parse()->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("width").value, 180.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("height").value, 70.0);
+}
+
+TEST_F(ParserTest, ContentBoxWithMultipleInsets)
+{
+    // padding(4px): horizontal = 8, vertical = 8
+    // border_thickness(2px): horizontal = 4, vertical = 4
+    // total: width -= 12, height -= 12
+    Parser parser("content_box((width: 100px, height: 60px), padding(4px), border_thickness(2px))");
+    auto result = parser.parse()->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("width").value, 88.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("height").value, 48.0);
+}
+
+TEST_F(ParserTest, ContentBoxWithNumericValue)
+{
+    // Single Numeric: both width and height start at 32px, subtract padding(4px) = 8px each side
+    Parser parser("content_box(32px, padding(4px))");
+    auto result = parser.parse()->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("width").value, 24.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("height").value, 24.0);
+}
+
+TEST_F(ParserTest, ContentBoxPreservesUnit)
+{
+    Parser parser("content_box((width: 100px, height: 50px), padding(10px))");
+    auto result = parser.parse()->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.get<Numeric>("width").unit, "px");
+    EXPECT_EQ(tuple.get<Numeric>("height").unit, "px");
+}
+
+TEST_F(ParserTest, ContentBoxTooFewArguments)
+{
+    Parser parser("content_box((width: 100px, height: 50px))");
+    auto expr = parser.parse();
+    EXPECT_THROW(expr->evaluate({.manager = &manager, .context = {}}), Base::ExpressionError);
+}

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -2812,6 +2812,31 @@ TEST_F(ParserTest, ContentBoxWithMultipleInsets)
     EXPECT_DOUBLE_EQ(tuple.get<Numeric>("height").value, 48.0);
 }
 
+TEST_F(ParserTest, ContentBoxWithSingleNumericInset)
+{
+    // Single numeric: all sides 4px → horizontal=8, vertical=8
+    Parser parser("content_box((width: 100px, height: 60px), 4px)");
+    auto result = parser.parse()->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("width").value, 92.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("height").value, 52.0);
+}
+
+TEST_F(ParserTest, ContentBoxWithTwoNumericInsets)
+{
+    // Each numeric arg is a separate uniform inset, accumulated independently:
+    // 4px all sides + 2px all sides → width -= 12, height -= 12
+    Parser parser("content_box((width: 100px, height: 60px), 4px, 2px)");
+    auto result = parser.parse()->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("width").value, 88.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("height").value, 48.0);
+}
+
 TEST_F(ParserTest, ContentBoxWithNumericValue)
 {
     // Single Numeric: both width and height start at 32px, subtract padding(4px) = 8px each side

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -2458,3 +2458,40 @@ TEST_F(ParserTest, BlendTwoGradientsThrows)
         Base::ExpressionError
     );
 }
+
+TEST_F(ParserTest, CoalesceReturnsFirstDefined)
+{
+    Parser parser("coalesce(@UndefinedParam, @TestParam)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Numeric>());
+    EXPECT_DOUBLE_EQ(result.get<Numeric>().value, 10.0);
+    EXPECT_EQ(result.get<Numeric>().unit, "px");
+}
+
+TEST_F(ParserTest, CoalesceReturnsFirstWhenDefined)
+{
+    Parser parser("coalesce(@TestColor, @TestParam)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Base::Color>());
+    EXPECT_NEAR(result.get<Base::Color>().r, 1.0F, 0.01F);
+}
+
+TEST_F(ParserTest, CoalesceAllUndefinedReturnsFallbackString)
+{
+    Parser parser("coalesce(@Undefined1, @Undefined2)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<std::string>());
+    EXPECT_EQ(result.get<std::string>(), "@Undefined2");
+}
+
+TEST_F(ParserTest, CoalesceSkipsMultipleUndefined)
+{
+    Parser parser("coalesce(@A, @B, @C, @TestNumber)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Numeric>());
+    EXPECT_DOUBLE_EQ(result.get<Numeric>().value, 5.0);
+}

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -23,6 +23,7 @@
 
 #include <gtest/gtest.h>
 
+#include <Base/OkLch.h>
 #include <Gui/Utilities.h>
 
 #include <Gui/StyleParameters/Corners.h>
@@ -1106,6 +1107,42 @@ TEST_F(ParserTest, TupleScalarMultiplyScalarFirst)
     EXPECT_EQ(tuple.at(0).get<Numeric>().unit, "px");
     EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 4.0);
     EXPECT_DOUBLE_EQ(tuple.at(2).get<Numeric>().value, 6.0);
+}
+
+TEST_F(ParserTest, TupleScalarMultiplyUnitOnScalar)
+{
+    Parser parser("4px * (1, 2, 3, 4)");
+    auto expr = parser.parse();
+
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    EXPECT_TRUE(result.holds<Tuple>());
+
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 4);
+    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 4.0);
+    EXPECT_EQ(tuple.at(0).get<Numeric>().unit, "px");
+    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 8.0);
+    EXPECT_EQ(tuple.at(1).get<Numeric>().unit, "px");
+    EXPECT_DOUBLE_EQ(tuple.at(2).get<Numeric>().value, 12.0);
+    EXPECT_EQ(tuple.at(2).get<Numeric>().unit, "px");
+    EXPECT_DOUBLE_EQ(tuple.at(3).get<Numeric>().value, 16.0);
+    EXPECT_EQ(tuple.at(3).get<Numeric>().unit, "px");
+}
+
+TEST_F(ParserTest, TupleScalarDivideUnitOnTuple)
+{
+    Parser parser("(10px, 20px) / 2");
+    auto expr = parser.parse();
+
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    EXPECT_TRUE(result.holds<Tuple>());
+
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 2);
+    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 5.0);
+    EXPECT_EQ(tuple.at(0).get<Numeric>().unit, "px");
+    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 10.0);
+    EXPECT_EQ(tuple.at(1).get<Numeric>().unit, "px");
 }
 
 TEST_F(ParserTest, TupleScalarDivide)
@@ -2494,4 +2531,243 @@ TEST_F(ParserTest, CoalesceSkipsMultipleUndefined)
     auto result = expr->evaluate({.manager = &manager, .context = {}});
     ASSERT_TRUE(result.holds<Numeric>());
     EXPECT_DOUBLE_EQ(result.get<Numeric>().value, 5.0);
+}
+
+// Shade function tests
+
+TEST_F(ParserTest, ShadeBasicColor)
+{
+    // Position 0.8 = darker than anchor (0.5), so result should be darker than original
+    Parser parser("shade(#ff0000, 0.8)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Base::Color>());
+
+    auto shaded = result.get<Base::Color>();
+    auto shadedOklch = Base::toOkLch(shaded);
+    auto originalOklch = Base::toOkLch(Base::Color(1.0f, 0.0f, 0.0f));
+    EXPECT_LT(shadedOklch.lightness, originalOklch.lightness);
+
+    // Hue should be approximately preserved
+    EXPECT_NEAR(shadedOklch.hue, originalOklch.hue, 5.0f);
+}
+
+TEST_F(ParserTest, ShadeWithPercentage)
+{
+    // 80% = position 0.8, same as shade(#ff0000, 0.8)
+    Parser parser("shade(#ff0000, 80%)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Base::Color>());
+
+    auto shaded = result.get<Base::Color>();
+    auto shadedOklch = Base::toOkLch(shaded);
+    auto originalOklch = Base::toOkLch(Base::Color(1.0f, 0.0f, 0.0f));
+    EXPECT_LT(shadedOklch.lightness, originalOklch.lightness);
+}
+
+TEST_F(ParserTest, ShadeAnchorReturnsOriginal)
+{
+    // Position 0.5 = anchor, color should be returned unchanged
+    Parser parser("shade(#E01B24, 0.5)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Base::Color>());
+
+    // NOLINTNEXTLINE(*-magic-numbers)
+    Base::Color original(0xE0 / 255.0F, 0x1B / 255.0F, 0x24 / 255.0F);
+    auto shaded = result.get<Base::Color>();
+    EXPECT_NEAR(shaded.r, original.r, 0.01f);
+    EXPECT_NEAR(shaded.g, original.g, 0.01f);
+    EXPECT_NEAR(shaded.b, original.b, 0.01f);
+}
+
+TEST_F(ParserTest, ShadeLighterPosition)
+{
+    // Position 0.2 = lighter than anchor, result should be lighter than original
+    Parser parser("shade(#ff0000, 0.2)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Base::Color>());
+
+    auto shaded = result.get<Base::Color>();
+    auto shadedOklch = Base::toOkLch(shaded);
+    auto originalOklch = Base::toOkLch(Base::Color(1.0f, 0.0f, 0.0f));
+    EXPECT_GT(shadedOklch.lightness, originalOklch.lightness);
+}
+
+TEST_F(ParserTest, ShadeGradient)
+{
+    // Position 0.5 = anchor, gradient stops should be unchanged
+    Parser parser("shade(linear_gradient(#ff0000, #0000ff), 0.5)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    LinearGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    auto originalRedOklch = Base::toOkLch(Base::Color(1.0f, 0.0f, 0.0f));
+    auto originalBlueOklch = Base::toOkLch(Base::Color(0.0f, 0.0f, 1.0f));
+    auto firstOklch = Base::toOkLch(stops[0].color);
+    auto secondOklch = Base::toOkLch(stops[1].color);
+    EXPECT_NEAR(firstOklch.lightness, originalRedOklch.lightness, 0.01f);
+    EXPECT_NEAR(secondOklch.lightness, originalBlueOklch.lightness, 0.01f);
+
+    // Positions should be preserved
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 1.0);
+}
+
+TEST_F(ParserTest, ShadesLighterAndDarker)
+{
+    // Position 0.1 = lighter than anchor, 0.9 = darker than anchor
+    Parser parser("shades(#ff0000, (light: 0.1, dark: 0.9))");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 2);
+
+    auto originalOklch = Base::toOkLch(Base::Color(1.0F, 0.0F, 0.0F));
+
+    // "light" shade should be lighter than anchor
+    const auto* lightValue = tuple.find("light");
+    ASSERT_NE(lightValue, nullptr);
+    ASSERT_TRUE(lightValue->holds<Base::Color>());
+    auto lightOklch = Base::toOkLch(lightValue->get<Base::Color>());
+    EXPECT_GT(lightOklch.lightness, originalOklch.lightness);
+
+    // "dark" shade should be darker than anchor
+    const auto* darkValue = tuple.find("dark");
+    ASSERT_NE(darkValue, nullptr);
+    ASSERT_TRUE(darkValue->holds<Base::Color>());
+    auto darkOklch = Base::toOkLch(darkValue->get<Base::Color>());
+    EXPECT_LT(darkOklch.lightness, originalOklch.lightness);
+}
+
+TEST_F(ParserTest, ShadesAnchorExactMatch)
+{
+    // Position 0.5 should produce the exact input color
+    // NOLINTNEXTLINE(*-magic-numbers)
+    Base::Color input(0xE0 / 255.0F, 0x1B / 255.0F, 0x24 / 255.0F);
+
+    Parser parser("shades(#E01B24, (500: 50%))");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 1);
+
+    auto* shade500 = tuple.find("500");
+    ASSERT_NE(shade500, nullptr);
+    auto color = shade500->get<Base::Color>();
+    EXPECT_NEAR(color.r, input.r, 0.001F);
+    EXPECT_NEAR(color.g, input.g, 0.001F);
+    EXPECT_NEAR(color.b, input.b, 0.001F);
+}
+
+TEST_F(ParserTest, ShadesMonotonicLightness)
+{
+    // Lightness must strictly decrease from 050 to 900 — no duplicate shades
+    Parser parser(
+        "shades(#E01B24, "
+        "(050: 5%, 100: 10%, 200: 20%, 300: 30%, 400: 40%, "
+        "500: 50%, 600: 60%, 700: 70%, 800: 80%, 900: 90%))"
+    );
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 10);
+
+    std::vector<std::string> steps
+        = {"050", "100", "200", "300", "400", "500", "600", "700", "800", "900"};
+    float previousLightness = 1.0F;
+    for (const auto& step : steps) {
+        auto* value = tuple.find(step);
+        ASSERT_NE(value, nullptr) << "Missing step " << step;
+        auto oklch = Base::toOkLch(value->get<Base::Color>());
+        EXPECT_LT(oklch.lightness, previousLightness)
+            << "Step " << step << " should be darker than previous";
+        previousLightness = oklch.lightness;
+    }
+
+    // Lightest should not be pure white, darkest should not be pure black
+    auto lightest = Base::toOkLch(tuple.find("050")->get<Base::Color>());
+    auto darkest = Base::toOkLch(tuple.find("900")->get<Base::Color>());
+    EXPECT_LT(lightest.lightness, 0.99F);
+    EXPECT_GT(darkest.lightness, 0.10F);
+}
+
+TEST_F(ParserTest, ShadesPreservesHue)
+{
+    Parser parser("shades(#ff0000, (a: 10%, b: 50%, c: 90%))");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 3);
+
+    auto originalOklch = Base::toOkLch(Base::Color(1.0F, 0.0F, 0.0F));
+
+    for (const auto& element : tuple.elements) {
+        ASSERT_TRUE(element.value->holds<Base::Color>());
+        auto shadeOklch = Base::toOkLch(element.value->get<Base::Color>());
+        // At extreme lightness, chroma can be very low making hue unreliable
+        if (shadeOklch.chroma > 0.01F) {
+            EXPECT_NEAR(shadeOklch.hue, originalOklch.hue, 5.0F);
+        }
+    }
+}
+
+TEST_F(ParserTest, ShadesCustomRange)
+{
+    // A narrower range should produce less variation in lightness
+    Parser parser("shades(#E01B24, (light: 5%, dark: 95%), range: 40%)");
+    auto expr = parser.parse();
+    auto narrowResult = expr->evaluate({.manager = &manager, .context = {}});
+
+    Parser wideParser("shades(#E01B24, (light: 5%, dark: 95%), range: 80%)");
+    auto wideExpr = wideParser.parse();
+    auto wideResult = wideExpr->evaluate({.manager = &manager, .context = {}});
+
+    const auto& narrowTuple = narrowResult.get<Tuple>();
+    const auto& wideTuple = wideResult.get<Tuple>();
+
+    auto narrowLight = Base::toOkLch(narrowTuple.find("light")->get<Base::Color>());
+    auto narrowDark = Base::toOkLch(narrowTuple.find("dark")->get<Base::Color>());
+    float narrowSpan = narrowLight.lightness - narrowDark.lightness;
+
+    auto wideLight = Base::toOkLch(wideTuple.find("light")->get<Base::Color>());
+    auto wideDark = Base::toOkLch(wideTuple.find("dark")->get<Base::Color>());
+    float wideSpan = wideLight.lightness - wideDark.lightness;
+
+    EXPECT_LT(narrowSpan, wideSpan);
+}
+
+TEST_F(ParserTest, ShadesCustomMinMax)
+{
+    // Custom min/max should clamp the lightness range
+    Parser parser("shades(#E01B24, (light: 5%, dark: 95%), min: 20%, max: 90%)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+
+    auto lightOklch = Base::toOkLch(tuple.find("light")->get<Base::Color>());
+    auto darkOklch = Base::toOkLch(tuple.find("dark")->get<Base::Color>());
+
+    // Lightness should stay within the specified bounds (with some tolerance for OKLCH conversion)
+    EXPECT_LE(lightOklch.lightness, 0.91F);
+    EXPECT_GE(darkOklch.lightness, 0.19F);
 }

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -25,6 +25,7 @@
 
 #include <Gui/Utilities.h>
 
+#include <Gui/StyleParameters/Insets.h>
 #include <Gui/StyleParameters/Parser.h>
 #include <Gui/StyleParameters/ParameterManager.h>
 
@@ -1504,4 +1505,396 @@ TEST_F(ArgumentParserTest, TypedGetMissingName)
     auto resolved = ArgumentParser {{.name = "x"}}.resolve(args);
 
     EXPECT_THROW(resolved.get<Numeric>("nonexistent"), Base::ExpressionError);
+}
+
+// Insets / shorthand constructor tests
+
+TEST_F(ParserTest, PaddingShorthand1Arg)
+{
+    Parser parser("padding(10px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_EQ(tuple.size(), 4);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("right").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 10.0);
+}
+
+TEST_F(ParserTest, PaddingShorthand2Args)
+{
+    Parser parser("padding(10px, 5px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("right").value, 5.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 5.0);
+}
+
+TEST_F(ParserTest, PaddingShorthand3Args)
+{
+    Parser parser("padding(10px, 5px, 20px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("right").value, 5.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom").value, 20.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 5.0);
+}
+
+TEST_F(ParserTest, PaddingShorthand4Args)
+{
+    Parser parser("padding(10px, 5px, 20px, 15px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("right").value, 5.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom").value, 20.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 15.0);
+}
+
+TEST_F(ParserTest, PaddingNamedVerticalHorizontal)
+{
+    Parser parser("padding(vertical: 10px, horizontal: 5px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("right").value, 5.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 5.0);
+}
+
+TEST_F(ParserTest, PaddingNamedExplicitSides)
+{
+    Parser parser("padding(top: 1px, right: 2px, bottom: 3px, left: 4px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 1.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("right").value, 2.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom").value, 3.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 4.0);
+}
+
+TEST_F(ParserTest, PaddingMixedNamedOverride)
+{
+    // Start with uniform 10px, then override top
+    Parser parser("padding(10px, top: 20px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 20.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("right").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 10.0);
+}
+
+TEST_F(ParserTest, MarginsFunction)
+{
+    Parser parser("margins(5px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Margins);
+}
+
+TEST_F(ParserTest, InsetsConvertsTupleArgToTargetKind)
+{
+    // padding(margins(...)) should re-tag the margins tuple as padding
+    Parser parser("padding(margins(1px, 2px, 3px, 4px))");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 1.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("right").value, 2.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom").value, 3.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 4.0);
+}
+
+TEST_F(ParserTest, InsetsConvertsGenericTupleArg)
+{
+    Parser parser("padding((top: 5px, right: 10px, bottom: 15px, left: 20px))");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top").value, 5.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("left").value, 20.0);
+}
+
+TEST_F(ParserTest, BorderThicknessFunction)
+{
+    Parser parser("border_thickness(1px, 2px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::BorderThickness);
+    EXPECT_DOUBLE_EQ(result.get<Tuple>().get<Numeric>("top").value, 1.0);
+    EXPECT_DOUBLE_EQ(result.get<Tuple>().get<Numeric>("right").value, 2.0);
+}
+
+// Kind propagation through arithmetic
+
+TEST_F(ParserTest, KindPreservedThroughAdd)
+{
+    Parser parser("padding(10px) + padding(5px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(result.get<Tuple>().get<Numeric>("top").value, 15.0);
+}
+
+TEST_F(ParserTest, KindPreservedThroughScalarMultiply)
+{
+    Parser parser("padding(10px) * 2");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(result.get<Tuple>().get<Numeric>("top").value, 20.0);
+}
+
+TEST_F(ParserTest, KindPreservedThroughNegate)
+{
+    Parser parser("-padding(10px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(result.get<Tuple>().get<Numeric>("top").value, -10.0);
+}
+
+TEST_F(ParserTest, KindMismatchError)
+{
+    EXPECT_THROW(
+        {
+            Parser parser("padding(10px) + margins(5px)");
+            auto expr = parser.parse();
+            expr->evaluate({.manager = &manager, .context = {}});
+        },
+        Base::ExpressionError
+    );
+}
+
+TEST_F(ParserTest, TypedKindPlusGenericKeepsKind)
+{
+    Parser parser("padding(10px) + (top: 5px, right: 5px, bottom: 5px, left: 5px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Padding);
+    EXPECT_DOUBLE_EQ(result.get<Tuple>().get<Numeric>("top").value, 15.0);
+}
+
+// Insets C++ wrapper tests
+
+TEST_F(ParserTest, InsetsPaddingWrapper)
+{
+    Parser parser("padding(1px, 2px, 3px, 4px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    Padding padding(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(padding.top().value, 1.0);
+    EXPECT_DOUBLE_EQ(padding.right().value, 2.0);
+    EXPECT_DOUBLE_EQ(padding.bottom().value, 3.0);
+    EXPECT_DOUBLE_EQ(padding.left().value, 4.0);
+    EXPECT_DOUBLE_EQ(padding.horizontal().value, 6.0);
+    EXPECT_DOUBLE_EQ(padding.vertical().value, 4.0);
+}
+
+TEST_F(ParserTest, InsetsWrongKindCoercedFromNamedElements)
+{
+    // A Padding tuple has named top/right/bottom/left elements; constructing Margins from it
+    // re-expands via those names and produces valid Margins with the same values.
+    Parser parser("padding(10px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    Margins margins(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(margins.top().value, 10.0);
+    EXPECT_DOUBLE_EQ(margins.right().value, 10.0);
+    EXPECT_DOUBLE_EQ(margins.bottom().value, 10.0);
+    EXPECT_DOUBLE_EQ(margins.left().value, 10.0);
+}
+
+// Typed resolve via ParameterManager
+
+TEST_F(ParserTest, ResolveTypedPadding)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{.name = "TestPadding", .value = "padding(1px, 2px, 3px, 4px)"}},
+        ParameterSource::Metadata {.name = "Insets Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    // Construct a default Padding for the definition
+    Tuple defaultTuple;
+    defaultTuple.kind = TupleKind::Padding;
+    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
+    defaultTuple.elements.push_back({.name = "top", .value = zero});
+    defaultTuple.elements.push_back({.name = "right", .value = zero});
+    defaultTuple.elements.push_back({.name = "bottom", .value = zero});
+    defaultTuple.elements.push_back({.name = "left", .value = zero});
+
+    ParameterDefinition<Padding> def {.name = "TestPadding", .defaultValue = Padding(defaultTuple)};
+    auto resolved = mgr.resolve(def);
+
+    EXPECT_DOUBLE_EQ(resolved.top().value, 1.0);
+    EXPECT_DOUBLE_EQ(resolved.right().value, 2.0);
+    EXPECT_DOUBLE_EQ(resolved.bottom().value, 3.0);
+    EXPECT_DOUBLE_EQ(resolved.left().value, 4.0);
+}
+
+TEST_F(ParserTest, ResolveGenericTupleAsPadding)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {
+            {.name = "ButtonPadding", .value = "(top: 10px, right: 5px, bottom: 10px, left: 20px)"}
+        },
+        ParameterSource::Metadata {.name = "Generic Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    Tuple defaultTuple;
+    defaultTuple.kind = TupleKind::Padding;
+    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
+    defaultTuple.elements.push_back({.name = "top", .value = zero});
+    defaultTuple.elements.push_back({.name = "right", .value = zero});
+    defaultTuple.elements.push_back({.name = "bottom", .value = zero});
+    defaultTuple.elements.push_back({.name = "left", .value = zero});
+
+    ParameterDefinition<Padding> def {.name = "ButtonPadding", .defaultValue = Padding(defaultTuple)};
+    auto resolved = mgr.resolve(def);
+
+    EXPECT_DOUBLE_EQ(resolved.top().value, 10.0);
+    EXPECT_DOUBLE_EQ(resolved.right().value, 5.0);
+    EXPECT_DOUBLE_EQ(resolved.bottom().value, 10.0);
+    EXPECT_DOUBLE_EQ(resolved.left().value, 20.0);
+}
+
+TEST_F(ParserTest, ResolveGenericTupleWithGroupNames)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{.name = "ButtonPadding", .value = "(horizontal: 10px, vertical: 20px)"}},
+        ParameterSource::Metadata {.name = "Generic Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    Tuple defaultTuple;
+    defaultTuple.kind = TupleKind::Padding;
+    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
+    defaultTuple.elements.push_back({.name = "top", .value = zero});
+    defaultTuple.elements.push_back({.name = "right", .value = zero});
+    defaultTuple.elements.push_back({.name = "bottom", .value = zero});
+    defaultTuple.elements.push_back({.name = "left", .value = zero});
+
+    ParameterDefinition<Padding> def {.name = "ButtonPadding", .defaultValue = Padding(defaultTuple)};
+    auto resolved = mgr.resolve(def);
+
+    EXPECT_DOUBLE_EQ(resolved.top().value, 20.0);
+    EXPECT_DOUBLE_EQ(resolved.right().value, 10.0);
+    EXPECT_DOUBLE_EQ(resolved.bottom().value, 20.0);
+    EXPECT_DOUBLE_EQ(resolved.left().value, 10.0);
+}
+
+TEST_F(ParserTest, ResolveGenericTupleWithPositionalShorthand)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{.name = "ButtonPadding", .value = "(10px, 5px)"}},
+        ParameterSource::Metadata {.name = "Generic Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    Tuple defaultTuple;
+    defaultTuple.kind = TupleKind::Padding;
+    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
+    defaultTuple.elements.push_back({.name = "top", .value = zero});
+    defaultTuple.elements.push_back({.name = "right", .value = zero});
+    defaultTuple.elements.push_back({.name = "bottom", .value = zero});
+    defaultTuple.elements.push_back({.name = "left", .value = zero});
+
+    ParameterDefinition<Padding> def {.name = "ButtonPadding", .defaultValue = Padding(defaultTuple)};
+    auto resolved = mgr.resolve(def);
+
+    EXPECT_DOUBLE_EQ(resolved.top().value, 10.0);
+    EXPECT_DOUBLE_EQ(resolved.right().value, 5.0);
+    EXPECT_DOUBLE_EQ(resolved.bottom().value, 10.0);
+    EXPECT_DOUBLE_EQ(resolved.left().value, 5.0);
+}
+
+TEST_F(ParserTest, ResolveTypedPaddingFromMarginsToken)
+{
+    // A Margins token has named top/right/bottom/left elements; resolving it as Padding
+    // re-expands via those names and produces valid Padding with the token's values.
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{.name = "TestMargins", .value = "margins(10px)"}},
+        ParameterSource::Metadata {.name = "Insets Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    Tuple defaultTuple;
+    defaultTuple.kind = TupleKind::Padding;
+    auto five = std::make_shared<const Value>(Numeric {.value = 5, .unit = "px"});
+    defaultTuple.elements.push_back({.name = "top", .value = five});
+    defaultTuple.elements.push_back({.name = "right", .value = five});
+    defaultTuple.elements.push_back({.name = "bottom", .value = five});
+    defaultTuple.elements.push_back({.name = "left", .value = five});
+
+    ParameterDefinition<Padding> def {.name = "TestMargins", .defaultValue = Padding(defaultTuple)};
+    auto resolved = mgr.resolve(def);
+
+    // Kind coercion succeeds — returns the token's values, not the default.
+    EXPECT_DOUBLE_EQ(resolved.top().value, 10.0);
+}
+
+TEST_F(ParserTest, ResolveTypedPaddingFallsBackOnMissing)
+{
+    Gui::StyleParameters::ParameterManager mgr;
+
+    Tuple defaultTuple;
+    defaultTuple.kind = TupleKind::Padding;
+    auto seven = std::make_shared<const Value>(Numeric {.value = 7, .unit = "px"});
+    defaultTuple.elements.push_back({.name = "top", .value = seven});
+    defaultTuple.elements.push_back({.name = "right", .value = seven});
+    defaultTuple.elements.push_back({.name = "bottom", .value = seven});
+    defaultTuple.elements.push_back({.name = "left", .value = seven});
+
+    ParameterDefinition<Padding> def {.name = "NonExistent", .defaultValue = Padding(defaultTuple)};
+    auto resolved = mgr.resolve(def);
+
+    EXPECT_DOUBLE_EQ(resolved.top().value, 7.0);
 }

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -2341,3 +2341,120 @@ TEST_F(ParserTest, ResolveTypedLinearGradient)
     EXPECT_DOUBLE_EQ(stops[2].position.value, 1.0);
     EXPECT_DOUBLE_EQ(stops[1].color.g, 1.0);  // middle stop is green
 }
+
+// Gradient color function tests
+
+TEST_F(ParserTest, LightenGradient)
+{
+    Parser parser("lighten(linear_gradient(#ff0000, #0000ff), 20)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    LinearGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    // Each stop should be lighter than the original
+    auto originalRed = QColor(0xff, 0x00, 0x00);
+    auto originalBlue = QColor(0x00, 0x00, 0xff);
+    EXPECT_GT(stops[0].color.asValue<QColor>().lightness(), originalRed.lightness());
+    EXPECT_GT(stops[1].color.asValue<QColor>().lightness(), originalBlue.lightness());
+
+    // Positions should be preserved
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 1.0);
+}
+
+TEST_F(ParserTest, DarkenGradient)
+{
+    Parser parser("darken(radial_gradient(#ff0000, #00ff00), 20)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::RadialGradient);
+
+    RadialGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    // Each stop should be darker than the original
+    auto originalRed = QColor(0xff, 0x00, 0x00);
+    auto originalGreen = QColor(0x00, 0xff, 0x00);
+    EXPECT_LT(stops[0].color.asValue<QColor>().lightness(), originalRed.lightness());
+    EXPECT_LT(stops[1].color.asValue<QColor>().lightness(), originalGreen.lightness());
+
+    // Geometry should be preserved
+    EXPECT_DOUBLE_EQ(gradient.cx(), 0.5);
+    EXPECT_DOUBLE_EQ(gradient.cy(), 0.5);
+    EXPECT_DOUBLE_EQ(gradient.radius(), 0.5);
+}
+
+TEST_F(ParserTest, BlendGradientWithColor)
+{
+    Parser parser("blend(linear_gradient(#ff0000, #0000ff), #000000, 50)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    LinearGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    // 50% blend of red with black should be ~half red
+    EXPECT_NEAR(stops[0].color.r, 0.5, 0.02);
+    EXPECT_NEAR(stops[0].color.g, 0.0, 0.02);
+    EXPECT_NEAR(stops[0].color.b, 0.0, 0.02);
+
+    // 50% blend of blue with black should be ~half blue
+    EXPECT_NEAR(stops[1].color.r, 0.0, 0.02);
+    EXPECT_NEAR(stops[1].color.g, 0.0, 0.02);
+    EXPECT_NEAR(stops[1].color.b, 0.5, 0.02);
+}
+
+TEST_F(ParserTest, BlendColorWithGradient)
+{
+    Parser parser("blend(#000000, linear_gradient(#ff0000, #0000ff), 50)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    LinearGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    // 50% blend of black with red should be ~half red
+    EXPECT_NEAR(stops[0].color.r, 0.5, 0.02);
+    EXPECT_NEAR(stops[0].color.g, 0.0, 0.02);
+    EXPECT_NEAR(stops[0].color.b, 0.0, 0.02);
+
+    // 50% blend of black with blue should be ~half blue
+    EXPECT_NEAR(stops[1].color.r, 0.0, 0.02);
+    EXPECT_NEAR(stops[1].color.g, 0.0, 0.02);
+    EXPECT_NEAR(stops[1].color.b, 0.5, 0.02);
+}
+
+TEST_F(ParserTest, BlendTwoGradientsThrows)
+{
+    EXPECT_THROW(
+        {
+            Parser parser(
+                "blend(linear_gradient(#ff0000, #0000ff), linear_gradient(#00ff00, #ffff00), 50)"
+            );
+            auto expr = parser.parse();
+            expr->evaluate({.manager = &manager, .context = {}});
+        },
+        Base::ExpressionError
+    );
+}

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -1290,28 +1290,13 @@ TEST_F(ParserTest, TupleNestedScalarMultiply)
 
 class ArgumentParserTest: public ::testing::Test
 {
-    struct NameValuePair
-    {
-        std::optional<std::string> name;
-        Value value;
-    };
-
-protected:
-    static Tuple makeTuple(std::vector<NameValuePair> elements)
-    {
-        Tuple tuple;
-        for (auto& [name, value] : elements) {
-            tuple.elements.emplace_back(name, std::make_shared<const Value>(std::move(value)));
-        }
-        return tuple;
-    }
 };
 
 TEST_F(ArgumentParserTest, AllPositional)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 2, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
@@ -1323,9 +1308,9 @@ TEST_F(ArgumentParserTest, AllPositional)
 
 TEST_F(ArgumentParserTest, AllNamed)
 {
-    auto args = makeTuple({
-        {.name = std::string("x"), .value = Numeric {.value = 10, .unit = ""}},
-        {.name = std::string("y"), .value = Numeric {.value = 20, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("x", Numeric {.value = 10, .unit = ""}),
+        Tuple::Element::named("y", Numeric {.value = 20, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
@@ -1335,9 +1320,9 @@ TEST_F(ArgumentParserTest, AllNamed)
 
 TEST_F(ArgumentParserTest, AllNamedReversedOrder)
 {
-    auto args = makeTuple({
-        {.name = std::string("y"), .value = Numeric {.value = 20, .unit = ""}},
-        {.name = std::string("x"), .value = Numeric {.value = 10, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("y", Numeric {.value = 20, .unit = ""}),
+        Tuple::Element::named("x", Numeric {.value = 10, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
@@ -1348,9 +1333,9 @@ TEST_F(ArgumentParserTest, AllNamedReversedOrder)
 TEST_F(ArgumentParserTest, MixedPositionalThenNamed)
 {
     // f(1, y: 2) with signature (x, y)
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::string("y"), .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::named("y", Numeric {.value = 2, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
@@ -1361,9 +1346,9 @@ TEST_F(ArgumentParserTest, MixedPositionalThenNamed)
 TEST_F(ArgumentParserTest, NamedThenPositionalFillsRemainingSlot)
 {
     // f(y: 2, 1) with signature (x, y) — positional 1 fills unclaimed x
-    auto args = makeTuple({
-        {.name = std::string("y"), .value = Numeric {.value = 2, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("y", Numeric {.value = 2, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
@@ -1373,8 +1358,8 @@ TEST_F(ArgumentParserTest, NamedThenPositionalFillsRemainingSlot)
 
 TEST_F(ArgumentParserTest, DefaultValueUsedWhenMissing)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
     });
     auto resolved = ArgumentParser {
         {.name = "x"},
@@ -1387,9 +1372,9 @@ TEST_F(ArgumentParserTest, DefaultValueUsedWhenMissing)
 
 TEST_F(ArgumentParserTest, DefaultValueOverriddenByPositional)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 2, .unit = ""}),
     });
     auto resolved = ArgumentParser {
         {.name = "x"},
@@ -1401,9 +1386,9 @@ TEST_F(ArgumentParserTest, DefaultValueOverriddenByPositional)
 
 TEST_F(ArgumentParserTest, DefaultValueOverriddenByName)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::string("y"), .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::named("y", Numeric {.value = 2, .unit = ""}),
     });
     auto resolved = ArgumentParser {
         {.name = "x"},
@@ -1415,9 +1400,9 @@ TEST_F(ArgumentParserTest, DefaultValueOverriddenByName)
 
 TEST_F(ArgumentParserTest, ResolvedTupleHasCorrectOrder)
 {
-    auto args = makeTuple({
-        {.name = std::string("y"), .value = Numeric {.value = 2, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("y", Numeric {.value = 2, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
@@ -1428,9 +1413,9 @@ TEST_F(ArgumentParserTest, ResolvedTupleHasCorrectOrder)
 
 TEST_F(ArgumentParserTest, MixedTypes)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Base::Color(1.0, 0.0, 0.0)},
-        {.name = std::nullopt, .value = Numeric {.value = 20, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Base::Color(1.0, 0.0, 0.0)),
+        Tuple::Element::unnamed(Numeric {.value = 20, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "color"}, {.name = "amount"}}.resolve(args);
 
@@ -1440,8 +1425,8 @@ TEST_F(ArgumentParserTest, MixedTypes)
 
 TEST_F(ArgumentParserTest, ErrorOnUnknownName)
 {
-    auto args = makeTuple({
-        {.name = std::string("unknown"), .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("unknown", Numeric {.value = 1, .unit = ""}),
     });
     ArgumentParser parser {{"x"}, {"y"}};
     EXPECT_THROW(parser.resolve(args), Base::ExpressionError);
@@ -1449,9 +1434,9 @@ TEST_F(ArgumentParserTest, ErrorOnUnknownName)
 
 TEST_F(ArgumentParserTest, ErrorOnDuplicateName)
 {
-    auto args = makeTuple({
-        {.name = std::string("x"), .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::string("x"), .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("x", Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::named("x", Numeric {.value = 2, .unit = ""}),
     });
     ArgumentParser parser {{"x"}, {"y"}};
     EXPECT_THROW(parser.resolve(args), Base::ExpressionError);
@@ -1459,8 +1444,8 @@ TEST_F(ArgumentParserTest, ErrorOnDuplicateName)
 
 TEST_F(ArgumentParserTest, ErrorOnMissingRequired)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
     });
     ArgumentParser parser {{"x"}, {"y"}};
     EXPECT_THROW(parser.resolve(args), Base::ExpressionError);
@@ -1468,10 +1453,10 @@ TEST_F(ArgumentParserTest, ErrorOnMissingRequired)
 
 TEST_F(ArgumentParserTest, ErrorOnExcessPositional)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 2, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 3, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 2, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 3, .unit = ""}),
     });
     ArgumentParser parser {{"x"}, {"y"}};
     EXPECT_THROW(parser.resolve(args), Base::ExpressionError);
@@ -1479,9 +1464,9 @@ TEST_F(ArgumentParserTest, ErrorOnExcessPositional)
 
 TEST_F(ArgumentParserTest, TypedGetSuccess)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Base::Color(1.0, 0.0, 0.0)},
-        {.name = std::nullopt, .value = Numeric {.value = 20, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Base::Color(1.0, 0.0, 0.0)),
+        Tuple::Element::unnamed(Numeric {.value = 20, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "color"}, {.name = "amount"}}.resolve(args);
 
@@ -1492,9 +1477,9 @@ TEST_F(ArgumentParserTest, TypedGetSuccess)
 
 TEST_F(ArgumentParserTest, TypedGetWrongType)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 10, .unit = "px"}},
-        {.name = std::nullopt, .value = Numeric {.value = 20, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 10, .unit = "px"}),
+        Tuple::Element::unnamed(Numeric {.value = 20, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "color"}, {.name = "amount"}}.resolve(args);
 
@@ -1503,7 +1488,7 @@ TEST_F(ArgumentParserTest, TypedGetWrongType)
 
 TEST_F(ArgumentParserTest, TypedGetMissingName)
 {
-    auto args = makeTuple({{.name = std::nullopt, .value = Numeric {.value = 10, .unit = ""}}});
+    Tuple args({Tuple::Element::unnamed(Numeric {.value = 10, .unit = ""})});
     auto resolved = ArgumentParser {{.name = "x"}}.resolve(args);
 
     EXPECT_THROW(resolved.get<Numeric>("nonexistent"), Base::ExpressionError);
@@ -1756,13 +1741,15 @@ TEST_F(ParserTest, ResolveTypedPadding)
     mgr.addSource(source.get());
 
     // Construct a default Padding for the definition
-    Tuple defaultTuple;
-    defaultTuple.kind = TupleKind::Padding;
-    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
-    defaultTuple.elements.push_back({.name = "top", .value = zero});
-    defaultTuple.elements.push_back({.name = "right", .value = zero});
-    defaultTuple.elements.push_back({.name = "bottom", .value = zero});
-    defaultTuple.elements.push_back({.name = "left", .value = zero});
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("top", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("right", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("bottom", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("left", Numeric {.value = 0, .unit = "px"}),
+        },
+        TupleKind::Padding
+    );
 
     ParameterDefinition<Padding> def {.name = "TestPadding", .defaultValue = Padding(defaultTuple)};
     auto resolved = mgr.resolve(def);
@@ -1785,13 +1772,15 @@ TEST_F(ParserTest, ResolveGenericTupleAsPadding)
     Gui::StyleParameters::ParameterManager mgr;
     mgr.addSource(source.get());
 
-    Tuple defaultTuple;
-    defaultTuple.kind = TupleKind::Padding;
-    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
-    defaultTuple.elements.push_back({.name = "top", .value = zero});
-    defaultTuple.elements.push_back({.name = "right", .value = zero});
-    defaultTuple.elements.push_back({.name = "bottom", .value = zero});
-    defaultTuple.elements.push_back({.name = "left", .value = zero});
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("top", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("right", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("bottom", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("left", Numeric {.value = 0, .unit = "px"}),
+        },
+        TupleKind::Padding
+    );
 
     ParameterDefinition<Padding> def {.name = "ButtonPadding", .defaultValue = Padding(defaultTuple)};
     auto resolved = mgr.resolve(def);
@@ -1812,13 +1801,15 @@ TEST_F(ParserTest, ResolveGenericTupleWithGroupNames)
     Gui::StyleParameters::ParameterManager mgr;
     mgr.addSource(source.get());
 
-    Tuple defaultTuple;
-    defaultTuple.kind = TupleKind::Padding;
-    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
-    defaultTuple.elements.push_back({.name = "top", .value = zero});
-    defaultTuple.elements.push_back({.name = "right", .value = zero});
-    defaultTuple.elements.push_back({.name = "bottom", .value = zero});
-    defaultTuple.elements.push_back({.name = "left", .value = zero});
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("top", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("right", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("bottom", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("left", Numeric {.value = 0, .unit = "px"}),
+        },
+        TupleKind::Padding
+    );
 
     ParameterDefinition<Padding> def {.name = "ButtonPadding", .defaultValue = Padding(defaultTuple)};
     auto resolved = mgr.resolve(def);
@@ -1839,13 +1830,15 @@ TEST_F(ParserTest, ResolveGenericTupleWithPositionalShorthand)
     Gui::StyleParameters::ParameterManager mgr;
     mgr.addSource(source.get());
 
-    Tuple defaultTuple;
-    defaultTuple.kind = TupleKind::Padding;
-    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
-    defaultTuple.elements.push_back({.name = "top", .value = zero});
-    defaultTuple.elements.push_back({.name = "right", .value = zero});
-    defaultTuple.elements.push_back({.name = "bottom", .value = zero});
-    defaultTuple.elements.push_back({.name = "left", .value = zero});
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("top", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("right", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("bottom", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("left", Numeric {.value = 0, .unit = "px"}),
+        },
+        TupleKind::Padding
+    );
 
     ParameterDefinition<Padding> def {.name = "ButtonPadding", .defaultValue = Padding(defaultTuple)};
     auto resolved = mgr.resolve(def);
@@ -1868,13 +1861,15 @@ TEST_F(ParserTest, ResolveTypedPaddingFromMarginsToken)
     Gui::StyleParameters::ParameterManager mgr;
     mgr.addSource(source.get());
 
-    Tuple defaultTuple;
-    defaultTuple.kind = TupleKind::Padding;
-    auto five = std::make_shared<const Value>(Numeric {.value = 5, .unit = "px"});
-    defaultTuple.elements.push_back({.name = "top", .value = five});
-    defaultTuple.elements.push_back({.name = "right", .value = five});
-    defaultTuple.elements.push_back({.name = "bottom", .value = five});
-    defaultTuple.elements.push_back({.name = "left", .value = five});
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("top", Numeric {.value = 5, .unit = "px"}),
+            Tuple::Element::named("right", Numeric {.value = 5, .unit = "px"}),
+            Tuple::Element::named("bottom", Numeric {.value = 5, .unit = "px"}),
+            Tuple::Element::named("left", Numeric {.value = 5, .unit = "px"}),
+        },
+        TupleKind::Padding
+    );
 
     ParameterDefinition<Padding> def {.name = "TestMargins", .defaultValue = Padding(defaultTuple)};
     auto resolved = mgr.resolve(def);
@@ -1887,13 +1882,15 @@ TEST_F(ParserTest, ResolveTypedPaddingFallsBackOnMissing)
 {
     Gui::StyleParameters::ParameterManager mgr;
 
-    Tuple defaultTuple;
-    defaultTuple.kind = TupleKind::Padding;
-    auto seven = std::make_shared<const Value>(Numeric {.value = 7, .unit = "px"});
-    defaultTuple.elements.push_back({.name = "top", .value = seven});
-    defaultTuple.elements.push_back({.name = "right", .value = seven});
-    defaultTuple.elements.push_back({.name = "bottom", .value = seven});
-    defaultTuple.elements.push_back({.name = "left", .value = seven});
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("top", Numeric {.value = 7, .unit = "px"}),
+            Tuple::Element::named("right", Numeric {.value = 7, .unit = "px"}),
+            Tuple::Element::named("bottom", Numeric {.value = 7, .unit = "px"}),
+            Tuple::Element::named("left", Numeric {.value = 7, .unit = "px"}),
+        },
+        TupleKind::Padding
+    );
 
     ParameterDefinition<Padding> def {.name = "NonExistent", .defaultValue = Padding(defaultTuple)};
     auto resolved = mgr.resolve(def);
@@ -2052,13 +2049,15 @@ TEST_F(ParserTest, ResolveTypedCorners)
     Gui::StyleParameters::ParameterManager mgr;
     mgr.addSource(source.get());
 
-    Tuple defaultTuple;
-    defaultTuple.kind = TupleKind::Corners;
-    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
-    defaultTuple.elements.push_back({.name = "top_left", .value = zero});
-    defaultTuple.elements.push_back({.name = "top_right", .value = zero});
-    defaultTuple.elements.push_back({.name = "bottom_right", .value = zero});
-    defaultTuple.elements.push_back({.name = "bottom_left", .value = zero});
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("top_left", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("top_right", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("bottom_right", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("bottom_left", Numeric {.value = 0, .unit = "px"}),
+        },
+        TupleKind::Corners
+    );
 
     ParameterDefinition<Corners> def {.name = "TestRadius", .defaultValue = Corners(defaultTuple)};
     auto resolved = mgr.resolve(def);
@@ -2307,37 +2306,26 @@ TEST_F(ParserTest, ResolveTypedLinearGradient)
     mgr.addSource(source.get());
 
     // Build a default LinearGradient tuple
-    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = ""});
-    auto one = std::make_shared<const Value>(Numeric {.value = 1, .unit = ""});
-    Tuple defaultStopsTuple;
-    {
-        Tuple stop0;
-        stop0.elements.push_back({.name = std::nullopt, .value = zero});
-        stop0.elements.push_back(
-            {.name = std::nullopt, .value = std::make_shared<const Value>(Base::Color(0, 0, 0))}
-        );
-        Tuple stop1;
-        stop1.elements.push_back({.name = std::nullopt, .value = one});
-        stop1.elements.push_back(
-            {.name = std::nullopt, .value = std::make_shared<const Value>(Base::Color(1, 1, 1))}
-        );
-        defaultStopsTuple.elements.push_back(
-            {.name = std::nullopt, .value = std::make_shared<const Value>(std::move(stop0))}
-        );
-        defaultStopsTuple.elements.push_back(
-            {.name = std::nullopt, .value = std::make_shared<const Value>(std::move(stop1))}
-        );
-    }
+    Tuple defaultStopsTuple({
+        Tuple::Element::unnamed(Tuple({
+            Tuple::Element::unnamed(Numeric {.value = 0, .unit = ""}),
+            Tuple::Element::unnamed(Base::Color(0, 0, 0)),
+        })),
+        Tuple::Element::unnamed(Tuple({
+            Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+            Tuple::Element::unnamed(Base::Color(1, 1, 1)),
+        })),
+    });
 
-    Tuple defaultTuple;
-    defaultTuple.kind = TupleKind::LinearGradient;
-    defaultTuple.elements.push_back({.name = std::string("x1"), .value = zero});
-    defaultTuple.elements.push_back({.name = std::string("y1"), .value = zero});
-    defaultTuple.elements.push_back({.name = std::string("x2"), .value = zero});
-    defaultTuple.elements.push_back({.name = std::string("y2"), .value = one});
-    defaultTuple.elements.push_back(
-        {.name = std::string("stops"),
-         .value = std::make_shared<const Value>(std::move(defaultStopsTuple))}
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("x1", Numeric {.value = 0, .unit = ""}),
+            Tuple::Element::named("y1", Numeric {.value = 0, .unit = ""}),
+            Tuple::Element::named("x2", Numeric {.value = 0, .unit = ""}),
+            Tuple::Element::named("y2", Numeric {.value = 1, .unit = ""}),
+            Tuple::Element::named("stops", std::move(defaultStopsTuple)),
+        },
+        TupleKind::LinearGradient
     );
 
     ParameterDefinition<LinearGradient> def {

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -25,6 +25,7 @@
 
 #include <Gui/Utilities.h>
 
+#include <Gui/StyleParameters/Corners.h>
 #include <Gui/StyleParameters/Insets.h>
 #include <Gui/StyleParameters/Parser.h>
 #include <Gui/StyleParameters/ParameterManager.h>
@@ -1897,4 +1898,172 @@ TEST_F(ParserTest, ResolveTypedPaddingFallsBackOnMissing)
     auto resolved = mgr.resolve(def);
 
     EXPECT_DOUBLE_EQ(resolved.top().value, 7.0);
+}
+
+// Corners / border_radius tests
+
+TEST_F(ParserTest, BorderRadiusShorthand1Arg)
+{
+    Parser parser("border_radius(10px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_EQ(tuple.size(), 4);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_left").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_right").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_right").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_left").value, 10.0);
+}
+
+TEST_F(ParserTest, BorderRadiusShorthand2Args)
+{
+    // 2 values: top-left/bottom-right, top-right/bottom-left (diagonal pairing)
+    Parser parser("border_radius(10px, 5px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_left").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_right").value, 5.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_right").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_left").value, 5.0);
+}
+
+TEST_F(ParserTest, BorderRadiusShorthand3Args)
+{
+    // 3 values: top-left, top-right/bottom-left, bottom-right
+    Parser parser("border_radius(10px, 5px, 20px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_left").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_right").value, 5.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_right").value, 20.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_left").value, 5.0);
+}
+
+TEST_F(ParserTest, BorderRadiusShorthand4Args)
+{
+    Parser parser("border_radius(10px, 5px, 20px, 15px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_left").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_right").value, 5.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_right").value, 20.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_left").value, 15.0);
+}
+
+TEST_F(ParserTest, BorderRadiusNamedOverride)
+{
+    Parser parser("border_radius(10px, top_left: 20px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_left").value, 20.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_right").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_right").value, 10.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_left").value, 10.0);
+}
+
+TEST_F(ParserTest, BorderRadiusConvertsTupleArg)
+{
+    // Single tuple argument gets re-tagged
+    Parser parser(
+        "border_radius((top_left: 1px, top_right: 2px, bottom_right: 3px, bottom_left: 4px))"
+    );
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("top_left").value, 1.0);
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("bottom_right").value, 3.0);
+}
+
+TEST_F(ParserTest, BorderRadiusKindPreservedThroughArithmetic)
+{
+    Parser parser("border_radius(10px) + border_radius(5px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Corners);
+    EXPECT_DOUBLE_EQ(result.get<Tuple>().get<Numeric>("top_left").value, 15.0);
+}
+
+TEST_F(ParserTest, BorderRadiusKindMismatchWithInsetsThrows)
+{
+    EXPECT_THROW(
+        {
+            Parser parser("border_radius(10px) + padding(5px)");
+            auto expr = parser.parse();
+            expr->evaluate({.manager = &manager, .context = {}});
+        },
+        Base::ExpressionError
+    );
+}
+
+TEST_F(ParserTest, CornersWrapper)
+{
+    Parser parser("border_radius(1px, 2px, 3px, 4px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    Corners radii(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(radii.topLeft().value, 1.0);
+    EXPECT_DOUBLE_EQ(radii.topRight().value, 2.0);
+    EXPECT_DOUBLE_EQ(radii.bottomRight().value, 3.0);
+    EXPECT_DOUBLE_EQ(radii.bottomLeft().value, 4.0);
+}
+
+TEST_F(ParserTest, CornersFromUnrelatedTupleDefaultsToZero)
+{
+    // A Padding tuple has no corner-named elements; constructing Corners from it
+    // produces zero radii for all corners rather than throwing.
+    Parser parser("padding(10px)");
+    auto expr = parser.parse();
+    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    Corners corners(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(corners.topLeft().value, 0.0);
+    EXPECT_DOUBLE_EQ(corners.topRight().value, 0.0);
+    EXPECT_DOUBLE_EQ(corners.bottomRight().value, 0.0);
+    EXPECT_DOUBLE_EQ(corners.bottomLeft().value, 0.0);
+}
+
+TEST_F(ParserTest, ResolveTypedCorners)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{.name = "TestRadius", .value = "border_radius(1px, 2px, 3px, 4px)"}},
+        ParameterSource::Metadata {.name = "Corners Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    Tuple defaultTuple;
+    defaultTuple.kind = TupleKind::Corners;
+    auto zero = std::make_shared<const Value>(Numeric {.value = 0, .unit = "px"});
+    defaultTuple.elements.push_back({.name = "top_left", .value = zero});
+    defaultTuple.elements.push_back({.name = "top_right", .value = zero});
+    defaultTuple.elements.push_back({.name = "bottom_right", .value = zero});
+    defaultTuple.elements.push_back({.name = "bottom_left", .value = zero});
+
+    ParameterDefinition<Corners> def {.name = "TestRadius", .defaultValue = Corners(defaultTuple)};
+    auto resolved = mgr.resolve(def);
+
+    EXPECT_DOUBLE_EQ(resolved.topLeft().value, 1.0);
+    EXPECT_DOUBLE_EQ(resolved.topRight().value, 2.0);
+    EXPECT_DOUBLE_EQ(resolved.bottomRight().value, 3.0);
+    EXPECT_DOUBLE_EQ(resolved.bottomLeft().value, 4.0);
 }

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -1407,6 +1407,36 @@ TEST_F(ParserTest, CornersFromUnrelatedTupleDefaultsToZero)
     EXPECT_DOUBLE_EQ(corners.bottomLeft().value, 0.0);
     EXPECT_THAT(capture.messages(), Contains(HasSubstr("Expected Corners tuple, got Padding")));
 }
+
+TEST_F(ParserTest, ResolveTypedCorners)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {{.name = "TestRadius", .value = "border_radius(1px, 2px, 3px, 4px)"}},
+        ParameterSource::Metadata {.name = "Corners Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("top_left", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("top_right", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("bottom_right", Numeric {.value = 0, .unit = "px"}),
+            Tuple::Element::named("bottom_left", Numeric {.value = 0, .unit = "px"}),
+        },
+        TupleKind::Corners
+    );
+
+    ParameterDefinition<Corners> def {.name = "TestRadius", .defaultValue = Corners(defaultTuple)};
+    auto resolved = mgr.resolve(def);
+
+    EXPECT_DOUBLE_EQ(resolved.topLeft().value, 1.0);
+    EXPECT_DOUBLE_EQ(resolved.topRight().value, 2.0);
+    EXPECT_DOUBLE_EQ(resolved.bottomRight().value, 3.0);
+    EXPECT_DOUBLE_EQ(resolved.bottomLeft().value, 4.0);
+}
+
 // Gradient tests
 
 TEST_F(ParserTest, LinearGradientMinimal)
@@ -1652,6 +1682,56 @@ TEST_F(ParserTest, GradientStopsAccessibleViaMemberAccess)
     ASSERT_TRUE(result.holds<Tuple>());
     EXPECT_EQ(result.get<Tuple>().size(), 2);
 }
+
+TEST_F(ParserTest, ResolveTypedLinearGradient)
+{
+    auto source = std::make_unique<InMemoryParameterSource>(
+        std::list<Parameter> {
+            {.name = "TestGradient", .value = "linear_gradient(#ff0000, #00ff00, #0000ff)"}
+        },
+        ParameterSource::Metadata {.name = "Gradient Source"}
+    );
+
+    Gui::StyleParameters::ParameterManager mgr;
+    mgr.addSource(source.get());
+
+    // Build a default LinearGradient tuple
+    Tuple defaultStopsTuple({
+        Tuple::Element::unnamed(Tuple({
+            Tuple::Element::unnamed(Numeric {.value = 0, .unit = ""}),
+            Tuple::Element::unnamed(Base::Color(0, 0, 0)),
+        })),
+        Tuple::Element::unnamed(Tuple({
+            Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+            Tuple::Element::unnamed(Base::Color(1, 1, 1)),
+        })),
+    });
+
+    Tuple defaultTuple(
+        {
+            Tuple::Element::named("x1", Numeric {.value = 0, .unit = ""}),
+            Tuple::Element::named("y1", Numeric {.value = 0, .unit = ""}),
+            Tuple::Element::named("x2", Numeric {.value = 0, .unit = ""}),
+            Tuple::Element::named("y2", Numeric {.value = 1, .unit = ""}),
+            Tuple::Element::named("stops", std::move(defaultStopsTuple)),
+        },
+        TupleKind::LinearGradient
+    );
+
+    ParameterDefinition<LinearGradient> def {
+        .name = "TestGradient",
+        .defaultValue = LinearGradient(defaultTuple),
+    };
+    auto resolved = mgr.resolve(def);
+
+    auto stops = resolved.colorStops();
+    ASSERT_EQ(stops.size(), 3);
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 0.5);
+    EXPECT_DOUBLE_EQ(stops[2].position.value, 1.0);
+    EXPECT_DOUBLE_EQ(stops[1].color.g, 1.0);  // middle stop is green
+}
+
 // Gradient color function tests
 
 TEST_F(ParserTest, LightenGradient)

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -470,16 +470,6 @@ TEST_F(ParserTest, ParseErrors)
         },
         Base::ExpressionError
     );
-
-    // Function with wrong argument type
-    EXPECT_THROW(
-        {
-            Parser parser("lighten(10px, 20)");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::ExpressionError
-    );
 }
 
 // Test whitespace handling
@@ -838,7 +828,8 @@ TEST_F(ParserTest, TupleAtOutOfBounds)
 
     EXPECT_NO_THROW(tuple.at(0));
     EXPECT_NO_THROW(tuple.at(1));
-    EXPECT_THROW(tuple.at(2), Base::RuntimeError);
+    EXPECT_EQ(tuple.tryAt(2), nullptr);
+    EXPECT_DOUBLE_EQ(tuple.at(2).get<Numeric>().value, 0.0);
 }
 
 // Test Tuple::find nonexistent name
@@ -1018,16 +1009,6 @@ TEST_F(ParserTest, MemberAccessErrors)
             expr->evaluate({.manager = &manager, .context = {}});
         },
         Base::ExpressionError
-    );
-
-    // Index out of bounds
-    EXPECT_THROW(
-        {
-            Parser parser("@TestIndexedTuple.5");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::RuntimeError
     );
 
     // Member access on non-tuple
@@ -1495,7 +1476,8 @@ TEST_F(ArgumentParserTest, TypedGetWrongType)
     });
     auto resolved = ArgumentParser {{.name = "color"}, {.name = "amount"}}.resolve(args);
 
-    EXPECT_THROW(resolved.get<Base::Color>("color"), Base::ExpressionError);
+    EXPECT_EQ(resolved.tryGet<Base::Color>("color"), nullptr);
+    EXPECT_FLOAT_EQ(resolved.get<Base::Color>("color").a, 0.0F);
 }
 
 TEST_F(ArgumentParserTest, TypedGetMissingName)
@@ -1503,5 +1485,6 @@ TEST_F(ArgumentParserTest, TypedGetMissingName)
     auto args = makeTuple({{.name = std::nullopt, .value = Numeric {.value = 10, .unit = ""}}});
     auto resolved = ArgumentParser {{.name = "x"}}.resolve(args);
 
-    EXPECT_THROW(resolved.get<Numeric>("nonexistent"), Base::ExpressionError);
+    EXPECT_EQ(resolved.tryGet<Numeric>("nonexistent"), nullptr);
+    EXPECT_DOUBLE_EQ(resolved.get<Numeric>("nonexistent").value, 0.0);
 }

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -2202,3 +2202,22 @@ TEST_F(ParserTest, ColorFunctionTypeErrorsAreContainedByResolve)
         EXPECT_EQ(resolved->get<std::string>(), "lighten(10px, 20)");
     });
 }
+
+TEST_F(ParserTest, MalformedGradientConvertsToNoBrush)
+{
+    // A LinearGradient-kinded tuple whose stops element is not a tuple of stops.
+    Tuple broken(
+        {
+            Tuple::Element::named("x1", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("y1", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("x2", Numeric {.value = 0.0, .unit = ""}),
+            Tuple::Element::named("y2", Numeric {.value = 1.0, .unit = ""}),
+            Tuple::Element::named("stops", Numeric {.value = 1.0, .unit = ""}),
+        },
+        TupleKind::LinearGradient
+    );
+
+    QBrush brush;
+    EXPECT_NO_THROW({ brush = Base::convertTo<QBrush>(Value {broken}); });
+    EXPECT_EQ(brush.style(), Qt::NoBrush);
+}

--- a/tests/src/Gui/StyleParameters/ParserTest.cpp
+++ b/tests/src/Gui/StyleParameters/ParserTest.cpp
@@ -21,14 +21,25 @@
  *                                                                          *
  ***************************************************************************/
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <Base/OkLch.h>
 #include <Gui/Utilities.h>
 
+#include <Gui/StyleParameters/Corners.h>
+#include <Gui/StyleParameters/Gradient.h>
+#include <Gui/StyleParameters/Insets.h>
 #include <Gui/StyleParameters/Parser.h>
 #include <Gui/StyleParameters/ParameterManager.h>
 
+#include "DiagnosticsCapture.h"
+#include "ValueMatchers.h"
+
 using namespace Gui::StyleParameters;
+using namespace Gui::StyleParameters::Matchers;
+using ::testing::Contains;
+using ::testing::HasSubstr;
 
 class ParserTest: public ::testing::Test
 {
@@ -52,6 +63,18 @@ protected:
         sources.push_back(std::move(source));
     }
 
+    /// Parses an expression without evaluating it.
+    static std::unique_ptr<Expr> parse(const std::string& expression)
+    {
+        return Parser(expression).parse();
+    }
+
+    /// Parses and evaluates an expression against the fixture's parameter manager.
+    Value evaluate(const std::string& expression) const
+    {
+        return parse(expression)->evaluate({.manager = &manager, .context = {}});
+    }
+
     Gui::StyleParameters::ParameterManager manager;
     std::vector<std::unique_ptr<ParameterSource>> sources;
 };
@@ -60,43 +83,23 @@ protected:
 TEST_F(ParserTest, ParseNumbers)
 {
     {
-        Parser parser("42");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 42.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("42");
+        EXPECT_THAT(result, IsNumeric(42.0, ""));
     }
 
     {
-        Parser parser("10.5px");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 10.5);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("10.5px");
+        EXPECT_THAT(result, IsNumeric(10.5, "px"));
     }
 
     {
-        Parser parser("2.5em");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 2.5);
-        EXPECT_EQ(length.unit, "em");
+        auto result = evaluate("2.5em");
+        EXPECT_THAT(result, IsNumeric(2.5, "em"));
     }
 
     {
-        Parser parser("100%");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 100.0);
-        EXPECT_EQ(length.unit, "%");
+        auto result = evaluate("100%");
+        EXPECT_THAT(result, IsNumeric(100.0, "%"));
     }
 }
 
@@ -104,55 +107,28 @@ TEST_F(ParserTest, ParseNumbers)
 TEST_F(ParserTest, ParseColors)
 {
     {
-        Parser parser("#ff0000");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
-        auto color = std::get<Base::Color>(result);
-        EXPECT_EQ(color.r, 1);
-        EXPECT_EQ(color.g, 0);
-        EXPECT_EQ(color.b, 0);
+        auto result = evaluate("#ff0000");
+        EXPECT_THAT(result, IsColor(Base::Color(1, 0, 0)));
     }
 
     {
-        Parser parser("#00ff00");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
-        auto color = std::get<Base::Color>(result);
-        EXPECT_EQ(color.r, 0);
-        EXPECT_EQ(color.g, 1);
-        EXPECT_EQ(color.b, 0);
+        auto result = evaluate("#00ff00");
+        EXPECT_THAT(result, IsColor(Base::Color(0, 1, 0)));
     }
 
     {
-        Parser parser("#0000ff");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
-        auto color = std::get<Base::Color>(result);
-        EXPECT_EQ(color.r, 0);
-        EXPECT_EQ(color.g, 0);
-        EXPECT_EQ(color.b, 1);
+        auto result = evaluate("#0000ff");
+        EXPECT_THAT(result, IsColor(Base::Color(0, 0, 1)));
     }
 
     {
-        Parser parser("rgb(255, 0, 0)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
-        auto color = std::get<Base::Color>(result);
-        EXPECT_EQ(color.r, 1);
-        EXPECT_EQ(color.g, 0);
-        EXPECT_EQ(color.b, 0);
+        auto result = evaluate("rgb(255, 0, 0)");
+        EXPECT_THAT(result, IsColor(Base::Color(1, 0, 0)));
     }
 
     {
-        Parser parser("rgba(255, 0, 0, 128)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
-        auto color = std::get<Base::Color>(result);
+        auto result = evaluate("rgba(255, 0, 0, 128)");
+        auto color = result.get<Base::Color>();
         EXPECT_DOUBLE_EQ(color.r, 1);
         EXPECT_DOUBLE_EQ(color.g, 0);
         EXPECT_DOUBLE_EQ(color.b, 0);
@@ -164,34 +140,18 @@ TEST_F(ParserTest, ParseColors)
 TEST_F(ParserTest, ParseParameterReferences)
 {
     {
-        Parser parser("@TestParam");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 10.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("@TestParam");
+        EXPECT_THAT(result, IsNumeric(10.0, "px"));
     }
 
     {
-        Parser parser("@TestColor");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
-        auto color = std::get<Base::Color>(result);
-        EXPECT_EQ(color.r, 1);
-        EXPECT_EQ(color.g, 0);
-        EXPECT_EQ(color.b, 0);
+        auto result = evaluate("@TestColor");
+        EXPECT_THAT(result, IsColor(Base::Color(1, 0, 0)));
     }
 
     {
-        Parser parser("@TestNumber");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 5.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("@TestNumber");
+        EXPECT_THAT(result, IsNumeric(5.0, ""));
     }
 }
 
@@ -199,83 +159,43 @@ TEST_F(ParserTest, ParseParameterReferences)
 TEST_F(ParserTest, ParseArithmeticOperations)
 {
     {
-        Parser parser("10 + 5");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 15.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("10 + 5");
+        EXPECT_THAT(result, IsNumeric(15.0, ""));
     }
 
     {
-        Parser parser("10px + 5px");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 15.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("10px + 5px");
+        EXPECT_THAT(result, IsNumeric(15.0, "px"));
     }
 
     {
-        Parser parser("10 - 5");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 5.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("10 - 5");
+        EXPECT_THAT(result, IsNumeric(5.0, ""));
     }
 
     {
-        Parser parser("10px - 5px");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 5.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("10px - 5px");
+        EXPECT_THAT(result, IsNumeric(5.0, "px"));
     }
 
     {
-        Parser parser("10 * 5");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 50.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("10 * 5");
+        EXPECT_THAT(result, IsNumeric(50.0, ""));
     }
 
     {
-        Parser parser("10px * 2");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 20.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("10px * 2");
+        EXPECT_THAT(result, IsNumeric(20.0, "px"));
     }
 
     {
-        Parser parser("10 / 2");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 5.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("10 / 2");
+        EXPECT_THAT(result, IsNumeric(5.0, ""));
     }
 
     {
-        Parser parser("10px / 2");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 5.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("10px / 2");
+        EXPECT_THAT(result, IsNumeric(5.0, "px"));
     }
 }
 
@@ -283,43 +203,23 @@ TEST_F(ParserTest, ParseArithmeticOperations)
 TEST_F(ParserTest, ParseComplexExpressions)
 {
     {
-        Parser parser("(10 + 5) * 2");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 30.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("(10 + 5) * 2");
+        EXPECT_THAT(result, IsNumeric(30.0, ""));
     }
 
     {
-        Parser parser("(10px + 5px) * 2");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 30.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("(10px + 5px) * 2");
+        EXPECT_THAT(result, IsNumeric(30.0, "px"));
     }
 
     {
-        Parser parser("@TestParam + 5px");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 15.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("@TestParam + 5px");
+        EXPECT_THAT(result, IsNumeric(15.0, "px"));
     }
 
     {
-        Parser parser("@TestParam * @TestNumber");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 50.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("@TestParam * @TestNumber");
+        EXPECT_THAT(result, IsNumeric(50.0, "px"));
     }
 }
 
@@ -327,33 +227,18 @@ TEST_F(ParserTest, ParseComplexExpressions)
 TEST_F(ParserTest, ParseUnaryOperations)
 {
     {
-        Parser parser("+10");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 10.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("+10");
+        EXPECT_THAT(result, IsNumeric(10.0, ""));
     }
 
     {
-        Parser parser("-10");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, -10.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("-10");
+        EXPECT_THAT(result, IsNumeric(-10.0, ""));
     }
 
     {
-        Parser parser("-10px");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, -10.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("-10px");
+        EXPECT_THAT(result, IsNumeric(-10.0, "px"));
     }
 }
 
@@ -361,9 +246,7 @@ TEST_F(ParserTest, ParseUnaryOperations)
 TEST_F(ParserTest, ParseFunctionCalls)
 {
     {
-        Parser parser("lighten(#ff0000, 20)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
+        auto result = evaluate("lighten(#ff0000, 20)");
         EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
         auto color = std::get<Base::Color>(result).asValue<QColor>();
         // The result should be lighter than the original red
@@ -371,9 +254,7 @@ TEST_F(ParserTest, ParseFunctionCalls)
     }
 
     {
-        Parser parser("darken(#ff0000, 20)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
+        auto result = evaluate("darken(#ff0000, 20)");
         EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
         auto color = std::get<Base::Color>(result).asValue<QColor>();
         // The result should be darker than the original red
@@ -381,9 +262,7 @@ TEST_F(ParserTest, ParseFunctionCalls)
     }
 
     {
-        Parser parser("lighten(@TestColor, 20)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
+        auto result = evaluate("lighten(@TestColor, 20)");
         EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
         auto color = std::get<Base::Color>(result).asValue<QColor>();
         // The result should be lighter than the original red
@@ -395,115 +274,49 @@ TEST_F(ParserTest, ParseFunctionCalls)
 TEST_F(ParserTest, ParseErrors)
 {
     // Invalid color format
-    EXPECT_THROW(
-        {
-            Parser parser("#invalid");
-            parser.parse();
-        },
-        Base::ParserError
-    );
+    EXPECT_THROW(parse("#invalid"), Base::ParserError);
 
     // Invalid RGB format
-    EXPECT_THROW(
-        {
-            Parser parser("rgb(invalid)");
-            parser.parse();
-        },
-        Base::ParserError
-    );
+    EXPECT_THROW(parse("rgb(invalid)"), Base::ParserError);
 
     // Missing closing parenthesis
-    EXPECT_THROW(
-        {
-            Parser parser("(10 + 5");
-            parser.parse();
-        },
-        Base::ParserError
-    );
+    EXPECT_THROW(parse("(10 + 5"), Base::ParserError);
 
     // Invalid function
-    EXPECT_THROW(
-        {
-            Parser parser("invalid()");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::ExpressionError
-    );
+    EXPECT_THROW({ evaluate("invalid()"); }, Base::ExpressionError);
 
     // Division by zero
-    EXPECT_THROW(
-        {
-            Parser parser("10 / 0");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::RuntimeError
-    );
+    EXPECT_THROW({ evaluate("10 / 0"); }, Base::RuntimeError);
 
     // Unit mismatch
-    EXPECT_THROW(
-        {
-            Parser parser("10px + 5em");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::RuntimeError
-    );
+    EXPECT_THROW({ evaluate("10px + 5em"); }, Base::RuntimeError);
 
     // Unary operation on color
-    EXPECT_THROW(
-        {
-            Parser parser("-@TestColor");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::ExpressionError
-    );
+    EXPECT_THROW({ evaluate("-@TestColor"); }, Base::ExpressionError);
 
     // Function with wrong number of arguments
-    EXPECT_THROW(
-        {
-            Parser parser("lighten(#ff0000)");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::ExpressionError
-    );
+    EXPECT_THROW({ evaluate("lighten(#ff0000)"); }, Base::ExpressionError);
+
+    // Function with wrong argument type
+    EXPECT_THROW({ evaluate("lighten(10px, 20)"); }, Base::ExpressionError);
 }
 
 // Test whitespace handling
 TEST_F(ParserTest, ParseWhitespace)
 {
     {
-        Parser parser("  10  +  5  ");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 15.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("  10  +  5  ");
+        EXPECT_THAT(result, IsNumeric(15.0, ""));
     }
 
     {
-        Parser parser("10px+5px");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 15.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("10px+5px");
+        EXPECT_THAT(result, IsNumeric(15.0, "px"));
     }
 
     {
-        Parser parser("rgb(255,0,0)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
-        auto color = std::get<Base::Color>(result);
-        EXPECT_EQ(color.r, 1);
-        EXPECT_EQ(color.g, 0);
-        EXPECT_EQ(color.b, 0);
+        auto result = evaluate("rgb(255,0,0)");
+        EXPECT_THAT(result, IsColor(Base::Color(1, 0, 0)));
     }
 }
 
@@ -511,55 +324,27 @@ TEST_F(ParserTest, ParseWhitespace)
 TEST_F(ParserTest, ParseEdgeCases)
 {
     // Empty input
-    EXPECT_THROW(
-        {
-            Parser parser("");
-            parser.parse();
-        },
-        Base::ParserError
-    );
+    EXPECT_THROW(parse(""), Base::ParserError);
 
     // Just whitespace
-    EXPECT_THROW(
-        {
-            Parser parser("   ");
-            parser.parse();
-        },
-        Base::ParserError
-    );
+    EXPECT_THROW(parse("   "), Base::ParserError);
 
     // Single number
     {
-        Parser parser("42");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 42.0);
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("42");
+        EXPECT_THAT(result, IsNumeric(42.0, ""));
     }
 
     // Single color
     {
-        Parser parser("#ff0000");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Base::Color>(result));
-        auto color = std::get<Base::Color>(result);
-        EXPECT_EQ(color.r, 1);
-        EXPECT_EQ(color.g, 0);
-        EXPECT_EQ(color.b, 0);
+        auto result = evaluate("#ff0000");
+        EXPECT_THAT(result, IsColor(Base::Color(1, 0, 0)));
     }
 
     // Single parameter reference
     {
-        Parser parser("@TestParam");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 10.0);
-        EXPECT_EQ(length.unit, "px");
+        auto result = evaluate("@TestParam");
+        EXPECT_THAT(result, IsNumeric(10.0, "px"));
     }
 }
 
@@ -567,168 +352,108 @@ TEST_F(ParserTest, ParseEdgeCases)
 TEST_F(ParserTest, ParseOperatorPrecedence)
 {
     {
-        Parser parser("2 + 3 * 4");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 14.0);  // 2 + (3 * 4) = 2 + 12 = 14
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("2 + 3 * 4");
+        EXPECT_THAT(result, IsNumeric(14.0, ""));  // 2 + (3 * 4) = 2 + 12 = 14
     }
 
     {
-        Parser parser("10 - 3 * 2");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 4.0);  // 10 - (3 * 2) = 10 - 6 = 4
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("10 - 3 * 2");
+        EXPECT_THAT(result, IsNumeric(4.0, ""));  // 10 - (3 * 2) = 10 - 6 = 4
     }
 
     {
-        Parser parser("20 / 4 + 3");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 8.0);  // (20 / 4) + 3 = 5 + 3 = 8
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("20 / 4 + 3");
+        EXPECT_THAT(result, IsNumeric(8.0, ""));  // (20 / 4) + 3 = 5 + 3 = 8
     }
 }
 
 // Test unnamed tuple
 TEST_F(ParserTest, ParseUnnamedTuple)
 {
-    Parser parser("(10, 20, 30)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(10, 20, 30)");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 3);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(tuple.at(0)).value, 10.0);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(tuple.at(1)).value, 20.0);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(tuple.at(2)).value, 30.0);
+    EXPECT_THAT(tuple, HasNumericElement(0, 10.0));
+    EXPECT_THAT(tuple, HasNumericElement(1, 20.0));
+    EXPECT_THAT(tuple, HasNumericElement(2, 30.0));
 }
 
 // Test named tuple
 TEST_F(ParserTest, ParseNamedTuple)
 {
-    Parser parser("(x: 10, y: 20)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(x: 10, y: 20)");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
 
-    auto* x = tuple.find("x");
-    ASSERT_NE(x, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*x).value, 10.0);
-
-    auto* y = tuple.find("y");
-    ASSERT_NE(y, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*y).value, 20.0);
+    EXPECT_THAT(tuple, HasNumericField("x", 10.0));
+    EXPECT_THAT(tuple, HasNumericField("y", 20.0));
 }
 
 // Test mixed named/unnamed tuple
 TEST_F(ParserTest, ParseMixedTuple)
 {
-    Parser parser("(x: 10, 20)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(x: 10, 20)");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
 
-    auto* x = tuple.find("x");
-    ASSERT_NE(x, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*x).value, 10.0);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(tuple.at(1)).value, 20.0);
+    EXPECT_THAT(tuple, HasNumericField("x", 10.0));
+    EXPECT_THAT(tuple, HasNumericElement(1, 20.0));
 }
 
 // Test named tuple with numeric-starting names (e.g. shade keys like 050, 100)
 TEST_F(ParserTest, ParseNamedTupleWithNumericNames)
 {
-    Parser parser("(050: 0.05, 100: 0.1)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(050: 0.05, 100: 0.1)");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
 
-    auto* shade050 = tuple.find("050");
-    ASSERT_NE(shade050, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*shade050).value, 0.05);
-
-    auto* shade100 = tuple.find("100");
-    ASSERT_NE(shade100, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*shade100).value, 0.1);
+    EXPECT_THAT(tuple, HasNumericField("050", 0.05));
+    EXPECT_THAT(tuple, HasNumericField("100", 0.1));
 }
 
 // Test single named element is a tuple, not a grouped expression
 TEST_F(ParserTest, ParseSingleNamedElementIsTuple)
 {
-    Parser parser("(x: 10)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(x: 10)");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 1);
 
-    auto* x = tuple.find("x");
-    ASSERT_NE(x, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*x).value, 10.0);
+    EXPECT_THAT(tuple, HasNumericField("x", 10.0));
 }
 
 // Test expressions inside tuple elements
 TEST_F(ParserTest, ParseTupleWithExpressions)
 {
-    Parser parser("(x: 10 + 5, y: @TestParam)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(x: 10 + 5, y: @TestParam)");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
 
-    auto* x = tuple.find("x");
-    ASSERT_NE(x, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*x).value, 15.0);
-
-    auto* y = tuple.find("y");
-    ASSERT_NE(y, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*y).value, 10.0);
-    EXPECT_EQ(std::get<Numeric>(*y).unit, "px");
+    EXPECT_THAT(tuple, HasNumericField("x", 15.0));
+    EXPECT_THAT(tuple, HasNumericField("y", 10.0, "px"));
 }
 
 // Test mixed types in tuple
 TEST_F(ParserTest, ParseTupleWithMixedTypes)
 {
-    Parser parser("(color: #ff0000, opacity: 0.5)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(color: #ff0000, opacity: 0.5)");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
 
-    auto* color = tuple.find("color");
-    ASSERT_NE(color, nullptr);
-    EXPECT_TRUE(std::holds_alternative<Base::Color>(*color));
-    auto c = std::get<Base::Color>(*color);
-    EXPECT_EQ(c.r, 1);
-    EXPECT_EQ(c.g, 0);
-    EXPECT_EQ(c.b, 0);
-
-    auto* opacity = tuple.find("opacity");
-    ASSERT_NE(opacity, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*opacity).value, 0.5);
+    EXPECT_THAT(tuple, HasField("color", IsColor(Base::Color(1, 0, 0))));
+    EXPECT_THAT(tuple, HasNumericField("opacity", 0.5));
 }
 
 // Test nested tuples
 TEST_F(ParserTest, ParseNestedTuples)
 {
-    Parser parser("((1, 2), (3, 4))");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("((1, 2), (3, 4))");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& outer = result.get<Tuple>();
     EXPECT_EQ(outer.size(), 2);
@@ -736,22 +461,20 @@ TEST_F(ParserTest, ParseNestedTuples)
     EXPECT_TRUE(outer.at(0).holds<Tuple>());
     const auto& inner1 = outer.at(0).get<Tuple>();
     EXPECT_EQ(inner1.size(), 2);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(inner1.at(0)).value, 1.0);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(inner1.at(1)).value, 2.0);
+    EXPECT_THAT(inner1, HasNumericElement(0, 1.0));
+    EXPECT_THAT(inner1, HasNumericElement(1, 2.0));
 
     EXPECT_TRUE(outer.at(1).holds<Tuple>());
     const auto& inner2 = outer.at(1).get<Tuple>();
     EXPECT_EQ(inner2.size(), 2);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(inner2.at(0)).value, 3.0);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(inner2.at(1)).value, 4.0);
+    EXPECT_THAT(inner2, HasNumericElement(0, 3.0));
+    EXPECT_THAT(inner2, HasNumericElement(1, 4.0));
 }
 
 // Test complex expressions in tuple elements
 TEST_F(ParserTest, ParseTupleWithComplexExpressions)
 {
-    Parser parser("(x: lighten(#ff0000, 20), y: 10px * 2)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(x: lighten(#ff0000, 20), y: 10px * 2)");
     EXPECT_TRUE(result.holds<Tuple>());
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
@@ -760,35 +483,26 @@ TEST_F(ParserTest, ParseTupleWithComplexExpressions)
     ASSERT_NE(x, nullptr);
     EXPECT_TRUE(std::holds_alternative<Base::Color>(*x));
 
-    auto* y = tuple.find("y");
-    ASSERT_NE(y, nullptr);
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(*y).value, 20.0);
-    EXPECT_EQ(std::get<Numeric>(*y).unit, "px");
+    EXPECT_THAT(tuple, HasNumericField("y", 20.0, "px"));
 }
 
 // Test tuple toString roundtrip
 TEST_F(ParserTest, TupleToString)
 {
     {
-        Parser parser("(x: 10, y: 20)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
+        auto result = evaluate("(x: 10, y: 20)");
         auto str = result.toString();
         EXPECT_EQ(str, "(x: 10, y: 20)");
     }
 
     {
-        Parser parser("(10, 20, 30)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
+        auto result = evaluate("(10, 20, 30)");
         auto str = result.toString();
         EXPECT_EQ(str, "(10, 20, 30)");
     }
 
     {
-        Parser parser("(x: 10, 20)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
+        auto result = evaluate("(x: 10, 20)");
         auto str = result.toString();
         EXPECT_EQ(str, "(x: 10, 20)");
     }
@@ -810,9 +524,7 @@ TEST_F(ParserTest, ValueHoldsAndGet)
     EXPECT_TRUE(stringValue.holds<std::string>());
     EXPECT_FALSE(stringValue.holds<Tuple>());
 
-    Parser parser("(1, 2)");
-    auto expr = parser.parse();
-    auto tupleValue = expr->evaluate({.manager = &manager, .context = {}});
+    auto tupleValue = evaluate("(1, 2)");
     EXPECT_TRUE(tupleValue.holds<Tuple>());
     EXPECT_FALSE(tupleValue.holds<Numeric>());
     EXPECT_EQ(tupleValue.get<Tuple>().size(), 2);
@@ -821,9 +533,7 @@ TEST_F(ParserTest, ValueHoldsAndGet)
 // Test Tuple::at out of bounds
 TEST_F(ParserTest, TupleAtOutOfBounds)
 {
-    Parser parser("(10, 20)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(10, 20)");
     const auto& tuple = result.get<Tuple>();
 
     EXPECT_NO_THROW(tuple.at(0));
@@ -835,9 +545,7 @@ TEST_F(ParserTest, TupleAtOutOfBounds)
 // Test Tuple::find nonexistent name
 TEST_F(ParserTest, TupleFindNonexistent)
 {
-    Parser parser("(x: 10, y: 20)");
-    auto expr = parser.parse();
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
+    auto result = evaluate("(x: 10, y: 20)");
     const auto& tuple = result.get<Tuple>();
 
     EXPECT_NE(tuple.find("x"), nullptr);
@@ -848,34 +556,22 @@ TEST_F(ParserTest, TupleFindNonexistent)
 // Test error: missing ')' in tuple
 TEST_F(ParserTest, TupleMissingClosingParen)
 {
-    EXPECT_THROW(
-        {
-            Parser parser("(x: 10, y: 20");
-            parser.parse();
-        },
-        Base::ParserError
-    );
+    EXPECT_THROW(parse("(x: 10, y: 20"), Base::ParserError);
 }
 
 // Test that grouped expressions still work (backward compatibility)
 TEST_F(ParserTest, GroupedExpressionStillWorks)
 {
     {
-        Parser parser("(10 + 5) * 2");
-        auto expr = parser.parse();
+        auto result = evaluate("(10 + 5) * 2");
 
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        EXPECT_DOUBLE_EQ(std::get<Numeric>(result).value, 30.0);
+        EXPECT_THAT(result, IsNumeric(30.0));
     }
 
     {
-        Parser parser("(42)");
-        auto expr = parser.parse();
+        auto result = evaluate("(42)");
 
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        EXPECT_DOUBLE_EQ(std::get<Numeric>(result).value, 42.0);
+        EXPECT_THAT(result, IsNumeric(42.0));
     }
 }
 
@@ -883,23 +579,13 @@ TEST_F(ParserTest, GroupedExpressionStillWorks)
 TEST_F(ParserTest, ParseNestedParentheses)
 {
     {
-        Parser parser("((2 + 3) * 4)");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 20.0);  // (5) * 4 = 20
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("((2 + 3) * 4)");
+        EXPECT_THAT(result, IsNumeric(20.0, ""));  // (5) * 4 = 20
     }
 
     {
-        Parser parser("(10 - (3 + 2)) * 2");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 10.0);  // (10 - 5) * 2 = 5 * 2 = 10
-        EXPECT_EQ(length.unit, "");
+        auto result = evaluate("(10 - (3 + 2)) * 2");
+        EXPECT_THAT(result, IsNumeric(10.0, ""));  // (10 - 5) * 2 = 5 * 2 = 10
     }
 }
 
@@ -907,27 +593,15 @@ TEST_F(ParserTest, ParseNestedParentheses)
 TEST_F(ParserTest, MemberAccessNamed)
 {
     {
-        Parser parser("@TestTupleParam.left");
-        auto expr = parser.parse();
+        auto result = evaluate("@TestTupleParam.left");
 
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 1.0);
-        EXPECT_EQ(length.unit, "px");
+        EXPECT_THAT(result, IsNumeric(1.0, "px"));
     }
 
     {
-        Parser parser("@TestTupleParam.right");
-        auto expr = parser.parse();
+        auto result = evaluate("@TestTupleParam.right");
 
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-
-        auto length = std::get<Numeric>(result);
-        EXPECT_DOUBLE_EQ(length.value, 2.0);
-        EXPECT_EQ(length.unit, "px");
+        EXPECT_THAT(result, IsNumeric(2.0, "px"));
     }
 }
 
@@ -935,21 +609,15 @@ TEST_F(ParserTest, MemberAccessNamed)
 TEST_F(ParserTest, MemberAccessIndexed)
 {
     {
-        Parser parser("@TestIndexedTuple.0");
-        auto expr = parser.parse();
+        auto result = evaluate("@TestIndexedTuple.0");
 
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        EXPECT_DOUBLE_EQ(std::get<Numeric>(result).value, 10.0);
+        EXPECT_THAT(result, IsNumeric(10.0));
     }
 
     {
-        Parser parser("@TestIndexedTuple.2");
-        auto expr = parser.parse();
+        auto result = evaluate("@TestIndexedTuple.2");
 
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        EXPECT_DOUBLE_EQ(std::get<Numeric>(result).value, 30.0);
+        EXPECT_THAT(result, IsNumeric(30.0));
     }
 }
 
@@ -957,297 +625,242 @@ TEST_F(ParserTest, MemberAccessIndexed)
 TEST_F(ParserTest, MemberAccessInlineTuple)
 {
     {
-        Parser parser("(x: 10, y: 20).x");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        EXPECT_DOUBLE_EQ(std::get<Numeric>(result).value, 10.0);
+        auto result = evaluate("(x: 10, y: 20).x");
+        EXPECT_THAT(result, IsNumeric(10.0));
     }
 
     {
-        Parser parser("(10, 20, 30).1");
-        auto expr = parser.parse();
-        auto result = expr->evaluate({.manager = &manager, .context = {}});
-        EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-        EXPECT_DOUBLE_EQ(std::get<Numeric>(result).value, 20.0);
+        auto result = evaluate("(10, 20, 30).1");
+        EXPECT_THAT(result, IsNumeric(20.0));
     }
 }
 
 // Test member access in arithmetic expressions
 TEST_F(ParserTest, MemberAccessInArithmetic)
 {
-    Parser parser("@TestTupleParam.left + @TestTupleParam.right");
-    auto expr = parser.parse();
+    auto result = evaluate("@TestTupleParam.left + @TestTupleParam.right");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
-    EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-
-    auto length = std::get<Numeric>(result);
-    EXPECT_DOUBLE_EQ(length.value, 3.0);
-    EXPECT_EQ(length.unit, "px");
+    EXPECT_THAT(result, IsNumeric(3.0, "px"));
 }
 
 // Test chained member access on nested tuples
 TEST_F(ParserTest, MemberAccessChained)
 {
-    Parser parser("@TestNestedTuple.0.x");
-    auto expr = parser.parse();
+    auto result = evaluate("@TestNestedTuple.0.x");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
-    EXPECT_TRUE(std::holds_alternative<Numeric>(result));
-    EXPECT_DOUBLE_EQ(std::get<Numeric>(result).value, 1.0);
+    EXPECT_THAT(result, IsNumeric(1.0));
 }
 
 // Test member access error cases
 TEST_F(ParserTest, MemberAccessErrors)
 {
     // Named member not found
-    EXPECT_THROW(
-        {
-            Parser parser("@TestTupleParam.nonexistent");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::ExpressionError
-    );
+    EXPECT_THROW({ evaluate("@TestTupleParam.nonexistent"); }, Base::ExpressionError);
+
+    // Index out of bounds
+    EXPECT_THROW({ evaluate("@TestIndexedTuple.5"); }, Base::ExpressionError);
 
     // Member access on non-tuple
-    EXPECT_THROW(
-        {
-            Parser parser("@TestNumber.foo");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::ExpressionError
-    );
+    EXPECT_THROW({ evaluate("@TestNumber.foo"); }, Base::ExpressionError);
 }
 
 // Tuple arithmetic tests
 
 TEST_F(ParserTest, TupleElementWiseAdd)
 {
-    Parser parser("(1px, 2px) + (3px, 4px)");
-    auto expr = parser.parse();
+    auto result = evaluate("(1px, 2px) + (3px, 4px)");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 4.0);
-    EXPECT_EQ(tuple.at(0).get<Numeric>().unit, "px");
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 6.0);
-    EXPECT_EQ(tuple.at(1).get<Numeric>().unit, "px");
+    EXPECT_THAT(tuple, HasNumericElement(0, 4.0, "px"));
+    EXPECT_THAT(tuple, HasNumericElement(1, 6.0, "px"));
 }
 
 TEST_F(ParserTest, TupleElementWiseSubtract)
 {
-    Parser parser("(10, 20) - (3, 7)");
-    auto expr = parser.parse();
+    auto result = evaluate("(10, 20) - (3, 7)");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 7.0);
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 13.0);
+    EXPECT_THAT(tuple, HasNumericElement(0, 7.0));
+    EXPECT_THAT(tuple, HasNumericElement(1, 13.0));
 }
 
 TEST_F(ParserTest, TupleScalarMultiplyTupleFirst)
 {
-    Parser parser("(1px, 2px, 3px) * 2");
-    auto expr = parser.parse();
+    auto result = evaluate("(1px, 2px, 3px) * 2");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 3);
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 2.0);
-    EXPECT_EQ(tuple.at(0).get<Numeric>().unit, "px");
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 4.0);
-    EXPECT_DOUBLE_EQ(tuple.at(2).get<Numeric>().value, 6.0);
+    EXPECT_THAT(tuple, HasNumericElement(0, 2.0, "px"));
+    EXPECT_THAT(tuple, HasNumericElement(1, 4.0));
+    EXPECT_THAT(tuple, HasNumericElement(2, 6.0));
 }
 
 TEST_F(ParserTest, TupleScalarMultiplyScalarFirst)
 {
-    Parser parser("2 * (1px, 2px, 3px)");
-    auto expr = parser.parse();
+    auto result = evaluate("2 * (1px, 2px, 3px)");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 3);
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 2.0);
-    EXPECT_EQ(tuple.at(0).get<Numeric>().unit, "px");
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 4.0);
-    EXPECT_DOUBLE_EQ(tuple.at(2).get<Numeric>().value, 6.0);
+    EXPECT_THAT(tuple, HasNumericElement(0, 2.0, "px"));
+    EXPECT_THAT(tuple, HasNumericElement(1, 4.0));
+    EXPECT_THAT(tuple, HasNumericElement(2, 6.0));
 }
 
-TEST_F(ParserTest, TupleScalarDivide)
+TEST_F(ParserTest, TupleScalarMultiplyUnitOnScalar)
 {
-    Parser parser("(10, 20) / 2");
-    auto expr = parser.parse();
+    auto result = evaluate("4px * (1, 2, 3, 4)");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
-    EXPECT_TRUE(result.holds<Tuple>());
-
-    const auto& tuple = result.get<Tuple>();
-    EXPECT_EQ(tuple.size(), 2);
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 5.0);
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 10.0);
-}
-
-TEST_F(ParserTest, TupleUnaryNegate)
-{
-    Parser parser("-(1px, 2px)");
-    auto expr = parser.parse();
-
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
-    EXPECT_TRUE(result.holds<Tuple>());
-
-    const auto& tuple = result.get<Tuple>();
-    EXPECT_EQ(tuple.size(), 2);
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, -1.0);
-    EXPECT_EQ(tuple.at(0).get<Numeric>().unit, "px");
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, -2.0);
-    EXPECT_EQ(tuple.at(1).get<Numeric>().unit, "px");
-}
-
-TEST_F(ParserTest, TupleAddPreservesNames)
-{
-    Parser parser("(x: 1, y: 2) + (x: 3, y: 4)");
-    auto expr = parser.parse();
-
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
-    EXPECT_TRUE(result.holds<Tuple>());
-
-    const auto& tuple = result.get<Tuple>();
-    EXPECT_EQ(tuple.size(), 2);
-
-    auto* x = tuple.find("x");
-    ASSERT_NE(x, nullptr);
-    EXPECT_DOUBLE_EQ(x->get<Numeric>().value, 4.0);
-
-    auto* y = tuple.find("y");
-    ASSERT_NE(y, nullptr);
-    EXPECT_DOUBLE_EQ(y->get<Numeric>().value, 6.0);
-}
-
-TEST_F(ParserTest, TupleAddMatchesByName)
-{
-    Parser parser("(x: 10, y: 20) + (y: 30, x: 5)");
-    auto expr = parser.parse();
-
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
-    EXPECT_TRUE(result.holds<Tuple>());
-
-    const auto& tuple = result.get<Tuple>();
-    EXPECT_EQ(tuple.size(), 2);
-
-    auto* x = tuple.find("x");
-    ASSERT_NE(x, nullptr);
-    EXPECT_DOUBLE_EQ(x->get<Numeric>().value, 15.0);
-
-    auto* y = tuple.find("y");
-    ASSERT_NE(y, nullptr);
-    EXPECT_DOUBLE_EQ(y->get<Numeric>().value, 50.0);
-}
-
-TEST_F(ParserTest, TupleParamArithmetic)
-{
-    Parser parser("@TestTupleParam + @TestTupleParam");
-    auto expr = parser.parse();
-
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 4);
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 2.0);
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 4.0);
-    EXPECT_DOUBLE_EQ(tuple.at(2).get<Numeric>().value, 6.0);
-    EXPECT_DOUBLE_EQ(tuple.at(3).get<Numeric>().value, 8.0);
+    EXPECT_THAT(tuple, HasNumericElement(0, 4.0, "px"));
+    EXPECT_THAT(tuple, HasNumericElement(1, 8.0, "px"));
+    EXPECT_THAT(tuple, HasNumericElement(2, 12.0, "px"));
+    EXPECT_THAT(tuple, HasNumericElement(3, 16.0, "px"));
+}
+
+TEST_F(ParserTest, TupleScalarDivideUnitOnTuple)
+{
+    auto result = evaluate("(10px, 20px) / 2");
+
+    EXPECT_TRUE(result.holds<Tuple>());
+
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 2);
+    EXPECT_THAT(tuple, HasNumericElement(0, 5.0, "px"));
+    EXPECT_THAT(tuple, HasNumericElement(1, 10.0, "px"));
+}
+
+TEST_F(ParserTest, TupleScalarDivide)
+{
+    auto result = evaluate("(10, 20) / 2");
+
+    EXPECT_TRUE(result.holds<Tuple>());
+
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 2);
+    EXPECT_THAT(tuple, HasNumericElement(0, 5.0));
+    EXPECT_THAT(tuple, HasNumericElement(1, 10.0));
+}
+
+TEST_F(ParserTest, TupleUnaryNegate)
+{
+    auto result = evaluate("-(1px, 2px)");
+
+    EXPECT_TRUE(result.holds<Tuple>());
+
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 2);
+    EXPECT_THAT(tuple, HasNumericElement(0, -1.0, "px"));
+    EXPECT_THAT(tuple, HasNumericElement(1, -2.0, "px"));
+}
+
+TEST_F(ParserTest, TupleAddPreservesNames)
+{
+    auto result = evaluate("(x: 1, y: 2) + (x: 3, y: 4)");
+
+    EXPECT_TRUE(result.holds<Tuple>());
+
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 2);
+
+    EXPECT_THAT(tuple, HasNumericField("x", 4.0));
+    EXPECT_THAT(tuple, HasNumericField("y", 6.0));
+}
+
+TEST_F(ParserTest, TupleAddMatchesByName)
+{
+    auto result = evaluate("(x: 10, y: 20) + (y: 30, x: 5)");
+
+    EXPECT_TRUE(result.holds<Tuple>());
+
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 2);
+
+    EXPECT_THAT(tuple, HasNumericField("x", 15.0));
+    EXPECT_THAT(tuple, HasNumericField("y", 50.0));
+}
+
+TEST_F(ParserTest, TupleParamArithmetic)
+{
+    auto result = evaluate("@TestTupleParam + @TestTupleParam");
+
+    EXPECT_TRUE(result.holds<Tuple>());
+
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 4);
+    EXPECT_THAT(tuple, HasNumericElement(0, 2.0));
+    EXPECT_THAT(tuple, HasNumericElement(1, 4.0));
+    EXPECT_THAT(tuple, HasNumericElement(2, 6.0));
+    EXPECT_THAT(tuple, HasNumericElement(3, 8.0));
 }
 
 TEST_F(ParserTest, TupleUnionMixedNamedUnnamed)
 {
     // (x: 5, 10) + (y: 10, 5, 20) → (x: 5, y: 10, 15, 20)
-    Parser parser("(x: 5, 10) + (y: 10, 5, 20)");
-    auto expr = parser.parse();
+    auto result = evaluate("(x: 5, 10) + (y: 10, 5, 20)");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 4);
 
-    auto* x = tuple.find("x");
-    ASSERT_NE(x, nullptr);
-    EXPECT_DOUBLE_EQ(x->get<Numeric>().value, 5.0);
-
-    auto* y = tuple.find("y");
-    ASSERT_NE(y, nullptr);
-    EXPECT_DOUBLE_EQ(y->get<Numeric>().value, 10.0);
-
-    EXPECT_DOUBLE_EQ(tuple.at(2).get<Numeric>().value, 15.0);
-    EXPECT_DOUBLE_EQ(tuple.at(3).get<Numeric>().value, 20.0);
+    EXPECT_THAT(tuple, HasNumericField("x", 5.0));
+    EXPECT_THAT(tuple, HasNumericField("y", 10.0));
+    EXPECT_THAT(tuple, HasNumericElement(2, 15.0));
+    EXPECT_THAT(tuple, HasNumericElement(3, 20.0));
 }
 
 TEST_F(ParserTest, TupleUnionNamedDifferentSizes)
 {
     // (x: 1, y: 2) + (x: 3, y: 4, z: 5) → (x: 4, y: 6, z: 5)
-    Parser parser("(x: 1, y: 2) + (x: 3, y: 4, z: 5)");
-    auto expr = parser.parse();
+    auto result = evaluate("(x: 1, y: 2) + (x: 3, y: 4, z: 5)");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 3);
 
-    EXPECT_DOUBLE_EQ(tuple.find("x")->get<Numeric>().value, 4.0);
-    EXPECT_DOUBLE_EQ(tuple.find("y")->get<Numeric>().value, 6.0);
-    EXPECT_DOUBLE_EQ(tuple.find("z")->get<Numeric>().value, 5.0);
+    EXPECT_THAT(tuple, HasNumericField("x", 4.0));
+    EXPECT_THAT(tuple, HasNumericField("y", 6.0));
+    EXPECT_THAT(tuple, HasNumericField("z", 5.0));
 }
 
 TEST_F(ParserTest, TupleUnionUnnamedDifferentSizes)
 {
     // (1, 2) + (3, 4, 5) → (4, 6, 5)
-    Parser parser("(1, 2) + (3, 4, 5)");
-    auto expr = parser.parse();
+    auto result = evaluate("(1, 2) + (3, 4, 5)");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& tuple = result.get<Tuple>();
     EXPECT_EQ(tuple.size(), 3);
 
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 4.0);
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 6.0);
-    EXPECT_DOUBLE_EQ(tuple.at(2).get<Numeric>().value, 5.0);
+    EXPECT_THAT(tuple, HasNumericElement(0, 4.0));
+    EXPECT_THAT(tuple, HasNumericElement(1, 6.0));
+    EXPECT_THAT(tuple, HasNumericElement(2, 5.0));
 }
 
 TEST_F(ParserTest, TupleAddNumericError)
 {
-    EXPECT_THROW(
-        {
-            Parser parser("(1, 2) + 5");
-            auto expr = parser.parse();
-            expr->evaluate({.manager = &manager, .context = {}});
-        },
-        Base::ExpressionError
-    );
+    EXPECT_THROW({ evaluate("(1, 2) + 5"); }, Base::ExpressionError);
 }
 
 TEST_F(ParserTest, TupleNestedScalarMultiply)
 {
-    Parser parser("((1, 2), (3, 4)) * 2");
-    auto expr = parser.parse();
+    auto result = evaluate("((1, 2), (3, 4)) * 2");
 
-    auto result = expr->evaluate({.manager = &manager, .context = {}});
     EXPECT_TRUE(result.holds<Tuple>());
 
     const auto& outer = result.get<Tuple>();
@@ -1255,160 +868,143 @@ TEST_F(ParserTest, TupleNestedScalarMultiply)
 
     EXPECT_TRUE(outer.at(0).holds<Tuple>());
     const auto& inner1 = outer.at(0).get<Tuple>();
-    EXPECT_DOUBLE_EQ(inner1.at(0).get<Numeric>().value, 2.0);
-    EXPECT_DOUBLE_EQ(inner1.at(1).get<Numeric>().value, 4.0);
+    EXPECT_THAT(inner1, HasNumericElement(0, 2.0));
+    EXPECT_THAT(inner1, HasNumericElement(1, 4.0));
 
     EXPECT_TRUE(outer.at(1).holds<Tuple>());
     const auto& inner2 = outer.at(1).get<Tuple>();
-    EXPECT_DOUBLE_EQ(inner2.at(0).get<Numeric>().value, 6.0);
-    EXPECT_DOUBLE_EQ(inner2.at(1).get<Numeric>().value, 8.0);
+    EXPECT_THAT(inner2, HasNumericElement(0, 6.0));
+    EXPECT_THAT(inner2, HasNumericElement(1, 8.0));
 }
 
 // ArgumentParser tests
 
 class ArgumentParserTest: public ::testing::Test
 {
-    struct NameValuePair
-    {
-        std::optional<std::string> name;
-        Value value;
-    };
-
-protected:
-    static Tuple makeTuple(std::vector<NameValuePair> elements)
-    {
-        Tuple tuple;
-        for (auto& [name, value] : elements) {
-            tuple.elements.emplace_back(name, std::make_shared<const Value>(std::move(value)));
-        }
-        return tuple;
-    }
 };
 
 TEST_F(ArgumentParserTest, AllPositional)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 2, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
-    ASSERT_NE(resolved.find("x"), nullptr);
-    ASSERT_NE(resolved.find("y"), nullptr);
-    EXPECT_DOUBLE_EQ(resolved.find("x")->get<Numeric>().value, 1.0);
-    EXPECT_DOUBLE_EQ(resolved.find("y")->get<Numeric>().value, 2.0);
+    EXPECT_THAT(resolved, HasNumericField("x", 1.0));
+    EXPECT_THAT(resolved, HasNumericField("y", 2.0));
 }
 
 TEST_F(ArgumentParserTest, AllNamed)
 {
-    auto args = makeTuple({
-        {.name = std::string("x"), .value = Numeric {.value = 10, .unit = ""}},
-        {.name = std::string("y"), .value = Numeric {.value = 20, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("x", Numeric {.value = 10, .unit = ""}),
+        Tuple::Element::named("y", Numeric {.value = 20, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
-    EXPECT_DOUBLE_EQ(resolved.find("x")->get<Numeric>().value, 10.0);
-    EXPECT_DOUBLE_EQ(resolved.find("y")->get<Numeric>().value, 20.0);
+    EXPECT_THAT(resolved, HasNumericField("x", 10.0));
+    EXPECT_THAT(resolved, HasNumericField("y", 20.0));
 }
 
 TEST_F(ArgumentParserTest, AllNamedReversedOrder)
 {
-    auto args = makeTuple({
-        {.name = std::string("y"), .value = Numeric {.value = 20, .unit = ""}},
-        {.name = std::string("x"), .value = Numeric {.value = 10, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("y", Numeric {.value = 20, .unit = ""}),
+        Tuple::Element::named("x", Numeric {.value = 10, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
-    EXPECT_DOUBLE_EQ(resolved.find("x")->get<Numeric>().value, 10.0);
-    EXPECT_DOUBLE_EQ(resolved.find("y")->get<Numeric>().value, 20.0);
+    EXPECT_THAT(resolved, HasNumericField("x", 10.0));
+    EXPECT_THAT(resolved, HasNumericField("y", 20.0));
 }
 
 TEST_F(ArgumentParserTest, MixedPositionalThenNamed)
 {
     // f(1, y: 2) with signature (x, y)
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::string("y"), .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::named("y", Numeric {.value = 2, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
-    EXPECT_DOUBLE_EQ(resolved.find("x")->get<Numeric>().value, 1.0);
-    EXPECT_DOUBLE_EQ(resolved.find("y")->get<Numeric>().value, 2.0);
+    EXPECT_THAT(resolved, HasNumericField("x", 1.0));
+    EXPECT_THAT(resolved, HasNumericField("y", 2.0));
 }
 
 TEST_F(ArgumentParserTest, NamedThenPositionalFillsRemainingSlot)
 {
     // f(y: 2, 1) with signature (x, y) — positional 1 fills unclaimed x
-    auto args = makeTuple({
-        {.name = std::string("y"), .value = Numeric {.value = 2, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("y", Numeric {.value = 2, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
-    EXPECT_DOUBLE_EQ(resolved.find("x")->get<Numeric>().value, 1.0);
-    EXPECT_DOUBLE_EQ(resolved.find("y")->get<Numeric>().value, 2.0);
+    EXPECT_THAT(resolved, HasNumericField("x", 1.0));
+    EXPECT_THAT(resolved, HasNumericField("y", 2.0));
 }
 
 TEST_F(ArgumentParserTest, DefaultValueUsedWhenMissing)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
     });
     auto resolved = ArgumentParser {
         {.name = "x"},
         {.name = "y", .defaultValue = Numeric {.value = 99, .unit = ""}}
     }.resolve(args);
 
-    EXPECT_DOUBLE_EQ(resolved.find("x")->get<Numeric>().value, 1.0);
-    EXPECT_DOUBLE_EQ(resolved.find("y")->get<Numeric>().value, 99.0);
+    EXPECT_THAT(resolved, HasNumericField("x", 1.0));
+    EXPECT_THAT(resolved, HasNumericField("y", 99.0));
 }
 
 TEST_F(ArgumentParserTest, DefaultValueOverriddenByPositional)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 2, .unit = ""}),
     });
     auto resolved = ArgumentParser {
         {.name = "x"},
         {.name = "y", .defaultValue = Numeric {.value = 99, .unit = ""}}
     }.resolve(args);
 
-    EXPECT_DOUBLE_EQ(resolved.find("y")->get<Numeric>().value, 2.0);
+    EXPECT_THAT(resolved, HasNumericField("y", 2.0));
 }
 
 TEST_F(ArgumentParserTest, DefaultValueOverriddenByName)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::string("y"), .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::named("y", Numeric {.value = 2, .unit = ""}),
     });
     auto resolved = ArgumentParser {
         {.name = "x"},
         {.name = "y", .defaultValue = Numeric {.value = 99, .unit = ""}}
     }.resolve(args);
 
-    EXPECT_DOUBLE_EQ(resolved.find("y")->get<Numeric>().value, 2.0);
+    EXPECT_THAT(resolved, HasNumericField("y", 2.0));
 }
 
 TEST_F(ArgumentParserTest, ResolvedTupleHasCorrectOrder)
 {
-    auto args = makeTuple({
-        {.name = std::string("y"), .value = Numeric {.value = 2, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("y", Numeric {.value = 2, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "x"}, {.name = "y"}}.resolve(args);
 
     // at(0) is x, at(1) is y — matches declaration order
-    EXPECT_DOUBLE_EQ(resolved.at(0).get<Numeric>().value, 1.0);
-    EXPECT_DOUBLE_EQ(resolved.at(1).get<Numeric>().value, 2.0);
+    EXPECT_THAT(resolved, HasNumericElement(0, 1.0));
+    EXPECT_THAT(resolved, HasNumericElement(1, 2.0));
 }
 
 TEST_F(ArgumentParserTest, MixedTypes)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Base::Color(1.0, 0.0, 0.0)},
-        {.name = std::nullopt, .value = Numeric {.value = 20, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Base::Color(1.0, 0.0, 0.0)),
+        Tuple::Element::unnamed(Numeric {.value = 20, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "color"}, {.name = "amount"}}.resolve(args);
 
@@ -1418,8 +1014,8 @@ TEST_F(ArgumentParserTest, MixedTypes)
 
 TEST_F(ArgumentParserTest, ErrorOnUnknownName)
 {
-    auto args = makeTuple({
-        {.name = std::string("unknown"), .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("unknown", Numeric {.value = 1, .unit = ""}),
     });
     ArgumentParser parser {{"x"}, {"y"}};
     EXPECT_THROW(parser.resolve(args), Base::ExpressionError);
@@ -1427,9 +1023,9 @@ TEST_F(ArgumentParserTest, ErrorOnUnknownName)
 
 TEST_F(ArgumentParserTest, ErrorOnDuplicateName)
 {
-    auto args = makeTuple({
-        {.name = std::string("x"), .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::string("x"), .value = Numeric {.value = 2, .unit = ""}},
+    Tuple args({
+        Tuple::Element::named("x", Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::named("x", Numeric {.value = 2, .unit = ""}),
     });
     ArgumentParser parser {{"x"}, {"y"}};
     EXPECT_THROW(parser.resolve(args), Base::ExpressionError);
@@ -1437,8 +1033,8 @@ TEST_F(ArgumentParserTest, ErrorOnDuplicateName)
 
 TEST_F(ArgumentParserTest, ErrorOnMissingRequired)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
     });
     ArgumentParser parser {{"x"}, {"y"}};
     EXPECT_THROW(parser.resolve(args), Base::ExpressionError);
@@ -1446,10 +1042,10 @@ TEST_F(ArgumentParserTest, ErrorOnMissingRequired)
 
 TEST_F(ArgumentParserTest, ErrorOnExcessPositional)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 1, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 2, .unit = ""}},
-        {.name = std::nullopt, .value = Numeric {.value = 3, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 1, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 2, .unit = ""}),
+        Tuple::Element::unnamed(Numeric {.value = 3, .unit = ""}),
     });
     ArgumentParser parser {{"x"}, {"y"}};
     EXPECT_THROW(parser.resolve(args), Base::ExpressionError);
@@ -1457,22 +1053,22 @@ TEST_F(ArgumentParserTest, ErrorOnExcessPositional)
 
 TEST_F(ArgumentParserTest, TypedGetSuccess)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Base::Color(1.0, 0.0, 0.0)},
-        {.name = std::nullopt, .value = Numeric {.value = 20, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Base::Color(1.0, 0.0, 0.0)),
+        Tuple::Element::unnamed(Numeric {.value = 20, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "color"}, {.name = "amount"}}.resolve(args);
 
     EXPECT_NO_THROW(resolved.get<Base::Color>("color"));
     EXPECT_NO_THROW(resolved.get<Numeric>("amount"));
-    EXPECT_DOUBLE_EQ(resolved.get<Numeric>("amount").value, 20.0);
+    EXPECT_THAT(resolved, HasNumericField("amount", 20.0));
 }
 
 TEST_F(ArgumentParserTest, TypedGetWrongType)
 {
-    auto args = makeTuple({
-        {.name = std::nullopt, .value = Numeric {.value = 10, .unit = "px"}},
-        {.name = std::nullopt, .value = Numeric {.value = 20, .unit = ""}},
+    Tuple args({
+        Tuple::Element::unnamed(Numeric {.value = 10, .unit = "px"}),
+        Tuple::Element::unnamed(Numeric {.value = 20, .unit = ""}),
     });
     auto resolved = ArgumentParser {{.name = "color"}, {.name = "amount"}}.resolve(args);
 
@@ -1482,9 +1078,1047 @@ TEST_F(ArgumentParserTest, TypedGetWrongType)
 
 TEST_F(ArgumentParserTest, TypedGetMissingName)
 {
-    auto args = makeTuple({{.name = std::nullopt, .value = Numeric {.value = 10, .unit = ""}}});
+    Tuple args({Tuple::Element::unnamed(Numeric {.value = 10, .unit = ""})});
     auto resolved = ArgumentParser {{.name = "x"}}.resolve(args);
 
     EXPECT_EQ(resolved.tryGet<Numeric>("nonexistent"), nullptr);
     EXPECT_DOUBLE_EQ(resolved.get<Numeric>("nonexistent").value, 0.0);
+}
+
+// Insets / shorthand constructor tests
+
+TEST_F(ParserTest, PaddingShorthand1Arg)
+{
+    auto result = evaluate("padding(10px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_EQ(tuple.size(), 4);
+    EXPECT_THAT(tuple, HasSides(10.0, 10.0, 10.0, 10.0));
+}
+
+TEST_F(ParserTest, PaddingShorthand2Args)
+{
+    auto result = evaluate("padding(10px, 5px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_THAT(tuple, HasSides(10.0, 5.0, 10.0, 5.0));
+}
+
+TEST_F(ParserTest, PaddingShorthand3Args)
+{
+    auto result = evaluate("padding(10px, 5px, 20px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_THAT(tuple, HasSides(10.0, 5.0, 20.0, 5.0));
+}
+
+TEST_F(ParserTest, PaddingShorthand4Args)
+{
+    auto result = evaluate("padding(10px, 5px, 20px, 15px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_THAT(tuple, HasSides(10.0, 5.0, 20.0, 15.0));
+}
+
+TEST_F(ParserTest, PaddingNamedVerticalHorizontal)
+{
+    auto result = evaluate("padding(vertical: 10px, horizontal: 5px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasSides(10.0, 5.0, 10.0, 5.0));
+}
+
+TEST_F(ParserTest, PaddingNamedExplicitSides)
+{
+    auto result = evaluate("padding(top: 1px, right: 2px, bottom: 3px, left: 4px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasSides(1.0, 2.0, 3.0, 4.0));
+}
+
+TEST_F(ParserTest, PaddingMixedNamedOverride)
+{
+    // Start with uniform 10px, then override top
+    auto result = evaluate("padding(10px, top: 20px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasSides(20.0, 10.0, 10.0, 10.0));
+}
+
+TEST_F(ParserTest, MarginsFunction)
+{
+    auto result = evaluate("margins(5px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Margins);
+}
+
+TEST_F(ParserTest, InsetsConvertsTupleArgToTargetKind)
+{
+    // padding(margins(...)) should re-tag the margins tuple as padding
+    auto result = evaluate("padding(margins(1px, 2px, 3px, 4px))");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_THAT(tuple, HasSides(1.0, 2.0, 3.0, 4.0));
+}
+
+TEST_F(ParserTest, InsetsConvertsGenericTupleArg)
+{
+    auto result = evaluate("padding((top: 5px, right: 10px, bottom: 15px, left: 20px))");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_THAT(tuple, HasNumericField("top", 5.0));
+    EXPECT_THAT(tuple, HasNumericField("left", 20.0));
+}
+
+TEST_F(ParserTest, InsetsNamedOverrideBeatsTupleArgument)
+{
+    // The tuple argument only supplies the base shape; the named side still wins over it.
+    auto result = evaluate("padding((1px, 2px), top: 9px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_THAT(tuple, HasSides(9.0, 2.0, 1.0, 2.0));
+}
+
+TEST_F(ParserTest, InsetsGroupOverrideBeatsTupleArgument)
+{
+    auto result = evaluate("padding(margins(1px, 2px, 3px, 4px), vertical: 9px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Padding);
+    EXPECT_THAT(tuple, HasSides(9.0, 2.0, 9.0, 4.0));
+}
+
+TEST_F(ParserTest, BorderThicknessFunction)
+{
+    auto result = evaluate("border_thickness(1px, 2px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::BorderThickness);
+    EXPECT_THAT(result.get<Tuple>(), HasNumericField("top", 1.0));
+    EXPECT_THAT(result.get<Tuple>(), HasNumericField("right", 2.0));
+}
+
+// Kind propagation through arithmetic
+
+TEST_F(ParserTest, KindPreservedThroughAdd)
+{
+    auto result = evaluate("padding(10px) + padding(5px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Padding);
+    EXPECT_THAT(result.get<Tuple>(), HasNumericField("top", 15.0));
+}
+
+TEST_F(ParserTest, KindPreservedThroughScalarMultiply)
+{
+    auto result = evaluate("padding(10px) * 2");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Padding);
+    EXPECT_THAT(result.get<Tuple>(), HasNumericField("top", 20.0));
+}
+
+TEST_F(ParserTest, KindPreservedThroughNegate)
+{
+    auto result = evaluate("-padding(10px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Padding);
+    EXPECT_THAT(result.get<Tuple>(), HasNumericField("top", -10.0));
+}
+
+TEST_F(ParserTest, KindMismatchError)
+{
+    EXPECT_THROW({ evaluate("padding(10px) + margins(5px)"); }, Base::ExpressionError);
+}
+
+TEST_F(ParserTest, TypedKindPlusGenericKeepsKind)
+{
+    auto result = evaluate("padding(10px) + (top: 5px, right: 5px, bottom: 5px, left: 5px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Padding);
+    EXPECT_THAT(result.get<Tuple>(), HasNumericField("top", 15.0));
+}
+
+TEST_F(ParserTest, ExtraNamedElementDropsKind)
+{
+    // The result has the four sides plus a stray fifth element, so it is no longer padding —
+    // keeping the kind would let it serialize as five QSS values.
+    auto result = evaluate("padding(10px) + (foo: 5px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Generic);
+    EXPECT_EQ(tuple.size(), 5);
+}
+
+TEST_F(ParserTest, UnmatchedUnnamedElementsDropKind)
+{
+    // The named sides never pair with the unnamed operands, so the result grows to eight
+    // elements and cannot claim to be padding.
+    auto result = evaluate("padding(10px) + (1px, 2px, 3px, 4px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Generic);
+}
+
+// Insets C++ wrapper tests
+
+TEST_F(ParserTest, InsetsPaddingWrapper)
+{
+    auto result = evaluate("padding(1px, 2px, 3px, 4px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    Padding padding(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(padding.top().value, 1.0);
+    EXPECT_DOUBLE_EQ(padding.right().value, 2.0);
+    EXPECT_DOUBLE_EQ(padding.bottom().value, 3.0);
+    EXPECT_DOUBLE_EQ(padding.left().value, 4.0);
+    EXPECT_DOUBLE_EQ(padding.horizontal().value, 6.0);
+    EXPECT_DOUBLE_EQ(padding.vertical().value, 4.0);
+}
+
+TEST_F(ParserTest, InsetsWrongKindCoercedFromNamedElements)
+{
+    // A Padding tuple has named top/right/bottom/left elements; constructing Margins from it
+    // re-expands via those names and produces valid Margins with the same values.
+    auto result = evaluate("padding(10px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    Margins margins(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(margins.top().value, 10.0);
+    EXPECT_DOUBLE_EQ(margins.right().value, 10.0);
+    EXPECT_DOUBLE_EQ(margins.bottom().value, 10.0);
+    EXPECT_DOUBLE_EQ(margins.left().value, 10.0);
+}
+
+// Corners / border_radius tests
+
+TEST_F(ParserTest, BorderRadiusShorthand1Arg)
+{
+    auto result = evaluate("border_radius(10px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_EQ(tuple.size(), 4);
+    EXPECT_THAT(tuple, HasCorners(10.0, 10.0, 10.0, 10.0));
+}
+
+TEST_F(ParserTest, BorderRadiusShorthand2Args)
+{
+    // 2 values: top-left/bottom-right, top-right/bottom-left (diagonal pairing)
+    auto result = evaluate("border_radius(10px, 5px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_THAT(tuple, HasCorners(10.0, 5.0, 10.0, 5.0));
+}
+
+TEST_F(ParserTest, BorderRadiusShorthand3Args)
+{
+    // 3 values: top-left, top-right/bottom-left, bottom-right
+    auto result = evaluate("border_radius(10px, 5px, 20px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_THAT(tuple, HasCorners(10.0, 5.0, 20.0, 5.0));
+}
+
+TEST_F(ParserTest, BorderRadiusShorthand4Args)
+{
+    auto result = evaluate("border_radius(10px, 5px, 20px, 15px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_THAT(tuple, HasCorners(10.0, 5.0, 20.0, 15.0));
+}
+
+TEST_F(ParserTest, BorderRadiusNamedOverride)
+{
+    auto result = evaluate("border_radius(10px, top_left: 20px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasCorners(20.0, 10.0, 10.0, 10.0));
+}
+
+TEST_F(ParserTest, BorderRadiusConvertsTupleArg)
+{
+    // Single tuple argument gets re-tagged
+    auto result = evaluate(
+        "border_radius((top_left: 1px, top_right: 2px, bottom_right: 3px, bottom_left: 4px))"
+    );
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_THAT(tuple, HasNumericField("top_left", 1.0));
+    EXPECT_THAT(tuple, HasNumericField("bottom_right", 3.0));
+}
+
+TEST_F(ParserTest, BorderRadiusNamedOverrideBeatsTupleArgument)
+{
+    // The tuple argument only supplies the base shape; the named corner still wins over it.
+    auto result = evaluate("border_radius((1px, 2px), top_left: 9px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::Corners);
+    EXPECT_THAT(tuple, HasCorners(9.0, 2.0, 1.0, 2.0));
+}
+
+TEST_F(ParserTest, BorderRadiusKindPreservedThroughArithmetic)
+{
+    auto result = evaluate("border_radius(10px) + border_radius(5px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().kind, TupleKind::Corners);
+    EXPECT_THAT(result.get<Tuple>(), HasNumericField("top_left", 15.0));
+}
+
+TEST_F(ParserTest, BorderRadiusKindMismatchWithInsetsThrows)
+{
+    EXPECT_THROW({ evaluate("border_radius(10px) + padding(5px)"); }, Base::ExpressionError);
+}
+
+TEST_F(ParserTest, CornersWrapper)
+{
+    auto result = evaluate("border_radius(1px, 2px, 3px, 4px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    Corners radii(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(radii.topLeft().value, 1.0);
+    EXPECT_DOUBLE_EQ(radii.topRight().value, 2.0);
+    EXPECT_DOUBLE_EQ(radii.bottomRight().value, 3.0);
+    EXPECT_DOUBLE_EQ(radii.bottomLeft().value, 4.0);
+}
+
+TEST_F(ParserTest, CornersFromUnrelatedTupleDefaultsToZero)
+{
+    // A Padding tuple has no corner-named elements. Without the kind gate in Corners'
+    // validated(), expand() would silently backfill zeros for all four corners with no
+    // diagnostic at all; the total constructor must degrade to zero *and* say why.
+    DiagnosticsCapture capture;
+
+    auto result = evaluate("padding(10px)");
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    Corners corners(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(corners.topLeft().value, 0.0);
+    EXPECT_DOUBLE_EQ(corners.topRight().value, 0.0);
+    EXPECT_DOUBLE_EQ(corners.bottomRight().value, 0.0);
+    EXPECT_DOUBLE_EQ(corners.bottomLeft().value, 0.0);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("Expected Corners tuple, got Padding")));
+}
+// Gradient tests
+
+TEST_F(ParserTest, LinearGradientMinimal)
+{
+    auto result = evaluate("linear_gradient(#ff0000, #0000ff)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    // Default geometry: top to bottom
+    EXPECT_THAT(tuple, HasNumericField("x1", 0.0));
+    EXPECT_THAT(tuple, HasNumericField("y1", 0.0));
+    EXPECT_THAT(tuple, HasNumericField("x2", 0.0));
+    EXPECT_THAT(tuple, HasNumericField("y2", 1.0));
+
+    // Stops gathered in named "stops" element
+    const auto* stopsValue = tuple.find("stops");
+    ASSERT_NE(stopsValue, nullptr);
+    ASSERT_TRUE(stopsValue->holds<Tuple>());
+    const auto& stopsTuple = stopsValue->get<Tuple>();
+    EXPECT_EQ(stopsTuple.size(), 2);
+
+    // First stop: position 0, red
+    const auto& firstStop = stopsTuple.at(0).get<Tuple>();
+    EXPECT_THAT(firstStop, HasNumericElement(0, 0.0));
+    EXPECT_THAT(firstStop, HasElement(1, IsColor(Base::Color(1.0, 0.0, 0.0))));
+
+    // Second stop: position 1, blue
+    const auto& secondStop = stopsTuple.at(1).get<Tuple>();
+    EXPECT_THAT(secondStop, HasNumericElement(0, 1.0));
+    EXPECT_THAT(secondStop, HasElement(1, IsColor(Base::Color(0.0, 0.0, 1.0))));
+}
+
+TEST_F(ParserTest, LinearGradientExplicitStops)
+{
+    auto result = evaluate("linear_gradient((0, #ff0000), (0.5, #00ff00), (1, #0000ff))");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    const auto& stopsTuple = tuple.get<Tuple>("stops");
+    EXPECT_EQ(stopsTuple.size(), 3);
+
+    EXPECT_THAT(stopsTuple.at(0).get<Tuple>(), HasNumericElement(0, 0.0));
+    EXPECT_THAT(stopsTuple.at(1).get<Tuple>(), HasNumericElement(0, 0.5));
+    EXPECT_THAT(stopsTuple.at(2).get<Tuple>(), HasNumericElement(0, 1.0));
+
+    // Middle stop is green
+    EXPECT_DOUBLE_EQ(stopsTuple.at(1).get<Tuple>().at(1).get<Base::Color>().g, 1.0);
+}
+
+TEST_F(ParserTest, LinearGradientCustomGeometry)
+{
+    auto result = evaluate("linear_gradient(x1: 0, y1: 0, x2: 1, y2: 0, #ff0000, #0000ff)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    // Custom geometry: left to right
+    EXPECT_THAT(tuple, HasNumericField("x1", 0.0));
+    EXPECT_THAT(tuple, HasNumericField("y1", 0.0));
+    EXPECT_THAT(tuple, HasNumericField("x2", 1.0));
+    EXPECT_THAT(tuple, HasNumericField("y2", 0.0));
+
+    const auto& stopsTuple = tuple.get<Tuple>("stops");
+    EXPECT_EQ(stopsTuple.size(), 2);
+}
+
+TEST_F(ParserTest, LinearGradientMixedStops)
+{
+    // Bare color + explicit (position, color) tuples
+    auto result = evaluate("linear_gradient(#ff0000, (0.5, #00ff00), #0000ff)");
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    const auto& stopsTuple = result.get<Tuple>().get<Tuple>("stops");
+    EXPECT_EQ(stopsTuple.size(), 3);
+
+    // Bare #ff0000 at index 0 → position 0/2 = 0.0
+    EXPECT_THAT(stopsTuple.at(0).get<Tuple>(), HasNumericElement(0, 0.0));
+    // Explicit (0.5, #00ff00)
+    EXPECT_THAT(stopsTuple.at(1).get<Tuple>(), HasNumericElement(0, 0.5));
+    // Bare #0000ff at index 2 → position 2/2 = 1.0
+    EXPECT_THAT(stopsTuple.at(2).get<Tuple>(), HasNumericElement(0, 1.0));
+}
+
+TEST_F(ParserTest, RadialGradientMinimal)
+{
+    auto result = evaluate("radial_gradient(#ff0000, #0000ff)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::RadialGradient);
+
+    // Default geometry
+    EXPECT_THAT(tuple, HasNumericField("cx", 0.5));
+    EXPECT_THAT(tuple, HasNumericField("cy", 0.5));
+    EXPECT_THAT(tuple, HasNumericField("radius", 0.5));
+    EXPECT_THAT(tuple, HasNumericField("fx", 0.5));
+    EXPECT_THAT(tuple, HasNumericField("fy", 0.5));
+
+    const auto& stopsTuple = tuple.get<Tuple>("stops");
+    EXPECT_EQ(stopsTuple.size(), 2);
+}
+
+TEST_F(ParserTest, RadialGradientCustomGeometry)
+{
+    auto result = evaluate(
+        "radial_gradient(cx: 0.3, cy: 0.3, radius: 0.8, (0, #ff0000), (1, #0000ff))"
+    );
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+
+    EXPECT_THAT(tuple, HasNumericField("cx", 0.3));
+    EXPECT_THAT(tuple, HasNumericField("cy", 0.3));
+    EXPECT_THAT(tuple, HasNumericField("radius", 0.8));
+    // fx/fy default to cx/cy when not specified
+    EXPECT_THAT(tuple, HasNumericField("fx", 0.3));
+    EXPECT_THAT(tuple, HasNumericField("fy", 0.3));
+}
+
+TEST_F(ParserTest, RadialGradientExplicitFocalPoint)
+{
+    auto result = evaluate("radial_gradient(cx: 0.5, cy: 0.5, fx: 0.2, fy: 0.8, #ff0000, #0000ff)");
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+
+    EXPECT_THAT(tuple, HasNumericField("fx", 0.2));
+    EXPECT_THAT(tuple, HasNumericField("fy", 0.8));
+}
+
+TEST_F(ParserTest, GradientTooFewStopsDegrades)
+{
+    {
+        Value result;
+        EXPECT_NO_THROW({ result = evaluate("linear_gradient(#ff0000)"); });
+        ASSERT_TRUE(result.holds<Tuple>());
+        EXPECT_EQ(result.get<Tuple>().kind, TupleKind::LinearGradient);
+
+        const LinearGradient gradient(result.get<Tuple>());
+        for (const auto& stop : gradient.colorStops()) {
+            EXPECT_FLOAT_EQ(stop.color.a, 0.0F);
+        }
+    }
+
+    {
+        Value result;
+        EXPECT_NO_THROW({ result = evaluate("radial_gradient()"); });
+        ASSERT_TRUE(result.holds<Tuple>());
+        EXPECT_EQ(result.get<Tuple>().kind, TupleKind::RadialGradient);
+
+        const RadialGradient gradient(result.get<Tuple>());
+        for (const auto& stop : gradient.colorStops()) {
+            EXPECT_FLOAT_EQ(stop.color.a, 0.0F);
+        }
+    }
+}
+
+TEST_F(ParserTest, GradientAcceptsPercentagesAsNormalizedCoordinates)
+{
+    DiagnosticsCapture capture;
+
+    auto result = evaluate("linear_gradient(x2: 100%, (0%, #ff0000), (50%, #0000ff))");
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    const LinearGradient gradient(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(gradient.x2(), 1.0);
+
+    const auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2U);
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 0.5);
+    EXPECT_THAT(capture.messages(), ::testing::IsEmpty());
+}
+
+TEST_F(ParserTest, GradientGeometryWithUnitReportsAndDefaults)
+{
+    DiagnosticsCapture capture;
+
+    // 10px is not a point on the normalized gradient scale; dropping the unit would silently
+    // put the end point at 10.
+    auto result = evaluate("linear_gradient(x2: 10px, #ff0000, #0000ff)");
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    const LinearGradient gradient(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(gradient.x2(), 0.0);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("'x2' must be a number or percentage")));
+}
+
+TEST_F(ParserTest, GradientStopPositionWithUnitReportsAndDegrades)
+{
+    DiagnosticsCapture capture;
+
+    Value result;
+    EXPECT_NO_THROW({ result = evaluate("linear_gradient((10px, #ff0000), (1, #0000ff))"); });
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    const LinearGradient gradient(result.get<Tuple>());
+    for (const auto& stop : gradient.colorStops()) {
+        EXPECT_FLOAT_EQ(stop.color.a, 0.0F);
+    }
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("number or percentage")));
+}
+
+TEST_F(ParserTest, GradientWrapper)
+{
+    auto result = evaluate("linear_gradient(x1: 0.1, y1: 0.2, x2: 0.3, y2: 0.4, #ff0000, #0000ff)");
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    LinearGradient gradient(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(gradient.x1(), 0.1);
+    EXPECT_DOUBLE_EQ(gradient.y1(), 0.2);
+    EXPECT_DOUBLE_EQ(gradient.x2(), 0.3);
+    EXPECT_DOUBLE_EQ(gradient.y2(), 0.4);
+
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[0].color.r, 1.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 1.0);
+    EXPECT_DOUBLE_EQ(stops[1].color.b, 1.0);
+}
+
+TEST_F(ParserTest, RadialGradientWrapper)
+{
+    auto result = evaluate(
+        "radial_gradient(cx: 0.3, cy: 0.4, radius: 0.7, fx: 0.1, fy: 0.2, #ff0000, #0000ff)"
+    );
+    ASSERT_TRUE(result.holds<Tuple>());
+
+    RadialGradient gradient(result.get<Tuple>());
+    EXPECT_DOUBLE_EQ(gradient.cx(), 0.3);
+    EXPECT_DOUBLE_EQ(gradient.cy(), 0.4);
+    EXPECT_DOUBLE_EQ(gradient.radius(), 0.7);
+    EXPECT_DOUBLE_EQ(gradient.fx(), 0.1);
+    EXPECT_DOUBLE_EQ(gradient.fy(), 0.2);
+
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+}
+
+TEST_F(ParserTest, GradientStopsAccessibleViaMemberAccess)
+{
+    auto result = evaluate("linear_gradient(#ff0000, #0000ff).stops");
+    ASSERT_TRUE(result.holds<Tuple>());
+    EXPECT_EQ(result.get<Tuple>().size(), 2);
+}
+// Gradient color function tests
+
+TEST_F(ParserTest, LightenGradient)
+{
+    auto result = evaluate("lighten(linear_gradient(#ff0000, #0000ff), 20)");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    LinearGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    // Each stop should be lighter than the original
+    auto originalRed = QColor(0xff, 0x00, 0x00);
+    auto originalBlue = QColor(0x00, 0x00, 0xff);
+    EXPECT_GT(stops[0].color.asValue<QColor>().lightness(), originalRed.lightness());
+    EXPECT_GT(stops[1].color.asValue<QColor>().lightness(), originalBlue.lightness());
+
+    // Positions should be preserved
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 1.0);
+}
+
+TEST_F(ParserTest, DarkenGradient)
+{
+    auto result = evaluate("darken(radial_gradient(#ff0000, #00ff00), 20)");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::RadialGradient);
+
+    RadialGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    // Each stop should be darker than the original
+    auto originalRed = QColor(0xff, 0x00, 0x00);
+    auto originalGreen = QColor(0x00, 0xff, 0x00);
+    EXPECT_LT(stops[0].color.asValue<QColor>().lightness(), originalRed.lightness());
+    EXPECT_LT(stops[1].color.asValue<QColor>().lightness(), originalGreen.lightness());
+
+    // Geometry should be preserved
+    EXPECT_DOUBLE_EQ(gradient.cx(), 0.5);
+    EXPECT_DOUBLE_EQ(gradient.cy(), 0.5);
+    EXPECT_DOUBLE_EQ(gradient.radius(), 0.5);
+}
+
+TEST_F(ParserTest, BlendGradientWithColor)
+{
+    auto result = evaluate("blend(linear_gradient(#ff0000, #0000ff), #000000, 50)");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    LinearGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    // 50% blend of red with black should be ~half red
+    EXPECT_THAT(stops[0].color, ColorNear(Base::Color(0.5F, 0.0F, 0.0F), 0.02));
+
+    // 50% blend of blue with black should be ~half blue
+    EXPECT_THAT(stops[1].color, ColorNear(Base::Color(0.0F, 0.0F, 0.5F), 0.02));
+}
+
+TEST_F(ParserTest, BlendColorWithGradient)
+{
+    auto result = evaluate("blend(#000000, linear_gradient(#ff0000, #0000ff), 50)");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    LinearGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    // 50% blend of black with red should be ~half red
+    EXPECT_THAT(stops[0].color, ColorNear(Base::Color(0.5F, 0.0F, 0.0F), 0.02));
+
+    // 50% blend of black with blue should be ~half blue
+    EXPECT_THAT(stops[1].color, ColorNear(Base::Color(0.0F, 0.0F, 0.5F), 0.02));
+}
+
+TEST_F(ParserTest, BlendTwoGradientsThrows)
+{
+    EXPECT_THROW(
+        {
+            evaluate("blend(linear_gradient(#ff0000, #0000ff), linear_gradient(#00ff00, #ffff00), 50)");
+        },
+        Base::ExpressionError
+    );
+}
+
+TEST_F(ParserTest, CoalesceReturnsFirstDefined)
+{
+    auto result = evaluate("coalesce(@UndefinedParam, @TestParam)");
+    ASSERT_TRUE(result.holds<Numeric>());
+    EXPECT_DOUBLE_EQ(result.get<Numeric>().value, 10.0);
+    EXPECT_EQ(result.get<Numeric>().unit, "px");
+}
+
+TEST_F(ParserTest, CoalesceReturnsFirstWhenDefined)
+{
+    auto result = evaluate("coalesce(@TestColor, @TestParam)");
+    ASSERT_TRUE(result.holds<Base::Color>());
+    EXPECT_NEAR(result.get<Base::Color>().r, 1.0F, 0.01F);
+}
+
+TEST_F(ParserTest, CoalesceAllUndefinedReturnsFallbackString)
+{
+    auto result = evaluate("coalesce(@Undefined1, @Undefined2)");
+    ASSERT_TRUE(result.holds<std::string>());
+    EXPECT_EQ(result.get<std::string>(), "@Undefined2");
+}
+
+TEST_F(ParserTest, CoalesceSkipsMultipleUndefined)
+{
+    auto result = evaluate("coalesce(@A, @B, @C, @TestNumber)");
+    ASSERT_TRUE(result.holds<Numeric>());
+    EXPECT_DOUBLE_EQ(result.get<Numeric>().value, 5.0);
+}
+
+// Shade function tests
+
+TEST_F(ParserTest, ShadeBasicColor)
+{
+    // Position 0.8 = darker than anchor (0.5), so result should be darker than original
+    auto result = evaluate("shade(#ff0000, 0.8)");
+    ASSERT_TRUE(result.holds<Base::Color>());
+
+    auto shaded = result.get<Base::Color>();
+    auto shadedOklch = Base::toOkLch(shaded);
+    auto originalOklch = Base::toOkLch(Base::Color(1.0f, 0.0f, 0.0f));
+    EXPECT_LT(shadedOklch.lightness, originalOklch.lightness);
+
+    // Hue should be approximately preserved
+    EXPECT_NEAR(shadedOklch.hue, originalOklch.hue, 5.0f);
+}
+
+TEST_F(ParserTest, ShadeWithPercentage)
+{
+    const Value percentage = evaluate("shade(#ff0000, 80%)");
+
+    const Value fraction = evaluate("shade(#ff0000, 0.8)");
+
+    ASSERT_TRUE(percentage.holds<Base::Color>());
+    ASSERT_TRUE(fraction.holds<Base::Color>());
+    EXPECT_EQ(percentage.get<Base::Color>(), fraction.get<Base::Color>());
+}
+
+TEST_F(ParserTest, ShadeAnchorReturnsOriginal)
+{
+    // Position 0.5 = anchor, color should be returned unchanged
+    auto result = evaluate("shade(#E01B24, 0.5)");
+    ASSERT_TRUE(result.holds<Base::Color>());
+
+    // NOLINTNEXTLINE(*-magic-numbers)
+    Base::Color original(0xE0 / 255.0F, 0x1B / 255.0F, 0x24 / 255.0F);
+    EXPECT_THAT(result, IsColorNear(original, 0.01));
+}
+
+TEST_F(ParserTest, ShadeLighterPosition)
+{
+    // Position 0.2 = lighter than anchor, result should be lighter than original
+    auto result = evaluate("shade(#ff0000, 0.2)");
+    ASSERT_TRUE(result.holds<Base::Color>());
+
+    auto shaded = result.get<Base::Color>();
+    auto shadedOklch = Base::toOkLch(shaded);
+    auto originalOklch = Base::toOkLch(Base::Color(1.0f, 0.0f, 0.0f));
+    EXPECT_GT(shadedOklch.lightness, originalOklch.lightness);
+}
+
+TEST_F(ParserTest, ShadeGradient)
+{
+    // Position 0.5 = anchor, gradient stops should be unchanged
+    auto result = evaluate("shade(linear_gradient(#ff0000, #0000ff), 0.5)");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.kind, TupleKind::LinearGradient);
+
+    LinearGradient gradient(tuple);
+    auto stops = gradient.colorStops();
+    ASSERT_EQ(stops.size(), 2);
+
+    auto originalRedOklch = Base::toOkLch(Base::Color(1.0f, 0.0f, 0.0f));
+    auto originalBlueOklch = Base::toOkLch(Base::Color(0.0f, 0.0f, 1.0f));
+    auto firstOklch = Base::toOkLch(stops[0].color);
+    auto secondOklch = Base::toOkLch(stops[1].color);
+    EXPECT_NEAR(firstOklch.lightness, originalRedOklch.lightness, 0.01f);
+    EXPECT_NEAR(secondOklch.lightness, originalBlueOklch.lightness, 0.01f);
+
+    // Positions should be preserved
+    EXPECT_DOUBLE_EQ(stops[0].position.value, 0.0);
+    EXPECT_DOUBLE_EQ(stops[1].position.value, 1.0);
+}
+
+TEST_F(ParserTest, ShadesLighterAndDarker)
+{
+    // Position 0.1 = lighter than anchor, 0.9 = darker than anchor
+    auto result = evaluate("shades(#ff0000, (light: 0.1, dark: 0.9))");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 2);
+
+    auto originalOklch = Base::toOkLch(Base::Color(1.0F, 0.0F, 0.0F));
+
+    // "light" shade should be lighter than anchor
+    const auto* lightValue = tuple.find("light");
+    ASSERT_NE(lightValue, nullptr);
+    ASSERT_TRUE(lightValue->holds<Base::Color>());
+    auto lightOklch = Base::toOkLch(lightValue->get<Base::Color>());
+    EXPECT_GT(lightOklch.lightness, originalOklch.lightness);
+
+    // "dark" shade should be darker than anchor
+    const auto* darkValue = tuple.find("dark");
+    ASSERT_NE(darkValue, nullptr);
+    ASSERT_TRUE(darkValue->holds<Base::Color>());
+    auto darkOklch = Base::toOkLch(darkValue->get<Base::Color>());
+    EXPECT_LT(darkOklch.lightness, originalOklch.lightness);
+}
+
+TEST_F(ParserTest, ShadesAnchorExactMatch)
+{
+    // Position 0.5 should produce the exact input color
+    // NOLINTNEXTLINE(*-magic-numbers)
+    Base::Color input(0xE0 / 255.0F, 0x1B / 255.0F, 0x24 / 255.0F);
+
+    auto result = evaluate("shades(#E01B24, (500: 50%))");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 1);
+
+    EXPECT_THAT(tuple, HasField("500", IsColorNear(input, 0.001)));
+}
+
+TEST_F(ParserTest, ShadesMonotonicLightness)
+{
+    // Lightness must strictly decrease from 050 to 900 — no duplicate shades
+    auto result = evaluate(
+        "shades(#E01B24, "
+        "(050: 5%, 100: 10%, 200: 20%, 300: 30%, 400: 40%, "
+        "500: 50%, 600: 60%, 700: 70%, 800: 80%, 900: 90%))"
+    );
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 10);
+
+    std::vector<std::string> steps
+        = {"050", "100", "200", "300", "400", "500", "600", "700", "800", "900"};
+    float previousLightness = 1.0F;
+    for (const auto& step : steps) {
+        auto* value = tuple.find(step);
+        ASSERT_NE(value, nullptr) << "Missing step " << step;
+        auto oklch = Base::toOkLch(value->get<Base::Color>());
+        EXPECT_LT(oklch.lightness, previousLightness)
+            << "Step " << step << " should be darker than previous";
+        previousLightness = oklch.lightness;
+    }
+
+    // Lightest should not be pure white, darkest should not be pure black
+    auto lightest = Base::toOkLch(tuple.find("050")->get<Base::Color>());
+    auto darkest = Base::toOkLch(tuple.find("900")->get<Base::Color>());
+    EXPECT_LT(lightest.lightness, 0.99F);
+    EXPECT_GT(darkest.lightness, 0.10F);
+}
+
+TEST_F(ParserTest, ShadesPreservesHue)
+{
+    auto result = evaluate("shades(#ff0000, (a: 10%, b: 50%, c: 90%))");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_EQ(tuple.size(), 3);
+
+    auto originalOklch = Base::toOkLch(Base::Color(1.0F, 0.0F, 0.0F));
+
+    for (const auto& element : tuple.elements) {
+        ASSERT_TRUE(element.value->holds<Base::Color>());
+        auto shadeOklch = Base::toOkLch(element.value->get<Base::Color>());
+        // At extreme lightness, chroma can be very low making hue unreliable
+        if (shadeOklch.chroma > 0.01F) {
+            EXPECT_NEAR(shadeOklch.hue, originalOklch.hue, 5.0F);
+        }
+    }
+}
+
+TEST_F(ParserTest, ShadesCustomRange)
+{
+    // A narrower range should produce less variation in lightness
+    auto narrowResult = evaluate("shades(#E01B24, (light: 5%, dark: 95%), range: 40%)");
+
+    auto wideResult = evaluate("shades(#E01B24, (light: 5%, dark: 95%), range: 80%)");
+
+    const auto& narrowTuple = narrowResult.get<Tuple>();
+    const auto& wideTuple = wideResult.get<Tuple>();
+
+    auto narrowLight = Base::toOkLch(narrowTuple.find("light")->get<Base::Color>());
+    auto narrowDark = Base::toOkLch(narrowTuple.find("dark")->get<Base::Color>());
+    float narrowSpan = narrowLight.lightness - narrowDark.lightness;
+
+    auto wideLight = Base::toOkLch(wideTuple.find("light")->get<Base::Color>());
+    auto wideDark = Base::toOkLch(wideTuple.find("dark")->get<Base::Color>());
+    float wideSpan = wideLight.lightness - wideDark.lightness;
+
+    EXPECT_LT(narrowSpan, wideSpan);
+}
+
+TEST_F(ParserTest, ShadesCustomMinMax)
+{
+    // Custom min/max should clamp the lightness range
+    auto result = evaluate("shades(#E01B24, (light: 5%, dark: 95%), min: 20%, max: 90%)");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+
+    auto lightOklch = Base::toOkLch(tuple.find("light")->get<Base::Color>());
+    auto darkOklch = Base::toOkLch(tuple.find("dark")->get<Base::Color>());
+
+    // Lightness should stay within the specified bounds (with some tolerance for OKLCH conversion)
+    EXPECT_LE(lightOklch.lightness, 0.91F);
+    EXPECT_GE(darkOklch.lightness, 0.19F);
+}
+
+// content_box() tests
+
+TEST_F(ParserTest, ContentBoxWithSizeTupleAndPadding)
+{
+    auto result = evaluate("content_box((width: 100px, height: 50px), padding(10px))");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasNumericField("width", 80.0, "px"));
+    EXPECT_THAT(tuple, HasNumericField("height", 30.0, "px"));
+}
+
+TEST_F(ParserTest, ContentBoxWithAsymmetricPadding)
+{
+    // padding(top, right, bottom, left): horizontal = right + left = 5 + 15 = 20
+    //                                    vertical   = top + bottom = 10 + 20 = 30
+    auto result = evaluate(
+        "content_box((width: 200px, height: 100px), padding(10px, 5px, 20px, 15px))"
+    );
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasNumericField("width", 180.0));
+    EXPECT_THAT(tuple, HasNumericField("height", 70.0));
+}
+
+TEST_F(ParserTest, ContentBoxWithMultipleInsets)
+{
+    // padding(4px): horizontal = 8, vertical = 8
+    // border_thickness(2px): horizontal = 4, vertical = 4
+    // total: width -= 12, height -= 12
+    auto result = evaluate(
+        "content_box((width: 100px, height: 60px), padding(4px), border_thickness(2px))"
+    );
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasNumericField("width", 88.0));
+    EXPECT_THAT(tuple, HasNumericField("height", 48.0));
+}
+
+TEST_F(ParserTest, ContentBoxWithSingleNumericInset)
+{
+    // Single numeric: all sides 4px → horizontal=8, vertical=8
+    auto result = evaluate("content_box((width: 100px, height: 60px), 4px)");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasNumericField("width", 92.0));
+    EXPECT_THAT(tuple, HasNumericField("height", 52.0));
+}
+
+TEST_F(ParserTest, ContentBoxWithTwoNumericInsets)
+{
+    // Each numeric arg is a separate uniform inset, accumulated independently:
+    // 4px all sides + 2px all sides → width -= 12, height -= 12
+    auto result = evaluate("content_box((width: 100px, height: 60px), 4px, 2px)");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasNumericField("width", 88.0));
+    EXPECT_THAT(tuple, HasNumericField("height", 48.0));
+}
+
+TEST_F(ParserTest, ContentBoxWithNumericValue)
+{
+    // Single Numeric: both width and height start at 32px, subtract padding(4px) = 8px each side
+    auto result = evaluate("content_box(32px, padding(4px))");
+
+    ASSERT_TRUE(result.holds<Tuple>());
+    const auto& tuple = result.get<Tuple>();
+    EXPECT_THAT(tuple, HasNumericField("width", 24.0));
+    EXPECT_THAT(tuple, HasNumericField("height", 24.0));
+}
+
+TEST_F(ParserTest, ContentBoxTooFewArguments)
+{
+    EXPECT_THROW(evaluate("content_box((width: 100px, height: 50px))"), Base::ExpressionError);
+}
+
+TEST_F(ParserTest, ColorFunctionsRejectNonColorArguments)
+{
+    for (const char* expression : {
+             "lighten(10px, 20)",
+             "darken(10px, 20)",
+             "shade(10px, 0.3)",
+             "shades(10px, (0.1, 0.9))",
+             "blend(10px, #ff0000, 50)",
+             "blend(#ff0000, 10px, 50)",
+             "blend(linear_gradient(#ff0000, #0000ff), 10px, 50)",
+             "blend(10px, linear_gradient(#ff0000, #0000ff), 50)",
+         }) {
+        EXPECT_THROW(evaluate(expression), Base::ExpressionError)
+
+            << "expression: " << expression;
+    }
+}
+
+// Numeric and Tuple arguments are rejected as firmly as the color arguments above. Degrading
+// them instead produces confident nonsense: lighten(#ff0000, #00ff00) resolves to unmodified
+// red (the amount degrades to 0) and shades(#ff0000, 10px) to an empty tuple.
+TEST_F(ParserTest, ColorFunctionsRejectNonNumericOrNonTupleArguments)
+{
+    for (const char* expression : {
+             "lighten(#ff0000, #00ff00)",            // amount must be numeric
+             "darken(#ff0000, #00ff00)",             // amount must be numeric
+             "blend(#ff0000, #00ff00, #0000ff)",     // amount must be numeric
+             "shade(#ff0000, #00ff00)",              // lightness must be numeric
+             "shades(#ff0000, 10px)",                // shades spec must be a tuple
+             "shade(#ff0000, 0.3, range: #00ff00)",  // explicit range must be numeric
+             "shade(#ff0000, 0.3, min: #00ff00)",    // explicit min must be numeric
+             "shade(#ff0000, 0.3, max: #00ff00)",    // explicit max must be numeric
+             "shade(#ff0000, 0.3, pivot: #00ff00)",  // explicit pivot must be numeric
+             "shade(#ff0000, 0.3, q: #00ff00)",      // explicit q must be numeric
+             "content_box((width: #ff0000, height: 50px), padding(10px))",  // width must be numeric
+             "content_box((width: 100px, height: #ff0000), padding(10px))",  // height must be numeric
+         }) {
+        EXPECT_THROW(evaluate(expression), Base::ExpressionError)
+
+            << "expression: " << expression;
+    }
+}
+
+TEST_F(ParserTest, ColorFunctionTypeErrorsAreContainedByResolve)
+{
+    InMemoryParameterSource source(
+        std::list<Parameter> {{.name = "BadLighten", .value = "lighten(10px, 20)"}},
+        ParameterSource::Metadata {.name = "Bad Color Source"}
+    );
+    manager.addSource(&source);
+
+    EXPECT_NO_THROW({
+        const auto resolved = manager.resolve("BadLighten");
+        ASSERT_TRUE(resolved.has_value());
+        ASSERT_TRUE(resolved->holds<std::string>());
+        EXPECT_EQ(resolved->get<std::string>(), "lighten(10px, 20)");
+    });
 }

--- a/tests/src/Gui/StyleParameters/ValueAccessTest.cpp
+++ b/tests/src/Gui/StyleParameters/ValueAccessTest.cpp
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <Gui/StyleParameters/ParameterManager.h>
+#include <Gui/StyleParameters/Parser.h>
+#include <Gui/StyleParameters/Value.h>
+
+#include "DiagnosticsCapture.h"
+
+using namespace Gui::StyleParameters;
+using ::testing::Contains;
+using ::testing::HasSubstr;
+using ::testing::IsEmpty;
+
+TEST(ValueAccessTest, StyleDefaultsAreEmptyValues)
+{
+    EXPECT_DOUBLE_EQ(styleDefault<Numeric>().value, 0.0);
+    EXPECT_EQ(styleDefault<Numeric>().unit, "");
+    EXPECT_FLOAT_EQ(styleDefault<Base::Color>().a, 0.0F);
+    EXPECT_EQ(styleDefault<std::string>(), "");
+    EXPECT_EQ(styleDefault<Tuple>().size(), 0U);
+}
+
+TEST(ValueAccessTest, ValueGetWrongTypeReturnsDefaultAndReports)
+{
+    DiagnosticsCapture capture;
+    const Value value {Base::Color(1.0F, 0.0F, 0.0F)};
+
+    EXPECT_DOUBLE_EQ(value.get<Numeric>().value, 0.0);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("numeric")));
+}
+
+TEST(ValueAccessTest, ValueGetWithFallbackReturnsFallback)
+{
+    const Value value {Base::Color(1.0F, 0.0F, 0.0F)};
+
+    EXPECT_DOUBLE_EQ(value.get<Numeric>(Numeric {.value = 8.0, .unit = "px"}).value, 8.0);
+}
+
+TEST(ValueAccessTest, ValueTryGetReturnsNullOnMismatchAndReportsNothing)
+{
+    DiagnosticsCapture capture;
+    const Value value {Base::Color(1.0F, 0.0F, 0.0F)};
+
+    EXPECT_EQ(value.tryGet<Numeric>(), nullptr);
+    EXPECT_NE(value.tryGet<Base::Color>(), nullptr);
+    EXPECT_THAT(capture.messages(), IsEmpty());
+}
+
+TEST(ValueAccessTest, TupleGetMissingNameReturnsDefaultAndReports)
+{
+    DiagnosticsCapture capture;
+    const Tuple tuple({Tuple::Element::named("width", Numeric {.value = 4.0, .unit = "px"})});
+
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("height").value, 0.0);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("Missing argument 'height'")));
+}
+
+TEST(ValueAccessTest, TupleGetWrongTypeReturnsDefaultAndReports)
+{
+    DiagnosticsCapture capture;
+    const Tuple tuple({Tuple::Element::named("width", Base::Color(1.0F, 0.0F, 0.0F))});
+
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("width").value, 0.0);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("'width' must be numeric")));
+}
+
+TEST(ValueAccessTest, TupleGetWithFallbackReturnsFallback)
+{
+    const Tuple tuple({Tuple::Element::named("width", Base::Color(1.0F, 0.0F, 0.0F))});
+
+    EXPECT_DOUBLE_EQ(tuple.get<Numeric>("width", Numeric {.value = 8.0, .unit = "px"}).value, 8.0);
+}
+
+TEST(ValueAccessTest, TupleAtOutOfRangeReturnsDefaultAndReports)
+{
+    DiagnosticsCapture capture;
+    const Tuple tuple({Tuple::Element::unnamed(Numeric {.value = 1.0, .unit = ""})});
+
+    EXPECT_EQ(tuple.tryAt(1), nullptr);
+    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 0.0);
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("out of range")));
+}
+// Regression: with exactly one gradient operand, blend() called Value::get<Base::Color>() on
+// the other operand without checking it, throwing std::bad_variant_access past every catch
+// site on the resolve path.
+TEST(ValueAccessTest, BlendWithNonColorOperandIsContainedByResolve)
+{
+    Gui::StyleParameters::ParameterManager manager;
+    InMemoryParameterSource source(
+        std::list<Parameter> {
+            {.name = "Broken", .value = "blend(linear_gradient(#ff0000, #0000ff), 10px, 50)"},
+        },
+        ParameterSource::Metadata {.name = "Test Source"}
+    );
+    manager.addSource(&source);
+
+    EXPECT_NO_THROW({
+        const auto resolved = manager.resolve("Broken");
+        ASSERT_TRUE(resolved.has_value());
+        EXPECT_TRUE(resolved->holds<std::string>());
+    });
+}

--- a/tests/src/Gui/StyleParameters/ValueAccessTest.cpp
+++ b/tests/src/Gui/StyleParameters/ValueAccessTest.cpp
@@ -104,6 +104,27 @@ TEST(ValueAccessTest, TupleAtOutOfRangeReturnsDefaultAndReports)
     EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 0.0);
     EXPECT_THAT(capture.messages(), Contains(HasSubstr("out of range")));
 }
+
+// Regression: shades() read every element of its spec tuple with an unchecked get<Numeric>,
+// throwing std::bad_variant_access past every catch site on the resolve path.
+TEST(ValueAccessTest, ShadesWithNonNumericSpecIsContainedByResolve)
+{
+    DiagnosticsCapture capture;
+    Gui::StyleParameters::ParameterManager manager;
+    InMemoryParameterSource source(
+        std::list<Parameter> {{.name = "Broken", .value = "shades(#ff0000, (050: #ffffff))"}},
+        ParameterSource::Metadata {.name = "Test Source"}
+    );
+    manager.addSource(&source);
+
+    EXPECT_NO_THROW({
+        const auto resolved = manager.resolve("Broken");
+        ASSERT_TRUE(resolved.has_value());
+        EXPECT_TRUE(resolved->holds<Tuple>());
+    });
+    EXPECT_THAT(capture.messages(), Contains(HasSubstr("Expected numeric value")));
+}
+
 // Regression: with exactly one gradient operand, blend() called Value::get<Base::Color>() on
 // the other operand without checking it, throwing std::bad_variant_access past every catch
 // site on the resolve path.

--- a/tests/src/Gui/StyleParameters/ValueMatchers.cpp
+++ b/tests/src/Gui/StyleParameters/ValueMatchers.cpp
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Test-only helper. Nothing in shipped code uses this.
+
+#include "ValueMatchers.h"
+
+#include <fmt/format.h>
+
+using ::testing::AllOf;
+using ::testing::DoubleEq;
+using ::testing::Eq;
+using ::testing::Field;
+using ::testing::FloatNear;
+using ::testing::Matcher;
+using ::testing::Pointee;
+using ::testing::ResultOf;
+
+namespace Gui::StyleParameters::Matchers
+{
+
+namespace
+{
+
+/// Lifts a matcher on T onto a Value, failing when the Value holds another type.
+template<typename T>
+Matcher<Value> holding(Matcher<T> matcher)
+{
+    return ResultOf(
+        valueTypeName<T>(),
+        [](const Value& value) { return value.tryGet<T>(); },
+        Pointee(std::move(matcher))
+    );
+}
+
+}  // namespace
+
+Matcher<Base::Color> ColorNear(const Base::Color& expected, double tolerance)
+{
+    const auto margin = static_cast<float>(tolerance);
+
+    return AllOf(
+        Field("r", &Base::Color::r, FloatNear(expected.r, margin)),
+        Field("g", &Base::Color::g, FloatNear(expected.g, margin)),
+        Field("b", &Base::Color::b, FloatNear(expected.b, margin))
+    );
+}
+
+Matcher<Value> IsNumeric(double value)
+{
+    return holding<Numeric>(Field("value", &Numeric::value, DoubleEq(value)));
+}
+
+Matcher<Value> IsNumeric(double value, std::string_view unit)
+{
+    return holding<Numeric>(AllOf(
+        Field("value", &Numeric::value, DoubleEq(value)),
+        Field("unit", &Numeric::unit, Eq(std::string {unit}))
+    ));
+}
+
+Matcher<Value> IsColor(const Base::Color& expected)
+{
+    return holding<Base::Color>(Eq(expected));
+}
+
+Matcher<Value> IsColorNear(const Base::Color& expected, double tolerance)
+{
+    return holding<Base::Color>(ColorNear(expected, tolerance));
+}
+
+Matcher<Tuple> HasField(std::string name, Matcher<Value> matcher)
+{
+    return ResultOf(
+        fmt::format("field '{}'", name),
+        [name = std::move(name)](const Tuple& tuple) { return tuple.find(name); },
+        Pointee(matcher)
+    );
+}
+
+Matcher<Tuple> HasElement(size_t index, Matcher<Value> matcher)
+{
+    return ResultOf(
+        fmt::format("element {}", index),
+        [index](const Tuple& tuple) { return tuple.tryAt(index); },
+        Pointee(matcher)
+    );
+}
+
+Matcher<Tuple> HasNumericField(std::string name, double value)
+{
+    return HasField(std::move(name), IsNumeric(value));
+}
+
+Matcher<Tuple> HasNumericField(std::string name, double value, std::string_view unit)
+{
+    return HasField(std::move(name), IsNumeric(value, unit));
+}
+
+Matcher<Tuple> HasNumericElement(size_t index, double value)
+{
+    return HasElement(index, IsNumeric(value));
+}
+
+Matcher<Tuple> HasNumericElement(size_t index, double value, std::string_view unit)
+{
+    return HasElement(index, IsNumeric(value, unit));
+}
+
+Matcher<Tuple> HasSides(double top, double right, double bottom, double left)
+{
+    return AllOf(
+        HasNumericField("top", top),
+        HasNumericField("right", right),
+        HasNumericField("bottom", bottom),
+        HasNumericField("left", left)
+    );
+}
+
+Matcher<Tuple> HasCorners(double topLeft, double topRight, double bottomRight, double bottomLeft)
+{
+    return AllOf(
+        HasNumericField("top_left", topLeft),
+        HasNumericField("top_right", topRight),
+        HasNumericField("bottom_right", bottomRight),
+        HasNumericField("bottom_left", bottomLeft)
+    );
+}
+
+}  // namespace Gui::StyleParameters::Matchers

--- a/tests/src/Gui/StyleParameters/ValueMatchers.h
+++ b/tests/src/Gui/StyleParameters/ValueMatchers.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// Test-only helper. Nothing in shipped code uses this.
+
+#pragma once
+
+#include <ostream>
+#include <string>
+#include <string_view>
+
+#include <gmock/gmock.h>
+
+#include <Gui/StyleParameters/Value.h>
+
+namespace Base
+{
+inline void PrintTo(const Color& color, std::ostream* os)
+{
+    *os << Gui::StyleParameters::Value {color}.toString();
+}
+}  // namespace Base
+
+namespace Gui::StyleParameters
+{
+
+inline void PrintTo(const Value& value, std::ostream* os)
+{
+    *os << value.toString();
+}
+
+inline void PrintTo(const Numeric& numeric, std::ostream* os)
+{
+    *os << Value {numeric}.toString();
+}
+
+inline void PrintTo(const Tuple& tuple, std::ostream* os)
+{
+    *os << Value {tuple}.toString();
+}
+
+inline void PrintTo(TupleKind kind, std::ostream* os)
+{
+    *os << tupleKindName(kind);
+}
+
+/**
+ * @brief Matchers for the shapes style parameter tests assert over and over.
+ *
+ * Each matcher checks exactly what it names and nothing else, so a test that only cares about
+ * two sides of a box says so instead of being forced to pin all four.
+ */
+namespace Matchers
+{
+
+::testing::Matcher<Base::Color> ColorNear(const Base::Color& expected, double tolerance);
+::testing::Matcher<Value> IsNumeric(double value);
+::testing::Matcher<Value> IsNumeric(double value, std::string_view unit);
+::testing::Matcher<Value> IsColor(const Base::Color& expected);
+::testing::Matcher<Value> IsColorNear(const Base::Color& expected, double tolerance);
+::testing::Matcher<Tuple> HasField(std::string name, ::testing::Matcher<Value> matcher);
+::testing::Matcher<Tuple> HasElement(size_t index, ::testing::Matcher<Value> matcher);
+
+::testing::Matcher<Tuple> HasNumericField(std::string name, double value);
+::testing::Matcher<Tuple> HasNumericField(std::string name, double value, std::string_view unit);
+
+::testing::Matcher<Tuple> HasNumericElement(size_t index, double value);
+::testing::Matcher<Tuple> HasNumericElement(size_t index, double value, std::string_view unit);
+
+::testing::Matcher<Tuple> HasSides(double top, double right, double bottom, double left);
+
+::testing::Matcher<Tuple> HasCorners(double topLeft, double topRight, double bottomRight, double bottomLeft);
+
+}  // namespace Matchers
+}  // namespace Gui::StyleParameters

--- a/tests/src/Gui/StyleParameters/YamlParameterSourceTest.cpp
+++ b/tests/src/Gui/StyleParameters/YamlParameterSourceTest.cpp
@@ -144,6 +144,7 @@ TEST_F(YamlParameterSourceTest, SequenceResolvesToTupleValue)
 
     const auto& tuple = result->get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
+    EXPECT_EQ(tuple.kind, TupleKind::Generic);
     EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 10.0);
     EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 20.0);
 }

--- a/tests/src/Gui/StyleParameters/YamlParameterSourceTest.cpp
+++ b/tests/src/Gui/StyleParameters/YamlParameterSourceTest.cpp
@@ -24,14 +24,19 @@
 #include <filesystem>
 #include <fstream>
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <Gui/Application.h>
 #include <Gui/StyleParameters/ParameterManager.h>
 #include <Gui/StyleParameters/Value.h>
+
 #include <src/TempDirectory.h>
 
+#include "ValueMatchers.h"
+
 using namespace Gui::StyleParameters;
+using namespace Gui::StyleParameters::Matchers;
 
 // Alias to avoid ambiguity with ParameterGrp::Manager() from Base/Parameter.h.
 using StyleParameterManager = Gui::StyleParameters::ParameterManager;
@@ -144,8 +149,9 @@ TEST_F(YamlParameterSourceTest, SequenceResolvesToTupleValue)
 
     const auto& tuple = result->get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
-    EXPECT_DOUBLE_EQ(tuple.at(0).get<Numeric>().value, 10.0);
-    EXPECT_DOUBLE_EQ(tuple.at(1).get<Numeric>().value, 20.0);
+    EXPECT_EQ(tuple.kind, TupleKind::Generic);
+    EXPECT_THAT(tuple, HasNumericElement(0, 10.0));
+    EXPECT_THAT(tuple, HasNumericElement(1, 20.0));
 }
 
 TEST_F(YamlParameterSourceTest, MapResolvesToNamedTupleValue)
@@ -163,10 +169,8 @@ TEST_F(YamlParameterSourceTest, MapResolvesToNamedTupleValue)
 
     const auto& tuple = result->get<Tuple>();
     EXPECT_EQ(tuple.size(), 2);
-    ASSERT_NE(tuple.find("top"), nullptr);
-    EXPECT_DOUBLE_EQ(tuple.find("top")->get<Numeric>().value, 10.0);
-    ASSERT_NE(tuple.find("right"), nullptr);
-    EXPECT_DOUBLE_EQ(tuple.find("right")->get<Numeric>().value, 20.0);
+    EXPECT_THAT(tuple, HasNumericField("top", 10.0));
+    EXPECT_THAT(tuple, HasNumericField("right", 20.0));
 }
 
 TEST_F(YamlParameterSourceTest, MixedFileLoadsAllParameters)


### PR DESCRIPTION
 This PR extends the StyleParameters system with typed tuple shapes, gradient support, OKLCH-based color shading, and several new expression parser functions. It builds on top of #28924 (the foundational tuple type) to make tuples semantically meaningful - each has a `TupleKind` that identifies it as a `LinearGradient`, `RadialGradient`, `Corners`, `Padding`, etc., allowing consuming code to interpret and validate structure rather than treating all tuples identically.

Linear and radial gradients are first-class values: they can be defined in YAML or expressions, composed with `lighten()`/`darken()`/`blend()`, and shaded across a perceptual scale with the new `shade()` and `shades()` functions (which use OKLCH color space for uniform-looking results). The `coalesce()` and `content_box()` functions round out the parser, and inline expression substitution allows token values to be interpolated directly into QSS strings. The Theme Editor gains gradient preview swatches and displays the specific gradient type instead of the generic "Tuple" label.

If needed, I can split the PR into smaller, more thematic parts for easier reviewing. However, a full split isn't possible - some parts will still span multiple themes.

  ## Issues

  - Fixes https://github.com/FreeCAD/FreeCAD/issues/27594
  - Part of https://github.com/FreeCAD/FPA-grant-proposals/issues/58

  ## Images

<img width="1170" height="592" alt="image" src="https://github.com/user-attachments/assets/6a75971f-bfce-4ab1-bb09-e0550aa58033" />
