### PR TITLE
Draft: importSVG - Approximation to arcs and lines

### DIFF
--- a/src/Mod/Draft/Resources/ui/preferences-svg.ui
+++ b/src/Mod/Draft/Resources/ui/preferences-svg.ui
@@ -182,6 +182,57 @@ a raw wire from the original shape is added</string>
         </item>
        </layout>
       </item>
+      <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11">
+          <item>
+            <widget class="QLabel" name="label">
+              <property name="text">
+                <string>Maximum deviation for approximation of complex curves</string>
+              </property>
+            </widget>
+          </item>
+          <item>
+            <spacer name="horizontalSpacer">
+              <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+                <size>
+                  <width>40</width>
+                  <height>20</height>
+                </size>
+              </property>
+            </spacer>
+          </item>
+          <item>
+            <widget class="Gui::PrefDoubleSpinBox" name="doubleSpinBox">
+              <property name="toolTip">
+                <string>Maximum deviation for the approximation of ellipses, hyperbolas, parabolas, and
+Bézier and B-spline curves to arcs and lines. Can be useful for the CAM Workbench.
+Set to zero to disable approximation.</string>
+              </property>
+              <property name="suffix">
+                <string notr="true"> mm</string>
+              </property>
+              <property name="maximum">
+                <double>10.0</double>
+              </property>
+              <property name="decimals">
+                <number>4</number>
+              </property>
+              <property name="singleStep">
+                <double>0.01</double>
+              </property>
+              <property name="prefEntry" stdset="0">
+                <cstring>svgDeviation</cstring>
+              </property>
+              <property name="prefPath" stdset="0">
+                <cstring>Mod/Draft</cstring>
+              </property>
+            </widget>
+          </item>
+        </layout>
+      </item>
      </layout>
     </widget>
    </item>
@@ -263,9 +314,6 @@ a raw wire from the original shape is added</string>
          <widget class="QLabel" name="label">
           <property name="text">
            <string>Maximum segment length for discretized arcs</string>
-          </property>
-          <property name="buddy">
-           <cstring/>
           </property>
          </widget>
         </item>

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -457,6 +457,56 @@ def getrgb(color):
     return "#" + r + g + b
 
 
+def approximateWire(wire, tolerance=0.01):
+    """approximateWire approximates any non-line/arc edges with lines or arcs.
+    Edges that are lines or circular arcs are kept as-is.
+    tolerance: Deflection tolerance for approximation. Must be positive if wire contains non-line/arc edges.
+    Returns the wire with non-line/arc edges replaced by arcs and line segments.
+    """
+    processed_edges = []
+    modified = False
+    for edge in wire.Edges:
+        curve = edge.Curve
+        if isinstance(curve, (Part.Line, Part.LineSegment, Part.Circle, Part.ArcOfCircle)):
+            # Keep lines and arcs as-is
+            processed_edges.append(edge)
+        else:
+            # Approximate with lines and arcs
+            if tolerance <= 0:
+                raise ValueError(
+                    "tolerance parameter is required to be a positive value to approximate non-line/arc edges"
+                )
+            modified = True
+
+            # Convert to BSpline first if appropriate, to enable arc fitting
+            if isinstance(curve, (Part.Ellipse, Part.Hyperbola, Part.Parabola)):
+                # Convert edge to NURBS (BSpline)
+                shape = edge.toNurbs()
+                edge = shape.Edges[0]
+            elif isinstance(curve, Part.BezierCurve):
+                # Convert BezierCurve to BSpline
+                curve = edge.Curve.toBSpline()
+                edge = curve.toShape()
+
+            if isinstance(edge.Curve, Part.BSplineCurve):
+                # Convert BSpline to arcs
+                curves = edge.Curve.toBiArcs(tolerance)
+                for curve in curves:
+                    processed_edges.append(curve.toShape())
+            else:
+                # For other curve types, fall back to discretization to line segments
+                vertices = edge.discretize(Deflection=tolerance)
+                line_edges = [
+                    Part.makeLine(vertices[i], vertices[i + 1]) for i in range(len(vertices) - 1)
+                ]
+                processed_edges.extend(line_edges)
+
+    # Reassemble the wire if any edges were replaced
+    if modified:
+        return Part.Wire(Part.__sortEdges__(processed_edges))
+    return wire
+
+
 class svgHandler(xml.sax.ContentHandler):
     """Parse SVG files and create FreeCAD objects."""
 
@@ -467,6 +517,7 @@ class svgHandler(xml.sax.ContentHandler):
         self.disableUnitScaling = params.get_param("svgDisableUnitScaling")
         self.make_cuts = params.get_param("svgMakeCuts")
         self.add_wire_for_invalid_face = params.get_param("svgAddWireForInvalidFace")
