### PR TITLE
  BIM: reduce topo-naming noise for wall area analysis

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -66,6 +66,18 @@ else:
     # \endcond
 
 
+def _make_projected_horizontal_area_face(projected_faces):
+    """Build one transient XY face from projected coplanar analysis faces."""
+
+    if not projected_faces:
+        return None
+
+    fused_face = projected_faces[0].copy(noElementMap=True)
+    for face in projected_faces[1:]:
+        fused_face = fused_face.fuse(face, noElementMap=True)
+    return fused_face.removeSplitter()
+
+
 def addToComponent(compobject, addobject, prop):
     """Add an object to a component's property.
 
@@ -1482,9 +1494,10 @@ class AreaCalculator:
     def _computeHorizontalAreaAndPerimeter(self, horizontalAreaFaces):
         """Compute the horizontal area and perimeter length.
 
-        Projects the given faces onto the XY plane, fuses them, and calculates:
-        - The total horizontal area.
-        - The perimeter length of the fused horizontal area.
+        Projects the given faces onto the XY plane, combines the projected
+        areas into one transient union shape, and calculates:
+        - the total horizontal area
+        - the perimeter length of the combined horizontal outline
 
         Parameters
         ----------
@@ -1522,12 +1535,20 @@ class AreaCalculator:
                         self.resetAreas()
                         return
                     wire = TechDraw.findShapeOutline(face, 1, direction)
-                    projectedFace = Part.makeFace([wire], "Part::FaceMakerSimple")
+                    projectedFace = Part.makeFace(
+                        [wire],
+                        "Part::FaceMakerSimple",
+                        noElementMap=True,
+                    )
                 else:
                     edges = TechDraw.project(face, direction)[0].Edges
                     wires = DraftGeomUtils.findWires(edges)
                     # Using "Part::FaceMakerCheese" as the face can have holes
-                    projectedFace = Part.makeFace(wires, "Part::FaceMakerCheese")
+                    projectedFace = Part.makeFace(
+                        wires,
+                        "Part::FaceMakerCheese",
+                        noElementMap=True,
+                    )
                 # Part.show(projectedFace)
                 projectedFaces.append(projectedFace)
             except Part.OCCError:
@@ -1547,13 +1568,22 @@ class AreaCalculator:
         else:
             param_grp.SetBool("allowCrazyEdge", old_allow_crazy_edge)
 
+        fusedFace = None
         if projectedFaces:
-            fusedFace = projectedFaces.pop()
-            for face in projectedFaces:
-                fusedFace = fusedFace.fuse(face)
-            fusedFace = fusedFace.removeSplitter()
-            # Part.show(fusedFace)
+            try:
+                fusedFace = _make_projected_horizontal_area_face(projectedFaces)
+            except Part.OCCError:
+                FreeCAD.Console.PrintWarning(
+                    translate(
+                        "Arch",
+                        f"Error computing areas for {self.obj.Label}: unable to combine "
+                        "projected horizontal faces. Area values will be reset to 0.\n",
+                    )
+                )
+                self.resetAreas()
+                return
 
+        if fusedFace:
             if self.obj.HorizontalArea.Value != fusedFace.Area:
                 self.obj.HorizontalArea = fusedFace.Area
 

--- a/src/Mod/BIM/bimtests/TestArchComponent.py
+++ b/src/Mod/BIM/bimtests/TestArchComponent.py
@@ -25,6 +25,7 @@
 # Unit tests for the ArchComponent module
 
 import Arch
+import ArchComponent
 import Draft
 import Part
 import FreeCAD as App
@@ -48,6 +49,77 @@ class TestArchComponent(TestArchBase.TestArchBase):
         App.ActiveDocument.recompute()
         r = w.Shape.Volume > 1.5
         self.assertTrue(r, "Arch Add failed")
+
+    def testMakeProjectedHorizontalAreaFace(self):
+        """Projected horizontal analysis face should preserve union semantics."""
+
+        face_a = Part.makeFace(
+            [
+                Part.makePolygon(
+                    [
+                        App.Vector(0, 0, 0),
+                        App.Vector(2, 0, 0),
+                        App.Vector(2, 1, 0),
+                        App.Vector(0, 1, 0),
+                        App.Vector(0, 0, 0),
+                    ]
+                )
+            ],
+            "Part::FaceMakerCheese",
+        )
+        face_b = Part.makeFace(
+            [
+                Part.makePolygon(
+                    [
+                        App.Vector(1, 0, 0),
+                        App.Vector(3, 0, 0),
+                        App.Vector(3, 1, 0),
+                        App.Vector(1, 1, 0),
+                        App.Vector(1, 0, 0),
+                    ]
+                )
+            ],
+            "Part::FaceMakerCheese",
+        )
+        face_c = Part.makeFace(
+            [
+                Part.makePolygon(
+                    [
+                        App.Vector(0, 1, 0),
+                        App.Vector(3, 1, 0),
+                        App.Vector(3, 2, 0),
+                        App.Vector(0, 2, 0),
+                        App.Vector(0, 1, 0),
+                    ]
+                )
+            ],
+            "Part::FaceMakerCheese",
+        )
+
+        # Seed element maps so the test verifies the transient fuse drops
+        # naming metadata, not just that the projected faces union geometrically.
+        face_a.ElementMap = {"FaceA": "FaceA"}
+        face_b.ElementMap = {"FaceB": "FaceB"}
+        face_c.ElementMap = {"FaceC": "FaceC"}
+        self.assertGreater(face_a.ElementMapSize, 0)
+        self.assertGreater(face_b.ElementMapSize, 0)
+        self.assertGreater(face_c.ElementMapSize, 0)
+
+        single = ArchComponent._make_projected_horizontal_area_face([face_a])
+        overlapping_union = ArchComponent._make_projected_horizontal_area_face([face_a, face_b])
+        fused = ArchComponent._make_projected_horizontal_area_face([face_a, face_b, face_c])
+
+        self.assertIsNotNone(single)
+        self.assertEqual(0, single.ElementMapSize)
+        self.assertAlmostEqual(2.0, single.Area, places=7)
+        self.assertIsNotNone(overlapping_union)
+        self.assertEqual(0, overlapping_union.ElementMapSize)
+        self.assertAlmostEqual(3.0, overlapping_union.Area, places=7)
+        self.assertEqual(1, len(overlapping_union.Faces))
+        self.assertAlmostEqual(8.0, overlapping_union.Faces[0].OuterWire.Length, places=7)
+        self.assertIsNotNone(fused)
+        self.assertEqual(0, fused.ElementMapSize)
+        self.assertAlmostEqual(6.0, fused.Area, places=7)
 
     def testRemove(self):
         App.Console.PrintLog("Checking Arch Remove...\n")
