### PR TITLE
Part: improve boolean/refine diagnostics and detect refine corruption

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -78,6 +78,7 @@
 #include "FeatureMirroring.h"
 #include "FeatureOffset.h"
 #include "FeaturePartBoolean.h"
+#include "FeaturePartRefinable.h"
 #include "FeaturePartBox.h"
 #include "FeaturePartCircle.h"
 #include "FeaturePartCommon.h"
@@ -454,6 +455,7 @@ PyMOD_INIT_FUNC(Part)
     Part::Primitive             ::init();
     Part::Box                   ::init();
     Part::Spline                ::init();
+    Part::RefinableFeature      ::init();
     Part::Boolean               ::init();
     Part::Common                ::init();
     Part::MultiCommon           ::init();

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -168,6 +168,8 @@ generate_from_py(ShapeUpgrade/UnifySameDomain)
 SET(Features_SRCS
     FeaturePartBoolean.cpp
     FeaturePartBoolean.h
+    FeaturePartRefinable.cpp
+    FeaturePartRefinable.h
     FeaturePartBox.cpp
     FeaturePartBox.h
     FeaturePartCircle.cpp

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -27,13 +27,10 @@
 #include <memory>
 
 #include <Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h>
-#include <BOPAlgo_ArgumentAnalyzer.hxx>
-#include <BRepBuilderAPI_Copy.hxx>
 #include <BRepCheck_Analyzer.hxx>
 #include <Standard_Failure.hxx>
 
 #include <App/Application.h>
-#include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Parameter.h>
 #include <Base/ProgramVersion.h>
@@ -87,48 +84,9 @@ void throwIfInvalidIfCheckModel(const TopoDS_Shape& shape)
     }
 }
 
-bool getRefineModelParameter()
-{
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
-                                             .GetUserParameter()
-                                             .GetGroup("BaseApp")
-                                             ->GetGroup("Preferences")
-                                             ->GetGroup("Mod/Part/Boolean");
-    return hGrp->GetBool("RefineModel", true);
-}
-
-bool getCheckRefineParameter()
-{
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
-                                             .GetUserParameter()
-                                             .GetGroup("BaseApp")
-                                             ->GetGroup("Preferences")
-                                             ->GetGroup("Mod/Part/Boolean");
-    return hGrp->GetBool("CheckRefine", false);
-}
-
-bool refineResultIsValid(const TopoDS_Shape& shape, bool checkRefine)
-{
-    if (!checkRefine) {
-        return true;  // validation disabled, assume valid
-    }
-
-    // Run BOPAlgo_ArgumentAnalyzer to detect self-intersections that
-    // BRepCheck_Analyzer misses.  This catches corruption introduced by
-    // ShapeUpgrade_UnifySameDomain (removeSplitter/Refine) on shapes with
-    // coplanar faces and partial overlap.
-    TopoDS_Shape copy = BRepBuilderAPI_Copy(shape).Shape();
-    BOPAlgo_ArgumentAnalyzer checker;
-    checker.SetShape1(copy);
-    checker.SelfInterMode() = true;
-    checker.SetRunParallel(true);
-    checker.Perform();
-    return !checker.HasFaulty();
-}
-
 }  // namespace Part
 
-PROPERTY_SOURCE_ABSTRACT(Part::Boolean, Part::Feature)
+PROPERTY_SOURCE_ABSTRACT(Part::Boolean, Part::RefinableFeature)
 
 
 Boolean::Boolean()
@@ -144,23 +102,6 @@ Boolean::Boolean()
     );
     History.setSize(0);
 
-    ADD_PROPERTY_TYPE(
-        Refine,
-        (0),
-        "Boolean",
-        (App::PropertyType)(App::Prop_None),
-        "Refine shape (clean up redundant edges) after this boolean operation"
-    );
-    ADD_PROPERTY_TYPE(
-        CheckRefine,
-        (false),
-        "Boolean",
-        (App::PropertyType)(App::Prop_None),
-        "Validate refine result and revert if it introduces self-intersections (slower)"
-    );
-
-    this->Refine.setValue(getRefineModelParameter());
-    this->CheckRefine.setValue(getCheckRefineParameter());
 }
 
 short Boolean::mustExecute() const
@@ -244,22 +185,7 @@ App::DocumentObjectExecReturn* Boolean::execute()
 
         TopoShape res(0);
         res.makeElementShape(*mkBool, shapes, opCode());
-        if (this->Refine.getValue()) {
-            TopoShape preRefine = res;
-            res = res.makeElementRefine();
-            if (!refineResultIsValid(res.getShape(), this->CheckRefine.getValue())) {
-                res = preRefine;
-                Base::Console().warning(
-                    "'%s': The boolean result is correct, but the Refine "
-                    "(cleanup) step damaged it and was skipped. The result "
-                    "may have extra internal edges. To prevent this, disable "
-                    "Refine in this feature's properties. This is a known "
-                    "limitation of the geometry engine. "
-                    "See: https://wiki.freecad.org/Boolean_Troubleshooting\n",
-                    this->Label.getValue()
-                );
-            }
-        }
+        this->applyRefine(res);
         this->Shape.setValue(res);
         copyMaterial(base);
         return Part::Feature::execute();

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -27,10 +27,13 @@
 #include <memory>
 
 #include <Mod/Part/App/FCBRepAlgoAPI_BooleanOperation.h>
+#include <BOPAlgo_ArgumentAnalyzer.hxx>
+#include <BRepBuilderAPI_Copy.hxx>
 #include <BRepCheck_Analyzer.hxx>
 #include <Standard_Failure.hxx>
 
 #include <App/Application.h>
+#include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Parameter.h>
 #include <Base/ProgramVersion.h>
@@ -68,6 +71,31 @@ bool getRefineModelParameter()
                                              ->GetGroup("Preferences")
                                              ->GetGroup("Mod/Part/Boolean");
     return hGrp->GetBool("RefineModel", true);
+}
+
+bool refineResultIsValid(const TopoDS_Shape& shape)
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/Part/Boolean");
+
+    if (!hGrp->GetBool("CheckRefine", false)) {
+        return true;  // validation disabled, assume valid
+    }
+
+    // Run BOPAlgo_ArgumentAnalyzer to detect self-intersections that
+    // BRepCheck_Analyzer misses.  This catches corruption introduced by
+    // ShapeUpgrade_UnifySameDomain (removeSplitter/Refine) on shapes with
+    // coplanar faces and partial overlap.
+    TopoDS_Shape copy = BRepBuilderAPI_Copy(shape).Shape();
+    BOPAlgo_ArgumentAnalyzer checker;
+    checker.SetShape1(copy);
+    checker.SelfInterMode() = true;
+    checker.SetRunParallel(true);
+    checker.Perform();
+    return !checker.HasFaulty();
 }
 
 }  // namespace Part
@@ -169,7 +197,21 @@ App::DocumentObjectExecReturn* Boolean::execute()
         TopoShape res(0);
         res.makeElementShape(*mkBool, shapes, opCode());
         if (this->Refine.getValue()) {
+            TopoShape preRefine = res;
             res = res.makeElementRefine();
+            if (!refineResultIsValid(res.getShape())) {
+                res = preRefine;
+                Base::Console().warning(
+                    "'%s': Refine (removeSplitter) produced invalid geometry "
+                    "(self-intersections) and was skipped. The result is "
+                    "geometrically correct but contains redundant edges that "
+                    "may slow downstream operations. Consider disabling Refine "
+                    "on this feature, or restructuring input geometry to avoid "
+                    "coplanar faces with partial overlap. This is a known issue "
+                    "in the CAD kernel (OCCT ShapeUpgrade_UnifySameDomain).\n",
+                    this->Label.getValue()
+                );
+            }
         }
         this->Shape.setValue(res);
         copyMaterial(base);

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -101,7 +101,6 @@ Boolean::Boolean()
         "Shape history"
     );
     History.setSize(0);
