### PR TITLE
Gui: fix toolbar icon size reset after stylesheet reload

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -706,6 +706,7 @@ void ToolBarManager::setup(ToolBarItem* toolBarItems)
             toolbar->setObjectName(name);
 
             getMainWindow()->addToolBar(toolbar);
+            setToolBarIconSize(toolbar);
 
             if (nameAsToolTip) {
                 auto tooltip = QChar::fromLatin1('[')


### PR DESCRIPTION
## Summary
- Toolbars created during workbench switches had no explicit icon size, so stylesheet reloads (e.g. from Theme Editor) reset them to Qt's default 24px
- Fix: call `setToolBarIconSize()` right after `addToolBar()` so new toolbars always have an explicit size

Fixes #28657

## Test plan
- Set toolbar icon size to 32px in Preferences → General → General, restart FreeCAD
- Open Preferences → User Interface → Open Theme Editor, change any value, click Apply
- Close Theme Editor and Preferences — icons should remain at 32px