### PR TITLE
PartDesign: use FaceMakerBuildFace for SubShapeBinder face building

### DIFF
--- a/src/Mod/PartDesign/App/ShapeBinder.cpp
+++ b/src/Mod/PartDesign/App/ShapeBinder.cpp
@@ -924,7 +924,7 @@ void SubShapeBinder::update(SubShapeBinder::UpdateOption options)
             result = result.makeElementWires();
             if (MakeFace.getValue()) {
                 try {
-                    result = result.makeElementFace(nullptr);
+                    result = result.makeElementFace(nullptr, "Part::FaceMakerBuildFace");
                 }
                 catch (...) {
                 }


### PR DESCRIPTION
Summary

  - SubShapeBinder used the default FaceMakerBullseye when building faces from edges, which fails on overlapping geometry (e.g. concentric circles, intersecting sketch wires)
  - Switch to FaceMakerBuildFace which splits edges at intersections and finds all bounded
  - This matches the face maker already used by Sketch's buildInternals()

Before:

[Screencast_20260410_151201.webm](https://github.com/user-attachments/assets/3ae91d5b-8cd2-47a8-a569-66965e8bcf0e)


After:

[Screencast_20260410_150308.webm](https://github.com/user-attachments/assets/43e92831-1b1d-4ea3-a910-491438bfdb06)

