### PR TITLE
Draft/BIM: make Arch Wall interactive cleanup explicit

### DIFF
--- a/src/Mod/BIM/bimcommands/BimWall.py
+++ b/src/Mod/BIM/bimcommands/BimWall.py
@@ -51,6 +51,10 @@ class Arch_Wall:
     https://wiki.freecad.org/Arch_Wall
     """
 
+    def __init__(self):
+        self.tracker = None
+        self._reset_interactive_buffers()
+
     def GetResources(self):
         """Returns a dictionary with the visual aspects of the Arch Wall tool."""
 
@@ -68,6 +72,45 @@ class Arch_Wall:
 
         v = hasattr(FreeCADGui.getMainWindow().getActiveWindow(), "getSceneGraph")
         return v
+
+    def _reset_interactive_buffers(self):
+        """Clear Arch Wall's local interactive buffers."""
+        self.points = []
+        self.existing = []
+        self.Length = None
+
+    def _restore_working_plane(self):
+        wp = getattr(self, "wp", None)
+        if wp is not None:
+            wp._restore()
+
+    def _teardown_interactive_session(self, restore_working_plane=True):
+        """Tear down the active interactive wall session."""
+        if restore_working_plane:
+            self._restore_working_plane()
+
+        tracker = self.tracker
+        self.tracker = None
+        if tracker is not None:
+            tracker.finalize()
+
+        # Snapper.off() leaves command-owned UI active while a Draft command is
+        # registered, so clear the command before canceling the point request.
+        FreeCAD.activeDraftCommand = None
+
+        snapper = getattr(FreeCADGui, "Snapper", None)
+        if snapper is not None:
+            snapper.cancelPointRequest()
+
+        self._reset_interactive_buffers()
+
+    def cancel_interactive(self):
+        """Cancel the current interactive wall creation session."""
+        self._teardown_interactive_session()
+
+    def finish(self):
+        """Finish the interactive wall command."""
+        self.cancel_interactive()
 
     def Activated(self):
         """Executed when Arch Wall is called.
@@ -101,7 +144,7 @@ class Arch_Wall:
             self.baseline_mode = WallBaselineMode.NONE
         self.AUTOJOIN = params.get_param_arch("autoJoinWalls")
         sel = FreeCADGui.Selection.getSelectionEx()
-        self.existing = []
+        self._reset_interactive_buffers()
         self.wp = None
 
         if sel:
@@ -178,18 +221,11 @@ class Arch_Wall:
         """
 
         import Draft
-        import ArchWall
-        from draftutils import gui_utils
 
-        if obj:
-            if Draft.getType(obj) == "Wall":
-                if not obj in self.existing:
-                    self.existing.append(obj)
+        if obj and Draft.getType(obj) == "Wall" and obj not in self.existing:
+            self.existing.append(obj)
         if point is None:
-            self.wp._restore()
-            FreeCAD.activeDraftCommand = None
-            FreeCADGui.Snapper.off()
-            self.tracker.finalize()
+            self.cancel_interactive()
             return
         self.points.append(point)
         if len(self.points) == 1:
@@ -399,10 +435,7 @@ class Arch_Wall:
         """Orchestrate wall creation according to the baseline mode."""
         from draftutils import params
 
-        self.wp._restore()
-        FreeCAD.activeDraftCommand = None
-        FreeCADGui.Snapper.off()
-        self.tracker.off()
+        self._restore_working_plane()
 
         p0 = self.wp.get_local_coords(self.points[0])
         p1 = self.wp.get_local_coords(self.points[1])
@@ -429,8 +462,9 @@ class Arch_Wall:
         # Finalization
         self.doc.commitTransaction()
         self.doc.recompute()
-        self.tracker.finalize()
-        if FreeCADGui.draftToolBar.continueMode:
+        continue_mode = FreeCADGui.draftToolBar.continueMode
+        self._teardown_interactive_session(restore_working_plane=False)
+        if continue_mode:
             self.Activated()
 
     def update(self, point, info):

