### PR TITLE
Start: offload FCStd info & thumbnail fetching to thread pool

### DIFF
--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -582,7 +582,7 @@ void ProjectFile::readInputFile(const std::string& name, std::ostream& str)
 
 // Read the given input file from the zip directly into the given stream (not using a temporary
 // file)
-void ProjectFile::readInputFileDirect(const std::string& name, std::ostream& str)
+void ProjectFile::readInputFileDirect(const std::string& name, std::ostream& str) const
 {
     zipios::ZipFile project(stdFile);
     std::unique_ptr<std::istream> istr(project.getInputStream(name));

--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -488,6 +488,13 @@ bool ProjectFile::containsFile(const std::string& name) const
     return entry != nullptr;
 }
 
+uint32_t ProjectFile::sizeOfFile(const std::string& name) const
+{
+    zipios::ZipFile project(stdFile);
+    auto entry = project.getEntry(name);
+    return entry == nullptr ? 0 : entry->getSize();
+}
+
 std::list<std::string> ProjectFile::getInputFiles(const std::string& name) const
 {
     // <ObjectData Count="1">

--- a/src/App/ProjectFile.h
+++ b/src/App/ProjectFile.h
@@ -148,6 +148,11 @@ public:
      */
     bool containsFile(const std::string& name) const;
     /**
+     * Retrieves the (uncompressed) file size of @a name, or 0 if it does not
+     * exist in the project file.
+     */
+    uint32_t sizeOfFile(const std::string& name) const;
+    /**
      * Retrieves a list of input file names referenced to the given object name.
      * This method does the same as @ref getPropertyFiles() unless that it only
      * returns the file names.

--- a/src/App/ProjectFile.h
+++ b/src/App/ProjectFile.h
@@ -170,7 +170,7 @@ public:
     /**
      * Directly extracts the content of an input file of @a name.
      */
-    void readInputFileDirect(const std::string& name, std::ostream& str);
+    void readInputFileDirect(const std::string& name, std::ostream& str) const;
     /**
      * Replaces the input file @a name with the content of the given @a stream.
      * The method returns the file name of the newly created project file.

--- a/src/Mod/Start/App/CMakeLists.txt
+++ b/src/Mod/Start/App/CMakeLists.txt
@@ -27,12 +27,14 @@ set(Start_LIBS
 
 set(Start_SRCS
         AppStart.cpp
+        CustomFolderModel.cpp
+        CustomFolderModel.h
         DisplayedFilesModel.cpp
         DisplayedFilesModel.h
         ExamplesModel.cpp
         ExamplesModel.h
-        CustomFolderModel.cpp
-        CustomFolderModel.h
+        FcstdInfoSource.cpp
+        FcstdInfoSource.h
         FileUtilities.cpp
         FileUtilities.h
         PreCompiled.h

--- a/src/Mod/Start/App/DisplayedFilesModel.cpp
+++ b/src/Mod/Start/App/DisplayedFilesModel.cpp
@@ -21,95 +21,36 @@
  *                                                                          *
  ***************************************************************************/
 
-#include <boost/algorithm/string/predicate.hpp>
-#include <QByteArray>
-#include <QFileInfo>
-#include <QLocale>
-#include <QProcess>
-#include <QTimeZone>
-#include <QThreadPool>
-#include <QUrl>
-
-
 #include "DisplayedFilesModel.h"
 
+#include <boost/algorithm/string/predicate.hpp>
 
+#include <QThreadPool>
+
+#include <App/Application.h>
+
+#include "FcstdInfoSource.h"
 #include "FileUtilities.h"
 #include "ThumbnailSource.h"
-#include <App/Application.h>
-#include <App/ProjectFile.h>
-#include <Base/FileInfo.h>
-#include <Base/TimeInfo.h>
-#include <Base/Stream.h>
 
 
 using namespace Start;
 
-
-FileStats fileInfoFromFreeCADFile(const std::string& path)
-{
-    App::ProjectFile proj(path);
-    proj.loadDocument();
-    auto metadata = proj.getMetadata();
-    FileStats result;
-    result.insert(std::make_pair(DisplayedFilesModelRoles::author, metadata.createdBy));
-    result.insert(std::make_pair(DisplayedFilesModelRoles::modifiedTime, metadata.lastModifiedDate));
-    result.insert(std::make_pair(DisplayedFilesModelRoles::creationTime, metadata.creationDate));
-    result.insert(std::make_pair(DisplayedFilesModelRoles::company, metadata.company));
-    result.insert(std::make_pair(DisplayedFilesModelRoles::license, metadata.license));
-    result.insert(std::make_pair(DisplayedFilesModelRoles::description, metadata.comment));
-    return result;
-}
-
-/// Load the thumbnail image data (if any) that is stored in an FCStd file.
-/// \returns The image bytes, or an empty QByteArray (if no thumbnail was stored)
-QByteArray loadFCStdThumbnail(const QString& pathToFCStdFile)
-{
-    if (App::ProjectFile proj(pathToFCStdFile.toStdString()); proj.loadDocument()) {
-        try {
-            const QString pathToCachedThumbnail = getPathToCachedThumbnail(pathToFCStdFile);
-            if (!useCachedThumbnail(pathToCachedThumbnail, pathToFCStdFile)) {
-                static const QString pathToThumbnail = defaultThumbnailPath;
-                if (proj.containsFile(pathToThumbnail.toStdString())) {
-                    createThumbnailsDir();
-                    const Base::FileInfo fi(pathToCachedThumbnail.toStdString());
-                    Base::ofstream stream(fi, std::ios::out | std::ios::binary);
-                    proj.readInputFileDirect(pathToThumbnail.toStdString(), stream);
-                    stream.close();
-                }
-            }
-
-            if (auto inputFile = QFile(pathToCachedThumbnail); inputFile.exists()) {
-                inputFile.open(QIODevice::OpenModeFlag::ReadOnly);
-                return inputFile.readAll();
-            }
-        }
-        catch (...) {
-            Base::Console().log("Failed to load thumbnail for %s\n", pathToFCStdFile.toStdString());
-        }
-    }
-    return {};
-}
-
-FileStats getFileInfo(const std::string& path)
+/// Get information common to all file types.
+static FileStats getCommonFileInfo(const std::string& path)
 {
     FileStats result;
     const Base::FileInfo file(path);
-    if (file.hasExtension("FCStd")) {
-        result = fileInfoFromFreeCADFile(path);
-    }
-    else {
-        result.insert(
-            std::make_pair(DisplayedFilesModelRoles::modifiedTime, getLastModifiedAsString(file))
-        );
-    }
+    result.insert(
+        std::make_pair(DisplayedFilesModelRoles::modifiedTime, getLastModifiedAsString(file))
+    );
     result.insert(std::make_pair(DisplayedFilesModelRoles::path, path));
     result.insert(std::make_pair(DisplayedFilesModelRoles::size, humanReadableSize(file.size())));
     result.insert(std::make_pair(DisplayedFilesModelRoles::baseName, file.fileName()));
     return result;
 }
 
-bool freecadCanOpen(const QString& extension)
+static bool freecadCanOpen(const QString& extension)
 {
     std::string ext = extension.toStdString();
     auto importTypes = App::GetApplication().getImportTypes();
@@ -133,6 +74,7 @@ int DisplayedFilesModel::rowCount(const QModelIndex& parent) const
 
 QVariant DisplayedFilesModel::data(const QModelIndex& index, int role) const
 {
+    QMutexLocker locker(&_mutex);
     const int row = index.row();
     if (row < 0 || row >= static_cast<int>(_fileInfoCache.size())) {
         return {};
@@ -208,8 +150,22 @@ void DisplayedFilesModel::addFile(const QString& filePath)
         return;
     }
 
-    _fileInfoCache.emplace_back(getFileInfo(filePath.toStdString()));
+    {
+        QMutexLocker locker(&_mutex);
+        _fileInfoCache.emplace_back(getCommonFileInfo(filePath.toStdString()));
+    }
+
     const auto lowercaseExtension = qfi.suffix().toLower();
+    if (lowercaseExtension == QLatin1String("fcstd")) {
+        const auto runner = new FcstdInfoSource(filePath);
+        connect(
+            runner->signals(),
+            &FcstdInfoSource::Signals::infoAvailable,
+            this,
+            &DisplayedFilesModel::processNewFcstdInfo
+        );
+        QThreadPool::globalInstance()->start(runner);
+    }
     const QStringList ignoredExtensions {
         QLatin1String("fcmacro"),
         QLatin1String("py"),
@@ -217,29 +173,24 @@ void DisplayedFilesModel::addFile(const QString& filePath)
         QLatin1String("csv"),
         QLatin1String("txt")
     };
-    if (lowercaseExtension == QLatin1String("fcstd")) {
-        if (const auto thumbnail = loadFCStdThumbnail(filePath); !thumbnail.isEmpty()) {
-            _imageCache.insert(filePath, thumbnail);
-        }
-    }
-    else if (ignoredExtensions.contains(lowercaseExtension)) {
+    if (ignoredExtensions.contains(lowercaseExtension)) {
         // Don't try to generate a thumbnail for things like this: FreeCAD can read them, but
         // there's not much point in showing anything besides a generic icon
+        return;
     }
-    else {
-        const auto runner = new ThumbnailSource(filePath);
-        connect(
-            runner->signals(),
-            &ThumbnailSourceSignals::thumbnailAvailable,
-            this,
-            &DisplayedFilesModel::processNewThumbnail
-        );
-        QThreadPool::globalInstance()->start(runner);
-    }
+    const auto runner = new ThumbnailSource(filePath);
+    connect(
+        runner->signals(),
+        &ThumbnailSource::Signals::thumbnailAvailable,
+        this,
+        &DisplayedFilesModel::processNewThumbnail
+    );
+    QThreadPool::globalInstance()->start(runner);
 }
 
 void DisplayedFilesModel::clear()
 {
+    QMutexLocker locker(&_mutex);
     _fileInfoCache.clear();
 }
 
@@ -260,23 +211,61 @@ QHash<int, QByteArray> DisplayedFilesModel::roleNames() const
     return nameMap;
 }
 
-void DisplayedFilesModel::processNewThumbnail(const QString& file, const QByteArray& thumbnail)
+static std::size_t indexOfFile(const std::vector<FileStats>& fileInfoCache, const std::string& filePath)
 {
-    if (!thumbnail.isEmpty()) {
-        _imageCache.insert(file, thumbnail);
+    auto it = std::ranges::find_if(fileInfoCache, [filePath](const FileStats& row) {
+        auto pathIt = row.find(DisplayedFilesModelRoles::path);
+        return pathIt != row.end() && pathIt->second == filePath;
+    });
+    return std::distance(fileInfoCache.begin(), it);
+}
 
-        // Figure out the index of this file...
-        auto it = std::ranges::find_if(_fileInfoCache, [file](const FileStats& row) {
-            auto pathIt = row.find(DisplayedFilesModelRoles::path);
-            return pathIt != row.end() && pathIt->second == file.toStdString();
-        });
-        if (it != _fileInfoCache.end()) {
-            std::size_t index = std::distance(_fileInfoCache.begin(), it);
-            QModelIndex qmi = createIndex(index, 0);
-            Q_EMIT(dataChanged(qmi, qmi, {static_cast<int>(DisplayedFilesModelRoles::image)}));
-        }
-        else {
-            Base::Console().log("Unrecognized path %s\n", file.toStdString());
-        }
+void DisplayedFilesModel::processNewFcstdInfo(
+    const QString& filePath,
+    const FileStats& stats,
+    const QByteArray& thumbnail
+)
+{
+    QMutexLocker locker(&_mutex);
+
+    const std::size_t index = indexOfFile(_fileInfoCache, filePath.toStdString());
+    if (index == _fileInfoCache.size()) {
+        return;
     }
+
+    QList<int> changedRoles;
+    auto& info = _fileInfoCache[index];
+    for (auto stat : stats) {
+        info.insert(stat);
+        changedRoles.append(static_cast<int>(stat.first));
+    }
+
+    if (!thumbnail.isEmpty()) {
+        _imageCache.insert(filePath, thumbnail);
+        changedRoles.append(static_cast<int>(DisplayedFilesModelRoles::image));
+    }
+
+    locker.unlock();
+    QModelIndex qmi = createIndex(index, 0);
+    Q_EMIT(dataChanged(qmi, qmi, changedRoles));
+}
+
+void DisplayedFilesModel::processNewThumbnail(const QString& filePath, const QByteArray& thumbnail)
+{
+    if (thumbnail.isEmpty()) {
+        return;
+    }
+
+    QMutexLocker locker(&_mutex);
+    _imageCache.insert(filePath, thumbnail);
+
+    const std::size_t index = indexOfFile(_fileInfoCache, filePath.toStdString());
+    if (index == _fileInfoCache.size()) {
+        Base::Console().log("Unrecognized path %s\n", filePath.toStdString());
+        return;
+    }
+
+    locker.unlock();
+    QModelIndex qmi = createIndex(index, 0);
+    Q_EMIT(dataChanged(qmi, qmi, {static_cast<int>(DisplayedFilesModelRoles::image)}));
 }

--- a/src/Mod/Start/App/DisplayedFilesModel.h
+++ b/src/Mod/Start/App/DisplayedFilesModel.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <QMutex>
 #include <Base/Parameter.h>
 
 #include "../StartGlobal.h"
@@ -49,6 +50,7 @@ using FileStats = std::map<DisplayedFilesModelRoles, std::string>;
 
 /// A model for displaying a list of files including a thumbnail or icon, plus various file
 /// statistics.
+/// Manipulation operations are thread-safe.
 class StartExport DisplayedFilesModel: public QAbstractListModel
 {
     Q_OBJECT
@@ -68,10 +70,14 @@ protected:
     /// DisplayedFilesModelRoles enumeration
     QHash<int, QByteArray> roleNames() const override;
 
+    /// Process incoming metadata & thumbnail about an FCStd file
+    void processNewFcstdInfo(const QString& filePath, const FileStats& stats, const QByteArray& thumbnail);
+
     /// Process a new thumbnail produces by some sort of worker thread
     void processNewThumbnail(const QString& file, const QByteArray& thumbnail);
 
 private:
+    mutable QMutex _mutex;
     std::vector<FileStats> _fileInfoCache;
     QMap<QString, QByteArray> _imageCache;
 };

--- a/src/Mod/Start/App/FcstdInfoSource.cpp
+++ b/src/Mod/Start/App/FcstdInfoSource.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2026 The FreeCAD Project Association AISBL               *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "FcstdInfoSource.h"
+
+#include <sstream>
+
+#include <Base/Console.h>
+#include <Base/Stream.h>
+
+#include <App/ProjectFile.h>
+
+#include "FileUtilities.h"
+
+
+using namespace Start;
+
+/// Load the thumbnail image data (if any) that is stored in an FCStd file.
+/// \returns The image bytes, or an empty QByteArray (if no thumbnail was stored)
+static QByteArray loadFCStdThumbnail(const App::ProjectFile& proj, const QString& filePath)
+{
+    try {
+        const QString pathToCachedThumbnail = getPathToCachedThumbnail(filePath);
+        if (useCachedThumbnail(pathToCachedThumbnail, filePath)) {
+            if (auto inputFile = QFile(pathToCachedThumbnail);
+                inputFile.exists() && inputFile.open(QIODevice::OpenModeFlag::ReadOnly)) {
+                return inputFile.readAll();
+            }
+        }
+        else {
+            const auto pathToThumbnail = QString(defaultThumbnailPath).toStdString();
+            if (proj.containsFile(pathToThumbnail)) {
+                createThumbnailsDir();
+
+                // Read the thumbnail into a buffer
+                QByteArray data(proj.sizeOfFile(pathToThumbnail), Qt::Uninitialized);
+                std::ostringstream dataStream;
+                dataStream.rdbuf()->pubsetbuf(data.data(), data.size());
+                proj.readInputFileDirect(pathToThumbnail, dataStream);
+
+                // Save that buffer to the thumbnail cache
+                const Base::FileInfo thumbnailFileInfo(pathToCachedThumbnail.toStdString());
+                Base::ofstream thumbnailFileStream(thumbnailFileInfo, std::ios::out | std::ios::binary);
+                thumbnailFileStream.write(data.data(), data.size());
+                thumbnailFileStream.close();
+
+                return data;
+            }
+        }
+    }
+    catch (...) {
+        Base::Console().log("Failed to load thumbnail for %s", filePath.toStdString());
+    }
+    return {};
+}
+
+static FileStats getProjectFileInfo(const App::ProjectFile& proj)
+{
+    FileStats result;
+    auto metadata = proj.getMetadata();
+    result.insert(std::make_pair(DisplayedFilesModelRoles::author, metadata.createdBy));
+    result.insert(std::make_pair(DisplayedFilesModelRoles::modifiedTime, metadata.lastModifiedDate));
+    result.insert(std::make_pair(DisplayedFilesModelRoles::creationTime, metadata.creationDate));
+    result.insert(std::make_pair(DisplayedFilesModelRoles::company, metadata.company));
+    result.insert(std::make_pair(DisplayedFilesModelRoles::license, metadata.license));
+    result.insert(std::make_pair(DisplayedFilesModelRoles::description, metadata.comment));
+    return result;
+}
+
+FcstdInfoSource::FcstdInfoSource(QString filePath)
+    : _filePath(std::move(filePath))
+{}
+
+void FcstdInfoSource::run()
+{
+    const std::string stdFilePath(_filePath.toStdString());
+    App::ProjectFile proj(stdFilePath);
+    proj.loadDocument();
+    auto fileStats = getProjectFileInfo(proj);
+    auto thumbnail = loadFCStdThumbnail(proj, _filePath);
+    Q_EMIT _signals.infoAvailable(_filePath, fileStats, thumbnail);
+}

--- a/src/Mod/Start/App/FcstdInfoSource.h
+++ b/src/Mod/Start/App/FcstdInfoSource.h
@@ -23,33 +23,32 @@
 
 #pragma once
 
-#include <QtClassHelperMacros>
 #include <QObject>
 #include <QRunnable>
 #include <QString>
 
+#include "DisplayedFilesModel.h"
+
 namespace Start
 {
 
-class ThumbnailSourceSignals: public QObject
+class FcstdInfoSourceSignals: public QObject
 {
     Q_OBJECT
 public:
 Q_SIGNALS:
-    void thumbnailAvailable(const QString& file, const QByteArray& data);
+    void infoAvailable(const QString& filePath, const FileStats& stats, const QByteArray& thumbnail);
 };
 
-class ThumbnailSource: public QRunnable
+class FcstdInfoSource: public QRunnable
 {
-    // Don't make copies of a ThumbnailSource (it's probably running a process, what would it mean
-    // to copy it?):
-    Q_DISABLE_COPY_MOVE(ThumbnailSource)
+    Q_DISABLE_COPY_MOVE(FcstdInfoSource)
 
 public:
-    using Signals = ThumbnailSourceSignals;
+    using Signals = FcstdInfoSourceSignals;
 
-    explicit ThumbnailSource(QString file);
-    ~ThumbnailSource() override = default;
+    explicit FcstdInfoSource(QString filePath);
+    ~FcstdInfoSource() override = default;
 
     void run() override;
 
@@ -62,8 +61,7 @@ private:
     // Having a signal QObject as part of the QRunnable ensures signal connections
     // are properly cleaned up when the QRunnable gets destroyed as it finishes its work.
     Signals _signals;
-    QString _file;
-    QString _thumbnailPath;
+    QString _filePath;
 };
 
 }  // namespace Start

--- a/src/Mod/Start/App/ThumbnailSource.cpp
+++ b/src/Mod/Start/App/ThumbnailSource.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 /****************************************************************************
  *                                                                          *
- *   Copyright (c) 2025 The FreeCAD Project Association AISBL               *
+ *   Copyright (c) 2026 The FreeCAD Project Association AISBL               *
  *                                                                          *
  *   This file is part of FreeCAD.                                          *
  *                                                                          *
@@ -21,81 +21,37 @@
  *                                                                          *
  ***************************************************************************/
 
-#include <QFile>
-#include <QMetaObject>
-#include <QMutexLocker>
-#include <QObject>
-#include <QProcess>
-#include <QTimer>
-
 #include "ThumbnailSource.h"
 
-#include <QThread>
+#include <QFile>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QProcess>
+#include <QStringList>
 
-#include "FileUtilities.h"
+#include <Base/Console.h>
+#include <Base/Parameter.h>
 
 #include <App/Application.h>
 
+#include "FileUtilities.h"
+
+
 using namespace Start;
 
-ThumbnailSource::F3DInstallation ThumbnailSource::_f3d {};
-QMutex ThumbnailSource::_mutex;
-
-ThumbnailSource::ThumbnailSource(QString file)
-    : _file(std::move(file))
-{}
-
-ThumbnailSourceSignals* ThumbnailSource::signals()
+/// Gather together all of the f3d information protected by the mutex: data in this struct
+/// should be accessed only after a call to setupF3D() to ensure synchronization.
+static struct F3DInstallation
 {
-    return &_signals;
-}
+    bool initialized {false};
+    int major {0};
+    int minor {0};
+    QStringList baseArgs;
+} f3d;
 
-void ThumbnailSource::run()
-{
-    _thumbnailPath = getPathToCachedThumbnail(_file);
-    if (!useCachedThumbnail(_thumbnailPath, _file)) {
-        // Go through the mutex to ensure data is not stale.
-        // Contention on the lock is diminished because of first checking the cache.
-        setupF3D();
-        if (_f3d.major < 2) {
-            return;
-        }
-        const ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Preferences/Mod/Start"
-        );
-        const auto f3d = QString::fromUtf8(hGrp->GetASCII("f3d", "f3d").c_str());
-        QStringList args(_f3d.baseArgs);
-        args << QLatin1String("--output=") + _thumbnailPath << _file;
+static QMutex mutex;
 
-        QProcess process;
-        Base::Console().log("Creating thumbnail for %s...\n", _file.toStdString());
-        process.start(f3d, args);
-        if (!process.waitForFinished()) {
-            process.kill();
-            Base::Console().log("Creating thumbnail for %s timed out\n", _file.toStdString());
-            return;
-        }
-        if (process.exitStatus() == QProcess::CrashExit) {
-            Base::Console().log("Creating thumbnail for %s crashed\n", _file.toStdString());
-            return;
-        }
-        if (process.exitCode() != 0) {
-            Base::Console().log("Creating thumbnail for %s failed\n", _file.toStdString());
-            return;
-        }
-        Base::Console().log(
-            "Creating thumbnail for %s succeeded, wrote to %s\n",
-            _file.toStdString(),
-            _thumbnailPath.toStdString()
-        );
-    }
-    if (QFile thumbnailFile(_thumbnailPath); thumbnailFile.exists()) {
-        thumbnailFile.open(QIODevice::OpenModeFlag::ReadOnly);
-        Q_EMIT _signals.thumbnailAvailable(_file, thumbnailFile.readAll());
-    }
-}
-
-std::tuple<int, int, int> extractF3DVersion(const QString& stdoutString)
+static std::tuple<int, int, int> extractF3DVersion(const QString& stdoutString)
 {
     int major {0};
     int minor {0};
@@ -121,7 +77,15 @@ std::tuple<int, int, int> extractF3DVersion(const QString& stdoutString)
     return std::make_tuple(major, minor, patch);
 }
 
-QStringList getF3DOptions(const QString& f3d)
+static QString getF3dPath()
+{
+    const ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Start"
+    );
+    return QString::fromUtf8(hGrp->GetASCII("f3d", "f3d").c_str());
+}
+
+static QStringList getF3DOptions(const QString& f3dPath)
 {
     // F3D is under active development, and the available options change with some regularity.
     // Rather than hardcode per version, just check the ones we care about.
@@ -141,7 +105,7 @@ QStringList getF3DOptions(const QString& f3d)
         QStringList args;
         args << option << QStringLiteral("--no-render");
         QProcess process;
-        process.start(f3d, args);
+        process.start(f3dPath, args);
         if (!process.waitForFinished()) {
             process.kill();
             continue;
@@ -155,10 +119,10 @@ QStringList getF3DOptions(const QString& f3d)
     return goodOptions;
 }
 
-void ThumbnailSource::setupF3D()
+static void setupF3D()
 {
-    QMutexLocker locker(&_mutex);
-    if (_f3d.initialized) {
+    QMutexLocker locker(&mutex);
+    if (f3d.initialized) {
         return;
     }
 
@@ -168,14 +132,11 @@ void ThumbnailSource::setupF3D()
     // data. ThumbnailSource is run in its own thread, so blocking here is appropriate and will not
     // affect any other part of the program.
 
-    _f3d.initialized = true;  // Set immediately so we can use early-return below
-    const ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Start"
-    );
-    const auto f3d = QString::fromUtf8(hGrp->GetASCII("f3d", "f3d").c_str());
+    f3d.initialized = true;  // Set immediately so we can use early-return below
+    const auto f3dPath = getF3dPath();
     const QStringList args {QLatin1String("--version")};
     QProcess process;
-    process.start(f3d, args);
+    process.start(f3dPath, args);
     if (!process.waitForFinished()) {
         process.kill();
     }
@@ -185,10 +146,59 @@ void ThumbnailSource::setupF3D()
     const QByteArray stdoutBytes = process.readAllStandardOutput();
     const auto stdoutString = QString::fromUtf8(stdoutBytes);
     const auto version = extractF3DVersion(stdoutString);
-    _f3d.major = std::get<0>(version);
-    _f3d.minor = std::get<1>(version);
-    if (_f3d.major >= 2) {
-        _f3d.baseArgs = getF3DOptions(f3d);
+    f3d.major = std::get<0>(version);
+    f3d.minor = std::get<1>(version);
+    if (f3d.major >= 2) {
+        f3d.baseArgs = getF3DOptions(f3dPath);
     }
-    Base::Console().log("Running f3d version %d.%d\n", _f3d.major, _f3d.minor);
+    Base::Console().log("Running f3d version %d.%d\n", f3d.major, f3d.minor);
+}
+
+ThumbnailSource::ThumbnailSource(QString file)
+    : _file(std::move(file))
+{}
+
+void ThumbnailSource::run()
+{
+    _thumbnailPath = getPathToCachedThumbnail(_file);
+    if (!useCachedThumbnail(_thumbnailPath, _file)) {
+        // Go through the mutex to ensure data is not stale.
+        // Contention on the lock is diminished because of first checking the cache.
+        setupF3D();
+        if (f3d.major < 2) {
+            return;
+        }
+        const auto f3dPath = getF3dPath();
+        QStringList args(f3d.baseArgs);
+        args << QLatin1String("--output=") + _thumbnailPath << _file;
+
+        Base::Console().log("Creating thumbnail for %s...\n", _file.toStdString());
+        QProcess process;
+        process.start(f3dPath, args);
+        if (!process.waitForFinished()) {
+            process.kill();
+            Base::Console().log("Creating thumbnail for %s timed out\n", _file.toStdString());
+            return;
+        }
+        if (process.exitStatus() == QProcess::CrashExit) {
+            Base::Console().log("Creating thumbnail for %s crashed\n", _file.toStdString());
+            return;
+        }
+        if (process.exitCode() != 0) {
+            Base::Console().log(
+                "Creating thumbnail for %s failed: f3d exited with code %d\n",
+                _file.toStdString(),
+                process.exitCode()
+            );
+            return;
+        }
+        Base::Console().log(
+            "Creating thumbnail for %s succeeded, wrote to %s\n",
+            _file.toStdString(),
+            _thumbnailPath.toStdString()
+        );
+    }
+    if (QFile thumbnailFile(_thumbnailPath); thumbnailFile.open(QIODevice::OpenModeFlag::ReadOnly)) {
+        Q_EMIT _signals.thumbnailAvailable(_file, thumbnailFile.readAll());
+    }
 }


### PR DESCRIPTION
Fetching the metadata from an FCStd's Document.xml takes a few milliseconds, and so can extracting its thumbnail; especially if the file is on slow storage like spinning rust or network storage.

Status quo is this is done synchronously and can severely delay app startup (as in, reaching an interactive state).
    
Move this work off to a QRunnable in the global thread pool, just like ThumbnailSource did for F3D model previews.

Sync work now offloaded (work done at around the 2 sec mark):
<img width="1140" height="490" alt="thumbnails2_after" src="https://github.com/user-attachments/assets/0162d2f8-768c-4d15-bbff-8f22ce411c92" />

Asynchronous loading on display (load times artificially inflated here):

https://github.com/user-attachments/assets/4c5865ac-fcad-408f-8380-42fe3f403d92

