### PR TITLE
Macro: Open user defined path

### DIFF
--- a/src/Gui/CommandMacro.cpp
+++ b/src/Gui/CommandMacro.cpp
@@ -331,8 +331,11 @@ StdCmdMacrosFolder::StdCmdMacrosFolder()
 void StdCmdMacrosFolder::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-
-    QString path = QString::fromStdString(App::Application::getUserMacroDir());
+    std::string macroDir = App::GetApplication()
+                               .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
+                               ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+    std::ranges::replace(macroDir, '/', PATHSEP);
+    QString path = QString::fromStdString(macroDir);
     QUrl url = QUrl::fromLocalFile(path);
     QDesktopServices::openUrl(url);
 }

--- a/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
+++ b/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
@@ -1128,7 +1128,11 @@ void DlgMacroExecuteImp::onAddonsButtonClicked()
  */
 void DlgMacroExecuteImp::onFolderButtonClicked()
 {
-    QString path = QString::fromStdString(App::Application::getUserMacroDir());
+    std::string macroDir = App::GetApplication()
+                               .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
+                               ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+    std::ranges::replace(macroDir, '/', PATHSEP);
+    QString path = QString::fromStdString(macroDir);
     QUrl url = QUrl::fromLocalFile(path);
     QDesktopServices::openUrl(url);
 }


### PR DESCRIPTION
Open user defined path instead of default path

Touched Macro dialog and command `Std_OpenMacrosFolder`

<img width="656" height="418" alt="Screenshot_20260409_210909_lossy" src="https://github.com/user-attachments/assets/26e2e868-7cab-42bc-bd97-1acdde80a487" />

---

Code copied from

https://github.com/FreeCAD/FreeCAD/blob/94d04470a0e610fccd23051172fa2f55b23304d2/src/App/ApplicationPy.cpp#L917-L923