### PR TITLE
Draft: fix crash when deleting object while in edit mode

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -313,6 +313,7 @@ class Edit(gui_base_original.Modifier):
         for obj in self.edited_objects:
             self.setTrackers(obj, self.getEditPoints(obj))
 
+        App.addDocumentObserver(self)
         self.register_editing_callbacks()
 
     def numericInput(self, numx, numy, numz):
@@ -324,8 +325,15 @@ class Edit(gui_base_original.Modifier):
         self.endEditing(self.obj, self.editing, App.Vector(numx, numy, numz))
         App.ActiveDocument.recompute()
 
+    def slotDeletedObject(self, obj):
+        """Document observer callback: exit edit mode if the edited object is deleted."""
+        if obj in self.edited_objects:
+            App.removeDocumentObserver(self)
+            QtCore.QTimer.singleShot(0, self.finish)
+
     def finish(self, cont=False):
         """Terminate Edit Tool."""
+        App.removeDocumentObserver(self)
         self.unregister_selection_callback()
         self.unregister_editing_callbacks()
         self.editing = None
@@ -431,11 +439,8 @@ class Edit(gui_base_original.Modifier):
                 self.finish()
             if key == 101:  # "e"
                 self.display_tracker_menu(event)
-            if (
-                key == 65535 and Gui.Selection.getSelection() is None
-            ):  # BUG: delete key activate Std::Delete command at the same time!
-                print("DELETE PRESSED\n")
-                self.delPoint(event)
+            if key == coin.SoKeyboardEvent.DELETE:  # exit edit mode before Std_Delete fires
+                self.finish()
 
     def mousePressed(self, event_callback):
         """


### PR DESCRIPTION
Fixes #29038

When an object is deleted while Draft Edit is active, the edit tool now exits cleanly via a document observer instead of leaving stale trackers that crash on hover.