@@ -273,7 +345,6 @@ class TestArchComponent(TestArchBase.TestArchBase):
         white-box testing on the internal calculator.
         """
         import math
-        import ArchComponent
 
         tolerance = Part.Precision.confusion()
 

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -486,9 +486,12 @@ public:
         add_keyword_method(
             "makeFace",
             &Module::makeFace,
-            "makeFace(list_of_shapes_or_compound, maker_class_name) -- Create a face (faces) using "
-            "facemaker class.\n"
-            "maker_class_name is a string like 'Part::FaceMakerSimple'."
+            "makeFace(list_of_shapes_or_compound, [maker_class_name, op], "
+            "*, noElementMap=False) -- "
+            "Create a face (faces) using facemaker class.\n"
+            "maker_class_name is a string like 'Part::FaceMakerSimple'.\n"
+            "Set noElementMap=True for transient geometry where stable element "
+            "naming is not needed."
         );
         add_keyword_method(
             "makeFilledSurface",
@@ -746,7 +749,8 @@ public:
         add_keyword_method(
             "getShape",
             &Module::getShape,
-            "getShape(obj,subname=None,mat=None,needSubElement=False,transform=True,retType=0):\n"
+            "getShape(obj,subname=None,mat=None,needSubElement=False,transform=True,retType=0,"
+            "noElementMap=False,refine=False):\n"
             "Obtain the TopoShape of a given object with SubName reference\n\n"
             "* obj: the input object\n"
             "* subname: dot separated sub-object reference\n"
@@ -761,6 +765,8 @@ public:
             "'subname',\n"
             "              and 'mat' is the accumulated transformation matrix of that sub-object.\n"
             "           2: same as 1, but make sure 'subObj' is resolved if it is a link.\n"
+            "* noElementMap: if True, return a shape without mapped element names. Use this for "
+            "transient geometry where stable element naming is not needed.\n"
             "* refine: refine the returned shape"
         );
         add_varargs_method(
@@ -1137,19 +1143,27 @@ private:
         PyObject* obj;
         const char* className = nullptr;
         const char* op = nullptr;
-        const std::array<const char*, 4> kwd_list = {"shapes", "class_name", "op", nullptr};
+        PyObject* noElementMap = Py_False;
+        const std::array<const char*, 5> kwd_list
+            = {"shapes", "class_name", "op", "noElementMap", nullptr};
         if (!Base::Wrapped_ParseTupleAndKeywords(
                 args.ptr(),
                 kwds.ptr(),
-                "O|ss",
+                "O|ss$O!",
                 kwd_list,
                 &obj,
                 &className,
-                &op
+                &op,
+                &PyBool_Type,
+                &noElementMap
             )) {
             throw Py::Exception();
         }
-        return shape2pyshape(TopoShape().makeElementFace(getPyShapes(obj), op, className));
+        auto elementMapPolicy = Base::asBoolean(noElementMap) ? ElementMapPolicy::Drop
+                                                              : ElementMapPolicy::Propagate;
+        return shape2pyshape(
+            TopoShape().makeElementFace(getPyShapes(obj), op, className, nullptr, elementMapPolicy)
+        );
     }
 
     template<class F>

--- a/src/Mod/Part/App/FaceMaker.cpp
+++ b/src/Mod/Part/App/FaceMaker.cpp
@@ -210,6 +210,12 @@ struct ElementName
 void Part::FaceMaker::postBuild()
 {
     this->myTopoShape.setShape(this->myShape);
+    if (this->MyElementMapPolicy == ElementMapPolicy::Drop) {
+        this->myTopoShape.dropElementNaming();
+        this->Done();
+        return;
+    }
+
     this->myTopoShape.Hasher = this->MyHasher;
     this->myTopoShape.mapSubElement(this->mySourceShapes);
 

--- a/src/Mod/Part/App/FaceMaker.h
+++ b/src/Mod/Part/App/FaceMaker.h
@@ -110,6 +110,7 @@ public:
 
     const char* MyOp = 0;
     App::StringHasherRef MyHasher;
+    ElementMapPolicy MyElementMapPolicy = ElementMapPolicy::Propagate;
 
 protected:
     std::vector<TopoShape> mySourceShapes;  // wire or compound

--- a/src/Mod/Part/App/TopoShape.h
+++ b/src/Mod/Part/App/TopoShape.h
@@ -63,6 +63,13 @@ class TopoShape;
 class TopoShapeCache;
 using TopoShapeMap = std::unordered_map<TopoShape, TopoShape, ShapeHasher, ShapeHasher>;
 
+/** Controls whether shape-making operations preserve mapped element names. */
+enum class ElementMapPolicy
+{
+    Propagate,
+    Drop
+};
+
 /* A special sub-class to indicate null shapes
  */
 // NOLINTNEXTLINE cppcoreguidelines-special-member-functions
@@ -1585,7 +1592,8 @@ public:
     TopoShape& makeElementXor(
         const std::vector<TopoShape>& sources,
         const char* op = nullptr,
-        double tol = -1.0
+        double tol = -1.0,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
     /** Make a boolean xor of this shape with an input shape
      *
@@ -1596,9 +1604,14 @@ public:
      *
      * @return Return the new shape. The TopoShape itself is not modified.
      */
-    TopoShape makeElementXor(const TopoShape& source, const char* op = nullptr, double tol = -1.0) const
+    TopoShape makeElementXor(
+        const TopoShape& source,
+        const char* op = nullptr,
+        double tol = -1.0,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
+    ) const
     {
-        return TopoShape(0, Hasher).makeElementXor({*this, source}, op, tol);
+        return TopoShape(0, Hasher).makeElementXor({*this, source}, op, tol, elementMapPolicy);
     }
 
     /** Try to simplify geometry of any linear/planar subshape to line/plane
@@ -1852,6 +1865,7 @@ public:
      * @param sources: list of source shapes.
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the given new shape. The function returns the TopoShape
@@ -1862,7 +1876,8 @@ public:
         const TopoDS_Shape& shape,
         const Mapper& mapper,
         const std::vector<TopoShape>& sources,
-        const char* op = nullptr
+        const char* op = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
     /**
      * When given a single shape to create a compound, two results are possible: either to simply
@@ -1880,6 +1895,7 @@ public:
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
      * @param policy: set behavior when only a single shape is given
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape. The function returns the TopoShape itself as
@@ -1889,7 +1905,8 @@ public:
     TopoShape& makeElementCompound(
         const std::vector<TopoShape>& shapes,
         const char* op = nullptr,
-        SingleShapeCompoundCreationPolicy policy = SingleShapeCompoundCreationPolicy::forceCompound
+        SingleShapeCompoundCreationPolicy policy = SingleShapeCompoundCreationPolicy::forceCompound,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
 
 
@@ -1914,6 +1931,7 @@ public:
      *                Note that edges may be modified after adding to the wire,
      *                so the output edges may not be the same as the input
      *                ones.
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The function produces either a wire or a compound of wires. The
      *         original content of this TopoShape is discarded and replaced
@@ -1926,7 +1944,8 @@ public:
         const char* op = nullptr,
         double tol = 0.0,
         ConnectionPolicy policy = ConnectionPolicy::mergeWithTolerance,
-        TopoShapeMap* output = nullptr
+        TopoShapeMap* output = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
 
 
@@ -1945,6 +1964,7 @@ public:
      *                Note that edges may be modified after adding to the wire,
      *                so the output edges may not be the same as the input
      *                ones.
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The function produces either a wire or a compound of wires. The
      *         original content of this TopoShape is discarded and replaced
@@ -1957,7 +1977,8 @@ public:
         const char* op = nullptr,
         double tol = 0.0,
         ConnectionPolicy policy = ConnectionPolicy::mergeWithTolerance,
-        TopoShapeMap* output = nullptr
+        TopoShapeMap* output = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
 
     /** Make a compound of wires by connecting input edges in the given order
@@ -2000,6 +2021,7 @@ public:
      *                Note that edges may be modified after adding to the wire,
      *                so the output edges may not be the same as the input
      *                ones.
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      *
      * @return The function returns a new shape of either a single wire or a
@@ -2009,10 +2031,11 @@ public:
         const char* op = nullptr,
         double tol = 0.0,
         ConnectionPolicy policy = ConnectionPolicy::mergeWithTolerance,
-        TopoShapeMap* output = nullptr
+        TopoShapeMap* output = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     ) const
     {
-        return TopoShape(0, Hasher).makeElementWires(*this, op, tol, policy, output);
+        return TopoShape(0, Hasher).makeElementWires(*this, op, tol, policy, output, elementMapPolicy);
     }
 
     /** Make a new shape with transformation that may contain non-uniform scaling
@@ -2064,6 +2087,7 @@ public:
      *            the operation
      * @param copyGeom: whether to copy internal geometry of the shape
      * @param copyMesh: whether to copy internal meshes of the shape
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with a deep copy of the input shape. The function returns the
@@ -2074,7 +2098,8 @@ public:
         const TopoShape& source,
         const char* op = nullptr,
         bool copyGeom = true,
-        bool copyMesh = false
+        bool copyMesh = false,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
 
     /** Make a deep copy of the shape
@@ -2083,13 +2108,19 @@ public:
      *            the operation
      * @param copyGeom: whether to copy internal geometry of the shape
      * @param copyMesh: whether to copy internal meshes of the shape
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return Return a deep copy of the shape. The shape itself is not
      *         modified
      */
-    TopoShape makeElementCopy(const char* op = nullptr, bool copyGeom = true, bool copyMesh = false) const
+    TopoShape makeElementCopy(
+        const char* op = nullptr,
+        bool copyGeom = true,
+        bool copyMesh = false,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
+    ) const
     {
-        return TopoShape(Tag, Hasher).makeElementCopy(*this, op, copyGeom, copyMesh);
+        return TopoShape(Tag, Hasher).makeElementCopy(*this, op, copyGeom, copyMesh, elementMapPolicy);
     }
 
 
@@ -2100,6 +2131,7 @@ public:
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
      * @param tol: tolerance option available to some shape making algorithm
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape built by the shape maker. The function
@@ -2111,7 +2143,8 @@ public:
         const char* maker,
         const std::vector<TopoShape>& sources,
         const char* op = nullptr,
-        double tol = -1.0
+        double tol = -1.0,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
     /** Generalized shape making with mapped element name from shape history
      *
@@ -2120,6 +2153,7 @@ public:
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
      * @param tol: tolerance option available to some shape making algorithm
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape built by the shape maker. The function
@@ -2131,7 +2165,8 @@ public:
         const char* maker,
         const TopoShape& source,
         const char* op = nullptr,
-        double tol = -1.0
+        double tol = -1.0,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
 
     /** Generalized shape making with mapped element name from shape history
@@ -2140,14 +2175,20 @@ public:
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
      * @param tol: tolerance option available to some shape making algorithm
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return Returns the new shape with mappend element name generated from
      *         shape history using this shape as the source. The shape itself
      *         is not modified.
      */
-    TopoShape makeElementBoolean(const char* maker, const char* op = nullptr, double tol = -1.0) const
+    TopoShape makeElementBoolean(
+        const char* maker,
+        const char* op = nullptr,
+        double tol = -1.0,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
+    ) const
     {
-        return TopoShape(0, Hasher).makeElementBoolean(maker, *this, op, tol);
+        return TopoShape(0, Hasher).makeElementBoolean(maker, *this, op, tol, elementMapPolicy);
     }
 
     /** Make a mirrored shape
@@ -2512,13 +2553,18 @@ public:
      * @param silent: whether to throw exception on failure
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape. The function returns the TopoShape itself as
      *         a self reference so that multiple operations can be carried out
      *         for the same shape in the same line of code.
      */
-    TopoShape& makeElementShell(bool silent = true, const char* op = nullptr);
+    TopoShape& makeElementShell(
+        bool silent = true,
+        const char* op = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
+    );
 
     /* Make a shell with input wires
      *
@@ -2526,6 +2572,7 @@ public:
      * @param silent: whether to throw exception on failure
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape. The function returns the TopoShape itself as
@@ -2535,7 +2582,8 @@ public:
     TopoShape& makeElementShellFromWires(
         const std::vector<TopoShape>& wires,
         bool silent = true,
-        const char* op = nullptr
+        const char* op = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
     /* Make a shell with input wires
      *
@@ -2543,12 +2591,17 @@ public:
      * @param silent: whether to throw exception on failure
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return Return the new shape. The TopoShape itself is not modified.
      */
-    TopoShape& makeElementShellFromWires(bool silent = true, const char* op = nullptr)
+    TopoShape& makeElementShellFromWires(
+        bool silent = true,
+        const char* op = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
+    )
     {
-        return makeElementShellFromWires(getSubTopoShapes(TopAbs_WIRE), silent, op);
+        return makeElementShellFromWires(getSubTopoShapes(TopAbs_WIRE), silent, op, elementMapPolicy);
     }
 
     /** Make a planar face with the input wires or edges
@@ -2560,6 +2613,7 @@ public:
      * @param maker: optional type name of the face maker. If not given,
      *               default to "Part::FaceMakerBullseye"
      * @param plane: optional plane of the face.
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The function creates a planar face. The original content of this
      *         TopoShape is discarded and replaced with the new shape. The
@@ -2571,7 +2625,8 @@ public:
         const std::vector<TopoShape>& shapes,
         const char* op = nullptr,
         const char* maker = nullptr,
-        const gp_Pln* plane = nullptr
+        const gp_Pln* plane = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
     /** Make a planar face with the input wire or edge
      *
@@ -2582,6 +2637,7 @@ public:
      * @param maker: optional type name of the face maker. If not given,
      *               default to "Part::FaceMakerBullseye"
      * @param plane: optional plane of the face.
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The function creates a planar face. The original content of this
      *         TopoShape is discarded and replaced with the new shape. The
@@ -2593,7 +2649,8 @@ public:
         const TopoShape& shape,
         const char* op = nullptr,
         const char* maker = nullptr,
-        const gp_Pln* plane = nullptr
+        const gp_Pln* plane = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
     /** Make a planar face using this shape
      *
@@ -2602,6 +2659,7 @@ public:
      * @param maker: optional type name of the face maker. If not given,
      *               default to "Part::FaceMakerBullseye"
      * @param plane: optional plane of the face.
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The function returns a new planar face made using the wire or edge
      *         inside this shape. The shape itself is not modified.
@@ -2609,10 +2667,11 @@ public:
     TopoShape makeElementFace(
         const char* op = nullptr,
         const char* maker = nullptr,
-        const gp_Pln* plane = nullptr
+        const gp_Pln* plane = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     ) const
     {
-        return TopoShape(0, Hasher).makeElementFace(*this, op, maker, plane);
+        return TopoShape(0, Hasher).makeElementFace(*this, op, maker, plane, elementMapPolicy);
     }
 
     /** Make a face with BSpline (or Bezier) surface
@@ -2776,6 +2835,7 @@ public:
      * @param sources: list of source shapes.
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape built by the shape maker. The function
@@ -2786,7 +2846,8 @@ public:
     TopoShape& makeElementShape(
         BRepBuilderAPI_MakeShape& mkShape,
         const std::vector<TopoShape>& sources,
-        const char* op = nullptr
+        const char* op = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
     /** Generic shape making with mapped element name from shape history
      *
@@ -2794,6 +2855,7 @@ public:
      * @param source: source shape.
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return The original content of this TopoShape is discarded and replaced
      *         with the new shape built by the shape maker. The function
@@ -2804,21 +2866,27 @@ public:
     TopoShape& makeElementShape(
         BRepBuilderAPI_MakeShape& mkShape,
         const TopoShape& source,
-        const char* op = nullptr
+        const char* op = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
     );
     /** Generic shape making with mapped element name from shape history
      *
      * @param mkShape: OCCT shape maker.
      * @param op: optional string to be encoded into topo naming for indicating
      *            the operation
+     * @param elementMapPolicy: whether to propagate or drop mapped element names
      *
      * @return Returns the new shape built by the shape maker with mappend element
      *         name generated using this shape as the source. The shape itself
      *         is not modified.
      */
-    TopoShape makeElementShape(BRepBuilderAPI_MakeShape& mkShape, const char* op = nullptr) const
+    TopoShape makeElementShape(
+        BRepBuilderAPI_MakeShape& mkShape,
+        const char* op = nullptr,
+        ElementMapPolicy elementMapPolicy = ElementMapPolicy::Propagate
+    ) const
     {
-        return TopoShape(0, Hasher).makeElementShape(mkShape, *this, op);
+        return TopoShape(0, Hasher).makeElementShape(mkShape, *this, op, elementMapPolicy);
     }
 
     /** Specialized shape making for BRepBuilderAPI_MakePrism with mapped element name
@@ -2852,9 +2920,12 @@ public:
      * the appropriate operation if so.
      */
 
+    friend class FaceMaker;
     friend class TopoShapeCache;
 
 private:
+    void dropElementNaming();
+
     // Cache storage
     mutable std::shared_ptr<TopoShapeCache> _parentCache;
     mutable std::shared_ptr<TopoShapeCache> _cache;

--- a/src/Mod/Part/App/TopoShape.pyi
+++ b/src/Mod/Part/App/TopoShape.pyi
@@ -243,12 +243,18 @@ class TopoShape(ComplexGeoData):
         ...
 
     @constmethod
-    def fuse(self, tools: Tuple[TopoShape, ...], tolerance: float = 0.0, /) -> TopoShape:
+    def fuse(
+        self,
+        tools: Tuple[TopoShape, ...],
+        tolerance: float = 0.0,
+        *,
+        noElementMap: bool = False,
+    ) -> TopoShape:
         """
         Union of this and a given (list of) topo shape.
         fuse(tool) -> Shape
           or