+        self.deviation = params.get_param("svgDeviation")
         self.count = 0
         self.transform = None
         self.grouptransform = []
@@ -503,21 +554,28 @@ class svgHandler(xml.sax.ContentHandler):
             if self.fill:
                 v.ShapeColor = self.fill
 
-    def __addFaceToDoc(self, named_face):
-        """Create a named document object from a name/face tuple
+    def __addShapeToDoc(self, named_shape):
+        """Create a named document object from a name/shape tuple
 
         Parameters
         ----------
-        named_face : name : str, face : Part.Face
-                     The Face/Wire to add, and its name
+        named_shape : name : str, shape : Part.Face, Part.Shell or Part.Wire
         """
-        name, face = named_face
-        if not face:
+        name, shape = named_shape
+        if not shape:
             return
 
-        face = self.applyTrans(face)
+        shape = self.applyTrans(shape)
+
+        if self.deviation:
+            aWires = [approximateWire(w, tolerance=self.deviation) for w in shape.Wires]
+            if shape.Faces:
+                shape = Part.makeFace(aWires, "Part::FaceMakerBullseye")
+            else:
+                shape = aWires[0]
+
         obj = self.doc.addObject("Part::Feature", name)
-        obj.Shape = face
+        obj.Shape = shape
         self.format(obj)
 
     def startElement(self, name, attrs):
@@ -769,7 +827,7 @@ class svgHandler(xml.sax.ContentHandler):
                     svgPath.doCuts()
                 shapes = svgPath.getShapeList()
                 for named_shape in shapes:
-                    self.__addFaceToDoc(named_shape)
+                    self.__addShapeToDoc(named_shape)
 
         # Process rects
         if name == "rect":
@@ -843,6 +901,8 @@ class svgHandler(xml.sax.ContentHandler):
                     # elliptical segments
                     edges.append(esh2)
             sh = Part.Wire(edges)
+            if self.deviation:
+                sh = approximateWire(sh, tolerance=self.deviation)
             if self.fill:
                 sh = Part.Face(sh)
             sh = self.applyTrans(sh)
@@ -913,8 +973,10 @@ class svgHandler(xml.sax.ContentHandler):
             else:
                 sh = Part.Ellipse(c, ry, rx).toShape()
                 sh.rotate(c, Vector(0, 0, 1), 90)
+            sh = Part.Wire([sh])
+            if self.deviation:
+                sh = approximateWire(sh, tolerance=self.deviation)
             if self.fill:
-                sh = Part.Wire([sh])
                 sh = Part.Face(sh)
             sh = self.applyTrans(sh)
             obj = self.doc.addObject("Part::Feature", pathname)
@@ -1375,8 +1437,8 @@ def export(exportList, filename):
     svg.close()
     if hidden_doc is not None:
         try:
-            App.closeDocument(hidden_doc.Name)
-        except:
+            FreeCAD.closeDocument(hidden_doc.Name)
+        except Exception:
             pass
 
 


### PR DESCRIPTION
Curves `Ellipse`, `Hyperbola`, `Parabola`, `BezierCurve` and `BSplineCurve` creates a lot of problems and complicates work process in **CAM** workbench

- Shape which looks like circle can be not a real circle and do not contains important information (center point, diameter) 
- Surfaces is not really 'flat' while vertical extrusion from such curves
   <img width="1030" height="359" alt="Screenshot_20260408_100817_lossy" src="https://github.com/user-attachments/assets/5a5943d8-9c4c-40c3-9bd6-d6e7d024ec77" />

---

Suggest to add ability to approximate such edges to `Part.Arc`(s) and `Part.Line`(s) while import geometry from **svg** files

New property `svgDeviation` is used to adjust accuracy
Value 0.0 disable approximation feature

---

> [!NOTE]
> Method `approximateWire()` already present in [src/Mod/CAM/Path/Op/Util.py](https://github.com/FreeCAD/FreeCAD/blob/16278fb01e4b52faaf6b9a322221308e0aa87ce9/src/Mod/CAM/Path/Op/Util.py#L180),
> but I do not know good way to exclude code duplication and do not add additional dependencies between **CAM** and **Draft** 

---

<img width="953" height="400" alt="Screenshot_20260414_125846_lossy" src="https://github.com/user-attachments/assets/31632fd2-bfcc-47ff-b1ab-b12e48848b2a" />

<img width="964" height="369" alt="ksnip_20260407-133811_lossy" src="https://github.com/user-attachments/assets/26be16ce-b42c-44ad-a710-752e70449d3c" />
