### PR TITLE
TechDraw: Do not maximize MDIView when closing

### DIFF
--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -25,6 +25,7 @@
 #include <QAction>
 #include <QApplication>
 #include <QContextMenuEvent>
+#include <QMdiSubWindow>
 #include <QMenu>
 #include <QMessageBox>
 #include <QPageLayout>
@@ -164,13 +165,31 @@ void MDIViewPage::closeEvent(QCloseEvent* event)
         App::Document* doc = _pcDocument->getDocument();
         if (doc) {
             App::DocumentObject* obj = doc->getObject(m_objectName.c_str());
-            Gui::ViewProvider* vp = _pcDocument->getViewProvider(obj);
-            if (vp) {
-                vp->hide();
+            if (auto* vpPage = freecad_cast<ViewProviderPage*>(
+                    _pcDocument->getViewProvider(obj))) {
+                // Don't call vpPage->hide() here: that path calls removeMDIView()
+                // -> removeWindow() -> setParent(nullptr) re-entrantly from
+                // inside QMdiSubWindow::closeEvent, making it briefly top-level.
+                vpPage->onMDIViewClosed();
             }
         }
     }
     blockSceneSelection(false);
+}
+
+void MDIViewPage::closeWithoutSavePrompt()
+{
+    // Close through the normal Qt sequence
+    bool savedPassive = bIsPassive;
+    bIsPassive = true;
+    QWidget* parent = parentWidget();
+    if (qobject_cast<QMdiSubWindow*>(parent)) {
+        parent->close();
+    }
+    else {
+        close();
+    }
+    bIsPassive = savedPassive;
 }
 
 void MDIViewPage::onDeleteObject(const App::DocumentObject& obj)

--- a/src/Mod/TechDraw/Gui/MDIViewPage.h
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.h
@@ -102,6 +102,7 @@ public:
     ViewProviderPage* getViewProviderPage() const {return m_vpPage;}
 
     void setTabText(std::string tabText);
+    void closeWithoutSavePrompt();
 
     void contextMenuEvent(QContextMenuEvent *event) override;
 

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.cpp
@@ -23,6 +23,8 @@
 
 # include <QAction>
 # include <QList>
+# include <QMdiArea>
+# include <QMdiSubWindow>
 # include <QMenu>
 # include <QMessageBox>
 # include <QPointer>
@@ -284,7 +286,6 @@ void ViewProviderPage::show()
 void ViewProviderPage::hide()
 {
     if (getMDIView()) {
-        getMDIView()->hide();  // this doesn't remove the mdiViewPage from the mainWindow
         removeMDIView();
     }
     ViewProviderDocumentObject::hide();
@@ -346,22 +347,22 @@ void ViewProviderPage::switchToMdiViewPage()
     m_graphicsView->setFocus();
 }
 
-//NOTE: removing MDIViewPage (parent) destroys QGVPage (eventually)
+// Called by MDIViewPage::closeEvent() so we don't call removeWindow() re-entrantly
+// from inside QMdiSubWindow's own close-event chain (which would make the subwindow
+// briefly top-level and visible as a maximized window).  Qt handles QMdiSubWindow
+// cleanup; we only need to null our references and update visibility state.
+void ViewProviderPage::onMDIViewClosed()
+{
+    m_mdiView = nullptr;
+    m_graphicsView = nullptr;
+    ViewProviderDocumentObject::hide();
+}
+
 void ViewProviderPage::removeMDIView()
 {
-    if (!m_mdiView.isNull()) {//m_mdiView is a QPointer
-        QList<QWidget*> wList = Gui::getMainWindow()->windows();
-        if (wList.contains(m_mdiView)) {
-            Gui::getMainWindow()->removeWindow(m_mdiView);
-            m_mdiView = nullptr;     //m_mdiView will eventually be deleted and
-            m_graphicsView = nullptr;//will take m_graphicsView with it
-            Gui::MDIView* aw =
-                Gui::getMainWindow()
-                    ->activeWindow();//WF: this bit should be in the remove window logic, not here.
-            if (aw) {
-                aw->showMaximized();
-            }
-        }
+    if (!m_mdiView.isNull()) {
+        // Use the same close sequence as closing the tab
+        m_mdiView->closeWithoutSavePrompt();
     }
 }
 

--- a/src/Mod/TechDraw/Gui/ViewProviderPage.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderPage.h
@@ -142,6 +142,10 @@ public:
 
     void redrawPage() const;
 
+    // Called by MDIViewPage::closeEvent() instead of hide() to avoid re-entrantly
+    // calling removeWindow() on a QMdiSubWindow that is mid-closeEvent.
+    void onMDIViewClosed();
+
 protected:
     bool setEdit(int ModNum) override;
     void createMDIViewPage();


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Do not maximize MDIView when closing.

In 1.1 when a MDIView with a TechDraw page is closed or the document/app is closed, the TechDraw view gets maximized and closes afterwards.
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
#### Before:

https://github.com/user-attachments/assets/0a797171-fda0-4afa-8c88-5a96dfde4c46


#### After:

https://github.com/user-attachments/assets/2a6aa772-ee1a-467a-8616-9d46ac14516f




<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
