### PR TITLE
Fix attachment editor bold not following user mode selection

### DIFF
--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -122,6 +122,7 @@ TaskAttacher::TaskAttacher(
     , ui(new Ui_TaskAttacher)
     , visibilityFunc(visFunc)
     , completed(false)
+    , userSelectedMode(false)
 {
     // check if we are attachable
     if (!ViewProvider->getObject()->hasExtension(Part::AttachExtension::getExtensionClassTypeId())) {
@@ -675,6 +676,7 @@ void TaskAttacher::addToReference(const std::vector<SubAndObjName>& pairs)
     }
 
     try {
+        userSelectedMode = false;
         updateListOfModes();
         eMapMode mmode = getActiveMapMode();  // will be mmDeactivated, if selected or if no modes
                                               // are available
@@ -832,7 +834,10 @@ void TaskAttacher::onModeSelect()
 
     Part::AttachExtension* pcAttach
         = ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
-    pcAttach->MapMode.setValue(getActiveMapMode());
+    eMapMode activeMode = getActiveMapMode();
+    pcAttach->MapMode.setValue(activeMode);
+    userSelectedMode = true;
+    applyBoldMode(activeMode);
     updatePreview();
 }
 
@@ -863,6 +868,7 @@ void TaskAttacher::onRefName(const QString& text, unsigned idx)
             }
         }
         pcAttach->AttachmentSupport.setValues(newrefs, newrefnames);
+        userSelectedMode = false;
         updateListOfModes();
         pcAttach->MapMode.setValue(getActiveMapMode());
         selectMapMode(getActiveMapMode());
@@ -967,6 +973,7 @@ void TaskAttacher::onRefName(const QString& text, unsigned idx)
         refnames.emplace_back(subElement);
     }
     pcAttach->AttachmentSupport.setValues(refs, refnames);
+    userSelectedMode = false;
     updateListOfModes();
     pcAttach->MapMode.setValue(getActiveMapMode());
     selectMapMode(getActiveMapMode());
@@ -1153,6 +1160,12 @@ void TaskAttacher::updateListOfModes()
         }
     }
 
+    // determine which mode to bold: user's explicit choice takes priority, else suggest best fit
+    eMapMode activeSavedMode = eMapMode(pcAttach->MapMode.getValue());
+    eMapMode boldMode = (userSelectedMode || activeSavedMode != mmDeactivated)
+        ? activeSavedMode
+        : this->lastSuggestResult.bestFitMode;
+
     // populate list
     ui->listOfModes->blockSignals(true);
     ui->listOfModes->clear();
@@ -1197,8 +1210,8 @@ void TaskAttacher::updateListOfModes()
                     item->setText(tr("%1 (add more references)").arg(item->text()));
                 }
             }
-            else if (mmode == this->lastSuggestResult.bestFitMode) {
-                // suggested mode - make bold
+            else if (mmode == boldMode) {
+                // active or suggested mode - make bold
                 QFont fnt = item->font();
                 fnt.setBold(true);
                 item->setFont(fnt);
@@ -1225,6 +1238,19 @@ void TaskAttacher::selectMapMode(eMapMode mmode)
     }
 
     ui->listOfModes->blockSignals(false);
+}
+
+void TaskAttacher::applyBoldMode(eMapMode boldMode)
+{
+    for (int i = 0; i < ui->listOfModes->count(); ++i) {
+        QListWidgetItem* item = ui->listOfModes->item(i);
+        if (!(item->flags() & Qt::ItemFlag::ItemIsEnabled)) {
+            continue;
+        }
+        QFont fnt = item->font();
+        fnt.setBold(modesInList[i] == boldMode);
+        item->setFont(fnt);
+    }
 }
 
 void TaskAttacher::showPlacementUtilities()

--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -155,6 +155,12 @@ private:
      */
     void selectMapMode(Attacher::eMapMode mmode);
 
+    /**
+     * @brief applyBoldMode Sets bold font on the enabled list item matching boldMode,
+     * clears bold on all others.
+     */
+    void applyBoldMode(Attacher::eMapMode boldMode);
+
     void showPlacementUtilities();
 
 protected:
@@ -175,6 +181,7 @@ private:
                                                   // into listOfModes widget.
     Attacher::SuggestResult lastSuggestResult;
     bool completed;
+    bool userSelectedMode;  // true when the user has explicitly clicked a mode in the list
 
     using Connection = fastsignals::connection;
     Connection connectDelObject;


### PR DESCRIPTION
Fixes #26693

When the user manually selects a mode in the attachment editor list, the bold indicator was staying on the suggestors bestFitMode instead of moving to the selected mode.

**Root cause:** `updateListOfModes()` always bolded `bestFitMode`, and `onModeSelect()` did not update bold at all.

**Fix:**
- Add `userSelectedMode` flag to track explicit user clicks
- Add `applyBoldMode()` helper to update bold on enabled items only (skips grayed-out reachable modes)
- `onModeSelect()` sets `userSelectedMode = true` and calls `applyBoldMode()` immediately
- `updateListOfModes()` bolds the active mode when user has made a choice, falls back to `bestFitMode` otherwise
- Reset `userSelectedMode` whenever references change so the suggestor takes over again