### PR TITLE
CAM: Fix bug where the new PP dialog was being shown for legacy flow.

### DIFF
--- a/src/Mod/CAM/Path/Post/Command.py
+++ b/src/Mod/CAM/Path/Post/Command.py
@@ -90,9 +90,12 @@ class DlgSelectPostProcessor:
         if item.text() in self.tooltips:
             tooltip = self.tooltips[item.text()]
         else:
-            processor = PostProcessor.load(item.text())
-            self.tooltips[item.text()] = processor.tooltip
-            tooltip = processor.tooltip
+            try:
+                processor = PostProcessorFactory.get_post_processor(None, item.text())
+                tooltip = processor.tooltip if processor else ""
+            except Exception:
+                tooltip = ""
+            self.tooltips[item.text()] = tooltip
         self.dialog.lwPostProcessor.setToolTip(tooltip)
 
     def exec_(self):
@@ -201,8 +204,13 @@ class CommandPathPost:
         """
         Path.Log.debug(self.candidate.Name)
 
-        # Show the unified post-processing dialog before starting any work.
-        if FreeCAD.GuiUp:
+        # Determine if we use new flow (machine-based) or old flow (legacy)
+        # New flow: Job has Machine property -> get postprocessor from machine config -> use export2()
+        # Old flow: Job lacks Machine -> get postprocessor from job property -> use export()
+        use_new_flow = hasattr(self.candidate, "Machine") and self.candidate.Machine
+
+        # Show the unified post-processing dialog only for the new machine-based flow.
+        if use_new_flow and FreeCAD.GuiUp:
             from Path.Post.Gui.DlgPostProcess import PostProcessDialog
 
             dlg = PostProcessDialog(self.candidate)
@@ -214,11 +222,6 @@ class CommandPathPost:
             return
 
         FreeCAD.ActiveDocument.openTransaction("Post Process the Selected Job")
-
-        # Determine if we use new flow (machine-based) or old flow (legacy)
-        # New flow: Job has Machine property -> get postprocessor from machine config -> use export2()
-        # Old flow: Job lacks Machine -> get postprocessor from job property -> use export()
-        use_new_flow = hasattr(self.candidate, "Machine") and self.candidate.Machine
 
         if use_new_flow:
             Path.Log.debug("Using new flow (machine-based)")
@@ -241,7 +244,12 @@ class CommandPathPost:
         else:
             Path.Log.debug("Using old flow (legacy)")
             # Old flow: Get postprocessor from job property
-            postprocessor_name = _resolve_post_processor_name(self.candidate)
+            try:
+                postprocessor_name = _resolve_post_processor_name(self.candidate)
+            except ValueError as e:
+                FreeCAD.Console.PrintError(f"{e}\n")
+                FreeCAD.ActiveDocument.abortTransaction()
+                return
 
         Path.Log.debug(f"Post Processor: {postprocessor_name}")
 
@@ -303,9 +311,10 @@ class CommandPathPost:
             # a file.  There may be other uses found for this capability over time.
             #
             if gcode is not None:
-                # Show editor if user preference is enabled and GUI is available
                 final_gcode = gcode
-                if FreeCAD.GuiUp and Path.Preferences.showEditorOnPostProcess():
+                # Show editor only for the new flow; legacy scripts
+                # handle their own editor dialog inside export().
+                if use_new_flow and FreeCAD.GuiUp and Path.Preferences.showEditorOnPostProcess():
                     if len(gcode) > 100000:
                         FreeCAD.Console.PrintWarning(
                             "Skipping editor since output is greater than 100kb\n"


### PR DESCRIPTION
The new dialog should only be shown for machine-based postprocessing. 
The check was in the wrong place so it was being shown for both flows.