### PR TITLE
Sketcher: skip autoscale when dimension value yields invalid scale factor

### DIFF
--- a/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
+++ b/src/Mod/Sketcher/Gui/EditDatumDialog.cpp
@@ -49,6 +49,8 @@
 #include "SketcherSettings.h"
 #include "ui_InsertDatum.h"
 
+#include <Precision.hxx>
+#include <cmath>
 #include <numeric>
 
 
@@ -489,7 +491,16 @@ void EditDatumDialog::performAutoScale(double newDatum)
             }
 
             double oldDatum = sketch->getDatum(ConstrNbr);
+            if (!std::isfinite(newDatum) || !std::isfinite(oldDatum)
+                || std::abs(oldDatum) <= Precision::Confusion()) {
+                return;
+            }
+
             double scaleFactor = newDatum / oldDatum;
+            if (!std::isfinite(scaleFactor) || scaleFactor <= Precision::Confusion()
+                || std::abs(scaleFactor - 1.0) <= Precision::Confusion()) {
+                return;
+            }
             centerScale(scaleFactor);
 
             // Some constraints cannot be scaled so the actual datum constraint


### PR DESCRIPTION
Fixes #29089

Added an early return in `EditDatumDialog::performAutoScale` when the computed scale factor is zero or invalid, so entering `0` as a dimension value no longer triggers the warning.