### PR TITLE
code: formatting `.clang-tidy` update configuration file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,7 +5,7 @@ concurrency-*,-modernize-use-trailing-return-type, -modernize-use-nodiscard,-rea
 -readability-redundant-access-specifiers,-readability-qualified-auto,-readability-implicit-bool-conversion,
 -cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-owning-memory,-cppcoreguidelines-avoid-do-while,
 -readability-convert-member-functions-to-static,-bugprone-easily-swappable-parameters,
--cppcoreguidelines-pro-type-static-cast-downcast'
+-cppcoreguidelines-pro-type-static-cast-downcast,-readability-isolate-declaration'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 FormatStyle:     file


### PR DESCRIPTION
this pr makes a one line change to the `.clang-tidy` file. according to the freecad dev handbook cpp style guidelines, ie. c++ practices

https://freecad.github.io/DevelopersHandbook/bestpractices/c++practices

specifically

https://freecad.github.io/DevelopersHandbook/bestpractices/c++practices#initialization

## Issues

NA

## Before and After Images

in my code editor before this change i'll see a diagnostic warning like the following, and with the below diagnostic warning,

```
Multiple declarations in a single statement reduces readability (fix available)
```

<img width="2872" height="1654" alt="image" src="https://github.com/user-attachments/assets/e55f96eb-6964-49e6-b36c-161009e21f65" />
