### PR TITLE
BIM: Introduce Arch component `Footprint` display mode

### DIFF
--- a/.github/scripts/run_gui_tests.py
+++ b/.github/scripts/run_gui_tests.py
@@ -86,7 +86,13 @@ def run_and_capture(cmd: list[str]) -> tuple[int, str]:
     """
     try:
         proc = subprocess.run(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, check=False
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
         )
         return proc.returncode, proc.stdout
     except FileNotFoundError:

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -250,6 +250,17 @@ class BuildingPart(ArchIFC.IfcProduct):
                 QT_TRANSLATE_NOOP("App::Property", "The level of the (0,0,0) point of this level"),
                 locked=True,
             )
+        if not "PlanCutHeight" in pl:
+            obj.addProperty(
+                "App::PropertyLength",
+                "PlanCutHeight",
+                "BuildingPart",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "The plan cut height of this level for derived footprint views",
+                ),
+                locked=True,
+            )
         if not "Area" in pl:
             obj.addProperty(
                 "App::PropertyArea",
@@ -317,6 +328,7 @@ class BuildingPart(ArchIFC.IfcProduct):
                 ),
                 locked=True,
             )
+        self._sync_plan_cut_height_property(obj)
 
     def onDocumentRestored(self, obj):
 
@@ -367,6 +379,8 @@ class BuildingPart(ArchIFC.IfcProduct):
 
         if (prop == "Height" or prop == "HeightPropagate") and obj.Height.Value:
             self.touchChildren(obj)
+        elif prop == "IfcType":
+            self._sync_plan_cut_height_property(obj)
 
         elif prop == "Placement":
             if hasattr(self, "oldPlacement") and self.oldPlacement != obj.Placement:
@@ -388,6 +402,23 @@ class BuildingPart(ArchIFC.IfcProduct):
                         )
                     if deltap:
                         child.Placement.move(deltap)
+
+    def _sync_plan_cut_height_property(self, obj):
+        """Expose plan cut height only on building storeys.
+
+        The footprint display mode uses this document-saved value to derive
+        plan cuts for objects contained in a level. Other BuildingPart roles do
+        not currently consume it, so keep the property hidden there.
+        """
+
+        if not hasattr(obj, "PlanCutHeight"):
+            return
+        if getattr(obj, "IfcType", "") == "Building Storey":
+            obj.setEditorMode("PlanCutHeight", 0)
+            if not obj.PlanCutHeight.Value:
+                obj.PlanCutHeight = 1000
+        else:
+            obj.setEditorMode("PlanCutHeight", 2)
 
     def execute(self, obj):
         "gather all the child shapes into a compound"

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -50,6 +50,8 @@ import Draft
 
 from draftutils import params
 
+DEFAULT_PLAN_CUT_HEIGHT = 1000.0
+
 if FreeCAD.GuiUp:
     from PySide import QtGui, QtCore
     from PySide.QtCore import QT_TRANSLATE_NOOP
@@ -64,6 +66,24 @@ else:
         return txt
 
     # \endcond
+
+
+class PlanContext:
+    """Plan view definition used to derive object plan representations.
+
+    `cut_z` is the absolute document Z coordinate where solid objects are cut.
+    `target_z` is the absolute document Z coordinate where the resulting plan
+    faces should be placed. `source` can reference the document object that
+    supplied the context, such as a Building Storey. The generic Footprint
+    display mode uses this as its default preview context, but callers can pass
+    another context to request a different plan representation of the same
+    object.
+    """
+
+    def __init__(self, cut_z=None, target_z=None, source=None):
+        self.cut_z = cut_z
+        self.target_z = target_z
+        self.source = source
 
 
 def addToComponent(compobject, addobject, prop):
@@ -553,6 +573,57 @@ class Component(ArchIFC.IfcProduct):
                 if obj in parent.Additions:
                     return self.getParentHeight(parent)
         return 0
+
+    def getParentBuildingPart(self, obj, ifc_type=None):
+        """Return the nearest containing BuildingPart, optionally filtered by IFC type."""
+
+        for parent in obj.InList:
+            if Draft.getType(parent) == "BuildingPart":
+                if obj in getattr(parent, "Group", []):
+                    if (ifc_type is None) or (getattr(parent, "IfcType", "") == ifc_type):
+                        return parent
+        for parent in obj.InList:
+            if hasattr(parent, "Group"):
+                if obj in parent.Group:
+                    building_part = self.getParentBuildingPart(parent, ifc_type)
+                    if building_part:
+                        return building_part
+        for parent in obj.InList:
+            if hasattr(parent, "Additions"):
+                if obj in parent.Additions:
+                    building_part = self.getParentBuildingPart(parent, ifc_type)
+                    if building_part:
+                        return building_part
+        return None
+
+    def getDefaultPlanContext(self, obj, default_cut_height=DEFAULT_PLAN_CUT_HEIGHT):
+        """Return the default plan context for generic footprint previews.
+
+        Contained objects use their parent Building Storey's `PlanCutHeight`,
+        measured from the storey level. Standalone objects fall back to a simple
+        cut height above the object's base. `getFootprint()` wrappers use this
+        default context to preserve the existing display-mode API while
+        `getPlanRepresentation()` provides the view-aware extension point.
+        """
+
+        shape = getattr(obj, "Shape", None)
+        if shape and not shape.isNull():
+            target_z = shape.BoundBox.ZMin
+        else:
+            target_z = obj.Placement.Base.z
+
+        storey = self.getParentBuildingPart(obj, ifc_type="Building Storey")
+        if storey and hasattr(storey, "PlanCutHeight") and storey.PlanCutHeight.Value > 0:
+            level_offset = getattr(storey, "LevelOffset", 0)
+            if hasattr(level_offset, "Value"):
+                level_offset = level_offset.Value
+            cut_z = storey.Placement.Base.z + level_offset + storey.PlanCutHeight.Value
+            return PlanContext(cut_z=cut_z, target_z=target_z, source=storey)
+
+        return PlanContext(
+            cut_z=target_z + default_cut_height,
+            target_z=target_z,
+        )
 
     def clone(self, obj):
         """If the object is a clone, copy the shape.

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -1656,7 +1656,73 @@ class ViewProviderComponent:
                         if len(obj.CloneOf.ViewObject.DiffuseColor) > 1:
                             obj.ViewObject.DiffuseColor = obj.CloneOf.ViewObject.DiffuseColor
                             obj.ViewObject.update()
