### PR TITLE
Security: validate module imports in Restore()

### DIFF
--- a/src/App/PropertyPythonObject.cpp
+++ b/src/App/PropertyPythonObject.cpp
@@ -24,8 +24,10 @@
 
 
 
+#include <algorithm>
 #include <iostream>
-#include <boost/regex.hpp>
+#include <string>
+#include <vector>
 
 #include <Base/Base64.h>
 #include <Base/Console.h>
@@ -33,11 +35,155 @@
 #include <Base/Reader.h>
 #include <Base/Writer.h>
 
+#include "Application.h"
 #include "PropertyPythonObject.h"
 #include "DocumentObject.h"
 
 
 using namespace App;
+
+namespace {
+
+/**
+ * @brief Check whether a path starts with a given directory prefix.
+ *
+ * @param[in] filePath The file path to check.
+ * @param[in] directory The directory prefix to match against.
+ * @return @c true if @p filePath starts with @p directory.
+ */
+bool isUnderDirectory(std::string filePath, std::string directory)
+{
+    std::ranges::replace(filePath, '\\', '/');
+    std::ranges::replace(directory, '\\', '/');
+    // Collapse repeated slashes (e.g. home path "build/debug//" + "Mod")
+    auto collapseSlashes = [](std::string& s) {
+        auto out = s.begin();
+        for (auto it = s.begin(); it != s.end(); ++it) {
+            if (*it == '/' && out != s.begin() && *(out - 1) == '/') {
+                continue;
+            }
+            *out++ = *it;
+        }
+        s.erase(out, s.end());
+    };
+    collapseSlashes(filePath);
+    collapseSlashes(directory);
+    if (!directory.empty() && directory.back() != '/') {
+        directory += '/';
+    }
+    return filePath.starts_with(directory);
+}
+
+/**
+ * @brief Check whether a module import should be allowed during document restore.
+ *
+ * Modules already in @c sys.modules are permitted -- they were loaded by FreeCAD core or addons
+ * during normal startup.  For modules not yet loaded we use @c importlib.util.find_spec() to
+ * locate where the module would come from without executing it, then verify that path is under
+ * a FreeCAD module directory.  This prevents a crafted FCStd from importing arbitrary modules
+ * (whose <tt>__init__.py</tt> could run malicious code on import) while still allowing
+ * legitimate lazy-loaded FreeCAD workbench modules to restore.
+ *
+ * @param[in] moduleName The fully qualified Python module name to check.
+ * @return @c true if the module is allowed, @c false otherwise.
+ */
+bool isAllowedModule(const std::string& moduleName)
+{
+    Py::Dict sysModules(PyImport_GetModuleDict());
+    if (sysModules.isNone()) {
+        return false;
+    }
+
+    // 1) Already loaded? Must be safe.
+    if (sysModules.hasKey(moduleName)) {
+        return true;
+    }
+
+    // 2) Is it *in* an already loaded module? Safe.
+    std::string::size_type dot = moduleName.find('.');
+    if (dot != std::string::npos) {
+        std::string topLevel = moduleName.substr(0, dot);
+        if (sysModules.hasKey(topLevel)) {
+            return true;
+        }
+    }
+
+    // 3) The complicated path. Use importlib.util.find_spec() to find the origin of the module,
+    // being careful to NOT load it (which is the code-execution vulnerability we're trying to
+    // avoid in the first place). See if it's in one of our "safe" paths, and if it is, allow it.
+    // Safe paths are a few subdirectories we recognize in the set "home", "resource", and
+    // "userData" paths. Don't allow modules from outside of these directories. Not 100% mitigation,
+    // but it's better than nothing.
+    PyObject* importlibUtil = PyImport_ImportModule("importlib.util");
+    if (!importlibUtil) {
+        PyErr_Clear();
+        return false;
+    }
+    Py::Module importlib(importlibUtil, true);
+    Py::Callable findSpec(importlib.getAttr("find_spec"));
+
+    // FreeCAD adds each workbench directory to sys.path individually (e.g. .../Mod/Assembly/),
+    // so a module stored as "Assembly.JointObject" in the FCStd is actually importable as just
+    // "JointObject". Try the full name first, then the part after the first dot.
+    std::vector<std::string> namesToTry = {moduleName};
+    if (dot != std::string::npos) {
+        namesToTry.push_back(moduleName.substr(dot + 1));
+    }
+    Py::Object spec;
+    for (const std::string& name : namesToTry) {
+        Py::Tuple args(1);
+        args.setItem(0, Py::String(name));
+        try {
+            spec = findSpec.apply(args);
+        }
+        catch (Py::Exception&) {
+            PyErr_Clear();
+            continue;
+        }
+        if (!spec.isNone()) {
+            break;
+        }
+    }
+    if (spec.isNone()) {
+        return false;
+    }
+
+    std::string home = Application::getHomePath();
+    std::string userData = Application::getUserAppDataDir();
+    std::string resource = Application::getResourceDir();
+
+    auto isUnderFreeCAD = [&](const std::string& path) {
+        return isUnderDirectory(path, home + "Mod")
+            || isUnderDirectory(path, home + "Ext")
+            || isUnderDirectory(path, resource + "Mod")
+            || isUnderDirectory(path, resource + "Ext")
+            || isUnderDirectory(path, userData + "Mod");
+    };
+
+    // Get the origin (i.e. the file path) from the spec.
+    Py::Object origin = spec.getAttr("origin");
+    if (!origin.isNone() && origin.isString()) {
+        return isUnderFreeCAD(Py::String(origin).as_std_string());
+    }
+
+    // No origin -- this could be a built-in module (why is an FCStd trying to load this? Very
+    // suspicious, block it) or a synthetic module from a FreeCAD migration finder like
+    // FemMigrateApp (which we will allow).  Check whether the spec's loader itself comes from a
+    // FreeCAD module directory.
+    if (!spec.hasAttr("loader") || spec.getAttr("loader").isNone()) {
+        return false;
+    }
+    Py::Object loader = spec.getAttr("loader");
+    auto loaderType = loader.type();
+    if (!loaderType.hasAttr("__module__")) {
+        return false;
+    }
+    std::string loaderModuleName = Py::String(loaderType.getAttr("__module__")).as_std_string();
+    Py::Object loaderMod = sysModules.getItem(loaderModuleName);
+    return isUnderFreeCAD(Py::String(loaderMod.getAttr("__file__")).as_std_string());
+}
+
+}  // anonymous namespace
 
 
 TYPESYSTEM_SOURCE(App::PropertyPythonObject, App::Property)
