### PR TITLE
Sketcher: Prevent repeated CarbonCopy from TreeWidget drag-selection

### DIFF
--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -21,6 +21,7 @@ set(Sketcher_TestScripts
     SketcherTests/TestSketchCarbonCopyReverseMapping.py
     SketcherTests/TestSketchCarbonCopyReverseMapping.FCStd
     SketcherTests/TestSketchInternalFaces.py
+    SketcherTests/TestSketcherGuiModelTreeWidget.py
 )
 
 if(BUILD_GUI)

--- a/src/Mod/Sketcher/Gui/AppSketcherGui.cpp
+++ b/src/Mod/Sketcher/Gui/AppSketcherGui.cpp
@@ -67,6 +67,12 @@ public:
     Module()
         : Py::ExtensionModule<Module>("SketcherGui")
     {
+        add_varargs_method(
+            "hasModelTreeWidget",
+            &Module::hasModelTreeWidgetPy,
+            "Returns True if the Model TreeWidget exists"
+        );
+
         initialize("This module is the SketcherGui module.");  // register with Python
     }
 
@@ -74,6 +80,10 @@ public:
     {}
 
 private:
+    Py::Object hasModelTreeWidgetPy(const Py::Tuple&)
+    {
+        return Py::Boolean(SketcherGui::hasModelTreeWidget());
+    }
 };
 
 PyObject* initModule()

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -25,12 +25,14 @@
 #pragma once
 
 #include <QApplication>
+#include <QDockWidget>
 
 #include <Gui/Notifications.h>
 #include <Gui/Selection/SelectionFilter.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
 #include <Gui/MDIView.h>
+#include <Gui/Tree.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 
@@ -129,6 +131,27 @@ public:
     }
 };
 
+class CarbonCopyTreeWidgetFilter : public QObject
+{
+    Q_OBJECT
+public:
+    CarbonCopyTreeWidgetFilter(QObject* parent = nullptr)
+        : QObject(parent)
+    {}
+
+protected:
+    bool eventFilter(QObject* obj, QEvent* event) override
+    {
+        // Filter out mouse move events
+        // to prevent drag-selection in the TreeWidget,
+        // avoiding repeated CarbonCopy execution
+        if (event->type() == QEvent::MouseMove) {
+            return true;
+        }
+        return QObject::eventFilter(obj, event);
+    }
+};
+
 class DrawSketchHandlerCarbonCopy: public DrawSketchHandler
 {
     Q_DECLARE_TR_FUNCTIONS(SketcherGui::DrawSketchHandlerCarbonCopy)
@@ -224,6 +247,17 @@ private:
         Gui::Selection().clearSelection();
         Gui::Selection().rmvSelectionGate();
         Gui::Selection().addSelectionGate(new CarbonCopySelection(sketchgui->getObject()));
+
+        treeWidgetFilter = std::make_unique<CarbonCopyTreeWidgetFilter>();
+        Gui::MainWindow* mw = Gui::getMainWindow();
+        if (mw) {
+            auto dock = mw->findChild<QDockWidget*>("Model");
+            tree = dock ? dock->findChild<Gui::TreeWidget*>() : nullptr;
+            if (tree && treeWidgetFilter) {
+                tree->installEventFilter(treeWidgetFilter.get());
+                tree->viewport()->installEventFilter(treeWidgetFilter.get());
+            }
+        }
     }
 
     QString getCrosshairCursorSVGName() const override
@@ -235,7 +269,18 @@ private:
     {
         Q_UNUSED(sketchgui);
         setAxisPickStyle(true);
+        if (tree && treeWidgetFilter) {
+            tree->removeEventFilter(treeWidgetFilter.get());
+            tree->viewport()->removeEventFilter(treeWidgetFilter.get());
+        }
+        if (treeWidgetFilter) {
+            treeWidgetFilter.reset();
+        }
+        tree = nullptr;
     }
+
+    Gui::TreeWidget* tree = nullptr;
+    std::unique_ptr<CarbonCopyTreeWidgetFilter> treeWidgetFilter;
 
 public:
     std::list<Gui::InputHint> getToolHints() const override

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -25,14 +25,12 @@
 #pragma once
 
 #include <QApplication>
-#include <QDockWidget>
 
 #include <Gui/Notifications.h>
 #include <Gui/Selection/SelectionFilter.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
 #include <Gui/MDIView.h>
