### PR TITLE
Part: don't show mode as reachable if it's already applicable

### DIFF
--- a/src/Mod/Part/App/Attacher.cpp
+++ b/src/Mod/Part/App/Attacher.cpp
@@ -545,6 +545,11 @@ void AttachEngine::suggestMapModes(SuggestResult& result) const
             }
         }
     }
+
+    // A mode already in allApplicableModes should not also appear in reachableModes
+    for (eMapMode mode : mlist) {
+        mlist_reachable.erase(mode);
+    }
 }
 
 void AttachEngine::EnableAllSupportedModes()


### PR DESCRIPTION
Fixes the issue reported in #29010 where a mode like "Inertia 2-3" appears twice in the attachment editor mode list — once as an applicable (enabled) mode and once grayed out as "Inertia 2-3 (add more references)".

Root cause: `suggestMapModes()` builds two lists — `allApplicableModes` (modes that work with current references) and `reachableModes` (modes that need more references). Modes that accept a variable number of references (e.g. `mmInertialCS` accepts 1–4) were added to both lists simultaneously.

Fix: after both lists are built, remove any mode from `reachableModes` that is already in `allApplicableModes`.