### PR TITLE
Part: Add missing post-build step for FaceMakerExtrusion

### DIFF
--- a/src/Mod/Part/App/FeatureExtrusion.cpp
+++ b/src/Mod/Part/App/FeatureExtrusion.cpp
@@ -474,18 +474,12 @@ void FaceMakerExtrusion::Build()
     }
 
     if (!wires.empty()) {
-        // try {
         TopoDS_Shape res = FaceMakerCheese::makeFace(wires);
         if (!res.IsNull()) {
             this->myShape = res;
         }
-        //}
-        // catch (...) {
-
-        //}
     }
-
-    this->Done();
+    postBuild();
 }
 
 void Part::Extrusion::setupObject()


### PR DESCRIPTION
The Toponaming merge inadvertently broke `FaceMakerExtrusion` by skipping the `postBuild()` step (which among other things actually stores a pointer to the toposhape, which is otherwise null). So no file that used this extrusion method has worked since the release of 1.0, up to and including 1.1.0 -- for an example, see [this trivial case](https://github.com/FreeCAD/FreeCAD-library/raw/refs/heads/master/Mechanical%20Parts/Profiles%20EN/EN10060%20Round%20steel%20bars/Round%20Bar%2045%20EN10060%20S235JR.FCStd) in the Parts library, which has 346 files that currently fail to recompute due to this bug. Of course, you *also* can't create *new* geometry that uses the "Extrusion" FaceMaker, trying that will also fail without this PR.

(Note that `this->Done()` is still happening, it's done by the code in `postBuild()`)