-        fuse((tool1,tool2,...),[tolerance=0.0]) -> Shape
+        fuse((tool1,tool2,...),[tolerance=0.0], noElementMap=False) -> Shape
         --
         Union of this and a given list of topo shapes.
 
@@ -258,14 +264,22 @@ class TopoShape(ComplexGeoData):
         - Parallelization of Boolean Operations algorithm
 
         Beginning from OCCT 6.8.1 a tolerance value can be specified.
+        Set noElementMap=True for transient analysis geometry where stable
+        element naming is not needed.
         """
         ...
 
     @constmethod
-    def multiFuse(self, tools: Tuple[TopoShape, ...], tolerance: float = 0.0, /) -> TopoShape:
+    def multiFuse(
+        self,
+        tools: Tuple[TopoShape, ...],
+        tolerance: float = 0.0,
+        *,
+        noElementMap: bool = False,
+    ) -> TopoShape:
         """
         Union of this and a given list of topo shapes.
-        multiFuse((tool1,tool2,...),[tolerance=0.0]) -> Shape
+        multiFuse((tool1,tool2,...),[tolerance=0.0], noElementMap=False) -> Shape
         --
         Supports (OCCT 6.9.0 and above):
         - Fuzzy Boolean operations (global tolerance for a Boolean operation)
