### PR TITLE
Gui: Add show placement to Part Datums

### DIFF
--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -27,6 +27,7 @@
 #include <QMenu>
 #include <Inventor/draggers/SoDragger.h>
 #include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoSwitch.h>
 #include <Inventor/nodes/SoTransform.h>
 
 #include <App/GeoFeature.h>
@@ -60,6 +61,13 @@ PROPERTY_SOURCE(Gui::ViewProviderDragger, Gui::ViewProviderDocumentObject)
 ViewProviderDragger::ViewProviderDragger()
 {
     ADD_PROPERTY_TYPE(TransformOrigin, ({}), nullptr, App::Prop_Hidden, nullptr);
+    ADD_PROPERTY_TYPE(
+        ShowPlacement,
+        (false),
+        "Display Options",
+        App::Prop_None,
+        "If true, placement of object is additionally rendered."
+    );
 
     pcPlacement = new SoSwitch;
     pcPlacement->whichChild = SO_SWITCH_NONE;
@@ -105,6 +113,11 @@ void ViewProviderDragger::onChanged(const App::Property* property)
 {
     if (property == &TransformOrigin) {
         updateDraggerPosition();
+    }
+    else if (property == &ShowPlacement || property == &Visibility) {
+        pcPlacement->whichChild = (ShowPlacement.getValue() && Visibility.getValue())
+            ? SO_SWITCH_ALL
+            : SO_SWITCH_NONE;
     }
 
     ViewProviderDocumentObject::onChanged(property);

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -63,6 +63,7 @@ public:
     /// Dragger is normally placed at the transform origin, unless explicitly overridden via
     /// ViewProviderDragger#setDraggerPlacement() method.
     App::PropertyPlacement TransformOrigin;
+    App::PropertyBool ShowPlacement;
 
     void attach(App::DocumentObject* pcObject) override;
 

--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -1259,8 +1259,8 @@ void TaskAttacher::showPlacementUtilities()
         overrides.override(planarViewProvider->ShowPlane, true);
     }
 
-    if (auto partViewProvider = freecad_cast<PartGui::ViewProviderPartExt*>(ViewProvider)) {
-        overrides.override(partViewProvider->ShowPlacement, true);
+    if (auto draggerViewProvider = freecad_cast<Gui::ViewProviderDragger*>(ViewProvider)) {
+        overrides.override(draggerViewProvider->ShowPlacement, true);
     }
 }
 

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -219,14 +219,6 @@ ViewProviderPartExt::ViewProviderPartExt()
         "Defines the style of the edges in the 3D view."
     );
     DrawStyle.setEnums(DrawStyleEnums);
-    ADD_PROPERTY_TYPE(
-        ShowPlacement,
-        (false),
-        "Display Options",
-        App::Prop_None,
-        "If true, placement of object is additionally rendered."
-    );
-
     coords = new SoCoordinate3();
     coords->ref();
     faceset = new SoBrepFaceSet();
@@ -441,11 +433,6 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
         else {
             pcLineStyle->linePattern = 0xff88;
         }
-    }
-    else if (prop == &ShowPlacement) {
-        pcPlacement->whichChild = (ShowPlacement.getValue() && Visibility.getValue())
-            ? SO_SWITCH_ALL
-            : SO_SWITCH_NONE;
     }
     else {
         // if the object was invisible and has been changed, recreate the visual

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -81,9 +81,6 @@ public:
     App::PropertyAngle AngularDeflection;
     App::PropertyEnumeration Lighting;
     App::PropertyEnumeration DrawStyle;
-    /// Property controlling visibility of the placement indicator, useful for displaying origin
-    /// position of attached Document Object.
-    App::PropertyBool ShowPlacement;
     // Points
     App::PropertyFloatConstraint PointSize;
     App::PropertyColor PointColor;


### PR DESCRIPTION
https://github.com/FreeCAD/FreeCAD/pull/19671 introduced a helper to show the placement in the 3D view.
It workes for all objects but the core datums.
This PR adds this to the Core Datums.
AI helped.

Fixes https://github.com/FreeCAD/FreeCAD/issues/6046
Fixes https://github.com/FreeCAD/FreeCAD/issues/19894

<img width="1410" height="558" alt="Bildschirmfoto 2026-04-08 um 12 48 08" src="https://github.com/user-attachments/assets/b044abe7-beaa-4434-b7a8-c6fc28496258" />
