### PR TITLE
Style the action panel to remove its background

### DIFF
--- a/src/Gui/Stylesheets/FreeCAD.qss
+++ b/src/Gui/Stylesheets/FreeCAD.qss
@@ -1510,6 +1510,10 @@ Gui--PropertyEditor--PropertyEditor {
   qproperty-groupBackground: @GeneralHeaderBackgroundColor;
 }
 
+Gui--TaskView--TaskPanel QSint--ActionPanel {
+  background-color: transparent;
+}
+
 /* Action group */
 QFrame[class="panel"] {}
 QSint--ActionGroup {


### PR DESCRIPTION
Fixes #28530

Bisecting shows that the problem was introduced by f4665aa7 (that commit needs the fix in ad630cbb to compile, so that branch should probably have been cleaned up before it was pushed). Skimming changes in the commit it seems that most relate to transactions, but that changes to TaskView.h/.cpp and actionpanel.h/.cpp are related to the gui. The changes to TaskView changes the widget hierarchy from:
- TaskView:QWidget
  - QScrollArea
    - TaskPanel : ActionPanel : QFrame

to
- TaskView:QStackedWidget
  - TaskPanel:QWidget
    - QScrollArea
      - ActionPanel : QFrame

The problem can be fixed by adding `actionPanel->setAttribute(Qt::WA_TranslucentBackground);` in the `TaskPanel::TaskPanel(QWidget*)` constructor, indicating that the erroneous background is from the ActionPanel instance that is no longer subclassed by TaskPanel. I guess the qss would be the place to fix it.

Taking the liberty to add this PR as the other PR on this issue appear to be an LLM conversation.