### PR TITLE
Fix a crash on early error (#29071)

### DIFF
--- a/src/App/ApplicationDirectories.cpp
+++ b/src/App/ApplicationDirectories.cpp
@@ -154,7 +154,9 @@ fs::path ApplicationDirectories::findPath(const fs::path& stdHome, const fs::pat
         try {
             fs::create_directories(appData);
         } catch (const fs::filesystem_error& e) {
-            throw Base::FileSystemError("Could not create directories. Failed with: " + e.code().message());
+            THROWM(Base::FileSystemError,
+                   "Could not create directories in " + appData.string() + ". "
+                   "Failed with: " + e.code().message());
         }
     }
 

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -284,18 +284,17 @@ int main(int argc, char** argv)
         // Popup an own dialog box instead of that one of Windows
         QApplication app(argc, argv);
         QString appName = QString::fromStdString(App::Application::getExecutableName());
-        QString msg;
-        msg = QObject::tr(
-                  "While initializing %1 the following exception occurred: '%2'\n\n"
-                  "Python is searching for its files in the following directories:\n%3\n\n"
-                  "Python version information:\n%4\n"
-        )
-                  .arg(
-                      appName,
-                      QString::fromUtf8(e.what()),
-                      QString::fromStdString(Base::Interpreter().getPythonPath()),
-                      QString::fromLatin1(Py_GetVersion())
-                  );
+        QString msg = QObject::tr("While initializing %1 the following exception occurred: '%2'\n\n")
+                          .arg(appName, QString::fromUtf8(e.what()));
+        if (Py_IsInitialized()) {
+            msg += QObject::tr("Python is searching for its files in the following directories:\n%1\n\n")
+                       .arg(QString::fromStdString(Base::Interpreter().getPythonPath()));
+        }
+        else {
+            msg += QObject::tr("Python has not initialized yet.\n\n");
+        }
+        msg += QObject::tr("Python version information:\n%1\n")
+                   .arg(QString::fromLatin1(Py_GetVersion()));
         const char* pythonhome = getenv("PYTHONHOME");
         if (pythonhome) {
             msg += QObject::tr("\nThe environment variable PYTHONHOME is set to '%1'.")


### PR DESCRIPTION
## Issues
Errors that happen before the Python interpreter was created triggered a segfault instead of showing an error dialog, as said dialog tries to display the Python search path without checking for its initialization first, leading to a null deref.

FC not having write permission to the app home directory triggers one such early error; see #29071.

As a bonus, adds the failure path to the error message.

## Before and After Images
<img width="540" height="312" alt="image" src="https://github.com/user-attachments/assets/9e9a0330-b1ee-4afe-b1aa-66d133d01b5a" />
