### PR TITLE
[Backport releases/FreeCAD-1-1] Gui: Detect spnav daemon disconnect to prevent 100% CPU

### DIFF
--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.cpp
@@ -30,6 +30,9 @@
 
 #include <QSocketNotifier>
 
+#include <cerrno>
+#include <sys/socket.h>
+
 #include <spnav.h>
 
 Gui::GuiNativeEvent::GuiNativeEvent(Gui::GUIApplicationNativeEventAware* app)
@@ -38,11 +41,13 @@ Gui::GuiNativeEvent::GuiNativeEvent(Gui::GUIApplicationNativeEventAware* app)
 
 Gui::GuiNativeEvent::~GuiNativeEvent()
 {
-    if (spnav_close()) {
-        Base::Console().log("Couldn't disconnect from spacenav daemon\n");
-    }
-    else {
-        Base::Console().log("Disconnected from spacenav daemon\n");
+    if (spnavNotifier) {
+        if (spnav_close()) {
+            Base::Console().log("Couldn't disconnect from spacenav daemon\n");
+        }
+        else {
+            Base::Console().log("Disconnected from spacenav daemon\n");
+        }
     }
 }
 
@@ -56,9 +61,8 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
     }
     else {
         Base::Console().log("Connected to spacenav daemon\n");
-        QSocketNotifier* SpacenavNotifier
-            = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
-        connect(SpacenavNotifier, SIGNAL(activated(int)), this, SLOT(pollSpacenav()));
+        spnavNotifier = new QSocketNotifier(spnav_fd(), QSocketNotifier::Read, this);
+        connect(spnavNotifier, SIGNAL(activated(int)), this, SLOT(pollSpacenav()));
         mainApp->setSpaceballPresent(true);
     }
 }
@@ -66,7 +70,10 @@ void Gui::GuiNativeEvent::initSpaceball(QMainWindow* window)
 void Gui::GuiNativeEvent::pollSpacenav()
 {
     spnav_event ev;
+    bool gotEvent = false;
+
     while (spnav_poll_event(&ev)) {
+        gotEvent = true;
         switch (ev.type) {
             case SPNAV_EVENT_MOTION: {
                 motionDataArray[0] = -ev.motion.x;
@@ -81,6 +88,25 @@ void Gui::GuiNativeEvent::pollSpacenav()
             case SPNAV_EVENT_BUTTON: {
                 mainApp->postButtonEvent(ev.button.bnum, ev.button.press);
                 break;
+            }
+        }
+    }
+
+    if (!gotEvent) {
+        // QSocketNotifier fired but no events were available.
+        // Verify the connection is still alive using a non-consuming peek.
+        int fd = spnav_fd();
+        if (fd >= 0) {
+            char buf;
+            ssize_t ret = recv(fd, &buf, 1, MSG_PEEK | MSG_DONTWAIT);
+            if (ret == 0 || (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+                // EOF or socket error — spacenavd disconnected
+                Base::Console().warning(
+                    "Lost connection to spacenav daemon. Restart FreeCAD to reconnect.\n"
+                );
+                spnavNotifier->setEnabled(false);
+                spnav_close();
+                spnavNotifier = nullptr;
             }
         }
     }

--- a/src/Gui/3Dconnexion/GuiNativeEventLinux.h
+++ b/src/Gui/3Dconnexion/GuiNativeEventLinux.h
@@ -26,6 +26,7 @@
 #include "GuiAbstractNativeEvent.h"
 
 class QMainWindow;
+class QSocketNotifier;
 
 namespace Gui
 {
@@ -43,6 +44,9 @@ private:
     GuiNativeEvent();
     GuiNativeEvent(const GuiNativeEvent&);
     GuiNativeEvent& operator=(const GuiNativeEvent&);
+
+    QSocketNotifier* spnavNotifier {nullptr};
+
 private Q_SLOTS:
     void pollSpacenav();
 };


### PR DESCRIPTION
Manual backport of #28915 — the automatic cherry-pick failed due to conflicts with changes only present on main (event coalescing from #28110).

Resolved cleanly: only the disconnect detection is included, no unrelated changes from main.

When spacenavd stops or crashes, the Unix socket enters EOF state. QSocketNotifier fires continuously since EOF is always "readable", but `spnav_poll_event()` returns 0 for both "no events" and "dead connection", causing a tight loop at 100% CPU on one core.

After an empty poll cycle, `recv(MSG_PEEK)` checks for EOF. On disconnection, the QSocketNotifier is disabled and the spnav connection closed gracefully.

Fixes #17809