### PR TITLE
Proceed with object deletion when broken references are accepted

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1545,6 +1545,7 @@ void StdCmdDelete::activated(int iMsg)
             bool more = false;
             auto sels = Selection().getSelectionEx();
             bool autoDeletion = true;
+            bool forceDeletion = false;
             for (auto& sel : sels) {
                 auto obj = sel.getObject();
                 if (!obj) {
@@ -1608,6 +1609,7 @@ void StdCmdDelete::activated(int iMsg)
                 );
                 if (ret == QMessageBox::Yes) {
                     autoDeletion = true;
+                    forceDeletion = true;
                 }
             }
             if (autoDeletion) {
@@ -1617,7 +1619,8 @@ void StdCmdDelete::activated(int iMsg)
                     if (vp) {
                         manageDocCommand(obj->getDocument());
                         // ask the ViewProvider if it wants to do some clean up
-                        if (vp->onDelete(sel.getSubNames())) {
+                        // skip if user explicitly confirmed deletion of objects with dependencies
+                        if (forceDeletion || vp->onDelete(sel.getSubNames())) {
                             docs.insert(obj->getDocument());
                             FCMD_OBJ_DOC_CMD(obj, "removeObject('" << obj->getNameInDocument() << "')");
                         }


### PR DESCRIPTION
Fixes a bug where trying to delete an object with dependencies would just fail silently. Previously, clicking "Yes" on the warning prompt to accept broken references didn't actually do anything.  

This PR skips the ViewProvider's onDelete() check when the the user has already explicitly confirmed, so deletion now proceeds as expected.

## Issues
Fixes #26356 

## Post-Fix


https://github.com/user-attachments/assets/24939869-aab8-4734-8ac2-5dc88d0f4e48

