### PR TITLE
App/Gui: add Python workbench reload runtime and adopt it in BIM

### DIFF
--- a/cMake/FreeCadMacros.cmake
+++ b/cMake/FreeCadMacros.cmake
@@ -54,6 +54,28 @@ MACRO (fc_copy_file_if_different inputfile outputfile)
     endif()
 ENDMACRO(fc_copy_file_if_different)
 
+MACRO (fc_mirror_file inputfile outputfile)
+    if(BUILD_VERBOSE_GENERATION)
+        set(fc_details " (fc_mirror_file called from ${CMAKE_CURRENT_SOURCE_DIR})")
+    else()
+        set(fc_details "")
+    endif()
+
+    get_filename_component(infile "${inputfile}" ABSOLUTE)
+    get_filename_component(outfile "${outputfile}" ABSOLUTE)
+    add_file_dependencies("${infile}" "${outfile}")
+    ADD_CUSTOM_COMMAND(
+        COMMAND "${CMAKE_COMMAND}"
+            -DINPUTFILE="${infile}"
+            -DOUTPUTFILE="${outfile}"
+            -P "${CMAKE_SOURCE_DIR}/cMake/MirrorFile.cmake"
+        OUTPUT "${outfile}"
+        COMMENT "Mirroring ${infile} to ${outfile}${fc_details}"
+        MAIN_DEPENDENCY "${infile}"
+        DEPENDS "${CMAKE_SOURCE_DIR}/cMake/MirrorFile.cmake"
+    )
+ENDMACRO(fc_mirror_file)
+
 MACRO (fc_target_copy_resource target_name inpath outpath)
 # Macro to copy a list of files into a nested directory structure
 # Arguments -

--- a/cMake/LinkOrCopy.cmake
+++ b/cMake/LinkOrCopy.cmake
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+if(NOT DEFINED INPUTFILE OR NOT DEFINED OUTPUTFILE)
+    message(FATAL_ERROR "LinkOrCopy.cmake requires INPUTFILE and OUTPUTFILE")
+endif()
+
+get_filename_component(_output_dir "${OUTPUTFILE}" DIRECTORY)
+file(MAKE_DIRECTORY "${_output_dir}")
+file(CREATE_LINK "${INPUTFILE}" "${OUTPUTFILE}" SYMBOLIC COPY_ON_ERROR RESULT _link_result)
+
+if(NOT _link_result STREQUAL "0")
+    message(FATAL_ERROR "Failed to mirror ${INPUTFILE} to ${OUTPUTFILE}: ${_link_result}")
+endif()

--- a/cMake/MirrorFile.cmake
+++ b/cMake/MirrorFile.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 if(NOT DEFINED INPUTFILE OR NOT DEFINED OUTPUTFILE)
-    message(FATAL_ERROR "LinkOrCopy.cmake requires INPUTFILE and OUTPUTFILE")
+    message(FATAL_ERROR "MirrorFile.cmake requires INPUTFILE and OUTPUTFILE")
 endif()
 
 get_filename_component(_output_dir "${OUTPUTFILE}" DIRECTORY)

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -362,6 +362,20 @@ SET(FreeCADApp_SRCS
     PreCompiled.h
 )
 
+set(_freecad_init_tools_source "${CMAKE_CURRENT_SOURCE_DIR}/FreeCADInitTools.py")
+set(_freecad_init_tools_output "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/FreeCADInitTools.py")
+add_custom_command(
+    OUTPUT "${_freecad_init_tools_output}"
+    COMMAND "${CMAKE_COMMAND}"
+        -DINPUTFILE="${_freecad_init_tools_source}"
+        -DOUTPUTFILE="${_freecad_init_tools_output}"
+        -P "${CMAKE_SOURCE_DIR}/cMake/LinkOrCopy.cmake"
+    MAIN_DEPENDENCY "${_freecad_init_tools_source}"
+    DEPENDS "${CMAKE_SOURCE_DIR}/cMake/LinkOrCopy.cmake"
+    COMMENT "Mirroring ${_freecad_init_tools_source} to ${_freecad_init_tools_output}"
+)
+add_custom_target(FreeCADInitToolsMirror DEPENDS "${_freecad_init_tools_output}")
+
 if(FREECAD_USE_PCH)
     target_precompile_headers(FreeCADApp PRIVATE
         $<$<COMPILE_LANGUAGE:CXX>:"${CMAKE_CURRENT_LIST_DIR}/PreCompiled.h">
@@ -381,6 +395,7 @@ if (FREECAD_WARN_ERROR)
 endif()
 
 add_dependencies(FreeCADApp fc_version)
+add_dependencies(FreeCADApp FreeCADInitToolsMirror)
 
 SET_BIN_DIR(FreeCADApp FreeCADApp)
 
@@ -394,3 +409,10 @@ else(WIN32)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     )
 endif(WIN32)
