### PR TITLE
BIM: add MoveBase handling to getMovableChildren

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -506,30 +506,33 @@ class Component(ArchIFC.IfcProduct):
             List of child objects set to move with their host.
         """
 
-        ilist = obj.Additions + obj.Subtractions
+        child_list = obj.Additions + obj.Subtractions
         for o in obj.InList:
             if hasattr(o, "Hosts"):
                 if obj in o.Hosts:
-                    ilist.append(o)
+                    child_list.append(o)
             elif hasattr(o, "Host"):
                 if obj == o.Host:
-                    ilist.append(o)
+                    child_list.append(o)
 
         # Stairs railings should be considered as children
         # (RailingLeft and RailingRight property)
         if hasattr(obj, "RailingLeft") and obj.RailingLeft:
-            ilist.append(obj.RailingLeft)
+            child_list.append(obj.RailingLeft)
         if hasattr(obj, "RailingRight") and obj.RailingRight:
-            ilist.append(obj.RailingRight)
+            child_list.append(obj.RailingRight)
 
-        ilist2 = []
-        for o in ilist:
+        child_set = set()
+        for o in child_list:
             if hasattr(o, "MoveWithHost"):
                 if o.MoveWithHost:
-                    ilist2.append(o)
+                    if getattr(o, "MoveBase", False) and self.ensureBase(o):
+                        child_set.add(o.Base)
+                    else:
+                        child_set.add(o)
             else:
-                ilist2.append(o)
-        return ilist2
+                child_set.add(o)
+        return list(child_set)
 
     def getParentHeight(self, obj):
         """Get a height value from hosts.


### PR DESCRIPTION
When moving a wall with a window, where the window has `MoveBase` set to `True`, the return value of `getMovableChildren` function would include the window, instead of its base sketch. As a result the window object would be moved instead of its base, effectively ignoring the `MoveBase` property.

Test:
1. Open the attached file.
2. Select the wall.
3. Move the wall with the Draft_Move command.
4. Result: without this PR the window, instead of its base sketch, is moved.

[wall_window_move_test.FCStd.zip](https://github.com/user-attachments/files/26537737/wall_window_move_test.FCStd.zip) (remove .zip)
