### PR TITLE
BIM: fix beam task panel crash when changing category after first point

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -411,6 +411,11 @@ class _CommandStructure:
             return
         if self.bmode and (self.bpoint is None):
             self.bpoint = point
+            # Recreate precast/dents task boxes. The getPoint() call below replaces the task panel,
+            # destroying the task boxes that were embedded via extradlg by the first call.
+            self.precast = ArchPrecast._PrecastTaskPanel()
+            self.dents = ArchPrecast._DentsTaskPanel()
+            self.precast.Dents = self.dents
             FreeCADGui.Snapper.getPoint(
                 last=point,
                 callback=self.getPoint,


### PR DESCRIPTION
When the first beam point is picked, the `Snapper` recreates the task panel for the second point. This destroys the precast and dents task boxes embedded in the original panel.

Since they were not recreated, changing the category dropdown afterwards called `show()` on a destroyed widget, raising `RuntimeError`.

Recreate the precast and dents task boxes before the second `getPoint()` call so the new task panel receives live widgets.

## Issues

Fixes: #29049