### PR TITLE
CAM: Switch CAM Path.Log to per-module global class instance to prevent expensive backtraces

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathLogNew.py
+++ b/src/Mod/CAM/CAMTests/TestPathLogNew.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2016 sliptonic <shopinthewoods@gmail.com>               *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   This program is distributed in the hope that it will be useful,       *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with this program; if not, write to the Free Software   *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+import Path
+import unittest
+
+
+class TestPathLogNew(unittest.TestCase):
+    """Some basic tests for the new logging framework."""
+
+    logger = None
+
+    def setUp(self):
+        self.logger = Path.Log.getModuleLogger(withLevel=Path.Log.Level.RESET, enableTracking=False)
+        Path.Log.setLevel(Path.Log.Level.RESET)
+        Path.Log.untrackAllModules()
+
+    def callerFile(self):
+        return Path.Log._caller()[0]
+
+    def callerLine(self):
+        return Path.Log._caller()[1]
+
+    def callerFunc(self):
+        return Path.Log._caller()[2]
+
+    def test00(self):
+        """Check for proper module extraction."""
+        self.assertEqual(self.callerFile(), self.logger.getModule())
+
+    def test01(self):
+        """Check for proper function extraction."""
+        self.assertEqual(self.callerFunc(), "test01")
+
+    def test10(self):
+        """Verify default log levels is NOTICE."""
+        self.assertEqual(self.logger.getLevel(), Path.Log.Level.NOTICE)
+        self.assertEqual(Path.Log.getLevel(self.logger.getModule()), Path.Log.Level.NOTICE)
+
+    def test11(self):
+        """Verify setting global log level."""
+        Path.Log.setLevel(Path.Log.Level.DEBUG)
+
+        self.assertEqual(self.logger.getLevel(), Path.Log.Level.DEBUG)
+        self.assertEqual(Path.Log.getLevel(self.logger.getModule()), Path.Log.Level.DEBUG)
+
+    def test12(self):
+        """Verify setting module log level."""
+        self.logger.setLevel(Path.Log.Level.DEBUG)
+
+        self.assertEqual(Path.Log.getLevel(), Path.Log.Level.NOTICE)
+        self.assertEqual(self.logger.getLevel(), Path.Log.Level.DEBUG)
+        self.assertEqual(Path.Log.getLevel(self.logger.getModule()), Path.Log.Level.DEBUG)
+
+    def test13(self):
+        """Verify setting other modul's log level doesn't change this one's."""
+        # if this test fails then most likely the global RESET is broken
+        Path.Log.setLevel(Path.Log.Level.DEBUG, "SomeOtherModule")
+
+        self.assertEqual(self.logger.getLevel(), Path.Log.Level.NOTICE)
+        self.assertEqual(Path.Log.getLevel(self.logger.getModule()), Path.Log.Level.NOTICE)
+
+    def test14(self):
+        """Verify resetting log level for module falls back to global level."""
+        self.logger.setLevel(Path.Log.Level.DEBUG)
+        self.assertEqual(self.logger.getLevel(), Path.Log.Level.DEBUG)
+        self.assertEqual(Path.Log.getLevel(self.logger.getModule()), Path.Log.Level.DEBUG)
+        # changing global log level does not affect module
+        Path.Log.setLevel(Path.Log.Level.ERROR)
+        self.assertEqual(self.logger.getLevel(), Path.Log.Level.DEBUG)
+        self.assertEqual(Path.Log.getLevel(self.logger.getModule()), Path.Log.Level.DEBUG)
+        # resetting module log level restores global log level for module
+        self.logger.setLevel(Path.Log.Level.RESET)
+        self.assertEqual(self.logger.getLevel(), Path.Log.Level.ERROR)
+        self.assertEqual(Path.Log.getLevel(self.logger.getModule()), Path.Log.Level.ERROR)
+        # changing the global log level will also change the module log level
+        Path.Log.setLevel(Path.Log.Level.DEBUG)
+        self.assertEqual(self.logger.getLevel(), Path.Log.Level.DEBUG)
+        self.assertEqual(Path.Log.getLevel(self.logger.getModule()), Path.Log.Level.DEBUG)
+
+    def test20(self):
+        """Verify debug logs aren't logged by default."""
+        self.assertIsNone(self.logger.debug("this"))
+
+    def test21(self):
+        """Verify debug logs are logged if log level is set to DEBUG."""
+        self.logger.setLevel(Path.Log.Level.DEBUG)
+        self.assertIsNotNone(self.logger.debug("this"))
+
+    def test30(self):
+        """Verify log level ERROR."""
+        self.logger.setLevel(Path.Log.Level.ERROR)
+        self.assertIsNone(self.logger.debug("something"))
+        self.assertIsNone(self.logger.info("something"))
+        self.assertIsNone(self.logger.notice("something"))
+        self.assertIsNone(self.logger.warning("something"))
+        self.assertIsNotNone(self.logger.error("something"))
+
+    def test31(self):
+        """Verify log level WARNING."""
+        self.logger.setLevel(Path.Log.Level.WARNING)
+        self.assertIsNone(self.logger.debug("something"))
+        self.assertIsNone(self.logger.info("something"))
+        self.assertIsNone(self.logger.notice("something"))
+        self.assertIsNotNone(self.logger.warning("something"))
+        self.assertIsNotNone(self.logger.error("something"))
+
+    def test32(self):
+        """Verify log level NOTICE."""
+        self.logger.setLevel(Path.Log.Level.NOTICE)
+        self.assertIsNone(self.logger.debug("something"))
+        self.assertIsNone(self.logger.info("something"))
+        self.assertIsNotNone(self.logger.notice("something"))
+        self.assertIsNotNone(self.logger.warning("something"))
+        self.assertIsNotNone(self.logger.error("something"))
+
+    def test33(self):
+        """Verify log level INFO."""
+        self.logger.setLevel(Path.Log.Level.INFO)
+        self.assertIsNone(self.logger.debug("something"))
+        self.assertIsNotNone(self.logger.info("something"))
+        self.assertIsNotNone(self.logger.notice("something"))
+        self.assertIsNotNone(self.logger.warning("something"))
+        self.assertIsNotNone(self.logger.error("something"))
+
+    def test34(self):
+        """Verify log level DEBUG."""
+        self.logger.setLevel(Path.Log.Level.DEBUG)
+        self.assertIsNotNone(self.logger.debug("something"))
+        self.assertIsNotNone(self.logger.info("something"))
+        self.assertIsNotNone(self.logger.notice("something"))
+        self.assertIsNotNone(self.logger.warning("something"))
+        self.assertIsNotNone(self.logger.error("something"))
+
+    def test50(self):
+        """Verify no tracking by default."""
+        self.assertIsNone(self.logger.track("this", "and", "that"))
+
+    def test51(self):
+        """Verify enabling tracking for module results in tracking."""
+        self.logger.enableTracking()
+        # Don't want to rely on the line number matching - still want some
+        # indication that track does the right thing ....
+        msg = self.logger.track("this", "and", "that")
+        self.assertTrue(msg.startswith(self.logger.getModule()))
+        self.assertTrue(msg.endswith("test51(this, and, that)"))
+
+    def test52(self):
+        """Verify untracking stops tracking."""
+        self.logger.enableTracking()
+        self.assertIsNotNone(self.logger.track("this", "and", "that"))
+        self.logger.disableTracking()
+        self.assertIsNone(self.logger.track("this", "and", "that"))
+
+    def test53(self):
+        """Verify trackAllModules works correctly."""
+        Path.Log.trackAllModules(True)
+        self.assertIsNotNone(self.logger.track("this", "and", "that"))
+        Path.Log.trackAllModules(False)
+        self.assertIsNone(self.logger.track("this", "and", "that"))
+        Path.Log.trackAllModules(True)
+        self.logger.enableTracking()
+        self.assertIsNotNone(self.logger.track("this", "and", "that"))
+        Path.Log.trackAllModules(False)
+        self.assertIsNotNone(self.logger.track("this", "and", "that"))
+
+    def test60(self):
+        """Verify track handles no argument."""
+        self.logger.enableTracking()
+        msg = self.logger.track()
+        self.assertTrue(msg.startswith(self.logger.getModule()))
+        self.assertTrue(msg.endswith("test60()"))
+
+    def test61(self):
+        """Verify track handles arbitrary argument types correctly."""
+        self.logger.enableTracking()
+        msg = self.logger.track("this", None, 1, 18.25)
+        self.assertTrue(msg.startswith(self.logger.getModule()))
+        self.assertTrue(msg.endswith("test61(this, None, 1, 18.25)"))
+
+    def test70(self):
+        """Verify format args are properly passed to track."""
+        self.logger.enableTracking()
+        msg = self.logger.track("this", None, 1, 18.25, fmt="foo={} bar={} a={} b={}")
+        self.assertTrue(msg.startswith(f"{self.logger.getModule()}("))
+        self.assertTrue(msg.endswith(").test70(foo=this bar=None a=1 b=18.25)"))
+
+    def test71(self):
+        self.logger.setLevel(Path.Log.Level.DEBUG)
+
+        module = self.logger.getModule()
+        debug_message = self.logger.debug("something x={}", 1)
+        self.assertTrue(debug_message.startswith(f"{module}.DEBUG: ("))
+        self.assertTrue(debug_message.endswith(") - something x=1\n"))
+        self.assertEqual(self.logger.info("something x={}", 2), f"{module}.INFO: something x=2\n")
+        self.assertEqual(self.logger.notice("something x={}", 3), f"{module}.NOTICE: something x=3\n")
+        self.assertEqual(self.logger.warning("something x={}", 4), f"{module}.WARNING: something x=4\n")
+        self.assertEqual(self.logger.error("something x={}", 5), f"{module}.ERROR: something x=5\n")
+
+    def testzz(self):
+        """Restoring environment after tests."""
+        self.logger.setLevel(Path.Log.Level.RESET)

--- a/src/Mod/CAM/CAMTests/TestPathLogNew.py
+++ b/src/Mod/CAM/CAMTests/TestPathLogNew.py
@@ -213,8 +213,12 @@ class TestPathLogNew(unittest.TestCase):
         self.assertTrue(debug_message.startswith(f"{module}.DEBUG: ("))
         self.assertTrue(debug_message.endswith(") - something x=1\n"))
         self.assertEqual(self.logger.info("something x={}", 2), f"{module}.INFO: something x=2\n")