+
+INSTALL(
+    FILES
+        FreeCADInitTools.py
+    DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -364,16 +364,7 @@ SET(FreeCADApp_SRCS
 
 set(_freecad_init_tools_source "${CMAKE_CURRENT_SOURCE_DIR}/FreeCADInitTools.py")
 set(_freecad_init_tools_output "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/FreeCADInitTools.py")
-add_custom_command(
-    OUTPUT "${_freecad_init_tools_output}"
-    COMMAND "${CMAKE_COMMAND}"
-        -DINPUTFILE="${_freecad_init_tools_source}"
-        -DOUTPUTFILE="${_freecad_init_tools_output}"
-        -P "${CMAKE_SOURCE_DIR}/cMake/LinkOrCopy.cmake"
-    MAIN_DEPENDENCY "${_freecad_init_tools_source}"
-    DEPENDS "${CMAKE_SOURCE_DIR}/cMake/LinkOrCopy.cmake"
-    COMMENT "Mirroring ${_freecad_init_tools_source} to ${_freecad_init_tools_output}"
-)
+fc_mirror_file("${_freecad_init_tools_source}" "${_freecad_init_tools_output}")
 add_custom_target(FreeCADInitToolsMirror DEPENDS "${_freecad_init_tools_output}")
 
 if(FREECAD_USE_PCH)

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -1685,11 +1685,7 @@ class ApplicationRuntime:
 
 @transient
 def _app_runtime_table(_app=App) -> dict[str, ApplicationRuntime]:
-    runtimes = getattr(_app, "_pythonAppRuntimes", None)
-    if runtimes is None:
-        runtimes = {}
-        _app._pythonAppRuntimes = runtimes
-    return runtimes
+    return _app._pythonAppRuntimes
 
 
 @transient
@@ -1732,6 +1728,9 @@ def disposeAppRuntime(name: str, _table_getter=_app_runtime_table) -> bool:
     runtime.dispose()
     return True
 
+
+if not hasattr(App, "_pythonAppRuntimes"):
+    App._pythonAppRuntimes = {}
 
 App.appRuntime = appRuntime
 App.findAppRuntime = findAppRuntime

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -1577,6 +1577,167 @@ def dir_mod_app_compat_globals(source_globals: dict) -> dict:
     return dir_mod_compat_globals(source_globals, DIR_MOD_APP_COMPAT_GLOBAL_NAMES)
 
 
+@transient
+class ApplicationRuntime:
+    def __init__(self, name: str):
+        self.name = name
+        self._cleanup: list[coll_abc.Callable[[], None]] = []
+        self._owned: dict[str, tuple[object, coll_abc.Callable[[], None] | None]] = {}
+        self.data: dict[str, object] = {}
+        self._disposed = False
+
+    def _run_cleanup(self, cleanup: coll_abc.Callable[[], None]) -> None:
+        try:
+            cleanup()
+        except Exception:
+            Err(f"Application runtime cleanup failed for {self.name}")
+            Log(traceback.format_exc())
+
+    def _ensure_active(self) -> None:
+        if self._disposed:
+            raise RuntimeError(f"Application runtime '{self.name}' is disposed")
+
+    def onDispose(self, callback: coll_abc.Callable[[], None]):
+        self._ensure_active()
+        self._cleanup.append(callback)
+        return callback
+
+    def remember(self, key: str, value):
+        self._ensure_active()
+        self.data[key] = value
+        return value
+
+    def own(self, key: str, value, cleanup: coll_abc.Callable[[], None] | None = None):
+        self._ensure_active()
+        self.release(key)
+        self._owned[key] = (value, cleanup)
+        return value
+
+    def getOwned(self, key: str, default=None):
+        entry = self._owned.get(key)
+        if entry is None:
+            return default
+        return entry[0]
+
+    def owns(self, key: str) -> bool:
+        return key in self._owned
+
+    def release(self, key: str) -> bool:
+        self._ensure_active()
+        entry = self._owned.pop(key, None)
+        if entry is None:
+            return False
+
+        _value, cleanup = entry
+        if cleanup is not None:
+            self._run_cleanup(cleanup)
+        return True
+
+    def addDocumentObserver(self, observer, key: str | None = None):
+        self._ensure_active()
+        App.addDocumentObserver(observer)
+
+        def cleanup():
+            try:
+                App.removeDocumentObserver(observer)
+            except Exception:
+                pass
+
+        if key is not None:
+            self.own(key, observer, cleanup)
+        else:
+            self.onDispose(cleanup)
+        return observer
+
+    def addTimer(self, timer, *, stop: bool = True, delete: bool = False):
+        self._ensure_active()
+        def cleanup():
+            if stop and hasattr(timer, "stop"):
+                try:
+                    timer.stop()
+                except Exception:
+                    pass
+            if delete and hasattr(timer, "deleteLater"):
+                try:
+                    timer.deleteLater()
+                except Exception:
+                    pass
+
+        self.onDispose(cleanup)
+        return timer
+
+    def dispose(self) -> None:
+        if self._disposed:
+            return
+
+        self._disposed = True
+        while self._owned:
+            _key, (_value, cleanup) = self._owned.popitem()
+            if cleanup is not None:
+                self._run_cleanup(cleanup)
+
+        while self._cleanup:
+            cleanup = self._cleanup.pop()
+            self._run_cleanup(cleanup)
+
+        self.data.clear()
+
+
+@transient
+def _app_runtime_table(_app=App) -> dict[str, ApplicationRuntime]:
+    runtimes = getattr(_app, "_pythonAppRuntimes", None)
+    if runtimes is None:
+        runtimes = {}
+        _app._pythonAppRuntimes = runtimes
+    return runtimes
+
+
+@transient
+def appRuntime(
+    name: str,
+    _table_getter=_app_runtime_table,
+    _runtime_cls=ApplicationRuntime,
+) -> ApplicationRuntime:
+    if not name:
+        raise RuntimeError("Application runtime name is required")
+
+    runtimes = _table_getter()
+    runtime = runtimes.get(name)
+    if runtime is None or runtime._disposed:
+        runtime = _runtime_cls(name)
+        runtimes[name] = runtime
+    return runtime
+
+
+@transient
+def findAppRuntime(name: str, _table_getter=_app_runtime_table) -> ApplicationRuntime | None:
+    if not name:
+        return None
+
+    runtime = _table_getter().get(name)
+    if runtime is None or runtime._disposed:
+        return None
+    return runtime
+
+
+@transient
+def disposeAppRuntime(name: str, _table_getter=_app_runtime_table) -> bool:
+    if not name:
+        return False
+
+    runtime = _table_getter().pop(name, None)
+    if runtime is None:
+        return False
+
+    runtime.dispose()
+    return True
+
+
+App.appRuntime = appRuntime
+App.findAppRuntime = findAppRuntime
+App.disposeAppRuntime = disposeAppRuntime
+
+
 # ┌────────────────────────────────────────────────┐
 # │ Init Applications                              │
 # └────────────────────────────────────────────────┘

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -68,6 +68,22 @@ except ImportError:
     App.Console.PrintError("\n\nSeems the python standard libs are not installed, bailing out!\n\n")
     raise
 
+try:
+    from FreeCADInitTools import (
+        DIR_MOD_APP_COMPAT_GLOBAL_NAMES,
+        dir_mod_base_path,
+        dir_mod_compat_globals,
+        exec_dir_mod_file,
+    )
+except ModuleNotFoundError:
+    sys.path.append(App.getLibraryDir())
+    from FreeCADInitTools import (
+        DIR_MOD_APP_COMPAT_GLOBAL_NAMES,
+        dir_mod_base_path,
+        dir_mod_compat_globals,
+        exec_dir_mod_file,
+    )
+
 # ┌────────────────────────────────────────────────┐
 # │ Logging Frameworks                             │
 # └────────────────────────────────────────────────┘
@@ -1105,6 +1121,7 @@ class DirMod(Mod):
         self.state = ModState.Discovered
         self._path = collections.deque()
         self._path.append(path)
+        self._source_root: Path | None = None
 
     @property
     def kind(self) -> str:
@@ -1166,9 +1183,18 @@ class DirMod(Mod):
         return self._path[0]
 
     @property
+    def source_root(self) -> Path:
+        """Canonical filesystem root backing the active mod."""
+        return self._source_root or self.path.resolve()
+
+    @property
     def alternative_paths(self) -> list[Path]:
         """Alternative paths in priority order"""
         return list(self._path)[1:]
+
+    def remember_source_root(self, script_path: Path) -> Path:
+        self._source_root = dir_mod_base_path(script_path, self.path)
+        return self._source_root
 
     def check_disabled(self) -> bool:
         name = self.path.name
@@ -1208,9 +1234,13 @@ class DirMod(Mod):
             return
 
         try:
-            source = init_py.read_text(encoding="utf-8")
-            code = compile(source, init_py, 'exec')
-            exec(code)
+            self.remember_source_root(init_py)
+            exec_dir_mod_file(
+                self.name,
+                init_py,
+                self.path,
+                dir_mod_app_compat_globals(globals()),
+            )
         except Exception as ex:
             Log(f"Init:      Initializing {self.path!s}... failed")
             Log(utils.HLine)
@@ -1443,6 +1473,10 @@ class InitPipeline:
         search_paths = self.search_paths
         search_paths.commit()
 
+        # Dir mods live under the synthetic `freecad._dir_mods` namespace, so the
+        # real top-level `freecad` package must exist before any legacy mod runs.
+        import freecad
+
         # Dir Mods first
         for mod in self.dir_mod_scanner.iter():
             if mod.state == ModState.Resolved:
@@ -1537,6 +1571,10 @@ class InitPipeline:
         self.post()
         self.report()
         self.setup_tty()
+
+
+def dir_mod_app_compat_globals(source_globals: dict) -> dict:
+    return dir_mod_compat_globals(source_globals, DIR_MOD_APP_COMPAT_GLOBAL_NAMES)
 
 
 # ┌────────────────────────────────────────────────┐

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -1641,6 +1641,7 @@ class ApplicationRuntime:
             try:
                 App.removeDocumentObserver(observer)
             except Exception:
+                # Best-effort cleanup: the observer may already be detached.
                 pass
 
         if key is not None:
@@ -1656,11 +1657,13 @@ class ApplicationRuntime:
                 try:
                     timer.stop()
                 except Exception:
+                    # Best-effort cleanup: the timer may already be stopped.
                     pass
             if delete and hasattr(timer, "deleteLater"):
                 try:
                     timer.deleteLater()
                 except Exception:
+                    # Best-effort cleanup: the timer may already be deleted.
                     pass
 
         self.onDispose(cleanup)
@@ -1672,7 +1675,7 @@ class ApplicationRuntime:
 
         self._disposed = True
         while self._owned:
-            _key, (_value, cleanup) = self._owned.popitem()
+            _, (_value, cleanup) = self._owned.popitem()
             if cleanup is not None:
                 self._run_cleanup(cleanup)
 

--- a/src/App/FreeCADInitTools.py
+++ b/src/App/FreeCADInitTools.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Shared helpers for embedded FreeCAD init scripts."""
+
+from pathlib import Path
+import importlib
+import sys
+import types
+
+
+DIR_MOD_NAMESPACE = "freecad._dir_mods"
+DIR_MOD_APP_COMPAT_GLOBAL_NAMES = (
+    "App",
+    "FreeCAD",
+    "Log",
+    "Msg",
+    "Err",
+    "Wrn",
+    "Crt",
+    "Ntf",
+    "Tnf",
+    "IntEnum",
+    "datetime",
+    "Path",
+    "collections",
+    "coll_abc",
+    "dataclasses",
+    "functools",
+    "importlib",
+    "inspect",
+    "os",
+    "pkgutil",
+    "platform",
+    "re",
+    "resources",
+    "sys",
+    "traceback",
+    "types",
+)
+def _dir_mod_safe_segment(segment: str) -> str:
+    value = "".join(char if (char.isalnum() or char == "_") else "_" for char in segment)
+    if not value:
+        return "_"
+    if value[0].isdigit():
+        return f"_{value}"
+    return value
+
+
+def dir_mod_package_name(mod_name: str) -> str:
+    return f"{DIR_MOD_NAMESPACE}.{_dir_mod_safe_segment(mod_name)}"
+
+
+def dir_mod_relative_parent(script_path, mod_path):
+    script_path = Path(script_path)
+    mod_root = Path(mod_path).absolute()
+
+    script_parents = (
+        script_path.absolute().parent,
+        script_path.resolve().parent,
+    )
+    mod_roots = (
+        mod_root,
+        mod_root.resolve(),
+    )
+    for script_parent in script_parents:
+        for candidate_mod_root in mod_roots:
+            try:
+                return script_parent.relative_to(candidate_mod_root)
+            except ValueError:
+                continue
+
+    resolved_script_path = script_path.resolve()
+    for ancestor in resolved_script_path.parents:
+        if ancestor.name != mod_root.name:
+            continue
+        try:
+            relative_parent = resolved_script_path.parent.relative_to(ancestor)
+        except ValueError:
+            continue
+
+        build_candidate = mod_root / relative_parent / script_path.name
+        try:
+            if build_candidate.exists() and build_candidate.resolve() == resolved_script_path:
+                return relative_parent
+        except OSError:
+            continue
+
+    raise ValueError(
+        f"{resolved_script_path.parent!s} is not within dir mod root {mod_root!s}"
+    )
+
+
+def dir_mod_module_name(mod_name: str, script_path, mod_path) -> str:
+    script_path = Path(script_path).absolute()
+    relative_parent = dir_mod_relative_parent(script_path, mod_path)
+    parts = [dir_mod_package_name(mod_name)]
+    if relative_parent != Path():
+        parts.extend(_dir_mod_safe_segment(part) for part in relative_parent.parts)
+    parts.append(_dir_mod_safe_segment(script_path.stem))
+    return ".".join(parts)
+
+
+def dir_mod_base_path(script_path, mod_path) -> Path:
+    script_path = Path(script_path)
+    mod_root = Path(mod_path).resolve()
+    resolved_script_path = script_path.resolve()
+    if resolved_script_path == mod_root or resolved_script_path.is_relative_to(mod_root):
+        return mod_root
+
+    relative_parent = dir_mod_relative_parent(script_path, mod_path)
+    source_root = resolved_script_path.parent
+    for _ in relative_parent.parts:
+        source_root = source_root.parent
+    return source_root.resolve()
+
+
+def _bind_module_to_parent(module_name: str, module) -> None:
+    if "." not in module_name:
+        return
+
+    parent_name, child_name = module_name.rsplit(".", 1)
+    parent = sys.modules.get(parent_name)
+    if parent is not None:
+        setattr(parent, child_name, module)
+
+
+def _ensure_package_module(package_name: str, path: str | None = None):
+    package = sys.modules.get(package_name)
+    if package is None:
+        package = types.ModuleType(package_name)
+        package.__package__ = package_name
+        package.__path__ = []
+        package.__spec__ = importlib.machinery.ModuleSpec(
+            package_name,
+            loader=None,
+            is_package=True,
+        )
+        package.__spec__.submodule_search_locations = package.__path__
+        sys.modules[package_name] = package
+        _bind_module_to_parent(package_name, package)
+
+    if path is not None and path not in package.__path__:
+        package.__path__.append(path)
+
+    return package
+
+
+def _ensure_dir_mod_packages(mod_name: str, script_path, mod_path) -> None:
+    mod_path = Path(mod_path).absolute()
+    relative_parent = dir_mod_relative_parent(script_path, mod_path)
+
+    freecad = importlib.import_module("freecad")
+    if not hasattr(freecad, "__path__"):
+        raise ImportError("'freecad' must be an importable package before loading dir mods")
+    _ensure_package_module("freecad")
+    _ensure_package_module(DIR_MOD_NAMESPACE)
+
+    package_name = dir_mod_package_name(mod_name)
+    current_path = mod_path
+    _ensure_package_module(package_name, str(current_path))
+
+    for part in relative_parent.parts:
+        package_name = f"{package_name}.{_dir_mod_safe_segment(part)}"
+        current_path = current_path / part
+        _ensure_package_module(package_name, str(current_path))
+
+
+def dir_mod_compat_globals(source_globals: dict, names: tuple[str, ...]) -> dict:
+    compat = {"__builtins__": source_globals.get("__builtins__", __builtins__)}
+    for name in names:
+        if name in source_globals:
+            compat[name] = source_globals[name]
+    return compat
+
+
+def exec_file_as_module(module_name: str, script_path, injected_globals: dict):
+    script_path = Path(script_path).absolute()
+    previous = sys.modules.get(module_name)
+    missing = object()
+    parent = None
+    child_name = None
+    previous_parent_child = missing
+    if "." in module_name:
+        parent_name, child_name = module_name.rsplit(".", 1)
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            previous_parent_child = getattr(parent, child_name, missing)
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None:
+        raise ImportError(f"Failed to create import spec for {script_path!s}")
+
+    module = importlib.util.module_from_spec(spec)
+    module.__dict__.update(injected_globals)
+    module.__dict__["__name__"] = module_name
+    module.__dict__["__file__"] = str(script_path)
+    module.__dict__["__package__"] = module_name.rsplit(".", 1)[0]
+    module.__dict__["__loader__"] = spec.loader
+    module.__dict__["__spec__"] = spec
+
+    sys.modules[module_name] = module
+    _bind_module_to_parent(module_name, module)
+
+    try:
+        source = script_path.read_text(encoding="utf-8")
+        code = compile(source, script_path, "exec")
+        exec(code, module.__dict__)
+    except Exception:
+        if previous is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = previous
+        if parent is not None and child_name is not None:
+            if previous_parent_child is missing:
+                try:
+                    delattr(parent, child_name)
+                except AttributeError:
+                    pass
+            else:
+                setattr(parent, child_name, previous_parent_child)
+        raise
+
+    return module
+
+
+def exec_dir_mod_file(mod_name: str, script_path, mod_path, injected_globals: dict):
+    _ensure_dir_mod_packages(mod_name, script_path, mod_path)
+    module_name = dir_mod_module_name(mod_name, script_path, mod_path)
+    return exec_file_as_module(module_name, script_path, injected_globals)

--- a/src/App/FreeCADTest.py
+++ b/src/App/FreeCADTest.py
@@ -55,9 +55,7 @@ Log("░░░▀▀▀░▀░▀░▀▀▀░░▀░░░░░▀░░
 import sys
 import TestApp
 
-testCase = FreeCAD.ConfigGet("TestCase")
-
-testResult = TestApp.TestText(testCase)
+testResult = TestApp.RunConfiguredTextTest()
 
 Log("FreeCAD test done\n")
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -79,6 +79,7 @@
 #include "FileDialog.h"
 #include "GuiApplication.h"
 #include "GuiInitScript.h"
+#include "GuiTestScript.h"
 #include "InputHintPy.h"
 #include "LinkViewPy.h"
 #include "MainWindow.h"
@@ -2329,6 +2330,7 @@ void Application::initApplication()
     try {
         initTypes();
         new Base::ScriptProducer("FreeCADGuiInit", FreeCADGuiInit);
+        new Base::ScriptProducer("FreeCADGuiTest", FreeCADGuiTest);
         init_resources();
         setCategoryFilterRules();
         old_qtmsg_handler = qInstallMessageHandler(messageHandler);

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -170,6 +170,28 @@ extern const long NlErrorCode;  // initialized before main() by navlib_load.cpp
 namespace Gui
 {
 
+namespace
+{
+
+void invalidateWorkbenchBinding(PyObject* handlerObject)
+{
+    if (!handlerObject) {
+        return;
+    }
+
+    try {
+        Py::Object handler(handlerObject);
+        if (handler.hasAttr(std::string("__Workbench__"))) {
+            handler.delAttr(std::string("__Workbench__"));
+        }
+    }
+    catch (Py::Exception& e) {
+        e.clear();
+    }
+}
+
+}  // namespace
+
 class ViewProviderMap
 {
     std::unordered_map<const App::DocumentObject*, ViewProvider*> map;
@@ -1973,6 +1995,43 @@ bool Application::activateWorkbench(const char* name)
     }
 
     return ok;
+}
+
+bool Application::removeWorkbench(const char* name)
+{
+    Base::PyGILStateLocker lock;
+
+    Workbench* active = WorkbenchManager::instance()->active();
+    if (active && active->name() == name) {
+        return false;
+    }
+
+    PyObject* wb = PyDict_GetItemString(_pcWorkbenchDictionary, name);
+    if (!wb) {
+        return false;
+    }
+
+    invalidateWorkbenchBinding(wb);
+    WorkbenchManager::instance()->removeWorkbench(name);
+    PyDict_DelItemString(_pcWorkbenchDictionary, name);
+    signalRefreshWorkbenches();
+    return true;
+}
+
+bool Application::resetWorkbench(const char* name)
+{
+    if (qstrcmp(name, "NoneWorkbench") == 0) {
+        return false;
+    }
+
+    Workbench* active = WorkbenchManager::instance()->active();
+    bool wasActive = active && active->name() == name;
+
+    if (wasActive && !activateWorkbench("NoneWorkbench")) {
+        return false;
+    }
+
+    return removeWorkbench(name);
 }
 
 QPixmap Application::workbenchIcon(const QString& wb) const

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -237,6 +237,10 @@ public:
     //@{
     /// Activate a named workbench
     bool activateWorkbench(const char* name);
+    /// Remove a named inactive workbench and detach it from the GUI lifecycle
+    bool removeWorkbench(const char* name);
+    /// Reset a named workbench, switching away first if it is currently active
+    bool resetWorkbench(const char* name);
     QPixmap workbenchIcon(const QString&) const;
     QString workbenchToolTip(const QString&) const;
     QString workbenchMenuText(const QString&) const;

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -24,6 +24,7 @@
 #include <QDir>
 #include <QPrinter>
 #include <QFileInfo>
+#include <memory>
 #include <Inventor/SoInput.h>
 #include <Inventor/actions/SoGetPrimitiveCountAction.h>
 #include <Inventor/nodes/SoSeparator.h>
@@ -72,6 +73,33 @@
 
 using namespace Gui;
 
+namespace
+{
+
+void validatePythonCommandResources(const Py::Object& command, bool isGroup)
+{
+    Py::Callable getResources(command.getAttr("GetResources"));
+    Py::Tuple args;
+    Py::Object resources = getResources.apply(args);
+    if (PyDict_Check(resources.ptr())) {
+        return;
+    }
+
+    if (isGroup) {
+        throw Base::TypeError(
+            "PythonGroupCommand::PythonGroupCommand(): Method GetResources() of the Python "
+            "command object returns the wrong type (has to be dict)"
+        );
+    }
+
+    throw Base::TypeError(
+        "PythonCommand::PythonCommand(): Method GetResources() of the Python "
+        "command object returns the wrong type (has to be dict)"
+    );
+}
+
+}  // namespace
+
 // Application methods structure
 PyMethodDef ApplicationPy::Methods[] = {
     {"activateWorkbench",
@@ -93,6 +121,20 @@ PyMethodDef ApplicationPy::Methods[] = {
      "workbench : Workbench, Workbench type\n"
      "    Instance of a Workbench subclass or subclass of the\n"
      "    Workbench class."},
+    {"resetWorkbench",
+     (PyCFunction)ApplicationPy::sResetWorkbenchHandler,
+     METH_VARARGS,
+     "resetWorkbench(name) -> bool\n"
+     "\n"
+     "Reset a workbench by removing its Python handler and C++ instance.\n"
+     "If the workbench is active, switch to NoneWorkbench first.\n"
+     "\n"
+     "name : str\n    Name of the workbench to reset.\n"
+     "\n"
+     "Returns\n"
+     "-------\n"
+     "bool\n"
+     "    True if the workbench existed and was reset."},
     {"removeWorkbench",
      (PyCFunction)ApplicationPy::sRemoveWorkbenchHandler,
      METH_VARARGS,
@@ -1206,11 +1248,50 @@ PyObject* ApplicationPy::sRemoveWorkbenchHandler(PyObject* /*self*/, PyObject* a
         return nullptr;
     }
 
-    WorkbenchManager::instance()->removeWorkbench(psKey);
-    PyDict_DelItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
-    Application::Instance->signalRefreshWorkbenches();
+    Workbench* active = WorkbenchManager::instance()->active();
+    if (active && active->name() == psKey) {
+        if (!Application::Instance->resetWorkbench(psKey)) {
+            PyErr_Format(PyExc_RuntimeError, "Failed to remove active workbench '%s'", psKey);
+            return nullptr;
+        }
+    }
+    else if (!Application::Instance->removeWorkbench(psKey)) {
+        PyErr_Format(PyExc_RuntimeError, "Failed to remove workbench '%s'", psKey);
+        return nullptr;
+    }
 
     Py_Return;
+}
+
+PyObject* ApplicationPy::sResetWorkbenchHandler(PyObject* /*self*/, PyObject* args)
+{
+    char* psKey = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &psKey)) {
+        return nullptr;
+    }
+
+    PyObject* wb = PyDict_GetItemString(Application::Instance->_pcWorkbenchDictionary, psKey);
+    if (!wb) {
+        PyErr_Format(PyExc_KeyError, "No such workbench '%s'", psKey);
+        return nullptr;
+    }
+
+    try {
+        bool ok = Application::Instance->resetWorkbench(psKey);
+        return Py::new_reference_to(Py::Boolean(ok));
+    }
+    catch (const Base::Exception& e) {
+        std::stringstream err;
+        err << psKey << ": " << e.what();
+        PyErr_SetString(e.getPyExceptionType(), err.str().c_str());
+        return nullptr;
+    }
+    catch (...) {
+        std::stringstream err;
+        err << "Unknown C++ exception raised in resetWorkbench('" << psKey << "')";
+        PyErr_SetString(Base::PyExc_FC_GeneralError, err.str().c_str());
+        return nullptr;
+    }
 }
 
 PyObject* ApplicationPy::sGetWorkbenchHandler(PyObject* /*self*/, PyObject* args)
@@ -1453,29 +1534,51 @@ PyObject* ApplicationPy::sAddCommand(PyObject* /*self*/, PyObject* args)
     catch (Py::Exception& e) {
         e.clear();
     }
+
+    CommandManager& commandManager = Application::Instance->commandManager();
+    Command* existing = commandManager.getCommandByName(pName);
+    if (existing) {
+        if (dynamic_cast<PythonCommand*>(existing) || dynamic_cast<PythonGroupCommand*>(existing)) {
+            // Replacing Python commands is allowed, but validate the new
+            // command resources before dropping the existing one.
+        }
+        else {
+            Base::Console().warning("Command '%s' already exists and is not reloadable\n", pName);
+            Py_Return;
+        }
+    }
+
     try {
         Base::PyGILStateLocker lock;
 
         Py::Object cmd(pcCmdObj);
-        if (cmd.hasAttr("GetCommands")) {
-            Command* cmd = new PythonGroupCommand(pName, pcCmdObj);
+        bool isGroupCommand = cmd.hasAttr("GetCommands");
+        if (existing) {
+            validatePythonCommandResources(cmd, isGroupCommand);
+            commandManager.removeCommand(existing);
+        }
+
+        if (isGroupCommand) {
+            std::unique_ptr<PythonGroupCommand> groupCommand
+                = std::make_unique<PythonGroupCommand>(pName, pcCmdObj);
             if (!module.empty()) {
-                cmd->setAppModuleName(module.c_str());
+                groupCommand->setAppModuleName(module.c_str());
             }
             if (!group.empty()) {
-                cmd->setGroupName(group.c_str());
+                groupCommand->setGroupName(group.c_str());
             }
-            Application::Instance->commandManager().addCommand(cmd);
+            commandManager.addCommand(groupCommand.release());
         }
         else {
-            Command* cmd = new PythonCommand(pName, pcCmdObj, pSource);
+            std::unique_ptr<PythonCommand> pythonCommand
+                = std::make_unique<PythonCommand>(pName, pcCmdObj, pSource);
             if (!module.empty()) {
-                cmd->setAppModuleName(module.c_str());
+                pythonCommand->setAppModuleName(module.c_str());
             }
             if (!group.empty()) {
-                cmd->setGroupName(group.c_str());
+                pythonCommand->setGroupName(group.c_str());
             }
-            Application::Instance->commandManager().addCommand(cmd);
+            commandManager.addCommand(pythonCommand.release());
         }
     }
     catch (const Base::Exception& e) {

--- a/src/Gui/ApplicationPy.h
+++ b/src/Gui/ApplicationPy.h
@@ -42,6 +42,7 @@ public:
     // static python wrapper of the exported functions
     static PyObject* sActivateWorkbenchHandler (PyObject *self,PyObject *args); // activates a workbench object
     static PyObject* sAddWorkbenchHandler      (PyObject *self,PyObject *args); // adds a new workbench handler to a list
+    static PyObject* sResetWorkbenchHandler    (PyObject *self,PyObject *args); // resets a workbench handler and its C++ instance
     static PyObject* sRemoveWorkbenchHandler   (PyObject *self,PyObject *args); // removes a workbench handler from the list
     static PyObject* sGetWorkbenchHandler      (PyObject *self,PyObject *args); // retrieves the workbench handler
     static PyObject* sListWorkbenchHandlers    (PyObject *self,PyObject *args); // retrieves a list of all workbench handlers

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -340,6 +340,7 @@ generate_from_py(Command)
 generate_from_py(Navigation/NavigationStyle)
 
 generate_embed_from_py(FreeCADGuiInit GuiInitScript.h)
+generate_embed_from_py(FreeCADGuiTest GuiTestScript.h)
 
 # The Pyi files
 SET(FreeCADGui_Pyi_SRCS
@@ -1425,6 +1426,7 @@ SET(FreeCADGui_SRCS
     ExpressionBindingPy.h
     ExpressionCompleter.h
     FreeCADGuiInit.py
+    FreeCADGuiTest.py
     FreeCADStyle.h
     GraphicsViewZoom.h
     GuiApplication.h

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -486,15 +486,24 @@ def _refresh_workbench_if_active(workbench_name: str) -> None:
         _reload_active_workbench()
 
 
+def _find_workbench_handler(name: str):
+    workbenches = Gui.listWorkbenches()
+    handler = workbenches.get(name)
+    if handler is not None:
+        return handler
+
+    for handler in workbenches.values():
+        if getattr(handler, "MenuText", None) == name:
+            return handler
+    return None
+
+
 def _get_workbench_handler(name: str | None = None):
-    if name:
-        try:
-            return Gui.getWorkbench(name)
-        except Exception:
-            for workbench_name, handler in Gui.listWorkbenches().items():
-                if workbench_name == name or getattr(handler, "MenuText", None) == name:
-                    return handler
-            raise
+    if name is not None:
+        handler = _find_workbench_handler(name)
+        if handler is None:
+            raise RuntimeError(f"Workbench '{name}' is not available")
+        return handler
     return Gui.activeWorkbench()
 
 
@@ -602,7 +611,18 @@ def _purge_dir_mod_modules(base_path: Path, module_prefix: str | None = None) ->
     return sorted(removed)
 
 
-def _resolve_reload_target(name: str | None = None) -> dict[str, typing.Any]:
+@dataclass(frozen=True)
+class ReloadTarget:
+    handler: typing.Any
+    name: str
+    kind: str
+    mod: typing.Any
+    source_path: Path
+    base_path: Path
+    module_prefix: str | None = None
+
+
+def _resolve_reload_target(name: str | None = None) -> ReloadTarget:
     handler = _get_workbench_handler(name)
     workbench_name = handler.__class__.__name__
     source_path = _workbench_source_path(handler)
@@ -616,52 +636,48 @@ def _resolve_reload_target(name: str | None = None) -> dict[str, typing.Any]:
             base_path = mod.source_root
             module_prefix = dir_mod_package_name(mod.name)
             if handler_module == module_prefix or handler_module.startswith(f"{module_prefix}."):
-                return {
-                    "handler": handler,
-                    "name": workbench_name,
-                    "kind": "Dir",
-                    "mod": mod,
-                    "source_path": source_path,
-                    "module_prefix": module_prefix,
-                    "base_path": base_path,
-                }
+                return ReloadTarget(
+                    handler=handler,
+                    name=workbench_name,
+                    kind="Dir",
+                    mod=mod,
+                    source_path=source_path,
+                    module_prefix=module_prefix,
+                    base_path=base_path,
+                )
             if source_path == base_path or source_path.is_relative_to(base_path):
-                return {
-                    "handler": handler,
-                    "name": workbench_name,
-                    "kind": "Dir",
-                    "mod": mod,
-                    "source_path": source_path,
-                    "base_path": base_path,
-                }
+                return ReloadTarget(
+                    handler=handler,
+                    name=workbench_name,
+                    kind="Dir",
+                    mod=mod,
+                    source_path=source_path,
+                    base_path=base_path,
+                )
 
         if mod.kind == "Ext":
             if handler_module == mod.name or handler_module.startswith(f"{mod.name}."):
-                return {
-                    "handler": handler,
-                    "name": workbench_name,
-                    "kind": "Ext",
-                    "mod": mod,
-                    "source_path": source_path,
-                    "module_prefix": mod.name,
-                    "base_path": source_path.parent,
-                }
+                return ReloadTarget(
+                    handler=handler,
+                    name=workbench_name,
+                    kind="Ext",
+                    mod=mod,
+                    source_path=source_path,
+                    module_prefix=mod.name,
+                    base_path=source_path.parent,
+                )
 
     raise RuntimeError(f"Workbench '{workbench_name}' is not backed by a reloadable Python module")
 
 
 def _resolve_workbench_runtime_name(name: str | None = None) -> str | None:
     if name is None:
-        try:
-            handler = _get_workbench_handler()
-        except Exception:
-            return None
-        return handler.__class__.__name__ if handler else None
+        return _active_workbench_name()
 
-    try:
-        return _get_workbench_handler(name).__class__.__name__
-    except Exception:
+    handler = _find_workbench_handler(name)
+    if handler is None:
         return name
+    return handler.__class__.__name__
 
 
 class WorkbenchRuntime:
@@ -843,17 +859,7 @@ class WorkbenchRuntime:
 
 
 def _runtime_tables():
-    runtimes = getattr(Gui, "_pythonWorkbenchRuntimes", None)
-    if runtimes is None:
-        runtimes = {}
-        Gui._pythonWorkbenchRuntimes = runtimes
-
-    generations = getattr(Gui, "_pythonWorkbenchRuntimeGenerations", None)
-    if generations is None:
-        generations = {}
-        Gui._pythonWorkbenchRuntimeGenerations = generations
-
-    return runtimes, generations
+    return Gui._pythonWorkbenchRuntimes, Gui._pythonWorkbenchRuntimeGenerations
 
 
 def workbenchRuntime(name: str | None = None) -> WorkbenchRuntime:
@@ -910,19 +916,11 @@ def _resolve_session_runtime_target(
 
 
 def _session_runtime_table() -> dict[str, SessionRuntime]:
-    runtimes = getattr(Gui, "_pythonSessionRuntimes", None)
-    if runtimes is None:
-        runtimes = {}
-        Gui._pythonSessionRuntimes = runtimes
-    return runtimes
+    return Gui._pythonSessionRuntimes
 
 
 def _auto_reloaders_table() -> dict[str, "_PythonWorkbenchAutoReloader"]:
-    reloaders = getattr(Gui, "_pythonWorkbenchReloaders", None)
-    if reloaders is None:
-        reloaders = {}
-        Gui._pythonWorkbenchReloaders = reloaders
-    return reloaders
+    return Gui._pythonWorkbenchReloaders
 
 
 def sessionRuntime(name: str, workbench_name: str | None = None) -> SessionRuntime:
@@ -1016,7 +1014,7 @@ def reloadPythonWorkbench(name: str | None = None) -> list[str]:
     """
 
     target = _resolve_reload_target(name)
-    workbench_name = target["name"]
+    workbench_name = target.name
     was_active = _active_workbench_name() == workbench_name
 
     if hasattr(Gui, "resetWorkbench"):
@@ -1030,18 +1028,18 @@ def reloadPythonWorkbench(name: str | None = None) -> list[str]:
     _disposeSessionRuntimes(_resolve_workbench_runtime_name(workbench_name) or workbench_name)
     disposeWorkbenchRuntime(workbench_name)
 
-    if target["kind"] == "Dir":
-        removed = _purge_dir_mod_modules(target["base_path"], target.get("module_prefix"))
-        loader = DirModGui(target["mod"])
+    if target.kind == "Dir":
+        removed = _purge_dir_mod_modules(target.base_path, target.module_prefix)
+        loader = DirModGui(target.mod)
         sub_workbench = (
             None
-            if target["source_path"].parent == target["mod"].path.resolve()
-            else target["source_path"].parent
+            if target.source_path.parent == target.mod.path.resolve()
+            else target.source_path.parent
         )
         ok = loader.run_init_gui(sub_workbench)
     else:
-        removed = _purge_modules_by_prefix(target["module_prefix"])
-        loader = ExtModGui(target["mod"])
+        removed = _purge_modules_by_prefix(target.module_prefix)
+        loader = ExtModGui(target.mod)
         ok = loader.run_init_gui()
 
     if not ok:
@@ -1066,7 +1064,7 @@ def _canonical_auto_reload_name(name: str | None = None) -> str | None:
         return _active_workbench_name()
 
     try:
-        return _resolve_reload_target(name)["name"]
+        return _resolve_reload_target(name).name
     except Exception:
         return _resolve_workbench_runtime_name(name) or name
 
@@ -1098,7 +1096,7 @@ class _PythonWorkbenchAutoReloader:
     def _iter_watch_paths(self) -> typing.Iterable[str]:
         target = _resolve_reload_target(self.name)
         yield from _iter_watch_paths_for_base(
-            target["base_path"],
+            target.base_path,
             self.WATCHED_SUFFIXES,
             self.EXCLUDED_DIRS,
         )
@@ -1140,15 +1138,15 @@ class _PythonWorkbenchAutoReloader:
 def startPythonWorkbenchAutoReload(name: str | None = None, debounce_ms: int = 500) -> None:
     target = _resolve_reload_target(name)
     reloaders = _auto_reloaders_table()
-    existing = reloaders.get(target["name"])
+    existing = reloaders.get(target.name)
     if existing:
         existing.stop()
 
-    reloader = _PythonWorkbenchAutoReloader(target["name"], debounce_ms=debounce_ms)
-    reloaders[target["name"]] = reloader
+    reloader = _PythonWorkbenchAutoReloader(target.name, debounce_ms=debounce_ms)
+    reloaders[target.name] = reloader
     Gui._pythonWorkbenchReloaders = reloaders
 
-    Log(f"Started Python auto reload for {target['name']}\n")
+    Log(f"Started Python auto reload for {target.name}\n")
 
 
 def stopPythonWorkbenchAutoReload(name: str | None = None) -> bool:
@@ -1202,7 +1200,7 @@ class Std_ReloadActivePythonWorkbench:
 
     def Activated(self):
         target = _resolve_reload_target()
-        workbench_name = target["name"]
+        workbench_name = target.name
         removed = reloadPythonWorkbench(workbench_name)
         App.Console.PrintMessage(
             f"Reloaded {workbench_name} ({len(removed)} Python modules cleared)\n"
@@ -1230,7 +1228,7 @@ class Std_ToggleActivePythonWorkbenchAutoReload:
 
     def Activated(self):
         target = _resolve_reload_target()
-        workbench_name = target["name"]
+        workbench_name = target.name
         if isPythonWorkbenchAutoReloadActive(workbench_name):
             stopPythonWorkbenchAutoReload(workbench_name)
             App.Console.PrintMessage(f"Stopped Python auto reload for {workbench_name}\n")
@@ -1297,6 +1295,14 @@ def GeneratePackageIcon(
 App.GuiUp = 1
 App.Gui = FreeCADGui
 FreeCADGui.Workbench = Workbench
+if not hasattr(Gui, "_pythonWorkbenchRuntimes"):
+    Gui._pythonWorkbenchRuntimes = {}
+if not hasattr(Gui, "_pythonWorkbenchRuntimeGenerations"):
+    Gui._pythonWorkbenchRuntimeGenerations = {}
+if not hasattr(Gui, "_pythonSessionRuntimes"):
+    Gui._pythonSessionRuntimes = {}
+if not hasattr(Gui, "_pythonWorkbenchReloaders"):
+    Gui._pythonWorkbenchReloaders = {}
 Gui.workbenchRuntime = workbenchRuntime
 Gui.findWorkbenchRuntime = findWorkbenchRuntime
 Gui.disposeWorkbenchRuntime = disposeWorkbenchRuntime

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -37,6 +37,8 @@
 
 from enum import IntEnum, Enum
 from dataclasses import dataclass
+import inspect
+import os
 import traceback
 import typing
 import re
@@ -270,6 +272,53 @@ Gui.InputHint = InputHint
 Gui.HintManager = HintManager()
 
 
+_DIR_MOD_AUTO_RELOAD_EXCLUDED_DIRS = (
+    "__pycache__",
+    ".git",
+    "Resources/translations",
+    "build",
+)
+
+
+def _is_excluded_relative_path(relative: Path, excluded_dirs) -> bool:
+    if not relative.parts:
+        return False
+
+    relative_text = relative.as_posix()
+    for excluded in excluded_dirs:
+        if "/" in excluded:
+            if relative_text == excluded or relative_text.startswith(f"{excluded}/"):
+                return True
+        elif excluded in relative.parts:
+            return True
+    return False
+
+
+def _iter_watch_paths_for_base(base_path: Path, watched_suffixes, excluded_dirs):
+    base_path = Path(base_path).resolve()
+    watched_suffixes = set(watched_suffixes)
+    excluded_dirs = tuple(excluded_dirs)
+
+    yield str(base_path)
+    for directory, dirnames, filenames in os.walk(base_path):
+        directory_path = Path(directory).resolve()
+        relative = directory_path.relative_to(base_path)
+        if _is_excluded_relative_path(relative, excluded_dirs):
+            dirnames[:] = []
+            continue
+
+        yield str(directory_path)
+        dirnames[:] = [
+            dirname
+            for dirname in dirnames
+            if not _is_excluded_relative_path(relative / dirname, excluded_dirs)
+        ]
+        for filename in filenames:
+            file_path = directory_path / filename
+            if file_path.suffix in watched_suffixes:
+                yield str(file_path)
+
+
 class ModGui:
     """
     Mod Gui Loader.
@@ -405,6 +454,96 @@ class ExtModGui(ModGui):
         return False
 
 
+def _qt_core():
+    try:
+        from PySideWrapper import QtCore
+    except ImportError:
+        for candidate in ("PySide6.QtCore", "PySide2.QtCore", "PySide.QtCore"):
+            try:
+                return importlib.import_module(candidate)
+            except ImportError:
+                continue
+        raise
+    return QtCore
+
+
+def _active_workbench_name() -> str | None:
+    try:
+        return Gui.activeWorkbench().name()
+    except Exception:
+        return None
+
+
+def _reload_active_workbench() -> None:
+    try:
+        Gui.activeWorkbench().reloadActive()
+    except Exception:
+        pass
+
+
+def _refresh_workbench_if_active(workbench_name: str) -> None:
+    if _active_workbench_name() == workbench_name:
+        _reload_active_workbench()
+
+
+def _get_workbench_handler(name: str | None = None):
+    if name:
+        try:
+            return Gui.getWorkbench(name)
+        except Exception:
+            for workbench_name, handler in Gui.listWorkbenches().items():
+                if workbench_name == name or getattr(handler, "MenuText", None) == name:
+                    return handler
+            raise
+    return Gui.activeWorkbench()
+
+
+def _workbench_source_path(handler) -> Path:
+    candidates = (
+        getattr(handler, "Initialize", None),
+        getattr(handler, "Activated", None),
+        handler.__class__,
+    )
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            source = inspect.getsourcefile(candidate) or inspect.getfile(candidate)
+        except (OSError, TypeError):
+            continue
+        if source:
+            return Path(source).resolve()
+    raise RuntimeError("Unable to resolve workbench source path")
+
+
+def _module_paths(module) -> typing.Iterable[Path]:
+    seen = set()
+
+    if file := getattr(module, "__file__", None):
+        raw_path = Path(file)
+        for resolver in (Path.absolute, Path.resolve):
+            try:
+                candidate = resolver(raw_path)
+            except OSError:
+                continue
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            yield candidate
+
+    for package_path in getattr(module, "__path__", []):
+        raw_path = Path(package_path)
+        for resolver in (Path.absolute, Path.resolve):
+            try:
+                candidate = resolver(raw_path)
+            except OSError:
+                continue
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            yield candidate
+
+
 DIR_MOD_GUI_COMPAT_GLOBAL_NAMES = DIR_MOD_APP_COMPAT_GLOBAL_NAMES + (
     "Enum",
     "Gui",
@@ -424,6 +563,673 @@ DIR_MOD_GUI_COMPAT_GLOBAL_NAMES = DIR_MOD_APP_COMPAT_GLOBAL_NAMES + (
 
 def dir_mod_gui_compat_globals(source_globals: dict) -> dict:
     return dir_mod_compat_globals(source_globals, DIR_MOD_GUI_COMPAT_GLOBAL_NAMES)
+
+
+def _purge_modules_by_path(base_path: Path) -> list[str]:
+    removed = []
+    for module_name, module in list(sys.modules.items()):
+        if module_name in {"__main__", "FreeCADGuiInit"}:
+            continue
+        if module is None:
+            continue
+
+        for module_path in _module_paths(module):
+            if module_path == base_path or module_path.is_relative_to(base_path):
+                sys.modules.pop(module_name, None)
+                removed.append(module_name)
+                break
+
+    removed.sort()
+    return removed
+
+
+def _purge_modules_by_prefix(prefix: str) -> list[str]:
+    removed = []
+    for module_name in list(sys.modules):
+        if module_name == prefix or module_name.startswith(f"{prefix}."):
+            sys.modules.pop(module_name, None)
+            removed.append(module_name)
+    removed.sort()
+    return removed
+
+
+def _purge_dir_mod_modules(base_path: Path, module_prefix: str | None = None) -> list[str]:
+    # Dir mods still expose many legacy top-level imports (for example `BimSelect`),
+    # so reloading must purge by filesystem path as well as the synthetic namespace.
+    removed = set(_purge_modules_by_path(base_path))
+    if module_prefix:
+        removed.update(_purge_modules_by_prefix(module_prefix))
+    return sorted(removed)
+
+
+def _resolve_reload_target(name: str | None = None) -> dict[str, typing.Any]:
+    handler = _get_workbench_handler(name)
+    workbench_name = handler.__class__.__name__
+    source_path = _workbench_source_path(handler)
+    handler_module = handler.__class__.__module__
+
+    for mod in App.__ModCache__:
+        if mod.state != ModState.Loaded:
+            continue
+
+        if mod.kind == "Dir":
+            base_path = mod.source_root
+            module_prefix = dir_mod_package_name(mod.name)
+            if handler_module == module_prefix or handler_module.startswith(f"{module_prefix}."):
+                return {
+                    "handler": handler,
+                    "name": workbench_name,
+                    "kind": "Dir",
+                    "mod": mod,
+                    "source_path": source_path,
+                    "module_prefix": module_prefix,
+                    "base_path": base_path,
+                }
+            if source_path == base_path or source_path.is_relative_to(base_path):
+                return {
+                    "handler": handler,
+                    "name": workbench_name,
+                    "kind": "Dir",
+                    "mod": mod,
+                    "source_path": source_path,
+                    "base_path": base_path,
+                }
+
+        if mod.kind == "Ext":
+            if handler_module == mod.name or handler_module.startswith(f"{mod.name}."):
+                return {
+                    "handler": handler,
+                    "name": workbench_name,
+                    "kind": "Ext",
+                    "mod": mod,
+                    "source_path": source_path,
+                    "module_prefix": mod.name,
+                    "base_path": source_path.parent,
+                }
+
+    raise RuntimeError(f"Workbench '{workbench_name}' is not backed by a reloadable Python module")
+
+
+def _resolve_workbench_runtime_name(name: str | None = None) -> str | None:
+    if name is None:
+        try:
+            handler = _get_workbench_handler()
+        except Exception:
+            return None
+        return handler.__class__.__name__ if handler else None
+
+    try:
+        return _get_workbench_handler(name).__class__.__name__
+    except Exception:
+        return name
+
+
+class WorkbenchRuntime:
+    def __init__(self, name: str, generation: int):
+        self.name = name
+        self.generation = generation
+        self._cleanup: list[typing.Callable[[], None]] = []
+        self._owned: dict[str, tuple[typing.Any, typing.Callable[[], None] | None]] = {}
+        self.data: dict[str, typing.Any] = {}
+        self._disposed = False
+
+    def _run_cleanup(self, cleanup: typing.Callable[[], None]) -> None:
+        try:
+            cleanup()
+        except Exception:
+            Err(f"Workbench runtime cleanup failed for {self.name}\n")
+            Log(traceback.format_exc())
+
+    def _ensure_active(self) -> None:
+        if self._disposed:
+            raise RuntimeError(f"Workbench runtime '{self.name}' is disposed")
+
+    def onDispose(self, callback: typing.Callable[[], None]):
+        self._ensure_active()
+        self._cleanup.append(callback)
+        return callback
+
+    def remember(self, key: str, value):
+        self._ensure_active()
+        self.data[key] = value
+        return value
+
+    def own(self, key: str, value, cleanup: typing.Callable[[], None] | None = None):
+        self._ensure_active()
+        self.release(key)
+        self._owned[key] = (value, cleanup)
+        return value
+
+    def getOwned(self, key: str, default=None):
+        entry = self._owned.get(key)
+        if entry is None:
+            return default
+        return entry[0]
+
+    def owns(self, key: str) -> bool:
+        return key in self._owned
+
+    def release(self, key: str) -> bool:
+        self._ensure_active()
+        entry = self._owned.pop(key, None)
+        if entry is None:
+            return False
+
+        _value, cleanup = entry
+        if cleanup is not None:
+            self._run_cleanup(cleanup)
+        return True
+
+    def addDocumentObserver(self, observer):
+        self._ensure_active()
+        Gui.addDocumentObserver(observer)
+
+        def cleanup():
+            try:
+                Gui.removeDocumentObserver(observer)
+            except Exception:
+                pass
+
+        self.onDispose(cleanup)
+        return observer
+
+    def addSelectionObserver(
+        self,
+        observer,
+        *args,
+        key: str | None = None,
+        **kwargs,
+    ):
+        self._ensure_active()
+        Gui.Selection.addObserver(observer, *args, **kwargs)
+
+        def cleanup():
+            try:
+                Gui.Selection.removeObserver(observer)
+            except Exception:
+                pass
+
+        if key is not None:
+            self.own(key, observer, cleanup)
+        else:
+            self.onDispose(cleanup)
+        return observer
+
+    def addWorkbenchManipulator(
+        self,
+        manipulator,
+        refresh: bool = False,
+        key: str | None = None,
+    ):
+        self._ensure_active()
+        Gui.addWorkbenchManipulator(manipulator)
+        if refresh:
+            _refresh_workbench_if_active(self.name)
+
+        def cleanup():
+            try:
+                Gui.removeWorkbenchManipulator(manipulator)
+            except Exception:
+                pass
+            if refresh:
+                _refresh_workbench_if_active(self.name)
+
+        if key is not None:
+            self.own(key, manipulator, cleanup)
+        else:
+            self.onDispose(cleanup)
+        return manipulator
+
+    def setTaskWatcher(self, watchers):
+        self._ensure_active()
+        Gui.Control.clearTaskWatcher()
+        Gui.Control.addTaskWatcher(watchers)
+
+        def cleanup():
+            try:
+                Gui.Control.clearTaskWatcher()
+            except Exception:
+                pass
+
+        self.onDispose(cleanup)
+        return watchers
+
+    def addTimer(self, timer, *, stop: bool = True, delete: bool = False):
+        self._ensure_active()
+
+        def cleanup():
+            if stop and hasattr(timer, "stop"):
+                try:
+                    timer.stop()
+                except Exception:
+                    pass
+            if delete and hasattr(timer, "deleteLater"):
+                try:
+                    timer.deleteLater()
+                except Exception:
+                    pass
+
+        self.onDispose(cleanup)
+        return timer
+
+    def overrideActionShortcut(self, key: str, action, shortcut) -> None:
+        self._ensure_active()
+        previous_shortcut = action.shortcut()
+        action.setShortcut(shortcut)
+
+        def cleanup():
+            try:
+                action.setShortcut(previous_shortcut)
+            except Exception:
+                pass
+
+        self.own(key, previous_shortcut, cleanup)
+
+    def dispose(self) -> None:
+        if self._disposed:
+            return
+
+        self._disposed = True
+        while self._owned:
+            _key, (_value, cleanup) = self._owned.popitem()
+            if cleanup is not None:
+                self._run_cleanup(cleanup)
+
+        while self._cleanup:
+            cleanup = self._cleanup.pop()
+            self._run_cleanup(cleanup)
+
+        self.data.clear()
+
+
+def _runtime_tables():
+    runtimes = getattr(Gui, "_pythonWorkbenchRuntimes", None)
+    if runtimes is None:
+        runtimes = {}
+        Gui._pythonWorkbenchRuntimes = runtimes
+
+    generations = getattr(Gui, "_pythonWorkbenchRuntimeGenerations", None)
+    if generations is None:
+        generations = {}
+        Gui._pythonWorkbenchRuntimeGenerations = generations
+
+    return runtimes, generations
+
+
+def workbenchRuntime(name: str | None = None) -> WorkbenchRuntime:
+    runtime_name = _resolve_workbench_runtime_name(name)
+    if not runtime_name:
+        raise RuntimeError("No active Python workbench runtime")
+    runtimes, generations = _runtime_tables()
+    runtime = runtimes.get(runtime_name)
+    if runtime is None or runtime._disposed:
+        generation = generations.get(runtime_name, 0) + 1
+        generations[runtime_name] = generation
+        runtime = WorkbenchRuntime(runtime_name, generation)
+        runtimes[runtime_name] = runtime
+    return runtime
+
+
+def findWorkbenchRuntime(name: str | None = None) -> WorkbenchRuntime | None:
+    runtime_name = _resolve_workbench_runtime_name(name)
+    if not runtime_name:
+        return None
+
+    runtimes, _generations = _runtime_tables()
+    runtime = runtimes.get(runtime_name)
+    if runtime is None or runtime._disposed:
+        return None
+    return runtime
+
+
+class SessionRuntime(WorkbenchRuntime):
+    def __init__(self, workbench_name: str, session_name: str, generation: int):
+        super().__init__(f"{workbench_name}:{session_name}", generation)
+        self.workbench_name = workbench_name
+        self.session_name = session_name
+
+
+def _resolve_session_runtime_target(
+    name: str,
+    workbench_name: str | None = None,
+) -> tuple[str, str, str]:
+    if not name:
+        raise RuntimeError("Session runtime name is required")
+
+    if workbench_name is None and ":" in name:
+        explicit_workbench, explicit_name = name.split(":", 1)
+        if explicit_workbench and explicit_name:
+            workbench_name = explicit_workbench
+            name = explicit_name
+
+    runtime_workbench_name = _resolve_workbench_runtime_name(workbench_name)
+    if not runtime_workbench_name:
+        raise RuntimeError("Session runtime parent workbench is required")
+
+    return runtime_workbench_name, name, f"{runtime_workbench_name}:{name}"
+
+
+def _session_runtime_table() -> dict[str, SessionRuntime]:
+    runtimes = getattr(Gui, "_pythonSessionRuntimes", None)
+    if runtimes is None:
+        runtimes = {}
+        Gui._pythonSessionRuntimes = runtimes
+    return runtimes
+
+
+def sessionRuntime(name: str, workbench_name: str | None = None) -> SessionRuntime:
+    runtime_workbench_name, session_name, qualified_name = _resolve_session_runtime_target(
+        name,
+        workbench_name,
+    )
+    runtimes = _session_runtime_table()
+    runtime = runtimes.get(qualified_name)
+    if runtime is None or runtime._disposed:
+        runtime = SessionRuntime(runtime_workbench_name, session_name, generation=0)
+        runtimes[qualified_name] = runtime
+    return runtime
+
+
+def findSessionRuntime(name: str, workbench_name: str | None = None) -> SessionRuntime | None:
+    if not name:
+        return None
+
+    try:
+        _runtime_workbench_name, _session_name, qualified_name = _resolve_session_runtime_target(
+            name,
+            workbench_name,
+        )
+    except Exception:
+        return None
+
+    runtime = _session_runtime_table().get(qualified_name)
+    if runtime is None or runtime._disposed:
+        return None
+    return runtime
+
+
+def disposeSessionRuntime(name: str, workbench_name: str | None = None) -> bool:
+    if not name:
+        return False
+
+    try:
+        _runtime_workbench_name, _session_name, qualified_name = _resolve_session_runtime_target(
+            name,
+            workbench_name,
+        )
+    except Exception:
+        return False
+
+    runtime = _session_runtime_table().pop(qualified_name, None)
+    if runtime is None:
+        return False
+
+    runtime.dispose()
+    return True
+
+
+def _disposeSessionRuntimes(workbench_name: str | None = None) -> int:
+    runtimes = _session_runtime_table()
+    if workbench_name:
+        runtime_workbench_name = _resolve_workbench_runtime_name(workbench_name) or workbench_name
+        names = [
+            name
+            for name, runtime in list(runtimes.items())
+            if runtime.workbench_name == runtime_workbench_name
+        ]
+    else:
+        names = list(runtimes)
+
+    disposed = 0
+    for name in names:
+        if disposeSessionRuntime(name):
+            disposed += 1
+    return disposed
+
+
+def disposeWorkbenchRuntime(name: str | None = None) -> bool:
+    runtime_name = _resolve_workbench_runtime_name(name)
+    if not runtime_name:
+        return False
+
+    runtimes, _generations = _runtime_tables()
+    runtime = runtimes.pop(runtime_name, None)
+    if not runtime:
+        return False
+
+    runtime.dispose()
+    return True
+
+
+def reloadPythonWorkbench(name: str | None = None) -> list[str]:
+    """
+    Reload a Python workbench by removing its handler, clearing imported modules, rerunning the
+    workbench bootstrap, and restoring the previous active workbench when needed.
+    """
+
+    target = _resolve_reload_target(name)
+    workbench_name = target["name"]
+    was_active = _active_workbench_name() == workbench_name
+
+    if hasattr(Gui, "resetWorkbench"):
+        if not Gui.resetWorkbench(workbench_name):
+            raise RuntimeError(f"Resetting workbench '{workbench_name}' failed")
+    else:
+        if was_active:
+            Gui.activateWorkbench("NoneWorkbench")
+        Gui.removeWorkbench(workbench_name)
+
+    _disposeSessionRuntimes(_resolve_workbench_runtime_name(workbench_name) or workbench_name)
+    disposeWorkbenchRuntime(workbench_name)
+
+    if target["kind"] == "Dir":
+        removed = _purge_dir_mod_modules(target["base_path"], target.get("module_prefix"))
+        loader = DirModGui(target["mod"])
+        sub_workbench = (
+            None
+            if target["source_path"].parent == target["mod"].path.resolve()
+            else target["source_path"].parent
+        )
+        ok = loader.run_init_gui(sub_workbench)
+    else:
+        removed = _purge_modules_by_prefix(target["module_prefix"])
+        loader = ExtModGui(target["mod"])
+        ok = loader.run_init_gui()
+
+    if not ok:
+        raise RuntimeError(f"Reloading workbench '{workbench_name}' failed")
+
+    if was_active:
+        Gui.activateWorkbench(workbench_name)
+
+    return removed
+
+
+def canReloadPythonWorkbench(name: str | None = None) -> bool:
+    try:
+        _resolve_reload_target(name)
+    except Exception:
+        return False
+    return True
+
+
+def _canonical_auto_reload_name(name: str | None = None) -> str | None:
+    if name is None:
+        return _active_workbench_name()
+
+    try:
+        return _resolve_reload_target(name)["name"]
+    except Exception:
+        return _resolve_workbench_runtime_name(name) or name
+
+
+class _PythonWorkbenchAutoReloader:
+    WATCHED_SUFFIXES = {
+        ".py",
+        ".pyi",
+        ".qrc",
+        ".qss",
+        ".svg",
+        ".ui",
+        ".xml",
+    }
+    EXCLUDED_DIRS = _DIR_MOD_AUTO_RELOAD_EXCLUDED_DIRS
+
+    def __init__(self, name: str, debounce_ms: int = 500):
+        self.name = name
+        self.debounce_ms = debounce_ms
+        self.QtCore = _qt_core()
+        self.watcher = self.QtCore.QFileSystemWatcher()
+        self.timer = self.QtCore.QTimer()
+        self.timer.setSingleShot(True)
+        self.timer.timeout.connect(self.reload)
+        self.watcher.fileChanged.connect(self.schedule_reload)
+        self.watcher.directoryChanged.connect(self.schedule_reload)
+        self.rearm()
+
+    def _iter_watch_paths(self) -> typing.Iterable[str]:
+        target = _resolve_reload_target(self.name)
+        yield from _iter_watch_paths_for_base(
+            target["base_path"],
+            self.WATCHED_SUFFIXES,
+            self.EXCLUDED_DIRS,
+        )
+
+    def rearm(self):
+        current = self.watcher.files() + self.watcher.directories()
+        if current:
+            self.watcher.removePaths(current)
+
+        paths = []
+        for path in sorted(set(self._iter_watch_paths())):
+            if Path(path).exists():
+                paths.append(path)
+
+        if paths:
+            self.watcher.addPaths(paths)
+
+    def schedule_reload(self, _path):
+        self.timer.start(self.debounce_ms)
+
+    def reload(self):
+        try:
+            removed = reloadPythonWorkbench(self.name)
+        except Exception as ex:
+            Err(f"Auto reload failed for {self.name}: {ex!s}\n")
+            Log(traceback.format_exc())
+        else:
+            Log(f"Auto reloaded {self.name} " f"({len(removed)} Python modules cleared)\n")
+        finally:
+            self.rearm()
+
+    def stop(self):
+        self.timer.stop()
+        current = self.watcher.files() + self.watcher.directories()
+        if current:
+            self.watcher.removePaths(current)
+
+
+def startPythonWorkbenchAutoReload(name: str | None = None, debounce_ms: int = 500) -> None:
+    target = _resolve_reload_target(name)
+    reloaders = getattr(Gui, "_pythonWorkbenchReloaders", {})
+    existing = reloaders.get(target["name"])
+    if existing:
+        existing.stop()
+
+    reloader = _PythonWorkbenchAutoReloader(target["name"], debounce_ms=debounce_ms)
+    reloaders[target["name"]] = reloader
+    Gui._pythonWorkbenchReloaders = reloaders
+
+    Log(f"Started Python auto reload for {target['name']}\n")
+
+
+def stopPythonWorkbenchAutoReload(name: str | None = None) -> bool:
+    reloaders = getattr(Gui, "_pythonWorkbenchReloaders", {})
+    target_name = _canonical_auto_reload_name(name)
+    if not target_name:
+        return False
+
+    reloader = reloaders.pop(target_name, None)
+    if not reloader:
+        return False
+
+    reloader.stop()
+    Gui._pythonWorkbenchReloaders = reloaders
+    Log(f"Stopped Python auto reload for {target_name}\n")
+    return True
+
+
+def isPythonWorkbenchAutoReloadActive(name: str | None = None) -> bool:
+    reloaders = getattr(Gui, "_pythonWorkbenchReloaders", {})
+    target_name = _canonical_auto_reload_name(name)
+    if not target_name:
+        return False
+    return target_name in reloaders
+
+
+def _report_python_workbench_reload_limitations(workbench_name: str) -> None:
+    App.Console.PrintMessage(
+        f"{workbench_name} reload note: existing Python document proxies/view providers may still "
+        "need recreation, and C++ changes still require a rebuild/restart.\n"
+    )
+
+
+class Std_ReloadActivePythonWorkbench:
+    def GetResources(self):
+        return {
+            "Pixmap": "",
+            "MenuText": QT_TRANSLATE_NOOP(
+                "Std_ReloadActivePythonWorkbench",
+                "Reload Active Python Workbench",
+            ),
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "Std_ReloadActivePythonWorkbench",
+                "Reload the active reloadable Python workbench without restarting FreeCAD."
+                " Existing Python document proxies or C++ changes are not hot-reloaded.",
+            ),
+        }
+
+    def IsActive(self):
+        return canReloadPythonWorkbench()
+
+    def Activated(self):
+        target = _resolve_reload_target()
+        workbench_name = target["name"]
+        removed = reloadPythonWorkbench(workbench_name)
+        App.Console.PrintMessage(
+            f"Reloaded {workbench_name} ({len(removed)} Python modules cleared)\n"
+        )
+        _report_python_workbench_reload_limitations(workbench_name)
+
+
+class Std_ToggleActivePythonWorkbenchAutoReload:
+    def GetResources(self):
+        return {
+            "Pixmap": "",
+            "MenuText": QT_TRANSLATE_NOOP(
+                "Std_ToggleActivePythonWorkbenchAutoReload",
+                "Toggle Active Python Workbench Auto Reload",
+            ),
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "Std_ToggleActivePythonWorkbenchAutoReload",
+                "Start or stop file-watch auto reload for the active reloadable Python workbench."
+                " Existing Python proxies/view providers are not refreshed automatically.",
+            ),
+        }
+
+    def IsActive(self):
+        return canReloadPythonWorkbench() and hasattr(Gui, "stopPythonWorkbenchAutoReload")
+
+    def Activated(self):
+        target = _resolve_reload_target()
+        workbench_name = target["name"]
+        if isPythonWorkbenchAutoReloadActive(workbench_name):
+            stopPythonWorkbenchAutoReload(workbench_name)
+            App.Console.PrintMessage(f"Stopped Python auto reload for {workbench_name}\n")
+        else:
+            startPythonWorkbenchAutoReload(workbench_name)
+            App.Console.PrintMessage(f"Started Python auto reload for {workbench_name}\n")
+            _report_python_workbench_reload_limitations(workbench_name)
 
 
 def InitApplications():
@@ -483,6 +1289,22 @@ def GeneratePackageIcon(
 App.GuiUp = 1
 App.Gui = FreeCADGui
 FreeCADGui.Workbench = Workbench
+Gui.workbenchRuntime = workbenchRuntime
+Gui.findWorkbenchRuntime = findWorkbenchRuntime
+Gui.disposeWorkbenchRuntime = disposeWorkbenchRuntime
+Gui.sessionRuntime = sessionRuntime
+Gui.findSessionRuntime = findSessionRuntime
+Gui.disposeSessionRuntime = disposeSessionRuntime
+Gui.canReloadPythonWorkbench = canReloadPythonWorkbench
+Gui.reloadPythonWorkbench = reloadPythonWorkbench
+Gui.startPythonWorkbenchAutoReload = startPythonWorkbenchAutoReload
+Gui.stopPythonWorkbenchAutoReload = stopPythonWorkbenchAutoReload
+Gui.isPythonWorkbenchAutoReloadActive = isPythonWorkbenchAutoReloadActive
+Gui.addCommand("Std_ReloadActivePythonWorkbench", Std_ReloadActivePythonWorkbench())
+Gui.addCommand(
+    "Std_ToggleActivePythonWorkbenchAutoReload",
+    Std_ToggleActivePythonWorkbenchAutoReload(),
+)
 
 Gui.addWorkbench(NoneWorkbench())
 
@@ -518,5 +1340,5 @@ if not typing.TYPE_CHECKING:
     del InitApplications
     del NoneWorkbench
     del StandardWorkbench
-    del App.__ModCache__, ModGui, DirModGui, ExtModGui
-    del typing, re, Path, importlib
+    del ModGui
+    del typing, re

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -478,6 +478,7 @@ def _reload_active_workbench() -> None:
     try:
         Gui.activeWorkbench().reloadActive()
     except Exception:
+        # Best-effort refresh: some workbenches may not expose reloadActive().
         pass
 
 
@@ -744,6 +745,7 @@ class WorkbenchRuntime:
             try:
                 Gui.removeDocumentObserver(observer)
             except Exception:
+                # Best-effort cleanup: the observer may already be detached.
                 pass
 
         self.onDispose(cleanup)
@@ -763,6 +765,7 @@ class WorkbenchRuntime:
             try:
                 Gui.Selection.removeObserver(observer)
             except Exception:
+                # Best-effort cleanup: the observer may already be detached.
                 pass
 
         if key is not None:
@@ -786,6 +789,7 @@ class WorkbenchRuntime:
             try:
                 Gui.removeWorkbenchManipulator(manipulator)
             except Exception:
+                # Best-effort cleanup: the manipulator may already be removed.
                 pass
             if refresh:
                 _refresh_workbench_if_active(self.name)
@@ -805,6 +809,7 @@ class WorkbenchRuntime:
             try:
                 Gui.Control.clearTaskWatcher()
             except Exception:
+                # Best-effort cleanup: the task watcher may already be gone.
                 pass
 
         self.onDispose(cleanup)
@@ -818,11 +823,13 @@ class WorkbenchRuntime:
                 try:
                     timer.stop()
                 except Exception:
+                    # Best-effort cleanup: the timer may already be stopped.
                     pass
             if delete and hasattr(timer, "deleteLater"):
                 try:
                     timer.deleteLater()
                 except Exception:
+                    # Best-effort cleanup: the timer may already be deleted.
                     pass
 
         self.onDispose(cleanup)
@@ -837,6 +844,7 @@ class WorkbenchRuntime:
             try:
                 action.setShortcut(previous_shortcut)
             except Exception:
+                # Best-effort cleanup: the action may already be deleted.
                 pass
 
         self.own(key, previous_shortcut, cleanup)
@@ -847,7 +855,7 @@ class WorkbenchRuntime:
 
         self._disposed = True
         while self._owned:
-            _key, (_value, cleanup) = self._owned.popitem()
+            _, (_value, cleanup) = self._owned.popitem()
             if cleanup is not None:
                 self._run_cleanup(cleanup)
 

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -917,6 +917,14 @@ def _session_runtime_table() -> dict[str, SessionRuntime]:
     return runtimes
 
 
+def _auto_reloaders_table() -> dict[str, "_PythonWorkbenchAutoReloader"]:
+    reloaders = getattr(Gui, "_pythonWorkbenchReloaders", None)
+    if reloaders is None:
+        reloaders = {}
+        Gui._pythonWorkbenchReloaders = reloaders
+    return reloaders
+
+
 def sessionRuntime(name: str, workbench_name: str | None = None) -> SessionRuntime:
     runtime_workbench_name, session_name, qualified_name = _resolve_session_runtime_target(
         name,
@@ -1131,7 +1139,7 @@ class _PythonWorkbenchAutoReloader:
 
 def startPythonWorkbenchAutoReload(name: str | None = None, debounce_ms: int = 500) -> None:
     target = _resolve_reload_target(name)
-    reloaders = getattr(Gui, "_pythonWorkbenchReloaders", {})
+    reloaders = _auto_reloaders_table()
     existing = reloaders.get(target["name"])
     if existing:
         existing.stop()
@@ -1144,7 +1152,7 @@ def startPythonWorkbenchAutoReload(name: str | None = None, debounce_ms: int = 5
 
 
 def stopPythonWorkbenchAutoReload(name: str | None = None) -> bool:
-    reloaders = getattr(Gui, "_pythonWorkbenchReloaders", {})
+    reloaders = _auto_reloaders_table()
     target_name = _canonical_auto_reload_name(name)
     if not target_name:
         return False
@@ -1160,7 +1168,7 @@ def stopPythonWorkbenchAutoReload(name: str | None = None) -> bool:
 
 
 def isPythonWorkbenchAutoReloadActive(name: str | None = None) -> bool:
-    reloaders = getattr(Gui, "_pythonWorkbenchReloaders", {})
+    reloaders = _auto_reloaders_table()
     target_name = _canonical_auto_reload_name(name)
     if not target_name:
         return False

--- a/src/Gui/FreeCADGuiInit.py
+++ b/src/Gui/FreeCADGuiInit.py
@@ -40,16 +40,34 @@ from dataclasses import dataclass
 import traceback
 import typing
 import re
+import sys
 from pathlib import Path
 import importlib
 import FreeCAD
 import FreeCADGui
+
+try:
+    from FreeCADInitTools import (
+        DIR_MOD_APP_COMPAT_GLOBAL_NAMES,
+        dir_mod_compat_globals,
+        dir_mod_package_name,
+        exec_dir_mod_file,
+    )
+except ModuleNotFoundError:
+    sys.path.append(FreeCAD.getLibraryDir())
+    from FreeCADInitTools import (
+        DIR_MOD_APP_COMPAT_GLOBAL_NAMES,
+        dir_mod_compat_globals,
+        dir_mod_package_name,
+        exec_dir_mod_file,
+    )
 
 # shortcuts
 Gui = FreeCADGui
 App = FreeCAD
 
 translate = FreeCAD.Qt.translate
+QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
 
 App.Console.PrintLog("Init: Running FreeCADGuiInit.py start script...\n")
 App.Console.PrintLog("░░░▀█▀░█▀█░▀█▀░▀█▀░░░█▀▀░█░█░▀█▀░░\n")
@@ -292,9 +310,13 @@ class DirModGui(ModGui):
         init_gui_py = target / self.INIT_GUI_PY
         if init_gui_py.exists():
             try:
-                source = init_gui_py.read_text(encoding="utf-8")
-                code = compile(source, init_gui_py, "exec")
-                exec(code)
+                self.mod.remember_source_root(init_gui_py)
+                exec_dir_mod_file(
+                    self.mod.name,
+                    init_gui_py,
+                    self.mod.path,
+                    dir_mod_gui_compat_globals(globals()),
+                )
             except Exception as ex:
                 sep = "-" * 100 + "\n"
                 Log(f"Init:      Initializing {target!s}... failed\n")
@@ -381,6 +403,27 @@ class ExtModGui(ModGui):
             Log(traceback.format_exc())
             Log(sep)
         return False
+
+
+DIR_MOD_GUI_COMPAT_GLOBAL_NAMES = DIR_MOD_APP_COMPAT_GLOBAL_NAMES + (
+    "Enum",
+    "Gui",
+    "FreeCADGui",
+    "HintManager",
+    "InputHint",
+    "ModState",
+    "ResolveMode",
+    "SelectionStyle",
+    "ToggleVisibilityMode",
+    "Workbench",
+    "dataclass",
+    "translate",
+    "typing",
+)
+
+
+def dir_mod_gui_compat_globals(source_globals: dict) -> dict:
+    return dir_mod_compat_globals(source_globals, DIR_MOD_GUI_COMPAT_GLOBAL_NAMES)
 
 
 def InitApplications():

--- a/src/Gui/FreeCADGuiTest.py
+++ b/src/Gui/FreeCADGuiTest.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2026 FreeCAD contributors                               *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Lesser General Public License for more details.                   *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+"""Run command-line GUI tests after the GUI startup path has completed."""
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from __main__ import Log
+
+
+Log("Init: starting Gui::FreeCADGuiTest.py\n")
+
+import TestApp
+
+test_result = TestApp.RunConfiguredTextTest()

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1721,30 +1721,30 @@ void MainWindow::delayedStartup()
 {
     // automatically run unit tests in Gui
     if (App::Application::Config()["RunMode"] == "Internal") {
-        QTimer::singleShot(1000, this, [] {
-            try {
-                string command = "import sys\n"
-                                 "import FreeCAD\n"
-                                 "import QtUnitGui\n\n"
-                                 "testCase = FreeCAD.ConfigGet(\"TestCase\")\n"
-                                 "QtUnitGui.addTest(testCase)\n"
-                                 "QtUnitGui.setTest(testCase)\n"
-                                 "result = QtUnitGui.runTest()\n"
-                                 "sys.stdout.flush()\n";
-                if (App::Application::Config()["ExitTests"] == "yes") {
-                    command += "sys.exit(0 if result else 1)";
-                }
-                Base::Interpreter().runString(command.c_str());
+        try {
+            // Command-line GUI tests should not depend on the interactive QtUnitGui
+            // dialog. In headless runs such as QT_QPA_PLATFORM=offscreen/minimal,
+            // that dialog path can hang before the test body executes. Run the
+            // embedded text-based GUI test script directly once startup reaches
+            // delayedStartup().
+            Base::Interpreter().runString(Base::ScriptFactory().ProduceScript("FreeCADGuiTest"));
+            if (App::Application::Config()["ExitTests"] == "yes") {
+                Base::Interpreter().runString(
+                    "import sys\n"
+                    "sys.exit(0 if test_result.wasSuccessful() else 1)\n"
+                );
             }
-            catch (const Base::SystemExitException&) {
-                // Properly quit the Qt event loop before propagating the exception
-                QApplication::quit();
-                throw;
-            }
-            catch (const Base::Exception& e) {
-                e.reportException();
-            }
-        });
+        }
+        catch (const Base::SystemExitException&) {
+            // Properly quit the Qt event loop before propagating the exception
+            QApplication::quit();
+            throw;
+        }
+        catch (const Base::Exception& e) {
+            e.reportException();
+            QApplication::quit();
+            throw;
+        }
         return;
     }
 

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -27,6 +27,10 @@ if(BUILD_GUI)
 
     add_executable(FreeCADMain WIN32 ${FreeCAD_SRCS})
     target_link_libraries(FreeCADMain ${FreeCAD_LIBS})
+    if(BUILD_TEST)
+        add_dependencies(FreeCADMain TestSources)
+        add_dependencies(FreeCADMain TestGuiSources)
+    endif()
     if (FREECAD_WARN_ERROR)
         target_compile_warn_error(FreeCADMain)
     endif()
@@ -58,6 +62,9 @@ SET(FreeCADMainCmd_SRCS
 )
 
 add_executable(FreeCADMainCmd ${FreeCADMainCmd_SRCS})
+if(BUILD_TEST)
+    add_dependencies(FreeCADMainCmd TestSources)
+endif()
 
 SET(FreeCADMainCmd_LIBS
     FreeCADApp

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -54,6 +54,74 @@ else:
     # \endcond
 
 
+SURVEY_WORKBENCH_NAME = "BIMWorkbench"
+SURVEY_SESSION_NAME = "survey"
+SURVEY_OBSERVER_KEY = "observer"
+SURVEY_DIALOG_KEY = "dialog"
+
+
+def _get_session_runtime(name, create=False):
+    if not FreeCAD.GuiUp:
+        return None
+
+    getter = getattr(
+        FreeCADGui,
+        "sessionRuntime" if create else "findSessionRuntime",
+        None,
+    )
+    if getter is None:
+        return None
+    try:
+        return getter(name, workbench_name=SURVEY_WORKBENCH_NAME)
+    except Exception:
+        return None
+
+
+def _get_survey_session(create=False):
+    return _get_session_runtime(SURVEY_SESSION_NAME, create=create)
+
+
+def _get_survey_observer():
+    runtime = _get_survey_session(create=False)
+    if runtime is None:
+        return None
+    return runtime.getOwned(SURVEY_OBSERVER_KEY)
+
+
+def _get_survey_dialog():
+    runtime = _get_survey_session(create=False)
+    if runtime is None:
+        return None
+    return runtime.getOwned(SURVEY_DIALOG_KEY)
+
+
+def _clear_survey_labels(observer=None):
+    observer = observer or _get_survey_observer()
+    if observer is None:
+        return
+
+    for label in list(observer.labels):
+        try:
+            if FreeCAD.ActiveDocument:
+                FreeCAD.ActiveDocument.removeObject(label)
+        except Exception:
+            pass
+    observer.labels = []
+
+
+def _dispose_survey_session():
+    runtime = _get_survey_session(create=False)
+    if runtime is None:
+        return False
+
+    observer = runtime.getOwned(SURVEY_OBSERVER_KEY)
+    _clear_survey_labels(observer)
+    return FreeCADGui.disposeSessionRuntime(
+        SURVEY_SESSION_NAME,
+        workbench_name=SURVEY_WORKBENCH_NAME,
+    )
+
+
 # module functions ###############################################
 
 
@@ -1079,47 +1147,43 @@ def survey(callback=False):
     """survey(): starts survey mode, where you can click edges and faces to get their lengths or area.
     Clicking on no object (on an empty area) resets the count."""
     if not callback:
-        if hasattr(FreeCAD, "SurveyObserver"):
-            for label in FreeCAD.SurveyObserver.labels:
-                FreeCAD.ActiveDocument.removeObject(label)
-            FreeCADGui.Selection.removeObserver(FreeCAD.SurveyObserver)
-            del FreeCAD.SurveyObserver
-            FreeCADGui.Control.closeDialog()
-            if hasattr(FreeCAD, "SurveyDialog"):
-                del FreeCAD.SurveyDialog
+        if _get_survey_observer():
+            _dispose_survey_session()
         else:
-            FreeCAD.SurveyObserver = _SurveyObserver(callback=survey)
-            FreeCADGui.Selection.addObserver(FreeCAD.SurveyObserver)
-            FreeCAD.SurveyDialog = SurveyTaskPanel()
-            FreeCADGui.Control.showDialog(FreeCAD.SurveyDialog)
+            runtime = _get_survey_session(create=True)
+            observer = runtime.addSelectionObserver(
+                _SurveyObserver(callback=survey),
+                key=SURVEY_OBSERVER_KEY,
+            )
+            runtime.onDispose(lambda: _clear_survey_labels(observer))
+            runtime.onDispose(FreeCADGui.Control.closeDialog)
+            dialog = runtime.own(SURVEY_DIALOG_KEY, SurveyTaskPanel())
+            FreeCADGui.Control.showDialog(dialog)
     else:
         sel = FreeCADGui.Selection.getSelectionEx()
-        if hasattr(FreeCAD, "SurveyObserver"):
+        observer = _get_survey_observer()
+        dialog = _get_survey_dialog()
+        if observer:
             if not sel:
-                if FreeCAD.SurveyObserver.labels:
-                    for label in FreeCAD.SurveyObserver.labels:
-                        FreeCAD.ActiveDocument.removeObject(label)
-                    tl = FreeCAD.SurveyObserver.totalLength
-                    ta = FreeCAD.SurveyObserver.totalArea
-                    FreeCAD.SurveyObserver.labels = []
-                    FreeCAD.SurveyObserver.selection = []
-                    FreeCAD.SurveyObserver.totalLength = 0
-                    FreeCAD.SurveyObserver.totalArea = 0
-                    FreeCAD.SurveyObserver.totalVolume = 0
-                    if not FreeCAD.SurveyObserver.cancellable:
+                if observer.labels:
+                    _clear_survey_labels(observer)
+                    tl = observer.totalLength
+                    ta = observer.totalArea
+                    observer.selection = []
+                    observer.totalLength = 0
+                    observer.totalArea = 0
+                    observer.totalVolume = 0
+                    if not observer.cancellable:
                         FreeCAD.Console.PrintMessage("\n---- Reset ----\n\n")
-                        FreeCAD.SurveyObserver.cancellable = True
-                        if hasattr(FreeCAD, "SurveyDialog"):
-                            FreeCAD.SurveyDialog.newline(tl, ta)
+                        observer.cancellable = True
+                        if dialog:
+                            dialog.newline(tl, ta)
                     else:
-                        FreeCADGui.Selection.removeObserver(FreeCAD.SurveyObserver)
-                        del FreeCAD.SurveyObserver
-                        FreeCADGui.Control.closeDialog()
-                        if hasattr(FreeCAD, "SurveyDialog"):
-                            del FreeCAD.SurveyDialog
+                        _dispose_survey_session()
+                        return
             else:
-                FreeCAD.SurveyObserver.cancellable = False
-                basesel = FreeCAD.SurveyObserver.selection
+                observer.cancellable = False
+                basesel = observer.selection
                 newsels = []
                 for o in sel:
                     found = False
@@ -1145,7 +1209,7 @@ def survey(callback=False):
                                     anno.BasePosition = o.Object.Shape.CenterOfMass
                                 else:
                                     anno.BasePosition = o.Object.Shape.BoundBox.Center
-                                FreeCAD.SurveyObserver.labels.append(anno.Name)
+                                observer.labels.append(anno.Name)
                                 if o.Object.Shape.Solids:
                                     u = FreeCAD.Units.Quantity(
                                         o.Object.Shape.Volume, FreeCAD.Units.Volume
@@ -1156,7 +1220,7 @@ def survey(callback=False):
                                     FreeCAD.Console.PrintMessage(
                                         "Object: " + n + ", Element: Whole, Volume: " + t + "\n"
                                     )
-                                    FreeCAD.SurveyObserver.totalVolume += u.Value
+                                    observer.totalVolume += u.Value
                                 elif o.Object.Shape.Faces:
                                     u = FreeCAD.Units.Quantity(
                                         o.Object.Shape.Area, FreeCAD.Units.Area
@@ -1167,9 +1231,9 @@ def survey(callback=False):
                                     FreeCAD.Console.PrintMessage(
                                         "Object: " + n + ", Element: Whole, Area: " + t + "\n"
                                     )
-                                    FreeCAD.SurveyObserver.totalArea += u.Value
-                                    if hasattr(FreeCAD, "SurveyDialog"):
-                                        FreeCAD.SurveyDialog.update(2, t)
+                                    observer.totalArea += u.Value
+                                    if dialog:
+                                        dialog.update(2, t)
                                 else:
                                     u = FreeCAD.Units.Quantity(
                                         o.Object.Shape.Length, FreeCAD.Units.Length
@@ -1179,9 +1243,9 @@ def survey(callback=False):
                                     FreeCAD.Console.PrintMessage(
                                         "Object: " + n + ", Element: Whole, Length: " + t + "\n"
                                     )
-                                    FreeCAD.SurveyObserver.totalLength += u.Value
-                                    if hasattr(FreeCAD, "SurveyDialog"):
-                                        FreeCAD.SurveyDialog.update(1, t)
+                                    observer.totalLength += u.Value
+                                    if dialog:
+                                        dialog.update(1, t)
                                 if FreeCAD.GuiUp and t:
                                     if showUnit:
                                         QtGui.QApplication.clipboard().setText(t)
@@ -1201,7 +1265,7 @@ def survey(callback=False):
                                             anno.BasePosition = e.CenterOfMass
                                         else:
                                             anno.BasePosition = e.BoundBox.Center
-                                    FreeCAD.SurveyObserver.labels.append(anno.Name)
+                                    observer.labels.append(anno.Name)
                                     if "Face" in el:
                                         u = FreeCAD.Units.Quantity(e.Area, FreeCAD.Units.Area)
                                         t = u.getUserPreferred()[0]
@@ -1216,9 +1280,9 @@ def survey(callback=False):
                                             + t
                                             + "\n"
                                         )
-                                        FreeCAD.SurveyObserver.totalArea += u.Value
-                                        if hasattr(FreeCAD, "SurveyDialog"):
-                                            FreeCAD.SurveyDialog.update(2, t)
+                                        observer.totalArea += u.Value
+                                        if dialog:
+                                            dialog.update(2, t)
                                     elif "Edge" in el:
                                         u = FreeCAD.Units.Quantity(e.Length, FreeCAD.Units.Length)
                                         t = u.getUserPreferred()[0]
@@ -1232,9 +1296,9 @@ def survey(callback=False):
                                             + t
                                             + "\n"
                                         )
-                                        FreeCAD.SurveyObserver.totalLength += u.Value
-                                        if hasattr(FreeCAD, "SurveyDialog"):
-                                            FreeCAD.SurveyDialog.update(1, t)
+                                        observer.totalLength += u.Value
+                                        if dialog:
+                                            dialog.update(1, t)
                                     elif "Vertex" in el:
                                         u = FreeCAD.Units.Quantity(e.Z, FreeCAD.Units.Length)
                                         t = u.getUserPreferred()[0]
@@ -1254,31 +1318,21 @@ def survey(callback=False):
                                         else:
                                             QtGui.QApplication.clipboard().setText(str(u.Value))
 
-                    FreeCAD.SurveyObserver.selection.extend(newsels)
-            if hasattr(FreeCAD, "SurveyObserver"):
-                if (
-                    FreeCAD.SurveyObserver.totalLength
-                    or FreeCAD.SurveyObserver.totalArea
-                    or FreeCAD.SurveyObserver.totalVolume
-                ):
+                    observer.selection.extend(newsels)
+            if observer:
+                if observer.totalLength or observer.totalArea or observer.totalVolume:
                     msg = " Total:"
-                    if FreeCAD.SurveyObserver.totalLength:
-                        u = FreeCAD.Units.Quantity(
-                            FreeCAD.SurveyObserver.totalLength, FreeCAD.Units.Length
-                        )
+                    if observer.totalLength:
+                        u = FreeCAD.Units.Quantity(observer.totalLength, FreeCAD.Units.Length)
                         t = u.getUserPreferred()[0]
                         msg += " Length: " + t
-                    if FreeCAD.SurveyObserver.totalArea:
-                        u = FreeCAD.Units.Quantity(
-                            FreeCAD.SurveyObserver.totalArea, FreeCAD.Units.Area
-                        )
+                    if observer.totalArea:
+                        u = FreeCAD.Units.Quantity(observer.totalArea, FreeCAD.Units.Area)
                         t = u.getUserPreferred()[0]
                         t = t.replace("^2", "²")
                         msg += " Area: " + t
-                    if FreeCAD.SurveyObserver.totalVolume:
-                        u = FreeCAD.Units.Quantity(
-                            FreeCAD.SurveyObserver.totalVolume, FreeCAD.Units.Volume
-                        )
+                    if observer.totalVolume:
+                        u = FreeCAD.Units.Quantity(observer.totalVolume, FreeCAD.Units.Volume)
                         t = u.getUserPreferred()[0]
                         t = t.replace("^3", "³")
                         msg += " Volume: " + t
@@ -1372,19 +1426,16 @@ class SurveyTaskPanel:
         return QtGui.QDialogButtonBox.Close
 
     def reject(self):
-        if hasattr(FreeCAD, "SurveyObserver"):
-            for label in FreeCAD.SurveyObserver.labels:
-                FreeCAD.ActiveDocument.removeObject(label)
-            FreeCADGui.Selection.removeObserver(FreeCAD.SurveyObserver)
-            del FreeCAD.SurveyObserver
+        _dispose_survey_session()
         return True
 
     def clear(self):
         FreeCADGui.Selection.clearSelection()
 
     def clipLength(self):
-        if hasattr(FreeCAD, "SurveyObserver"):
-            u = FreeCAD.Units.Quantity(FreeCAD.SurveyObserver.totalLength, FreeCAD.Units.Length)
+        observer = _get_survey_observer()
+        if observer:
+            u = FreeCAD.Units.Quantity(observer.totalLength, FreeCAD.Units.Length)
             t = u.getUserPreferred()[0]
             if params.get_param_arch("surveyUnits"):
                 QtGui.QApplication.clipboard().setText(t)
@@ -1392,8 +1443,9 @@ class SurveyTaskPanel:
                 QtGui.QApplication.clipboard().setText(str(u.Value / u.getUserPreferred()[1]))
 
     def clipArea(self):
-        if hasattr(FreeCAD, "SurveyObserver"):
-            u = FreeCAD.Units.Quantity(FreeCAD.SurveyObserver.totalArea, FreeCAD.Units.Area)
+        observer = _get_survey_observer()
+        if observer:
+            u = FreeCAD.Units.Quantity(observer.totalArea, FreeCAD.Units.Area)
             t = u.getUserPreferred()[0]
             t = t.replace("^2", "²")
             if params.get_param_arch("surveyUnits"):

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -64,15 +64,10 @@ def _get_session_runtime(name, create=False):
     if not FreeCAD.GuiUp:
         return None
 
-    getter = getattr(
-        FreeCADGui,
-        "sessionRuntime" if create else "findSessionRuntime",
-        None,
-    )
-    if getter is None:
-        return None
     try:
-        return getter(name, workbench_name=SURVEY_WORKBENCH_NAME)
+        if create:
+            return FreeCADGui.sessionRuntime(name, workbench_name=SURVEY_WORKBENCH_NAME)
+        return FreeCADGui.findSessionRuntime(name, workbench_name=SURVEY_WORKBENCH_NAME)
     except Exception:
         return None
 

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -100,6 +100,7 @@ def _clear_survey_labels(observer=None):
             if FreeCAD.ActiveDocument:
                 FreeCAD.ActiveDocument.removeObject(label)
         except Exception:
+            # Best-effort cleanup: the temporary label may already be gone.
             pass
     observer.labels = []
 

--- a/src/Mod/BIM/ArchCommands.py
+++ b/src/Mod/BIM/ArchCommands.py
@@ -68,7 +68,7 @@ def _get_session_runtime(name, create=False):
         if create:
             return FreeCADGui.sessionRuntime(name, workbench_name=SURVEY_WORKBENCH_NAME)
         return FreeCADGui.findSessionRuntime(name, workbench_name=SURVEY_WORKBENCH_NAME)
-    except Exception:
+    except RuntimeError:
         return None
 
 

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -65,6 +65,61 @@ else:
 
     # \endcond
 
+ARCH_SELECTION_WORKBENCH_NAME = "BIMWorkbench"
+ARCH_SELECTION_SESSION_NAME = "arch_selection"
+ARCH_SELECTION_OBSERVER_KEY = "observer"
+
+
+def _get_arch_selection_session(create=False):
+    if not FreeCAD.GuiUp:
+        return None
+
+    getter = getattr(
+        FreeCADGui,
+        "sessionRuntime" if create else "findSessionRuntime",
+        None,
+    )
+    if getter is None:
+        return None
+    try:
+        return getter(
+            ARCH_SELECTION_SESSION_NAME,
+            workbench_name=ARCH_SELECTION_WORKBENCH_NAME,
+        )
+    except Exception:
+        return None
+
+
+def getSelectionObserver():
+    runtime = _get_arch_selection_session(create=False)
+    if runtime is None:
+        return None
+    return runtime.getOwned(ARCH_SELECTION_OBSERVER_KEY)
+
+
+def clearSelectionSession():
+    if not FreeCAD.GuiUp:
+        return False
+
+    disposer = getattr(FreeCADGui, "disposeSessionRuntime", None)
+    if disposer is None:
+        return False
+    return disposer(
+        ARCH_SELECTION_SESSION_NAME,
+        workbench_name=ARCH_SELECTION_WORKBENCH_NAME,
+    )
+
+
+def startSelectionSession(observer):
+    if not FreeCAD.GuiUp:
+        return observer
+
+    clearSelectionSession()
+    runtime = _get_arch_selection_session(create=True)
+    if runtime is None:
+        return observer
+    return runtime.addSelectionObserver(observer, key=ARCH_SELECTION_OBSERVER_KEY)
+
 
 def addToComponent(compobject, addobject, prop):
     """Add an object to a component's property.
@@ -2054,10 +2109,9 @@ class ArchSelectionObserver:
         """
 
         if not self.watched:
-            FreeCADGui.Selection.removeObserver(FreeCAD.ArchObserver)
+            clearSelectionSession()
             if self.nextCommand:
                 FreeCADGui.runCommand(self.nextCommand)
-            del FreeCAD.ArchObserver
         elif object == self.watched.Name:
             if not element:
                 FreeCAD.Console.PrintMessage(translate("Arch", "Closing Sketch edit"))
@@ -2067,9 +2121,7 @@ class ArchSelectionObserver:
                         self.origin.ViewObject.Selectable = True
                     self.watched.ViewObject.hide()
                 FreeCADGui.activateWorkbench("BIMWorkbench")
-                if hasattr(FreeCAD, "ArchObserver"):
-                    FreeCADGui.Selection.removeObserver(FreeCAD.ArchObserver)
-                    del FreeCAD.ArchObserver
+                clearSelectionSession()
                 if self.nextCommand:
                     FreeCADGui.Selection.clearSelection()
                     FreeCADGui.Selection.addSelection(self.watched)
@@ -2093,9 +2145,7 @@ class SelectionTaskPanel:
     def reject(self):
         """The method run when the user selects the cancel button."""
 
-        if hasattr(FreeCAD, "ArchObserver"):
-            FreeCADGui.Selection.removeObserver(FreeCAD.ArchObserver)
-            del FreeCAD.ArchObserver
+        clearSelectionSession()
         return True
 
 
@@ -2406,8 +2456,7 @@ class ComponentTaskPanel:
                 self.accept()
                 if obj.isDerivedFrom("Sketcher::SketchObject"):
                     FreeCADGui.activateWorkbench("SketcherWorkbench")
-                FreeCAD.ArchObserver = ArchSelectionObserver(self.obj, obj)
-                FreeCADGui.Selection.addObserver(FreeCAD.ArchObserver)
+                startSelectionSession(ArchSelectionObserver(self.obj, obj))
                 FreeCADGui.ActiveDocument.setEdit(obj.Name, 0)
 
     def retranslateUi(self, TaskPanel):

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -74,15 +74,13 @@ def _get_arch_selection_session(create=False):
     if not FreeCAD.GuiUp:
         return None
 
-    getter = getattr(
-        FreeCADGui,
-        "sessionRuntime" if create else "findSessionRuntime",
-        None,
-    )
-    if getter is None:
-        return None
     try:
-        return getter(
+        if create:
+            return FreeCADGui.sessionRuntime(
+                ARCH_SELECTION_SESSION_NAME,
+                workbench_name=ARCH_SELECTION_WORKBENCH_NAME,
+            )
+        return FreeCADGui.findSessionRuntime(
             ARCH_SELECTION_SESSION_NAME,
             workbench_name=ARCH_SELECTION_WORKBENCH_NAME,
         )
@@ -101,10 +99,7 @@ def clearSelectionSession():
     if not FreeCAD.GuiUp:
         return False
 
-    disposer = getattr(FreeCADGui, "disposeSessionRuntime", None)
-    if disposer is None:
-        return False
-    return disposer(
+    return FreeCADGui.disposeSessionRuntime(
         ARCH_SELECTION_SESSION_NAME,
         workbench_name=ARCH_SELECTION_WORKBENCH_NAME,
     )

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -84,7 +84,7 @@ def _get_arch_selection_session(create=False):
             ARCH_SELECTION_SESSION_NAME,
             workbench_name=ARCH_SELECTION_WORKBENCH_NAME,
         )
-    except Exception:
+    except RuntimeError:
         return None
 
 

--- a/src/Mod/BIM/BimSelect.py
+++ b/src/Mod/BIM/BimSelect.py
@@ -32,11 +32,10 @@ SETUP_RUNTIME_KEY = "cyclic_selection_setup"
 def _get_bim_runtime(create=False):
     import FreeCADGui
 
-    getter = getattr(FreeCADGui, "workbenchRuntime" if create else "findWorkbenchRuntime", None)
-    if getter is None:
-        return None
     try:
-        return getter(WORKBENCH_NAME)
+        if create:
+            return FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
+        return FreeCADGui.findWorkbenchRuntime(WORKBENCH_NAME)
     except Exception:
         return None
 

--- a/src/Mod/BIM/BimSelect.py
+++ b/src/Mod/BIM/BimSelect.py
@@ -36,7 +36,7 @@ def _get_bim_runtime(create=False):
         if create:
             return FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
         return FreeCADGui.findWorkbenchRuntime(WORKBENCH_NAME)
-    except Exception:
+    except RuntimeError:
         return None
 
 

--- a/src/Mod/BIM/BimSelect.py
+++ b/src/Mod/BIM/BimSelect.py
@@ -24,6 +24,29 @@
 
 import FreeCAD
 
+WORKBENCH_NAME = "BIMWorkbench"
+CYCLIC_SELECTION_OBSERVER_KEY = "cyclic_selection_observer"
+SETUP_RUNTIME_KEY = "cyclic_selection_setup"
+
+
+def _get_bim_runtime(create=False):
+    import FreeCADGui
+
+    getter = getattr(FreeCADGui, "workbenchRuntime" if create else "findWorkbenchRuntime", None)
+    if getter is None:
+        return None
+    try:
+        return getter(WORKBENCH_NAME)
+    except Exception:
+        return None
+
+
+def _release_cyclic_selection_observer():
+    runtime = _get_bim_runtime(create=False)
+    if runtime is None:
+        return False
+    return runtime.release(CYCLIC_SELECTION_OBSERVER_KEY)
+
 
 class CyclicSelectionObserver:
     def addSelection(self, document, object, element, position):
@@ -31,11 +54,11 @@ class CyclicSelectionObserver:
 
         if not FreeCAD.ActiveDocument:
             return
-        if not hasattr(FreeCAD, "CyclicSelectionObserver"):
+        runtime = _get_bim_runtime(create=False)
+        if runtime is None or not runtime.owns(CYCLIC_SELECTION_OBSERVER_KEY):
             return
         FreeCADGui.Selection.removeSelection(FreeCAD.ActiveDocument.getObject(object))
-        FreeCADGui.Selection.removeObserver(FreeCAD.CyclicSelectionObserver)
-        del FreeCAD.CyclicSelectionObserver
+        _release_cyclic_selection_observer()
         preselection = FreeCADGui.Selection.getPreselection()
         FreeCADGui.Selection.addSelection(
             FreeCAD.ActiveDocument.getObject(preselection.Object.Name),
@@ -67,13 +90,17 @@ class CyclicObjectSelector:
 
         if not element_list:
             self.selectableObjects = []
-            if hasattr(FreeCAD, "CyclicSelectionObserver"):
-                FreeCADGui.Selection.removeObserver(FreeCAD.CyclicSelectionObserver)
-                del FreeCAD.CyclicSelectionObserver
+            _release_cyclic_selection_observer()
             return
 
-        FreeCAD.CyclicSelectionObserver = CyclicSelectionObserver()
-        FreeCADGui.Selection.addObserver(FreeCAD.CyclicSelectionObserver)
+        runtime = _get_bim_runtime(create=True)
+        if runtime is None:
+            return
+        if not runtime.owns(CYCLIC_SELECTION_OBSERVER_KEY):
+            runtime.addSelectionObserver(
+                CyclicSelectionObserver(),
+                key=CYCLIC_SELECTION_OBSERVER_KEY,
+            )
 
     def cycleSelectableObjects(self, event_callback):
         import FreeCADGui
@@ -111,14 +138,51 @@ class CyclicObjectSelector:
 
 
 class Setup:
-    def slotActivateDocument(self, doc):
+    def __init__(self):
+        self._view_callbacks = []
+
+    def _attach_view(self, view):
         from pivy import coin
 
+        if not view or not hasattr(view, "getSceneGraph"):
+            return
+        if any(registered_view is view for registered_view, _callbacks in self._view_callbacks):
+            return
+
         cos = CyclicObjectSelector()
-        if doc and doc.ActiveView and hasattr(doc.ActiveView, "getSceneGraph"):
-            self.callback = doc.ActiveView.addEventCallbackPivy(
-                coin.SoMouseButtonEvent.getClassTypeId(), cos.selectObject
-            )
-            self.callback = doc.ActiveView.addEventCallbackPivy(
-                coin.SoKeyboardEvent.getClassTypeId(), cos.cycleSelectableObjects
-            )
+        callbacks = [
+            (
+                coin.SoMouseButtonEvent.getClassTypeId(),
+                view.addEventCallbackPivy(
+                    coin.SoMouseButtonEvent.getClassTypeId(),
+                    cos.selectObject,
+                ),
+            ),
+            (
+                coin.SoKeyboardEvent.getClassTypeId(),
+                view.addEventCallbackPivy(
+                    coin.SoKeyboardEvent.getClassTypeId(),
+                    cos.cycleSelectableObjects,
+                ),
+            ),
+        ]
+        self._view_callbacks.append((view, callbacks))
+
+    def _detach_view(self, view, callbacks):
+        for event_type, callback in callbacks:
+            try:
+                view.removeEventCallbackPivy(event_type, callback)
+            except Exception:
+                pass
+
+    def dispose(self):
+        while self._view_callbacks:
+            view, callbacks = self._view_callbacks.pop()
+            self._detach_view(view, callbacks)
+        _release_cyclic_selection_observer()
+
+    def activeCallbackCount(self):
+        return sum(len(callbacks) for _view, callbacks in self._view_callbacks)
+
+    def slotActivateDocument(self, doc):
+        self._attach_view(getattr(doc, "ActiveView", None))

--- a/src/Mod/BIM/BimSelect.py
+++ b/src/Mod/BIM/BimSelect.py
@@ -172,6 +172,7 @@ class Setup:
             try:
                 view.removeEventCallbackPivy(event_type, callback)
             except Exception:
+                # Best-effort cleanup: the 3D view callback may already be detached.
                 pass
 
     def dispose(self):

--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -144,7 +144,8 @@ def setStatusIcons(show=True):
             # ifc widgets
             try:
                 from nativeifc import ifc_status
-            except:
+            except ImportError:
+                # NativeIFC remains optional when ifcopenshell is unavailable.
                 pass
             else:
                 ifc_status.set_status_widget(statuswidget)

--- a/src/Mod/BIM/BimStatus.py
+++ b/src/Mod/BIM/BimStatus.py
@@ -91,9 +91,11 @@ def setStatusIcons(show=True):
         statuswidget = st.findChild(QtGui.QToolBar, "BIMStatusWidget")
         if show:
             if statuswidget:
-                statuswidget.show()
                 if hasattr(statuswidget, "propertybuttons"):
-                    statuswidget.propertybuttons.show()
+                    statuswidget.propertybuttons.hide()
+                    statuswidget.propertybuttons.deleteLater()
+                    del statuswidget.propertybuttons
+                statuswidget.clear()
             else:
                 statuswidget = FreeCADGui.UiLoader().createWidget("Gui::ToolBar")
                 statuswidget.setObjectName("BIMStatusWidget")
@@ -109,71 +111,71 @@ def setStatusIcons(show=True):
                 statuswidget.setIconSize(QtCore.QSize(s, s))
                 st.insertPermanentWidget(2, statuswidget)
 
-                # bim views widget toggle button
-                from bimcommands import BimViews
+            # bim views widget toggle button
+            from bimcommands import BimViews
 
-                bimviewsbutton = QtGui.QAction()
-                bimviewsbutton.setIcon(QtGui.QIcon(":/icons/BIM_Views.svg"))
+            bimviewsbutton = QtGui.QAction()
+            bimviewsbutton.setIcon(QtGui.QIcon(":/icons/BIM_Views.svg"))
 
-                bimviewsbutton.setText("")
-                bimviewsbutton.setToolTip(
-                    translate("BIM", "Toggles the BIM Views Manager on/off (Ctrl+9)")
+            bimviewsbutton.setText("")
+            bimviewsbutton.setToolTip(
+                translate("BIM", "Toggles the BIM Views Manager on/off (Ctrl+9)")
+            )
+            bimviewsbutton.setCheckable(True)
+            if BimViews.findWidget():
+                bimviewsbutton.setChecked(True)
+            statuswidget.bimviewsbutton = bimviewsbutton
+            bimviewsbutton.triggered.connect(toggleBimViews)
+            statuswidget.addAction(bimviewsbutton)
+
+            # background toggle button
+            bgbutton = QtGui.QAction()
+            # bwidth = bgbutton.fontMetrics().boundingRect("AAAA").width()
+            # bgbutton.setMaximumWidth(bwidth)
+            bgbutton.setIcon(QtGui.QIcon(":/icons/BIM_Background.svg"))
+            bgbutton.setText("")
+            bgbutton.setToolTip(
+                translate("BIM", "Toggles the 3D View background between simple and gradient")
+            )
+            statuswidget.bgbutton = bgbutton
+            bgbutton.triggered.connect(toggleBackground)
+            statuswidget.addAction(bgbutton)
+
+            # ifc widgets
+            try:
+                from nativeifc import ifc_status
+            except:
+                pass
+            else:
+                ifc_status.set_status_widget(statuswidget)
+
+            # nudge button
+            nudge = QtGui.QPushButton(nudgeLabelsM[-1])
+            nudge.setIcon(QtGui.QIcon(":/icons/BIM_Nudge.svg"))
+            nudge.setFlat(True)
+            nudge.setToolTip(
+                translate(
+                    "BIM",
+                    "The value of the nudge movement (rotation is always 45°)."
+                    "Alt+arrows to move\nAlt+, to rotate left"
+                    "Alt+. to rotate right\nAlt+PgUp to extend extrusion"
+                    "Alt+PgDown to shrink extrusion"
+                    "Alt+/ to switch between auto and manual mode",
                 )
-                bimviewsbutton.setCheckable(True)
-                if BimViews.findWidget():
-                    bimviewsbutton.setChecked(True)
-                statuswidget.bimviewsbutton = bimviewsbutton
-                bimviewsbutton.triggered.connect(toggleBimViews)
-                statuswidget.addAction(bimviewsbutton)
-
-                # background toggle button
-                bgbutton = QtGui.QAction()
-                # bwidth = bgbutton.fontMetrics().boundingRect("AAAA").width()
-                # bgbutton.setMaximumWidth(bwidth)
-                bgbutton.setIcon(QtGui.QIcon(":/icons/BIM_Background.svg"))
-                bgbutton.setText("")
-                bgbutton.setToolTip(
-                    translate("BIM", "Toggles the 3D View background between simple and gradient")
-                )
-                statuswidget.bgbutton = bgbutton
-                bgbutton.triggered.connect(toggleBackground)
-                statuswidget.addAction(bgbutton)
-
-                # ifc widgets
-                try:
-                    from nativeifc import ifc_status
-                except:
-                    pass
-                else:
-                    ifc_status.set_status_widget(statuswidget)
-
-                # nudge button
-                nudge = QtGui.QPushButton(nudgeLabelsM[-1])
-                nudge.setIcon(QtGui.QIcon(":/icons/BIM_Nudge.svg"))
-                nudge.setFlat(True)
-                nudge.setToolTip(
-                    translate(
-                        "BIM",
-                        "The value of the nudge movement (rotation is always 45°)."
-                        "Alt+arrows to move\nAlt+, to rotate left"
-                        "Alt+. to rotate right\nAlt+PgUp to extend extrusion"
-                        "Alt+PgDown to shrink extrusion"
-                        "Alt+/ to switch between auto and manual mode",
-                    )
-                )
-                statuswidget.addWidget(nudge)
-                statuswidget.nudge = nudge
-                menu = QtGui.QMenu(nudge)
-                gnudge = QtGui.QActionGroup(menu)
-                for u in nudgeLabelsM:
-                    a = QtGui.QAction(gnudge)
-                    a.setText(u)
-                    menu.addAction(a)
-                nudge.setMenu(menu)
-                gnudge.triggered.connect(setNudge)
-                statuswidget.nudgeLabelsI = nudgeLabelsI
-                statuswidget.nudgeLabelsM = nudgeLabelsM
-                statuswidget.show()
+            )
+            statuswidget.addWidget(nudge)
+            statuswidget.nudge = nudge
+            menu = QtGui.QMenu(nudge)
+            gnudge = QtGui.QActionGroup(menu)
+            for u in nudgeLabelsM:
+                a = QtGui.QAction(gnudge)
+                a.setText(u)
+                menu.addAction(a)
+            nudge.setMenu(menu)
+            gnudge.triggered.connect(setNudge)
+            statuswidget.nudgeLabelsI = nudgeLabelsI
+            statuswidget.nudgeLabelsM = nudgeLabelsM
+            statuswidget.show()
 
         else:
             if statuswidget is None:

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(Arch_SRCS
     BimStatus.py
     TestArch.py
     TestArchGui.py
+    TestArchReloadGui.py
     ArchReport.py
     ArchSql.py
 )
@@ -231,6 +232,7 @@ SET(bimtests_SRCS
     bimtests/TestArchSpace.py
     bimtests/TestArchWall.py
     bimtests/TestArchWallGui.py
+    bimtests/TestArchReloadGui.py
     bimtests/TestArchMaterial.py
     bimtests/TestArchPanel.py
     bimtests/TestArchWindow.py

--- a/src/Mod/BIM/DEVELOPMENT.md
+++ b/src/Mod/BIM/DEVELOPMENT.md
@@ -1,0 +1,32 @@
+# BIM Development Notes
+
+## Python Workbench Reload
+
+The BIM workbench supports reloading its Python-side code without restarting FreeCAD.
+
+Command ids:
+- `Std_ReloadActivePythonWorkbench`
+- `Std_ToggleActivePythonWorkbenchAutoReload`
+
+Python API:
+
+```python
+import FreeCADGui as Gui
+
+Gui.reloadPythonWorkbench("BIMWorkbench")
+Gui.startPythonWorkbenchAutoReload("BIMWorkbench")
+Gui.stopPythonWorkbenchAutoReload("BIMWorkbench")
+```
+
+Reload support includes:
+- rerunning `InitGui.py` and reimporting BIM Python modules
+- resetting and rebuilding the Python workbench handler
+- disposing workbench- and session-owned GUI state such as observers, manipulators, task watchers, and similar runtime-managed objects
+
+These are generic active-workbench commands backed by `Gui.reloadPythonWorkbench(...)`
+and the auto-reload APIs.
+
+Out of scope:
+- document proxies or view providers created from older Python classes; recreate affected objects after reload
+- open task or dialog sessions; reopen them after reload
+- C++ changes; rebuild and restart FreeCAD

--- a/src/Mod/BIM/InitGui.py
+++ b/src/Mod/BIM/InitGui.py
@@ -614,9 +614,14 @@ class BIMWorkbench(Workbench):
 
         import BimSelect
 
-        if hasattr(FreeCADGui, "addDocumentObserver") and not hasattr(self, "BimSelectObserver"):
-            self.BimSelectObserver = BimSelect.Setup()
-            FreeCADGui.addDocumentObserver(self.BimSelectObserver)
+        if hasattr(FreeCADGui, "addDocumentObserver"):
+            runtime = Gui.workbenchRuntime(self.__class__.__name__)
+            setup = BimSelect.Setup()
+            runtime.addDocumentObserver(setup)
+            runtime.own(BimSelect.SETUP_RUNTIME_KEY, setup, setup.dispose)
+            active_document = getattr(FreeCADGui, "ActiveDocument", None)
+            if active_document:
+                setup.slotActivateDocument(active_document)
 
     def Activated(self):
 
@@ -627,6 +632,7 @@ class BIMWorkbench(Workbench):
         from draftutils import grid_observer
 
         PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
+        runtime = Gui.workbenchRuntime(self.__class__.__name__)
 
         if hasattr(FreeCADGui, "draftToolBar"):
             FreeCADGui.draftToolBar.Activated()
@@ -650,7 +656,6 @@ class BIMWorkbench(Workbench):
         if PARAMS.GetBool("FirstTime", True) and (not hasattr(FreeCAD, "TestEnvironment")):
             todo.ToDo.delay(FreeCADGui.runCommand, "BIM_Welcome")
         todo.ToDo.delay(BimStatus.setStatusIcons, True)
-        FreeCADGui.Control.clearTaskWatcher()
 
         class BimWatcher:
             def __init__(self, cmds, name, invert=False):
@@ -668,7 +673,7 @@ class BIMWorkbench(Workbench):
                         not FreeCADGui.Selection.getSelection()
                     )
 
-        FreeCADGui.Control.addTaskWatcher(
+        runtime.setTaskWatcher(
             [
                 BimWatcher(self.draftingtools + self.annotationtools, "2D Geometry"),
                 BimWatcher(self.bimtools, "3D/BIM Geometry"),
@@ -703,12 +708,7 @@ class BIMWorkbench(Workbench):
                     {"insert": "BIM_Welcome", "menuItem": "Std_ReportBug", "after": ""},
                 ]
 
-        reload = hasattr(Gui, "BIM_WBManipulator")  # BIM WB has previously been loaded.
-        if not getattr(Gui, "BIM_WBManipulator", None):
-            Gui.BIM_WBManipulator = BIM_WBManipulator()
-        Gui.addWorkbenchManipulator(Gui.BIM_WBManipulator)
-        if reload:
-            Gui.activeWorkbench().reloadActive()
+        runtime.addWorkbenchManipulator(BIM_WBManipulator(), refresh=True)
 
         Log("BIM workbench activated\n")
 
@@ -722,10 +722,7 @@ class BIMWorkbench(Workbench):
         from draftutils import grid_observer
 
         PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/BIM")
-
-        if hasattr(self, "BimSelectObserver"):
-            FreeCADGui.removeDocumentObserver(self.BimSelectObserver)
-            del self.BimSelectObserver
+        Gui.disposeWorkbenchRuntime(self.__class__.__name__)
 
         if hasattr(FreeCADGui, "draftToolBar"):
             FreeCADGui.draftToolBar.Deactivated()
@@ -738,7 +735,6 @@ class BIMWorkbench(Workbench):
 
         # print("Deactivating status icon")
         todo.ToDo.delay(BimStatus.setStatusIcons, False)
-        FreeCADGui.Control.clearTaskWatcher()
 
         # store views widget state and vertical size
         w = BimViews.findWidget()
@@ -758,12 +754,6 @@ class BIMWorkbench(Workbench):
             ifc_status.toggle_lock(False)
         except:
             pass
-
-        # remove manipulator
-        if hasattr(Gui, "BIM_WBManipulator"):
-            Gui.removeWorkbenchManipulator(Gui.BIM_WBManipulator)
-            Gui.BIM_WBManipulator = None
-            Gui.activeWorkbench().reloadActive()
 
         Log("BIM workbench deactivated\n")
 
@@ -847,6 +837,6 @@ FreeCADGui.addPreferencePage(":/ui/preferences-sh3d-import.ui", t)
 FreeCADGui.addPreferencePage(":/ui/preferences-webgl.ui", t)
 
 # Add unit tests
-FreeCAD.__unit_test__ += ["TestArchGui"]
+FreeCAD.__unit_test__ += ["TestArchGui", "TestArchReloadGui"]
 # The NativeIFC tests require internet connection and file download
 # FreeCAD.__unit_test__ += ["nativeifc.ifc_selftest"]

--- a/src/Mod/BIM/TestArchReloadGui.py
+++ b/src/Mod/BIM/TestArchReloadGui.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2026 OpenAI                                             *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation; either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# ***************************************************************************
+
+"""Top-level BIM GUI reload regression test entry point."""
+
+from bimtests.TestArchReloadGui import TestArchReloadGui

--- a/src/Mod/BIM/TestArchReloadGui.py
+++ b/src/Mod/BIM/TestArchReloadGui.py
@@ -24,4 +24,6 @@
 
 """Top-level BIM GUI reload regression test entry point."""
 
-from bimtests.TestArchReloadGui import TestArchReloadGui
+from bimtests.TestArchReloadGui import TestArchReloadGui as _TestArchReloadGui
+
+TestArchReloadGui = _TestArchReloadGui

--- a/src/Mod/BIM/bimcommands/BimRebar.py
+++ b/src/Mod/BIM/bimcommands/BimRebar.py
@@ -85,13 +85,14 @@ class Arch_Rebar:
                     # we have only a structure: open the sketcher
                     FreeCADGui.activateWorkbench("SketcherWorkbench")
                     FreeCADGui.runCommand("Sketcher_NewSketch")
-                    FreeCAD.ArchObserver = ArchComponent.ArchSelectionObserver(
-                        obj,
-                        FreeCAD.ActiveDocument.Objects[-1],
-                        hide=False,
-                        nextCommand="Arch_Rebar",
+                    ArchComponent.startSelectionSession(
+                        ArchComponent.ArchSelectionObserver(
+                            obj,
+                            FreeCAD.ActiveDocument.Objects[-1],
+                            hide=False,
+                            nextCommand="Arch_Rebar",
+                        )
                     )
-                    FreeCADGui.Selection.addObserver(FreeCAD.ArchObserver)
                     return
             elif hasattr(obj, "Shape"):
                 if len(obj.Shape.Wires) == 1:
@@ -117,8 +118,9 @@ class Arch_Rebar:
         )
         FreeCADGui.Control.closeDialog()
         FreeCADGui.Control.showDialog(ArchComponent.SelectionTaskPanel())
-        FreeCAD.ArchObserver = ArchComponent.ArchSelectionObserver(nextCommand="Arch_Rebar")
-        FreeCADGui.Selection.addObserver(FreeCAD.ArchObserver)
+        ArchComponent.startSelectionSession(
+            ArchComponent.ArchSelectionObserver(nextCommand="Arch_Rebar")
+        )
 
 
 FreeCADGui.addCommand("Arch_Rebar", Arch_Rebar())

--- a/src/Mod/BIM/bimcommands/BimRoof.py
+++ b/src/Mod/BIM/bimcommands/BimRoof.py
@@ -92,8 +92,9 @@ class Arch_Roof:
         else:
             FreeCAD.Console.PrintMessage(translate("Arch", "Please select a base object") + "\n")
             FreeCADGui.Control.showDialog(ArchComponent.SelectionTaskPanel())
-            FreeCAD.ArchObserver = ArchComponent.ArchSelectionObserver(nextCommand="Arch_Roof")
-            FreeCADGui.Selection.addObserver(FreeCAD.ArchObserver)
+            ArchComponent.startSelectionSession(
+                ArchComponent.ArchSelectionObserver(nextCommand="Arch_Roof")
+            )
 
 
 FreeCADGui.addCommand("Arch_Roof", Arch_Roof())

--- a/src/Mod/BIM/bimcommands/BimSpace.py
+++ b/src/Mod/BIM/bimcommands/BimSpace.py
@@ -69,8 +69,9 @@ class Arch_Space:
         else:
             FreeCAD.Console.PrintMessage(translate("Arch", "Please select a base object") + "\n")
             FreeCADGui.Control.showDialog(ArchComponent.SelectionTaskPanel())
-            FreeCAD.ArchObserver = ArchComponent.ArchSelectionObserver(nextCommand="Arch_Space")
-            FreeCADGui.Selection.addObserver(FreeCAD.ArchObserver)
+            ArchComponent.startSelectionSession(
+                ArchComponent.ArchSelectionObserver(nextCommand="Arch_Space")
+            )
 
 
 FreeCADGui.addCommand("Arch_Space", Arch_Space())

--- a/src/Mod/BIM/bimtests/TestArchReloadGui.py
+++ b/src/Mod/BIM/bimtests/TestArchReloadGui.py
@@ -97,6 +97,7 @@ class TestArchReloadGui(TestArchBaseGui):
                 try:
                     FreeCAD.closeDocument(doc_name)
                 except Exception:
+                    # Test cleanup only: the document may already be closed.
                     pass
         finally:
             super().tearDown()

--- a/src/Mod/BIM/bimtests/TestArchReloadGui.py
+++ b/src/Mod/BIM/bimtests/TestArchReloadGui.py
@@ -1,0 +1,415 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *                                                                         *
+# *   Copyright (c) 2026 OpenAI                                             *
+# *                                                                         *
+# *   This file is part of FreeCAD.                                         *
+# *                                                                         *
+# *   FreeCAD is free software: you can redistribute it and/or modify it    *
+# *   under the terms of the GNU Lesser General Public License as           *
+# *   published by the Free Software Foundation, either version 2.1 of the  *
+# *   License, or (at your option) any later version.                       *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful, but        *
+# *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+# *   Lesser General Public License for more details.                       *
+# *                                                                         *
+# *   You should have received a copy of the GNU Lesser General Public      *
+# *   License along with FreeCAD. If not, see                               *
+# *   <https://www.gnu.org/licenses/>.                                      *
+# *                                                                         *
+# **************************************************************************
+
+"""GUI regression tests for BIM reload ownership helpers."""
+
+import importlib
+from pathlib import Path
+import sys
+import tempfile
+
+import FreeCAD
+import FreeCADGui
+
+from bimtests.TestArchBaseGui import TestArchBaseGui
+
+WORKBENCH_NAME = "BIMWorkbench"
+APP_RUNTIME_NAME = "bim_reload_gui_test_app"
+SESSION_RUNTIME_NAME = "reload_gui_test"
+
+
+class _DummyWorkbenchManipulator:
+    def modifyMenuBar(self):
+        return []
+
+    def modifyToolBars(self):
+        return []
+
+
+class _DocumentObserver:
+    def __init__(self):
+        self.created_documents = []
+
+    def slotCreatedDocument(self, doc):
+        self.created_documents.append(doc.Name)
+
+
+class _SelectionObserver:
+    def __init__(self):
+        self.events = []
+
+    def addSelection(self, document, obj, element, position):
+        self.events.append((document, obj, element))
+
+
+class _DummyGuiCommand:
+    def __init__(self, menu_text):
+        self.menu_text = menu_text
+
+    def GetResources(self):
+        return {
+            "MenuText": self.menu_text,
+            "ToolTip": self.menu_text,
+            "Pixmap": "",
+        }
+
+    def Activated(self):
+        return None
+
+
+class TestArchReloadGui(TestArchBaseGui):
+    def setUp(self):
+        super().setUp()
+        self.extra_documents = []
+        self._activate_bim_workbench()
+
+    def tearDown(self):
+        try:
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.stopPythonWorkbenchAutoReload(WORKBENCH_NAME)
+            FreeCADGui.disposeSessionRuntime(
+                SESSION_RUNTIME_NAME,
+                workbench_name=WORKBENCH_NAME,
+            )
+            FreeCAD.disposeAppRuntime(APP_RUNTIME_NAME)
+            for doc_name in reversed(self.extra_documents):
+                try:
+                    FreeCAD.closeDocument(doc_name)
+                except Exception:
+                    pass
+        finally:
+            super().tearDown()
+
+    def _activate_bim_workbench(self):
+        FreeCADGui.activateWorkbench(WORKBENCH_NAME)
+        self.pump_gui_events()
+
+    def _new_aux_document(self, suffix):
+        doc = FreeCAD.newDocument(f"{self.doc_name}_{suffix}")
+        self.extra_documents.append(doc.Name)
+        self.pump_gui_events()
+        return doc
+
+    def _close_aux_document(self, doc):
+        if doc is None:
+            return
+        doc_name = doc.Name
+        try:
+            FreeCAD.closeDocument(doc_name)
+        finally:
+            if doc_name in self.extra_documents:
+                self.extra_documents.remove(doc_name)
+        self.pump_gui_events()
+
+    def _install_reload_resources(self, workbench_cleanup, session_cleanup):
+        runtime = FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
+        runtime.addWorkbenchManipulator(
+            _DummyWorkbenchManipulator(),
+            key="reload_gui_test_manipulator",
+        )
+        runtime.own(
+            "reload_gui_test_cleanup",
+            object(),
+            lambda: workbench_cleanup.append(runtime.generation),
+        )
+
+        session = FreeCADGui.sessionRuntime(
+            SESSION_RUNTIME_NAME,
+            workbench_name=WORKBENCH_NAME,
+        )
+        observer = _SelectionObserver()
+        session.addSelectionObserver(observer, key="selection_observer")
+        session.own(
+            "reload_gui_test_cleanup",
+            object(),
+            lambda: session_cleanup.append("disposed"),
+        )
+        return runtime, session, observer
+
+    def test_python_command_reregistration_replaces_existing_command(self):
+        command_name = f"TestArchReloadGui_{self._testMethodName}"
+
+        FreeCADGui.addCommand(command_name, _DummyGuiCommand("Initial label"))
+        initial_info = FreeCADGui.Command.get(command_name).getInfo()
+        self.assertEqual(initial_info["menuText"], "Initial label")
+
+        FreeCADGui.addCommand(command_name, _DummyGuiCommand("Updated label"))
+        updated_info = FreeCADGui.Command.get(command_name).getInfo()
+        self.assertEqual(updated_info["menuText"], "Updated label")
+
+    def test_generic_active_workbench_reload_commands_are_available(self):
+        self.assertTrue(FreeCADGui.canReloadPythonWorkbench(WORKBENCH_NAME))
+        self.assertTrue(FreeCADGui.isCommandActive("Std_ReloadActivePythonWorkbench"))
+        self.assertTrue(FreeCADGui.isCommandActive("Std_ToggleActivePythonWorkbenchAutoReload"))
+
+        reload_info = FreeCADGui.Command.get("Std_ReloadActivePythonWorkbench").getInfo()
+        toggle_info = FreeCADGui.Command.get("Std_ToggleActivePythonWorkbenchAutoReload").getInfo()
+        self.assertEqual(reload_info["menuText"], "Reload Active Python Workbench")
+        self.assertEqual(
+            toggle_info["menuText"],
+            "Toggle Active Python Workbench Auto Reload",
+        )
+
+    def test_auto_reload_accepts_workbench_aliases(self):
+        alias = getattr(FreeCADGui.getWorkbench(WORKBENCH_NAME), "MenuText", None)
+        if not alias or alias == WORKBENCH_NAME:
+            self.skipTest("Workbench does not expose a distinct alias")
+
+        FreeCADGui.startPythonWorkbenchAutoReload(alias, debounce_ms=50)
+        self.assertTrue(FreeCADGui.isPythonWorkbenchAutoReloadActive(alias))
+        self.assertTrue(FreeCADGui.isPythonWorkbenchAutoReloadActive(WORKBENCH_NAME))
+        self.assertTrue(FreeCADGui.stopPythonWorkbenchAutoReload(alias))
+        self.assertFalse(FreeCADGui.isPythonWorkbenchAutoReloadActive(WORKBENCH_NAME))
+
+    def test_reload_cleans_cyclic_selection_view_callbacks(self):
+        import BimSelect
+
+        runtime = FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
+        setup = runtime.getOwned(BimSelect.SETUP_RUNTIME_KEY)
+        self.assertIsNotNone(setup)
+
+        active_document = getattr(FreeCADGui, "ActiveDocument", None)
+        self.assertIsNotNone(active_document)
+        callback_count_before = setup.activeCallbackCount()
+        setup.slotActivateDocument(active_document)
+        callback_count_after_first_attach = setup.activeCallbackCount()
+        self.assertGreaterEqual(callback_count_after_first_attach, callback_count_before)
+        self.assertLessEqual(callback_count_after_first_attach, callback_count_before + 2)
+
+        setup.slotActivateDocument(active_document)
+        self.assertEqual(setup.activeCallbackCount(), callback_count_after_first_attach)
+
+        FreeCADGui.reloadPythonWorkbench(WORKBENCH_NAME)
+        self.pump_gui_events()
+
+        self.assertEqual(setup.activeCallbackCount(), 0)
+
+    def test_reload_rebinds_status_widget_controls(self):
+        from PySide import QtGui
+
+        statuswidget = (
+            FreeCADGui.getMainWindow()
+            .statusBar()
+            .findChild(
+                QtGui.QToolBar,
+                "BIMStatusWidget",
+            )
+        )
+        self.assertIsNotNone(statuswidget)
+        old_lock_button = getattr(statuswidget, "lock_button", None)
+        old_propertybuttons = getattr(statuswidget, "propertybuttons", None)
+        self.assertIsNotNone(old_lock_button)
+        self.assertIsNotNone(old_propertybuttons)
+
+        FreeCADGui.reloadPythonWorkbench(WORKBENCH_NAME)
+        self.pump_gui_events()
+
+        statuswidget = (
+            FreeCADGui.getMainWindow()
+            .statusBar()
+            .findChild(
+                QtGui.QToolBar,
+                "BIMStatusWidget",
+            )
+        )
+        self.assertIsNotNone(statuswidget)
+        self.assertIsNot(old_lock_button, getattr(statuswidget, "lock_button", None))
+        self.assertIsNot(
+            old_propertybuttons,
+            getattr(statuswidget, "propertybuttons", None),
+        )
+
+    def test_reload_refreshes_nativeifc_document_observer(self):
+        fake_ifcopenshell = None
+        imported_ifcopenshell = None
+        runtime = FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                fake_ifcopenshell = Path(tmpdir) / "ifcopenshell.py"
+                fake_ifcopenshell.write_text("version = '0.0'\n", encoding="utf-8")
+                sys.path.insert(0, tmpdir)
+                importlib.invalidate_caches()
+
+                nativeifc = importlib.import_module("nativeifc")
+                nativeifc.invalidate_ifcopenshell_cache()
+                ifc_observer = importlib.import_module("nativeifc.ifc_observer")
+                ifc_observer.add_observer()
+
+                old_observer = runtime.getOwned(ifc_observer.OBSERVER_KEY)
+                self.assertIsNotNone(old_observer)
+
+                FreeCADGui.reloadPythonWorkbench(WORKBENCH_NAME)
+                self.pump_gui_events()
+
+                imported_ifcopenshell = importlib.import_module("nativeifc")
+                imported_ifcopenshell.invalidate_ifcopenshell_cache()
+                reloaded_ifc_observer = importlib.import_module("nativeifc.ifc_observer")
+                reloaded_runtime = FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
+                new_observer = reloaded_runtime.getOwned(reloaded_ifc_observer.OBSERVER_KEY)
+                self.assertIsNotNone(new_observer)
+                self.assertIsNot(old_observer, new_observer)
+
+                reloaded_ifc_observer.remove_observer()
+        finally:
+            if fake_ifcopenshell is not None and str(fake_ifcopenshell.parent) in sys.path:
+                sys.path.remove(str(fake_ifcopenshell.parent))
+            importlib.invalidate_caches()
+            if imported_ifcopenshell is not None:
+                imported_ifcopenshell.invalidate_ifcopenshell_cache()
+
+    def test_reload_preserves_runtime_boundaries_without_leaks(self):
+        app_cleanup = []
+        workbench_cleanup = []
+        session_cleanup = []
+
+        app_runtime = FreeCAD.appRuntime(APP_RUNTIME_NAME)
+        app_observer = _DocumentObserver()
+        app_runtime.addDocumentObserver(app_observer, key="observer")
+        app_runtime.own("cleanup", object(), lambda: app_cleanup.append("disposed"))
+
+        aux_doc = self._new_aux_document("AppObserver")
+        self.assertIn(aux_doc.Name, app_observer.created_documents)
+        self._close_aux_document(aux_doc)
+        self._activate_bim_workbench()
+
+        runtime, _session, selection_observer = self._install_reload_resources(
+            workbench_cleanup,
+            session_cleanup,
+        )
+        initial_generation = runtime.generation
+
+        box = self.document.addObject("Part::Box", "ReloadRuntimeBox")
+        self.document.recompute()
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(box)
+        self.pump_gui_events()
+        self.assertEqual(len(selection_observer.events), 1)
+
+        for reload_index in range(2):
+            FreeCADGui.reloadPythonWorkbench(WORKBENCH_NAME)
+            self.pump_gui_events()
+
+            self.assertIsNotNone(FreeCAD.findAppRuntime(APP_RUNTIME_NAME))
+            self.assertIsNone(
+                FreeCADGui.findSessionRuntime(
+                    SESSION_RUNTIME_NAME,
+                    workbench_name=WORKBENCH_NAME,
+                )
+            )
+            self.assertEqual(len(workbench_cleanup), reload_index + 1)
+            self.assertEqual(len(session_cleanup), reload_index + 1)
+
+            aux_doc = self._new_aux_document(f"Reload{reload_index}")
+            self.assertIn(aux_doc.Name, app_observer.created_documents)
+            self._close_aux_document(aux_doc)
+            self._activate_bim_workbench()
+
+            reloaded_runtime = FreeCADGui.findWorkbenchRuntime(WORKBENCH_NAME)
+            self.assertIsNotNone(reloaded_runtime)
+            self.assertGreater(reloaded_runtime.generation, initial_generation)
+            initial_generation = reloaded_runtime.generation
+
+            if reload_index == 0:
+                _runtime, _session, selection_observer = self._install_reload_resources(
+                    workbench_cleanup,
+                    session_cleanup,
+                )
+                FreeCADGui.Selection.clearSelection()
+                FreeCADGui.Selection.addSelection(box)
+                self.pump_gui_events()
+                self.assertEqual(len(selection_observer.events), 1)
+
+        created_before_dispose = list(app_observer.created_documents)
+        self.assertTrue(FreeCAD.disposeAppRuntime(APP_RUNTIME_NAME))
+        self.assertEqual(app_cleanup, ["disposed"])
+        self.assertIsNone(FreeCAD.findAppRuntime(APP_RUNTIME_NAME))
+
+        aux_doc = self._new_aux_document("AfterDispose")
+        self._close_aux_document(aux_doc)
+        self.assertEqual(created_before_dispose, app_observer.created_documents)
+
+    def test_reload_reimports_legacy_top_level_bim_modules(self):
+        original_module = importlib.import_module("BimSelect")
+
+        removed = FreeCADGui.reloadPythonWorkbench(WORKBENCH_NAME)
+        self.pump_gui_events()
+
+        self.assertIn("BimSelect", removed)
+        reloaded_module = importlib.import_module("BimSelect")
+        self.assertIsNot(original_module, reloaded_module)
+
+    def test_watch_path_builder_excludes_only_requested_subtrees(self):
+        watch_path_builder = FreeCADGui.reloadPythonWorkbench.__globals__[
+            "_iter_watch_paths_for_base"
+        ]
+        excluded_dirs = FreeCADGui.reloadPythonWorkbench.__globals__[
+            "_DIR_MOD_AUTO_RELOAD_EXCLUDED_DIRS"
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_path = Path(tmpdir)
+            (base_path / "InitGui.py").write_text("# test\n", encoding="utf-8")
+            (base_path / "bimcommands").mkdir()
+            (base_path / "bimcommands" / "BimReloadWorkbench.py").write_text(
+                "# test\n",
+                encoding="utf-8",
+            )
+            (base_path / "Resources").mkdir()
+            (base_path / "Resources" / "translations").mkdir()
+            (base_path / "Resources" / "translations" / "BIM.ts").write_text(
+                "<TS/>\n",
+                encoding="utf-8",
+            )
+            (base_path / "__pycache__").mkdir()
+            (base_path / "__pycache__" / "BimSelect.pyc").write_text("", encoding="utf-8")
+            (base_path / "build").mkdir()
+            (base_path / "build" / "scratch.py").write_text("# test\n", encoding="utf-8")
+            (base_path / "icons").mkdir()
+            (base_path / "icons" / "BIM.svg").write_text("<svg/>\n", encoding="utf-8")
+
+            watched = set(
+                watch_path_builder(
+                    base_path,
+                    {".py", ".svg"},
+                    excluded_dirs,
+                )
+            )
+
+            self.assertIn(str(base_path.resolve()), watched)
+            self.assertIn(str((base_path / "InitGui.py").resolve()), watched)
+            self.assertIn(str((base_path / "bimcommands").resolve()), watched)
+            self.assertIn(
+                str((base_path / "bimcommands" / "BimReloadWorkbench.py").resolve()), watched
+            )
+            self.assertIn(str((base_path / "Resources").resolve()), watched)
+            self.assertIn(str((base_path / "icons" / "BIM.svg").resolve()), watched)
+            self.assertNotIn(str((base_path / "Resources" / "translations").resolve()), watched)
+            self.assertNotIn(
+                str((base_path / "Resources" / "translations" / "BIM.ts").resolve()),
+                watched,
+            )
+            self.assertNotIn(str((base_path / "__pycache__").resolve()), watched)
+            self.assertNotIn(str((base_path / "build").resolve()), watched)
+            self.assertNotIn(str((base_path / "build" / "scratch.py").resolve()), watched)

--- a/src/Mod/BIM/nativeifc/__init__.py
+++ b/src/Mod/BIM/nativeifc/__init__.py
@@ -1,0 +1,51 @@
+"""Shared NativeIFC availability helpers."""
+
+import importlib.util
+
+import FreeCAD
+
+translate = FreeCAD.Qt.translate
+
+_has_ifcopenshell = None
+_reported_missing_ifcopenshell = False
+
+
+def invalidate_ifcopenshell_cache():
+    """Clears the cached ifcopenshell availability state."""
+
+    global _has_ifcopenshell, _reported_missing_ifcopenshell
+
+    _has_ifcopenshell = None
+    _reported_missing_ifcopenshell = False
+
+
+def has_ifcopenshell(report=False):
+    """Returns True when ifcopenshell is importable in this runtime."""
+
+    global _has_ifcopenshell
+
+    if _has_ifcopenshell is None:
+        _has_ifcopenshell = importlib.util.find_spec("ifcopenshell") is not None
+
+    if report and not _has_ifcopenshell:
+        report_missing_ifcopenshell()
+
+    return _has_ifcopenshell
+
+
+def report_missing_ifcopenshell():
+    """Reports the missing ifcopenshell dependency once per runtime."""
+
+    global _reported_missing_ifcopenshell
+
+    if _reported_missing_ifcopenshell:
+        return
+
+    FreeCAD.Console.PrintError(
+        translate(
+            "BIM",
+            "IfcOpenShell was not found on this system. IFC support is disabled",
+        )
+        + "\n"
+    )
+    _reported_missing_ifcopenshell = True

--- a/src/Mod/BIM/nativeifc/__init__.py
+++ b/src/Mod/BIM/nativeifc/__init__.py
@@ -6,39 +6,35 @@ import FreeCAD
 
 translate = FreeCAD.Qt.translate
 
-_has_ifcopenshell = None
-_reported_missing_ifcopenshell = False
+_ifcopenshell_state = {
+    "available": None,
+    "reported_missing": False,
+}
 
 
 def invalidate_ifcopenshell_cache():
     """Clears the cached ifcopenshell availability state."""
 
-    global _has_ifcopenshell, _reported_missing_ifcopenshell
-
-    _has_ifcopenshell = None
-    _reported_missing_ifcopenshell = False
+    _ifcopenshell_state["available"] = None
+    _ifcopenshell_state["reported_missing"] = False
 
 
 def has_ifcopenshell(report=False):
     """Returns True when ifcopenshell is importable in this runtime."""
 
-    global _has_ifcopenshell
+    if _ifcopenshell_state["available"] is None:
+        _ifcopenshell_state["available"] = importlib.util.find_spec("ifcopenshell") is not None
 
-    if _has_ifcopenshell is None:
-        _has_ifcopenshell = importlib.util.find_spec("ifcopenshell") is not None
-
-    if report and not _has_ifcopenshell:
+    if report and not _ifcopenshell_state["available"]:
         report_missing_ifcopenshell()
 
-    return _has_ifcopenshell
+    return _ifcopenshell_state["available"]
 
 
 def report_missing_ifcopenshell():
     """Reports the missing ifcopenshell dependency once per runtime."""
 
-    global _reported_missing_ifcopenshell
-
-    if _reported_missing_ifcopenshell:
+    if _ifcopenshell_state["reported_missing"]:
         return
 
     FreeCAD.Console.PrintError(
@@ -48,4 +44,4 @@ def report_missing_ifcopenshell():
         )
         + "\n"
     )
-    _reported_missing_ifcopenshell = True
+    _ifcopenshell_state["reported_missing"] = True

--- a/src/Mod/BIM/nativeifc/ifc_observer.py
+++ b/src/Mod/BIM/nativeifc/ifc_observer.py
@@ -43,7 +43,7 @@ def _get_observer_runtime(create=False):
         if create:
             return FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
         return FreeCADGui.findWorkbenchRuntime(WORKBENCH_NAME)
-    except Exception:
+    except RuntimeError:
         return None
 
 

--- a/src/Mod/BIM/nativeifc/ifc_observer.py
+++ b/src/Mod/BIM/nativeifc/ifc_observer.py
@@ -25,23 +25,59 @@
 """Document observer to act on documents containing NativeIFC objects"""
 
 import FreeCAD
+from . import has_ifcopenshell
 
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/NativeIFC")
+WORKBENCH_NAME = "BIMWorkbench"
+LEGACY_APP_RUNTIME_NAME = "nativeifc"
+OBSERVER_KEY = "nativeifc_document_observer"
+
+
+def _get_observer_runtime(create=False):
+    if not FreeCAD.GuiUp:
+        return None
+
+    import FreeCADGui
+
+    getter = getattr(FreeCADGui, "workbenchRuntime" if create else "findWorkbenchRuntime", None)
+    if getter is None:
+        return None
+    try:
+        return getter(WORKBENCH_NAME)
+    except Exception:
+        return None
+
+
+def _remove_document_observer(observer):
+    try:
+        FreeCAD.removeDocumentObserver(observer)
+    except Exception:
+        pass
 
 
 def add_observer():
     """Adds this observer to the running FreeCAD instance"""
 
-    FreeCAD.BIMobserver = ifc_observer()
-    FreeCAD.addDocumentObserver(FreeCAD.BIMobserver)
+    if not has_ifcopenshell(report=True):
+        return
+
+    runtime = _get_observer_runtime(create=True)
+    if runtime is None:
+        return
+
+    runtime.release(OBSERVER_KEY)
+    observer = ifc_observer()
+    FreeCAD.addDocumentObserver(observer)
+    runtime.own(OBSERVER_KEY, observer, lambda: _remove_document_observer(observer))
 
 
 def remove_observer():
     """Removes this observer if present"""
 
-    if hasattr(FreeCAD, "BIMobserver"):
-        FreeCAD.removeDocumentObserver(FreeCAD.BIMobserver)
-        del FreeCAD.BIMobserver
+    runtime = _get_observer_runtime(create=False)
+    if runtime is not None:
+        runtime.release(OBSERVER_KEY)
+    FreeCAD.disposeAppRuntime(LEGACY_APP_RUNTIME_NAME)
 
 
 class ifc_observer:
@@ -55,6 +91,8 @@ class ifc_observer:
 
     def slotStartSaveDocument(self, doc, value):
         """Save all IFC documents in this doc"""
+        if not has_ifcopenshell():
+            return
 
         from PySide import QtCore  # lazy loading
 
@@ -66,6 +104,8 @@ class ifc_observer:
 
     def slotDeletedObject(self, obj):
         """Deletes the corresponding object in the IFC document"""
+        if not has_ifcopenshell():
+            return
 
         from . import ifc_tools  # lazy loading
 
@@ -80,6 +120,8 @@ class ifc_observer:
 
     def slotChangedDocument(self, doc, prop):
         """Watch document IFC properties"""
+        if not has_ifcopenshell():
+            return
 
         # only look at locked IFC documents
         if "IfcFilePath" not in doc.PropertiesList:
@@ -107,6 +149,8 @@ class ifc_observer:
 
     def slotCreatedObject(self, obj):
         """If this is an IFC document, turn the object into IFC"""
+        if not has_ifcopenshell():
+            return
 
         doc = getattr(obj, "Document", None)
         if doc:
@@ -120,12 +164,16 @@ class ifc_observer:
 
     def slotActivateDocument(self, doc):
         """Check if we need to lock"""
+        if not has_ifcopenshell():
+            return
 
         from . import ifc_status
 
         ifc_status.on_activate()
 
     def slotRemoveDynamicProperty(self, obj, prop):
+        if not has_ifcopenshell():
+            return
 
         from . import ifc_psets
 
@@ -143,6 +191,8 @@ class ifc_observer:
 
     def save(self):
         """Saves all IFC documents contained in self.docname Document"""
+        if not has_ifcopenshell():
+            return
 
         if not hasattr(self, "docname"):
             return
@@ -185,6 +235,8 @@ class ifc_observer:
 
     def convert(self):
         """Converts an object to IFC"""
+        if not has_ifcopenshell():
+            return
 
         if not hasattr(self, "objname") or not hasattr(self, "docname"):
             return

--- a/src/Mod/BIM/nativeifc/ifc_observer.py
+++ b/src/Mod/BIM/nativeifc/ifc_observer.py
@@ -51,6 +51,7 @@ def _remove_document_observer(observer):
     try:
         FreeCAD.removeDocumentObserver(observer)
     except Exception:
+        # Best-effort cleanup: the observer may already be detached.
         pass
 
 

--- a/src/Mod/BIM/nativeifc/ifc_observer.py
+++ b/src/Mod/BIM/nativeifc/ifc_observer.py
@@ -39,11 +39,10 @@ def _get_observer_runtime(create=False):
 
     import FreeCADGui
 
-    getter = getattr(FreeCADGui, "workbenchRuntime" if create else "findWorkbenchRuntime", None)
-    if getter is None:
-        return None
     try:
-        return getter(WORKBENCH_NAME)
+        if create:
+            return FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
+        return FreeCADGui.findWorkbenchRuntime(WORKBENCH_NAME)
     except Exception:
         return None
 

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -29,6 +29,8 @@ from packaging.version import Version
 import FreeCAD
 import FreeCADGui
 from addonmanager_utilities import create_pip_call
+from . import has_ifcopenshell
+from . import invalidate_ifcopenshell_cache
 
 translate = FreeCAD.Qt.translate
 QT_TRANSLATE_NOOP = FreeCAD.Qt.QT_TRANSLATE_NOOP
@@ -123,6 +125,15 @@ class IFC_UpdateIOS:
         ]
         result = self.run_pip(args)
         QtGui.QApplication.restoreOverrideCursor()
+        if result and result.returncode == 0:
+            invalidate_ifcopenshell_cache()
+            if has_ifcopenshell():
+                try:
+                    from . import ifc_observer
+
+                    ifc_observer.add_observer()
+                except Exception:
+                    pass
         return result
 
     def run_pip(self, args):

--- a/src/Mod/BIM/nativeifc/ifc_openshell.py
+++ b/src/Mod/BIM/nativeifc/ifc_openshell.py
@@ -133,6 +133,7 @@ class IFC_UpdateIOS:
 
                     ifc_observer.add_observer()
                 except Exception:
+                    # Best-effort refresh: observer installation should not hide pip success.
                     pass
         return result
 

--- a/src/Mod/BIM/nativeifc/ifc_status.py
+++ b/src/Mod/BIM/nativeifc/ifc_status.py
@@ -81,6 +81,7 @@ def set_properties_editor(statuswidget):
             statuswidget.propertybuttons.hide()
             statuswidget.propertybuttons.deleteLater()
         except Exception:
+            # Best-effort cleanup: the old property widget may already be gone.
             pass
         del statuswidget.propertybuttons
 

--- a/src/Mod/BIM/nativeifc/ifc_status.py
+++ b/src/Mod/BIM/nativeifc/ifc_status.py
@@ -44,7 +44,7 @@ def _get_bim_runtime(create=False):
         if create:
             return FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
         return FreeCADGui.findWorkbenchRuntime(WORKBENCH_NAME)
-    except Exception:
+    except RuntimeError:
         return None
 
 

--- a/src/Mod/BIM/nativeifc/ifc_status.py
+++ b/src/Mod/BIM/nativeifc/ifc_status.py
@@ -40,11 +40,10 @@ IFC_SAVE_SHORTCUT_KEY = "ifc_save_shortcut"
 
 
 def _get_bim_runtime(create=False):
-    getter = getattr(FreeCADGui, "workbenchRuntime" if create else "findWorkbenchRuntime", None)
-    if getter is None:
-        return None
     try:
-        return getter(WORKBENCH_NAME)
+        if create:
+            return FreeCADGui.workbenchRuntime(WORKBENCH_NAME)
+        return FreeCADGui.findWorkbenchRuntime(WORKBENCH_NAME)
     except Exception:
         return None
 

--- a/src/Mod/BIM/nativeifc/ifc_status.py
+++ b/src/Mod/BIM/nativeifc/ifc_status.py
@@ -34,6 +34,19 @@ translate = FreeCAD.Qt.translate
 PARAMS = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/NativeIFC")
 text_on = translate("BIM", "Strict IFC mode is ON (all objects are IFC)")
 text_off = translate("BIM", "Strict IFC mode is OFF (IFC and non-IFC objects allowed)")
+WORKBENCH_NAME = "BIMWorkbench"
+IFC_MENU_MANIPULATOR_KEY = "ifc_menu_manipulator"
+IFC_SAVE_SHORTCUT_KEY = "ifc_save_shortcut"
+
+
+def _get_bim_runtime(create=False):
+    getter = getattr(FreeCADGui, "workbenchRuntime" if create else "findWorkbenchRuntime", None)
+    if getter is None:
+        return None
+    try:
+        return getter(WORKBENCH_NAME)
+    except Exception:
+        return None
 
 
 def set_status_widget(statuswidget):
@@ -65,33 +78,38 @@ def set_properties_editor(statuswidget):
     """Adds additional buttons to the properties editor"""
 
     if hasattr(statuswidget, "propertybuttons"):
-        statuswidget.propertybuttons.show()
-    else:
-        from PySide import QtCore, QtGui  # lazy loading
+        try:
+            statuswidget.propertybuttons.hide()
+            statuswidget.propertybuttons.deleteLater()
+        except Exception:
+            pass
+        del statuswidget.propertybuttons
 
-        mw = FreeCADGui.getMainWindow()
-        editor = mw.findChild(QtGui.QTabWidget, "propertyTab")
-        if editor:
-            pTabCornerWidget = QtGui.QWidget()
-            pButton1 = QtGui.QToolButton(pTabCornerWidget)
-            pButton1.setText("")
-            pButton1.setToolTip(translate("BIM", "Add IFC property..."))
-            pButton1.setIcon(QtGui.QIcon(":/icons/IFC.svg"))
-            pButton1.clicked.connect(on_add_property)
-            pButton2 = QtGui.QToolButton(pTabCornerWidget)
-            pButton2.setText("")
-            pButton2.setToolTip(translate("BIM", "Add standard IFC Property Set..."))
-            pButton2.setIcon(QtGui.QIcon(":/icons/BIM_IfcProperties.svg"))
-            pButton2.clicked.connect(on_add_pset)
-            pHLayout = QtGui.QHBoxLayout(pTabCornerWidget)
-            pHLayout.addWidget(pButton1)
-            pHLayout.addWidget(pButton2)
-            pHLayout.setSpacing(2)
-            pHLayout.setContentsMargins(2, 2, 0, 0)
-            pHLayout.insertStretch(0)
-            editor.setCornerWidget(pTabCornerWidget, QtCore.Qt.BottomRightCorner)
-            statuswidget.propertybuttons = pTabCornerWidget
-            QtCore.QTimer.singleShot(0, pTabCornerWidget.show)
+    from PySide import QtCore, QtGui  # lazy loading
+
+    mw = FreeCADGui.getMainWindow()
+    editor = mw.findChild(QtGui.QTabWidget, "propertyTab")
+    if editor:
+        pTabCornerWidget = QtGui.QWidget()
+        pButton1 = QtGui.QToolButton(pTabCornerWidget)
+        pButton1.setText("")
+        pButton1.setToolTip(translate("BIM", "Add IFC property..."))
+        pButton1.setIcon(QtGui.QIcon(":/icons/IFC.svg"))
+        pButton1.clicked.connect(on_add_property)
+        pButton2 = QtGui.QToolButton(pTabCornerWidget)
+        pButton2.setText("")
+        pButton2.setToolTip(translate("BIM", "Add standard IFC Property Set..."))
+        pButton2.setIcon(QtGui.QIcon(":/icons/BIM_IfcProperties.svg"))
+        pButton2.clicked.connect(on_add_pset)
+        pHLayout = QtGui.QHBoxLayout(pTabCornerWidget)
+        pHLayout.addWidget(pButton1)
+        pHLayout.addWidget(pButton2)
+        pHLayout.setSpacing(2)
+        pHLayout.setContentsMargins(2, 2, 0, 0)
+        pHLayout.insertStretch(0)
+        editor.setCornerWidget(pTabCornerWidget, QtCore.Qt.BottomRightCorner)
+        statuswidget.propertybuttons = pTabCornerWidget
+        QtCore.QTimer.singleShot(0, pTabCornerWidget.show)
 
 
 def on_add_property():
@@ -285,23 +303,33 @@ def set_menu(locked=False):
     mw = FreeCADGui.getMainWindow()
     wb = FreeCADGui.activeWorkbench()
     save_action = mw.findChild(QtGui.QAction, "Std_Save")
+    if not save_action:
+        return
     if locked and "IFC_Save" in FreeCADGui.listCommands():
-        if not hasattr(FreeCADGui, "IFC_WBManipulator"):
-            FreeCADGui.IFC_WBManipulator = IFC_WBManipulator()
-        # we need to void the shortcut otherwise it keeps active
-        # even if the command is not shown
-        FreeCADGui.IFC_saveshortcut = save_action.shortcut()
-        save_action.setShortcut("")
-        FreeCADGui.addWorkbenchManipulator(FreeCADGui.IFC_WBManipulator)
-        wb.reloadActive()
+        runtime = _get_bim_runtime(create=True)
+        if runtime is None:
+            return
+
+        changed = False
+        if not runtime.owns(IFC_SAVE_SHORTCUT_KEY):
+            # We need to void the shortcut otherwise it keeps active
+            # even if the command is not shown.
+            runtime.overrideActionShortcut(IFC_SAVE_SHORTCUT_KEY, save_action, "")
+            changed = True
+        if not runtime.owns(IFC_MENU_MANIPULATOR_KEY):
+            runtime.addWorkbenchManipulator(IFC_WBManipulator(), key=IFC_MENU_MANIPULATOR_KEY)
+            changed = True
+        if changed:
+            wb.reloadActive()
     else:
-        if hasattr(FreeCADGui, "IFC_saveshortcut"):
-            save_action.setShortcut(FreeCADGui.IFC_saveshortcut)
-            del FreeCADGui.IFC_saveshortcut
-        if hasattr(FreeCADGui, "IFC_WBManipulator"):
-            FreeCADGui.removeWorkbenchManipulator(FreeCADGui.IFC_WBManipulator)
-            del FreeCADGui.IFC_WBManipulator
-        wb.reloadActive()
+        runtime = _get_bim_runtime(create=False)
+        if runtime is None:
+            return
+
+        changed = runtime.release(IFC_SAVE_SHORTCUT_KEY)
+        changed = runtime.release(IFC_MENU_MANIPULATOR_KEY) or changed
+        if changed:
+            wb.reloadActive()
 
 
 def set_button(checked=False, setchecked=False):

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -32,6 +32,7 @@ import FreeCAD
 import Arch
 import ArchBuildingPart
 import Draft
+from . import report_missing_ifcopenshell
 
 from draftviewproviders import view_layer
 
@@ -50,15 +51,7 @@ try:
     import ifcopenshell.util.unit
     import ifcopenshell.entity_instance
 except ImportError as e:
-    import FreeCAD
-
-    FreeCAD.Console.PrintError(
-        translate(
-            "BIM",
-            "IfcOpenShell was not found on this system. IFC support is disabled",
-        )
-        + "\n"
-    )
+    report_missing_ifcopenshell()
     raise e
 
 from . import ifc_objects

--- a/src/Mod/Test/CMakeLists.txt
+++ b/src/Mod/Test/CMakeLists.txt
@@ -37,7 +37,18 @@ if(BUILD_GUI)
     list (APPEND Test_SRCS InitGui.py)
 endif(BUILD_GUI)
 
+set(Test_COPY_OUTPUTS)
+foreach(test_src ${Test_SRCS})
+    list(APPEND Test_COPY_OUTPUTS "${CMAKE_BINARY_DIR}/Mod/Test/${test_src}")
+endforeach()
+foreach(test_data_src ${TestData_SRCS})
+    list(APPEND Test_COPY_OUTPUTS "${CMAKE_BINARY_DIR}/Mod/Test/${test_data_src}")
+endforeach()
+
+add_custom_target(TestSources DEPENDS ${Test_COPY_OUTPUTS})
+
 ADD_CUSTOM_TARGET(Test ALL
+    DEPENDS TestSources
     SOURCES ${Test_SRCS} ${TestData_SRCS}
 )
 

--- a/src/Mod/Test/Gui/CMakeLists.txt
+++ b/src/Mod/Test/Gui/CMakeLists.txt
@@ -42,6 +42,12 @@ SET(TestGuiIcon_SVG
     Resources/icons/TestWorkbench.svg
 )
 
+set(TestGui_COPY_OUTPUTS
+    "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_DATADIR}/Mod/Test/Resources/icons/TestWorkbench.svg"
+)
+
+add_custom_target(TestGuiSources DEPENDS ${TestGui_COPY_OUTPUTS})
+
 add_library(QtUnitGui SHARED ${TestGui_SRCS} ${TestGuiPy_SRCS} ${TestGuiIcon_SVG})
 
 if(FREECAD_USE_PCH)
@@ -58,7 +64,7 @@ target_include_directories(
 )
 
 target_link_libraries(QtUnitGui ${TestGui_LIBS})
-add_dependencies(QtUnitGui Test)
+add_dependencies(QtUnitGui TestSources TestGuiSources)
 
 if (MSVC)
     target_compile_options(QtUnitGui PRIVATE /wd4251)

--- a/src/Mod/Test/TestApp.py
+++ b/src/Mod/Test/TestApp.py
@@ -92,6 +92,11 @@ def TestText(s):
     return retval
 
 
+def RunConfiguredTextTest():
+    test_case = FreeCAD.ConfigGet("TestCase")
+    return TestText(test_case)
+
+
 def Test(s):
     TestText(s)
 

--- a/src/Mod/Test/TestDirModLoader.py
+++ b/src/Mod/Test/TestDirModLoader.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import collections
+import collections.abc as coll_abc
+import dataclasses
+from datetime import datetime
+from enum import IntEnum
+import functools
+import importlib
+import importlib.resources as resources
+import inspect
+import os
+import pkgutil
+import platform
+import re
+import sys
+import tempfile
+import traceback
+import types
+import unittest
+from pathlib import Path
+
+import FreeCAD
+import FreeCADInitTools
+
+
+class DirModLoaderTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.mod_root = Path(self.tempdir.name) / "AuditMod"
+        self.mod_root.mkdir()
+        self.init_py = self.mod_root / "Init.py"
+        self.mod_name = f"audit_loader_{self._testMethodName}"
+        self.compat_globals = FreeCADInitTools.dir_mod_compat_globals(
+            {
+                "__builtins__": __builtins__,
+                "App": FreeCAD,
+                "FreeCAD": FreeCAD,
+                "Log": lambda *_args, **_kwargs: None,
+                "Msg": lambda *_args, **_kwargs: None,
+                "Err": lambda *_args, **_kwargs: None,
+                "Wrn": lambda *_args, **_kwargs: None,
+                "Crt": lambda *_args, **_kwargs: None,
+                "Ntf": lambda *_args, **_kwargs: None,
+                "Tnf": lambda *_args, **_kwargs: None,
+                "IntEnum": IntEnum,
+                "datetime": datetime,
+                "Path": Path,
+                "collections": collections,
+                "coll_abc": coll_abc,
+                "dataclasses": dataclasses,
+                "functools": functools,
+                "importlib": importlib,
+                "inspect": inspect,
+                "os": os,
+                "pkgutil": pkgutil,
+                "platform": platform,
+                "re": re,
+                "resources": resources,
+                "sys": sys,
+                "traceback": traceback,
+                "types": types,
+            },
+            FreeCADInitTools.DIR_MOD_APP_COMPAT_GLOBAL_NAMES,
+        )
+
+    def tearDown(self):
+        prefix = FreeCADInitTools.dir_mod_package_name(self.mod_name)
+        for module_name in list(sys.modules):
+            if module_name == prefix or module_name.startswith(f"{prefix}."):
+                sys.modules.pop(module_name, None)
+        self.tempdir.cleanup()
+
+    def test_exec_dir_mod_file_preserves_module_identity(self):
+        self.init_py.write_text(
+            "class Marker:\n" "    pass\n" "value = App is FreeCAD\n",
+            encoding="utf-8",
+        )
+
+        module = FreeCADInitTools.exec_dir_mod_file(
+            self.mod_name,
+            self.init_py,
+            self.mod_root,
+            self.compat_globals,
+        )
+        expected = FreeCADInitTools.dir_mod_module_name(
+            self.mod_name,
+            self.init_py,
+            self.mod_root,
+        )
+
+        self.assertEqual(expected, module.__name__)
+        self.assertEqual(expected, module.Marker.__module__)
+        self.assertTrue(module.value)
+
+    def test_failed_reload_restores_parent_binding(self):
+        self.init_py.write_text("VALUE = 1\n", encoding="utf-8")
+        module = FreeCADInitTools.exec_dir_mod_file(
+            self.mod_name,
+            self.init_py,
+            self.mod_root,
+            self.compat_globals,
+        )
+        expected = FreeCADInitTools.dir_mod_module_name(
+            self.mod_name,
+            self.init_py,
+            self.mod_root,
+        )
+
+        parent_name, child_name = expected.rsplit(".", 1)
+        parent = sys.modules[parent_name]
+        self.assertIs(getattr(parent, child_name), module)
+
+        self.init_py.write_text("raise RuntimeError('boom')\n", encoding="utf-8")
+        with self.assertRaises(RuntimeError):
+            FreeCADInitTools.exec_dir_mod_file(
+                self.mod_name,
+                self.init_py,
+                self.mod_root,
+                self.compat_globals,
+            )
+
+        self.assertIs(sys.modules[expected], module)
+        self.assertIs(getattr(parent, child_name), module)
+
+    def test_exec_dir_mod_file_handles_symlinked_build_tree_paths(self):
+        source_root = Path(self.tempdir.name) / "src" / "Mod" / "AuditMod"
+        build_root = Path(self.tempdir.name) / "build" / "Mod" / "AuditMod"
+        source_root.mkdir(parents=True)
+        build_root.mkdir(parents=True)
+
+        source_init = source_root / "Init.py"
+        source_init.write_text("VALUE = 1\n", encoding="utf-8")
+        build_init = build_root / "Init.py"
+        build_init.symlink_to(source_init)
+
+        module = FreeCADInitTools.exec_dir_mod_file(
+            self.mod_name,
+            build_init,
+            build_root,
+            self.compat_globals,
+        )
+        expected = FreeCADInitTools.dir_mod_module_name(
+            self.mod_name,
+            build_init,
+            build_root,
+        )
+
+        self.assertEqual(expected, module.__name__)
+        self.assertEqual(str(build_init.absolute()), module.__file__)
+
+    def test_dir_mod_module_name_accepts_source_file_with_build_root(self):
+        source_root = Path(self.tempdir.name) / "src" / "Mod" / "AuditMod"
+        build_root = Path(self.tempdir.name) / "build" / "Mod" / "AuditMod"
+        source_root.mkdir(parents=True)
+        build_root.mkdir(parents=True)
+
+        source_init = source_root / "InitGui.py"
+        source_init.write_text("VALUE = 1\n", encoding="utf-8")
+        (build_root / "InitGui.py").symlink_to(source_init)
+
+        module_name = FreeCADInitTools.dir_mod_module_name(
+            self.mod_name,
+            source_init,
+            build_root,
+        )
+
+        self.assertEqual(
+            f"{FreeCADInitTools.dir_mod_package_name(self.mod_name)}.InitGui",
+            module_name,
+        )
+
+    def test_dir_mod_base_path_accepts_source_file_with_build_root(self):
+        source_root = Path(self.tempdir.name) / "src" / "Mod" / "AuditMod"
+        build_root = Path(self.tempdir.name) / "build" / "Mod" / "AuditMod"
+        source_root.mkdir(parents=True)
+        build_root.mkdir(parents=True)
+
+        source_init_gui = source_root / "InitGui.py"
+        source_init_gui.write_text("VALUE = 1\n", encoding="utf-8")
+        (build_root / "InitGui.py").symlink_to(source_init_gui)
+
+        base_path = FreeCADInitTools.dir_mod_base_path(
+            source_init_gui,
+            build_root,
+        )
+
+        self.assertEqual(source_root.resolve(), base_path)
+
+    def test_exec_dir_mod_file_preserves_real_freecad_namespace_package(self):
+        freecad = importlib.import_module("freecad")
+        freecad_paths = tuple(freecad.__path__)
+        from freecad import module_io
+
+        self.init_py.write_text("VALUE = 1\n", encoding="utf-8")
+        FreeCADInitTools.exec_dir_mod_file(
+            self.mod_name,
+            self.init_py,
+            self.mod_root,
+            self.compat_globals,
+        )
+
+        reloaded_freecad = importlib.import_module("freecad")
+        from freecad import module_io as imported_module_io
+
+        self.assertIs(freecad, reloaded_freecad)
+        self.assertEqual(freecad_paths, tuple(reloaded_freecad.__path__))
+        self.assertIs(module_io, imported_module_io)
+        self.assertIn("freecad._dir_mods", sys.modules)
+
+    def test_runtime_compat_globals_are_curated(self):
+        self.assertIn("__builtins__", self.compat_globals)
+        self.assertIn("App", self.compat_globals)
+        self.assertIn("Log", self.compat_globals)
+        self.assertIn("inspect", self.compat_globals)
+        self.assertNotIn("exec_dir_mod_file", self.compat_globals)
+        self.assertNotIn("_ensure_dir_mod_packages", self.compat_globals)
+
+    def test_support_module_is_importable(self):
+        self.assertEqual("FreeCADInitTools", FreeCADInitTools.__name__)
+
+    def test_support_module_loads_from_library_dir(self):
+        expected = Path(FreeCAD.getLibraryDir()).resolve() / "FreeCADInitTools.py"
+        self.assertEqual(expected, Path(FreeCADInitTools.__file__).absolute())

--- a/src/Mod/Test/Workbench.py
+++ b/src/Mod/Test/Workbench.py
@@ -206,6 +206,54 @@ class WorkbenchTestCase(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             runtime.onDispose(lambda: None)
 
+    def testAppRuntimeLookupAndDisposeRoundTrip(self):
+        runtime_name = "Test_AppRuntimeLookup"
+        self.assertIsNone(FreeCAD.findAppRuntime(runtime_name))
+
+        runtime = FreeCAD.appRuntime(runtime_name)
+        self.assertIs(runtime, FreeCAD.findAppRuntime(runtime_name))
+
+        self.assertTrue(FreeCAD.disposeAppRuntime(runtime_name))
+        self.assertIsNone(FreeCAD.findAppRuntime(runtime_name))
+
+    def testRuntimeApiResolvesWorkbenchAliasNames(self):
+        import __main__
+
+        class UnitAliasWorkbench(__main__.Workbench):
+            MenuText = "Runtime Alias"
+            ToolTip = "Runtime Alias"
+
+            def Initialize(self):
+                pass
+
+            def GetClassName(self):
+                return "Gui::PythonWorkbench"
+
+        handler = UnitAliasWorkbench()
+        FreeCADGui.addWorkbench(handler)
+        self.assertTrue(FreeCADGui.activateWorkbench("UnitAliasWorkbench"))
+
+        runtime = FreeCADGui.workbenchRuntime("Runtime Alias")
+        self.assertEqual(runtime.name, "UnitAliasWorkbench")
+        self.assertIs(runtime, FreeCADGui.findWorkbenchRuntime("Runtime Alias"))
+
+        session = FreeCADGui.sessionRuntime("alias_session", workbench_name="Runtime Alias")
+        self.assertEqual(session.workbench_name, "UnitAliasWorkbench")
+        self.assertIs(
+            session,
+            FreeCADGui.findSessionRuntime("alias_session", workbench_name="Runtime Alias"),
+        )
+        self.assertIs(
+            session,
+            FreeCADGui.findSessionRuntime("UnitAliasWorkbench:alias_session"),
+        )
+
+        self.assertTrue(
+            FreeCADGui.disposeSessionRuntime("alias_session", workbench_name="Runtime Alias")
+        )
+        self.assertTrue(FreeCADGui.disposeWorkbenchRuntime("Runtime Alias"))
+        self.assertTrue(FreeCADGui.resetWorkbench("UnitAliasWorkbench"))
+
     def tearDown(self):
         FreeCADGui.activateWorkbench(self.Active.name())
         FreeCAD.Console.PrintLog(self.Active.name())

--- a/src/Mod/Test/Workbench.py
+++ b/src/Mod/Test/Workbench.py
@@ -159,6 +159,53 @@ class WorkbenchTestCase(unittest.TestCase):
         self.assertFalse(hasattr(handler, "__Workbench__"))
         self.assertNotIn("UnitReplaceResetWorkbench", FreeCADGui.listWorkbenches())
 
+    def testDisposedWorkbenchRuntimeRejectsMutation(self):
+        import __main__
+
+        class UnitRuntimeWorkbench(__main__.Workbench):
+            MenuText = "Runtime Unittest"
+            ToolTip = "Runtime Unittest"
+
+            def Initialize(self):
+                pass
+
+            def GetClassName(self):
+                return "Gui::PythonWorkbench"
+
+        handler = UnitRuntimeWorkbench()
+        session_name = "reload_test"
+        FreeCADGui.addWorkbench(handler)
+        self.assertTrue(FreeCADGui.activateWorkbench("UnitRuntimeWorkbench"))
+
+        runtime = FreeCADGui.workbenchRuntime("UnitRuntimeWorkbench")
+        session = FreeCADGui.sessionRuntime(session_name)
+        self.assertEqual(session.workbench_name, "UnitRuntimeWorkbench")
+        self.assertIs(session, FreeCADGui.findSessionRuntime(session_name))
+        self.assertIs(
+            session,
+            FreeCADGui.findSessionRuntime("UnitRuntimeWorkbench:reload_test"),
+        )
+
+        self.assertTrue(FreeCADGui.disposeSessionRuntime(session_name))
+        self.assertTrue(FreeCADGui.disposeWorkbenchRuntime("UnitRuntimeWorkbench"))
+
+        with self.assertRaises(RuntimeError):
+            session.own("session_key", object())
+        with self.assertRaises(RuntimeError):
+            runtime.own("workbench_key", object())
+
+        self.assertTrue(FreeCADGui.resetWorkbench("UnitRuntimeWorkbench"))
+
+    def testDisposedAppRuntimeRejectsMutation(self):
+        runtime_name = "Test_DisposedAppRuntime"
+        runtime = FreeCAD.appRuntime(runtime_name)
+        self.assertTrue(FreeCAD.disposeAppRuntime(runtime_name))
+
+        with self.assertRaises(RuntimeError):
+            runtime.own("runtime_key", object())
+        with self.assertRaises(RuntimeError):
+            runtime.onDispose(lambda: None)
+
     def tearDown(self):
         FreeCADGui.activateWorkbench(self.Active.name())
         FreeCAD.Console.PrintLog(self.Active.name())

--- a/src/Mod/Test/Workbench.py
+++ b/src/Mod/Test/Workbench.py
@@ -104,6 +104,61 @@ class WorkbenchTestCase(unittest.TestCase):
             FreeCADGui.activateWorkbench("MyExtWorkbench")
         FreeCADGui.removeWorkbench("MyExtWorkbench")
 
+    def testResetClearsStaleWorkbenchBinding(self):
+        import __main__
+
+        class UnitResetWorkbench(__main__.Workbench):
+            MenuText = "Reset Unittest"
+            ToolTip = "Reset Unittest"
+
+            def Initialize(self):
+                pass
+
+            def GetClassName(self):
+                return "Gui::PythonWorkbench"
+
+        handler = UnitResetWorkbench()
+        FreeCADGui.addWorkbench(handler)
+        self.assertFalse(hasattr(handler, "__Workbench__"))
+        self.assertTrue(FreeCADGui.activateWorkbench("UnitResetWorkbench"))
+        self.assertTrue(hasattr(handler, "__Workbench__"))
+        self.assertTrue(FreeCADGui.resetWorkbench("UnitResetWorkbench"))
+        self.assertFalse(hasattr(handler, "__Workbench__"))
+        self.assertNotIn("UnitResetWorkbench", FreeCADGui.listWorkbenches())
+
+    def testResetAfterPythonCommandReplacementDoesNotCrash(self):
+        import __main__
+
+        class UnitReplaceResetWorkbench(__main__.Workbench):
+            MenuText = "Replace Reset Unittest"
+            ToolTip = "Replace Reset Unittest"
+
+            def Initialize(self):
+                pass
+
+            def GetClassName(self):
+                return "Gui::PythonWorkbench"
+
+        class WorkingCommand:
+            def __init__(self, label):
+                self.label = label
+
+            def GetResources(self):
+                return {"MenuText": self.label}
+
+            def Activated(self):
+                pass
+
+        command_name = "Test_CommandReplacementReset"
+        handler = UnitReplaceResetWorkbench()
+        FreeCADGui.addWorkbench(handler)
+        self.assertTrue(FreeCADGui.activateWorkbench("UnitReplaceResetWorkbench"))
+        FreeCADGui.addCommand(command_name, WorkingCommand("Initial label"))
+        FreeCADGui.addCommand(command_name, WorkingCommand("Updated label"))
+        self.assertTrue(FreeCADGui.resetWorkbench("UnitReplaceResetWorkbench"))
+        self.assertFalse(hasattr(handler, "__Workbench__"))
+        self.assertNotIn("UnitReplaceResetWorkbench", FreeCADGui.listWorkbenches())
+
     def tearDown(self):
         FreeCADGui.activateWorkbench(self.Active.name())
         FreeCAD.Console.PrintLog(self.Active.name())
@@ -121,6 +176,33 @@ class CommandTestCase(unittest.TestCase):
         name = FreeCADGui.Command.createCustomCommand(macroName)
         cmd = FreeCADGui.Command.get(name)
         cmd.run()
+
+    def testPythonCommandReplacementPreservesWorkingCommandOnFailure(self):
+        command_name = "Test_CommandReplacementFailure"
+
+        class WorkingCommand:
+            def GetResources(self):
+                return {"MenuText": "Stable label"}
+
+            def Activated(self):
+                pass
+
+        class BrokenCommand:
+            def GetResources(self):
+                return []
+
+            def Activated(self):
+                pass
+
+        FreeCADGui.addCommand(command_name, WorkingCommand())
+        initial_info = FreeCADGui.Command.get(command_name).getInfo()
+        self.assertEqual(initial_info["menuText"], "Stable label")
+
+        with self.assertRaises(TypeError):
+            FreeCADGui.addCommand(command_name, BrokenCommand())
+
+        updated_info = FreeCADGui.Command.get(command_name).getInfo()
+        self.assertEqual(updated_info["menuText"], "Stable label")
 
 
 class TestNavigationStyle(unittest.TestCase):


### PR DESCRIPTION
## Summary

This draft PR adds a generic Python workbench reload/runtime layer in App/Gui and adopts it in BIM as the first consumer.

The goal is to shorten Python-side BIM iteration cycles without restarting FreeCAD, while giving workbenches explicit ownership of reload-sensitive runtime state.

## Commit stack

1. `Init: extract dir-mod loader support`
2. `Gui: add resettable Python workbench hooks`
3. `App/Gui: add Python workbench runtime and reload APIs`
4. `BIM: adopt Python workbench reload runtime`

## How reload works

For a Python workbench, reload means:

1. reset/remove the current Python workbench handler
2. dispose runtime-owned workbench/session state
3. purge the workbench's imported Python modules
4. rerun `InitGui.py`
5. reactivate the workbench when needed

This PR is about making that sequence deterministic and safe for Python-side workbench development.

## Generic changes

This series adds generic support for Python workbench reload:

- reset/remove support for Python workbenches
- Python command re-registration
- app/workbench/session runtime ownership APIs
- `FreeCAD.appRuntime(...)`, `FreeCAD.findAppRuntime(...)`, `FreeCAD.disposeAppRuntime(...)`
- `FreeCADGui.workbenchRuntime(...)`, `FreeCADGui.findWorkbenchRuntime(...)`, `FreeCADGui.disposeWorkbenchRuntime(...)`
- `FreeCADGui.sessionRuntime(...)`, `FreeCADGui.findSessionRuntime(...)`, `FreeCADGui.disposeSessionRuntime(...)`
- `FreeCADGui.reloadPythonWorkbench(...)`
- `FreeCADGui.startPythonWorkbenchAutoReload(...)`
- `FreeCADGui.stopPythonWorkbenchAutoReload(...)`
- `FreeCADGui.isPythonWorkbenchAutoReloadActive(...)`

The runtime model is the ownership boundary for reload-sensitive side effects such as:

- document observers
- selection observers
- workbench manipulators
- task watchers
- timers
- similar GUI/session state that must be disposed before reloading Python code

## Dir-mod loader changes

The dir-mod loader was also cleaned up so reload behavior is predictable:

- shared dir-mod loader support is extracted into `FreeCADInitTools.py`
- directory modules receive stable internal identities under `freecad._dir_mods.*`
- the real `freecad` namespace package is preserved
- symlinked source-build layouts are handled correctly
- init scripts use curated compatibility globals instead of replaying full script globals

The `freecad._dir_mods.*` namespace is an internal compatibility mechanism for the current `Init.py` / `InitGui.py` startup model. It is not intended as a new public package surface. The longer-term ideal remains normal importable Python packages for workbenches, but this keeps the current directory-module model reloadable without breaking existing modules.

## Why BIM

BIM is the first consumer because it has enough long-lived Python GUI state to exercise the infrastructure in realistic conditions:

- workbench and session observers
- selection flows
- task watchers
- workbench manipulators
- survey session state
- cyclic selection view callbacks
- NativeIFC observer lifecycle
- NativeIFC menu/shortcut state
- status-widget rebinding on reload

This PR targets reload-sensitive workbench/session state. It does not try to migrate every existing BIM global or every long-lived object path at once.

## Qt/UI implications

One subtle part of reload is persistent Qt state. Widgets that survive reload keep their existing signal bindings, which still point at old Python code. For that reason, BIM now rebuilds or rebinds persistent UI surfaces such as the NativeIFC status/property controls during reload instead of only reimporting their modules.

Similarly, the NativeIFC document observer is now refreshed through BIM's runtime lifecycle so edits to that code are actually picked up during reload.

## Scope

This PR is focused on Python workbench reload for developer workflows.

It does not attempt to hot-reload:

- existing live document proxies or view providers created from older Python classes
- open task or dialog sessions
- C++ changes

Existing document objects can still hold references to older Python classes, so this PR focuses on workbench/runtime state rather than object re-instantiation. Those cases still require recreating the affected state or rebuilding/restarting FreeCAD.

## Tests

Verified with:

```bash
build/bin/FreeCADCmd -P src/Mod/Test -t TestDirModLoader
build/bin/FreeCAD -P src/Mod/BIM -P src/Mod/Test -t bimtests.TestArchReloadGui
```

Test strategy is split intentionally:

- `TestDirModLoader` covers the generic loader/runtime substrate
- `bimtests.TestArchReloadGui` covers end-to-end GUI reload behavior through BIM as the first real consumer

Coverage includes:

- dir-mod loader behavior
- Python command re-registration
- workbench/session runtime cleanup across reload
- legacy top-level BIM module reimport
- auto-reload alias handling
- cyclic selection callback cleanup
- NativeIFC observer refresh on reload
- status-widget rebinding on reload