-#include <Gui/Tree.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 
@@ -249,14 +247,10 @@ private:
         Gui::Selection().addSelectionGate(new CarbonCopySelection(sketchgui->getObject()));
 
         treeWidgetFilter = std::make_unique<CarbonCopyTreeWidgetFilter>();
-        Gui::MainWindow* mw = Gui::getMainWindow();
-        if (mw) {
-            auto dock = mw->findChild<QDockWidget*>("Model");
-            tree = dock ? dock->findChild<Gui::TreeWidget*>() : nullptr;
-            if (tree && treeWidgetFilter) {
-                tree->installEventFilter(treeWidgetFilter.get());
-                tree->viewport()->installEventFilter(treeWidgetFilter.get());
-            }
+        tree = SketcherGui::findModelTreeWidget();
+        if (tree && treeWidgetFilter) {
+            tree->installEventFilter(treeWidgetFilter.get());
+            tree->viewport()->installEventFilter(treeWidgetFilter.get());
         }
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerCarbonCopy.h
@@ -131,7 +131,7 @@ public:
     }
 };
 
-class CarbonCopyTreeWidgetFilter : public QObject
+class CarbonCopyTreeWidgetFilter: public QObject
 {
     Q_OBJECT
 public:

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -1062,12 +1062,14 @@ QMap<QString, QString> SketcherGui::findAvailableFontFiles()
 Gui::TreeWidget* SketcherGui::findModelTreeWidget()
 {
     Gui::MainWindow* mw = Gui::getMainWindow();
-    if (!mw)
+    if (!mw) {
         return nullptr;
+    }
 
     auto dock = mw->findChild<QDockWidget*>("Model");
-    if (!dock)
+    if (!dock) {
         return nullptr;
+    }
 
     return dock->findChild<Gui::TreeWidget*>();
 }
@@ -1076,4 +1078,3 @@ bool SketcherGui::hasModelTreeWidget()
 {
     return SketcherGui::findModelTreeWidget() != nullptr;
 }
-

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -27,6 +27,7 @@
 #include <QRegularExpression>
 #include <QDir>
 #include <QDirIterator>
+#include <QDockWidget>
 #include <QFileInfo>
 
 #include <App/Application.h>
@@ -35,6 +36,7 @@
 #include <Base/UnitsApi.h>
 #include <Gui/CommandT.h>
 #include <Gui/Document.h>
+#include <Gui/MainWindow.h>
 #include <Gui/Selection/Selection.h>
 #include <Mod/Sketcher/App/GeometryFacade.h>
 #include <Mod/Sketcher/App/SketchObject.h>
@@ -1056,3 +1058,22 @@ QMap<QString, QString> SketcherGui::findAvailableFontFiles()
     }
     return fontMap;
 }
+
+Gui::TreeWidget* SketcherGui::findModelTreeWidget()
+{
+    Gui::MainWindow* mw = Gui::getMainWindow();
+    if (!mw)
+        return nullptr;
+
+    auto dock = mw->findChild<QDockWidget*>("Model");
+    if (!dock)
+        return nullptr;
+
+    return dock->findChild<Gui::TreeWidget*>();
+}
+
+bool SketcherGui::hasModelTreeWidget()
+{
+    return SketcherGui::findModelTreeWidget() != nullptr;
+}
+

--- a/src/Mod/Sketcher/Gui/Utils.cpp
+++ b/src/Mod/Sketcher/Gui/Utils.cpp
@@ -1071,7 +1071,12 @@ Gui::TreeWidget* SketcherGui::findModelTreeWidget()
         return nullptr;
     }
 
-    return dock->findChild<Gui::TreeWidget*>();
+    for (auto* w : dock->findChildren<QWidget*>()) {
+        if (w->inherits("Gui::TreeWidget")) {
+            return static_cast<Gui::TreeWidget*>(w);
+        }
+    }
+    return nullptr;
 }
 
 bool SketcherGui::hasModelTreeWidget()

--- a/src/Mod/Sketcher/Gui/Utils.h
+++ b/src/Mod/Sketcher/Gui/Utils.h
@@ -27,6 +27,7 @@
 #include <Base/Exception.h>
 #include <Base/Tools.h>
 #include <Base/Tools2D.h>
+#include <Gui/Tree.h>
 #include <Mod/Sketcher/App/GeoEnum.h>
 #include <QListWidget>
 #include <QMap>
@@ -254,6 +255,10 @@ inline void scrollTo(QListWidget* list, int i, bool select)
 }
 
 QMap<QString, QString> findAvailableFontFiles();
