### PR TITLE
Draft: fix BIM task panel Deactivated error

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -1929,7 +1929,10 @@ class DraftToolBar:
     def Deactivated(self):
         if FreeCAD.activeDraftCommand is not None:
             self.continueMode = False
-            FreeCAD.activeDraftCommand.finish()
+            if hasattr(FreeCAD.activeDraftCommand, "finish"):
+                FreeCAD.activeDraftCommand.finish()
+            elif hasattr(FreeCADGui, "draftToolBar") and hasattr(FreeCADGui.draftToolBar, "cancel"):
+                FreeCADGui.draftToolBar.cancel()
         FreeCADGui.Control.clearTaskWatcher()
         # self.tray = None
         if hasattr(self, "tray"):


### PR DESCRIPTION
Fixes #29053.

Some BIM commands are set as `activeDraftCommand` but do not have a `finish` function.