+        if prop in ("Shape", "Placement"):
+            self.refreshFootprint(obj.ViewObject)
         return
+
+    def updateFootprint(self):
+        self.fset.coordIndex.deleteValues(0)
+        self.fcoords.point.deleteValues(0)
+        faces = self.Object.Proxy.getFootprint(self.Object)
+        if faces:
+            inverse_placement = self.Object.Placement.inverse()
+            verts = []
+            fdata = []
+            idx = 0
+            for face in faces:
+                tri = face.tessellate(1)
+                for v in tri[0]:
+                    # getFootprint() returns placed geometry. Store the
+                    # cached footprint node in object-local coordinates so
+                    # Placement changes do not double-transform it.
+                    if inverse_placement is not None:
+                        v = inverse_placement.multVec(v)
+                    verts.append([v.x, v.y, v.z])
+                for f in tri[1]:
+                    fdata.extend([f[0] + idx, f[1] + idx, f[2] + idx, -1])
+                idx += len(tri[0])
+            self.fcoords.point.setValues(verts)
+            self.fset.coordIndex.setValues(0, len(fdata), fdata)
+
+    def ensureFootprintGroup(self, vobj=None):
+        """Ensure the generic Footprint display mode node exists.
+
+        This is idempotent and safe to call from attach, update, and display
+        mode transitions. Objects with footprint support only need to provide
+        `createFootprintGroup()` and `updateFootprint()`.
+        """
+
+        if hasattr(self, "footprintgroup") and self.footprintgroup is not None:
+            return self.footprintgroup
+        if not hasattr(self, "createFootprintGroup"):
+            return None
+        if vobj is None:
+            obj = getattr(self, "Object", None)
+            vobj = obj.ViewObject if obj else None
+        if not vobj:
+            return None
+        try:
+            self.footprintgroup = self.createFootprintGroup()
+            self.footprintgroup.setName("Footprint")
+            vobj.addDisplayMode(self.footprintgroup, "Footprint")
+            return self.footprintgroup
+        except Exception:
+            return None
+
+    def refreshFootprint(self, vobj=None):
+        """Refresh derived footprint display data when footprint mode is available.
+
+        Footprint geometry is a derived GUI cache. Failures here should not break
+        generic attach/update paths for the rest of the view provider.
+        """
+
+        if not self.ensureFootprintGroup(vobj):
+            return False
+        try:
+            self.updateFootprint()
+        except Exception:
+            return False
+        return True
 
     def getIcon(self):
         """Return the path to the appropriate icon.
@@ -1735,7 +1801,7 @@ class ViewProviderComponent:
         lines. This data is stored as additional coin nodes which are children
         of the display mode node.
 
-        Add the HiRes display mode.
+        Add the HiRes and Footprint display modes (if provided by object).
 
         Parameters
         ----------
@@ -1751,6 +1817,7 @@ class ViewProviderComponent:
         self.hiresgroup.addChild(self.meshcolor)
         self.hiresgroup.setName("HiRes")
         vobj.addDisplayMode(self.hiresgroup, "HiRes")
+        self.refreshFootprint(vobj)
         return
 
     def getDisplayModes(self, vobj):
@@ -1771,6 +1838,8 @@ class ViewProviderComponent:
         """
 
         modes = ["HiRes"]
+        if hasattr(self, "footprintgroup") and self.footprintgroup is not None:
+            modes.append("Footprint")
         return modes
 
     def setDisplayMode(self, mode):
