### PR TITLE
CAM: Dressup Tag improve scaling with many edges

### DIFF
--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -829,9 +829,9 @@ class PathData:
         tagCount = 0
         currentLength += edge.Length
         if edge.Length >= minLength:
-            while lastTagLength + tagDistance < currentLength:
-                tagCount += 1
-                lastTagLength += tagDistance
+            steps = max(0, int((currentLength - lastTagLength - 1) // tagDistance))
+            tagCount += steps
+            lastTagLength += steps * tagDistance
             if tagCount > 0:
                 Path.Log.debug("      index=%d -> count=%d" % (index, tagCount))
                 edgeDict[index] = tagCount

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -656,7 +656,7 @@ class _RapidEdges:
                 round(v0.z, self.precision),
                 round(v1.x, self.precision),
                 round(v1.y, self.precision),
-                round(v1.z, self.precision)
+                round(v1.z, self.precision),
             )
         except (AttributeError, IndexError):
             return None
@@ -1193,7 +1193,10 @@ class ObjectTagDressup:
         for i, tag in enumerate(self.pathData.sortedTags(rawTags)):
             if tag.enabled:
                 if prev:
-                    if prev.solid.BoundBox.intersect(tag.solid.BoundBox) and prev.solid.common(tag.solid).Faces:
+                    if (
+                        prev.solid.BoundBox.intersect(tag.solid.BoundBox)
+                        and prev.solid.common(tag.solid).Faces
+                    ):
                         Path.Log.info("Tag #%d intersects with previous tag - disabling\n" % i)
                         Path.Log.debug("this tag = %d [%s]" % (i, tag.solid.BoundBox))
                         tag.enabled = False

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -234,6 +234,9 @@ class Tag:
     def nextIntersectionClosestTo(self, edge, solid, refPt):
         # debugEdge(edge, 'intersects_')
 
+        if not edge.BoundBox.intersect(solid.BoundBox):
+            return None
+
         vertexes = edge.common(solid).Vertexes
         if vertexes:
             pt = sorted(vertexes, key=lambda v: (v.Point - refPt).Length)[0].Point
@@ -1190,7 +1193,7 @@ class ObjectTagDressup:
         for i, tag in enumerate(self.pathData.sortedTags(rawTags)):
             if tag.enabled:
                 if prev:
-                    if prev.solid.common(tag.solid).Faces:
+                    if prev.solid.BoundBox.intersect(tag.solid.BoundBox) and prev.solid.common(tag.solid).Faces:
                         Path.Log.info("Tag #%d intersects with previous tag - disabling\n" % i)
                         Path.Log.debug("this tag = %d [%s]" % (i, tag.solid.BoundBox))
                         tag.enabled = False

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -667,7 +667,7 @@ class _RapidEdges:
 
     def markRapid(self, edge):
         key = self._get_coords_key(edge)
-        if key:
+        if key is not None:
             self.rapid_coords.add(key)
 
 
@@ -858,7 +858,7 @@ class PathData:
         tagCount = 0
         currentLength += edge.Length
         if edge.Length >= minLength:
-            steps = max(0, int((currentLength - lastTagLength - 1) // tagDistance))
+            steps = max(0, math.ceil((currentLength - lastTagLength) / tagDistance) - 1)
             tagCount += steps
             lastTagLength += steps * tagDistance
             if tagCount > 0:

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -625,25 +625,47 @@ class MapWireToTag:
 
 class _RapidEdges:
     def __init__(self, rapid):
-        self.rapid = rapid
+        self.rapid_coords = set()
+
+        # Calculate precision based on Path.Geom.Tolerance
+        # e.g., 0.001 -> 3 decimal places
+        try:
+            tol = Path.Geom.Tolerance
+            self.precision = max(0, int(math.ceil(-math.log10(tol))))
+        except (AttributeError, ValueError, OverflowError):
+            self.precision = 6  # Reasonable default
+
+        for edge in rapid:
+            self.markRapid(edge)
+
+    def _get_coords_key(self, edge):
+        """Generates a hashable tuple of rounded coordinates."""
+        try:
+            if type(edge.Curve) not in [Part.Line, Part.LineSegment]:
+                return None
+
+            v0 = edge.Vertexes[0].Point
+            v1 = edge.Vertexes[1].Point
+
+            return (
+                round(v0.x, self.precision),
+                round(v0.y, self.precision),
+                round(v0.z, self.precision),
+                round(v1.x, self.precision),
+                round(v1.y, self.precision),
+                round(v1.z, self.precision)
+            )
+        except (AttributeError, IndexError):
+            return None
 
     def isRapid(self, edge):
-        if type(edge.Curve) in [Part.Line, Part.LineSegment]:
-            v0 = edge.Vertexes[0]
-            v1 = edge.Vertexes[1]
-            for r in self.rapid:
-                r0 = r.Vertexes[0]
-                r1 = r.Vertexes[1]
-                if (
-                    Path.Geom.isRoughly(r0.X, v0.X)
-                    and Path.Geom.isRoughly(r0.Y, v0.Y)
-                    and Path.Geom.isRoughly(r0.Z, v0.Z)
-                    and Path.Geom.isRoughly(r1.X, v1.X)
-                    and Path.Geom.isRoughly(r1.Y, v1.Y)
-                    and Path.Geom.isRoughly(r1.Z, v1.Z)
-                ):
-                    return True
-        return False
+        key = self._get_coords_key(edge)
+        return key is not None and key in self.rapid_coords
+
+    def markRapid(self, edge):
+        key = self._get_coords_key(edge)
+        if key:
+            self.rapid_coords.add(key)
 
 
 class PathData:

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -724,7 +724,11 @@ class PathData:
         self, obj, count, width=None, height=None, angle=None, radius=None, spacing=None
     ):
         Path.Log.track(count, width, height, angle, spacing)
-        # for e in self.baseWire.Edges:
+
+        # copy edge list into python array for (much) faster random access
+        Edges = list(self.baseWire.Edges)
+
+        # for e in Edges:
         #    debugMarker(e.Vertexes[0].Point, 'base', (0.0, 1.0, 1.0), 0.2)
 
         if spacing:
@@ -740,14 +744,14 @@ class PathData:
         # start assigning tags on the longest segment
         shortestEdge, longestEdge = self.shortestAndLongestPathEdge()
         startIndex = 0
-        for i in range(0, len(self.baseWire.Edges)):
-            edge = self.baseWire.Edges[i]
+        for i in range(0, len(Edges)):
+            edge = Edges[i]
             Path.Log.debug("  %d: %.2f" % (i, edge.Length))
             if Path.Geom.isRoughly(edge.Length, longestEdge.Length):
                 startIndex = i
                 break
 
-        startEdge = self.baseWire.Edges[startIndex]
+        startEdge = Edges[startIndex]
         startCount = int(startEdge.Length / tagDistance)
         if (longestEdge.Length - shortestEdge.Length) > shortestEdge.Length:
             startCount = int(startEdge.Length / tagDistance) + 1
@@ -777,13 +781,13 @@ class PathData:
 
         edgeDict = {startIndex: startCount}
 
-        for i in range(startIndex + 1, len(self.baseWire.Edges)):
-            edge = self.baseWire.Edges[i]
+        for i in range(startIndex + 1, len(Edges)):
+            edge = Edges[i]
             currentLength, lastTagLength = self.processEdge(
                 i, edge, currentLength, lastTagLength, tagDistance, minLength, edgeDict
             )
         for i in range(0, startIndex):
-            edge = self.baseWire.Edges[i]
+            edge = Edges[i]
             currentLength, lastTagLength = self.processEdge(
                 i, edge, currentLength, lastTagLength, tagDistance, minLength, edgeDict
             )
@@ -791,7 +795,7 @@ class PathData:
         tags = []
 
         for i, count in edgeDict.items():
-            edge = self.baseWire.Edges[i]
+            edge = Edges[i]
             Path.Log.debug(" %d: %d" % (i, count))
             # debugMarker(edge.Vertexes[0].Point, 'base', (1.0, 0.0, 0.0), 0.2)
             # debugMarker(edge.Vertexes[1].Point, 'base', (0.0, 1.0, 0.0), 0.2)


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

This fixes the most obvious causes of #29093.

The non C++ changes already speed up the code quite a lot.

Most of the performance benefit of the C++ changes comes from the added bounding box checks.
If adding new functions to the C++ code is not acceptable for some reason an alternative would be to do these bounding box checks and keep the current boolean operations.
However, I did not find a way to do a bounding box intersection test in python.

The new C++ methods are currently implemented in `TopoShapePyImp.py`, the python interface to the C++ library.
It would probably be better to move them to a different  part of the library and only call them from this interface file (as is done with most other methods). I am find with keeping them here though.

The commit adding the profiling is temporary and will be removed before merging.

Here are some benchmarks for comparison, the bulk of the time is spent in unused logging calls (see !29092):
see #29093 for the state before this PR.

### findZLimits
```
         2213 function calls in 0.044 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.044    0.044    0.044    0.044 Tags.py:684(findZLimits)
     2209    0.000    0.000    0.000    0.000 Tags.py:636(isRapid)
        1    0.000    0.000    0.044    0.044 {built-in method builtins.exec}
        1    0.000    0.000    0.044    0.044 <string>:1(<module>)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
```

### createPath
```
936826 function calls (936824 primitive calls) in 0.597 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        9    0.070    0.008    0.070    0.008 {method 'common' of 'Part.Shape' objects}
    11335    0.069    0.000    0.216    0.000 traceback.py:394(_extract_from_extended_frame_gen)
     3975    0.058    0.000    0.058    0.000 {method 'closestIntersectionPoint' of 'Part.Shape' objects}
        1    0.044    0.044    0.594    0.594 Tags.py:1072(createPath)
    22670    0.043    0.000    0.043    0.000 {built-in method posix.stat}
     6630    0.038    0.000    0.116    0.000 Tags.py:247(intersects)
     2236    0.032    0.000    0.038    0.000 Geom.py:280(cmdsForEdge)
    45340    0.018    0.000    0.049    0.000 traceback.py:313(line)
    22670    0.017    0.000    0.061    0.000 linecache.py:52(checkcache)
    11335    0.016    0.000    0.296    0.000 Log.py:97(_caller)
    11335    0.013    0.000    0.239    0.000 traceback.py:217(extract_stack)
    34005    0.013    0.000    0.026    0.000 linecache.py:26(getline)
    45340    0.010    0.000    0.016    0.000 traceback.py:386(extended_frame_gen)
    34005    0.010    0.000    0.010    0.000 traceback.py:261(__init__)
    34005    0.009    0.000    0.011    0.000 linecache.py:36(getlines)
    34005    0.009    0.000    0.011    0.000 linecache.py:147(lazycache)
   150281    0.009    0.000    0.009    0.000 {built-in method builtins.len}
     3975    0.008    0.000    0.067    0.000 Tags.py:235(nextIntersectionClosestTo)
    11335    0.008    0.000    0.014    0.000 <frozen posixpath>:140(basename)
    24250    0.008    0.000    0.008    0.000 {method 'valueAt' of 'Part.Edge' objects}
    11335    0.007    0.000    0.009    0.000 <frozen genericpath>:121(_splitext)
    11335    0.007    0.000    0.018    0.000 <frozen posixpath>:117(splitext)
    45340    0.007    0.000    0.007    0.000 traceback.py:322(walk_stack)
    11335    0.006    0.000    0.222    0.000 traceback.py:372(extract)
    11335    0.006    0.000    0.010    0.000 traceback.py:297(__iter__)
     6672    0.006    0.000    0.189    0.000 Log.py:125(debug)
     4614    0.004    0.000    0.125    0.000 Tags.py:49(debugEdge)
    45340    0.004    0.000    0.004    0.000 {method 'strip' of 'str' objects}
    34005    0.004    0.000    0.004    0.000 {method 'rfind' of 'str' objects}
    11292    0.003    0.000    0.004    0.000 Log.py:85(getLevel)
       78    0.003    0.000    0.003    0.000 {method 'isInside' of 'Part.Shape' objects}
    11335    0.003    0.000    0.004    0.000 <frozen posixpath>:41(_get_sep)
        1    0.002    0.002    0.597    0.597 <string>:1(<module>)
     9288    0.002    0.000    0.004    0.000 Tags.py:248(isDefinitelySmaller)
     6678    0.002    0.000    0.005    0.000 Log.py:103(_log)
     7030    0.002    0.000    0.003    0.000 Geom.py:98(isRoughly)
    36441    0.002    0.000    0.002    0.000 {method 'append' of 'list' objects}
    25411    0.002    0.000    0.002    0.000 {built-in method builtins.isinstance}
    34005    0.002    0.000    0.002    0.000 {method 'add' of 'set' objects}
     6672    0.002    0.000    0.002    0.000 {method 'format' of 'str' objects}
    22670    0.002    0.000    0.002    0.000 {built-in method posix.fspath}
     4614    0.001    0.000    0.119    0.000 Log.py:92(thisModule)
    11420    0.001    0.000    0.001    0.000 {method 'get' of 'dict' objects}
     6630    0.001    0.000    0.001    0.000 Tags.py:148(top)
    11337    0.001    0.000    0.001    0.000 {built-in method sys._getframe}
    11335    0.001    0.000    0.001    0.000 {built-in method builtins.iter}
     7030    0.001    0.000    0.001    0.000 {built-in method math.fabs}
        9    0.001    0.000    0.007    0.001 Tags.py:353(cleanupEdges)
    11335    0.001    0.000    0.001    0.000 {method 'reverse' of 'list' objects}
     2038    0.001    0.000    0.002    0.000 Geom.py:253(speedBetweenPoints)
      431    0.001    0.000    0.001    0.000 Geom.py:104(pointsCoincide)
     2215    0.001    0.000    0.001    0.000 Tags.py:636(isRapid)
        9    0.000    0.000    0.083    0.009 Tags.py:547(commandsForEdges)
     2453    0.000    0.000    0.000    0.000 {method 'update' of 'dict' objects}
        9    0.000    0.000    0.000    0.000 Tags.py:542(<listcomp>)
      990    0.000    0.000    0.001    0.000 Geom.py:107(<genexpr>)
        9    0.000    0.000    0.003    0.000 Tags.py:435(orderAndFlipEdges)
        9    0.000    0.000    0.001    0.000 Geom.py:681(flipEdge)
       18    0.000    0.000    0.001    0.000 Geom.py:580(splitEdgeAt)
      687    0.000    0.000    0.000    0.000 Geom.py:247(xy)
        9    0.000    0.000    0.001    0.000 Tags.py:514(shell)
      223    0.000    0.000    0.000    0.000 Geom.py:163(isVertical)
       12    0.000    0.000    0.099    0.008 Tags.py:600(add)
     2245    0.000    0.000    0.000    0.000 {method 'extend' of 'list' objects}
        9    0.000    0.000    0.000    0.000 {method 'extrude' of 'Part.Shape' objects}
        9    0.000    0.000    0.002    0.000 Tags.py:273(__init__)
        1    0.000    0.000    0.000    0.000 {method 'signalChangeIcon' of 'Gui.ViewProvider' objects}
        9    0.000    0.000    0.000    0.000 Tags.py:1061(isValidTagStartIntersection)
      431    0.000    0.000    0.001    0.000 {built-in method builtins.all}
        6    0.000    0.000    0.000    0.000 Geom.py:570(splitArcAt)
        9    0.000    0.000    0.000    0.000 {method 'discretize' of 'Part.Edge' objects}
        3    0.000    0.000    0.000    0.000 {built-in method __FreeCADConsole__.PrintWarning}
       75    0.000    0.000    0.000    0.000 copy.py:66(copy)
       43    0.000    0.000    0.001    0.000 Log.py:188(track)
        1    0.000    0.000    0.000    0.000 Tags.py:998(onChanged)
        1    0.000    0.000    0.597    0.597 {built-in method builtins.exec}
       12    0.000    0.000    0.000    0.000 {method 'toShape' of 'Part.Curve' objects}
      2/1    0.000    0.000    0.000    0.000 PathUtils.py:512(findParentJob)
        3    0.000    0.000    0.000    0.000 {built-in method __FreeCADConsole__.PrintMessage}
        9    0.000    0.000    0.000    0.000 {built-in method builtins.hasattr}
        6    0.000    0.000    0.000    0.000 {method 'parameter' of 'Part.Curve' objects}
       12    0.000    0.000    0.000    0.000 Tags.py:331(addEdge)
       36    0.000    0.000    0.000    0.000 {method 'remove' of 'list' objects}
        3    0.000    0.000    0.000    0.000 {method 'add' of 'Part.Wire' objects}
       75    0.000    0.000    0.000    0.000 {method 'copy' of 'list' objects}
        3    0.000    0.000    0.000    0.000 {built-in method translate}
      3/2    0.000    0.000    0.000    0.000 Utils.py:68(baseOp)
       12    0.000    0.000    0.000    0.000 {method 'copy' of 'Part.Geometry' objects}
        1    0.000    0.000    0.000    0.000 Utils.py:75(toolController)
        1    0.000    0.000    0.000    0.000 Tags.py:533(getIcon)
        2    0.000    0.000    0.000    0.000 loader.py:59(feature_import)
        3    0.000    0.000    0.000    0.000 Log.py:133(info)
        3    0.000    0.000    0.000    0.000 Log.py:143(warning)
        2    0.000    0.000    0.000    0.000 feature.py:88(feature_import)
        6    0.000    0.000    0.000    0.000 Log.py:47(toString)
        2    0.000    0.000    0.000    0.000 loader.py:67(feature_imported)
       12    0.000    0.000    0.000    0.000 Tags.py:626(mappingComplete)
        1    0.000    0.000    0.000    0.000 Tags.py:461(updateData)
        1    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
        2    0.000    0.000    0.000    0.000 feature.py:134(feature_imported)
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
```

generateTags:
```
         64819 function calls in 0.037 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.006    0.006    0.037    0.037 Tags.py:711(generateTags)
      870    0.005    0.000    0.017    0.000 traceback.py:394(_extract_from_extended_frame_gen)
        1    0.004    0.004    0.004    0.004 Tags.py:698(shortestAndLongestPathEdge)
      439    0.003    0.000    0.015    0.000 Tags.py:833(processEdge)
     1740    0.003    0.000    0.003    0.000 {built-in method posix.stat}
     3480    0.001    0.000    0.004    0.000 traceback.py:313(line)
     1740    0.001    0.000    0.005    0.000 linecache.py:52(checkcache)
      870    0.001    0.000    0.022    0.000 Log.py:97(_caller)
     2610    0.001    0.000    0.002    0.000 linecache.py:26(getline)
      870    0.001    0.000    0.018    0.000 traceback.py:217(extract_stack)
     2610    0.001    0.000    0.001    0.000 linecache.py:36(getlines)
     3480    0.001    0.000    0.001    0.000 traceback.py:386(extended_frame_gen)
     2610    0.001    0.000    0.001    0.000 traceback.py:261(__init__)
     2610    0.001    0.000    0.001    0.000 linecache.py:147(lazycache)
      867    0.001    0.000    0.024    0.000 Log.py:125(debug)
      870    0.001    0.000    0.001    0.000 <frozen posixpath>:140(basename)
     9572    0.001    0.000    0.001    0.000 {built-in method builtins.len}
      870    0.001    0.000    0.001    0.000 <frozen genericpath>:121(_splitext)
      870    0.001    0.000    0.001    0.000 <frozen posixpath>:117(splitext)
     3480    0.000    0.000    0.000    0.000 traceback.py:322(walk_stack)
      870    0.000    0.000    0.017    0.000 traceback.py:372(extract)
      870    0.000    0.000    0.001    0.000 traceback.py:297(__iter__)
      867    0.000    0.000    0.001    0.000 Log.py:103(_log)
     3480    0.000    0.000    0.000    0.000 {method 'strip' of 'str' objects}
     2610    0.000    0.000    0.000    0.000 {method 'rfind' of 'str' objects}
      867    0.000    0.000    0.000    0.000 Log.py:85(getLevel)
      870    0.000    0.000    0.000    0.000 <frozen posixpath>:41(_get_sep)
      867    0.000    0.000    0.000    0.000 {method 'format' of 'str' objects}
     2610    0.000    0.000    0.000    0.000 {method 'add' of 'set' objects}
     2612    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
      424    0.000    0.000    0.000    0.000 Geom.py:98(isRoughly)
     1740    0.000    0.000    0.000    0.000 {built-in method builtins.isinstance}
     1740    0.000    0.000    0.000    0.000 {built-in method posix.fspath}
      870    0.000    0.000    0.000    0.000 {method 'get' of 'dict' objects}
      870    0.000    0.000    0.000    0.000 {built-in method sys._getframe}
      870    0.000    0.000    0.000    0.000 {built-in method builtins.iter}
        1    0.000    0.000    0.037    0.037 {built-in method builtins.exec}
      870    0.000    0.000    0.000    0.000 {method 'reverse' of 'list' objects}
      430    0.000    0.000    0.000    0.000 {built-in method math.fabs}
        1    0.000    0.000    0.037    0.037 <string>:1(<module>)
        1    0.000    0.000    0.000    0.000 {built-in method FreeCAD.ParamGet}
        2    0.000    0.000    0.000    0.000 Tags.py:114(__init__)
        1    0.000    0.000    0.000    0.000 TagPreferences.py:72(defaultRadius)
        1    0.000    0.000    0.000    0.000 Preferences.py:87(preferences)
        3    0.000    0.000    0.000    0.000 Log.py:188(track)
        1    0.000    0.000    0.000    0.000 {built-in method GetFloat}
        2    0.000    0.000    0.000    0.000 {method 'value' of 'Part.Curve' objects}
        1    0.000    0.000    0.000    0.000 Tags.py:875(defaultTagRadius)
        3    0.000    0.000    0.000    0.000 {built-in method builtins.max}
        2    0.000    0.000    0.000    0.000 {built-in method builtins.getattr}
        1    0.000    0.000    0.000    0.000 {built-in method builtins.min}
        1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
        1    0.000    0.000    0.000    0.000 {method 'items' of 'dict' objects}
```

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #29093


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