-
 }
 
 short Boolean::mustExecute() const

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -47,6 +47,21 @@ using namespace Part;
 
 namespace Part
 {
+const char* shapeTypeName(TopAbs_ShapeEnum type)
+{
+    switch (type) {
+        case TopAbs_COMPOUND:  return "Compound";
+        case TopAbs_COMPSOLID: return "CompSolid";
+        case TopAbs_SOLID:     return "Solid";
+        case TopAbs_SHELL:     return "Shell";
+        case TopAbs_FACE:      return "Face";
+        case TopAbs_WIRE:      return "Wire";
+        case TopAbs_EDGE:      return "Edge";
+        case TopAbs_VERTEX:    return "Vertex";
+        default:               return "Shape";
+    }
+}
+
 void throwIfInvalidIfCheckModel(const TopoDS_Shape& shape)
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication()
@@ -179,12 +194,25 @@ App::DocumentObjectExecReturn* Boolean::execute()
         if (!mkBool->IsDone()) {
             std::stringstream error;
             error << "Boolean operation failed";
-            if (BaseShape.ShapeType() != TopAbs_SOLID) {
-                error << std::endl << base->Label.getValue() << " is not a solid";
-            }
-            if (ToolShape.ShapeType() != TopAbs_SOLID) {
-                error << std::endl << tool->Label.getValue() << " is not a solid";
-            }
+            error << std::endl << std::endl;
+            error << "This is usually caused by a limitation in the geometry "
+                     "engine, not a problem with your model. Faces that are "
+                     "exactly aligned, nearly touching, or in complex coplanar "
+                     "arrangements can be difficult for the engine to process.";
+            error << std::endl << std::endl;
+            error << "Things to try:" << std::endl;
+            error << "  - Reposition one shape slightly (e.g. add 0.01 mm "
+                     "in Placement)" << std::endl;
+            error << "  - Combine shapes in a different order" << std::endl;
+            error << "  - Check each input with Part > Check Geometry";
+            error << std::endl << std::endl;
+            error << "Input types: '"
+                  << base->Label.getValue() << "' ("
+                  << shapeTypeName(BaseShape.ShapeType()) << "), '"
+                  << tool->Label.getValue() << "' ("
+                  << shapeTypeName(ToolShape.ShapeType()) << ")";
+            error << std::endl;
+            error << "See: https://wiki.freecad.org/Boolean_Troubleshooting";
             return new App::DocumentObjectExecReturn(error.str());
         }
         TopoDS_Shape resShape = mkBool->Shape();
@@ -202,13 +230,12 @@ App::DocumentObjectExecReturn* Boolean::execute()
             if (!refineResultIsValid(res.getShape())) {
                 res = preRefine;
                 Base::Console().warning(
-                    "'%s': Refine (removeSplitter) produced invalid geometry "
-                    "(self-intersections) and was skipped. The result is "
-                    "geometrically correct but contains redundant edges that "
-                    "may slow downstream operations. Consider disabling Refine "
-                    "on this feature, or restructuring input geometry to avoid "
-                    "coplanar faces with partial overlap. This is a known issue "
-                    "in the CAD kernel (OCCT ShapeUpgrade_UnifySameDomain).\n",
+                    "'%s': The boolean result is correct, but the Refine "
+                    "(cleanup) step damaged it and was skipped. The result "
+                    "may have extra internal edges. To prevent this, disable "
+                    "Refine in this feature's properties. This is a known "
+                    "limitation of the geometry engine. "
+                    "See: https://wiki.freecad.org/Boolean_Troubleshooting\n",
                     this->Label.getValue()
                 );
             }

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -97,15 +97,19 @@ bool getRefineModelParameter()
     return hGrp->GetBool("RefineModel", true);
 }
 
-bool refineResultIsValid(const TopoDS_Shape& shape)
+bool getCheckRefineParameter()
 {
     Base::Reference<ParameterGrp> hGrp = App::GetApplication()
                                              .GetUserParameter()
                                              .GetGroup("BaseApp")
                                              ->GetGroup("Preferences")
                                              ->GetGroup("Mod/Part/Boolean");
+    return hGrp->GetBool("CheckRefine", false);
+}
 
-    if (!hGrp->GetBool("CheckRefine", false)) {
+bool refineResultIsValid(const TopoDS_Shape& shape, bool checkRefine)
+{
+    if (!checkRefine) {
         return true;  // validation disabled, assume valid
     }
 
@@ -147,8 +151,16 @@ Boolean::Boolean()
         (App::PropertyType)(App::Prop_None),
         "Refine shape (clean up redundant edges) after this boolean operation"
     );
+    ADD_PROPERTY_TYPE(
+        CheckRefine,
+        (false),
+        "Boolean",
+        (App::PropertyType)(App::Prop_None),
+        "Validate refine result and revert if it introduces self-intersections (slower)"
+    );
 
     this->Refine.setValue(getRefineModelParameter());
+    this->CheckRefine.setValue(getCheckRefineParameter());
 }
 
 short Boolean::mustExecute() const
