### PR TITLE
PartGui: improve programmatic SoBrepFaceSet face overlays

### DIFF
--- a/src/Gui/FreeCADGui.Selection.module.pyi
+++ b/src/Gui/FreeCADGui.Selection.module.pyi
@@ -9,13 +9,14 @@ close to the GUI selection implementation.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from enum import IntEnum
-from typing import Protocol, overload
+from enum import Enum, IntEnum
+from typing import Literal, Protocol, overload
 
 from FreeCAD import DocumentObject
 from FreeCADGui import SelectionObject
 
 _Point3 = tuple[float, float, float]
+_RGBColor = tuple[float, float, float]
 
 class ResolveMode(IntEnum):
     """How selection queries should resolve linked or mapped elements."""
@@ -30,6 +31,13 @@ class SelectionStyle(IntEnum):
 
     NormalSelection = 0
     GreedySelection = 1
+
+class SelectionActionMode(str, Enum):
+    """Low-level Coin selection action accepted by :func:`applyCoinSelection`."""
+
+    Append = "append"
+    Remove = "remove"
+    All = "all"
 
 class _SelectionGate(Protocol):
     """Protocol for custom selection-gate objects."""
@@ -150,6 +158,43 @@ def getPreselection() -> SelectionObject:
 
 def clearPreselection() -> None:
     """Clear the current preselection target."""
+    ...
+
+def applyCoinHighlight(
+    path: object,
+    detail: object | None = None,
+    color: _RGBColor | None = None,
+) -> None:
+    """Apply a low-level Coin highlight to one scene-graph path.
+
+    ``detail`` may target one specific Coin sub-element detail. When omitted,
+    the whole path is highlighted. ``color`` overrides the current View
+    preference highlight color for this action only.
+    """
+    ...
+
+def clearCoinHighlight(path: object) -> None:
+    """Clear a low-level Coin highlight from one scene-graph path."""
+    ...
+
+def applyCoinSelection(
+    path: object,
+    detail: object | None = None,
+    mode: (
+        SelectionActionMode | Literal["append", "remove", "all"] | None
+    ) = SelectionActionMode.Append,
+    color: _RGBColor | None = None,
+) -> None:
+    """Apply a low-level Coin selection action to one scene-graph path.
+
+    ``detail`` may target one specific Coin sub-element detail. When omitted,
+    the whole path is targeted. ``color`` overrides the current View preference
+    selection color for this action only.
+    """
+    ...
+
+def clearCoinSelection(path: object) -> None:
+    """Clear low-level Coin selection state from one scene-graph path."""
     ...
 
 def countObjectsOfType(

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -81,6 +81,12 @@ class SelectionStyle(IntEnum):
     GreedySelection = 1
 
 
+class SelectionActionMode(str, Enum):
+    Append = "append"
+    Remove = "remove"
+    All = "all"
+
+
 # The values must match with that of the Python enum class in ViewProvider.pyi
 class ToggleVisibilityMode(Enum):
     CanToggleVisibility = "CanToggleVisibility"
@@ -96,6 +102,7 @@ def _isCommandActive(name: str) -> bool:
 Gui.listCommands = Gui.Command.listAll
 Gui.isCommandActive = _isCommandActive
 Gui.Selection.SelectionStyle = SelectionStyle
+Gui.Selection.SelectionActionMode = SelectionActionMode
 
 
 # Important definitions

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -25,9 +25,14 @@
 
 #include <array>
 #include <set>
+#include <cstdint>
+
 #include <boost/algorithm/string/predicate.hpp>
 #include <QApplication>
 
+#include <Inventor/SbColor.h>
+#include <Inventor/SoPath.h>
+#include <Inventor/details/SoDetail.h>
 
 #include <App/Application.h>
 #include <App/Document.h>
@@ -51,10 +56,13 @@
 #include "MDIView.h"
 #include "SelectionFilter.h"
 #include "SelectionFilterPy.h"
+#include "SelectionColors.h"
 #include "SelectionObserverPython.h"
+#include "SoFCUnifiedSelection.h"
 #include "Tree.h"
 #include "ViewProvider.h"
 #include "ViewProviderDocumentObject.h"
+#include "Window.h"
 
 
 FC_LOG_LEVEL_INIT("Selection", false, true, true)
@@ -2536,6 +2544,52 @@ PyMethodDef SelectionSingleton::Methods[] = {
      "clearPreselection() -> None\n"
      "\n"
      "Clear the preselection."},
+    {"applyCoinHighlight",
+     reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>(SelectionSingleton::sApplyCoinHighlight)),
+     METH_VARARGS | METH_KEYWORDS,
+     "applyCoinHighlight(path, detail=None, color=None) -> None\n"
+     "\n"
+     "Apply a low-level Coin highlight to a path.\n"
+     "\n"
+     "path : coin.SoPath\n"
+     "    Coin scene-graph path to update.\n"
+     "detail : coin.SoDetail, None\n"
+     "    Optional sub-element detail. When omitted, highlight the whole path.\n"
+     "color : tuple(float, float, float), None\n"
+     "    Optional normalized RGB override. When omitted, use the current View preference color."},
+    {"clearCoinHighlight",
+     reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>(SelectionSingleton::sClearCoinHighlight)),
+     METH_VARARGS | METH_KEYWORDS,
+     "clearCoinHighlight(path) -> None\n"
+     "\n"
+     "Clear a low-level Coin highlight from a path.\n"
+     "\n"
+     "path : coin.SoPath\n"
+     "    Coin scene-graph path to update."},
+    {"applyCoinSelection",
+     reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>(SelectionSingleton::sApplyCoinSelection)),
+     METH_VARARGS | METH_KEYWORDS,
+     "applyCoinSelection(path, detail=None, mode='append', color=None) -> None\n"
+     "\n"
+     "Apply a low-level Coin selection action to a path.\n"
+     "\n"
+     "path : coin.SoPath\n"
+     "    Coin scene-graph path to update.\n"
+     "detail : coin.SoDetail, None\n"
+     "    Optional sub-element detail. When omitted, target the whole path.\n"
+     "mode : str, SelectionActionMode, None\n"
+     "    One of 'append', 'remove', 'all'.\n"
+     "color : tuple(float, float, float), None\n"
+     "    Optional normalized RGB override. When omitted, use the current View preference color."},
+    {"clearCoinSelection",
+     reinterpret_cast<PyCFunction>(reinterpret_cast<void (*)()>(SelectionSingleton::sClearCoinSelection)),
+     METH_VARARGS | METH_KEYWORDS,
+     "clearCoinSelection(path) -> None\n"
+     "\n"
+     "Clear a low-level Coin selection from a path.\n"
+     "\n"
+     "path : coin.SoPath\n"
+     "    Coin scene-graph path to update."},
     {"countObjectsOfType",
      (PyCFunction)SelectionSingleton::sCountObjectsOfType,
      METH_VARARGS,
@@ -2912,6 +2966,94 @@ ResolveMode toEnum(int value)
             throw Base::ValueError("Wrong enum value");
     }
 }