@@ -273,6 +287,8 @@ class TopoShape(ComplexGeoData):
         - Parallelization of Boolean Operations algorithm
 
         Beginning from OCCT 6.8.1 a tolerance value can be specified.
+        Set noElementMap=True for transient analysis geometry where stable
+        element naming is not needed.
         Deprecated: use fuse() instead.
         """
         ...
@@ -893,15 +909,23 @@ class TopoShape(ComplexGeoData):
         ...
 
     @constmethod
-    def copy(self, copyGeom: bool = True, copyMesh: bool = False, /) -> TopoShape:
+    def copy(
+        self,
+        copyGeom: bool = True,
+        copyMesh: bool = False,
+        *,
+        noElementMap: bool = False,
+    ) -> TopoShape:
         """
         Create a copy of this shape
-        copy(copyGeom=True, copyMesh=False) -> Shape
+        copy(copyGeom=True, copyMesh=False, noElementMap=False) -> Shape
         --
         If copyMesh is True, triangulation contained in original shape will be
         copied along with geometry.
         If copyGeom is False, only topological objects will be copied, while
         geometry and triangulation will be shared with original shape.
+        Set noElementMap=True for transient geometry where stable element
+        naming is not needed.
         """
         ...
 

--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -167,6 +167,14 @@ Data::ElementMapPtr TopoShape::resetElementMap(Data::ElementMapPtr elementMap)
     return Data::ComplexGeoData::resetElementMap(elementMap);
 }
 
+void TopoShape::dropElementNaming()
+{
+    resetElementMap();
+    Tag = 0;
+    Hasher = nullptr;
+    initCache(1);
+}
+
 void TopoShape::flushElementMap() const
 {
     initCache();
@@ -1409,12 +1417,18 @@ TopoShape& TopoShape::makeShapeWithElementMap(
     const TopoDS_Shape& shape,
     const Mapper& mapper,
     const std::vector<TopoShape>& shapes,
-    const char* op
+    const char* op,
+    ElementMapPolicy elementMapPolicy
 )
 {
     setShape(shape);
     if (shape.IsNull()) {
         FC_THROWM(NullShapeException, "Null shape");
+    }
+
+    if (elementMapPolicy == ElementMapPolicy::Drop) {
+        dropElementNaming();
+        return *this;
     }
 
     if (shapes.empty()) {
@@ -2350,11 +2364,15 @@ TopoShape& TopoShape::makeElementRuledSurface(
 TopoShape& TopoShape::makeElementCompound(
     const std::vector<TopoShape>& shapes,
     const char* op,
-    SingleShapeCompoundCreationPolicy policy
+    SingleShapeCompoundCreationPolicy policy,
+    ElementMapPolicy elementMapPolicy
 )
 {
     if (policy == SingleShapeCompoundCreationPolicy::returnShape && shapes.size() == 1) {
         *this = shapes[0];
+        if (elementMapPolicy == ElementMapPolicy::Drop) {
+            dropElementNaming();
+        }
         return *this;
     }
 
@@ -2364,13 +2382,21 @@ TopoShape& TopoShape::makeElementCompound(
 
     if (shapes.empty()) {
         setShape(comp);
+        if (elementMapPolicy == ElementMapPolicy::Drop) {
+            dropElementNaming();
+        }
         return *this;
     }
     addShapesToBuilder(shapes, builder, comp);
     setShape(comp);
-    initCache();
 
-    mapSubElement(shapes, op);
+    if (elementMapPolicy == ElementMapPolicy::Drop) {
+        dropElementNaming();
+    }
+    else {
+        initCache();
+        mapSubElement(shapes, op);
+    }
     return *this;
 }
 
@@ -3108,10 +3134,11 @@ TopoShape& TopoShape::makeElementWires(
     const char* op,
     double tol,
     ConnectionPolicy policy,
-    TopoShapeMap* output
+    TopoShapeMap* output,
+    ElementMapPolicy elementMapPolicy
 )
 {
-    return makeElementWires(std::vector<TopoShape> {shape}, op, tol, policy, output);
+    return makeElementWires(std::vector<TopoShape> {shape}, op, tol, policy, output, elementMapPolicy);
 }
 
 
@@ -3120,7 +3147,8 @@ TopoShape& TopoShape::makeElementWires(
     const char* op,
     double tol,
     ConnectionPolicy policy,
-    TopoShapeMap* output
+    TopoShapeMap* output,
+    ElementMapPolicy elementMapPolicy
 )
 {
     if (!op) {
@@ -3152,10 +3180,20 @@ TopoShape& TopoShape::makeElementWires(
         std::vector<TopoShape> wires;
         for (int i = 1; i <= hWires->Length(); i++) {
             auto wire = hWires->Value(i);
-            wires.emplace_back(Tag, Hasher, wire);
-            wires.back().mapSubElement(shapes, op);
+            if (elementMapPolicy == ElementMapPolicy::Drop) {
+                wires.emplace_back(wire);
+            }
+            else {
+                wires.emplace_back(Tag, Hasher, wire);
+                wires.back().mapSubElement(shapes, op);
+            }
         }
-        return makeElementCompound(wires, "", SingleShapeCompoundCreationPolicy::returnShape);
+        return makeElementCompound(
+            wires,
+            "",
+            SingleShapeCompoundCreationPolicy::returnShape,
+            elementMapPolicy
+        );
     }
 
     std::vector<TopoShape> wires;
@@ -3212,10 +3250,17 @@ TopoShape& TopoShape::makeElementWires(
         }
 
         wires.emplace_back(new_wire);
-        wires.back().mapSubElement(edges, op);
+        if (elementMapPolicy == ElementMapPolicy::Propagate) {
+            wires.back().mapSubElement(edges, op);
+        }
         wires.back().fix();
     }
-    return makeElementCompound(wires, nullptr, SingleShapeCompoundCreationPolicy::returnShape);
+    return makeElementCompound(
+        wires,
+        nullptr,
+        SingleShapeCompoundCreationPolicy::returnShape,
+        elementMapPolicy
+    );
 }
 
 namespace
@@ -3524,7 +3569,13 @@ TopoShape& TopoShape::makeElementGTransform(
     return *this;
 }
 
-TopoShape& TopoShape::makeElementCopy(const TopoShape& shape, const char* op, bool copyGeom, bool copyMesh)
+TopoShape& TopoShape::makeElementCopy(
+    const TopoShape& shape,
+    const char* op,
+    bool copyGeom,
+    bool copyMesh,
+    ElementMapPolicy elementMapPolicy
+)
 {
     if (shape.isNull()) {
         return *this;
@@ -3532,6 +3583,12 @@ TopoShape& TopoShape::makeElementCopy(const TopoShape& shape, const char* op, bo
 
     TopoShape tmp(shape);
     tmp.setShape(BRepBuilderAPI_Copy(shape.getShape(), copyGeom, copyMesh).Shape(), false);
+
+    if (elementMapPolicy == ElementMapPolicy::Drop) {
+        setShape(tmp._Shape);
+        dropElementNaming();
+        return *this;
+    }
 
     if (op || (shape.Tag && shape.Tag != Tag)) {
         setShape(tmp._Shape);
@@ -4243,7 +4300,12 @@ TopoShape& TopoShape::makeElementCut(const std::vector<TopoShape>& shapes, const
     return makeElementBoolean(Part::OpCodes::Cut, shapes, op, tol);
 }
 
-TopoShape& TopoShape::makeElementXor(const std::vector<TopoShape>& shapes, const char* op, double tol)
+TopoShape& TopoShape::makeElementXor(
+    const std::vector<TopoShape>& shapes,
+    const char* op,
+    double tol,
+    ElementMapPolicy elementMapPolicy
+)
 {
     if (shapes.empty()) {
         FC_THROWM(NullShapeException, "Null shape");
@@ -4283,6 +4345,9 @@ TopoShape& TopoShape::makeElementXor(const std::vector<TopoShape>& shapes, const
     }
     if (inputs.size() == 1) {
         *this = inputs[0];
+        if (elementMapPolicy == ElementMapPolicy::Drop) {
+            dropElementNaming();
+        }
         if (shapes.size() == 1) {
             FC_WARN("Boolean operation with only one shape input");
         }
@@ -4296,42 +4361,71 @@ TopoShape& TopoShape::makeElementXor(const std::vector<TopoShape>& shapes, const
 
         // Step 1: Union(A, B) - intermediate result, no op code.
         TopoShape tempUnion(0, Hasher);
-        tempUnion.makeElementBoolean(Part::OpCodes::Fuse, {result, inputs[i]}, nullptr, tol);
+        tempUnion.makeElementBoolean(
+            Part::OpCodes::Fuse,
+            {result, inputs[i]},
+            nullptr,
+            tol,
+            elementMapPolicy
+        );
 
         // Step 2: Common(A, B) - intermediate result, no op code.
         TopoShape tempCommon(0, Hasher);
-        tempCommon.makeElementBoolean(Part::OpCodes::Common, {result, inputs[i]}, nullptr, tol);
+        tempCommon.makeElementBoolean(
+            Part::OpCodes::Common,
+            {result, inputs[i]},
+            nullptr,
+            tol,
+            elementMapPolicy
+        );
 
         // Step 3: Compute the final result for this iteration
         if (tempCommon.isNull() || tempCommon.getShape().IsNull()) {
             // No intersection, XOR is the same as Union.
             // We still call the boolean op to get the correct history.
-            result.makeElementBoolean(Part::OpCodes::Fuse, {result, inputs[i]}, currentOp, tol);
+            result.makeElementBoolean(
+                Part::OpCodes::Fuse,
+                {result, inputs[i]},
+                currentOp,
+                tol,
+                elementMapPolicy
+            );
         }
         else {
             // Final result is Cut(Union, Common).
-            result.makeElementBoolean(Part::OpCodes::Cut, {tempUnion, tempCommon}, currentOp, tol);
+            result.makeElementBoolean(
+                Part::OpCodes::Cut,
+                {tempUnion, tempCommon},
+                currentOp,
+                tol,
+                elementMapPolicy
+            );
         }
     }
 
     *this = result;
+    if (elementMapPolicy == ElementMapPolicy::Drop) {
+        dropElementNaming();
+    }
     return *this;
 }
 
 TopoShape& TopoShape::makeElementShape(
     BRepBuilderAPI_MakeShape& mkShape,
     const TopoShape& source,
-    const char* op
+    const char* op,
+    ElementMapPolicy elementMapPolicy
 )
 {
     std::vector<TopoShape> sources(1, source);
-    return makeElementShape(mkShape, sources, op);
+    return makeElementShape(mkShape, sources, op, elementMapPolicy);
 }
 
 TopoShape& TopoShape::makeElementShape(
     BRepBuilderAPI_MakeShape& mkShape,
     const std::vector<TopoShape>& shapes,
-    const char* op
+    const char* op,
+    ElementMapPolicy elementMapPolicy
 )
 {
     TopoDS_Shape shape;
@@ -4342,7 +4436,7 @@ TopoShape& TopoShape::makeElementShape(
     else {
         shape = mkShape.Shape();
     }
-    return makeShapeWithElementMap(shape, MapperMaker(mkShape), shapes, op);
+    return makeShapeWithElementMap(shape, MapperMaker(mkShape), shapes, op, elementMapPolicy);
 }
 
 TopoShape& TopoShape::makeElementShape(
@@ -4784,7 +4878,8 @@ TopoShape& TopoShape::makeElementFace(
     const TopoShape& shape,
     const char* op,
     const char* maker,
-    const gp_Pln* plane
+    const gp_Pln* plane,
+    ElementMapPolicy elementMapPolicy
 )
 {
     std::vector<TopoShape> shapes;
@@ -4797,14 +4892,15 @@ TopoShape& TopoShape::makeElementFace(
     else {
         shapes.push_back(shape);
     }
-    return makeElementFace(shapes, op, maker, plane);
+    return makeElementFace(shapes, op, maker, plane, elementMapPolicy);
 }
 
 TopoShape& TopoShape::makeElementFace(
     const std::vector<TopoShape>& shapes,
     const char* op,
     const char* maker,
-    const gp_Pln* plane
+    const gp_Pln* plane,
+    ElementMapPolicy elementMapPolicy
 )
 {
     if (!maker || !maker[0]) {
@@ -4813,6 +4909,7 @@ TopoShape& TopoShape::makeElementFace(
     std::unique_ptr<FaceMaker> mkFace = FaceMaker::ConstructFromType(maker);
     mkFace->MyHasher = Hasher;
     mkFace->MyOp = op;
+    mkFace->MyElementMapPolicy = elementMapPolicy;
     if (plane) {
         mkFace->setPlane(*plane);
     }
@@ -4833,8 +4930,13 @@ TopoShape& TopoShape::makeElementFace(
 
     const auto& ret = mkFace->getTopoShape();
     setShape(ret._Shape);
-    Hasher = ret.Hasher;
-    resetElementMap(ret.elementMap());
+    if (elementMapPolicy == ElementMapPolicy::Drop) {
+        dropElementNaming();
+    }
+    else {
+        Hasher = ret.Hasher;
+        resetElementMap(ret.elementMap());
+    }
     if (!isValid()) {
         ShapeFix_ShapeTolerance aSFT;
         aSFT.LimitTolerance(getShape(), Precision::Confusion(), Precision::Confusion(), TopAbs_SHAPE);
@@ -5637,7 +5739,7 @@ const std::vector<TopoDS_Shape>& MapperHistory::generated(const TopoDS_Shape& s)
 }
 
 // topo naming counterpart of TopoShape::makeShell()
-TopoShape& TopoShape::makeElementShell(bool silent, const char* op)
+TopoShape& TopoShape::makeElementShell(bool silent, const char* op, ElementMapPolicy elementMapPolicy)
 {
     if (silent) {
         if (isNull()) {
@@ -5687,9 +5789,13 @@ TopoShape& TopoShape::makeElementShell(bool silent, const char* op)
             builder.Add(shell, face);
         }
 
-        TopoShape tmp(Tag, Hasher, shell);
-        tmp.resetElementMap();
-        tmp.mapSubElement(*this, op);
+        Data::ElementMapPtr elementMap;
+        if (elementMapPolicy == ElementMapPolicy::Propagate) {
+            TopoShape tmp(Tag, Hasher, shell);
+            tmp.resetElementMap();
+            tmp.mapSubElement(*this, op);
+            elementMap = tmp.elementMap();
+        }
 
         shape = shell;
         BRepCheck_Analyzer check(shell);
@@ -5718,7 +5824,12 @@ TopoShape& TopoShape::makeElementShell(bool silent, const char* op)
         }
 
         setShape(shape);
-        resetElementMap(tmp.elementMap());
+        if (elementMapPolicy == ElementMapPolicy::Drop) {
+            dropElementNaming();
+        }
+        else {
+            resetElementMap(elementMap);
+        }
     }
     catch (Standard_Failure& e) {
         if (!silent) {
@@ -5732,7 +5843,8 @@ TopoShape& TopoShape::makeElementShell(bool silent, const char* op)
 TopoShape& TopoShape::makeElementShellFromWires(
     const std::vector<TopoShape>& wires,
     bool silent,
-    const char* op
+    const char* op,
+    ElementMapPolicy elementMapPolicy
 )
 {
     BRepFill_Generator maker;
@@ -5749,7 +5861,7 @@ TopoShape& TopoShape::makeElementShellFromWires(
         FC_THROWM(NullShapeException, "No input shapes");
     }
     maker.Perform();
-    this->makeShapeWithElementMap(maker.Shell(), MapperFill(maker), wires, op);
+    this->makeShapeWithElementMap(maker.Shell(), MapperFill(maker), wires, op, elementMapPolicy);
     return *this;
 }
 
@@ -5812,10 +5924,11 @@ TopoShape& TopoShape::makeElementBoolean(
     const char* maker,
     const TopoShape& shape,
     const char* op,
-    double tolerance
+    double tolerance,
+    ElementMapPolicy elementMapPolicy
 )
 {
-    return makeElementBoolean(maker, std::vector<TopoShape>(1, shape), op, tolerance);
+    return makeElementBoolean(maker, std::vector<TopoShape>(1, shape), op, tolerance, elementMapPolicy);
 }
 
 
@@ -5824,7 +5937,8 @@ TopoShape& TopoShape::makeElementBoolean(
     const char* maker,
     const std::vector<TopoShape>& shapes,
     const char* op,
-    double tolerance
+    double tolerance,
+    ElementMapPolicy elementMapPolicy
 )
 {
     if (!maker) {
@@ -5844,7 +5958,12 @@ TopoShape& TopoShape::makeElementBoolean(
     }
 
     if (strcmp(maker, Part::OpCodes::Compound) == 0) {
-        return makeElementCompound(shapes, op, SingleShapeCompoundCreationPolicy::returnShape);
+        return makeElementCompound(
+            shapes,
+            op,
+            SingleShapeCompoundCreationPolicy::returnShape,
+            elementMapPolicy
+        );
     }
     else if (boost::starts_with(maker, Part::OpCodes::Face)) {
         std::string prefix(Part::OpCodes::Face);
@@ -5853,10 +5972,17 @@ TopoShape& TopoShape::makeElementBoolean(
         if (boost::starts_with(maker, prefix)) {
             face_maker = maker + prefix.size();
         }
-        return makeElementFace(shapes, op, face_maker);
+        return makeElementFace(shapes, op, face_maker, nullptr, elementMapPolicy);
     }
     else if (strcmp(maker, Part::OpCodes::Wire) == 0) {
-        return makeElementWires(shapes, op);
+        return makeElementWires(
+            shapes,
+            op,
+            0.0,
+            ConnectionPolicy::mergeWithTolerance,
+            nullptr,
+            elementMapPolicy
+        );
     }
     else if (strcmp(maker, Part::OpCodes::Compsolid) == 0) {
         BRep_Builder builder;
@@ -5868,7 +5994,12 @@ TopoShape& TopoShape::makeElementBoolean(
             }
         }
         setShape(Comp);
-        mapSubElement(shapes, op);
+        if (elementMapPolicy == ElementMapPolicy::Drop) {
+            dropElementNaming();
+        }
+        else {
+            mapSubElement(shapes, op);
+        }
         return *this;
     }
 
@@ -5883,7 +6014,7 @@ TopoShape& TopoShape::makeElementBoolean(
             FC_THROWM(Base::CADKernelError, "Spine shape is not a wire");
         }
         BRepOffsetAPI_MakePipe mkPipe(TopoDS::Wire(shapes[0].getShape()), shapes[1].getShape());
-        return makeElementShape(mkPipe, shapes, op);
+        return makeElementShape(mkPipe, shapes, op, elementMapPolicy);
     }
 
     if (strcmp(maker, Part::OpCodes::Shell) == 0) {
@@ -5894,18 +6025,26 @@ TopoShape& TopoShape::makeElementBoolean(
             builder.Add(shell, s.getShape());
         }
         setShape(shell);
-        mapSubElement(shapes, op);
+        if (elementMapPolicy == ElementMapPolicy::Drop) {
+            dropElementNaming();
+        }
+        else {
+            mapSubElement(shapes, op);
+        }
         BRepCheck_Analyzer check(shell);
         if (!check.IsValid()) {
             ShapeUpgrade_ShellSewing sewShell;
             setShape(sewShell.ApplySewing(shell), false);
             // TODO: confirm the above won't change OCCT topological naming
+            if (elementMapPolicy == ElementMapPolicy::Drop) {
+                dropElementNaming();
+            }
         }
         return *this;
     }
 
     if (strcmp(maker, Part::OpCodes::Xor) == 0) {
-        return makeElementXor(shapes, op, tolerance);
+        return makeElementXor(shapes, op, tolerance, elementMapPolicy);
     }
 
     bool buildShell = true;
@@ -5959,6 +6098,9 @@ TopoShape& TopoShape::makeElementBoolean(
     }
     if (inputs.size() == 1) {
         *this = inputs[0];
+        if (elementMapPolicy == ElementMapPolicy::Drop) {
+            dropElementNaming();
+        }
         if (shapes.size() == 1) {
             // _shapes has fewer items than shapes due to compound expansion.
             // Only warn if the caller passes one shape.
@@ -6019,10 +6161,10 @@ TopoShape& TopoShape::makeElementBoolean(
     if (Base::Sequencer().wasCanceled()) {
         FC_THROWM(Base::CADKernelError, "User aborted");
     }
-    makeElementShape(*mk, inputs, op);
+    makeElementShape(*mk, inputs, op, elementMapPolicy);
 
     if (buildShell) {
-        makeElementShell();
+        makeElementShell(true, nullptr, elementMapPolicy);
     }
     return *this;
 }

--- a/src/Mod/Part/App/TopoShapePyImp.cpp
+++ b/src/Mod/Part/App/TopoShapePyImp.cpp
@@ -203,26 +203,46 @@ int TopoShapePy::PyInit(PyObject* args, PyObject* keywds)
     return 0;
 }
 
-PyObject* TopoShapePy::copy(PyObject* args) const
+PyObject* TopoShapePy::copy(PyObject* args, PyObject* keywds) const
 {
     PyObject* copyGeom = Py_True;
     PyObject* copyMesh = Py_False;
+    PyObject* noElementMap = Py_False;
     const char* op = nullptr;
     PyObject* pyHasher = nullptr;
-    if (!PyArg_ParseTuple(
+    static const std::array<const char*, 4> kwd_list {"copyGeom", "copyMesh", "noElementMap", nullptr};
+    if (!Base::Wrapped_ParseTupleAndKeywords(
             args,
-            "|sO!O!O!",
-            &op,
-            &App::StringHasherPy::Type,
-            &pyHasher,
+            keywds,
+            "|O!O!$O!",
+            kwd_list,
             &PyBool_Type,
             &copyGeom,
             &PyBool_Type,
-            &copyMesh
+            &copyMesh,
+            &PyBool_Type,
+            &noElementMap
         )) {
         PyErr_Clear();
-        if (!PyArg_ParseTuple(args, "|O!O!", &PyBool_Type, &copyGeom, &PyBool_Type, &copyMesh)) {
-            return 0;
+        if (keywds && PyDict_Size(keywds) != 0) {
+            PyErr_SetString(PyExc_TypeError, "copy() received invalid keyword arguments");
+            return nullptr;
+        }
+        if (!PyArg_ParseTuple(
+                args,
+                "|sO!O!O!",
+                &op,
+                &App::StringHasherPy::Type,
+                &pyHasher,
+                &PyBool_Type,
+                &copyGeom,
+                &PyBool_Type,
+                &copyMesh
+            )) {
+            PyErr_Clear();
+            if (!PyArg_ParseTuple(args, "|O!O!", &PyBool_Type, &copyGeom, &PyBool_Type, &copyMesh)) {
+                return 0;
+            }
         }
     }
     if (op && !op[0]) {
@@ -233,9 +253,11 @@ PyObject* TopoShapePy::copy(PyObject* args) const
         hasher = static_cast<App::StringHasherPy*>(pyHasher)->getStringHasherPtr();
     }
     auto& self = *getTopoShapePtr();
+    auto elementMapPolicy = Base::asBoolean(noElementMap) ? ElementMapPolicy::Drop
+                                                          : ElementMapPolicy::Propagate;
     return Py::new_reference_to(shape2pyshape(
         TopoShape(self.Tag, hasher)
-            .makeElementCopy(self, op, PyObject_IsTrue(copyGeom), PyObject_IsTrue(copyMesh))
+            .makeElementCopy(self, op, PyObject_IsTrue(copyGeom), PyObject_IsTrue(copyMesh), elementMapPolicy)
     ));
 }
 
@@ -709,6 +731,38 @@ PyObject* TopoShapePy::check(PyObject* args) const
     Py_Return;
 }
 
+static PyObject* makeShape(const char* op, const TopoShape& shape, PyObject* args, PyObject* keywds)
+{
+    double tol = 0;
+    PyObject* pcObj;
+    PyObject* noElementMap = Py_False;
+    static const std::array<const char*, 4> kwd_list {"tools", "tolerance", "noElementMap", nullptr};
+    if (!Base::Wrapped_ParseTupleAndKeywords(
+            args,
+            keywds,
+            "O|d$O!",
+            kwd_list,
+            &pcObj,
+            &tol,
+            &PyBool_Type,
+            &noElementMap
+        )) {
+        return 0;
+    }
+    PY_TRY
+    {
+        auto elementMapPolicy = Base::asBoolean(noElementMap) ? ElementMapPolicy::Drop
+                                                              : ElementMapPolicy::Propagate;
+        std::vector<TopoShape> shapes;
+        shapes.push_back(shape);
+        getPyShapes(pcObj, shapes);
+        return Py::new_reference_to(
+            shape2pyshape(TopoShape().makeElementBoolean(op, shapes, 0, tol, elementMapPolicy))
+        );
+    }
+    PY_CATCH_OCC
+}
+
 static PyObject* makeShape(const char* op, const TopoShape& shape, PyObject* args)
 {
     double tol = 0;
@@ -726,14 +780,14 @@ static PyObject* makeShape(const char* op, const TopoShape& shape, PyObject* arg
     PY_CATCH_OCC
 }
 
-PyObject* TopoShapePy::fuse(PyObject* args) const
+PyObject* TopoShapePy::fuse(PyObject* args, PyObject* keywds) const
 {
-    return makeShape(Part::OpCodes::Fuse, *getTopoShapePtr(), args);
+    return makeShape(Part::OpCodes::Fuse, *getTopoShapePtr(), args, keywds);
 }
 
-PyObject* TopoShapePy::multiFuse(PyObject* args) const
+PyObject* TopoShapePy::multiFuse(PyObject* args, PyObject* keywds) const
 {
-    return makeShape(Part::OpCodes::Fuse, *getTopoShapePtr(), args);
+    return makeShape(Part::OpCodes::Fuse, *getTopoShapePtr(), args, keywds);
 }
 
 PyObject* TopoShapePy::common(PyObject* args) const

--- a/src/Mod/Part/parttests/TopoShapeTest.py
+++ b/src/Mod/Part/parttests/TopoShapeTest.py
@@ -470,6 +470,33 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
             self.assertEqual(compound.ElementMapSize, 52)
             self.assertEqual(compound_cleaned.ElementMapSize, 52)
 
+    def testTopoShapeCopyWithoutElementMap(self):
+        # Arrange
+        self.doc.addObject("Part::Compound", "Compound")
+        self.doc.Compound.Links = [
+            App.activeDocument().Box1,
+            App.activeDocument().Box2,
+        ]
+        self.doc.recompute()
+        compound = self.doc.Compound.Shape
+        # Act
+        compound_plain = compound.copy(noElementMap=True)
+        # Assert elementMap
+        if compound.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertEqual(compound.ElementMapSize, 52)
+            self.assertEqual(compound_plain.ElementMapSize, 0)
+
+    def testTopoShapeMakeFaceWithoutElementMap(self):
+        # Act
+        face = Part.makeFace(
+            self.doc.Box1.Shape.Faces[0],
+            "Part::FaceMakerCheese",
+            noElementMap=True,
+        )
+        # Assert elementMap
+        if face.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertEqual(face.ElementMapSize, 0)
+
     def testTopoShapeReplaceShape(self):
         # Arrange
         self.doc.addObject("Part::Compound", "Compound")
@@ -532,6 +559,14 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         if fused.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(fused.ElementMapSize, 58)
 
+    def testTopoShapeFuseWithoutElementMap(self):
+        # Act
+        fused = self.doc.Box1.Shape.fuse(self.doc.Box2.Shape, noElementMap=True)
+        self.doc.recompute()
+        # Assert elementMap
+        if fused.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertEqual(fused.ElementMapSize, 0)
+
     def testTopoShapeMultiFuse(self):
         # Act
         fused = self.doc.Box1.Shape.multiFuse([self.doc.Box2.Shape])
@@ -539,6 +574,14 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
         # Assert elementMap
         if fused.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
             self.assertEqual(fused.ElementMapSize, 58)
+
+    def testTopoShapeMultiFuseWithoutElementMap(self):
+        # Act
+        fused = self.doc.Box1.Shape.multiFuse([self.doc.Box2.Shape], noElementMap=True)
+        self.doc.recompute()
+        # Assert elementMap
+        if fused.ElementMapVersion != "":  # Should be '4' as of Mar 2023.
+            self.assertEqual(fused.ElementMapSize, 0)
 
     def testTopoShapeCommon(self):
         # Act


### PR DESCRIPTION
## Summary

This reduces `TopoShapeExpansion.cpp` warning noise from BIM horizontal area analysis by letting transient projected geometry opt out of topo-naming metadata.

`ArchComponent` horizontal area calculation builds temporary projected faces and fuses them only to compute area and perimeter values. Those intermediate shapes are not user-addressable document geometry, so building element maps for them adds noise without practical value.

This PR adds a small Part API for that case and applies it to the BIM horizontal area path.

## Changes

### Part

- introduce a Part/TopoShape opt-out for transient geometry via `noElementMap=True`
- thread the lower-layer policy through the operations needed here
- add focused Part tests covering:
- copy without element maps
- face creation without element maps
- fuse without element maps
- multiFuse without element maps

### BIM

- update `ArchComponent` horizontal area calculation to build projected faces with `noElementMap=True`
- fuse projected horizontal analysis faces with `noElementMap=True`
- add focused BIM tests for projected horizontal area face generation

## Why

The underlying geometry is valid, but the topo-naming machinery was being exercised for temporary analysis shapes where stable subelement references are not useful.

This PR makes that intent explicit: horizontal area analysis can use plain transient geometry, while final document geometry continues to preserve element maps by default.