@@ -235,7 +247,7 @@ App::DocumentObjectExecReturn* Boolean::execute()
         if (this->Refine.getValue()) {
             TopoShape preRefine = res;
             res = res.makeElementRefine();
-            if (!refineResultIsValid(res.getShape())) {
+            if (!refineResultIsValid(res.getShape(), this->CheckRefine.getValue())) {
                 res = preRefine;
                 Base::Console().warning(
                     "'%s': The boolean result is correct, but the Refine "

--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -50,15 +50,24 @@ namespace Part
 const char* shapeTypeName(TopAbs_ShapeEnum type)
 {
     switch (type) {
-        case TopAbs_COMPOUND:  return "Compound";
-        case TopAbs_COMPSOLID: return "CompSolid";
-        case TopAbs_SOLID:     return "Solid";
-        case TopAbs_SHELL:     return "Shell";
-        case TopAbs_FACE:      return "Face";
-        case TopAbs_WIRE:      return "Wire";
-        case TopAbs_EDGE:      return "Edge";
-        case TopAbs_VERTEX:    return "Vertex";
-        default:               return "Shape";
+        case TopAbs_COMPOUND:
+            return "Compound";
+        case TopAbs_COMPSOLID:
+            return "CompSolid";
+        case TopAbs_SOLID:
+            return "Solid";
+        case TopAbs_SHELL:
+            return "Shell";
+        case TopAbs_FACE:
+            return "Face";
+        case TopAbs_WIRE:
+            return "Wire";
+        case TopAbs_EDGE:
+            return "Edge";
+        case TopAbs_VERTEX:
+            return "Vertex";
+        default:
+            return "Shape";
     }
 }
 
@@ -202,15 +211,14 @@ App::DocumentObjectExecReturn* Boolean::execute()
             error << std::endl << std::endl;
             error << "Things to try:" << std::endl;
             error << "  - Reposition one shape slightly (e.g. add 0.01 mm "
-                     "in Placement)" << std::endl;
+                     "in Placement)"
+                  << std::endl;
             error << "  - Combine shapes in a different order" << std::endl;
             error << "  - Check each input with Part > Check Geometry";
             error << std::endl << std::endl;
-            error << "Input types: '"
-                  << base->Label.getValue() << "' ("
-                  << shapeTypeName(BaseShape.ShapeType()) << "), '"
-                  << tool->Label.getValue() << "' ("
-                  << shapeTypeName(ToolShape.ShapeType()) << ")";
+            error << "Input types: '" << base->Label.getValue() << "' ("
+                  << shapeTypeName(BaseShape.ShapeType()) << "), '" << tool->Label.getValue()
+                  << "' (" << shapeTypeName(ToolShape.ShapeType()) << ")";
             error << std::endl;
             error << "See: https://wiki.freecad.org/Boolean_Troubleshooting";
             return new App::DocumentObjectExecReturn(error.str());

--- a/src/Mod/Part/App/FeaturePartBoolean.h
+++ b/src/Mod/Part/App/FeaturePartBoolean.h
@@ -29,14 +29,14 @@
 
 #include <Mod/Part/PartGlobal.h>
 
-#include "PartFeature.h"
+#include "FeaturePartRefinable.h"
 
 class FCBRepAlgoAPI_BooleanOperation;
 
 namespace Part
 {
 
-class PartExport Boolean: public Part::Feature
+class PartExport Boolean: public Part::RefinableFeature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::Boolean);
 
@@ -46,8 +46,6 @@ public:
     App::PropertyLink Base;
     App::PropertyLink Tool;
     PropertyShapeHistory History;
-    App::PropertyBool Refine;
-    App::PropertyBool CheckRefine;
 
     /** @name methods override Feature */
     //@{

--- a/src/Mod/Part/App/FeaturePartBoolean.h
+++ b/src/Mod/Part/App/FeaturePartBoolean.h
@@ -47,6 +47,7 @@ public:
     App::PropertyLink Tool;
     PropertyShapeHistory History;
     App::PropertyBool Refine;
+    App::PropertyBool CheckRefine;
 
     /** @name methods override Feature */
     //@{

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -117,52 +117,63 @@ void MultiCommon::Restore(Base::XMLReader& reader)
 
 App::DocumentObjectExecReturn* MultiCommon::execute()
 {
-    std::vector<TopoShape> shapes;
-    for (auto obj : Shapes.getValues()) {
-        TopoShape sh = Feature::getTopoShape(obj, ShapeOption::ResolveLink | ShapeOption::Transform);
-        if (sh.isNull()) {
-            return new App::DocumentObjectExecReturn("Input shape is null");
+    try {
+        std::vector<TopoShape> shapes;
+        for (auto obj : Shapes.getValues()) {
+            TopoShape sh =
+                Feature::getTopoShape(obj, ShapeOption::ResolveLink | ShapeOption::Transform);
+            if (sh.isNull()) {
+                return new App::DocumentObjectExecReturn("Input shape is null");
+            }
+            shapes.push_back(sh);
         }
-        shapes.push_back(sh);
-    }
 
-    TopoShape res;
+        TopoShape res;
 
-    if (Behavior.getValue() == CommonOfAllShapes) {
-        // special case - if there is only one argument, and it is compound - expand it
-        if (shapes.size() == 1) {
-            TopoShape shape = shapes.front();
+        if (Behavior.getValue() == CommonOfAllShapes) {
+            // special case - if there is only one argument, and it is compound - expand it
+            if (shapes.size() == 1) {
+                TopoShape shape = shapes.front();
 
-            if (shape.shapeType() == TopAbs_COMPOUND) {
-                shapes.clear();
-                std::ranges::copy(shape.getSubTopoShapes(), std::back_inserter(shapes));
+                if (shape.shapeType() == TopAbs_COMPOUND) {
+                    shapes.clear();
+                    std::ranges::copy(shape.getSubTopoShapes(), std::back_inserter(shapes));
+                }
+            }
+
+            res = shapes.front();
+
+            // to achieve common of all shapes, we need to do it one shape at a time
+            for (const auto& tool : shapes) {
+                res = res.makeElementBoolean(OpCodes::Common, {res, tool});
             }
         }
-
-        res = shapes.front();
-
-        // to achieve common of all shapes, we need to do it one shape at a time
-        for (const auto& tool : shapes) {
-            res = res.makeElementBoolean(OpCodes::Common, {res, tool});
+        else {
+            res = TopoShape(0);
+            res.makeElementBoolean(OpCodes::Common, shapes);
         }
-    }
-    else {
-        res = TopoShape(0);
-        res.makeElementBoolean(OpCodes::Common, shapes);
-    }
 
-    if (res.isNull()) {
-        throw Base::RuntimeError("Resulting shape is null");
+        if (res.isNull()) {
+            return new App::DocumentObjectExecReturn("Resulting shape is null");
+        }
+
+        throwIfInvalidIfCheckModel(res.getShape());
+
+        this->applyRefine(res);
+        this->Shape.setValue(res);
+        if (Shapes.getSize() > 0) {
+            App::DocumentObject* link = Shapes.getValues()[0];
+            copyMaterial(link);
+        }
+
+        return Part::Feature::execute();
     }
-
-    throwIfInvalidIfCheckModel(res.getShape());
-
-    this->applyRefine(res);
-    this->Shape.setValue(res);
-    if (Shapes.getSize() > 0) {
-        App::DocumentObject* link = Shapes.getValues()[0];
-        copyMaterial(link);
+    catch (const Base::Exception& e) {
+        return new App::DocumentObjectExecReturn(e.what());
     }
-
-    return Part::Feature::execute();
+    catch (...) {
+        return new App::DocumentObjectExecReturn(
+            "A fatal error occurred when running boolean operation"
+        );
+    }
 }

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -120,8 +120,8 @@ App::DocumentObjectExecReturn* MultiCommon::execute()
     try {
         std::vector<TopoShape> shapes;
         for (auto obj : Shapes.getValues()) {
-            TopoShape sh =
-                Feature::getTopoShape(obj, ShapeOption::ResolveLink | ShapeOption::Transform);
+            TopoShape sh
+                = Feature::getTopoShape(obj, ShapeOption::ResolveLink | ShapeOption::Transform);
             if (sh.isNull()) {
                 return new App::DocumentObjectExecReturn("Input shape is null");
             }

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -89,7 +89,6 @@ MultiCommon::MultiCommon()
         "compatibility with FreeCAD 1.0)."
     );
     Behavior.setEnums(BehaviorEnums);
-
 }
 
 short MultiCommon::mustExecute() const

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -44,7 +44,8 @@ namespace Part
 {
 extern void throwIfInvalidIfCheckModel(const TopoDS_Shape& shape);
 extern bool getRefineModelParameter();
-extern bool refineResultIsValid(const TopoDS_Shape& shape);
+extern bool getCheckRefineParameter();
+extern bool refineResultIsValid(const TopoDS_Shape& shape, bool checkRefine);
 }  // namespace Part
 
 PROPERTY_SOURCE(Part::Common, Part::Boolean)
@@ -88,6 +89,13 @@ MultiCommon::MultiCommon()
         (App::PropertyType)(App::Prop_None),
         "Refine shape (clean up redundant edges) after this boolean operation"
     );
+    ADD_PROPERTY_TYPE(
+        CheckRefine,
+        (false),
+        "Boolean",
+        (App::PropertyType)(App::Prop_None),
+        "Validate refine result and revert if it introduces self-intersections (slower)"
+    );
 
     ADD_PROPERTY_TYPE(
         Behavior,
@@ -101,6 +109,7 @@ MultiCommon::MultiCommon()
     Behavior.setEnums(BehaviorEnums);
 
     this->Refine.setValue(getRefineModelParameter());
+    this->CheckRefine.setValue(getCheckRefineParameter());
 }
 
 short MultiCommon::mustExecute() const
@@ -172,7 +181,7 @@ App::DocumentObjectExecReturn* MultiCommon::execute()
     if (this->Refine.getValue()) {
         TopoShape preRefine = res;
         res = res.makeElementRefine();
-        if (!refineResultIsValid(res.getShape())) {
+        if (!refineResultIsValid(res.getShape(), this->CheckRefine.getValue())) {
             res = preRefine;
             Base::Console().warning(
                 "'%s': The boolean result is correct, but the Refine "

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -34,6 +34,7 @@
 #include "TopoShapeOpCode.h"
 #include "modelRefine.h"
 
+#include <Base/Console.h>
 #include <Base/ProgramVersion.h>
 
 
@@ -43,6 +44,7 @@ namespace Part
 {
 extern void throwIfInvalidIfCheckModel(const TopoDS_Shape& shape);
 extern bool getRefineModelParameter();
+extern bool refineResultIsValid(const TopoDS_Shape& shape);
 }  // namespace Part
 
 PROPERTY_SOURCE(Part::Common, Part::Boolean)
@@ -168,7 +170,21 @@ App::DocumentObjectExecReturn* MultiCommon::execute()
     throwIfInvalidIfCheckModel(res.getShape());
 
     if (this->Refine.getValue()) {
+        TopoShape preRefine = res;
         res = res.makeElementRefine();
+        if (!refineResultIsValid(res.getShape())) {
+            res = preRefine;
+            Base::Console().warning(
+                "'%s': Refine (removeSplitter) produced invalid geometry "
+                "(self-intersections) and was skipped. The result is "
+                "geometrically correct but contains redundant edges that "
+                "may slow downstream operations. Consider disabling Refine "
+                "on this feature, or restructuring input geometry to avoid "
+                "coplanar faces with partial overlap. This is a known issue "
+                "in the CAD kernel (OCCT ShapeUpgrade_UnifySameDomain).\n",
+                this->Label.getValue()
+            );
+        }
     }
     this->Shape.setValue(res);
     if (Shapes.getSize() > 0) {

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -43,9 +43,6 @@ using namespace Part;
 namespace Part
 {
 extern void throwIfInvalidIfCheckModel(const TopoDS_Shape& shape);
-extern bool getRefineModelParameter();
-extern bool getCheckRefineParameter();
-extern bool refineResultIsValid(const TopoDS_Shape& shape, bool checkRefine);
 }  // namespace Part
 
 PROPERTY_SOURCE(Part::Common, Part::Boolean)
@@ -65,7 +62,7 @@ BRepAlgoAPI_BooleanOperation* Common::makeOperation(const TopoDS_Shape& base, co
 
 // ----------------------------------------------------
 
-PROPERTY_SOURCE(Part::MultiCommon, Part::Feature)
+PROPERTY_SOURCE(Part::MultiCommon, Part::RefinableFeature)
 
 const char* MultiCommon::BehaviorEnums[] = {"CommonOfAllShapes", "CommonOfFirstAndRest", nullptr};
 
@@ -83,21 +80,6 @@ MultiCommon::MultiCommon()
     History.setSize(0);
 
     ADD_PROPERTY_TYPE(
-        Refine,
-        (0),
-        "Boolean",
-        (App::PropertyType)(App::Prop_None),
-        "Refine shape (clean up redundant edges) after this boolean operation"
-    );
-    ADD_PROPERTY_TYPE(
-        CheckRefine,
-        (false),
-        "Boolean",
-        (App::PropertyType)(App::Prop_None),
-        "Validate refine result and revert if it introduces self-intersections (slower)"
-    );
-
-    ADD_PROPERTY_TYPE(
         Behavior,
         (CommonOfAllShapes),
         "Compatibility",
@@ -108,8 +90,6 @@ MultiCommon::MultiCommon()
     );
     Behavior.setEnums(BehaviorEnums);
 
-    this->Refine.setValue(getRefineModelParameter());
-    this->CheckRefine.setValue(getCheckRefineParameter());
 }
 
 short MultiCommon::mustExecute() const
@@ -178,22 +158,7 @@ App::DocumentObjectExecReturn* MultiCommon::execute()
 
     throwIfInvalidIfCheckModel(res.getShape());
 
-    if (this->Refine.getValue()) {
-        TopoShape preRefine = res;
-        res = res.makeElementRefine();
-        if (!refineResultIsValid(res.getShape(), this->CheckRefine.getValue())) {
-            res = preRefine;
-            Base::Console().warning(
-                "'%s': The boolean result is correct, but the Refine "
-                "(cleanup) step damaged it and was skipped. The result "
-                "may have extra internal edges. To prevent this, disable "
-                "Refine in this feature's properties. This is a known "
-                "limitation of the geometry engine. "
-                "See: https://wiki.freecad.org/Boolean_Troubleshooting\n",
-                this->Label.getValue()
-            );
-        }
-    }
+    this->applyRefine(res);
     this->Shape.setValue(res);
     if (Shapes.getSize() > 0) {
         App::DocumentObject* link = Shapes.getValues()[0];

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -175,13 +175,12 @@ App::DocumentObjectExecReturn* MultiCommon::execute()
         if (!refineResultIsValid(res.getShape())) {
             res = preRefine;
             Base::Console().warning(
-                "'%s': Refine (removeSplitter) produced invalid geometry "
-                "(self-intersections) and was skipped. The result is "
-                "geometrically correct but contains redundant edges that "
-                "may slow downstream operations. Consider disabling Refine "
-                "on this feature, or restructuring input geometry to avoid "
-                "coplanar faces with partial overlap. This is a known issue "
-                "in the CAD kernel (OCCT ShapeUpgrade_UnifySameDomain).\n",
+                "'%s': The boolean result is correct, but the Refine "
+                "(cleanup) step damaged it and was skipped. The result "
+                "may have extra internal edges. To prevent this, disable "
+                "Refine in this feature's properties. This is a known "
+                "limitation of the geometry engine. "
+                "See: https://wiki.freecad.org/Boolean_Troubleshooting\n",
                 this->Label.getValue()
             );
         }

--- a/src/Mod/Part/App/FeaturePartCommon.h
+++ b/src/Mod/Part/App/FeaturePartCommon.h
@@ -64,6 +64,7 @@ public:
     App::PropertyLinkList Shapes;
     PropertyShapeHistory History;
     App::PropertyBool Refine;
+    App::PropertyBool CheckRefine;
     App::PropertyEnumeration Behavior;
 
     /** @name methods override feature */

--- a/src/Mod/Part/App/FeaturePartCommon.h
+++ b/src/Mod/Part/App/FeaturePartCommon.h
@@ -54,7 +54,7 @@ enum CommonBehavior
     CommonOfFirstAndRest,
 };
 
-class PartExport MultiCommon: public Part::Feature
+class PartExport MultiCommon: public Part::RefinableFeature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::MultiCommon);
 
@@ -63,8 +63,6 @@ public:
 
     App::PropertyLinkList Shapes;
     PropertyShapeHistory History;
-    App::PropertyBool Refine;
-    App::PropertyBool CheckRefine;
     App::PropertyEnumeration Behavior;
 
     /** @name methods override feature */

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -80,7 +80,6 @@ MultiFuse::MultiFuse()
         "Shape history"
     );
     History.setSize(0);
-
 }
 
 short MultiFuse::mustExecute() const

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -45,9 +45,6 @@ using namespace Part;
 namespace Part
 {
 extern void throwIfInvalidIfCheckModel(const TopoDS_Shape& shape);
-extern bool getRefineModelParameter();
-extern bool getCheckRefineParameter();
-extern bool refineResultIsValid(const TopoDS_Shape& shape, bool checkRefine);
 }  // namespace Part
 
 PROPERTY_SOURCE(Part::Fuse, Part::Boolean)
@@ -68,7 +65,7 @@ const char* Fuse::opCode() const
 
 // ----------------------------------------------------
 
-PROPERTY_SOURCE(Part::MultiFuse, Part::Feature)
+PROPERTY_SOURCE(Part::MultiFuse, Part::RefinableFeature)
 
 
 MultiFuse::MultiFuse()
@@ -84,23 +81,6 @@ MultiFuse::MultiFuse()
     );
     History.setSize(0);
 
-    ADD_PROPERTY_TYPE(
-        Refine,
-        (0),
-        "Boolean",
-        (App::PropertyType)(App::Prop_None),
-        "Refine shape (clean up redundant edges) after this boolean operation"
-    );
-    ADD_PROPERTY_TYPE(
-        CheckRefine,
-        (false),
-        "Boolean",
-        (App::PropertyType)(App::Prop_None),
-        "Validate refine result and revert if it introduces self-intersections (slower)"
-    );
-
-    this->Refine.setValue(getRefineModelParameter());
-    this->CheckRefine.setValue(getCheckRefineParameter());
 }
 
 short MultiFuse::mustExecute() const
@@ -192,7 +172,7 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
                 try {
                     TopoDS_Shape oldShape = res.getShape();
                     BRepBuilderAPI_RefineModel mkRefine(oldShape);
-                    if (!refineResultIsValid(mkRefine.Shape(), this->CheckRefine.getValue())) {
+                    if (!this->isRefineResultValid(mkRefine.Shape())) {
                         Base::Console().warning(
                             "'%s': The boolean result is correct, but the "
                             "Refine (cleanup) step damaged it and was skipped. "

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -46,6 +46,7 @@ namespace Part
 {
 extern void throwIfInvalidIfCheckModel(const TopoDS_Shape& shape);
 extern bool getRefineModelParameter();
+extern bool refineResultIsValid(const TopoDS_Shape& shape);
 }  // namespace Part
 
 PROPERTY_SOURCE(Part::Fuse, Part::Boolean)
@@ -172,11 +173,29 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
                 try {
                     TopoDS_Shape oldShape = res.getShape();
                     BRepBuilderAPI_RefineModel mkRefine(oldShape);
-                    // We just built an element map above for the fuse, don't erase it for a refine.
-                    res.setShape(mkRefine.Shape(), false);
-                    ShapeHistory hist = buildHistory(mkRefine, TopAbs_FACE, res.getShape(), oldShape);
-                    for (auto& jt : history) {
-                        jt = joinHistory(jt, hist);
+                    if (!refineResultIsValid(mkRefine.Shape())) {
+                        Base::Console().warning(
+                            "'%s': Refine (removeSplitter) produced invalid "
+                            "geometry (self-intersections) and was skipped. The "
+                            "result is geometrically correct but contains "
+                            "redundant edges that may slow downstream "
+                            "operations. Consider disabling Refine on this "
+                            "feature, or restructuring input geometry to avoid "
+                            "coplanar faces with partial overlap. This is a "
+                            "known issue in the CAD kernel "
+                            "(OCCT ShapeUpgrade_UnifySameDomain).\n",
+                            this->Label.getValue()
+                        );
+                    }
+                    else {
+                        // We just built an element map above for the fuse,
+                        // don't erase it for a refine.
+                        res.setShape(mkRefine.Shape(), false);
+                        ShapeHistory hist = buildHistory(
+                            mkRefine, TopAbs_FACE, res.getShape(), oldShape);
+                        for (auto& jt : history) {
+                            jt = joinHistory(jt, hist);
+                        }
                     }
                 }
                 catch (Standard_Failure&) {

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -46,7 +46,8 @@ namespace Part
 {
 extern void throwIfInvalidIfCheckModel(const TopoDS_Shape& shape);
 extern bool getRefineModelParameter();
-extern bool refineResultIsValid(const TopoDS_Shape& shape);
+extern bool getCheckRefineParameter();
+extern bool refineResultIsValid(const TopoDS_Shape& shape, bool checkRefine);
 }  // namespace Part
 
 PROPERTY_SOURCE(Part::Fuse, Part::Boolean)
@@ -90,8 +91,16 @@ MultiFuse::MultiFuse()
         (App::PropertyType)(App::Prop_None),
         "Refine shape (clean up redundant edges) after this boolean operation"
     );
+    ADD_PROPERTY_TYPE(
+        CheckRefine,
+        (false),
+        "Boolean",
+        (App::PropertyType)(App::Prop_None),
+        "Validate refine result and revert if it introduces self-intersections (slower)"
+    );
 
     this->Refine.setValue(getRefineModelParameter());
+    this->CheckRefine.setValue(getCheckRefineParameter());
 }
 
 short MultiFuse::mustExecute() const
@@ -183,7 +192,7 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
                 try {
                     TopoDS_Shape oldShape = res.getShape();
                     BRepBuilderAPI_RefineModel mkRefine(oldShape);
-                    if (!refineResultIsValid(mkRefine.Shape())) {
+                    if (!refineResultIsValid(mkRefine.Shape(), this->CheckRefine.getValue())) {
                         Base::Console().warning(
                             "'%s': The boolean result is correct, but the "
                             "Refine (cleanup) step damaged it and was skipped. "

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -155,7 +155,17 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
             mkFuse.Build();
 
             if (!mkFuse.IsDone()) {
-                throw Base::RuntimeError("MultiFusion failed");
+                throw Base::RuntimeError(
+                    "MultiFusion failed. This is usually caused by a "
+                    "limitation in the geometry engine, not a problem with "
+                    "your model. Faces that are exactly aligned, nearly "
+                    "touching, or in complex coplanar arrangements can be "
+                    "difficult for the engine to process. Try repositioning "
+                    "one shape slightly (e.g. add 0.01 mm in Placement), "
+                    "combining in a different order, or fusing in smaller "
+                    "groups. See: https://wiki.freecad.org/"
+                    "Boolean_Troubleshooting"
+                );
             }
 
             TopoShape res(0);
@@ -175,15 +185,13 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
                     BRepBuilderAPI_RefineModel mkRefine(oldShape);
                     if (!refineResultIsValid(mkRefine.Shape())) {
                         Base::Console().warning(
-                            "'%s': Refine (removeSplitter) produced invalid "
-                            "geometry (self-intersections) and was skipped. The "
-                            "result is geometrically correct but contains "
-                            "redundant edges that may slow downstream "
-                            "operations. Consider disabling Refine on this "
-                            "feature, or restructuring input geometry to avoid "
-                            "coplanar faces with partial overlap. This is a "
-                            "known issue in the CAD kernel "
-                            "(OCCT ShapeUpgrade_UnifySameDomain).\n",
+                            "'%s': The boolean result is correct, but the "
+                            "Refine (cleanup) step damaged it and was skipped. "
+                            "The result may have extra internal edges. To "
+                            "prevent this, disable Refine in this feature's "
+                            "properties. This is a known limitation of the "
+                            "geometry engine. See: https://wiki.freecad.org/"
+                            "Boolean_Troubleshooting\n",
                             this->Label.getValue()
                         );
                     }

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -199,8 +199,8 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
                         // We just built an element map above for the fuse,
                         // don't erase it for a refine.
                         res.setShape(mkRefine.Shape(), false);
-                        ShapeHistory hist = buildHistory(
-                            mkRefine, TopAbs_FACE, res.getShape(), oldShape);
+                        ShapeHistory hist
+                            = buildHistory(mkRefine, TopAbs_FACE, res.getShape(), oldShape);
                         for (auto& jt : history) {
                             jt = joinHistory(jt, hist);
                         }

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -144,14 +144,11 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
 
             if (!mkFuse.IsDone()) {
                 return new App::DocumentObjectExecReturn(
-                    "MultiFusion failed. This is usually caused by a "
-                    "limitation in the geometry engine, not a problem with "
-                    "your model. Faces that are exactly aligned, nearly "
-                    "touching, or in complex coplanar arrangements can be "
-                    "difficult for the engine to process. Try repositioning "
-                    "one shape slightly (e.g. add 0.01 mm in Placement), "
-                    "combining in a different order, or fusing in smaller "
-                    "groups. See: https://wiki.freecad.org/"
+                    "MultiFusion failed. Likely due to a geometry engine "
+                    "limitation. Nearly touching, aligned, or complex coplanar "
+                    "faces may cause it. Try slightly moving a shape (e.g. "
+                    "0.01 mm in Placement), changing the fusion order, or "
+                    "fusing smaller groups. See: https://wiki.freecad.org/"
                     "Boolean_Troubleshooting"
                 );
             }

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -143,7 +143,7 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
             mkFuse.Build();
 
             if (!mkFuse.IsDone()) {
-                throw Base::RuntimeError(
+                return new App::DocumentObjectExecReturn(
                     "MultiFusion failed. This is usually caused by a "
                     "limitation in the geometry engine, not a problem with "
                     "your model. Faces that are exactly aligned, nearly "
@@ -236,6 +236,9 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
             App::DocumentObject* link = Shapes.getValues()[0];
             copyMaterial(link);
             return Part::Feature::execute();
+        }
+        catch (Base::Exception& e) {
+            return new App::DocumentObjectExecReturn(e.what());
         }
         catch (Standard_Failure& e) {
             return new App::DocumentObjectExecReturn(e.GetMessageString());

--- a/src/Mod/Part/App/FeaturePartFuse.h
+++ b/src/Mod/Part/App/FeaturePartFuse.h
@@ -48,7 +48,7 @@ protected:
     //@}
 };
 
-class PartExport MultiFuse: public Part::Feature
+class PartExport MultiFuse: public Part::RefinableFeature
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Part::MultiFuse);
 
@@ -57,8 +57,6 @@ public:
 
     App::PropertyLinkList Shapes;
     PropertyShapeHistory History;
-    App::PropertyBool Refine;
-    App::PropertyBool CheckRefine;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/App/FeaturePartFuse.h
+++ b/src/Mod/Part/App/FeaturePartFuse.h
@@ -58,6 +58,7 @@ public:
     App::PropertyLinkList Shapes;
     PropertyShapeHistory History;
     App::PropertyBool Refine;
+    App::PropertyBool CheckRefine;
 
     /** @name methods override feature */
     //@{

--- a/src/Mod/Part/App/FeaturePartRefinable.cpp
+++ b/src/Mod/Part/App/FeaturePartRefinable.cpp
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2007 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,   *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <FCConfig.h>
+
+#include <BOPAlgo_ArgumentAnalyzer.hxx>
+#include <BRepBuilderAPI_Copy.hxx>
+
+#include <App/Application.h>
+#include <Base/Console.h>
+#include <Base/Parameter.h>
+
+#include "FeaturePartRefinable.h"
+#include "TopoShape.h"
+
+using namespace Part;
+
+namespace
+{
+
+bool getRefineModelParameter()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/Part/Boolean");
+    return hGrp->GetBool("RefineModel", true);
+}
+
+bool getCheckRefineParameter()
+{
+    Base::Reference<ParameterGrp> hGrp = App::GetApplication()
+                                             .GetUserParameter()
+                                             .GetGroup("BaseApp")
+                                             ->GetGroup("Preferences")
+                                             ->GetGroup("Mod/Part/Boolean");
+    return hGrp->GetBool("CheckRefine", false);
+}
+
+}  // namespace
+
+PROPERTY_SOURCE_ABSTRACT(Part::RefinableFeature, Part::Feature)
+
+
+RefinableFeature::RefinableFeature()
+{
+    ADD_PROPERTY_TYPE(
+        Refine,
+        (0),
+        "Boolean",
+        (App::PropertyType)(App::Prop_None),
+        "Refine shape (clean up redundant edges) after this boolean operation"
+    );
+    ADD_PROPERTY_TYPE(
+        CheckRefine,
+        (false),
+        "Boolean",
+        (App::PropertyType)(App::Prop_None),
+        "Validate refine result and revert if it introduces self-intersections (slower)"
+    );
+
+    this->Refine.setValue(getRefineModelParameter());
+    this->CheckRefine.setValue(getCheckRefineParameter());
+}
+
+bool RefinableFeature::isRefineResultValid(const TopoDS_Shape& shape) const
+{
+    if (!this->CheckRefine.getValue()) {
+        return true;  // validation disabled, assume valid
+    }
+
+    // Run BOPAlgo_ArgumentAnalyzer to detect self-intersections that
+    // BRepCheck_Analyzer misses.  This catches corruption introduced by
+    // ShapeUpgrade_UnifySameDomain (removeSplitter/Refine) on shapes with
+    // coplanar faces and partial overlap.
+    TopoDS_Shape copy = BRepBuilderAPI_Copy(shape).Shape();
+    BOPAlgo_ArgumentAnalyzer checker;
+    checker.SetShape1(copy);
+    checker.SelfInterMode() = true;
+    checker.SetRunParallel(true);
+    checker.Perform();
+    return !checker.HasFaulty();
+}
+
+void RefinableFeature::applyRefine(TopoShape& res) const
+{
+    if (!this->Refine.getValue()) {
+        return;
+    }
+
+    TopoShape preRefine = res;
+    res = res.makeElementRefine();
+    if (!isRefineResultValid(res.getShape())) {
+        res = preRefine;
+        Base::Console().warning(
+            "'%s': The boolean result is correct, but the Refine "
+            "(cleanup) step damaged it and was skipped. The result "
+            "may have extra internal edges. To prevent this, disable "
+            "Refine in this feature's properties. This is a known "
+            "limitation of the geometry engine. "
+            "See: https://wiki.freecad.org/Boolean_Troubleshooting\n",
+            this->Label.getValue()
+        );
+    }
+}

--- a/src/Mod/Part/App/FeaturePartRefinable.h
+++ b/src/Mod/Part/App/FeaturePartRefinable.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2007 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,   *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <Mod/Part/PartGlobal.h>
+
+#include "PartFeature.h"
+
+namespace Part
+{
+
+/// Abstract base for boolean features that support Refine and CheckRefine.
+///
+/// Owns the Refine and CheckRefine properties and the logic to validate and
+/// apply the refine step. Boolean, MultiFuse, and MultiCommon all inherit
+/// from this class so the properties and behaviour are defined once.
+class PartExport RefinableFeature: public Part::Feature
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::RefinableFeature);
+
+public:
+    RefinableFeature();
+
+    /// Refine shape (clean up redundant edges) after the boolean operation.
+    App::PropertyBool Refine;
+
+    /// Validate the refined shape using BOPAlgo self-intersection detection
+    /// and revert to the pre-refine result if corruption is detected.
+    /// Seeded from the CheckRefine user preference at feature creation time.
+    /// Has no effect when Refine is false.
+    App::PropertyBool CheckRefine;
+
+protected:
+    /// Check whether @p shape is valid after a refine step.
+    ///
+    /// Returns true immediately when CheckRefine is false (fast path).
+    /// Otherwise runs BOPAlgo_ArgumentAnalyzer with self-intersection
+    /// detection, which catches corruption that BRepCheck_Analyzer misses.
+    bool isRefineResultValid(const TopoDS_Shape& shape) const;
+
+    /// Apply makeElementRefine() to @p res.
+    ///
+    /// When Refine is false, does nothing. When Refine is true, applies the
+    /// refine step; if CheckRefine is true and the result is invalid, reverts
+    /// to the pre-refine shape and emits a warning to the Report View.
+    void applyRefine(TopoShape& res) const;
+};
+
+}  // namespace Part

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -239,28 +239,6 @@ bool CmdPartPrimitives::isActive()
 
 namespace PartGui
 {
-bool checkForSolids(const TopoDS_Shape& shape)
-{
-    TopExp_Explorer xp;
-    xp.Init(shape, TopAbs_FACE, TopAbs_SHELL);
-    if (xp.More()) {
-        return false;
-    }
-    xp.Init(shape, TopAbs_WIRE, TopAbs_FACE);
-    if (xp.More()) {
-        return false;
-    }
-    xp.Init(shape, TopAbs_EDGE, TopAbs_WIRE);
-    if (xp.More()) {
-        return false;
-    }
-    xp.Init(shape, TopAbs_VERTEX, TopAbs_EDGE);
-    if (xp.More()) {
-        return false;
-    }
-
-    return true;
-}
 /*
  * returns vector of Part::TopoShapes from selected Part::Feature derived objects,
  * App::Links linked to Part::Features, or App::Part containers with visible Part::Features
@@ -336,31 +314,8 @@ void CmdPartCut::activated(int iMsg)
         return;
     }
 
-    bool askUser = false;
     std::vector<std::string> names;
     for (const auto& it : Sel) {
-        const App::DocumentObject* obj = it.getObject();
-        const TopoDS_Shape& shape = Part::Feature::getShape(
-            obj,
-            Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
-        );
-        if (!PartGui::checkForSolids(shape) && !askUser) {
-            int ret = QMessageBox::warning(
-                Gui::getMainWindow(),
-                QObject::tr("Non-solids selected"),
-                QObject::tr(
-                    "The use of non-solids for boolean operations may lead to unexpected results.\n"
-                    "Continue?"
-                ),
-                QMessageBox::Yes,
-                QMessageBox::No
-            );
-            if (ret == QMessageBox::No) {
-                return;
-            }
-            askUser = true;
-        }
-
         names.push_back(Base::Tools::quoted(it.getFeatName()));
     }
 
@@ -413,31 +368,8 @@ void CmdPartCommon::activated(int iMsg)
         return;
     }
 
-    bool askUser = false;
     std::vector<std::string> names;
     for (const auto& it : Sel) {
-        const App::DocumentObject* obj = it.getObject();
-        const TopoDS_Shape& shape = Part::Feature::getShape(
-            obj,
-            Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
-        );
-        if (!PartGui::checkForSolids(shape) && !askUser) {
-            int ret = QMessageBox::warning(
-                Gui::getMainWindow(),
-                QObject::tr("Non-solids selected"),
-                QObject::tr(
-                    "The use of non-solids for boolean operations may lead to unexpected results.\n"
-                    "Continue?"
-                ),
-                QMessageBox::Yes,
-                QMessageBox::No
-            );
-            if (ret == QMessageBox::No) {
-                return;
-            }
-            askUser = true;
-        }
-
         names.push_back(Base::Tools::quoted(it.getFeatName()));
     }
 
@@ -513,31 +445,8 @@ void CmdPartFuse::activated(int iMsg)
         return;
     }
 
-    bool askUser = false;
     std::vector<std::string> names;
     for (const auto& it : Sel) {
-        const App::DocumentObject* obj = it.getObject();
-        const TopoDS_Shape& shape = Part::Feature::getShape(
-            obj,
-            Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform
-        );
-        if (!PartGui::checkForSolids(shape) && !askUser) {
-            int ret = QMessageBox::warning(
-                Gui::getMainWindow(),
-                QObject::tr("Non-solids selected"),
-                QObject::tr(
-                    "The use of non-solids for boolean operations may lead to unexpected results.\n"
-                    "Continue?"
-                ),
-                QMessageBox::Yes,
-                QMessageBox::No
-            );
-            if (ret == QMessageBox::No) {
-                return;
-            }
-            askUser = true;
-        }
-
         names.push_back(Base::Tools::quoted(it.getFeatName()));
     }
 

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -44,6 +44,28 @@
        </widget>
       </item>
       <item row="1" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkRefineValidation">
+        <property name="text">
+         <string>Validate refine result and warn on failure (slower)</string>
+        </property>
+        <property name="toolTip">
+         <string>After refining (removing redundant edges), run a geometry check
+on the result. If refine introduced invalid geometry (a known issue
+in the CAD kernel), skip the refine and warn in the Report View.
+This adds computation time but catches silent geometry corruption.</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>CheckRefine</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Part/Boolean</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBooleanRefine">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -68,7 +90,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="Gui::PrefCheckBox" name="checkSketchBaseRefine">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -93,7 +115,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="Gui::PrefCheckBox" name="checkAllowCompoundBody">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -30,6 +30,7 @@ from FreeCAD import Base
 
 App = FreeCAD
 
+from parttests.BooleanFeatureTest import TestBooleanFeatures
 from parttests.BRep_tests import BRepTests
 from parttests.Geom2d_tests import Geom2dTests
 from parttests.regression_tests import RegressionTests

--- a/src/Mod/Part/parttests/BooleanFeatureTest.py
+++ b/src/Mod/Part/parttests/BooleanFeatureTest.py
@@ -16,9 +16,7 @@ def _make_boxes(doc):
 
     b2 = doc.addObject("Part::Box", "Box2")
     b2.Length = b2.Width = b2.Height = 10.0
-    b2.Placement = FreeCAD.Placement(
-        FreeCAD.Vector(5, 0, 0), FreeCAD.Rotation()
-    )
+    b2.Placement = FreeCAD.Placement(FreeCAD.Vector(5, 0, 0), FreeCAD.Rotation())
     doc.recompute()
     return b1, b2
 
@@ -69,7 +67,9 @@ class TestBooleanFeatures(unittest.TestCase):
         mc = self.doc.addObject("Part::MultiCommon", "MultiCommon")
         mc.Shapes = [b1, b2]
         self.assertTrue(hasattr(mc, "Refine"), "Part::MultiCommon missing Refine property")
-        self.assertTrue(hasattr(mc, "CheckRefine"), "Part::MultiCommon missing CheckRefine property")
+        self.assertTrue(
+            hasattr(mc, "CheckRefine"), "Part::MultiCommon missing CheckRefine property"
+        )
 
     # ------------------------------------------------------------------
     # Basic execute() smoke tests

--- a/src/Mod/Part/parttests/BooleanFeatureTest.py
+++ b/src/Mod/Part/parttests/BooleanFeatureTest.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# Tests for Part boolean feature classes (Fuse, Common, Cut, MultiFuse, MultiCommon).
+# Exercises the feature-level API (document objects with properties) rather than
+# the raw TopoShape API, so class registration, property inheritance, and
+# execute() are all exercised.
+
+import unittest
+import FreeCAD
+import Part
+
+
+def _make_boxes(doc):
+    """Return two overlapping box features ready to use as boolean inputs."""
+    b1 = doc.addObject("Part::Box", "Box1")
+    b1.Length = b1.Width = b1.Height = 10.0
+
+    b2 = doc.addObject("Part::Box", "Box2")
+    b2.Length = b2.Width = b2.Height = 10.0
+    b2.Placement = FreeCAD.Placement(
+        FreeCAD.Vector(5, 0, 0), FreeCAD.Rotation()
+    )
+    doc.recompute()
+    return b1, b2
+
+
+class TestBooleanFeatures(unittest.TestCase):
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("BooleanFeatureTest")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.doc.Name)
+
+    # ------------------------------------------------------------------
+    # Registration / property inheritance
+    # ------------------------------------------------------------------
+
+    def test_refinable_feature_registered(self):
+        """RefinableFeature must be initialised so property inheritance works."""
+        self.assertFalse(
+            FreeCAD.Base.TypeId.fromName("Part::RefinableFeature").isBad(),
+            "Part::RefinableFeature is not registered — missing init() call in AppPart.cpp",
+        )
+
+    def test_refine_and_check_refine_on_fuse(self):
+        b1, b2 = _make_boxes(self.doc)
+        fuse = self.doc.addObject("Part::Fuse", "Fuse")
+        fuse.Base = b1
+        fuse.Tool = b2
+        self.assertTrue(hasattr(fuse, "Refine"), "Part::Fuse missing Refine property")
+        self.assertTrue(hasattr(fuse, "CheckRefine"), "Part::Fuse missing CheckRefine property")
+
+    def test_refine_and_check_refine_on_common(self):
+        b1, b2 = _make_boxes(self.doc)
+        common = self.doc.addObject("Part::Common", "Common")
+        common.Base = b1
+        common.Tool = b2
+        self.assertTrue(hasattr(common, "Refine"), "Part::Common missing Refine property")
+        self.assertTrue(hasattr(common, "CheckRefine"), "Part::Common missing CheckRefine property")
+
+    def test_refine_and_check_refine_on_multifuse(self):
+        b1, b2 = _make_boxes(self.doc)
+        mf = self.doc.addObject("Part::MultiFuse", "MultiFuse")
+        mf.Shapes = [b1, b2]
+        self.assertTrue(hasattr(mf, "Refine"), "Part::MultiFuse missing Refine property")
+        self.assertTrue(hasattr(mf, "CheckRefine"), "Part::MultiFuse missing CheckRefine property")
+
+    def test_refine_and_check_refine_on_multicommon(self):
+        b1, b2 = _make_boxes(self.doc)
+        mc = self.doc.addObject("Part::MultiCommon", "MultiCommon")
+        mc.Shapes = [b1, b2]
+        self.assertTrue(hasattr(mc, "Refine"), "Part::MultiCommon missing Refine property")
+        self.assertTrue(hasattr(mc, "CheckRefine"), "Part::MultiCommon missing CheckRefine property")
+
+    # ------------------------------------------------------------------
+    # Basic execute() smoke tests
+    # ------------------------------------------------------------------
+
+    def test_fuse_two_boxes(self):
+        b1, b2 = _make_boxes(self.doc)
+        fuse = self.doc.addObject("Part::Fuse", "Fuse")
+        fuse.Base = b1
+        fuse.Tool = b2
+        self.doc.recompute()
+        shape = fuse.Shape
+        self.assertFalse(shape.isNull(), "Part::Fuse result is null")
+        self.assertGreater(shape.Volume, 0, "Part::Fuse result has no volume")
+
+    def test_common_two_boxes(self):
+        b1, b2 = _make_boxes(self.doc)
+        common = self.doc.addObject("Part::Common", "Common")
+        common.Base = b1
+        common.Tool = b2
+        self.doc.recompute()
+        shape = common.Shape
+        self.assertFalse(shape.isNull(), "Part::Common result is null")
+        self.assertGreater(shape.Volume, 0, "Part::Common result has no volume")
+
+    def test_cut_two_boxes(self):
+        b1, b2 = _make_boxes(self.doc)
+        cut = self.doc.addObject("Part::Cut", "Cut")
+        cut.Base = b1
+        cut.Tool = b2
+        self.doc.recompute()
+        shape = cut.Shape
+        self.assertFalse(shape.isNull(), "Part::Cut result is null")
+        self.assertGreater(shape.Volume, 0, "Part::Cut result has no volume")
+
+    def test_multifuse_two_boxes(self):
+        b1, b2 = _make_boxes(self.doc)
+        mf = self.doc.addObject("Part::MultiFuse", "MultiFuse")
+        mf.Shapes = [b1, b2]
+        self.doc.recompute()
+        shape = mf.Shape
+        self.assertFalse(shape.isNull(), "Part::MultiFuse result is null")
+        self.assertGreater(shape.Volume, 0, "Part::MultiFuse result has no volume")
+
+    def test_multicommon_two_boxes(self):
+        b1, b2 = _make_boxes(self.doc)
+        mc = self.doc.addObject("Part::MultiCommon", "MultiCommon")
+        mc.Shapes = [b1, b2]
+        self.doc.recompute()
+        shape = mc.Shape
+        self.assertFalse(shape.isNull(), "Part::MultiCommon result is null")
+        self.assertGreater(shape.Volume, 0, "Part::MultiCommon result has no volume")
+
+    def test_fuse_with_refine(self):
+        b1, b2 = _make_boxes(self.doc)
+        fuse = self.doc.addObject("Part::Fuse", "Fuse")
+        fuse.Base = b1
+        fuse.Tool = b2
+        fuse.Refine = True
+        self.doc.recompute()
+        shape = fuse.Shape
+        self.assertFalse(shape.isNull(), "Part::Fuse with Refine=True result is null")
+        self.assertGreater(shape.Volume, 0, "Part::Fuse with Refine=True result has no volume")

--- a/src/Mod/Part/parttests/run_boolean_smoke_test.py
+++ b/src/Mod/Part/parttests/run_boolean_smoke_test.py
@@ -1,0 +1,15 @@
+"""
+Headless smoke test runner for Part boolean feature tests.
+Run via: pixi run smoke-test-boolean
+"""
+import sys
+import unittest
+
+sys.path.insert(0, "src/Mod/Part")
+
+from parttests.BooleanFeatureTest import TestBooleanFeatures
+
+suite = unittest.TestLoader().loadTestsFromTestCase(TestBooleanFeatures)
+runner = unittest.TextTestRunner(verbosity=2)
+result = runner.run(suite)
+sys.exit(0 if result.wasSuccessful() else 1)

--- a/src/Mod/Part/parttests/run_boolean_smoke_test.py
+++ b/src/Mod/Part/parttests/run_boolean_smoke_test.py
@@ -2,6 +2,7 @@
 Headless smoke test runner for Part boolean feature tests.
 Run via: pixi run smoke-test-boolean
 """
+
 import sys
 import unittest
 


### PR DESCRIPTION
## Summary

- Improve boolean failure messages: replace "Boolean operation failed" with actionable guidance for non-expert users (reposition shape, combine in different order, etc.)
- Add opt-in post-refine validation (`CheckRefine` preference) that detects when `removeSplitter` introduces self-intersections, reverts to the correct pre-refine shape, and warns
- All messages link to a troubleshooting wiki page (draft below)

## Motivation

Boolean failures and silent Refine corruption are among the most frustrating experiences for FreeCAD users. The current error messages ("Boolean operation failed") give no clue about what went wrong or what to try. The Refine step can silently corrupt geometry, causing mysterious failures in downstream operations far from the root cause.

These issues are ultimately caused by limitations in the OCCT geometry engine, not by user error. The goal of this PR is to make that clear and give users concrete actions.

**Refine corruption root cause:** `ShapeUpgrade_UnifySameDomain` introduces self-intersections on shapes with coplanar faces and partial overlap. Filed upstream: https://github.com/Open-Cascade-SAS/OCCT/issues/1193

**Supersedes #27760** — that PR attempted to block non-solid boolean inputs, but feedback from @FEA-eng showed that mixed-type booleans (solid + shell) are legitimate operations. This PR takes a different approach: don't block anything, but provide better diagnostics when things fail.

## Changes

### Improved error messages (FeaturePartBoolean.cpp, FeaturePartFuse.cpp)

When a boolean fails, the error now explains:
- This is an engine limitation, not a model problem
- Common triggers (exact face alignment, near-coincident faces, complex coplanar arrangements)
- Concrete actions to try (reposition by 0.01mm in Placement, combine in different order, check inputs with Part > Check Geometry)
- Input shape types for diagnostics
- Link to troubleshooting wiki page

### Refine validation (FeaturePartBoolean.cpp, FeaturePartFuse.cpp, FeaturePartCommon.cpp)

New opt-in preference: **"Validate refine result and warn on failure"** (`CheckRefine`, default off).

When enabled, after each Refine step:
1. Runs `BOPAlgo_ArgumentAnalyzer` with self-intersection detection on the refined shape
2. If corruption detected: reverts to the pre-refine shape and warns in Report View
3. If clean: uses the refined shape normally

`BRepCheck_Analyzer` (the lightweight checker) does NOT detect this class of corruption — only the full BOP analysis catches it. The preference defaults to off because the BOP check adds computation time.

### UI (DlgSettingsGeneral.ui)

New checkbox in Edit > Preferences > Part Design > General > Model Settings:
"Validate refine result and warn on failure (slower)"

## Draft wiki page: Boolean Troubleshooting

The following content is proposed for `https://wiki.freecad.org/Boolean_Troubleshooting`. All error messages in this PR link to this page.

---

### The key concept

When you design a model, you think in exact geometry: this face is *exactly* flat, these two walls meet at *exactly* the same plane, this array steps by *exactly* 10 mm. Your design intent is mathematically precise.

But computers represent numbers with limited precision -- about 15 significant digits. Every coordinate, every face boundary, every intersection point is rounded to fit. Most of the time this doesn't matter: the errors are smaller than an atom. But when the geometry engine needs to decide whether two faces are *exactly* aligned, or whether a point is *exactly* on a surface, these tiny rounding errors can lead to wrong answers.

This is the root cause of most boolean failures. Your model is correct. The computer's representation of it has limitations that the engine can't always handle.

### "Boolean operation failed"

**Arrangements that cause problems:**
- Shapes that share an exact face (the engine must decide which shape "owns" the boundary)
- Faces that nearly but don't quite touch (engine can't tell if touching, overlapping, or separate)
- Coplanar faces with partial overlap (e.g. a row of planks fused to a wider wall)
- Rotated/transformed geometry (clean coordinates become irrational numbers truncated to 15 digits; two shapes that are mathematically coplanar after rotation may not be exactly coplanar in the computer's representation)

**What to try:**
- Reposition one shape slightly (e.g. add 0.01 mm to the Z Position in Placement)
- Combine shapes in a different order
- Fuse in smaller groups instead of all at once
- Check each input with Part > Check Geometry

### "Refine produced invalid geometry"

The boolean succeeded, but the cleanup step (Refine) damaged the result. FreeCAD detected this and kept the pre-cleanup version. The algorithm that removes redundant edges has a known bug in the geometry engine (OpenCASCADE) that is difficult to work around reliably at the FreeCAD level.

The kept shape is geometrically correct but may have extra internal edges that can slow downstream operations or interfere with filleting/chamfering.

**What to try:**
- Disable Refine in the feature's properties
- Restructure geometry to avoid shapes sharing an exact face while a third shape partially overlaps that boundary

### Enabling automatic detection

Edit > Preferences > Part Design > General > "Validate refine result and warn on failure." When enabled, FreeCAD skips the Refine step if it would produce bad geometry and warns in the Report View.

---

## Test plan

- [ ] Boolean failure produces improved error message with shape types and wiki link
- [ ] MultiFuse failure produces improved error message
- [ ] With CheckRefine=true: fusing wedge+wedge+offset-box triggers refine warning and keeps valid pre-refine shape
- [ ] With CheckRefine=false (default): no change in behavior, refine runs unchecked
- [ ] New checkbox appears in Preferences > Part Design > General
- [ ] Existing boolean operations that succeed are not affected
- [ ] Build succeeds on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)