+
+bool convertCoinPointer(PyObject* object, const char* primaryType, const char* fallbackType, void** ptr)
+{
+    *ptr = nullptr;
+    Base::Interpreter().convertSWIGPointerObj("pivy.coin", primaryType, object, ptr, 0);
+    if (!*ptr && fallbackType) {
+        Base::Interpreter().convertSWIGPointerObj("pivy.coin", fallbackType, object, ptr, 0);
+    }
+    return *ptr != nullptr;
+}
+
+SoPath* getCoinPath(PyObject* object)
+{
+    void* ptr = nullptr;
+    if (!convertCoinPointer(object, "SoPath *", "_p_SoPath", &ptr)) {
+        throw Base::TypeError("'path' must be a pivy.coin.SoPath");
+    }
+    return static_cast<SoPath*>(ptr);
+}
+
+const SoDetail* getCoinDetail(PyObject* object)
+{
+    if (!object || object == Py_None) {
+        return nullptr;
+    }
+
+    void* ptr = nullptr;
+    if (!convertCoinPointer(object, "SoDetail *", "_p_SoDetail", &ptr)) {
+        throw Base::TypeError("'detail' must be a pivy.coin.SoDetail or None");
+    }
+    return static_cast<const SoDetail*>(ptr);
+}
+
+SbColor getCoinColor(PyObject* object, const char* argName, const SbColor& fallback)
+{
+    if (!object || object == Py_None) {
+        return fallback;
+    }
+
+    if (!PyTuple_Check(object) && !PyList_Check(object)) {
+        throw Base::TypeError(std::string("'") + argName + "' must be a 3-item RGB tuple/list or None");
+    }
+
+    Py::Sequence sequence(object);
+    if (sequence.length() != 3) {
+        throw Base::TypeError(std::string("'") + argName + "' must contain exactly 3 values");
+    }
+
+    return SbColor(
+        static_cast<float>(Py::Float(sequence.getItem(0))),
+        static_cast<float>(Py::Float(sequence.getItem(1))),
+        static_cast<float>(Py::Float(sequence.getItem(2)))
+    );
+}
+
+std::string getCoinString(PyObject* object, const char* argName)
+{
+    if (PyUnicode_Check(object)) {
+        return Py::String(object).as_std_string("utf-8");
+    }
+
+    if (PyBytes_Check(object)) {
+        return Py::Bytes(object).as_std_string();
+    }
+
+    throw Base::TypeError(
+        std::string("'") + argName + "' must be a string, SelectionActionMode, or None"
+    );
+}
+
+Gui::SoSelectionElementAction::Type getCoinSelectionType(PyObject* object)
+{
+    if (!object || object == Py_None) {
+        return Gui::SoSelectionElementAction::Append;
+    }
+
+    std::string value = getCoinString(object, "mode");
+    if (boost::iequals(value, "append")) {
+        return Gui::SoSelectionElementAction::Append;
+    }
+    if (boost::iequals(value, "remove")) {
+        return Gui::SoSelectionElementAction::Remove;
+    }
+    if (boost::iequals(value, "all")) {
+        return Gui::SoSelectionElementAction::All;
+    }
+    throw Base::ValueError("Unsupported 'mode'; expected one of: append, remove, all");
+}
 }  // namespace
 
 PyObject* SelectionSingleton::sIsSelected(PyObject* /*self*/, PyObject* args)
