### PR TITLE
Base: Remove extraneous #endif from PR merge

### DIFF
--- a/src/Base/PreCompiled.h
+++ b/src/Base/PreCompiled.h
@@ -118,5 +118,3 @@
 // Unicode
 #include <unicode/unistr.h>
 #include <unicode/uchar.h>
-
-#endif  // BASE_PRECOMPILED_H


### PR DESCRIPTION
Missed during merge of fddb13cbc3.