### PR TITLE
Gui: Fall back to legacy driver when NavLib init fails

### DIFF
--- a/src/Gui/3Dconnexion/navlib/NavlibInterface.h
+++ b/src/Gui/3Dconnexion/navlib/NavlibInterface.h
@@ -64,7 +64,7 @@ class NavlibInterface: public CNav3D
 public:
     NavlibInterface();
     ~NavlibInterface();
-    void enableNavigation();
+    bool enableNavigation();
     void disableNavigation();
 
 private:

--- a/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
@@ -187,7 +187,7 @@ void NavlibInterface::onViewChanged(const Gui::MDIView* view)
     }
 }
 
-void NavlibInterface::enableNavigation()
+bool NavlibInterface::enableNavigation()
 {
 #if defined(Q_OS_MAC)
     if (!CFBundleGetIdentifier(CFBundleGetMainBundle())) {
@@ -196,7 +196,7 @@ void NavlibInterface::enableNavigation()
         // than opening the .app. If future versions of the driver report the error,
         // this special case can be removed.
         Base::Console().error("3Dconnexion Navigation Framework does not support running apart from an .app!\n");
-        return;
+        return false;
     }
 #endif
 
@@ -204,7 +204,7 @@ void NavlibInterface::enableNavigation()
     CNav3D::EnableNavigation(true, errorCode);
     if (errorCode) {
         Base::Console().error("NavlibInterface::EnableNavigation error %d\n", errorCode.value());
-        return;
+        return false;
     }
 
     PutFrameTimingSource(TimingSource::SpaceMouse);
@@ -221,6 +221,7 @@ void NavlibInterface::enableNavigation()
 
     initializePivot();
     connectActiveTab();
+    return true;
 }
 
 void NavlibInterface::connectActiveTab()

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2673,8 +2673,10 @@ void Application::init3DMouse(MainWindow* mainWindow, QApplication* qtApp)
             Instance->pNavlibInterface = new NavlibInterface();
             Base::Console().log("Init: Enabling 3Dconnexion Navigation Framework\n");
             if (!Instance->pNavlibInterface->enableNavigation()) {
-                Base::Console().log("Init: 3Dconnexion Navigation Framework failed, "
-                                    "falling back to legacy support\n");
+                Base::Console().log(
+                    "Init: 3Dconnexion Navigation Framework failed, "
+                    "falling back to legacy support\n"
+                );
                 Instance->pNavlibInterface = nullptr;
             }
         }

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2672,7 +2672,11 @@ void Application::init3DMouse(MainWindow* mainWindow, QApplication* qtApp)
             // Instantiate the 3Dconnexion controller
             Instance->pNavlibInterface = new NavlibInterface();
             Base::Console().log("Init: Enabling 3Dconnexion Navigation Framework\n");
-            Instance->pNavlibInterface->enableNavigation();
+            if (!Instance->pNavlibInterface->enableNavigation()) {
+                Base::Console().log("Init: 3Dconnexion Navigation Framework failed, "
+                                    "falling back to legacy support\n");
+                Instance->pNavlibInterface = nullptr;
+            }
         }
     }
     else {

--- a/src/Gui/GuiApplicationNativeEventAware.cpp
+++ b/src/Gui/GuiApplicationNativeEventAware.cpp
@@ -71,20 +71,9 @@ Gui::GUIApplicationNativeEventAware::~GUIApplicationNativeEventAware() = default
 void Gui::GUIApplicationNativeEventAware::initSpaceball(QMainWindow* window)
 {
 #if defined(_USE_3DCONNEXION_SDK) || defined(SPNAV_FOUND)
-# if defined(USE_3DCONNEXION_NAVLIB)
-    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/View"
-    );
-    if (nativeEvent && hViewGrp->GetBool("LegacySpaceMouseDevices", false)) {
-        // Even though Navlib is enabled, process native events to support legacy devices.
+    if (nativeEvent) {
         nativeEvent->initSpaceball(window);
     }
-    else {
-        Base::Console().log("Legacy device support not enabled\n");
-    }
-# else
-    nativeEvent->initSpaceball(window);
-# endif
 #else
     Base::Console().log("3D mouse support not enabled in this build\n");
     Q_UNUSED(window);


### PR DESCRIPTION
After #26100, SpaceMouse stopped working on macOS.

Two things go wrong in init3DMouse():

1. enableNavigation() returns void, so when it fails (macOS bundle check, EnableNavigation error) there's no way for the caller to know. pNavlibInterface stays non-null and the legacy fallback never runs.

2. initSpaceball() checks LegacySpaceMouseDevices (default false), blocking legacy support even if the fallback were reached.

On macOS this gets triggered because the weekly build launcher uses execve() to the real binary, losing the CFBundle identity. enableNavigation() sees no bundle identifier and bails — silently.

Fix: change enableNavigation() to return bool. On failure, null the pointer so init3DMouse() falls through to legacy init. Remove the LegacySpaceMouseDevices gate from initSpaceball() since the caller already decides NavLib vs legacy.

Reproduced on MacBook Air M1 with weekly-2026.04.01. Confirmed the fallback path triggers with a build from current main.

Fixes #29003