### PR TITLE
Extending CircularHoleBase.py holePosition() to use shape.CenterOfMass

### DIFF
--- a/src/Mod/CAM/Path/Op/CircularHoleBase.py
+++ b/src/Mod/CAM/Path/Op/CircularHoleBase.py
@@ -185,7 +185,7 @@ class ObjectOp(PathOp.ObjectOp):
                     center = shape.Edges[0].Curve.Center
                     if all(Path.Geom.pointsCoincide(center, e.Curve.Center) for e in shape.Edges):
                         return FreeCAD.Vector(center.x, center.y, 0)
-
+            return FreeCAD.Vector(shape.CenterOfMass.x, shape.CenterOfMass.y, 0)
         except Part.OCCError as e:
             Path.Log.error(e)
 


### PR DESCRIPTION
Extending CircularHoleBase.py holePosition() to use shape.CenterOfMass instead failing hard with error.

Addresses circular holes not directly originating from Part::Circle or Part::Cylinder.

## Issues
partly fixes https://github.com/FreeCAD/FreeCAD/issues/29039
see https://github.com/FreeCAD/FreeCAD/pull/29027

## Before and After Images
![Screenshot_2026-04-03_14-55-22](https://github.com/user-attachments/assets/a2342863-1dee-45bd-b8ff-42f0bbe02cf5)
