### PR TITLE
Fix intra-sketch reference constraints.

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1042,7 +1042,7 @@ protected:
     void onDocumentRestored() override;
     void restoreFinished() override;
     void onSketchRestore();
-    
+
     bool expressionHasIntraSketchReference(std::shared_ptr<const App::Expression> expr);
     bool hasIntraSketchReference();
 

--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -1042,6 +1042,9 @@ protected:
     void onDocumentRestored() override;
     void restoreFinished() override;
     void onSketchRestore();
+    
+    bool expressionHasIntraSketchReference(std::shared_ptr<const App::Expression> expr);
+    bool hasIntraSketchReference();
 
     std::string validateExpression(
         const App::ObjectIdentifier& path,

--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -35,11 +35,14 @@
 #include <Base/Console.h>
 #include <Base/Tools.h>
 #include <Base/Vector3D.h>
+#include <Base/Writer.h>
 
 #include <memory>
 
 #include "GeoEnum.h"
 #include "SketchObject.h"
+
+#define INTRASKETCH_REFERENCE_REFERENCE_STRICT false
 
 
 #undef DEBUG
@@ -128,10 +131,86 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
         err = -5;
     }
     else {
-        lastSolverStatus = solvedSketch.solve();
-        if (lastSolverStatus != 0) {// solving
-            err = -1;
+        // Cache the original geometry and constraints.
+        // We may need them later if there is an error.
+        auto originalGeometry = Geometry.Copy();
+        std::vector<Constraint*> originalConstraints;
+        for (auto c : Constraints.getValuesForce()) {
+            originalConstraints.push_back(c->clone());
         }
+        try {
+            // Solve the sketch.
+            lastSolverStatus = solvedSketch.solve();
+            if (lastSolverStatus != 0) {// solving
+                err = -1;
+            } else if (hasIntraSketchReference()) {
+                // We need to check for unstable intra-sketch references.
+                // We are going to serialize the result of the first solution and the second solution.
+                Base::StringWriter writer1, writer2;
+                // Extract the first solution.
+                std::vector<Part::Geometry*> geomlist1 = solvedSketch.extractGeometry(true, true);
+                Part::PropertyGeometryList tmp1;
+                tmp1.setValues(std::move(geomlist1));
+                tmp1.Save(writer1);
+                // Update the active geometry.
+                // That is the easiest way to get the expression engine to run.
+                Geometry.Paste(tmp1);
+                // Recompute expressions.
+                auto eeres1 = ExpressionEngine.execute();
+                if (eeres1) {
+                    delete eeres1;
+                    eeres1 = NULL;
+                }
+                // Solve a second time.
+                Sketch solvedSketch2;
+                int lastDoF2 = solvedSketch2.setUpSketch(
+                    tmp1.getValues(), Constraints.getValues(), getExternalGeometryCount());
+                lastSolverStatus = solvedSketch2.solve();
+                // Extract the second solution.
+                std::vector<Part::Geometry*> geomlist2 = solvedSketch2.extractGeometry(true, true);
+                Part::PropertyGeometryList tmp2;
+                tmp2.setValues(std::move(geomlist2));
+                tmp2.Save(writer2);
+                // Check that the results are identical.
+                bool mismatch = (lastDoF != lastDoF2) || (writer1.getString() != writer2.getString());
+                // Roll back and rerun the first solution to allow the regular process to run its course.
+                Constraints.setValues(std::move(originalConstraints));
+                originalConstraints.clear();
+                Geometry.Paste(*originalGeometry);
+                eeres1 = ExpressionEngine.execute();
+                if (eeres1) {
+                    delete eeres1;
+                    eeres1 = NULL;
+                }
+                lastDoF = solvedSketch.setUpSketch(
+                    getCompleteGeometry(), Constraints.getValues(), getExternalGeometryCount());
+                // This operation ought to succeed since it succeeded before.
+                if ((lastSolverStatus = solvedSketch.solve()) != 0) err = -1;
+                else if (mismatch) {
+                    // If there was a mismatch before, the sketch is not stable.
+                    // Report an error.
+                    err = -6;
+                    Base::Console().error(
+                        this->getFullLabel(),
+                        QT_TRANSLATE_NOOP("Notifications", "The Sketch has cyclic or unstable references"
+                        " to internal reference constraints!") "\n");
+                }
+            }
+        }
+        catch (...) {
+            // Something failed.
+            // Clean up.
+            for (auto c : originalConstraints) {
+                delete c;
+            }
+            delete originalGeometry;
+            throw;
+        }
+        // The cycle test is complete. Clean up.
+        for (auto c : originalConstraints) {
+            delete c;
+        }
+        delete originalGeometry;
     }
 
     if (lastHasMalformedConstraints) {
@@ -2210,6 +2289,44 @@ void SketchObject::validateConstraints()
     }
 }
 