--- a/src/Mod/BIM/bimtests/TestArchWallGui.py
+++ b/src/Mod/BIM/bimtests/TestArchWallGui.py
@@ -30,28 +30,46 @@ import Draft
 import Arch
 import Part
 import WorkingPlane
+from types import SimpleNamespace
 from bimtests import TestArchBaseGui
-from bimcommands.BimWall import Arch_Wall
+from bimcommands.BimWall import Arch_Wall, WallBaselineMode
 from unittest.mock import patch
 
 
 class MockTracker:
     """A dummy tracker to absorb GUI calls during logic tests."""
 
+    def __init__(self):
+        self.off_calls = 0
+        self.on_calls = 0
+        self.finalize_calls = 0
+        self.updated_points = []
+
     def off(self):
-        pass
+        self.off_calls += 1
 
     def on(self):
-        pass
+        self.on_calls += 1
 
     def finalize(self):
-        pass
+        self.finalize_calls += 1
+        self.off()
 
     def update(self, points):
-        pass
+        self.updated_points.append(points)
 
     def setorigin(self, arg):
         pass
+
+
+class RecordingSnapper:
+    """Capture the active command state at Snapper teardown time."""
+
+    def __init__(self):
+        self.active_commands_at_cancel = []
+
+    def cancelPointRequest(self):
+        self.active_commands_at_cancel.append(FreeCAD.activeDraftCommand)
 
 
 class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
@@ -458,6 +476,82 @@ class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
             # We put this here to ensure cleanup even if the wall creation fails
             if FreeCAD.activeDraftCommand is cmd:
                 FreeCAD.activeDraftCommand = None
+
+    def _make_teardown_case(self):
+        """Create a wall command with recording doubles for teardown tests."""
+        cmd = Arch_Wall()
+        tracker = MockTracker()
+        snapper = RecordingSnapper()
+        cmd.tracker = tracker
+        FreeCAD.activeDraftCommand = cmd
+        return cmd, tracker, snapper
+
+    def _assert_snapper_teardown_order(self, snapper):
+        """Assert snapper teardown runs after the wall command deactivates."""
+        self.assertEqual(
+            snapper.active_commands_at_cancel,
+            [None],
+            "Snapper teardown should run only after the wall command is deactivated.",
+        )
+        self.assertIsNone(FreeCAD.activeDraftCommand)
+
+    def _assert_tracker_teardown(self, cmd, tracker):
+        """Assert tracker-owned state is cleared during teardown."""
+        self.assertEqual(tracker.off_calls, 1)
+        self.assertEqual(tracker.finalize_calls, 1)
+        self.assertIsNone(cmd.tracker)
+
+    def test_cancel_interactive_deactivates_before_snapper_teardown(self):
+        """Verify interactive cancel clears the active command before snapper teardown."""
+        cmd, tracker, snapper = self._make_teardown_case()
+
+        with patch.object(FreeCADGui, "Snapper", snapper):
+            cmd.getPoint(None)
+
+        self._assert_snapper_teardown_order(snapper)
+        self._assert_tracker_teardown(cmd, tracker)
+        self.assertEqual(cmd.points, [])
+        self.assertEqual(cmd.existing, [])
+        self.assertIsNone(cmd.Length)
+
+    def test_finish_deactivates_before_snapper_teardown(self):
+        """Verify explicit finish uses the same teardown ordering as cancellation."""
+        cmd, tracker, snapper = self._make_teardown_case()
+
+        with patch.object(FreeCADGui, "Snapper", snapper):
+            cmd.finish()
+
+        self._assert_snapper_teardown_order(snapper)
+        self._assert_tracker_teardown(cmd, tracker)
+
+    def test_create_wall_deactivates_before_snapper_teardown(self):
+        """Verify successful wall creation uses the same teardown ordering."""
+        cmd = Arch_Wall()
+        tracker = MockTracker()
+        snapper = RecordingSnapper()
+        cmd.doc = self.document
+        cmd.Align = "Center"
+        cmd.Width = 200.0
+        cmd.Height = 2500.0
+        cmd.MultiMat = None
+        cmd.existing = []
+        cmd.tracker = tracker
+        cmd.wp = WorkingPlane.get_working_plane()
+        cmd.points = [FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(1000, 0, 0)]
+        cmd.baseline_mode = WallBaselineMode.NONE
+        FreeCAD.activeDraftCommand = cmd
+
+        toolbar = SimpleNamespace(continueMode=False)
+        initial_object_count = len(self.document.Objects)
+
+        with (
+            patch.object(FreeCADGui, "Snapper", snapper),
+            patch.object(FreeCADGui, "draftToolBar", toolbar),
+        ):
+            cmd.create_wall()
+
+        self._assert_snapper_teardown_order(snapper)
+        self.assertEqual(len(self.document.Objects), initial_object_count + 1)
 
     # Section 1: Baseless wall joining
 