@@ -1798,6 +1867,11 @@ class ViewProviderComponent:
         str:
             The name of the display mode the view provider has switched to.
         """
+
+        if mode == "Footprint" and self.refreshFootprint():
+            # Footprint is a generic component display mode, so refresh its
+            # derived display data whenever the viewer switches into it.
+            return "Footprint"
 
         if hasattr(self, "meshnode"):
             if self.meshnode:

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -758,6 +758,7 @@ class _Structure(ArchComponent.Component):
                 ),
                 locked=True,
             )
+
         if not "Width" in pl:
             obj.addProperty(
                 "App::PropertyLength",
@@ -887,6 +888,65 @@ class _Structure(ArchComponent.Component):
             self.ArchSkPropSetPickedUuid = ""
         if not hasattr(self, "ArchSkPropSetListPrev"):
             self.ArchSkPropSetListPrev = []
+
+    def getFootprint(self, obj):
+        """Return a light plan footprint for flat slabs.
+
+        This derives the outline from the highest horizontal slab faces and
+        flattens it to the slab base elevation. Sloped slabs will need a
+        projection-based footprint path instead. This is the default-preview
+        wrapper for `getPlanRepresentation()`.
+        """
+
+        context = self.getDefaultPlanContext(obj)
+        return self.getPlanRepresentation(obj, context)
+
+    def getPlanRepresentation(self, obj, context):
+        """Return slab plan faces for the supplied plan context.
+
+        The current slab implementation uses the context target elevation only:
+        it flattens the highest horizontal slab faces to that Z coordinate.
+        Future projection or section behavior can use the same context object
+        without changing the generic Footprint display mode contract.
+        """
+
+        if context is None:
+            context = self.getDefaultPlanContext(obj)
+        if getattr(obj, "IfcType", "Beam") != "Slab":
+            return []
+
+        shape = obj.Shape
+        if not shape or shape.isNull():
+            return []
+
+        top_faces = []
+        top_z = None
+        target_z = context.target_z if context.target_z is not None else shape.BoundBox.ZMin
+        for face in shape.Faces:
+            normal = face.normalAt(0, 0)
+            if normal.getAngle(FreeCAD.Vector(0, 0, 1)) >= 0.01:
+                continue
+            z_value = face.CenterOfMass.z
+            if top_z is None or z_value > top_z + 0.001:
+                top_faces = [face]
+                top_z = z_value
+            elif abs(z_value - top_z) < 0.001:
+                top_faces.append(face)
+
+        if not top_faces:
+            return []
+
+        delta_z = target_z - top_z
+        if abs(delta_z) < 0.001:
+            return top_faces
+
+        flattened = []
+        translation = FreeCAD.Vector(0, 0, delta_z)
+        for face in top_faces:
+            moved = face.copy()
+            moved.translate(translation)
+            flattened.append(moved)
+        return flattened
 
     def dumps(self):  # Supercede Arch.Component.dumps()
         dump = super().dumps()
@@ -1400,6 +1460,88 @@ class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
         self.setProperties(vobj)
         vobj.ShapeColor = ArchCommands.getDefaultColor("Structure")
 
+    def _is_slab(self, vobj):
+        obj = getattr(vobj, "Object", None)
+        return Draft.get_type(obj) == "Structure" and getattr(obj, "IfcType", "Beam") == "Slab"
+
+    def ensureFootprintGroup(self, vobj=None):
+        """Ensure slabs expose the generic Footprint display mode."""
+
+        if vobj is None:
+            vobj = getattr(getattr(self, "Object", None), "ViewObject", None)
+        if not vobj or not self._is_slab(vobj):
+            return None
+        return super().ensureFootprintGroup(vobj)
+
+    def getDisplayModes(self, vobj):
+        modes = super().getDisplayModes(vobj)
+        if not self._is_slab(vobj) and "Footprint" in modes:
+            modes.remove("Footprint")
+        return modes
+
+    def _drop_footprint_group(self, vobj):
+        if hasattr(self, "fcoords"):
+            self.fcoords.point.deleteValues(0)
+        if hasattr(self, "fset"):
+            self.fset.coordIndex.deleteValues(0)
+        if vobj.DisplayMode == "Footprint" and "Flat Lines" in vobj.listDisplayModes():
+            vobj.DisplayMode = "Flat Lines"
+
+    def _sync_display_mode_enums(self, vobj):
+        """Refresh the DisplayMode enumeration from the currently exposed modes.
+
+        PropertyEnumeration updates its available values when assigned a list,
+        which lets the view provider expose Footprint only while the structure
+        is a slab.
+        """
+
+        vobj.DisplayMode = vobj.listDisplayModes()
+
+    def createFootprintGroup(self):
+        """Set up a subtle filled footprint style for slabs."""
+
+        from pivy import coin
+
+        base_color = ArchCommands.getDefaultColor("Structure")
+        fill_color = tuple((component + 2.0) / 3.0 for component in base_color[:3])
+
+        self.fcoords = coin.SoCoordinate3()
+        self.fset = coin.SoIndexedFaceSet()
+        material = coin.SoMaterial()
+        material.diffuseColor.setValue(fill_color)
+        material.transparency.setValue(0.7)
+        shape_hints = coin.SoShapeHints()
+        shape_hints.faceType = coin.SoShapeHints.UNKNOWN_FACE_TYPE
+
+        sep = coin.SoSeparator()
+        sep.addChild(material)
+        sep.addChild(shape_hints)
+        sep.addChild(self.fcoords)
+        sep.addChild(self.fset)
+        return sep
+
+    def attach(self, vobj):
+        """Attach display modes and pre-register the slab footprint mask.
+
+        The DisplayMode enumeration is initialized during attach, so the
+        footprint mode must be registered here even if the structure starts as
+        a beam/column and only becomes a slab later.
+        """
+
+        from pivy import coin
+
+        self.Object = vobj.Object
+        self.hiresgroup = coin.SoSeparator()
+        self.meshcolor = coin.SoBaseColor()
+        self.hiresgroup.addChild(self.meshcolor)
+        self.hiresgroup.setName("HiRes")
+        vobj.addDisplayMode(self.hiresgroup, "HiRes")
+        ArchComponent.ViewProviderComponent.ensureFootprintGroup(self, vobj)
+        if self._is_slab(vobj):
+            self.refreshFootprint(vobj)
+        else:
+            self._drop_footprint_group(vobj)
+
     def setProperties(self, vobj):
 
         pl = vobj.PropertiesList
@@ -1493,8 +1635,12 @@ class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
                     IfcType = None
                 if IfcType == "Slab":
                     obj.ViewObject.NodeType = "Area"
+                    self.refreshFootprint(obj.ViewObject)
+                    self._sync_display_mode_enums(obj.ViewObject)
                 else:
                     obj.ViewObject.NodeType = "Linear"
+                    self._drop_footprint_group(obj.ViewObject)
+                    self._sync_display_mode_enums(obj.ViewObject)
         else:
             ArchComponent.ViewProviderComponent.updateData(self, obj, prop)
 

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -800,20 +800,88 @@ class _Wall(ArchComponent.Component):
         ArchComponent.Component.onChanged(self, obj, prop)
 
     def getFootprint(self, obj):
-        """Get the faces that make up the base/foot of the wall.
+        """Get the plan faces that represent this wall in footprint mode.
+
+        The preferred representation is a horizontal section through the wall
+        solid at a standard plan cut height. If the wall belongs to a Building
+        Storey, use that level's PlanCutHeight relative to the storey elevation.
+        Otherwise, fall back to the default 1000 mm plan cut above the wall
+        base. This makes hosted openings appear naturally in footprint mode
+        because the wall shape has already been cut by them. If that section
+        cannot be computed, fall back to the literal bottom faces of the wall.
+        This is the default-preview wrapper for `getPlanRepresentation()`.
 
         Returns
         -------
         list of <Part.Face>
-            The faces that make up the foot of the wall.
+            The faces that make up the wall footprint.
         """
 