+bool SketchObject::expressionHasIntraSketchReference(
+                                             std::shared_ptr<const App::Expression> expr)
+{
+    auto deps = expr->getDeps();
+    auto it = deps.find(this);
+    if (it == deps.end()) {
+        return false;
+    }
+
+    auto it2 = it->second.find("Constraints");
+    if (it2 != it->second.end()) {
+        for (auto& oid : it2->second) {
+            const Constraint* constraint = Constraints.getConstraint(oid);
+
+            if (!constraint->isDriving)
+                return true;
+        }
+    }
+    return false;
+}
+
+bool SketchObject::hasIntraSketchReference()
+{
+    const std::vector<Constraint*>& vals = Constraints.getValues();
+    for (size_t i = 0; i < vals.size(); ++i) {
+        if (!constraintHasExpression(static_cast<int>(i))) {
+            continue;
+        }
+        App::ObjectIdentifier path = Constraints.createPath(static_cast<int>(i));
+        auto info = getExpression(path);
+        if (info.expression) {
+             if (expressionHasIntraSketchReference(info.expression))
+                return true;
+        }
+    }
+    return false;
+}
+
 std::string SketchObject::validateExpression(const App::ObjectIdentifier& path,
                                              std::shared_ptr<const App::Expression> expr)
 {
@@ -2227,22 +2344,9 @@ std::string SketchObject::validateExpression(const App::ObjectIdentifier& path,
             return "Reference constraints cannot be set!";
     }
 
-    auto deps = expr->getDeps();
-    auto it = deps.find(this);
-    if (it == deps.end()) {
-        return "";
-    }
-
-    auto it2 = it->second.find("Constraints");
-    if (it2 != it->second.end()) {
-        for (auto& oid : it2->second) {
-            const Constraint* constraint = Constraints.getConstraint(oid);
-
-            if (!constraint->isDriving)
-                return "Reference constraint from this sketch cannot be used in this "
+    if (INTRASKETCH_REFERENCE_REFERENCE_STRICT && expressionHasIntraSketchReference(expr))
+        return "Reference constraint from this sketch cannot be used in this "
                     "expression.";
-        }
-    }
 
     geoMap.clear();
     const auto &vals = getInternalGeometry();


### PR DESCRIPTION
Remove the hard block on references to reference constraints within a sketch and add a check for stable convergence when such a reference exists.

## Issues
This closes #12655.

## Before and After Images
(Not applicable.)

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
    This closes #12655.
  - Has the conversation on the PR and related issue(s) reached consensus?
     Nobody agreed to fix the issue, but nobody objected to fixing it.
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
     The geometry handling and error reporting change, but the geometry and the errors display in the same way as before.
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
    The regression that this addresses was never documented, so fixing it requires no changes.
  - Has the impact on translation been considered appropriate action taken?
    This adds one additional string to translate. The string is wrapped appropriately for translation.
  - Will the PR affect existing user documents?
     Yes. There are certain cases in which the old behavior (after 0.21.2) is to break a sketch that has intra-sketch references. The new behavior is to retain them when they have stable results. Users are unlikely to object.

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
     Most likely.
  - Does the change include tests?
     No. [Reference_Test_1.zip](https://github.com/user-attachments/files/26522012/Reference_Test_1.zip) demonstrates the two cases of interest (stable intra-sketch references and unstable intra-sketch references).
  - Is the PR rebased on the current main branch with unnecessary commits squashed?
     Yes.

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
 
The contributor hereby grants the FreeCAD project unlimited worldwide rights to publish and to distribute contributed code under any license that disclaims contributor's liability for any damages associated with publication, distribution, or use of the code.