@@ -3066,6 +3208,99 @@ PyObject* SelectionSingleton::sRemPreselection(PyObject* /*self*/, PyObject* arg
     Selection().rmvPreselect();
 
     Py_Return;
+}
+
+PyObject* SelectionSingleton::sApplyCoinHighlight(PyObject* /*self*/, PyObject* args, PyObject* kwd)
+{
+    PyObject* pathObject = nullptr;
+    PyObject* detailObject = Py_None;
+    PyObject* colorObject = Py_None;
+    static const std::array<const char*, 4> kwlist {"path", "detail", "color", nullptr};
+    if (
+        !Base::Wrapped_ParseTupleAndKeywords(args, kwd, "O|OO", kwlist, &pathObject, &detailObject, &colorObject)
+    ) {
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        auto* path = getCoinPath(pathObject);
+        auto* detail = getCoinDetail(detailObject);
+
+        SoHighlightElementAction action;
+        action.setHighlighted(true);
+        action.setColor(getCoinColor(colorObject, "color", SelectionColors::defaultHighlightColor()));
+        action.setElement(detail);
+        action.apply(path);
+        Py_Return;
+    }
+    PY_CATCH;
+}
+
+PyObject* SelectionSingleton::sClearCoinHighlight(PyObject* /*self*/, PyObject* args, PyObject* kwd)
+{
+    PyObject* pathObject = nullptr;
+    static const std::array<const char*, 2> kwlist {"path", nullptr};
+    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwd, "O", kwlist, &pathObject)) {
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        SoHighlightElementAction action;
+        action.setHighlighted(false);
+        action.apply(getCoinPath(pathObject));
+        Py_Return;
+    }
+    PY_CATCH;
+}
+
+PyObject* SelectionSingleton::sApplyCoinSelection(PyObject* /*self*/, PyObject* args, PyObject* kwd)
+{
+    PyObject* pathObject = nullptr;
+    PyObject* detailObject = Py_None;
+    PyObject* modeObject = Py_None;
+    PyObject* colorObject = Py_None;
+    static const std::array<const char*, 5> kwlist {"path", "detail", "mode", "color", nullptr};
+    if (!Base::Wrapped_ParseTupleAndKeywords(
+            args,
+            kwd,
+            "O|OOO",
+            kwlist,
+            &pathObject,
+            &detailObject,
+            &modeObject,
+            &colorObject
+        )) {
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        SoSelectionElementAction action(getCoinSelectionType(modeObject));
+        action.setColor(getCoinColor(colorObject, "color", SelectionColors::defaultSelectionColor()));
+        action.setElement(getCoinDetail(detailObject));
+        action.apply(getCoinPath(pathObject));
+        Py_Return;
+    }
+    PY_CATCH;
+}
+
+PyObject* SelectionSingleton::sClearCoinSelection(PyObject* /*self*/, PyObject* args, PyObject* kwd)
+{
+    PyObject* pathObject = nullptr;
+    static const std::array<const char*, 2> kwlist {"path", nullptr};
+    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwd, "O", kwlist, &pathObject)) {
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        SoSelectionElementAction action(SoSelectionElementAction::None);
+        action.apply(getCoinPath(pathObject));
+        Py_Return;
+    }
+    PY_CATCH;
 }
 
 PyObject* SelectionSingleton::sGetCompleteSelection(PyObject* /*self*/, PyObject* args)

--- a/src/Gui/Selection/Selection.h
+++ b/src/Gui/Selection/Selection.h
@@ -750,6 +750,10 @@ protected:
     static PyObject* sSetPreselection(PyObject* self, PyObject* args, PyObject* kwd);
     static PyObject* sGetPreselection(PyObject* self, PyObject* args);
     static PyObject* sRemPreselection(PyObject* self, PyObject* args);
+    static PyObject* sApplyCoinHighlight(PyObject* self, PyObject* args, PyObject* kwd);
+    static PyObject* sClearCoinHighlight(PyObject* self, PyObject* args, PyObject* kwd);
+    static PyObject* sApplyCoinSelection(PyObject* self, PyObject* args, PyObject* kwd);
+    static PyObject* sClearCoinSelection(PyObject* self, PyObject* args, PyObject* kwd);
     static PyObject* sGetCompleteSelection(PyObject* self, PyObject* args);
     static PyObject* sGetSelectionEx(PyObject* self, PyObject* args);
     static PyObject* sGetSelectionObject(PyObject* self, PyObject* args);

--- a/src/Gui/Selection/SelectionColors.h
+++ b/src/Gui/Selection/SelectionColors.h
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 FreeCAD contributors
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+
+#include <Inventor/SbColor.h>
+
+#include "Window.h"
+
+namespace Gui::SelectionColors
+{
+inline SbColor highlightFallbackColor()
+{
+    // Keep this aligned with the generic Selection preferences page defaults.
+    return SbColor(225.0f / 255.0f, 225.0f / 255.0f, 20.0f / 255.0f);
+}
+
+inline SbColor selectionFallbackColor()
+{
+    // Keep this aligned with the generic Selection preferences page defaults.
+    return SbColor(28.0f / 255.0f, 173.0f / 255.0f, 28.0f / 255.0f);
+}
+
+inline SbColor viewPreferenceColor(const char* key, const SbColor& fallback)
+{
+    float transparency = 0.0f;
+    SbColor color = fallback;
+    auto hGrp = WindowParameter::getDefaultParameter()->GetGroup("View");
+    auto packed = static_cast<unsigned long>(color.getPackedValue());
+    packed = hGrp->GetUnsigned(key, packed);
+    color.setPackedValue(static_cast<std::uint32_t>(packed), transparency);
+    return color;
+}
+
+inline SbColor defaultHighlightColor()
+{
+    return viewPreferenceColor("HighlightColor", highlightFallbackColor());
+}
+
+inline SbColor defaultSelectionColor()
+{
+    return viewPreferenceColor("SelectionColor", selectionFallbackColor());
+}
+}  // namespace Gui::SelectionColors

