### PR TITLE
PartDesign: only import WizardShaft when the module is available

### DIFF
--- a/src/Mod/PartDesign/InitGui.py
+++ b/src/Mod/PartDesign/InitGui.py
@@ -55,10 +55,6 @@ class PartDesignWorkbench(Workbench):
                 FreeCAD.Console.PrintWarning(
                     "PartDesign WizardShaft could not be imported: {err}\n".format(err=str(err))
                 )
-                try:
-                    from FeatureHole import HoleGui
-                except Exception:
-                    pass
 
         import PartDesignGui
         import PartDesign


### PR DESCRIPTION
  ## Summary

  Avoid a noisy startup warning in PartDesign when `PartDesign.WizardShaft` is not present in the runtime tree.

  ## Changes

  - check whether `PartDesign.WizardShaft` exists before importing it
  - only warn on real import failure when the module is actually present