-        self.assertEqual(self.logger.notice("something x={}", 3), f"{module}.NOTICE: something x=3\n")
-        self.assertEqual(self.logger.warning("something x={}", 4), f"{module}.WARNING: something x=4\n")
+        self.assertEqual(
+            self.logger.notice("something x={}", 3), f"{module}.NOTICE: something x=3\n"
+        )
+        self.assertEqual(
+            self.logger.warning("something x={}", 4), f"{module}.WARNING: something x=4\n"
+        )
         self.assertEqual(self.logger.error("something x={}", 5), f"{module}.ERROR: something x=5\n")
 
     def testzz(self):

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -558,6 +558,7 @@ SET(Tests_SRCS
     CAMTests/TestPathHelixGenerator.py
     CAMTests/TestPathLanguage.py
     CAMTests/TestPathLog.py
+    CAMTests/TestPathLogNew.py
     CAMTests/TestPathOpDeburr.py
     CAMTests/TestPathOpUtil.py
     CAMTests/TestPostCore.py

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -74,9 +74,7 @@ def debugMarker(vector, label, color=None, radius=0.5):
         obj = FreeCAD.ActiveDocument.addObject("Part::Sphere", label)
         obj.Label = label
         obj.Radius = radius
-        obj.Placement = FreeCAD.Placement(
-            vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0)
-        )
+        obj.Placement = FreeCAD.Placement(vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0))
         if color:
             obj.ViewObject.ShapeColor = color
 
@@ -87,9 +85,7 @@ def debugCylinder(vector, r, height, label, color=None):
         obj.Label = label
         obj.Radius = r
         obj.Height = height
-        obj.Placement = FreeCAD.Placement(
-            vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0)
-        )
+        obj.Placement = FreeCAD.Placement(vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0))
         obj.ViewObject.Transparency = 90
         if color:
             obj.ViewObject.ShapeColor = color
@@ -102,9 +98,7 @@ def debugCone(vector, r1, r2, height, label, color=None):
         obj.Radius1 = r1
         obj.Radius2 = r2
         obj.Height = height
-        obj.Placement = FreeCAD.Placement(
-            vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0)
-        )
+        obj.Placement = FreeCAD.Placement(vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0))
         obj.ViewObject.Transparency = 90
         if color:
             obj.ViewObject.ShapeColor = color
@@ -191,9 +185,7 @@ class Tag:
             # degenerated case - no tag
             logger.debug("Part.makeSphere({} / 10000)", r1)
             self.solid = Part.makeSphere(r1 / 10000)
-        if not Path.Geom.isRoughly(
-            0, R
-        ):  # testing is easier if the solid is not rotated
+        if not Path.Geom.isRoughly(0, R):  # testing is easier if the solid is not rotated
             angle = -Path.Geom.getAngle(self.originAt(0)) * 180 / math.pi
             logger.debug("solid.rotate({})", angle)
             self.solid.rotate(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1), angle)
@@ -209,9 +201,7 @@ class Tag:
     def filterIntersections(self, pts, face):
         if type(face.Surface) in [Part.Cone, Part.Cylinder, Part.Toroid]:
             logger.track("it's a cone/cylinder, checking z")
-            return list(
-                [pt for pt in pts if pt.z >= self.bottom() and pt.z <= self.top()]
-            )
+            return list([pt for pt in pts if pt.z >= self.bottom() and pt.z <= self.top()])
         if type(face.Surface) is Part.Plane:
             logger.track("it's a plane, checking R")
             c = face.Edges[0].Curve
@@ -275,9 +265,7 @@ class Tag:
             zLast = edge.valueAt(edge.LastParameter).z
             zMax = self.top()
             if isDefinitelySmaller(zFirst, zMax) or isDefinitelySmaller(zLast, zMax):
-                return self.nextIntersectionClosestTo(
-                    edge, self.solid, edge.valueAt(param)
-                )
+                return self.nextIntersectionClosestTo(edge, self.solid, edge.valueAt(param))
         return None
 
     def bbEdges(self):
@@ -389,9 +377,9 @@ class MapWireToTag:
             p2 = e.valueAt(e.LastParameter)
             self.edgePoints.append(p1)
             self.edgePoints.append(p2)
-            if self.tag.solid.isInside(
-                p1, Path.Geom.Tolerance, False
-            ) or self.tag.solid.isInside(p2, Path.Geom.Tolerance, False):
+            if self.tag.solid.isInside(p1, Path.Geom.Tolerance, False) or self.tag.solid.isInside(
+                p2, Path.Geom.Tolerance, False
+            ):
                 edges.remove(e)
                 debugEdge(e, "......... X0", force=False)
             else:
@@ -409,9 +397,7 @@ class MapWireToTag:
         # we need to add in the missing segment and collect the new entry/exit edges.
         if not self.entryEdges:
             logger.debug("fill entryEdges…")
-            self.realEntry = sorted(
-                self.edgePoints, key=lambda p: (p - self.entry).Length
-            )[0]
+            self.realEntry = sorted(self.edgePoints, key=lambda p: (p - self.entry).Length)[0]
             self.entryEdges = list(
                 [e for e in edges if Path.Geom.edgeConnectsTo(e, self.realEntry)]
             )
@@ -420,12 +406,8 @@ class MapWireToTag:
             self.realEntry = None
         if not self.exitEdges:
             logger.debug("fill exitEdges…")
-            self.realExit = sorted(
-                self.edgePoints, key=lambda p: (p - self.exit).Length
-            )[0]
-            self.exitEdges = list(
-                [e for e in edges if Path.Geom.edgeConnectsTo(e, self.realExit)]
-            )
+            self.realExit = sorted(self.edgePoints, key=lambda p: (p - self.exit).Length)[0]
+            self.exitEdges = list([e for e in edges if Path.Geom.edgeConnectsTo(e, self.realExit)])
             edges.append(Part.Edge(Part.LineSegment(self.realExit, self.exit)))
         else:
             self.realExit = None
@@ -492,9 +474,7 @@ class MapWireToTag:
                         cnt = 0
                         for p in reversed(e.discretize(Deflection=0.01)):
                             if p0 is not None:
-                                outputEdges.append(
-                                    (Part.Edge(Part.LineSegment(p0, p)), True)
-                                )
+                                outputEdges.append((Part.Edge(Part.LineSegment(p0, p)), True))
                                 cnt = cnt + 1
                             p0 = p
                         logger.info("replaced edge with {} straight segments", cnt)
@@ -592,9 +572,7 @@ class MapWireToTag:
                     else:
                         if rapid:
                             commands.append(
-                                Path.Command(
-                                    "G0", {"X": rapid.x, "Y": rapid.y, "Z": rapid.z}
-                                )
+                                Path.Command("G0", {"X": rapid.x, "Y": rapid.y, "Z": rapid.z})
                             )
                             rapid = None
                         commands.extend(
@@ -606,9 +584,7 @@ class MapWireToTag:
                             )
                         )
                 if rapid:
-                    commands.append(
-                        Path.Command("G0", {"X": rapid.x, "Y": rapid.y, "Z": rapid.z})
-                    )
+                    commands.append(Path.Command("G0", {"X": rapid.x, "Y": rapid.y, "Z": rapid.z}))
                     # rapid = None  # commented out per LGTM suggestion
                 return commands
             except Exception as e:
@@ -635,9 +611,7 @@ class MapWireToTag:
     def add(self, edge):
         self.tail = None
         self.finalEdge = edge
-        if self.tag.solid.isInside(
-            edge.valueAt(edge.LastParameter), Path.Geom.Tolerance, True
-        ):
+        if self.tag.solid.isInside(edge.valueAt(edge.LastParameter), Path.Geom.Tolerance, True):
             logger.track("solid.isInside")
             self.addEdge(edge)
         else:
@@ -762,9 +736,7 @@ class PathData:
         edges = sorted(wire.Edges, key=lambda e: e.Length)
         return (edges[0], edges[-1])
 
-    def generateTags(
-        self, obj, count, width=None, height=None, angle=None, radius=None
-    ):
+    def generateTags(self, obj, count, width=None, height=None, angle=None, radius=None):
         tags = []
         for wire in self.baseWires:
             logger.track(count, width, height, angle)
@@ -1144,14 +1116,10 @@ class ObjectTagDressup:
         vertRapid = tc.VertRapid.Value
 
         while edge or lastEdge < len(pathData.edges):
-            logger.debug(
-                "------- lastEdge = {}/{}.{}/{}", lastEdge, lastTag, t, len(tags)
-            )
+            logger.debug("------- lastEdge = {}/{}.{}/{}", lastEdge, lastTag, t, len(tags))
             if not edge:
                 edge = pathData.edges[lastEdge]
-                debugEdge(
-                    edge, "=======  new edge: {}/{}", lastEdge, len(pathData.edges)
-                )
+                debugEdge(edge, "=======  new edge: {}/{}", lastEdge, len(pathData.edges))
                 lastEdge += 1
 
             if mapper:
@@ -1193,14 +1161,10 @@ class ObjectTagDressup:
                             and not Path.Geom.isRoughly(0, v.Z)
                         ):
                             # The very first move is just to move to ClearanceHeight
-                            commands.append(
-                                Path.Command("G0", {"Z": v.Z, "F": horizRapid})
-                            )
+                            commands.append(Path.Command("G0", {"Z": v.Z, "F": horizRapid}))
                         else:
                             commands.append(
-                                Path.Command(
-                                    "G0", {"X": v.X, "Y": v.Y, "Z": v.Z, "F": vertRapid}
-                                )
+                                Path.Command("G0", {"X": v.X, "Y": v.Y, "Z": v.Z, "F": vertRapid})
                             )
                     else:
                         commands.extend(
@@ -1247,21 +1211,17 @@ class ObjectTagDressup:
                         prev.solid.BoundBox.intersect(tag.solid.BoundBox)
                         and prev.solid.common(tag.solid).Faces
                     ):
-                        logger.info(
-                            "Tag #%d intersects with previous tag - disabling\n" % i
-                        )
+                        logger.info("Tag #%d intersects with previous tag - disabling\n" % i)
                         logger.debug("this tag = %d [%s]" % (i, tag.solid.BoundBox))
                         tag.enabled = False
                 elif self.pathData.edges:
                     e = self.pathData.edges[0]
                     p0 = e.valueAt(e.FirstParameter)
                     p1 = e.valueAt(e.LastParameter)
-                    if tag.solid.isInside(
-                        p0, Path.Geom.Tolerance, True
-                    ) or tag.solid.isInside(p1, Path.Geom.Tolerance, True):
-                        logger.info(
-                            "Tag #{} intersects with starting point - disabling\n", i
-                        )
+                    if tag.solid.isInside(p0, Path.Geom.Tolerance, True) or tag.solid.isInside(
+                        p1, Path.Geom.Tolerance, True
+                    ):
+                        logger.info("Tag #{} intersects with starting point - disabling\n", i)
                         tag.enabled = False
 
             if tag.enabled:
@@ -1303,9 +1263,7 @@ class ObjectTagDressup:
                 obj, obj.Positions, obj.Disabled
             )
             if obj.Disabled != disabled:
-                logger.debug(
-                    "Updating properties.... {} vs. {}", obj.Disabled, disabled
-                )
+                logger.debug("Updating properties.... {} vs. {}", obj.Disabled, disabled)
                 obj.Positions = positions
                 obj.Disabled = disabled
 
@@ -1407,9 +1365,7 @@ def Create(baseObject, name="DressupTag"):
     Create(basePath, name='DressupTag') … create tag dressup object for the given base path.
     """
     if not baseObject.isDerivedFrom("Path::Feature"):
-        logger.error(
-            translate("CAM_DressupTag", "The selected object is not a path") + "\n"
-        )
+        logger.error(translate("CAM_DressupTag", "The selected object is not a path") + "\n")
         return None
 
     if baseObject.isDerivedFrom("Path::FeatureCompoundPython"):

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -46,7 +46,9 @@ def debugEdge(edge, prefix, *args, force=False):
         prefixFmt = prefix.format(args)
         if type(edge.Curve) in [Part.Line, Part.LineSegment]:
             print(
-                "{} {}(({:.2f}, {:.2f}, {:.2f}) - ({:.2f}, {:.2f}, {:.2f}))".format(prefixFmt, type(edge.Curve), pf.x, pf.y, pf.z, pl.x, pl.y, pl.z)
+                "{} {}(({:.2f}, {:.2f}, {:.2f}) - ({:.2f}, {:.2f}, {:.2f}))".format(
+                    prefixFmt, type(edge.Curve), pf.x, pf.y, pf.z, pl.x, pl.y, pl.z
+                )
             )
         else:
             pm = edge.valueAt((edge.FirstParameter + edge.LastParameter) / 2)
@@ -72,7 +74,9 @@ def debugMarker(vector, label, color=None, radius=0.5):
         obj = FreeCAD.ActiveDocument.addObject("Part::Sphere", label)
         obj.Label = label
         obj.Radius = radius
-        obj.Placement = FreeCAD.Placement(vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0))
+        obj.Placement = FreeCAD.Placement(
+            vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0)
+        )
         if color:
             obj.ViewObject.ShapeColor = color
 
@@ -83,7 +87,9 @@ def debugCylinder(vector, r, height, label, color=None):
         obj.Label = label
         obj.Radius = r
         obj.Height = height
-        obj.Placement = FreeCAD.Placement(vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0))
+        obj.Placement = FreeCAD.Placement(
+            vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0)
+        )
         obj.ViewObject.Transparency = 90
         if color:
             obj.ViewObject.ShapeColor = color
@@ -96,7 +102,9 @@ def debugCone(vector, r1, r2, height, label, color=None):
         obj.Radius1 = r1
         obj.Radius2 = r2
         obj.Height = height
-        obj.Placement = FreeCAD.Placement(vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0))
+        obj.Placement = FreeCAD.Placement(
+            vector, FreeCAD.Rotation(FreeCAD.Vector(0, 0, 1), 0)
+        )
         obj.ViewObject.Transparency = 90
         if color:
             obj.ViewObject.ShapeColor = color
@@ -104,7 +112,16 @@ def debugCone(vector, r1, r2, height, label, color=None):
 
 class Tag:
     def __init__(self, nr, x, y, width, height, angle, radius, enabled=True):
-        logger.track(x, y, width, height, float(angle), float(radius), enabled, fmt="{:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {}")
+        logger.track(
+            x,
+            y,
+            width,
+            height,
+            float(angle),
+            float(radius),
+            enabled,
+            fmt="{:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {}",
+        )
         self.nr = nr
         self.x = x
         self.y = y
@@ -172,11 +189,13 @@ class Tag:
             self.solid = Part.makeCone(r1, r2, height)
         else:
             # degenerated case - no tag
-            logger.debug("Part.makeSphere({} / 10000)" , r1)
+            logger.debug("Part.makeSphere({} / 10000)", r1)
             self.solid = Part.makeSphere(r1 / 10000)
-        if not Path.Geom.isRoughly(0, R):  # testing is easier if the solid is not rotated
+        if not Path.Geom.isRoughly(
+            0, R
+        ):  # testing is easier if the solid is not rotated
             angle = -Path.Geom.getAngle(self.originAt(0)) * 180 / math.pi
-            logger.debug("solid.rotate({})" , angle)
+            logger.debug("solid.rotate({})", angle)
             self.solid.rotate(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1), angle)
         orig = self.originAt(z - 0.01 * self.actualHeight)
         logger.debug("solid.translate({})", orig)
@@ -190,7 +209,9 @@ class Tag:
     def filterIntersections(self, pts, face):
         if type(face.Surface) in [Part.Cone, Part.Cylinder, Part.Toroid]:
             logger.track("it's a cone/cylinder, checking z")
-            return list([pt for pt in pts if pt.z >= self.bottom() and pt.z <= self.top()])
+            return list(
+                [pt for pt in pts if pt.z >= self.bottom() and pt.z <= self.top()]
+            )
         if type(face.Surface) is Part.Plane:
             logger.track("it's a plane, checking R")
             c = face.Edges[0].Curve
@@ -234,7 +255,12 @@ class Tag:
             debugEdge(
                 edge,
                 "intersects ({:.2f}, {:.2f}, {:.2f}) -> ({:.2f}, {:.2f}, {:.2f})",
-                refPt.x, refPt.y, refPt.z, pt.x, pt.y, pt.z
+                refPt.x,
+                refPt.y,
+                refPt.z,
+                pt.x,
+                pt.y,
+                pt.z,
             )
             return pt
         return None
@@ -249,7 +275,9 @@ class Tag:
             zLast = edge.valueAt(edge.LastParameter).z
             zMax = self.top()
             if isDefinitelySmaller(zFirst, zMax) or isDefinitelySmaller(zLast, zMax):
-                return self.nextIntersectionClosestTo(edge, self.solid, edge.valueAt(param))
+                return self.nextIntersectionClosestTo(
+                    edge, self.solid, edge.valueAt(param)
+                )
         return None
 
     def bbEdges(self):
@@ -361,9 +389,9 @@ class MapWireToTag:
             p2 = e.valueAt(e.LastParameter)
             self.edgePoints.append(p1)
             self.edgePoints.append(p2)
-            if self.tag.solid.isInside(p1, Path.Geom.Tolerance, False) or self.tag.solid.isInside(
-                p2, Path.Geom.Tolerance, False
-            ):
+            if self.tag.solid.isInside(
+                p1, Path.Geom.Tolerance, False
+            ) or self.tag.solid.isInside(p2, Path.Geom.Tolerance, False):
                 edges.remove(e)
                 debugEdge(e, "......... X0", force=False)
             else:
@@ -381,7 +409,9 @@ class MapWireToTag:
         # we need to add in the missing segment and collect the new entry/exit edges.
         if not self.entryEdges:
             logger.debug("fill entryEdges…")
-            self.realEntry = sorted(self.edgePoints, key=lambda p: (p - self.entry).Length)[0]
+            self.realEntry = sorted(
+                self.edgePoints, key=lambda p: (p - self.entry).Length
+            )[0]
             self.entryEdges = list(
                 [e for e in edges if Path.Geom.edgeConnectsTo(e, self.realEntry)]
             )
@@ -390,8 +420,12 @@ class MapWireToTag:
             self.realEntry = None
         if not self.exitEdges:
             logger.debug("fill exitEdges…")
-            self.realExit = sorted(self.edgePoints, key=lambda p: (p - self.exit).Length)[0]
-            self.exitEdges = list([e for e in edges if Path.Geom.edgeConnectsTo(e, self.realExit)])
+            self.realExit = sorted(
+                self.edgePoints, key=lambda p: (p - self.exit).Length
+            )[0]
+            self.exitEdges = list(
+                [e for e in edges if Path.Geom.edgeConnectsTo(e, self.realExit)]
+            )
             edges.append(Part.Edge(Part.LineSegment(self.realExit, self.exit)))
         else:
             self.realExit = None
@@ -430,7 +464,7 @@ class MapWireToTag:
             self.exit.x,
             self.exit.y,
             self.exit.z,
-            fmt="entry({:.2f}, {:.2f}, {:.2f}), exit({:.2f}, {:.2f}, {:.2f})"
+            fmt="entry({:.2f}, {:.2f}, {:.2f}), exit({:.2f}, {:.2f}, {:.2f})",
         )
         self.edgesOrder = []
         outputEdges = []
@@ -458,7 +492,9 @@ class MapWireToTag:
                         cnt = 0
                         for p in reversed(e.discretize(Deflection=0.01)):
                             if p0 is not None:
-                                outputEdges.append((Part.Edge(Part.LineSegment(p0, p)), True))
+                                outputEdges.append(
+                                    (Part.Edge(Part.LineSegment(p0, p)), True)
+                                )
                                 cnt = cnt + 1
                             p0 = p
                         logger.info("replaced edge with {} straight segments", cnt)
@@ -486,7 +522,12 @@ class MapWireToTag:
             elif lastP:
                 logger.debug(
                     "xxxxxx ({:.2f}, {:.2f}, {:.2f}) ({:.2f}, {:.2f}, {:.2f})",
-                    p0.x, p0.y, p0.z, lastP.x, lastP.y, lastP.z
+                    p0.x,
+                    p0.y,
+                    p0.z,
+                    lastP.x,
+                    lastP.y,
+                    lastP.z,
                 )
             else:
                 logger.debug("xxxxxx ({:.2f}, {:.2f}, {:.2f}) -", p0.x, p0.y, p0.z)
@@ -551,7 +592,9 @@ class MapWireToTag:
                     else:
                         if rapid:
                             commands.append(
-                                Path.Command("G0", {"X": rapid.x, "Y": rapid.y, "Z": rapid.z})
+                                Path.Command(
+                                    "G0", {"X": rapid.x, "Y": rapid.y, "Z": rapid.z}
+                                )
                             )
                             rapid = None
                         commands.extend(
@@ -563,13 +606,17 @@ class MapWireToTag:
                             )
                         )
                 if rapid:
-                    commands.append(Path.Command("G0", {"X": rapid.x, "Y": rapid.y, "Z": rapid.z}))
+                    commands.append(
+                        Path.Command("G0", {"X": rapid.x, "Y": rapid.y, "Z": rapid.z})
+                    )
                     # rapid = None  # commented out per LGTM suggestion
                 return commands
             except Exception as e:
                 logger.error(
                     "Exception during processing tag @({:.2f}, {:.2f}) ({}) - disabling the tag",
-                    self.tag.x, self.tag.y, e.args[0]
+                    self.tag.x,
+                    self.tag.y,
+                    e.args[0],
                 )
                 self.tag.enabled = False
                 commands = []
@@ -588,7 +635,9 @@ class MapWireToTag:
     def add(self, edge):
         self.tail = None
         self.finalEdge = edge
-        if self.tag.solid.isInside(edge.valueAt(edge.LastParameter), Path.Geom.Tolerance, True):
+        if self.tag.solid.isInside(
+            edge.valueAt(edge.LastParameter), Path.Geom.Tolerance, True
+        ):
             logger.track("solid.isInside")
             self.addEdge(edge)
         else:
@@ -713,7 +762,9 @@ class PathData:
         edges = sorted(wire.Edges, key=lambda e: e.Length)
         return (edges[0], edges[-1])
 
-    def generateTags(self, obj, count, width=None, height=None, angle=None, radius=None):
+    def generateTags(
+        self, obj, count, width=None, height=None, angle=None, radius=None
+    ):
         tags = []
         for wire in self.baseWires:
             logger.track(count, width, height, angle)
@@ -774,12 +825,24 @@ class PathData:
             for i in range(startIndex + 1, len(Edges)):
                 edge = Edges[i]
                 currentLength, lastTagLength = self.processEdge(
-                    i, edge, currentLength, lastTagLength, tagDistance, minLength, edgeDict
+                    i,
+                    edge,
+                    currentLength,
+                    lastTagLength,
+                    tagDistance,
+                    minLength,
+                    edgeDict,
                 )
             for i in range(0, startIndex):
                 edge = Edges[i]
                 currentLength, lastTagLength = self.processEdge(
-                    i, edge, currentLength, lastTagLength, tagDistance, minLength, edgeDict
+                    i,
+                    edge,
+                    currentLength,
+                    lastTagLength,
+                    tagDistance,
+                    minLength,
+                    edgeDict,
                 )
 
             for i, counter in edgeDict.items():
@@ -887,7 +950,10 @@ class PathData:
         for tag in tags:
             logger.info(
                 "Tag #{} ({:.2f}, {:.2f}, {:.2f}) not on base wire - disabling\n",
-                len(ordered), tag.x, tag.y, self.minZ
+                len(ordered),
+                tag.x,
+                tag.y,
+                self.minZ,
             )
             tag.enabled = False
             ordered.append(tag)
@@ -1078,10 +1144,14 @@ class ObjectTagDressup:
         vertRapid = tc.VertRapid.Value
 
         while edge or lastEdge < len(pathData.edges):
-            logger.debug("------- lastEdge = {}/{}.{}/{}", lastEdge, lastTag, t, len(tags))
+            logger.debug(
+                "------- lastEdge = {}/{}.{}/{}", lastEdge, lastTag, t, len(tags)
+            )
             if not edge:
                 edge = pathData.edges[lastEdge]
-                debugEdge(edge, "=======  new edge: {}/{}", lastEdge, len(pathData.edges))
+                debugEdge(
+                    edge, "=======  new edge: {}/{}", lastEdge, len(pathData.edges)
+                )
                 lastEdge += 1
 
             if mapper:
@@ -1123,10 +1193,14 @@ class ObjectTagDressup:
                             and not Path.Geom.isRoughly(0, v.Z)
                         ):
                             # The very first move is just to move to ClearanceHeight
-                            commands.append(Path.Command("G0", {"Z": v.Z, "F": horizRapid}))
+                            commands.append(
+                                Path.Command("G0", {"Z": v.Z, "F": horizRapid})
+                            )
                         else:
                             commands.append(
-                                Path.Command("G0", {"X": v.X, "Y": v.Y, "Z": v.Z, "F": vertRapid})
+                                Path.Command(
+                                    "G0", {"X": v.X, "Y": v.Y, "Z": v.Z, "F": vertRapid}
+                                )
                             )
                     else:
                         commands.extend(
@@ -1173,17 +1247,21 @@ class ObjectTagDressup:
                         prev.solid.BoundBox.intersect(tag.solid.BoundBox)
                         and prev.solid.common(tag.solid).Faces
                     ):
-                        logger.info("Tag #%d intersects with previous tag - disabling\n" % i)
+                        logger.info(
+                            "Tag #%d intersects with previous tag - disabling\n" % i
+                        )
                         logger.debug("this tag = %d [%s]" % (i, tag.solid.BoundBox))
                         tag.enabled = False
                 elif self.pathData.edges:
                     e = self.pathData.edges[0]
                     p0 = e.valueAt(e.FirstParameter)
                     p1 = e.valueAt(e.LastParameter)
-                    if tag.solid.isInside(p0, Path.Geom.Tolerance, True) or tag.solid.isInside(
-                        p1, Path.Geom.Tolerance, True
-                    ):
-                        logger.info("Tag #{} intersects with starting point - disabling\n", i)
+                    if tag.solid.isInside(
+                        p0, Path.Geom.Tolerance, True
+                    ) or tag.solid.isInside(p1, Path.Geom.Tolerance, True):
+                        logger.info(
+                            "Tag #{} intersects with starting point - disabling\n", i
+                        )
                         tag.enabled = False
 
             if tag.enabled:
@@ -1225,7 +1303,9 @@ class ObjectTagDressup:
                 obj, obj.Positions, obj.Disabled
             )
             if obj.Disabled != disabled:
-                logger.debug("Updating properties.... {} vs. {}", obj.Disabled, disabled)
+                logger.debug(
+                    "Updating properties.... {} vs. {}", obj.Disabled, disabled
+                )
                 obj.Positions = positions
                 obj.Disabled = disabled
 
@@ -1327,7 +1407,9 @@ def Create(baseObject, name="DressupTag"):
     Create(basePath, name='DressupTag') … create tag dressup object for the given base path.
     """
     if not baseObject.isDerivedFrom("Path::Feature"):
