### PR TITLE
ExpressionTokenizer: fix autocomplete deleting operators when replacing mid-expression token

### DIFF
--- a/src/App/ExpressionTokenizer.cpp
+++ b/src/App/ExpressionTokenizer.cpp
@@ -81,9 +81,11 @@ QString ExpressionTokenizer::perform(const QString& prefix, int pos)
             // Include the immediately followed '.' or '#', because we'll be
             // inserting these separators too, in ExpressionCompleteModel::pathFromIndex()
             if (it != tokens.begin() && tokenType != '.' && tokenType != '#') {
-                it = it - 1;
+                --it;
+                location = std::get<1>(*it);
+                tokenLength = static_cast<int>(std::get<2>(*it).size());
             }
-            tokens.resize(it - tokens.begin() + 1); // Invalidates it, but we already calculated tokenLength
+            tokens.resize(it - tokens.begin() + 1);
             prefixEnd = start + location + tokenLength;
             break;
         }


### PR DESCRIPTION
## Summary
- Autocomplete deleted operators (e.g. `-`) when replacing a token in the middle of an expression
- After stepping back with `--it`, `location` and `tokenLength` still held values from the wrong token, making `prefixEnd` extend too far
- Fix: re-read both values from `*it` after `--it`

Fixes #28987

## Test plan
- Open expression `VarSet.LargoEtiqueta - VarSet.AnchoEtiqueta * 3`, place cursor inside `LargoEtiqueta`, use autocomplete to replace it
- Verify ` - VarSet.AnchoEtiqueta * 3` is preserved