+        context = self.getDefaultPlanContext(obj)
+        return self.getPlanRepresentation(obj, context)
+
+    def getPlanRepresentation(self, obj, context):
+        """Return wall plan faces for the supplied plan context.
+
+        The context defines both the absolute cut elevation and the elevation
+        where the resulting faces are placed. This lets callers ask for
+        different plan representations of the same wall without changing the
+        generic Footprint display mode contract.
+        """
+
+        import Part
+
+        if context is None:
+            context = self.getDefaultPlanContext(obj)
+        shape = obj.Shape
+        if shape and (not shape.isNull()) and shape.Solids:
+            bb = shape.BoundBox
+            if bb.ZLength > 0.001 and context.cut_z is not None:
+                cut_z = context.cut_z
+                cut_z = max(bb.ZMin + 0.001, min(bb.ZMax - 0.001, cut_z))
+                target_z = context.target_z if context.target_z is not None else bb.ZMin
+                cut_plane = Part.makePlane(1, 1)
+                cut_plane.translate(FreeCAD.Vector(bb.Center.x, bb.Center.y, cut_z))
+                try:
+                    section_plane, _, _ = ArchCommands.getCutVolume(cut_plane, shape)
+                    if section_plane:
+                        section = shape.section(section_plane)
+                        if section and section.Edges:
+                            try:
+                                edge_groups = Part.sortEdges(section.Edges)
+                            except AttributeError:
+                                edge_groups = Part.__sortEdges__(section.Edges)
+                            faces = []
+                            for edges in edge_groups:
+                                wire = Part.Wire(edges)
+                                if not wire.isClosed():
+                                    continue
+                                face = Part.Face(wire)
+                                if face.Area <= 0:
+                                    continue
+                                face.translate(FreeCAD.Vector(0, 0, target_z - cut_z))
+                                faces.append(face)
+                            if faces:
+                                return faces
+                except Part.OCCError:
+                    # Sectioning can fail on OCC edge cases; fall back to the
+                    # wall's literal bottom faces below instead of breaking the
+                    # footprint display mode.
+                    pass
+
         faces = []
-        if obj.Shape:
-            for f in obj.Shape.Faces:
+        if shape:
+            bb = shape.BoundBox
+            target_z = context.target_z if context.target_z is not None else bb.ZMin
+            for f in shape.Faces:
                 if f.normalAt(0, 0).getAngle(FreeCAD.Vector(0, 0, -1)) < 0.01:
-                    if abs(abs(f.CenterOfMass.z) - abs(obj.Shape.BoundBox.ZMin)) < 0.001:
-                        faces.append(f)
+                    if abs(abs(f.CenterOfMass.z) - abs(bb.ZMin)) < 0.001:
+                        face = f
+                        delta_z = target_z - bb.ZMin
+                        if abs(delta_z) >= 0.001:
+                            face = f.copy()
+                            face.translate(FreeCAD.Vector(0, 0, delta_z))
+                        faces.append(face)
         return faces
 
     def getExtrusionData(self, obj):

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1929,21 +1929,9 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
                 return ":/icons/Arch_Wall_Tree_Assembly.svg"
         return ":/icons/Arch_Wall_Tree.svg"
 
-    def attach(self, vobj):
-        """Add display modes' data to the coin scenegraph.
+    def createFootprintGroup(self):
+        """Sets up the Coin group for footprint display mode"""
 
-        Add each display mode as a coin node, whose parent is this view
-        provider.
-
-        Each display mode's node includes the data needed to display the object
-        in that mode. This might include colors of faces, or the draw style of
-        lines. This data is stored as additional coin nodes which are children
-        of the display mode node.
-
-        Add the textures used in the Footprint display mode.
-        """
-
-        self.Object = vobj.Object
         from pivy import coin
 
         tex = coin.SoTexture2()
