### PR TITLE
core: fixes #29090 allow navigation ie. pan, orbit, track after using long LMB press

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -1596,6 +1596,12 @@ void NavigationStyle::stopSelection()
     }
 }
 
+void NavigationStyle::resetButtonState()
+{
+    button1down = button2down = button3down = false;
+    setViewingMode(IDLE);
+}
+
 SbBool NavigationStyle::isSelecting() const
 {
     return (mouseSelection ? true : false);

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -201,6 +201,7 @@ public:
     void startSelection(SelectionMode = Lasso);
     void abortSelection();
     void stopSelection();
+    void resetButtonState();
     SbBool isSelecting() const;
     const std::vector<SbVec2s>& getPolygon(SelectionRole* role = nullptr) const;
 
@@ -210,6 +211,7 @@ public:
     {
         return ClarifySelectionMode::Default;
     }
+
 
     void setOrbitStyle(OrbitStyle style);
     OrbitStyle getOrbitStyle() const;

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -191,6 +191,13 @@ public:
 private:
     void triggerClarifySelection()
     {
+        // reset navigation state so button1down doesn't stay stuck ie. gh issue #29090
+        // (the blocking QMenu::exec in ClarifySelection steals the LMB release)
+        if (currentViewer) {
+            if (auto* nav = currentViewer->navigationStyle()) {
+                nav->resetButtonState();
+            }
+        }
         Gui::Command::runCommand(Gui::Command::Gui, "Gui.runCommand('Std_ClarifySelection')");
     }
 


### PR DESCRIPTION
this PR fixes the issue defined in #29090 add the below check to reset the navigation state for all three mouse buttons.

```cpp
// reset navigation state so button1down doesn't stay stuck ie. gh issue #29090
// (the blocking QMenu::exec in ClarifySelection steals the LMB release)
if (currentViewer) {
    if (auto* nav = currentViewer->navigationStyle()) {
        nav->resetButtonState();
    }
}
```

## Issues

- https://github.com/freecad/freecad/issues/29090

## Before and After Images