@@ -180,31 +326,6 @@ void PropertyPythonObject::fromString(const std::string& repr)
     }
 }
 
-void PropertyPythonObject::loadPickle(const std::string& str)
-{
-    // find the custom attributes and restore them
-    Base::PyGILStateLocker lock;
-    try {
-        std::string buffer = str;
-        boost::regex pickle(R"(S'(\w+)'.+S'(\w+)'\n)");
-        boost::match_results<std::string::const_iterator> what;
-        std::string::const_iterator start, end;
-        start = buffer.begin();
-        end = buffer.end();
-        while (boost::regex_search(start, end, what, pickle)) {
-            std::string key = std::string(what[1].first, what[1].second);
-            std::string val = std::string(what[2].first, what[2].second);
-            this->object.setAttr(key, Py::String(val));
-            buffer = std::string(what[2].second, end);
-            start = buffer.begin();
-            end = buffer.end();
-        }
-    }
-    catch (Py::Exception&) {
-        Base::PyException e;  // extract the Python error text
-        e.reportException();
-    }
-}
 
 std::string PropertyPythonObject::encodeValue(const std::string& str) const
 {
@@ -341,7 +462,6 @@ void PropertyPythonObject::Restore(Base::XMLReader& reader)
     }
     else {
         bool load_json = false;
-        bool load_pickle = false;
         bool load_failed = false;
         std::string buffer = reader.getAttribute<const char*>("value");
         if (reader.hasAttribute("encoded") && strcmp(reader.getAttribute<const char*>("encoded"), "yes") == 0) {
@@ -353,21 +473,25 @@ void PropertyPythonObject::Restore(Base::XMLReader& reader)
 
         Base::PyGILStateLocker lock;
         try {
-            boost::regex pickle(R"(^\(i(\w+)\n(\w+)\n)");
-            boost::match_results<std::string::const_iterator> what;
-            std::string::const_iterator start, end;
-            start = buffer.begin();
-            end = buffer.end();
             if (reader.hasAttribute("module") && reader.hasAttribute("class")) {
-                Py::Module mod(PyImport_ImportModule(reader.getAttribute<const char*>("module")), true);
+                std::string moduleName = reader.getAttribute<const char*>("module");
+                if (!isAllowedModule(moduleName)) {
+                    Base::Console().warning(
+                        "PropertyPythonObject::Restore: blocked import of module '%s' during"
+                        " document restore. Only modules from FreeCAD or installed addons"
+                        " are permitted.\n",
+                        moduleName.c_str());
+                    throw Py::ImportError("module not permitted: " + moduleName);
+                }
+                Py::Module mod(PyImport_ImportModule(moduleName.c_str()), true);
                 if (mod.isNull()) {
                     throw Py::Exception();
                 }
-                PyObject* cls = mod.getAttr(reader.getAttribute<const char*>("class")).ptr();
+                std::string className = reader.getAttribute<const char*>("class");
+                PyObject* cls = mod.getAttr(className).ptr();
                 if (!cls) {
                     std::stringstream s;
-                    s << "Module " << reader.getAttribute<const char*>("module") << " has no class "
-                      << reader.getAttribute<const char*>("class");
+                    s << "Module " << moduleName << " has no class " << className;
                     throw Py::AttributeError(s.str());
                 }
                 if (PyType_Check(cls)) {
@@ -377,17 +501,6 @@ void PropertyPythonObject::Restore(Base::XMLReader& reader)
                     throw Py::TypeError("neither class nor type object");
                 }
                 load_json = true;
-            }
-            else if (boost::regex_search(start, end, what, pickle)) {
-                std::string name = std::string(what[1].first, what[1].second);
-                std::string type = std::string(what[2].first, what[2].second);
-                Py::Module mod(PyImport_ImportModule(name.c_str()), true);
-                if (mod.isNull()) {
-                    throw Py::Exception();
-                }
-                this->object = PyObject_CallObject(mod.getAttr(type).ptr(), nullptr);
-                load_pickle = true;
-                buffer = std::string(what[2].second, end);
             }
             else if (reader.hasAttribute("json")) {
                 load_json = true;
@@ -403,9 +516,6 @@ void PropertyPythonObject::Restore(Base::XMLReader& reader)
         aboutToSetValue();
         if (load_json) {
             this->fromString(buffer);
-        }
-        else if (load_pickle) {
-            this->loadPickle(buffer);
         }
         else if (!load_failed) {
             Base::Console().warning(

--- a/src/App/PropertyPythonObject.h
+++ b/src/App/PropertyPythonObject.h
@@ -77,7 +77,6 @@ private:
     void restoreObject(Base::XMLReader& reader);
     std::string encodeValue(const std::string& str) const;
     std::string decodeValue(const std::string& str) const;
-    void loadPickle(const std::string& str);
     Py::Object object;
 };
 


### PR DESCRIPTION
Multi-stage validation of module imports when loading an FCStd file: 
1) Has the module already been loaded? If so, it's OK 
2) Is the module located in a known location? (e.g. Mod, Ext, etc.) OK. 
3) Legacy modules that are now handled by a loader module that is in a known location (for example, femobjects._FemElementGeometry2D) are OK. This case got complicated in a hurry, since FreeCAD manually injects its internal modules into the path, so they can be loaded without a prefix. I've tested this against all of the files in the FreeCAD parts library and it correctly blocks everything where I don't have the addon installed, and allows all the ones I do. It also passes @marioalexis84's test case, and loads the AssemblyExample.FCStd files (which were the ones I used as my main testbeds when writing)

If the module is outside these parameters it is rejected. This addresses a potential code-execution-when-loading security vulnerability reported in GHSA-493w-pp4h-h77 and assigned CVE-2026-34789.

This commit also removes the fallback Pickle code for handling files in FreeCAD 0.12 and earlier, which itself was a minor vulnerability.

@maxwxyz I'd like to get this into a weekly BEFORE we backport it, so if it causes unforseen problems we can figure out a new path forward. But ultimately it should be targeted at 1.1.1 since it does resolve an open CVE.