### PR TITLE
[Draft] allow UTF-16 Svg files to be imported

### DIFF
--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -1456,9 +1456,7 @@ def replace_use_with_reference(file_path):
         with pyopen(file_path, "r", encoding="UTF-16") as f:
             f.readline()
             current_encoding = "UTF-16"
-    FreeCAD.Console.PrintLog(
-        f"ImportSVG - '{filename}' is encoded using {current_encoding}\n"
-    )
+    FreeCAD.Console.PrintLog(f"ImportSVG - '{filename}' is encoded using {current_encoding}\n")
 
     # open file and read
     svg_content = pyopen(file_path, encoding=current_encoding).read()

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -1450,15 +1450,14 @@ def replace_use_with_reference(file_path):
     current_encoding = ""
     try:
         with pyopen(file_path, "r", encoding="UTF-8") as f:
-            top_line = f.readline()
+            f.readline()
             current_encoding = "UTF-8"
     except UnicodeError:
         with pyopen(file_path, "r", encoding="UTF-16") as f:
-            top_line = f.readline()
+            f.readline()
             current_encoding = "UTF-16"
-    encoding_text = translate("ImportSVG", "is encoded using")
     FreeCAD.Console.PrintLog(
-        "ImportSVG - '" + file_path + "' " + encoding_text + " " + current_encoding + "\n"
+        f"ImportSVG - '{filename}' is encoded using {current_encoding}\n"
     )
 
     # open file and read

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -1447,8 +1447,21 @@ def replace_use_with_reference(file_path):
             parent = parent_map[deftag]
             parent.remove(deftag)
 
+    current_encoding = ""
+    try:
+        with pyopen(file_path, "r", encoding="UTF-8") as f:
+            top_line = f.readline()
+            current_encoding = "UTF-8"
+    except UnicodeError:
+        with pyopen(file_path, "r", encoding="UTF-16") as f:
+            top_line = f.readline()
+            current_encoding = "UTF-16"
+    encoding_text = translate("ImportSVG", "is encoded using")
+    FreeCAD.Console.PrintLog(
+        "ImportSVG - '" + file_path + "' " + encoding_text + " " + current_encoding + "\n")
+
     # open file and read
-    svg_content = pyopen(file_path).read()
+    svg_content = pyopen(file_path, encoding=current_encoding).read()
     # register namespace before parsing
     register_svg_namespaces(svg_content)
     # parse as xml.

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -1458,7 +1458,8 @@ def replace_use_with_reference(file_path):
             current_encoding = "UTF-16"
     encoding_text = translate("ImportSVG", "is encoded using")
     FreeCAD.Console.PrintLog(
-        "ImportSVG - '" + file_path + "' " + encoding_text + " " + current_encoding + "\n")
+        "ImportSVG - '" + file_path + "' " + encoding_text + " " + current_encoding + "\n"
+    )
 
     # open file and read
     svg_content = pyopen(file_path, encoding=current_encoding).read()


### PR DESCRIPTION
Fixes #28687 

This applies to Windows generated Svg files from applications such as Corel Draw.
