### PR TITLE
Sketcher: fix inverted null check in purgeHandler leaving selection enabled

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -758,7 +758,7 @@ void ViewProviderSketch::purgeHandler()
         return editdoc->getEditViewProvider() == this;
     });
     Gui::View3DInventor* view = nullptr;
-    if (!editDoc) {
+    if (editDoc) {
         view = dynamic_cast<Gui::View3DInventor*>(editDoc->getActiveView());
     }
 


### PR DESCRIPTION
Fixes #28977

The root cause appears to be an inverted null-check in `ViewProviderSketch::purgeHandler()` introduced by #21978.

`DrawSketchHandlerExternal::activated()` calls `viewer->setSelectionEnabled(true)` to enable 3D object picking during projection. `purgeHandler()` is supposed to restore `setSelectionEnabled(false)` when the tool exits, but the guard introduced in the refactor reads `if (!editDoc)` instead of `if (editDoc)`, so `view` is always null and the restore never runs. The same path would also cover `DrawSketchHandlerCarbonCopy`.

The fix looks like a one-character change in `purgeHandler()` — `!editDoc` → `editDoc`. Verified with a Python test against `selectionRoot->selectionEnabled` before/after tool activation and cancellation.