-        logger.error(translate("CAM_DressupTag", "The selected object is not a path") + "\n")
+        logger.error(
+            translate("CAM_DressupTag", "The selected object is not a path") + "\n"
+        )
         return None
 
     if baseObject.isDerivedFrom("Path::FeatureCompoundPython"):

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -34,30 +34,25 @@ from lazy_loader.lazy_loader import LazyLoader
 
 Part = LazyLoader("Part", globals(), "Part")
 
-if False:
-    Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
-    Path.Log.trackModule(Path.Log.thisModule())
-else:
-    Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
+logger = Path.Log.getModuleLoggerWithLevelOrDebug(Path.Log.Level.INFO, False)
 
 translate = FreeCAD.Qt.translate
 
 
-def debugEdge(edge, prefix, force=False):
-    if force or Path.Log.getLevel(Path.Log.thisModule()) == Path.Log.Level.DEBUG:
+def debugEdge(edge, prefix, *args, force=False):
+    if force or logger.getLevel() == Path.Log.Level.DEBUG:
         pf = edge.valueAt(edge.FirstParameter)
         pl = edge.valueAt(edge.LastParameter)
+        prefixFmt = prefix.format(args)
         if type(edge.Curve) in [Part.Line, Part.LineSegment]:
             print(
-                "%s %s((%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f))"
-                % (prefix, type(edge.Curve), pf.x, pf.y, pf.z, pl.x, pl.y, pl.z)
+                "{} {}(({:.2f}, {:.2f}, {:.2f}) - ({:.2f}, {:.2f}, {:.2f}))".format(prefixFmt, type(edge.Curve), pf.x, pf.y, pf.z, pl.x, pl.y, pl.z)
             )
         else:
             pm = edge.valueAt((edge.FirstParameter + edge.LastParameter) / 2)
             print(
-                "%s %s((%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f) - (%.2f, %.2f, %.2f))"
-                % (
-                    prefix,
+                "{} {}(({:.2f}, {:.2f}, {:.2f}) - ({:.2f}, {:.2f}, {:.2f}) - ({:.2f}, {:.2f}, {:.2f}))".format(
+                    prefixFmt,
                     type(edge.Curve),
                     pf.x,
                     pf.y,
@@ -73,7 +68,7 @@ def debugEdge(edge, prefix, force=False):
 
 
 def debugMarker(vector, label, color=None, radius=0.5):
-    if Path.Log.getLevel(Path.Log.thisModule()) == Path.Log.Level.DEBUG:
+    if logger.getLevel() == Path.Log.Level.DEBUG:
         obj = FreeCAD.ActiveDocument.addObject("Part::Sphere", label)
         obj.Label = label
         obj.Radius = radius
@@ -83,7 +78,7 @@ def debugMarker(vector, label, color=None, radius=0.5):
 
 
 def debugCylinder(vector, r, height, label, color=None):
-    if Path.Log.getLevel(Path.Log.thisModule()) == Path.Log.Level.DEBUG:
+    if logger.getLevel() == Path.Log.Level.DEBUG:
         obj = FreeCAD.ActiveDocument.addObject("Part::Cylinder", label)
         obj.Label = label
         obj.Radius = r
@@ -95,7 +90,7 @@ def debugCylinder(vector, r, height, label, color=None):
 
 
 def debugCone(vector, r1, r2, height, label, color=None):
-    if Path.Log.getLevel(Path.Log.thisModule()) == Path.Log.Level.DEBUG:
+    if logger.getLevel() == Path.Log.Level.DEBUG:
         obj = FreeCAD.ActiveDocument.addObject("Part::Cone", label)
         obj.Label = label
         obj.Radius1 = r1
@@ -109,9 +104,7 @@ def debugCone(vector, r1, r2, height, label, color=None):
 
 class Tag:
     def __init__(self, nr, x, y, width, height, angle, radius, enabled=True):
-        Path.Log.track(
-            "%.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %d" % (x, y, width, height, angle, radius, enabled)
-        )
+        logger.track(x, y, width, height, float(angle), float(radius), enabled, fmt="{:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {:.2f}, {}")
         self.nr = nr
         self.x = x
         self.y = y
@@ -158,7 +151,7 @@ class Tag:
             self.isSquare = True
             self.solid = Part.makeCylinder(r1, height)
             radius = min(min(self.radius, r1), self.height)
-            Path.Log.debug("Part.makeCylinder(%f, %f)" % (r1, height))
+            logger.debug("Part.makeCylinder({}, {})", r1, height)
         elif self.angle > 0.0 and height > 0.0:
             # cone
             rad = math.radians(self.angle)
@@ -175,31 +168,31 @@ class Tag:
                 height = r1 * tangens * 1.01
                 self.actualHeight = height
             self.r2 = r2
-            Path.Log.debug("Part.makeCone(%f, %f, %f)" % (r1, r2, height))
+            logger.debug("Part.makeCone({}, {}, {})", r1, r2, height)
             self.solid = Part.makeCone(r1, r2, height)
         else:
             # degenerated case - no tag
-            Path.Log.debug("Part.makeSphere(%f / 10000)" % (r1))
+            logger.debug("Part.makeSphere({} / 10000)" , r1)
             self.solid = Part.makeSphere(r1 / 10000)
         if not Path.Geom.isRoughly(0, R):  # testing is easier if the solid is not rotated
             angle = -Path.Geom.getAngle(self.originAt(0)) * 180 / math.pi
-            Path.Log.debug("solid.rotate(%f)" % angle)
+            logger.debug("solid.rotate({})" , angle)
             self.solid.rotate(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1), angle)
         orig = self.originAt(z - 0.01 * self.actualHeight)
-        Path.Log.debug("solid.translate(%s)" % orig)
+        logger.debug("solid.translate({})", orig)
         self.solid.translate(orig)
         radius = min(self.radius, radius)
         self.realRadius = radius
         if not Path.Geom.isRoughly(0, radius):
-            Path.Log.debug("makeFillet(%.4f)" % radius)
+            logger.debug("makeFillet({:.4f})", radius)
             self.solid = self.solid.makeFillet(radius, [self.solid.Edges[0]])
 
     def filterIntersections(self, pts, face):
         if type(face.Surface) in [Part.Cone, Part.Cylinder, Part.Toroid]:
-            Path.Log.track("it's a cone/cylinder, checking z")
+            logger.track("it's a cone/cylinder, checking z")
             return list([pt for pt in pts if pt.z >= self.bottom() and pt.z <= self.top()])
         if type(face.Surface) is Part.Plane:
-            Path.Log.track("it's a plane, checking R")
+            logger.track("it's a plane, checking R")
             c = face.Edges[0].Curve
             if type(c) is Part.Circle:
                 return list(
@@ -210,7 +203,7 @@ class Tag:
                         or Path.Geom.isRoughly((pt - c.Center).Length, c.Radius)
                     ]
                 )
-        Path.Log.error("==== we got a %s" % face.Surface)
+        logger.error("==== we got a {}", face.Surface)
 
     def isPointOnEdge(self, pt, edge):
         param = edge.Curve.parameter(pt)
@@ -222,7 +215,7 @@ class Tag:
             edge.LastParameter, param
         ):
             return True
