### PR TITLE
FEM: Fix highlight selection for compsolid pop-up tool

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -1473,6 +1473,15 @@ void ViewProviderPartExt::updateVisual()
     TopoDS_Shape shape = getRenderedShape().getShape();
 
     if (!VisualTouched && lastRenderedShape.IsPartner(shape)) {
+        // shape unchanged so do not rebuild geometry
+        // but still re-apply materials in case colors changed
+        Gui::SoHighlightElementAction haction;
+        haction.apply(this->faceset);
+        haction.apply(this->lineset);
+        haction.apply(this->nodeset);
+        setHighlightedFaces(ShapeAppearance.getValues());
+        setHighlightedEdges(LineColorArray.getValues());
+        setHighlightedPoints(PointColorArray.getValue());
         return;
     }
 


### PR DESCRIPTION
this PR fixes issue #28903

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/28903

## Before and After Images

~~will post a picture in a second.~~

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/85d9cadd-8823-4d08-b40a-5255145dfa25" />

```
OS: Fedora Linux 42 (Adams) (tty)
Architecture: arm64
Version: 1.2.0dev.46162 (Git)
Build date: 2026/04/03 19:34:15
Build type: Release
Branch: ipatch.tshoot.28903
Hash: 773a85cf88a9e13d21bcf38878fa1136854b1fc8
Python 3.13.12, Qt 6.11.0, Coin 4.0.8, Vtk 9.5.2, boost 1_90, Eigen3 5.0.1, PySide 6.11.0
shiboken 6.11.0, SMESH 7.7.1.0, xerces-c 3.3.0, IfcOpenShell 0.8.4.post1, OCC 7.9.3
Locale: English/United States (en_US) [ OS: English/United States (en_US) ]
Stylesheet/Theme/QtStyle: FreeCAD.qss/FreeCAD Light/
Navigation Style/Orbit Style/Rotation Mode: Blender/Trackball/Drag at cursor
Logical DPI/Physical DPI/Pixel Ratio: 96/95.958/1
```