### PR TITLE
Draft: fix arrow alignment for BezCurve and BSpline

### DIFF
--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -1141,11 +1141,19 @@ def get_svg(
             and hasattr(vobj, "ArrowTypeEnd")
             and hasattr(vobj, "ArrowSizeStart")
             and hasattr(vobj, "ArrowSizeEnd")
-            and len(obj.Shape.Vertexes) > 1
+            and len(obj.Points) > 1
         ):
-            # Draft_Wire
+            # Draft_Wire, Draft_BezCurve and Draft_BSpline.
+            shp = obj.Shape
+            if utils.get_type(obj) == "BSpline":
+                v1 = shp.tangentAt(shp.FirstParameter)
+                v2 = -shp.tangentAt(shp.LastParameter)
+            else:
+                rot = obj.Placement.Rotation
+                v1 = rot.multVec(obj.Points[1].sub(obj.Points[0]))
+                v2 = rot.multVec(obj.Points[-2].sub(obj.Points[-1]))
             p1 = get_proj(obj.Shape.Vertexes[0].Point, plane)
-            p2 = get_proj(obj.Shape.Vertexes[1].Point, plane)
+            p2 = get_proj(obj.Shape.Vertexes[0].Point + v1, plane)
             svg += get_arrow(
                 obj,
                 vobj.ArrowTypeStart,
@@ -1156,7 +1164,7 @@ def get_svg(
                 -DraftVecUtils.angle(p2 - p1),
             )
             p1 = get_proj(obj.Shape.Vertexes[-1].Point, plane)
-            p2 = get_proj(obj.Shape.Vertexes[-2].Point, plane)
+            p2 = get_proj(obj.Shape.Vertexes[-1].Point + v2, plane)
             svg += get_arrow(
                 obj,
                 vobj.ArrowTypeEnd,

--- a/src/Mod/Draft/draftviewproviders/view_wire.py
+++ b/src/Mod/Draft/draftviewproviders/view_wire.py
@@ -117,15 +117,21 @@ class ViewProviderWire(ViewProviderDraft):
             and hasattr(self, "coords1")
             and hasattr(self, "coords2")
         ):
+            if utils.get_type(obj) == "BSpline":
+                shp = obj.Shape
+                rot = obj.Placement.Rotation.inverted()
+                v1 = rot.multVec(shp.tangentAt(shp.FirstParameter))
+                v2 = -rot.multVec(shp.tangentAt(shp.LastParameter))
+            else:
+                v1 = obj.Points[1].sub(obj.Points[0])
+                v2 = obj.Points[-2].sub(obj.Points[-1])
             self.coords1.translation.setValue(*obj.Points[0])
-            v1 = obj.Points[1].sub(obj.Points[0])
             if not DraftVecUtils.isNull(v1):
                 v1.normalize()
                 rot1 = coin.SbRotation()
                 rot1.setValue(coin.SbVec3f(1, 0, 0), coin.SbVec3f(*v1))
                 self.coords1.rotation.setValue(rot1)
             self.coords2.translation.setValue(*obj.Points[-1])
-            v2 = obj.Points[-2].sub(obj.Points[-1])
             if not DraftVecUtils.isNull(v2):
                 v2.normalize()
                 rot2 = coin.SbRotation()


### PR DESCRIPTION
Reported on the forum (for Draft_BSplines):
https://forum.freecad.org/viewtopic.php?t=104532

PR to fix the faulty alignment of arrows for Draft_BezCurves (in TD DraftView; red in the images) and Draft_BSplines (in 3D View and in TD DraftView; magenta in the images).

Test file (remove the .zip extension):
[arrows.FCStd.zip](https://github.com/user-attachments/files/26609539/arrows.FCStd.zip)

## Before

<img width="1059" height="637" alt="afbeelding" src="https://github.com/user-attachments/assets/c58747ee-1218-42f5-90fc-45941978b388" />

## After

<img width="1059" height="637" alt="afbeelding" src="https://github.com/user-attachments/assets/c4a2f8c8-b32d-4934-953f-a0285da75ac5" />
