### PR TITLE
Gui: Fix Link window on top of the main window on macOS

### DIFF
--- a/src/Gui/Dialogs/DlgPropertyLink.cpp
+++ b/src/Gui/Dialogs/DlgPropertyLink.cpp
@@ -77,6 +77,10 @@ DlgPropertyLink::DlgPropertyLink(QWidget* parent)
     , SelectionObserver(false, ResolveMode::NoResolve)
     , ui(new Ui_DlgPropertyLink)
 {
+#if defined(Q_OS_MACOS)
+    // Clicking the 3D view would push this window behind the main window without this.
+    setWindowFlag(Qt::WindowStaysOnTopHint);
+#endif
     // clang-format off
     ui->setupUi(this);
     connect(ui->checkObjectType, &QCheckBox::toggled,


### PR DESCRIPTION
The link window was hidden on macOS by the main window.
Fixes https://github.com/FreeCAD/FreeCAD/issues/10840