--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -70,6 +70,7 @@ SET(Draft_tests
     drafttests/test_modification.py
     drafttests/test_oca.py
     drafttests/test_pivy.py
+    drafttests/test_snapper.py
     drafttests/test_svg.py
     drafttests/README.md
     drafttests/Issue24314.dxf

--- a/src/Mod/Draft/TestDraftGui.py
+++ b/src/Mod/Draft/TestDraftGui.py
@@ -103,6 +103,7 @@ from drafttests.test_pivy import DraftPivy as DraftTestGui03
 from drafttests.test_dimension_gui import DraftGuiDimension as DraftTestGui04
 from drafttests.test_manual_input_gui import DraftGuiManualInput as DraftTestGui05
 from drafttests.test_lines_gui import DraftGuiLines as DraftTestGui06
+from drafttests.test_snapper import DraftSnapper as DraftTestGui07
 
 # Use the modules so that code checkers don't complain (flake8)
 True if DraftTestGui01 else False
@@ -111,3 +112,4 @@ True if DraftTestGui03 else False
 True if DraftTestGui04 else False
 True if DraftTestGui05 else False
 True if DraftTestGui06 else False
+True if DraftTestGui07 else False

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -1325,6 +1325,64 @@ class Snapper:
             if toolbar:
                 toolbar.hide()
 
+    def _clear_point_callbacks(self):
+        """Remove the current point-picking callbacks, if any."""
+        had_callbacks = bool(self.callbackClick or self.callbackMove)
+        view = getattr(self, "view", None) or gui_utils.get_3d_view()
+
+        try:
+            if view and self.callbackClick:
+                view.removeEventCallbackPivy(
+                    coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick
+                )
+            if view and self.callbackMove:
+                view.removeEventCallbackPivy(
+                    coin.SoLocation2Event.getClassTypeId(), self.callbackMove
+                )
+            if had_callbacks:
+                # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
+                gui_utils.end_all_events()
+        except RuntimeError:
+            # the view has been deleted already
+            pass
+
+        self.callbackClick = None
+        self.callbackMove = None
+
+    def _teardown_point_request(self, hints=None):
+        """Tear down the current point-picking session.
+
+        This clears callbacks, turns the Snapper off, and closes the Draft
+        toolbar UI. It does not reset edit mode; cancelPointRequest() owns
+        that explicit-cancel path.
+        """
+        self._clear_point_callbacks()
+        self.off()
+        toolbar = getattr(Gui, "draftToolBar", None)
+        if toolbar:
+            toolbar.offUi()
+        if hints:
+            QtCore.QTimer.singleShot(0, Gui.HintManager.hide)
+
+    def _dispatch_point_callback(self, callback, point, obj=None):
+        """Invoke a point-picking callback with the expected argument shape."""
+        if not callback:
+            return
+        if len(inspect.getfullargspec(callback).args) > 1:
+            callback(point, obj)
+        else:
+            callback(point)
+
+    def cancelPointRequest(self):
+        """Explicitly cancel the current point-picking request."""
+        self._teardown_point_request()
+        gui_doc = Gui.ActiveDocument
+        if gui_doc and gui_doc.getInEdit() is not None:
+            # This explicit cancel path can bypass DraftToolBar.finish(), so
+            # leave edit mode here as well.
+            gui_doc.resetEdit()
+        self.pt = None
+
     def setSelectMode(self, mode):
         """Set the snapper into select mode (hides snapping temporarily)."""
         self.selectMode = mode
@@ -1462,36 +1520,26 @@ class Snapper:
         title is the title of the point task box mode is the dialog box
         you want (default is point, you can also use wire and line)
 
-        If getPoint() is invoked without any argument, nothing is done
-        but the callbacks are removed, so it can be used as a cancel function.
+        If getPoint() is invoked without any argument, only the existing
+        callbacks are cleared for backward compatibility. Prefer
+        cancelPointRequest() for explicit teardown.
 
         ``hints`` is an optional list of ``Gui.InputHint`` instances to
         display in the status bar for the duration of the point pick. They are
         cleared automatically when the user picks a point or cancels.
         """
+        no_point_request_args = all(
+            arg is None for arg in (last, callback, movecallback, extradlg, title)
+        )
+        if mode == "point" and no_point_request_args:
+            self._clear_point_callbacks()
+            return
+
         self.pt = None
         self.holdPoints = []
         self.ui = Gui.draftToolBar
         self.view = gui_utils.get_3d_view()
-
-        # remove any previous leftover callbacks
-        try:
-            if self.callbackClick:
-                self.view.removeEventCallbackPivy(
-                    coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick
-                )
-            if self.callbackMove:
-                self.view.removeEventCallbackPivy(
-                    coin.SoLocation2Event.getClassTypeId(), self.callbackMove
-                )
-            if self.callbackClick or self.callbackMove:
-                # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
-                gui_utils.end_all_events()
-        except RuntimeError:
-            # the view has been deleted already
-            pass
-        self.callbackClick = None
-        self.callbackMove = None
+        self._clear_point_callbacks()
 
         def move(event_cb):
             if not self.ui.mouse:
@@ -1527,64 +1575,18 @@ class Snapper:
                     accept()
 
         def accept():
-            try:
-                if self.callbackClick:
-                    self.view.removeEventCallbackPivy(
-                        coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick
-                    )
-                if self.callbackMove:
-                    self.view.removeEventCallbackPivy(
-                        coin.SoLocation2Event.getClassTypeId(), self.callbackMove
-                    )
-                if self.callbackClick or self.callbackMove:
-                    # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
-                    gui_utils.end_all_events()
-            except RuntimeError:
-                # the view has been deleted already
-                pass
-            self.callbackClick = None
-            self.callbackMove = None
-            Gui.Snapper.off()
-            self.ui.offUi()
-            if hints:
-                QtCore.QTimer.singleShot(0, Gui.HintManager.hide)
-            if callback:
-                if len(inspect.getfullargspec(callback).args) > 1:
-                    obj = None
-                    if self.snapInfo and ("Object" in self.snapInfo) and self.snapInfo["Object"]:
-                        obj = App.ActiveDocument.getObject(self.snapInfo["Object"])
-                    callback(self.pt, obj)
-                else:
-                    callback(self.pt)
+            point = self.pt
+            self._teardown_point_request(hints=hints)
+            obj = None
+            if self.snapInfo and ("Object" in self.snapInfo) and self.snapInfo["Object"]:
+                obj = App.ActiveDocument.getObject(self.snapInfo["Object"])
+            self._dispatch_point_callback(callback, point, obj)
             self.pt = None
 
         def cancel():
-            try:
-                if self.callbackClick:
-                    self.view.removeEventCallbackPivy(
-                        coin.SoMouseButtonEvent.getClassTypeId(), self.callbackClick
-                    )
-                if self.callbackMove:
-                    self.view.removeEventCallbackPivy(
-                        coin.SoLocation2Event.getClassTypeId(), self.callbackMove
-                    )
-                if self.callbackClick or self.callbackMove:
-                    # Next line fixes https://github.com/FreeCAD/FreeCAD/issues/10469:
-                    gui_utils.end_all_events()
-            except RuntimeError:
-                # the view has been deleted already
-                pass
-            self.callbackClick = None
-            self.callbackMove = None
-            Gui.Snapper.off()
-            self.ui.offUi()
-            if hints:
-                QtCore.QTimer.singleShot(0, Gui.HintManager.hide)
-            if callback:
-                if len(inspect.getfullargspec(callback).args) > 1:
-                    callback(None, None)
-                else:
-                    callback(None)
+            self._teardown_point_request(hints=hints)
+            self._dispatch_point_callback(callback, None, None)
+            self.pt = None
 
         # adding callback functions
         if mode == "line":

--- a/src/Mod/Draft/drafttests/test_snapper.py
+++ b/src/Mod/Draft/drafttests/test_snapper.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD Project Association
+# SPDX-FileNotice: Part of the FreeCAD project.
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""Unit tests for Draft snapping behavior."""
+
+## @package test_snapper
+# \ingroup drafttests
+# \brief Unit tests for Draft snapping behavior.
+
+## \addtogroup drafttests
+# @{
+
+from unittest.mock import patch
+
+import FreeCADGui as Gui
+from drafttests import test_base
+
+
+class DraftSnapper(test_base.DraftTestCaseNoDoc):
+    """Tests for Draft Snapper lifecycle behavior."""
+
+    def test_cancel_point_request_resets_edit_mode(self):
+        """Canceling a point request should leave Draft edit mode."""
+        from draftguitools.gui_snapper import Snapper
+
+        class FakeToolbar:
+            def __init__(self):
+                self.off_ui_calls = 0
+
+            def offUi(self):
+                self.off_ui_calls += 1
+
+        class FakeGuiDocument:
+            def __init__(self):
+                self.in_edit = object()
+                self.reset_edit_calls = 0
+
+            def getInEdit(self):
+                return self.in_edit
+
+            def resetEdit(self):
+                self.reset_edit_calls += 1
+                self.in_edit = None
+
+        snapper = Snapper()
+        snapper.view = object()
+        toolbar = FakeToolbar()
+        gui_doc = FakeGuiDocument()
+
+        with (
+            patch.object(Gui, "draftToolBar", toolbar, create=True),
+            patch.object(Gui, "ActiveDocument", gui_doc, create=True),
+        ):
+            snapper.cancelPointRequest()
+
+        self.assertEqual(toolbar.off_ui_calls, 1)
+        self.assertEqual(gui_doc.reset_edit_calls, 1)
+        self.assertIsNone(gui_doc.getInEdit())
+
+
+## @}


### PR DESCRIPTION

## Summary

This makes interactive cleanup explicit in Draft and uses it to give
Arch Wall creation a single, consistent cleanup path.

The wall command was previously relying on partial cleanup in a few places, and
its behavior depended on knowing that `Snapper.getPoint()` with no arguments
clears pending callbacks. This change introduces an explicit
`Snapper.cancelPointRequest()` API, then centralizes Arch Wall cleanup on top
of it so tracker, snapper, Draft UI state, and command state are reset
consistently after cancel, finish, and successful wall creation.

## Changes

- add `Snapper.cancelPointRequest()` as an explicit public point-request
cleanup API
- factor Snapper callback cleanup and callback dispatch into shared helpers
- keep the legacy no-argument `getPoint()` behavior as callback-only cleanup for
backward compatibility
- make Draft tracker cleanup tolerant of repeated cleanup
- add dedicated interactive cancel/finish handling for `Arch_Wall`
- centralize Arch Wall cleanup so `activeDraftCommand` is cleared before
snapper cleanup
- reuse the same cleanup path when the command is cancelled, finished, or
completes wall creation successfully
- add GUI regression tests covering cancel, finish, and successful wall
creation cleanup ordering

## Files

- `src/Mod/Draft/draftguitools/gui_snapper.py`
- `src/Mod/Draft/draftguitools/gui_trackers.py`
- `src/Mod/BIM/bimcommands/BimWall.py`
- `src/Mod/BIM/bimtests/TestArchWallGui.py`

## Notes

This is intentionally scoped to the Arch Wall interactive lifecycle plus the
Draft-side cleanup needed to support it safely. Other BIM commands still use
older cleanup patterns and can migrate in follow-up changes.