-        # print("-------- X %.2f <= %.2f <=%.2f   (%.2f, %.2f, %.2f)   %.2f:%.2f" % (edge.FirstParameter, param, edge.LastParameter, pt.x, pt.y, pt.z, edge.Curve.parameter(edge.valueAt(edge.FirstParameter)), edge.Curve.parameter(edge.valueAt(edge.LastParameter))))
+        # print("-------- X {:.2f} <= {:.2f} <={:.2f}   ({:.2f}, {:.2f}, {:.2f})   {:.2f}:{:.2f}".format(edge.FirstParameter, param, edge.LastParameter, pt.x, pt.y, pt.z, edge.Curve.parameter(edge.valueAt(edge.FirstParameter)), edge.Curve.parameter(edge.valueAt(edge.LastParameter))))
         # p1 = edge.Vertexes[0]
         # f1 = edge.Curve.parameter(FreeCAD.Vector(p1.X, p1.Y, p1.Z))
         # p2 = edge.Vertexes[1]
@@ -240,8 +233,8 @@ class Tag:
             pt = sorted(vertexes, key=lambda v: (v.Point - refPt).Length)[0].Point
             debugEdge(
                 edge,
-                "intersects (%.2f, %.2f, %.2f) -> (%.2f, %.2f, %.2f)"
-                % (refPt.x, refPt.y, refPt.z, pt.x, pt.y, pt.z),
+                "intersects ({:.2f}, {:.2f}, {:.2f}) -> ({:.2f}, {:.2f}, {:.2f})",
+                refPt.x, refPt.y, refPt.z, pt.x, pt.y, pt.z
             )
             return pt
         return None
@@ -273,7 +266,7 @@ class Tag:
 
 class MapWireToTag:
     def __init__(self, edge, tag, i, maxZ, hSpeed, vSpeed, tolerance):
-        debugEdge(edge, "MapWireToTag(%.2f, %.2f, %.2f)" % (i.x, i.y, i.z))
+        debugEdge(edge, "MapWireToTag({:.2f}, {:.2f}, {:.2f})", i.x, i.y, i.z)
         self.tag = tag
         self.maxZ = maxZ
         self.hSpeed = hSpeed
@@ -307,9 +300,9 @@ class MapWireToTag:
         self.edges = []
         self.entry = i
         if tail:
-            Path.Log.debug("MapWireToTag(%s - %s)" % (i, tail.valueAt(tail.FirstParameter)))
+            logger.debug("MapWireToTag({} - {})", i, tail.valueAt(tail.FirstParameter))
         else:
-            Path.Log.debug("MapWireToTag(%s - )" % i)
+            logger.debug("MapWireToTag({} - )", i)
         self.complete = False
         self.haveProblem = False
 
@@ -349,13 +342,13 @@ class MapWireToTag:
 
     def cleanupEdges(self, edges):
         # want to remove all edges from the wire itself, and all internal struts
-        Path.Log.track("+cleanupEdges")
-        Path.Log.debug(" edges:")
+        logger.track("+cleanupEdges")
+        logger.debug(" edges:")
         if not edges:
             return edges
         for e in edges:
             debugEdge(e, "   ")
-        Path.Log.debug(":")
+        logger.debug(":")
         self.edgesCleanup = [copy.copy(edges)]
 
         # remove any edge that has a point inside the tag solid
@@ -372,7 +365,7 @@ class MapWireToTag:
                 p2, Path.Geom.Tolerance, False
             ):
                 edges.remove(e)