@@ -1954,14 +1942,31 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         s = params.get_param_arch("patternScale")
         texcoords.directionS.setValue(s, 0, 0)
         texcoords.directionT.setValue(0, s, 0)
+
         self.fcoords = coin.SoCoordinate3()
         self.fset = coin.SoIndexedFaceSet()
+
         sep = coin.SoSeparator()
         sep.addChild(tex)
         sep.addChild(texcoords)
         sep.addChild(self.fcoords)
         sep.addChild(self.fset)
-        vobj.RootNode.addChild(sep)
+
+        return sep
+
+    def attach(self, vobj):
+        """Add display modes' data to the coin scenegraph.
+
+        Add each display mode as a coin node, whose parent is this view
+        provider.
+
+        Each display mode's node includes the data needed to display the object
+        in that mode. This might include colors of faces, or the draw style of
+        lines. This data is stored as additional coin nodes which are children
+        of the display mode node.
+        """
+
+        self.Object = vobj.Object
         ArchComponent.ViewProviderComponent.attach(self, vobj)
 
     def updateData(self, obj, prop):
@@ -2031,7 +2036,7 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
             List containing the names of the new display modes.
         """
 
-        modes = ArchComponent.ViewProviderComponent.getDisplayModes(self, vobj) + ["Footprint"]
+        modes = ArchComponent.ViewProviderComponent.getDisplayModes(self, vobj)
         return modes
 
     def setDisplayMode(self, mode):
@@ -2056,26 +2061,9 @@ class _ViewProviderWall(ArchComponent.ViewProviderComponent):
         str:
             The name of the display mode the view provider has switched to.
         """
-
-        self.fset.coordIndex.deleteValues(0)
-        self.fcoords.point.deleteValues(0)
         if mode == "Footprint":