--- a/src/Gui/Selection/SoFCSelection.cpp
+++ b/src/Gui/Selection/SoFCSelection.cpp
@@ -42,6 +42,7 @@
 #include <Base/UnitsApi.h>
 
 #include "SoFCSelection.h"
+#include "SelectionColors.h"
 #include "MainWindow.h"
 #include "SoFullPathHelper.h"
 #include "SoFCSelectionAction.h"
@@ -78,8 +79,8 @@ SoFCSelection::SoFCSelection()
 {
     SO_NODE_CONSTRUCTOR(SoFCSelection);
 
-    SO_NODE_ADD_FIELD(colorHighlight, (SbColor(0.8f, 0.1f, 0.1f)));
-    SO_NODE_ADD_FIELD(colorSelection, (SbColor(0.1f, 0.8f, 0.1f)));
+    SO_NODE_ADD_FIELD(colorHighlight, (SelectionColors::highlightFallbackColor()));
+    SO_NODE_ADD_FIELD(colorSelection, (SelectionColors::selectionFallbackColor()));
     SO_NODE_ADD_FIELD(style, (EMISSIVE));
     SO_NODE_ADD_FIELD(preselectionMode, (AUTO));
     SO_NODE_ADD_FIELD(selectionMode, (SEL_ON));
@@ -797,7 +798,6 @@ void SoFCSelection::applySettings()
 {
     // TODO Some view providers got copy of this code: make them use this (2015-09-03, Fat-Zer)
     // Note: SoFCUnifiedSelection got the same code, keep in sync or think about a way to share it
-    float transparency;
     ParameterGrp::handle hGrp = Gui::WindowParameter::getDefaultParameter()->GetGroup("View");
     bool enablePre = hGrp->GetBool("EnablePreselection", true);
     bool enableSel = hGrp->GetBool("EnableSelection", true);
@@ -805,22 +805,12 @@ void SoFCSelection::applySettings()
         this->preselectionMode = Gui::SoFCSelection::OFF;
     }
     else {
-        // Search for a user defined value with the current color as default
-        SbColor highlightColor = this->colorHighlight.getValue();
-        auto highlight = (unsigned long)(highlightColor.getPackedValue());
-        highlight = hGrp->GetUnsigned("HighlightColor", highlight);
-        highlightColor.setPackedValue((uint32_t)highlight, transparency);
-        this->colorHighlight.setValue(highlightColor);
+        this->colorHighlight.setValue(SelectionColors::defaultHighlightColor());
     }
     if (!enableSel) {
         this->selectionMode = Gui::SoFCSelection::SEL_OFF;
     }
     else {
-        // Do the same with the selection color
-        SbColor selectionColor = this->colorSelection.getValue();
-        auto selection = (unsigned long)(selectionColor.getPackedValue());
-        selection = hGrp->GetUnsigned("SelectionColor", selection);
-        selectionColor.setPackedValue((uint32_t)selection, transparency);
-        this->colorSelection.setValue(selectionColor);
+        this->colorSelection.setValue(SelectionColors::defaultSelectionColor());
     }
 }

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -81,6 +81,7 @@
 #include <Base/UnitsApi.h>
 
 #include "SoFCUnifiedSelection.h"
+#include "SelectionColors.h"
 #include "Application.h"
 #include "Document.h"
 #include "DocumentObserver.h"
@@ -189,8 +190,8 @@ SoFCUnifiedSelection::SoFCUnifiedSelection()
 {
     SO_NODE_CONSTRUCTOR(SoFCUnifiedSelection);
 
-    SO_NODE_ADD_FIELD(colorHighlight, (SbColor(1.0f, 0.6f, 0.0f)));
-    SO_NODE_ADD_FIELD(colorSelection, (SbColor(0.1f, 0.8f, 0.1f)));
+    SO_NODE_ADD_FIELD(colorHighlight, (SelectionColors::highlightFallbackColor()));
+    SO_NODE_ADD_FIELD(colorSelection, (SelectionColors::selectionFallbackColor()));
     SO_NODE_ADD_FIELD(preselectionMode, (AUTO));
     SO_NODE_ADD_FIELD(selectionMode, (ON));
     SO_NODE_ADD_FIELD(selectionEnabled, (true));
@@ -249,19 +250,13 @@ bool SoFCUnifiedSelection::hasHighlight()
 
 void SoFCUnifiedSelection::applySettings()
 {
-    float transparency;
     ParameterGrp::handle hGrp = Gui::WindowParameter::getDefaultParameter()->GetGroup("View");
     bool enablePreselection = hGrp->GetBool("EnablePreselection", true);
     if (!enablePreselection) {
         this->preselectionMode = SoFCUnifiedSelection::OFF;
     }
     else {
-        // Search for a user defined value with the current color as default
-        SbColor highlightColor = this->colorHighlight.getValue();
-        auto highlight = (unsigned long)(highlightColor.getPackedValue());
-        highlight = hGrp->GetUnsigned("HighlightColor", highlight);
-        highlightColor.setPackedValue((uint32_t)highlight, transparency);
-        this->colorHighlight.setValue(highlightColor);
+        this->colorHighlight.setValue(SelectionColors::defaultHighlightColor());
     }
 
     bool enableSelection = hGrp->GetBool("EnableSelection", true);
@@ -269,12 +264,7 @@ void SoFCUnifiedSelection::applySettings()
         this->selectionMode = SoFCUnifiedSelection::OFF;
     }
     else {
-        // Do the same with the selection color
-        SbColor selectionColor = this->colorSelection.getValue();
-        auto selection = (unsigned long)(selectionColor.getPackedValue());
-        selection = hGrp->GetUnsigned("SelectionColor", selection);
-        selectionColor.setPackedValue((uint32_t)selection, transparency);
-        this->colorSelection.setValue(selectionColor);
+        this->colorSelection.setValue(SelectionColors::defaultSelectionColor());
     }
 }
 

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -32,6 +32,7 @@
 
 #include "NaviCube.h"
 #include "Navigation/NavigationStyle.h"