-                debugEdge(e, "......... X0", False)
+                debugEdge(e, "......... X0", force=False)
             else:
                 if Path.Geom.pointsCoincide(p1, self.entry) or Path.Geom.pointsCoincide(
                     p2, self.entry
@@ -387,7 +380,7 @@ class MapWireToTag:
         # if there are no edges connected to entry/exit, it means the plunge in/out is vertical
         # we need to add in the missing segment and collect the new entry/exit edges.
         if not self.entryEdges:
-            Path.Log.debug("fill entryEdges…")
+            logger.debug("fill entryEdges…")
             self.realEntry = sorted(self.edgePoints, key=lambda p: (p - self.entry).Length)[0]
             self.entryEdges = list(
                 [e for e in edges if Path.Geom.edgeConnectsTo(e, self.realEntry)]
@@ -396,7 +389,7 @@ class MapWireToTag:
         else:
             self.realEntry = None
         if not self.exitEdges:
-            Path.Log.debug("fill exitEdges…")
+            logger.debug("fill exitEdges…")
             self.realExit = sorted(self.edgePoints, key=lambda p: (p - self.exit).Length)[0]
             self.exitEdges = list([e for e in edges if Path.Geom.edgeConnectsTo(e, self.realExit)])
             edges.append(Part.Edge(Part.LineSegment(self.realExit, self.exit)))
@@ -406,40 +399,38 @@ class MapWireToTag:
 
         # if there are 2 edges attached to entry/exit, throw away the one that is "lower"
         if len(self.entryEdges) > 1:
-            debugEdge(self.entryEdges[0], " entry[0]", False)
-            debugEdge(self.entryEdges[1], " entry[1]", False)
+            debugEdge(self.entryEdges[0], " entry[0]", force=False)
+            debugEdge(self.entryEdges[1], " entry[1]", force=False)
             if self.entryEdges[0].BoundBox.ZMax < self.entryEdges[1].BoundBox.ZMax:
                 edges.remove(self.entryEdges[0])
-                debugEdge(e, "......... X1", False)
+                debugEdge(e, "......... X1", force=False)
             else:
                 edges.remove(self.entryEdges[1])
-                debugEdge(e, "......... X2", False)
+                debugEdge(e, "......... X2", force=False)
         if len(self.exitEdges) > 1:
-            debugEdge(self.exitEdges[0], " exit[0]", False)
-            debugEdge(self.exitEdges[1], " exit[1]", False)
+            debugEdge(self.exitEdges[0], " exit[0]", force=False)
+            debugEdge(self.exitEdges[1], " exit[1]", force=False)
             if self.exitEdges[0].BoundBox.ZMax < self.exitEdges[1].BoundBox.ZMax:
                 if self.exitEdges[0] in edges:
                     edges.remove(self.exitEdges[0])
-                debugEdge(e, "......... X3", False)
+                debugEdge(e, "......... X3", force=False)
             else:
                 if self.exitEdges[1] in edges:
                     edges.remove(self.exitEdges[1])
-                debugEdge(e, "......... X4", False)
+                debugEdge(e, "......... X4", force=False)
 
         self.edgesCleanup.append(copy.copy(edges))
         return edges
 
     def orderAndFlipEdges(self, inputEdges):
-        Path.Log.track(
-            "entry(%.2f, %.2f, %.2f), exit(%.2f, %.2f, %.2f)"
-            % (
-                self.entry.x,
-                self.entry.y,
-                self.entry.z,
-                self.exit.x,
-                self.exit.y,
-                self.exit.z,
-            )
+        logger.track(
+            self.entry.x,
+            self.entry.y,
+            self.entry.z,
+            self.exit.x,
+            self.exit.y,
+            self.exit.z,
+            fmt="entry({:.2f}, {:.2f}, {:.2f}), exit({:.2f}, {:.2f}, {:.2f})"
         )
         self.edgesOrder = []
         outputEdges = []
@@ -447,7 +438,7 @@ class MapWireToTag:
         lastP = p0
         edges = copy.copy(inputEdges)
         while edges:
-            # print("(%.2f, %.2f, %.2f) %d %d" % (p0.x, p0.y, p0.z))
+            # print("({:.2f}, {:.2f}, {:.2f}) {} {}".format(p0.x, p0.y, p0.z))
             for e in copy.copy(edges):
                 p1 = e.valueAt(e.FirstParameter)
                 p2 = e.valueAt(e.LastParameter)
@@ -470,37 +461,37 @@ class MapWireToTag:
                                 outputEdges.append((Part.Edge(Part.LineSegment(p0, p)), True))
                                 cnt = cnt + 1
                             p0 = p
-                        Path.Log.info("replaced edge with %d straight segments" % cnt)
+                        logger.info("replaced edge with {} straight segments", cnt)
                     edges.remove(e)
                     lastP = None
                     p0 = p1
                     debugEdge(e, ">>>>> flip")
                     break
                 else:
-                    debugEdge(e, "<<<<< (%.2f, %.2f, %.2f)" % (p0.x, p0.y, p0.z))
+                    debugEdge(e, "<<<<< ({:.2f}, {:.2f}, {:.2f})", p0.x, p0.y, p0.z)
 
             if lastP == p0:
                 self.edgesOrder.append(outputEdges)
                 self.edgesOrder.append(edges)
-                Path.Log.debug("input edges:")
+                logger.debug("input edges:")
                 for e in inputEdges:
-                    debugEdge(e, "  ", False)
-                Path.Log.debug("ordered edges:")
+                    debugEdge(e, "  ", force=False)
+                logger.debug("ordered edges:")
                 for e, flip in outputEdges:
-                    debugEdge(e, "  %c " % ("<" if flip else ">"), False)
-                Path.Log.debug("remaining edges:")
+                    debugEdge(e, "  {} ", "<" if flip else ">", force=False)
+                logger.debug("remaining edges:")
                 for e in edges:
-                    debugEdge(e, "    ", False)
-                raise ValueError("No connection to %s" % (p0))
+                    debugEdge(e, "    ", force=False)
+                raise ValueError(f"No connection to {p0}")
             elif lastP:
-                Path.Log.debug(
-                    "xxxxxx (%.2f, %.2f, %.2f) (%.2f, %.2f, %.2f)"
-                    % (p0.x, p0.y, p0.z, lastP.x, lastP.y, lastP.z)
+                logger.debug(
+                    "xxxxxx ({:.2f}, {:.2f}, {:.2f}) ({:.2f}, {:.2f}, {:.2f})",
+                    p0.x, p0.y, p0.z, lastP.x, lastP.y, lastP.z
                 )
             else:
-                Path.Log.debug("xxxxxx (%.2f, %.2f, %.2f) -" % (p0.x, p0.y, p0.z))
+                logger.debug("xxxxxx ({:.2f}, {:.2f}, {:.2f}) -", p0.x, p0.y, p0.z)
             lastP = p0
-        Path.Log.track("-")
+        logger.track("-")
         return outputEdges
 
     def isStrut(self, edge):
@@ -548,7 +539,7 @@ class MapWireToTag:
                 commands = []
                 rapid = None
                 for e, flip in self.orderAndFlipEdges(self.cleanupEdges(shape.Edges)):
-                    debugEdge(e, "++++++++ %s" % ("<" if flip else ">"), False)
+                    debugEdge(e, "++++++++ {}", "<" if flip else ">", force=False)
                     p1 = e.valueAt(e.FirstParameter)
                     p2 = e.valueAt(e.LastParameter)
                     if (
@@ -576,9 +567,9 @@ class MapWireToTag:
                     # rapid = None  # commented out per LGTM suggestion
                 return commands
             except Exception as e:
-                Path.Log.error(
-                    "Exception during processing tag @(%.2f, %.2f) (%s) - disabling the tag"
-                    % (self.tag.x, self.tag.y, e.args[0])
+                logger.error(
+                    "Exception during processing tag @({:.2f}, {:.2f}) ({}) - disabling the tag",
+                    self.tag.x, self.tag.y, e.args[0]
                 )
                 self.tag.enabled = False
                 commands = []
@@ -598,21 +589,21 @@ class MapWireToTag:
         self.tail = None
         self.finalEdge = edge
         if self.tag.solid.isInside(edge.valueAt(edge.LastParameter), Path.Geom.Tolerance, True):
-            Path.Log.track("solid.isInside")
+            logger.track("solid.isInside")
             self.addEdge(edge)
         else:
             i = self.tag.intersects(edge, edge.LastParameter)
             if not i:
                 self.offendingEdge = edge
-                debugEdge(edge, "offending Edge:", False)
+                debugEdge(edge, "offending Edge:", force=False)
                 o = self.tag.originAt(self.tag.z)
-                Path.Log.debug("originAt: (%.2f, %.2f, %.2f)" % (o.x, o.y, o.z))
+                logger.debug("originAt: ({:.2f}, {:.2f}, {:.2f})", o.x, o.y, o.z)
                 i = edge.valueAt(edge.FirstParameter)
             if Path.Geom.pointsCoincide(i, edge.valueAt(edge.FirstParameter)):
-                Path.Log.track("tail")
+                logger.track("tail")
                 self.tail = edge
             else:
-                Path.Log.track("split")
+                logger.track("split")
                 e, tail = Path.Geom.splitEdgeAt(edge, i)
                 self.addEdge(e)
                 self.tail = tail
@@ -671,7 +662,7 @@ class _RapidEdges:
 
 class PathData:
     def __init__(self, obj):
-        Path.Log.track(obj.Base.Name)
+        logger.track(obj.Base.Name)
         self.obj = obj
         path = PathUtils.getPathWithPlacement(obj.Base)
         self.wire, rapid, rapid_indexes = Path.Geom.wireForPath(path)
@@ -725,7 +716,7 @@ class PathData:
     def generateTags(self, obj, count, width=None, height=None, angle=None, radius=None):
         tags = []
         for wire in self.baseWires:
-            Path.Log.track(count, width, height, angle)
+            logger.track(count, width, height, angle)
 
             # copy edge list into python array for (much) faster random access
             Edges = list(wire.Edges)
@@ -745,7 +736,7 @@ class PathData:
             startIndex = 0
             for i in range(len(Edges)):
                 edge = Edges[i]
-                Path.Log.debug("  %d: %.2f" % (i, edge.Length))
+                logger.debug("  %d: %.2f" % (i, edge.Length))
                 if Path.Geom.isRoughly(edge.Length, longestEdge.Length):
                     startIndex = i
                     break
@@ -760,7 +751,7 @@ class PathData:
 
             minLength = min(2.0 * W, longestEdge.Length)
 
-            Path.Log.debug(
+            logger.debug(
                 "length=%.2f shortestEdge=%.2f(%.2f) longestEdge=%.2f(%.2f) minLength=%.2f"
                 % (
                     wire.Length,
@@ -771,12 +762,12 @@ class PathData:
                     minLength,
                 )
             )
-            Path.Log.debug(
+            logger.debug(
                 "   start: index=%-2d count=%d (length=%.2f, distance=%.2f)"
                 % (startIndex, startCount, startEdge.Length, tagDistance)
             )
-            Path.Log.debug("               -> lastTagLength=%.2f)" % lastTagLength)
-            Path.Log.debug("               -> currentLength=%.2f)" % currentLength)
+            logger.debug("               -> lastTagLength=%.2f)" % lastTagLength)
+            logger.debug("               -> currentLength=%.2f)" % currentLength)
 
             edgeDict = {startIndex: startCount}
 
@@ -793,7 +784,7 @@ class PathData:
 
             for i, counter in edgeDict.items():
                 edge = Edges[i]
-                Path.Log.debug(" %d: %d" % (i, counter))
+                logger.debug(" %d: %d" % (i, counter))
                 # debugMarker(edge.Vertexes[0].Point, 'base', (1.0, 0.0, 0.0), 0.2)
                 # debugMarker(edge.Vertexes[1].Point, 'base', (0.0, 1.0, 0.0), 0.2)
                 if counter:
@@ -841,10 +832,10 @@ class PathData:
             tagCount += steps
             lastTagLength += steps * tagDistance
             if tagCount > 0:
-                Path.Log.debug("      index=%d -> count=%d" % (index, tagCount))
+                logger.debug("      index={} -> count={}", index, tagCount)
                 edgeDict[index] = tagCount
         else:
-            Path.Log.debug("      skipping=%-2d (%.2f)" % (index, edge.Length))
+            logger.debug("      skipping={:<2d} ({:.2f})", index, edge.Length)
 
         return (currentLength, lastTagLength)
 
@@ -894,9 +885,9 @@ class PathData:
                 ordered.append(t)
         # disable all tags that are not on the base wire.
         for tag in tags:
-            Path.Log.info(
-                "Tag #%d (%.2f, %.2f, %.2f) not on base wire - disabling\n"
-                % (len(ordered), tag.x, tag.y, self.minZ)
+            logger.info(
+                "Tag #{} ({:.2f}, {:.2f}, {:.2f}) not on base wire - disabling\n",
+                len(ordered), tag.x, tag.y, self.minZ
             )
             tag.enabled = False
             ordered.append(tag)
@@ -904,7 +895,7 @@ class PathData:
 
     def pointIsOnPath(self, p):
         v = Part.Vertex(self.pointAtBottom(p))
-        Path.Log.debug("pt = (%f, %f, %f)" % (v.X, v.Y, v.Z))
+        logger.debug("pt = (%f, %f, %f)" % (v.X, v.Y, v.Z))
         for sortedEdges in self.bottomEdges:
             for e in sortedEdges:
                 indent = "{} ".format(e.distToShape(v)[0])
@@ -1068,7 +1059,7 @@ class ObjectTagDressup:
         return True
 
     def createPath(self, obj, pathData, tags):
-        Path.Log.track()
+        logger.track()
         commands = []
         lastEdge = 0
         lastTag = 0
@@ -1087,10 +1078,10 @@ class ObjectTagDressup:
         vertRapid = tc.VertRapid.Value
 
         while edge or lastEdge < len(pathData.edges):
-            Path.Log.debug("------- lastEdge = %d/%d.%d/%d" % (lastEdge, lastTag, t, len(tags)))
+            logger.debug("------- lastEdge = {}/{}.{}/{}", lastEdge, lastTag, t, len(tags))
             if not edge:
                 edge = pathData.edges[lastEdge]
-                debugEdge(edge, "=======  new edge: %d/%d" % (lastEdge, len(pathData.edges)))
+                debugEdge(edge, "=======  new edge: {}/{}", lastEdge, len(pathData.edges))
                 lastEdge += 1
 
             if mapper:
@@ -1182,8 +1173,8 @@ class ObjectTagDressup:
                         prev.solid.BoundBox.intersect(tag.solid.BoundBox)
                         and prev.solid.common(tag.solid).Faces
                     ):
-                        Path.Log.info("Tag #%d intersects with previous tag - disabling\n" % i)
-                        Path.Log.debug("this tag = %d [%s]" % (i, tag.solid.BoundBox))
+                        logger.info("Tag #%d intersects with previous tag - disabling\n" % i)
+                        logger.debug("this tag = %d [%s]" % (i, tag.solid.BoundBox))
                         tag.enabled = False
                 elif self.pathData.edges:
                     e = self.pathData.edges[0]
@@ -1192,12 +1183,12 @@ class ObjectTagDressup:
                     if tag.solid.isInside(p0, Path.Geom.Tolerance, True) or tag.solid.isInside(
                         p1, Path.Geom.Tolerance, True
                     ):
-                        Path.Log.info("Tag #%d intersects with starting point - disabling\n" % i)
+                        logger.info("Tag #{} intersects with starting point - disabling\n", i)
                         tag.enabled = False
 
             if tag.enabled:
                 prev = tag
-                Path.Log.debug("previousTag = %d [%s]" % (i, prev))
+                logger.debug("previousTag = {} [{}]", i, prev)
             else:
                 disabled.append(i)
             tag.nr = i  # assign final nr
@@ -1225,7 +1216,7 @@ class ObjectTagDressup:
 
         pathData = self.setup(obj)
         if not pathData:
-            Path.Log.debug("execute - no pathData")
+            logger.debug("execute - no pathData")
             return
 
         self.tags = []
@@ -1234,19 +1225,19 @@ class ObjectTagDressup:
                 obj, obj.Positions, obj.Disabled
             )
             if obj.Disabled != disabled:
-                Path.Log.debug("Updating properties.... %s vs. %s" % (obj.Disabled, disabled))
+                logger.debug("Updating properties.... {} vs. {}", obj.Disabled, disabled)
                 obj.Positions = positions
                 obj.Disabled = disabled
 
         if not self.tags:
-            Path.Log.debug("execute - no tags")
+            logger.debug("execute - no tags")
             obj.Path = PathUtils.getPathWithPlacement(obj.Base)
             return
 
         try:
             self.processTags(obj)
         except Exception as e:
-            Path.Log.error("processing tags failed clearing all tags… '%s'" % (e.args[0]))
+            logger.error("processing tags failed clearing all tags… '{}'", e.args[0])
             obj.Path = PathUtils.getPathWithPlacement(obj.Base)
 
         # update disabled in case there are some additional ones
@@ -1263,26 +1254,26 @@ class ObjectTagDressup:
     @waiting_effects
     def processTags(self, obj):
         tagID = 0
-        if Path.Log.getLevel(Path.Log.thisModule()) == Path.Log.Level.DEBUG:
+        if logger.getLevel() == Path.Log.Level.DEBUG:
             for tag in self.tags:
                 tagID += 1
                 if tag.enabled:
-                    Path.Log.debug("x=%s, y=%s, z=%s" % (tag.x, tag.y, self.pathData.minZ))
-                    # debugMarker(FreeCAD.Vector(tag.x, tag.y, self.pathData.minZ), "tag-%02d" % tagID , (1.0, 0.0, 1.0), 0.5)
+                    logger.debug("x={}, y={}, z={}", tag.x, tag.y, self.pathData.minZ)
+                    # debugMarker(FreeCAD.Vector(tag.x, tag.y, self.pathData.minZ), "tag-{:02d}".format(tagID) , (1.0, 0.0, 1.0), 0.5)
                     # if not Path.Geom.isRoughly(90, tag.angle):
-                    #    debugCone(tag.originAt(self.pathData.minZ), tag.r1, tag.r2, tag.actualHeight, "tag-%02d" % tagID)
+                    #    debugCone(tag.originAt(self.pathData.minZ), tag.r1, tag.r2, tag.actualHeight, "tag-{:02d}".format(tagID))
                     # else:
-                    #    debugCylinder(tag.originAt(self.pathData.minZ), tag.fullWidth()/2, tag.actualHeight, "tag-%02d" % tagID)
+                    #    debugCylinder(tag.originAt(self.pathData.minZ), tag.fullWidth()/2, tag.actualHeight, "tag-{:02d}".format(tagID))
 
         obj.Path = self.createPath(obj, self.pathData, self.tags)
 
     def setup(self, obj, generate=False):
-        Path.Log.debug("setup")
+        logger.debug("setup")
         self.obj = obj
         try:
             pathData = PathData(obj)
         except ValueError:
-            Path.Log.error(
+            logger.error(
                 translate(
                     "CAM_DressupTag",
                     "Cannot insert holding tags for this path - select a profile path",
@@ -1303,13 +1294,13 @@ class ObjectTagDressup:
         return self.pathData
 
     def setXyEnabled(self, triples):
-        Path.Log.track()
+        logger.track()
         if not self.pathData:
             self.setup(self.obj)
         positions = []
         disabled = []
         for i, (x, y, enabled) in enumerate(triples):
-            # print("%d: (%.2f, %.2f) %d" % (i, x, y, enabled))
+            # print("{}: ({:.2f}, {:.2f}) {}".format(i, x, y, enabled))
             positions.append(FreeCAD.Vector(x, y, 0))
             if not enabled:
                 disabled.append(i)
@@ -1336,11 +1327,11 @@ def Create(baseObject, name="DressupTag"):
     Create(basePath, name='DressupTag') … create tag dressup object for the given base path.
     """
     if not baseObject.isDerivedFrom("Path::Feature"):
-        Path.Log.error(translate("CAM_DressupTag", "The selected object is not a path") + "\n")
+        logger.error(translate("CAM_DressupTag", "The selected object is not a path") + "\n")
         return None
 
     if baseObject.isDerivedFrom("Path::FeatureCompoundPython"):
-        Path.Log.error(translate("CAM_DressupTag", "Select a profile object"))
+        logger.error(translate("CAM_DressupTag", "Select a profile object"))
         return None
 
     obj = FreeCAD.ActiveDocument.addObject("Path::FeaturePython", name)
@@ -1351,4 +1342,4 @@ def Create(baseObject, name="DressupTag"):
     return obj
 
 
-Path.Log.notice("Loading CAM_DressupTag… done\n")
+logger.notice("Loading CAM_DressupTag… done\n")

--- a/src/Mod/CAM/Path/Log.py
+++ b/src/Mod/CAM/Path/Log.py
@@ -89,9 +89,7 @@ class ModuleLogger:
         if not self.willLogAt(level):
             return None
 
-        message = ("{}.{}: " + str(msg)).format(
-            self.getModule(), Level.toString(level), *args
-        )
+        message = ("{}.{}: " + str(msg)).format(self.getModule(), Level.toString(level), *args)
 
         if _useConsole:
             message += "\n"

--- a/src/Mod/CAM/Path/Log.py
+++ b/src/Mod/CAM/Path/Log.py
@@ -89,7 +89,9 @@ class ModuleLogger:
         if not self.willLogAt(level):
             return None
 
-        message = ("{}.{}: " + str(msg)).format(self.getModule(), Level.toString(level), *args)
+        message = ("{}.{}: " + str(msg)).format(
+            self.getModule(), Level.toString(level), *args
+        )
 
         if _useConsole:
             message += "\n"
@@ -220,7 +222,7 @@ def untrackAllModules():
 
     _trackAll = False
 
-    for module in _moduleLoggers:
+    for module in _moduleLoggers.values():
         module.disableTracking()
 
 # deprecated methods:
@@ -241,7 +243,7 @@ def setLevel(level, module=None):
         if level == Level.RESET:
             _defaultLogLevel = Level.NOTICE
 
-            for module in _moduleLoggers:
+            for module in _moduleLoggers.values():
                 module.setLevel(Level.RESET)
         else:
             _defaultLogLevel = level

--- a/src/Mod/CAM/Path/Log.py
+++ b/src/Mod/CAM/Path/Log.py
@@ -225,6 +225,7 @@ def untrackAllModules():
     for module in _moduleLoggers.values():
         module.disableTracking()
 
+
 # deprecated methods:
 
 

--- a/src/Mod/CAM/Path/Log.py
+++ b/src/Mod/CAM/Path/Log.py
@@ -236,9 +236,7 @@ def setLevel(level, module=None):
     Otherwise the module specific log level is changed (use RESET to clear)."""
     global _defaultLogLevel
     global _moduleLoggers
-    if module:
-        getModuleLogger(module).setLevel(level)
-    else:
+    if module is None:
         if level == Level.RESET:
             _defaultLogLevel = Level.NOTICE
 
@@ -246,6 +244,8 @@ def setLevel(level, module=None):
                 module.setLevel(Level.RESET)
         else:
             _defaultLogLevel = level
+    else:
+        getModuleLogger(module).setLevel(level)
 
 
 def getLevel(module=None):
@@ -253,10 +253,10 @@ def getLevel(module=None):
 
     deprecated - use logger.getLevel instead
     """
-    if module:
+    if module is None:
+        return _defaultLogLevel
+    else:
         return getModuleLogger(module).getLevel()
-
-    return _defaultLogLevel
 
 
 def trackModule(module=None):

--- a/src/Mod/CAM/Path/Log.py
+++ b/src/Mod/CAM/Path/Log.py
@@ -126,9 +126,9 @@ class ModuleLogger:
 
     def setLevel(self, level):
         if level == Level.RESET:
-            self.level = None
+            self._logLevel = None
         else:
-            self.level = level
+            self._logLevel = level
 
     def willLogAt(self, level):
         """(level)"""

--- a/src/Mod/CAM/Path/Log.py
+++ b/src/Mod/CAM/Path/Log.py
@@ -332,4 +332,16 @@ def track(*args):
 
     deprecated - use logger.track(format, *args) instead
     """
-    return getModuleLogger(_caller()[0]).track(*args)
+    module, line, func = _caller()
+
+    if getModuleLogger(module).isTrackingEnabled():
+
+        formattedArgs = ", ".join([str(arg) for arg in args])
+
+        message = f"{module}({line}).{func}({formattedArgs})"
+        if _useConsole:
+            FreeCAD.Console.PrintMessage(message + "\n")
+        else:
+            print(message)
+        return message
+    return None

--- a/src/Mod/CAM/Path/Log.py
+++ b/src/Mod/CAM/Path/Log.py
@@ -49,48 +49,14 @@ class Level:
         return cls._names.get(level, "UNKNOWN")
 
 
-_defaultLogLevel = Level.NOTICE
-_moduleLogLevel = {}
-_useConsole = True
-_trackModule = {}
-_trackAll = False
-
-
 def logToConsole(yes):
     """(boolean) - if set to True (default behaviour) log messages are printed to the console. Otherwise they are printed to stdout."""
     global _useConsole
     _useConsole = yes
 
 
-def setLevel(level, module=None):
-    """(level, module = None)
-    if no module is specified the default log level is set.
-    Otherwise the module specific log level is changed (use RESET to clear)."""
-    global _defaultLogLevel
-    global _moduleLogLevel
-    if module:
-        if level == Level.RESET:
-            if _moduleLogLevel.get(module, -1) != -1:
-                del _moduleLogLevel[module]
-        else:
-            _moduleLogLevel[module] = level
-    else:
-        if level == Level.RESET:
-            _defaultLogLevel = Level.NOTICE
-            _moduleLogLevel = {}
-        else:
-            _defaultLogLevel = level
-
-
-def getLevel(module=None):
-    """(module = None) - return the global (None) or module specific log level."""
-    if module:
-        return _moduleLogLevel.get(module, _defaultLogLevel)
-    return _defaultLogLevel
-
-
 def thisModule():
-    """returns the module id of the caller, can be used for setLevel, getLevel and trackModule."""
+    """returns the module id of the caller please use logger.getModule instead if possible"""
     return _caller()[0]
 
 
@@ -100,12 +66,31 @@ def _caller():
     return os.path.splitext(os.path.basename(filename))[0], line, func
 
 
-def _log(level, module_line_func, msg):
-    """internal function to do the logging"""
-    module, line, func = module_line_func
+_defaultLogLevel = Level.NOTICE
+_useConsole = True
+_trackAll = False
+_moduleLoggers = {}
 
-    if getLevel(module) >= level:
-        message = "%s.%s: %s" % (module, Level.toString(level), msg)
+
+class ModuleLogger:
+    _tracked = False
+    _logLevel = None
+
+    def __init__(self, module, initialLogLevel=None):
+        self._logLevel = initialLogLevel
+        self._module = module
+
+    def getModule(self):
+        return self._module
+
+    def _log(self, level, msg, *args):
+        """internal function to do the logging"""
+
+        if not self.willLogAt(level):
+            return None
+
+        message = ("{}.{}: " + str(msg)).format(self.getModule(), Level.toString(level), *args)
+
         if _useConsole:
             message += "\n"
             if level == Level.NOTICE:
@@ -119,35 +104,107 @@ def _log(level, module_line_func, msg):
         else:
             print(message)
         return message
-    return None
+
+    def isTrackingEnabled(self):
+        return self._tracked or _trackAll
+
+    def setTrackingEnabled(self, enabled):
+        """(enabled)"""
+        self._tracked = enabled
+
+    def enableTracking(self):
+        self.setTrackingEnabled(True)
+
+    def disableTracking(self):
+        self.setTrackingEnabled(False)
+
+    def getLevel(self):
+        if self._logLevel is None:
+            return _defaultLogLevel
+        else:
+            return self._logLevel
+
+    def setLevel(self, level):
+        if level == Level.RESET:
+            self.level = None
+        else:
+            self.level = level
+
+    def willLogAt(self, level):
+        """(level)"""
+        return self.getLevel() >= level
+
+    def debug(self, message, *args):
+        """(message, *args)"""
+        if not self.willLogAt(Level.DEBUG):
+            return None
+
+        module, line, func = _caller()
+        return self._log(Level.DEBUG, "({}) - " + str(message), line, *args)
+
+    def info(self, message, *args):
+        """(message, *args)"""
+        return self._log(Level.INFO, message, *args)
+
+    def notice(self, message, *args):
+        """(message, *args)"""
+        return self._log(Level.NOTICE, message, *args)
+
+    def warning(self, message, *args):
+        """(message, *args)"""
+        return self._log(Level.WARNING, message, *args)
+
+    def error(self, message, *args):
+        """(message, *args)"""
+        return self._log(Level.ERROR, message, *args)
+
+    def track(self, *args, fmt=None):
+        """(....) - call with arguments of current function you want logged if tracking is enabled."""
+
+        if self.isTrackingEnabled():
+            module, line, func = _caller()
+
+            if fmt is None:
+                formattedArgs = ", ".join([str(arg) for arg in args])
+            else:
+                formattedArgs = fmt.format(*args)
+
+            message = f"{module}({line}).{func}({formattedArgs})"
+            if _useConsole:
+                FreeCAD.Console.PrintMessage(message + "\n")
+            else:
+                print(message)
+            return message
+        return None
 
 
-def debug(msg):
-    """(message)"""
-    caller_info = _caller()
-    _, line, _ = caller_info
-    msg = "({}) - {}".format(line, msg)
-    return _log(Level.DEBUG, caller_info, msg)
+def getModuleLoggerWithLevelOrDebug(level, debug, module=None):
+    """(level, debug, module=None)"""
+
+    if module is None:
+        module = _caller()[0]
+
+    withLevel = Level.DEBUG if debug else level
+    return getModuleLogger(module, withLevel=withLevel, enableTracking=debug)
 
 
-def info(msg):
-    """(message)"""
-    return _log(Level.INFO, _caller(), msg)
+def getModuleLogger(module=None, withLevel=None, enableTracking=None):
+    """(module=None, withLevel=None, enableTracking=None)"""
 
+    if module is None:
+        module = _caller()[0]
 
-def notice(msg):
-    """(message)"""
-    return _log(Level.NOTICE, _caller(), msg)
+    logger = _moduleLoggers.get(module, None)
+    if logger is None:
+        logger = ModuleLogger(module, initialLogLevel=withLevel)
+        _moduleLoggers[module] = logger
+    elif withLevel is not None:
+        logger.setLevel(withLevel)
 
+    if enableTracking is not None:
+        logger.setTrackingEnabled(enableTracking)
 
-def warning(msg):
-    """(message)"""
-    return _log(Level.WARNING, _caller(), msg)
-
-
-def error(msg):
-    """(message)"""
-    return _log(Level.ERROR, _caller(), msg)
+    return logger
 
 
 def trackAllModules(boolean):
@@ -159,45 +216,120 @@ def trackAllModules(boolean):
 def untrackAllModules():
     """In addition to stop tracking all modules it also clears the tracking flag for all individual modules."""
     global _trackAll
-    global _trackModule
+    global _moduleLoggers
+
     _trackAll = False
-    _trackModule = {}
+
+    for module in _moduleLoggers:
+        module.disableTracking()
+
+# deprecated methods:
+
+
+def setLevel(level, module=None):
+    """(level, module = None)
+
+    deprecated - use logger.setLevel instead
+
+    if no module is specified the default log level is set.
+    Otherwise the module specific log level is changed (use RESET to clear)."""
+    global _defaultLogLevel
+    global _moduleLoggers
+    if module:
+        getModuleLogger(module).setLevel(level)
+    else:
+        if level == Level.RESET:
+            _defaultLogLevel = Level.NOTICE
+
+            for module in _moduleLoggers:
+                module.setLevel(Level.RESET)
+        else:
+            _defaultLogLevel = level
+
+
+def getLevel(module=None):
+    """(module = None) - return the global (None) or module specific log level.
+
+    deprecated - use logger.getLevel instead
+    """
+    if module:
+        return getModuleLogger(module).getLevel()
+
+    return _defaultLogLevel
 
 
 def trackModule(module=None):
-    """(module = None) - start tracking given module, current module if not set."""
-    global _trackModule
-    if module:
-        _trackModule[module] = True
-    else:
-        mod, line, func = _caller()
-        _trackModule[mod] = True
+    """(module = None) - start tracking given module, current module if not set.
+
+    deprecated - use logger.enableTracking instead
+    """
+
+    if module is None:
+        module, _, _ = _caller()
+
+    getModuleLogger(module).enableTracking()
 
 
 def untrackModule(module=None):
-    """(module = None) - stop tracking given module, current module if not set."""
-    global _trackModule
-    if module and _trackModule.get(module, None):
-        del _trackModule[module]
-    elif not module:
-        mod, line, func = _caller()
-        if _trackModule.get(mod, None):
-            del _trackModule[mod]
+    """(module = None) - stop tracking given module, current module if not set.
+
+    deprecated - use logger.disableTracking instead
+    """
+    global _moduleLoggers
+
+    if module is None:
+        module, _, _ = _caller()
+
+    logger = _moduleLoggers.get(module, None)
+
+    if logger is not None:
+        logger.disableTracking()
+
+
+def debug(msg):
+    """(msg)
+
+    deprecated - use logger.debug(format, *args) instead
+    """
+    module, line, func = _caller()
+    return getModuleLogger(module)._log(Level.DEBUG, "({}) - {}", line, msg)
+
+
+def info(msg):
+    """(msg)
+
+    deprecated - use logger.info(format, *args) instead
+    """
+    return getModuleLogger(_caller()[0]).info("{}", msg)
+
+
+def notice(msg):
+    """(msg)
+
+    deprecated - use logger.notice(format, *args) instead
+    """
+    return getModuleLogger(_caller()[0]).notice("{}", msg)
+
+
+def warning(msg):
+    """(msg)
+
+    deprecated - use logger.warning(format, *args) instead
+    """
+    return getModuleLogger(_caller()[0]).warning("{}", msg)
+
+
+def error(msg):
+    """(msg)
+
+    deprecated - use logger.error(format, *args) instead
+    """
+    return getModuleLogger(_caller()[0]).error("{}", msg)
 
 
 def track(*args):
-    """(....) - call with arguments of current function you want logged if tracking is enabled."""
-    module, line, func = _caller()
-    if _trackAll or _trackModule.get(module, None):
-        message = "%s(%d).%s(%s)" % (
-            module,
-            line,
-            func,
-            ", ".join([str(arg) for arg in args]),
-        )
-        if _useConsole:
-            FreeCAD.Console.PrintMessage(message + "\n")
-        else:
-            print(message)
-        return message
-    return None
+    """(*args)
+
+    deprecated - use logger.track(format, *args) instead
+    """
+    return getModuleLogger(_caller()[0]).track(*args)

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -52,6 +52,7 @@ from CAMTests.TestPathHelix import TestPathHelix
 from CAMTests.TestPathHelixGenerator import TestPathHelixGenerator
 from CAMTests.TestPathSpiralGenerator import TestPathSpiralGenerator
 from CAMTests.TestPathLog import TestPathLog
+from CAMTests.TestPathLogNew import TestPathLogNew
 from CAMTests.TestPathOpUtil import TestPathOpUtil
 from CAMTests.TestPostToolProcessing import TestToolLengthOffset, TestToolProcessing
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

While profiling some slow parts of FreeCAD I noticed that a *lot* of time is spent capturing backtraces and calling `posix.stat`.

It turns out that the current implementation of `Path.log` will unconditionally use `_caller()` to find the module it was called from. This is costly and most importantly **this cost is paid even if the target log level is disabled**.

To prevent this while keeping the same semantics I suggest moving the information about the log level and tracking status to a `ModuleLogger` class.

Each module can then use a global `logger = Path.Log.getModuleLogger()` and set its own default logging level in the process (currently most files have a `Path.Log.setLevel(..., Path.Log.currentModule())`) at the top.

This setup prevent repeated backtrace generation and should logging calls for disabled log level effectively free.

It is still possible to use `Path.Log.setLevel` and firends to remotely configure a logger for a different module.

#### NOTE
As this logging approach is used throughout a lot of the code this PR touches a lot of code.
The first commit implements the new logging class, the second uses it in the codebase.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #29091

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
