### PR TITLE
Move gui tests to dedicated files

### DIFF
--- a/.github/scripts/run_gui_tests.py
+++ b/.github/scripts/run_gui_tests.py
@@ -78,17 +78,25 @@ def validate_executable(path: str) -> tuple[bool, str]:
     return True, ""
 
 
-def run_and_capture(cmd: list[str]) -> tuple[int, str]:
+def run_and_capture(cmd: list[str], timeout: int = 120) -> tuple[int, str]:
     """Run `cmd` and return (returncode, combined stdout+stderr string).
 
     If the executable is not found a return code of 127 is returned and a small error string is
-    provided as output to aid diagnosis.
+    provided as output to aid diagnosis. If the process does not complete within `timeout` seconds
+    it is killed and a return code of 126 is returned.
     """
     try:
         proc = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+            timeout=timeout,
         )
         return proc.returncode, proc.stdout
+    except subprocess.TimeoutExpired as e:
+        return 126, (e.stdout or "") + f"\nProcess timed out after {timeout} seconds\n"
     except FileNotFoundError:
         return 127, f"Executable not found: {cmd[0]}\n"
 

--- a/src/Mod/Assembly/CMakeLists.txt
+++ b/src/Mod/Assembly/CMakeLists.txt
@@ -37,7 +37,10 @@ set(Assembly_Scripts
 )
 
 if(BUILD_GUI)
-    list (APPEND Assembly_Scripts InitGui.py)
+    list (APPEND Assembly_Scripts
+          InitGui.py
+          TestAssemblyGui.py
+    )
 endif(BUILD_GUI)
 
 INSTALL(

--- a/src/Mod/Assembly/InitGui.py
+++ b/src/Mod/Assembly/InitGui.py
@@ -295,3 +295,5 @@ class AssemblyWorkbench(Workbench):
 
 
 Gui.addWorkbench(AssemblyWorkbench())
+
+FreeCAD.__unit_test__ += ["TestAssemblyGui"]

--- a/src/Mod/Assembly/TestAssemblyGui.py
+++ b/src/Mod/Assembly/TestAssemblyGui.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from AssemblyTests.TestCommandInsertLink import TestCommandInsertLink
+
+# Use the module so that code checkers don't complain (flake8)
+True if TestCommandInsertLink else False

--- a/src/Mod/Assembly/TestAssemblyWorkbench.py
+++ b/src/Mod/Assembly/TestAssemblyWorkbench.py
@@ -24,8 +24,6 @@
 import TestApp
 
 from AssemblyTests.TestCore import TestCore
-from AssemblyTests.TestCommandInsertLink import TestCommandInsertLink
 
 # Use the modules so that code checkers don't complain (flake8)
 True if TestCore else False
-True if TestCommandInsertLink else False

--- a/src/Mod/Spreadsheet/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/CMakeLists.txt
@@ -13,7 +13,10 @@ set(Spreadsheet_Scripts
 )
 
 if(BUILD_GUI)
-    list (APPEND Spreadsheet_Scripts InitGui.py)
+    list (APPEND Spreadsheet_Scripts
+          InitGui.py
+          TestSpreadsheetGui.py
+    )
 endif(BUILD_GUI)
 
 add_custom_target(SpreadsheetScripts ALL

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -723,23 +723,43 @@ Py::Object SheetViewPy::selectedCells(const Py::Tuple& args)
     return list;
 }
 
+namespace
+{
+/// Convert a Python object to a long, accepting plain ints and PySide6 enum objects (via .value).
+long pyEnumAsLong(PyObject* obj)
+{
+    if (PyLong_Check(obj)) {
+        return PyLong_AsLong(obj);
+    }
+    Py::Object value(PyObject_GetAttrString(obj, "value"), true);
+    if (!value.isNull() && PyLong_Check(value.ptr())) {
+        return PyLong_AsLong(value.ptr());
+    }
+    throw Base::TypeError("Expected an int or enum with a .value attribute");
+}
+}  // namespace
+
 Py::Object SheetViewPy::select(const Py::Tuple& _args)
 {
     SheetView* sheetView = getSheetViewPtr();
 
     Py::Sequence args(_args.ptr());
 
-    const char* cell;
-    const char* topLeft;
-    const char* bottomRight;
-    int flags = 0;
-    if (args.size() == 2 && PyArg_ParseTuple(_args.ptr(), "si", &cell, &flags)) {
+    const char* cell {nullptr};
+    const char* topLeft {nullptr};
+    const char* bottomRight {nullptr};
+    PyObject* flagsObj = nullptr;
+    if (args.size() == 2 && PyArg_ParseTuple(_args.ptr(), "sO", &cell, &flagsObj)) {
+        auto flags = pyEnumAsLong(flagsObj);
         sheetView->select(
             App::CellAddress(cell),
             static_cast<QItemSelectionModel::SelectionFlags>(flags)
         );
     }
-    else if (args.size() == 3 && PyArg_ParseTuple(_args.ptr(), "ssi", &topLeft, &bottomRight, &flags)) {
+    else if (
+        args.size() == 3 && PyArg_ParseTuple(_args.ptr(), "ssO", &topLeft, &bottomRight, &flagsObj)
+    ) {
+        auto flags = pyEnumAsLong(flagsObj);
         sheetView->select(
             App::CellAddress(topLeft),
             App::CellAddress(bottomRight),
@@ -747,24 +767,10 @@ Py::Object SheetViewPy::select(const Py::Tuple& _args)
         );
     }
     else {
-        if (args.size() == 2) {
-            throw Base::TypeError(
-                "Expects the arguments to be a cell name (e.g. 'A1') and "
-                "QItemSelectionModel.SelectionFlags"
-            );
-        }
-        else if (args.size() == 3) {
-            throw Base::TypeError(
-                "Expects the arguments to be a cell name (e.g. 'A1'), a second "
-                "cell name (e.g. 'B5'), and QItemSelectionModel.SelectionFlags"
-            );
-        }
-        else {
-            throw Base::TypeError(
-                "Wrong arguments to select: specify either a cell, or two cells "
-                "(for a range), and QItemSelectionModel.SelectionFlags"
-            );
-        }
+        throw Base::TypeError(
+            "Wrong arguments to select: specify either a cell, or two cells "
+            "(for a range), and QItemSelectionModel.SelectionFlags"
+        );
     }
     return Py::None();
 }

--- a/src/Mod/Spreadsheet/InitGui.py
+++ b/src/Mod/Spreadsheet/InitGui.py
@@ -50,5 +50,7 @@ class SpreadsheetWorkbench(Workbench):
 
 Gui.addWorkbench(SpreadsheetWorkbench())
 
+FreeCAD.__unit_test__ += ["TestSpreadsheetGui"]
+
 # Append the open handler
 FreeCAD.addImportType("Spreadsheet formats (*.csv *.CSV)", "SpreadsheetGui")


### PR DESCRIPTION
While investigating #28839 I found that we had several other tests that were not structured correctly and so were not getting run by CI. This adds the appropriate GUI test files (where required) and then ensures that any test that needs the GUI to be up is actually in the Gui test file and not the App test file. We also weren't actually registering all the existing Gui test files, so I fixed that too. It will be interesting to see if this passes CI :).