### PR TITLE
gui: fix crash with filedialog when selected filter not found in filter list

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -321,7 +321,6 @@ struct FilterSpec
         }
 
         QString formatted(name);
-        formatted += QLatin1Char(' ');
 
         // Deduplicate the extensions which usually come in both *.ext & *.EXT variants.
         // Keeps the first case encountered for a given extension set.
@@ -349,7 +348,7 @@ struct FilterSpec
         }
 
         if (dedupExtensions.size() <= MaxFiltersLength) {
-            formatted += QLatin1Char('(');
+            formatted += QLatin1String(" (");
             formatted += dedupExtensions;
             formatted += QLatin1Char(')');
         }
@@ -891,8 +890,10 @@ QStringList FileDialog::getOpenFileNames(
             dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
         }
         if (dlg.exec() == QDialog::Accepted) {
-            if (selectedFilter) {
-                *selectedFilter = filters[qtFilterList.indexOf(dlg.selectedNameFilter())];
+            // add bounds check see github issue #29024
+            auto idx = qtFilterList.indexOf(dlg.selectedNameFilter());
+            if (selectedFilter && idx >= 0) {
+                *selectedFilter = filters[idx];
             }
             files = dlg.selectedFiles();
         }


### PR DESCRIPTION
issue. opening a file with the file open dialog when the below cmake var is set was causing a crash as reported in the below issue. the segfualt begins in the `QString::operator=` when using the below cmake var.

```
-DFREECAD_USE_QT_DIALOGS=1
```

`getDisplayName(showExtensions=true)` unconditionally appends a space after the filter name. when the deduplicated extension list exceeds 128 characters ie. the "supported formats" filter, the parenthesized extensions are omitted but the trailing space remains. `toQtFilter()` then prepends another space before `(`, producing a double space in the filter string. qt's dialog normalizes this to a single space, so `selectedNameFilter()` no longer matched the original string in `qtFilterList` `indexOf` returns `-1` and `filters[-1]` is an "out-of-bounds" access.

add a bounds check on the `indexOf` result to prevent the "out-of-bounds" access / exception violation. 

🥱 🛌

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/29238

## Before and After Images

move along nothing to see here. 💂
