### PR TITLE
BIM: fix unwanted roll on tilted profile beams in placeAlongEdge

### DIFF
--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2625,7 +2625,7 @@ def makeStructuralSystem(objects=[], axes=[], name=None):
         return structural_systems
 
 
-def placeAlongEdge(p1, p2, horizontal=False):
+def placeAlongEdge(p1, p2, horizontal=False, wp=None):
     """Compute a Placement that orients a beam or column along an edge.
 
     Used for both beam and column placement. The edge direction (*p1* to *p2*) defines the element's
@@ -2648,6 +2648,9 @@ def placeAlongEdge(p1, p2, horizontal=False):
         If ``True``, beam-style placement: the local X axis points along the edge. If ``False``
         (default), column-style placement: the frame is rotated 90 degrees so the local Z
         extrusion axis ends up along the edge.
+    wp : WorkingPlane.PlaneBase, optional
+        Working plane whose normal is used as the "up" reference. Defaults to the active working
+        plane.
 
     Returns
     -------
@@ -2667,7 +2670,7 @@ def placeAlongEdge(p1, p2, horizontal=False):
     placement = FreeCAD.Placement()
     placement.Base = p1
 
-    wp_normal = WorkingPlane.get_working_plane(update=False).axis
+    wp_normal = (wp or WorkingPlane.get_working_plane(update=False)).axis
     edge_direction = p2.sub(p1)
     cross_section_horizontal = wp_normal.cross(edge_direction)
 

--- a/src/Mod/BIM/Arch.py
+++ b/src/Mod/BIM/Arch.py
@@ -2626,17 +2626,15 @@ def makeStructuralSystem(objects=[], axes=[], name=None):
 
 
 def placeAlongEdge(p1, p2, horizontal=False, wp=None):
-    """Compute a Placement that orients a beam or column along an edge.
+    """Compute a Placement that orients a structural element along an edge.
 
-    Used for both beam and column placement. The edge direction (*p1* to *p2*) defines the element's
-    span, and a right-handed coordinate frame is constructed around it. The working plane's normal
-    is used as the "up" reference: the cross product of up with the edge direction gives the
-    cross-section's sideways axis, and a second cross product completes the frame.
+    Structural elements are built by extruding a cross-section face along a local axis. The edge
+    direction (p1 to p2) defines that extrusion span, and the working plane's normal is used as the
+    "up" reference to keep the cross-section upright.
 
-    For beams (``horizontal=True``), the local X axis is aligned with the edge direction, so the
-    element's extrusion (along X) runs from *p1* to *p2*. For columns (``horizontal=False``), the
-    frame is built with the edge direction along Z, then rotated 90 degrees so the extrusion
-    (normally along Z) ends up running along the edge.
+    For elements that extrude along local X (``horizontal=True``), the local X axis is aligned with
+    the edge direction so the extrusion runs from *p1* to *p2*. For elements that extrude along
+    local Z (``horizontal=False``), the local Z axis is aligned with the edge direction.
 
     Parameters
     ----------
@@ -2645,9 +2643,8 @@ def placeAlongEdge(p1, p2, horizontal=False, wp=None):
     p2 : FreeCAD.Vector
         End point of the edge. Together with *p1*, defines the element's span direction.
     horizontal : bool, optional
-        If ``True``, beam-style placement: the local X axis points along the edge. If ``False``
-        (default), column-style placement: the frame is rotated 90 degrees so the local Z
-        extrusion axis ends up along the edge.
+        If ``True``, extrudes along local X (cross-section in the local YZ plane. If ``False``
+        (default), extrudes along local Z (cross-section in the local XY plane).
     wp : WorkingPlane.PlaneBase, optional
         Working plane whose normal is used as the "up" reference. Defaults to the active working
         plane.
@@ -2656,13 +2653,8 @@ def placeAlongEdge(p1, p2, horizontal=False, wp=None):
     -------
     FreeCAD.Placement
         A placement at *p1* with orientation derived from the edge direction. If the edge is
-        parallel to the working plane's normal, the cross product is zero and the rotation is left
-        at identity (degenerate case).
-
-    Notes
-    -----
-    The current implementation uses a single cross-product chain to construct the frame, which can
-    produce unintuitive roll (rotation around the span axis) for non-orthogonal edge directions.
+        zero-length or parallel to the working plane's normal, the cross product is zero and the
+        rotation is left at identity (degenerate case).
     """
 
     import WorkingPlane
