### PR TITLE
macos: fix build error for macos 26 tahoe, rm explicit template argument specification, not required

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1127,7 +1127,7 @@ protected:
             TechDraw::pointPair pp = dim->getLinearPoints();
             float dx = pp.first().x - pp.second().x;
             float dy = pp.first().y - pp.second().y;
-            int alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));
+            int alpha = std::round(Base::toDegrees(std::abs(std::atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));
             std::string sAlpha = std::to_string(alpha);
             std::string formatSpec = dim->FormatSpec.getStrValue();
             formatSpec = formatSpec + " x" + sAlpha + "°";

--- a/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
@@ -1984,7 +1984,7 @@ void execCreateHorizChamferDimension(Gui::Command* cmd) {
         dim->Y.setValue(-yMax);
         float dx = allVertexes[0].point.x - allVertexes[1].point.x;
         float dy = allVertexes[0].point.y - allVertexes[1].point.y;
-        float alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(dy / dx))));
+        float alpha = std::round(Base::toDegrees(std::abs(std::atan(dy / dx))));
         std::string sAlpha = std::to_string((int)alpha);
         std::string formatSpec = dim->FormatSpec.getStrValue();
         formatSpec = formatSpec + " x" + sAlpha + "°";
@@ -2050,7 +2050,7 @@ void execCreateVertChamferDimension(Gui::Command* cmd) {
         dim->Y.setValue(-mid.y);
         float dx = allVertexes[0].point.x - allVertexes[1].point.x;
         float dy = allVertexes[0].point.y - allVertexes[1].point.y;
-        float alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(dx / dy))));
+        float alpha = std::round(Base::toDegrees(std::abs(std::atan(dx / dy))));
         std::string sAlpha = std::to_string((int)alpha);
         std::string formatSpec = dim->FormatSpec.getStrValue();
         formatSpec = formatSpec + " x" + sAlpha + "°";


### PR DESCRIPTION
this PR addresses the below github issue. did a little reseaerch on this, explicity defining `<float>` where this PR removes thoses explicit template arguments allows the compiler ie. gcc or clang to determine the type, which it does by default (from my understanding) so being explicit in this case is actually "hurting" the situation, and causes "uncessary work".

in a future PR it might even be better to use `atan2` instead `atan` which has support for avoiding division by 0.

did a search through code base for this type "template argument specification" and got the below results.

```
╰─λ rg --fixed-strings -i --hidden -g '!*.ts' 'std::abs<' .
./src/Mod/TechDraw/Gui/CommandExtensionDims.cpp
1987:        float alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(dy / dx))));
2053:        float alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(dx / dy))));

./src/Mod/TechDraw/Gui/CommandCreateDims.cpp
1130:            int alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));
```

and also noticed the below in the git log.

```diff
commit a34c0cb093e830937d92c3b30a2187758c16010d
Author: Benjamin Nauck <benjamin@nauck.se>
Date:   Thu Apr 17 00:19:26 2025 +0200

    TechDraw: Potential fix for snap builds, specify type.. again (#20831)

    * TechDraw: Potential fix for snap builds, specify type

    * Techdraw: Fix more toDegrees-issues

diff --git a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1143,1 +1144,1 @@
-            int alpha = round(Base::toDegrees(abs(atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));
+            int alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));

commit 3ed366b6290e9525394209fb302dad2fdcbbac82
...skipping...
diff --git a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1143,1 +1144,1 @@
-            int alpha = round(Base::toDegrees(abs(atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));
+            int alpha = std::round(Base::toDegrees(std::abs<float>(std::atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));

commit 3ed366b6290e9525394209fb302dad2fdcbbac82
Author: PaddleStroke <pierrelouis.boyer@gmail.com>
Date:   Tue Apr 30 09:24:05 2024 +0200

    TechDraw: Smart Dimension tool : Integrate the 'chamfer' tool.

diff --git a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
--- a/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
+++ b/src/Mod/TechDraw/Gui/CommandCreateDims.cpp
@@ -1105,0 +1136,1 @@
+            int alpha = round(Base::toDegrees(abs(atan(type == "DistanceY" ? (dx / dy) : (dy / dx)))));
```

so these changes should be minor and fix builds when using the macos 26 sdk. 🤞

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/28983

## Before and After Images

