### PR TITLE
core: fixes #28703 allow transform gizmo to hover / update with files with ext links

### DIFF
--- a/src/Gui/Selection/Selection.h
+++ b/src/Gui/Selection/Selection.h
@@ -253,6 +253,11 @@ public:
     void attachSelection();
     /** Detaches from the selection. */
     void detachSelection();
+    /** clears the document scope filter, allowing cross-document selection events. */
+    void clearDocumentScope()
+    {
+        documentScopeName.clear();
+    }
 
 private:
     virtual void onSelectionChanged(const SelectionChanges& msg) = 0;

--- a/src/Gui/TaskTransform.cpp
+++ b/src/Gui/TaskTransform.cpp
@@ -92,6 +92,7 @@ TaskTransform::TaskTransform(
     , ui(new Ui_TaskTransformDialog)
 {
     blockSelection(true);
+    clearDocumentScope();  // allow cross-document selection for links
 
     dragger->addStartCallback(dragStartCallback, this);
     dragger->addMotionCallback(dragMotionCallback, this);


### PR DESCRIPTION
this PR aims at resolving issue #28703 ie. fixies #28703. and this PR aims to be as surgical as possible without polluting the codebase with unnecessary bs. with these code changes a user can reference external vertices, edges and faces from a linked object from an external file. i created a componian branch with all debug statements for those who care.

the root cause of this issue is the `SelectionObserver` constructor sets `documentScopeName` to the active document, and `_onSelectionChanged` filters out any message where `msg.pDocName` doesn't match. when the transform tool hovers over linked geometry that resolves to an external file ie. document, the preselect message comes in with the document name, and gets silently dropped.

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/28703

## Before and After Images

see original issue for before images.

- [x] will post an after image in a sec. (editing via neovim from a terminal).

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/5bf8624c-1de1-4e41-8b12-a36b98973941" />

