### PR TITLE
Draft: Remove WaitCursor if DxfImportDialog is not displayed

### DIFF
--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -2860,6 +2860,8 @@ def _import_dxf_file(filename, doc_name=None):
                 params.set_param("dxfImportAsFused", mode == 3)
                 hGrp.SetBool("dxfShowDialog", dlg.get_show_dialog_again())
             else:
+                if gui:
+                    FreeCADGui.resumeWaitCursor()
                 return None, None, None, None  # Return None to indicate cancellation
     finally:
         if gui:


### PR DESCRIPTION
Fixes #29042.

The issue occurred when running TestDraft from the Test Framework WB. The Test Framework dialog prevents the DxfImportDialog from executing.