-            if hasattr(self, "Object"):
-                faces = self.Object.Proxy.getFootprint(self.Object)
-                if faces:
-                    verts = []
-                    fdata = []
-                    idx = 0
-                    for face in faces:
-                        tri = face.tessellate(1)
-                        for v in tri[0]:
-                            verts.append([v.x, v.y, v.z])
-                        for f in tri[1]:
-                            fdata.extend([f[0] + idx, f[1] + idx, f[2] + idx, -1])
-                        idx += len(tri[0])
-                    self.fcoords.point.setValues(verts)
-                    self.fset.coordIndex.setValues(0, len(fdata), fdata)
-            return "Wireframe"
+            if self.refreshFootprint():
+                return "Footprint"
         return ArchComponent.ViewProviderComponent.setDisplayMode(self, mode)
 
     def setEdit(self, vobj, mode):

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -252,6 +252,7 @@ SET(bimtests_SRCS
     bimtests/TestArchTruss.py
     bimtests/TestWebGLExport.py
     bimtests/TestWebGLExportGui.py
+    bimtests/TestArchFootprintGui.py
     bimtests/TestArchImportersGui.py
     bimtests/TestArchBuildingPartGui.py
     bimtests/TestArchStairsGui.py

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -258,6 +258,7 @@ SET(bimtests_SRCS
     bimtests/TestArchStairsGui.py
     bimtests/TestArchReport.py
     bimtests/TestArchReportGui.py
+    bimtests/TestArchStructureGui.py
 )
 
 set(bimtests_FIXTURES

--- a/src/Mod/BIM/TestArchGui.py
+++ b/src/Mod/BIM/TestArchGui.py
@@ -31,5 +31,6 @@ from bimtests.TestArchFootprintGui import TestArchFootprintGui
 from bimtests.TestArchStairsGui import TestArchStairsGui
 from bimtests.TestArchReportGui import TestArchReportGui
 from bimtests.TestArchSiteGui import TestArchSiteGui
+from bimtests.TestArchStructureGui import TestArchStructureGui
 from bimtests.TestArchWallGui import TestArchWallGui
 from bimtests.TestWebGLExportGui import TestWebGLExportGui

--- a/src/Mod/BIM/TestArchGui.py
+++ b/src/Mod/BIM/TestArchGui.py
@@ -27,6 +27,7 @@
 from bimtests.TestArchImportersGui import TestArchImportersGui
 from bimtests.TestArchAxisGui import TestArchAxisGui
 from bimtests.TestArchBuildingPartGui import TestArchBuildingPartGui
+from bimtests.TestArchFootprintGui import TestArchFootprintGui
 from bimtests.TestArchStairsGui import TestArchStairsGui
 from bimtests.TestArchReportGui import TestArchReportGui
 from bimtests.TestArchSiteGui import TestArchSiteGui

--- a/src/Mod/BIM/bimtests/TestArchBaseGui.py
+++ b/src/Mod/BIM/bimtests/TestArchBaseGui.py
@@ -74,15 +74,10 @@ class TestArchBaseGui(TestArchBase):
         """Run the Qt event loop briefly so queued GUI callbacks execute.
 
         This helper starts a QEventLoop and quits it after `timeout_ms` milliseconds using
-        QTimer.singleShot. Any exception (e.g. missing Qt in the environment) is silently ignored so
-        tests can still run in pure-CLI environments where the GUI isn't available.
+        QTimer.singleShot.
         """
-        try:
-            from PySide import QtCore
+        from PySide import QtCore
 
-            loop = QtCore.QEventLoop()
-            QtCore.QTimer.singleShot(int(timeout_ms), loop.quit)
-            loop.exec_()
-        except Exception:
-            # Best-effort: if Qt isn't present or event pumping fails, continue.
-            pass
+        loop = QtCore.QEventLoop()
+        QtCore.QTimer.singleShot(int(timeout_ms), loop.quit)
+        loop.exec_()

--- a/src/Mod/BIM/bimtests/TestArchBuildingPart.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPart.py
@@ -81,6 +81,9 @@ class TestArchBuildingPart(TestArchBase.TestArchBase):
         floor = Arch.makeFloor(name="TestFloor")
         self.assertIsNotNone(floor, "makeFloor failed to create a floor object.")
         self.assertEqual(floor.Label, "TestFloor", "Floor label is incorrect.")
+        self.assertAlmostEqual(
+            floor.PlanCutHeight.Value, 1000.0, msg="Floor plan cut height default is incorrect."
+        )
 
     def test_makeBuilding(self):
         """Test the makeBuilding function."""

--- a/src/Mod/BIM/bimtests/TestArchFootprintGui.py
+++ b/src/Mod/BIM/bimtests/TestArchFootprintGui.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD contributors
+# SPDX-FileNotice: Part of the FreeCAD project.
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""GUI regressions for footprint display data."""
+
+import Arch
+import FreeCAD
+from bimtests import TestArchBaseGui
+
+
+class TestArchFootprintGui(TestArchBaseGui.TestArchBaseGui):
+
+    def test_new_wall_populates_footprint_display_data(self):
+        """New walls should populate their footprint nodes on shape update."""
+
+        wall = Arch.makeWall(length=3000, width=200, height=2500)
+        self.document.recompute()
+        self.pump_gui_events()
+
+        proxy = wall.ViewObject.Proxy
+        self.assertIn("Footprint", wall.ViewObject.listDisplayModes())
+        self.assertTrue(hasattr(proxy, "fcoords"))
+        self.assertTrue(hasattr(proxy, "fset"))
+        self.assertGreater(proxy.fcoords.point.getNum(), 0)
+        self.assertGreater(proxy.fset.coordIndex.getNum(), 0)
+
+    def test_wall_footprint_display_data_is_local_to_placement(self):
+        """Footprint display data should be stored in object-local coordinates."""
+
+        wall = Arch.makeWall(length=3000, width=200, height=2500)
+        wall.Placement.Base = FreeCAD.Vector(1234, 5678, 0)
+        self.document.recompute()
+        self.pump_gui_events()
+
+        points = wall.ViewObject.Proxy.fcoords.point
+        xs = []
+        ys = []
+        for idx in range(points.getNum()):
+            point = points[idx]
+            xs.append(point[0])
+            ys.append(point[1])
+
+        self.assertLess(min(xs), -1000)
+        self.assertGreater(max(xs), 1000)
+        self.assertLess(min(ys), 0)
+        self.assertGreater(max(ys), 0)
+        self.assertLess(max(abs(value) for value in xs), 5000)
+        self.assertLess(max(abs(value) for value in ys), 500)

--- a/src/Mod/BIM/bimtests/TestArchSiteGui.py
+++ b/src/Mod/BIM/bimtests/TestArchSiteGui.py
@@ -115,7 +115,9 @@ class TestArchSiteGui(TestArchBaseGui.TestArchBaseGui):
         finally:
             try:
                 os.unlink(path)
-            except Exception:
+            except FileNotFoundError:
+                # The temp file may already be gone if setup failed before it
+                # was fully written, which is fine for test cleanup.
                 pass
 
     def test_legacy_site_migration(self):

--- a/src/Mod/BIM/bimtests/TestArchStructure.py
+++ b/src/Mod/BIM/bimtests/TestArchStructure.py
@@ -26,6 +26,8 @@ import unittest
 import FreeCAD as App
 from FreeCAD import Vector
 import Arch
+import ArchComponent
+import Draft
 from bimtests import TestArchBase
 
 
@@ -35,6 +37,28 @@ class TestArchStructure(TestArchBase.TestArchBase):
         App.Console.PrintLog("Checking BIM Structure...\n")
         structure = Arch.makeStructure(length=2, width=3, height=5)
         self.assertTrue(structure, "BIM Structure failed")
+
+    def test_slab_get_footprint(self):
+        """Slabs should expose a flattened footprint for plan display."""
+        self.printTestMessage("Checking slab footprint faces")
+
+        rect = Draft.makeRectangle(length=4000, height=3000)
+        slab = Arch.makeStructure(rect, height=200, name="TestSlab")
+        slab.IfcType = "Slab"
+        self.document.recompute()
+
+        faces = slab.Proxy.getFootprint(slab)
+        self.assertEqual(len(faces), 1, "Expected one footprint face for a rectangular slab.")
+        self.assertAlmostEqual(faces[0].Area, 4000 * 3000, places=3)
+        bbox = faces[0].BoundBox
+        self.assertAlmostEqual(bbox.ZMin, slab.Shape.BoundBox.ZMin, places=6)
+        self.assertAlmostEqual(bbox.ZMax, slab.Shape.BoundBox.ZMin, places=6)
+
+        context = ArchComponent.PlanContext(cut_z=0.0, target_z=42.0)
+        context_faces = slab.Proxy.getPlanRepresentation(slab, context)
+        context_bbox = context_faces[0].BoundBox
+        self.assertAlmostEqual(context_bbox.ZMin, 42.0, places=6)
+        self.assertAlmostEqual(context_bbox.ZMax, 42.0, places=6)
 
     #  Dimensions
     def test_makeStructure_explicit_dimensions(self):

--- a/src/Mod/BIM/bimtests/TestArchStructureGui.py
+++ b/src/Mod/BIM/bimtests/TestArchStructureGui.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 FreeCAD contributors
+# SPDX-FileNotice: Part of the FreeCAD project.
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""GUI tests for slab footprint display."""
+
+import Arch
+import Draft
+from bimtests import TestArchBaseGui
+
+
+class TestArchStructureGui(TestArchBaseGui.TestArchBaseGui):
+
+    def test_structure_footprint_mode_remains_slab_only(self):
+        """Structure footprints should only be exposed while the object is a slab."""
+
+        slab = Arch.makeStructure(length=3000, width=2000, height=250, name="TestSlab")
+        self.document.recompute()
+        self.pump_gui_events()
+
+        self.assertNotIn("Footprint", slab.ViewObject.listDisplayModes())
+
+        slab.IfcType = "Slab"
+        self.document.recompute()
+        self.pump_gui_events()
+
+        self.assertIn("Footprint", slab.ViewObject.listDisplayModes())
+        slab.ViewObject.DisplayMode = "Footprint"
+        self.pump_gui_events()
+
+        slab.IfcType = "Beam"
+        self.document.recompute()
+        self.pump_gui_events()
+
+        self.assertNotIn("Footprint", slab.ViewObject.listDisplayModes())
+        self.assertNotEqual(slab.ViewObject.DisplayMode, "Footprint")
+
+    def test_slab_populates_footprint_display_data(self):
+        """Slabs should expose populated footprint data in the GUI view provider."""
+
+        rect = Draft.makeRectangle(length=4000, height=3000)
+        slab = Arch.makeStructure(rect, height=200, name="GuiSlab")
+        slab.IfcType = "Slab"
+        self.document.recompute()
+        self.pump_gui_events()
+
+        proxy = slab.ViewObject.Proxy
+        self.assertIn("Footprint", slab.ViewObject.listDisplayModes())
+        self.assertTrue(hasattr(proxy, "fcoords"))
+        self.assertTrue(hasattr(proxy, "fset"))
+        self.assertGreater(proxy.fcoords.point.getNum(), 0)
+        self.assertGreater(proxy.fset.coordIndex.getNum(), 0)

--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -26,6 +26,7 @@
 
 import os
 import Arch
+import ArchComponent
 import Draft
 import Part
 import FreeCAD as App
@@ -33,6 +34,31 @@ from bimtests import TestArchBase
 
 
 class TestArchWall(TestArchBase.TestArchBase):
+
+    def _make_hosted_window(self, wall, name, x_start, z_start, width=800.0, height=1200.0):
+        sketch = self.document.addObject("Sketcher::SketchObject", name + "Sketch")
+        sketch.addGeometry(
+            [
+                Part.LineSegment(App.Vector(0, 0, 0), App.Vector(width, 0, 0)),
+                Part.LineSegment(App.Vector(width, 0, 0), App.Vector(width, height, 0)),
+                Part.LineSegment(App.Vector(width, height, 0), App.Vector(0, height, 0)),
+                Part.LineSegment(App.Vector(0, height, 0), App.Vector(0, 0, 0)),
+            ]
+        )
+        sketch.Placement.Rotation = App.Rotation(App.Vector(1, 0, 0), 90)
+        sketch.Placement.Base = App.Vector(x_start, 0, z_start)
+        self.document.recompute()
+
+        window = Arch.makeWindow(sketch, name=name)
+        window.Width = width
+        window.Height = height
+        window.HoleDepth = 0
+        window.WindowParts = ["DefaultFrame", "Frame", "Wire0", "60", "0"]
+        self.document.recompute()
+
+        Arch.addComponents(window, wall)
+        self.document.recompute()
+        return window
 
     def testWall(self):
         operation = "Checking Arch Wall..."
@@ -103,6 +129,157 @@ class TestArchWall(TestArchBase.TestArchBase):
         wall = Arch.makeWall(length=5000, width=200, height=3000)
         self.assertIsNotNone(wall, "makeWall failed to create a wall object.")
         self.assertEqual(wall.Label, "Wall", "Wall label is incorrect.")
+
+    def test_wall_footprint_shows_hosted_opening_gap(self):
+        """Hosted windows should split the wall footprint at the plan cut height."""
+        self.printTestMessage("Checking wall footprint with hosted opening...")
+
+        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(3000, 0, 0))
+        wall = Arch.makeWall(line, width=200, height=3000)
+        self.document.recompute()
+
+        initial_faces = wall.Proxy.getFootprint(wall)
+        self.assertEqual(
+            len(initial_faces), 1, "Straight wall footprint should start as a single face."
+        )
+
+        window_width = 800.0
+        self._make_hosted_window(
+            wall,
+            "FootprintWindow",
+            x_start=1100,
+            z_start=800,
+            width=window_width,
+            height=1200.0,
+        )
+
+        footprint_faces = wall.Proxy.getFootprint(wall)
+        self.assertEqual(
+            len(footprint_faces),
+            2,
+            "Hosted opening should split a straight wall footprint into two faces.",
+        )
+        footprint_area = sum(face.Area for face in footprint_faces)
+        expected_area = (wall.Length.Value - window_width) * wall.Width.Value
+        self.assertAlmostEqual(
+            footprint_area,
+            expected_area,
+            places=3,
+            msg="Wall footprint area should reflect the hosted opening gap at plan cut height.",
+        )
+
+    def test_wall_footprint_ignores_openings_above_cut_height(self):
+        """Only openings intersecting the plan cut height should affect the wall footprint."""
+        self.printTestMessage("Checking wall footprint ignores openings above cut height...")
+
+        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(4000, 0, 0))
+        wall = Arch.makeWall(line, width=200, height=3000)
+        self.document.recompute()
+
+        low_window_width = 700.0
+        self._make_hosted_window(
+            wall,
+            "LowFootprintWindow",
+            x_start=700,
+            z_start=700,
+            width=low_window_width,
+            height=1200.0,
+        )
+        high_window_width = 500.0
+        self._make_hosted_window(
+            wall,
+            "HighFootprintWindow",
+            x_start=2400,
+            z_start=1800,
+            width=high_window_width,
+            height=700.0,
+        )
+
+        footprint_faces = wall.Proxy.getFootprint(wall)
+        self.assertEqual(
+            len(footprint_faces),
+            2,
+            "Only the opening crossing the cut height should split the wall footprint.",
+        )
+        footprint_area = sum(face.Area for face in footprint_faces)
+        expected_area = (wall.Length.Value - low_window_width) * wall.Width.Value
+        self.assertAlmostEqual(
+            footprint_area,
+            expected_area,
+            places=3,
+            msg="Openings above the cut height must not remove area from the wall footprint.",
+        )
+        high_cut_context = ArchComponent.PlanContext(
+            cut_z=2200.0,
+            target_z=wall.Shape.BoundBox.ZMin,
+        )
+        high_cut_faces = wall.Proxy.getPlanRepresentation(wall, high_cut_context)
+        high_cut_area = sum(face.Area for face in high_cut_faces)
+        expected_high_cut_area = (wall.Length.Value - high_window_width) * wall.Width.Value
+        self.assertAlmostEqual(
+            high_cut_area,
+            expected_high_cut_area,
+            places=3,
+            msg="Explicit plan contexts should drive wall plan representation height.",
+        )
+
+    def test_wall_footprint_uses_parent_storey_plan_cut_height(self):
+        """Parent storeys should define the absolute plan cut for contained walls."""
+        self.printTestMessage("Checking wall footprint uses parent storey plan cut height...")
+
+        line = Draft.makeLine(App.Vector(0, 0, 0), App.Vector(4000, 0, 0))
+        wall = Arch.makeWall(line, width=200, height=3000)
+        storey = Arch.makeFloor(name="FootprintLevel")
+        storey.LevelOffset = 1200
+        storey.PlanCutHeight = 1500
+        storey.addObject(wall)
+        self.document.recompute()
+
+        low_window_width = 500.0
+        self._make_hosted_window(
+            wall,
+            "LowStoreyWindow",
+            x_start=700,
+            z_start=700,
+            width=low_window_width,
+            height=900.0,
+        )
+        high_window_width = 900.0
+        self._make_hosted_window(
+            wall,
+            "HighStoreyWindow",
+            x_start=2200,
+            z_start=2200,
+            width=high_window_width,
+            height=700.0,
+        )
+
+        context = wall.Proxy.getDefaultPlanContext(wall)
+        self.assertAlmostEqual(
+            context.cut_z,
+            2700.0,
+            places=6,
+            msg="Contained walls should derive their plan cut from the parent storey level.",
+        )
+        self.assertIs(
+            context.source,
+            storey,
+            "The default wall plan context should record the parent storey source.",
+        )
+        footprint_faces = wall.Proxy.getFootprint(wall)
+        self.assertEqual(
+            len(footprint_faces),
+            2,
+            "Only the opening crossing the parent storey cut height should split the wall.",
+        )
+        footprint_area = sum(face.Area for face in footprint_faces)
+        expected_area = (wall.Length.Value - high_window_width) * wall.Width.Value
+        self.assertAlmostEqual(
+            footprint_area,
+            expected_area,
+            places=3,
+            msg="Parent storey plan cut height should override the default wall-base cut.",
+        )
 
     def test_joinWalls(self):
         """Test the joinWalls function."""


