### PR TITLE
Part: Fixes getSortedClusters() for short edges

### DIFF
--- a/src/Mod/Part/App/edgecluster.cpp
+++ b/src/Mod/Part/App/edgecluster.cpp
@@ -137,7 +137,7 @@ bool Edgecluster::PerformEdges(gp_Pnt& point)
     }
 
     gp_Pnt nextPoint;
-    if (P2.IsEqual(point, 0.2)) {
+    if (P2.IsEqual(point, Precision::Confusion())) {
         // need to reverse the edge
 
         theEdge.Reverse();
@@ -211,11 +211,11 @@ bool Edgecluster::IsValidEdge(const TopoDS_Edge& edge)
     gp_Pnt mpoint = bac.Value((fparam + lparam) * 0.5);
 
     Standard_Real dist = mpoint.Distance(lpoint);
-    if (dist <= 1e-5) {
+    if (dist <= Precision::Confusion()) {
         return false;
     }
     dist = mpoint.Distance(fpoint);
-    if (dist <= 1e-5) {
+    if (dist <= Precision::Confusion()) {
         return false;
     }
 

--- a/src/Mod/Part/App/edgecluster.h
+++ b/src/Mod/Part/App/edgecluster.h
@@ -29,6 +29,7 @@
 
 #include <gp_Pnt.hxx>
 #include <TopoDS_Edge.hxx>
+#include <Precision.hxx>
 
 #include <Mod/Part/PartGlobal.h>
 
@@ -43,13 +44,13 @@ struct Edgesort_gp_Pnt_Less
         Standard_Real x1, y1, z1, x2, y2, z2;
         _Left.Coord(x1, y1, z1);
         _Right.Coord(x2, y2, z2);
-        if (fabs(x1 - x2) > 0.2) {
+        if (fabs(x1 - x2) > Precision::Confusion()) {
             return x1 < x2;
         }
-        else if (fabs(y1 - y2) > 0.2) {
+        else if (fabs(y1 - y2) > Precision::Confusion()) {
             return y1 < y2;
         }
-        else if (fabs(z1 - z2) > 0.2) {
+        else if (fabs(z1 - z2) > Precision::Confusion()) {
             return z1 < z2;
         }
         return false;

--- a/src/Mod/Part/parttests/regression_tests.py
+++ b/src/Mod/Part/parttests/regression_tests.py
@@ -227,6 +227,21 @@ class RegressionTests(unittest.TestCase):
             # AttacherEngine should show "Engine Plane" (not "Engine 3D")
             self.assertEqual(attacher_engine, "Engine Plane")
 
+    def test_getSortedClusters(self):
+        "Part.getSortedClusters() may crash with short edges"
+        poly = self.Doc.addObject("Part::RegularPolygon", "RegularPolygon")
+        poly.Circumradius = 1
+        for i in range(3, 1004, 50):
+            poly.Polygon = i
+            poly.recompute()
+            clusters = Part.getSortedClusters(poly.Shape.Edges)
+
+            # should be only one cluster
+            self.assertEqual(len(clusters), 1)
+
+            # cluster should contain all edges
+            self.assertEqual(len(clusters[0]), i)
+
     def tearDown(self):
         """Clean up our test, optionally preserving the test document"""
         # This flag allows doing something like this:


### PR DESCRIPTION
> [!WARNING]
> Please check carefully
> For me this is a randomly changes which solves specific case, but I don't understand what the consequences might be

---

Fixes #28990
[Forum](https://forum.freecad.org/viewtopic.php?p=882234#p882234)

Method `Part.getSortedClusters()` should return lists of edges from which wires can be created
Unlike method `Part.sortEdges`, `Part.getSortedClusters()` do not reorient edges, but returns edges as is
 
It is freeze, take all RAM and crash while process some shapes with edges shorter than 0.1 mm
Probably this depends from how edges oriented inside shape

In my example shape imported from **KiCAD** contains edge with min length `9.99999997e-07` 
- #28990

---

### Description of the problem

`Part.getSortedClusters()` skip edges which middle point closer than 1e-5 to end point
So edges with length greater than 2e-5 is valid

https://github.com/FreeCAD/FreeCAD/blob/d7dd27411ee6c4f0d859251d287fa98205be6f92/src/Mod/Part/App/edgecluster.cpp#L211-L220

But compares coordinates with tolerance 0.2 mm

https://github.com/FreeCAD/FreeCAD/blob/6aa5b83d810d6ef97fde99e67842cd40397f0d12/src/Mod/Part/App/edgecluster.cpp#L140

https://github.com/FreeCAD/FreeCAD/blob/d7dd27411ee6c4f0d859251d287fa98205be6f92/src/Mod/Part/App/edgecluster.h#L46-L53

Probably while process edges with length 2e-5, incorrect to use tolerance 0.2

---

> [!NOTE]
> This PR related with
> - #26644
