### PR TITLE
TD: Implement ISO 13715 Edge Symbols

### DIFF
--- a/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_EdgeSymbol.svg
+++ b/src/Mod/TechDraw/Gui/Resources/icons/actions/TechDraw_EdgeSymbol.svg
@@ -1,0 +1,9 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.8705 53.4047L25 42H55" stroke="#0B1521" stroke-width="8.00001" stroke-linecap="round" stroke-linejoin="round"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6 58V46L18 58H6Z" fill="#3465A4" stroke="#0B1521" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.8705 53.4047L25 42H55" stroke="#3465A4" stroke-width="3.99999" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.7121 52.1453L24.595 40.9078L53.9995 41.0002" stroke="#729FCF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M30 9V33H55" stroke="#0B1521" stroke-width="7.9999" stroke-linecap="round"/>
+<path d="M30 9V33H55" stroke="#3465A4" stroke-width="3.99995" stroke-linecap="round"/>
+<path d="M54 32H29V9" stroke="#729FCF" stroke-width="1.99998" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Initial Draft PR addressing the implementation of ISO 13715 Edge Symbols

I shall update the stage-wise progress here...

- [x] Review the ISO standards
- [x] Draft the requirements
- [x] Create a custom icon `actions/TechDraw_EdgeSymbol` (Made in PenPot)
- [x] Add icon to qrc 
- [x] Add necessary files following the feature addition checklist and existing patterns
```
src/Mod/TechDraw/App/DrawEdgeSymbol.h
src/Mod/TechDraw/App/DrawEdgeSymbol.cpp
src/Mod/TechDraw/App/DrawEdgeSymbol.pyi
src/Mod/TechDraw/App/DrawEdgeSymbolPyImp.cpp
src/Mod/TechDraw/App/DrawTileEdge.h
src/Mod/TechDraw/App/DrawTileEdge.cpp
src/Mod/TechDraw/App/DrawTileEdge.pyi
src/Mod/TechDraw/App/DrawTileEdgePyImp.cpp
src/Mod/TechDraw/App/DrawTileEdgePy.h
src/Mod/TechDraw/App/DrawTileEdgePy.cpp
src/Mod/TechDraw/Gui/QGIEdgeSymbol.h
src/Mod/TechDraw/Gui/QGIEdgeSymbol.cpp
src/Mod/TechDraw/Gui/TaskEdgeSymbol.h
src/Mod/TechDraw/Gui/TaskEdgeSymbol.cpp
src/Mod/TechDraw/Gui/TaskEdgeSymbol.ui
src/Mod/TechDraw/Gui/ViewProviderEdge.h
src/Mod/TechDraw/Gui/ViewProviderEdge.cpp
```
- [x] Update module's CmakeList.txt
- [ ] more to come...