@@ -2682,9 +2674,6 @@ def placeAlongEdge(p1, p2, horizontal=False, wp=None):
             )
         else:
             placement.Rotation = FreeCAD.Rotation(
-                cross_section_vertical, cross_section_horizontal, edge_direction, "ZXY"
+                cross_section_horizontal, cross_section_vertical, edge_direction, "ZXY"
             )
-            placement.Rotation = FreeCAD.Rotation(
-                placement.Rotation.multVec(FreeCAD.Vector(0, 0, 1)), 90
-            ).multiply(placement.Rotation)
     return placement

--- a/src/Mod/BIM/bimtests/TestArchStructure.py
+++ b/src/Mod/BIM/bimtests/TestArchStructure.py
@@ -26,6 +26,7 @@ import unittest
 import FreeCAD as App
 from FreeCAD import Vector
 import Arch
+import Part
 from bimtests import TestArchBase
 
 
@@ -36,7 +37,7 @@ class TestArchStructure(TestArchBase.TestArchBase):
         structure = Arch.makeStructure(length=2, width=3, height=5)
         self.assertTrue(structure, "BIM Structure failed")
 
-    #  Dimensions
+    # Dimensions
     def test_makeStructure_explicit_dimensions(self):
         """Explicit length/width/height are stored on the object."""
         self.printTestMessage("makeStructure with explicit dimensions")
@@ -55,7 +56,7 @@ class TestArchStructure(TestArchBase.TestArchBase):
         self.assertGreater(structure.Width.Value, 0, "Default Width should be positive")
         self.assertGreater(structure.Height.Value, 0, "Default Height should be positive")
 
-    #  IfcType classification
+    # IfcType classification
     def test_makeStructure_ifc_type_column(self):
         """Height > Length produces IfcType 'Column'."""
         self.printTestMessage("makeStructure IfcType Column")
@@ -76,7 +77,7 @@ class TestArchStructure(TestArchBase.TestArchBase):
         # from _Structure.__init__ ("Beam") is preserved.
         self.assertEqual(structure.IfcType, "Beam")
 
-    #  Auto-Label
+    # Auto-Label
     def test_makeStructure_custom_label(self):
         """A custom name overrides the automatic label."""
         self.printTestMessage("makeStructure custom label")
@@ -95,7 +96,7 @@ class TestArchStructure(TestArchBase.TestArchBase):
         structure = Arch.makeStructure(length=3000, height=100)
         self.assertIn("Beam", structure.Label)
 
-    #  Structural System
+    # Structural System
     def test_makeStructuralSystem_basic(self):
         """A structural system is created from a structure and an axis."""
         self.printTestMessage("makeStructuralSystem basic creation")
@@ -113,7 +114,7 @@ class TestArchStructure(TestArchBase.TestArchBase):
         result = Arch.makeStructuralSystem([], [])
         self.assertIsNone(result)
 
-    #  placeAlongEdge — base position
+    # placeAlongEdge: base position
     def test_placeAlongEdge_base_is_p1(self):
         """Placement base is always the first point."""
         self.printTestMessage("placeAlongEdge base == p1")
@@ -121,107 +122,86 @@ class TestArchStructure(TestArchBase.TestArchBase):
         end = Vector(100, 200, 3300)
         placement = Arch.placeAlongEdge(start, end)
         self.assertTrue(
-            placement.Base.isEqual(start, 1e-6),
+            placement.Base.isEqual(start, Part.Precision.confusion()),
             f"Placement base {placement.Base} should equal start {start}",
         )
 