### PR DESCRIPTION
## Summary

This is a rework of #19045, rebased on current `main` and split down to the footprint foundation only.

The main idea is still the same: introduce a proper `Footprint` display mode at the Arch component/view-provider level, instead of handling footprints as ad hoc object-specific display logic.

This version narrows the scope to the generic foundation and the first concrete consumers:
- Arch component `Footprint` display mode support
- wall footprint display from a configurable plan cut height
- refresh of footprint display data on shape changes
- slab footprint display mode
- localized footprint display data so placement changes do not double-transform cached geometry

## What changed

- add a generic `Footprint` display mode path in `ArchComponent`
- make walls derive their footprint from a horizontal cut when possible
- refresh cached footprint display data on shape and placement updates
- add slab footprint display mode support in `ArchStructure`
- keep structure `Footprint` mode slab-only
- store cached footprint display geometry in object-local coordinates

## Notes

Compared to #19045, this PR is intentionally smaller and focused on the base display-mode infrastructure and footprint cache behavior.

Hosted opening symbols and other follow-up footprint work are kept for separate stacked PRs.

For slabs, the current implementation targets flat slabs:
- it derives the outline from the highest horizontal slab faces
- then flattens that outline to the slab base elevation

A projection-based path would be a better follow-up for future sloped slab support.

## Tests

Adds/updates GUI and BIM tests covering:
- wall footprint population
- wall footprint localization to object placement
- slab footprint display mode
- slab-only exposure of structure footprint mode
