### PR TITLE
PartDesign: Attachment dialog on new sketch

### DIFF
--- a/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.cpp
@@ -82,6 +82,7 @@ void DlgSettingsGeneral::saveSettings()
     ui->checkShowTransparentPreview->onSave();
     ui->checkShowProfilePreview->onSave();
     ui->checkSwitchToTask->onSave();
+    ui->checkNewSketchAttachmentDialog->onSave();
 }
 
 void DlgSettingsGeneral::loadSettings()
@@ -103,6 +104,7 @@ void DlgSettingsGeneral::loadSettings()
     ui->checkShowTransparentPreview->onRestore();
     ui->checkShowProfilePreview->onRestore();
     ui->checkSwitchToTask->onRestore();
+    ui->checkNewSketchAttachmentDialog->onRestore();
 }
 
 /**

--- a/src/Mod/Part/Gui/DlgSettingsGeneral.ui
+++ b/src/Mod/Part/Gui/DlgSettingsGeneral.ui
@@ -246,6 +246,31 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="Gui::PrefCheckBox" name="checkNewSketchAttachmentDialog">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Always open the attachment dialog when creating a new sketch in Part Design, regardless of selection or holding the Shift key. Without this, only a single face or datum plane selection skips the dialog.</string>
+        </property>
+        <property name="text">
+         <string>Always open attachment dialog for new sketches</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>NewSketchUseAttachmentDialog</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/PartDesign</cstring>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -25,10 +25,15 @@
 
 
 #include <sstream>
+#include <QApplication>
 #include <QMessageBox>
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>
+#include <QTimer>
 #include <Standard_Failure.hxx>
+
+#include <Inventor/events/SoMouseButtonEvent.h>
+#include <Inventor/nodes/SoEventCallback.h>
 
 
 #include <App/Application.h>
@@ -40,7 +45,11 @@
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/CommandT.h>
+#include <Gui/Control.h>
 #include <Gui/Document.h>
+#include <Gui/MainWindow.h>
+#include <Gui/View3DInventor.h>
+#include <Gui/View3DInventorViewer.h>
 #include <Gui/DocumentObserver.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/ViewProvider.h>
@@ -1471,14 +1480,85 @@ TaskDlgAttacher::TaskDlgAttacher(
         parameter = new TaskAttacher(ViewProvider, nullptr, QString(), tr("Attachment"));
         Content.push_back(parameter);
     }
+
+    // Double-click on a valid attachment element in the 3D view confirms the dialog
+    if (onAccept) {
+        auto* view3d = qobject_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow());
+        if (view3d) {
+            dblClickViewer = view3d->getViewer();
+            dblClickViewer->addEventCallback(
+                SoMouseButtonEvent::getClassTypeId(),
+                &TaskDlgAttacher::handleMouseButtonCB,
+                this
+            );
+        }
+    }
 }
 
 TaskDlgAttacher::~TaskDlgAttacher()
 {
+    if (dblClickViewer) {
+        // Re-enable selection in case it was disabled for a double-click that never completed
+        dblClickViewer->setSelectionEnabled(true);
+        dblClickViewer->removeEventCallback(
+            SoMouseButtonEvent::getClassTypeId(),
+            &TaskDlgAttacher::handleMouseButtonCB,
+            this
+        );
+    }
     if (accepted && onAccept) {
         onAccept();
     }
-};
+}
+
+void TaskDlgAttacher::handleMouseButtonCB(void* userdata, SoEventCallback* cb)
+{
+    auto* self = static_cast<TaskDlgAttacher*>(userdata);
+    const SoEvent* ev = cb->getEvent();
+    if (!ev->isOfType(SoMouseButtonEvent::getClassTypeId())) {
+        return;
+    }
+    const auto* mbe = static_cast<const SoMouseButtonEvent*>(ev);
+
+    if (mbe->getButton() != SoMouseButtonEvent::BUTTON1 || mbe->getState() != SoButtonEvent::DOWN) {
+        return;
+    }
+
+    const SbVec2s pos = mbe->getPosition();
+    const SbTime now = SbTime::getTimeOfDay();
+    const float dci = static_cast<float>(QApplication::doubleClickInterval()) / 1000.0F;
+    constexpr int dblClickRadius = 5;
+
+    const bool inWindow = SbVec2f(pos - self->lastClickPos).length() < dblClickRadius
+        && (now - self->lastClickTime).getValue() < dci;
+
+    auto* pcAttach = self->ViewProvider->getObject()->getExtensionByType<Part::AttachExtension>();
+    const bool validState = pcAttach && !pcAttach->AttachmentSupport.getValues().empty()
+        && pcAttach->MapMode.getValue() != mmDeactivated;
+
+    if (inWindow && validState && self->dblClickViewer) {
+        // Block SoFCUnifiedSelection from processing second click (would add the parent object instead)
+        self->dblClickViewer->setSelectionEnabled(false);
+
+        // Anti-retrigger: park tracking far away and reset time
+        self->lastClickTime = SbTime();
+        self->lastClickPos = SbVec2s(-16000, -16000);
+
+        auto* doc = self->ViewProvider->getDocument()->getDocument();
+        QPointer<Gui::View3DInventorViewer> viewer = self->dblClickViewer;
+        QTimer::singleShot(0, [doc, viewer]() {
+            if (viewer) {
+                viewer->setSelectionEnabled(true);
+            }
+            Gui::Control().accept(doc);
+        });
+        return;
+    }
+
+    // Not a double-click
+    self->lastClickTime = now;
+    self->lastClickPos = pos;
+}
 
 //==== calls from the TaskView ===============================================================
 

--- a/src/Mod/Part/Gui/TaskAttacher.h
+++ b/src/Mod/Part/Gui/TaskAttacher.h
@@ -36,14 +36,25 @@
 
 #include <functional>
 
+#include <QPointer>
+
+#include <Inventor/SbLinear.h>
+#include <Inventor/SbTime.h>
+
 #include <Mod/Part/PartGlobal.h>
 
 class Ui_TaskAttacher;
 class QLineEdit;
+class SoEventCallback;
 
 namespace App
 {
 class Property;
+}
+
+namespace Gui
+{
+class View3DInventorViewer;
 }
 
 namespace Gui
@@ -241,6 +252,14 @@ protected:
     std::function<void()> onAccept;
     std::function<void()> onReject;
     bool accepted;
+    int tid;
+
+private:
+    // Double-click accept
+    static void handleMouseButtonCB(void* userdata, SoEventCallback* cb);
+    QPointer<Gui::View3DInventorViewer> dblClickViewer;
+    SbTime lastClickTime;
+    SbVec2s lastClickPos = SbVec2s(-16000, -16000);
 };
 
 }  // namespace PartGui

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <QApplication>
 #include <QMessageBox>
 
 
@@ -41,7 +42,9 @@
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/DatumPlane.h>
 #include <Mod/PartDesign/App/ShapeBinder.h>
+#include <Mod/Part/App/AttachExtension.h>
 #include <Mod/Part/App/Attacher.h>
+#include <Mod/Part/App/Part2DObject.h>
 #include <Mod/Part/App/TopoShape.h>
 #include <Mod/Sketcher/Gui/ViewProviderSketch.h>
 
@@ -208,6 +211,13 @@ public:
     bool matches()
     {
         return faceFilter.match() || planeFilter.match() || sketchFilter.match();
+    }
+
+    // True only when a single planar face or datum plane is selected (not a sketch).
+    // Used for the fast-path that skips the attachment dialog.
+    bool isSingleFaceOrPlane()
+    {
+        return (faceFilter.match() || planeFilter.match()) && !sketchFilter.match();
     }
 
     std::string getSupport() const
@@ -533,17 +543,7 @@ private:
     {
         createBodyOrThrow();
 
-        bool useAttachment = App::GetApplication()
-                                 .GetParameterGroupByPath(
-                                     "User parameter:BaseApp/Preferences/Mod/PartDesign"
-                                 )
-                                 ->GetBool("NewSketchUseAttachmentDialog", false);
-        if (useAttachment) {
-            createSketchAndShowAttachment();
-        }
-        else {
-            findAndSelectPlane();
-        }
+        createSketchAndShowAttachment();
     }
 
     void createBodyOrThrow()
@@ -584,11 +584,40 @@ private:
     {
         setOriginTemporaryVisibility();
 
+        // Capture selection before clearing it to pre-populate the attachment dialog.
+        // This mirrors UnifiedDatumCommand: use attacher to find the best fit mode.
+        App::PropertyLinkSubList support;
+        Gui::Selection().getAsPropertyLinkSubList(support);
+        support.removeValue(activeBody);
+
+        // Don't pre-populate when the selection contains sketches. A sketch selected
+        // from prior work should not automatically become the attachment reference —
+        // the user can choose a face or plane in the dialog.
+        bool hasSketch = std::ranges::any_of(support.getValues(), [](App::DocumentObject* obj) {
+            return obj && obj->isDerivedFrom<Part::Part2DObject>();
+        });
+
         // Create sketch
         App::Document* doc = activeBody->getDocument();
         std::string FeatName = doc->getUniqueObjectName("Sketch");
         FCMD_OBJ_CMD(activeBody, "newObject('Sketcher::SketchObject','" << FeatName << "')");
         auto sketch = doc->getObject(FeatName.c_str());
+
+        if (!hasSketch && support.getSize() > 0) {
+            if (auto* pcAttach = sketch->getExtensionByType<Part::AttachExtension>()) {
+                pcAttach->attacher().setReferences(support);
+                Attacher::SuggestResult sugr;
+                pcAttach->attacher().suggestMapModes(sugr);
+                if (sugr.message == Attacher::SuggestResult::srOK) {
+                    FCMD_OBJ_CMD(sketch, "AttachmentSupport = " << support.getPyReprString());
+                    FCMD_OBJ_CMD(
+                        sketch,
+                        "MapMode = '" << Attacher::AttachEngine::getModeName(sugr.bestFitMode) << "'"
+                    );
+                    Gui::Command::updateActive();
+                }
+            }
+        }
 
         PartDesign::Body* partDesignBody = activeBody;
         auto onAccept = [partDesignBody, sketch]() {
@@ -845,18 +874,41 @@ void SketchWorkflow::tryCreateSketch()
         return;
     }
 
+    bool useAttachment = App::GetApplication()
+                             .GetParameterGroupByPath(
+                                 "User parameter:BaseApp/Preferences/Mod/PartDesign"
+                             )
+                             ->GetBool("NewSketchUseAttachmentDialog", false);
+
+    bool shiftHeld = QApplication::queryKeyboardModifiers() & Qt::ShiftModifier;
+
     auto filters = getFilters();
     SketchPreselection sketchOnFace {guidocument, activeBody, filters};
 
-    if (sketchOnFace.matches()) {
-        // create Sketch on Face or Plane
-        sketchOnFace.createSupport();
-        sketchOnFace.createSketchOnSupport(sketchOnFace.getSupport());
+    // Fast path: single face or datum plane, preference off, Shift not held.
+    // If the face turns out to be non-planar or otherwise invalid, fall through
+    // to the attachment dialog instead of showing an error.
+    // A selected sketch, multiple references, no selection, Shift, or preference on
+    // all go through the attachment dialog.
+    if (!useAttachment && !shiftHeld && sketchOnFace.isSingleFaceOrPlane()) {
+        try {
+            sketchOnFace.createSupport();
+            sketchOnFace.createSketchOnSupport(sketchOnFace.getSupport());
+            return;
+        }
+        catch (const WrongSupportException&) {
+            // Fall through to attachment dialog
+        }
+        catch (const WrongSelectionException&) {
+            // Fall through to attachment dialog
+        }
+        catch (const SupportNotPlanarException&) {
+            // Fall through to attachment dialog
+        }
     }
-    else {
-        SketchRequestSelection requestSelection {guidocument, activeBody};
-        requestSelection.findSupport();
-    }
+
+    SketchRequestSelection requestSelection {guidocument, activeBody};
+    requestSelection.findSupport();
 }
 
 std::tuple<bool, PartDesign::Body*> SketchWorkflow::shouldCreateBody()

--- a/src/Mod/PartDesign/TestPartDesignGui.py
+++ b/src/Mod/PartDesign/TestPartDesignGui.py
@@ -314,16 +314,14 @@ class CreateSketch(unittest.TestCase):
         FreeCADGui.activateView("Gui::View3DInventor", True)
         FreeCADGui.activeView().setActiveObject("pdbody", App.activeDocument().Body)
         FreeCADGui.Selection.clearSelection()
-        FreeCADGui.Selection.addSelection(App.ActiveDocument.Body)
         FreeCADGui.runCommand("Std_OrthographicCamera", 1)
-        mw = FreeCADGui.getMainWindow()
         workflowcheck = CallableCheckExemptionDialog(self)
         QtCore.QTimer.singleShot(100, workflowcheck)
         FreeCADGui.runCommand("PartDesign_CompSketches", 0)
-        taskspanel = mw.findChild(QtGui.QWidget, "PartDesignGui__TaskFeaturePick")
-        self.assertTrue(taskspanel is not None)
-        if taskspanel is not None:
-            QtCore.QTimer.singleShot(0, taskspanel, QtCore.SLOT("hide()"))
+        activeDialog = FreeCADGui.Control.activeDialog()
+        self.assertIsNotNone(activeDialog)
+        if activeDialog is not None:
+            FreeCADGui.Control.closeDialog()
         App.closeDocument(App.ActiveDocument.Name)
         param.SetBool("NewSketchUseAttachmentDialog", useAttachmentSaved)
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

1. Adds a preference for the already existing parameter to open the attachment dialog when a new sketch is created in Part Design
2. Fix issue to show attachment dialog also with a preselection

With AI help.

Based on DWG discussion this default behavior:

- show attachment when nothing is selected
- show attachment when something is selected that is not planar
- do NOT show attachment when ONE planar element is selected (face, datum,...)
- show attachment when a Sketch is preselected and do NOT populate attachment dialog with that sketch
- show attachment with Shift+Click regardless of selection
- confirm attachment when double clicking the first selection entry in the 3D view
- preference to show attachment always (default off)

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/11133
Fixes https://github.com/FreeCAD/FreeCAD/issues/22507

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

#### Before:
This thing:

<img width="1130" height="710" alt="Bildschirmfoto 2026-04-08 um 08 17 07" src="https://github.com/user-attachments/assets/5e7da6ce-9770-4e63-a5fb-149dc8b5f2bf" />



#### After: 

https://github.com/user-attachments/assets/c0424fcf-f991-47d1-af1b-072dee1792f2



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