-    #  placeAlongEdge — vertical column (non-horizontal mode)
-    def test_placeAlongEdge_vertical_column_z_axis(self):
-        """Vertical column: the placement's local Z axis should point upward."""
-        self.printTestMessage("placeAlongEdge vertical column Z axis")
-        start = Vector(0, 0, 0)
-        end = Vector(0, 0, 1000)
+    # placeAlongEdge: degenerate cases
+    def test_placeAlongEdge_coincident_points(self):
+        """Coincident points (zero-length edge) should return identity placement."""
+        self.printTestMessage("placeAlongEdge coincident points")
+        start = Vector(10, 10, 10)
+        end = Vector(10, 10, 10)
         placement = Arch.placeAlongEdge(start, end)
-        local_z = placement.Rotation.multVec(Vector(0, 0, 1))
-        self.assertAlmostEqual(
-            abs(local_z.z),
-            1,
-            places=5,
-            msg=f"Local Z {local_z} should be aligned with global Z",
+        self.assertTrue(placement.Base.isEqual(start, Part.Precision.confusion()))
+        self.assertEqual(
+            placement.Rotation.Angle, 0.0, "Zero-length edge should result in identity rotation"
         )
 
-    #  placeAlongEdge — horizontal (beam) mode
-    def test_placeAlongEdge_horizontal_along_x(self):
-        """Horizontal beam along X: local X axis points along the beam direction."""
-        self.printTestMessage("placeAlongEdge horizontal along X")
-        start = Vector(0, 0, 0)
-        end = Vector(1000, 0, 0)
-        placement = Arch.placeAlongEdge(start, end, horizontal=True)
-        local_x = placement.Rotation.multVec(Vector(1, 0, 0))
-        self.assertAlmostEqual(
-            abs(local_x.x),
-            1,
-            places=5,
-            msg=f"Local X {local_x} should be aligned with global X",
-        )
+    # placeAlongEdge: orientation permutations
+    _WP_ALIGNMENTS = [
+        ("top", App.Rotation()),
+        ("front", App.Rotation(Vector(1, 0, 0), 90)),
+        ("right", App.Rotation(Vector(0, 1, 0), 90)),
+        ("45 degrees", App.Rotation(Vector(0, 0, 1), 45)),
+    ]
 
-    def test_placeAlongEdge_horizontal_along_y(self):
-        """Horizontal beam along Y: local X axis points along the beam direction."""
-        self.printTestMessage("placeAlongEdge horizontal along Y")
-        start = Vector(0, 0, 0)
-        end = Vector(0, 1000, 0)
-        placement = Arch.placeAlongEdge(start, end, horizontal=True)
-        local_x = placement.Rotation.multVec(Vector(1, 0, 0))
-        self.assertAlmostEqual(
-            abs(local_x.y),
-            1,
-            places=5,
-            msg=f"Local X {local_x} should be aligned with global Y",
-        )
+    _BEAM_DIRECTIONS = [
+        ("X axis", Vector(0, 0, 0), Vector(1000, 0, 0)),
+        ("Y axis", Vector(0, 0, 0), Vector(0, 1000, 0)),
+        ("Z axis", Vector(0, 0, 0), Vector(0, 0, 1000)),
+        ("XZ tilt", Vector(0, 0, 0), Vector(1000, 0, 300)),
+        ("XY diagonal", Vector(0, 0, 0), Vector(1000, 1000, 0)),
+        ("3D diagonal", Vector(0, 0, 0), Vector(2000, 2000, 2000)),
+    ]
 
-    def test_placeAlongEdge_horizontal_diagonal_x_axis(self):
-        """Diagonal horizontal beam: local X axis points along the beam direction."""
-        self.printTestMessage("placeAlongEdge horizontal diagonal X axis")
-        start = Vector(0, 0, 0)
-        end = Vector(1000, 500, 300)
-        placement = Arch.placeAlongEdge(start, end, horizontal=True)
-        beam_dir = end - start
-        beam_dir.normalize()
-        local_x = placement.Rotation.multVec(Vector(1, 0, 0))
-        local_x.normalize()
-        dot = abs(local_x.dot(beam_dir))
-        self.assertAlmostEqual(
-            dot,
-            1,
-            places=5,
-            msg=f"Local X {local_x} should be aligned with beam direction {beam_dir}",
-        )
+    def _check_beam_orientation(self, wp_rotation, start, end, horizontal, label):
+        """Verify axis alignment and absence of roll for non-degenerate edges."""
+        import WorkingPlane
 
-    #  placeAlongEdge — frame orthogonality
-    def test_placeAlongEdge_orthogonal_frame(self):
-        """The resulting rotation frame has mutually orthogonal axes."""
-        self.printTestMessage("placeAlongEdge orthogonal frame")
-        start = Vector(0, 0, 0)
-        end = Vector(1000, 500, 300)
-        placement = Arch.placeAlongEdge(start, end)
-        local_x = placement.Rotation.multVec(Vector(1, 0, 0))
-        local_y = placement.Rotation.multVec(Vector(0, 1, 0))
-        local_z = placement.Rotation.multVec(Vector(0, 0, 1))
-        self.assertAlmostEqual(
-            local_x.dot(local_y), 0, places=5, msg="X and Y axes should be orthogonal"
-        )
-        self.assertAlmostEqual(
-            local_x.dot(local_z), 0, places=5, msg="X and Z axes should be orthogonal"
-        )
-        self.assertAlmostEqual(
-            local_y.dot(local_z), 0, places=5, msg="Y and Z axes should be orthogonal"
-        )
+        wp = WorkingPlane.PlaneBase()
+        wp.align_to_rotation(wp_rotation)
+        wp_normal = wp.axis
 
-    def test_placeAlongEdge_diagonal_orthogonal_frame(self):
-        """Diagonal beam in XZ plane also has an orthogonal frame."""
-        self.printTestMessage("placeAlongEdge diagonal orthogonal frame")
-        start = Vector(0, 0, 0)
-        end = Vector(1000, 0, 1000)
-        placement = Arch.placeAlongEdge(start, end)
-        local_x = placement.Rotation.multVec(Vector(1, 0, 0))
-        local_y = placement.Rotation.multVec(Vector(0, 1, 0))
-        local_z = placement.Rotation.multVec(Vector(0, 0, 1))
-        self.assertAlmostEqual(local_x.dot(local_y), 0, places=5)
-        self.assertAlmostEqual(local_x.dot(local_z), 0, places=5)
-        self.assertAlmostEqual(local_y.dot(local_z), 0, places=5)
+        placement = Arch.placeAlongEdge(start, end, horizontal, wp=wp)
+        rotation = placement.Rotation
+        edge_direction = end.sub(start)
+        edge_direction.normalize()
 
-    #  placeAlongEdge — cross-section roll
-    @unittest.expectedFailure
+        local_x = rotation.multVec(Vector(1, 0, 0))
+        local_y = rotation.multVec(Vector(0, 1, 0))
+        local_z = rotation.multVec(Vector(0, 0, 1))
+
+        lateral = wp_normal.cross(edge_direction)
+        lateral.normalize()
+
+        if horizontal:
+            self.assertAlmostEqual(
+                abs(local_x.dot(edge_direction)),
+                1,
+                places=5,
+                msg=f"{label}: local X should align with edge direction",
+            )
+            self.assertAlmostEqual(
+                local_z.dot(lateral),
+                0,
+                places=5,
+                msg=f"{label}: local Z should lie in the edge/WP-normal plane (no roll)",
+            )
+        else:
+            self.assertAlmostEqual(
+                abs(local_z.dot(edge_direction)),
+                1,
+                places=5,
+                msg=f"{label}: local Z should align with edge direction",
+            )
+            self.assertAlmostEqual(
+                local_y.dot(lateral),
+                0,
+                places=5,
+                msg=f"{label}: local Y should lie in the edge/WP-normal plane (no roll)",
+            )
+
     def test_placeAlongEdge_tilted_beam_cross_section_stays_upright(self):
         """For a tilted beam, the cross-section Y axis must remain perfectly
         horizontal (zero roll).
@@ -231,63 +211,50 @@ class TestArchStructure(TestArchBase.TestArchBase):
         global XY plane. Any deviation in the Z component of local Y
         indicates roll.
         """
+        import WorkingPlane
+
         self.printTestMessage("placeAlongEdge tilted beam zero roll")
         start = Vector(0, 0, 0)
         end = Vector(1000, 0, 300)
-        placement = Arch.placeAlongEdge(start, end)
+        wp = WorkingPlane.PlaneBase()
+        placement = Arch.placeAlongEdge(start, end, horizontal=False, wp=wp)
 
         # Transform the local Y axis (0, 1, 0) into global coordinates
         local_y = placement.Rotation.multVec(Vector(0, 1, 0))
 
-        # In a perfect Yaw-Pitch rotation sequence, the local Y axis stays
-        # strictly in the horizontal plane (Z=0).
-        self.assertAlmostEqual(
-            local_y.z,
-            0.0,
-            places=7,
-            msg=f"Cross-section Y axis {local_y} has roll: Z component is {local_y.z:.7f} (expected 0.0)",
-        )
+        edge_direction = end.sub(start)
+        edge_direction.normalize()
+        lateral = wp.axis.cross(edge_direction)
+        lateral.normalize()
 
-    def test_placeAlongEdge_steep_beam_cross_section_roll(self):
-        """For a steeply tilted beam (45°), the cross-section should still have
-        a predictable roll that keeps the Y axis roughly level."""
-        self.printTestMessage("placeAlongEdge steep beam roll")
-        start = Vector(0, 0, 0)
-        end = Vector(1000, 500, 1000)
-        placement = Arch.placeAlongEdge(start, end)
-        local_y = placement.Rotation.multVec(Vector(0, 1, 0))
-        # Even at 45° tilt, the cross-section Y should not plunge nearly
-        # vertical. |local_y.z| should be well under 1.
-        self.assertLess(
-            abs(local_y.z),
-            0.75,
-            msg=f"Cross-section Y axis {local_y} has too much Z component "
-            f"({abs(local_y.z):.3f}), indicating excessive roll",
-        )
-
-    #  placeAlongEdge — degenerate cases
-    def test_placeAlongEdge_parallel_to_up_returns_identity(self):
-        """When beam direction is parallel to the WP axis, the cross product
-        is zero and the function returns identity rotation."""
-        self.printTestMessage("placeAlongEdge parallel to WP up axis")
-        start = Vector(0, 0, 0)
-        end = Vector(0, 0, 1000)
-        placement = Arch.placeAlongEdge(start, end, horizontal=True)
-        identity = App.Rotation()
+        # The cross-section Y axis must lie in the span/WP-normal plane (no roll).
         self.assertAlmostEqual(
-            placement.Rotation.Angle,
-            identity.Angle,
+            local_y.dot(lateral),
+            0,
             places=5,
-            msg="Should be identity rotation when beam is parallel to WP axis",
+            msg=f"Cross-section Y axis {local_y} has roll around the span axis",
         )
 
-    def test_placeAlongEdge_coincident_points(self):
-        """Coincident points (zero-length edge) should return identity placement."""
-        self.printTestMessage("placeAlongEdge coincident points")
-        start = Vector(10, 10, 10)
-        end = Vector(10, 10, 10)
-        placement = Arch.placeAlongEdge(start, end)
-        self.assertTrue(placement.Base.isEqual(start, 1e-6))
-        self.assertEqual(
-            placement.Rotation.Angle, 0.0, "Zero-length edge should result in identity rotation"
-        )
+    def test_placeAlongEdge_orientation(self):
+        """Axis alignment and roll across WP alignments, beam directions, and modes.
+
+        Skips combinations where the edge is parallel to the WP normal; the
+        identity-rotation behaviour for that degenerate case is covered by
+        ``test_placeAlongEdge_parallel_to_up_returns_identity``.
+        """
+        import WorkingPlane
+
+        self.printTestMessage("placeAlongEdge orientation permutations")
+        for wp_name, wp_rotation in self._WP_ALIGNMENTS:
+            wp = WorkingPlane.PlaneBase()
+            wp.align_to_rotation(wp_rotation)
+            for direction_name, start, end in self._BEAM_DIRECTIONS:
+                edge = end.sub(start)
+                edge.normalize()
+                if wp.axis.cross(edge).Length <= Part.Precision.confusion():
+                    continue
+                for horizontal in (True, False):
+                    mode = "beam" if horizontal else "profile"
+                    label = f"{wp_name} WP, {direction_name}, {mode}"
+                    with self.subTest(label):
+                        self._check_beam_orientation(wp_rotation, start, end, horizontal, label)


### PR DESCRIPTION
> [!NOTE]
>
> This is not yet ready for review. It's taking the review notes from https://github.com/FreeCAD/FreeCAD/pull/28893#issuecomment-4186810967 into account, but there are many cases to check and I've not covered them all, or fully understood them yet.

Tilted structural profile beams (H, U, etc.) were placed with unwanted roll around their span axis. For those profile beams the cross-section vectors were assigned to the wrong local axis slots (X and Y swapped), and the resulting misalignment was patched up with a 90° correction rotation. The correction made the placement look right for level beams but left tilted ones rolled.

Fix by assignin  the cross-section vectors to the correct local axis slots and dropping the 90° correction. There is no o change in behaviour for level beams, but now tilted profile beams are now placed without roll.

Tests were refactored from a list of individual methods into a permutation of working plane, edge direction and placement. The previously `@expectedFailure` tilted beam test is kept now as a passing test, with a corrected assertion.

## Structure creation scenarios

For reference purposes as context to test/review this PR:

<details>

| Entry point | Mode | Profile selection | What's created | Placement method | horizontal parameter |
| -- | -- | -- | -- | -- | -- |
| BimColumn | COLUMN | None (plain box) | makeStructure(l,w,h) | Single point + WP rotation | N/A |
| BimColumn | COLUMN | Structural profile (H, U, L, T, C, R, RH, TSLOT) | makeProfile() + makeStructure(p, height=H) | Single point + WP rotation | N/A |
| BimColumn | COLUMN | Precast concrete | ArchPrecast.makePrecast(...) | Single point + WP rotation + delta offset | N/A |
| BimBeam | BEAM | None (plain box) | makeStructure(l,w,h) | **placeAlongEdge**(bp, pt, True) | True |
| BimBeam | BEAM | Structural profile (H, U, L, T, C, R, RH, TSLOT) | makeProfile() + makeStructure(p, length=L) | **placeAlongEdge**(bp, pt, False) | False |
| BimBeam | BEAM | Precast concrete | ArchPrecast.makePrecast(...) | **placeAlongEdge**(bp, pt, True) | True |

</details>

## Notes

1. The fact that we need a `horizontal` parameter that is exclusively used to differentiate whether a beam is extruded in the X or Z direction makes the code unnecessarily complex, and less readable/maintainable. I _think_ we could unify the extrusion direction, but then we'd probably need to add a migration for old files. I've preferred not to do this to avoid scope creep. I probably won't follow up on this in a subsequent PR either, but someone else who might be interested could.
2. Better names for the `horizontal` parameter could be `extruded_horizontally`, `extruded_along_x` or something along these lines. The name has been left unchanded.
3. The `wp` parameter has been added for testability. Passing `wp=` directly seems to be the only way to define a non-default (top) WP into `placeAlongEdge` in the headless tests environment.

## Issues

Fixes: https://github.com/FreeCAD/FreeCAD/issues/15704