### PR TITLE
Gui/PartGui: Rework legacy OpenGL code to Coin nodes

### DIFF
--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -1,30 +1,33 @@
-/***************************************************************************
- *   Copyright (c) 2005 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2005 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <QApplication>
 #include <QDir>
 #include <QPrinter>
 #include <QFileInfo>
+#include <map>
 #include <Inventor/SoInput.h>
+#include <Inventor/SoPath.h>
 #include <Inventor/actions/SoGetPrimitiveCountAction.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <xercesc/util/TranscodingException.hpp>
@@ -69,6 +72,7 @@
 #include "WorkbenchManipulatorPython.h"
 #include "Inventor/MarkerBitmaps.h"
 #include "Language/Translator.h"
+#include "Selection/SoFCUnifiedSelection.h"
 
 
 using namespace Gui;
@@ -82,6 +86,158 @@ void requirePythonMainThread(const char* api)
     }
     catch (const Base::Exception& exception) {
         throw Py::RuntimeError(exception.what());
+    }
+}
+
+struct CoinActionTarget
+{
+    SoNode* node {nullptr};
+    SoPath* path {nullptr};
+};
+
+std::string pythonStringToStdString(PyObject* value)
+{
+    if (PyUnicode_Check(value)) {
+        const char* utf8 = PyUnicode_AsUTF8(value);
+        if (!utf8) {
+            throw Py::Exception();
+        }
+        return utf8;
+    }
+
+    if (PyBytes_Check(value)) {
+        char* data = nullptr;
+        Py_ssize_t size = 0;
+        if (PyBytes_AsStringAndSize(value, &data, &size) != 0) {
+            throw Py::Exception();
+        }
+        return std::string(data, static_cast<std::size_t>(size));
+    }
+
+    throw Py::TypeError("color override keys must be strings");
+}
+
+Base::Color pythonToColor(PyObject* value)
+{
+    Base::Color color;
+    if (PyTuple_Check(value) && (PyTuple_Size(value) == 3 || PyTuple_Size(value) == 4)) {
+        PyObject* item = PyTuple_GetItem(value, 0);
+        if (PyFloat_Check(item)) {
+            color.r = static_cast<float>(PyFloat_AsDouble(item));
+            item = PyTuple_GetItem(value, 1);
+            if (!PyFloat_Check(item)) {
+                throw Py::TypeError("color tuples must use consistent float components");
+            }
+            color.g = static_cast<float>(PyFloat_AsDouble(item));
+            item = PyTuple_GetItem(value, 2);
+            if (!PyFloat_Check(item)) {
+                throw Py::TypeError("color tuples must use consistent float components");
+            }
+            color.b = static_cast<float>(PyFloat_AsDouble(item));
+            if (PyTuple_Size(value) == 4) {
+                item = PyTuple_GetItem(value, 3);
+                if (!PyFloat_Check(item)) {
+                    throw Py::TypeError("color tuples must use consistent float components");
+                }
+                color.a = static_cast<float>(PyFloat_AsDouble(item));
+            }
+            return color;
+        }
+
+        if (PyLong_Check(item)) {
+            color.r = static_cast<float>(PyLong_AsLong(item)) / 255.0F;
+            item = PyTuple_GetItem(value, 1);
+            if (!PyLong_Check(item)) {
+                throw Py::TypeError("color tuples must use consistent integer components");
+            }
+            color.g = static_cast<float>(PyLong_AsLong(item)) / 255.0F;
+            item = PyTuple_GetItem(value, 2);
+            if (!PyLong_Check(item)) {
+                throw Py::TypeError("color tuples must use consistent integer components");
+            }
+            color.b = static_cast<float>(PyLong_AsLong(item)) / 255.0F;
+            if (PyTuple_Size(value) == 4) {
+                item = PyTuple_GetItem(value, 3);
+                if (!PyLong_Check(item)) {
+                    throw Py::TypeError("color tuples must use consistent integer components");
+                }
+                color.a = static_cast<float>(PyLong_AsLong(item)) / 255.0F;
+            }
+            return color;
+        }
+
+        throw Py::TypeError("color tuples must contain either floats or integers");
+    }
+
+    if (PyLong_Check(value)) {
+        color.setPackedValue(PyLong_AsUnsignedLong(value));
+        return color;
+    }
+
+    throw Py::TypeError("colors must be packed integers or RGB/RGBA tuples");
+}
+
+std::map<std::string, Base::Color> pythonToColorOverrideMap(PyObject* value)
+{
+    if (!PyDict_Check(value)) {
+        throw Py::TypeError("colors must be a dict mapping element names to colors");
+    }
+
+    std::map<std::string, Base::Color> colors;
+    PyObject* key = nullptr;
+    PyObject* item = nullptr;
+    Py_ssize_t pos = 0;
+    while (PyDict_Next(value, &pos, &key, &item)) {
+        colors.emplace(pythonStringToStdString(key), pythonToColor(item));
+    }
+    return colors;
+}
+
+CoinActionTarget pythonToCoinActionTarget(PyObject* proxy)
+{
+    CoinActionTarget target;
+    void* ptr = nullptr;
+
+    try {
+        Base::Interpreter().convertSWIGPointerObj("pivy.coin", "SoPath *", proxy, &ptr, 0);
+    }
+    catch (const Base::Exception&) {
+        ptr = nullptr;
+    }
+    if (ptr) {
+        target.path = static_cast<SoPath*>(ptr);
+        return target;
+    }
+
+    try {
+        Base::Interpreter().convertSWIGPointerObj("pivy.coin", "SoNode *", proxy, &ptr, 0);
+    }
+    catch (const Base::Exception&) {
+        ptr = nullptr;
+    }
+    if (ptr) {
+        target.node = static_cast<SoNode*>(ptr);
+        return target;
+    }
+
+    throw Py::TypeError("target must be of type coin.SoNode or coin.SoPath");
+}
+
+void applyElementColorOverrideAction(
+    const CoinActionTarget& target,
+    std::map<std::string, Base::Color> colors
+)
+{
+    SoSelectionElementAction action(SoSelectionElementAction::Color, true);
+    action.swapColors(colors);
+    if (target.path) {
+        action.apply(target.path);
+    }
+    else if (target.node) {
+        action.apply(target.node);
+    }
+    else {
+        throw Py::TypeError("target must be of type coin.SoNode or coin.SoPath");
     }
 }
 }  // namespace
@@ -554,6 +710,26 @@ PyMethodDef ApplicationPy::Methods[] = {
      "Remove all children from a group node.\n"
      "\n"
      "node : object"},
+    {"applyElementColorOverride",
+     (PyCFunction)ApplicationPy::sApplyElementColorOverride,
+     METH_VARARGS,
+     "applyElementColorOverride(target, colors) -> None\n"
+     "\n"
+     "Apply a secondary element color override to a Coin node or path.\n"
+     "\n"
+     "target : coin.SoNode | coin.SoPath\n"
+     "colors : dict[str, color]\n"
+     "    Maps element names such as 'Face', 'Face1', 'Edge3', or '' to colors.\n"
+     "    Color values use the same packed-int or RGB/RGBA tuple formats accepted by\n"
+     "    FreeCAD material colors."},
+    {"clearElementColorOverride",
+     (PyCFunction)ApplicationPy::sClearElementColorOverride,
+     METH_VARARGS,
+     "clearElementColorOverride(target) -> None\n"
+     "\n"
+     "Clear a previously applied secondary element color override from a Coin node or path.\n"
+     "\n"
+     "target : coin.SoNode | coin.SoPath"},
     {"suspendWaitCursor",
      (PyCFunction)ApplicationPy::sSuspendWaitCursor,
      METH_VARARGS,
@@ -1958,6 +2134,42 @@ PyObject* ApplicationPy::sCoinRemoveAllChildren(PyObject* /*self*/, PyObject* ar
         }
 
         coinRemoveAllChildren(static_cast<SoGroup*>(ptr));
+        Py_Return;
+    }
+    PY_CATCH;
+}
+
+PyObject* ApplicationPy::sApplyElementColorOverride(PyObject* /*self*/, PyObject* args)
+{
+    PyObject* targetObj = nullptr;
+    PyObject* colorsObj = nullptr;
+    if (!PyArg_ParseTuple(args, "OO", &targetObj, &colorsObj)) {
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        requirePythonMainThread("FreeCADGui.applyElementColorOverride");
+        auto target = pythonToCoinActionTarget(targetObj);
+        auto colors = pythonToColorOverrideMap(colorsObj);
+        applyElementColorOverrideAction(target, std::move(colors));
+        Py_Return;
+    }
+    PY_CATCH;
+}
+
+PyObject* ApplicationPy::sClearElementColorOverride(PyObject* /*self*/, PyObject* args)
+{
+    PyObject* targetObj = nullptr;
+    if (!PyArg_ParseTuple(args, "O", &targetObj)) {
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        requirePythonMainThread("FreeCADGui.clearElementColorOverride");
+        auto target = pythonToCoinActionTarget(targetObj);
+        applyElementColorOverrideAction(target, {});
         Py_Return;
     }
     PY_CATCH;

--- a/src/Gui/ApplicationPy.h
+++ b/src/Gui/ApplicationPy.h
@@ -1,25 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2004 Jürgen Riegel <juergen.riegel@web.de>              *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2004 Jürgen Riegel <juergen.riegel@web.de>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -80,6 +80,8 @@ public:
     static PyObject* sLoadFile                 (PyObject *self,PyObject *args); // open all types of files
 
     static PyObject* sCoinRemoveAllChildren    (PyObject *self,PyObject *args);
+    static PyObject* sApplyElementColorOverride(PyObject *self,PyObject *args);
+    static PyObject* sClearElementColorOverride(PyObject *self,PyObject *args);
 
     static PyObject* sActiveDocument           (PyObject *self,PyObject *args);
     static PyObject* sSetActiveDocument        (PyObject *self,PyObject *args);

--- a/src/Gui/GLPainter.cpp
+++ b/src/Gui/GLPainter.cpp
@@ -1,28 +1,45 @@
-/***************************************************************************
- *   Copyright (c) 2013 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2013 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <algorithm>
 
 #include <QOpenGLWidget>
 
+#include <Inventor/SbViewportRegion.h>
+#include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/nodes/SoDepthBuffer.h>
+#include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoLightModel.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoLineSet.h>
+#include <Inventor/nodes/SoPointSet.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoVertexProperty.h>
+
 #include "GLPainter.h"
+#include "Quarter/QuarterWidget.h"
 #include "View3DInventorViewer.h"
 
 
@@ -30,14 +47,84 @@ using namespace Gui;
 
 TYPESYSTEM_SOURCE_ABSTRACT(Gui::GLGraphicsItem, Base::BaseClass)
 
-GLPainter::GLPainter()
+namespace
 {
-    depthrange[0] = 0;
-    depthrange[1] = 0;
-    for (int i = 0; i < 16; i++) {
-        projectionmatrix[i] = 0.0;
+float clamp01(float value)
+{
+    return std::clamp(value, 0.0f, 1.0f);
+}
+
+SbVec3f toOverlayPoint(int x, int y, int width, int height)
+{
+    return {
+        static_cast<float>(x) - 0.5f * static_cast<float>(width),
+        0.5f * static_cast<float>(height) - static_cast<float>(y),
+        0.0f,
+    };
+}
+
+SoSeparator* createOverlayRoot(int width, int height)
+{
+    auto* root = new SoSeparator;
+    root->ref();
+
+    auto* camera = new SoOrthographicCamera;
+    camera->aspectRatio.setValue(static_cast<float>(width) / static_cast<float>(height));
+    camera->height.setValue(static_cast<float>(height));
+    root->addChild(camera);
+
+    auto* depth = new SoDepthBuffer;
+    depth->test.setValue(false);
+    depth->write.setValue(false);
+    depth->function.setValue(SoDepthBuffer::ALWAYS);
+    root->addChild(depth);
+
+    auto* lightModel = new SoLightModel;
+    lightModel->model.setValue(SoLightModel::BASE_COLOR);
+    root->addChild(lightModel);
+
+    return root;
+}
+
+void setOverlayCacheContext(
+    SoGLRenderAction& action,
+    const QOpenGLWidget* widget,
+    const View3DInventorViewer* viewer
+)
+{
+    if (viewer && viewer->getSoRenderManager()) {
+        if (auto* glra = viewer->getSoRenderManager()->getGLRenderAction()) {
+            action.setCacheContext(glra->getCacheContext());
+            return;
+        }
+    }
+
+    for (QObject* current = const_cast<QOpenGLWidget*>(widget); current; current = current->parent()) {
+        if (auto* quarter = qobject_cast<SIM::Coin3D::Quarter::QuarterWidget*>(current)) {
+            action.setCacheContext(quarter->getCacheContextId());
+            return;
+        }
     }
 }
+
+void applyOverlay(
+    SoNode* root,
+    int width,
+    int height,
+    const QOpenGLWidget* widget,
+    const View3DInventorViewer* viewer
+)
+{
+    SoGLRenderAction action(SbViewportRegion(width, height));
+    setOverlayCacheContext(action, widget, viewer);
+    action.setTransparencyType(SoGLRenderAction::BLEND);
+    action.apply(root);
+}
+
+}  // namespace
+
+GLPainter::GLPainter()
+{}
 
 GLPainter::~GLPainter()
 {
@@ -46,165 +133,213 @@ GLPainter::~GLPainter()
 
 bool GLPainter::begin(QPaintDevice* device)
 {
-    if (viewer) {
+    if (glWidget) {
         return false;
     }
 
-    viewer = dynamic_cast<QOpenGLWidget*>(device);
-    if (!viewer) {
+    glWidget = dynamic_cast<QOpenGLWidget*>(device);
+    if (!glWidget) {
         return false;
     }
 
-    // Make current context
-    QSize view = viewer->size();
-    this->width = view.width();
-    this->height = view.height();
+    viewer = qobject_cast<View3DInventorViewer*>(glWidget);
 
-    viewer->makeCurrent();
+    if (viewer && viewer->getSoRenderManager()) {
+        const SbViewportRegion vp = viewer->getSoRenderManager()->getViewportRegion();
+        const SbVec2s size = vp.getViewportSizePixels();
+        width = size[0];
+        height = size[1];
+    }
+    else {
+        const QSize view = glWidget->size();
+        const qreal dpr = glWidget->devicePixelRatioF();
+        width = static_cast<int>(view.width() * dpr);
+        height = static_cast<int>(view.height() * dpr);
+    }
 
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
+    if (width <= 0 || height <= 0) {
+        glWidget = nullptr;
+        viewer = nullptr;
+        return false;
+    }
 
-    glLoadIdentity();
-    glOrtho(0, this->width, 0, this->height, -1, 1);
+    glWidget->makeCurrent();
 
-    // Store GL state
-    glPushAttrib(GL_ALL_ATTRIB_BITS);
-    glGetFloatv(GL_DEPTH_RANGE, this->depthrange);
-    glGetDoublev(GL_PROJECTION_MATRIX, this->projectionmatrix);
-
-    glDepthFunc(GL_ALWAYS);
-    glDepthMask(GL_TRUE);
-    glDepthRange(0, 0);
-    glEnable(GL_DEPTH_TEST);
-    glDisable(GL_LIGHTING);
-    glEnable(GL_COLOR_MATERIAL);
-    glDisable(GL_BLEND);
-
-    glLineWidth(1.0f);
-    glColor4f(1.0, 1.0, 1.0, 0.0);
-    glViewport(0, 0, this->width, this->height);
+    lineWidth = 1.0f;
+    pointSize = 1.0f;
+    colorR = 1.0f;
+    colorG = 1.0f;
+    colorB = 1.0f;
+    transparency = 0.0f;
+    logicOp = false;
+    lineStipple = false;
+    lineStippleFactor = 1;
+    lineStipplePattern = 0xFFFF;
 
     return true;
 }
 
 bool GLPainter::end()
 {
-    if (!viewer) {
+    if (!glWidget) {
         return false;
     }
 
-    glFlush();
-
-    if (this->logicOp) {
-        this->logicOp = false;
-        glDisable(GL_COLOR_LOGIC_OP);
-    }
-
-    if (this->lineStipple) {
-        this->lineStipple = false;
-        glDisable(GL_LINE_STIPPLE);
-    }
-
-    // Reset original state
-    glDepthRange(this->depthrange[0], this->depthrange[1]);
-    glMatrixMode(GL_PROJECTION);
-    glLoadMatrixd(this->projectionmatrix);
-
-    glPopAttrib();
-    glPopMatrix();
-
+    glWidget = nullptr;
     viewer = nullptr;
     return true;
 }
 
 bool GLPainter::isActive() const
 {
-    return viewer != nullptr;
+    return glWidget != nullptr;
 }
 
 void GLPainter::setLineWidth(float w)
 {
-    glLineWidth(w);
+    lineWidth = w;
 }
 
 void GLPainter::setPointSize(float s)
 {
-    glPointSize(s);
+    pointSize = s;
 }
 
 void GLPainter::setColor(float r, float g, float b, float a)
 {
-    glColor4f(r, g, b, a);
+    colorR = clamp01(r);
+    colorG = clamp01(g);
+    colorB = clamp01(b);
+    transparency = 1.0f - clamp01(a);
 }
 
 void GLPainter::setLogicOp(GLenum mode)
 {
-    glEnable(GL_COLOR_LOGIC_OP);
-    glLogicOp(mode);
+    (void)mode;
     this->logicOp = true;
 }
 
 void GLPainter::resetLogicOp()
 {
-    glDisable(GL_COLOR_LOGIC_OP);
     this->logicOp = false;
 }
 
 void GLPainter::setDrawBuffer(GLenum mode)
 {
-    glDrawBuffer(mode);
+    (void)mode;
 }
 
 void GLPainter::setLineStipple(GLint factor, GLushort pattern)
 {
-    glEnable(GL_LINE_STIPPLE);
-    glLineStipple(factor, pattern);
+    lineStippleFactor = factor;
+    lineStipplePattern = pattern;
     this->lineStipple = true;
 }
 
 void GLPainter::resetLineStipple()
 {
-    glDisable(GL_LINE_STIPPLE);
     this->lineStipple = false;
 }
 
 // Draw routines
 void GLPainter::drawRect(int x1, int y1, int x2, int y2)
 {
-    if (!viewer) {
+    if (!glWidget) {
         return;
     }
 
-    glBegin(GL_LINE_LOOP);
-    glVertex3i(x1, this->height - y1, 0);
-    glVertex3i(x2, this->height - y1, 0);
-    glVertex3i(x2, this->height - y2, 0);
-    glVertex3i(x1, this->height - y2, 0);
-    glEnd();
+    SoSeparator* root = createOverlayRoot(width, height);
+
+    auto* material = new SoMaterial;
+    material->diffuseColor.setValue(colorR, colorG, colorB);
+    material->transparency.setValue(transparency);
+    root->addChild(material);
+
+    auto* drawStyle = new SoDrawStyle;
+    drawStyle->lineWidth.setValue(lineWidth);
+    if (lineStipple) {
+        drawStyle->linePatternScaleFactor.setValue(lineStippleFactor);
+        drawStyle->linePattern.setValue(lineStipplePattern);
+    }
+    root->addChild(drawStyle);
+
+    auto* vp = new SoVertexProperty;
+    vp->vertex.set1Value(0, toOverlayPoint(x1, y1, width, height));
+    vp->vertex.set1Value(1, toOverlayPoint(x2, y1, width, height));
+    vp->vertex.set1Value(2, toOverlayPoint(x2, y2, width, height));
+    vp->vertex.set1Value(3, toOverlayPoint(x1, y2, width, height));
+    vp->vertex.set1Value(4, toOverlayPoint(x1, y1, width, height));
+
+    auto* lineSet = new SoLineSet;
+    lineSet->vertexProperty.setValue(vp);
+    lineSet->numVertices.setValue(5);
+    root->addChild(lineSet);
+
+    applyOverlay(root, width, height, glWidget, viewer);
+    root->unref();
 }
 
 void GLPainter::drawLine(int x1, int y1, int x2, int y2)
 {
-    if (!viewer) {
+    if (!glWidget) {
         return;
     }
 
-    glBegin(GL_LINES);
-    glVertex3i(x1, this->height - y1, 0);
-    glVertex3i(x2, this->height - y2, 0);
-    glEnd();
+    SoSeparator* root = createOverlayRoot(width, height);
+
+    auto* material = new SoMaterial;
+    material->diffuseColor.setValue(colorR, colorG, colorB);
+    material->transparency.setValue(transparency);
+    root->addChild(material);
+
+    auto* drawStyle = new SoDrawStyle;
+    drawStyle->lineWidth.setValue(lineWidth);
+    if (lineStipple) {
+        drawStyle->linePatternScaleFactor.setValue(lineStippleFactor);
+        drawStyle->linePattern.setValue(lineStipplePattern);
+    }
+    root->addChild(drawStyle);
+
+    auto* vp = new SoVertexProperty;
+    vp->vertex.set1Value(0, toOverlayPoint(x1, y1, width, height));
+    vp->vertex.set1Value(1, toOverlayPoint(x2, y2, width, height));
+
+    auto* lineSet = new SoLineSet;
+    lineSet->vertexProperty.setValue(vp);
+    lineSet->numVertices.setValue(2);
+    root->addChild(lineSet);
+
+    applyOverlay(root, width, height, glWidget, viewer);
+    root->unref();
 }
 
 void GLPainter::drawPoint(int x, int y)
 {
-    if (!viewer) {
+    if (!glWidget) {
         return;
     }
 
-    glBegin(GL_POINTS);
-    glVertex3i(x, this->height - y, 0);
-    glEnd();
+    SoSeparator* root = createOverlayRoot(width, height);
+
+    auto* material = new SoMaterial;
+    material->diffuseColor.setValue(colorR, colorG, colorB);
+    material->transparency.setValue(transparency);
+    root->addChild(material);
+
+    auto* drawStyle = new SoDrawStyle;
+    drawStyle->pointSize.setValue(pointSize);
+    root->addChild(drawStyle);
+
+    auto* vp = new SoVertexProperty;
+    vp->vertex.set1Value(0, toOverlayPoint(x, y, width, height));
+
+    auto* pointSet = new SoPointSet;
+    pointSet->vertexProperty.setValue(vp);
+    pointSet->numPoints.setValue(1);
+    root->addChild(pointSet);
+
+    applyOverlay(root, width, height, glWidget, viewer);
+    root->unref();
 }
 
 //-----------------------------------------------
@@ -274,41 +409,80 @@ void Rubberband::paintGL()
         return;
     }
 
+    if (!viewer) {
+        return;
+    }
+
     const SbViewportRegion vp = viewer->getSoRenderManager()->getViewportRegion();
     SbVec2s size = vp.getViewportSizePixels();
-
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0, size[0], size[1], 0, 0, 100);
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-    glDisable(GL_TEXTURE_2D);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glLineWidth(4.0);
-    glColor4f(1.0f, 1.0f, 1.0f, 0.5f);
-    glRecti(x_old, y_old, x_new, y_new);
-
-    glLineWidth(4.0);
-    glColor4f(rgb_r, rgb_g, rgb_b, rgb_a);
-    if (stipple) {
-        glLineStipple(3, 0xAAAA);
-        glEnable(GL_LINE_STIPPLE);
-    }
-    glBegin(GL_LINE_LOOP);
-    glVertex2i(x_old, y_old);
-    glVertex2i(x_old, y_new);
-    glVertex2i(x_new, y_new);
-    glVertex2i(x_new, y_old);
-    glEnd();
-
-    glLineWidth(1.0);
-
-    if (stipple) {
-        glDisable(GL_LINE_STIPPLE);
+    const int viewportWidth = size[0];
+    const int viewportHeight = size[1];
+    if (viewportWidth <= 0 || viewportHeight <= 0) {
+        return;
     }
 
-    glDisable(GL_BLEND);
+    SoSeparator* root = createOverlayRoot(viewportWidth, viewportHeight);
+
+    const int xMin = std::min(x_old, x_new);
+    const int xMax = std::max(x_old, x_new);
+    const int yMin = std::min(y_old, y_new);
+    const int yMax = std::max(y_old, y_new);
+
+    {
+        auto* sep = new SoSeparator;
+
+        auto* material = new SoMaterial;
+        material->diffuseColor.setValue(1.0f, 1.0f, 1.0f);
+        material->transparency.setValue(1.0f - 0.5f);
+        sep->addChild(material);
+
+        auto* vp = new SoVertexProperty;
+        vp->vertex.set1Value(0, toOverlayPoint(xMin, yMin, viewportWidth, viewportHeight));
+        vp->vertex.set1Value(1, toOverlayPoint(xMin, yMax, viewportWidth, viewportHeight));
+        vp->vertex.set1Value(2, toOverlayPoint(xMax, yMax, viewportWidth, viewportHeight));
+        vp->vertex.set1Value(3, toOverlayPoint(xMax, yMin, viewportWidth, viewportHeight));
+
+        auto* faceSet = new SoFaceSet;
+        faceSet->vertexProperty.setValue(vp);
+        faceSet->numVertices.setValue(4);
+        sep->addChild(faceSet);
+
+        root->addChild(sep);
+    }
+
+    {
+        auto* sep = new SoSeparator;
+
+        auto* material = new SoMaterial;
+        material->diffuseColor.setValue(clamp01(rgb_r), clamp01(rgb_g), clamp01(rgb_b));
+        material->transparency.setValue(1.0f - clamp01(rgb_a));
+        sep->addChild(material);
+
+        auto* drawStyle = new SoDrawStyle;
+        drawStyle->lineWidth.setValue(4.0f);
+        if (stipple) {
+            drawStyle->linePatternScaleFactor.setValue(3);
+            drawStyle->linePattern.setValue(0xAAAA);
+        }
+        sep->addChild(drawStyle);
+
+        auto* vp = new SoVertexProperty;
+        vp->vertex.set1Value(0, toOverlayPoint(x_old, y_old, viewportWidth, viewportHeight));
+        vp->vertex.set1Value(1, toOverlayPoint(x_old, y_new, viewportWidth, viewportHeight));
+        vp->vertex.set1Value(2, toOverlayPoint(x_new, y_new, viewportWidth, viewportHeight));
+        vp->vertex.set1Value(3, toOverlayPoint(x_new, y_old, viewportWidth, viewportHeight));
+        vp->vertex.set1Value(4, toOverlayPoint(x_old, y_old, viewportWidth, viewportHeight));
+
+        auto* lineSet = new SoLineSet;
+        lineSet->vertexProperty.setValue(vp);
+        lineSet->numVertices.setValue(5);
+        sep->addChild(lineSet);
+
+        root->addChild(sep);
+    }
+
+    applyOverlay(root, viewportWidth, viewportHeight, nullptr, viewer);
+    root->unref();
 }
 
 // -----------------------------------------------------------------------------------
@@ -412,55 +586,95 @@ void Polyline::paintGL()
         return;
     }
 
+    if (!viewer) {
+        return;
+    }
+
     if (_cNodeVector.empty()) {
         return;
     }
 
     const SbViewportRegion vp = viewer->getSoRenderManager()->getViewportRegion();
     SbVec2s size = vp.getViewportSizePixels();
+    const int viewportWidth = size[0];
+    const int viewportHeight = size[1];
+    if (viewportWidth <= 0 || viewportHeight <= 0) {
+        return;
+    }
 
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0, size[0], size[1], 0, 0, 100);
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-    glDisable(GL_TEXTURE_2D);
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glLineWidth(line);
-    glColor4f(rgb_r, rgb_g, rgb_b, rgb_a);
+    SoSeparator* root = createOverlayRoot(viewportWidth, viewportHeight);
+
+    auto* material = new SoMaterial;
+    material->diffuseColor.setValue(clamp01(rgb_r), clamp01(rgb_g), clamp01(rgb_b));
+    material->transparency.setValue(1.0f - clamp01(rgb_a));
+    root->addChild(material);
+
+    auto* drawStyle = new SoDrawStyle;
+    drawStyle->lineWidth.setValue(line);
+    root->addChild(drawStyle);
+
+    const int count = static_cast<int>(_cNodeVector.size());
+    if (count <= 1) {
+        root->unref();
+        return;
+    }
 
     if (closed && !stippled) {
-        glBegin(GL_LINE_LOOP);
-
-        for (const QPoint& it : _cNodeVector) {
-            glVertex2i(it.x(), it.y());
+        auto* vp = new SoVertexProperty;
+        for (int i = 0; i < count; ++i) {
+            const QPoint& pnt = _cNodeVector[static_cast<size_t>(i)];
+            vp->vertex.set1Value(i, toOverlayPoint(pnt.x(), pnt.y(), viewportWidth, viewportHeight));
         }
+        const QPoint& first = _cNodeVector.front();
+        vp->vertex.set1Value(count, toOverlayPoint(first.x(), first.y(), viewportWidth, viewportHeight));
 
-        glEnd();
+        auto* lineSet = new SoLineSet;
+        lineSet->vertexProperty.setValue(vp);
+        lineSet->numVertices.setValue(count + 1);
+        root->addChild(lineSet);
     }
     else {
-        glBegin(GL_LINES);
-
-        QPoint start = _cNodeVector.front();
-        for (const QPoint& it : _cNodeVector) {
-            glVertex2i(start.x(), start.y());
-            start = it;
-            glVertex2i(it.x(), it.y());
+        auto* vp = new SoVertexProperty;
+        for (int i = 0; i < count; ++i) {
+            const QPoint& pnt = _cNodeVector[static_cast<size_t>(i)];
+            vp->vertex.set1Value(i, toOverlayPoint(pnt.x(), pnt.y(), viewportWidth, viewportHeight));
         }
 
-        glEnd();
+        auto* lineSet = new SoLineSet;
+        lineSet->vertexProperty.setValue(vp);
+        lineSet->numVertices.setValue(count);
+        root->addChild(lineSet);
 
         if (closed && stippled) {
-            glEnable(GL_LINE_STIPPLE);
-            glLineStipple(2, 0x3F3F);
-            glBegin(GL_LINES);
-            glVertex2i(_cNodeVector.back().x(), _cNodeVector.back().y());
-            glVertex2i(_cNodeVector.front().x(), _cNodeVector.front().y());
-            glEnd();
-            glDisable(GL_LINE_STIPPLE);
+            auto* sep = new SoSeparator;
+
+            auto* stippleStyle = new SoDrawStyle;
+            stippleStyle->lineWidth.setValue(line);
+            stippleStyle->linePatternScaleFactor.setValue(2);
+            stippleStyle->linePattern.setValue(0x3F3F);
+            sep->addChild(stippleStyle);
+
+            auto* closeVp = new SoVertexProperty;
+            const QPoint& last = _cNodeVector.back();
+            const QPoint& first = _cNodeVector.front();
+            closeVp->vertex.set1Value(
+                0,
+                toOverlayPoint(last.x(), last.y(), viewportWidth, viewportHeight)
+            );
+            closeVp->vertex.set1Value(
+                1,
+                toOverlayPoint(first.x(), first.y(), viewportWidth, viewportHeight)
+            );
+
+            auto* closeLine = new SoLineSet;
+            closeLine->vertexProperty.setValue(closeVp);
+            closeLine->numVertices.setValue(2);
+            sep->addChild(closeLine);
+
+            root->addChild(sep);
         }
     }
 
-    glDisable(GL_BLEND);
+    applyOverlay(root, viewportWidth, viewportHeight, nullptr, viewer);
+    root->unref();
 }

--- a/src/Gui/GLPainter.h
+++ b/src/Gui/GLPainter.h
@@ -1,25 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2013 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2013 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -74,12 +74,21 @@ public:
     //@}
 
 private:
-    GLfloat depthrange[2];
-    GLdouble projectionmatrix[16];
     GLint width {0}, height {0};
-    QOpenGLWidget* viewer {nullptr};
+    QOpenGLWidget* glWidget {nullptr};
+    View3DInventorViewer* viewer {nullptr};
+
+    float lineWidth {1.0f};
+    float pointSize {1.0f};
+    float colorR {1.0f};
+    float colorG {1.0f};
+    float colorB {1.0f};
+    float transparency {0.0f};
+
     bool logicOp {false};
     bool lineStipple {false};
+    GLint lineStippleFactor {1};
+    GLushort lineStipplePattern {0xFFFF};
 };
 
 class GuiExport GLGraphicsItem: public Base::BaseClass

--- a/src/Gui/Inventor/Draggers/SoPlanarDragger.cpp
+++ b/src/Gui/Inventor/Draggers/SoPlanarDragger.cpp
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2015 Thomas Anderson <blobfish[at]gmx.com>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2015 Thomas Anderson <blobfish[at]gmx.com>              *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <cassert>
 #include <numbers>
@@ -56,7 +55,7 @@
 #include "MainWindow.h"
 #include "SoFCDB.h"
 
-#include <SoTextLabel.h>
+#include <Gui/SoTextLabel.h>
 
 using namespace Gui;
 

--- a/src/Gui/Inventor/Draggers/SoTransformDragger.cpp
+++ b/src/Gui/Inventor/Draggers/SoTransformDragger.cpp
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2015 Thomas Anderson <blobfish[at]gmx.com>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2015 Thomas Anderson <blobfish[at]gmx.com>              *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <cassert>
 #include <numbers>
@@ -58,7 +57,7 @@
 #include "SoRotationDragger.h"
 #include "Utilities.h"
 
-#include <SoTextLabel.h>
+#include <Gui/SoTextLabel.h>
 
 
 /*

--- a/src/Gui/Inventor/SoAxisCrossKit.cpp
+++ b/src/Gui/Inventor/SoAxisCrossKit.cpp
@@ -1,45 +1,32 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2010 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2010 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
-
-#if defined(FC_OS_WIN32)
-# include <windows.h>
-#endif
-
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
 
 #include <sstream>
 
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/actions/SoGLRenderAction.h>
-#include <Inventor/bundles/SoMaterialBundle.h>
-#include <Inventor/bundles/SoTextureCoordinateBundle.h>
 #include <Inventor/elements/SoLazyElement.h>
 #include <Inventor/elements/SoModelMatrixElement.h>
 #include <Inventor/elements/SoViewportRegionElement.h>
@@ -49,8 +36,11 @@
 #include <Inventor/nodes/SoCone.h>
 #include <Inventor/nodes/SoCoordinate3.h>
 #include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoFontStyle.h>
 #include <Inventor/nodes/SoLineSet.h>
+#include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoPointSet.h>
 #include <Inventor/nodes/SoScale.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoText2.h>
@@ -270,28 +260,105 @@ SoRegPoint::SoRegPoint()
     root = new SoSeparator();
     root->ref();
 
-    // translation
-    auto move = new SoTranslation();
-    move->translation.setValue(base.getValue() + normal.getValue() * length.getValue());
-    root->addChild(move);
+    auto* pickStyle = new SoPickStyle();
+    pickStyle->style = SoPickStyle::UNPICKABLE;
+    root->addChild(pickStyle);
 
-    // sub-group
-    auto col = new SoBaseColor();
-    col->rgb.setValue(this->color.getValue());
+    const SbVec3f p1 = base.getValue();
+    const SbVec3f p2 = p1 + normal.getValue() * length.getValue();
 
-    auto font = new SoFontStyle;
+    geometryRoot = new SoSeparator();
+    root->addChild(geometryRoot);
+
+    geometryColor = new SoBaseColor();
+    geometryColor->rgb.setValue(this->color.getValue());
+    geometryRoot->addChild(geometryColor);
+
+    auto* lineStyle = new SoDrawStyle();
+    lineStyle->lineWidth = 1.0f;
+
+    lineCoordinates = new SoCoordinate3();
+    lineCoordinates->point.set1Value(0, p1);
+    lineCoordinates->point.set1Value(1, p2);
+
+    lineSet = new SoLineSet();
+    lineSet->numVertices.set1Value(0, 2);
+
+    auto* lineSep = new SoSeparator();
+    lineSep->addChild(lineStyle);
+    lineSep->addChild(lineCoordinates);
+    lineSep->addChild(lineSet);
+    geometryRoot->addChild(lineSep);
+
+    auto* basePointStyle = new SoDrawStyle();
+    basePointStyle->pointSize = 5.0f;
+
+    basePointCoordinates = new SoCoordinate3();
+    basePointCoordinates->point.set1Value(0, p1);
+
+    basePointSet = new SoPointSet();
+    basePointSet->numPoints = 1;
+
+    auto* basePointSep = new SoSeparator();
+    basePointSep->addChild(basePointStyle);
+    basePointSep->addChild(basePointCoordinates);
+    basePointSep->addChild(basePointSet);
+    geometryRoot->addChild(basePointSep);
+
+    auto* tipPointStyle = new SoDrawStyle();
+    tipPointStyle->pointSize = 2.0f;
+
+    tipPointCoordinates = new SoCoordinate3();
+    tipPointCoordinates->point.set1Value(0, p2);
+
+    tipPointSet = new SoPointSet();
+    tipPointSet->numPoints = 1;
+
+    auto* tipPointSep = new SoSeparator();
+    tipPointSep->addChild(tipPointStyle);
+    tipPointSep->addChild(tipPointCoordinates);
+    tipPointSep->addChild(tipPointSet);
+    geometryRoot->addChild(tipPointSep);
+
+    textRoot = new SoSeparator();
+    root->addChild(textRoot);
+
+    move = new SoTranslation();
+    move->translation.setValue(p2);
+    textRoot->addChild(move);
+
+    textColor = new SoBaseColor();
+    textColor->rgb.setValue(this->color.getValue());
+
+    auto* font = new SoFontStyle;
     font->size = 14;
 
-    auto sub = new SoSeparator();
-    sub->addChild(col);
+    label = new SoText2();
+    label->string = this->text.getValue();
+
+    auto* sub = new SoSeparator();
+    sub->addChild(textColor);
     sub->addChild(font);
-    sub->addChild(new SoText2());
-    root->addChild(sub);
+    sub->addChild(label);
+    textRoot->addChild(sub);
 }
 
 SoRegPoint::~SoRegPoint()
 {
     root->unref();
+    root = nullptr;
+    geometryRoot = nullptr;
+    geometryColor = nullptr;
+    lineCoordinates = nullptr;
+    lineSet = nullptr;
+    basePointCoordinates = nullptr;
+    basePointSet = nullptr;
+    tipPointCoordinates = nullptr;
+    tipPointSet = nullptr;
+    textRoot = nullptr;
+    move = nullptr;
+    textColor = nullptr;
+    label = nullptr;
 }
 
 /**
@@ -299,39 +366,29 @@ SoRegPoint::~SoRegPoint()
  */
 void SoRegPoint::GLRender(SoGLRenderAction* action)
 {
-    if (shouldGLRender(action)) {
-        SoState* state = action->getState();
-        state->push();
-        SoMaterialBundle mb(action);
-        SoTextureCoordinateBundle tb(action, true, false);
-        SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
-        mb.sendFirst();  // make sure we have the correct material
-
-        SbVec3f p1 = base.getValue();
-        SbVec3f p2 = p1 + normal.getValue() * length.getValue();
-
-        glLineWidth(1.0f);
-        glColor3fv(color.getValue().getValue());
-        glBegin(GL_LINE_STRIP);
-        glVertex3d(p1[0], p1[1], p1[2]);
-        glVertex3d(p2[0], p2[1], p2[2]);
-        glEnd();
-        glPointSize(5.0f);
-        glBegin(GL_POINTS);
-        glVertex3fv(p1.getValue());
-        glEnd();
-        glPointSize(2.0f);
-        glBegin(GL_POINTS);
-        glVertex3fv(p2.getValue());
-        glEnd();
-
-        root->GLRender(action);
-        state->pop();
+    if (!shouldGLRender(action) || !action) {
+        return;
     }
+
+    SoState* state = action->getState();
+    if (!state || !root) {
+        return;
+    }
+
+    state->push();
+    SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
+    root->GLRender(action);
+    state->pop();
 }
 
-void SoRegPoint::generatePrimitives(SoAction* /*action*/)
-{}
+void SoRegPoint::generatePrimitives(SoAction* action)
+{
+    // This node is implemented as a small internal scenegraph; delegate to it.
+    // This is primarily useful for non-GL actions and keeps behavior consistent.
+    if (root && action) {
+        root->doAction(action);
+    }
+}
 
 /**
  * Sets the bounding box of the probe to \a box and its center to \a center.
@@ -356,18 +413,35 @@ void SoRegPoint::notify(SoNotList* node)
 {
     SoField* f = node->getLastField();
     if (f == &this->base || f == &this->normal || f == &this->length) {
-        auto move = static_cast<SoTranslation*>(root->getChild(0));
-        move->translation.setValue(base.getValue() + normal.getValue() * length.getValue());
+        const SbVec3f p1 = base.getValue();
+        const SbVec3f p2 = p1 + normal.getValue() * length.getValue();
+
+        if (move) {
+            move->translation.setValue(p2);
+        }
+        if (lineCoordinates) {
+            lineCoordinates->point.set1Value(0, p1);
+            lineCoordinates->point.set1Value(1, p2);
+        }
+        if (basePointCoordinates) {
+            basePointCoordinates->point.set1Value(0, p1);
+        }
+        if (tipPointCoordinates) {
+            tipPointCoordinates->point.set1Value(0, p2);
+        }
     }
     else if (f == &this->color) {
-        auto sub = static_cast<SoSeparator*>(root->getChild(1));
-        auto col = static_cast<SoBaseColor*>(sub->getChild(0));
-        col->rgb = this->color.getValue();
+        if (geometryColor) {
+            geometryColor->rgb = this->color.getValue();
+        }
+        if (textColor) {
+            textColor->rgb = this->color.getValue();
+        }
     }
     else if (f == &this->text) {
-        auto sub = static_cast<SoSeparator*>(root->getChild(1));
-        auto label = static_cast<SoText2*>(sub->getChild(2));
-        label->string = this->text.getValue();
+        if (label) {
+            label->string = this->text.getValue();
+        }
     }
 
     SoShape::notify(node);

--- a/src/Gui/Inventor/SoAxisCrossKit.h
+++ b/src/Gui/Inventor/SoAxisCrossKit.h
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2010 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2010 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -37,6 +36,14 @@ class SbViewport;
 class SoState;
 class SbColor;
 class SbVec2s;
+class SoBaseColor;
+class SoCoordinate3;
+class SoDrawStyle;
+class SoLineSet;
+class SoPointSet;
+class SoSeparator;
+class SoText2;
+class SoTranslation;
 
 namespace Gui
 {
@@ -117,7 +124,20 @@ protected:
     void generatePrimitives(SoAction* action) override;
 
 private:
-    SoSeparator* root;
+    SoSeparator* root {nullptr};
+    SoSeparator* geometryRoot {nullptr};
+    SoBaseColor* geometryColor {nullptr};
+    SoCoordinate3* lineCoordinates {nullptr};
+    SoLineSet* lineSet {nullptr};
+    SoCoordinate3* basePointCoordinates {nullptr};
+    SoPointSet* basePointSet {nullptr};
+    SoCoordinate3* tipPointCoordinates {nullptr};
+    SoPointSet* tipPointSet {nullptr};
+
+    SoSeparator* textRoot {nullptr};
+    SoTranslation* move {nullptr};
+    SoBaseColor* textColor {nullptr};
+    SoText2* label {nullptr};
 };
 
 }  // namespace Gui

--- a/src/Gui/Inventor/SoDrawingGrid.cpp
+++ b/src/Gui/Inventor/SoDrawingGrid.cpp
@@ -1,46 +1,49 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2010 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2010 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
 #include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/elements/SoDepthBufferElement.h>
 #include <Inventor/elements/SoCacheElement.h>
+#include <Inventor/elements/SoGLTextureEnabledElement.h>
 #include <Inventor/elements/SoLazyElement.h>
 #include <Inventor/elements/SoModelMatrixElement.h>
+#include <Inventor/elements/SoMultiTextureEnabledElement.h>
 #include <Inventor/elements/SoProjectionMatrixElement.h>
 #include <Inventor/elements/SoViewingMatrixElement.h>
 #include <Inventor/elements/SoViewportRegionElement.h>
+#include <Inventor/SoPrimitiveVertex.h>
+#include <Inventor/details/SoLineDetail.h>
 
-#if defined(FC_OS_WIN32)
-# include <windows.h>
-#endif
+#include <Inventor/nodes/SoBaseColor.h>
+#include <Inventor/nodes/SoLineSet.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoVertexProperty.h>
 
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
+#include <algorithm>
+#include <cstdint>
+#include <vector>
 
 #include "SoDrawingGrid.h"
 
@@ -63,6 +66,29 @@ void SoDrawingGrid::initClass()
 SoDrawingGrid::SoDrawingGrid()
 {
     SO_NODE_CONSTRUCTOR(SoDrawingGrid);
+
+    m_Root = new SoSeparator;
+    m_Root->ref();
+
+    constexpr float legacyGridChannel = 10.0f / 255.0f;
+    auto* color = new SoBaseColor;
+    color->rgb.setValue(legacyGridChannel, legacyGridChannel, legacyGridChannel);
+    m_Root->addChild(color);
+
+    m_VertexProperty = new SoVertexProperty;
+    m_LineSet = new SoLineSet;
+    m_LineSet->vertexProperty.setValue(m_VertexProperty);
+    m_Root->addChild(m_LineSet);
+}
+
+SoDrawingGrid::~SoDrawingGrid()
+{
+    if (m_Root) {
+        m_Root->unref();
+        m_Root = nullptr;
+    }
+    m_VertexProperty = nullptr;
+    m_LineSet = nullptr;
 }
 
 void SoDrawingGrid::renderGrid(SoGLRenderAction* action)
@@ -75,49 +101,66 @@ void SoDrawingGrid::renderGrid(SoGLRenderAction* action)
     state->push();
     SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
 
-    const SbMatrix& mat = SoModelMatrixElement::get(state);
-    // const SbViewVolume & vv = SoViewVolumeElement::get(state);
-    // const SbMatrix & projmatrix = (mat * SoViewingMatrixElement::get(state) *
-    //                                SoProjectionMatrixElement::get(state));
-    const SbViewportRegion& vp = SoViewportRegionElement::get(state);
-    // SbVec2s vpsize = vp.getViewportSizePixels();
-    float fRatio = vp.getViewportAspectRatio();
-
-    // float width = vv.getWidth();
-    // float height = vv.getHeight();
-    SbVec3f worldcenter(0, 0, 0);
-    mat.multVecMatrix(worldcenter, worldcenter);
-
-    // float dist = (vv.getProjectionPoint() - worldcenter).length();
+    ensureGeometry(state);
 
     SoModelMatrixElement::set(state, this, SbMatrix::identity());
     SoViewingMatrixElement::set(state, this, SbMatrix::identity());
     SoProjectionMatrixElement::set(state, this, SbMatrix::identity());
 
-    glColor3f(1.0f, 0.0f, 0.0f);
-    glBegin(GL_LINES);
-    float p[3];
-    p[2] = 0.0f;
+    SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+    SoGLTextureEnabledElement::set(state, this, FALSE);
+    SoMultiTextureEnabledElement::set(state, this, FALSE);
 
-    int numX = 20;
-    for (int i = -numX; i < numX; i++) {
-        p[0] = (float)i / numX;
-        p[1] = -1.0f;
-        glVertex3fv(p);
-        p[1] = 1.0f;
-        glVertex3fv(p);
+    if (m_Root) {
+        m_Root->GLRender(action);
     }
-    int numY = numX / fRatio;
-    for (int i = -numY; i < numY; i++) {
-        p[0] = -1.0f;
-        p[1] = (float)i / numY;
-        glVertex3fv(p);
-        p[0] = 1.0;
-        glVertex3fv(p);
-    }
-    glEnd();
 
     state->pop();
+}
+
+void SoDrawingGrid::ensureGeometry(SoState* state)
+{
+    if (!state || !m_VertexProperty || !m_LineSet) {
+        return;
+    }
+
+    const SbViewportRegion& vp = SoViewportRegionElement::get(state);
+    const SbVec2s viewportSize = vp.getViewportSizePixels();
+    if (viewportSize == m_CachedViewportSize && m_VertexProperty->vertex.getNum() > 0) {
+        return;
+    }
+
+    m_CachedViewportSize = viewportSize;
+
+    constexpr int numX = 20;
+    const float aspectRatio = vp.getViewportAspectRatio();
+    int numY = static_cast<int>(static_cast<float>(numX) / aspectRatio);
+    numY = std::max(1, numY);
+
+    const int verticalLineCount = 2 * numX;
+    const int horizontalLineCount = 2 * numY;
+    const int lineCount = verticalLineCount + horizontalLineCount;
+
+    std::vector<SbVec3f> vertices;
+    vertices.reserve(lineCount * 2);
+
+    for (int i = -numX; i < numX; i++) {
+        const float x = static_cast<float>(i) / static_cast<float>(numX);
+        vertices.emplace_back(x, -1.0f, 0.0f);
+        vertices.emplace_back(x, 1.0f, 0.0f);
+    }
+
+    for (int i = -numY; i < numY; i++) {
+        const float y = static_cast<float>(i) / static_cast<float>(numY);
+        vertices.emplace_back(-1.0f, y, 0.0f);
+        vertices.emplace_back(1.0f, y, 0.0f);
+    }
+
+    m_VertexProperty->vertex.setValues(0, static_cast<int>(vertices.size()), vertices.data());
+
+    std::vector<int32_t> numVertices;
+    numVertices.assign(lineCount, 2);
+    m_LineSet->numVertices.setValues(0, static_cast<int>(numVertices.size()), numVertices.data());
 }
 
 void SoDrawingGrid::GLRender(SoGLRenderAction* action)
@@ -143,14 +186,7 @@ void SoDrawingGrid::GLRenderBelowPath(SoGLRenderAction* action)
     // inherited::GLRenderBelowPath(action);
     // return;
     if (action->isRenderingDelayedPaths()) {
-        SbBool zbenabled = glIsEnabled(GL_DEPTH_TEST);
-        if (zbenabled) {
-            glDisable(GL_DEPTH_TEST);
-        }
         renderGrid(action);
-        if (zbenabled) {
-            glEnable(GL_DEPTH_TEST);
-        }
     }
     else {
         SoCacheElement::invalidate(action->getState());
@@ -163,14 +199,7 @@ void SoDrawingGrid::GLRenderInPath(SoGLRenderAction* action)
     // inherited::GLRenderInPath(action);
     // return;
     if (action->isRenderingDelayedPaths()) {
-        SbBool zbenabled = glIsEnabled(GL_DEPTH_TEST);
-        if (zbenabled) {
-            glDisable(GL_DEPTH_TEST);
-        }
         renderGrid(action);
-        if (zbenabled) {
-            glEnable(GL_DEPTH_TEST);
-        }
     }
     else {
         SoCacheElement::invalidate(action->getState());
@@ -183,13 +212,55 @@ void SoDrawingGrid::GLRenderOffPath(SoGLRenderAction*)
 
 void SoDrawingGrid::generatePrimitives(SoAction* action)
 {
-    (void)action;
+    SoState* state = action ? action->getState() : nullptr;
+    if (!state || !m_LineSet) {
+        return;
+    }
+
+    state->push();
+    ensureGeometry(state);
+    SoModelMatrixElement::set(state, this, SbMatrix::identity());
+    SoViewingMatrixElement::set(state, this, SbMatrix::identity());
+    SoProjectionMatrixElement::set(state, this, SbMatrix::identity());
+
+    const int numLines = m_LineSet->numVertices.getNum();
+    const int32_t* counts = m_LineSet->numVertices.getValues(0);
+    const int numVerts = m_VertexProperty->vertex.getNum();
+    const SbVec3f* verts = m_VertexProperty->vertex.getValues(0);
+
+    SoLineDetail lineDetail;
+    SoPrimitiveVertex pv;
+
+    int vIndex = 0;
+    for (int lineIdx = 0; lineIdx < numLines; lineIdx++) {
+        const int count = counts[lineIdx];
+        if (count < 2) {
+            vIndex += count;
+            continue;
+        }
+        if (vIndex + count > numVerts) {
+            break;
+        }
+
+        lineDetail.setLineIndex(lineIdx);
+        lineDetail.setPartIndex(0);
+
+        beginShape(action, LINE_STRIP, &lineDetail);
+        for (int i = 0; i < count; i++) {
+            pv.setPoint(verts[vIndex + i]);
+            shapeVertex(&pv);
+        }
+        endShape();
+
+        vIndex += count;
+    }
+    state->pop();
 }
 
 void SoDrawingGrid::computeBBox(SoAction* action, SbBox3f& box, SbVec3f& center)
 {
     (void)action;
-    (void)box;
-    (void)center;
-    // SoState*  state = action->getState();
+    // Overlay grid rendered in clip/screen space: do not contribute a world-space bbox.
+    box.makeEmpty();
+    center.setValue(0.0f, 0.0f, 0.0f);
 }

--- a/src/Gui/Inventor/SoDrawingGrid.h
+++ b/src/Gui/Inventor/SoDrawingGrid.h
@@ -1,31 +1,36 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2010 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2010 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
+#include <Inventor/SbVec2s.h>
 #include <Inventor/nodes/SoShape.h>
 #include <FCGlobal.h>
+
+class SoLineSet;
+class SoSeparator;
+class SoState;
+class SoVertexProperty;
 
 namespace Gui
 {
@@ -52,8 +57,15 @@ public:
 
 private:
     void renderGrid(SoGLRenderAction* action);
+    void ensureGeometry(SoState* state);
     // Force using the reference count mechanism.
-    ~SoDrawingGrid() override = default;
+    ~SoDrawingGrid() override;
+
+private:
+    SoSeparator* m_Root {nullptr};
+    SoVertexProperty* m_VertexProperty {nullptr};
+    SoLineSet* m_LineSet {nullptr};
+    SbVec2s m_CachedViewportSize {0, 0};
 };
 
 }  // namespace Inventor

--- a/src/Gui/Inventor/SoFCBackgroundGradient.cpp
+++ b/src/Gui/Inventor/SoFCBackgroundGradient.cpp
@@ -1,70 +1,50 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2005 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2005 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <array>
-#include <boost/math/constants/constants.hpp>
 #include <cmath>
 #include <numbers>
 
-#include <FCConfig.h>
-
-#ifdef FC_OS_WIN32
-# include <windows.h>
-#endif
-
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
+#include <Inventor/SbMatrix.h>
+#include <Inventor/SbVec2f.h>
+#include <Inventor/SbVec3f.h>
+#include <Inventor/SbViewVolume.h>
+#include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/elements/SoDepthBufferElement.h>
+#include <Inventor/elements/SoGLTextureEnabledElement.h>
+#include <Inventor/elements/SoLazyElement.h>
+#include <Inventor/elements/SoModelMatrixElement.h>
+#include <Inventor/elements/SoMultiTextureEnabledElement.h>
+#include <Inventor/elements/SoProjectionMatrixElement.h>
+#include <Inventor/elements/SoViewingMatrixElement.h>
+#include <Inventor/elements/SoViewVolumeElement.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoShapeHints.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoVertexProperty.h>
 
 #include "SoFCBackgroundGradient.h"
-
-static const std::array<GLfloat[2], 32> big_circle = [] {
-    constexpr float pi = std::numbers::pi_v<float>;
-    constexpr float sqrt2 = std::numbers::sqrt2_v<float>;
-    std::array<GLfloat[2], 32> result;
-    int c = 0;
-    for (GLfloat i = 0; i < 2 * pi; i += 2 * pi / 32, c++) {
-        result[c][0] = sqrt2 * cosf(i);
-        result[c][1] = sqrt2 * sinf(i);
-    }
-    return result;
-}();
-static const std::array<GLfloat[2], 32> small_oval = [] {
-    constexpr float pi = std::numbers::pi_v<float>;
-    constexpr float sqrt2 = std::numbers::sqrt2_v<float>;
-    static const float sqrt1_2 = std::sqrt(1 / 2.F);
-
-    std::array<GLfloat[2], 32> result;
-    int c = 0;
-    for (GLfloat i = 0; i < 2 * pi; i += 2 * pi / 32, c++) {
-        result[c][0] = 0.3 * sqrt2 * cosf(i);
-        result[c][1] = sqrt1_2 * sinf(i);
-    }
-    return result;
-}();
 
 using namespace Gui;
 
@@ -75,9 +55,6 @@ void SoFCBackgroundGradient::finish()
     atexit_cleanup();
 }
 
-/*!
-  Constructor.
-*/
 SoFCBackgroundGradient::SoFCBackgroundGradient()
 {
     SO_NODE_CONSTRUCTOR(SoFCBackgroundGradient);
@@ -85,112 +62,102 @@ SoFCBackgroundGradient::SoFCBackgroundGradient()
     tCol.setValue(0.7f, 0.7f, 0.9f);
     mCol.setValue(1.0f, 1.0f, 1.0f);
     gradient = Gradient::LINEAR;
+
+    gradientSwitch = new SoSwitch;
+    gradientSwitch->ref();
+
+    // Linear gradient geometry
+    linearSeparator = new SoSeparator;
+    auto* linearHints = new SoShapeHints;
+    linearHints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
+    linearHints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+    linearSeparator->addChild(linearHints);
+
+    linearVertexProperty = new SoVertexProperty;
+    linearVertexProperty->materialBinding = SoVertexProperty::PER_VERTEX;
+    linearFaces = new SoFaceSet;
+    linearFaces->vertexProperty.setValue(linearVertexProperty);
+    linearSeparator->addChild(linearFaces);
+
+    // Radial gradient geometry
+    radialSeparator = new SoSeparator;
+    auto* radialHints = new SoShapeHints;
+    radialHints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
+    radialHints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+    radialSeparator->addChild(radialHints);
+
+    radialFanVertexProperty = new SoVertexProperty;
+    radialFanVertexProperty->materialBinding = SoVertexProperty::PER_VERTEX;
+    radialFan = new SoFaceSet;
+    radialFan->vertexProperty.setValue(radialFanVertexProperty);
+    radialRingVertexProperty = new SoVertexProperty;
+    radialRingVertexProperty->materialBinding = SoVertexProperty::PER_VERTEX;
+    radialRing = new SoFaceSet;
+    radialRing->vertexProperty.setValue(radialRingVertexProperty);
+    radialSeparator->addChild(radialFan);
+    radialSeparator->addChild(radialRing);
+
+    gradientSwitch->addChild(linearSeparator);
+    gradientSwitch->addChild(radialSeparator);
+    gradientSwitch->whichChild = 0;
 }
 
-/*!
-  Destructor.
-*/
-SoFCBackgroundGradient::~SoFCBackgroundGradient() = default;
+SoFCBackgroundGradient::~SoFCBackgroundGradient()
+{
+    if (gradientSwitch) {
+        gradientSwitch->unref();
+        gradientSwitch = nullptr;
+    }
+}
 
-// doc from parent
 void SoFCBackgroundGradient::initClass()
 {
     SO_NODE_INIT_CLASS(SoFCBackgroundGradient, SoNode, "Node");
 }
 
-void SoFCBackgroundGradient::GLRender(SoGLRenderAction* /*action*/)
+void SoFCBackgroundGradient::GLRender(SoGLRenderAction* action)
 {
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
-    glLoadIdentity();
-    glOrtho(-1, 1, -1, 1, -1, 1);
-    glMatrixMode(GL_MODELVIEW);
-    glPushMatrix();
-    glLoadIdentity();
-    glPushAttrib(GL_ENABLE_BIT);
-    glDisable(GL_DEPTH_TEST);
-    glDisable(GL_LIGHTING);
-    glDisable(GL_TEXTURE_2D);
-
-    if (gradient == Gradient::LINEAR) {
-        glBegin(GL_TRIANGLE_STRIP);
-        if (mCol[0] < 0) {
-            glColor3f(fCol[0], fCol[1], fCol[2]);
-            glVertex2f(-1, 1);
-            glColor3f(tCol[0], tCol[1], tCol[2]);
-            glVertex2f(-1, -1);
-            glColor3f(fCol[0], fCol[1], fCol[2]);
-            glVertex2f(1, 1);
-            glColor3f(tCol[0], tCol[1], tCol[2]);
-            glVertex2f(1, -1);
-        }
-        else {
-            glColor3f(fCol[0], fCol[1], fCol[2]);
-            glVertex2f(-1, 1);
-            glColor3f(mCol[0], mCol[1], mCol[2]);
-            glVertex2f(-1, 0);
-            glColor3f(fCol[0], fCol[1], fCol[2]);
-            glVertex2f(1, 1);
-            glColor3f(mCol[0], mCol[1], mCol[2]);
-            glVertex2f(1, 0);
-            glEnd();
-            glBegin(GL_TRIANGLE_STRIP);
-            glColor3f(mCol[0], mCol[1], mCol[2]);
-            glVertex2f(-1, 0);
-            glColor3f(tCol[0], tCol[1], tCol[2]);
-            glVertex2f(-1, -1);
-            glColor3f(mCol[0], mCol[1], mCol[2]);
-            glVertex2f(1, 0);
-            glColor3f(tCol[0], tCol[1], tCol[2]);
-            glVertex2f(1, -1);
-        }
+    if (!action || !gradientSwitch) {
+        return;
     }
-    else {  // radial gradient
-        glBegin(GL_TRIANGLE_FAN);
-        glColor3f(fCol[0], fCol[1], fCol[2]);
-        glVertex2f(0.0f, 0.0f);
 
-        if (mCol[0] < 0) {  // simple radial gradient
-            glColor3f(tCol[0], tCol[1], tCol[2]);
-            for (const GLfloat* vertex : big_circle) {
-                glVertex2fv(vertex);
-            }
-            glVertex2fv(big_circle.front());
-        }
-        else {
-            glColor3f(mCol[0], mCol[1], mCol[2]);
-            for (const GLfloat* vertex : small_oval) {
-                glVertex2fv(vertex);
-            }
-            glVertex2fv(small_oval.front());
-            glEnd();
+    SoState* state = action->getState();
+    if (!state) {
+        return;
+    }
 
-            glBegin(GL_TRIANGLE_STRIP);
-            for (std::size_t i = 0; i < small_oval.size(); i++) {
-                glColor3f(mCol[0], mCol[1], mCol[2]);
-                glVertex2fv(small_oval[i]);
-                glColor3f(tCol[0], tCol[1], tCol[2]);
-                glVertex2fv(big_circle[i]);
-            }
+    state->push();
 
-            glColor3f(mCol[0], mCol[1], mCol[2]);
-            glVertex2fv(small_oval.front());
-            glColor3f(tCol[0], tCol[1], tCol[2]);
-            glVertex2fv(big_circle.front());
-        }
-    }  // end of radial gradient
-    glEnd();
+    SoModelMatrixElement::set(state, this, SbMatrix::identity());
+    SoViewingMatrixElement::set(state, this, SbMatrix::identity());
 
-    glPopAttrib();
-    glPopMatrix();  // restore modelview
-    glMatrixMode(GL_PROJECTION);
-    glPopMatrix();
-    glMatrixMode(GL_MODELVIEW);
+    SbViewVolume viewVolume;
+    viewVolume.ortho(-1.0f, 1.0f, -1.0f, 1.0f, -1.0f, 1.0f);
+    SbMatrix affine;
+    SbMatrix projection;
+    viewVolume.getMatrices(affine, projection);
+    SoProjectionMatrixElement::set(state, this, projection);
+    SoViewVolumeElement::set(state, this, viewVolume);
+
+    SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+    SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
+    SoGLTextureEnabledElement::set(state, this, FALSE);
+    SoMultiTextureEnabledElement::set(state, this, FALSE);
+
+    ensureGeometry();
+    gradientSwitch->whichChild = (gradient == Gradient::LINEAR) ? 0 : 1;
+    gradientSwitch->GLRender(action);
+
+    state->pop();
 }
 
 void SoFCBackgroundGradient::setGradient(SoFCBackgroundGradient::Gradient grad)
 {
-    gradient = grad;
+    if (gradient != grad) {
+        gradient = grad;
+        geometryDirty = true;
+        this->touch();
+    }
 }
 
 SoFCBackgroundGradient::Gradient SoFCBackgroundGradient::getGradient() const
@@ -203,6 +170,8 @@ void SoFCBackgroundGradient::setColorGradient(const SbColor& fromColor, const Sb
     fCol = fromColor;
     tCol = toColor;
     mCol[0] = -1.0f;
+    geometryDirty = true;
+    this->touch();
 }
 
 void SoFCBackgroundGradient::setColorGradient(
@@ -214,4 +183,163 @@ void SoFCBackgroundGradient::setColorGradient(
     fCol = fromColor;
     tCol = toColor;
     mCol = midColor;
+    geometryDirty = true;
+    this->touch();
+}
+
+void SoFCBackgroundGradient::ensureGeometry()
+{
+    if (!geometryDirty) {
+        return;
+    }
+
+    geometryDirty = false;
+
+    if (gradient == Gradient::LINEAR) {
+        updateLinearGeometry();
+    }
+    else {
+        updateRadialGeometry();
+    }
+}
+
+void SoFCBackgroundGradient::updateLinearGeometry()
+{
+    if (!linearVertexProperty || !linearFaces) {
+        return;
+    }
+
+    const bool hasMid = mCol[0] >= 0.0f;
+    if (!hasMid) {
+        static const SbVec3f quadVertices[4] = {
+            SbVec3f(-1.0f, 1.0f, 0.0f),
+            SbVec3f(1.0f, 1.0f, 0.0f),
+            SbVec3f(1.0f, -1.0f, 0.0f),
+            SbVec3f(-1.0f, -1.0f, 0.0f)
+        };
+        linearVertexProperty->vertex.setValues(0, 4, quadVertices);
+        const uint32_t colors[4] = {
+            fCol.getPackedValue(),
+            fCol.getPackedValue(),
+            tCol.getPackedValue(),
+            tCol.getPackedValue()
+        };
+        linearVertexProperty->orderedRGBA.setValues(0, 4, colors);
+        linearFaces->numVertices.setNum(1);
+        linearFaces->numVertices.set1Value(0, 4);
+    }
+    else {
+        static const SbVec3f vertices[8] = {
+            SbVec3f(-1.0f, 1.0f, 0.0f),
+            SbVec3f(1.0f, 1.0f, 0.0f),
+            SbVec3f(1.0f, 0.0f, 0.0f),
+            SbVec3f(-1.0f, 0.0f, 0.0f),
+            SbVec3f(-1.0f, 0.0f, 0.0f),
+            SbVec3f(1.0f, 0.0f, 0.0f),
+            SbVec3f(1.0f, -1.0f, 0.0f),
+            SbVec3f(-1.0f, -1.0f, 0.0f)
+        };
+        linearVertexProperty->vertex.setValues(0, 8, vertices);
+        const uint32_t topColor = fCol.getPackedValue();
+        const uint32_t midColor = mCol.getPackedValue();
+        const uint32_t bottomColor = tCol.getPackedValue();
+        const uint32_t colors[8]
+            = {topColor, topColor, midColor, midColor, midColor, midColor, bottomColor, bottomColor};
+        linearVertexProperty->orderedRGBA.setValues(0, 8, colors);
+        linearFaces->numVertices.setNum(2);
+        linearFaces->numVertices.set1Value(0, 4);
+        linearFaces->numVertices.set1Value(1, 4);
+    }
+}
+
+void SoFCBackgroundGradient::updateRadialGeometry()
+{
+    if (!radialFan || !radialFanVertexProperty || !radialRing || !radialRingVertexProperty) {
+        return;
+    }
+
+    const bool hasMid = mCol[0] >= 0.0f;
+    constexpr float twoPi = 2.0f * std::numbers::pi_v<float>;
+    constexpr float sqrt2 = std::numbers::sqrt2_v<float>;
+    const float angleStep = twoPi / CircleSegments;
+
+    const uint32_t fromColor = fCol.getPackedValue();
+    const uint32_t toColor = tCol.getPackedValue();
+    uint32_t midColor = 0;
+
+    std::array<SbVec3f, CircleSegments> outerPoints;
+    for (int i = 0; i < CircleSegments; ++i) {
+        const float angle = angleStep * i;
+        outerPoints[i].setValue(sqrt2 * std::cos(angle), sqrt2 * std::sin(angle), 0.0f);
+    }
+
+    std::array<SbVec3f, CircleSegments> innerPoints;
+    if (hasMid) {
+        midColor = mCol.getPackedValue();
+        const float sqrtHalf = std::sqrt(0.5f);
+        for (int i = 0; i < CircleSegments; ++i) {
+            const float angle = angleStep * i;
+            innerPoints[i].setValue(0.3f * sqrt2 * std::cos(angle), sqrtHalf * std::sin(angle), 0.0f);
+        }
+    }
+
+    // Build triangle fan (center to inner or outer circle)
+    radialFan->numVertices.setNum(CircleSegments);
+    const int fanVertexCount = CircleSegments * 3;
+    radialFanVertexProperty->vertex.setNum(fanVertexCount);
+    radialFanVertexProperty->orderedRGBA.setNum(fanVertexCount);
+    for (int i = 0; i < CircleSegments; ++i) {
+        const int next = (i + 1) % CircleSegments;
+        const int base = i * 3;
+
+        radialFanVertexProperty->vertex.set1Value(base + 0, SbVec3f(0.0f, 0.0f, 0.0f));
+        radialFanVertexProperty->orderedRGBA.set1Value(base + 0, fromColor);
+
+        const SbVec3f& first = hasMid ? innerPoints[i] : outerPoints[i];
+        const SbVec3f& second = hasMid ? innerPoints[next] : outerPoints[next];
+        const uint32_t color = hasMid ? midColor : toColor;
+
+        radialFanVertexProperty->vertex.set1Value(base + 1, first);
+        radialFanVertexProperty->orderedRGBA.set1Value(base + 1, color);
+        radialFanVertexProperty->vertex.set1Value(base + 2, second);
+        radialFanVertexProperty->orderedRGBA.set1Value(base + 2, color);
+
+        radialFan->numVertices.set1Value(i, 3);
+    }
+
+    if (hasMid) {
+        const int ringTriangles = CircleSegments * 2;
+        const int ringVertexCount = ringTriangles * 3;
+        radialRing->numVertices.setNum(ringTriangles);
+        radialRingVertexProperty->vertex.setNum(ringVertexCount);
+        radialRingVertexProperty->orderedRGBA.setNum(ringVertexCount);
+
+        for (int i = 0; i < CircleSegments; ++i) {
+            const int next = (i + 1) % CircleSegments;
+            const int base = i * 6;
+
+            // Triangle: inner_i, outer_i, outer_next
+            radialRingVertexProperty->vertex.set1Value(base + 0, innerPoints[i]);
+            radialRingVertexProperty->orderedRGBA.set1Value(base + 0, midColor);
+            radialRingVertexProperty->vertex.set1Value(base + 1, outerPoints[i]);
+            radialRingVertexProperty->orderedRGBA.set1Value(base + 1, toColor);
+            radialRingVertexProperty->vertex.set1Value(base + 2, outerPoints[next]);
+            radialRingVertexProperty->orderedRGBA.set1Value(base + 2, toColor);
+            radialRing->numVertices.set1Value(i * 2, 3);
+
+            // Triangle: inner_i, outer_next, inner_next
+            radialRingVertexProperty->vertex.set1Value(base + 3, innerPoints[i]);
+            radialRingVertexProperty->orderedRGBA.set1Value(base + 3, midColor);
+            radialRingVertexProperty->vertex.set1Value(base + 4, outerPoints[next]);
+            radialRingVertexProperty->orderedRGBA.set1Value(base + 4, toColor);
+            radialRingVertexProperty->vertex.set1Value(base + 5, innerPoints[next]);
+            radialRingVertexProperty->orderedRGBA.set1Value(base + 5, midColor);
+            radialRing->numVertices.set1Value(i * 2 + 1, 3);
+        }
+    }
+    else {
+        radialRing->numVertices.setNum(0);
+        radialRingVertexProperty->vertex.setNum(0);
+        radialRingVertexProperty->orderedRGBA.setNum(0);
+    }
 }

--- a/src/Gui/Inventor/SoFCBackgroundGradient.h
+++ b/src/Gui/Inventor/SoFCBackgroundGradient.h
@@ -1,28 +1,29 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2005 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2005 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
+
+#include <cstdint>
 
 #include <Inventor/SbColor.h>
 #include <Inventor/nodes/SoNode.h>
@@ -32,6 +33,10 @@
 
 class SbColor;
 class SoGLRenderAction;
+class SoSeparator;
+class SoSwitch;
+class SoFaceSet;
+class SoVertexProperty;
 
 namespace Gui
 {
@@ -59,7 +64,25 @@ public:
     void setColorGradient(const SbColor& fromColor, const SbColor& toColor, const SbColor& midColor);
 
 private:
+    void ensureGeometry();
+    void updateLinearGeometry();
+    void updateRadialGeometry();
+
+    static constexpr int CircleSegments = 32;
+
     Gradient gradient;
+    bool geometryDirty {true};
+
+    SoSwitch* gradientSwitch {nullptr};
+    SoSeparator* linearSeparator {nullptr};
+    SoFaceSet* linearFaces {nullptr};
+    SoVertexProperty* linearVertexProperty {nullptr};
+
+    SoSeparator* radialSeparator {nullptr};
+    SoFaceSet* radialFan {nullptr};
+    SoVertexProperty* radialFanVertexProperty {nullptr};
+    SoFaceSet* radialRing {nullptr};
+    SoVertexProperty* radialRingVertexProperty {nullptr};
 
 protected:
     ~SoFCBackgroundGradient() override;

--- a/src/Gui/Inventor/SoFCPlacementIndicatorKit.cpp
+++ b/src/Gui/Inventor/SoFCPlacementIndicatorKit.cpp
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-/****************************************************************************
- *                                                                          *
- *   Copyright (c) 2024 Kacper Donat <kacper@kadet.net>                     *
- *                                                                          *
- *   This file is part of FreeCAD.                                          *
- *                                                                          *
- *   FreeCAD is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as            *
- *   published by the Free Software Foundation, either version 2.1 of the   *
- *   License, or (at your option) any later version.                        *
- *                                                                          *
- *   FreeCAD is distributed in the hope that it will be useful, but         *
- *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
- *   Lesser General Public License for more details.                        *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with FreeCAD. If not, see                                *
- *   <https://www.gnu.org/licenses/>.                                       *
- *                                                                          *
- ***************************************************************************/
+// SPDX-FileCopyrightText: 2024 Kacper Donat <kacper@kadet.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <sstream>
 
@@ -42,7 +42,7 @@
 #include "So3DAnnotation.h"
 #include "SoAxisCrossKit.h"
 
-#include <SoTextLabel.h>
+#include <Gui/SoTextLabel.h>
 #include <Utilities.h>
 #include <ViewParams.h>
 #include <ViewProvider.h>

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-// SPDX-FileCopyrightText: 2017 Kustaa Nyholm <kustaa.nyholm@sparetimelabs.com>
-// SPDX-FileCopyrightText: 2025 Joao Matos
+// SPDX-FileCopyrightText: 2025-2026 Joao Matos
 // SPDX-FileNotice: Part of the FreeCAD project.
 
 /******************************************************************************
  *                                                                            *
  *   FreeCAD is free software: you can redistribute it and/or modify          *
  *   it under the terms of the GNU Lesser General Public License as           *
- *   published by the Free Software Foundation, either version 2.1            *
- *   of the License, or (at your option) any later version.                   *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
  *                                                                            *
- *   FreeCAD is distributed in the hope that it will be useful,               *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
- *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
- *   See the GNU Lesser General Public License for more details.              *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
  *                                                                            *
  *   You should have received a copy of the GNU Lesser General Public         *
- *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
  *                                                                            *
  ******************************************************************************/
 
@@ -25,42 +25,52 @@
 #ifdef FC_OS_WIN32
 # include <windows.h>
 #endif
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
-#include <Inventor/SbVec2f.h>
-#include <Inventor/SbVec4f.h>
-
-#include <Inventor/actions/SoGLRenderAction.h>
-#include <Inventor/bundles/SoMaterialBundle.h>
-#include <Inventor/elements/SoLazyElement.h>
-#include <Inventor/elements/SoLineWidthElement.h>
-#include <Inventor/elements/SoMaterialBindingElement.h>
-#include <Inventor/elements/SoDepthBufferElement.h>
-#include <Inventor/elements/SoModelMatrixElement.h>
-#include <Inventor/elements/SoPointSizeElement.h>
-#include <Inventor/elements/SoProjectionMatrixElement.h>
-#include <Inventor/elements/SoShapeHintsElement.h>
-#include <Inventor/elements/SoShapeStyleElement.h>
-#include <Inventor/elements/SoViewingMatrixElement.h>
-#include <Inventor/elements/SoViewportRegionElement.h>
-#include <Inventor/elements/SoDrawStyleElement.h>
-#include <Inventor/elements/SoLightModelElement.h>
-#include <Inventor/elements/SoPolygonOffsetElement.h>
-#include <Inventor/misc/SoState.h>
-#include <Inventor/errors/SoDebugError.h>
-#include <Inventor/details/SoCubeDetail.h>
-#include <Inventor/nodes/SoMaterial.h>
-#include <Inventor/SoPrimitiveVertex.h>
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
-#include <memory>
 #include <limits>
+#include <memory>
 #include <numbers>
+
+#include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/actions/SoRayPickAction.h>
+#include <Inventor/details/SoFaceDetail.h>
+#include <Inventor/lists/SoPickedPointList.h>
+#include <Inventor/SoPickedPoint.h>
+#include <Inventor/elements/SoLazyElement.h>
+#include <Inventor/elements/SoOverrideElement.h>
+#include <Inventor/elements/SoShapeStyleElement.h>
+#include <Inventor/elements/SoViewportRegionElement.h>
+#include <Inventor/elements/SoGLLazyElement.h>
+#include <Inventor/elements/SoLightModelElement.h>
+#include <Inventor/elements/SoGLShaderProgramElement.h>
+#include <Inventor/elements/SoGLTextureEnabledElement.h>
+#include <Inventor/elements/SoTextureQualityElement.h>
+#include <Inventor/misc/SoState.h>
+#include <Inventor/nodes/SoDepthBuffer.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoIndexedFaceSet.h>
+#include <Inventor/nodes/SoIndexedLineSet.h>
+#include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoMaterialBinding.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoPerspectiveCamera.h>
+#include <Inventor/nodes/SoPointSet.h>
+#include <Inventor/nodes/SoPolygonOffset.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoShapeHints.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoTransform.h>
+#include <Inventor/nodes/SoTexture2.h>
+#include <Inventor/nodes/SoTransparencyType.h>
+#include <Inventor/nodes/SoVertexProperty.h>
+#include <Inventor/SbVec2f.h>
+#include <Inventor/SbVec4f.h>
+#include <Inventor/SbViewVolume.h>
+#include <Inventor/system/gl.h>
 
 #include "SoNaviCube.h"
 
@@ -70,6 +80,308 @@ SO_NODE_SOURCE(SoNaviCube);
 
 namespace
 {
+
+constexpr std::array<SoNaviCube::PickId, 26> kCubeFacePickOrder = {
+    SoNaviCube::PickId::Top,
+    SoNaviCube::PickId::Front,
+    SoNaviCube::PickId::Left,
+    SoNaviCube::PickId::Rear,
+    SoNaviCube::PickId::Right,
+    SoNaviCube::PickId::Bottom,
+    SoNaviCube::PickId::FrontTopRight,
+    SoNaviCube::PickId::FrontTopLeft,
+    SoNaviCube::PickId::FrontBottomRight,
+    SoNaviCube::PickId::FrontBottomLeft,
+    SoNaviCube::PickId::RearTopRight,
+    SoNaviCube::PickId::RearTopLeft,
+    SoNaviCube::PickId::RearBottomRight,
+    SoNaviCube::PickId::RearBottomLeft,
+    SoNaviCube::PickId::FrontTop,
+    SoNaviCube::PickId::FrontBottom,
+    SoNaviCube::PickId::RearBottom,
+    SoNaviCube::PickId::RearTop,
+    SoNaviCube::PickId::RearRight,
+    SoNaviCube::PickId::FrontRight,
+    SoNaviCube::PickId::FrontLeft,
+    SoNaviCube::PickId::RearLeft,
+    SoNaviCube::PickId::TopLeft,
+    SoNaviCube::PickId::TopRight,
+    SoNaviCube::PickId::BottomRight,
+    SoNaviCube::PickId::BottomLeft
+};
+
+constexpr std::array<SoNaviCube::PickId, 6> kLabelPickIds = {
+    SoNaviCube::PickId::Top,
+    SoNaviCube::PickId::Front,
+    SoNaviCube::PickId::Left,
+    SoNaviCube::PickId::Rear,
+    SoNaviCube::PickId::Right,
+    SoNaviCube::PickId::Bottom
+};
+
+constexpr std::array<SoNaviCube::PickId, 9> kButtonPickIds = {
+    SoNaviCube::PickId::ArrowNorth,
+    SoNaviCube::PickId::ArrowSouth,
+    SoNaviCube::PickId::ArrowEast,
+    SoNaviCube::PickId::ArrowWest,
+    SoNaviCube::PickId::ArrowRight,
+    SoNaviCube::PickId::ArrowLeft,
+    SoNaviCube::PickId::Backside,
+    SoNaviCube::PickId::Home,
+    SoNaviCube::PickId::ViewMenu
+};
+
+constexpr int cubeFaceIndex(SoNaviCube::PickId id)
+{
+    for (size_t i = 0; i < kCubeFacePickOrder.size(); ++i) {
+        if (kCubeFacePickOrder[i] == id) {
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+SoSeparator* depthClearScene()
+{
+    static SoSeparator* root = nullptr;
+    if (root) {
+        return root;
+    }
+
+    root = new SoSeparator;
+    root->ref();
+
+    // Ensure the quad is drawn with blending enabled and without relying on any inherited
+    // backface-culling assumptions. The quad uses alpha=0, so with blending it won't touch the
+    // color buffer while still writing depth.
+    {
+        auto* transparency = new SoTransparencyType;
+        transparency->value = SoTransparencyType::BLEND;
+        root->addChild(transparency);
+
+        auto* hints = new SoShapeHints;
+        hints->vertexOrdering = SoShapeHints::UNKNOWN_ORDERING;
+        hints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+        hints->faceType = SoShapeHints::UNKNOWN_FACE_TYPE;
+        root->addChild(hints);
+    }
+
+    // Use a dedicated camera so the caller doesn't need to manually override projection/view
+    // matrices. The quad is placed on the far plane so it writes depth=1.0 everywhere.
+    {
+        auto* cam = new SoOrthographicCamera;
+        using Mapping = SoCamera::ViewportMapping;
+        cam->viewportMapping = Mapping::LEAVE_ALONE;
+        cam->aspectRatio = 1.0F;
+        cam->position = SbVec3f(0.0F, 0.0F, 0.0F);
+        cam->orientation = SbRotation();
+        cam->nearDistance = 0.0F;
+        cam->farDistance = 1.0F;
+        cam->focalDistance = 1.0F;
+        cam->height = 2.0F;
+        root->addChild(cam);
+    }
+
+    auto* depth = new SoDepthBuffer;
+    depth->test = TRUE;
+    depth->write = TRUE;
+    depth->function = SoDepthBuffer::ALWAYS;
+    depth->range = SbVec2f(0.0F, 1.0F);
+    root->addChild(depth);
+
+    // Render fully transparent to avoid touching the color buffer; only depth is reset.
+    auto* mat = new SoMaterial;
+    mat->diffuseColor.setValue(1.0F, 1.0F, 1.0F);
+    mat->transparency = 1.0F;
+    root->addChild(mat);
+
+    auto* face = new SoFaceSet;
+    face->numVertices.set1Value(0, 4);
+    auto* vp = new SoVertexProperty;
+    face->vertexProperty = vp;
+    vp->vertex.setNum(4);
+    vp->vertex.set1Value(0, SbVec3f(-1.0F, -1.0F, -1.0F));
+    vp->vertex.set1Value(1, SbVec3f(1.0F, -1.0F, -1.0F));
+    vp->vertex.set1Value(2, SbVec3f(1.0F, 1.0F, -1.0F));
+    vp->vertex.set1Value(3, SbVec3f(-1.0F, 1.0F, -1.0F));
+    root->addChild(face);
+
+    return root;
+}
+
+bool pointInTriangle2D(const SbVec2f& p, const SbVec2f& a, const SbVec2f& b, const SbVec2f& c)
+{
+    const float px = p[0];
+    const float py = p[1];
+    const float ax = a[0];
+    const float ay = a[1];
+    const float bx = b[0];
+    const float by = b[1];
+    const float cx = c[0];
+    const float cy = c[1];
+
+    const float v0x = cx - ax;
+    const float v0y = cy - ay;
+    const float v1x = bx - ax;
+    const float v1y = by - ay;
+    const float v2x = px - ax;
+    const float v2y = py - ay;
+
+    const float dot00 = v0x * v0x + v0y * v0y;
+    const float dot01 = v0x * v1x + v0y * v1y;
+    const float dot02 = v0x * v2x + v0y * v2y;
+    const float dot11 = v1x * v1x + v1y * v1y;
+    const float dot12 = v1x * v2x + v1y * v2y;
+
+    const float denom = dot00 * dot11 - dot01 * dot01;
+    if (std::abs(denom) < 1e-18F) {
+        return false;
+    }
+    const float invDenom = 1.0F / denom;
+    const float u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+    const float v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+    return (u >= 0.0F) && (v >= 0.0F) && (u + v <= 1.0F);
+}
+
+bool triangulatePolygon2D(const std::vector<SbVec3f>& verts, std::vector<int>& triIndices)
+{
+    triIndices.clear();
+    const int n = static_cast<int>(verts.size());
+    if (n < 3) {
+        return false;
+    }
+
+    double signedArea2 = 0.0;
+    for (int i = 0, j = n - 1; i < n; j = i++) {
+        const double xi = verts[i][0];
+        const double yi = verts[i][1];
+        const double xj = verts[j][0];
+        const double yj = verts[j][1];
+        signedArea2 += (xj * yi) - (xi * yj);
+    }
+    if (std::abs(signedArea2) < 1e-12) {
+        return false;
+    }
+    const bool wantCCW = (signedArea2 > 0.0);
+
+    auto crossZ = [&](int ia, int ib, int ic) {
+        const double abx = verts[ib][0] - verts[ia][0];
+        const double aby = verts[ib][1] - verts[ia][1];
+        const double bcx = verts[ic][0] - verts[ib][0];
+        const double bcy = verts[ic][1] - verts[ib][1];
+        return abx * bcy - aby * bcx;
+    };
+
+    std::vector<int> remaining;
+    remaining.reserve(static_cast<size_t>(n));
+    for (int i = 0; i < n; ++i) {
+        remaining.push_back(i);
+    }
+
+    auto isConvex = [&](int ia, int ib, int ic) {
+        const double z = crossZ(ia, ib, ic);
+        return wantCCW ? (z > 1e-18) : (z < -1e-18);
+    };
+
+    constexpr int MAX_ITERS_MULT = 4;
+    int iters = 0;
+    while (remaining.size() > 3 && iters < MAX_ITERS_MULT * n) {
+        bool clipped = false;
+        const size_t m = remaining.size();
+        for (size_t i = 0; i < m; ++i) {
+            const int ib = remaining[i];
+            const int ia = remaining[(i + m - 1) % m];
+            const int ic = remaining[(i + 1) % m];
+
+            if (!isConvex(ia, ib, ic)) {
+                continue;
+            }
+
+            const SbVec2f a(verts[ia][0], verts[ia][1]);
+            const SbVec2f b(verts[ib][0], verts[ib][1]);
+            const SbVec2f c(verts[ic][0], verts[ic][1]);
+
+            bool anyInside = false;
+            for (size_t k = 0; k < m; ++k) {
+                const int ip = remaining[k];
+                if (ip == ia || ip == ib || ip == ic) {
+                    continue;
+                }
+                const SbVec2f p(verts[ip][0], verts[ip][1]);
+                if (pointInTriangle2D(p, a, b, c)) {
+                    anyInside = true;
+                    break;
+                }
+            }
+            if (anyInside) {
+                continue;
+            }
+
+            if (wantCCW) {
+                triIndices.push_back(ia);
+                triIndices.push_back(ib);
+                triIndices.push_back(ic);
+            }
+            else {
+                triIndices.push_back(ic);
+                triIndices.push_back(ib);
+                triIndices.push_back(ia);
+            }
+            remaining.erase(remaining.begin() + static_cast<std::vector<int>::difference_type>(i));
+            clipped = true;
+            break;
+        }
+        if (!clipped) {
+            triIndices.clear();
+            return false;
+        }
+        ++iters;
+    }
+
+    if (remaining.size() == 3) {
+        const int ia = remaining[0];
+        const int ib = remaining[1];
+        const int ic = remaining[2];
+        if (wantCCW) {
+            triIndices.push_back(ia);
+            triIndices.push_back(ib);
+            triIndices.push_back(ic);
+        }
+        else {
+            triIndices.push_back(ic);
+            triIndices.push_back(ib);
+            triIndices.push_back(ia);
+        }
+        return true;
+    }
+
+    triIndices.clear();
+    return false;
+}
+
+float toTransparency(float alpha)
+{
+    alpha = std::clamp(alpha, 0.0F, 1.0F);
+    return 1.0F - alpha;
+}
+
+bool nearlyEqual(float a, float b, float eps = 1e-6F)
+{
+    return std::abs(a - b) <= eps;
+}
+
+bool nearlyEqual(const SbColor& a, const SbColor& b, float eps = 1e-6F)
+{
+    return nearlyEqual(a[0], b[0], eps) && nearlyEqual(a[1], b[1], eps)
+        && nearlyEqual(a[2], b[2], eps);
+}
+
+constexpr float OVERLAY_NEAR = 0.1F;
+constexpr float OVERLAY_FAR = 10.1F;
+constexpr float OVERLAY_ORTHO_EXTENT = 2.1F;
+constexpr float OVERLAY_FOV_SCALE = 1.1F;
+constexpr float OVERLAY_CUBE_Z = -5.1F;
+constexpr float OVERLAY_BUTTON_Z = -4.0F;  // in front of the cube (cube is centered at z≈-5.1)
 
 }  // namespace
 
@@ -100,79 +412,917 @@ SoNaviCube::SoNaviCube()
     SO_NODE_ADD_FIELD(viewportRect, (SbVec4f(0.0F, 0.0F, 0.0F, 0.0F)));
 }
 
+SoNaviCube::~SoNaviCube()
+{
+    if (sceneRoot) {
+        sceneRoot->unref();
+        sceneRoot = nullptr;
+    }
+    clearLabelTextures();
+}
+
 void SoNaviCube::setChamfer(float chamfer)
 {
     float clamped = std::clamp(chamfer, 0.05F, 0.18F);
-    if (std::abs(clamped - m_Chamfer) > std::numeric_limits<float>::epsilon()) {
-        m_Chamfer = clamped;
-        m_GeometryDirty = true;
+    if (std::abs(clamped - this->chamfer) > std::numeric_limits<float>::epsilon()) {
+        this->chamfer = clamped;
+        geometryDirty = true;
+        sceneDirty = true;
         touch();
     }
 }
 
-const SoNaviCube::FaceMap& SoNaviCube::faces() const
+void SoNaviCube::setLabelImage(PickId id, const SbVec2s& size, int numComponents, const unsigned char* pixels)
 {
     ensureGeometry();
-    return m_Faces;
-}
 
-const SoNaviCube::Face* SoNaviCube::faceForId(PickId id) const
-{
-    ensureGeometry();
-    auto it = m_Faces.find(id);
-    if (it != m_Faces.end()) {
-        return &it->second;
+    auto& slot = labelSlots[pickIndex(id)];
+    if (!pixels || size[0] <= 0 || size[1] <= 0 || numComponents <= 0) {
+        if (slot.texture) {
+            slot.texture->unref();
+            slot.texture = nullptr;
+            if (labelTextureCount > 0) {
+                --labelTextureCount;
+            }
+        }
+        sceneDirty = true;
+        return;
     }
-    return nullptr;
-}
 
-const SoNaviCube::FaceMap& SoNaviCube::buttonFaces() const
-{
-    ensureGeometry();
-    return m_ButtonFaces;
-}
-
-const SoNaviCube::Face* SoNaviCube::buttonFaceForId(PickId id) const
-{
-    ensureGeometry();
-    auto it = m_ButtonFaces.find(id);
-    if (it != m_ButtonFaces.end()) {
-        return &it->second;
+    if (!slot.texture) {
+        slot.texture = new SoTexture2();
+        slot.texture->ref();
+        ++labelTextureCount;
+        slot.texture->wrapS = SoTexture2::CLAMP;
+        slot.texture->wrapT = SoTexture2::CLAMP;
+        // Match legacy GL behavior: labels are white text in the texture, and we modulate them
+        // with the current material color (usually the emphase/border color).
+        slot.texture->model = SoTexture2::MODULATE;
+        slot.texture->enableCompressedTexture = FALSE;
     }
-    return nullptr;
-}
-
-const SoNaviCube::LabelMap& SoNaviCube::labelSlots() const
-{
-    ensureGeometry();
-    return m_LabelSlots;
-}
-
-const SoNaviCube::LabelSlot* SoNaviCube::labelSlotForId(PickId id) const
-{
-    ensureGeometry();
-    auto it = m_LabelSlots.find(id);
-    if (it != m_LabelSlots.end()) {
-        return &it->second;
+    else {
+        // Keep the model consistent in case the slot was created before this policy.
+        slot.texture->model = SoTexture2::MODULATE;
     }
-    return nullptr;
-}
 
-void SoNaviCube::setLabelTexture(PickId id, unsigned int textureId)
-{
-    ensureGeometry();
-    m_LabelSlots[id].textureId = textureId;
+    slot.texture->image.setValue(size, numComponents, pixels, SoSFImage::COPY);
+    sceneDirty = true;
 }
 
 void SoNaviCube::clearLabelTextures()
 {
-    for (auto& [_, slot] : m_LabelSlots) {
-        slot.textureId = 0;
+    for (auto& slot : labelSlots) {
+        if (slot.texture) {
+            slot.texture->unref();
+            slot.texture = nullptr;
+        }
+    }
+    labelTextureCount = 0;
+    sceneDirty = true;
+}
+
+void SoNaviCube::ensureSceneGraph() const
+{
+    if (!sceneRoot) {
+        sceneRoot = new SoSeparator;
+        sceneRoot->ref();
+        sceneDirty = true;
+    }
+
+    if (sceneDirty) {
+        rebuildSceneGraph();
     }
 }
 
-void SoNaviCube::renderGL(bool pickMode) const
+void SoNaviCube::resetSceneGraph() const
 {
+    if (!sceneRoot) {
+        return;
+    }
+
+    sceneRoot->removeAllChildren();
+    for (auto& nodes : labelNodes) {
+        nodes = {};
+    }
+    for (auto& nodes : buttonNodes) {
+        nodes = {};
+    }
+    style.lastHiliteFaceIndex = -1;
+    style.lastHilitePick = PickId::None;
+    style.buttonDirty = true;
+    style.labelDirty = true;
+    style.axisDirty = true;
+    style.lastButtonsHilitePick = PickId::None;
+    style.showCS = false;
+
+    cameraSwitch = nullptr;
+    orthoCamera = nullptr;
+    perspCamera = nullptr;
+    rootTransform = nullptr;
+    axisSwitch = nullptr;
+    for (AxisNodes& nodes : axisNodes) {
+        nodes = {};
+    }
+    cubeSep = nullptr;
+    cubeMaterial = nullptr;
+    cubeVertexProperty = nullptr;
+    cubeFaces = nullptr;
+    edgeSep = nullptr;
+    edgeMaterial = nullptr;
+    edgeDrawStyle = nullptr;
+    edgeVertexProperty = nullptr;
+    edges = nullptr;
+    labelsSep = nullptr;
+    buttonsSep = nullptr;
+}
+
+void SoNaviCube::buildCamerasAndStyle() const
+{
+    if (!sceneRoot) {
+        return;
+    }
+
+    cameraSwitch = new SoSwitch;
+    sceneRoot->addChild(cameraSwitch);
+
+    orthoCamera = new SoOrthographicCamera;
+    cameraSwitch->addChild(orthoCamera);
+
+    perspCamera = new SoPerspectiveCamera;
+    cameraSwitch->addChild(perspCamera);
+
+    // The overlay uses a fixed projection independent of viewport aspect ratio, matching the
+    // legacy GL code path. (Non-square viewports will therefore stretch the overlay similarly.)
+    cameraSwitch->whichChild = 0;
+
+    // Force filled rendering for the overlay by default, regardless of viewer draw style.
+    {
+        auto* drawStyle = new SoDrawStyle;
+        drawStyle->style = SoDrawStyle::FILLED;
+        sceneRoot->addChild(drawStyle);
+    }
+
+    {
+        using Mapping = SoCamera::ViewportMapping;
+        // Legacy projection assumed a fixed (square) aspect ratio.
+        orthoCamera->viewportMapping = Mapping::LEAVE_ALONE;
+        perspCamera->viewportMapping = Mapping::LEAVE_ALONE;
+        orthoCamera->aspectRatio = 1.0F;
+        perspCamera->aspectRatio = 1.0F;
+
+        orthoCamera->position = SbVec3f(0.0F, 0.0F, 0.0F);
+        perspCamera->position = SbVec3f(0.0F, 0.0F, 0.0F);
+        orthoCamera->orientation = SbRotation();
+        perspCamera->orientation = SbRotation();
+
+        orthoCamera->nearDistance = OVERLAY_NEAR;
+        orthoCamera->farDistance = OVERLAY_FAR;
+        perspCamera->nearDistance = OVERLAY_NEAR;
+        perspCamera->farDistance = OVERLAY_FAR;
+        orthoCamera->focalDistance = std::abs(OVERLAY_CUBE_Z);
+        perspCamera->focalDistance = std::abs(OVERLAY_CUBE_Z);
+
+        // Equivalent to ortho [-2.1..2.1] in Y.
+        orthoCamera->height = 2.0F * OVERLAY_ORTHO_EXTENT;
+
+        // Match the legacy frustum: dim = near * tan(pi/8) * scale.
+        const float halfAngle = std::atan(
+            std::tan(std::numbers::pi_v<float> / 8.0F) * OVERLAY_FOV_SCALE
+        );
+        perspCamera->heightAngle = 2.0F * halfAngle;
+    }
+}
+
+void SoNaviCube::buildCubeSection() const
+{
+    if (!sceneRoot) {
+        return;
+    }
+
+    auto* cubeGroup = new SoSeparator;
+    sceneRoot->addChild(cubeGroup);
+
+    // Ensure the overlay depth behavior is stable regardless of viewer state: after the depth-clear
+    // pass we want normal depth testing for the cube/labels/axes (buttons handle their own depth
+    // settings separately).
+    {
+        auto* depth = new SoDepthBuffer;
+        depth->test = TRUE;
+        depth->write = TRUE;
+        depth->function = SoDepthBuffer::LEQUAL;
+        depth->range = SbVec2f(0.0F, 1.0F);
+        cubeGroup->addChild(depth);
+    }
+
+    rootTransform = new SoTransform;
+    cubeGroup->addChild(rootTransform);
+
+    buildAxisSection(cubeGroup);
+
+    cubeSep = new SoSeparator;
+    cubeGroup->addChild(cubeSep);
+
+    cubeMaterial = new SoMaterial;
+    cubeSep->addChild(cubeMaterial);
+
+    // Explicit binding node to match legacy behavior and avoid inheriting upstream binding state.
+    {
+        auto* binding = new SoMaterialBinding;
+        binding->value = SoMaterialBinding::PER_FACE_INDEXED;
+        cubeSep->addChild(binding);
+    }
+
+    // Match the legacy render ordering: offset filled faces slightly so edges/labels can be drawn
+    // "on top" without z-fighting.
+    {
+        auto* offset = new SoPolygonOffset;
+        offset->factor = 1.0F;
+        offset->units = 1.0F;
+        offset->styles = SoPolygonOffset::FILLED;
+        offset->on = TRUE;
+        cubeSep->addChild(offset);
+
+        // Ensure consistent front-face orientation and enable solid face culling for the cube.
+        auto* hints = new SoShapeHints;
+        hints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
+        hints->shapeType = SoShapeHints::SOLID;
+        hints->faceType = SoShapeHints::CONVEX;
+        cubeSep->addChild(hints);
+    }
+
+    cubeFaces = new SoIndexedFaceSet;
+    cubeSep->addChild(cubeFaces);
+
+    {
+        cubeVertexProperty = new SoVertexProperty;
+        cubeFaces->vertexProperty = cubeVertexProperty;
+        cubeVertexProperty->materialBinding = SoVertexProperty::PER_FACE_INDEXED;
+        if (!cubeCoordsData.empty()) {
+            cubeVertexProperty->vertex
+                .setValues(0, static_cast<int>(cubeCoordsData.size()), cubeCoordsData.data());
+        }
+        if (!cubeCoordIndexData.empty()) {
+            cubeFaces->coordIndex.setValues(
+                0,
+                static_cast<int>(cubeCoordIndexData.size()),
+                cubeCoordIndexData.data()
+            );
+        }
+        const int faceCount = static_cast<int>(kCubeFacePickOrder.size());
+        cubeFaces->materialIndex.setNum(faceCount);
+        for (int i = 0; i < faceCount; ++i) {
+            cubeFaces->materialIndex.set1Value(i, 0);
+        }
+    }
+
+    edgeSep = new SoSeparator;
+    cubeGroup->addChild(edgeSep);
+
+    edgeMaterial = new SoMaterial;
+    edgeSep->addChild(edgeMaterial);
+
+    edgeDrawStyle = new SoDrawStyle;
+    edgeSep->addChild(edgeDrawStyle);
+
+    edges = new SoIndexedLineSet;
+    edgeSep->addChild(edges);
+
+    {
+        edgeVertexProperty = new SoVertexProperty;
+        edges->vertexProperty = edgeVertexProperty;
+        if (!edgeCoordsData.empty()) {
+            edgeVertexProperty->vertex
+                .setValues(0, static_cast<int>(edgeCoordsData.size()), edgeCoordsData.data());
+        }
+        if (!edgeCoordIndexData.empty()) {
+            edges->coordIndex.setValues(
+                0,
+                static_cast<int>(edgeCoordIndexData.size()),
+                edgeCoordIndexData.data()
+            );
+        }
+    }
+
+    labelsSep = new SoSeparator;
+    cubeGroup->addChild(labelsSep);
+
+    // Labels should render slightly "on top" of cube faces and without being affected by any
+    // backface culling settings inherited from the axis/cube/edges.
+    SoSeparator* labelsGroup = nullptr;
+    {
+        labelsGroup = new SoSeparator;
+        labelsSep->addChild(labelsGroup);
+
+        auto* depth = new SoDepthBuffer;
+        depth->test = TRUE;
+        depth->write = FALSE;
+        depth->function = SoDepthBuffer::LEQUAL;
+        labelsGroup->addChild(depth);
+
+        auto* offset = new SoPolygonOffset;
+        offset->factor = -1.0F;
+        offset->units = -1.0F;
+        offset->styles = SoPolygonOffset::FILLED;
+        offset->on = TRUE;
+        labelsGroup->addChild(offset);
+
+        auto* hints = new SoShapeHints;
+        hints->vertexOrdering = SoShapeHints::UNKNOWN_ORDERING;
+        hints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+        hints->faceType = SoShapeHints::UNKNOWN_FACE_TYPE;
+        labelsGroup->addChild(hints);
+    }
+
+    for (PickId pickId : kLabelPickIds) {
+        const auto& slot = labelSlots[pickIndex(pickId)];
+        if (slot.quad.size() != 4 || !slot.texture) {
+            continue;
+        }
+
+        LabelNodes nodes;
+        nodes.sep = new SoSeparator;
+
+        nodes.material = new SoMaterial;
+        nodes.sep->addChild(nodes.material);
+
+        nodes.texture = slot.texture;
+        nodes.sep->addChild(nodes.texture);
+
+        nodes.face = new SoFaceSet;
+        nodes.face->numVertices.set1Value(0, 4);
+        nodes.vertexProperty = new SoVertexProperty;
+        nodes.face->vertexProperty = nodes.vertexProperty;
+        nodes.vertexProperty->vertex.setNum(4);
+        nodes.vertexProperty->texCoord.setNum(4);
+        nodes.vertexProperty->texCoord.set1Value(0, SbVec2f(0.0F, 0.0F));
+        nodes.vertexProperty->texCoord.set1Value(1, SbVec2f(1.0F, 0.0F));
+        nodes.vertexProperty->texCoord.set1Value(2, SbVec2f(1.0F, 1.0F));
+        nodes.vertexProperty->texCoord.set1Value(3, SbVec2f(0.0F, 1.0F));
+        for (int i = 0; i < 4; ++i) {
+            nodes.vertexProperty->vertex.set1Value(i, slot.quad[static_cast<size_t>(i)]);
+        }
+        nodes.sep->addChild(nodes.face);
+
+        labelsGroup->addChild(nodes.sep);
+        labelNodes[pickIndex(pickId)] = nodes;
+    }
+}
+
+void SoNaviCube::buildAxisSection(SoSeparator* cubeGroup) const
+{
+    if (!cubeGroup) {
+        return;
+    }
+
+    axisSwitch = new SoSwitch;
+    cubeGroup->addChild(axisSwitch);
+
+    constexpr float a = -1.1F;
+    constexpr float b = -1.05F;
+    constexpr float c = 0.5F;
+    const SbVec3f axisSegments[3][2] = {
+        {SbVec3f(b, a, a), SbVec3f(c, a, a)},
+        {SbVec3f(a, b, a), SbVec3f(a, c, a)},
+        {SbVec3f(a, a, b), SbVec3f(a, a, c)}
+    };
+
+    for (int axis = 0; axis < 3; ++axis) {
+        AxisNodes nodes;
+        nodes.sep = new SoSeparator;
+
+        nodes.material = new SoMaterial;
+        nodes.sep->addChild(nodes.material);
+
+        nodes.drawStyle = new SoDrawStyle;
+        nodes.sep->addChild(nodes.drawStyle);
+
+        nodes.vertexProperty = new SoVertexProperty;
+        nodes.vertexProperty->vertex.setNum(2);
+        nodes.vertexProperty->vertex.set1Value(0, axisSegments[axis][0]);
+        nodes.vertexProperty->vertex.set1Value(1, axisSegments[axis][1]);
+
+        nodes.line = new SoIndexedLineSet;
+        nodes.line->vertexProperty = nodes.vertexProperty;
+        const std::int32_t lineIdx[3] = {0, 1, -1};
+        nodes.line->coordIndex.setValues(0, 3, lineIdx);
+        nodes.sep->addChild(nodes.line);
+
+        nodes.points = new SoPointSet;
+        nodes.points->vertexProperty = nodes.vertexProperty;
+        nodes.points->numPoints = 2;
+        nodes.sep->addChild(nodes.points);
+
+        axisSwitch->addChild(nodes.sep);
+        axisNodes[axis] = nodes;
+    }
+}
+
+void SoNaviCube::buildButtonsSection() const
+{
+    if (!sceneRoot) {
+        return;
+    }
+
+    auto* buttonsGroup = new SoSeparator;
+    sceneRoot->addChild(buttonsGroup);
+
+    buttonsSep = new SoSeparator;
+    buttonsGroup->addChild(buttonsSep);
+
+    // Buttons are UI controls and should not be depth-tested against the cube. Some button meshes
+    // are concave or have inconsistent winding, so we also avoid relying on culling.
+    {
+        auto* depth = new SoDepthBuffer;
+        depth->test = FALSE;
+        depth->write = FALSE;
+        depth->function = SoDepthBuffer::ALWAYS;
+        buttonsSep->addChild(depth);
+
+        auto* hints = new SoShapeHints;
+        hints->vertexOrdering = SoShapeHints::UNKNOWN_ORDERING;
+        hints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+        hints->faceType = SoShapeHints::UNKNOWN_FACE_TYPE;
+        buttonsSep->addChild(hints);
+    }
+
+    SbViewVolume ortho;
+    ortho.ortho(
+        -OVERLAY_ORTHO_EXTENT,
+        OVERLAY_ORTHO_EXTENT,
+        -OVERLAY_ORTHO_EXTENT,
+        OVERLAY_ORTHO_EXTENT,
+        OVERLAY_NEAR,
+        OVERLAY_FAR
+    );
+
+    SbViewVolume persp;
+    const float dim = OVERLAY_NEAR * static_cast<float>(std::tan(std::numbers::pi / 8.0F))
+        * OVERLAY_FOV_SCALE;
+    persp.frustum(-dim, dim, -dim, dim, OVERLAY_NEAR, OVERLAY_FAR);
+
+    const float buttonPlaneDist = std::abs(OVERLAY_BUTTON_Z);
+
+    for (PickId pickId : kButtonPickIds) {
+        const auto& verts = buttonOverlayVerts[pickIndex(pickId)];
+        const size_t n = verts.size();
+        if (n < 3) {
+            continue;
+        }
+
+        ButtonNodes nodes;
+        nodes.sep = new SoSeparator;
+
+        nodes.fillMaterial = new SoMaterial;
+        nodes.sep->addChild(nodes.fillMaterial);
+
+        nodes.coordsSwitch = new SoSwitch;
+        nodes.sep->addChild(nodes.coordsSwitch);
+
+        nodes.vertexOrtho = new SoVertexProperty;
+        nodes.vertexOrtho->vertex.setNum(static_cast<int>(n));
+        nodes.coordsSwitch->addChild(nodes.vertexOrtho);
+
+        nodes.vertexPersp = new SoVertexProperty;
+        nodes.vertexPersp->vertex.setNum(static_cast<int>(n));
+        nodes.coordsSwitch->addChild(nodes.vertexPersp);
+
+        // Default: match the current camera mode. (updateSceneGraph() keeps it in sync.)
+        nodes.coordsSwitch->whichChild = cameraIsOrthographic.getValue() ? 0 : 1;
+
+        for (int i = 0; i < static_cast<int>(n); ++i) {
+            const SbVec3f& overlayPoint = verts[static_cast<size_t>(i)];
+            const SbVec2f normPoint(overlayPoint[0], 1.0F - overlayPoint[1]);
+            nodes.vertexOrtho->vertex.set1Value(i, ortho.getPlanePoint(buttonPlaneDist, normPoint));
+            nodes.vertexPersp->vertex.set1Value(i, persp.getPlanePoint(buttonPlaneDist, normPoint));
+        }
+
+        nodes.fill = new SoIndexedFaceSet;
+        {
+            std::vector<std::int32_t> idx;
+            const auto& tris = buttonTriangleIndices[pickIndex(pickId)];
+            if (tris.size() >= 3) {
+                idx.reserve(tris.size() + (tris.size() / 3));
+                for (size_t i = 0; i + 2 < tris.size(); i += 3) {
+                    idx.push_back(tris[i]);
+                    idx.push_back(tris[i + 1]);
+                    idx.push_back(tris[i + 2]);
+                    idx.push_back(-1);
+                }
+            }
+            else {
+                const std::int32_t n32 = static_cast<std::int32_t>(n);
+                idx.reserve((n32 - 2) * 4);
+                for (std::int32_t i = 1; i + 1 < n32; ++i) {
+                    idx.push_back(0);
+                    idx.push_back(i);
+                    idx.push_back(i + 1);
+                    idx.push_back(-1);
+                }
+            }
+            nodes.fill->coordIndex.setValues(0, static_cast<int>(idx.size()), idx.data());
+        }
+        nodes.sep->addChild(nodes.fill);
+
+        nodes.outlineMaterial = new SoMaterial;
+        nodes.sep->addChild(nodes.outlineMaterial);
+
+        nodes.outlineDrawStyle = new SoDrawStyle;
+        nodes.sep->addChild(nodes.outlineDrawStyle);
+
+        nodes.outline = new SoIndexedLineSet;
+        {
+            std::vector<std::int32_t> idx;
+            const auto& outlineIdx = buttonOutlineIndices[pickIndex(pickId)];
+            if (!outlineIdx.empty()) {
+                idx = outlineIdx;
+            }
+            else {
+                idx.reserve(n + 2);
+                for (std::int32_t i = 0; i < static_cast<std::int32_t>(n); ++i) {
+                    idx.push_back(i);
+                }
+                idx.push_back(0);
+                idx.push_back(-1);
+            }
+            nodes.outline->coordIndex.setValues(0, static_cast<int>(idx.size()), idx.data());
+        }
+        nodes.sep->addChild(nodes.outline);
+
+        buttonsSep->addChild(nodes.sep);
+        buttonNodes[pickIndex(pickId)] = nodes;
+    }
+}
+
+void SoNaviCube::rebuildSceneGraph() const
+{
+    ensureGeometry();
+
+    if (!sceneRoot) {
+        return;
+    }
+
+    resetSceneGraph();
+    buildCamerasAndStyle();
+    buildCubeSection();
+    buildButtonsSection();
+
+    sceneDirty = false;
+}
+
+struct SoNaviCube::RenderParams
+{
+    float currentOpacity {1.0F};
+    float bw {1.0F};
+    PickId hilitePick {PickId::None};
+    SbColor baseRgb;
+    SbColor hiliteRgb;
+    SbColor emphRgb;
+    float baseTr {0.0F};
+    float hiliteTr {0.0F};
+    float emphTr {0.0F};
+    bool transparentMaterial {false};
+    bool transparentTexture {false};
+    std::array<SbColor, 3> axisRgb;
+    float axisTr {0.0F};
+    bool showCS {false};
+    bool ortho {true};
+    int coordChild {0};
+};
+
+SoNaviCube::RenderParams SoNaviCube::makeRenderParams() const
+{
+    RenderParams params;
+
+    params.currentOpacity = std::clamp(opacity.getValue(), 0.0F, 1.0F);
+    params.bw = borderWidth.getValue();
+    params.hilitePick = static_cast<PickId>(hiliteId.getValue());
+
+    params.baseRgb = baseColor.getValue();
+    params.hiliteRgb = hiliteColor.getValue();
+    params.emphRgb = emphaseColor.getValue();
+
+    const float baseA = std::clamp(baseAlpha.getValue(), 0.0F, 1.0F) * params.currentOpacity;
+    const float hiliteA = std::clamp(hiliteAlpha.getValue(), 0.0F, 1.0F) * params.currentOpacity;
+    const float emphA = std::clamp(emphaseAlpha.getValue(), 0.0F, 1.0F) * params.currentOpacity;
+    params.baseTr = toTransparency(baseA);
+    params.hiliteTr = toTransparency(hiliteA);
+    params.emphTr = toTransparency(emphA);
+
+    params.axisRgb = {axisXColor.getValue(), axisYColor.getValue(), axisZColor.getValue()};
+    params.axisTr = toTransparency(params.currentOpacity);
+    params.showCS = showCoordinateSystem.getValue();
+
+    params.ortho = cameraIsOrthographic.getValue();
+    params.coordChild = params.ortho ? 0 : 1;
+
+    params.transparentMaterial = (opacity.getValue() < 0.999F) || (baseAlpha.getValue() < 0.999F)
+        || (emphaseAlpha.getValue() < 0.999F) || (hiliteAlpha.getValue() < 0.999F);
+    params.transparentTexture = (labelTextureCount > 0);
+
+    return params;
+}
+
+void SoNaviCube::updateSceneGraph(const RenderParams& params) const
+{
+    updateCameraAndTransform(params);
+    updateCube(params);
+    updateEdges(params);
+    updateAxes(params);
+    updateButtons(params);
+    updateLabels(params);
+}
+
+void SoNaviCube::updateCameraAndTransform(const RenderParams& params) const
+{
+    if (cameraSwitch) {
+        cameraSwitch->whichChild = params.ortho ? 0 : 1;
+    }
+
+    if (rootTransform) {
+        const SbRotation cam = cameraOrientation.getValue();
+        rootTransform->rotation = cam.inverse();
+        rootTransform->translation = SbVec3f(0.0F, 0.0F, OVERLAY_CUBE_Z);
+    }
+}
+
+void SoNaviCube::updateCube(const RenderParams& params) const
+{
+    if (cubeMaterial) {
+        cubeMaterial->diffuseColor.setNum(2);
+        cubeMaterial->diffuseColor.set1Value(0, params.baseRgb);
+        cubeMaterial->diffuseColor.set1Value(1, params.hiliteRgb);
+        cubeMaterial->transparency.setNum(2);
+        cubeMaterial->transparency.set1Value(0, params.baseTr);
+        cubeMaterial->transparency.set1Value(1, params.hiliteTr);
+    }
+
+    if (!cubeFaces) {
+        return;
+    }
+
+    const int count = static_cast<int>(kCubeFacePickOrder.size());
+    if (cubeFaces->materialIndex.getNum() != count) {
+        cubeFaces->materialIndex.setNum(count);
+        for (int i = 0; i < count; ++i) {
+            cubeFaces->materialIndex.set1Value(i, 0);
+        }
+        style.lastHiliteFaceIndex = -1;
+        style.lastHilitePick = PickId::None;
+    }
+
+    if (params.hilitePick == style.lastHilitePick) {
+        return;
+    }
+
+    const int newHiliteIndex = (params.hilitePick == PickId::None)
+        ? -1
+        : cubeFaceIndex(params.hilitePick);
+
+    if (newHiliteIndex != style.lastHiliteFaceIndex) {
+        if (style.lastHiliteFaceIndex >= 0 && style.lastHiliteFaceIndex < count) {
+            cubeFaces->materialIndex.set1Value(style.lastHiliteFaceIndex, 0);
+        }
+        if (newHiliteIndex >= 0 && newHiliteIndex < count) {
+            cubeFaces->materialIndex.set1Value(newHiliteIndex, 1);
+        }
+        style.lastHiliteFaceIndex = newHiliteIndex;
+    }
+    style.lastHilitePick = params.hilitePick;
+}
+
+void SoNaviCube::updateEdges(const RenderParams& params) const
+{
+    if (edgeMaterial) {
+        edgeMaterial->diffuseColor.setValue(params.emphRgb);
+        edgeMaterial->transparency = params.emphTr;
+    }
+    if (edgeDrawStyle) {
+        edgeDrawStyle->lineWidth = params.bw;
+    }
+}
+
+void SoNaviCube::updateAxes(const RenderParams& params) const
+{
+    bool axisColorsChanged = false;
+    for (size_t i = 0; i < params.axisRgb.size(); ++i) {
+        if (!nearlyEqual(params.axisRgb[i], style.axisRgb[i])) {
+            axisColorsChanged = true;
+            break;
+        }
+    }
+
+    const bool axisStyleChanged = style.axisDirty || axisColorsChanged
+        || !nearlyEqual(params.axisTr, style.axisTr) || !nearlyEqual(params.bw, style.axisBw)
+        || (params.showCS != style.showCS);
+
+    if (!axisStyleChanged) {
+        return;
+    }
+
+    for (int axis = 0; axis < 3; ++axis) {
+        AxisNodes& nodes = axisNodes[axis];
+        if (nodes.material) {
+            nodes.material->diffuseColor.setValue(params.axisRgb[static_cast<size_t>(axis)]);
+            nodes.material->transparency = params.axisTr;
+        }
+        if (nodes.drawStyle) {
+            nodes.drawStyle->lineWidth = params.bw * 2.0F;
+            nodes.drawStyle->pointSize = params.bw * 2.0F;
+        }
+    }
+
+    if (axisSwitch) {
+        axisSwitch->whichChild = params.showCS ? SO_SWITCH_ALL : SO_SWITCH_NONE;
+    }
+
+    style.axisRgb = params.axisRgb;
+    style.axisTr = params.axisTr;
+    style.axisBw = params.bw;
+    style.showCS = params.showCS;
+    style.axisDirty = false;
+}
+
+void SoNaviCube::updateButtons(const RenderParams& params) const
+{
+    for (PickId pickId : kButtonPickIds) {
+        ButtonNodes& nodes = buttonNodes[pickIndex(pickId)];
+        if (nodes.coordsSwitch && nodes.coordsSwitch->whichChild.getValue() != params.coordChild) {
+            nodes.coordsSwitch->whichChild = params.coordChild;
+        }
+    }
+
+    const bool buttonsStyleChanged = style.buttonDirty
+        || !nearlyEqual(style.buttonsBaseRgb, params.baseRgb)
+        || !nearlyEqual(style.buttonsHiliteRgb, params.hiliteRgb)
+        || !nearlyEqual(style.buttonsOutlineRgb, params.emphRgb)
+        || !nearlyEqual(style.buttonsBaseTr, params.baseTr)
+        || !nearlyEqual(style.buttonsHiliteTr, params.hiliteTr)
+        || !nearlyEqual(style.buttonsOutlineTr, params.emphTr)
+        || !nearlyEqual(style.buttonsLineWidth, params.bw);
+
+    const auto updateButtonFill = [&](PickId id, bool hilite) {
+        ButtonNodes& nodes = buttonNodes[pickIndex(id)];
+        if (!nodes.fillMaterial) {
+            return;
+        }
+        nodes.fillMaterial->diffuseColor.setValue(hilite ? params.hiliteRgb : params.baseRgb);
+        nodes.fillMaterial->transparency = hilite ? params.hiliteTr : params.baseTr;
+    };
+
+    if (buttonsStyleChanged) {
+        for (PickId pickId : kButtonPickIds) {
+            ButtonNodes& nodes = buttonNodes[pickIndex(pickId)];
+            if (nodes.fillMaterial) {
+                const bool hilite = (pickId == params.hilitePick);
+                nodes.fillMaterial->diffuseColor.setValue(hilite ? params.hiliteRgb : params.baseRgb);
+                nodes.fillMaterial->transparency = hilite ? params.hiliteTr : params.baseTr;
+            }
+            if (nodes.outlineMaterial) {
+                nodes.outlineMaterial->diffuseColor.setValue(params.emphRgb);
+                nodes.outlineMaterial->transparency = params.emphTr;
+            }
+            if (nodes.outlineDrawStyle) {
+                nodes.outlineDrawStyle->lineWidth = params.bw;
+            }
+        }
+        style.buttonsBaseRgb = params.baseRgb;
+        style.buttonsHiliteRgb = params.hiliteRgb;
+        style.buttonsOutlineRgb = params.emphRgb;
+        style.buttonsBaseTr = params.baseTr;
+        style.buttonsHiliteTr = params.hiliteTr;
+        style.buttonsOutlineTr = params.emphTr;
+        style.buttonsLineWidth = params.bw;
+        style.lastButtonsHilitePick = params.hilitePick;
+        style.buttonDirty = false;
+    }
+    else if (params.hilitePick != style.lastButtonsHilitePick) {
+        updateButtonFill(style.lastButtonsHilitePick, false);
+        updateButtonFill(params.hilitePick, true);
+        style.lastButtonsHilitePick = params.hilitePick;
+    }
+}
+
+void SoNaviCube::updateLabels(const RenderParams& params) const
+{
+    const bool labelsStyleChanged = style.labelDirty || !nearlyEqual(style.labelsRgb, params.emphRgb)
+        || !nearlyEqual(style.labelsTr, params.emphTr);
+
+    if (!labelsStyleChanged) {
+        return;
+    }
+
+    for (PickId pickId : kLabelPickIds) {
+        LabelNodes& nodes = labelNodes[pickIndex(pickId)];
+        if (nodes.material) {
+            nodes.material->diffuseColor.setValue(params.emphRgb);
+            nodes.material->transparency = params.emphTr;
+        }
+    }
+    style.labelsRgb = params.emphRgb;
+    style.labelsTr = params.emphTr;
+    style.labelDirty = false;
+}
+
+void SoNaviCube::updateSceneGraph() const
+{
+    if (!sceneRoot) {
+        return;
+    }
+
+    updateSceneGraph(makeRenderParams());
+}
+
+void SoNaviCube::beginOverlayPass(
+    SoGLRenderAction* action,
+    const RenderParams& params,
+    int viewportX,
+    int viewportY,
+    int viewportWidth,
+    int viewportHeight
+)
+{
+    if (!action) {
+        return;
+    }
+    SoState* state = action->getState();
+    if (!state) {
+        return;
+    }
+
+    // The viewer scenegraph can have color/transparency overrides active (e.g. selection/highlight).
+    // As an overlay, the NaviCube must render with its own colors regardless of such overrides.
+    SoOverrideElement::setDiffuseColorOverride(state, this, FALSE);
+    SoOverrideElement::setTransparencyOverride(state, this, FALSE);
+    SoOverrideElement::setLightModelOverride(state, this, FALSE);
+    SoOverrideElement::setMaterialBindingOverride(state, this, FALSE);
+    SoOverrideElement::setColorIndexOverride(state, this, FALSE);
+    // Some view modes can force wireframe or otherwise override draw style. The legacy GL path
+    // always draws filled primitives for buttons/handles, so the Coin backend must ignore any
+    // upstream draw-style overrides too (otherwise filled buttons become outlines only).
+    SoOverrideElement::setDrawStyleOverride(state, this, FALSE);
+
+    // Avoid inheriting any texture/shader state from the main scene (which can otherwise tint
+    // the overlay geometry if texturing is left enabled/bound).
+    SoGLTextureEnabledElement::disableAll(state);
+    SoLazyElement::setColorMaterial(state, FALSE);
+    SoGLShaderProgramElement::enable(state, FALSE);
+
+    // Allow Coin to use vertex arrays/VBOs for retained-mode rendering of the overlay geometry.
+    SoShapeStyleElement::setVertexArrayRendering(state, TRUE);
+
+    // The overlay must render immediately (not deferred/sorted by transparency passes), but it
+    // still needs to respect its alpha (inactive opacity). For that, keep per-node transparency
+    // type as BLEND and advertise transparency when needed.
+    SoShapeStyleElement::setTransparentMaterial(state, params.transparentMaterial ? TRUE : FALSE);
+    SoShapeStyleElement::setTransparentTexture(state, params.transparentTexture ? TRUE : FALSE);
+    SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+    SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+
+    SbViewportRegion vp = SoViewportRegionElement::get(state);
+    vp.setViewportPixels(viewportX, viewportY, viewportWidth, viewportHeight);
+    SoViewportRegionElement::set(state, vp);
+
+    // Reset depth within the overlay viewport so the NaviCube can self-occlude and render
+    // translucency correctly without being affected by whatever the main scene left in the depth
+    // buffer.
+    state->push();
+    depthClearScene()->GLRender(action);
+    state->pop();
+
+    // Enforce overlay render state after the depth-clear pass.
+    SoLightModelElement::set(state, this, SoLightModelElement::BASE_COLOR);
+    SoShapeStyleElement::setLightModel(state, SoLazyElement::BASE_COLOR);
+    SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
+    SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+    SoLazyElement::enableBlending(state, GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+    SoLazyElement::setVertexOrdering(state, SoLazyElement::CCW);
+    SoLazyElement::setTwosideLighting(state, FALSE);
+}
+
+void SoNaviCube::renderOverlayScene(SoGLRenderAction* action)
+{
+    if (!action) {
+        return;
+    }
+    SoState* state = action->getState();
+    if (!state) {
+        return;
+    }
+    if (!sceneRoot) {
+        return;
+    }
+
+    SoTextureQualityElement::set(state, this, 1.0F);
+    sceneRoot->GLRender(action);
+    SoGLTextureEnabledElement::disableAll(state);
+}
+
+void SoNaviCube::renderCoin(SoGLRenderAction* action)
+{
+    if (!action) {
+        return;
+    }
+
     const SbVec4f& rect = viewportRect.getValue();
     const int viewportX = static_cast<int>(std::lround(rect[0]));
     const int viewportY = static_cast<int>(std::lround(rect[1]));
@@ -183,228 +1333,20 @@ void SoNaviCube::renderGL(bool pickMode) const
         return;
     }
 
-    const float currentOpacity = opacity.getValue();
-    const bool showCS = showCoordinateSystem.getValue();
-    const bool cameraOrthographic = cameraIsOrthographic.getValue();
-    const float borderWidthValue = borderWidth.getValue();
-    const ColorWithAlpha base = {baseColor.getValue(), baseAlpha.getValue()};
-    const ColorWithAlpha emph = {emphaseColor.getValue(), emphaseAlpha.getValue()};
-    const ColorWithAlpha hilite = {hiliteColor.getValue(), hiliteAlpha.getValue()};
-    const SbColor axisRGB[3] = {axisXColor.getValue(), axisYColor.getValue(), axisZColor.getValue()};
-    const PickId hilitePick = static_cast<PickId>(hiliteId.getValue());
-    const SbRotation camOrientation = cameraOrientation.getValue();
+    SoState* state = action->getState();
+    if (!state) {
+        return;
+    }
 
     ensureGeometry();
+    ensureSceneGraph();
+    const RenderParams params = makeRenderParams();
+    updateSceneGraph(params);
 
-    glPushAttrib(GL_ALL_ATTRIB_BITS);
-
-    glViewport(viewportX, viewportY, viewportWidth, viewportHeight);
-
-    glEnable(GL_DEPTH_TEST);
-    glDepthMask(GL_TRUE);
-    glDepthRange(0.0F, 1.0F);
-    glClearDepth(1.0F);
-    glClear(GL_DEPTH_BUFFER_BIT);
-    glDepthFunc(GL_LEQUAL);
-
-    glDisable(GL_LIGHTING);
-
-    glTexEnvi(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
-
-    glEnable(GL_CULL_FACE);
-    glCullFace(GL_BACK);
-    glFrontFace(GL_CCW);
-
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-    if (pickMode) {
-        glDisable(GL_BLEND);
-        glShadeModel(GL_FLAT);
-        glDisable(GL_DITHER);
-        glDisable(GL_POLYGON_SMOOTH);
-        glClearColor(0.0F, 0.0F, 0.0F, 1.0F);
-        glClear(GL_COLOR_BUFFER_BIT);
-    }
-    else {
-        glEnable(GL_POLYGON_OFFSET_FILL);
-        glPolygonOffset(1.0F, 1.0F);
-        glEnable(GL_BLEND);
-        glShadeModel(GL_SMOOTH);
-    }
-
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
-    glLoadIdentity();
-    constexpr float NEARVAL = 0.1F;
-    constexpr float FARVAL = 10.1F;
-    if (cameraOrthographic) {
-        glOrtho(-2.1, 2.1, -2.1, 2.1, NEARVAL, FARVAL);
-    }
-    else {
-        const float dim = NEARVAL * static_cast<float>(std::tan(std::numbers::pi / 8.0)) * 1.1F;
-        glFrustum(-dim, dim, -dim, dim, NEARVAL, FARVAL);
-    }
-
-    glMatrixMode(GL_MODELVIEW);
-    glPushMatrix();
-
-    SbMatrix mx;
-    camOrientation.getValue(mx);
-    mx = mx.inverse();
-    mx[3][0] = 0.0F;
-    mx[3][1] = 0.0F;
-    mx[3][2] = -5.1F;
-    glLoadMatrixf(reinterpret_cast<const float*>(&mx[0][0]));
-
-    glEnableClientState(GL_VERTEX_ARRAY);
-
-    if (!pickMode && showCS) {
-        glLineWidth(borderWidthValue * 2.0F);
-        glPointSize(borderWidthValue * 2.0F);
-        constexpr float a = -1.1F;
-        constexpr float b = -1.05F;
-        constexpr float c = 0.5F;
-        const float pointData[] = {b, a, a, c, a, a, a, b, a, a, c, a, a, a, b, a, a, c, a, a, a};
-        glVertexPointer(3, GL_FLOAT, 0, pointData);
-
-        const float* xColor = axisRGB[0].getValue();
-        glColor4f(xColor[0], xColor[1], xColor[2], currentOpacity);
-        glDrawArrays(GL_LINES, 0, 2);
-        glDrawArrays(GL_POINTS, 0, 2);
-
-        const float* yColor = axisRGB[1].getValue();
-        glColor4f(yColor[0], yColor[1], yColor[2], currentOpacity);
-        glDrawArrays(GL_LINES, 2, 2);
-        glDrawArrays(GL_POINTS, 2, 2);
-
-        const float* zColor = axisRGB[2].getValue();
-        glColor4f(zColor[0], zColor[1], zColor[2], currentOpacity);
-        glDrawArrays(GL_LINES, 4, 2);
-        glDrawArrays(GL_POINTS, 4, 2);
-    }
-
-    const auto& baseFaces = faces();
-    for (const auto& [pickId, face] : baseFaces) {
-        if (face.vertexArray.empty() && face.trianglesArray.empty()) {
-            continue;
-        }
-        if (pickMode) {
-            glColor3ub(static_cast<GLubyte>(pickId), 0, 0);
-        }
-        else {
-            const auto& color = hilitePick == pickId ? hilite : base;
-            const float* rgb = color.rgb.getValue();
-            glColor4f(rgb[0], rgb[1], rgb[2], color.alpha * currentOpacity);
-        }
-        if (!face.trianglesArray.empty()) {
-            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.trianglesArray.data()));
-            glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(face.trianglesArray.size()));
-        }
-        else if (!face.vertexArray.empty()) {
-            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
-            glDrawArrays(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(face.vertexArray.size()));
-        }
-    }
-
-    if (!pickMode) {
-        glLineWidth(borderWidthValue);
-        const float* borderRGB = emph.rgb.getValue();
-        const float borderAlpha = emph.alpha * currentOpacity;
-        for (const auto& [pickId, face] : baseFaces) {
-            (void)pickId;
-            if (face.vertexArray.empty()) {
-                continue;
-            }
-            glColor4f(borderRGB[0], borderRGB[1], borderRGB[2], borderAlpha);
-            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
-            glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(face.vertexArray.size()));
-        }
-
-        glDisable(GL_POLYGON_OFFSET_FILL);
-        glEnable(GL_TEXTURE_2D);
-        glEnableClientState(GL_TEXTURE_COORD_ARRAY);
-        static const float texCoords[] = {0.0F, 0.0F, 1.0F, 0.0F, 1.0F, 1.0F, 0.0F, 1.0F};
-        glTexCoordPointer(2, GL_FLOAT, 0, texCoords);
-
-        const float* emphRGB = emph.rgb.getValue();
-        const float emphAlpha = emph.alpha * currentOpacity;
-        glColor4f(emphRGB[0], emphRGB[1], emphRGB[2], emphAlpha);
-
-        const auto& labels = labelSlots();
-        for (const auto& [pickId, slot] : labels) {
-            (void)pickId;
-            if (slot.quad.size() != 4 || slot.textureId == 0) {
-                continue;
-            }
-            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(slot.quad.data()));
-            glBindTexture(GL_TEXTURE_2D, slot.textureId);
-            glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
-        }
-
-        glDisableClientState(GL_TEXTURE_COORD_ARRAY);
-        glDisable(GL_TEXTURE_2D);
-        glEnable(GL_POLYGON_OFFSET_FILL);
-    }
-
-    const auto& buttons = buttonFaces();
-    glDisable(GL_CULL_FACE);
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0.0, 1.0, 1.0, 0.0, 0.0, 1.0);
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-
-    for (const auto& [pickId, face] : buttons) {
-        // 1. Allow faces that use explicit triangles to pass through
-        if (face.vertexArray.empty() && face.trianglesArray.empty()) {
-            continue;
-        }
-
-        if (pickMode) {
-            glColor3ub(static_cast<GLubyte>(pickId), 0, 0);
-        }
-        else {
-            const auto& color = hilitePick == pickId ? hilite : base;
-            const float* rgb = color.rgb.getValue();
-            glColor4f(rgb[0], rgb[1], rgb[2], color.alpha * currentOpacity);
-        }
-
-        // 2. Draw the filled shape using triangles if available, else fallback to fans
-        if (!face.trianglesArray.empty()) {
-            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.trianglesArray.data()));
-            glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(face.trianglesArray.size()));
-        }
-        else if (!face.vertexArray.empty()) {
-            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
-            glDrawArrays(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(face.vertexArray.size()));
-        }
-
-        // 3. Draw the outlines
-        if (!pickMode) {
-            const float* rgb = emph.rgb.getValue();
-            glColor4f(rgb[0], rgb[1], rgb[2], emph.alpha * currentOpacity);
-            if (!face.lineLoops.empty()) {
-                for (const auto& loop : face.lineLoops) {
-                    if (loop.empty()) {
-                        continue;
-                    }
-                    glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(loop.data()));
-                    glDrawArrays(GL_LINE_LOOP, 0, static_cast<GLsizei>(loop.size()));
-                }
-            }
-            else if (!face.vertexArray.empty()) {
-                glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
-                glDrawArrays(GL_LINE_LOOP, 0, static_cast<GLsizei>(face.vertexArray.size()));
-            }
-        }
-    }
-
-    glPopMatrix();
-    glMatrixMode(GL_PROJECTION);
-    glPopMatrix();
-    glPopAttrib();
+    state->push();
+    beginOverlayPass(action, params, viewportX, viewportY, viewportWidth, viewportHeight);
+    renderOverlayScene(action);
+    state->pop();
 }
 
 void SoNaviCube::GLRender(SoGLRenderAction* action)
@@ -412,12 +1354,8 @@ void SoNaviCube::GLRender(SoGLRenderAction* action)
     if (!shouldGLRender(action)) {
         return;
     }
-    ensureGeometry();
-    renderGL(false);
+    renderCoin(action);
 }
-
-void SoNaviCube::generatePrimitives(SoAction*)
-{}
 
 void SoNaviCube::computeBBox(SoAction*, SbBox3f& box, SbVec3f& center)
 {
@@ -426,9 +1364,121 @@ void SoNaviCube::computeBBox(SoAction*, SbBox3f& box, SbVec3f& center)
     center.setValue(0.0F, 0.0F, 0.0F);
 }
 
+SoNaviCube::PickId SoNaviCube::pickAt(const SbVec2s& point) const
+{
+    ensureGeometry();
+    ensureSceneGraph();
+    updateSceneGraph();
+
+    const SbVec4f& rect = viewportRect.getValue();
+    const float viewportX = rect[0];
+    const float viewportY = rect[1];
+    const float viewportWidth = rect[2];
+    const float viewportHeight = rect[3];
+    if (viewportWidth <= 0.0F || viewportHeight <= 0.0F) {
+        return PickId::None;
+    }
+
+    const SbVec2s localPoint(
+        static_cast<short>(static_cast<float>(point[0]) - viewportX),
+        static_cast<short>(static_cast<float>(point[1]) - viewportY)
+    );
+    if (localPoint[0] < 0 || localPoint[1] < 0 || localPoint[0] >= static_cast<short>(viewportWidth)
+        || localPoint[1] >= static_cast<short>(viewportHeight)) {
+        return PickId::None;
+    }
+
+    const SbViewportRegion vp(static_cast<int>(viewportWidth), static_cast<int>(viewportHeight));
+    SoRayPickAction pick(vp);
+    pick.setPoint(localPoint);
+    {
+        float radius = 1.0F;
+        if (const char* env = std::getenv("FREECAD_NAVICUBE_PICK_RADIUS")) {
+            char* end = nullptr;
+            const float value = std::strtof(env, &end);
+            if (end != env && std::isfinite(value) && value >= 0.0F) {
+                radius = value;
+            }
+        }
+        pick.setRadius(radius);
+    }
+    pick.setPickAll(TRUE);
+    pick.apply(sceneRoot);
+
+    const SoPickedPointList& hits = pick.getPickedPointList();
+    if (hits.getLength() == 0) {
+        return PickId::None;
+    }
+
+    const auto resolveHit = [&](const SoPickedPoint* hit) -> PickId {
+        if (!hit) {
+            return PickId::None;
+        }
+
+        const SoPath* path = hit->getPath();
+        const SoNode* tail = path ? path->getTail() : nullptr;
+        if (!tail) {
+            return PickId::None;
+        }
+
+        for (PickId pickId : kButtonPickIds) {
+            const ButtonNodes& nodes = buttonNodes[pickIndex(pickId)];
+            if (tail == nodes.fill || tail == nodes.outline) {
+                return pickId;
+            }
+        }
+
+        for (PickId pickId : kLabelPickIds) {
+            const LabelNodes& nodes = labelNodes[pickIndex(pickId)];
+            if (tail == nodes.face) {
+                return pickId;
+            }
+        }
+
+        if (tail == cubeFaces) {
+            const SoDetail* detail = hit->getDetail();
+            if (detail && detail->isOfType(SoFaceDetail::getClassTypeId())) {
+                const auto* face = static_cast<const SoFaceDetail*>(detail);
+                const int faceIndex = face->getFaceIndex();
+                if (faceIndex >= 0 && faceIndex < static_cast<int>(kCubeFacePickOrder.size())) {
+                    return kCubeFacePickOrder[static_cast<size_t>(faceIndex)];
+                }
+            }
+        }
+
+        return PickId::None;
+    };
+
+    // Prefer hits with face details (filled geometry) to avoid selecting edges/lines.
+    for (int i = 0; i < hits.getLength(); ++i) {
+        const SoPickedPoint* hit = hits[i];
+        const SoDetail* detail = hit ? hit->getDetail() : nullptr;
+        if (detail && detail->isOfType(SoFaceDetail::getClassTypeId())) {
+            const PickId id = resolveHit(hit);
+            if (id != PickId::None) {
+                return id;
+            }
+        }
+    }
+
+    for (int i = 0; i < hits.getLength(); ++i) {
+        const PickId id = resolveHit(hits[i]);
+        if (id != PickId::None) {
+            return id;
+        }
+    }
+
+    return PickId::None;
+}
+
+void SoNaviCube::generatePrimitives(SoAction* action)
+{
+    (void)action;
+}
+
 void SoNaviCube::ensureGeometry() const
 {
-    if (!m_GeometryDirty) {
+    if (!geometryDirty) {
         return;
     }
     rebuildGeometry();
@@ -436,62 +1486,130 @@ void SoNaviCube::ensureGeometry() const
 
 void SoNaviCube::rebuildGeometry() const
 {
-    constexpr float pi = std::numbers::pi_v<float>;
-    constexpr float piHalf = pi / 2.0F;
+    std::array<LabelSlot, kPickIdCount> oldLabelSlots;
+    oldLabelSlots.swap(labelSlots);
 
-    LabelMap oldLabelSlots;
-    oldLabelSlots.swap(m_LabelSlots);
+    for (auto& verts : faces) {
+        verts.clear();
+    }
+    for (auto& verts : buttonOverlayVerts) {
+        verts.clear();
+    }
+    for (auto& tris : buttonTriangleIndices) {
+        tris.clear();
+    }
+    for (auto& slot : labelSlots) {
+        slot.quad.clear();
+        slot.texture = nullptr;
+    }
 
-    m_Faces.clear();
-    m_ButtonFaces.clear();
-    m_LabelSlots.clear();
+    cubeCoordsData.clear();
+    cubeCoordIndexData.clear();
+    edgeCoordsData.clear();
+    edgeCoordIndexData.clear();
 
     const SbVec3f x(1.0F, 0.0F, 0.0F);
     const SbVec3f y(0.0F, 1.0F, 0.0F);
     const SbVec3f z(0.0F, 0.0F, 1.0F);
 
     // Main faces
-    addCubeFace(x, z, FaceType::Main, PickId::Top, 0.0F);
-    addCubeFace(x, -y, FaceType::Main, PickId::Front, 0.0F);
-    addCubeFace(-y, -x, FaceType::Main, PickId::Left, 0.0F);
-    addCubeFace(-x, y, FaceType::Main, PickId::Rear, 0.0F);
-    addCubeFace(y, x, FaceType::Main, PickId::Right, 0.0F);
-    addCubeFace(x, -z, FaceType::Main, PickId::Bottom, 0.0F);
+    addCubeFace(x, z, CubeFaceKind::Main, PickId::Top);
+    addCubeFace(x, -y, CubeFaceKind::Main, PickId::Front);
+    addCubeFace(-y, -x, CubeFaceKind::Main, PickId::Left);
+    addCubeFace(-x, y, CubeFaceKind::Main, PickId::Rear);
+    addCubeFace(y, x, CubeFaceKind::Main, PickId::Right);
+    addCubeFace(x, -z, CubeFaceKind::Main, PickId::Bottom);
 
     // Corner faces
-    addCubeFace(-x - y, x - y + z, FaceType::Corner, PickId::FrontTopRight, pi);
-    addCubeFace(-x + y, -x - y + z, FaceType::Corner, PickId::FrontTopLeft, pi);
-    addCubeFace(x + y, x - y - z, FaceType::Corner, PickId::FrontBottomRight, 0.0F);
-    addCubeFace(x - y, -x - y - z, FaceType::Corner, PickId::FrontBottomLeft, 0.0F);
-    addCubeFace(x - y, x + y + z, FaceType::Corner, PickId::RearTopRight, pi);
-    addCubeFace(x + y, -x + y + z, FaceType::Corner, PickId::RearTopLeft, pi);
-    addCubeFace(-x + y, x + y - z, FaceType::Corner, PickId::RearBottomRight, 0.0F);
-    addCubeFace(-x - y, -x + y - z, FaceType::Corner, PickId::RearBottomLeft, 0.0F);
+    addCubeFace(-x - y, x - y + z, CubeFaceKind::Corner, PickId::FrontTopRight);
+    addCubeFace(-x + y, -x - y + z, CubeFaceKind::Corner, PickId::FrontTopLeft);
+    addCubeFace(x + y, x - y - z, CubeFaceKind::Corner, PickId::FrontBottomRight);
+    addCubeFace(x - y, -x - y - z, CubeFaceKind::Corner, PickId::FrontBottomLeft);
+    addCubeFace(x - y, x + y + z, CubeFaceKind::Corner, PickId::RearTopRight);
+    addCubeFace(x + y, -x + y + z, CubeFaceKind::Corner, PickId::RearTopLeft);
+    addCubeFace(-x + y, x + y - z, CubeFaceKind::Corner, PickId::RearBottomRight);
+    addCubeFace(-x - y, -x + y - z, CubeFaceKind::Corner, PickId::RearBottomLeft);
 
     // Edge faces
-    addCubeFace(x, z - y, FaceType::Edge, PickId::FrontTop, 0.0F);
-    addCubeFace(x, -z - y, FaceType::Edge, PickId::FrontBottom, 0.0F);
-    addCubeFace(x, y - z, FaceType::Edge, PickId::RearBottom, pi);
-    addCubeFace(x, y + z, FaceType::Edge, PickId::RearTop, pi);
-    addCubeFace(z, x + y, FaceType::Edge, PickId::RearRight, piHalf);
-    addCubeFace(z, x - y, FaceType::Edge, PickId::FrontRight, piHalf);
-    addCubeFace(z, -x - y, FaceType::Edge, PickId::FrontLeft, piHalf);
-    addCubeFace(z, y - x, FaceType::Edge, PickId::RearLeft, piHalf);
-    addCubeFace(y, z - x, FaceType::Edge, PickId::TopLeft, pi);
-    addCubeFace(y, x + z, FaceType::Edge, PickId::TopRight, 0.0F);
-    addCubeFace(y, x - z, FaceType::Edge, PickId::BottomRight, 0.0F);
-    addCubeFace(y, -z - x, FaceType::Edge, PickId::BottomLeft, pi);
+    addCubeFace(x, z - y, CubeFaceKind::Edge, PickId::FrontTop);
+    addCubeFace(x, -z - y, CubeFaceKind::Edge, PickId::FrontBottom);
+    addCubeFace(x, y - z, CubeFaceKind::Edge, PickId::RearBottom);
+    addCubeFace(x, y + z, CubeFaceKind::Edge, PickId::RearTop);
+    addCubeFace(z, x + y, CubeFaceKind::Edge, PickId::RearRight);
+    addCubeFace(z, x - y, CubeFaceKind::Edge, PickId::FrontRight);
+    addCubeFace(z, -x - y, CubeFaceKind::Edge, PickId::FrontLeft);
+    addCubeFace(z, y - x, CubeFaceKind::Edge, PickId::RearLeft);
+    addCubeFace(y, z - x, CubeFaceKind::Edge, PickId::TopLeft);
+    addCubeFace(y, x + z, CubeFaceKind::Edge, PickId::TopRight);
+    addCubeFace(y, x - z, CubeFaceKind::Edge, PickId::BottomRight);
+    addCubeFace(y, -z - x, CubeFaceKind::Edge, PickId::BottomLeft);
+
+    // Precompute cube and edge geometry arrays used by the scene graph nodes.
+    {
+        size_t totalVerts = 0;
+        for (PickId pickId : kCubeFacePickOrder) {
+            const auto& verts = faces[pickIndex(pickId)];
+            if (verts.size() >= 3) {
+                totalVerts += verts.size();
+            }
+        }
+        cubeCoordsData.reserve(totalVerts);
+        cubeCoordIndexData.reserve(totalVerts + kCubeFacePickOrder.size());
+
+        std::int32_t base = 0;
+        for (PickId pickId : kCubeFacePickOrder) {
+            const auto& verts = faces[pickIndex(pickId)];
+            if (verts.size() < 3) {
+                continue;
+            }
+            for (const SbVec3f& p : verts) {
+                cubeCoordsData.push_back(p);
+                cubeCoordIndexData.push_back(base++);
+            }
+            cubeCoordIndexData.push_back(-1);
+        }
+
+        size_t edgeVerts = 0;
+        size_t edgeSegs = 0;
+        for (PickId pickId : kCubeFacePickOrder) {
+            const auto& verts = faces[pickIndex(pickId)];
+            edgeVerts += verts.size();
+            edgeSegs += verts.size() / 2;
+        }
+        edgeCoordsData.reserve(edgeVerts);
+        edgeCoordIndexData.reserve(edgeSegs * 3);
+
+        std::int32_t edgeBase = 0;
+        for (PickId pickId : kCubeFacePickOrder) {
+            const auto& verts = faces[pickIndex(pickId)];
+            const size_t n = verts.size();
+            if (n < 2) {
+                continue;
+            }
+
+            for (const SbVec3f& p : verts) {
+                edgeCoordsData.push_back(p);
+            }
+
+            for (size_t i = 0; i + 1 < n; i += 2) {
+                edgeCoordIndexData.push_back(edgeBase + static_cast<std::int32_t>(i));
+                edgeCoordIndexData.push_back(edgeBase + static_cast<std::int32_t>(i + 1));
+                edgeCoordIndexData.push_back(-1);
+            }
+            edgeBase += static_cast<std::int32_t>(n);
+        }
+    }
 
     auto setLabelQuad = [&](PickId pickId, const SbVec3f& xVec, const SbVec3f& zVec) {
-        auto& slot = m_LabelSlots[pickId];
+        auto& slot = labelSlots[pickIndex(pickId)];
         slot.quad.clear();
 
         SbVec3f negZ = zVec;
         negZ.negate();
 
         SbVec3f yVec = xVec.cross(negZ);
-        SbVec3f x2 = xVec * (1.0F - m_Chamfer * 2.0F);
-        SbVec3f y2 = yVec * (1.0F - m_Chamfer * 2.0F);
+        SbVec3f x2 = xVec * (1.0F - this->chamfer * 2.0F);
+        SbVec3f y2 = yVec * (1.0F - this->chamfer * 2.0F);
 
         slot.quad.reserve(4);
         slot.quad.emplace_back(zVec - x2 - y2);
@@ -499,9 +1617,10 @@ void SoNaviCube::rebuildGeometry() const
         slot.quad.emplace_back(zVec + x2 + y2);
         slot.quad.emplace_back(zVec - x2 + y2);
 
-        auto it = oldLabelSlots.find(pickId);
-        if (it != oldLabelSlots.end()) {
-            slot.textureId = it->second.textureId;
+        auto& oldSlot = oldLabelSlots[pickIndex(pickId)];
+        if (oldSlot.texture) {
+            slot.texture = oldSlot.texture;
+            oldSlot.texture = nullptr;
         }
     };
 
@@ -514,90 +1633,96 @@ void SoNaviCube::rebuildGeometry() const
 
     rebuildButtonFaces();
 
-    m_GeometryDirty = false;
+    for (auto& slot : oldLabelSlots) {
+        if (slot.texture) {
+            slot.texture->unref();
+            slot.texture = nullptr;
+        }
+    }
+
+    geometryDirty = false;
+    sceneDirty = true;
 }
 
-void SoNaviCube::addCubeFace(const SbVec3f& x, const SbVec3f& z, FaceType type, PickId pickId, float rotZ) const
+void SoNaviCube::addCubeFace(const SbVec3f& x, const SbVec3f& z, CubeFaceKind kind, PickId pickId) const
 {
-    auto& face = m_Faces[pickId];
-    face.type = type;
-    face.vertexArray.clear();
+    auto& verts = faces[pickIndex(pickId)];
+    verts.clear();
 
     SbVec3f y = x.cross(-z);
 
-    SbVec3f xN = x;
-    SbVec3f yN = y;
-    SbVec3f zN = z;
-    xN.normalize();
-    yN.normalize();
-    zN.normalize();
+    if (kind == CubeFaceKind::Corner) {
+        SbVec3f xC = x * this->chamfer;
+        SbVec3f yC = y * this->chamfer;
+        SbVec3f zC = z * (1.0F - 2.0F * this->chamfer);
 
-    SbMatrix R(xN[0], yN[0], zN[0], 0, xN[1], yN[1], zN[1], 0, xN[2], yN[2], zN[2], 0, 0, 0, 0, 1);
-
-    face.rotation = (SbRotation(R) * SbRotation(SbVec3f(0, 0, 1), rotZ)).inverse();
-
-    if (type == FaceType::Corner) {
-        SbVec3f xC = x * m_Chamfer;
-        SbVec3f yC = y * m_Chamfer;
-        SbVec3f zC = z * (1.0F - 2.0F * m_Chamfer);
-
-        face.vertexArray.reserve(6);
-        face.vertexArray.emplace_back(zC - xC * 2.0F);
-        face.vertexArray.emplace_back((zC - xC) - yC);
-        face.vertexArray.emplace_back((zC + xC) - yC);
-        face.vertexArray.emplace_back(zC + xC * 2.0F);
-        face.vertexArray.emplace_back((zC + xC) + yC);
-        face.vertexArray.emplace_back((zC - xC) + yC);
+        verts.reserve(6);
+        verts.emplace_back(zC - xC * 2.0F);
+        verts.emplace_back((zC - xC) - yC);
+        verts.emplace_back((zC + xC) - yC);
+        verts.emplace_back(zC + xC * 2.0F);
+        verts.emplace_back((zC + xC) + yC);
+        verts.emplace_back((zC - xC) + yC);
     }
-    else if (type == FaceType::Edge) {
-        SbVec3f x4 = x * (1.0F - m_Chamfer * 4.0F);
-        SbVec3f yE = y * m_Chamfer;
-        SbVec3f zE = z * (1.0F - m_Chamfer);
+    else if (kind == CubeFaceKind::Edge) {
+        SbVec3f x4 = x * (1.0F - this->chamfer * 4.0F);
+        SbVec3f yE = y * this->chamfer;
+        SbVec3f zE = z * (1.0F - this->chamfer);
 
-        face.vertexArray.reserve(4);
-        face.vertexArray.emplace_back((zE - x4) - yE);
-        face.vertexArray.emplace_back((zE + x4) - yE);
-        face.vertexArray.emplace_back((zE + x4) + yE);
-        face.vertexArray.emplace_back((zE - x4) + yE);
+        verts.reserve(4);
+        verts.emplace_back((zE - x4) - yE);
+        verts.emplace_back((zE + x4) - yE);
+        verts.emplace_back((zE + x4) + yE);
+        verts.emplace_back((zE - x4) + yE);
     }
-    else if (type == FaceType::Main) {
-        SbVec3f x2 = x * (1.0F - m_Chamfer * 2.0F);
-        SbVec3f y2 = y * (1.0F - m_Chamfer * 2.0F);
-        SbVec3f x4 = x * (1.0F - m_Chamfer * 4.0F);
-        SbVec3f y4 = y * (1.0F - m_Chamfer * 4.0F);
+    else {
+        SbVec3f x2 = x * (1.0F - this->chamfer * 2.0F);
+        SbVec3f y2 = y * (1.0F - this->chamfer * 2.0F);
+        SbVec3f x4 = x * (1.0F - this->chamfer * 4.0F);
+        SbVec3f y4 = y * (1.0F - this->chamfer * 4.0F);
 
-        face.vertexArray.reserve(8);
-        face.vertexArray.emplace_back((z - x2) - y4);
-        face.vertexArray.emplace_back((z - x4) - y2);
-        face.vertexArray.emplace_back((z + x4) - y2);
-        face.vertexArray.emplace_back((z + x2) - y4);
-        face.vertexArray.emplace_back((z + x2) + y4);
-        face.vertexArray.emplace_back((z + x4) + y2);
-        face.vertexArray.emplace_back((z - x4) + y2);
-        face.vertexArray.emplace_back((z - x2) + y4);
+        verts.reserve(8);
+        verts.emplace_back((z - x2) - y4);
+        verts.emplace_back((z - x4) - y2);
+        verts.emplace_back((z + x4) - y2);
+        verts.emplace_back((z + x2) - y4);
+        verts.emplace_back((z + x2) + y4);
+        verts.emplace_back((z + x4) + y2);
+        verts.emplace_back((z - x4) + y2);
+        verts.emplace_back((z - x2) + y4);
     }
 }
 
 void SoNaviCube::rebuildButtonFaces() const
 {
-    m_ButtonFaces.clear();
-    addButtonFace(PickId::ArrowNorth, SbVec3f(-1, 0, 0));
-    addButtonFace(PickId::ArrowSouth, SbVec3f(1, 0, 0));
-    addButtonFace(PickId::ArrowEast, SbVec3f(0, 1, 0));
-    addButtonFace(PickId::ArrowWest, SbVec3f(0, -1, 0));
-    addButtonFace(PickId::ArrowLeft, SbVec3f(0, 0, 1));
-    addButtonFace(PickId::ArrowRight, SbVec3f(0, 0, -1));
-    addButtonFace(PickId::Backside, SbVec3f(0, 1, 0));
+    for (auto& verts : buttonOverlayVerts) {
+        verts.clear();
+    }
+    for (auto& tris : buttonTriangleIndices) {
+        tris.clear();
+    }
+    for (auto& outline : buttonOutlineIndices) {
+        outline.clear();
+    }
+    addButtonFace(PickId::ArrowNorth);
+    addButtonFace(PickId::ArrowSouth);
+    addButtonFace(PickId::ArrowEast);
+    addButtonFace(PickId::ArrowWest);
+    addButtonFace(PickId::ArrowLeft);
+    addButtonFace(PickId::ArrowRight);
+    addButtonFace(PickId::Backside);
     addButtonFace(PickId::Home);
     addButtonFace(PickId::ViewMenu);
 }
 
-void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
+void SoNaviCube::addButtonFace(PickId pickId) const
 {
-    auto& face = m_ButtonFaces[pickId];
-    face.vertexArray.clear();
-    face.trianglesArray.clear();
-    face.lineLoops.clear();
+    auto& verts = buttonOverlayVerts[pickIndex(pickId)];
+    auto& outline = buttonOutlineIndices[pickIndex(pickId)];
+    auto& tris = buttonTriangleIndices[pickIndex(pickId)];
+    verts.clear();
+    outline.clear();
+    tris.clear();
     float scale = 0.005F;
     float offx = 0.5F;
     float offy = 0.5F;
@@ -615,6 +1740,25 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
         }
         else {
             return SbVec3f(x, y, 0.0F);
+        }
+    };
+
+    const auto appendLoop = [&](const std::vector<float>& pts) {
+        const auto base = static_cast<std::int32_t>(verts.size());
+        const int count = static_cast<int>(pts.size()) / 2;
+        verts.reserve(verts.size() + static_cast<size_t>(count));
+        for (int i = 0; i < count; ++i) {
+            verts.push_back(transform(pts[i * 2], pts[i * 2 + 1]));
+            outline.push_back(base + i);
+        }
+        outline.push_back(-1);
+        return base;
+    };
+
+    const auto appendTriangles = [&](std::int32_t base, const std::initializer_list<int>& idx) {
+        tris.reserve(tris.size() + idx.size());
+        for (int i : idx) {
+            tris.push_back(base + i);
         }
     };
 
@@ -638,118 +1782,72 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
         case PickId::ViewMenu: {
             offx = 0.90F;
             offy = 0.95F;
-
-            // 1. The small bar on top
-            std::vector<float> ptsBar = {-13.0F, -20.0F, 13.0F, -20.0F, 13.0F, -16.0F, -13.0F, -16.0F};
-            std::vector<SbVec3f> loopBar;
-            for (size_t i = 0; i < ptsBar.size(); i += 2) {
-                loopBar.push_back(transform(ptsBar[i], ptsBar[i + 1]));
-            }
-            face.lineLoops.push_back(loopBar);
-
-            face.trianglesArray.push_back(loopBar[0]);
-            face.trianglesArray.push_back(loopBar[1]);
-            face.trianglesArray.push_back(loopBar[2]);
-            face.trianglesArray.push_back(loopBar[0]);
-            face.trianglesArray.push_back(loopBar[2]);
-            face.trianglesArray.push_back(loopBar[3]);
-
-            // 2. The triangle pointing down
-            std::vector<float> ptsTri = {-13.0F, -12.0F, 13.0F, -12.0F, 0.0F, 0.0F};
-            std::vector<SbVec3f> loopTri;
-            for (size_t i = 0; i < ptsTri.size(); i += 2) {
-                loopTri.push_back(transform(ptsTri[i], ptsTri[i + 1]));
-            }
-            face.lineLoops.push_back(loopTri);
-
-            face.trianglesArray.push_back(loopTri[0]);
-            face.trianglesArray.push_back(loopTri[1]);
-            face.trianglesArray.push_back(loopTri[2]);
+            const auto bar = appendLoop({-13.0F, -20.0F, 13.0F, -20.0F, 13.0F, -16.0F, -13.0F, -16.0F});
+            appendTriangles(bar, {0, 1, 2, 0, 2, 3});
+            const auto triangle = appendLoop({-13.0F, -12.0F, 13.0F, -12.0F, 0.0F, 0.0F});
+            appendTriangles(triangle, {0, 1, 2});
             break;
         }
         case PickId::Home: {
             offx = 0.09F;
             offy = 0.09F;
-            std::vector<float> pts = {0.0F,   -18.0F, 18.0F,  -6.0F, 12.0F,  -6.0F, 12.0F, 8.0F,
-                                      4.0F,   8.0F,   4.0F,   0.0F,  -4.0F,  0.0F,  -4.0F, 8.0F,
-                                      -12.0F, 8.0F,   -12.0F, -6.0F, -18.0F, -6.0F};
-            std::vector<SbVec3f> loop;
-            for (size_t i = 0; i < pts.size(); i += 2) {
-                loop.push_back(transform(pts[i], pts[i + 1]));
-            }
-            face.lineLoops.push_back(loop);
-            face.trianglesArray.push_back(transform(-18, -6));
-            face.trianglesArray.push_back(transform(18, -6));
-            face.trianglesArray.push_back(transform(0, -18));
-            face.trianglesArray.push_back(transform(-12, -6));
-            face.trianglesArray.push_back(transform(12, -6));
-            face.trianglesArray.push_back(transform(12, 0));
-            face.trianglesArray.push_back(transform(-12, -6));
-            face.trianglesArray.push_back(transform(12, 0));
-            face.trianglesArray.push_back(transform(-12, 0));
-            face.trianglesArray.push_back(transform(-12, 0));
-            face.trianglesArray.push_back(transform(-4, 0));
-            face.trianglesArray.push_back(transform(-4, 8));
-            face.trianglesArray.push_back(transform(-12, 0));
-            face.trianglesArray.push_back(transform(-4, 8));
-            face.trianglesArray.push_back(transform(-12, 8));
-            face.trianglesArray.push_back(transform(4, 0));
-            face.trianglesArray.push_back(transform(12, 0));
-            face.trianglesArray.push_back(transform(12, 8));
-            face.trianglesArray.push_back(transform(4, 0));
-            face.trianglesArray.push_back(transform(12, 8));
-            face.trianglesArray.push_back(transform(4, 8));
+            const auto base = appendLoop({0.0F,   -18.0F, 18.0F,  -6.0F, 12.0F,  -6.0F, 12.0F, 8.0F,
+                                          4.0F,   8.0F,   4.0F,   0.0F,  -4.0F,  0.0F,  -4.0F, 8.0F,
+                                          -12.0F, 8.0F,   -12.0F, -6.0F, -18.0F, -6.0F});
+            appendTriangles(base, {10, 1, 0, 9, 2, 1, 9, 3, 2, 9, 8, 3,
+                                   8,  7, 3, 7, 4, 3, 7, 6, 5, 7, 5, 4});
             break;
         }
         case PickId::Backside: {
             offx = 0.80F;
             offy = 0.0F;
-            std::vector<float> pts1 = {24.,  21.5, 17.,  29.1, 16.7, 25.6, 12.0, 25.3, 8.2,
-                                       24.0, 4.,   22.,  1.2,  19.,  0.,   15.,  0.,   10.,
-                                       1.5,  8.1,  4.4,  6.1,  8.0,  5.5,  14.,  4.,   14.6,
-                                       9.2,  10.1, 10.2, 6.,   12.,  3.5,  14.,  3.4,  14.5,
-                                       6.0,  15.8, 10.,  17.,  16.3, 18.,  16.3, 13.6};
-            std::vector<SbVec3f> loop1;
-            for (size_t i = 0; i < pts1.size(); i += 2) {
-                loop1.push_back(transform(pts1[i], pts1[i + 1]));
-            }
-            face.lineLoops.push_back(loop1);
-            std::vector<int> idx1 = {0,  1,  2, 0,  2,  20, 0,  20, 21, 2,  20, 3,  20, 19, 3,
-                                     3,  19, 4, 19, 18, 4,  4,  18, 5,  18, 17, 5,  5,  17, 6,
-                                     17, 16, 6, 6,  16, 7,  16, 15, 7,  7,  15, 8,  15, 14, 8,
-                                     8,  14, 9, 14, 13, 9,  9,  13, 10, 10, 13, 11, 11, 13, 12};
-            for (int i : idx1) {
-                face.trianglesArray.push_back(loop1[i]);
-            }
+            const auto loop1 = appendLoop(
+                {24.0F, 21.5F, 17.0F, 29.1F, 16.7F, 25.6F, 12.0F, 25.3F, 8.2F,  24.0F, 4.0F,
+                 22.0F, 1.2F,  19.0F, 0.0F,  15.0F, 0.0F,  10.0F, 1.5F,  8.1F,  4.4F,  6.1F,
+                 8.0F,  5.5F,  14.0F, 4.0F,  14.6F, 9.2F,  10.1F, 10.2F, 6.0F,  12.0F, 3.5F,
+                 14.0F, 3.4F,  14.5F, 6.0F,  15.8F, 10.0F, 17.0F, 16.3F, 18.0F, 16.3F, 13.6F}
+            );
+            appendTriangles(loop1, {0,  1,  2, 0,  2,  20, 0,  20, 21, 2,  20, 3,  20, 19, 3,
+                                    3,  19, 4, 19, 18, 4,  4,  18, 5,  18, 17, 5,  5,  17, 6,
+                                    17, 16, 6, 6,  16, 7,  16, 15, 7,  7,  15, 8,  15, 14, 8,
+                                    8,  14, 9, 14, 13, 9,  9,  13, 10, 10, 13, 11, 11, 13, 12});
 
-            std::vector<float> pts2 = {18.,  6.,   22.6, 0.,   22.5, 3.0,  27.,  3.3,  31.4,
-                                       4.3,  35.0, 5.6,  37.5, 7.1,  40.,  9.7,  40.,  12.8,
-                                       38.5, 16.5, 36.2, 20.,  33.,  21.9, 28.3, 22.9, 28.7,
-                                       16.,  32.8, 15.,  36.4, 12.9, 33.8, 10.8, 30.,  9.3,
-                                       26.1, 8.5,  22.5, 8.1,  22.4, 10.8};
-            std::vector<SbVec3f> loop2;
-            for (size_t i = 0; i < pts2.size(); i += 2) {
-                loop2.push_back(transform(pts2[i], pts2[i + 1]));
-            }
-            face.lineLoops.push_back(loop2);
-            std::vector<int> idx2 = {0,  1,  2, 0,  2,  19, 0,  19, 20, 2,  19, 3, 19, 18, 3,
-                                     3,  18, 4, 18, 17, 4,  4,  17, 5,  17, 16, 5, 5,  16, 6,
-                                     16, 15, 6, 6,  15, 7,  15, 14, 7,  7,  14, 8, 14, 13, 8,
-                                     8,  13, 9, 9,  13, 10, 10, 13, 11, 11, 13, 12};
-            for (int i : idx2) {
-                face.trianglesArray.push_back(loop2[i]);
-            }
+            const auto loop2 = appendLoop(
+                {18.0F, 6.0F,  22.6F, 0.0F,  22.5F, 3.0F,  27.0F, 3.3F,  31.4F, 4.3F,  35.0F,
+                 5.6F,  37.5F, 7.1F,  40.0F, 9.7F,  40.0F, 12.8F, 38.5F, 16.5F, 36.2F, 20.0F,
+                 33.0F, 21.9F, 28.3F, 22.9F, 28.7F, 16.0F, 32.8F, 15.0F, 36.4F, 12.9F, 33.8F,
+                 10.8F, 30.0F, 9.3F,  26.1F, 8.5F,  22.5F, 8.1F,  22.4F, 10.8F}
+            );
+            appendTriangles(loop2, {0,  1,  2, 0,  2,  19, 0,  19, 20, 2,  19, 3, 19, 18, 3,
+                                    3,  18, 4, 18, 17, 4,  4,  17, 5,  17, 16, 5, 5,  16, 6,
+                                    16, 15, 6, 6,  15, 7,  15, 14, 7,  7,  14, 8, 14, 13, 8,
+                                    8,  13, 9, 9,  13, 10, 10, 13, 11, 11, 13, 12});
             break;
         }
     }
 
     if (!pointData.empty()) {
-        int count = static_cast<int>(pointData.size()) / 2;
-        face.vertexArray.reserve(count);
-        for (int i = 0; i < count; i++) {
-            face.vertexArray.push_back(transform(pointData[i * 2], pointData[i * 2 + 1]));
+        const int count = static_cast<int>(pointData.size()) / 2;
+        verts.reserve(static_cast<size_t>(count));
+        for (int i = 0; i < count; ++i) {
+            verts.push_back(transform(pointData[i * 2], pointData[i * 2 + 1]));
         }
     }
-    face.type = FaceType::Button;
-    face.rotation = SbRotation(direction, 1).inverse();
+
+    if (outline.empty() && !verts.empty()) {
+        outline.reserve(verts.size() + 1);
+        for (std::int32_t i = 0; i < static_cast<std::int32_t>(verts.size()); ++i) {
+            outline.push_back(i);
+        }
+        outline.push_back(-1);
+    }
+
+    if (tris.empty()) {
+        if (triangulatePolygon2D(verts, tris) && (tris.size() % 3 == 0) && tris.size() >= 3) {
+            // ok
+        }
+        else if (verts.size() == 3) {
+            tris = {0, 1, 2};
+        }
+    }
 }

--- a/src/Gui/Inventor/SoNaviCube.h
+++ b/src/Gui/Inventor/SoNaviCube.h
@@ -1,22 +1,23 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
-// SPDX-FileCopyrightText: 2017 Kustaa Nyholm <kustaa.nyholm@sparetimelabs.com>
-// SPDX-FileCopyrightText: 2025 Joao Matos
+// SPDX-FileCopyrightText: 2017 Kustaa Nyholm  <kustaa.nyholm@sparetimelabs.com>
+// SPDX-FileCopyrightText: 2025-2026 Joao Matos
 // SPDX-FileNotice: Part of the FreeCAD project.
 
 /******************************************************************************
  *                                                                            *
  *   FreeCAD is free software: you can redistribute it and/or modify          *
  *   it under the terms of the GNU Lesser General Public License as           *
- *   published by the Free Software Foundation, either version 2.1            *
- *   of the License, or (at your option) any later version.                   *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
  *                                                                            *
- *   FreeCAD is distributed in the hope that it will be useful,               *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
- *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
- *   See the GNU Lesser General Public License for more details.              *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
  *                                                                            *
  *   You should have received a copy of the GNU Lesser General Public         *
- *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
  *                                                                            *
  ******************************************************************************/
 
@@ -24,6 +25,7 @@
 
 #include <FCGlobal.h>
 #include <Inventor/SbColor.h>
+#include <Inventor/SbVec2s.h>
 #include <Inventor/SbVec3f.h>
 #include <Inventor/SbRotation.h>
 #include <Inventor/fields/SoSFBool.h>
@@ -35,14 +37,35 @@
 #include <Inventor/fields/SoSFVec4f.h>
 #include <Inventor/nodes/SoShape.h>
 
-#include <map>
+#include <cstdint>
+#include <array>
 #include <vector>
 
+class SoTexture2;
+class SoSeparator;
+class SoSwitch;
+class SoMaterial;
+class SoIndexedFaceSet;
+class SoIndexedLineSet;
+class SoPointSet;
+class SoDrawStyle;
+class SoFaceSet;
+class SoPolygonOffset;
+class SoDepthBuffer;
+class SoShapeHints;
+class SoCamera;
+class SoOrthographicCamera;
+class SoPerspectiveCamera;
+class SoTransform;
+class SoVertexProperty;
 namespace Gui
 {
 
 /**
- * Coin node for the navigation cube overlay.
+ * Placeholder Coin node for the navigation cube overlay.
+ *
+ * Rendering responsibilities will be migrated from NaviCubeImplementation
+ * into this node in subsequent steps.
  */
 class GuiExport SoNaviCube: public SoShape
 {
@@ -54,7 +77,7 @@ public:
     static void initClass();
     SoNaviCube();
 
-    //! Cube edge length in viewer units.
+    //! Cube edge length in viewer units (wired up by the controller later).
     SoSFFloat size;
 
     enum class PickId
@@ -97,75 +120,163 @@ public:
         ViewMenu
     };
 
-    enum class FaceType
-    {
-        None,
-        Main,
-        Edge,
-        Corner,
-        Button
-    };
-
-    struct Face
-    {
-        FaceType type {FaceType::None};
-        std::vector<SbVec3f> vertexArray;
-        std::vector<SbVec3f> trianglesArray;
-        std::vector<std::vector<SbVec3f>> lineLoops;
-        SbRotation rotation;
-    };
-
-    using FaceMap = std::map<PickId, Face>;
-
-    struct LabelSlot
-    {
-        std::vector<SbVec3f> quad;
-        unsigned int textureId {0};
-    };
-
-    using LabelMap = std::map<PickId, LabelSlot>;
-
-    struct ColorWithAlpha
-    {
-        SbColor rgb {1.0F, 1.0F, 1.0F};
-        float alpha {1.0F};
-    };
-
     void setChamfer(float chamfer);
-    [[nodiscard]] float chamfer() const
-    {
-        return m_Chamfer;
-    }
-    [[nodiscard]] const FaceMap& faces() const;
-    [[nodiscard]] const Face* faceForId(PickId id) const;
-    [[nodiscard]] const FaceMap& buttonFaces() const;
-    [[nodiscard]] const Face* buttonFaceForId(PickId id) const;
-    [[nodiscard]] const LabelMap& labelSlots() const;
-    [[nodiscard]] const LabelSlot* labelSlotForId(PickId id) const;
-    void setLabelTexture(PickId id, unsigned int textureId);
+    void setLabelImage(PickId id, const SbVec2s& size, int numComponents, const unsigned char* pixels);
     void clearLabelTextures();
-    void renderGL(bool pickMode) const;
+    [[nodiscard]] PickId pickAt(const SbVec2s& point) const;
 
 protected:
-    ~SoNaviCube() override = default;
+    ~SoNaviCube() override;
 
     void GLRender(SoGLRenderAction* action) override;
     void generatePrimitives(SoAction* action) override;
     void computeBBox(SoAction* action, SbBox3f& box, SbVec3f& center) override;
 
 private:
+    enum class CubeFaceKind
+    {
+        Main,
+        Edge,
+        Corner
+    };
+
+    struct LabelSlot
+    {
+        std::vector<SbVec3f> quad;
+        ::SoTexture2* texture {nullptr};
+    };
+
+    void renderCoin(SoGLRenderAction* action);
+    void ensureSceneGraph() const;
+    void rebuildSceneGraph() const;
+    void resetSceneGraph() const;
+    void buildCamerasAndStyle() const;
+    void buildCubeSection() const;
+    void buildAxisSection(SoSeparator* cubeGroup) const;
+    void buildButtonsSection() const;
+    struct RenderParams;
+    [[nodiscard]] RenderParams makeRenderParams() const;
+    void updateSceneGraph(const RenderParams& params) const;
+    void updateCameraAndTransform(const RenderParams& params) const;
+    void updateCube(const RenderParams& params) const;
+    void updateEdges(const RenderParams& params) const;
+    void updateAxes(const RenderParams& params) const;
+    void updateButtons(const RenderParams& params) const;
+    void updateLabels(const RenderParams& params) const;
+    void updateSceneGraph() const;
+    void beginOverlayPass(
+        SoGLRenderAction* action,
+        const RenderParams& params,
+        int viewportX,
+        int viewportY,
+        int viewportWidth,
+        int viewportHeight
+    );
+    void renderOverlayScene(SoGLRenderAction* action);
     void ensureGeometry() const;
     void rebuildGeometry() const;
-    void addCubeFace(const SbVec3f& x, const SbVec3f& z, FaceType type, PickId pickId, float rotZ) const;
+    void addCubeFace(const SbVec3f& x, const SbVec3f& z, CubeFaceKind kind, PickId pickId) const;
     void rebuildButtonFaces() const;
-    void addButtonFace(PickId pickId, const SbVec3f& direction = SbVec3f(0, 0, 0)) const;
+    void addButtonFace(PickId pickId) const;
 
 private:
-    float m_Chamfer {0.12F};
-    mutable bool m_GeometryDirty {true};
-    mutable FaceMap m_Faces;
-    mutable FaceMap m_ButtonFaces;
-    mutable LabelMap m_LabelSlots;
+    static constexpr size_t kPickIdCount = static_cast<size_t>(PickId::ViewMenu) + 1;
+
+    static constexpr size_t pickIndex(PickId id)
+    {
+        return static_cast<size_t>(id);
+    }
+
+    struct AxisNodes
+    {
+        SoSeparator* sep {nullptr};
+        SoMaterial* material {nullptr};
+        SoDrawStyle* drawStyle {nullptr};
+        SoVertexProperty* vertexProperty {nullptr};
+        SoIndexedLineSet* line {nullptr};
+        SoPointSet* points {nullptr};
+    };
+
+    struct LabelNodes
+    {
+        SoSeparator* sep {nullptr};
+        SoMaterial* material {nullptr};
+        SoTexture2* texture {nullptr};
+        SoVertexProperty* vertexProperty {nullptr};
+        SoFaceSet* face {nullptr};
+    };
+
+    struct ButtonNodes
+    {
+        SoSeparator* sep {nullptr};
+        SoMaterial* fillMaterial {nullptr};
+        SoMaterial* outlineMaterial {nullptr};
+        SoDrawStyle* outlineDrawStyle {nullptr};
+        SoSwitch* coordsSwitch {nullptr};
+        SoVertexProperty* vertexOrtho {nullptr};
+        SoVertexProperty* vertexPersp {nullptr};
+        SoIndexedFaceSet* fill {nullptr};
+        SoIndexedLineSet* outline {nullptr};
+    };
+
+    mutable SoSeparator* sceneRoot {nullptr};
+    mutable SoSwitch* cameraSwitch {nullptr};
+    mutable SoOrthographicCamera* orthoCamera {nullptr};
+    mutable SoPerspectiveCamera* perspCamera {nullptr};
+    mutable SoTransform* rootTransform {nullptr};
+    mutable SoSwitch* axisSwitch {nullptr};
+    mutable AxisNodes axisNodes[3];
+    mutable SoSeparator* cubeSep {nullptr};
+    mutable SoMaterial* cubeMaterial {nullptr};
+    mutable SoVertexProperty* cubeVertexProperty {nullptr};
+    mutable SoIndexedFaceSet* cubeFaces {nullptr};
+    mutable SoSeparator* edgeSep {nullptr};
+    mutable SoMaterial* edgeMaterial {nullptr};
+    mutable SoDrawStyle* edgeDrawStyle {nullptr};
+    mutable SoVertexProperty* edgeVertexProperty {nullptr};
+    mutable SoIndexedLineSet* edges {nullptr};
+    mutable SoSeparator* labelsSep {nullptr};
+    mutable SoSeparator* buttonsSep {nullptr};
+    mutable std::array<LabelNodes, kPickIdCount> labelNodes;
+    mutable std::array<ButtonNodes, kPickIdCount> buttonNodes;
+
+    struct StyleState
+    {
+        int lastHiliteFaceIndex {-1};
+        PickId lastHilitePick {PickId::None};
+        PickId lastButtonsHilitePick {PickId::None};
+        bool buttonDirty {true};
+        bool labelDirty {true};
+        bool axisDirty {true};
+        SbColor buttonsBaseRgb;
+        SbColor buttonsHiliteRgb;
+        SbColor buttonsOutlineRgb;
+        float buttonsBaseTr {0.0F};
+        float buttonsHiliteTr {0.0F};
+        float buttonsOutlineTr {0.0F};
+        float buttonsLineWidth {0.0F};
+        SbColor labelsRgb;
+        float labelsTr {0.0F};
+        std::array<SbColor, 3> axisRgb;
+        float axisTr {0.0F};
+        float axisBw {0.0F};
+        bool showCS {false};
+    };
+
+    mutable StyleState style;
+    mutable bool sceneDirty {true};
+    float chamfer {0.12F};
+    mutable bool geometryDirty {true};
+    mutable std::array<std::vector<SbVec3f>, kPickIdCount> faces;
+    mutable std::array<std::vector<SbVec3f>, kPickIdCount> buttonOverlayVerts;
+    mutable std::array<std::vector<int>, kPickIdCount> buttonTriangleIndices;
+    mutable std::array<std::vector<std::int32_t>, kPickIdCount> buttonOutlineIndices;
+    mutable std::vector<SbVec3f> cubeCoordsData;
+    mutable std::vector<std::int32_t> cubeCoordIndexData;
+    mutable std::vector<SbVec3f> edgeCoordsData;
+    mutable std::vector<std::int32_t> edgeCoordIndexData;
+    mutable std::array<LabelSlot, kPickIdCount> labelSlots;
+    int labelTextureCount {0};
 
 public:
     SoSFFloat opacity;

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1,62 +1,56 @@
-/***************************************************************************
- *   Copyright (c) 2017 Kustaa Nyholm  <kustaa.nyholm@sparetimelabs.com>   *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2017 Kustaa Nyholm  <kustaa.nyholm@sparetimelabs.com>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
 #include <algorithm>
 #include <cmath>
-#include <numbers>
-#include <mutex>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
-#ifdef FC_OS_WIN32
-# include <windows.h>
-#endif
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
+#include <numbers>
+#include <set>
+#include <vector>
+
 #include <boost/math/constants/constants.hpp>
-#include <Inventor/actions/SoAction.h>
-#include <Inventor/actions/SoGLRenderAction.h>
-#include <Inventor/actions/SoPickAction.h>
-#include <Inventor/actions/SoRayPickAction.h>
-#include <Inventor/elements/SoViewportRegionElement.h>
-#include <Inventor/nodes/SoCallback.h>
-#include <Inventor/nodes/SoOrthographicCamera.h>
-#include <Inventor/nodes/SoSeparator.h>
+
 #include <Inventor/SbVec3f.h>
 #include <Inventor/SbVec4f.h>
+#include <Inventor/actions/SoAction.h>
+#include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/elements/SoViewportRegionElement.h>
 #include <Inventor/events/SoEvent.h>
 #include <Inventor/events/SoLocation2Event.h>
 #include <Inventor/events/SoMouseButtonEvent.h>
+#include <Inventor/nodes/SoCallback.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoSeparator.h>
+
 #include <QApplication>
-#include <QElapsedTimer>
 #include <QCursor>
+#include <QElapsedTimer>
 #include <QImage>
 #include <QMenu>
-#include <QOpenGLFramebufferObject>
-#include <QOpenGLTexture>
-#include <QOpenGLWidget>
 #include <QPainterPath>
 
 #include <Base/Color.h>
@@ -78,19 +72,15 @@ using namespace std;
 using namespace Gui;
 
 using PickId = Gui::SoNaviCube::PickId;
-using FaceType = Gui::SoNaviCube::FaceType;
-using Face = Gui::SoNaviCube::Face;
 
-namespace
+enum class FaceType
 {
-
-// Keep FBO sizing and pick-coordinate mapping on the same rounded pixel grid.
-int getPickingFramebufferExtent(qreal physicalCubeWidgetSize)
-{
-    return std::max(1L, std::lround(physicalCubeWidgetSize * 2.0));
-}
-
-}  // namespace
+    None,
+    Main,
+    Edge,
+    Corner,
+    Button
+};
 
 class NaviCubeImplementation
 {
@@ -109,10 +99,11 @@ public:
     void requestRedraw(bool touchNode = true);
 
 private:
+    void resetClickState();
+    void setHiliteWithHysteresis(PickId);
     struct LabelTexture
     {
         qreal fontSize = 0.0;
-        QOpenGLTexture* texture = nullptr;
         string label;
     };
     bool mousePressed(short x, short y);
@@ -127,7 +118,6 @@ private:
 
     void setHilite(PickId);
 
-    const Face* findFace(PickId) const;
     FaceType getFaceType(PickId) const;
     SbRotation getFaceRotation(PickId) const;
 
@@ -141,283 +131,274 @@ private:
         int viewportWidth,
         int viewportHeight
     );
-    bool isFramebufferValid() const;
-    void ensureFramebufferValid();
 
     SbRotation getNearestOrientation(PickId pickId);
     qreal getPhysicalCubeWidgetSize();
 
 public:
-    static int m_CubeWidgetSize;
-    QColor m_BaseColor;
-    QColor m_EmphaseColor;
-    QColor m_HiliteColor;
-    bool m_ShowCS = true;
-    PickId m_HiliteId = PickId::None;
-    double m_BorderWidth = 1.1;
-    bool m_RotateToNearest = true;
-    int m_NaviStepByTurn = 8;
-    float m_FontZoom = 0.3F;
-    float m_Chamfer = 0.12F;
-    std::string m_TextFont;
-    int m_FontWeight = 0;
-    int m_FontStretch = 0;
-    float m_InactiveOpacity = 0.5;
-    SbVec2s m_PosOffset = SbVec2s(0, 0);
+    static int cubeWidgetSize;
+    QColor baseColor;
+    QColor emphaseColor;
+    QColor hiliteColor;
+    bool showCS = true;
+    PickId hiliteId = PickId::None;
+    double borderWidth = 1.1;
+    bool rotateToNearest = true;
+    int naviStepByTurn = 8;
+    float fontZoom = 0.3F;
+    float chamfer = 0.12F;
+    std::string textFont;
+    int fontWeight = 0;
+    int fontStretch = 0;
+    float inactiveOpacity = 0.5;
+    SbVec2s posOffset = SbVec2s(0, 0);
 
-    Base::Color m_xColor;
-    Base::Color m_yColor;
-    Base::Color m_zColor;
+    Base::Color xColor;
+    Base::Color yColor;
+    Base::Color zColor;
 
-    bool m_Prepared = false;
-    static vector<string> m_commands;
-    bool m_Draggable = false;
-    SbVec2s m_ViewSize = SbVec2s(0, 0);
+    bool prepared = false;
+    static vector<string> commands;
+    bool draggable = false;
+    SbVec2s viewSize = SbVec2s(0, 0);
 
 private:
-    bool m_MouseDown = false;
-    bool m_Dragging = false;
-    bool m_MightDrag = false;
-    bool m_Hovering = false;
+    bool mouseDown = false;
+    bool dragging = false;
+    bool mightDrag = false;
+    bool hovering = false;
+    QElapsedTimer clickTimer;
+    PickId lastClickPickId = PickId::None;
+    PickId pendingHiliteId = PickId::None;
+    int pendingHiliteCount = 0;
 
-    QElapsedTimer m_ClickTimer;
-    PickId m_LastClickPickId = PickId::None;
+    SbVec2f relPos = SbVec2f(1.0f, 1.0f);
+    SbVec2s posAreaBase = SbVec2s(0, 0);
+    SbVec2s posAreaSize = SbVec2s(0, 0);
+    qreal devicePixelRatio = 1.0;
 
-    SbVec2f m_RelPos = SbVec2f(1.0f, 1.0f);
-    SbVec2s m_PosAreaBase = SbVec2s(0, 0);
-    SbVec2s m_PosAreaSize = SbVec2s(0, 0);
-    qreal m_DevicePixelRatio = 1.0;
+    Gui::View3DInventorViewer* viewer;
 
-    QOpenGLFramebufferObject* m_PickingFramebuffer;
-    Gui::View3DInventorViewer* m_View3DInventorViewer;
+    Gui::SoNaviCube* soNaviCube = nullptr;
 
-    Gui::SoNaviCube* m_SoNaviCube = nullptr;
+    map<PickId, LabelTexture> labelTextures;
 
-    map<PickId, LabelTexture> m_LabelTextures;
+    QMenu* menu;
 
-    QMenu* m_Menu;
-
-    std::shared_ptr<NavigationAnimation> m_flatButtonAnimation;
-    SbRotation m_flatButtonTargetOrientation;
+    std::shared_ptr<NavigationAnimation> flatButtonAnimation;
+    SbRotation flatButtonTargetOrientation;
 
     void syncNodeState(SoAction* action);
     static void traversalCallback(void* userdata, SoAction* action);
 
-    SoSeparator* m_CoinRoot = nullptr;
-    SoCallback* m_ActionSync = nullptr;
+    SoSeparator* coinRoot = nullptr;
+    SoCallback* actionSync = nullptr;
 };
 
-int NaviCubeImplementation::m_CubeWidgetSize = 132;
+int NaviCubeImplementation::cubeWidgetSize = 132;
 
 int NaviCube::getNaviCubeSize()
 {
-    return NaviCubeImplementation::m_CubeWidgetSize;
+    return NaviCubeImplementation::cubeWidgetSize;
 }
 
 SoNode* NaviCube::getCoinNode() const
 {
-    return m_NaviCubeImplementation->getCoinNode();
+    return naviCubeImplementation->getCoinNode();
 }
 
 NaviCube::NaviCube(Gui::View3DInventorViewer* viewer)
 {
-    m_NaviCubeImplementation = new NaviCubeImplementation(viewer);
+    naviCubeImplementation = new NaviCubeImplementation(viewer);
     updateColors();
 }
 
 NaviCube::~NaviCube()
 {
-    delete m_NaviCubeImplementation;
+    delete naviCubeImplementation;
 }
 
 void NaviCube::createContextMenu(const std::vector<std::string>& cmd)
 {
-    m_NaviCubeImplementation->createContextMenu(cmd);
+    naviCubeImplementation->createContextMenu(cmd);
 }
 
 bool NaviCube::processSoEvent(const SoEvent* ev)
 {
-    return m_NaviCubeImplementation->processSoEvent(ev);
+    return naviCubeImplementation->processSoEvent(ev);
 }
 
-vector<string> NaviCubeImplementation::m_commands;
+vector<string> NaviCubeImplementation::commands;
 
 void NaviCube::setCorner(Corner c)
 {
-    m_NaviCubeImplementation->moveToCorner(c);
+    naviCubeImplementation->moveToCorner(c);
 }
 
 void NaviCube::setOffset(int x, int y)
 {
-    m_NaviCubeImplementation->m_PosOffset = SbVec2s(x, y);
-    m_NaviCubeImplementation->m_ViewSize = SbVec2s(0, 0);
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->posOffset = SbVec2s(x, y);
+    naviCubeImplementation->viewSize = SbVec2s(0, 0);
+    naviCubeImplementation->requestRedraw();
 }
 
 bool NaviCube::isDraggable()
 {
-    return m_NaviCubeImplementation->m_Draggable;
+    return naviCubeImplementation->draggable;
 }
 
 void NaviCube::setDraggable(bool draggable)
 {
-    m_NaviCubeImplementation->m_Draggable = draggable;
+    naviCubeImplementation->draggable = draggable;
 }
 
 void NaviCube::setSize(int size)
 {
-    m_NaviCubeImplementation->setSize(size);
+    naviCubeImplementation->setSize(size);
 }
 
 void NaviCube::setChamfer(float chamfer)
 {
-    m_NaviCubeImplementation->m_Chamfer = min(max(0.05f, chamfer), 0.18f);
-    m_NaviCubeImplementation->m_Prepared = false;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->chamfer = min(max(0.05f, chamfer), 0.18f);
+    naviCubeImplementation->prepared = false;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setNaviRotateToNearest(bool toNearest)
 {
-    m_NaviCubeImplementation->m_RotateToNearest = toNearest;
+    naviCubeImplementation->rotateToNearest = toNearest;
 }
 
 void NaviCube::setNaviStepByTurn(int steps)
 {
-    m_NaviCubeImplementation->m_NaviStepByTurn = steps;
+    naviCubeImplementation->naviStepByTurn = steps;
 }
 
 void NaviCube::setFont(std::string font)
 {
-    m_NaviCubeImplementation->m_TextFont = font;
-    m_NaviCubeImplementation->m_Prepared = false;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->textFont = font;
+    naviCubeImplementation->prepared = false;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setFontWeight(int weight)
 {
-    m_NaviCubeImplementation->m_FontWeight = weight;
-    m_NaviCubeImplementation->m_Prepared = false;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->fontWeight = weight;
+    naviCubeImplementation->prepared = false;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setFontStretch(int stretch)
 {
-    m_NaviCubeImplementation->m_FontStretch = stretch;
-    m_NaviCubeImplementation->m_Prepared = false;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->fontStretch = stretch;
+    naviCubeImplementation->prepared = false;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setFontZoom(float zoom)
 {
-    m_NaviCubeImplementation->m_FontZoom = zoom;
-    m_NaviCubeImplementation->m_Prepared = false;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->fontZoom = zoom;
+    naviCubeImplementation->prepared = false;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setBaseColor(QColor bColor)
 {
-    m_NaviCubeImplementation->m_BaseColor = bColor;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->baseColor = bColor;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setEmphaseColor(QColor eColor)
 {
-    m_NaviCubeImplementation->m_EmphaseColor = eColor;
-    m_NaviCubeImplementation->m_Prepared = false;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->emphaseColor = eColor;
+    naviCubeImplementation->prepared = false;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setHiliteColor(QColor HiliteColor)
 {
-    m_NaviCubeImplementation->m_HiliteColor = HiliteColor;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->hiliteColor = HiliteColor;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setBorderWidth(double BorderWidth)
 {
-    m_NaviCubeImplementation->m_BorderWidth = BorderWidth;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->borderWidth = BorderWidth;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setShowCS(bool showCS)
 {
-    m_NaviCubeImplementation->m_ShowCS = showCS;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->showCS = showCS;
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setNaviCubeLabels(const std::vector<std::string>& labels)
 {
-    m_NaviCubeImplementation->setLabels(labels);
+    naviCubeImplementation->setLabels(labels);
 }
 
 void NaviCube::setInactiveOpacity(float opacity)
 {
-    m_NaviCubeImplementation->m_InactiveOpacity = opacity;
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->inactiveOpacity = opacity;
+    naviCubeImplementation->requestRedraw();
 }
 
 qreal NaviCubeImplementation::getPhysicalCubeWidgetSize()
 {
-    return m_CubeWidgetSize * m_DevicePixelRatio;
+    return cubeWidgetSize * devicePixelRatio;
 }
 
 void NaviCubeImplementation::setLabels(const std::vector<std::string>& labels)
 {
-    m_LabelTextures[PickId::Front].label = labels[0];
-    m_LabelTextures[PickId::Top].label = labels[1];
-    m_LabelTextures[PickId::Right].label = labels[2];
-    m_LabelTextures[PickId::Rear].label = labels[3];
-    m_LabelTextures[PickId::Bottom].label = labels[4];
-    m_LabelTextures[PickId::Left].label = labels[5];
-    m_Prepared = false;
+    labelTextures[PickId::Front].label = labels[0];
+    labelTextures[PickId::Top].label = labels[1];
+    labelTextures[PickId::Right].label = labels[2];
+    labelTextures[PickId::Rear].label = labels[3];
+    labelTextures[PickId::Bottom].label = labels[4];
+    labelTextures[PickId::Left].label = labels[5];
+    prepared = false;
     requestRedraw();
 }
 
 NaviCubeImplementation::NaviCubeImplementation(Gui::View3DInventorViewer* viewer)
-    : m_BaseColor {226, 232, 239}
-    , m_HiliteColor {170, 226, 255}
+    : baseColor {226, 232, 239}
+    , hiliteColor {170, 226, 255}
 {
-    m_SoNaviCube = new Gui::SoNaviCube();
-    m_SoNaviCube->ref();
+    soNaviCube = new Gui::SoNaviCube();
+    soNaviCube->ref();
 
-    m_CoinRoot = new SoSeparator();
-    m_CoinRoot->ref();
-    m_CoinRoot->setName("naviCubeRoot");
+    coinRoot = new SoSeparator();
+    coinRoot->ref();
+    coinRoot->setName("naviCubeRoot");
 
-    m_ActionSync = new SoCallback();
-    m_ActionSync->setCallback(NaviCubeImplementation::traversalCallback, this);
-    m_CoinRoot->addChild(m_ActionSync);
-    m_CoinRoot->addChild(m_SoNaviCube);
+    actionSync = new SoCallback();
+    actionSync->setCallback(NaviCubeImplementation::traversalCallback, this);
+    coinRoot->addChild(actionSync);
+    coinRoot->addChild(soNaviCube);
 
-    m_View3DInventorViewer = viewer;
-    m_PickingFramebuffer = nullptr;
-    m_Menu = createNaviCubeMenu();
+    this->viewer = viewer;
+    menu = createNaviCubeMenu();
 }
 
 NaviCubeImplementation::~NaviCubeImplementation()
 {
-    delete m_Menu;
-    if (m_PickingFramebuffer) {
-        delete m_PickingFramebuffer;
+    delete menu;
+    if (coinRoot) {
+        coinRoot->unref();
+        coinRoot = nullptr;
     }
-    for (auto tex : m_LabelTextures) {
-        delete tex.second.texture;
-    }
-    if (m_CoinRoot) {
-        m_CoinRoot->unref();
-        m_CoinRoot = nullptr;
-    }
-    m_ActionSync = nullptr;
-    if (m_SoNaviCube) {
-        m_SoNaviCube->clearLabelTextures();
-        m_SoNaviCube->unref();
-        m_SoNaviCube = nullptr;
+    actionSync = nullptr;
+    if (soNaviCube) {
+        soNaviCube->clearLabelTextures();
+        soNaviCube->unref();
+        soNaviCube = nullptr;
     }
 }
 
 SoNode* NaviCubeImplementation::getCoinNode() const
 {
-    return m_CoinRoot;
+    return coinRoot;
 }
 
 void NaviCubeImplementation::traversalCallback(void* userdata, SoAction* action)
@@ -442,7 +423,7 @@ void NaviCubeImplementation::syncNodeState(SoAction* action)
             return;
         }
     }
-    else if (!m_Prepared) {
+    else if (!prepared) {
         return;
     }
 
@@ -466,71 +447,194 @@ void NaviCubeImplementation::syncNodeState(SoAction* action)
 
     const int viewportWidth = static_cast<int>(physicalCubeWidgetSize);
     const int viewportHeight = static_cast<int>(physicalCubeWidgetSize);
-    const int posX = static_cast<int>(m_RelPos[0] * m_PosAreaSize[0]) + m_PosAreaBase[0]
+    const int posX = static_cast<int>(relPos[0] * posAreaSize[0]) + posAreaBase[0]
         - viewportWidth / 2;
-    const int posY = static_cast<int>(m_RelPos[1] * m_PosAreaSize[1]) + m_PosAreaBase[1]
+    const int posY = static_cast<int>(relPos[1] * posAreaSize[1]) + posAreaBase[1]
         - viewportHeight / 2;
 
     if (
-        !populateRenderParams(m_Hovering ? 1.0F : m_InactiveOpacity, posX, posY, viewportWidth, viewportHeight)
+        !populateRenderParams(hovering ? 1.0F : inactiveOpacity, posX, posY, viewportWidth, viewportHeight)
     ) {
         return;
     }
 
     if (!isGLRender) {
-        m_SoNaviCube->touch();
+        soNaviCube->touch();
     }
 }
 
 void NaviCubeImplementation::requestRedraw(bool touchNode)
 {
-    if (touchNode && m_SoNaviCube) {
-        m_SoNaviCube->touch();
+    if (touchNode && soNaviCube) {
+        soNaviCube->touch();
     }
-    if (m_View3DInventorViewer) {
-        if (auto* rm = m_View3DInventorViewer->getSoRenderManager()) {
+    if (viewer) {
+        if (auto* rm = viewer->getSoRenderManager()) {
             rm->scheduleRedraw();
         }
     }
 }
 
-const Face* NaviCubeImplementation::findFace(PickId id) const
-{
-    if (const Face* face = m_SoNaviCube->faceForId(id)) {
-        return face;
-    }
-    return m_SoNaviCube->buttonFaceForId(id);
-}
-
 FaceType NaviCubeImplementation::getFaceType(PickId id) const
 {
-    if (const Face* face = findFace(id)) {
-        return face->type;
+    switch (id) {
+        default:
+            return FaceType::None;
+        case PickId::Front:
+        case PickId::Top:
+        case PickId::Right:
+        case PickId::Rear:
+        case PickId::Bottom:
+        case PickId::Left:
+            return FaceType::Main;
+        case PickId::FrontTop:
+        case PickId::FrontBottom:
+        case PickId::FrontRight:
+        case PickId::FrontLeft:
+        case PickId::RearTop:
+        case PickId::RearBottom:
+        case PickId::RearRight:
+        case PickId::RearLeft:
+        case PickId::TopRight:
+        case PickId::TopLeft:
+        case PickId::BottomRight:
+        case PickId::BottomLeft:
+            return FaceType::Edge;
+        case PickId::FrontTopRight:
+        case PickId::FrontTopLeft:
+        case PickId::FrontBottomRight:
+        case PickId::FrontBottomLeft:
+        case PickId::RearTopRight:
+        case PickId::RearTopLeft:
+        case PickId::RearBottomRight:
+        case PickId::RearBottomLeft:
+            return FaceType::Corner;
+        case PickId::ArrowNorth:
+        case PickId::ArrowSouth:
+        case PickId::ArrowEast:
+        case PickId::ArrowWest:
+        case PickId::ArrowRight:
+        case PickId::ArrowLeft:
+        case PickId::Backside:
+        case PickId::Home:
+        case PickId::ViewMenu:
+            return FaceType::Button;
     }
-    return FaceType::None;
 }
 
 SbRotation NaviCubeImplementation::getFaceRotation(PickId id) const
 {
-    if (const Face* face = findFace(id)) {
-        return face->rotation;
+    const auto makeFaceRotation = [](SbVec3f x, SbVec3f z, float rotZ) {
+        SbVec3f y = x.cross(-z);
+        x.normalize();
+        y.normalize();
+        z.normalize();
+
+        SbMatrix R(x[0], y[0], z[0], 0, x[1], y[1], z[1], 0, x[2], y[2], z[2], 0, 0, 0, 0, 1);
+        return (SbRotation(R) * SbRotation(SbVec3f(0, 0, 1), rotZ)).inverse();
+    };
+
+    const SbVec3f x(1.0F, 0.0F, 0.0F);
+    const SbVec3f y(0.0F, 1.0F, 0.0F);
+    const SbVec3f z(0.0F, 0.0F, 1.0F);
+    constexpr float pi = std::numbers::pi_v<float>;
+
+    switch (id) {
+        default:
+            return SbRotation();
+
+        // Main faces
+        case PickId::Top:
+            return makeFaceRotation(x, z, 0.0F);
+        case PickId::Front:
+            return makeFaceRotation(x, -y, 0.0F);
+        case PickId::Left:
+            return makeFaceRotation(-y, -x, 0.0F);
+        case PickId::Rear:
+            return makeFaceRotation(-x, y, 0.0F);
+        case PickId::Right:
+            return makeFaceRotation(y, x, 0.0F);
+        case PickId::Bottom:
+            return makeFaceRotation(x, -z, 0.0F);
+
+        // Corner faces
+        case PickId::FrontTopRight:
+            return makeFaceRotation(-x - y, x - y + z, pi);
+        case PickId::FrontTopLeft:
+            return makeFaceRotation(-x + y, -x - y + z, pi);
+        case PickId::FrontBottomRight:
+            return makeFaceRotation(x + y, x - y - z, 0.0F);
+        case PickId::FrontBottomLeft:
+            return makeFaceRotation(x - y, -x - y - z, 0.0F);
+        case PickId::RearTopRight:
+            return makeFaceRotation(x - y, x + y + z, pi);
+        case PickId::RearTopLeft:
+            return makeFaceRotation(x + y, -x + y + z, pi);
+        case PickId::RearBottomRight:
+            return makeFaceRotation(-x + y, x + y - z, 0.0F);
+        case PickId::RearBottomLeft:
+            return makeFaceRotation(-x - y, -x + y - z, 0.0F);
+
+        // Edge faces
+        case PickId::FrontTop:
+            return makeFaceRotation(x, z - y, 0.0F);
+        case PickId::FrontBottom:
+            return makeFaceRotation(x, -z - y, 0.0F);
+        case PickId::RearBottom:
+            return makeFaceRotation(x, y - z, pi);
+        case PickId::RearTop:
+            return makeFaceRotation(x, y + z, pi);
+        case PickId::RearRight:
+            return makeFaceRotation(z, x + y, pi / 2.0F);
+        case PickId::FrontRight:
+            return makeFaceRotation(z, x - y, pi / 2.0F);
+        case PickId::FrontLeft:
+            return makeFaceRotation(z, -x - y, pi / 2.0F);
+        case PickId::RearLeft:
+            return makeFaceRotation(z, y - x, pi / 2.0F);
+        case PickId::TopLeft:
+            return makeFaceRotation(y, z - x, pi);
+        case PickId::TopRight:
+            return makeFaceRotation(y, x + z, 0.0F);
+        case PickId::BottomRight:
+            return makeFaceRotation(y, x - z, 0.0F);
+        case PickId::BottomLeft:
+            return makeFaceRotation(y, -z - x, pi);
+
+        // Buttons (axis rotations; angle is scaled by caller)
+        case PickId::ArrowNorth:
+            return SbRotation(SbVec3f(-1, 0, 0), 1).inverse();
+        case PickId::ArrowSouth:
+            return SbRotation(SbVec3f(1, 0, 0), 1).inverse();
+        case PickId::ArrowEast:
+            return SbRotation(SbVec3f(0, 1, 0), 1).inverse();
+        case PickId::ArrowWest:
+            return SbRotation(SbVec3f(0, -1, 0), 1).inverse();
+        case PickId::ArrowLeft:
+            return SbRotation(SbVec3f(0, 0, 1), 1).inverse();
+        case PickId::ArrowRight:
+            return SbRotation(SbVec3f(0, 0, -1), 1).inverse();
+        case PickId::Backside:
+            return SbRotation(SbVec3f(0, 1, 0), 1).inverse();
+        case PickId::Home:
+        case PickId::ViewMenu:
+            return SbRotation();
     }
-    return SbRotation();
 }
 
 void NaviCubeImplementation::moveToCorner(NaviCube::Corner c)
 {
     if (c == NaviCube::TopLeftCorner) {
-        m_RelPos = SbVec2f(0.0f, 1.0f);
+        relPos = SbVec2f(0.0f, 1.0f);
     }
     else if (c == NaviCube::TopRightCorner) {
-        m_RelPos = SbVec2f(1.0f, 1.0f);
+        relPos = SbVec2f(1.0f, 1.0f);
     }
     else if (c == NaviCube::BottomLeftCorner) {
-        m_RelPos = SbVec2f(0.0f, 0.0f);
+        relPos = SbVec2f(0.0f, 0.0f);
     }
     else if (c == NaviCube::BottomRightCorner) {
-        m_RelPos = SbVec2f(1.0f, 0.0f);
+        relPos = SbVec2f(1.0f, 0.0f);
     }
     requestRedraw();
 }
@@ -598,18 +702,18 @@ void NaviCubeImplementation::createCubeFaceTextures()
 {
     int texSize = 192;  // Works well for the max cube size 1024
     QFont font;
-    if (m_TextFont.empty()) {
+    if (textFont.empty()) {
         font.fromString(QStringLiteral("Arial"));
     }
     else {
-        font.fromString(QString::fromStdString(m_TextFont));
+        font.fromString(QString::fromStdString(textFont));
     }
     font.setStyleHint(QFont::SansSerif);
-    if (m_FontWeight > 0) {
-        font.setWeight(convertWeights(m_FontWeight));
+    if (fontWeight > 0) {
+        font.setWeight(convertWeights(fontWeight));
     }
-    if (m_FontStretch > 0) {
-        font.setStretch(m_FontStretch);
+    if (fontStretch > 0) {
+        font.setStretch(fontStretch);
     }
     font.setPointSizeF(texSize);
     QFontMetrics fm(font);
@@ -618,32 +722,32 @@ void NaviCubeImplementation::createCubeFaceTextures()
     vector<PickId> mains
         = {PickId::Front, PickId::Top, PickId::Right, PickId::Rear, PickId::Bottom, PickId::Left};
     for (PickId pickId : mains) {
-        auto t = QString::fromUtf8(m_LabelTextures[pickId].label.c_str());
+        auto t = QString::fromUtf8(labelTextures[pickId].label.c_str());
         QRect br = fm.boundingRect(t);
         float scale = (float)texSize / max(br.width(), br.height());
-        m_LabelTextures[pickId].fontSize = texSize * scale;
-        minFontSize = std::min(minFontSize, m_LabelTextures[pickId].fontSize);
-        maxFontSize = std::max(maxFontSize, m_LabelTextures[pickId].fontSize);
+        labelTextures[pickId].fontSize = texSize * scale;
+        minFontSize = std::min(minFontSize, labelTextures[pickId].fontSize);
+        maxFontSize = std::max(maxFontSize, labelTextures[pickId].fontSize);
     }
-    if (m_FontZoom > 0.0) {
-        maxFontSize = minFontSize + (maxFontSize - minFontSize) * m_FontZoom;
+    if (fontZoom > 0.0) {
+        maxFontSize = minFontSize + (maxFontSize - minFontSize) * fontZoom;
     }
     else {
-        maxFontSize = minFontSize * std::pow(2.0, m_FontZoom);
+        maxFontSize = minFontSize * std::pow(2.0, fontZoom);
     }
     for (PickId pickId : mains) {
         QImage image(texSize, texSize, QImage::Format_ARGB32);
         image.fill(qRgba(255, 255, 255, 0));
-        if (m_LabelTextures[pickId].fontSize > 0.5) {
+        if (labelTextures[pickId].fontSize > 0.5) {
             // 5% margin looks nice and prevents some artifacts
-            font.setPointSizeF(std::min(m_LabelTextures[pickId].fontSize, maxFontSize) * 0.9);
+            font.setPointSizeF(std::min(labelTextures[pickId].fontSize, maxFontSize) * 0.9);
             QPainter paint;
             paint.begin(&image);
             paint.setRenderHints(
                 QPainter::Antialiasing | QPainter::TextAntialiasing | QPainter::SmoothPixmapTransform
             );
             paint.setPen(Qt::white);
-            QString text = QString::fromUtf8(m_LabelTextures[pickId].label.c_str());
+            QString text = QString::fromUtf8(labelTextures[pickId].label.c_str());
             paint.setFont(font);
             paint.drawText(QRect(0, 0, texSize, texSize), Qt::AlignCenter, text);
             int offset = imageVerticalBalance(image, font.pointSize());
@@ -652,56 +756,47 @@ void NaviCubeImplementation::createCubeFaceTextures()
             paint.end();
         }
 
-        if (m_LabelTextures[pickId].texture) {
-            m_SoNaviCube->setLabelTexture(pickId, 0);
-            delete m_LabelTextures[pickId].texture;
+        // Coin backend: store as a Coin-managed texture (SoTexture2).
+        // Mirror to match the OpenGL texture coordinate origin (bottom-left).
+        const QImage rgba = image.mirrored().convertToFormat(QImage::Format_RGBA8888);
+        const int w = rgba.width();
+        const int h = rgba.height();
+        std::vector<unsigned char> pixels(static_cast<size_t>(w) * static_cast<size_t>(h) * 4U);
+        for (int y = 0; y < h; ++y) {
+            const unsigned char* src = rgba.constScanLine(y);
+            unsigned char* dst = pixels.data() + static_cast<size_t>(y) * static_cast<size_t>(w) * 4U;
+            std::memcpy(dst, src, static_cast<size_t>(w) * 4U);
         }
-#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
-        m_LabelTextures[pickId].texture = new QOpenGLTexture(image.mirrored());
-#else
-        m_LabelTextures[pickId].texture = new QOpenGLTexture(image.flipped(Qt::Vertical));
-#endif
-        m_LabelTextures[pickId].texture->setMaximumAnisotropy(4.0);
-        m_LabelTextures[pickId].texture->setMinificationFilter(QOpenGLTexture::LinearMipMapLinear);
-        m_LabelTextures[pickId].texture->setMagnificationFilter(QOpenGLTexture::Linear);
-        m_LabelTextures[pickId].texture->generateMipMaps();
-        m_SoNaviCube->setLabelTexture(pickId, m_LabelTextures[pickId].texture->textureId());
+
+        soNaviCube->setLabelImage(pickId, SbVec2s(w, h), 4, pixels.data());
     }
 }
 
 void NaviCubeImplementation::setSize(int size)
 {
-    m_CubeWidgetSize = size;
-    m_ViewSize = SbVec2s(0, 0);
-    m_Prepared = false;
+    cubeWidgetSize = size;
+    viewSize = SbVec2s(0, 0);
+    prepared = false;
     requestRedraw();
 }
 
 void NaviCubeImplementation::prepare()
 {
-    if (m_Prepared || !m_View3DInventorViewer->viewport()) {
+    if (prepared || !viewer->viewport()) {
         return;
     }
 
-    m_SoNaviCube->setChamfer(m_Chamfer);
-    (void)m_SoNaviCube->faces();
+    soNaviCube->setChamfer(chamfer);
 
     createCubeFaceTextures();
-
-    if (m_PickingFramebuffer) {
-        delete m_PickingFramebuffer;
-        m_PickingFramebuffer = nullptr;
-    }
-
-    ensureFramebufferValid();
-    m_Prepared = true;
+    prepared = true;
     requestRedraw();
 }
 
 bool NaviCubeImplementation::readyToRender()
 {
     prepare();
-    return m_Prepared;
+    return prepared;
 }
 
 bool NaviCubeImplementation::populateRenderParams(
@@ -712,38 +807,36 @@ bool NaviCubeImplementation::populateRenderParams(
     int viewportHeight
 )
 {
-    SoCamera* cam = m_View3DInventorViewer->getSoRenderManager()->getCamera();
+    SoCamera* cam = viewer->getSoRenderManager()->getCamera();
     if (!cam) {
         return false;
     }
 
-    m_SoNaviCube->size = static_cast<float>(m_CubeWidgetSize);
-    m_SoNaviCube->opacity = opacity;
-    m_SoNaviCube->borderWidth = static_cast<float>(m_BorderWidth);
-    m_SoNaviCube->showCoordinateSystem = m_ShowCS;
-    m_SoNaviCube->hiliteId = static_cast<int>(m_HiliteId);
-    m_SoNaviCube->baseColor.setValue(m_BaseColor.redF(), m_BaseColor.greenF(), m_BaseColor.blueF());
-    m_SoNaviCube->baseAlpha = static_cast<float>(m_BaseColor.alphaF());
-    m_SoNaviCube->emphaseColor
-        .setValue(m_EmphaseColor.redF(), m_EmphaseColor.greenF(), m_EmphaseColor.blueF());
-    m_SoNaviCube->emphaseAlpha = static_cast<float>(m_EmphaseColor.alphaF());
-    m_SoNaviCube->hiliteColor
-        .setValue(m_HiliteColor.redF(), m_HiliteColor.greenF(), m_HiliteColor.blueF());
-    m_SoNaviCube->hiliteAlpha = static_cast<float>(m_HiliteColor.alphaF());
-    m_SoNaviCube->axisXColor.setValue(
-        static_cast<float>(m_xColor.r),
-        static_cast<float>(m_xColor.g),
-        static_cast<float>(m_xColor.b)
+    soNaviCube->size = static_cast<float>(cubeWidgetSize);
+    soNaviCube->opacity = opacity;
+    soNaviCube->borderWidth = static_cast<float>(borderWidth);
+    soNaviCube->showCoordinateSystem = showCS;
+    soNaviCube->hiliteId = static_cast<int>(hiliteId);
+    soNaviCube->baseColor.setValue(baseColor.redF(), baseColor.greenF(), baseColor.blueF());
+    soNaviCube->baseAlpha = static_cast<float>(baseColor.alphaF());
+    soNaviCube->emphaseColor.setValue(emphaseColor.redF(), emphaseColor.greenF(), emphaseColor.blueF());
+    soNaviCube->emphaseAlpha = static_cast<float>(emphaseColor.alphaF());
+    soNaviCube->hiliteColor.setValue(hiliteColor.redF(), hiliteColor.greenF(), hiliteColor.blueF());
+    soNaviCube->hiliteAlpha = static_cast<float>(hiliteColor.alphaF());
+    soNaviCube->axisXColor.setValue(
+        static_cast<float>(xColor.r),
+        static_cast<float>(xColor.g),
+        static_cast<float>(xColor.b)
     );
-    m_SoNaviCube->axisYColor.setValue(
-        static_cast<float>(m_yColor.r),
-        static_cast<float>(m_yColor.g),
-        static_cast<float>(m_yColor.b)
+    soNaviCube->axisYColor.setValue(
+        static_cast<float>(yColor.r),
+        static_cast<float>(yColor.g),
+        static_cast<float>(yColor.b)
     );
-    m_SoNaviCube->axisZColor.setValue(
-        static_cast<float>(m_zColor.r),
-        static_cast<float>(m_zColor.g),
-        static_cast<float>(m_zColor.b)
+    soNaviCube->axisZColor.setValue(
+        static_cast<float>(zColor.r),
+        static_cast<float>(zColor.g),
+        static_cast<float>(zColor.b)
     );
 
     SbVec4f rect(
@@ -752,9 +845,9 @@ bool NaviCubeImplementation::populateRenderParams(
         static_cast<float>(viewportWidth),
         static_cast<float>(viewportHeight)
     );
-    m_SoNaviCube->viewportRect = rect;
-    m_SoNaviCube->cameraOrientation = cam->orientation.getValue();
-    m_SoNaviCube->cameraIsOrthographic = cam->getTypeId().isDerivedFrom(
+    soNaviCube->viewportRect = rect;
+    soNaviCube->cameraOrientation = cam->orientation.getValue();
+    soNaviCube->cameraIsOrthographic = cam->getTypeId().isDerivedFrom(
         SoOrthographicCamera::getClassTypeId()
     );
 
@@ -764,70 +857,28 @@ bool NaviCubeImplementation::populateRenderParams(
 void NaviCubeImplementation::createContextMenu(const std::vector<std::string>& cmd)
 {
     CommandManager& rcCmdMgr = Application::Instance->commandManager();
-    m_Menu->clear();
+    menu->clear();
 
     for (const auto& i : cmd) {
         Command* cmd = rcCmdMgr.getCommandByName(i.c_str());
         if (cmd) {
-            cmd->addTo(m_Menu);
+            cmd->addTo(menu);
         }
     }
 }
 
 void NaviCubeImplementation::handleResize(const SbVec2s& viewSize)
 {
-    qreal devicePixelRatio = m_View3DInventorViewer->devicePixelRatio();
-    if (viewSize != m_ViewSize || devicePixelRatio != m_DevicePixelRatio) {
-        m_DevicePixelRatio = devicePixelRatio;
+    qreal currentDevicePixelRatio = viewer->devicePixelRatio();
+    if (viewSize != this->viewSize || currentDevicePixelRatio != devicePixelRatio) {
+        devicePixelRatio = currentDevicePixelRatio;
         qreal physicalCubeWidgetSize = getPhysicalCubeWidgetSize();
-        m_PosAreaBase[0]
-            = std::min((int)(m_PosOffset[0] + physicalCubeWidgetSize * 0.55), viewSize[0] / 2);
-        m_PosAreaBase[1]
-            = std::min((int)(m_PosOffset[1] + physicalCubeWidgetSize * 0.55), viewSize[1] / 2);
-        m_PosAreaSize[0] = viewSize[0] - 2 * m_PosAreaBase[0];
-        m_PosAreaSize[1] = viewSize[1] - 2 * m_PosAreaBase[1];
-        m_ViewSize = viewSize;
+        posAreaBase[0] = std::min((int)(posOffset[0] + physicalCubeWidgetSize * 0.55), viewSize[0] / 2);
+        posAreaBase[1] = std::min((int)(posOffset[1] + physicalCubeWidgetSize * 0.55), viewSize[1] / 2);
+        posAreaSize[0] = viewSize[0] - 2 * posAreaBase[0];
+        posAreaSize[1] = viewSize[1] - 2 * posAreaBase[1];
+        this->viewSize = viewSize;
     }
-}
-
-bool NaviCubeImplementation::isFramebufferValid() const
-{
-    return m_PickingFramebuffer && m_PickingFramebuffer->isValid();
-}
-
-
-void NaviCubeImplementation::ensureFramebufferValid()
-{
-    int framebufferExtent = getPickingFramebufferExtent(getPhysicalCubeWidgetSize());
-    QSize expectedSize(framebufferExtent, framebufferExtent);
-
-    bool needsFramebuffer = !m_PickingFramebuffer;
-    if (!needsFramebuffer) {
-        needsFramebuffer = !m_PickingFramebuffer->isValid()
-            || m_PickingFramebuffer->size() != expectedSize;
-    }
-
-    if (!needsFramebuffer) {
-        return;
-    }
-
-    if (m_PickingFramebuffer) {
-        if (!m_PickingFramebuffer->isValid()) {
-            Base::Console().developerWarning(
-                "NaviCube",
-                "The frame buffer has become invalid, a new frame buffer will be created\n"
-            );
-        }
-
-        delete m_PickingFramebuffer;
-        m_PickingFramebuffer = nullptr;
-    }
-
-    m_PickingFramebuffer = new QOpenGLFramebufferObject(
-        framebufferExtent,
-        framebufferExtent,
-        QOpenGLFramebufferObject::CombinedDepthStencil
-    );
 }
 
 PickId NaviCubeImplementation::pickFace(short x, short y)
@@ -837,33 +888,26 @@ PickId NaviCubeImplementation::pickFace(short x, short y)
     }
 
     qreal physicalCubeWidgetSize = getPhysicalCubeWidgetSize();
-    GLubyte pixels[4] = {0};
-    ensureFramebufferValid();
-    if (m_PickingFramebuffer && std::abs(x) <= physicalCubeWidgetSize / 2
-        && std::abs(y) <= physicalCubeWidgetSize / 2) {
-        auto* viewportWidget = static_cast<QOpenGLWidget*>(m_View3DInventorViewer->viewport());
-        viewportWidget->makeCurrent();
-        m_PickingFramebuffer->bind();
-
-        int viewportSize = getPickingFramebufferExtent(physicalCubeWidgetSize);
-
-        if (populateRenderParams(1.0F, 0, 0, viewportSize, viewportSize)) {
-            m_SoNaviCube->renderGL(true);
-            glFinish();
-            int center = viewportSize / 2;
-            glReadPixels(2 * x + center, 2 * y + center, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, &pixels);
-        }
-
-        m_PickingFramebuffer->release();
-        viewportWidget->doneCurrent();
+    if (std::abs(x) > physicalCubeWidgetSize / 2 || std::abs(y) > physicalCubeWidgetSize / 2) {
+        return PickId::None;
     }
-    return pixels[3] == 255 ? static_cast<PickId>(pixels[0]) : PickId::None;
+
+    const int viewportSize = static_cast<int>(physicalCubeWidgetSize * 2.0);
+    if (!populateRenderParams(1.0F, 0, 0, viewportSize, viewportSize)) {
+        return PickId::None;
+    }
+
+    const int center = viewportSize / 2;
+    const SbVec2s point(static_cast<short>(2 * x + center), static_cast<short>(2 * y + center));
+    const PickId picked = soNaviCube->pickAt(point);
+
+    return picked;
 }
 
 bool NaviCubeImplementation::mousePressed(short x, short y)
 {
-    m_MouseDown = true;
-    m_MightDrag = inDragZone(x, y);
+    mouseDown = true;
+    mightDrag = inDragZone(x, y);
     PickId pick = pickFace(x, y);
     setHilite(pick);
     return pick != PickId::None;
@@ -871,12 +915,18 @@ bool NaviCubeImplementation::mousePressed(short x, short y)
 
 void NaviCubeImplementation::handleMenu()
 {
-    m_Menu->exec(QCursor::pos());
+    menu->exec(QCursor::pos());
+}
+
+void NaviCubeImplementation::resetClickState()
+{
+    lastClickPickId = PickId::None;
+    clickTimer.invalidate();
 }
 
 SbRotation NaviCubeImplementation::getNearestOrientation(PickId pickId)
 {
-    SbRotation cameraOrientation = m_View3DInventorViewer->getCameraOrientation();
+    SbRotation cameraOrientation = viewer->getCameraOrientation();
     SbRotation standardOrientation = getFaceRotation(pickId);
 
     SbVec3f cameraZ;
@@ -975,45 +1025,42 @@ SbRotation NaviCubeImplementation::getNearestOrientation(PickId pickId)
 bool NaviCubeImplementation::mouseReleased(short x, short y)
 {
     static const float pi = boost::math::constants::pi<float>();
-    auto resetClickState = [this]() {
-        m_LastClickPickId = PickId::None;
-        m_ClickTimer.invalidate();
-    };
 
     setHilite(PickId::None);
-    m_MouseDown = false;
+    mouseDown = false;
 
-    if (m_Dragging) {
-        m_Dragging = false;
+    if (dragging) {
+        dragging = false;
         resetClickState();
     }
     else {
         PickId pickId = pickFace(x, y);
-        long step = Base::clamp(long(m_NaviStepByTurn), 4L, 36L);
+        long step = Base::clamp(long(naviStepByTurn), 4L, 36L);
         float rotStepAngle = (2 * std::numbers::pi) / step;
 
         FaceType faceType = getFaceType(pickId);
         if (faceType == FaceType::Main || faceType == FaceType::Edge || faceType == FaceType::Corner) {
-            // Detect double-click: same face clicked twice within the system double-click interval
-            bool isDoubleClick = m_ClickTimer.isValid() && m_LastClickPickId == pickId
-                && m_ClickTimer.elapsed() < QApplication::doubleClickInterval();
+            // FIXME: Quarter currently flattens Qt double-clicks into ordinary Coin button
+            // presses, so NaviCube has to detect the recenter gesture locally.
+            bool moveToCenter = clickTimer.isValid() && lastClickPickId == pickId
+                && clickTimer.elapsed() < QApplication::doubleClickInterval();
 
             // Handle the cube faces
             SbRotation orientation;
-            if (m_RotateToNearest) {
+            if (rotateToNearest) {
                 orientation = getNearestOrientation(pickId);
             }
             else {
                 orientation = getFaceRotation(pickId);
             }
-            m_View3DInventorViewer->setCameraOrientation(orientation, isDoubleClick);
+            viewer->setCameraOrientation(orientation, moveToCenter);
 
-            if (isDoubleClick) {
+            if (moveToCenter) {
                 resetClickState();
             }
             else {
-                m_LastClickPickId = pickId;
-                m_ClickTimer.start();
+                lastClickPickId = pickId;
+                clickTimer.start();
             }
         }
         else if (faceType == FaceType::Button) {
@@ -1043,18 +1090,15 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             // If the previous flat button animation is still active then apply the rotation to the
             // previous target orientation, otherwise apply the rotation to the current camera
             // orientation
-            if (m_flatButtonAnimation
-                && m_flatButtonAnimation->state() == QAbstractAnimation::Running) {
-                m_flatButtonTargetOrientation = rotation * m_flatButtonTargetOrientation;
+            if (flatButtonAnimation != nullptr
+                && flatButtonAnimation->state() == QAbstractAnimation::Running) {
+                flatButtonTargetOrientation = rotation * flatButtonTargetOrientation;
             }
             else {
-                m_flatButtonTargetOrientation = rotation
-                    * m_View3DInventorViewer->getCameraOrientation();
+                flatButtonTargetOrientation = rotation * viewer->getCameraOrientation();
             }
 
-            m_flatButtonAnimation = m_View3DInventorViewer->setCameraOrientation(
-                m_flatButtonTargetOrientation
-            );
+            flatButtonAnimation = viewer->setCameraOrientation(flatButtonTargetOrientation);
         }
         else {
             resetClickState();
@@ -1066,12 +1110,12 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
 
 void NaviCubeImplementation::setHilite(PickId hilite)
 {
-    if (hilite != m_HiliteId) {
-        m_HiliteId = hilite;
-        if (m_SoNaviCube) {
-            m_SoNaviCube->hiliteId = static_cast<int>(m_HiliteId);
+    if (hilite != hiliteId) {
+        hiliteId = hilite;
+        if (soNaviCube) {
+            soNaviCube->hiliteId = static_cast<int>(hiliteId);
         }
-        m_View3DInventorViewer->getSoRenderManager()->scheduleRedraw();
+        viewer->getSoRenderManager()->scheduleRedraw();
     }
 }
 
@@ -1088,31 +1132,90 @@ bool NaviCubeImplementation::mouseMoved(short x, short y)
     bool hovering = std::abs(x) <= physicalCubeWidgetSize / 2
         && std::abs(y) <= physicalCubeWidgetSize / 2;
 
-    if (hovering != m_Hovering) {
-        m_Hovering = hovering;
-        m_View3DInventorViewer->getSoRenderManager()->scheduleRedraw();
+    if (hovering != this->hovering) {
+        this->hovering = hovering;
+        viewer->getSoRenderManager()->scheduleRedraw();
     }
 
-    if (!m_Dragging) {
-        setHilite(pickFace(x, y));
+    if (!dragging) {
+        PickId pick = pickFace(x, y);
+        if (!mouseDown) {
+            setHiliteWithHysteresis(pick);
+        }
+        else {
+            setHilite(pick);
+        }
     }
 
-    if (m_MouseDown && m_Draggable) {
-        if (m_MightDrag && !m_Dragging) {
-            m_Dragging = true;
+    if (mouseDown && draggable) {
+        if (mightDrag && !dragging) {
+            dragging = true;
             setHilite(PickId::None);
         }
-        if (m_Dragging && (std::abs(x) || std::abs(y))) {
-            float newX = m_RelPos[0] + (float)(x) / m_PosAreaSize[0];
-            float newY = m_RelPos[1] + (float)(y) / m_PosAreaSize[1];
-            m_RelPos[0] = std::min(std::max(newX, 0.0f), 1.0f);
-            m_RelPos[1] = std::min(std::max(newY, 0.0f), 1.0f);
+        if (dragging && (std::abs(x) || std::abs(y))) {
+            float newX = relPos[0] + (float)(x) / posAreaSize[0];
+            float newY = relPos[1] + (float)(y) / posAreaSize[1];
+            relPos[0] = std::min(std::max(newX, 0.0f), 1.0f);
+            relPos[1] = std::min(std::max(newY, 0.0f), 1.0f);
 
-            m_View3DInventorViewer->getSoRenderManager()->scheduleRedraw();
+            viewer->getSoRenderManager()->scheduleRedraw();
             return true;
         }
     }
     return false;
+}
+
+void NaviCubeImplementation::setHiliteWithHysteresis(PickId hilite)
+{
+    static const int stableFrames = []() -> int {
+        const char* env = std::getenv("FREECAD_NAVICUBE_PICK_STABLE_FRAMES");
+        if (!env || !*env) {
+            return 0;
+        }
+        char* end = nullptr;
+        long v = std::strtol(env, &end, 10);
+        if (end == env) {
+            return 0;
+        }
+        if (v < 0) {
+            v = 0;
+        }
+        if (v > 16) {
+            v = 16;
+        }
+        return static_cast<int>(v);
+    }();
+
+    if (stableFrames <= 1) {
+        setHilite(hilite);
+        return;
+    }
+
+    if (hilite == PickId::None) {
+        pendingHiliteId = PickId::None;
+        pendingHiliteCount = 0;
+        setHilite(PickId::None);
+        return;
+    }
+
+    if (hilite == hiliteId) {
+        pendingHiliteId = PickId::None;
+        pendingHiliteCount = 0;
+        return;
+    }
+
+    if (hilite != pendingHiliteId) {
+        pendingHiliteId = hilite;
+        pendingHiliteCount = 1;
+        return;
+    }
+
+    ++pendingHiliteCount;
+    if (pendingHiliteCount >= stableFrames) {
+        pendingHiliteId = PickId::None;
+        pendingHiliteCount = 0;
+        setHilite(hilite);
+    }
 }
 
 bool NaviCubeImplementation::processSoEvent(const SoEvent* ev)
@@ -1120,8 +1223,8 @@ bool NaviCubeImplementation::processSoEvent(const SoEvent* ev)
     short x, y;
     ev->getPosition().getValue(x, y);
     // translate to internal cube center based coordinates
-    short rx = x - (short)(m_PosAreaSize[0] * m_RelPos[0]) - m_PosAreaBase[0];
-    short ry = y - (short)(m_PosAreaSize[1] * m_RelPos[1]) - m_PosAreaBase[1];
+    short rx = x - (short)(posAreaSize[0] * relPos[0]) - posAreaBase[0];
+    short ry = y - (short)(posAreaSize[1] * relPos[1]) - posAreaBase[1];
     if (ev->getTypeId().isDerivedFrom(SoMouseButtonEvent::getClassTypeId())) {
         const auto mbev = static_cast<const SoMouseButtonEvent*>(ev);
         if (mbev->isButtonPressEvent(mbev, SoMouseButtonEvent::BUTTON1)) {
@@ -1147,17 +1250,17 @@ void NaviCube::updateColors()
     unsigned long colorLong;
 
     colorLong = Gui::ViewParams::instance()->getAxisXColor();
-    m_NaviCubeImplementation->m_xColor = Base::Color(static_cast<uint32_t>(colorLong));
+    naviCubeImplementation->xColor = Base::Color(static_cast<uint32_t>(colorLong));
     colorLong = Gui::ViewParams::instance()->getAxisYColor();
-    m_NaviCubeImplementation->m_yColor = Base::Color(static_cast<uint32_t>(colorLong));
+    naviCubeImplementation->yColor = Base::Color(static_cast<uint32_t>(colorLong));
     colorLong = Gui::ViewParams::instance()->getAxisZColor();
-    m_NaviCubeImplementation->m_zColor = Base::Color(static_cast<uint32_t>(colorLong));
-    m_NaviCubeImplementation->requestRedraw();
+    naviCubeImplementation->zColor = Base::Color(static_cast<uint32_t>(colorLong));
+    naviCubeImplementation->requestRedraw();
 }
 
 void NaviCube::setNaviCubeCommands(const std::vector<std::string>& cmd)
 {
-    NaviCubeImplementation::m_commands = cmd;
+    NaviCubeImplementation::commands = cmd;
 }
 
 DEF_STD_CMD_AC(NaviCubeDraggableCmd)
@@ -1211,20 +1314,20 @@ QMenu* NaviCubeImplementation::createNaviCubeMenu()
         rcCmdMgr.addCommand(new NaviCubeDraggableCmd);
     }
 
-    vector<string> commands = NaviCubeImplementation::m_commands;
-    if (commands.empty()) {
-        commands.emplace_back("Std_OrthographicCamera");
-        commands.emplace_back("Std_PerspectiveCamera");
-        commands.emplace_back("Std_ViewIsometric");
-        commands.emplace_back("Separator");
-        commands.emplace_back("Std_ViewFitAll");
-        commands.emplace_back("Std_ViewFitSelection");
-        commands.emplace_back("Std_AlignToSelection");
-        commands.emplace_back("Separator");
-        commands.emplace_back("NaviCubeDraggableCmd");
+    vector<string> menuCommands = NaviCubeImplementation::commands;
+    if (menuCommands.empty()) {
+        menuCommands.emplace_back("Std_OrthographicCamera");
+        menuCommands.emplace_back("Std_PerspectiveCamera");
+        menuCommands.emplace_back("Std_ViewIsometric");
+        menuCommands.emplace_back("Separator");
+        menuCommands.emplace_back("Std_ViewFitAll");
+        menuCommands.emplace_back("Std_ViewFitSelection");
+        menuCommands.emplace_back("Std_AlignToSelection");
+        menuCommands.emplace_back("Separator");
+        menuCommands.emplace_back("NaviCubeDraggableCmd");
     }
 
-    for (const auto& command : commands) {
+    for (const auto& command : menuCommands) {
         if (command == "Separator") {
             menu->addSeparator();
         }

--- a/src/Gui/NaviCube.h
+++ b/src/Gui/NaviCube.h
@@ -1,24 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2017 Kustaa Nyholm  <kustaa.nyholm@sparetimelabs.com>   *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2017 Kustaa Nyholm  <kustaa.nyholm@sparetimelabs.com>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -76,5 +77,5 @@ public:
     SoNode* getCoinNode() const;
 
 private:
-    NaviCubeImplementation* m_NaviCubeImplementation;
+    NaviCubeImplementation* naviCubeImplementation;
 };

--- a/src/Gui/Quarter/QuarterWidget.cpp
+++ b/src/Gui/Quarter/QuarterWidget.cpp
@@ -1,34 +1,25 @@
-/**************************************************************************\
- * Copyright (c) Kongsberg Oil & Gas Technologies AS
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
- * 
- * Redistributions of source code must retain the above copyright notice,
- * this list of conditions and the following disclaimer.
- * 
- * Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
- * 
- * Neither the name of the copyright holder nor the names of its
- * contributors may be used to endorse or promote products derived from
- * this software without specific prior written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-\**************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: Kongsberg Oil & Gas Technologies AS
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 /*!
   \class SIM::Coin3D::Quarter::QuarterWidget QuarterWidget.h Quarter/QuarterWidget.h
@@ -70,6 +61,7 @@
 #include <QMetaObject>
 #include <QOpenGLDebugLogger>
 #include <QOpenGLDebugMessage>
+#include <QOpenGLFunctions>
 #include <QOpenGLWidget>
 #include <QPaintEvent>
 #include <QResizeEvent>
@@ -138,10 +130,6 @@ using namespace SIM::Coin3D::Quarter;
   };
 
 #define PRIVATE(obj) obj->pimpl
-
-#ifndef GL_MULTISAMPLE_BIT_EXT
-#define GL_MULTISAMPLE_BIT_EXT 0x20000000
-#endif
 
 //We need to avoid buffer swapping when initializing a QPainter on this widget
 class CustomGLWidget : public QOpenGLWidget {
@@ -866,8 +854,6 @@ void QuarterWidget::paintEvent(QPaintEvent* event)
 
     getSoRenderManager()->activate();
 
-    glMatrixMode(GL_PROJECTION);
-
     QOpenGLWidget* w = static_cast<QOpenGLWidget*>(this->viewport());
     if (!w->isValid()) {
         qWarning() << "No valid GL context found!";
@@ -904,12 +890,23 @@ void QuarterWidget::paintEvent(QPaintEvent* event)
     w->makeCurrent();
     this->actualRedraw();
 
+    QOpenGLFunctions* functions = w->context() ? w->context()->functions() : nullptr;
+    const bool multisampleEnabled = functions && functions->glIsEnabled(GL_MULTISAMPLE) == GL_TRUE;
+
     //start the standard graphics view processing for all widgets and graphic items. As 
     //QGraphicsView initaliizes a QPainter which changes the Opengl context in an unpredictable 
     //manner we need to store the context and recreate it after Qt is done.
-    glPushAttrib(GL_MULTISAMPLE_BIT_EXT);
     inherited::paintEvent(event);
-    glPopAttrib();
+    w->makeCurrent();
+
+    if (functions) {
+        if (multisampleEnabled) {
+            functions->glEnable(GL_MULTISAMPLE);
+        }
+        else {
+            functions->glDisable(GL_MULTISAMPLE);
+        }
+    }
 
     // Causes an OpenGL error on resize
     //if (w->format().swapBehavior() == QSurfaceFormat::DoubleBuffer)

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.cpp
@@ -1,22 +1,25 @@
-/*
- * <one line to give the library's name and an idea of what it does.>
- * Copyright (C) 2014  Stefan Tröger <stefantroeger@gmx.net>
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- *
- */
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2014 Stefan Tröger <stefantroeger@gmx.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
@@ -30,11 +33,18 @@
 #include <Inventor/actions/SoHandleEventAction.h>
 #include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/actions/SoSearchAction.h>
+#include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/events/SoEvents.h>
 #include <Inventor/nodes/SoLocateHighlight.h>
 #include <Inventor/nodes/SoOrthographicCamera.h>
 #include <Inventor/nodes/SoPerspectiveCamera.h>
 #include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoBaseColor.h>
+#include <Inventor/nodes/SoDepthBuffer.h>
+#include <Inventor/nodes/SoFont.h>
+#include <Inventor/nodes/SoLightModel.h>
+#include <Inventor/nodes/SoText2.h>
+#include <Inventor/nodes/SoTranslation.h>
 
 # ifdef FC_OS_WIN32
 #  include <windows.h>
@@ -43,8 +53,6 @@
 # include <OpenGL/gl.h>
 # else
 # include <GL/gl.h>
-# include <GL/glext.h>
-# include <GL/glu.h>
 # endif
 
 #include "SoQTQuarterAdaptor.h"
@@ -53,107 +61,62 @@
 #include <tracy/Tracy.hpp>
 #endif
 
-// NOLINTBEGIN
-// clang-format off
-static unsigned char fps2dfont[][12] = {
-    {  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 }, //
-    {  0,  0, 12, 12,  0,  8, 12, 12, 12, 12, 12,  0 }, // !
-    {  0,  0,  0,  0,  0,  0,  0,  0,  0, 20, 20, 20 }, // \"
-    {  0,  0, 18, 18, 18, 63, 18, 18, 63, 18, 18,  0 }, // #
-    {  0,  8, 28, 42, 10, 10, 12, 24, 40, 42, 28,  8 }, // $
-    {  0,  0,  6, 73, 41, 22,  8, 52, 74, 73, 48,  0 }, // %
-    {  0, 12, 18, 18, 12, 25, 37, 34, 34, 29,  0,  0 }, // &
-    { 12, 12, 24,  0,  0,  0,  0,  0,  0,  0,  0,  0 }, // '
-    {  0,  6,  8,  8, 16, 16, 16, 16, 16,  8,  8,  6 }, // (
-    {  0, 48,  8,  8,  4,  4,  4,  4,  4,  8,  8, 48 }, //)
-    {  0,  0,  0,  0,  0,  0,  8, 42, 20, 42,  8,  0 }, // *
-    {  0,  0,  0,  8,  8,  8,127,  8,  8,  8,  0,  0 }, // +
-    {  0, 24, 12, 12,  0,  0,  0,  0,  0,  0,  0,  0 }, // ,
-    {  0,  0,  0,  0,  0,  0,127,  0,  0,  0,  0,  0 }, // -
-    {  0,  0, 24, 24,  0,  0,  0,  0,  0,  0,  0,  0 }, // .
-    {  0, 32, 32, 16, 16,  8,  8,  8,  4,  4,  2,  2 }, // /
-    {  0,  0, 28, 34, 34, 34, 34, 34, 34, 34, 28,  0 }, // 0
-    {  0,  0,  8,  8,  8,  8,  8,  8, 40, 24,  8,  0 }, // 1
-    {  0,  0, 62, 32, 16,  8,  4,  2,  2, 34, 28,  0 }, // 2
-    {  0,  0, 28, 34,  2,  2, 12,  2,  2, 34, 28,  0 }, // 3
-    {  0,  0,  4,  4,  4,126, 68, 36, 20, 12,  4,  0 }, // 4
-    {  0,  0, 28, 34,  2,  2,  2, 60, 32, 32, 62,  0 }, // 5
-    {  0,  0, 28, 34, 34, 34, 60, 32, 32, 34, 28,  0 }, // 6
-    {  0,  0, 16, 16, 16,  8,  8,  4,  2,  2, 62,  0 }, // 7
-    {  0,  0, 28, 34, 34, 34, 28, 34, 34, 34, 28,  0 }, // 8
-    {  0,  0, 28, 34,  2,  2, 30, 34, 34, 34, 28,  0 }, // 9
-    {  0,  0, 24, 24,  0,  0,  0, 24, 24,  0,  0,  0 }, // :
-    {  0, 48, 24, 24,  0,  0,  0, 24, 24,  0,  0,  0 }, // ;
-    {  0,  0,  0,  2,  4,  8, 16,  8,  4,  2,  0,  0 }, // <
-    {  0,  0,  0,  0,  0,127,  0,127,  0,  0,  0,  0 }, // =
-    {  0,  0,  0, 16,  8,  4,  2,  4,  8, 16,  0,  0 }, // >
-    {  0,  0, 16, 16,  0, 16, 28,  2,  2,  2, 60,  0 }, // ?
-    {  0,  0, 28, 32, 73, 86, 82, 82, 78, 34, 28,  0 }, // @
-    {  0,  0, 33, 33, 33, 63, 18, 18, 18, 12, 12,  0 }, // A
-    {  0,  0, 60, 34, 34, 34, 60, 34, 34, 34, 60,  0 }, // B
-    {  0,  0, 14, 16, 32, 32, 32, 32, 32, 18, 14,  0 }, // C
-    {  0,  0, 56, 36, 34, 34, 34, 34, 34, 36, 56,  0 }, // D
-    {  0,  0, 62, 32, 32, 32, 60, 32, 32, 32, 62,  0 }, // E
-    {  0,  0, 16, 16, 16, 16, 30, 16, 16, 16, 30,  0 }, // F
-    {  0,  0, 14, 18, 34, 34, 32, 32, 32, 18, 14,  0 }, // G
-    {  0,  0, 34, 34, 34, 34, 62, 34, 34, 34, 34,  0 }, // H
-    {  0,  0, 62,  8,  8,  8,  8,  8,  8,  8, 62,  0 }, // I
-    {  0,  0,112,  8,  8,  8,  8,  8,  8,  8, 62,  0 }, // J
-    {  0,  0, 33, 33, 34, 36, 56, 40, 36, 34, 33,  0 }, // K
-    {  0,  0, 30, 16, 16, 16, 16, 16, 16, 16, 16,  0 }, // L
-    {  0,  0, 33, 33, 33, 45, 45, 45, 51, 51, 33,  0 }, // M
-    {  0,  0, 34, 34, 38, 38, 42, 42, 50, 50, 34,  0 }, // N
-    {  0,  0, 12, 18, 33, 33, 33, 33, 33, 18, 12,  0 }, // O
-    {  0,  0, 32, 32, 32, 60, 34, 34, 34, 34, 60,  0 }, // P
-    {  3,  6, 12, 18, 33, 33, 33, 33, 33, 18, 12,  0 }, // Q
-    {  0,  0, 34, 34, 34, 36, 60, 34, 34, 34, 60,  0 }, // R
-    {  0,  0, 60,  2,  2,  6, 28, 48, 32, 32, 30,  0 }, // S
-    {  0,  0,  8,  8,  8,  8,  8,  8,  8,  8,127,  0 }, // T
-    {  0,  0, 28, 34, 34, 34, 34, 34, 34, 34, 34,  0 }, // U
-    {  0,  0, 12, 12, 18, 18, 18, 33, 33, 33, 33,  0 }, // V
-    {  0,  0, 34, 34, 34, 54, 85, 73, 73, 73, 65,  0 }, // W
-    {  0,  0, 34, 34, 20, 20,  8, 20, 20, 34, 34,  0 }, // X
-    {  0,  0,  8,  8,  8,  8, 20, 20, 34, 34, 34,  0 }, // Y
-    {  0,  0, 62, 32, 16, 16,  8,  4,  4,  2, 62,  0 }, // Z
-    {  0, 14,  8,  8,  8,  8,  8,  8,  8,  8,  8, 14 }, // [
-    {  0,  2,  2,  4,  4,  8,  8,  8, 16, 16, 32, 32 }, // [backslash]
-    {  0, 56,  8,  8,  8,  8,  8,  8,  8,  8,  8, 56 }, // ]
-    {  0,  0,  0,  0,  0, 34, 34, 20, 20,  8,  8,  0 }, // ^
-    {  0,127,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0 }, // _
-    {  0,  0,  0,  0,  0,  0,  0,  0,  0, 24, 24, 12 }, // `
-    {  0,  0, 29, 34, 34, 30,  2, 34, 28,  0,  0,  0 }, // a
-    {  0,  0, 60, 34, 34, 34, 34, 50, 44, 32, 32, 32 }, // b
-    {  0,  0, 14, 16, 32, 32, 32, 16, 14,  0,  0,  0 }, // c
-    {  0,  0, 26, 38, 34, 34, 34, 34, 30,  2,  2,  2 }, // d
-    {  0,  0, 28, 34, 32, 62, 34, 34, 28,  0,  0,  0 }, // e
-    {  0,  0, 16, 16, 16, 16, 16, 16, 62, 16, 16, 14 }, // f
-    { 28,  2,  2, 26, 38, 34, 34, 34, 30,  0,  0,  0 }, // g
-    {  0,  0, 34, 34, 34, 34, 34, 50, 44, 32, 32, 32 }, // h
-    {  0,  0,  8,  8,  8,  8,  8,  8, 56,  0,  8,  8 }, // i
-    { 56,  4,  4,  4,  4,  4,  4,  4, 60,  0,  4,  4 }, // j
-    {  0,  0, 33, 34, 36, 56, 40, 36, 34, 32, 32, 32 }, // k
-    {  0,  0,  8,  8,  8,  8,  8,  8,  8,  8,  8, 56 }, // l
-    {  0,  0, 73, 73, 73, 73, 73,109, 82,  0,  0,  0 }, // m
-    {  0,  0, 34, 34, 34, 34, 34, 50, 44,  0,  0,  0 }, // n
-    {  0,  0, 28, 34, 34, 34, 34, 34, 28,  0,  0,  0 }, // o
-    { 32, 32, 60, 34, 34, 34, 34, 50, 44,  0,  0,  0 }, // p
-    {  2,  2, 26, 38, 34, 34, 34, 34, 30,  0,  0,  0 }, // q
-    {  0,  0, 16, 16, 16, 16, 16, 24, 22,  0,  0,  0 }, // r
-    {  0,  0, 60,  2,  2, 28, 32, 32, 30,  0,  0,  0 }, // s
-    {  0,  0, 14, 16, 16, 16, 16, 16, 62, 16, 16,  0 }, // t
-    {  0,  0, 26, 38, 34, 34, 34, 34, 34,  0,  0,  0 }, // u
-    {  0,  0,  8,  8, 20, 20, 34, 34, 34,  0,  0,  0 }, // v
-    {  0,  0, 34, 34, 34, 85, 73, 73, 65,  0,  0,  0 }, // w
-    {  0,  0, 34, 34, 20,  8, 20, 34, 34,  0,  0,  0 }, // x
-    { 48, 16,  8,  8, 20, 20, 34, 34, 34,  0,  0,  0 }, // y
-    {  0,  0, 62, 32, 16,  8,  4,  2, 62,  0,  0,  0 }, // z
-    {  0,  6,  8,  8,  8,  4, 24,  4,  8,  8,  8,  6 }, // {
-    {  0,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8,  8 }, // |
-    {  0, 48,  8,  8,  8, 16, 12, 16,  8,  8,  8, 48 }, // }
-    {  0,  0,  0,  0,  0,  0, 78, 57,  0,  0,  0,  0 }  // ~
+namespace
+{
+struct OverlayTextState {
+    SoSeparator* root {nullptr};
+    SoOrthographicCamera* camera {nullptr};
+    SoDepthBuffer* depth {nullptr};
+    SoLightModel* lightModel {nullptr};
+    SoBaseColor* baseColor {nullptr};
+    SoFont* font {nullptr};
+    SoTranslation* translation {nullptr};
+    SoText2* text {nullptr};
+
+    void ensureCreated()
+    {
+        if (root) {
+            return;
+        }
+
+        root = new SoSeparator;
+        root->ref();
+
+        camera = new SoOrthographicCamera;
+        root->addChild(camera);
+
+        depth = new SoDepthBuffer;
+        depth->test.setValue(false);
+        depth->write.setValue(false);
+        depth->function.setValue(SoDepthBuffer::ALWAYS);
+        root->addChild(depth);
+
+        lightModel = new SoLightModel;
+        lightModel->model.setValue(SoLightModel::BASE_COLOR);
+        root->addChild(lightModel);
+
+        baseColor = new SoBaseColor;
+        root->addChild(baseColor);
+
+        font = new SoFont;
+        font->size.setValue(12.0f);
+        root->addChild(font);
+
+        translation = new SoTranslation;
+        root->addChild(translation);
+
+        text = new SoText2;
+        root->addChild(text);
+    }
 };
-// clang-format on
-// NOLINTEND
+
+OverlayTextState& overlayTextState()
+{
+    static OverlayTextState state;
+    return state;
+}
+
+}  // namespace
 
 constexpr const int defaultSize = 100;
 
@@ -651,58 +614,42 @@ void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::draw2DString(
     SbVec2f position,
     Base::Color color = Base::Color(1.0F, 1.0F, 0.0F))  // retains yellow as default color
 {
-    // Store GL state.
-    glPushAttrib(GL_ENABLE_BIT|GL_CURRENT_BIT);
-
-    glDisable(GL_LIGHTING);
-    glDisable(GL_DEPTH_TEST);
-    glDisable(GL_TEXTURE_2D);
-    glDisable(GL_BLEND);
-
-    glMatrixMode(GL_MODELVIEW);
-    glPushMatrix();
-    glLoadIdentity();
-
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
-    glLoadIdentity();
-    glOrtho(0.0, glsize[0], 0.0, glsize[1], -1, 1);
-
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-//   glColor3f(0.0, 0.0, 0.0);
-//   glRasterPos2f(position[0] + 1, position[1]);
-//   printString(str);
-//   glRasterPos2f(position[0] - 1, position[1]);
-//   printString(str);
-//   glRasterPos2f(position[0], position[1] + 1);
-//   printString(str);
-//   glRasterPos2f(position[0], position[1] - 1);
-//   printString(str);
-
-    glColor3f(color.r, color.g, color.b);
-    glRasterPos2f(position[0], position[1]);
-    printString(str);
-
-    glMatrixMode(GL_PROJECTION);
-    glPopMatrix();
-    glMatrixMode(GL_MODELVIEW);
-    glPopMatrix();
-
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 4); // restore default value
-
-    glPopAttrib();
-}
-
-void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::printString(const char* str)
-{
-    // NOLINTBEGIN
-    std::size_t len = strlen(str);
-
-    for(std::size_t i = 0; i < len; i++) {
-        glBitmap(8, 12, 0.0, 2.0, 10.0, 0.0, fps2dfont[str[i] - 32]);
+    if (!str || !str[0] || glsize[0] <= 0 || glsize[1] <= 0) {
+        return;
     }
-    // NOLINTEND
+
+    GLint viewport[4] = {0, 0, 0, 0};
+    glGetIntegerv(GL_VIEWPORT, viewport);
+    const int viewportWidth = viewport[2];
+    const int viewportHeight = viewport[3];
+    if (viewportWidth <= 0 || viewportHeight <= 0) {
+        return;
+    }
+
+    auto& overlay = overlayTextState();
+    overlay.ensureCreated();
+    if (!overlay.root || !overlay.camera || !overlay.translation || !overlay.text || !overlay.baseColor) {
+        return;
+    }
+
+    overlay.camera->aspectRatio.setValue(static_cast<float>(viewportWidth) / static_cast<float>(viewportHeight));
+    overlay.camera->height.setValue(static_cast<float>(viewportHeight));
+
+    const float x = (position[0] / static_cast<float>(glsize[0])) * static_cast<float>(viewportWidth);
+    const float y = (position[1] / static_cast<float>(glsize[1])) * static_cast<float>(viewportHeight);
+    overlay.translation->translation.setValue(
+        x - 0.5f * static_cast<float>(viewportWidth),
+        y - 0.5f * static_cast<float>(viewportHeight),
+        0.0f
+    );
+
+    overlay.baseColor->rgb.setValue(color.r, color.g, color.b);
+    overlay.text->string.setValue(str);
+
+    SoGLRenderAction action(SbViewportRegion(viewportWidth, viewportHeight));
+    action.setCacheContext(this->getCacheContextId());
+    action.setTransparencyType(SoGLRenderAction::BLEND);
+    action.apply(overlay.root);
 }
 
 void SIM::Coin3D::Quarter::SoQTQuarterAdaptor::moveCameraScreen(const SbVec2f& screenpos)

--- a/src/Gui/Quarter/SoQTQuarterAdaptor.h
+++ b/src/Gui/Quarter/SoQTQuarterAdaptor.h
@@ -1,3 +1,26 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2014 Stefan Tröger <stefantroeger@gmx.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
+
 /*
  * Extends the QuarterWidget with all functions the SoQtViewer has
  * Copyright (c) 2014 Stefan Tröger <stefantroeger@gmx.net>
@@ -154,8 +177,7 @@ private:
     SoNode * m_storedcamera = nullptr;
 
 protected:
-    static void draw2DString(const char * str, SbVec2s glsize, SbVec2f position, Base::Color color);
-    static void printString(const char * str);
+    void draw2DString(const char * str, SbVec2s glsize, SbVec2f position, Base::Color color);
     SbVec2f framesPerSecond;  // NOLINT
 };
 

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1,25 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2011-2012 Luke Parry <l.parry@warwick.ac.uk>            *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2011-2012 Luke Parry <l.parry@warwick.ac.uk>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
@@ -35,6 +35,7 @@
 #endif
 
 #include <algorithm>
+#include <cstdint>
 #include <cmath>
 #include <limits>
 #include <numbers>
@@ -48,6 +49,15 @@
 #include <Inventor/elements/SoViewportRegionElement.h>
 #include <Inventor/elements/SoViewVolumeElement.h>
 #include <Inventor/misc/SoState.h>
+#include <Inventor/nodes/SoBaseColor.h>
+#include <Inventor/nodes/SoCallback.h>
+#include <Inventor/nodes/SoDepthBuffer.h>
+#include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoLightModel.h>
+#include <Inventor/nodes/SoLineSet.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoVertexProperty.h>
 
 #include <Base/Tools.h>
 
@@ -71,63 +81,71 @@ using namespace Gui;
 namespace
 {
 
-void glVertex(const SbVec3f& pt)
+SbVec3f withZ(const SbVec3f& point, float z)
 {
-    glVertex3f(pt[0], pt[1], pt[2]);
+    SbVec3f out = point;
+    out[2] = z;
+    return out;
 }
 
-void glVertexes(const std::vector<SbVec3f>& pts)
+void appendLine(
+    std::vector<SbVec3f>& vertices,
+    std::vector<int32_t>& counts,
+    const SbVec3f& a,
+    const SbVec3f& b
+)
 {
-    for (auto pt : pts) {
-        glVertex3f(pt[0], pt[1], pt[2]);
-    }
+    vertices.push_back(a);
+    vertices.push_back(b);
+    counts.push_back(2);
 }
 
-void glDrawLine(const SbVec3f& p1, const SbVec3f& p2)
-{
-    glBegin(GL_LINES);
-    glVertexes({p1, p2});
-    glEnd();
-}
-
-void glDrawArc(
+void appendArc(
+    std::vector<SbVec3f>& vertices,
+    std::vector<int32_t>& counts,
     const SbVec3f& center,
     float radius,
-    float startAngle = 0.,
-    float endAngle = 2.0 * std::numbers::pi,
+    float startAngle,
+    float endAngle,
     int countSegments = 0
 )
 {
-    float range = endAngle - startAngle;
+    const float range = endAngle - startAngle;
 
     if (countSegments == 0) {
         countSegments = std::max(6, abs(int(25.0 * range / std::numbers::pi)));
     }
 
-    float segment = range / (countSegments - 1);
+    const float segment = range / (countSegments - 1);
 
-    glBegin(GL_LINE_STRIP);
     for (int i = 0; i < countSegments; i++) {
-        float theta = startAngle + segment * i;
-        SbVec3f v1 = center + radius * SbVec3f(cos(theta), sin(theta), 0);
-        glVertex(v1);
+        const float theta = startAngle + segment * i;
+        const SbVec3f v = center + radius * SbVec3f(cos(theta), sin(theta), 0);
+        vertices.push_back(v);
     }
-    glEnd();
+    counts.push_back(countSegments);
 }
 
-void glDrawArrow(const SbVec3f& base, const SbVec3f& dir, float width, float length)
+void appendArrowTriangle(
+    std::vector<SbVec3f>& vertices,
+    std::vector<int32_t>& counts,
+    const SbVec3f& base,
+    const SbVec3f& dir,
+    float width,
+    float length
+)
 {
-    // Calculate arrowhead points
-    SbVec3f normal(dir[1], -dir[0], 0);
-    SbVec3f arrowLeft = base - length * dir + width * normal;
-    SbVec3f arrowRight = base - length * dir - width * normal;
+    SbVec3f unitDir = dir;
+    unitDir.normalize();
 
-    // Draw arrowheads at elevated Z to render ON TOP of geometry lines
-    glBegin(GL_TRIANGLES);
-    glVertex3f(base[0], base[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(arrowLeft[0], arrowLeft[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(arrowRight[0], arrowRight[1], ZARROW_TEXT_OFFSET);
-    glEnd();
+    const SbVec3f normal(unitDir[1], -unitDir[0], 0);
+    const SbVec3f arrowLeft = base - length * unitDir + width * normal;
+    const SbVec3f arrowRight = base - length * unitDir - width * normal;
+
+    vertices.push_back(withZ(base, ZARROW_TEXT_OFFSET));
+    vertices.push_back(withZ(arrowLeft, ZARROW_TEXT_OFFSET));
+    vertices.push_back(withZ(arrowRight, ZARROW_TEXT_OFFSET));
+    counts.push_back(3);
 }
 
 
@@ -153,6 +171,11 @@ SbVec3f getArcMidDirection(float startAngle, float endAngle)
 SbVec3f getArcTextCenter(const SbVec3f& center, float startAngle, float endAngle, float distanceFromCenter)
 {
     return center + getArcMidDirection(startAngle, endAngle) * distanceFromCenter;
+}
+
+bool isGLRenderAction(SoAction* action)
+{
+    return action && action->getTypeId().isDerivedFrom(SoGLRenderAction::getClassTypeId());
 }
 }  // namespace
 
@@ -203,6 +226,60 @@ SoDatumLabel::SoDatumLabel()
     this->imgWidth = 0;
     this->imgHeight = 0;
     this->glimagevalid = false;
+
+    m_Root = new SoSeparator;
+    m_Root->ref();
+
+    m_GeometryDepth = new SoDepthBuffer;
+    m_GeometryDepth->test.setValue(true);
+    m_GeometryDepth->write.setValue(false);
+    m_Root->addChild(m_GeometryDepth);
+
+    m_LightModel = new SoLightModel;
+    m_LightModel->model.setValue(SoLightModel::BASE_COLOR);
+    m_Root->addChild(m_LightModel);
+
+    m_GeometryColor = new SoBaseColor;
+    m_GeometryColor->rgb.connectFrom(&this->textColor);
+    m_Root->addChild(m_GeometryColor);
+
+    m_DrawStyle = new SoDrawStyle;
+    m_DrawStyle->lineWidth.connectFrom(&this->lineWidth);
+    m_Root->addChild(m_DrawStyle);
+
+    m_LineVertexProperty = new SoVertexProperty;
+    m_LineSet = new SoLineSet;
+    m_LineSet->vertexProperty.setValue(m_LineVertexProperty);
+    m_Root->addChild(m_LineSet);
+
+    auto* triangleCullDisable = new SoCallback;
+    triangleCullDisable->setCallback(SoDatumLabel::disableCullFaceCallback, this);
+    m_Root->addChild(triangleCullDisable);
+
+    m_TriangleVertexProperty = new SoVertexProperty;
+    m_TriangleFaceSet = new SoFaceSet;
+    m_TriangleFaceSet->vertexProperty.setValue(m_TriangleVertexProperty);
+    m_Root->addChild(m_TriangleFaceSet);
+
+    auto* triangleCullRestore = new SoCallback;
+    triangleCullRestore->setCallback(SoDatumLabel::restoreCullFaceCallback, this);
+    m_Root->addChild(triangleCullRestore);
+}
+
+SoDatumLabel::~SoDatumLabel()
+{
+    if (m_Root) {
+        m_Root->unref();
+        m_Root = nullptr;
+    }
+    m_GeometryDepth = nullptr;
+    m_LightModel = nullptr;
+    m_GeometryColor = nullptr;
+    m_DrawStyle = nullptr;
+    m_LineVertexProperty = nullptr;
+    m_LineSet = nullptr;
+    m_TriangleVertexProperty = nullptr;
+    m_TriangleFaceSet = nullptr;
 }
 
 void SoDatumLabel::drawImage()
@@ -1152,6 +1229,288 @@ float SoDatumLabel::getScaleFactor(SoState* state) const
     return scale;
 }
 
+void SoDatumLabel::disableCullFaceCallback(void* userdata, SoAction* action)
+{
+    if (!userdata) {
+        return;
+    }
+
+    static_cast<SoDatumLabel*>(userdata)->disableCullFaceIfNeeded(action);
+}
+
+void SoDatumLabel::restoreCullFaceCallback(void* userdata, SoAction* action)
+{
+    if (!userdata) {
+        return;
+    }
+
+    static_cast<SoDatumLabel*>(userdata)->restoreCullFaceIfNeeded(action);
+}
+
+void SoDatumLabel::disableCullFaceIfNeeded(SoAction* action)
+{
+    if (!isGLRenderAction(action)) {
+        return;
+    }
+
+    m_CullFaceWasEnabled = (glIsEnabled(GL_CULL_FACE) == GL_TRUE);
+    if (m_CullFaceWasEnabled) {
+        GLint mode = GL_BACK;
+        glGetIntegerv(GL_CULL_FACE_MODE, &mode);
+        m_CullFaceMode = mode;
+        glDisable(GL_CULL_FACE);
+    }
+}
+
+void SoDatumLabel::restoreCullFaceIfNeeded(SoAction* action)
+{
+    if (!isGLRenderAction(action)) {
+        return;
+    }
+
+    if (m_CullFaceWasEnabled) {
+        glEnable(GL_CULL_FACE);
+        glCullFace(static_cast<GLenum>(m_CullFaceMode));
+    }
+}
+
+void SoDatumLabel::setVertexZ(SbVec3f& point, float z) const
+{
+    point[2] = z;
+}
+
+void SoDatumLabel::ensureCoinGeometry(const SbVec3f* points, int numPoints)
+{
+    if (!points || numPoints <= 0 || !m_LineVertexProperty || !m_LineSet
+        || !m_TriangleVertexProperty || !m_TriangleFaceSet) {
+        return;
+    }
+
+    std::vector<SbVec3f> lineVertices;
+    std::vector<int32_t> lineCounts;
+    std::vector<SbVec3f> triangleVertices;
+    std::vector<int32_t> triangleCounts;
+
+    const auto addTriangle = [&](SbVec3f a, SbVec3f b, SbVec3f c) {
+        setVertexZ(a, ZARROW_TEXT_OFFSET);
+        setVertexZ(b, ZARROW_TEXT_OFFSET);
+        setVertexZ(c, ZARROW_TEXT_OFFSET);
+        triangleVertices.push_back(a);
+        triangleVertices.push_back(b);
+        triangleVertices.push_back(c);
+        triangleCounts.push_back(3);
+    };
+
+    const auto type = static_cast<Type>(datumtype.getValue());
+
+    if (type == DISTANCE || type == DISTANCEX || type == DISTANCEY) {
+        if (numPoints >= 2) {
+            const DistanceGeometry geom = calculateDistanceGeometry(points);
+
+            if (param1.getValue() != 0.0F) {
+                appendLine(lineVertices, lineCounts, geom.p1, geom.perp1);
+                appendLine(lineVertices, lineCounts, geom.p2, geom.perp2);
+            }
+            appendLine(lineVertices, lineCounts, geom.par1, geom.par2);
+            appendLine(lineVertices, lineCounts, geom.par3, geom.par4);
+
+            addTriangle(geom.par1, geom.ar1, geom.ar2);
+            addTriangle(geom.par4, geom.ar3, geom.ar4);
+
+            if (type == DISTANCE && numPoints >= 4) {
+                const float range1 = param4.getValue();
+                if (range1 != 0.0F) {
+                    const float startAngle1 = param3.getValue();
+                    const float radius1 = param5.getValue();
+                    const SbVec3f center1 = points[2];
+                    appendArc(lineVertices, lineCounts, center1, radius1, startAngle1, startAngle1 + range1);
+                }
+
+                const float range2 = param7.getValue();
+                if (range2 != 0.0F) {
+                    const float startAngle2 = param6.getValue();
+                    const float radius2 = param8.getValue();
+                    const SbVec3f center2 = points[3];
+                    appendArc(lineVertices, lineCounts, center2, radius2, startAngle2, startAngle2 + range2);
+                }
+            }
+        }
+    }
+    else if (type == RADIUS || type == DIAMETER) {
+        if (numPoints >= 2) {
+            const DiameterGeometry geom = calculateDiameterGeometry(points);
+
+            appendLine(lineVertices, lineCounts, geom.p1, geom.pnt1);
+            appendLine(lineVertices, lineCounts, geom.pnt2, geom.p2);
+
+            addTriangle(geom.ar0, geom.ar1, geom.ar2);
+            if (geom.isDiameter) {
+                addTriangle(geom.ar0_1, geom.ar1_1, geom.ar2_1);
+            }
+
+            if (geom.startRange != 0.0F) {
+                appendArc(
+                    lineVertices,
+                    lineCounts,
+                    geom.center,
+                    geom.radius,
+                    geom.startAngle,
+                    geom.startAngle + geom.startRange
+                );
+            }
+            if (geom.endRange != 0.0F) {
+                appendArc(
+                    lineVertices,
+                    lineCounts,
+                    geom.center,
+                    geom.radius,
+                    geom.endAngle,
+                    geom.endAngle + geom.endRange
+                );
+            }
+        }
+    }
+    else if (type == ANGLE) {
+        if (numPoints >= 1) {
+            const AngleGeometry geom = calculateAngleGeometry(points);
+
+            appendArc(
+                lineVertices,
+                lineCounts,
+                geom.p0,
+                geom.r,
+                geom.startangle,
+                geom.startangle + geom.range / 2.0F - static_cast<float>(geom.textMargin)
+            );
+            appendArc(
+                lineVertices,
+                lineCounts,
+                geom.p0,
+                geom.r,
+                geom.startangle + geom.range / 2.0F + static_cast<float>(geom.textMargin),
+                geom.endangle
+            );
+
+            appendLine(lineVertices, lineCounts, geom.pnt1, geom.pnt2);
+            appendLine(lineVertices, lineCounts, geom.pnt3, geom.pnt4);
+
+            appendArrowTriangle(
+                triangleVertices,
+                triangleCounts,
+                geom.startArrowBase,
+                geom.dirStart,
+                geom.arrowWidth,
+                geom.arrowLength
+            );
+            appendArrowTriangle(
+                triangleVertices,
+                triangleCounts,
+                geom.endArrowBase,
+                geom.dirEnd,
+                geom.arrowWidth,
+                geom.arrowLength
+            );
+        }
+    }
+    else if (type == SYMMETRIC) {
+        if (numPoints >= 2) {
+            const SymmetricGeometry geom = calculateSymmetricGeometry(points);
+
+            SbVec3f p1 = geom.p1;
+            SbVec3f ar0 = geom.ar0;
+            SbVec3f p2 = geom.p2;
+            SbVec3f ar3 = geom.ar3;
+            setVertexZ(p1, ZCONSTR);
+            setVertexZ(ar0, ZCONSTR);
+            setVertexZ(p2, ZCONSTR);
+            setVertexZ(ar3, ZCONSTR);
+            appendLine(lineVertices, lineCounts, p1, ar0);
+            appendLine(lineVertices, lineCounts, p2, ar3);
+
+            appendLine(
+                lineVertices,
+                lineCounts,
+                withZ(geom.ar0, ZARROW_TEXT_OFFSET),
+                withZ(geom.ar1, ZARROW_TEXT_OFFSET)
+            );
+            appendLine(
+                lineVertices,
+                lineCounts,
+                withZ(geom.ar0, ZARROW_TEXT_OFFSET),
+                withZ(geom.ar2, ZARROW_TEXT_OFFSET)
+            );
+            appendLine(
+                lineVertices,
+                lineCounts,
+                withZ(geom.ar3, ZARROW_TEXT_OFFSET),
+                withZ(geom.ar4, ZARROW_TEXT_OFFSET)
+            );
+            appendLine(
+                lineVertices,
+                lineCounts,
+                withZ(geom.ar3, ZARROW_TEXT_OFFSET),
+                withZ(geom.ar5, ZARROW_TEXT_OFFSET)
+            );
+        }
+    }
+    else if (type == ARCLENGTH) {
+        if (numPoints >= 3) {
+            const ArcLengthGeometry geom = calculateArcLengthGeometry(points);
+
+            appendArc(
+                lineVertices,
+                lineCounts,
+                geom.arcCenter,
+                geom.arcRadius,
+                geom.startangle,
+                geom.endangle
+            );
+            appendLine(lineVertices, lineCounts, geom.pnt1, geom.pnt2);
+            appendLine(lineVertices, lineCounts, geom.pnt3, geom.pnt4);
+
+            const float arrowLength = geom.margin * 2.0F;
+            const float arrowWidth = geom.margin * 0.5F;
+            appendArrowTriangle(
+                triangleVertices,
+                triangleCounts,
+                geom.pnt2,
+                geom.dirStart,
+                arrowWidth,
+                arrowLength
+            );
+            appendArrowTriangle(
+                triangleVertices,
+                triangleCounts,
+                geom.pnt4,
+                geom.dirEnd,
+                arrowWidth,
+                arrowLength
+            );
+        }
+    }
+
+    if (!lineVertices.empty()) {
+        m_LineVertexProperty->vertex
+            .setValues(0, static_cast<int>(lineVertices.size()), lineVertices.data());
+        m_LineSet->numVertices.setValues(0, static_cast<int>(lineCounts.size()), lineCounts.data());
+    }
+    else {
+        m_LineVertexProperty->vertex.setNum(0);
+        m_LineSet->numVertices.setNum(0);
+    }
+
+    if (!triangleVertices.empty()) {
+        m_TriangleVertexProperty->vertex
+            .setValues(0, static_cast<int>(triangleVertices.size()), triangleVertices.data());
+        m_TriangleFaceSet->numVertices
+            .setValues(0, static_cast<int>(triangleCounts.size()), triangleCounts.data());
+    }
+    else {
+        m_TriangleVertexProperty->vertex.setNum(0);
+        m_TriangleFaceSet->numVertices.setNum(0);
+    }
+}
+
 void SoDatumLabel::GLRender(SoGLRenderAction* action)
 {
     SoState* state = action->getState();
@@ -1183,58 +1542,41 @@ void SoDatumLabel::GLRender(SoGLRenderAction* action)
 
     state->push();
 
-    // Set General OpenGL Properties
-    glPushAttrib(GL_ENABLE_BIT | GL_PIXEL_MODE_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    glDisable(GL_LIGHTING);
-    glDisable(GL_CULL_FACE);
-
-    // Enable depth testing so constraint lines use the sketch-local Z carried by their
-    // input points. That keeps them above coplanar model geometry while still rendering
-    // below sketch elements in the normal scene.
-    glEnable(GL_DEPTH_TEST);
-
-    // Enable Anti-alias
-    if (action->isSmoothing()) {
-        glEnable(GL_LINE_SMOOTH);
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        glHint(GL_LINE_SMOOTH_HINT, GL_NICEST);
-    }
-
-    // Position for Datum Text Label
-    float angle = 0;
-
-    // Get the colour
-    const SbColor& t = textColor.getValue();
-
-    // Set GL Properties
-    glLineWidth(this->lineWidth.getValue());
-    glColor3f(t[0], t[1], t[2]);
-
-    SbVec3f textOffset;
-
-    if (this->datumtype.getValue() == DISTANCE || this->datumtype.getValue() == DISTANCEX
-        || this->datumtype.getValue() == DISTANCEY) {
-        drawDistance(points, angle, textOffset);
-    }
-    else if (this->datumtype.getValue() == RADIUS || this->datumtype.getValue() == DIAMETER) {
-        drawRadiusOrDiameter(points, angle, textOffset);
-    }
-    else if (this->datumtype.getValue() == ANGLE) {
-        drawAngle(points, angle, textOffset);
-    }
-    else if (this->datumtype.getValue() == SYMMETRIC) {
-        drawSymmetric(points);
-    }
-    else if (this->datumtype.getValue() == ARCLENGTH) {
-        drawArcLength(points, angle, textOffset);
+    ensureCoinGeometry(points, this->pnts.getNum());
+    if (m_Root) {
+        m_Root->GLRender(action);
     }
 
     if (hasText) {
+        float angle = 0.0F;
+        SbVec3f textOffset;
+        const auto type = static_cast<Type>(datumtype.getValue());
+        if (type == DISTANCE || type == DISTANCEX || type == DISTANCEY) {
+            const DistanceGeometry geom = calculateDistanceGeometry(points);
+            angle = geom.angle;
+            textOffset = geom.textOffset;
+        }
+        else if (type == RADIUS || type == DIAMETER) {
+            const DiameterGeometry geom = calculateDiameterGeometry(points);
+            angle = geom.angle;
+            textOffset = geom.textOffset;
+        }
+        else if (type == ANGLE) {
+            const AngleGeometry geom = calculateAngleGeometry(points);
+            angle = geom.angle;
+            textOffset = geom.textOffset;
+        }
+        else if (type == ARCLENGTH && this->pnts.getNum() >= 3) {
+            const ArcLengthGeometry geom = calculateArcLengthGeometry(points);
+            angle = geom.angle;
+            textOffset = geom.textOffset;
+        }
+
+        glPushAttrib(GL_ENABLE_BIT | GL_PIXEL_MODE_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
         drawText(state, srcw, srch, angle, textOffset);
+        glPopAttrib();
     }
 
-    glPopAttrib();
     state->pop();
 }
 
@@ -1269,191 +1611,40 @@ void SoDatumLabel::getDimension(float scale, int& srcw, int& srch)
 
 void SoDatumLabel::drawDistance(const SbVec3f* points, float& angle, SbVec3f& textOffset)
 {
-    SoDatumLabel::DistanceGeometry geom = this->calculateDistanceGeometry(points);
-
-    angle = geom.angle;
-    textOffset = geom.textOffset;
-
-    // Get the colour
-    const SbColor& t = textColor.getValue();
-
-    // Set GL Properties
-    glLineWidth(this->lineWidth.getValue());
-    glColor3f(t[0], t[1], t[2]);
-
-    // Perp Lines
-    glBegin(GL_LINES);
-    if (this->param1.getValue() != 0.) {
-        glVertex(geom.p1);
-        glVertex(geom.perp1);
-
-        glVertex(geom.p2);
-        glVertex(geom.perp2);
-    }
-
-    glVertex(geom.par1);
-    glVertex(geom.par2);
-
-    glVertex(geom.par3);
-    glVertex(geom.par4);
-    glEnd();
-
-    // Draw the arrowheads at elevated Z to render ON TOP of geometry lines
-    glBegin(GL_TRIANGLES);
-    glVertex3f(geom.par1[0], geom.par1[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar1[0], geom.ar1[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar2[0], geom.ar2[1], ZARROW_TEXT_OFFSET);
-
-    glVertex3f(geom.par4[0], geom.par4[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar3[0], geom.ar3[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar4[0], geom.ar4[1], ZARROW_TEXT_OFFSET);
-    glEnd();
-
-    if (this->datumtype.getValue() == DISTANCE) {
-        drawDistance(points);
-    }
+    (void)points;
+    angle = 0.0F;
+    textOffset = {};
 }
 
 void SoDatumLabel::drawDistance(const SbVec3f* points)
 {
-    // Draw arc helpers if needed
-    float range1 = this->param4.getValue();
-    if (range1 != 0.0) {
-        float startAngle1 = this->param3.getValue();
-        float radius1 = this->param5.getValue();
-        SbVec3f center1 = points[2];
-        glDrawArc(center1, radius1, startAngle1, startAngle1 + range1);
-    }
-
-    float range2 = this->param7.getValue();
-    if (range2 != 0.0) {
-        float startAngle2 = this->param6.getValue();
-        float radius2 = this->param8.getValue();
-        SbVec3f center2 = points[3];
-        glDrawArc(center2, radius2, startAngle2, startAngle2 + range2);
-    }
+    (void)points;
 }
 
 void SoDatumLabel::drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbVec3f& textOffset)
 {
-    // Use shared geometry calculation
-    DiameterGeometry geom = calculateDiameterGeometry(points);
-
-    angle = geom.angle;
-    textOffset = geom.textOffset;
-
-    // Draw the Lines
-    glBegin(GL_LINES);
-    glVertex(geom.p1);
-    glVertex(geom.pnt1);
-
-    glVertex(geom.pnt2);
-    glVertex(geom.p2);
-    glEnd();
-
-    // Draw arrowhead at elevated Z to render ON TOP of geometry lines
-    glBegin(GL_TRIANGLES);
-    glVertex3f(geom.ar0[0], geom.ar0[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar1[0], geom.ar1[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar2[0], geom.ar2[1], ZARROW_TEXT_OFFSET);
-    glEnd();
-
-    if (geom.isDiameter) {
-        // Draw second arrowhead at elevated Z
-        glBegin(GL_TRIANGLES);
-        glVertex3f(geom.ar0_1[0], geom.ar0_1[1], ZARROW_TEXT_OFFSET);
-        glVertex3f(geom.ar1_1[0], geom.ar1_1[1], ZARROW_TEXT_OFFSET);
-        glVertex3f(geom.ar2_1[0], geom.ar2_1[1], ZARROW_TEXT_OFFSET);
-        glEnd();
-    }
-
-    // Draw arc helpers if needed
-    if (geom.startRange != 0.0) {
-        glDrawArc(geom.center, geom.radius, geom.startAngle, geom.startAngle + geom.startRange);
-    }
-
-    if (geom.endRange != 0.0) {
-        glDrawArc(geom.center, geom.radius, geom.endAngle, geom.endAngle + geom.endRange);
-    }
+    (void)points;
+    angle = 0.0F;
+    textOffset = {};
 }
 
 void SoDatumLabel::drawAngle(const SbVec3f* points, float& angle, SbVec3f& textOffset)
 {
-    // use shared geometry calculation
-    AngleGeometry geom = calculateAngleGeometry(points);
-
-    angle = geom.angle;
-    textOffset = geom.textOffset;
-
-    // draw arc segments
-    glDrawArc(geom.p0, geom.r, geom.startangle, geom.startangle + geom.range / 2.0 - geom.textMargin);
-    glDrawArc(geom.p0, geom.r, geom.startangle + geom.range / 2.0 + geom.textMargin, geom.endangle);
-
-    // draw extension lines
-    glDrawLine(geom.pnt1, geom.pnt2);
-    glDrawLine(geom.pnt3, geom.pnt4);
-
-    // draw arrowheads
-    glDrawArrow(geom.startArrowBase, geom.dirStart, geom.arrowWidth, geom.arrowLength);
-    glDrawArrow(geom.endArrowBase, geom.dirEnd, geom.arrowWidth, geom.arrowLength);
+    (void)points;
+    angle = 0.0F;
+    textOffset = {};
 }
 
 void SoDatumLabel::drawSymmetric(const SbVec3f* points)
 {
-    // use shared geometry calculation
-    SymmetricGeometry geom = calculateSymmetricGeometry(points);
-
-    // draw first constraint line (at constraint Z)
-    glBegin(GL_LINES);
-    glVertex3f(geom.p1[0], geom.p1[1], ZCONSTR);
-    glVertex3f(geom.ar0[0], geom.ar0[1], ZCONSTR);
-    glEnd();
-
-    // draw first arrowhead at elevated Z to render ON TOP of geometry lines
-    glBegin(GL_LINES);
-    glVertex3f(geom.ar0[0], geom.ar0[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar1[0], geom.ar1[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar0[0], geom.ar0[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar2[0], geom.ar2[1], ZARROW_TEXT_OFFSET);
-    glEnd();
-
-    // draw second constraint line (at constraint Z)
-    glBegin(GL_LINES);
-    glVertex3f(geom.p2[0], geom.p2[1], ZCONSTR);
-    glVertex3f(geom.ar3[0], geom.ar3[1], ZCONSTR);
-    glEnd();
-
-    // draw second arrowhead at elevated Z to render ON TOP of geometry lines
-    glBegin(GL_LINES);
-    glVertex3f(geom.ar3[0], geom.ar3[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar4[0], geom.ar4[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar3[0], geom.ar3[1], ZARROW_TEXT_OFFSET);
-    glVertex3f(geom.ar5[0], geom.ar5[1], ZARROW_TEXT_OFFSET);
-    glEnd();
+    (void)points;
 }
 
 void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& textOffset)
 {
-    // use shared geometry calculation
-    ArcLengthGeometry geom = calculateArcLengthGeometry(points);
-
-    // set output parameters
-    angle = geom.angle;
-    textOffset = geom.textOffset;
-
-    // draw arc
-    glDrawArc(geom.arcCenter, geom.arcRadius, geom.startangle, geom.endangle);
-
-    // draw lines
-    glDrawLine(geom.pnt1, geom.pnt2);
-    glDrawLine(geom.pnt3, geom.pnt4);
-
-    // create the arrowheads
-    float arrowLength = geom.margin * 2;
-    float arrowWidth = geom.margin * 0.5F;
-
-    glDrawArrow(geom.pnt2, geom.dirStart, arrowWidth, arrowLength);
-    glDrawArrow(geom.pnt4, geom.dirEnd, arrowWidth, arrowLength);
+    (void)points;
+    angle = 0.0F;
+    textOffset = {};
 }
 
 namespace

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -21,19 +21,6 @@
  *                                                                            *
  ******************************************************************************/
 
-#include <FCConfig.h>
-
-#ifdef FC_OS_WIN32
-# include <windows.h>
-# undef min
-# undef max
-#endif
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
-
 #include <algorithm>
 #include <cstdint>
 #include <cmath>
@@ -42,21 +29,28 @@
 #include <QFontMetrics>
 #include <QPainter>
 
+#include <Inventor/SbRotation.h>
+#include <Inventor/SbVec2f.h>
 #include <Inventor/SoPrimitiveVertex.h>
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/elements/SoFocalDistanceElement.h>
 #include <Inventor/elements/SoModelMatrixElement.h>
+#include <Inventor/elements/SoLazyElement.h>
+#include <Inventor/elements/SoTextureQualityElement.h>
 #include <Inventor/elements/SoViewportRegionElement.h>
 #include <Inventor/elements/SoViewVolumeElement.h>
 #include <Inventor/misc/SoState.h>
 #include <Inventor/nodes/SoBaseColor.h>
-#include <Inventor/nodes/SoCallback.h>
 #include <Inventor/nodes/SoDepthBuffer.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoFaceSet.h>
 #include <Inventor/nodes/SoLightModel.h>
 #include <Inventor/nodes/SoLineSet.h>
 #include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoShapeHints.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoTexture2.h>
+#include <Inventor/nodes/SoTransform.h>
 #include <Inventor/nodes/SoVertexProperty.h>
 
 #include <Base/Tools.h>
@@ -173,10 +167,25 @@ SbVec3f getArcTextCenter(const SbVec3f& center, float startAngle, float endAngle
     return center + getArcMidDirection(startAngle, endAngle) * distanceFromCenter;
 }
 
-bool isGLRenderAction(SoAction* action)
+float getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, bool flip)
 {
-    return action && action->getTypeId().isDerivedFrom(SoGLRenderAction::getClassTypeId());
+    SbVec3f camRight = viewVolume.lrf - viewVolume.llf;
+    SbVec3f camUp = viewVolume.ulf - viewVolume.llf;
+
+    camRight.normalize();
+    camUp.normalize();
+
+    const SbMatrix& matrix = SoModelMatrixElement::get(state);
+    SbVec3f xWorld;
+    matrix.multDirMatrix(SbVec3f(1.0f, 0.0f, 0.0f), xWorld);
+
+    const float cosAngle = xWorld.dot(camRight);
+    const float sinAngle = xWorld.dot(camUp);
+    const float angle = std::atan2(sinAngle, cosAngle);
+
+    return flip ? angle : -angle;
 }
+
 }  // namespace
 
 
@@ -247,23 +256,59 @@ SoDatumLabel::SoDatumLabel()
     m_DrawStyle->lineWidth.connectFrom(&this->lineWidth);
     m_Root->addChild(m_DrawStyle);
 
+    // Keep the label two-sided even when inherited rendering state enables face culling.
+    auto* hints = new SoShapeHints;
+    hints->vertexOrdering.setValue(SoShapeHints::UNKNOWN_ORDERING);
+    hints->shapeType.setValue(SoShapeHints::UNKNOWN_SHAPE_TYPE);
+    hints->faceType.setValue(SoShapeHints::UNKNOWN_FACE_TYPE);
+    m_Root->addChild(hints);
+
     m_LineVertexProperty = new SoVertexProperty;
     m_LineSet = new SoLineSet;
     m_LineSet->vertexProperty.setValue(m_LineVertexProperty);
     m_Root->addChild(m_LineSet);
-
-    auto* triangleCullDisable = new SoCallback;
-    triangleCullDisable->setCallback(SoDatumLabel::disableCullFaceCallback, this);
-    m_Root->addChild(triangleCullDisable);
 
     m_TriangleVertexProperty = new SoVertexProperty;
     m_TriangleFaceSet = new SoFaceSet;
     m_TriangleFaceSet->vertexProperty.setValue(m_TriangleVertexProperty);
     m_Root->addChild(m_TriangleFaceSet);
 
-    auto* triangleCullRestore = new SoCallback;
-    triangleCullRestore->setCallback(SoDatumLabel::restoreCullFaceCallback, this);
-    m_Root->addChild(triangleCullRestore);
+    m_TextSwitch = new SoSwitch;
+    m_TextSwitch->whichChild.setValue(SO_SWITCH_NONE);
+    m_Root->addChild(m_TextSwitch);
+
+    m_TextSeparator = new SoSeparator;
+    m_TextSwitch->addChild(m_TextSeparator);
+
+    m_TextDepth = new SoDepthBuffer;
+    m_TextDepth->test.setValue(false);
+    m_TextDepth->write.setValue(false);
+    m_TextDepth->function.setValue(SoDepthBuffer::ALWAYS);
+    m_TextSeparator->addChild(m_TextDepth);
+
+    auto* textLightModel = new SoLightModel;
+    textLightModel->model.setValue(SoLightModel::BASE_COLOR);
+    m_TextSeparator->addChild(textLightModel);
+
+    m_TextBaseColor = new SoBaseColor;
+    m_TextBaseColor->rgb.setValue(1.0f, 1.0f, 1.0f);
+    m_TextSeparator->addChild(m_TextBaseColor);
+
+    m_TextTexture = new SoTexture2;
+    m_TextTexture->wrapS = SoTexture2::CLAMP;
+    m_TextTexture->wrapT = SoTexture2::CLAMP;
+    m_TextTexture->model = SoTexture2::MODULATE;
+    m_TextTexture->image.connectFrom(&this->image);
+    m_TextSeparator->addChild(m_TextTexture);
+
+    m_TextTransform = new SoTransform;
+    m_TextSeparator->addChild(m_TextTransform);
+
+    m_TextVertexProperty = new SoVertexProperty;
+    m_TextFaceSet = new SoFaceSet;
+    m_TextFaceSet->vertexProperty.setValue(m_TextVertexProperty);
+    m_TextFaceSet->numVertices.set1Value(0, 4);
+    m_TextSeparator->addChild(m_TextFaceSet);
 }
 
 SoDatumLabel::~SoDatumLabel()
@@ -280,6 +325,14 @@ SoDatumLabel::~SoDatumLabel()
     m_LineSet = nullptr;
     m_TriangleVertexProperty = nullptr;
     m_TriangleFaceSet = nullptr;
+    m_TextSwitch = nullptr;
+    m_TextSeparator = nullptr;
+    m_TextDepth = nullptr;
+    m_TextBaseColor = nullptr;
+    m_TextTexture = nullptr;
+    m_TextTransform = nullptr;
+    m_TextVertexProperty = nullptr;
+    m_TextFaceSet = nullptr;
 }
 
 void SoDatumLabel::drawImage()
@@ -1229,51 +1282,6 @@ float SoDatumLabel::getScaleFactor(SoState* state) const
     return scale;
 }
 
-void SoDatumLabel::disableCullFaceCallback(void* userdata, SoAction* action)
-{
-    if (!userdata) {
-        return;
-    }
-
-    static_cast<SoDatumLabel*>(userdata)->disableCullFaceIfNeeded(action);
-}
-
-void SoDatumLabel::restoreCullFaceCallback(void* userdata, SoAction* action)
-{
-    if (!userdata) {
-        return;
-    }
-
-    static_cast<SoDatumLabel*>(userdata)->restoreCullFaceIfNeeded(action);
-}
-
-void SoDatumLabel::disableCullFaceIfNeeded(SoAction* action)
-{
-    if (!isGLRenderAction(action)) {
-        return;
-    }
-
-    m_CullFaceWasEnabled = (glIsEnabled(GL_CULL_FACE) == GL_TRUE);
-    if (m_CullFaceWasEnabled) {
-        GLint mode = GL_BACK;
-        glGetIntegerv(GL_CULL_FACE_MODE, &mode);
-        m_CullFaceMode = mode;
-        glDisable(GL_CULL_FACE);
-    }
-}
-
-void SoDatumLabel::restoreCullFaceIfNeeded(SoAction* action)
-{
-    if (!isGLRenderAction(action)) {
-        return;
-    }
-
-    if (m_CullFaceWasEnabled) {
-        glEnable(GL_CULL_FACE);
-        glCullFace(static_cast<GLenum>(m_CullFaceMode));
-    }
-}
-
 void SoDatumLabel::setVertexZ(SbVec3f& point, float z) const
 {
     point[2] = z;
@@ -1511,6 +1519,70 @@ void SoDatumLabel::ensureCoinGeometry(const SbVec3f* points, int numPoints)
     }
 }
 
+void SoDatumLabel::ensureCoinText(SoState* state, int srcw, int srch, float angle, const SbVec3f& textOffset)
+{
+    if (!state || !m_TextSwitch || !m_TextVertexProperty || !m_TextFaceSet || !m_TextTransform
+        || !m_TextTexture) {
+        return;
+    }
+
+    SbVec2s imgsize;
+    int nc {};
+    const unsigned char* dataptr = this->image.getValue(imgsize, nc);
+    if (!dataptr || srcw <= 0 || srch <= 0 || imgWidth <= 0.0f || imgHeight <= 0.0f) {
+        m_TextSwitch->whichChild.setValue(SO_SWITCH_NONE);
+        m_TextVertexProperty->vertex.setNum(0);
+        m_TextVertexProperty->texCoord.setNum(0);
+        m_TextFaceSet->numVertices.setNum(0);
+        return;
+    }
+
+    const SbViewVolume& vv = SoViewVolumeElement::get(state);
+    const SbVec3f z = vv.zVector();
+    const bool flip = norm.getValue().dot(z) > std::numeric_limits<float>::epsilon();
+    const float sketchAngle = getSketchRotationAngle(state, vv, flip);
+    const float absLabelAngle = std::abs(sketchAngle + angle);
+
+    constexpr float quarter = 90.0F;
+    constexpr float hysteresis = 15.0F;
+    constexpr float threshold = Base::toRadians(quarter + hysteresis);
+
+    if ((flip && absLabelAngle > threshold) || (!flip && absLabelAngle < threshold)) {
+        angle += std::numbers::pi;
+    }
+
+    m_TextTransform->translation.setValue(textOffset);
+    m_TextTransform->rotation.setValue(SbRotation(SbVec3f(0.0f, 0.0f, 1.0f), angle));
+
+    const float left = -imgWidth / 2.0f;
+    const float right = imgWidth / 2.0f;
+    const float bottom = -imgHeight / 2.0f;
+    const float top = imgHeight / 2.0f;
+
+    m_TextVertexProperty->vertex.setNum(4);
+    m_TextVertexProperty->vertex.set1Value(0, SbVec3f(left, top, 0.0f));
+    m_TextVertexProperty->vertex.set1Value(1, SbVec3f(left, bottom, 0.0f));
+    m_TextVertexProperty->vertex.set1Value(2, SbVec3f(right, bottom, 0.0f));
+    m_TextVertexProperty->vertex.set1Value(3, SbVec3f(right, top, 0.0f));
+
+    m_TextVertexProperty->texCoord.setNum(4);
+    if (flip) {
+        m_TextVertexProperty->texCoord.set1Value(0, SbVec2f(0.0f, 1.0f));
+        m_TextVertexProperty->texCoord.set1Value(1, SbVec2f(0.0f, 0.0f));
+        m_TextVertexProperty->texCoord.set1Value(2, SbVec2f(1.0f, 0.0f));
+        m_TextVertexProperty->texCoord.set1Value(3, SbVec2f(1.0f, 1.0f));
+    }
+    else {
+        m_TextVertexProperty->texCoord.set1Value(0, SbVec2f(1.0f, 1.0f));
+        m_TextVertexProperty->texCoord.set1Value(1, SbVec2f(1.0f, 0.0f));
+        m_TextVertexProperty->texCoord.set1Value(2, SbVec2f(0.0f, 0.0f));
+        m_TextVertexProperty->texCoord.set1Value(3, SbVec2f(0.0f, 1.0f));
+    }
+
+    m_TextFaceSet->numVertices.set1Value(0, 4);
+    m_TextSwitch->whichChild.setValue(0);
+}
+
 void SoDatumLabel::GLRender(SoGLRenderAction* action)
 {
     SoState* state = action->getState();
@@ -1542,14 +1614,22 @@ void SoDatumLabel::GLRender(SoGLRenderAction* action)
 
     state->push();
 
-    ensureCoinGeometry(points, this->pnts.getNum());
-    if (m_Root) {
-        m_Root->GLRender(action);
-    }
+    // Annotation faces should stay visible even when an ancestor enables back-face culling.
+    SoLazyElement::setBackfaceCulling(state, FALSE);
 
     if (hasText) {
-        float angle = 0.0F;
-        SbVec3f textOffset;
+        // Text labels are rendered as SoTexture2 on a quad. Coin's default texture quality
+        // (0.5) enables mipmaps, which can blur small UI text. Keep linear filtering but
+        // avoid mipmaps for crisper results.
+        SoTextureQualityElement::set(state, this, 0.49F);
+        SoLazyElement::setTransparencyType(state, static_cast<int32_t>(SoGLRenderAction::BLEND));
+    }
+
+    ensureCoinGeometry(points, this->pnts.getNum());
+
+    float angle = 0.0F;
+    SbVec3f textOffset;
+    if (hasText) {
         const auto type = static_cast<Type>(datumtype.getValue());
         if (type == DISTANCE || type == DISTANCEX || type == DISTANCEY) {
             const DistanceGeometry geom = calculateDistanceGeometry(points);
@@ -1572,9 +1652,14 @@ void SoDatumLabel::GLRender(SoGLRenderAction* action)
             textOffset = geom.textOffset;
         }
 
-        glPushAttrib(GL_ENABLE_BIT | GL_PIXEL_MODE_BIT | GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-        drawText(state, srcw, srch, angle, textOffset);
-        glPopAttrib();
+        ensureCoinText(state, srcw, srch, angle, textOffset);
+    }
+    else if (m_TextSwitch) {
+        m_TextSwitch->whichChild.setValue(SO_SWITCH_NONE);
+    }
+
+    if (m_Root) {
+        m_Root->GLRender(action);
     }
 
     state->pop();
@@ -1607,225 +1692,6 @@ void SoDatumLabel::getDimension(float scale, int& srcw, int& srch)
     float aspectRatio = (float)srcw / (float)srch;
     this->imgHeight = scale * (float)(srch) / sampling.getValue();
     this->imgWidth = aspectRatio * (float)this->imgHeight;
-}
-
-void SoDatumLabel::drawDistance(const SbVec3f* points, float& angle, SbVec3f& textOffset)
-{
-    (void)points;
-    angle = 0.0F;
-    textOffset = {};
-}
-
-void SoDatumLabel::drawDistance(const SbVec3f* points)
-{
-    (void)points;
-}
-
-void SoDatumLabel::drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbVec3f& textOffset)
-{
-    (void)points;
-    angle = 0.0F;
-    textOffset = {};
-}
-
-void SoDatumLabel::drawAngle(const SbVec3f* points, float& angle, SbVec3f& textOffset)
-{
-    (void)points;
-    angle = 0.0F;
-    textOffset = {};
-}
-
-void SoDatumLabel::drawSymmetric(const SbVec3f* points)
-{
-    (void)points;
-}
-
-void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& textOffset)
-{
-    (void)points;
-    angle = 0.0F;
-    textOffset = {};
-}
-
-namespace
-{
-/*!
- * \brief Compute sketch rotation angle in screen space.
- *
- * Calculates the rotation of the sketch relative to the camera view.
- * The angle is measured from the camera right vector to the sketch's local X axis.
- *
- * \param state Current Coin3D traversal state used to retrieve view and model matrices.
- * \param viewVolume Active view volume describing the camera projection and orientation.
- * \param flip If true, the resulting angle is inverted to account for back-facing view direction.
- *
- * \return Rotation angle in radians in the range [-pi, pi].
- *         Positive values correspond to counter-clockwise (CCW) rotation,
- *         negative values correspond to clockwise (CW) rotation.
- */
-float getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, bool flip)
-{
-    // Camera basis from view volume (screen space axes
-    SbVec3f camRight = viewVolume.lrf - viewVolume.llf;
-    SbVec3f camUp = viewVolume.ulf - viewVolume.llf;
-
-    camRight.normalize();
-    camUp.normalize();
-
-    // Sketch local X axis in world space
-    const SbMatrix& m = SoModelMatrixElement::get(state);
-    SbVec3f xWorld;
-    m.multDirMatrix(SbVec3f(1, 0, 0), xWorld);
-
-    // Compute angle in screen space
-    float cosA = xWorld.dot(camRight);
-    float sinA = xWorld.dot(camUp);
-
-    float angleRad = std::atan2(sinA, cosA);
-
-    // Optional flip correction (back-facing view)
-    return flip ? angleRad : -angleRad;
-}
-}  // unnamed namespace
-
-// NOLINTNEXTLINE
-void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, const SbVec3f& textOffset)
-{
-    SbVec2s imgsize;
-    int nc {};
-    const unsigned char* dataptr = this->image.getValue(imgsize, nc);
-
-    // Get the camera z-direction
-    const SbViewVolume& vv = SoViewVolumeElement::get(state);
-    SbVec3f z = vv.zVector();
-
-    bool flip = norm.getValue().dot(z) > std::numeric_limits<float>::epsilon();
-
-    const float sketchAngle = getSketchRotationAngle(state, vv, flip);
-    const float absLabelAngle = std::abs(sketchAngle + angle);
-
-    constexpr float quarter = 90.0F;  // vertical line
-    constexpr float hysteresis = 15.0F;  // extra to avoid flipping back and forth when close to vertical
-    constexpr float threshold = Base::toRadians(quarter + hysteresis);
-
-    if ((flip && absLabelAngle > threshold) || (!flip && absLabelAngle < threshold)) {
-        angle += std::numbers::pi;
-    }
-
-    static bool init = false;
-    static bool npot = false;
-    if (!init) {
-        init = true;
-        std::string ext = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));  // NOLINT
-        npot = (ext.find("GL_ARB_texture_non_power_of_two") != std::string::npos);
-    }
-
-    int w = srcw;
-    int h = srch;
-    if (!npot) {
-        // make power of two
-        if ((w & (w - 1)) != 0) {
-            int i = 1;
-            while (i < 8) {
-                if ((w >> i) == 0) {
-                    break;
-                }
-                i++;
-            }
-            w = (1 << i);
-        }
-        // make power of two
-        if ((h & (h - 1)) != 0) {
-            int i = 1;
-            while (i < 8) {
-                if ((h >> i) == 0) {
-                    break;
-                }
-                i++;
-            }
-            h = (1 << i);
-        }
-    }
-
-    glDisable(GL_DEPTH_TEST);
-    glEnable(GL_TEXTURE_2D);  // Enable Textures
-    glEnable(GL_BLEND);
-
-    // glGenTextures/glBindTexture was commented out but it must be active, see:
-    // #0000971: Tracing over a background image in Sketcher: image is overwritten by first
-    // dimensional constraint text #0001185: Planer image changes to number graphic when a part
-    // design constraint is made after the planar image
-    //
-    // Copy the text bitmap into memory and bind
-    GLuint myTexture {};
-    // generate a texture
-    glGenTextures(1, &myTexture);
-    glBindTexture(GL_TEXTURE_2D, myTexture);
-
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-
-    if (!npot) {
-        QImage imagedata(w, h, QImage::Format_ARGB32_Premultiplied);
-        imagedata.fill(0x00000000);
-        int sx = (w - srcw) / 2;
-        int sy = (h - srch) / 2;
-        glTexImage2D(
-            GL_TEXTURE_2D,
-            0,
-            nc,
-            w,
-            h,
-            0,
-            GL_RGBA,
-            GL_UNSIGNED_BYTE,
-            (const GLvoid*)imagedata.bits()
-        );
-        glTexSubImage2D(
-            GL_TEXTURE_2D,
-            0,
-            sx,
-            sy,
-            srcw,
-            srch,
-            GL_RGBA,
-            GL_UNSIGNED_BYTE,
-            (const GLvoid*)dataptr
-        );
-    }
-    else {
-        glTexImage2D(GL_TEXTURE_2D, 0, nc, srcw, srch, 0, GL_RGBA, GL_UNSIGNED_BYTE, (const GLvoid*)dataptr);
-    }
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-
-    glMatrixMode(GL_MODELVIEW);
-    glPushMatrix();
-
-    // Apply a rotation and translation matrix
-    glTranslatef(textOffset[0], textOffset[1], textOffset[2]);
-    glRotatef(Base::toDegrees<GLfloat>(angle), 0, 0, 1);
-    glBegin(GL_QUADS);
-
-    glColor3f(1.F, 1.F, 1.F);
-
-    glTexCoord2f(flip ? 0.F : 1.F, 1.F);
-    glVertex2f(-this->imgWidth / 2, this->imgHeight / 2);
-    glTexCoord2f(flip ? 0.F : 1.F, 0.F);
-    glVertex2f(-this->imgWidth / 2, -this->imgHeight / 2);
-    glTexCoord2f(flip ? 1.F : 0.F, 0.F);
-    glVertex2f(this->imgWidth / 2, -this->imgHeight / 2);
-    glTexCoord2f(flip ? 1.F : 0.F, 1.F);
-    glVertex2f(this->imgWidth / 2, this->imgHeight / 2);
-
-    glEnd();
-
-    // Reset the Mode
-    glPopMatrix();
-
-    // wmayer: see bug report below which is caused by generating but not
-    // deleting the texture.
-    // #0000721: massive memory leak when dragging an unconstrained model
-    glDeleteTextures(1, &myTexture);
 }
 
 void SoDatumLabel::setPoints(SbVec3f p1, SbVec3f p2)

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -38,10 +38,6 @@
 
 #include <FCGlobal.h>
 
-
-namespace Gui
-{
-
 class SoBaseColor;
 class SoDepthBuffer;
 class SoDrawStyle;
@@ -50,7 +46,12 @@ class SoLineSet;
 class SoSeparator;
 class SoLightModel;
 class SoSwitch;
+class SoTexture2;
+class SoTransform;
 class SoVertexProperty;
+
+namespace Gui
+{
 
 class GuiExport SoDatumLabel: public SoShape
 {
@@ -196,8 +197,6 @@ private:
     };
 
     float getScaleFactor(SoState*) const;
-    static void disableCullFaceCallback(void* userdata, SoAction* action);
-    static void restoreCullFaceCallback(void* userdata, SoAction* action);
     void generateDistancePrimitives(SoAction* action, const SbVec3f&, const SbVec3f&);
     void generateDiameterPrimitives(SoAction* action, const SbVec3f&, const SbVec3f&);
     void generateAnglePrimitives(SoAction* action, const SbVec3f&);
@@ -235,25 +234,15 @@ private:
         float width,
         float length
     );
-    void drawDistance(const SbVec3f* points, float& angle, SbVec3f& textOffset);
-    void drawDistance(const SbVec3f* points);
-    void drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbVec3f& textOffset);
-    void drawAngle(const SbVec3f* points, float& angle, SbVec3f& textOffset);
-    void drawSymmetric(const SbVec3f* points);
-    void drawArcLength(const SbVec3f* points, float& angle, SbVec3f& textOffset);
-    void drawText(SoState* state, int srcw, int srch, float angle, const SbVec3f& textOffset);
 
 private:
     void drawImage();
-    void disableCullFaceIfNeeded(SoAction* action);
     void ensureCoinGeometry(const SbVec3f* points, int numPoints);
-    void restoreCullFaceIfNeeded(SoAction* action);
+    void ensureCoinText(SoState* state, int srcw, int srch, float angle, const SbVec3f& textOffset);
     void setVertexZ(SbVec3f& point, float z) const;
     float imgWidth;
     float imgHeight;
     bool glimagevalid;
-    bool m_CullFaceWasEnabled {false};
-    int m_CullFaceMode {0};
 
     SoSeparator* m_Root {nullptr};
     SoDepthBuffer* m_GeometryDepth {nullptr};
@@ -264,6 +253,15 @@ private:
     SoLineSet* m_LineSet {nullptr};
     SoVertexProperty* m_TriangleVertexProperty {nullptr};
     SoFaceSet* m_TriangleFaceSet {nullptr};
+
+    SoSwitch* m_TextSwitch {nullptr};
+    SoSeparator* m_TextSeparator {nullptr};
+    SoDepthBuffer* m_TextDepth {nullptr};
+    SoBaseColor* m_TextBaseColor {nullptr};
+    SoTexture2* m_TextTexture {nullptr};
+    SoTransform* m_TextTransform {nullptr};
+    SoVertexProperty* m_TextVertexProperty {nullptr};
+    SoFaceSet* m_TextFaceSet {nullptr};
 };
 
 }  // namespace Gui

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -1,24 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2011-2012 Luke Parry <l.parry@warwick.ac.uk>            *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2011-2012 Luke Parry <l.parry@warwick.ac.uk>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -40,6 +41,16 @@
 
 namespace Gui
 {
+
+class SoBaseColor;
+class SoDepthBuffer;
+class SoDrawStyle;
+class SoFaceSet;
+class SoLineSet;
+class SoSeparator;
+class SoLightModel;
+class SoSwitch;
+class SoVertexProperty;
 
 class GuiExport SoDatumLabel: public SoShape
 {
@@ -94,7 +105,7 @@ public:
     bool useAntialiasing;
 
 protected:
-    ~SoDatumLabel() override = default;
+    ~SoDatumLabel() override;
     void GLRender(SoGLRenderAction* action) override;
     void computeBBox(SoAction*, SbBox3f& box, SbVec3f& center) override;
     void generatePrimitives(SoAction* action) override;
@@ -185,6 +196,8 @@ private:
     };
 
     float getScaleFactor(SoState*) const;
+    static void disableCullFaceCallback(void* userdata, SoAction* action);
+    static void restoreCullFaceCallback(void* userdata, SoAction* action);
     void generateDistancePrimitives(SoAction* action, const SbVec3f&, const SbVec3f&);
     void generateDiameterPrimitives(SoAction* action, const SbVec3f&, const SbVec3f&);
     void generateAnglePrimitives(SoAction* action, const SbVec3f&);
@@ -232,9 +245,25 @@ private:
 
 private:
     void drawImage();
+    void disableCullFaceIfNeeded(SoAction* action);
+    void ensureCoinGeometry(const SbVec3f* points, int numPoints);
+    void restoreCullFaceIfNeeded(SoAction* action);
+    void setVertexZ(SbVec3f& point, float z) const;
     float imgWidth;
     float imgHeight;
     bool glimagevalid;
+    bool m_CullFaceWasEnabled {false};
+    int m_CullFaceMode {0};
+
+    SoSeparator* m_Root {nullptr};
+    SoDepthBuffer* m_GeometryDepth {nullptr};
+    SoLightModel* m_LightModel {nullptr};
+    SoBaseColor* m_GeometryColor {nullptr};
+    SoDrawStyle* m_DrawStyle {nullptr};
+    SoVertexProperty* m_LineVertexProperty {nullptr};
+    SoLineSet* m_LineSet {nullptr};
+    SoVertexProperty* m_TriangleVertexProperty {nullptr};
+    SoFaceSet* m_TriangleFaceSet {nullptr};
 };
 
 }  // namespace Gui

--- a/src/Gui/SoTextLabel.cpp
+++ b/src/Gui/SoTextLabel.cpp
@@ -1,52 +1,47 @@
-/***************************************************************************
- *   Copyright (c) 2009 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2009 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
 #ifdef FC_OS_WIN32
 # include <windows.h>
 #endif
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
-
-#include <algorithm>
-
+#include <QFont>
 #include <QFontMetrics>
-#include <QOpenGLContext>
-#include <QOpenGLPaintDevice>
+#include <QImage>
 #include <QPainter>
 #include <QPen>
+#include <QStringList>
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/bundles/SoMaterialBundle.h>
 #include <Inventor/elements/SoLazyElement.h>
 #include <Inventor/misc/SoState.h>
 
+#include <Inventor/SbVec2f.h>
 #include <Inventor/C/basic.h>
 #include <Inventor/draggers/SoTranslate2Dragger.h>
 #include <Inventor/elements/SoCullElement.h>
-#include <Inventor/elements/SoFontNameElement.h>
+#include <Inventor/elements/SoDepthBufferElement.h>
 #include <Inventor/elements/SoGLTextureEnabledElement.h>
 #include <Inventor/elements/SoModelMatrixElement.h>
 #include <Inventor/elements/SoProjectionMatrixElement.h>
@@ -54,6 +49,10 @@
 #include <Inventor/elements/SoViewportRegionElement.h>
 #include <Inventor/elements/SoViewVolumeElement.h>
 #include <Inventor/elements/SoMultiTextureEnabledElement.h>
+
+#include <cstdint>
+#include <cstring>
+#include <algorithm>
 
 #include "SoTextLabel.h"
 #include "SoFCInteractiveElement.h"
@@ -76,6 +75,25 @@ SoTextLabel::SoTextLabel()
     SO_NODE_ADD_FIELD(backgroundColor, (SbVec3f(1.0f, 1.0f, 1.0f)));
     SO_NODE_ADD_FIELD(background, (true));
     SO_NODE_ADD_FIELD(frameSize, (10.0f));
+
+    backgroundSwitch = new SoSwitch;
+    backgroundSwitch->ref();
+
+    backgroundSeparator = new SoSeparator;
+    auto* hints = new SoShapeHints;
+    hints->vertexOrdering = SoShapeHints::COUNTERCLOCKWISE;
+    hints->shapeType = SoShapeHints::UNKNOWN_SHAPE_TYPE;
+    backgroundSeparator->addChild(hints);
+
+    backgroundVertexProperty = new SoVertexProperty;
+    backgroundVertexProperty->materialBinding = SoVertexProperty::PER_VERTEX;
+    backgroundFaceSet = new SoFaceSet;
+    backgroundFaceSet->vertexProperty.setValue(backgroundVertexProperty);
+    backgroundFaceSet->numVertices.set1Value(0, 4);
+    backgroundSeparator->addChild(backgroundFaceSet);
+
+    backgroundSwitch->addChild(backgroundSeparator);
+    backgroundSwitch->whichChild = SO_SWITCH_ALL;
 }
 
 /**
@@ -89,7 +107,14 @@ void SoTextLabel::GLRender(SoGLRenderAction* action)
 
     // only draw text without background
     if (!this->background.getValue()) {
+        if (backgroundSwitch) {
+            backgroundSwitch->whichChild = SO_SWITCH_NONE;
+        }
         inherited::GLRender(action);
+        return;
+    }
+
+    if (!backgroundSwitch) {
         return;
     }
 
@@ -105,21 +130,10 @@ void SoTextLabel::GLRender(SoGLRenderAction* action)
     if (!SoCullElement::cullTest(state, box, true)) {
         SoMaterialBundle mb(action);
         mb.sendFirst();
-        const SbMatrix& mat = SoModelMatrixElement::get(state);
-        const SbMatrix& projmatrix
-            = (mat * SoViewingMatrixElement::get(state) * SoProjectionMatrixElement::get(state));
         const SbViewportRegion& vp = SoViewportRegionElement::get(state);
         SbVec2s vpsize = vp.getViewportSizePixels();
 
-        // font stuff
-        SbName fontname = SoFontNameElement::get(state);
         int lines = this->string.getNum();
-
-        // get left bottom corner of the label
-        SbVec3f nilpoint(0.0f, 0.0f, 0.0f);
-        projmatrix.multVecMatrix(nilpoint, nilpoint);
-        nilpoint[0] = (nilpoint[0] + 1.0f) * 0.5f * vpsize[0];
-        nilpoint[1] = (nilpoint[1] + 1.0f) * 0.5f * vpsize[1];
 
         // Unfortunately, the size of the label is stored in the pimpl class of
         // SoText2 which cannot be accessed directly. However, there is a trick
@@ -136,92 +150,179 @@ void SoTextLabel::GLRender(SoGLRenderAction* action)
         vv.ortho(-1, 1, -1, 1, -1, 1);
         SoViewVolumeElement::set(state, this, vv);
 
-        SbBox3f box;
-        SbVec3f center;
-        this->computeBBox(action, box, center);
+        SbBox3f textBox;
+        SbVec3f textCenter;
+        this->computeBBox(action, textBox, textCenter);
         state->pop();
 
-        float xmin, ymin, zmin, xmax, ymax, zmax;
-        box.getBounds(xmin, ymin, zmin, xmax, ymax, zmax);
-        SbVec3f v0(xmin, ymax, zmax);
-        SbVec3f v1(xmax, ymax, zmax);
-        SbVec3f v2(xmax, ymin, zmax);
-        SbVec3f v3(xmin, ymin, zmax);
-        vv.projectToScreen(v0, v0);
-        vv.projectToScreen(v1, v1);
-        vv.projectToScreen(v2, v2);
-        vv.projectToScreen(v3, v3);
-
-        float width, height;
-        width = (v1[0] - v0[0]) * vpsize[0];
-        height = (v1[1] - v3[1]) * vpsize[1];
-        switch (this->justification.getValue()) {
-            case SoText2::RIGHT:
-                nilpoint[0] -= width;
-                break;
-            case SoText2::CENTER:
-                nilpoint[0] -= 0.5f * width;
-                break;
-            default:
-                break;
-        }
-
-        if (lines > 1) {
-            nilpoint[1] -= (float(lines - 1) / (float)lines * height);
-        }
-
-        SbVec3f toppoint = nilpoint;
-        toppoint[0] += width;
-        toppoint[1] += height;
-
-        // Set new state.
-        glMatrixMode(GL_MODELVIEW);
-        glPushMatrix();
-        glLoadIdentity();
-        glMatrixMode(GL_PROJECTION);
-        glPushMatrix();
-        glLoadIdentity();
-        glOrtho(0, vpsize[0], 0, vpsize[1], -1.0f, 1.0f);
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+        ensureBackgroundGeometry(state, textBox, lines);
 
         state->push();
 
-        // disable textures for all units
-        SoGLTextureEnabledElement::set(state, this, false);
-        SoMultiTextureEnabledElement::set(state, this, false);
+        SbViewVolume orthoVolume;
+        orthoVolume.ortho(
+            0.0f,
+            static_cast<float>(vpsize[0]),
+            0.0f,
+            static_cast<float>(vpsize[1]),
+            -1.0f,
+            1.0f
+        );
+        SbMatrix affine;
+        SbMatrix projection;
+        orthoVolume.getMatrices(affine, projection);
 
-        glPushAttrib(GL_ENABLE_BIT | GL_PIXEL_MODE_BIT | GL_COLOR_BUFFER_BIT);
-        glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT);
+        SoModelMatrixElement::set(state, this, SbMatrix::identity());
+        SoViewingMatrixElement::set(state, this, SbMatrix::identity());
+        SoProjectionMatrixElement::set(state, this, projection);
+        SoViewVolumeElement::set(state, this, orthoVolume);
 
-        // color and frame size
-        SbColor color = this->backgroundColor.getValue();
-        float fs = this->frameSize.getValue();
+        SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+        SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
+        SoGLTextureEnabledElement::set(state, this, FALSE);
+        SoMultiTextureEnabledElement::set(state, this, FALSE);
 
-        // draw background
-        glColor3f(color[0], color[1], color[2]);
-        glBegin(GL_QUADS);
-        glVertex3f(nilpoint[0] - fs, nilpoint[1] - fs, 0.0f);
-        glVertex3f(toppoint[0] + fs, nilpoint[1] - fs, 0.0f);
-        glVertex3f(toppoint[0] + fs, toppoint[1] + fs, 0.0f);
-        glVertex3f(nilpoint[0] - fs, toppoint[1] + fs, 0.0f);
-        glEnd();
+        backgroundSwitch->whichChild = 0;
+        backgroundSwitch->GLRender(action);
 
-        // pop old state
-        glPopClientAttrib();
-        glPopAttrib();
         state->pop();
-
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-        // Pop old GL matrix state.
-        glMatrixMode(GL_PROJECTION);
-        glPopMatrix();
-        glMatrixMode(GL_MODELVIEW);
-        glPopMatrix();
     }
 
     state->pop();
 
     inherited::GLRender(action);
+}
+
+SoTextLabel::~SoTextLabel()
+{
+    if (backgroundSwitch) {
+        backgroundSwitch->unref();
+        backgroundSwitch = nullptr;
+    }
+    backgroundSeparator = nullptr;
+    backgroundFaceSet = nullptr;
+    backgroundVertexProperty = nullptr;
+}
+
+void SoTextLabel::notify(SoNotList* list)
+{
+    if (list) {
+        SoField* f = list->getLastField();
+        if (f == &this->backgroundColor || f == &this->background || f == &this->frameSize
+            || f == &this->string || f == &this->justification) {
+            geometryDirty = true;
+        }
+    }
+
+    inherited::notify(list);
+}
+
+void SoTextLabel::ensureBackgroundGeometry(SoState* state, const SbBox3f& objectBounds, int lineCount)
+{
+    if (!state || !backgroundVertexProperty || !backgroundFaceSet) {
+        return;
+    }
+
+    const SbMatrix& model = SoModelMatrixElement::get(state);
+    const SbMatrix& viewing = SoViewingMatrixElement::get(state);
+    const SbMatrix& projection = SoProjectionMatrixElement::get(state);
+    const SbViewportRegion& viewport = SoViewportRegionElement::get(state);
+
+    SbVec2s viewportSize = viewport.getViewportSizePixels();
+
+    SbVec3f boundsMin;
+    SbVec3f boundsMax;
+    objectBounds
+        .getBounds(boundsMin[0], boundsMin[1], boundsMin[2], boundsMax[0], boundsMax[1], boundsMax[2]);
+
+    bool dirty = geometryDirty;
+    dirty = dirty || !model.equals(cachedModelMatrix, 0.0f)
+        || !viewing.equals(cachedViewingMatrix, 0.0f)
+        || !projection.equals(cachedProjectionMatrix, 0.0f) || cachedViewportSize != viewportSize
+        || cachedBBoxMin != boundsMin || cachedBBoxMax != boundsMax || cachedLineCount != lineCount;
+
+    const float frame = this->frameSize.getValue();
+    dirty = dirty || cachedFrameSize != frame;
+
+    SbColor color = this->backgroundColor.getValue();
+    dirty = dirty || cachedBackgroundColor != color;
+
+    if (!dirty) {
+        return;
+    }
+
+    geometryDirty = false;
+
+    cachedModelMatrix = model;
+    cachedViewingMatrix = viewing;
+    cachedProjectionMatrix = projection;
+    cachedViewportSize = viewportSize;
+    cachedBBoxMin = boundsMin;
+    cachedBBoxMax = boundsMax;
+    cachedLineCount = lineCount;
+    cachedFrameSize = frame;
+    cachedBackgroundColor = color;
+
+    SbMatrix combined = model * viewing * projection;
+
+    SbVec3f nilpoint(0.0f, 0.0f, 0.0f);
+    combined.multVecMatrix(nilpoint, nilpoint);
+    nilpoint[0] = (nilpoint[0] + 1.0f) * 0.5f * viewportSize[0];
+    nilpoint[1] = (nilpoint[1] + 1.0f) * 0.5f * viewportSize[1];
+
+    SbViewVolume localVolume;
+    localVolume.ortho(-1.0f, 1.0f, -1.0f, 1.0f, -1.0f, 1.0f);
+
+    SbVec3f v0(boundsMin[0], boundsMax[1], boundsMax[2]);
+    SbVec3f v1(boundsMax[0], boundsMax[1], boundsMax[2]);
+    SbVec3f v2(boundsMax[0], boundsMin[1], boundsMax[2]);
+    SbVec3f v3(boundsMin[0], boundsMin[1], boundsMax[2]);
+    localVolume.projectToScreen(v0, v0);
+    localVolume.projectToScreen(v1, v1);
+    localVolume.projectToScreen(v2, v2);
+    localVolume.projectToScreen(v3, v3);
+
+    float width = (v1[0] - v0[0]) * viewportSize[0];
+    float height = (v1[1] - v3[1]) * viewportSize[1];
+
+    switch (this->justification.getValue()) {
+        case SoText2::RIGHT:
+            nilpoint[0] -= width;
+            break;
+        case SoText2::CENTER:
+            nilpoint[0] -= 0.5f * width;
+            break;
+        default:
+            break;
+    }
+
+    if (lineCount > 1) {
+        nilpoint[1] -= (static_cast<float>(lineCount - 1) / static_cast<float>(lineCount) * height);
+    }
+
+    SbVec3f toppoint = nilpoint;
+    toppoint[0] += width;
+    toppoint[1] += height;
+
+    float left = nilpoint[0] - frame;
+    float right = toppoint[0] + frame;
+    float bottom = nilpoint[1] - frame;
+    float top = toppoint[1] + frame;
+
+    backgroundVertexProperty->vertex.setNum(4);
+    backgroundVertexProperty->vertex.set1Value(0, SbVec3f(left, bottom, 0.0f));
+    backgroundVertexProperty->vertex.set1Value(1, SbVec3f(right, bottom, 0.0f));
+    backgroundVertexProperty->vertex.set1Value(2, SbVec3f(right, top, 0.0f));
+    backgroundVertexProperty->vertex.set1Value(3, SbVec3f(left, top, 0.0f));
+
+    const uint32_t packedColor = color.getPackedValue();
+    backgroundVertexProperty->orderedRGBA.setNum(4);
+    backgroundVertexProperty->orderedRGBA.set1Value(0, packedColor);
+    backgroundVertexProperty->orderedRGBA.set1Value(1, packedColor);
+    backgroundVertexProperty->orderedRGBA.set1Value(2, packedColor);
+    backgroundVertexProperty->orderedRGBA.set1Value(3, packedColor);
+
+    backgroundFaceSet->numVertices.set1Value(0, 4);
 }
 
 // ------------------------------------------------------
@@ -267,6 +368,26 @@ SoStringLabel::SoStringLabel()
     SO_NODE_ADD_FIELD(textColor, (SbVec3f(1.0f, 1.0f, 1.0f)));
     SO_NODE_ADD_FIELD(name, ("Helvetica"));
     SO_NODE_ADD_FIELD(size, (12));
+
+    textSwitch = new SoSwitch;
+    textSwitch->ref();
+
+    textSeparator = new SoSeparator;
+
+    textTexture = new SoTexture2;
+    textTexture->wrapS = SoTexture2::CLAMP;
+    textTexture->wrapT = SoTexture2::CLAMP;
+    textTexture->model = SoTexture2::MODULATE;
+    textSeparator->addChild(textTexture);
+
+    textVertexProperty = new SoVertexProperty;
+    textFaceSet = new SoFaceSet;
+    textFaceSet->vertexProperty.setValue(textVertexProperty);
+    textFaceSet->numVertices.set1Value(0, 4);
+    textSeparator->addChild(textFaceSet);
+
+    textSwitch->addChild(textSeparator);
+    textSwitch->whichChild.setValue(SO_SWITCH_NONE);
 }
 
 /**
@@ -274,93 +395,196 @@ SoStringLabel::SoStringLabel()
  */
 void SoStringLabel::GLRender(SoGLRenderAction* action)
 {
+    if (!action || !textSwitch) {
+        return;
+    }
+
     SoState* state = action->getState();
+    if (!state) {
+        return;
+    }
+
     state->push();
     SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
-    if (!QOpenGLContext::currentContext()) {
+
+    ensureTextGeometry(state);
+
+    if (textSwitch->whichChild.getValue() == SO_SWITCH_NONE) {
         state->pop();
         return;
     }
 
     const SbViewportRegion& vp = SoViewportRegionElement::get(state);
     SbVec2s vpsize = vp.getViewportSizePixels();
-    if (vpsize[0] <= 0 || vpsize[1] <= 0) {
-        state->pop();
+
+    SbViewVolume ortho;
+    ortho.ortho(0.0f, static_cast<float>(vpsize[0]), 0.0f, static_cast<float>(vpsize[1]), -1.0f, 1.0f);
+    SbMatrix affine;
+    SbMatrix projection;
+    ortho.getMatrices(affine, projection);
+
+    SoModelMatrixElement::set(state, this, SbMatrix::identity());
+    SoViewingMatrixElement::set(state, this, SbMatrix::identity());
+    SoProjectionMatrixElement::set(state, this, projection);
+    SoViewVolumeElement::set(state, this, ortho);
+
+    SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+
+    SbColor white(1.0f, 1.0f, 1.0f);
+    SoLazyElement::setDiffuse(state, this, 1, &white, 0);
+    SoLazyElement::setTransparencyType(state, static_cast<int32_t>(SoGLRenderAction::BLEND));
+    SoGLTextureEnabledElement::set(state, this, TRUE);
+    SoMultiTextureEnabledElement::set(state, this, FALSE);
+
+    textSwitch->whichChild.setValue(0);
+    textSwitch->GLRender(action);
+
+    state->pop();
+}
+
+SoStringLabel::~SoStringLabel()
+{
+    if (textSwitch) {
+        textSwitch->unref();
+        textSwitch = nullptr;
+    }
+    textSeparator = nullptr;
+    textTexture = nullptr;
+    textFaceSet = nullptr;
+    textVertexProperty = nullptr;
+}
+
+void SoStringLabel::notify(SoNotList* list)
+{
+    if (list) {
+        SoField* f = list->getLastField();
+        if (f == &this->string || f == &this->textColor || f == &this->name || f == &this->size) {
+            textGeometryDirty = true;
+        }
+    }
+
+    inherited::notify(list);
+}
+
+void SoStringLabel::ensureTextGeometry(SoState* state)
+{
+    if (!state || !textTexture || !textVertexProperty || !textFaceSet || !textSwitch) {
         return;
     }
 
-    // Enter in 2D screen mode
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
-    glLoadIdentity();
-    glOrtho(-1, 1, -1, 1, -1, 1);
-    glMatrixMode(GL_MODELVIEW);
-    glPushMatrix();
-    glLoadIdentity();
-    glPushAttrib(GL_ENABLE_BIT);
-    glDisable(GL_DEPTH_TEST);
-    glDisable(GL_LIGHTING);
-    glDisable(GL_TEXTURE_2D);
-    glEnable(GL_BLEND);
+    const SbString* values = string.getValues(0);
+    const int count = string.getNum();
+    if (count <= 0) {
+        textSwitch->whichChild.setValue(SO_SWITCH_NONE);
+        textVertexProperty->vertex.setNum(0);
+        textVertexProperty->texCoord.setNum(0);
+        textFaceSet->numVertices.setNum(0);
+        textTexture->image.setValue(SbVec2s(0, 0), 0, nullptr);
+        cachedImageWidth = 0;
+        cachedImageHeight = 0;
+        textGeometryDirty = false;
+        return;
+    }
 
-    QFont font;
+    const SbMatrix& model = SoModelMatrixElement::get(state);
+    const SbMatrix& viewing = SoViewingMatrixElement::get(state);
+    const SbMatrix& projection = SoProjectionMatrixElement::get(state);
+    const SbViewportRegion& viewport = SoViewportRegionElement::get(state);
+    SbVec2s viewportSize = viewport.getViewportSizePixels();
+
+    bool dirty = textGeometryDirty || !model.equals(cachedModelMatrix, 0.0f)
+        || !viewing.equals(cachedViewingMatrix, 0.0f)
+        || !projection.equals(cachedProjectionMatrix, 0.0f) || cachedViewportSize != viewportSize;
+
+    if (!dirty) {
+        return;
+    }
+
+    cachedModelMatrix = model;
+    cachedViewingMatrix = viewing;
+    cachedProjectionMatrix = projection;
+    cachedViewportSize = viewportSize;
+    textGeometryDirty = false;
+
+    SbMatrix combined = model * viewing * projection;
+    SbVec3f anchor3(0.0f, 0.0f, 0.0f);
+    combined.multVecMatrix(anchor3, anchor3);
+    anchor3[0] = (anchor3[0] + 1.0f) * 0.5f * viewportSize[0];
+    anchor3[1] = (anchor3[1] + 1.0f) * 0.5f * viewportSize[1];
+    cachedAnchor.setValue(anchor3[0], anchor3[1]);
+
+    QStringList lines;
+    lines.reserve(count);
+    QString fontFamily = QString::fromLatin1(name.getValue().getString());
+    QFont font(fontFamily);
+    const int fontSize = std::max(1, size.getValue());
+    font.setPixelSize(fontSize);
     font.setStyleStrategy(QFont::NoAntialias);
-    font.setFamily(QLatin1String(this->name.getValue()));
-    font.setPixelSize(this->size.getValue());
 
-    glBlendFunc(GL_ONE, GL_SRC_ALPHA);
-
-    // text color
-    SbColor color = this->textColor.getValue();
-    glColor4f(color[0], color[1], color[2], 1);
-    const SbMatrix& mat = SoModelMatrixElement::get(state);
-    const SbMatrix& projmatrix
-        = (mat * SoViewingMatrixElement::get(state) * SoProjectionMatrixElement::get(state));
-    SbVec3f nil(0.0f, 0.0f, 0.0f);
-    projmatrix.multVecMatrix(nil, nil);
-    // Project to pixel coordinates. The resulting `nil` is in normalized device coordinates
-    // (-1..1). Map to viewport pixels, then convert to Qt's top-left coordinate system.
-    float px = (nil[0] + 1.0f) * 0.5f * vpsize[0];
-    float py = vpsize[1] - ((nil[1] + 1.0f) * 0.5f * vpsize[1]);
-    QStringList list;
-    for (int i = 0; i < this->string.getNum(); i++) {
-        list << QLatin1String(this->string[i].getString());
+    QFontMetrics metrics(font);
+    int maxWidth = 0;
+    for (int i = 0; i < count; ++i) {
+        QString line = QString::fromUtf8(values[i].getString());
+        maxWidth = std::max<int>(maxWidth, QtTools::horizontalAdvance(metrics, line));
+        lines << line;
     }
 
-    if (!list.isEmpty()) {
-        QFontMetrics fm(font);
-        int maxWidth = 0;
-        for (const auto& line : list) {
-            maxWidth = std::max(maxWidth, fm.horizontalAdvance(line));
-        }
-
-        // Center text horizontally on the projected point.
-        float x = px - 0.5f * float(maxWidth);
-        float y = py + float(fm.ascent());
-
-        QOpenGLPaintDevice device(vpsize[0], vpsize[1]);
-        QPainter painter(&device);
-        painter.setRenderHint(QPainter::Antialiasing, false);
-        painter.setRenderHint(QPainter::TextAntialiasing, false);
-        painter.setRenderHint(QPainter::SmoothPixmapTransform, false);
-        painter.setFont(font);
-
-        QPen pen(QColor::fromRgbF(color[0], color[1], color[2], 1.0f));
-        painter.setPen(pen);
-        for (int i = 0; i < list.size(); i++) {
-            painter.drawText(QPointF(x, y + float(i) * float(fm.height())), list[i]);
-        }
-        painter.end();
+    if (maxWidth <= 0) {
+        maxWidth = 1;
     }
 
-    // Leave 2D screen mode
-    glPopAttrib();
-    glPopMatrix();
-    glMatrixMode(GL_PROJECTION);
-    glPopMatrix();
-    glMatrixMode(GL_MODELVIEW);
+    const int lineHeight = std::max(1, metrics.height());
+    const int ascent = metrics.ascent();
+    const int descent = metrics.descent();
+    const int textHeight = std::max(1, ascent + descent + (count - 1) * lineHeight);
 
-    state->pop();
+    QImage image(maxWidth, textHeight, QImage::Format_ARGB32_Premultiplied);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    painter.setRenderHint(QPainter::TextAntialiasing);
+    painter.setFont(font);
+
+    const SbColor sbColor = this->textColor.getValue();
+    QColor colorQt;
+    colorQt.setRgbF(sbColor[0], sbColor[1], sbColor[2]);
+    painter.setPen(colorQt);
+
+    int baseline = ascent;
+    for (const QString& line : lines) {
+        painter.drawText(0, baseline, line);
+        baseline += lineHeight;
+    }
+    painter.end();
+
+    SoSFImage sfImage;
+    Gui::BitmapFactory().convert(image, sfImage);
+    textTexture->image = sfImage;
+
+    cachedImageWidth = maxWidth;
+    cachedImageHeight = textHeight;
+
+    const float anchorX = cachedAnchor[0];
+    const float anchorY = cachedAnchor[1];
+    // Anchor the text block at its projected top-center point.
+    const float left = anchorX - 0.5f * static_cast<float>(maxWidth);
+    const float right = left + static_cast<float>(maxWidth);
+    const float top = anchorY;
+    const float bottom = top - static_cast<float>(textHeight);
+
+    textVertexProperty->vertex.setNum(4);
+    textVertexProperty->vertex.set1Value(0, SbVec3f(left, bottom, 0.0f));
+    textVertexProperty->vertex.set1Value(1, SbVec3f(right, bottom, 0.0f));
+    textVertexProperty->vertex.set1Value(2, SbVec3f(right, top, 0.0f));
+    textVertexProperty->vertex.set1Value(3, SbVec3f(left, top, 0.0f));
+
+    textVertexProperty->texCoord.setNum(4);
+    textVertexProperty->texCoord.set1Value(0, SbVec2f(0.0f, 0.0f));
+    textVertexProperty->texCoord.set1Value(1, SbVec2f(1.0f, 0.0f));
+    textVertexProperty->texCoord.set1Value(2, SbVec2f(1.0f, 1.0f));
+    textVertexProperty->texCoord.set1Value(3, SbVec2f(0.0f, 1.0f));
+
+    textFaceSet->numVertices.set1Value(0, 4);
+    textSwitch->whichChild.setValue(0);
 }
 
 // ------------------------------------------------------

--- a/src/Gui/SoTextLabel.h
+++ b/src/Gui/SoTextLabel.h
@@ -1,24 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2009 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2009 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -28,8 +29,19 @@
 #include <Inventor/fields/SoSFFloat.h>
 #include <Inventor/fields/SoSFInt32.h>
 #include <Inventor/fields/SoSFName.h>
+#include <Inventor/SbColor.h>
+#include <Inventor/SbMatrix.h>
+#include <Inventor/SbVec2f.h>
+#include <Inventor/SbVec2s.h>
+#include <Inventor/SbVec3f.h>
 #include <Inventor/manips/SoTransformManip.h>
 #include <Inventor/nodes/SoImage.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoShapeHints.h>
+#include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoTexture2.h>
+#include <Inventor/nodes/SoVertexProperty.h>
 #include <Inventor/nodes/SoText2.h>
 #include <FCGlobal.h>
 
@@ -58,8 +70,27 @@ public:
     SoSFFloat frameSize;
 
 protected:
-    ~SoTextLabel() override = default;
+    ~SoTextLabel() override;
     void GLRender(SoGLRenderAction* action) override;
+    void notify(SoNotList* list) override;
+
+private:
+    void ensureBackgroundGeometry(SoState* state, const SbBox3f& objectBounds, int lineCount);
+
+    mutable SoSwitch* backgroundSwitch {nullptr};
+    mutable SoSeparator* backgroundSeparator {nullptr};
+    mutable SoFaceSet* backgroundFaceSet {nullptr};
+    mutable SoVertexProperty* backgroundVertexProperty {nullptr};
+    mutable bool geometryDirty {true};
+    mutable SbMatrix cachedModelMatrix;
+    mutable SbMatrix cachedViewingMatrix;
+    mutable SbMatrix cachedProjectionMatrix;
+    mutable SbVec2s cachedViewportSize;
+    mutable SbVec3f cachedBBoxMin;
+    mutable SbVec3f cachedBBoxMax;
+    mutable int cachedLineCount {0};
+    mutable float cachedFrameSize {0.0f};
+    mutable SbColor cachedBackgroundColor;
 };
 
 /**
@@ -96,8 +127,26 @@ public:
     SoSFInt32 size;
 
 protected:
-    ~SoStringLabel() override = default;
+    ~SoStringLabel() override;
     void GLRender(SoGLRenderAction* action) override;
+    void notify(SoNotList* list) override;
+
+private:
+    void ensureTextGeometry(SoState* state);
+
+    mutable SoSwitch* textSwitch {nullptr};
+    mutable SoSeparator* textSeparator {nullptr};
+    mutable SoTexture2* textTexture {nullptr};
+    mutable SoFaceSet* textFaceSet {nullptr};
+    mutable SoVertexProperty* textVertexProperty {nullptr};
+    mutable bool textGeometryDirty {true};
+    mutable SbMatrix cachedModelMatrix;
+    mutable SbMatrix cachedViewingMatrix;
+    mutable SbMatrix cachedProjectionMatrix;
+    mutable SbVec2s cachedViewportSize;
+    mutable SbVec2f cachedAnchor;
+    mutable int cachedImageWidth {0};
+    mutable int cachedImageHeight {0};
 };
 
 class GuiExport SoFrameLabel: public SoImage

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1,24 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2004 Jürgen Riegel <juergen.riegel@web.de>              *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2004 Jürgen Riegel <juergen.riegel@web.de>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
@@ -42,6 +43,7 @@
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/actions/SoGetMatrixAction.h>
+#include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/actions/SoHandleEventAction.h>
 #include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/annex/HardCopy/SoVectorizePSAction.h>
@@ -74,6 +76,11 @@
 #include <Inventor/nodes/SoSwitch.h>
 #include <Inventor/nodes/SoTransform.h>
 #include <Inventor/nodes/SoTranslation.h>
+#include <Inventor/nodes/SoDepthBuffer.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoTexture2.h>
+#include <Inventor/nodes/SoTextureCoordinate2.h>
+#include <Inventor/nodes/SoVertexProperty.h>
 #include <QBitmap>
 #include <QEventLoop>
 #if defined(Q_OS_LINUX) && QT_VERSION < QT_VERSION_CHECK(6, 6, 0)
@@ -167,6 +174,208 @@ public:
 private:
     View3DInventorViewer& viewer;
 };
+
+namespace
+{
+int qImageByteCount(const QImage& image)
+{
+#if QT_VERSION >= QT_VERSION_CHECK(5, 10, 0)
+    return static_cast<int>(image.sizeInBytes());
+#else
+    return image.byteCount();
+#endif
+}
+
+void setOverlayCacheContext(SoGLRenderAction& action, const View3DInventorViewer* viewer)
+{
+    if (!viewer || !viewer->getSoRenderManager()) {
+        return;
+    }
+
+    if (auto* glra = viewer->getSoRenderManager()->getGLRenderAction()) {
+        action.setCacheContext(glra->getCacheContext());
+    }
+}
+
+SoSeparator* create2DOverlayRoot(int viewportWidth, int viewportHeight)
+{
+    auto* root = new SoSeparator;
+    root->ref();
+
+    auto* camera = new SoOrthographicCamera;
+    camera->aspectRatio.setValue(
+        static_cast<float>(viewportWidth) / static_cast<float>(viewportHeight)
+    );
+    camera->height.setValue(static_cast<float>(viewportHeight));
+    root->addChild(camera);
+
+    auto* depth = new SoDepthBuffer;
+    depth->test.setValue(false);
+    depth->write.setValue(false);
+    depth->function.setValue(SoDepthBuffer::ALWAYS);
+    root->addChild(depth);
+
+    auto* lightModel = new SoLightModel;
+    lightModel->model.setValue(SoLightModel::BASE_COLOR);
+    root->addChild(lightModel);
+
+    return root;
+}
+
+void applyOverlay(SoNode* root, int viewportWidth, int viewportHeight, const View3DInventorViewer* viewer)
+{
+    SoGLRenderAction action(SbViewportRegion(viewportWidth, viewportHeight));
+    setOverlayCacheContext(action, viewer);
+    action.setTransparencyType(SoGLRenderAction::BLEND);
+    action.apply(root);
+}
+
+struct OverlayImageState
+{
+    SoSeparator* root {nullptr};
+    SoOrthographicCamera* camera {nullptr};
+    SoDepthBuffer* depth {nullptr};
+    SoLightModel* lightModel {nullptr};
+    SoMaterial* material {nullptr};
+    SoTexture2* texture {nullptr};
+    SoTextureCoordinate2* texCoord {nullptr};
+    SoVertexProperty* vertices {nullptr};
+    SoFaceSet* quad {nullptr};
+    std::vector<unsigned char> pixelStorage;
+
+    void ensureCreated()
+    {
+        if (root) {
+            return;
+        }
+
+        root = new SoSeparator;
+        root->ref();
+
+        camera = new SoOrthographicCamera;
+        root->addChild(camera);
+
+        depth = new SoDepthBuffer;
+        depth->test.setValue(false);
+        depth->write.setValue(false);
+        depth->function.setValue(SoDepthBuffer::ALWAYS);
+        root->addChild(depth);
+
+        lightModel = new SoLightModel;
+        lightModel->model.setValue(SoLightModel::BASE_COLOR);
+        root->addChild(lightModel);
+
+        material = new SoMaterial;
+        material->diffuseColor.setValue(1.0f, 1.0f, 1.0f);
+        material->transparency.setValue(0.0f);
+        root->addChild(material);
+
+        texture = new SoTexture2;
+        texture->wrapS.setValue(SoTexture2::CLAMP);
+        texture->wrapT.setValue(SoTexture2::CLAMP);
+        root->addChild(texture);
+
+        texCoord = new SoTextureCoordinate2;
+        texCoord->point.set1Value(0, SbVec2f(0.0f, 0.0f));
+        texCoord->point.set1Value(1, SbVec2f(1.0f, 0.0f));
+        texCoord->point.set1Value(2, SbVec2f(1.0f, 1.0f));
+        texCoord->point.set1Value(3, SbVec2f(0.0f, 1.0f));
+        root->addChild(texCoord);
+
+        vertices = new SoVertexProperty;
+
+        quad = new SoFaceSet;
+        quad->vertexProperty.setValue(vertices);
+        quad->numVertices.setValue(4);
+        root->addChild(quad);
+    }
+};
+
+OverlayImageState& overlayImageState()
+{
+    static OverlayImageState state;
+    return state;
+}
+
+bool hasFramebufferBlitSupport()
+{
+    return QOpenGLFramebufferObject::hasOpenGLFramebufferBlit();
+}
+
+void renderOverlayImage(
+    const QImage& image,
+    int viewportWidth,
+    int viewportHeight,
+    float drawWidth,
+    float drawHeight,
+    const View3DInventorViewer* viewer
+)
+{
+    if (viewportWidth <= 0 || viewportHeight <= 0 || image.isNull()) {
+        return;
+    }
+
+    auto& overlay = overlayImageState();
+    overlay.ensureCreated();
+    if (!overlay.root || !overlay.camera || !overlay.texture || !overlay.vertices) {
+        return;
+    }
+
+    overlay.camera->aspectRatio.setValue(
+        static_cast<float>(viewportWidth) / static_cast<float>(viewportHeight)
+    );
+    overlay.camera->height.setValue(static_cast<float>(viewportHeight));
+
+    QImage rgba = image.convertToFormat(QImage::Format_RGBA8888);
+    overlay.pixelStorage.assign(rgba.constBits(), rgba.constBits() + qImageByteCount(rgba));
+    overlay.texture->image
+        .setValue(SbVec2s(rgba.width(), rgba.height()), 4, overlay.pixelStorage.data());
+
+    const float baseX = -0.5f * static_cast<float>(viewportWidth);
+    const float baseY = -0.5f * static_cast<float>(viewportHeight);
+
+    overlay.vertices->vertex.set1Value(0, SbVec3f(baseX, baseY, 0.0f));
+    overlay.vertices->vertex.set1Value(1, SbVec3f(baseX + drawWidth, baseY, 0.0f));
+    overlay.vertices->vertex.set1Value(2, SbVec3f(baseX + drawWidth, baseY + drawHeight, 0.0f));
+    overlay.vertices->vertex.set1Value(3, SbVec3f(baseX, baseY + drawHeight, 0.0f));
+
+    applyOverlay(overlay.root, viewportWidth, viewportHeight, viewer);
+}
+
+void renderOverlaySolidColor(
+    const QColor& col,
+    int viewportWidth,
+    int viewportHeight,
+    const View3DInventorViewer* viewer
+)
+{
+    SoSeparator* root = create2DOverlayRoot(viewportWidth, viewportHeight);
+
+    auto* material = new SoMaterial;
+    material->diffuseColor.setValue(
+        static_cast<float>(col.redF()),
+        static_cast<float>(col.greenF()),
+        static_cast<float>(col.blueF())
+    );
+    material->transparency.setValue(1.0f - static_cast<float>(col.alphaF()));
+    root->addChild(material);
+
+    auto* vertices = new SoVertexProperty;
+    vertices->vertex.set1Value(0, SbVec3f(-0.5f * viewportWidth, -0.5f * viewportHeight, 0.0f));
+    vertices->vertex.set1Value(1, SbVec3f(0.5f * viewportWidth, -0.5f * viewportHeight, 0.0f));
+    vertices->vertex.set1Value(2, SbVec3f(0.5f * viewportWidth, 0.5f * viewportHeight, 0.0f));
+    vertices->vertex.set1Value(3, SbVec3f(-0.5f * viewportWidth, 0.5f * viewportHeight, 0.0f));
+
+    auto* face = new SoFaceSet;
+    face->vertexProperty.setValue(vertices);
+    face->numVertices.setValue(4);
+    root->addChild(face);
+
+    applyOverlay(root, viewportWidth, viewportHeight, viewer);
+    root->unref();
+}
+
+}  // namespace
 
 /*!
 As ProgressBar has no chance to control the incoming Qt events of Quarter so we need to stop
@@ -2330,7 +2539,7 @@ void View3DInventorViewer::setRenderType(RenderType type)
                 fboFormat.setSamples(getNumSamples());
                 fboFormat.setAttachment(QOpenGLFramebufferObject::Depth);
                 auto fbo = new QOpenGLFramebufferObject(width, height, fboFormat);
-                if (fbo->format().samples() > 0) {
+                if (fbo->format().samples() > 0 && hasFramebufferBlitSupport()) {
                     renderToFramebuffer(fbo);
                     framebuffer = new QOpenGLFramebufferObject(fbo->size());
                     // this is needed to be able to render the texture later
@@ -2338,6 +2547,16 @@ void View3DInventorViewer::setRenderType(RenderType type)
                     delete fbo;
                 }
                 else {
+                    if (fbo->format().samples() > 0 && !hasFramebufferBlitSupport()) {
+                        Base::Console().warning(
+                            "Framebuffer blit is unavailable; falling back to a single-sample "
+                            "offscreen buffer\n"
+                        );
+                        delete fbo;
+                        QOpenGLFramebufferObjectFormat fallbackFormat;
+                        fallbackFormat.setAttachment(QOpenGLFramebufferObject::Depth);
+                        fbo = new QOpenGLFramebufferObject(width, height, fallbackFormat);
+                    }
                     renderToFramebuffer(fbo);
                     framebuffer = fbo;
                 }
@@ -2482,8 +2701,6 @@ void View3DInventorViewer::renderToFramebuffer(QOpenGLFramebufferObject* fbo)
     int width = fbo->size().width();
     int height = fbo->size().height();
 
-    glDisable(GL_TEXTURE_2D);
-    glEnable(GL_LIGHTING);
     glEnable(GL_DEPTH_TEST);
     glEnable(GL_LINE_SMOOTH);
 
@@ -2541,68 +2758,74 @@ void View3DInventorViewer::renderFramebuffer()
 {
     const SbViewportRegion vp = this->getSoRenderManager()->getViewportRegion();
     SbVec2s size = vp.getViewportSizePixels();
+    const int viewportWidth = size[0];
+    const int viewportHeight = size[1];
+    if (!this->framebuffer || viewportWidth <= 0 || viewportHeight <= 0) {
+        return;
+    }
 
-    glPushAttrib(GL_ALL_ATTRIB_BITS);
-    glDisable(GL_LIGHTING);
-    glViewport(0, 0, size[0], size[1]);
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-    glDisable(GL_DEPTH_TEST);
+    static_cast<QOpenGLWidget*>(this->viewport())->makeCurrent();  // NOLINT
+    glViewport(0, 0, viewportWidth, viewportHeight);
 
-    glClear(GL_COLOR_BUFFER_BIT);
-    glEnable(GL_TEXTURE_2D);
-    glBindTexture(GL_TEXTURE_2D, this->framebuffer->texture());
-    glColor3f(1.0, 1.0, 1.0);
-
-    glBegin(GL_QUADS);
-    glTexCoord2f(0.0F, 0.0F);
-    glVertex2f(-1.0, -1.0F);
-    glTexCoord2f(1.0F, 0.0F);
-    glVertex2f(1.0F, -1.0F);
-    glTexCoord2f(1.0F, 1.0F);
-    glVertex2f(1.0F, 1.0F);
-    glTexCoord2f(0.0F, 1.0F);
-    glVertex2f(-1.0F, 1.0F);
-    glEnd();
+    if (hasFramebufferBlitSupport()) {
+        const QSize srcSize = this->framebuffer->size();
+        QOpenGLFramebufferObject::blitFramebuffer(
+            nullptr,
+            QRect(0, 0, viewportWidth, viewportHeight),
+            this->framebuffer,
+            QRect(0, 0, srcSize.width(), srcSize.height()),
+            GL_COLOR_BUFFER_BIT,
+            GL_NEAREST
+        );
+    }
+    else {
+        renderOverlayImage(
+            this->framebuffer->toImage(false),
+            viewportWidth,
+            viewportHeight,
+            static_cast<float>(viewportWidth),
+            static_cast<float>(viewportHeight),
+            this
+        );
+    }
 
     printDimension();
 
     for (auto it : this->graphicsItems) {
         it->paintGL();
     }
-
-    glPopAttrib();
 }
 
 void View3DInventorViewer::renderGLImage()
 {
     const SbViewportRegion vp = this->getSoRenderManager()->getViewportRegion();
     SbVec2s size = vp.getViewportSizePixels();
+    const int viewportWidth = size[0];
+    const int viewportHeight = size[1];
+    if (viewportWidth <= 0 || viewportHeight <= 0 || glImage.isNull()) {
+        return;
+    }
 
-    glPushAttrib(GL_ALL_ATTRIB_BITS);
-    glDisable(GL_LIGHTING);
-    glViewport(0, 0, size[0], size[1]);
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0, size[0], 0, size[1], 0, 100);  // NOLINT
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-
-    glDisable(GL_DEPTH_TEST);
+    static_cast<QOpenGLWidget*>(this->viewport())->makeCurrent();  // NOLINT
+    glViewport(0, 0, viewportWidth, viewportHeight);
+    const QColor col = this->backgroundColor();
+    glClearColor(float(col.redF()), float(col.greenF()), float(col.blueF()), 0.0f);
     glClear(GL_COLOR_BUFFER_BIT);
 
-    glRasterPos2f(0, 0);
-    glDrawPixels(glImage.width(), glImage.height(), GL_BGRA, GL_UNSIGNED_BYTE, glImage.bits());
+    renderOverlayImage(
+        glImage,
+        viewportWidth,
+        viewportHeight,
+        static_cast<float>(glImage.width()),
+        static_cast<float>(glImage.height()),
+        this
+    );
 
     printDimension();
 
     for (auto it : this->graphicsItems) {
         it->paintGL();
     }
-
-    glPopAttrib();
 }
 
 // #define ENABLE_GL_DEPTH_RANGE
@@ -2775,11 +2998,17 @@ void View3DInventorViewer::renderScene()
     // https://bugreports.qt.io/browse/QTBUG-119214
     // https://github.com/FreeCAD/FreeCAD/issues/8341
     // https://github.com/FreeCAD/FreeCAD/issues/6177
-    glPushAttrib(GL_COLOR_BUFFER_BIT);
+    GLboolean colorMask[4] = {GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE};
+    glGetBooleanv(GL_COLOR_WRITEMASK, colorMask);
+    GLfloat clearColor[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+    glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor);
+
     glColorMask(false, false, false, true);
     glClearColor(0, 0, 0, 1);
     glClear(GL_COLOR_BUFFER_BIT);
-    glPopAttrib();
+
+    glColorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
+    glClearColor(clearColor[0], clearColor[1], clearColor[2], clearColor[3]);
 }
 
 void View3DInventorViewer::setSeekMode(bool on)
@@ -4553,32 +4782,15 @@ void View3DInventorViewer::drawSingleBackground(const QColor& col)
     // Note: After changing the NaviCube code the content of an image plane may appear black.
     // A workaround is this function.
     // See also: https://github.com/FreeCAD/FreeCAD/pull/9356#issuecomment-1529521654
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
-    glLoadIdentity();
-    glOrtho(-1, 1, -1, 1, -1, 1);
-    glMatrixMode(GL_MODELVIEW);
-    glPushMatrix();
-    glLoadIdentity();
-    glPushAttrib(GL_ENABLE_BIT);
-    glDisable(GL_DEPTH_TEST);
-    glDisable(GL_LIGHTING);
-    glDisable(GL_TEXTURE_2D);
-    glBegin(GL_TRIANGLE_STRIP);
-    glColor3f(float(col.redF()), float(col.greenF()), float(col.blueF()));
-    glVertex2f(-1, 1);
-    glColor3f(float(col.redF()), float(col.greenF()), float(col.blueF()));
-    glVertex2f(-1, -1);
-    glColor3f(float(col.redF()), float(col.greenF()), float(col.blueF()));
-    glVertex2f(1, 1);
-    glColor3f(float(col.redF()), float(col.greenF()), float(col.blueF()));
-    glVertex2f(1, -1);
-    glEnd();
-    glPopAttrib();
-    glPopMatrix();
-    glMatrixMode(GL_PROJECTION);
-    glPopMatrix();
-    glMatrixMode(GL_MODELVIEW);
+    const SbViewportRegion vp = this->getSoRenderManager()->getViewportRegion();
+    const SbVec2s size = vp.getViewportSizePixels();
+    const int viewportWidth = size[0];
+    const int viewportHeight = size[1];
+    if (viewportWidth <= 0 || viewportHeight <= 0) {
+        return;
+    }
+
+    renderOverlaySolidColor(col, viewportWidth, viewportHeight, this);
 }
 
 // ************************************************************************

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -38,6 +38,9 @@
 
 #include <fmt/format.h>
 
+#include <algorithm>
+#include <array>
+
 #include <Inventor/SbBox.h>
 #include <Inventor/SoEventManager.h>
 #include <Inventor/SoPickedPoint.h>
@@ -373,6 +376,250 @@ void renderOverlaySolidColor(
 
     applyOverlay(root, viewportWidth, viewportHeight, viewer);
     root->unref();
+}
+
+SoSeparator* createAxisArrowGeometry()
+{
+    constexpr float shaftLength = 1.0f - 1.0f / 3.0f;
+    constexpr float halfThickness = 0.02f;
+    constexpr float headHalfExtent = 0.5f / 4.0f;
+
+    auto* root = new SoSeparator;
+
+    auto* vertices = new SoVertexProperty;
+    int v = 0;
+
+    auto add = [&](float x, float y, float z) {
+        vertices->vertex.set1Value(v++, SbVec3f(x, y, z));
+    };
+
+    // Shaft (5 quads)
+    add(0.0f, -halfThickness, halfThickness);
+    add(0.0f, halfThickness, halfThickness);
+    add(shaftLength, halfThickness, halfThickness);
+    add(shaftLength, -halfThickness, halfThickness);
+
+    add(0.0f, -halfThickness, -halfThickness);
+    add(0.0f, halfThickness, -halfThickness);
+    add(shaftLength, halfThickness, -halfThickness);
+    add(shaftLength, -halfThickness, -halfThickness);
+
+    add(0.0f, -halfThickness, halfThickness);
+    add(0.0f, -halfThickness, -halfThickness);
+    add(shaftLength, -halfThickness, -halfThickness);
+    add(shaftLength, -halfThickness, halfThickness);
+
+    add(0.0f, halfThickness, halfThickness);
+    add(0.0f, halfThickness, -halfThickness);
+    add(shaftLength, halfThickness, -halfThickness);
+    add(shaftLength, halfThickness, halfThickness);
+
+    add(0.0f, halfThickness, halfThickness);
+    add(0.0f, halfThickness, -halfThickness);
+    add(0.0f, -halfThickness, -halfThickness);
+    add(0.0f, -halfThickness, halfThickness);
+
+    // Tip (2 triangles)
+    add(1.0f, 0.0f, 0.0f);
+    add(shaftLength, headHalfExtent, 0.0f);
+    add(shaftLength, -headHalfExtent, 0.0f);
+
+    add(1.0f, 0.0f, 0.0f);
+    add(shaftLength, 0.0f, headHalfExtent);
+    add(shaftLength, 0.0f, -headHalfExtent);
+
+    // Tip base (1 quad)
+    add(shaftLength, headHalfExtent, 0.0f);
+    add(shaftLength, 0.0f, headHalfExtent);
+    add(shaftLength, -headHalfExtent, 0.0f);
+    add(shaftLength, 0.0f, -headHalfExtent);
+
+    static constexpr int faceCounts[] = {4, 4, 4, 4, 4, 3, 3, 4};
+    auto* faceSet = new SoFaceSet;
+    faceSet->vertexProperty.setValue(vertices);
+    faceSet->numVertices.setValues(0, static_cast<int>(std::size(faceCounts)), faceCounts);
+
+    root->addChild(faceSet);
+    return root;
+}
+
+struct OverlayAxisCrossState
+{
+    SoSeparator* axisRoot {nullptr};
+    SoPerspectiveCamera* axisCamera {nullptr};
+    SoDepthBuffer* axisDepth {nullptr};
+    SoLightModel* axisLightModel {nullptr};
+    SoTransform* axisTransform {nullptr};
+    SoSeparator* axisGroup {nullptr};
+
+    SoSeparator* xAxis {nullptr};
+    SoMaterial* xMaterial {nullptr};
+
+    SoSeparator* yAxis {nullptr};
+    SoMaterial* yMaterial {nullptr};
+    SoRotation* yRotation {nullptr};
+
+    SoSeparator* zAxis {nullptr};
+    SoMaterial* zMaterial {nullptr};
+    SoRotation* zRotation {nullptr};
+
+    SoSeparator* lettersRoot {nullptr};
+    SoOrthographicCamera* lettersCamera {nullptr};
+    SoDepthBuffer* lettersDepth {nullptr};
+    SoLightModel* lettersLightModel {nullptr};
+    SoMaterial* lettersMaterial {nullptr};
+
+    struct Letter
+    {
+        SoSeparator* root {nullptr};
+        SoTranslation* position {nullptr};
+        SoScale* scale {nullptr};
+        SoTexture2* texture {nullptr};
+        SoVertexProperty* vertices {nullptr};
+        SoFaceSet* quad {nullptr};
+    };
+
+    Letter xLetter;
+    Letter yLetter;
+    Letter zLetter;
+
+    void ensureCreated()
+    {
+        if (axisRoot) {
+            return;
+        }
+
+        axisRoot = new SoSeparator;
+        axisRoot->ref();
+
+        axisCamera = new SoPerspectiveCamera;
+        axisCamera->position.setValue(0.0f, 0.0f, 0.0f);
+        axisCamera->orientation.setValue(SbRotation::identity());
+        axisCamera->heightAngle.setValue(static_cast<float>(std::numbers::pi / 4.0));
+        axisCamera->nearDistance.setValue(0.1f);
+        axisCamera->farDistance.setValue(10.0f);
+        axisRoot->addChild(axisCamera);
+
+        axisDepth = new SoDepthBuffer;
+        axisDepth->test.setValue(false);
+        axisDepth->write.setValue(false);
+        axisDepth->function.setValue(SoDepthBuffer::ALWAYS);
+        axisRoot->addChild(axisDepth);
+
+        axisLightModel = new SoLightModel;
+        axisLightModel->model.setValue(SoLightModel::BASE_COLOR);
+        axisRoot->addChild(axisLightModel);
+
+        axisTransform = new SoTransform;
+        axisTransform->translation.setValue(0.0f, 0.0f, -3.5f);
+        axisRoot->addChild(axisTransform);
+
+        axisGroup = new SoSeparator;
+        axisRoot->addChild(axisGroup);
+
+        auto* arrow = createAxisArrowGeometry();
+
+        xAxis = new SoSeparator;
+        xAxis->ref();
+        xMaterial = new SoMaterial;
+        xAxis->addChild(xMaterial);
+        xAxis->addChild(arrow);
+
+        yAxis = new SoSeparator;
+        yAxis->ref();
+        yMaterial = new SoMaterial;
+        yAxis->addChild(yMaterial);
+        yRotation = new SoRotation;
+        yRotation->rotation.setValue(
+            SbVec3f(0.0f, 0.0f, 1.0f),
+            static_cast<float>(std::numbers::pi / 2.0)
+        );
+        yAxis->addChild(yRotation);
+        yAxis->addChild(arrow);
+
+        zAxis = new SoSeparator;
+        zAxis->ref();
+        zMaterial = new SoMaterial;
+        zAxis->addChild(zMaterial);
+        zRotation = new SoRotation;
+        zRotation->rotation.setValue(
+            SbVec3f(0.0f, 1.0f, 0.0f),
+            static_cast<float>(-std::numbers::pi / 2.0)
+        );
+        zAxis->addChild(zRotation);
+        zAxis->addChild(arrow);
+
+        lettersRoot = new SoSeparator;
+        lettersRoot->ref();
+
+        lettersCamera = new SoOrthographicCamera;
+        lettersRoot->addChild(lettersCamera);
+
+        lettersDepth = new SoDepthBuffer;
+        lettersDepth->test.setValue(false);
+        lettersDepth->write.setValue(false);
+        lettersDepth->function.setValue(SoDepthBuffer::ALWAYS);
+        lettersRoot->addChild(lettersDepth);
+
+        lettersLightModel = new SoLightModel;
+        lettersLightModel->model.setValue(SoLightModel::BASE_COLOR);
+        lettersRoot->addChild(lettersLightModel);
+
+        lettersMaterial = new SoMaterial;
+        lettersMaterial->diffuseColor.setValue(1.0f, 1.0f, 1.0f);
+        lettersMaterial->transparency.setValue(0.0f);
+        lettersRoot->addChild(lettersMaterial);
+
+        auto buildLetter = [](Letter& out, int w, int h) {
+            out.root = new SoSeparator;
+
+            out.position = new SoTranslation;
+            out.root->addChild(out.position);
+
+            out.scale = new SoScale;
+            out.root->addChild(out.scale);
+
+            out.texture = new SoTexture2;
+            out.texture->wrapS.setValue(SoTexture2::CLAMP);
+            out.texture->wrapT.setValue(SoTexture2::CLAMP);
+            out.texture->model.setValue(SoTexture2::MODULATE);
+            out.texture->enableCompressedTexture.setValue(FALSE);
+            out.root->addChild(out.texture);
+
+            out.vertices = new SoVertexProperty;
+            out.vertices->vertex.set1Value(0, SbVec3f(0.0f, 0.0f, 0.0f));
+            out.vertices->vertex.set1Value(1, SbVec3f(static_cast<float>(w), 0.0f, 0.0f));
+            out.vertices->vertex.set1Value(
+                2,
+                SbVec3f(static_cast<float>(w), static_cast<float>(h), 0.0f)
+            );
+            out.vertices->vertex.set1Value(3, SbVec3f(0.0f, static_cast<float>(h), 0.0f));
+
+            out.vertices->texCoord.set1Value(0, SbVec2f(0.0f, 0.0f));
+            out.vertices->texCoord.set1Value(1, SbVec2f(1.0f, 0.0f));
+            out.vertices->texCoord.set1Value(2, SbVec2f(1.0f, 1.0f));
+            out.vertices->texCoord.set1Value(3, SbVec2f(0.0f, 1.0f));
+
+            out.quad = new SoFaceSet;
+            out.quad->vertexProperty.setValue(out.vertices);
+            out.quad->numVertices.setValue(4);
+            out.root->addChild(out.quad);
+        };
+
+        buildLetter(xLetter, XPM_WIDTH, XPM_HEIGHT);
+        buildLetter(yLetter, YPM_WIDTH, YPM_HEIGHT);
+        buildLetter(zLetter, ZPM_WIDTH, ZPM_HEIGHT);
+
+        lettersRoot->addChild(xLetter.root);
+        lettersRoot->addChild(yLetter.root);
+        lettersRoot->addChild(zLetter.root);
+    }
+};
+
+OverlayAxisCrossState& overlayAxisCrossState()
+{
+    static OverlayAxisCrossState state;
+    return state;
 }
 
 }  // namespace
@@ -4540,241 +4787,138 @@ void View3DInventorViewer::updateColors()
 
 void View3DInventorViewer::drawAxisCross()
 {
-    // NOLINTBEGIN
-    // FIXME: convert this to a superimposition scenegraph instead of
-    // OpenGL calls. 20020603 mortene.
+    const SbVec2s view = this->getSoRenderManager()->getSize();
+    const int viewWidth = view[0];
+    const int viewHeight = view[1];
+    if (viewWidth <= 0 || viewHeight <= 0) {
+        return;
+    }
 
-    // Store GL state.
-    glPushAttrib(GL_ALL_ATTRIB_BITS);
-    GLfloat depthrange[2];
-    glGetFloatv(GL_DEPTH_RANGE, depthrange);
-    GLdouble projectionmatrix[16];
-    glGetDoublev(GL_PROJECTION_MATRIX, projectionmatrix);
+    const int pixelarea = static_cast<int>(
+        static_cast<float>(this->axiscrossSize) / 100.0F * std::min(viewWidth, viewHeight)
+    );
+    if (pixelarea <= 0) {
+        return;
+    }
 
-    glDepthFunc(GL_ALWAYS);
-    glDepthMask(GL_TRUE);
-    glDepthRange(0, 0);
-    glEnable(GL_DEPTH_TEST);
-    glDisable(GL_LIGHTING);
-    glEnable(GL_COLOR_MATERIAL);
-    glDisable(GL_BLEND);  // Kills transparency.
+    const SbVec2s origin(viewWidth - pixelarea, 0);
 
-    // Set the viewport in the OpenGL canvas. Dimensions are calculated
-    // as a percentage of the total canvas size.
-    SbVec2s view = this->getSoRenderManager()->getSize();
-    const int pixelarea = int(float(this->axiscrossSize) / 100.0F * std::min(view[0], view[1]));
-    SbVec2s origin(view[0] - pixelarea, 0);
-    glViewport(origin[0], origin[1], pixelarea, pixelarea);
+    constexpr float nearVal = 0.1f;
+    constexpr float farVal = 10.0f;
+    const float dim = nearVal * static_cast<float>(std::tan(std::numbers::pi / 8.0));
 
-    // Set up the projection matrix.
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-
-    const float NEARVAL = 0.1F;
-    const float FARVAL = 10.0F;
-    const float dim = NEARVAL * float(tan(std::numbers::pi / 8.0));  // FOV is 45 deg (45/360 = 1/8)
-    glFrustum(-dim, dim, -dim, dim, NEARVAL, FARVAL);
-
-
-    // Set up the model matrix.
-    glMatrixMode(GL_MODELVIEW);
-    glPushMatrix();
-    SbMatrix mx;
+    SbMatrix model;
     SoCamera* cam = this->getSoRenderManager()->getCamera();
-
-    // If there is no camera (like for an empty scene, for instance),
-    // just use an identity rotation.
     if (cam) {
-        mx = cam->orientation.getValue();
+        model = cam->orientation.getValue();
     }
     else {
-        mx = SbMatrix::identity();
+        model = SbMatrix::identity();
     }
+    model = model.inverse();
+    model[3][0] = 0.0f;
+    model[3][1] = 0.0f;
+    model[3][2] = -3.5f;
 
-    mx = mx.inverse();
-    mx[3][2] = -3.5;  // Translate away from the projection point (along z axis).
-    glLoadMatrixf((float*)mx);
+    SbViewVolume vv;
+    vv.frustum(-dim, dim, -dim, dim, nearVal, farVal);
+    SbMatrix affine;
+    SbMatrix projection;
+    vv.getMatrices(affine, projection);
 
-
-    // Find unit vector end points.
-    SbMatrix px;
-    glGetFloatv(GL_PROJECTION_MATRIX, (float*)px);
-    SbMatrix comb = mx.multRight(px);  // clazy:exclude=rule-of-two-soft
-
+    const SbMatrix comb = model.multRight(projection);
     SbVec3f xpos;
     comb.multVecMatrix(SbVec3f(1, 0, 0), xpos);
-    xpos[0] = (1 + xpos[0]) * view[0] / 2;
-    xpos[1] = (1 + xpos[1]) * view[1] / 2;
+    xpos[0] = (1 + xpos[0]) * static_cast<float>(viewWidth) / 2.0f;
+    xpos[1] = (1 + xpos[1]) * static_cast<float>(viewHeight) / 2.0f;
     SbVec3f ypos;
     comb.multVecMatrix(SbVec3f(0, 1, 0), ypos);
-    ypos[0] = (1 + ypos[0]) * view[0] / 2;
-    ypos[1] = (1 + ypos[1]) * view[1] / 2;
+    ypos[0] = (1 + ypos[0]) * static_cast<float>(viewWidth) / 2.0f;
+    ypos[1] = (1 + ypos[1]) * static_cast<float>(viewHeight) / 2.0f;
     SbVec3f zpos;
     comb.multVecMatrix(SbVec3f(0, 0, 1), zpos);
-    zpos[0] = (1 + zpos[0]) * view[0] / 2;
-    zpos[1] = (1 + zpos[1]) * view[1] / 2;
+    zpos[0] = (1 + zpos[0]) * static_cast<float>(viewWidth) / 2.0f;
+    zpos[1] = (1 + zpos[1]) * static_cast<float>(viewHeight) / 2.0f;
 
-
-    // Render the cross.
-    {
-        glLineWidth(2.0);
-
-        enum
-        {
-            XAXIS,
-            YAXIS,
-            ZAXIS
-        };
-        int idx[3] = {XAXIS, YAXIS, ZAXIS};
-        float val[3] = {xpos[2], ypos[2], zpos[2]};
-
-        // Bubble sort.. :-}
-        if (val[0] < val[1]) {
-            std::swap(val[0], val[1]);
-            std::swap(idx[0], idx[1]);
-        }
-
-        if (val[1] < val[2]) {
-            std::swap(val[1], val[2]);
-            std::swap(idx[1], idx[2]);
-        }
-
-        if (val[0] < val[1]) {
-            std::swap(val[0], val[1]);
-            std::swap(idx[0], idx[1]);
-        }
-
-        assert((val[0] >= val[1]) && (val[1] >= val[2]));  // Just checking..
-
-        for (const int& i : idx) {
-            glPushMatrix();
-
-            if (i == XAXIS) {                                             // X axis.
-                if (stereoMode() != Quarter::SoQTQuarterAdaptor::MONO) {  // What is this
-                    glColor3f(0.500F, 0.5F, 0.5F);                        // Why different colors??
-                }
-                else {
-                    glColor3f(m_xColor.r, m_xColor.g, m_xColor.b);
-                }
-            }
-            else if (i == YAXIS) {  // Y axis.
-                glRotatef(90, 0, 0, 1);
-
-                if (stereoMode() != Quarter::SoQTQuarterAdaptor::MONO) {
-                    glColor3f(0.400F, 0.4F, 0.4F);
-                }
-                else {
-                    glColor3f(m_yColor.r, m_yColor.g, m_yColor.b);
-                }
-            }
-            else {  // Z axis.
-                glRotatef(-90, 0, 1, 0);
-
-                if (stereoMode() != Quarter::SoQTQuarterAdaptor::MONO) {
-                    glColor3f(0.300F, 0.3F, 0.3F);
-                }
-                else {
-                    glColor3f(m_zColor.r, m_zColor.g, m_zColor.b);
-                }
-            }
-
-            drawArrow();
-            glPopMatrix();
-        }
+    auto& overlay = overlayAxisCrossState();
+    overlay.ensureCreated();
+    if (!overlay.axisRoot || !overlay.axisTransform || !overlay.axisGroup || !overlay.lettersRoot
+        || !overlay.lettersCamera) {
+        return;
     }
 
-    // Render axis notation letters ("X", "Y", "Z").
-    glMatrixMode(GL_PROJECTION);
-    glLoadIdentity();
-    glOrtho(0, view[0], 0, view[1], -1, 1);
-
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-
-    GLint unpack {};
-    glGetIntegerv(GL_UNPACK_ALIGNMENT, &unpack);
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-    if (stereoMode() != Quarter::SoQTQuarterAdaptor::MONO) {
-        glColor3fv(SbVec3f(1.0F, 1.0F, 1.0F).getValue());
+    SbRotation inv;
+    if (cam) {
+        inv = cam->orientation.getValue().inverse();
     }
     else {
-        glColor3fv(SbVec3f(0.0F, 0.0F, 0.0F).getValue());
+        inv = SbRotation::identity();
+    }
+    overlay.axisTransform->rotation.setValue(inv);
+    overlay.axisTransform->translation.setValue(0.0f, 0.0f, -3.5f);
+
+    const bool stereo = stereoMode() != Quarter::SoQTQuarterAdaptor::MONO;
+    if (stereo) {
+        overlay.xMaterial->diffuseColor.setValue(0.5f, 0.5f, 0.5f);
+        overlay.yMaterial->diffuseColor.setValue(0.4f, 0.4f, 0.4f);
+        overlay.zMaterial->diffuseColor.setValue(0.3f, 0.3f, 0.3f);
+    }
+    else {
+        overlay.xMaterial->diffuseColor.setValue(m_xColor.r, m_xColor.g, m_xColor.b);
+        overlay.yMaterial->diffuseColor.setValue(m_yColor.r, m_yColor.g, m_yColor.b);
+        overlay.zMaterial->diffuseColor.setValue(m_zColor.r, m_zColor.g, m_zColor.b);
     }
 
-    glEnable(GL_BLEND);
-    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glPixelZoom((float)axiscrossSize / 30, (float)axiscrossSize / 30);  // 30 = 3 (character pixmap
-                                                                        // ratio) * 10 (default
-                                                                        // axiscrossSize)
-    glRasterPos2d(xpos[0], xpos[1]);
-    glDrawPixels(XPM_WIDTH, XPM_HEIGHT, GL_RGBA, GL_UNSIGNED_BYTE, XPM_pixel_data);
-    glRasterPos2d(ypos[0], ypos[1]);
-    glDrawPixels(YPM_WIDTH, YPM_HEIGHT, GL_RGBA, GL_UNSIGNED_BYTE, YPM_pixel_data);
-    glRasterPos2d(zpos[0], zpos[1]);
-    glDrawPixels(ZPM_WIDTH, ZPM_HEIGHT, GL_RGBA, GL_UNSIGNED_BYTE, ZPM_pixel_data);
+    std::array<std::pair<float, SoNode*>, 3> axes = {
+        std::pair<float, SoNode*> {xpos[2], overlay.xAxis},
+        std::pair<float, SoNode*> {ypos[2], overlay.yAxis},
+        std::pair<float, SoNode*> {zpos[2], overlay.zAxis},
+    };
+    std::sort(axes.begin(), axes.end(), [](const auto& a, const auto& b) {
+        return a.first > b.first;
+    });
+    overlay.axisGroup->removeAllChildren();
+    for (const auto& axis : axes) {
+        overlay.axisGroup->addChild(axis.second);
+    }
 
-    glPixelStorei(GL_UNPACK_ALIGNMENT, unpack);
-    glPopMatrix();
+    overlay.lettersCamera->aspectRatio.setValue(
+        static_cast<float>(viewWidth) / static_cast<float>(viewHeight)
+    );
+    overlay.lettersCamera->height.setValue(static_cast<float>(viewHeight));
 
-    // Reset original state.
+    // The overlay viewport above is sized in physical framebuffer pixels, so
+    // the axis letters must scale by the device pixel ratio to keep the same
+    // perceived size as the axis cross on HiDPI displays.
+    const float scale = static_cast<float>(axiscrossSize) / 30.0f
+        * static_cast<float>(devicePixelRatio());
+    overlay.xLetter.scale->scaleFactor.setValue(scale, scale, 1.0f);
+    overlay.yLetter.scale->scaleFactor.setValue(scale, scale, 1.0f);
+    overlay.zLetter.scale->scaleFactor.setValue(scale, scale, 1.0f);
 
-    // FIXME: are these 3 lines really necessary, as we push
-    // GL_ALL_ATTRIB_BITS at the start? 20000604 mortene.
-    glDepthRange(depthrange[0], depthrange[1]);
-    glMatrixMode(GL_PROJECTION);
-    glLoadMatrixd(projectionmatrix);
+    overlay.xLetter.position->translation
+        .setValue(xpos[0] - 0.5f * viewWidth, xpos[1] - 0.5f * viewHeight, 0.0f);
+    overlay.yLetter.position->translation
+        .setValue(ypos[0] - 0.5f * viewWidth, ypos[1] - 0.5f * viewHeight, 0.0f);
+    overlay.zLetter.position->translation
+        .setValue(zpos[0] - 0.5f * viewWidth, zpos[1] - 0.5f * viewHeight, 0.0f);
 
-    glPopAttrib();
-    // NOLINTEND
-}
+    overlay.xLetter.texture->image.setValue(SbVec2s(XPM_WIDTH, XPM_HEIGHT), 4, XPM_pixel_data);
+    overlay.yLetter.texture->image.setValue(SbVec2s(YPM_WIDTH, YPM_HEIGHT), 4, YPM_pixel_data);
+    overlay.zLetter.texture->image.setValue(SbVec2s(ZPM_WIDTH, ZPM_HEIGHT), 4, ZPM_pixel_data);
 
-// Draw an arrow for the axis representation directly through OpenGL.
-void View3DInventorViewer::drawArrow()
-{
-    // NOLINTBEGIN
-    glDisable(GL_CULL_FACE);
-    glBegin(GL_QUADS);
-    glVertex3f(0.0F, -0.02F, 0.02F);
-    glVertex3f(0.0F, 0.02F, 0.02F);
-    glVertex3f(1.0F - 1.0F / 3.0F, 0.02F, 0.02F);
-    glVertex3f(1.0F - 1.0F / 3.0F, -0.02F, 0.02F);
+    SbViewportRegion vp = this->getSoRenderManager()->getViewportRegion();
+    vp.setViewportPixels(origin[0], origin[1], pixelarea, pixelarea);
 
-    glVertex3f(0.0F, -0.02F, -0.02F);
-    glVertex3f(0.0F, 0.02F, -0.02F);
-    glVertex3f(1.0F - 1.0F / 3.0F, 0.02F, -0.02F);
-    glVertex3f(1.0F - 1.0F / 3.0F, -0.02F, -0.02F);
+    SoGLRenderAction axisAction(vp);
+    setOverlayCacheContext(axisAction, this);
+    axisAction.setTransparencyType(SoGLRenderAction::BLEND);
+    axisAction.apply(overlay.axisRoot);
 
-    glVertex3f(0.0F, -0.02F, 0.02F);
-    glVertex3f(0.0F, -0.02F, -0.02F);
-    glVertex3f(1.0F - 1.0F / 3.0F, -0.02F, -0.02F);
-    glVertex3f(1.0F - 1.0F / 3.0F, -0.02F, 0.02F);
-
-    glVertex3f(0.0F, 0.02F, 0.02F);
-    glVertex3f(0.0F, 0.02F, -0.02F);
-    glVertex3f(1.0F - 1.0F / 3.0F, 0.02F, -0.02F);
-    glVertex3f(1.0F - 1.0F / 3.0F, 0.02F, 0.02F);
-
-    glVertex3f(0.0F, 0.02F, 0.02F);
-    glVertex3f(0.0F, 0.02F, -0.02F);
-    glVertex3f(0.0F, -0.02F, -0.02F);
-    glVertex3f(0.0F, -0.02F, 0.02F);
-    glEnd();
-    glBegin(GL_TRIANGLES);
-    glVertex3f(1.0F, 0.0F, 0.0F);
-    glVertex3f(1.0F - 1.0F / 3.0F, +0.5F / 4.0F, 0.0F);
-    glVertex3f(1.0F - 1.0F / 3.0F, -0.5F / 4.0F, 0.0F);
-    glVertex3f(1.0F, 0.0F, 0.0F);
-    glVertex3f(1.0F - 1.0F / 3.0F, 0.0F, +0.5F / 4.0F);
-    glVertex3f(1.0F - 1.0F / 3.0F, 0.0F, -0.5F / 4.0F);
-    glEnd();
-    glBegin(GL_QUADS);
-    glVertex3f(1.0F - 1.0F / 3.0F, +0.5F / 4.0F, 0.0F);
-    glVertex3f(1.0F - 1.0F / 3.0F, 0.0F, +0.5F / 4.0F);
-    glVertex3f(1.0F - 1.0F / 3.0F, -0.5F / 4.0F, 0.0F);
-    glVertex3f(1.0F - 1.0F / 3.0F, 0.0F, -0.5F / 4.0F);
-    glEnd();
-    // NOLINTEND
+    SoGLRenderAction letterAction(vp);
+    setOverlayCacheContext(letterAction, this);
+    letterAction.setTransparencyType(SoGLRenderAction::BLEND);
+    letterAction.apply(overlay.lettersRoot);
 }
 
 void View3DInventorViewer::drawSingleBackground(const QColor& col)

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -1,25 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2004 Jürgen Riegel <juergen.riegel@web.de>              *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2004 Jürgen Riegel <juergen.riegel@web.de>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -591,8 +591,7 @@ private:
     void initialize();
     void syncNaviCubeVisibility();
     void drawAxisCross();
-    static void drawArrow();
-    static void drawSingleBackground(const QColor&);
+    void drawSingleBackground(const QColor&);
     void setCursorRepresentation(int mode);
     void aboutToDestroyGLContext();
     void createStandardCursors();

--- a/src/Gui/ViewProviderLine.cpp
+++ b/src/Gui/ViewProviderLine.cpp
@@ -1,26 +1,26 @@
-/***************************************************************************
- *   Copyright (c) 2012 Jürgen Riegel <juergen.riegel@web.de>              *
- *   Copyright (c) 2015 Alexander Golubev (Fat-Zer) <fatzer2@gmail.com>    *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2012 Jürgen Riegel <juergen.riegel@web.de>
+// SPDX-FileCopyrightText: 2015 Alexander Golubev (Fat-Zer) <fatzer2@gmail.com>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <Inventor/nodes/SoText2.h>
 #include <Inventor/nodes/SoCoordinate3.h>
@@ -38,7 +38,7 @@
 #include "ViewProviderLine.h"
 #include "ViewProviderCoordinateSystem.h"
 
-#include <SoTextLabel.h>
+#include <Gui/SoTextLabel.h>
 
 
 using namespace Gui;

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -1,25 +1,25 @@
-/****************************************************************************
- *   Copyright (c) 2017 Zheng Lei (realthunder) <realthunder.dev@gmail.com> *
- *                                                                          *
- *   This file is part of the FreeCAD CAx development system.               *
- *                                                                          *
- *   This library is free software; you can redistribute it and/or          *
- *   modify it under the terms of the GNU Library General Public            *
- *   License as published by the Free Software Foundation; either           *
- *   version 2 of the License, or (at your option) any later version.       *
- *                                                                          *
- *   This library  is distributed in the hope that it will be useful,       *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Library General Public License for more details.                   *
- *                                                                          *
- *   You should have received a copy of the GNU Library General Public      *
- *   License along with this library; see the file COPYING.LIB. If not,     *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,          *
- *   Suite 330, Boston, MA  02111-1307, USA                                 *
- *                                                                          *
- ****************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2017 Zheng Lei (realthunder) <realthunder.dev@gmail.com>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <atomic>
 #include <cctype>
@@ -2522,7 +2522,7 @@ void ViewProviderLink::applyMaterial()
             true
         );  // true for secondary
         action.swapColors(colorMap);
-        linkView->getLinkRoot()->doAction(&action);
+        action.apply(linkView->getLinkRoot());
 
         // 5. Ensure the old global override mechanism is not used.
         linkView->setMaterial(-1, nullptr);
@@ -2533,7 +2533,7 @@ void ViewProviderLink::applyMaterial()
 
         // 1. Dispatch an empty Color action to clear the secondary context.
         SoSelectionElementAction action(SoSelectionElementAction::Color, true);
-        linkView->getLinkRoot()->doAction(&action);
+        action.apply(linkView->getLinkRoot());
 
         // 2. Re-apply any other material settings (e.g., for array elements,
         // or clear the old global override if it was set).

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -3930,13 +3930,14 @@ bool ViewProviderLink::applyColorsTo(ViewProviderDocumentObject* vp, bool prevOv
     }
 
     auto node = vp->getModeSwitch();
-    if (!node) {
+    auto root = vp->getRoot();
+    if (!node || !root) {
         return prevOverride;
     }
 
     SoSelectionElementAction action(SoSelectionElementAction::Color, true);
     // reset color and visibility first
-    action.apply(node);
+    action.apply(root);
 
     std::map<std::string, std::map<std::string, Base::Color>> colorMap;
     std::set<std::string> hideList;
@@ -3960,15 +3961,15 @@ bool ViewProviderLink::applyColorsTo(ViewProviderDocumentObject* vp, bool prevOv
     SoTempPath path(10);
     path.ref();
     for (auto& v : colorMap) {
-        action.swapColors(v.second);
+        action.setColors(v.second);
         if (v.first.empty()) {
             prevOverride = true;
-            action.apply(node);
+            action.apply(root);
             continue;
         }
         SoDetail* det = nullptr;
         path.truncate(0);
-        if (vp->getDetailPath(v.first.c_str(), &path, false, det)) {
+        if (vp->getDetailPath(v.first.c_str(), &path, true, det)) {
             prevOverride = true;
             action.apply(&path);
         }
@@ -3979,7 +3980,7 @@ bool ViewProviderLink::applyColorsTo(ViewProviderDocumentObject* vp, bool prevOv
     for (const auto& sub : hideList) {
         SoDetail* det = nullptr;
         path.truncate(0);
-        if (!sub.empty() && vp->getDetailPath(sub.c_str(), &path, false, det)) {
+        if (!sub.empty() && vp->getDetailPath(sub.c_str(), &path, true, det)) {
             prevOverride = true;
             action.apply(&path);
         }

--- a/src/Mod/Part/Gui/SoBrepEdgeSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepEdgeSet.cpp
@@ -1,50 +1,42 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2011 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
-#ifdef FC_OS_WIN32
-# include <windows.h>
-#endif
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
 #include <algorithm>
 #include <limits>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/SoPrimitiveVertex.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/actions/SoGLRenderAction.h>
-#include <Inventor/bundles/SoMaterialBundle.h>
 #include <Inventor/details/SoLineDetail.h>
 #include <Inventor/elements/SoCoordinateElement.h>
-#include <Inventor/elements/SoGLCoordinateElement.h>
 #include <Inventor/elements/SoDepthBufferElement.h>
 #include <Inventor/elements/SoLazyElement.h>
-#include <Inventor/elements/SoLineWidthElement.h>
+#include <Inventor/elements/SoMaterialBindingElement.h>
+#include <Inventor/elements/SoOverrideElement.h>
+#include <Inventor/elements/SoShapeStyleElement.h>
+#include <Inventor/elements/SoTextureEnabledElement.h>
 #include <Inventor/errors/SoDebugError.h>
 #include <Inventor/misc/SoState.h>
 #include <Inventor/nodes/SoGroup.h>
@@ -52,9 +44,8 @@
 
 #include <Gui/Selection/SoFCUnifiedSelection.h>
 #include <Gui/Selection/Selection.h>
-#include <Base/Console.h>
+#include <Base/Color.h>
 #include "SoBrepEdgeSet.h"
-#include "SoBrepFaceSet.h"
 #include "ViewProviderExt.h"
 
 #include <Gui/Inventor/So3DAnnotation.h>
@@ -69,6 +60,83 @@ struct SoBrepEdgeSet::SelContext: Gui::SoFCSelectionContextEx
     std::vector<int32_t> hl, sl;
 };
 
+static void applyOverlayPrimitiveState(SoState* state, SoNode* node)
+{
+    if (!state || !node) {
+        return;
+    }
+
+    SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
+    SoTextureEnabledElement::set(state, node, false);
+    SoMaterialBindingElement::set(state, SoMaterialBindingElement::OVERALL);
+    SoOverrideElement::setMaterialBindingOverride(state, node, true);
+}
+
+static void renderOverlayLines(
+    SoGLRenderAction* action,
+    SoIndexedLineSet* lineSet,
+    const int32_t* indices,
+    int numIndices,
+    const Base::Color& color
+)
+{
+    if (!action || !lineSet || !indices || numIndices <= 0) {
+        return;
+    }
+
+    // Match the legacy GL path by drawing each edge segment independently.
+    std::vector<int32_t> lineIndices;
+    lineIndices.reserve(static_cast<size_t>(numIndices) * 3);
+
+    int32_t previous = -1;
+    for (int i = 0; i < numIndices; i++) {
+        const int32_t current = indices[i];
+        if (current < 0) {
+            previous = -1;
+            continue;
+        }
+        if (previous >= 0) {
+            lineIndices.push_back(previous);
+            lineIndices.push_back(current);
+            lineIndices.push_back(-1);
+        }
+        previous = current;
+    }
+
+    if (lineIndices.empty()) {
+        return;
+    }
+
+    auto state = action->getState();
+    state->push();
+
+    applyOverlayPrimitiveState(state, lineSet);
+    SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+
+    const SbColor sbColor(color.r, color.g, color.b);
+    const float transparency = std::max(0.0f, 1.0f - color.a);
+    const bool hasTransparency = transparency > 0.0f;
+    if (hasTransparency) {
+        SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+        SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+    }
+
+    SoLazyElement::setEmissive(state, &sbColor);
+    uint32_t packedColor = sbColor.getPackedValue(transparency);
+    SoLazyElement::setPacked(state, lineSet, 1, &packedColor, hasTransparency);
+
+    // setValues() does not shrink the field, so rewrite the overlay index
+    // array to the exact size to avoid stale segments from the previous
+    // highlight.
+    lineSet->coordIndex.setNum(static_cast<int>(lineIndices.size()));
+    int32_t* coordIndex = lineSet->coordIndex.startEditing();
+    std::copy(lineIndices.begin(), lineIndices.end(), coordIndex);
+    lineSet->coordIndex.finishEditing();
+    lineSet->GLRender(action);
+
+    state->pop();
+}
+
 static void renderOverlayLines(
     SoGLRenderAction* action,
     SoIndexedLineSet* lineSet,
@@ -77,23 +145,77 @@ static void renderOverlayLines(
     const SbColor& color
 )
 {
-    if (!action || !lineSet || !indices || numIndices <= 0) {
+    renderOverlayLines(
+        action,
+        lineSet,
+        indices,
+        numIndices,
+        Base::Color(color[0], color[1], color[2], 1.0f)
+    );
+}
+
+static void renderColorOverrides(
+    SoGLRenderAction* action,
+    SoIndexedLineSet* lineSet,
+    const int32_t* indices,
+    int numIndices,
+    const std::map<int, Base::Color>& colors
+)
+{
+    if (!action || !lineSet || !indices || numIndices <= 0 || colors.empty()) {
         return;
     }
 
-    auto state = action->getState();
-    state->push();
+    struct ColorGroup
+    {
+        Base::Color color;
+        std::vector<int32_t> indices;
+    };
 
-    SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+    std::map<uint32_t, ColorGroup> colorGroups;
+    const auto wildcard = colors.find(-1);
 
-    SoLazyElement::setEmissive(state, &color);
-    uint32_t packedColor = color.getPackedValue(0.0);
-    SoLazyElement::setPacked(state, lineSet, 1, &packedColor, false);
+    int lineIndex = 0;
+    for (int i = 0; i < numIndices; ++lineIndex) {
+        const int sectionStart = i;
+        while (i < numIndices && indices[i] >= 0) {
+            ++i;
+        }
 
-    lineSet->coordIndex.setValues(0, numIndices, indices);
-    lineSet->GLRender(action);
+        const Base::Color* color = nullptr;
+        auto it = colors.find(lineIndex);
+        if (it != colors.end()) {
+            color = &it->second;
+        }
+        else if (wildcard != colors.end()) {
+            color = &wildcard->second;
+        }
 
-    state->pop();
+        if (color) {
+            const SbColor sbColor(color->r, color->g, color->b);
+            const uint32_t key = sbColor.getPackedValue(std::max(0.0f, 1.0f - color->a));
+            auto& group = colorGroups[key];
+            if (group.indices.empty()) {
+                group.color = *color;
+            }
+            group.indices.insert(group.indices.end(), indices + sectionStart, indices + i);
+            group.indices.push_back(-1);
+        }
+
+        if (i < numIndices && indices[i] < 0) {
+            ++i;
+        }
+    }
+
+    for (const auto& [_, group] : colorGroups) {
+        renderOverlayLines(
+            action,
+            lineSet,
+            group.indices.data(),
+            static_cast<int>(group.indices.size()),
+            group.color
+        );
+    }
 }
 
 void SoBrepEdgeSet::initClass()
@@ -175,145 +297,6 @@ void SoBrepEdgeSet::GLRender(SoGLRenderAction* action)
     }
 
     bool hasColorOverride = (ctx2 && !ctx2->colors.empty());
-    if (hasColorOverride) {
-        // Special handling for edge color overrides (e.g. highlighting specific edges).
-        // We initially attempted to use the same logic as SoBrepFaceSet (setting
-        // SoMaterialBindingElement::PER_PART_INDEXED and populating SoLazyElement arrays).
-        // However, this proved brittle for SoIndexedLineSet, causing persistent crashes
-        // in SoMaterialBundle/SoGLLazyElement (SIGSEGV) due to internal Coin3D state
-        // mismatches when mixing Lit (default) and Unlit (highlighted) states.
-        //
-        // To ensure stability, we bypass the base class GLRender entirely and perform
-        // a manual dual-pass render using direct OpenGL calls:
-        // Pass 1: Render default lines using the current Coin3D state (Lighting enabled).
-        // Pass 2: Render highlighted lines with Lighting disabled to ensure bright, flat colors.
-        state->push();
-
-        const SoCoordinateElement* coords;
-        const SbVec3f* normals;
-        const int32_t* cindices;
-        const int32_t* nindices;
-        const int32_t* tindices;
-        const int32_t* mindices;
-        int numcindices;
-        SbBool normalCacheUsed;
-
-        // We request normals (true) because default lines need them for lighting
-        this->getVertexData(
-            state,
-            coords,
-            normals,
-            cindices,
-            nindices,
-            tindices,
-            mindices,
-            numcindices,
-            true,
-            normalCacheUsed
-        );
-
-        const SbVec3f* coords3d = coords->getArrayPtr3();
-
-        // Apply the default material settings (Standard Lighting/Material)
-        // This ensures default lines look correct (e.g. Black)
-        SoMaterialBundle mb(action);
-        mb.sendFirst();
-
-        // We will collect highlighted segments to render them in a second pass
-        // so we don't have to switch GL state constantly.
-        struct HighlightSegment
-        {
-            int startIndex;
-            Base::Color color;
-        };
-        std::vector<HighlightSegment> highlights;
-
-        int linecount = 0;
-        int i = 0;
-
-        // --- PASS 1: Render Default Lines (Lit) ---
-        while (i < numcindices) {
-            int startIndex = i;
-
-            // Check if this line index has an override color
-            const Base::Color* pColor = nullptr;
-            auto it = ctx2->colors.find(linecount);
-            if (it != ctx2->colors.end()) {
-                pColor = &it->second;
-            }
-            else {
-                // Check for wildcard color
-                auto it_all = ctx2->colors.find(-1);
-                if (it_all != ctx2->colors.end()) {
-                    pColor = &it_all->second;
-                }
-            }
-
-            if (pColor) {
-                // This is a highlighted line. Save it for Pass 2.
-                highlights.push_back({startIndex, *pColor});
-
-                // Skip over the indices for this line
-                while (i < numcindices && cindices[i] >= 0) {
-                    i++;
-                }
-                i++;  // skip the -1 separator
-            }
-            else {
-                // This is a default line. Render immediately with current (Lit) state.
-                glBegin(GL_LINE_STRIP);
-                while (i < numcindices) {
-                    int32_t idx = cindices[i++];
-                    if (idx < 0) {
-                        break;
-                    }
-
-                    if (idx < coords->getNum()) {
-                        if (normals) {
-                            glNormal3fv((const GLfloat*)(normals + idx));
-                        }
-                        glVertex3fv((const GLfloat*)(coords3d + idx));
-                    }
-                }
-                glEnd();
-            }
-            linecount++;
-        }
-
-        // --- PASS 2: Render Highlighted Lines (Unlit) ---
-        if (!highlights.empty()) {
-            // Disable lighting and textures so the color is flat and bright
-            glPushAttrib(GL_LIGHTING_BIT | GL_CURRENT_BIT | GL_ENABLE_BIT);
-            glDisable(GL_LIGHTING);
-            glDisable(GL_TEXTURE_2D);
-
-            for (const auto& segment : highlights) {
-                // Apply the explicit color from the map
-                // Note: FreeCAD Base::Color transparency is 0.0 (opaque) to 1.0 (transparent)
-                // OpenGL Alpha is 1.0 (opaque) to 0.0 (transparent)
-                glColor4f(segment.color.r, segment.color.g, segment.color.b, 1.0f - segment.color.a);
-
-                glBegin(GL_LINE_STRIP);
-                int j = segment.startIndex;
-                while (j < numcindices) {
-                    int32_t idx = cindices[j++];
-                    if (idx < 0) {
-                        break;
-                    }
-
-                    if (idx < coords->getNum()) {
-                        glVertex3fv((const GLfloat*)(coords3d + idx));
-                    }
-                }
-                glEnd();
-            }
-            glPopAttrib();
-        }
-
-        // Do NOT call inherited::GLRender(action). We have handled all rendering manually.
-        state->pop();
-        return;
-    }
 
     if (ctx && ctx->highlightIndex == std::numeric_limits<int>::max()) {
         if (ctx->selectionIndex.empty() || ctx->isSelectAll()) {
@@ -364,7 +347,16 @@ void SoBrepEdgeSet::GLRender(SoGLRenderAction* action)
             renderSelection(action, ctx);
         }
     }
-    if (ctx2 && !ctx2->selectionIndex.empty()) {
+    if (hasColorOverride) {
+        renderColorOverrides(
+            action,
+            overlayLineSet,
+            this->coordIndex.getValues(0),
+            this->coordIndex.getNum(),
+            ctx2->colors
+        );
+    }
+    else if (ctx2 && !ctx2->selectionIndex.empty()) {
         renderSelection(action, ctx2, false);
     }
     else if (
@@ -372,10 +364,7 @@ void SoBrepEdgeSet::GLRender(SoGLRenderAction* action)
         && !Gui::SoDelayedAnnotationsElement::isProcessingDelayedPaths && hasAnyHighlight
     ) {
         state->push();
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        glDepthMask(false);
-        glDisable(GL_DEPTH_TEST);
+        SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
 
         inherited::GLRender(action);
 
@@ -465,78 +454,29 @@ void SoBrepEdgeSet::getBoundingBox(SoGetBoundingBoxAction* action)
     }
 }
 
-void SoBrepEdgeSet::renderShape(
-    const SoGLCoordinateElement* const coords,
-    const int32_t* cindices,
-    int numindices
-)
-{
-
-    const SbVec3f* coords3d = coords->getArrayPtr3();
-
-    int32_t i;
-    int previ;
-    const int32_t* end = cindices + numindices;
-    while (cindices < end) {
-        glBegin(GL_LINE_STRIP);
-        previ = *cindices++;
-        i = (cindices < end) ? *cindices++ : -1;
-        while (i >= 0) {
-            glVertex3fv((const GLfloat*)(coords3d + previ));
-            glVertex3fv((const GLfloat*)(coords3d + i));
-            previ = i;
-            i = cindices < end ? *cindices++ : -1;
-        }
-        glEnd();
-    }
-}
-
 void SoBrepEdgeSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx)
 {
     if (!ctx || ctx->highlightIndex < 0) {
         return;
     }
 
-    SoState* state = action->getState();
-    state->push();
-    // SoLineWidthElement::set(state, this, 4.0f);
-
-    SoLazyElement::setEmissive(state, &ctx->highlightColor);
-    packedColor = ctx->highlightColor.getPackedValue(0.0);
-    SoLazyElement::setPacked(state, this, 1, &packedColor, false);
-
-    const SoCoordinateElement* coords;
-    const SbVec3f* normals;
-    const int32_t* cindices;
-    int numcindices;
-    const int32_t* nindices;
-    const int32_t* tindices;
-    const int32_t* mindices;
-    SbBool normalCacheUsed;
-
-    this->getVertexData(
-        state,
-        coords,
-        normals,
-        cindices,
-        nindices,
-        tindices,
-        mindices,
-        numcindices,
-        false,
-        normalCacheUsed
-    );
-
-    SoMaterialBundle mb(action);
-    mb.sendFirst();  // make sure we have the correct material
+    const SoCoordinateElement* coords = SoCoordinateElement::getInstance(action->getState());
+    if (!coords) {
+        return;
+    }
 
     int num = (int)ctx->hl.size();
     if (num > 0) {
         if (ctx->hl[0] < 0) {
-            renderShape(static_cast<const SoGLCoordinateElement*>(coords), cindices, numcindices);
+            renderOverlayLines(
+                action,
+                overlayLineSet,
+                this->coordIndex.getValues(0),
+                this->coordIndex.getNum(),
+                ctx->highlightColor
+            );
         }
         else {
-            const int32_t* id = &(ctx->hl[0]);
             if (!validIndexes(coords, ctx->hl)) {
                 SoDebugError::postWarning(
                     "SoBrepEdgeSet::renderHighlight",
@@ -544,58 +484,35 @@ void SoBrepEdgeSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx)
                 );
             }
             else {
-                renderShape(static_cast<const SoGLCoordinateElement*>(coords), id, num);
+                renderOverlayLines(action, overlayLineSet, ctx->hl.data(), num, ctx->highlightColor);
             }
         }
     }
-    state->pop();
 }
 
-void SoBrepEdgeSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx, bool push)
+void SoBrepEdgeSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx, bool /*push*/)
 {
-    SoState* state = action->getState();
-    if (push) {
-        state->push();
-        // SoLineWidthElement::set(state, this, 4.0f);
-
-        SoLazyElement::setEmissive(state, &ctx->selectionColor);
-        packedColor = ctx->selectionColor.getPackedValue(0.0);
-        SoLazyElement::setPacked(state, this, 1, &packedColor, false);
+    if (!ctx) {
+        return;
     }
 
-    const SoCoordinateElement* coords;
-    const SbVec3f* normals;
-    const int32_t* cindices;
-    int numcindices;
-    const int32_t* nindices;
-    const int32_t* tindices;
-    const int32_t* mindices;
-    SbBool normalCacheUsed;
-
-    this->getVertexData(
-        state,
-        coords,
-        normals,
-        cindices,
-        nindices,
-        tindices,
-        mindices,
-        numcindices,
-        false,
-        normalCacheUsed
-    );
-
-    SoMaterialBundle mb(action);
-    mb.sendFirst();  // make sure we have the correct material
+    const SoCoordinateElement* coords = SoCoordinateElement::getInstance(action->getState());
+    if (!coords) {
+        return;
+    }
 
     int num = (int)ctx->sl.size();
     if (num > 0) {
         if (ctx->sl[0] < 0) {
-            renderShape(static_cast<const SoGLCoordinateElement*>(coords), cindices, numcindices);
+            renderOverlayLines(
+                action,
+                overlayLineSet,
+                this->coordIndex.getValues(0),
+                this->coordIndex.getNum(),
+                ctx->selectionColor
+            );
         }
         else {
-            cindices = &(ctx->sl[0]);
-            numcindices = (int)ctx->sl.size();
             if (!validIndexes(coords, ctx->sl)) {
                 SoDebugError::postWarning(
                     "SoBrepEdgeSet::renderSelection",
@@ -603,12 +520,9 @@ void SoBrepEdgeSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx,
                 );
             }
             else {
-                renderShape(static_cast<const SoGLCoordinateElement*>(coords), cindices, numcindices);
+                renderOverlayLines(action, overlayLineSet, ctx->sl.data(), num, ctx->selectionColor);
             }
         }
-    }
-    if (push) {
-        state->pop();
     }
 }
 

--- a/src/Mod/Part/Gui/SoBrepEdgeSet.h
+++ b/src/Mod/Part/Gui/SoBrepEdgeSet.h
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2011 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -35,8 +34,6 @@
 
 
 class SoCoordinateElement;
-class SoGLCoordinateElement;
-class SoTextureCoordinateBundle;
 
 namespace PartGui
 {
@@ -81,11 +78,6 @@ private:
     struct SelContext;
     using SelContextPtr = std::shared_ptr<SelContext>;
 
-    void renderShape(
-        const SoGLCoordinateElement* const vertexlist,
-        const int32_t* vertexindices,
-        int num_vertexindices
-    );
     void renderHighlight(SoGLRenderAction* action, SelContextPtr);
     void renderSelection(SoGLRenderAction* action, SelContextPtr, bool push = true);
     bool validIndexes(const SoCoordinateElement*, const std::vector<int32_t>&) const;
@@ -95,7 +87,6 @@ private:
     SelContextPtr selContext;
     SelContextPtr selContext2;
     Gui::SoFCSelectionCounter selCounter;
-    uint32_t packedColor {0};
     SoIndexedLineSet* overlayLineSet {nullptr};
 
     // backreference to viewprovider that owns this node

--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -453,15 +453,12 @@ void SoBrepFaceSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx,
 bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContextPtr ctx, SelContextPtr ctx2)
 {
     // SoBrepFaceSet groups rendered triangles into topological faces via
-    // partIndex. When we can express selection/highlight through Coin state,
-    // remap those per-part colors onto the per-face material binding that
-    // SoIndexedFaceSet actually consumes during GLRender().
+    // partIndex. Coin's IndexedFaceSet consumes one material index per
+    // rendered triangle face, so any per-part coloring must be remapped to
+    // per-face indices before GLRender(). Selection/highlight overlays reuse
+    // the same remap path.
     const bool hasPrimary = ctx && (ctx->isHighlighted() || !ctx->selectionIndex.empty());
     const bool hasSecondary = ctx2 && (!ctx2->colors.empty() || !ctx2->selectionIndex.empty());
-    if (!hasPrimary && !hasSecondary) {
-        return false;
-    }
-
     auto* state = action->getState();
     const auto mb = SoMaterialBindingElement::get(state);
     const int partCount = this->partIndex.getNum();
@@ -475,15 +472,19 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
         return false;
     }
     const int diffuseSize = element->getNumDiffuse();
-    if (mb != SoMaterialBindingElement::OVERALL
-        && !(mb == SoMaterialBindingElement::PER_PART && diffuseSize >= partCount)) {
+    const bool needsBasePerPartRemap
+        = (mb == SoMaterialBindingElement::PER_PART && diffuseSize >= partCount);
+    if (!hasPrimary && !hasSecondary && !needsBasePerPartRemap) {
+        return false;
+    }
+    if (mb != SoMaterialBindingElement::OVERALL && !needsBasePerPartRemap) {
         static bool warnedUnsupportedBinding = false;
         if (!warnedUnsupportedBinding) {
             warnedUnsupportedBinding = true;
             SoDebugError::postWarning(
                 "SoBrepFaceSet::overrideMaterialBinding",
                 "Unsupported material binding for Coin face remap; falling back to explicit "
-                "overlay passes. Current Part face highlighting expects OVERALL or PER_PART."
+                "overlay passes. Current Part face rendering expects OVERALL or PER_PART."
             );
         }
         return false;

--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -1,170 +1,184 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2011 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
-
-#include <FCConfig.h>
-
-#ifndef FC_OS_WIN32
-# ifndef GL_GLEXT_PROTOTYPES
-#  define GL_GLEXT_PROTOTYPES 1
-# endif
-#endif
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <algorithm>
 #include <limits>
-#include <map>
+#include <set>
+#include <vector>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/SoPrimitiveVertex.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/actions/SoGLRenderAction.h>
+#include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/bundles/SoMaterialBundle.h>
-#include <Inventor/bundles/SoTextureCoordinateBundle.h>
-#include <Inventor/elements/SoLazyElement.h>
-#include <Inventor/elements/SoOverrideElement.h>
-#include <Inventor/elements/SoCoordinateElement.h>
-#include <Inventor/elements/SoGLCoordinateElement.h>
-#include <Inventor/elements/SoGLCacheContextElement.h>
-#include <Inventor/elements/SoGLVBOElement.h>
-#include <Inventor/errors/SoDebugError.h>
 #include <Inventor/details/SoFaceDetail.h>
-#include <Inventor/misc/SoState.h>
-#include <Inventor/misc/SoContextHandler.h>
-#include <Inventor/elements/SoCacheElement.h>
+#include <Inventor/elements/SoCoordinateElement.h>
+#include <Inventor/elements/SoDepthBufferElement.h>
+#include <Inventor/elements/SoLazyElement.h>
+#include <Inventor/elements/SoMaterialBindingElement.h>
+#include <Inventor/elements/SoNormalBindingElement.h>
+#include <Inventor/elements/SoOverrideElement.h>
+#include <Inventor/elements/SoShapeStyleElement.h>
 #include <Inventor/elements/SoTextureEnabledElement.h>
-
-#ifdef FC_OS_WIN32
-# include <windows.h>
-# include <GL/gl.h>
-# include <GL/glext.h>
-#else
-# ifdef FC_OS_MACOSX
-#  include <OpenGL/gl.h>
-#  include <OpenGL/glext.h>
-# else
-#  include <GL/gl.h>
-#  include <GL/glext.h>
-# endif  // FC_OS_MACOSX
-#endif   // FC_OS_WIN32
-// Should come after glext.h to avoid warnings
-#include <Inventor/C/glue/gl.h>
+#include <Inventor/elements/SoPolygonOffsetElement.h>
+#include <Inventor/errors/SoDebugError.h>
+#include <Inventor/misc/SoState.h>
 
 #include <Base/Profiler.h>
 
 #include <Gui/SoFCInteractiveElement.h>
+#include <Gui/Selection/Selection.h>
 #include <Gui/Selection/SoFCSelectionAction.h>
 #include <Gui/Selection/SoFCUnifiedSelection.h>
 #include <Gui/Inventor/So3DAnnotation.h>
 
 #include "SoBrepFaceSet.h"
 #include "ViewProviderExt.h"
-#include "SoBrepEdgeSet.h"
-
 
 using namespace PartGui;
 
 SO_NODE_SOURCE(SoBrepFaceSet)
 
-#define PRIVATE(p) ((p)->pimpl)
-
-class SoBrepFaceSet::VBO
+namespace
 {
-public:
-    struct Buffer
-    {
-        uint32_t myvbo[2];
-        std::size_t vertex_array_size;
-        std::size_t index_array_size;
-        bool updateVbo;
-        bool vboLoaded;
-    };
 
-    static SbBool vboAvailable;
-    uint32_t indice_array;
-    std::map<uint32_t, Buffer> vbomap;
-
-    VBO()
-    {
-        SoContextHandler::addContextDestructionCallback(context_destruction_cb, this);
-        indice_array = 0;
+static void buildOverlayCoordIndex(
+    std::vector<int32_t>& out,
+    const int32_t* coordIndex,
+    int coordIndexCount,
+    const int32_t* partTriCounts,
+    int partCount,
+    const std::set<int>& parts,
+    bool selectAll
+)
+{
+    out.clear();
+    if (!coordIndex || coordIndexCount <= 0) {
+        return;
     }
-    ~VBO()
-    {
-        SoContextHandler::removeContextDestructionCallback(context_destruction_cb, this);
+    if (selectAll) {
+        out.insert(out.end(), coordIndex, coordIndex + coordIndexCount);
+        return;
+    }
+    if (!partTriCounts || partCount <= 0 || parts.empty()) {
+        return;
+    }
 
-        // schedule delete for all allocated GL resources
-        std::map<uint32_t, Buffer>::iterator it;
-        for (it = vbomap.begin(); it != vbomap.end(); ++it) {
-            void* ptr0 = (void*)((uintptr_t)it->second.myvbo[0]);
-            SoGLCacheContextElement::scheduleDeleteCallback(it->first, VBO::vbo_delete, ptr0);
-            void* ptr1 = (void*)((uintptr_t)it->second.myvbo[1]);
-            SoGLCacheContextElement::scheduleDeleteCallback(it->first, VBO::vbo_delete, ptr1);
+    std::vector<int32_t> face;
+    face.reserve(8);
+
+    int pos = 0;
+    for (int part = 0; part < partCount && pos < coordIndexCount; ++part) {
+        const bool include = (parts.find(part) != parts.end());
+        const int tris = partTriCounts[part];
+        for (int t = 0; t < tris && pos < coordIndexCount; ++t) {
+            // Skip any stray delimiters.
+            while (pos < coordIndexCount && coordIndex[pos] < 0) {
+                pos++;
+            }
+            face.clear();
+            while (pos < coordIndexCount && coordIndex[pos] >= 0) {
+                face.push_back(coordIndex[pos]);
+                pos++;
+            }
+            if (pos < coordIndexCount && coordIndex[pos] < 0) {
+                // Consume one delimiter.
+                pos++;
+            }
+            if (include && face.size() >= 3) {
+                out.insert(out.end(), face.begin(), face.end());
+                out.push_back(-1);
+            }
         }
     }
+}
 
-    void render(
-        SoGLRenderAction* action,
-        const SoGLCoordinateElement* const vertexlist,
-        const int32_t* vertexindices,
-        int num_vertexindices,
-        const int32_t* partindices,
-        int num_partindices,
-        const SbVec3f* normals,
-        const int32_t* normindices,
-        SoMaterialBundle* const materials,
-        const int32_t* matindices,
-        SoTextureCoordinateBundle* const texcoords,
-        const int32_t* texindices,
-        const int nbind,
-        const int mbind,
-        SbBool texture
-    );
-
-    static void context_destruction_cb(uint32_t context, void* userdata)
-    {
-        VBO* self = static_cast<VBO*>(userdata);
-
-        std::map<uint32_t, Buffer>::iterator it = self->vbomap.find(context);
-        if (it != self->vbomap.end()) {
-#ifdef FC_OS_WIN32
-            const cc_glglue* glue = cc_glglue_instance((int)context);
-            PFNGLDELETEBUFFERSARBPROC glDeleteBuffersARB
-                = (PFNGLDELETEBUFFERSARBPROC)cc_glglue_getprocaddress(glue, "glDeleteBuffersARB");
-#endif
-            auto& buffer = it->second;
-            glDeleteBuffersARB(2, buffer.myvbo);
-            self->vbomap.erase(it);
-        }
+static void renderOverlayFaces(
+    SoGLRenderAction* action,
+    SoIndexedFaceSet* faceSet,
+    const std::vector<int32_t>& coordIndex,
+    const SbColor& color,
+    bool onTop
+)
+{
+    if (!action || !faceSet || coordIndex.empty()) {
+        return;
     }
 
-    static void vbo_delete(void* closure, uint32_t contextid)
-    {
-        const cc_glglue* glue = cc_glglue_instance((int)contextid);
-        GLuint id = (GLuint)((uintptr_t)closure);
-        cc_glglue_glDeleteBuffers(glue, 1, &id);
-    }
-};
+    auto state = action->getState();
+    state->push();
 
-SbBool SoBrepFaceSet::VBO::vboAvailable = false;
+    SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
+    SoTextureEnabledElement::set(state, faceSet, false);
+    SoMaterialBindingElement::set(state, SoMaterialBindingElement::OVERALL);
+    SoOverrideElement::setMaterialBindingOverride(state, faceSet, true);
+
+    if (onTop) {
+        SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
+        SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+        SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+    }
+    else {
+        SoPolygonOffsetElement::set(state, faceSet, -0.00001f, -1.0f, SoPolygonOffsetElement::FILLED, TRUE);
+        SoDepthBufferElement::set(state, TRUE, FALSE, SoDepthBufferElement::LEQUAL, SbVec2f(0.0f, 1.0f));
+    }
+
+    SoLazyElement::setEmissive(state, &color);
+    const uint32_t packed = color.getPackedValue(0.0f);
+    SoLazyElement::setPacked(state, faceSet, 1, &packed, false);
+
+    faceSet->coordIndex.setValues(0, static_cast<int32_t>(coordIndex.size()), coordIndex.data());
+    faceSet->GLRender(action);
+
+    state->pop();
+}
+
+static void expandPartMaterialIndexToFaceMaterialIndex(
+    std::vector<int32_t>& outFaceMaterialIndex,
+    const int32_t* partTriCounts,
+    int partCount,
+    const std::vector<int32_t>& perPartMaterialIndex
+)
+{
+    outFaceMaterialIndex.clear();
+    if (!partTriCounts || partCount <= 0
+        || perPartMaterialIndex.size() < static_cast<size_t>(partCount)) {
+        return;
+    }
+
+    size_t triangleCount = 0;
+    for (int i = 0; i < partCount; ++i) {
+        triangleCount += static_cast<size_t>(std::max(partTriCounts[i], 0));
+    }
+
+    outFaceMaterialIndex.reserve(triangleCount);
+    for (int i = 0; i < partCount; ++i) {
+        const int repeats = std::max(partTriCounts[i], 0);
+        outFaceMaterialIndex.insert(outFaceMaterialIndex.end(), repeats, perPartMaterialIndex[i]);
+    }
+}
+
+}  // namespace
 
 void SoBrepFaceSet::initClass()
 {
@@ -187,15 +201,22 @@ SoBrepFaceSet::SoBrepFaceSet()
     selContext2 = std::make_shared<SelContext>();
     packedColor = 0;
 
-    pimpl = std::make_unique<VBO>();
+    overlayFaceSet = new SoIndexedFaceSet;
+    overlayFaceSet->ref();
 }
 
-SoBrepFaceSet::~SoBrepFaceSet() = default;
+SoBrepFaceSet::~SoBrepFaceSet()
+{
+    if (overlayFaceSet) {
+        overlayFaceSet->unref();
+        overlayFaceSet = nullptr;
+    }
+}
 
 void SoBrepFaceSet::doAction(SoAction* action)
 {
     if (action->getTypeId() == Gui::SoHighlightElementAction::getClassTypeId()) {
-        Gui::SoHighlightElementAction* hlaction = static_cast<Gui::SoHighlightElementAction*>(action);
+        auto* hlaction = static_cast<Gui::SoHighlightElementAction*>(action);
         selCounter.checkAction(hlaction);
         if (!hlaction->isHighlighted()) {
             SelContextPtr ctx
@@ -240,19 +261,19 @@ void SoBrepFaceSet::doAction(SoAction* action)
         return;
     }
     else if (action->getTypeId() == Gui::SoSelectionElementAction::getClassTypeId()) {
-        Gui::SoSelectionElementAction* selaction = static_cast<Gui::SoSelectionElementAction*>(action);
+        auto* selaction = static_cast<Gui::SoSelectionElementAction*>(action);
         switch (selaction->getType()) {
             case Gui::SoSelectionElementAction::All: {
                 SelContextPtr ctx
                     = Gui::SoFCSelectionRoot::getActionContext<SelContext>(action, this, selContext);
                 selCounter.checkAction(selaction, ctx);
-                ctx->selectionColor = selaction->getColor();
                 ctx->selectionIndex.clear();
                 ctx->selectionIndex.insert(-1);
+                ctx->selectionColor = selaction->getColor();
                 touch();
-                return;
+                break;
             }
-            case Gui::SoSelectionElementAction::None:
+            case Gui::SoSelectionElementAction::None: {
                 if (selaction->isSecondary()) {
                     if (Gui::SoFCSelectionRoot::removeActionContext(action, this)) {
                         touch();
@@ -261,13 +282,14 @@ void SoBrepFaceSet::doAction(SoAction* action)
                 else {
                     SelContextPtr ctx
                         = Gui::SoFCSelectionRoot::getActionContext(action, this, selContext, false);
-                    if (ctx) {
+                    if (ctx && (!ctx->selectionIndex.empty() || !ctx->colors.empty())) {
                         ctx->selectionIndex.clear();
                         ctx->colors.clear();
                         touch();
                     }
                 }
-                return;
+                break;
+            }
             case Gui::SoSelectionElementAction::Color:
                 if (selaction->isSecondary()) {
                     const auto& colors = selaction->getColors();
@@ -283,30 +305,27 @@ void SoBrepFaceSet::doAction(SoAction* action)
                         }
                         return;
                     }
-                    static std::string element("Face");
-                    if (colors.begin()->first.empty() || colors.lower_bound(element) != colors.end()) {
+
+                    static const std::string element("Face");
+                    auto it = colors.lower_bound(element);
+                    if (colors.begin()->first.empty()
+                        || (it != colors.end() && it->first.compare(0, element.size(), element) == 0)) {
                         if (!ctx) {
                             ctx = Gui::SoFCSelectionRoot::getActionContext<SelContext>(action, this);
                             selCounter.checkAction(selaction, ctx);
                             ctx->selectAll();
                         }
-                        if (ctx->setColors(selaction->getColors(), element)) {
+                        if (ctx->setColors(colors, element)) {
                             touch();
                         }
                     }
                 }
                 return;
-            case Gui::SoSelectionElementAction::Remove:
-            case Gui::SoSelectionElementAction::Append: {
+            case Gui::SoSelectionElementAction::Append:
+            case Gui::SoSelectionElementAction::Remove: {
                 const SoDetail* detail = selaction->getElement();
                 if (!detail || !detail->isOfType(SoFaceDetail::getClassTypeId())) {
                     if (selaction->isSecondary()) {
-                        // For secondary context, a detail of different type means
-                        // the user may want to partial render only other type of
-                        // geometry. So we call below to obtain a action context.
-                        // If no secondary context exist, it will create an empty
-                        // one, and an empty secondary context inhibites drawing
-                        // here.
                         auto ctx = Gui::SoFCSelectionRoot::getActionContext<SelContext>(action, this);
                         selCounter.checkAction(selaction, ctx);
                         touch();
@@ -340,257 +359,332 @@ void SoBrepFaceSet::doAction(SoAction* action)
         return;
     }
     else if (action->getTypeId() == Gui::SoVRMLAction::getClassTypeId()) {
-        // update the materialIndex field to match with the number of triangles if needed
+        // Keep materialIndex in sync when using PER_PART binding with one color per part.
         SoState* state = action->getState();
         Binding mbind = this->findMaterialBinding(state);
         if (mbind == PER_PART) {
             const SoLazyElement* mat = SoLazyElement::getInstance(state);
-            int numColor = 1;
-            int numParts = partIndex.getNum();
-            if (mat) {
-                numColor = mat->getNumDiffuse();
-                if (numColor == numParts) {
-                    int count = 0;
-                    const int32_t* indices = this->partIndex.getValues(0);
-                    for (int i = 0; i < numParts; i++) {
-                        count += indices[i];
-                    }
-                    this->materialIndex.setNum(count);
-                    int32_t* matind = this->materialIndex.startEditing();
-                    int32_t k = 0;
-                    for (int i = 0; i < numParts; i++) {
-                        for (int j = 0; j < indices[i]; j++) {
-                            matind[k++] = i;
-                        }
-                    }
-                    this->materialIndex.finishEditing();
+            const int numParts = partIndex.getNum();
+            if (mat && mat->getNumDiffuse() == numParts) {
+                int count = 0;
+                const int32_t* indices = this->partIndex.getValues(0);
+                for (int i = 0; i < numParts; i++) {
+                    count += indices[i];
                 }
+                this->materialIndex.setNum(count);
+                int32_t* matind = this->materialIndex.startEditing();
+                int32_t k = 0;
+                for (int i = 0; i < numParts; i++) {
+                    for (int j = 0; j < indices[i]; j++) {
+                        matind[k++] = i;
+                    }
+                }
+                this->materialIndex.finishEditing();
             }
-        }
-    }
-    // The recommended way to set 'updateVbo' is to reimplement the method 'notify'
-    // but the base class made this method private so that we can't override it.
-    // So, the alternative way is to write a custom SoAction class.
-    else if (action->getTypeId() == Gui::SoUpdateVBOAction::getClassTypeId()) {
-        for (auto& v : PRIVATE(this)->vbomap) {
-            v.second.updateVbo = true;
-            v.second.vboLoaded = false;
         }
     }
 
     inherited::doAction(action);
 }
 
-#ifdef RENDER_GLARRAYS
-void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
+void SoBrepFaceSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx)
 {
-    SoState* state = action->getState();
-    // Disable caching for this node
-    SoGLCacheContextElement::shouldAutoCache(state, SoGLCacheContextElement::DONT_AUTO_CACHE);
-
-    SoMaterialBundle mb(action);
-    Binding mbind = this->findMaterialBinding(state);
-
-    SoTextureCoordinateBundle tb(action, true, false);
-    SbBool doTextures = tb.needCoordinates();
-
-    if (ctx->coordIndex.getNum() < 3) {
+    if (!ctx || ctx->highlightIndex < 0) {
         return;
     }
 
-    SelContextPtr ctx2;
-    SelContextPtr ctx = Gui::SoFCSelectionRoot::getRenderContext<SelContext>(this, selContext, ctx2);
-    if (ctx2 && ctx2->selectionIndex.empty()) {
+    const int32_t* partCounts = this->partIndex.getValues(0);
+    const int partCount = this->partIndex.getNum();
+    const int32_t* ci = this->coordIndex.getValues(0);
+    const int ciCount = this->coordIndex.getNum();
+
+    const int id = ctx->highlightIndex;
+    if (id != std::numeric_limits<int>::max() && (id < 0 || id >= partCount)) {
+        SoDebugError::postWarning("SoBrepFaceSet::renderHighlight", "highlightIndex out of range");
         return;
     }
 
-    int32_t hl_idx = ctx ? ctx->highlightIndex : -1;
-    int32_t num_selected = ctx ? ctx->selectionIndex.size() : 0;
+    std::set<int> parts;
+    const bool selectAll = (id == std::numeric_limits<int>::max());
+    if (!selectAll) {
+        parts.insert(id);
+    }
+    buildOverlayCoordIndex(overlayCoordIndex, ci, ciCount, partCounts, partCount, parts, selectAll);
 
-    renderHighlight(action, ctx);
-    if (ctx && ctx->selectionIndex.size()) {
-        if (ctx->isSelectAll()) {
-            if (ctx2 && ctx2->selectionIndex.size()) {
-                ctx2->selectionColor = ctx->selectionColor;
-                renderSelection(action, ctx2);
-            }
-            else {
-                renderSelection(action, ctx);
-            }
-            return;
+    const bool onTop = Gui::Selection().isClarifySelectionActive()
+        && Gui::SoDelayedAnnotationsElement::isProcessingDelayedPaths;
+
+    renderOverlayFaces(action, overlayFaceSet, overlayCoordIndex, ctx->highlightColor, onTop);
+}
+
+void SoBrepFaceSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx, bool /*push*/)
+{
+    if (!ctx || ctx->selectionIndex.empty()) {
+        return;
+    }
+
+    const int32_t* partCounts = this->partIndex.getValues(0);
+    const int partCount = this->partIndex.getNum();
+    const int32_t* ci = this->coordIndex.getValues(0);
+    const int ciCount = this->coordIndex.getNum();
+
+    if (ctx->isSelectAll()) {
+        std::set<int> dummy;
+        buildOverlayCoordIndex(overlayCoordIndex, ci, ciCount, partCounts, partCount, dummy, true);
+        renderOverlayFaces(action, overlayFaceSet, overlayCoordIndex, ctx->selectionColor, false);
+        return;
+    }
+
+    std::set<int> parts;
+    for (int idx : ctx->selectionIndex) {
+        if (idx >= 0 && idx < partCount) {
+            parts.insert(idx);
         }
-        renderSelection(action, ctx);
     }
-    if (ctx2 && ctx2->selectionIndex.size()) {
-        renderSelection(action, ctx2, false);
+    if (parts.empty()) {
+        SoDebugError::postWarning("SoBrepFaceSet::renderSelection", "selectionIndex out of range");
+        return;
+    }
+
+    buildOverlayCoordIndex(overlayCoordIndex, ci, ciCount, partCounts, partCount, parts, false);
+    renderOverlayFaces(action, overlayFaceSet, overlayCoordIndex, ctx->selectionColor, false);
+}
+
+bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContextPtr ctx, SelContextPtr ctx2)
+{
+    // SoBrepFaceSet groups rendered triangles into topological faces via
+    // partIndex. When we can express selection/highlight through Coin state,
+    // remap those per-part colors onto the per-face material binding that
+    // SoIndexedFaceSet actually consumes during GLRender().
+    const bool hasPrimary = ctx && (ctx->isHighlighted() || !ctx->selectionIndex.empty());
+    const bool hasSecondary = ctx2 && (!ctx2->colors.empty() || !ctx2->selectionIndex.empty());
+    if (!hasPrimary && !hasSecondary) {
+        return false;
+    }
+
+    auto* state = action->getState();
+    const auto mb = SoMaterialBindingElement::get(state);
+    const int partCount = this->partIndex.getNum();
+    if (partCount <= 0) {
+        return false;
+    }
+
+    auto* element = SoLazyElement::getInstance(state);
+    const SbColor* diffuse = element->getDiffusePointer();
+    if (!diffuse) {
+        return false;
+    }
+    const int diffuseSize = element->getNumDiffuse();
+    if (mb != SoMaterialBindingElement::OVERALL
+        && !(mb == SoMaterialBindingElement::PER_PART && diffuseSize >= partCount)) {
+        static bool warnedUnsupportedBinding = false;
+        if (!warnedUnsupportedBinding) {
+            warnedUnsupportedBinding = true;
+            SoDebugError::postWarning(
+                "SoBrepFaceSet::overrideMaterialBinding",
+                "Unsupported material binding for Coin face remap; falling back to explicit "
+                "overlay passes. Current Part face highlighting expects OVERALL or PER_PART."
+            );
+        }
+        return false;
+    }
+
+    const float* trans = element->getTransparencyPointer();
+    const int transSize = element->getNumTransparencies();
+    float trans0 = 0.0f;
+    bool hasBaseTransparency = false;
+    if (trans && transSize > 0) {
+        for (int i = 0; i < transSize; ++i) {
+            if (trans[i] != 0.0f) {
+                hasBaseTransparency = true;
+                trans0 = trans[i];
+                break;
+            }
+        }
+    }
+
+    state->push();
+    packedColors.clear();
+
+    if (ctx2) {
+        ctx2->trans0 = trans0;
+    }
+
+    uint32_t diffuseColor = diffuse[0].getPackedValue(trans0);
+    int singleColor = 0;
+    if (ctx && ctx->isHighlightAll()) {
+        singleColor = 1;
+        diffuseColor = ctx->highlightColor.getPackedValue(trans0);
+    }
+    else if (ctx && ctx->isSelectAll()) {
+        diffuseColor = ctx->selectionColor.getPackedValue(trans0);
+        singleColor = ctx->isHighlighted() ? -1 : 1;
+    }
+    else if (ctx2 && ctx2->isSingleColor(diffuseColor, hasBaseTransparency)) {
+        singleColor = ctx ? -1 : 1;
+    }
+
+    const bool partialRender = ctx2 && !ctx2->selectionIndex.empty() && !ctx2->isSelectAll();
+
+    if (singleColor > 0 && !partialRender) {
+        SoMaterialBindingElement::set(state, SoMaterialBindingElement::OVERALL);
+        SoOverrideElement::setMaterialBindingOverride(state, this, true);
+        if (hasBaseTransparency) {
+            SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+            SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+        }
+        packedColors.push_back(diffuseColor);
+        SoLazyElement::setPacked(state, this, 1, packedColors.data(), hasBaseTransparency);
+        SoTextureEnabledElement::set(state, this, false);
+        return true;
+    }
+
+    std::vector<int32_t> perPartMaterialIndex;
+    perPartMaterialIndex.reserve(partCount);
+    const uint32_t fullyTransparent = SbColor(1.0f, 1.0f, 1.0f).getPackedValue(1.0f);
+
+    if (ctx && (ctx->isSelectAll() || ctx->isHighlightAll())) {
+        perPartMaterialIndex.resize(partCount, 0);
+        if (!partialRender) {
+            packedColors.push_back(diffuseColor);
+        }
+        else {
+            packedColors.push_back(fullyTransparent);
+            packedColors.push_back(diffuseColor);
+            if (ctx2) {
+                for (int idx : ctx2->selectionIndex) {
+                    if (idx >= 0 && idx < partCount) {
+                        perPartMaterialIndex[idx] = static_cast<int32_t>(packedColors.size() - 1);
+                    }
+                }
+            }
+        }
+        if (ctx->highlightIndex >= 0 && ctx->highlightIndex < partCount) {
+            packedColors.push_back(ctx->highlightColor.getPackedValue(trans0));
+            perPartMaterialIndex[ctx->highlightIndex] = static_cast<int32_t>(packedColors.size() - 1);
+        }
     }
     else {
+        if (partialRender) {
+            packedColors.push_back(fullyTransparent);
+            perPartMaterialIndex.resize(partCount, 0);
 
-        // When setting transparency shouldGLRender() handles the rendering and returns false.
-        // Therefore generatePrimitives() needs to be re-implemented to handle the materials
-        // correctly.
-        if (!this->shouldGLRender(action)) {
-            return;
-        }
-
-# ifdef RENDER_GLARRAYS
-        if (!doTextures && index_array.size() && hl_idx < 0 && num_selected <= 0) {
-            if (mbind == 0) {
-                mb.sendFirst();  // only one material -> apply it!
-                renderSimpleArray();
-                return;
+            if (mb == SoMaterialBindingElement::OVERALL || singleColor) {
+                packedColors.push_back(diffuseColor);
+                const auto visibleIndex = static_cast<int32_t>(packedColors.size() - 1);
+                for (int idx : ctx2->selectionIndex) {
+                    if (idx < 0 || idx >= partCount) {
+                        continue;
+                    }
+                    if (!singleColor && ctx2->applyColor(idx, packedColors, hasBaseTransparency)) {
+                        perPartMaterialIndex[idx] = static_cast<int32_t>(packedColors.size() - 1);
+                    }
+                    else {
+                        perPartMaterialIndex[idx] = visibleIndex;
+                    }
+                }
             }
-            else if (mbind == 1) {
-                renderColoredArray(&mb);
-                return;
+            else {
+                for (int idx : ctx2->selectionIndex) {
+                    if (idx < 0 || idx >= partCount) {
+                        continue;
+                    }
+                    if (!ctx2->applyColor(idx, packedColors, hasBaseTransparency)) {
+                        const float transparency = idx < transSize ? trans[idx] : trans0;
+                        packedColors.push_back(diffuse[idx].getPackedValue(transparency));
+                    }
+                    perPartMaterialIndex[idx] = static_cast<int32_t>(packedColors.size() - 1);
+                }
             }
         }
-# endif
+        else if (mb == SoMaterialBindingElement::OVERALL || singleColor) {
+            packedColors.push_back(diffuseColor);
+            perPartMaterialIndex.resize(partCount, 0);
 
-        Binding nbind = this->findNormalBinding(state);
-
-        const SoCoordinateElement* coords;
-        const SbVec3f* normals;
-        const int32_t* cindices;
-        int numindices;
-        const int32_t* nindices;
-        const int32_t* tindices;
-        const int32_t* mindices;
-        const int32_t* pindices;
-        int numparts;
-        SbBool normalCacheUsed;
-
-        SbBool sendNormals = !mb.isColorOnly() || tb.isFunction();
-
-        this->getVertexData(
-            state,
-            coords,
-            normals,
-            cindices,
-            nindices,
-            tindices,
-            mindices,
-            numindices,
-            sendNormals,
-            normalCacheUsed
-        );
-
-        mb.sendFirst();  // make sure we have the correct material
-
-        // just in case someone forgot
-        if (!mindices) {
-            mindices = cindices;
+            if (ctx2 && !singleColor) {
+                for (const auto& [idx, color] : ctx2->colors) {
+                    if (idx < 0 || idx >= partCount) {
+                        continue;
+                    }
+                    packedColors.push_back(ctx2->packColor(color, hasBaseTransparency));
+                    perPartMaterialIndex[idx] = static_cast<int32_t>(packedColors.size() - 1);
+                }
+            }
         }
-        if (!nindices) {
-            nindices = cindices;
+        else {
+            perPartMaterialIndex.reserve(partCount);
+            packedColors.reserve(
+                static_cast<size_t>(diffuseSize) + (ctx2 ? ctx2->colors.size() : 0) + 3
+            );
+            for (int i = 0; i < partCount; ++i) {
+                perPartMaterialIndex.push_back(i);
+                if (!ctx2 || !ctx2->applyColor(i, packedColors, hasBaseTransparency)) {
+                    const float transparency = i < transSize ? trans[i] : trans0;
+                    packedColors.push_back(diffuse[i].getPackedValue(transparency));
+                }
+            }
         }
-        pindices = this->partIndex.getValues(0);
-        numparts = this->partIndex.getNum();
 
-        renderShape(
-            state,
-            vboAvailable,
-            static_cast<const SoGLCoordinateElement*>(coords),
-            cindices,
-            numindices,
-            pindices,
-            numparts,
-            normals,
-            nindices,
-            &mb,
-            mindices,
-            &tb,
-            tindices,
-            nbind,
-            mbind,
-            doTextures ? 1 : 0
-        );
-
-        if (normalCacheUsed) {
-            this->readUnlockNormalCache();
+        if (ctx && !ctx->selectionIndex.empty()) {
+            packedColors.push_back(ctx->selectionColor.getPackedValue(trans0));
+            const auto selectedIndex = static_cast<int32_t>(packedColors.size() - 1);
+            for (int idx : ctx->selectionIndex) {
+                if (idx >= 0 && idx < partCount) {
+                    perPartMaterialIndex[idx] = selectedIndex;
+                }
+            }
+        }
+        if (ctx && ctx->highlightIndex >= 0 && ctx->highlightIndex < partCount) {
+            packedColors.push_back(ctx->highlightColor.getPackedValue(trans0));
+            perPartMaterialIndex[ctx->highlightIndex] = static_cast<int32_t>(packedColors.size() - 1);
         }
     }
-    renderHighlight(action, ctx);
-    renderSelection(action, ctx);
+
+    const int32_t* partCounts = this->partIndex.getValues(0);
+    // partIndex groups triangles into topological faces, while SoIndexedFaceSet
+    // consumes one material index per rendered triangle face.
+    expandPartMaterialIndexToFaceMaterialIndex(matIndex, partCounts, partCount, perPartMaterialIndex);
+    if (matIndex.empty()) {
+        state->pop();
+        return false;
+    }
+
+    const size_t num = materialIndex.getNum();
+    if (num != matIndex.size() || materialIndex.getValues(0) != matIndex.data()) {
+        SbBool notify = enableNotify(FALSE);
+        materialIndex.setValuesPointer(matIndex.size(), matIndex.data());
+        if (notify) {
+            enableNotify(notify);
+        }
+    }
+
+    const bool usesTransparencyMask = partialRender;
+    const bool hasTransparency = hasBaseTransparency || usesTransparencyMask;
+
+    SoMaterialBindingElement::set(state, this, SoMaterialBindingElement::PER_FACE_INDEXED);
+    if (hasTransparency) {
+        SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+        SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
+    }
+    SoLazyElement::setPacked(state, this, packedColors.size(), packedColors.data(), hasTransparency);
+    SoTextureEnabledElement::set(state, this, false);
+    return true;
 }
-
-//****************************************************************************
-// renderSimpleArray: normal and coord from vertex_array;
-// no texture, color, highlight or selection but highet possible speed;
-// all vertices written in one go!
-//
-void SoBrepFaceSet::renderSimpleArray()
-{
-    int cnt = index_array.size();
-    if (cnt == 0) {
-        return;
-    }
-
-    glEnableClientState(GL_NORMAL_ARRAY);
-    glEnableClientState(GL_VERTEX_ARRAY);
-
-    glInterleavedArrays(GL_N3F_V3F, 0, &(vertex_array[0]));
-    glDrawElements(GL_TRIANGLES, cnt, GL_UNSIGNED_INT, &(index_array[0]));
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_NORMAL_ARRAY);
-}
-
-//****************************************************************************
-// renderColoredArray: normal and coord from vertex_array;
-// no texture, highlight or selection but color / material array.
-// needs to iterate over parts (i.e. geometry faces)
-//
-void SoBrepFaceSet::renderColoredArray(SoMaterialBundle* const materials)
-{
-    int num_parts = partIndex.getNum();
-    int cnt = index_array.size();
-    if (cnt == 0) {
-        return;
-    }
-
-    glEnableClientState(GL_NORMAL_ARRAY);
-    glEnableClientState(GL_VERTEX_ARRAY);
-
-    glInterleavedArrays(GL_N3F_V3F, 0, &(vertex_array[0]));
-    const int32_t* ptr = &(index_array[0]);
-
-    for (int part_id = 0; part_id < num_parts; part_id++) {
-        int tris = partIndex[part_id];
-
-        if (tris > 0) {
-            materials->send(part_id, true);
-            glDrawElements(GL_TRIANGLES, 3 * tris, GL_UNSIGNED_INT, ptr);
-            ptr += 3 * tris;
-        }
-    }
-
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glDisableClientState(GL_NORMAL_ARRAY);
-}
-#else
 
 void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
 {
     ZoneScoped;
-
-    // SoBase::staticDataLock();
-    static bool init = false;
-    if (!init) {
-        std::string ext = (const char*)(glGetString(GL_EXTENSIONS));
-        PRIVATE(this)->vboAvailable = (ext.find("GL_ARB_vertex_buffer_object") != std::string::npos);
-        init = true;
-    }
-    // SoBase::staticDataUnlock();
 
     if (this->coordIndex.getNum() < 3) {
         return;
     }
 
     SelContextPtr ctx2;
-    std::vector<SelContextPtr> ctxs;
     SelContextPtr ctx = Gui::SoFCSelectionRoot::getRenderContext(this, selContext, ctx2);
-    if (ctx2 && ctx2->selectionIndex.empty()) {
+    const bool hasSecondaryColors = ctx2 && !ctx2->colors.empty();
+    const bool hasOverlayFields = (highlightPartIndex.getNum() > 0)
+        || (selectionPartIndex.getNum() > 0);
+    if (!hasOverlayFields && ctx2 && ctx2->selectionIndex.empty() && !hasSecondaryColors) {
         return;
     }
     if (selContext2->checkGlobal(ctx)) {
@@ -603,216 +697,55 @@ void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
     auto state = action->getState();
     selCounter.checkRenderCache(state);
 
-    bool hasContextHighlight = ctx && ctx->isHighlighted() && !ctx->isHighlightAll()
+    const bool hasContextHighlight = ctx && ctx->isHighlighted() && !ctx->isHighlightAll()
         && ctx->highlightIndex >= 0 && ctx->highlightIndex < partIndex.getNum();
 
-    // for the tool add this node to delayed paths as we want to render it on top of the scene
+    // Clarify selection: render highlight as delayed annotation on top.
     if (Gui::Selection().isClarifySelectionActive() && hasContextHighlight) {
-
         if (!Gui::SoDelayedAnnotationsElement::isProcessingDelayedPaths) {
             if (viewProvider) {
                 viewProvider->setFaceHighlightActive(true);
             }
-
             const SoPath* currentPath = action->getCurPath();
-            Gui::SoDelayedAnnotationsElement::addDelayedPath(action->getState(), currentPath->copy(), 100);
+            Gui::SoDelayedAnnotationsElement::addDelayedPath(state, currentPath->copy(), 100);
             return;
         }
-        else {
-            // during priority delayed paths processing:
-            // render base faces normally first, then render highlight on top
-
-            inherited::GLRender(action);
-
-            state->push();
-            glEnable(GL_BLEND);
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            glDepthMask(false);
-            glDisable(GL_DEPTH_TEST);
-
-            renderHighlight(action, ctx);
-
-            state->pop();
-            return;
-        }
-    }
-
-    // override material binding to PER_PART_INDEX to achieve
-    // preselection/selection with transparency
-    bool pushed = overrideMaterialBinding(action, ctx, ctx2);
-    if (!pushed) {
-        // for non transparent cases, we still use the old selection rendering
-        // code, because it can override emission color, which gives a more
-        // distinguishable selection highlight. The above material binding
-        // override method can't, because Coin does not support per part
-        // emission color
-
-        // There are a few factors affects the rendering order.
-        //
-        // 1) For normal case, the highlight (preselection) is the top layer. And since
-        // the depth buffer clipping is on here, we shall draw highlight first, then
-        // selection, then the rest part.
-        //
-        // 2) If action->isRenderingDelayedPaths() is true, it means we are rendering
-        // with depth buffer clipping turned off (always on top rendering), so we shall
-        // draw the top layer last, i.e. renderHighlight() last
-        //
-        // 3) If highlightIndex==INT_MAX, it means we are rendering full object highlight
-        // In order to not obscure selection layer, we shall draw highlight after selection
-        // if and only if it is not a full object selection.
-        //
-        // Transparency complicates stuff even more, but not here. It will be handled inside
-        // overrideMaterialBinding()
-        //
-        if (ctx && ctx->highlightIndex == std::numeric_limits<int>::max()) {
-            if (ctx->selectionIndex.empty() || ctx->isSelectAll()) {
-                if (ctx2) {
-                    ctx2->selectionColor = ctx->highlightColor;
-                    renderSelection(action, ctx2);
-                }
-                else {
-                    renderHighlight(action, ctx);
-                }
-            }
-            else {
-                if (!action->isRenderingDelayedPaths()) {
-                    renderSelection(action, ctx);
-                }
-                if (ctx2) {
-                    ctx2->selectionColor = ctx->highlightColor;
-                    renderSelection(action, ctx2);
-                }
-                else {
-                    renderHighlight(action, ctx);
-                }
-                if (action->isRenderingDelayedPaths()) {
-                    renderSelection(action, ctx);
-                }
-            }
-            return;
-        }
-
-        if (!action->isRenderingDelayedPaths()) {
-            renderHighlight(action, ctx);
-        }
-        if (ctx && !ctx->selectionIndex.empty()) {
-            if (ctx->isSelectAll()) {
-                if (ctx2) {
-                    ctx2->selectionColor = ctx->selectionColor;
-                    renderSelection(action, ctx2);
-                }
-                else {
-                    renderSelection(action, ctx);
-                }
-                if (action->isRenderingDelayedPaths()) {
-                    renderHighlight(action, ctx);
-                }
-                return;
-            }
-            if (!action->isRenderingDelayedPaths()) {
-                renderSelection(action, ctx);
-            }
-        }
-        if (ctx2) {
-            renderSelection(action, ctx2, false);
-            if (action->isRenderingDelayedPaths()) {
-                renderSelection(action, ctx);
-                renderHighlight(action, ctx);
-            }
-            return;
-        }
+        inherited::GLRender(action);
+        renderHighlight(action, ctx);
+        return;
     }
 
     SoMaterialBundle mb(action);
-    // It is important to send material before shouldGLRender(), otherwise
-    // material override with transparncy won't work.
     mb.sendFirst();
-
-    // When setting transparency shouldGLRender() handles the rendering and returns false.
-    // Therefore generatePrimitives() needs to be re-implemented to handle the materials
-    // correctly.
-    if (this->shouldGLRender(action)) {
-        Binding mbind = this->findMaterialBinding(state);
-        Binding nbind = this->findNormalBinding(state);
-
-        const SoCoordinateElement* coords;
-        const SbVec3f* normals;
-        const int32_t* cindices;
-        int numindices;
-        const int32_t* nindices;
-        const int32_t* tindices;
-        const int32_t* mindices;
-        const int32_t* pindices;
-        int numparts;
-        SbBool doTextures;
-        SbBool normalCacheUsed;
-
-        SoTextureCoordinateBundle tb(action, true, false);
-        doTextures = tb.needCoordinates();
-        SbBool sendNormals = !mb.isColorOnly() || tb.isFunction();
-
-        this->getVertexData(
-            state,
-            coords,
-            normals,
-            cindices,
-            nindices,
-            tindices,
-            mindices,
-            numindices,
-            sendNormals,
-            normalCacheUsed
-        );
-
-        // just in case someone forgot
-        if (!mindices) {
-            mindices = cindices;
+    const bool pushed = overrideMaterialBinding(action, ctx, ctx2);
+    if (!this->shouldGLRender(action)) {
+        if (pushed) {
+            state->pop();
         }
-        if (!nindices) {
-            nindices = cindices;
-        }
-        pindices = this->partIndex.getValues(0);
-        numparts = this->partIndex.getNum();
-
-        SbBool hasVBO = !ctx2 && PRIVATE(this)->vboAvailable;
-        if (hasVBO) {
-            // get the VBO status of the viewer
-            Gui::SoGLVBOActivatedElement::get(state, hasVBO);
-        }
-        renderShape(
-            action,
-            hasVBO,
-            static_cast<const SoGLCoordinateElement*>(coords),
-            cindices,
-            numindices,
-            pindices,
-            numparts,
-            normals,
-            nindices,
-            &mb,
-            mindices,
-            &tb,
-            tindices,
-            nbind,
-            mbind,
-            doTextures ? 1 : 0
-        );
-
-        if (normalCacheUsed) {
-            this->readUnlockNormalCache();
-        }
+        return;
     }
 
+    inherited::GLRender(action);
     if (pushed) {
         state->pop();
     }
-    else if (action->isRenderingDelayedPaths()) {
-        renderSelection(action, ctx);
-        renderHighlight(action, ctx);
+
+    if (!pushed) {
+        // If overrideMaterialBinding() cannot express the current material
+        // binding through Coin state, render selection and highlight with
+        // explicit overlay passes instead.
+        if (ctx2 && !hasSecondaryColors && !ctx2->selectionIndex.empty()) {
+            renderSelection(action, ctx2);
+        }
+        if (ctx && !ctx->selectionIndex.empty()) {
+            renderSelection(action, ctx);
+        }
+        if (ctx) {
+            renderHighlight(action, ctx);
+        }
     }
 
     // Optional overlay rendering for deterministic tests (and programmatic usage).
-    // Render selection first, then highlight on top.
     const int selNum = selectionPartIndex.getNum();
     const int hlNum = highlightPartIndex.getNum();
     if (selNum > 0 || hlNum > 0) {
@@ -851,1393 +784,20 @@ void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
         }
     }
 }
-#endif
-
-bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContextPtr ctx, SelContextPtr ctx2)
-{
-    if (!ctx && !ctx2) {
-        return false;
-    }
-
-    auto state = action->getState();
-    auto mb = SoMaterialBindingElement::get(state);
-
-    auto element = SoLazyElement::getInstance(state);
-    const SbColor* diffuse = element->getDiffusePointer();
-    if (!diffuse) {
-        return false;
-    }
-    int diffuse_size = element->getNumDiffuse();
-
-    const float* trans = element->getTransparencyPointer();
-    int trans_size = element->getNumTransparencies();
-    if (!trans || !trans_size) {
-        return false;
-    }
-    float trans0 = 0.0;
-    bool hasTransparency = false;
-    for (int i = 0; i < trans_size; ++i) {
-        if (trans[i] != 0.0) {
-            hasTransparency = true;
-            trans0 = trans[i];
-            break;
-        }
-    }
-
-    // Override material binding to PER_PART_INDEXED so that we can reuse coin
-    // rendering for both selection, preselection and partial rendering. The
-    // main purpose is such that selection and preselection can have correct
-    // transparency, too.
-    //
-    // Criteria of using material binding override:
-    // 1) original material binding is either overall or per_part. We can
-    //    support others, but omitted here to simplify coding logic, and
-    //    because it seems FC only uses these two.
-    // 2) either of the following :
-    //      a) has highlight or selection and Selection().needPickPoint, so that
-    //         any preselected/selected part automatically become transparent
-    //      b) has transparency
-    //      c) has color override in secondary context
-
-    if ((mb == SoMaterialBindingElement::OVERALL
-         || (mb == SoMaterialBindingElement::PER_PART && diffuse_size >= partIndex.getNum()))
-        && (trans0 != 0.0 || (ctx2 && !ctx2->colors.empty()))) {
-        state->push();
-
-        packedColors.clear();
-
-        if (ctx2) {
-            ctx2->trans0 = 0.0;
-        }
-
-        uint32_t diffuseColor = diffuse[0].getPackedValue(trans0);
-        int singleColor = 0;
-        if (ctx && ctx->isHighlightAll()) {
-            singleColor = 1;
-            diffuseColor = ctx->highlightColor.getPackedValue(trans0);
-        }
-        else if (ctx && ctx->isSelectAll()) {
-            diffuseColor = ctx->selectionColor.getPackedValue(trans0);
-            singleColor = ctx->isHighlighted() ? -1 : 1;
-        }
-        else if (ctx2 && ctx2->isSingleColor(diffuseColor, hasTransparency)) {
-            singleColor = ctx ? -1 : 1;
-        }
-
-        bool partialRender = (ctx2 && !ctx2->isSelectAll());
-
-        if (singleColor > 0 && !partialRender) {
-            // optimization for single color non-partial rendering
-            SoMaterialBindingElement::set(state, SoMaterialBindingElement::OVERALL);
-            SoOverrideElement::setMaterialBindingOverride(state, this, true);
-            packedColors.push_back(diffuseColor);
-            SoLazyElement::setPacked(state, this, 1, packedColors.data(), hasTransparency);
-            SoTextureEnabledElement::set(state, this, false);
-
-            if (hasTransparency && action->isRenderingDelayedPaths()) {
-                // rendering delayed paths means we are doing annotation (e.g.
-                // always on top rendering). To render transparency correctly in
-                // this case, we shall use openGL transparency blend. Override
-                // using SoLazyElement::setTransparencyType() doesn't seem to work
-                glEnable(GL_BLEND);
-                glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-                glDepthMask(false);
-            }
-            return true;
-        }
-
-        matIndex.clear();
-        matIndex.reserve(partIndex.getNum());
-
-        if (ctx && (ctx->isSelectAll() || ctx->isHighlightAll())) {
-            matIndex.resize(partIndex.getNum(), 0);
-            if (!partialRender) {
-                packedColors.push_back(diffuseColor);
-            }
-            else {
-                // default to full transparent
-                packedColors.push_back(SbColor(1.0, 1.0, 1.0).getPackedValue(1.0));
-                packedColors.push_back(diffuseColor);
-                for (auto idx : ctx2->selectionIndex) {
-                    if (idx >= 0 && idx < partIndex.getNum()) {
-                        matIndex[idx] = packedColors.size() - 1;  // show only the selected
-                    }
-                }
-            }
-            if (ctx->highlightIndex >= 0 && ctx->highlightIndex < partIndex.getNum()) {
-                packedColors.push_back(ctx->highlightColor.getPackedValue(trans0));
-                matIndex[ctx->highlightIndex] = packedColors.size() - 1;
-            }
-        }
-        else {
-            if (partialRender) {
-                packedColors.push_back(SbColor(1.0, 1.0, 1.0).getPackedValue(1.0));
-                matIndex.resize(partIndex.getNum(), 0);
-
-                if (mb == SoMaterialBindingElement::OVERALL || singleColor) {
-                    packedColors.push_back(diffuseColor);
-                    auto cidx = packedColors.size() - 1;
-                    for (auto idx : ctx2->selectionIndex) {
-                        if (idx >= 0 && idx < partIndex.getNum()) {
-                            if (!singleColor && ctx2->applyColor(idx, packedColors, hasTransparency)) {
-                                matIndex[idx] = packedColors.size() - 1;
-                            }
-                            else {
-                                matIndex[idx] = cidx;
-                            }
-                        }
-                    }
-                }
-                else {
-                    assert(diffuse_size >= partIndex.getNum());
-                    for (auto idx : ctx2->selectionIndex) {
-                        if (idx >= 0 && idx < partIndex.getNum()) {
-                            if (!ctx2->applyColor(idx, packedColors, hasTransparency)) {
-                                auto t = idx < trans_size ? trans[idx] : trans0;
-                                packedColors.push_back(diffuse[idx].getPackedValue(t));
-                            }
-                            matIndex[idx] = packedColors.size() - 1;
-                        }
-                    }
-                }
-            }
-            else if (mb == SoMaterialBindingElement::OVERALL || singleColor) {
-                packedColors.push_back(diffuseColor);
-                matIndex.resize(partIndex.getNum(), 0);
-
-                if (ctx2 && !singleColor) {
-                    for (auto& v : ctx2->colors) {
-                        int idx = v.first;
-                        if (idx >= 0 && idx < partIndex.getNum()) {
-                            packedColors.push_back(ctx2->packColor(v.second, hasTransparency));
-                            matIndex[idx] = packedColors.size() - 1;
-                        }
-                    }
-                }
-            }
-            else {
-                assert(diffuse_size >= partIndex.getNum());
-                packedColors.reserve(diffuse_size + 3);
-                for (int i = 0; i < diffuse_size; ++i) {
-                    auto t = i < trans_size ? trans[i] : trans0;
-                    matIndex.push_back(i);
-                    if (!ctx2 || !ctx2->applyColor(i, packedColors, hasTransparency)) {
-                        packedColors.push_back(diffuse[i].getPackedValue(t));
-                    }
-                }
-            }
-
-            if (ctx && !ctx->selectionIndex.empty()) {
-                packedColors.push_back(ctx->selectionColor.getPackedValue(trans0));
-                for (auto idx : ctx->selectionIndex) {
-                    if (idx >= 0 && idx < partIndex.getNum()) {
-                        matIndex[idx] = packedColors.size() - 1;
-                    }
-                }
-            }
-            if (ctx && ctx->highlightIndex >= 0 && ctx->highlightIndex < partIndex.getNum()) {
-                packedColors.push_back(ctx->highlightColor.getPackedValue(trans0));
-                matIndex[ctx->highlightIndex] = packedColors.size() - 1;
-            }
-        }
-
-        size_t num = materialIndex.getNum();
-        if (num != matIndex.size() || materialIndex.getValues(0) != matIndex.data()) {
-            SbBool notify = enableNotify(FALSE);
-            materialIndex.setValuesPointer(matIndex.size(), matIndex.data());
-            if (notify) {
-                enableNotify(notify);
-            }
-        }
-
-        SoMaterialBindingElement::set(state, this, SoMaterialBindingElement::PER_PART_INDEXED);
-        SoLazyElement::setPacked(state, this, packedColors.size(), packedColors.data(), hasTransparency);
-        SoTextureEnabledElement::set(state, this, false);
-
-        if (hasTransparency && action->isRenderingDelayedPaths()) {
-            // rendering delayed paths means we are doing annotation (e.g.
-            // always on top rendering). To render transparency correctly in
-            // this case, we shall use openGL transparency blend. Override
-            // using SoLazyElement::setTransparencyType() doesn't seem to work
-            glEnable(GL_BLEND);
-            glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-            glDepthMask(false);
-        }
-        return true;
-    }
-    return false;
-}
 
 void SoBrepFaceSet::GLRenderBelowPath(SoGLRenderAction* action)
 {
     inherited::GLRenderBelowPath(action);
 }
 
-void SoBrepFaceSet::getBoundingBox(SoGetBoundingBoxAction* action)
-{
-
-    if (this->coordIndex.getNum() < 3) {
-        return;
-    }
-
-    SelContextPtr ctx2 = Gui::SoFCSelectionRoot::getSecondaryActionContext<SelContext>(action, this);
-    if (!ctx2 || ctx2->isSelectAll()) {
-        inherited::getBoundingBox(action);
-        return;
-    }
-
-    if (ctx2->selectionIndex.empty()) {
-        return;
-    }
-
-    auto state = action->getState();
-    auto coords = SoCoordinateElement::getInstance(state);
-    const SbVec3f* coords3d = static_cast<const SoGLCoordinateElement*>(coords)->getArrayPtr3();
-    const int32_t* cindices = this->coordIndex.getValues(0);
-    const int32_t* pindices = this->partIndex.getValues(0);
-    int numparts = this->partIndex.getNum();
-
-    SbBox3f bbox;
-    for (auto id : ctx2->selectionIndex) {
-        if (id < 0 || id >= numparts) {
-            break;
-        }
-        // coords
-        int length = 0;
-        int start = 0;
-        length = (int)pindices[id] * 4;
-        for (int j = 0; j < id; j++) {
-            start += (int)pindices[j];
-        }
-        start *= 4;
-
-        auto viptr = &cindices[start];
-        auto viendptr = viptr + length;
-        while (viptr + 2 < viendptr) {
-            bbox.extendBy(coords3d[*viptr++]);
-            bbox.extendBy(coords3d[*viptr++]);
-            bbox.extendBy(coords3d[*viptr++]);
-            ++viptr;
-        }
-    }
-
-    if (!bbox.isEmpty()) {
-        action->extendBy(bbox);
-    }
-}
-
-// this macro actually makes the code below more readable  :-)
-#define DO_VERTEX(idx) \
-    if (mbind == PER_VERTEX) { \
-        pointDetail.setMaterialIndex(matnr); \
-        vertex.setMaterialIndex(matnr++); \
-    } \
-    else if (mbind == PER_VERTEX_INDEXED) { \
-        pointDetail.setMaterialIndex(*mindices); \
-        vertex.setMaterialIndex(*mindices++); \
-    } \
-    if (nbind == PER_VERTEX) { \
-        pointDetail.setNormalIndex(normnr); \
-        currnormal = &normals[normnr++]; \
-        vertex.setNormal(*currnormal); \
-    } \
-    else if (nbind == PER_VERTEX_INDEXED) { \
-        pointDetail.setNormalIndex(*nindices); \
-        currnormal = &normals[*nindices++]; \
-        vertex.setNormal(*currnormal); \
-    } \
-    if (tb.isFunction()) { \
-        vertex.setTextureCoords(tb.get(coords->get3(idx), *currnormal)); \
-        if (tb.needIndices()) \
-            pointDetail.setTextureCoordIndex(tindices ? *tindices++ : texidx++); \
-    } \
-    else if (tbind != NONE) { \
-        pointDetail.setTextureCoordIndex(tindices ? *tindices : texidx); \
-        vertex.setTextureCoords(tb.get(tindices ? *tindices++ : texidx++)); \
-    } \
-    vertex.setPoint(coords->get3(idx)); \
-    pointDetail.setCoordinateIndex(idx); \
-    this->shapeVertex(&vertex);
-
 void SoBrepFaceSet::generatePrimitives(SoAction* action)
 {
-    // This is highly experimental!!!
-
-    if (this->coordIndex.getNum() < 3) {
-        return;
-    }
-    SoState* state = action->getState();
-
-    if (this->vertexProperty.getValue()) {
-        state->push();
-        this->vertexProperty.getValue()->doAction(action);
-    }
-
-    Binding mbind = this->findMaterialBinding(state);
-    Binding nbind = this->findNormalBinding(state);
-
-    const SoCoordinateElement* coords;
-    const SbVec3f* normals;
-    const int32_t* cindices;
-    int numindices;
-    const int32_t* nindices;
-    const int32_t* tindices;
-    const int32_t* mindices;
-    SbBool doTextures;
-    SbBool sendNormals;
-    SbBool normalCacheUsed;
-
-    sendNormals = true;  // always generate normals
-
-    this->getVertexData(
-        state,
-        coords,
-        normals,
-        cindices,
-        nindices,
-        tindices,
-        mindices,
-        numindices,
-        sendNormals,
-        normalCacheUsed
-    );
-
-    SoTextureCoordinateBundle tb(action, false, false);
-    doTextures = tb.needCoordinates();
-
-    if (!sendNormals) {
-        nbind = OVERALL;
-    }
-    else if (normalCacheUsed && nbind == PER_VERTEX) {
-        nbind = PER_VERTEX_INDEXED;
-    }
-    else if (normalCacheUsed && nbind == PER_FACE_INDEXED) {
-        nbind = PER_FACE;
-    }
-
-    if (this->getNodeType() == SoNode::VRML1) {
-        // For VRML1, PER_VERTEX means per vertex in shape, not PER_VERTEX
-        // on the state.
-        if (mbind == PER_VERTEX) {
-            mbind = PER_VERTEX_INDEXED;
-            mindices = cindices;
-        }
-        if (nbind == PER_VERTEX) {
-            nbind = PER_VERTEX_INDEXED;
-            nindices = cindices;
-        }
-    }
-
-    Binding tbind = NONE;
-    if (doTextures) {
-        if (tb.isFunction() && !tb.needIndices()) {
-            tbind = NONE;
-            tindices = nullptr;
-        }
-        // FIXME: just call inherited::areTexCoordsIndexed() instead of
-        // the if-check? 20020110 mortene.
-        else if (
-            SoTextureCoordinateBindingElement::get(state) == SoTextureCoordinateBindingElement::PER_VERTEX
-        ) {
-            tbind = PER_VERTEX;
-            tindices = nullptr;
-        }
-        else {
-            tbind = PER_VERTEX_INDEXED;
-            if (!tindices) {
-                tindices = cindices;
-            }
-        }
-    }
-
-    if (nbind == PER_VERTEX_INDEXED && !nindices) {
-        nindices = cindices;
-    }
-    if (mbind == PER_VERTEX_INDEXED && !mindices) {
-        mindices = cindices;
-    }
-
-    int texidx = 0;
-    TriangleShape mode = POLYGON;
-    TriangleShape newmode;
-    const int32_t* viptr = cindices;
-    const int32_t* viendptr = viptr + numindices;
-    const int32_t* piptr = this->partIndex.getValues(0);
-    int num_partindices = this->partIndex.getNum();
-    const int32_t* piendptr = piptr + num_partindices;
-    int32_t v1, v2, v3, v4, v5 = 0, pi;  // v5 init unnecessary, but kills a compiler warning.
-
-    SoPrimitiveVertex vertex;
-    SoPointDetail pointDetail;
-    SoFaceDetail faceDetail;
-
-    vertex.setDetail(&pointDetail);
-
-    SbVec3f dummynormal(0, 0, 1);
-    const SbVec3f* currnormal = &dummynormal;
-    if (normals) {
-        currnormal = normals;
-    }
-    vertex.setNormal(*currnormal);
-
-    int matnr = 0;
-    int normnr = 0;
-    int trinr = 0;
-    pi = piptr < piendptr ? *piptr++ : -1;
-    while (pi == 0) {
-        // It may happen that a part has no triangles
-        pi = piptr < piendptr ? *piptr++ : -1;
-        if (mbind == PER_PART) {
-            matnr++;
-        }
-        else if (mbind == PER_PART_INDEXED) {
-            mindices++;
-        }
-    }
-
-    while (viptr + 2 < viendptr) {
-        v1 = *viptr++;
-        v2 = *viptr++;
-        v3 = *viptr++;
-        if (v1 < 0 || v2 < 0 || v3 < 0) {
-            break;
-        }
-        v4 = viptr < viendptr ? *viptr++ : -1;
-        if (v4 < 0) {
-            newmode = TRIANGLES;
-        }
-        else {
-            v5 = viptr < viendptr ? *viptr++ : -1;
-            if (v5 < 0) {
-                newmode = QUADS;
-            }
-            else {
-                newmode = POLYGON;
-            }
-        }
-        if (newmode != mode) {
-            if (mode != POLYGON) {
-                this->endShape();
-            }
-            mode = newmode;
-            this->beginShape(action, mode, &faceDetail);
-        }
-        else if (mode == POLYGON) {
-            this->beginShape(action, POLYGON, &faceDetail);
-        }
-
-        // vertex 1 can't use DO_VERTEX
-        if (mbind == PER_PART) {
-            if (trinr == 0) {
-                pointDetail.setMaterialIndex(matnr);
-                vertex.setMaterialIndex(matnr++);
-            }
-        }
-        else if (mbind == PER_PART_INDEXED) {
-            if (trinr == 0) {
-                pointDetail.setMaterialIndex(*mindices);
-                vertex.setMaterialIndex(*mindices++);
-            }
-        }
-        else if (mbind == PER_VERTEX || mbind == PER_FACE) {
-            pointDetail.setMaterialIndex(matnr);
-            vertex.setMaterialIndex(matnr++);
-        }
-        else if (mbind == PER_VERTEX_INDEXED || mbind == PER_FACE_INDEXED) {
-            pointDetail.setMaterialIndex(*mindices);
-            vertex.setMaterialIndex(*mindices++);
-        }
-        if (nbind == PER_VERTEX || nbind == PER_FACE) {
-            pointDetail.setNormalIndex(normnr);
-            currnormal = &normals[normnr++];
-            vertex.setNormal(*currnormal);
-        }
-        else if (nbind == PER_FACE_INDEXED || nbind == PER_VERTEX_INDEXED) {
-            pointDetail.setNormalIndex(*nindices);
-            currnormal = &normals[*nindices++];
-            vertex.setNormal(*currnormal);
-        }
-
-        if (tb.isFunction()) {
-            vertex.setTextureCoords(tb.get(coords->get3(v1), *currnormal));
-            if (tb.needIndices()) {
-                pointDetail.setTextureCoordIndex(tindices ? *tindices++ : texidx++);
-            }
-        }
-        else if (tbind != NONE) {
-            pointDetail.setTextureCoordIndex(tindices ? *tindices : texidx);
-            vertex.setTextureCoords(tb.get(tindices ? *tindices++ : texidx++));
-        }
-        pointDetail.setCoordinateIndex(v1);
-        vertex.setPoint(coords->get3(v1));
-        this->shapeVertex(&vertex);
-
-        DO_VERTEX(v2);
-        DO_VERTEX(v3);
-
-        if (mode != TRIANGLES) {
-            DO_VERTEX(v4);
-            if (mode == POLYGON) {
-                DO_VERTEX(v5);
-                v1 = viptr < viendptr ? *viptr++ : -1;
-                while (v1 >= 0) {
-                    DO_VERTEX(v1);
-                    v1 = viptr < viendptr ? *viptr++ : -1;
-                }
-                this->endShape();
-            }
-        }
-        faceDetail.incFaceIndex();
-        if (mbind == PER_VERTEX_INDEXED) {
-            mindices++;
-        }
-        if (nbind == PER_VERTEX_INDEXED) {
-            nindices++;
-        }
-        if (tindices) {
-            tindices++;
-        }
-
-        trinr++;
-        if (pi == trinr) {
-            pi = piptr < piendptr ? *piptr++ : -1;
-            while (pi == 0) {
-                // It may happen that a part has no triangles
-                pi = piptr < piendptr ? *piptr++ : -1;
-                if (mbind == PER_PART) {
-                    matnr++;
-                }
-                else if (mbind == PER_PART_INDEXED) {
-                    mindices++;
-                }
-            }
-            trinr = 0;
-        }
-    }
-    if (mode != POLYGON) {
-        this->endShape();
-    }
-
-    if (normalCacheUsed) {
-        this->readUnlockNormalCache();
-    }
-
-    if (this->vertexProperty.getValue()) {
-        state->pop();
-    }
+    inherited::generatePrimitives(action);
 }
 
-#undef DO_VERTEX
-
-void SoBrepFaceSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx)
+void SoBrepFaceSet::getBoundingBox(SoGetBoundingBoxAction* action)
 {
-    if (!ctx || ctx->highlightIndex < 0) {
-        return;
-    }
-
-    SoState* state = action->getState();
-    state->push();
-
-    SoLazyElement::setEmissive(state, &ctx->highlightColor);
-    // if shading is disabled then set also the diffuse color
-    if (SoLazyElement::getLightModel(state) == SoLazyElement::BASE_COLOR) {
-        packedColor = ctx->highlightColor.getPackedValue(0.0);
-        SoLazyElement::setPacked(state, this, 1, &packedColor, false);
-    }
-    SoTextureEnabledElement::set(state, this, false);
-
-    Binding mbind = this->findMaterialBinding(state);
-    Binding nbind = this->findNormalBinding(state);
-
-    const SoCoordinateElement* coords;
-    const SbVec3f* normals;
-    const int32_t* cindices;
-    int numindices;
-    const int32_t* nindices;
-    const int32_t* tindices;
-    const int32_t* mindices;
-    const int32_t* pindices;
-    SbBool doTextures;
-    SbBool normalCacheUsed;
-
-    SoMaterialBundle mb(action);
-    SoTextureCoordinateBundle tb(action, true, false);
-    doTextures = tb.needCoordinates();
-    SbBool sendNormals = !mb.isColorOnly() || tb.isFunction();
-
-    this->getVertexData(
-        state,
-        coords,
-        normals,
-        cindices,
-        nindices,
-        tindices,
-        mindices,
-        numindices,
-        sendNormals,
-        normalCacheUsed
-    );
-
-    mb.sendFirst();  // make sure we have the correct material
-
-    int id = ctx->highlightIndex;
-    if (id != std::numeric_limits<int>::max() && id >= this->partIndex.getNum()) {
-        SoDebugError::postWarning("SoBrepFaceSet::renderHighlight", "highlightIndex out of range");
-    }
-    else {
-        // just in case someone forgot
-        if (!mindices) {
-            mindices = cindices;
-        }
-        if (!nindices) {
-            nindices = cindices;
-        }
-        pindices = this->partIndex.getValues(0);
-
-        // coords
-        int start = 0;
-        int length;
-        if (id == std::numeric_limits<int>::max()) {
-            length = numindices;
-            id = 0;
-        }
-        else {
-            length = (int)pindices[id] * 4;
-            for (int i = 0; i < id; i++) {
-                start += (int)pindices[i];
-            }
-            start *= 4;
-        }
-
-        // normals
-        if (nbind == PER_VERTEX_INDEXED) {
-            nindices = &(nindices[start]);
-        }
-        else if (nbind == PER_VERTEX) {
-            normals = &(normals[start]);
-        }
-        else {
-            nbind = OVERALL;
-        }
-
-        // materials
-        mbind = OVERALL;
-        doTextures = false;
-
-        renderShape(
-            action,
-            false,
-            static_cast<const SoGLCoordinateElement*>(coords),
-            &(cindices[start]),
-            length,
-            &(pindices[id]),
-            1,
-            normals,
-            nindices,
-            &mb,
-            mindices,
-            &tb,
-            tindices,
-            nbind,
-            mbind,
-            doTextures
-        );
-    }
-    state->pop();
-
-    if (normalCacheUsed) {
-        this->readUnlockNormalCache();
-    }
-}
-
-void SoBrepFaceSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx, bool push)
-{
-    if (!ctx || ctx->selectionIndex.empty()) {
-        return;
-    }
-
-    SoState* state = action->getState();
-
-    if (push) {
-        state->push();
-
-        SoLazyElement::setEmissive(state, &ctx->selectionColor);
-        // if shading is disabled then set also the diffuse color
-        if (SoLazyElement::getLightModel(state) == SoLazyElement::BASE_COLOR) {
-            packedColor = ctx->selectionColor.getPackedValue(0.0);
-            SoLazyElement::setPacked(state, this, 1, &packedColor, false);
-        }
-        SoTextureEnabledElement::set(state, this, false);
-    }
-
-    Binding mbind = this->findMaterialBinding(state);
-    Binding nbind = this->findNormalBinding(state);
-
-    const SoCoordinateElement* coords;
-    const SbVec3f* normals;
-    const int32_t* cindices;
-    int numindices;
-    const int32_t* nindices;
-    const int32_t* tindices;
-    const int32_t* mindices;
-    const int32_t* pindices;
-    SbBool doTextures;
-    SbBool normalCacheUsed;
-
-    SoMaterialBundle mb(action);
-    SoTextureCoordinateBundle tb(action, true, false);
-    doTextures = tb.needCoordinates();
-    SbBool sendNormals = !mb.isColorOnly() || tb.isFunction();
-
-    this->getVertexData(
-        state,
-        coords,
-        normals,
-        cindices,
-        nindices,
-        tindices,
-        mindices,
-        numindices,
-        sendNormals,
-        normalCacheUsed
-    );
-
-    mb.sendFirst();  // make sure we have the correct material
-
-    // just in case someone forgot
-    if (!mindices) {
-        mindices = cindices;
-    }
-    if (!nindices) {
-        nindices = cindices;
-    }
-    pindices = this->partIndex.getValues(0);
-
-    if (push) {
-        // materials
-        mbind = OVERALL;
-        doTextures = false;
-    }
-
-    for (auto id : ctx->selectionIndex) {
-        if (id >= this->partIndex.getNum()) {
-            SoDebugError::postWarning("SoBrepFaceSet::renderSelection", "selectionIndex out of range");
-            break;
-        }
-        if (id >= 0 && id == ctx->highlightIndex) {
-            continue;
-        }
-
-        // coords
-        int length = 0;
-        int start = 0;
-        int numparts = 1;
-        // if < 0 then select everything
-        if (id < 0) {
-            length = numindices;
-            id = 0;
-        }
-        else {
-            length = (int)pindices[id] * 4;
-            for (int j = 0; j < id; j++) {
-                start += (int)pindices[j];
-            }
-            start *= 4;
-        }
-
-        // normals
-        const SbVec3f* normals_s = normals;
-        const int32_t* nindices_s = nindices;
-        if (nbind == PER_VERTEX_INDEXED) {
-            nindices_s = &(nindices[start]);
-        }
-        else if (nbind == PER_VERTEX) {
-            normals_s = &(normals[start]);
-        }
-        else {
-            nbind = OVERALL;
-        }
-
-        renderShape(
-            action,
-            false,
-            static_cast<const SoGLCoordinateElement*>(coords),
-            &(cindices[start]),
-            length,
-            &(pindices[id]),
-            numparts,
-            normals_s,
-            nindices_s,
-            &mb,
-            mindices,
-            &tb,
-            tindices,
-            nbind,
-            mbind,
-            doTextures ? 1 : 0
-        );
-    }
-    if (push) {
-        state->pop();
-    }
-
-    if (normalCacheUsed) {
-        this->readUnlockNormalCache();
-    }
-}
-
-void SoBrepFaceSet::VBO::render(
-    SoGLRenderAction* action,
-    const SoGLCoordinateElement* const vertexlist,
-    const int32_t* vertexindices,
-    int num_indices,
-    const int32_t* partindices,
-    int num_partindices,
-    const SbVec3f* normals,
-    const int32_t* normalindices,
-    SoMaterialBundle* const materials,
-    const int32_t* matindices,
-    SoTextureCoordinateBundle* const texcoords,
-    const int32_t* texindices,
-    const int nbind,
-    const int mbind,
-    SbBool texture
-)
-{
-    (void)texcoords;
-    (void)texindices;
-    (void)texture;
-    const SbVec3f* coords3d = vertexlist->getArrayPtr3();
-    SbVec3f* cur_coords3d = const_cast<SbVec3f*>(coords3d);
-
-    const int32_t* viptr = vertexindices;
-    const int32_t* viendptr = viptr + num_indices;
-    const int32_t* piptr = partindices;
-    const int32_t* piendptr = piptr + num_partindices;
-    int32_t v1, v2, v3, v4, pi;
-    SbVec3f dummynormal(0, 0, 1);
-    int numverts = vertexlist->getNum();
-
-    const SbVec3f* currnormal = &dummynormal;
-    if (normals) {
-        currnormal = normals;
-    }
-
-    int matnr = 0;
-    int trinr = 0;
-
-    float* vertex_array = nullptr;
-    GLuint* index_array = nullptr;
-    SbColor mycolor1, mycolor2, mycolor3;
-    SbVec3f* mynormal1 = const_cast<SbVec3f*>(currnormal);
-    SbVec3f* mynormal2 = const_cast<SbVec3f*>(currnormal);
-    SbVec3f* mynormal3 = const_cast<SbVec3f*>(currnormal);
-    int indice = 0;
-    uint32_t RGBA, R, G, B, A;
-    float Rf, Gf, Bf, Af;
-
-    uint32_t contextId = action->getCacheContext();
-    auto res = this->vbomap.insert(std::make_pair(contextId, VBO::Buffer()));
-    VBO::Buffer& buf = res.first->second;
-    if (res.second) {
-#ifdef FC_OS_WIN32
-        const cc_glglue* glue = cc_glglue_instance(action->getCacheContext());
-        PFNGLGENBUFFERSPROC glGenBuffersARB
-            = (PFNGLGENBUFFERSPROC)cc_glglue_getprocaddress(glue, "glGenBuffersARB");
-#endif
-        glGenBuffersARB(2, buf.myvbo);
-        buf.vertex_array_size = 0;
-        buf.index_array_size = 0;
-        buf.vboLoaded = false;
-    }
-
-    if ((buf.vertex_array_size != (sizeof(float) * num_indices * 10))
-        || (buf.index_array_size != (sizeof(GLuint) * num_indices))) {
-        if ((buf.vertex_array_size != 0) && (buf.index_array_size != 0)) {
-            buf.updateVbo = true;
-        }
-    }
-
-    // vbo loaded is defining if we must pre-load data into the VBO. When the variable is set to 0
-    // it means that the VBO has not been initialized
-    // updateVbo is tracking the need to update the content of the VBO which act as a buffer within
-    // the graphic card
-    // TODO FINISHING THE COLOR SUPPORT !
-
-    if (!buf.vboLoaded || buf.updateVbo) {
-#ifdef FC_OS_WIN32
-        const cc_glglue* glue = cc_glglue_instance(action->getCacheContext());
-
-        PFNGLBINDBUFFERARBPROC glBindBufferARB
-            = (PFNGLBINDBUFFERARBPROC)cc_glglue_getprocaddress(glue, "glBindBufferARB");
-        // PFNGLMAPBUFFERARBPROC glMapBufferARB = (PFNGLMAPBUFFERARBPROC)
-        // cc_glglue_getprocaddress(glue, "glMapBufferARB");
-        PFNGLGENBUFFERSPROC glGenBuffersARB
-            = (PFNGLGENBUFFERSPROC)cc_glglue_getprocaddress(glue, "glGenBuffersARB");
-        PFNGLDELETEBUFFERSARBPROC glDeleteBuffersARB
-            = (PFNGLDELETEBUFFERSARBPROC)cc_glglue_getprocaddress(glue, "glDeleteBuffersARB");
-        PFNGLBUFFERDATAARBPROC glBufferDataARB
-            = (PFNGLBUFFERDATAARBPROC)cc_glglue_getprocaddress(glue, "glBufferDataARB");
-#endif
-        // We must manage buffer size increase let's clear everything and re-init to test the
-        // clearing process
-        glDeleteBuffersARB(2, buf.myvbo);
-        glGenBuffersARB(2, buf.myvbo);
-        vertex_array = (float*)malloc(sizeof(float) * num_indices * 10);
-        index_array = (GLuint*)malloc(sizeof(GLuint) * num_indices);
-        buf.vertex_array_size = sizeof(float) * num_indices * 10;
-        buf.index_array_size = sizeof(GLuint) * num_indices;
-        this->vbomap[contextId] = buf;
-        this->indice_array = 0;
-
-        // Get the initial colors
-        SoState* state = action->getState();
-        mycolor1 = SoLazyElement::getDiffuse(state, 0);
-        mycolor2 = SoLazyElement::getDiffuse(state, 0);
-        mycolor3 = SoLazyElement::getDiffuse(state, 0);
-
-        pi = piptr < piendptr ? *piptr++ : -1;
-        while (pi == 0) {
-            // It may happen that a part has no triangles
-            pi = piptr < piendptr ? *piptr++ : -1;
-            if (mbind == PER_PART) {
-                matnr++;
-            }
-            else if (mbind == PER_PART_INDEXED) {
-                matindices++;
-            }
-        }
-
-        while (viptr + 2 < viendptr) {
-            v1 = *viptr++;
-            v2 = *viptr++;
-            v3 = *viptr++;
-            // This test is for robustness upon buggy data sets
-            if (v1 < 0 || v2 < 0 || v3 < 0 || v1 >= numverts || v2 >= numverts || v3 >= numverts) {
-                break;
-            }
-            v4 = viptr < viendptr ? *viptr++ : -1;
-            (void)v4;
-
-            if (mbind == PER_PART) {
-                if (trinr == 0) {
-                    materials->send(matnr++, true);
-                    mycolor1 = SoLazyElement::getDiffuse(state, matnr - 1);
-                    mycolor2 = mycolor1;
-                    mycolor3 = mycolor1;
-                }
-            }
-            else if (mbind == PER_PART_INDEXED) {
-                if (trinr == 0) {
-                    materials->send(*matindices++, true);
-                }
-            }
-            else if (mbind == PER_VERTEX || mbind == PER_FACE) {
-                materials->send(matnr++, true);
-            }
-            else if (mbind == PER_VERTEX_INDEXED || mbind == PER_FACE_INDEXED) {
-                materials->send(*matindices++, true);
-            }
-
-            if (normals) {
-                if (nbind == PER_VERTEX || nbind == PER_FACE) {
-                    currnormal = normals++;
-                    mynormal1 = const_cast<SbVec3f*>(currnormal);
-                }
-                else if (nbind == PER_VERTEX_INDEXED || nbind == PER_FACE_INDEXED) {
-                    currnormal = &normals[*normalindices++];
-                    mynormal1 = const_cast<SbVec3f*>(currnormal);
-                }
-            }
-            if (mbind == PER_VERTEX) {
-                materials->send(matnr++, true);
-            }
-            else if (mbind == PER_VERTEX_INDEXED) {
-                materials->send(*matindices++, true);
-            }
-
-            if (normals) {
-                if (nbind == PER_VERTEX) {
-                    currnormal = normals++;
-                    mynormal2 = const_cast<SbVec3f*>(currnormal);
-                }
-                else if (nbind == PER_VERTEX_INDEXED) {
-                    currnormal = &normals[*normalindices++];
-                    mynormal2 = const_cast<SbVec3f*>(currnormal);
-                }
-            }
-
-            if (mbind == PER_VERTEX) {
-                materials->send(matnr++, true);
-            }
-            else if (mbind == PER_VERTEX_INDEXED) {
-                materials->send(*matindices++, true);
-            }
-            if (normals) {
-                if (nbind == PER_VERTEX) {
-                    currnormal = normals++;
-                    mynormal3 = const_cast<SbVec3f*>(currnormal);
-                }
-                else if (nbind == PER_VERTEX_INDEXED) {
-                    currnormal = &normals[*normalindices++];
-                    mynormal3 = const_cast<SbVec3f*>(currnormal);
-                }
-            }
-            if (nbind == PER_VERTEX_INDEXED) {
-                normalindices++;
-            }
-
-            /* We building the Vertex dataset there and push it to a VBO */
-            /* The Vertex array shall contain per element vertex_coordinates[3],
-            normal_coordinates[3], color_value[3] (RGBA format) */
-
-            index_array[this->indice_array] = this->indice_array;
-            index_array[this->indice_array + 1] = this->indice_array + 1;
-            index_array[this->indice_array + 2] = this->indice_array + 2;
-            this->indice_array += 3;
-
-
-            ((SbVec3f*)(cur_coords3d + v1))
-                ->getValue(vertex_array[indice + 0], vertex_array[indice + 1], vertex_array[indice + 2]);
-
-            ((SbVec3f*)(mynormal1))
-                ->getValue(vertex_array[indice + 3], vertex_array[indice + 4], vertex_array[indice + 5]);
-
-            /* We decode the Vertex1 color */
-            RGBA = mycolor1.getPackedValue();
-            R = (RGBA & 0xFF000000) >> 24;
-            G = (RGBA & 0xFF0000) >> 16;
-            B = (RGBA & 0xFF00) >> 8;
-            A = (RGBA & 0xFF);
-
-            Rf = (((float)R) / 255.0);
-            Gf = (((float)G) / 255.0);
-            Bf = (((float)B) / 255.0);
-            Af = (((float)A) / 255.0);
-
-            vertex_array[indice + 6] = Rf;
-            vertex_array[indice + 7] = Gf;
-            vertex_array[indice + 8] = Bf;
-            vertex_array[indice + 9] = Af;
-            indice += 10;
-
-            ((SbVec3f*)(cur_coords3d + v2))
-                ->getValue(vertex_array[indice + 0], vertex_array[indice + 1], vertex_array[indice + 2]);
-            ((SbVec3f*)(mynormal2))
-                ->getValue(vertex_array[indice + 3], vertex_array[indice + 4], vertex_array[indice + 5]);
-
-            RGBA = mycolor2.getPackedValue();
-            R = (RGBA & 0xFF000000) >> 24;
-            G = (RGBA & 0xFF0000) >> 16;
-            B = (RGBA & 0xFF00) >> 8;
-            A = (RGBA & 0xFF);
-
-            Rf = (((float)R) / 255.0);
-            Gf = (((float)G) / 255.0);
-            Bf = (((float)B) / 255.0);
-            Af = (((float)A) / 255.0);
-
-            vertex_array[indice + 6] = Rf;
-            vertex_array[indice + 7] = Gf;
-            vertex_array[indice + 8] = Bf;
-            vertex_array[indice + 9] = Af;
-            indice += 10;
-
-            ((SbVec3f*)(cur_coords3d + v3))
-                ->getValue(vertex_array[indice + 0], vertex_array[indice + 1], vertex_array[indice + 2]);
-            ((SbVec3f*)(mynormal3))
-                ->getValue(vertex_array[indice + 3], vertex_array[indice + 4], vertex_array[indice + 5]);
-
-            RGBA = mycolor3.getPackedValue();
-            R = (RGBA & 0xFF000000) >> 24;
-            G = (RGBA & 0xFF0000) >> 16;
-            B = (RGBA & 0xFF00) >> 8;
-            A = (RGBA & 0xFF);
-
-            Rf = (((float)R) / 255.0);
-            Gf = (((float)G) / 255.0);
-            Bf = (((float)B) / 255.0);
-            Af = (((float)A) / 255.0);
-
-            vertex_array[indice + 6] = Rf;
-            vertex_array[indice + 7] = Gf;
-            vertex_array[indice + 8] = Bf;
-            vertex_array[indice + 9] = Af;
-            indice += 10;
-
-            /* ============================================================ */
-            trinr++;
-            if (pi == trinr) {
-                pi = piptr < piendptr ? *piptr++ : -1;
-                while (pi == 0) {
-                    // It may happen that a part has no triangles
-                    pi = piptr < piendptr ? *piptr++ : -1;
-                    if (mbind == PER_PART) {
-                        matnr++;
-                    }
-                    else if (mbind == PER_PART_INDEXED) {
-                        matindices++;
-                    }
-                }
-                trinr = 0;
-            }
-        }
-
-        glBindBufferARB(GL_ARRAY_BUFFER_ARB, buf.myvbo[0]);
-        glBufferDataARB(GL_ARRAY_BUFFER_ARB, sizeof(float) * indice, vertex_array, GL_DYNAMIC_DRAW_ARB);
-
-        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, buf.myvbo[1]);
-        glBufferDataARB(
-            GL_ELEMENT_ARRAY_BUFFER_ARB,
-            sizeof(GLuint) * this->indice_array,
-            &index_array[0],
-            GL_DYNAMIC_DRAW_ARB
-        );
-
-        glBindBufferARB(GL_ARRAY_BUFFER_ARB, 0);
-        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, 0);
-
-        buf.vboLoaded = true;
-        buf.updateVbo = false;
-        free(vertex_array);
-        free(index_array);
-    }
-
-    // This is the VBO rendering code
-#ifdef FC_OS_WIN32
-    const cc_glglue* glue = cc_glglue_instance(action->getCacheContext());
-    PFNGLBINDBUFFERARBPROC glBindBufferARB
-        = (PFNGLBINDBUFFERARBPROC)cc_glglue_getprocaddress(glue, "glBindBufferARB");
-#endif
-
-    if (!buf.updateVbo) {
-        glBindBufferARB(GL_ARRAY_BUFFER_ARB, buf.myvbo[0]);
-        glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, buf.myvbo[1]);
-    }
-
-    glEnableClientState(GL_VERTEX_ARRAY);
-    glEnableClientState(GL_NORMAL_ARRAY);
-    glEnableClientState(GL_COLOR_ARRAY);
-
-    glVertexPointer(3, GL_FLOAT, 10 * sizeof(GLfloat), nullptr);
-    glNormalPointer(GL_FLOAT, 10 * sizeof(GLfloat), (GLvoid*)(3 * sizeof(GLfloat)));
-    glColorPointer(4, GL_FLOAT, 10 * sizeof(GLfloat), (GLvoid*)(6 * sizeof(GLfloat)));
-
-    glDrawElements(GL_TRIANGLES, this->indice_array, GL_UNSIGNED_INT, (void*)nullptr);
-
-    glDisableClientState(GL_COLOR_ARRAY);
-    glDisableClientState(GL_NORMAL_ARRAY);
-    glDisableClientState(GL_VERTEX_ARRAY);
-    glBindBufferARB(GL_ARRAY_BUFFER_ARB, 0);
-    glBindBufferARB(GL_ELEMENT_ARRAY_BUFFER_ARB, 0);
-    buf.updateVbo = false;
-    // The data is within the VBO we can clear it at application level
-}
-
-void SoBrepFaceSet::renderShape(
-    SoGLRenderAction* action,
-    SbBool hasVBO,
-    const SoGLCoordinateElement* const vertexlist,
-    const int32_t* vertexindices,
-    int num_indices,
-    const int32_t* partindices,
-    int num_partindices,
-    const SbVec3f* normals,
-    const int32_t* normalindices,
-    SoMaterialBundle* const materials,
-    const int32_t* matindices,
-    SoTextureCoordinateBundle* const texcoords,
-    const int32_t* texindices,
-    const int nbind,
-    const int mbind,
-    SbBool texture
-)
-{
-    // Can we use vertex buffer objects?
-    if (hasVBO) {
-        int nbinding = nbind;
-        SoState* state = action->getState();
-        if (SoLazyElement::getLightModel(state) == SoLazyElement::BASE_COLOR) {
-            // if no shading is set then the normals are all equal
-            nbinding = static_cast<int>(OVERALL);
-        }
-        PRIVATE(this)->render(
-            action,
-            vertexlist,
-            vertexindices,
-            num_indices,
-            partindices,
-            num_partindices,
-            normals,
-            normalindices,
-            materials,
-            matindices,
-            texcoords,
-            texindices,
-            nbinding,
-            mbind,
-            texture
-        );
-        return;
-    }
-
-    int texidx = 0;
-
-    const SbVec3f* coords3d = nullptr;
-    coords3d = vertexlist->getArrayPtr3();
-
-    const int32_t* viptr = vertexindices;
-    const int32_t* viendptr = viptr + num_indices;
-    const int32_t* piptr = partindices;
-    const int32_t* piendptr = piptr + num_partindices;
-    int32_t v1, v2, v3, v4, pi;
-    SbVec3f dummynormal(0, 0, 1);
-    int numverts = vertexlist->getNum();
-
-    const SbVec3f* currnormal = &dummynormal;
-    if (normals) {
-        currnormal = normals;
-    }
-
-    int matnr = 0;
-    int trinr = 0;
-
-    // Legacy code without VBO support
-    pi = piptr < piendptr ? *piptr++ : -1;
-    while (pi == 0) {
-        // It may happen that a part has no triangles
-        pi = piptr < piendptr ? *piptr++ : -1;
-        if (mbind == PER_PART) {
-            matnr++;
-        }
-        else if (mbind == PER_PART_INDEXED) {
-            matindices++;
-        }
-    }
-
-    glBegin(GL_TRIANGLES);
-    while (viptr + 2 < viendptr) {
-        v1 = *viptr++;
-        v2 = *viptr++;
-        v3 = *viptr++;
-        if (v1 < 0 || v2 < 0 || v3 < 0 || v1 >= numverts || v2 >= numverts || v3 >= numverts) {
-            break;
-        }
-        v4 = viptr < viendptr ? *viptr++ : -1;
-        (void)v4;
-        /* vertex 1 *********************************************************/
-        if (mbind == PER_PART) {
-            if (trinr == 0) {
-                materials->send(matnr++, true);
-            }
-        }
-        else if (mbind == PER_PART_INDEXED) {
-            if (trinr == 0) {
-                materials->send(*matindices++, true);
-            }
-        }
-        else if (mbind == PER_VERTEX || mbind == PER_FACE) {
-            materials->send(matnr++, true);
-        }
-        else if (mbind == PER_VERTEX_INDEXED || mbind == PER_FACE_INDEXED) {
-            materials->send(*matindices++, true);
-        }
-
-        if (normals) {
-            if (nbind == PER_VERTEX || nbind == PER_FACE) {
-                currnormal = normals++;
-                glNormal3fv((const GLfloat*)currnormal);
-            }
-            else if (nbind == PER_VERTEX_INDEXED || nbind == PER_FACE_INDEXED) {
-                currnormal = &normals[*normalindices++];
-                glNormal3fv((const GLfloat*)currnormal);
-            }
-        }
-
-        if (texture) {
-            texcoords->send(texindices ? *texindices++ : texidx++, vertexlist->get3(v1), *currnormal);
-        }
-        glVertex3fv((const GLfloat*)(coords3d + v1));
-
-        /* vertex 2 *********************************************************/
-        if (mbind == PER_VERTEX) {
-            materials->send(matnr++, true);
-        }
-        else if (mbind == PER_VERTEX_INDEXED) {
-            materials->send(*matindices++, true);
-        }
-
-        if (normals) {
-            if (nbind == PER_VERTEX) {
-                currnormal = normals++;
-                glNormal3fv((const GLfloat*)currnormal);
-            }
-            else if (nbind == PER_VERTEX_INDEXED) {
-                currnormal = &normals[*normalindices++];
-                glNormal3fv((const GLfloat*)currnormal);
-            }
-        }
-
-        if (texture) {
-            texcoords->send(texindices ? *texindices++ : texidx++, vertexlist->get3(v2), *currnormal);
-        }
-
-        glVertex3fv((const GLfloat*)(coords3d + v2));
-
-        /* vertex 3 *********************************************************/
-        if (mbind == PER_VERTEX) {
-            materials->send(matnr++, true);
-        }
-        else if (mbind == PER_VERTEX_INDEXED) {
-            materials->send(*matindices++, true);
-        }
-
-        if (normals) {
-            if (nbind == PER_VERTEX) {
-                currnormal = normals++;
-                glNormal3fv((const GLfloat*)currnormal);
-            }
-            else if (nbind == PER_VERTEX_INDEXED) {
-                currnormal = &normals[*normalindices++];
-                glNormal3fv((const GLfloat*)currnormal);
-            }
-        }
-
-        if (texture) {
-            texcoords->send(texindices ? *texindices++ : texidx++, vertexlist->get3(v3), *currnormal);
-        }
-
-        glVertex3fv((const GLfloat*)(coords3d + v3));
-
-        if (mbind == PER_VERTEX_INDEXED) {
-            matindices++;
-        }
-
-        if (nbind == PER_VERTEX_INDEXED) {
-            normalindices++;
-        }
-
-        if (texture && texindices) {
-            texindices++;
-        }
-
-        trinr++;
-        if (pi == trinr) {
-            pi = piptr < piendptr ? *piptr++ : -1;
-            while (pi == 0) {
-                // It may happen that a part has no triangles
-                pi = piptr < piendptr ? *piptr++ : -1;
-                if (mbind == PER_PART) {
-                    matnr++;
-                }
-                else if (mbind == PER_PART_INDEXED) {
-                    matindices++;
-                }
-            }
-            trinr = 0;
-        }
-    }
-    glEnd();
+    inherited::getBoundingBox(action);
 }
 
 SoDetail* SoBrepFaceSet::createTriangleDetail(
@@ -2250,10 +810,10 @@ SoDetail* SoBrepFaceSet::createTriangleDetail(
 {
     SoDetail* detail = inherited::createTriangleDetail(action, v1, v2, v3, pp);
     const int32_t* indices = this->partIndex.getValues(0);
-    int num = this->partIndex.getNum();
+    const int num = this->partIndex.getNum();
     if (indices) {
-        SoFaceDetail* face_detail = static_cast<SoFaceDetail*>(detail);
-        int index = face_detail->getFaceIndex();
+        auto* face_detail = static_cast<SoFaceDetail*>(detail);
+        const int index = face_detail->getFaceIndex();
         int count = 0;
         for (int i = 0; i < num; i++) {
             count += indices[i];
@@ -2269,7 +829,7 @@ SoDetail* SoBrepFaceSet::createTriangleDetail(
 SoBrepFaceSet::Binding SoBrepFaceSet::findMaterialBinding(SoState* const state) const
 {
     Binding binding = OVERALL;
-    SoMaterialBindingElement::Binding matbind = SoMaterialBindingElement::get(state);
+    const auto matbind = SoMaterialBindingElement::get(state);
 
     switch (matbind) {
         case SoMaterialBindingElement::OVERALL:
@@ -2302,8 +862,9 @@ SoBrepFaceSet::Binding SoBrepFaceSet::findMaterialBinding(SoState* const state) 
 SoBrepFaceSet::Binding SoBrepFaceSet::findNormalBinding(SoState* const state) const
 {
     Binding binding = PER_VERTEX_INDEXED;
-    SoNormalBindingElement::Binding normbind
-        = (SoNormalBindingElement::Binding)SoNormalBindingElement::get(state);
+    const auto normbind = static_cast<SoNormalBindingElement::Binding>(
+        SoNormalBindingElement::get(state)
+    );
 
     switch (normbind) {
         case SoNormalBindingElement::OVERALL:
@@ -2332,5 +893,3 @@ SoBrepFaceSet::Binding SoBrepFaceSet::findNormalBinding(SoState* const state) co
     }
     return binding;
 }
-
-#undef PRIVATE

--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -530,10 +530,6 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
     if (singleColor > 0 && !partialRender) {
         SoMaterialBindingElement::set(state, SoMaterialBindingElement::OVERALL);
         SoOverrideElement::setMaterialBindingOverride(state, this, true);
-        if (hasBaseTransparency) {
-            SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
-            SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
-        }
         packedColors.push_back(diffuseColor);
         SoLazyElement::setPacked(state, this, 1, packedColors.data(), hasBaseTransparency);
         SoTextureEnabledElement::set(state, this, false);
@@ -663,10 +659,6 @@ bool SoBrepFaceSet::overrideMaterialBinding(SoGLRenderAction* action, SelContext
     const bool hasTransparency = hasBaseTransparency || usesTransparencyMask;
 
     SoMaterialBindingElement::set(state, this, SoMaterialBindingElement::PER_FACE_INDEXED);
-    if (hasTransparency) {
-        SoShapeStyleElement::setTransparencyType(state, SoGLRenderAction::BLEND);
-        SoLazyElement::setTransparencyType(state, SoGLRenderAction::BLEND);
-    }
     SoLazyElement::setPacked(state, this, packedColors.size(), packedColors.data(), hasTransparency);
     SoTextureEnabledElement::set(state, this, false);
     return true;

--- a/src/Mod/Part/Gui/SoBrepFaceSet.h
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.h
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2011 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -31,10 +30,6 @@
 #include <vector>
 #include <Gui/Selection/SoFCSelectionContext.h>
 #include <Mod/Part/PartGlobal.h>
-
-
-class SoGLCoordinateElement;
-class SoTextureCoordinateBundle;
 
 
 namespace PartGui
@@ -132,25 +127,6 @@ private:
     };
     Binding findMaterialBinding(SoState* const state) const;
     Binding findNormalBinding(SoState* const state) const;
-    void renderShape(
-        SoGLRenderAction* action,
-        SbBool hasVBO,
-        const SoGLCoordinateElement* const vertexlist,
-        const int32_t* vertexindices,
-        int num_vertexindices,
-        const int32_t* partindices,
-        int num_partindices,
-        const SbVec3f* normals,
-        const int32_t* normindices,
-        SoMaterialBundle* const materials,
-        const int32_t* matindices,
-        SoTextureCoordinateBundle* const texcoords,
-        const int32_t* texindices,
-        const int nbind,
-        const int mbind,
-        SbBool texture
-    );
-
     using SelContext = Gui::SoFCSelectionContextEx;
     using SelContextPtr = Gui::SoFCSelectionContextExPtr;
 
@@ -176,9 +152,8 @@ private:
     uint32_t packedColor;
     Gui::SoFCSelectionCounter selCounter;
 
-    // Define some VBO pointer for the current mesh
-    class VBO;
-    std::unique_ptr<VBO> pimpl;
+    SoIndexedFaceSet* overlayFaceSet {nullptr};
+    std::vector<int32_t> overlayCoordIndex;
 
     // backreference to viewprovider that owns this node
     ViewProviderPartExt* viewProvider = nullptr;

--- a/src/Mod/Part/Gui/SoBrepPointSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepPointSet.cpp
@@ -1,47 +1,40 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2011 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
-#ifdef FC_OS_WIN32
-# include <windows.h>
-#endif
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
 #include <algorithm>
 #include <limits>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
 #include <Inventor/actions/SoGLRenderAction.h>
-#include <Inventor/bundles/SoMaterialBundle.h>
 #include <Inventor/details/SoPointDetail.h>
 #include <Inventor/elements/SoCoordinateElement.h>
 #include <Inventor/elements/SoDepthBufferElement.h>
 #include <Inventor/elements/SoLazyElement.h>
+#include <Inventor/elements/SoMaterialBindingElement.h>
+#include <Inventor/elements/SoOverrideElement.h>
 #include <Inventor/elements/SoPointSizeElement.h>
+#include <Inventor/elements/SoTextureEnabledElement.h>
 #include <Inventor/errors/SoDebugError.h>
 #include <Inventor/misc/SoState.h>
 #include <Inventor/nodes/SoIndexedPointSet.h>
@@ -56,6 +49,18 @@
 using namespace PartGui;
 
 SO_NODE_SOURCE(SoBrepPointSet)
+
+static void applyOverlayPrimitiveState(SoState* state, SoNode* node)
+{
+    if (!state || !node) {
+        return;
+    }
+
+    SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
+    SoTextureEnabledElement::set(state, node, false);
+    SoMaterialBindingElement::set(state, SoMaterialBindingElement::OVERALL);
+    SoOverrideElement::setMaterialBindingOverride(state, node, true);
+}
 
 static void renderOverlayPoints(
     SoGLRenderAction* action,
@@ -87,6 +92,7 @@ static void renderOverlayPoints(
     auto state = action->getState();
     state->push();
 
+    applyOverlayPrimitiveState(state, pointSet);
     SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
 
     SoLazyElement::setEmissive(state, &color);
@@ -98,7 +104,12 @@ static void renderOverlayPoints(
         SoPointSizeElement::set(state, pointSet, 4.0f);
     }
 
-    pointSet->coordIndex.setValues(0, static_cast<int>(pointIndices.size()), pointIndices.data());
+    // setValues() does not shrink the field, so rewrite the overlay index array
+    // to the exact size to avoid stale points from the previous overlay render.
+    pointSet->coordIndex.setNum(static_cast<int>(pointIndices.size()));
+    int32_t* coordIndex = pointSet->coordIndex.startEditing();
+    std::copy(pointIndices.begin(), pointIndices.end(), coordIndex);
+    pointSet->coordIndex.finishEditing();
     pointSet->GLRender(action);
 
     state->pop();
@@ -224,10 +235,10 @@ void SoBrepPointSet::GLRender(SoGLRenderAction* action)
         renderSelection(action, ctx2, false);
     }
     else if (Gui::SoDelayedAnnotationsElement::isProcessingDelayedPaths) {
-        glPushAttrib(GL_DEPTH_BUFFER_BIT);
-        glDepthFunc(GL_ALWAYS);
+        state->push();
+        SoDepthBufferElement::set(state, FALSE, FALSE, SoDepthBufferElement::ALWAYS, SbVec2f(0.0f, 1.0f));
         inherited::GLRender(action);
-        glPopAttrib();
+        state->pop();
     }
     else {
         inherited::GLRender(action);
@@ -311,97 +322,87 @@ void SoBrepPointSet::renderHighlight(SoGLRenderAction* action, SelContextPtr ctx
         return;
     }
 
-    SoState* state = action->getState();
-    state->push();
-    float ps = SoPointSizeElement::get(state);
-    if (ps < 4.0f) {
-        SoPointSizeElement::set(state, this, 4.0f);
+    const SoCoordinateElement* coords = SoCoordinateElement::getInstance(action->getState());
+    if (!coords) {
+        return;
     }
-
-    SoLazyElement::setEmissive(state, &ctx->highlightColor);
-    packedColor = ctx->highlightColor.getPackedValue(0.0);
-    SoLazyElement::setPacked(state, this, 1, &packedColor, false);
-
-    const SoCoordinateElement* coords;
-    const SbVec3f* normals;
-
-    this->getVertexData(state, coords, normals, false);
-
-    SoMaterialBundle mb(action);
-    mb.sendFirst();  // make sure we have the correct material
 
     int id = ctx->highlightIndex;
-    const SbVec3f* coords3d = coords->getArrayPtr3();
-    if (coords3d) {
-        if (id == std::numeric_limits<int>::max()) {
-            glBegin(GL_POINTS);
-            for (int idx = startIndex.getValue(); idx < coords->getNum(); ++idx) {
-                glVertex3fv((const GLfloat*)(coords3d + idx));
-            }
-            glEnd();
+    if (id == std::numeric_limits<int>::max()) {
+        std::vector<int32_t> pointIndices;
+        pointIndices.reserve(coords->getNum() - startIndex.getValue());
+        for (int idx = startIndex.getValue(); idx < coords->getNum(); ++idx) {
+            pointIndices.push_back(static_cast<int32_t>(idx));
         }
-        else if (id < this->startIndex.getValue() || id >= coords->getNum()) {
-            SoDebugError::postWarning("SoBrepPointSet::renderHighlight", "highlightIndex out of range");
-        }
-        else {
-            glBegin(GL_POINTS);
-            glVertex3fv((const GLfloat*)(coords3d + id));
-            glEnd();
-        }
+        renderOverlayPoints(
+            action,
+            overlayPointSet,
+            pointIndices.data(),
+            static_cast<int>(pointIndices.size()),
+            ctx->highlightColor
+        );
+        return;
     }
-    state->pop();
+    if (id < this->startIndex.getValue() || id >= coords->getNum()) {
+        SoDebugError::postWarning("SoBrepPointSet::renderHighlight", "highlightIndex out of range");
+        return;
+    }
+
+    const int32_t pointIndices[1] = {static_cast<int32_t>(id)};
+    renderOverlayPoints(action, overlayPointSet, pointIndices, 1, ctx->highlightColor);
 }
 
-void SoBrepPointSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx, bool push)
+void SoBrepPointSet::renderSelection(SoGLRenderAction* action, SelContextPtr ctx, bool /*push*/)
 {
-    SoState* state = action->getState();
-    if (push) {
-        state->push();
-        float ps = SoPointSizeElement::get(state);
-        if (ps < 4.0f) {
-            SoPointSizeElement::set(state, this, 4.0f);
-        }
-
-        SoLazyElement::setEmissive(state, &ctx->selectionColor);
-        packedColor = ctx->selectionColor.getPackedValue(0.0);
-        SoLazyElement::setPacked(state, this, 1, &packedColor, false);
+    if (!ctx) {
+        return;
     }
 
-    const SoCoordinateElement* coords;
-    const SbVec3f* normals;
+    const SoCoordinateElement* coords = SoCoordinateElement::getInstance(action->getState());
+    if (!coords) {
+        return;
+    }
 
-    this->getVertexData(state, coords, normals, false);
-
-    SoMaterialBundle mb(action);
-    mb.sendFirst();  // make sure we have the correct material
-
-    bool warn = false;
     int startIndex = this->startIndex.getValue();
-    const SbVec3f* coords3d = coords->getArrayPtr3();
-    if (coords3d) {
-        glBegin(GL_POINTS);
-        if (ctx->isSelectAll()) {
-            for (int idx = startIndex; idx < coords->getNum(); ++idx) {
-                glVertex3fv((const GLfloat*)(coords3d + idx));
+    if (ctx->isSelectAll()) {
+        std::vector<int32_t> pointIndices;
+        pointIndices.reserve(coords->getNum() - startIndex);
+        for (int idx = startIndex; idx < coords->getNum(); ++idx) {
+            pointIndices.push_back(static_cast<int32_t>(idx));
+        }
+        renderOverlayPoints(
+            action,
+            overlayPointSet,
+            pointIndices.data(),
+            static_cast<int>(pointIndices.size()),
+            ctx->selectionColor
+        );
+    }
+    else {
+        std::vector<int32_t> pointIndices;
+        pointIndices.reserve(ctx->selectionIndex.size());
+        bool warn = false;
+
+        for (auto idx : ctx->selectionIndex) {
+            if (idx >= startIndex && idx < coords->getNum()) {
+                pointIndices.push_back(static_cast<int32_t>(idx));
+            }
+            else {
+                warn = true;
             }
         }
-        else {
-            for (auto idx : ctx->selectionIndex) {
-                if (idx >= startIndex && idx < coords->getNum()) {
-                    glVertex3fv((const GLfloat*)(coords3d + idx));
-                }
-                else {
-                    warn = true;
-                }
-            }
+
+        renderOverlayPoints(
+            action,
+            overlayPointSet,
+            pointIndices.data(),
+            static_cast<int>(pointIndices.size()),
+            ctx->selectionColor
+        );
+
+        if (warn) {
+            SoDebugError::postWarning("SoBrepPointSet::renderSelection", "selectionIndex out of range");
         }
-        glEnd();
-    }
-    if (warn) {
-        SoDebugError::postWarning("SoBrepPointSet::renderSelection", "selectionIndex out of range");
-    }
-    if (push) {
-        state->pop();
     }
 }
 

--- a/src/Mod/Part/Gui/SoBrepPointSet.h
+++ b/src/Mod/Part/Gui/SoBrepPointSet.h
@@ -1,26 +1,25 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2011 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2011 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
 
@@ -34,8 +33,6 @@
 
 
 class SoCoordinateElement;
-class SoGLCoordinateElement;
-class SoTextureCoordinateBundle;
 class SoIndexedPointSet;
 
 namespace PartGui
@@ -81,7 +78,6 @@ private:
     SelContextPtr selContext;
     SelContextPtr selContext2;
     Gui::SoFCSelectionCounter selCounter;
-    uint32_t packedColor {0};
     SoIndexedPointSet* overlayPointSet {nullptr};
 
     // backreference to viewprovider that owns this node

--- a/src/Mod/Part/Gui/SoFCShapeObject.cpp
+++ b/src/Mod/Part/Gui/SoFCShapeObject.cpp
@@ -1,44 +1,36 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2008 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <FCConfig.h>
 
-#ifdef FC_OS_WIN32
-# include <windows.h>
-#endif
-#ifdef FC_OS_MACOSX
-# include <OpenGL/gl.h>
-#else
-# include <GL/gl.h>
-#endif
 #include <algorithm>
 #include <limits>
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/bundles/SoMaterialBundle.h>
-#include <Inventor/bundles/SoTextureCoordinateBundle.h>
 #include <Inventor/elements/SoCoordinateElement.h>
 #include <Inventor/elements/SoLazyElement.h>
+#include <Inventor/elements/SoLineWidthElement.h>
+#include <Inventor/elements/SoPointSizeElement.h>
 #include <Inventor/errors/SoReadError.h>
 #include <Inventor/misc/SoState.h>
 
@@ -81,6 +73,13 @@ SoFCControlPoints::SoFCControlPoints()
     SO_NODE_ADD_FIELD(numKnotsU, (0));
     SO_NODE_ADD_FIELD(numKnotsV, (0));
     SO_NODE_ADD_FIELD(lineColor, (c));
+
+    meshLineSet = new SoIndexedLineSet;
+    meshLineSet->ref();
+    polesPointSet = new SoPointSet;
+    polesPointSet->ref();
+    knotsPointSet = new SoPointSet;
+    knotsPointSet->ref();
 }
 
 /**
@@ -94,74 +93,113 @@ void SoFCControlPoints::GLRender(SoGLRenderAction* action)
         if (!coords) {
             return;
         }
-        const SbVec3f* points = coords->getArrayPtr3();
-        if (!points) {
-            return;
-        }
 
         SoMaterialBundle mb(action);
-        SoTextureCoordinateBundle tb(action, true, false);
         SoLazyElement::setLightModel(state, SoLazyElement::BASE_COLOR);
         mb.sendFirst();  // make sure we have the correct material
 
-        int32_t len = coords->getNum();
-        drawControlPoints(points, len);
+        const int32_t len = coords->getNum();
+
+        const uint32_t nCtU = numPolesU.getValue();
+        const uint32_t nCtV = numPolesV.getValue();
+        const uint32_t poles = nCtU * nCtV;
+        if (poles > static_cast<uint32_t>(len)) {
+            return;  // wrong setup, too few points
+        }
+
+        const uint32_t knots = numKnotsU.getValue() * numKnotsV.getValue();
+        const uint32_t total = poles + knots;
+        if (total > static_cast<uint32_t>(len)) {
+            return;  // wrong setup, too few points
+        }
+
+        updateMeshCoordIndex(nCtU, nCtV);
+
+        const SbColor poleColor = lineColor.getValue();
+        const SbColor knotColor(1.0f, 1.0f, 0.0f);
+
+        // Draw control mesh.
+        state->push();
+        SoLineWidthElement::set(state, 1.0f);
+        SoLazyElement::setEmissive(state, &poleColor);
+        uint32_t packed = poleColor.getPackedValue(0.0f);
+        SoLazyElement::setPacked(state, meshLineSet, 1, &packed, false);
+        meshLineSet->coordIndex
+            .setValues(0, static_cast<int32_t>(meshCoordIndex.size()), meshCoordIndex.data());
+        meshLineSet->GLRender(action);
+        state->pop();
+
+        // Draw poles.
+        state->push();
+        SoPointSizeElement::set(state, 5.0f);
+        SoLazyElement::setEmissive(state, &poleColor);
+        packed = poleColor.getPackedValue(0.0f);
+        SoLazyElement::setPacked(state, polesPointSet, 1, &packed, false);
+        polesPointSet->startIndex.setValue(0);
+        polesPointSet->numPoints.setValue(static_cast<int32_t>(poles));
+        polesPointSet->GLRender(action);
+        state->pop();
+
+        // Draw knots, if available.
+        if (knots > 0) {
+            state->push();
+            SoPointSizeElement::set(state, 6.0f);
+            SoLazyElement::setEmissive(state, &knotColor);
+            packed = knotColor.getPackedValue(0.0f);
+            SoLazyElement::setPacked(state, knotsPointSet, 1, &packed, false);
+            knotsPointSet->startIndex.setValue(static_cast<int32_t>(poles));
+            knotsPointSet->numPoints.setValue(static_cast<int32_t>(knots));
+            knotsPointSet->GLRender(action);
+            state->pop();
+        }
     }
 }
 
-/**
- * Renders the control points and knots.
- */
-void SoFCControlPoints::drawControlPoints(const SbVec3f* points, int32_t len) const
+SoFCControlPoints::~SoFCControlPoints()
 {
-    glLineWidth(1.0f);
-    glColor3fv(lineColor.getValue().getValue());
-
-    uint32_t nCtU = numPolesU.getValue();
-    uint32_t nCtV = numPolesV.getValue();
-    uint32_t poles = nCtU * nCtV;
-    if (poles > (uint32_t)len) {
-        return;  // wrong setup, too few points
+    if (meshLineSet) {
+        meshLineSet->unref();
+        meshLineSet = nullptr;
     }
-    // draw control mesh
-    glBegin(GL_LINES);
-    for (uint32_t u = 0; u < nCtU - 1; ++u) {
-        for (uint32_t v = 0; v < nCtV - 1; ++v) {
-            glVertex3fv(points[u * nCtV + v].getValue());
-            glVertex3fv(points[u * nCtV + v + 1].getValue());
-            glVertex3fv(points[u * nCtV + v].getValue());
-            glVertex3fv(points[(u + 1) * nCtV + v].getValue());
+    if (polesPointSet) {
+        polesPointSet->unref();
+        polesPointSet = nullptr;
+    }
+    if (knotsPointSet) {
+        knotsPointSet->unref();
+        knotsPointSet = nullptr;
+    }
+}
+
+void SoFCControlPoints::updateMeshCoordIndex(uint32_t nCtU, uint32_t nCtV)
+{
+    if (nCtU == cachedNumPolesU && nCtV == cachedNumPolesV) {
+        return;
+    }
+
+    cachedNumPolesU = nCtU;
+    cachedNumPolesV = nCtV;
+    meshCoordIndex.clear();
+
+    if (nCtU < 2 || nCtV < 2) {
+        return;
+    }
+
+    // Polylines along V for each U.
+    for (uint32_t u = 0; u < nCtU; ++u) {
+        for (uint32_t v = 0; v < nCtV; ++v) {
+            meshCoordIndex.push_back(static_cast<int32_t>(u * nCtV + v));
         }
-        glVertex3fv(points[(u + 1) * nCtV - 1].getValue());
-        glVertex3fv(points[(u + 2) * nCtV - 1].getValue());
+        meshCoordIndex.push_back(-1);
     }
-    for (uint32_t v = 0; v < nCtV - 1; ++v) {
-        glVertex3fv(points[(nCtU - 1) * nCtV + v].getValue());
-        glVertex3fv(points[(nCtU - 1) * nCtV + v + 1].getValue());
-    }
-    glEnd();
 
-    // draw poles
-    glPointSize(5.0f);
-    glBegin(GL_POINTS);
-    for (uint32_t p = 0; p < poles; p++) {
-        glVertex3fv(points[p].getValue());
+    // Polylines along U for each V.
+    for (uint32_t v = 0; v < nCtV; ++v) {
+        for (uint32_t u = 0; u < nCtU; ++u) {
+            meshCoordIndex.push_back(static_cast<int32_t>(u * nCtV + v));
+        }
+        meshCoordIndex.push_back(-1);
     }
-    glEnd();
-
-    // draw knots if available
-    uint32_t knots = numKnotsU.getValue() * numKnotsV.getValue();
-    uint32_t index = poles + knots;
-    if (index > (uint32_t)len) {
-        return;  // wrong setup, too few points
-    }
-    glColor3f(1.0f, 1.0f, 0.0f);
-    glPointSize(6.0f);
-    glBegin(GL_POINTS);
-    for (uint32_t p = poles; p < index; p++) {
-        glVertex3fv(points[p].getValue());
-    }
-    glEnd();
 }
 
 void SoFCControlPoints::generatePrimitives(SoAction* /*action*/)

--- a/src/Mod/Part/Gui/SoFCShapeObject.h
+++ b/src/Mod/Part/Gui/SoFCShapeObject.h
@@ -1,28 +1,29 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2008 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
 
-/***************************************************************************
- *   Copyright (c) 2008 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the     *
+ *   License, or (at your option) any later version.                          *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful, but           *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+ *   GNU Lesser General Public License for more details.                      *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD.  If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                         *
+ *                                                                            *
+ ******************************************************************************/
 
 #pragma once
+
+#include <vector>
 
 #include "SoBrepEdgeSet.h"
 #include "SoBrepFaceSet.h"
@@ -31,7 +32,9 @@
 #include <Inventor/fields/SoSFColor.h>
 #include <Inventor/fields/SoSFUInt32.h>
 #include <Inventor/nodes/SoCoordinate3.h>
+#include <Inventor/nodes/SoIndexedLineSet.h>
 #include <Inventor/nodes/SoNormal.h>
+#include <Inventor/nodes/SoPointSet.h>
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoShape.h>
 
@@ -73,14 +76,21 @@ public:
     SoSFColor lineColor;
 
 protected:
-    ~SoFCControlPoints() override = default;
-    ;
+    ~SoFCControlPoints() override;
     void GLRender(SoGLRenderAction* action) override;
     void computeBBox(SoAction* action, SbBox3f& box, SbVec3f& center) override;
     void generatePrimitives(SoAction* action) override;
 
 private:
-    void drawControlPoints(const SbVec3f*, int32_t) const;
+    void updateMeshCoordIndex(uint32_t nCtU, uint32_t nCtV);
+
+    uint32_t cachedNumPolesU {0};
+    uint32_t cachedNumPolesV {0};
+    std::vector<int32_t> meshCoordIndex;
+
+    SoIndexedLineSet* meshLineSet {nullptr};
+    SoPointSet* polesPointSet {nullptr};
+    SoPointSet* knotsPointSet {nullptr};
 };
 
 }  // namespace PartGui

--- a/src/Mod/Sketcher/SketcherTests/GuiTestCase.py
+++ b/src/Mod/Sketcher/SketcherTests/GuiTestCase.py
@@ -159,3 +159,13 @@ class SketcherGuiTestCase(unittest.TestCase):
             max(margin, min(pos.x(), rect.right() - margin)),
             max(margin, min(pos.y(), rect.bottom() - margin)),
         )
+
+    def device_pixel_ratio(self, widget):
+        return widget.devicePixelRatioF()
+
+    def viewport_to_qpoint(self, view, viewport, point):
+        _, height = view.getSize()
+        scale = self.device_pixel_ratio(viewport)
+        x = int(round(point[0] / scale))
+        y = int(round((height - point[1] - 1) / scale))
+        return QtCore.QPoint(x, y)

--- a/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
+++ b/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
@@ -37,6 +37,7 @@ import unittest
 import FreeCAD
 import Part
 import Sketcher
+from SketcherTests.GuiTestCase import SketcherGuiTestCase
 
 try:
     import FreeCADGui
@@ -49,11 +50,10 @@ if GUI_AVAILABLE:
     from PySide import QtCore, QtGui
 
 
-class TestExternalFacePreselection(unittest.TestCase):
+class TestExternalFacePreselection(SketcherGuiTestCase):
 
     def setUp(self):
-        if not GUI_AVAILABLE:
-            self.skipTest("GUI not available")
+        super().setUp()
 
         FreeCADGui.activateWorkbench("PartDesignWorkbench")
         self.doc = FreeCAD.newDocument("TestExtFacePresel")
@@ -93,19 +93,26 @@ class TestExternalFacePreselection(unittest.TestCase):
         self.body = body
         self.pad = pad
 
-    def tearDown(self):
-        if not GUI_AVAILABLE:
-            return
-        gui_doc = FreeCADGui.ActiveDocument
-        if gui_doc is not None:
-            gui_doc.resetEdit()
-        if self.doc.Name in FreeCAD.listDocuments():
-            FreeCAD.closeDocument(self.doc.Name)
+    def hover_for_preselection(self, viewport, center_pos, span=6, step=2):
+        for dy in range(-span, span + 1, step):
+            for dx in range(-span, span + 1, step):
+                pos = QtCore.QPoint(center_pos.x() + dx, center_pos.y() + dy)
+                event = QtGui.QMouseEvent(
+                    QtCore.QEvent.MouseMove,
+                    pos,
+                    viewport.mapToGlobal(pos),
+                    QtCore.Qt.NoButton,
+                    QtCore.Qt.NoButton,
+                    QtCore.Qt.NoModifier,
+                )
+                QtGui.QApplication.sendEvent(viewport, event)
+                self.pump(100)
 
-    def pump(self, timeout_ms=50):
-        loop = QtCore.QEventLoop()
-        QtCore.QTimer.singleShot(timeout_ms, loop.quit)
-        loop.exec_()
+                presel = FreeCADGui.Selection.getPreselection()
+                if presel.ObjectName:
+                    return presel
+
+        return FreeCADGui.Selection.getPreselection()
 
     @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
     def testNoDepthBufferInEditRoot(self):
@@ -222,28 +229,14 @@ class TestExternalFacePreselection(unittest.TestCase):
         viewport = view.graphicsView().viewport()
         face_center_3d = FreeCAD.Vector(0, -20, 10)
         screen_pt = view.getPointOnScreen(face_center_3d)
-        hover_pos = QtCore.QPoint(int(screen_pt[0]), int(screen_pt[1]))
-
-        # Send mouse move events
-        for offset in [(0, 0), (1, 0), (0, 1)]:
-            pos = QtCore.QPoint(hover_pos.x() + offset[0], hover_pos.y() + offset[1])
-            event = QtGui.QMouseEvent(
-                QtCore.QEvent.MouseMove,
-                pos,
-                viewport.mapToGlobal(pos),
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoButton,
-                QtCore.Qt.NoModifier,
-            )
-            QtGui.QApplication.sendEvent(viewport, event)
-            self.pump(100)
-
-        presel = FreeCADGui.Selection.getPreselection()
+        hover_pos = self.viewport_to_qpoint(view, viewport, screen_pt)
+        presel = self.hover_for_preselection(viewport, hover_pos)
         self.assertNotEqual(
             presel.ObjectName,
             "",
             "No object was preselected — mouse hover did not produce a "
-            "pick. This may indicate the #28639 regression.",
+            f"pick near viewport point {hover_pos}. This may indicate "
+            "the #28639 regression.",
         )
         sub_names = presel.SubElementNames
         self.assertTrue(

--- a/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
+++ b/src/Mod/Sketcher/SketcherTests/TestOnViewParameterGui.py
@@ -92,7 +92,9 @@ class TestOnViewParameterGui(SketcherGuiTestCase):
         self.pump(100)
 
         viewport = view.graphicsView().viewport()
-        first_point = QtCore.QPoint(*view.getPointOnScreen(FreeCAD.Vector(0, 0, 0)))
+        first_point = self.viewport_to_qpoint(
+            view, viewport, view.getPointOnScreen(FreeCAD.Vector(0, 0, 0))
+        )
         self.assertTrue(
             viewport.rect().contains(first_point),
             f"Expected {first_point} to fall inside the sketch viewport {viewport.rect()}",

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Joao Matos
+# SPDX-FileNotice: Part of the FreeCAD project.
 
 SET(Test_SRCS
     __init__.py
@@ -23,6 +26,7 @@ SET(Test_SRCS
     TestRubberbandSelection.py
     TestCoinNodeSnapshots.py
     TestCoinSelectionVisual.py
+    TestViewProviderLink.py
 )
 
 SET(TestData_SRCS

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -32,6 +32,4 @@ FreeCAD.__unit_test__ += [
     "StringHasher",
     "UnicodeTests",
     "TestPythonSyntax",
-    "TestCoinNodeSnapshots",
-    "TestViewProviderLink",
 ]

--- a/src/Mod/Test/Init.py
+++ b/src/Mod/Test/Init.py
@@ -1,25 +1,25 @@
-# ***************************************************************************
-# *   Copyright (c) 2001,2002 Juergen Riegel <juergen.riegel@web.de>        *
-# *                                                                         *
-# *   This file is part of the FreeCAD CAx development system.              *
-# *                                                                         *
-# *   This program is free software; you can redistribute it and/or modify  *
-# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
-# *   as published by the Free Software Foundation; either version 2 of     *
-# *   the License, or (at your option) any later version.                   *
-# *   for detail see the LICENCE text file.                                 *
-# *                                                                         *
-# *   FreeCAD is distributed in the hope that it will be useful,            *
-# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
-# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
-# *   GNU Lesser General Public License for more details.                   *
-# *                                                                         *
-# *   You should have received a copy of the GNU Library General Public     *
-# *   License along with FreeCAD; if not, write to the Free Software        *
-# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
-# *   USA                                                                   *
-# *                                                                         *
-# ***************************************************************************/
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2001,2002 Juergen Riegel <juergen.riegel@web.de>
+# SPDX-FileCopyrightText: 2026 Joao Matos
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+# ******************************************************************************
+# *                                                                            *
+# *   FreeCAD is free software: you can redistribute it and/or modify          *
+# *   it under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the     *
+# *   License, or (at your option) any later version.                          *
+# *                                                                            *
+# *   FreeCAD is distributed in the hope that it will be useful, but           *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+# *   GNU Lesser General Public License for more details.                      *
+# *                                                                            *
+# *   You should have received a copy of the GNU Lesser General Public         *
+# *   License along with FreeCAD.  If not, see                                *
+# *   <https://www.gnu.org/licenses/>.                                         *
+# *                                                                            *
+# ******************************************************************************
 
 # FreeCAD init script of the test module
 
@@ -33,4 +33,5 @@ FreeCAD.__unit_test__ += [
     "UnicodeTests",
     "TestPythonSyntax",
     "TestCoinNodeSnapshots",
+    "TestViewProviderLink",
 ]

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -100,4 +100,6 @@ FreeCAD.__unit_test__ += [
     "GuiDocument",
     "TestRubberbandSelection",
     "TestCoinSelectionVisual",
+    "TestCoinNodeSnapshots",
+    "TestViewProviderLink",
 ]

--- a/src/Mod/Test/TestCoinNodeSnapshots.py
+++ b/src/Mod/Test/TestCoinNodeSnapshots.py
@@ -1017,6 +1017,35 @@ def _mean_rgb(path: Path, x: int, y: int, radius: int = 2) -> tuple[float, float
     return (r_total / count, g_total / count, b_total / count)
 
 
+def _bbox_relative_point(
+    bbox: tuple[int, int, int, int], x_ratio: float, y_ratio: float
+) -> tuple[int, int]:
+    min_x, min_y, max_x, max_y = bbox
+    width = max(1, max_x - min_x)
+    height = max(1, max_y - min_y)
+    x = min_x + int(width * x_ratio)
+    y = min_y + int(height * y_ratio)
+    return (x, y)
+
+
+def _make_top_view_scene(coin, node, *, center: tuple[float, float, float], camera_height: float):
+    root = coin.SoSeparator()
+
+    cam = coin.SoOrthographicCamera()
+    cam.position.setValue(center[0], center[1], center[2] + 30.0)
+    cam.nearDistance.setValue(1.0)
+    cam.farDistance.setValue(100.0)
+    cam.height.setValue(camera_height)
+    root.addChild(cam)
+
+    light_model = coin.SoLightModel()
+    light_model.model.setValue(coin.SoLightModel.BASE_COLOR)
+    root.addChild(light_model)
+
+    root.addChild(node)
+    return root
+
+
 def _compare_images(
     expected_path: Path,
     actual_path: Path,
@@ -1472,6 +1501,90 @@ class CoinNodeSnapshotTestCase(unittest.TestCase):
                 120.0,
                 f"{label} should stay visibly red (got {rgb}, image={actual_path})",
             )
+
+    def test_so_brep_face_set_partial_render_transparency_regression(self):
+        FreeCAD, FreeCADGui, coin = _require_gui()
+        importlib.import_module("Part")
+        importlib.import_module("PartGui")
+
+        width = int(os.environ.get("FC_VISUAL_WIDTH", "512"))
+        height = int(os.environ.get("FC_VISUAL_HEIGHT", "512"))
+        out_dir = Path(
+            os.environ.get(
+                "FC_VISUAL_OUT_DIR",
+                os.path.join(tempfile.gettempdir(), "FreeCADTesting", "CoinNodeSnapshots"),
+            )
+        )
+        actual_path = out_dir / "actual" / "SoBrepFaceSetPartialRenderTransparencyRegression.png"
+
+        doc = FreeCAD.newDocument("SoBrepFaceSetPartialRenderTransparencyRegression")
+        try:
+            box = doc.addObject("Part::Box", "Box")
+            doc.recompute()
+            FreeCADGui.ActiveDocument = FreeCADGui.getDocument(doc.Name)
+
+            box.ViewObject.DiffuseColor = [
+                (0.90, 0.18, 0.18, 1.0),
+                (0.18, 0.78, 0.22, 1.0),
+                (0.18, 0.38, 0.92, 1.0),
+                (0.94, 0.82, 0.18, 1.0),
+                (0.82, 0.28, 0.86, 1.0),
+                (0.92, 0.18, 0.18, 1.0),
+            ]
+            box.ViewObject.Transparency = 35
+            box.ViewObject.partialRender(["Face6"], False)
+            FreeCADGui.updateGui()
+
+            root = _make_top_view_scene(
+                coin,
+                box.ViewObject.RootNode,
+                center=(5.0, 5.0, 5.0),
+                camera_height=14.0,
+            )
+            _render_png(FreeCADGui, coin, root, actual_path, width, height, frame_camera=False)
+
+            self.assertTrue(actual_path.exists(), f"missing snapshot: {actual_path}")
+            self.assertGreater(
+                _non_background_pixel_count(actual_path),
+                1000,
+                f"partial transparent face render seems empty: {actual_path}",
+            )
+
+            bbox = _pixel_bbox(actual_path, lambda r, g, b, _a: min(r, g, b) < 250)
+            self.assertIsNotNone(
+                bbox, f"partial transparent face render produced no visible pixels: {actual_path}"
+            )
+
+            top_left_rgb = _mean_rgb(actual_path, *_bbox_relative_point(bbox, 0.35, 0.35), radius=8)
+            bottom_right_rgb = _mean_rgb(
+                actual_path, *_bbox_relative_point(bbox, 0.65, 0.65), radius=8
+            )
+
+            for label, rgb in (
+                ("top-left triangle", top_left_rgb),
+                ("bottom-right triangle", bottom_right_rgb),
+            ):
+                r, g, b = rgb
+                self.assertGreater(
+                    r,
+                    g + 30.0,
+                    f"{label} should keep the partially rendered top face's red color (got {rgb}, image={actual_path})",
+                )
+                self.assertGreater(
+                    r,
+                    b + 30.0,
+                    f"{label} should keep the partially rendered top face's red color (got {rgb}, image={actual_path})",
+                )
+                self.assertGreater(
+                    r,
+                    150.0,
+                    f"{label} should stay visibly red even with transparency (got {rgb}, image={actual_path})",
+                )
+        finally:
+            if getattr(FreeCADGui, "Selection", None) is not None:
+                FreeCADGui.Selection.clearSelection()
+            if FreeCAD.getDocument(doc.Name):
+                FreeCAD.closeDocument(doc.Name)
 
     def test_coin_node_snapshots(self):
         """Render each configured node and compare against baseline images."""

--- a/src/Mod/Test/TestCoinNodeSnapshots.py
+++ b/src/Mod/Test/TestCoinNodeSnapshots.py
@@ -1,4 +1,24 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Joao Matos
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+# ******************************************************************************
+# *                                                                            *
+# *   FreeCAD is free software: you can redistribute it and/or modify          *
+# *   it under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the     *
+# *   License, or (at your option) any later version.                          *
+# *                                                                            *
+# *   FreeCAD is distributed in the hope that it will be useful, but           *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+# *   GNU Lesser General Public License for more details.                      *
+# *                                                                            *
+# *   You should have received a copy of the GNU Lesser General Public         *
+# *   License along with FreeCAD.  If not, see                                *
+# *   <https://www.gnu.org/licenses/>.                                         *
+# *                                                                            *
+# ******************************************************************************
 
 """
 Visual snapshot tests for selected Coin/Inventor nodes.
@@ -870,40 +890,50 @@ def _make_scene_for_node(coin, type_name: str):
     return root
 
 
-def _render_png(FreeCADGui, coin, root, out_path: Path, width: int, height: int) -> None:
+def _render_png(
+    FreeCADGui,
+    coin,
+    root,
+    out_path: Path,
+    width: int,
+    height: int,
+    *,
+    frame_camera: bool = True,
+) -> None:
     viewport = coin.SbViewportRegion(width, height)
-    # Tighten the camera to what we're rendering.
-    cam = root.getChild(0)
-    # Some GUI helper nodes (e.g. SoDatumLabel) compute a camera-dependent bounding box.
-    # That makes `SoCamera::viewAll()` unstable and can shift the framing of the snapshot.
-    # For these, frame the camera from the rest of the scene and render the full graph.
-    removed = None
-    dtype = coin.SoType.fromName("SoDatumLabel")
-    if not dtype.isBad():
-        search = coin.SoSearchAction()
-        search.setType(dtype)
-        search.setSearchingAll(False)
-        search.apply(root)
-        path = search.getPath()
-        if path is not None and path.getLength() >= 2:
-            label = path.getTail()
-            parent = path.getNode(path.getLength() - 2)
-            idx = parent.findChild(label)
-            if idx >= 0:
-                # Keep the node alive while it's detached (Coin ref-counting).
-                label.ref()
-                parent.removeChild(idx)
-                removed = (parent, idx, label)
+    if frame_camera:
+        # Tighten the camera to what we're rendering.
+        cam = root.getChild(0)
+        # Some GUI helper nodes (e.g. SoDatumLabel) compute a camera-dependent bounding box.
+        # That makes `SoCamera::viewAll()` unstable and can shift the framing of the snapshot.
+        # For these, frame the camera from the rest of the scene and render the full graph.
+        removed = None
+        dtype = coin.SoType.fromName("SoDatumLabel")
+        if not dtype.isBad():
+            search = coin.SoSearchAction()
+            search.setType(dtype)
+            search.setSearchingAll(False)
+            search.apply(root)
+            path = search.getPath()
+            if path is not None and path.getLength() >= 2:
+                label = path.getTail()
+                parent = path.getNode(path.getLength() - 2)
+                idx = parent.findChild(label)
+                if idx >= 0:
+                    # Keep the node alive while it's detached (Coin ref-counting).
+                    label.ref()
+                    parent.removeChild(idx)
+                    removed = (parent, idx, label)
 
-    cam.viewAll(root, viewport)
+        cam.viewAll(root, viewport)
 
-    if removed is not None:
-        parent, idx, label = removed
-        parent.insertChild(label, idx)
-        label.unref()
-    # `SoCamera::viewAll()` can choose a near plane that clips geometry located near the origin.
-    # This shows up particularly with `SoText2`/`SoTextLabel` (text draws, but gets clipped away).
-    cam.nearDistance.setValue(min(cam.nearDistance.getValue(), 0.1))
+        if removed is not None:
+            parent, idx, label = removed
+            parent.insertChild(label, idx)
+            label.unref()
+        # `SoCamera::viewAll()` can choose a near plane that clips geometry located near the origin.
+        # This shows up particularly with `SoText2`/`SoTextLabel` (text draws, but gets clipped away).
+        cam.nearDistance.setValue(min(cam.nearDistance.getValue(), 0.1))
 
     out_path.parent.mkdir(parents=True, exist_ok=True)
     off = FreeCADGui.SoQtOffscreenRenderer(width, height)
@@ -927,6 +957,39 @@ def _non_background_pixel_count(path: Path) -> int:
             if img.pixel(x, y) != white:
                 count += 1
     return count
+
+
+def _pixel_bbox(path: Path, predicate):
+    from PySide.QtGui import QImage  # type: ignore
+
+    img = QImage(str(path))
+    if img.isNull():
+        return None
+
+    min_x = img.width()
+    min_y = img.height()
+    max_x = -1
+    max_y = -1
+
+    for y in range(img.height()):
+        for x in range(img.width()):
+            pixel = img.pixel(x, y)
+            r = (pixel >> 16) & 0xFF
+            g = (pixel >> 8) & 0xFF
+            b = pixel & 0xFF
+            a = (pixel >> 24) & 0xFF
+            if not predicate(r, g, b, a):
+                continue
+
+            min_x = min(min_x, x)
+            min_y = min(min_y, y)
+            max_x = max(max_x, x)
+            max_y = max(max_y, y)
+
+    if max_x < min_x or max_y < min_y:
+        return None
+
+    return (min_x, min_y, max_x, max_y)
 
 
 def _compare_images(
@@ -1082,6 +1145,187 @@ def _compare_images(
 
 class CoinNodeSnapshotTestCase(unittest.TestCase):
     """Render Coin nodes offscreen and compare against PNG baselines."""
+
+    def test_so_reg_point_unpickable_regression(self):
+        _, _, coin = _require_gui()
+
+        root = coin.SoSeparator()
+        probe = _instantiate(coin, "SoRegPoint")
+        probe.base.setValue(0.0, 0.0, 0.0)
+        probe.normal.setValue(0.0, 0.0, 1.0)
+        probe.length.setValue(1.0)
+        probe.text.setValue("probe")
+        root.addChild(probe)
+
+        pick = coin.SoRayPickAction(coin.SbViewportRegion(512, 512))
+        pick.setRadius(8.0)
+        pick.setPickAll(True)
+        pick.setRay(coin.SbVec3f(0.0, 0.0, 5.0), coin.SbVec3f(0.0, 0.0, -1.0), 0.0, 10.0)
+        pick.apply(root)
+
+        self.assertIsNone(
+            pick.getPickedPoint(),
+            "SoRegPoint should stay unpickable so manual-alignment markers do not intercept clicks",
+        )
+
+    def test_so_datum_label_ignores_parent_cull_face(self):
+        _, FreeCADGui, coin = _require_gui()
+
+        width = int(os.environ.get("FC_VISUAL_WIDTH", "512"))
+        height = int(os.environ.get("FC_VISUAL_HEIGHT", "512"))
+        out_dir = Path(
+            os.environ.get(
+                "FC_VISUAL_OUT_DIR",
+                os.path.join(tempfile.gettempdir(), "FreeCADTesting", "CoinNodeSnapshots"),
+            )
+        )
+        actual_path = out_dir / "actual" / "SoDatumLabelCullFaceRegression.png"
+
+        root = coin.SoSeparator()
+
+        cam = coin.SoOrthographicCamera()
+        cam.position.setValue(0.0, 0.0, 2.0)
+        cam.nearDistance.setValue(1.0)
+        cam.farDistance.setValue(5.0)
+        cam.height.setValue(2.0)
+        root.addChild(cam)
+
+        light = coin.SoDirectionalLight()
+        root.addChild(light)
+
+        callback = coin.SoCallback()
+
+        def _enable_backface_culling(userdata, action):
+            coin.SoLazyElement.setBackfaceCulling(action.getState(), True)
+
+        callback.setCallback(_enable_backface_culling, None)
+        root.addChild(callback)
+
+        transform = coin.SoTransform()
+        transform.rotation.setValue(coin.SbRotation(coin.SbVec3f(0.0, 1.0, 0.0), 3.141592653589793))
+        root.addChild(transform)
+
+        label = _instantiate(coin, "SoDatumLabel")
+        label.string.setValue("CullFace")
+        label.textColor.setValue(0.0, 0.4, 0.9)
+        label.name.setValue(_DEFAULT_FONT_FAMILY)
+        label.size.setValue(28)
+        label.lineWidth.setValue(1.0)
+        label.sampling.setValue(2.0)
+        # `Gui::SoDatumLabel::Type::DISTANCE == 1`.
+        label.datumtype.setValue(1)
+        label.param1.setValue(0.18)
+        label.param2.setValue(0.0)
+        label.pnts.setValues(
+            0,
+            2,
+            [coin.SbVec3f(-0.08, -0.02, 0.0), coin.SbVec3f(0.08, 0.02, 0.0)],
+        )
+        root.addChild(label)
+
+        _render_png(FreeCADGui, coin, root, actual_path, width, height, frame_camera=False)
+        self.assertTrue(actual_path.exists(), f"missing snapshot: {actual_path}")
+        self.assertGreater(
+            _non_background_pixel_count(actual_path),
+            50,
+            f"SoDatumLabel text disappeared under inherited face culling: {actual_path}",
+        )
+
+    def test_so_string_label_anchor_regression(self):
+        _, FreeCADGui, coin = _require_gui()
+
+        width = int(os.environ.get("FC_VISUAL_WIDTH", "512"))
+        height = int(os.environ.get("FC_VISUAL_HEIGHT", "512"))
+        out_dir = Path(
+            os.environ.get(
+                "FC_VISUAL_OUT_DIR",
+                os.path.join(tempfile.gettempdir(), "FreeCADTesting", "CoinNodeSnapshots"),
+            )
+        )
+        actual_path = out_dir / "actual" / "SoStringLabelAnchorRegression.png"
+
+        root = coin.SoSeparator()
+
+        cam = coin.SoOrthographicCamera()
+        cam.position.setValue(0.0, 0.0, 2.0)
+        cam.nearDistance.setValue(1.0)
+        cam.farDistance.setValue(5.0)
+        cam.height.setValue(2.0)
+        root.addChild(cam)
+
+        light = coin.SoDirectionalLight()
+        root.addChild(light)
+
+        font = coin.SoFont()
+        font.name.setValue(_DEFAULT_FONT_FAMILY)
+        font.size.setValue(28.0)
+        root.addChild(font)
+
+        marker_material = coin.SoMaterial()
+        marker_material.diffuseColor.setValue(1.0, 0.0, 0.0)
+        root.addChild(marker_material)
+
+        marker_style = coin.SoDrawStyle()
+        marker_style.pointSize.setValue(11.0)
+        root.addChild(marker_style)
+
+        marker_coords = coin.SoCoordinate3()
+        marker_coords.point.setValues(0, 1, [coin.SbVec3f(0.0, 0.0, 0.0)])
+        root.addChild(marker_coords)
+
+        marker = coin.SoPointSet()
+        marker.numPoints.setValue(1)
+        root.addChild(marker)
+
+        text_material = coin.SoMaterial()
+        text_material.diffuseColor.setValue(0.05, 0.05, 0.05)
+        root.addChild(text_material)
+
+        label = _instantiate(coin, "SoStringLabel")
+        label.string.setValues(0, 2, ["OOOO", "OOOO"])
+        label.name.setValue(_DEFAULT_FONT_FAMILY)
+        label.size.setValue(28)
+        label.textColor.setValue(0.0, 0.0, 0.0)
+        root.addChild(label)
+
+        _render_png(FreeCADGui, coin, root, actual_path, width, height, frame_camera=False)
+        self.assertTrue(actual_path.exists(), f"missing snapshot: {actual_path}")
+
+        marker_bbox = _pixel_bbox(
+            actual_path,
+            lambda r, g, b, _a: r >= 200 and g <= 80 and b <= 80,
+        )
+        text_bbox = _pixel_bbox(
+            actual_path,
+            lambda r, g, b, _a: max(r, g, b) <= 100 and (max(r, g, b) - min(r, g, b)) <= 24,
+        )
+
+        self.assertIsNotNone(marker_bbox, f"origin marker not visible: {actual_path}")
+        self.assertIsNotNone(text_bbox, f"text pixels not visible: {actual_path}")
+
+        marker_min_x, marker_min_y, marker_max_x, marker_max_y = marker_bbox
+        text_min_x, text_min_y, text_max_x, _text_max_y = text_bbox
+
+        marker_center_x = (marker_min_x + marker_max_x) / 2.0
+        marker_center_y = (marker_min_y + marker_max_y) / 2.0
+        text_center_x = (text_min_x + text_max_x) / 2.0
+
+        self.assertLessEqual(
+            abs(text_center_x - marker_center_x),
+            6.0,
+            (
+                "SoStringLabel should stay horizontally centered on its projected origin "
+                f"(marker bbox={marker_bbox}, text bbox={text_bbox}, image={actual_path})"
+            ),
+        )
+        self.assertGreaterEqual(
+            text_min_y,
+            marker_center_y - 2.0,
+            (
+                "SoStringLabel should extend downward from its projected origin "
+                f"(marker bbox={marker_bbox}, text bbox={text_bbox}, image={actual_path})"
+            ),
+        )
 
     def test_coin_node_snapshots(self):
         """Render each configured node and compare against baseline images."""

--- a/src/Mod/Test/TestCoinNodeSnapshots.py
+++ b/src/Mod/Test/TestCoinNodeSnapshots.py
@@ -992,6 +992,31 @@ def _pixel_bbox(path: Path, predicate):
     return (min_x, min_y, max_x, max_y)
 
 
+def _mean_rgb(path: Path, x: int, y: int, radius: int = 2) -> tuple[float, float, float]:
+    from PySide.QtGui import QImage  # type: ignore
+
+    img = QImage(str(path)).convertToFormat(QImage.Format_ARGB32)
+    if img.isNull():
+        raise AssertionError(f"unreadable image: {path}")
+
+    r_total = 0
+    g_total = 0
+    b_total = 0
+    count = 0
+    for yy in range(max(0, y - radius), min(img.height(), y + radius + 1)):
+        for xx in range(max(0, x - radius), min(img.width(), x + radius + 1)):
+            pixel = img.pixel(xx, yy)
+            r_total += (pixel >> 16) & 0xFF
+            g_total += (pixel >> 8) & 0xFF
+            b_total += pixel & 0xFF
+            count += 1
+
+    if count == 0:
+        raise AssertionError(f"sample window around ({x}, {y}) is empty for {path}")
+
+    return (r_total / count, g_total / count, b_total / count)
+
+
 def _compare_images(
     expected_path: Path,
     actual_path: Path,
@@ -1326,6 +1351,127 @@ class CoinNodeSnapshotTestCase(unittest.TestCase):
                 f"(marker bbox={marker_bbox}, text bbox={text_bbox}, image={actual_path})"
             ),
         )
+
+    def test_so_brep_face_set_per_part_material_binding_regression(self):
+        _, FreeCADGui, coin = _require_gui()
+
+        if importlib.util.find_spec("PartGui") is not None:
+            importlib.import_module("PartGui")
+
+        width = int(os.environ.get("FC_VISUAL_WIDTH", "512"))
+        height = int(os.environ.get("FC_VISUAL_HEIGHT", "512"))
+        out_dir = Path(
+            os.environ.get(
+                "FC_VISUAL_OUT_DIR",
+                os.path.join(tempfile.gettempdir(), "FreeCADTesting", "CoinNodeSnapshots"),
+            )
+        )
+        actual_path = out_dir / "actual" / "SoBrepFaceSetPerPartMaterialBindingRegression.png"
+
+        root = coin.SoSeparator()
+
+        cam = coin.SoOrthographicCamera()
+        cam.position.setValue(0.0, 0.0, 2.0)
+        cam.nearDistance.setValue(1.0)
+        cam.farDistance.setValue(5.0)
+        cam.height.setValue(2.0)
+        root.addChild(cam)
+
+        root.addChild(coin.SoDirectionalLight())
+
+        light_model = coin.SoLightModel()
+        light_model.model.setValue(coin.SoLightModel.BASE_COLOR)
+        root.addChild(light_model)
+
+        coords = coin.SoCoordinate3()
+        coords.point.setValues(
+            0,
+            8,
+            [
+                coin.SbVec3f(-0.7, -0.7, 0.0),
+                coin.SbVec3f(0.7, -0.7, 0.0),
+                coin.SbVec3f(0.7, 0.7, 0.0),
+                coin.SbVec3f(-0.7, 0.7, 0.0),
+                coin.SbVec3f(-0.7, -0.7, -0.2),
+                coin.SbVec3f(0.7, -0.7, -0.2),
+                coin.SbVec3f(0.7, 0.7, -0.2),
+                coin.SbVec3f(-0.7, 0.7, -0.2),
+            ],
+        )
+        root.addChild(coords)
+
+        material = coin.SoMaterial()
+        material.diffuseColor.setValues(
+            0,
+            2,
+            [
+                coin.SbColor(0.90, 0.15, 0.15),
+                coin.SbColor(0.15, 0.75, 0.20),
+            ],
+        )
+        root.addChild(material)
+
+        material_binding = coin.SoMaterialBinding()
+        material_binding.value = coin.SoMaterialBinding.PER_PART
+        root.addChild(material_binding)
+
+        faces = _instantiate(coin, "SoBrepFaceSet")
+        faces.coordIndex.setValues(
+            0,
+            16,
+            [
+                0,
+                1,
+                2,
+                -1,
+                0,
+                2,
+                3,
+                -1,
+                4,
+                5,
+                6,
+                -1,
+                4,
+                6,
+                7,
+                -1,
+            ],
+        )
+        faces.partIndex.setValues(0, 2, [2, 2])
+        root.addChild(faces)
+
+        _render_png(FreeCADGui, coin, root, actual_path, width, height, frame_camera=False)
+        self.assertTrue(actual_path.exists(), f"missing snapshot: {actual_path}")
+        self.assertGreater(
+            _non_background_pixel_count(actual_path),
+            1000,
+            f"SoBrepFaceSet per-part regression render seems empty: {actual_path}",
+        )
+
+        top_left_rgb = _mean_rgb(actual_path, int(width * 0.35), int(height * 0.35), radius=8)
+        bottom_right_rgb = _mean_rgb(actual_path, int(width * 0.65), int(height * 0.65), radius=8)
+
+        for label, rgb in (
+            ("top-left triangle", top_left_rgb),
+            ("bottom-right triangle", bottom_right_rgb),
+        ):
+            r, g, b = rgb
+            self.assertGreater(
+                r,
+                g + 60.0,
+                f"{label} should keep the front face's red material (got {rgb}, image={actual_path})",
+            )
+            self.assertGreater(
+                r,
+                b + 60.0,
+                f"{label} should keep the front face's red material (got {rgb}, image={actual_path})",
+            )
+            self.assertGreater(
+                r,
+                120.0,
+                f"{label} should stay visibly red (got {rgb}, image={actual_path})",
+            )
 
     def test_coin_node_snapshots(self):
         """Render each configured node and compare against baseline images."""

--- a/src/Mod/Test/TestCoinNodeSnapshots.py
+++ b/src/Mod/Test/TestCoinNodeSnapshots.py
@@ -254,6 +254,9 @@ def _require_gui():
 
     _configure_software_gl_for_snapshots()
 
+    if os.environ.get("CI", "").strip() and not sys.platform.startswith("linux"):
+        raise unittest.SkipTest("Coin node snapshot visual tests are only supported on Linux CI")
+
     # `FreeCADCmd -t 0` runs the base test suite without X11/Wayland. Creating a Qt application
     # in that environment can abort the whole process (instead of raising a Python exception).
     # Skip early unless a display (or explicit headless Qt platform) is configured.
@@ -1521,7 +1524,10 @@ class CoinNodeSnapshotTestCase(unittest.TestCase):
         try:
             box = doc.addObject("Part::Box", "Box")
             doc.recompute()
-            FreeCADGui.ActiveDocument = FreeCADGui.getDocument(doc.Name)
+            FreeCADGui.setActiveDocument(doc.Name)
+            gui_doc = FreeCADGui.getDocument(doc.Name) or FreeCADGui.activeDocument()
+            if gui_doc is None:
+                raise AssertionError(f"failed to resolve Gui document for {doc.Name}")
 
             box.ViewObject.DiffuseColor = [
                 (0.90, 0.18, 0.18, 1.0),
@@ -1591,11 +1597,6 @@ class CoinNodeSnapshotTestCase(unittest.TestCase):
         is_ci = bool(os.environ.get("CI", "").strip())
         is_linux = sys.platform.startswith("linux")
         smoke_mode = is_ci and not is_linux
-
-        if is_ci and not is_linux:
-            raise unittest.SkipTest(
-                "Coin node snapshot visual tests are only supported on Linux CI"
-            )
 
         _, FreeCADGui, coin = _require_gui()
 

--- a/src/Mod/Test/TestViewProviderLink.py
+++ b/src/Mod/Test/TestViewProviderLink.py
@@ -391,3 +391,60 @@ class TestViewProviderLink(unittest.TestCase):
                 120.0,
                 f"{label} should stay visibly cyan through the link render path (got {rgb})",
             )
+
+    def test_link_face_element_override_renders_in_view(self):
+        box = self.doc.addObject("Part::Box", "Box")
+        link = self.doc.addObject("App::Link", "Link")
+        link.LinkedObject = box
+
+        self.doc.recompute()
+        self.FreeCADGui.updateGui()
+
+        box.ViewObject.Visibility = False
+        box.ViewObject.DiffuseColor = [
+            (1.0, 0.0, 0.0, 1.0),
+            (0.0, 1.0, 0.0, 1.0),
+            (0.0, 0.0, 1.0, 1.0),
+            (1.0, 1.0, 0.0, 1.0),
+            (1.0, 0.0, 1.0, 1.0),
+            (0.0, 1.0, 1.0, 1.0),
+        ]
+        self.FreeCADGui.updateGui()
+
+        view = self.FreeCADGui.getDocument(self.doc.Name).ActiveView
+        self.assertIsNotNone(view, "expected the GUI document to expose an active 3D view")
+
+        width = 512
+        height = 512
+        out_dir = Path(tempfile.gettempdir()) / "FreeCADTesting" / "ViewProviderLink"
+        base_path = out_dir / "link-face6-base.png"
+        override_path = out_dir / "link-face6-override.png"
+
+        _save_active_view_png(view, base_path, width, height, view_fn="viewTop")
+        br, bg, bb = _mean_rgb(base_path, width // 2, height // 2)
+        self.assertGreater(
+            bg,
+            br + 60.0,
+            f"expected the linked top face to start cyan/green-dominant: {(br, bg, bb)}",
+        )
+        self.assertGreater(
+            bb,
+            br + 60.0,
+            f"expected the linked top face to start cyan/blue-dominant: {(br, bg, bb)}",
+        )
+
+        link.ViewObject.setElementColors({"Face6": (1.0, 0.0, 0.0, 1.0)})
+        self.FreeCADGui.updateGui()
+
+        _save_active_view_png(view, override_path, width, height, view_fn="viewTop")
+        or_, og, ob = _mean_rgb(override_path, width // 2, height // 2)
+        self.assertGreater(
+            or_,
+            og + 80.0,
+            f"link Face6 override did not render red on the visible top face: {(or_, og, ob)}",
+        )
+        self.assertGreater(
+            or_,
+            ob + 80.0,
+            f"link Face6 override did not render red on the visible top face: {(or_, og, ob)}",
+        )

--- a/src/Mod/Test/TestViewProviderLink.py
+++ b/src/Mod/Test/TestViewProviderLink.py
@@ -105,11 +105,13 @@ def _instantiate(coin, type_name: str):
     return node
 
 
-def _save_active_view_png(view, out_path: Path, width: int, height: int) -> None:
+def _save_active_view_png(
+    view, out_path: Path, width: int, height: int, *, view_fn: str = "viewFront"
+) -> None:
     out_path.parent.mkdir(parents=True, exist_ok=True)
     if hasattr(view, "setAxisCross"):
         view.setAxisCross(False)
-    view.viewFront()
+    getattr(view, view_fn)()
     view.fitAll()
     view.saveImage(str(out_path), width, height, "White")
 
@@ -137,6 +139,49 @@ def _mean_rgb(path: Path, x: int, y: int, radius: int = 2) -> tuple[float, float
         raise AssertionError(f"sample window around ({x}, {y}) is empty for {path}")
 
     return (r_total / count, g_total / count, b_total / count)
+
+
+def _pixel_bbox(path: Path, predicate):
+    from PySide.QtGui import QImage  # type: ignore
+
+    img = QImage(str(path))
+    if img.isNull():
+        return None
+
+    min_x = img.width()
+    min_y = img.height()
+    max_x = -1
+    max_y = -1
+
+    for y in range(img.height()):
+        for x in range(img.width()):
+            pixel = img.pixel(x, y)
+            r = (pixel >> 16) & 0xFF
+            g = (pixel >> 8) & 0xFF
+            b = pixel & 0xFF
+            if not predicate(r, g, b):
+                continue
+
+            min_x = min(min_x, x)
+            min_y = min(min_y, y)
+            max_x = max(max_x, x)
+            max_y = max(max_y, y)
+
+    if max_x < min_x or max_y < min_y:
+        return None
+
+    return (min_x, min_y, max_x, max_y)
+
+
+def _bbox_relative_point(
+    bbox: tuple[int, int, int, int], x_ratio: float, y_ratio: float
+) -> tuple[int, int]:
+    min_x, min_y, max_x, max_y = bbox
+    width = max(1, max_x - min_x)
+    height = max(1, max_y - min_y)
+    x = min_x + int(width * x_ratio)
+    y = min_y + int(height * y_ratio)
+    return (x, y)
 
 
 def _make_material(view_object, rgba: tuple[float, float, float, float], transparency: float = 0.0):
@@ -286,3 +331,63 @@ class TestViewProviderLink(unittest.TestCase):
         self.assertGreater(
             cg, cb + 80, f"clearing face override did not restore green: {(cr, cg, cb)}"
         )
+
+    def test_link_renders_per_face_colors_without_triangle_split(self):
+        box = self.doc.addObject("Part::Box", "Box")
+        link = self.doc.addObject("App::Link", "Link")
+        link.LinkedObject = box
+
+        self.doc.recompute()
+        self.FreeCADGui.updateGui()
+
+        box.ViewObject.Visibility = False
+
+        view = self.FreeCADGui.getDocument(self.doc.Name).ActiveView
+        self.assertIsNotNone(view, "expected the GUI document to expose an active 3D view")
+
+        width = 512
+        height = 512
+        out_dir = Path(tempfile.gettempdir()) / "FreeCADTesting" / "ViewProviderLink"
+        override_path = out_dir / "link-per-face-top.png"
+
+        box.ViewObject.DiffuseColor = [
+            (1.0, 0.0, 0.0, 1.0),
+            (0.0, 1.0, 0.0, 1.0),
+            (0.0, 0.0, 1.0, 1.0),
+            (1.0, 1.0, 0.0, 1.0),
+            (1.0, 0.0, 1.0, 1.0),
+            (0.0, 1.0, 1.0, 1.0),
+        ]
+        self.FreeCADGui.updateGui()
+
+        _save_active_view_png(view, override_path, width, height, view_fn="viewTop")
+        bbox = _pixel_bbox(override_path, lambda r, g, b: min(r, g, b) < 250)
+        self.assertIsNotNone(
+            bbox, f"linked per-face colors did not render any visible pixels: {override_path}"
+        )
+
+        top_left_rgb = _mean_rgb(override_path, *_bbox_relative_point(bbox, 0.35, 0.35), radius=8)
+        bottom_right_rgb = _mean_rgb(
+            override_path, *_bbox_relative_point(bbox, 0.65, 0.65), radius=8
+        )
+
+        for label, rgb in (
+            ("top-left triangle", top_left_rgb),
+            ("bottom-right triangle", bottom_right_rgb),
+        ):
+            r, g, b = rgb
+            self.assertGreater(
+                g,
+                r + 40.0,
+                f"{label} should keep the linked top face's cyan color (got {rgb})",
+            )
+            self.assertGreater(
+                b,
+                r + 40.0,
+                f"{label} should keep the linked top face's cyan color (got {rgb})",
+            )
+            self.assertGreater(
+                min(g, b),
+                120.0,
+                f"{label} should stay visibly cyan through the link render path (got {rgb})",
+            )

--- a/src/Mod/Test/TestViewProviderLink.py
+++ b/src/Mod/Test/TestViewProviderLink.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Joao Matos
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+# ******************************************************************************
+# *                                                                            *
+# *   FreeCAD is free software: you can redistribute it and/or modify          *
+# *   it under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the     *
+# *   License, or (at your option) any later version.                          *
+# *                                                                            *
+# *   FreeCAD is distributed in the hope that it will be useful, but           *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of               *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            *
+# *   GNU Lesser General Public License for more details.                      *
+# *                                                                            *
+# *   You should have received a copy of the GNU Lesser General Public         *
+# *   License along with FreeCAD.  If not, see                                *
+# *   <https://www.gnu.org/licenses/>.                                         *
+# *                                                                            *
+# ******************************************************************************
+
+"""GUI tests for ViewProviderLink color override plumbing.
+
+To run tests:
+    FreeCAD -t TestViewProviderLink
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _configure_software_gl():
+    if not sys.platform.startswith("linux"):
+        return
+
+    force = os.environ.get("FC_VISUAL_FORCE_SOFTWARE_GL", "1").strip().lower()
+    if force in ("", "0", "false", "no"):
+        return
+
+    os.environ.setdefault("LIBGL_ALWAYS_SOFTWARE", "1")
+    os.environ.setdefault("MESA_LOADER_DRIVER_OVERRIDE", "llvmpipe")
+
+
+def _require_gui():
+    try:
+        import FreeCAD  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise RuntimeError("FreeCAD module not available") from exc
+
+    _configure_software_gl()
+
+    if sys.platform.startswith("linux"):
+        has_display = bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+        qpa = os.environ.get("QT_QPA_PLATFORM", "").strip().lower()
+        headless_qpa = {"offscreen", "minimal", "eglfs", "linuxfb", "vnc"}
+        if not has_display and qpa not in headless_qpa:
+            raise unittest.SkipTest(
+                "No display available (run under xvfb-run or set QT_QPA_PLATFORM=offscreen)"
+            )
+
+    try:
+        import FreeCADGui  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise unittest.SkipTest("FreeCADGui not available in this build") from exc
+
+    setup_without_gui = getattr(FreeCADGui, "setupWithoutGUI", None)
+    if callable(setup_without_gui):
+        setup_without_gui()
+
+    home = Path(FreeCAD.getHomePath())
+    mod_dir = home / "Mod"
+    if mod_dir.is_dir():
+        for p in (mod_dir, mod_dir / "Part"):
+            ps = str(p)
+            if ps not in sys.path:
+                sys.path.insert(0, ps)
+
+    try:
+        from PySide import QtGui  # type: ignore
+
+        if QtGui.QGuiApplication.instance() is None:
+            QtGui.QGuiApplication(sys.argv)
+    except Exception as exc:  # pragma: no cover
+        raise unittest.SkipTest("Qt (PySide) not available") from exc
+
+    try:
+        from pivy import coin  # type: ignore
+    except Exception as exc:  # pragma: no cover
+        raise unittest.SkipTest("pivy.coin not available") from exc
+
+    return FreeCAD, FreeCADGui, coin
+
+
+def _instantiate(coin, type_name: str):
+    t = coin.SoType.fromName(type_name)
+    if t.isBad():
+        raise unittest.SkipTest(f"Coin type not registered: {type_name}")
+    node = t.createInstance()
+    if node is None:
+        raise RuntimeError(f"Failed to instantiate {type_name}")
+    return node
+
+
+def _save_active_view_png(view, out_path: Path, width: int, height: int) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if hasattr(view, "setAxisCross"):
+        view.setAxisCross(False)
+    view.viewFront()
+    view.fitAll()
+    view.saveImage(str(out_path), width, height, "White")
+
+
+def _mean_rgb(path: Path, x: int, y: int, radius: int = 2) -> tuple[float, float, float]:
+    from PySide.QtGui import QImage  # type: ignore
+
+    img = QImage(str(path)).convertToFormat(QImage.Format_ARGB32)
+    if img.isNull():
+        raise AssertionError(f"unreadable image: {path}")
+
+    r_total = 0
+    g_total = 0
+    b_total = 0
+    count = 0
+    for yy in range(max(0, y - radius), min(img.height(), y + radius + 1)):
+        for xx in range(max(0, x - radius), min(img.width(), x + radius + 1)):
+            pixel = img.pixel(xx, yy)
+            r_total += (pixel >> 16) & 0xFF
+            g_total += (pixel >> 8) & 0xFF
+            b_total += pixel & 0xFF
+            count += 1
+
+    if count == 0:
+        raise AssertionError(f"sample window around ({x}, {y}) is empty for {path}")
+
+    return (r_total / count, g_total / count, b_total / count)
+
+
+def _make_material(view_object, rgba: tuple[float, float, float, float], transparency: float = 0.0):
+    material = view_object.ShapeMaterial
+    material.DiffuseColor = rgba
+    material.Transparency = transparency
+    view_object.ShapeMaterial = material
+
+
+class TestViewProviderLink(unittest.TestCase):
+    def setUp(self):
+        self.FreeCAD, self.FreeCADGui, self.coin = _require_gui()
+        import Part  # noqa: F401
+        import PartGui  # noqa: F401
+
+        self.doc = self.FreeCAD.newDocument("TestViewProviderLink")
+        self.FreeCADGui.ActiveDocument = self.FreeCADGui.getDocument(self.doc.Name)
+
+    def tearDown(self):
+        if getattr(self, "doc", None) is None:
+            return
+        try:
+            self.FreeCADGui.Selection.clearSelection()
+        except Exception:
+            # Best-effort cleanup: the GUI selection singleton may already be torn down here.
+            pass
+        if self.FreeCAD.getDocument(self.doc.Name):
+            self.FreeCAD.closeDocument(self.doc.Name)
+
+    def test_apply_element_color_override_api(self):
+        root = self.coin.SoSeparator()
+        sel_root = _instantiate(self.coin, "SoFCSelectionRoot")
+        child = self.coin.SoSeparator()
+        leaf = self.coin.SoCube()
+
+        root.addChild(sel_root)
+        sel_root.addChild(child)
+        child.addChild(leaf)
+
+        search = self.coin.SoSearchAction()
+        search.setNode(leaf)
+        search.apply(root)
+        path = search.getPath()
+        self.assertIsNotNone(path, "expected a Coin path to the test leaf node")
+
+        self.assertTrue(hasattr(self.FreeCADGui, "applyElementColorOverride"))
+        self.assertTrue(hasattr(self.FreeCADGui, "clearElementColorOverride"))
+
+        self.FreeCADGui.applyElementColorOverride(sel_root, {"Face1": (1.0, 0.1, 0.1, 1.0)})
+        self.FreeCADGui.clearElementColorOverride(sel_root)
+
+        self.FreeCADGui.applyElementColorOverride(
+            path,
+            {"Face": (255, 64, 64, 255), "": 0xFF0000FF},
+        )
+        self.FreeCADGui.clearElementColorOverride(path)
+
+        with self.assertRaises(TypeError):
+            self.FreeCADGui.applyElementColorOverride(42, {"Face1": (1.0, 0.1, 0.1, 1.0)})
+        with self.assertRaises(TypeError):
+            self.FreeCADGui.applyElementColorOverride(sel_root, {"Face1": "not-a-color"})
+        with self.assertRaises(TypeError):
+            self.FreeCADGui.applyElementColorOverride(sel_root, {1: (1.0, 0.1, 0.1, 1.0)})
+        with self.assertRaises(TypeError):
+            self.FreeCADGui.clearElementColorOverride("not-a-node-or-path")
+
+    def test_apply_element_color_override_on_view_provider_link_targets(self):
+        box = self.doc.addObject("Part::Box", "Box")
+        link = self.doc.addObject("App::Link", "Link")
+        link.LinkedObject = box
+
+        self.doc.recompute()
+        self.FreeCADGui.updateGui()
+
+        link_view = link.ViewObject.LinkView
+        self.assertIsNotNone(link_view, "expected ViewProviderLink to expose a LinkView handle")
+        self.assertIsNotNone(
+            link.ViewObject.RootNode, "expected ViewProviderLink to expose its Coin root"
+        )
+        self.assertIsNotNone(
+            link_view.RootNode, "expected ViewProviderLink to expose its link root"
+        )
+        self.assertEqual(link.ViewObject.getElementColors(), {})
+
+        self.FreeCADGui.applyElementColorOverride(
+            link.ViewObject.RootNode,
+            {"Face1": (1.0, 0.2, 0.2, 1.0)},
+        )
+        self.FreeCADGui.clearElementColorOverride(link.ViewObject.RootNode)
+        self.assertEqual(link.ViewObject.getElementColors(), {})
+
+        search = self.coin.SoSearchAction()
+        search.setNode(link_view.RootNode)
+        search.apply(link.ViewObject.RootNode)
+        path = search.getPath()
+        self.assertIsNotNone(path, "expected a Coin path to the link root")
+
+        self.FreeCADGui.applyElementColorOverride(
+            path,
+            {"Face": (64, 96, 255, 255)},
+        )
+        self.FreeCADGui.clearElementColorOverride(path)
+        self.assertEqual(link.ViewObject.getElementColors(), {})
+
+    def test_face_override_renders_in_view(self):
+        box = self.doc.addObject("Part::Box", "Box")
+        link = self.doc.addObject("App::Link", "Link")
+        link.LinkedObject = box
+
+        self.doc.recompute()
+        self.FreeCADGui.updateGui()
+
+        _make_material(box.ViewObject, (0.1, 0.85, 0.15, 1.0))
+        box.ViewObject.Visibility = False
+
+        view = self.FreeCADGui.getDocument(self.doc.Name).ActiveView
+        self.assertIsNotNone(view, "expected the GUI document to expose an active 3D view")
+
+        width = 512
+        height = 512
+        out_dir = Path(tempfile.gettempdir()) / "FreeCADTesting" / "ViewProviderLink"
+        base_path = out_dir / "base.png"
+        override_path = out_dir / "override.png"
+        cleared_path = out_dir / "cleared.png"
+
+        _save_active_view_png(view, base_path, width, height)
+        br, bg, bb = _mean_rgb(base_path, width // 2, height // 2)
+        self.assertGreater(bg, br + 80, f"unexpected base face color: {(br, bg, bb)}")
+        self.assertGreater(bg, bb + 80, f"unexpected base face color: {(br, bg, bb)}")
+
+        link.ViewObject.setElementColors({"Face": (0.25, 0.38, 1.0, 1.0)})
+        self.FreeCADGui.updateGui()
+        _save_active_view_png(view, override_path, width, height)
+        or_, og, ob = _mean_rgb(override_path, width // 2, height // 2)
+        self.assertGreater(
+            ob, or_ + 100, f"link face override did not render blue: {(or_, og, ob)}"
+        )
+        self.assertGreater(ob, og + 80, f"link face override did not render blue: {(or_, og, ob)}")
+
+        link.ViewObject.setElementColors({})
+        self.FreeCADGui.updateGui()
+        _save_active_view_png(view, cleared_path, width, height)
+        cr, cg, cb = _mean_rgb(cleared_path, width // 2, height // 2)
+        self.assertGreater(
+            cg, cr + 80, f"clearing face override did not restore green: {(cr, cg, cb)}"
+        )
+        self.assertGreater(
+            cg, cb + 80, f"clearing face override did not restore green: {(cr, cg, cb)}"
+        )

--- a/src/Mod/Test/TestViewProviderLink.py
+++ b/src/Mod/Test/TestViewProviderLink.py
@@ -198,7 +198,12 @@ class TestViewProviderLink(unittest.TestCase):
         import PartGui  # noqa: F401
 
         self.doc = self.FreeCAD.newDocument("TestViewProviderLink")
-        self.FreeCADGui.ActiveDocument = self.FreeCADGui.getDocument(self.doc.Name)
+        self.FreeCADGui.setActiveDocument(self.doc.Name)
+        self.gui_doc = (
+            self.FreeCADGui.getDocument(self.doc.Name) or self.FreeCADGui.activeDocument()
+        )
+        if self.gui_doc is None:
+            raise AssertionError(f"failed to resolve Gui document for {self.doc.Name}")
 
     def tearDown(self):
         if getattr(self, "doc", None) is None:
@@ -297,7 +302,7 @@ class TestViewProviderLink(unittest.TestCase):
         _make_material(box.ViewObject, (0.1, 0.85, 0.15, 1.0))
         box.ViewObject.Visibility = False
 
-        view = self.FreeCADGui.getDocument(self.doc.Name).ActiveView
+        view = self.gui_doc.ActiveView
         self.assertIsNotNone(view, "expected the GUI document to expose an active 3D view")
 
         width = 512
@@ -342,7 +347,7 @@ class TestViewProviderLink(unittest.TestCase):
 
         box.ViewObject.Visibility = False
 
-        view = self.FreeCADGui.getDocument(self.doc.Name).ActiveView
+        view = self.gui_doc.ActiveView
         self.assertIsNotNone(view, "expected the GUI document to expose an active 3D view")
 
         width = 512
@@ -411,7 +416,7 @@ class TestViewProviderLink(unittest.TestCase):
         ]
         self.FreeCADGui.updateGui()
 
-        view = self.FreeCADGui.getDocument(self.doc.Name).ActiveView
+        view = self.gui_doc.ActiveView
         self.assertIsNotNone(view, "expected the GUI document to expose an active 3D view")
 
         width = 512


### PR DESCRIPTION
## Summary
Ports the remaining Gui and PartGui overlay/highlight nodes off direct legacy OpenGL calls and onto Coin scenegraph geometry/state.

This moves viewer overlays, labels, the NaviCube, datum helpers, and PartGui highlight/control-point rendering to Coin-native nodes.

## Why
This change is intended to move rendering onto Coin3D-managed geometry and state so FreeCAD can move off legacy OpenGL.

## Changes
- Ports Gui overlay/helper nodes to Coin geometry and rendering nodes:
  `SoFCBackgroundGradient`, `SoTextLabel`, `SoStringLabel`, `SoDatumLabel`, `SoDrawingGrid`, `SoRegPoint`, `SoNaviCube`, and the axis cross overlay.
- Removes legacy GL compositing/state handling from `View3DInventorViewer`, `GLPainter`, and Quarter integration points touched by these overlays.
- Updates dependent call sites and includes for the migrated label/navigation nodes.
- Reworks PartGui highlight and control-point rendering to use Coin-managed overlay primitives instead of raw OpenGL in:
  `SoBrepEdgeSet`, `SoBrepPointSet`, `SoBrepFaceSet`, and `SoFCShapeObject`.

Part of FPA modernizing rendering grant at https://github.com/FreeCAD/FPA-grant-proposals/issues/35