+
+// Model TreeWidget helpers
+Gui::TreeWidget* findModelTreeWidget();
+bool hasModelTreeWidget();
 
 }  // namespace SketcherGui
 

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherGuiModelTreeWidget.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherGuiModelTreeWidget.py
@@ -7,13 +7,11 @@ try:
 except ImportError:
     SketcherGui = None
 
+
 @unittest.skipIf(SketcherGui is None, "GUI not available")
 class TestSketcherGuiModelTreeWidget(unittest.TestCase):
 
     def test_hasModelTreeWidget(self):
         result = SketcherGui.hasModelTreeWidget()
         self.assertIsInstance(result, bool)
-        self.assertTrue(
-            result,
-            "Model TreeWidget expected to be available in GUI environment"
-        )
+        self.assertTrue(result, "Model TreeWidget expected to be available in GUI environment")

--- a/src/Mod/Sketcher/SketcherTests/TestSketcherGuiModelTreeWidget.py
+++ b/src/Mod/Sketcher/SketcherTests/TestSketcherGuiModelTreeWidget.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+try:
+    import SketcherGui
+except ImportError:
+    SketcherGui = None
+
+@unittest.skipIf(SketcherGui is None, "GUI not available")
+class TestSketcherGuiModelTreeWidget(unittest.TestCase):
+
+    def test_hasModelTreeWidget(self):
+        result = SketcherGui.hasModelTreeWidget()
+        self.assertIsInstance(result, bool)
+        self.assertTrue(
+            result,
+            "Model TreeWidget expected to be available in GUI environment"
+        )

--- a/src/Mod/Sketcher/TestSketcherApp.py
+++ b/src/Mod/Sketcher/TestSketcherApp.py
@@ -30,7 +30,6 @@ from SketcherTests.TestSketchExpression import TestSketchExpression
 from SketcherTests.TestSketchValidateCoincidents import TestSketchValidateCoincidents
 from SketcherTests.TestSketchCarbonCopyReverseMapping import TestSketchCarbonCopyReverseMapping
 from SketcherTests.TestSketchInternalFaces import TestSketchInternalFaces
-from SketcherTests.TestSketcherGuiModelTreeWidget import TestSketcherGuiModelTreeWidget
 
 # GUI-dependent tests - only import if GUI is available
 try:
@@ -38,6 +37,7 @@ try:
 
     if FreeCADGui.getMainWindow() is not None:
         from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
+        from SketcherTests.TestSketcherGuiModelTreeWidget import TestSketcherGuiModelTreeWidget
 except (ImportError, AttributeError):
     pass  # GUI not available, skip GUI tests
 

--- a/src/Mod/Sketcher/TestSketcherApp.py
+++ b/src/Mod/Sketcher/TestSketcherApp.py
@@ -30,6 +30,7 @@ from SketcherTests.TestSketchExpression import TestSketchExpression
 from SketcherTests.TestSketchValidateCoincidents import TestSketchValidateCoincidents
 from SketcherTests.TestSketchCarbonCopyReverseMapping import TestSketchCarbonCopyReverseMapping
 from SketcherTests.TestSketchInternalFaces import TestSketchInternalFaces
+from SketcherTests.TestSketcherGuiModelTreeWidget import TestSketcherGuiModelTreeWidget
 
 # GUI-dependent tests - only import if GUI is available
 try:


### PR DESCRIPTION
This fixes #10325.

In CarbonCopy mode, drag-selection in the "Model" TreeWidget can trigger multiple selection events, causing CarbonCopy to run multiple times for a single user action.

I explored two approaches to address this issue, outlined in:
https://github.com/FreeCAD/FreeCAD/issues/10325#issuecomment-4189077953

This PR implements approach A (eventFilter), which: it installs an event filter during CarbonCopy mode to prevent the TreeWidget from entering drag-selection, avoiding repeated execution.

For comparison, an alternative approach B is also available:
https://github.com/marbocub/FreeCAD/commit/4882e1ec0ccb1a3592381686517f858d617650df

- Approach A (this PR): prevents the root cause (drag-selection) via event filtering
- Approach B: avoids duplicate execution by tracking already processed sketches

Approach A provides clean behavior and works well in practice, but it relies on the current GUI structure (MainWindow → "Model" QDockWidget → TreeWidget), which may be fragile against future UI changes.

Approach B is more robust against such structural changes, but prevents repeated execution at runtime rather than addressing the root cause.

Feedback on which approach is preferable would be highly appreciated, especially regarding long-term maintainability and robustness against UI changes.