+#include "Selection/SelectionColors.h"
 #include "SoFCSelectionAction.h"
 #include "View3DSettings.h"
 #include "View3DInventorViewer.h"
@@ -260,26 +261,16 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
         }
     }
     else if (strcmp(Reason, "HighlightColor") == 0) {
-        float transparency;
-        SbColor highlightColor(0.8f, 0.1f, 0.1f);
-        auto highlight = (unsigned long)(highlightColor.getPackedValue());
-        highlight = rGrp.GetUnsigned("HighlightColor", highlight);
-        highlightColor.setPackedValue((uint32_t)highlight, transparency);
         SoSFColor col;
-        col.setValue(highlightColor);
+        col.setValue(SelectionColors::defaultHighlightColor());
         SoFCHighlightColorAction cAct(col);
         for (auto _viewer : _viewers) {
             cAct.apply(_viewer->getSceneGraph());
         }
     }
     else if (strcmp(Reason, "SelectionColor") == 0) {
-        float transparency;
-        SbColor selectionColor(0.1f, 0.8f, 0.1f);
-        auto selection = (unsigned long)(selectionColor.getPackedValue());
-        selection = rGrp.GetUnsigned("SelectionColor", selection);
-        selectionColor.setPackedValue((uint32_t)selection, transparency);
         SoSFColor col;
-        col.setValue(selectionColor);
+        col.setValue(SelectionColors::defaultSelectionColor());
         SoFCSelectionColorAction cAct(col);
         for (auto _viewer : _viewers) {
             cAct.apply(_viewer->getSceneGraph());

--- a/src/Gui/ViewProviderAnnotation.cpp
+++ b/src/Gui/ViewProviderAnnotation.cpp
@@ -48,6 +48,7 @@
 #include <Base/Parameter.h>
 
 #include "ViewProviderAnnotation.h"
+#include "Selection/SelectionColors.h"
 #include "Application.h"
 #include "BitmapFactory.h"
 #include "Document.h"
@@ -195,18 +196,9 @@ void ViewProviderAnnotation::attach(App::DocumentObject* f)
     auto textsep = new SoFCSelection();
 
     // set selection/highlight colors
-    float transparency;
-    ParameterGrp::handle hGrp = Gui::WindowParameter::getDefaultParameter()->GetGroup("View");
-    SbColor highlightColor = textsep->colorHighlight.getValue();
-    auto highlight = (unsigned long)(highlightColor.getPackedValue());
-    highlight = hGrp->GetUnsigned("HighlightColor", highlight);
-    highlightColor.setPackedValue((uint32_t)highlight, transparency);
+    SbColor highlightColor = SelectionColors::defaultHighlightColor();
     textsep->colorHighlight.setValue(highlightColor);
-    // Do the same with the selection color
-    SbColor selectionColor = textsep->colorSelection.getValue();
-    auto selection = (unsigned long)(selectionColor.getPackedValue());
-    selection = hGrp->GetUnsigned("SelectionColor", selection);
-    selectionColor.setPackedValue((uint32_t)selection, transparency);
+    SbColor selectionColor = SelectionColors::defaultSelectionColor();
     textsep->colorSelection.setValue(selectionColor);
 
     textsep->objectName = pcObject->getNameInDocument();

--- a/src/Gui/ViewProviderBuilder.cpp
+++ b/src/Gui/ViewProviderBuilder.cpp
@@ -27,6 +27,7 @@
 #include <App/PropertyStandard.h>
 
 #include "ViewProviderBuilder.h"
+#include "Selection/SelectionColors.h"
 #include "SoFCSelection.h"
 #include "Window.h"
 
@@ -57,7 +58,6 @@ Gui::SoFCSelection* ViewProviderBuilder::createSelection()
 {
     auto sel = new Gui::SoFCSelection();
 
-    float transparency;
     ParameterGrp::handle hGrp = Gui::WindowParameter::getDefaultParameter()->GetGroup("View");
     bool enablePre = hGrp->GetBool("EnablePreselection", true);
     bool enableSel = hGrp->GetBool("EnableSelection", true);
@@ -65,23 +65,13 @@ Gui::SoFCSelection* ViewProviderBuilder::createSelection()
         sel->preselectionMode = Gui::SoFCSelection::OFF;
     }
     else {
-        // Search for a user defined value with the current color as default
-        SbColor highlightColor = sel->colorHighlight.getValue();
-        auto highlight = (unsigned long)(highlightColor.getPackedValue());
-        highlight = hGrp->GetUnsigned("HighlightColor", highlight);
-        highlightColor.setPackedValue((uint32_t)highlight, transparency);
-        sel->colorHighlight.setValue(highlightColor);
+        sel->colorHighlight.setValue(SelectionColors::defaultHighlightColor());
     }
     if (!enableSel) {
         sel->selectionMode = Gui::SoFCSelection::SEL_OFF;
     }
     else {
-        // Do the same with the selection color
-        SbColor selectionColor = sel->colorSelection.getValue();
-        auto selection = (unsigned long)(selectionColor.getPackedValue());
-        selection = hGrp->GetUnsigned("SelectionColor", selection);
-        selectionColor.setPackedValue((uint32_t)selection, transparency);
-        sel->colorSelection.setValue(selectionColor);
+        sel->colorSelection.setValue(SelectionColors::defaultSelectionColor());
     }
 
     return sel;

--- a/src/Mod/Part/Gui/SoBrepFaceSet.cpp
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.cpp
@@ -175,11 +175,12 @@ SoBrepFaceSet::SoBrepFaceSet()
 {
     SO_NODE_CONSTRUCTOR(SoBrepFaceSet);
     SO_NODE_ADD_FIELD(partIndex, (-1));
-    SO_NODE_ADD_FIELD(highlightPartIndex, (-1));
+    SO_NODE_ADD_FIELD(highlightPartIndex, (0));
     SO_NODE_ADD_FIELD(selectionPartIndex, (0));
     SO_NODE_ADD_FIELD(highlightColor, (SbColor(1.0f, 0.0f, 0.0f)));
     SO_NODE_ADD_FIELD(selectionColor, (SbColor(0.0f, 0.6f, 0.0f)));
 
+    highlightPartIndex.setNum(0);
     selectionPartIndex.setNum(0);
 
     selContext = std::make_shared<SelContext>();
@@ -589,9 +590,7 @@ void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
     SelContextPtr ctx2;
     std::vector<SelContextPtr> ctxs;
     SelContextPtr ctx = Gui::SoFCSelectionRoot::getRenderContext(this, selContext, ctx2);
-    const bool hasOverlayFields = (highlightPartIndex.getValue() >= 0)
-        || (selectionPartIndex.getNum() > 0);
-    if (!hasOverlayFields && ctx2 && ctx2->selectionIndex.empty()) {
+    if (ctx2 && ctx2->selectionIndex.empty()) {
         return;
     }
     if (selContext2->checkGlobal(ctx)) {
@@ -815,21 +814,41 @@ void SoBrepFaceSet::GLRender(SoGLRenderAction* action)
     // Optional overlay rendering for deterministic tests (and programmatic usage).
     // Render selection first, then highlight on top.
     const int selNum = selectionPartIndex.getNum();
-    if (selNum > 0) {
-        SelContextPtr octx = std::make_shared<SelContext>();
-        octx->selectionColor = selectionColor.getValue();
-        const int32_t* vals = selectionPartIndex.getValues(0);
-        for (int i = 0; i < selNum; i++) {
-            octx->selectionIndex.insert(vals[i]);
+    const int hlNum = highlightPartIndex.getNum();
+    if (selNum > 0 || hlNum > 0) {
+        GLint oldDepthFunc = GL_LEQUAL;
+        glGetIntegerv(GL_DEPTH_FUNC, &oldDepthFunc);
+        if (oldDepthFunc != GL_LEQUAL) {
+            glDepthFunc(GL_LEQUAL);
         }
-        renderSelection(action, octx);
-    }
-    const int hl = highlightPartIndex.getValue();
-    if (hl >= 0) {
-        SelContextPtr octx = std::make_shared<SelContext>();
-        octx->highlightIndex = hl;
-        octx->highlightColor = highlightColor.getValue();
-        renderHighlight(action, octx);
+
+        if (selNum > 0) {
+            SelContextPtr octx = std::make_shared<SelContext>();
+            octx->selectionColor = selectionColor.getValue();
+            const int32_t* vals = selectionPartIndex.getValues(0);
+            for (int i = 0; i < selNum; i++) {
+                octx->selectionIndex.insert(vals[i]);
+            }
+            renderSelection(action, octx);
+        }
+        if (hlNum > 0) {
+            const int32_t* vals = highlightPartIndex.getValues(0);
+            for (int i = 0; i < hlNum; i++) {
+                SelContextPtr octx = std::make_shared<SelContext>();
+                octx->highlightIndex = vals[i];
+                octx->highlightColor = highlightColor.getValue();
+                renderHighlight(action, octx);
+            }
+        }
+        // Keep live face preselection on top when it overlaps the explicit
+        // overlay selection/highlight fields.
+        if (hasContextHighlight) {
+            renderHighlight(action, ctx);
+        }
+
+        if (oldDepthFunc != GL_LEQUAL) {
+            glDepthFunc(oldDepthFunc);
+        }
     }
 }
 #endif

--- a/src/Mod/Part/Gui/SoBrepFaceSet.h
+++ b/src/Mod/Part/Gui/SoBrepFaceSet.h
@@ -25,7 +25,6 @@
 #pragma once
 
 #include <Inventor/fields/SoMFInt32.h>
-#include <Inventor/fields/SoSFInt32.h>
 #include <Inventor/fields/SoSFColor.h>
 #include <Inventor/nodes/SoIndexedFaceSet.h>
 #include <memory>
@@ -99,7 +98,7 @@ public:
     SoMFInt32 partIndex;
     // Optional overlay rendering for deterministic tests (and programmatic usage).
     // These fields do not participate in the normal selection/highlight pipeline unless set.
-    SoSFInt32 highlightPartIndex;
+    SoMFInt32 highlightPartIndex;
     SoMFInt32 selectionPartIndex;
     SoSFColor highlightColor;
     SoSFColor selectionColor;

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(Test_SRCS
     TestTreeSelection.py
     TestRubberbandSelection.py
     TestCoinNodeSnapshots.py
+    TestCoinSelectionVisual.py
 )
 
 SET(TestData_SRCS

--- a/src/Mod/Test/InitGui.py
+++ b/src/Mod/Test/InitGui.py
@@ -99,4 +99,5 @@ FreeCAD.__unit_test__ += [
     "Menu.MenuCreateCases",
     "GuiDocument",
     "TestRubberbandSelection",
+    "TestCoinSelectionVisual",
 ]

--- a/src/Mod/Test/TestCoinNodeSnapshots.py
+++ b/src/Mod/Test/TestCoinNodeSnapshots.py
@@ -832,7 +832,7 @@ def _make_scene_for_node(coin, type_name: str):
 
         if type_name == "SoBrepFaceSetHighlight":
             # Highlight the front face (part 2).
-            faces.highlightPartIndex.setValue(2)
+            faces.highlightPartIndex.setValues(0, 1, [2])
             faces.highlightColor.setValue(1.0, 0.0, 0.0)
         elif type_name == "SoBrepFaceSetSelection":
             # Select a couple of faces to exercise the selection overlay.

--- a/src/Mod/Test/TestCoinSelectionVisual.py
+++ b/src/Mod/Test/TestCoinSelectionVisual.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""GUI visual regression test for Coin selection/preselection ordering.
+
+Run with:
+    FreeCAD -t TestCoinSelectionVisual
+"""
+
+from contextlib import suppress
+import time
+import unittest
+
+import FreeCAD
+import FreeCADGui
+from FreeCADGui import Selection
+import Part
+from pivy import coin
+
+try:
+    from PySide6 import QtWidgets
+except ImportError:
+    from PySide import QtGui as QtWidgets  # type: ignore
+
+
+PART_PLANE_TYPE = f"{Part.__name__}::Plane"
+
+
+class TestCoinSelectionVisual(unittest.TestCase):
+    """Verify that live preselection draws above Coin selection overlays."""
+
+    _COLOR_DELTA_MIN = 0.15
+    _COLOR_DELTA_RESTORE_MAX = 0.05
+
+    def setUp(self):
+        self.doc = FreeCAD.newDocument("TestCoinSelectionVisual")
+        FreeCADGui.ActiveDocument = FreeCADGui.getDocument(self.doc.Name)
+        self.view = FreeCADGui.ActiveDocument.ActiveView
+        self.viewer = self.view.getViewer()
+        self._path = None
+
+        self._had_axis_cross = self.view.hasAxisCross()
+        self.view.setAxisCross(False)
+
+        self._had_navi_cube = self.viewer.isEnabledNaviCube()
+        self.viewer.setEnabledNaviCube(False)
+
+    def tearDown(self):
+        with suppress(Exception):
+            Selection.clearPreselection()
+
+        if self._path is not None:
+            with suppress(Exception):
+                Selection.clearCoinSelection(self._path)
+            with suppress(Exception):
+                Selection.clearCoinHighlight(self._path)
+            with suppress(Exception):
+                self._path.unref()
+
+        with suppress(Exception):
+            self.view.setAxisCross(self._had_axis_cross)
+
+        self._set_navi_cube_enabled(self._had_navi_cube)
+
+        if FreeCAD.getDocument(self.doc.Name):
+            FreeCAD.closeDocument(self.doc.Name)
+
+    def test_preselection_overrides_coin_selection_overlay(self):
+        plane = self._create_test_plane()
+        self._prepare_view()
+        self._path = self._find_scene_path(plane.ViewObject.RootNode)
+
+        base_color = self._center_pixel_color()
+
+        Selection.applyCoinSelection(
+            self._path,
+            mode=Selection.SelectionActionMode.All,
+            color=(0.0, 0.6, 0.0),
+        )
+        self._flush_gui()
+        selection_color = self._center_pixel_color()
+
+        Selection.setPreselection(plane, "Face1")
+        self._flush_gui()
+        preselection_color = self._center_pixel_color()
+
+        self.assertGreater(
+            self._color_distance(base_color, selection_color),
+            self._COLOR_DELTA_MIN,
+            msg=(
+                "Coin selection overlay did not visibly change the rendered face. "
+                f"base={base_color}, selection={selection_color}"
+            ),
+        )
+        self.assertGreater(
+            self._color_distance(selection_color, preselection_color),
+            self._COLOR_DELTA_MIN,
+            msg=(
+                "Preselection did not visibly override the Coin selection overlay. "
+                f"selection={selection_color}, preselection={preselection_color}"
+            ),
+        )
+
+    def test_coin_selection_can_be_cleared(self):
+        plane = self._create_test_plane()
+        self._prepare_view()
+        self._path = self._find_scene_path(plane.ViewObject.RootNode)
+
+        base_color = self._center_pixel_color()
+
+        Selection.applyCoinSelection(
+            self._path,
+            mode=Selection.SelectionActionMode.All,
+            color=(0.0, 0.6, 0.0),
+        )
+        self._flush_gui()
+        selection_color = self._center_pixel_color()
+
+        Selection.clearCoinSelection(self._path)
+        self._flush_gui()
+        cleared_color = self._center_pixel_color()
+
+        self._assert_color_changed(
+            base_color,
+            selection_color,
+            "Coin selection overlay did not visibly change the rendered face.",
+        )
+        self._assert_color_restored(
+            base_color,
+            cleared_color,
+            "Clearing Coin selection did not restore the original rendering.",
+        )
+
+    def test_coin_highlight_can_be_cleared(self):
+        plane = self._create_test_plane()
+        self._prepare_view()
+        self._path = self._find_scene_path(plane.ViewObject.RootNode)
+
+        base_color = self._center_pixel_color()
+
+        Selection.applyCoinHighlight(self._path, color=(0.85, 0.2, 0.2))
+        self._flush_gui()
+        highlight_color = self._center_pixel_color()
+
+        Selection.clearCoinHighlight(self._path)
+        self._flush_gui()
+        cleared_color = self._center_pixel_color()
+
+        self._assert_color_changed(
+            base_color,
+            highlight_color,
+            "Coin highlight did not visibly change the rendered face.",
+        )
+        self._assert_color_restored(
+            base_color,
+            cleared_color,
+            "Clearing Coin highlight did not restore the original rendering.",
+        )
+
+    def _create_test_plane(self):
+        plane = self.doc.addObject(PART_PLANE_TYPE, "Plane")
+        plane.Length = 40
+        plane.Width = 40
+        plane.ViewObject.ShapeColor = (0.66, 0.66, 0.74)
+        self.doc.recompute()
+        return plane
+
+    def _prepare_view(self):
+        self.view.viewTop()
+        self._set_orthographic_if_supported()
+        self.view.fitAll()
+        self._flush_gui()
+
+    def _set_orthographic_if_supported(self):
+        with suppress(Exception):
+            self.view.setCameraType("Orthographic")
+
+    def _set_navi_cube_enabled(self, enabled):
+        with suppress(Exception):
+            self.viewer.setEnabledNaviCube(enabled)
+
+    def _flush_gui(self):
+        for _ in range(4):
+            FreeCADGui.updateGui()
+            QtWidgets.QApplication.processEvents()
+            self.view.redraw()
+            time.sleep(0.05)
+
+    def _find_scene_path(self, root_node):
+        search = coin.SoSearchAction()
+        search.setNode(root_node)
+        search.setSearchingAll(False)
+        search.apply(self.view.getSceneGraph())
+
+        path = search.getPath()
+        self.assertIsNotNone(
+            path, "Could not find the object root node in the active 3D scene graph"
+        )
+        # Retain the returned path; SoSearchAction owns it otherwise.
+        path.ref()
+        return path
+
+    def _center_pixel_color(self):
+        image = self.viewer.grabFramebuffer()
+        color = image.pixelColor(image.width() // 2, image.height() // 2)
+        return (color.redF(), color.greenF(), color.blueF())
+
+    def _assert_color_changed(self, before, after, message):
+        self.assertGreater(
+            self._color_distance(before, after),
+            self._COLOR_DELTA_MIN,
+            msg=f"{message} before={before}, after={after}",
+        )
+
+    def _assert_color_restored(self, expected, actual, message):
+        self.assertLess(
+            self._color_distance(expected, actual),
+            self._COLOR_DELTA_RESTORE_MAX,
+            msg=f"{message} expected={expected}, actual={actual}",
+        )
+
+    @staticmethod
+    def _color_distance(lhs, rhs):
+        return sum((a - b) ** 2 for a, b in zip(lhs, rhs)) ** 0.5


### PR DESCRIPTION
This draft improves the optional programmatic/test overlay path in `SoBrepFaceSet`.

It includes three focused changes:

- change `highlightPartIndex` from `SoSFInt32` to `SoMFInt32`, so callers can highlight multiple faces at once
- make the explicit face overlay pass use `GL_LEQUAL`, matching the existing selection/highlight depth behavior for coplanar overlay rendering in the 3D viewer
- keep live face preselection on top when it overlaps the explicit overlay selection/highlight fields

The motivation is the [discussion on `4e114d9b8667f2af6c2d5e97b2bd3c577b4c8347`](https://github.com/FreeCAD/FreeCAD/commit/4e114d9b8667f2af6c2d5e97b2bd3c577b4c8347#commitcomment-181792049), especially the FEM/prototyping use case where one logical element can span multiple faces, and the follow-up reports that the test-style overlay fields were not showing up in the 3D view and that mouse preselection should still override programmatic face selection.

Scope of this draft:

- keep the normal face selection/preselection pipeline unchanged
- keep the existing face snapshot baselines unchanged
- improve only the optional overlay/programmatic path
