### PR TITLE
[TD]Warn on wrong geometry

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1878,3 +1878,21 @@ std::vector<int> GeometryUtils::findNestedFaceIndices(const std::vector<FacePtr>
     return nestedFaceIndices;
 }
 
+//! get a description for a GeomType.  Do not add a default case, as we want to
+//! ensure that we are always in sync with the GeomType enum.
+std::string GeometryUtils::getGeomTypeName(GeomType typeEnumValue)
+{
+    switch (typeEnumValue) {
+        case GeomType::NOTDEF: return "Not Defined";
+        case GeomType::CIRCLE: return "Circle";
+        case GeomType::ARCOFCIRCLE: return "Arc of Circle";
+        case GeomType::ELLIPSE: return "Ellipse";
+        case GeomType::ARCOFELLIPSE: return "Arc of Ellipse";
+        case GeomType::BEZIER: return "Bezier Curve";
+        case GeomType::BSPLINE: return "B-spline Curve";
+        case GeomType::GENERIC: return "Line";
+    }
+}
+
+
+

--- a/src/Mod/TechDraw/App/Geometry.h
+++ b/src/Mod/TechDraw/App/Geometry.h
@@ -472,6 +472,8 @@ class TechDrawExport GeometryUtils
 
         static std::vector<FacePtr> removeNestedHoles(const std::vector<FacePtr>& holes);
         static std::vector<int> findNestedFaceIndices(const std::vector<FacePtr>& holes);
+
+        static std::string getGeomTypeName(GeomType typeEnumValue);
 };
 
 } //end namespace TechDraw

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -89,6 +89,7 @@ void getSelectedShapes(Gui::Command* cmd,
 
 std::pair<App::DocumentObject*, std::string> faceFromSelection();
 std::pair<Base::Vector3d, Base::Vector3d> viewDirection();
+Base::Vector3d checkDirectionVsBasis(Base::Vector3d dir);
 
 class Vertex;
 using namespace TechDrawGui;
@@ -515,10 +516,11 @@ void CmdTechDrawView::activated(int iMsg)
     dvp->XSource.setValues(xShapes);
 
     getDocument()->setStatus(App::Document::Status::SkipRecompute, true);
-    auto dirs = viewDirection();
+    std::pair<Base::Vector3d, Base::Vector3d> dirs = viewDirection();
+    Base::Vector3d checkedDir = checkDirectionVsBasis(dirs.first);
     doCommand(Doc,
               "App.activeDocument().%s.Direction = FreeCAD.Vector(%.12f, %.12f, %.12f)",
-              FeatName.c_str(), dirs.first.x, dirs.first.y, dirs.first.z);
+              FeatName.c_str(), checkedDir.x, checkedDir.y, checkedDir.z);
     doCommand(Doc,
               "App.activeDocument().%s.RotationVector = FreeCAD.Vector(%.12f, %.12f, %.12f)",
               FeatName.c_str(), dirs.second.x, dirs.second.y, dirs.second.z);
@@ -668,7 +670,7 @@ void CmdTechDrawBrokenView::activated(int iMsg)
         dirs = DrawGuiUtil::get3DDirAndRot();
     }
 
-    Base::Vector3d projDir = dirs.first;
+    Base::Vector3d projDir = checkDirectionVsBasis(dirs.first);
     doCommand(Doc, "App.activeDocument().%s.Direction = FreeCAD.Vector(%.6f,%.6f,%.6f)",
               FeatName.c_str(), projDir.x, projDir.y, projDir.z);
     doCommand(Doc, "App.activeDocument().%s.XDirection = FreeCAD.Vector(%.6f,%.6f,%.6f)",
@@ -1153,10 +1155,11 @@ void CmdTechDrawProjectionGroup::activated(int iMsg)
         DrawGuiUtil::getProjDirFromFace(partObj, faceName)
         : DrawGuiUtil::get3DDirAndRot();
 
+    Base::Vector3d checkedDir = checkDirectionVsBasis(dirs.first);
     getDocument()->setStatus(App::Document::Status::SkipRecompute, true);
     doCommand(Doc,
         "App.activeDocument().%s.Anchor.Direction = FreeCAD.Vector(%.12f, %.12f, %.12f)",
-        multiViewName.c_str(), dirs.first.x, dirs.first.y, dirs.first.z);
+        multiViewName.c_str(), checkedDir.x, checkedDir.y, checkedDir.z);
     doCommand(Doc,
         "App.activeDocument().%s.Anchor.RotationVector = FreeCAD.Vector(%.12f, %.12f, %.12f)",
         multiViewName.c_str(), dirs.second.x, dirs.second.y, dirs.second.z);
@@ -1627,6 +1630,7 @@ void CmdTechDrawDraftView::activated(int iMsg)
     std::string PageName = page->getNameInDocument();
 
     std::pair<Base::Vector3d, Base::Vector3d> dirs = DrawGuiUtil::get3DDirAndRot();
+    Base::Vector3d checkedDir = checkDirectionVsBasis(dirs.first);
     for (auto* obj : objects) {
          if (obj->isDerivedFrom<TechDraw::DrawPage>() ||
              obj->isDerivedFrom<TechDraw::DrawView>()) {
@@ -1645,7 +1649,7 @@ void CmdTechDrawDraftView::activated(int iMsg)
         doCommand(Doc, "App.activeDocument().%s.addView(App.activeDocument().%s)", PageName.c_str(),
                   FeatName.c_str());
         doCommand(Doc, "App.activeDocument().%s.Direction = FreeCAD.Vector(%.12f, %.12f, %.12f)",
-                  FeatName.c_str(), dirs.first.x, dirs.first.y, dirs.first.z);
+                  FeatName.c_str(), checkedDir.x, checkedDir.y, checkedDir.z);
         updateActive();
         commitCommand();
     }
@@ -2063,3 +2067,34 @@ std::pair<App::DocumentObject*, std::string> faceFromSelection()
 
     return { nullptr, "" };
 }
+
+//! checks for directions that are almost +/- x,y,z.
+Base::Vector3d checkDirectionVsBasis(Base::Vector3d dir)
+{
+    Base::Vector3d closest = DrawUtil::closestBasisOriented(dir);
+    if (dir.IsEqual(closest, Precision::Confusion())) {
+        return closest;
+    }
+
+    double angleDeg = Base::toDegrees(dir.GetAngle(closest));
+    constexpr double MaxAngleDeg{1.0};  // absolutely a WAG.
+    if (std::fabs(angleDeg) < MaxAngleDeg) {
+        // close to a basis, but not quite equal
+        auto msgText = QObject::tr("Selected Direction is within %1 degrees of a standard direction. "
+                    "Replace selected Direction with %2?")
+                    .arg(QString::number(angleDeg))
+                    .arg(QString::fromStdString(DU::formatVector(closest)));
+        QMessageBox::StandardButton rc = QMessageBox::question(
+            Gui::getMainWindow(), QObject::tr("Direction is close to standard"),
+            msgText,
+            QMessageBox::StandardButtons(QMessageBox::Yes | QMessageBox::No));
+        if (rc == QMessageBox::Yes) {
+            return closest;
+        }
+    }
+
+    // not close to a basis vector.
+    return dir;
+
+}
+

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -115,6 +115,11 @@ void execHoleCircle(Gui::Command* cmd)
             if (geom->getGeomType() == GeomType::CIRCLE || geom->getGeomType() == GeomType::ARCOFCIRCLE) {
                 TechDraw::CirclePtr cgen = std::static_pointer_cast<TechDraw::Circle>(geom);
                 Circles.push_back(cgen);
+            } else {
+                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw hole circle"),
+                                     QObject::tr("Can not make hole circle for %1")
+                                         .arg(GeometryUtils::getGeomTypeName(geom->getGeomType())));
+
             }
         }
     }
@@ -230,6 +235,10 @@ void execCircleCenterLines(Gui::Command* cmd)
                 // number and not the number from line attributes
                 horiz->m_format.setLineNumber(Preferences::CenterLineStyle());
                 vert->m_format.setLineNumber(Preferences::CenterLineStyle());
+            } else {
+                QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw circle centerlines"),
+                                     QObject::tr("Can not make centerlines for %1")
+                                        .arg(GeometryUtils::getGeomTypeName(geom->getGeomType())));
             }
         }
     }
@@ -990,7 +999,6 @@ void CmdTechDrawCosmeticCircle::activated(int iMsg)
             QObject::tr("Close active task dialog and try again."));
         return;
     }
-
     execCosmeticCircleCenter(this);
 
     updateActive();
@@ -1660,6 +1668,11 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend)
                         }
                         objFeat->requestPaint();
                     }
+                } else {
+                    QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw extend/shorten line"),
+                                         QObject::tr("Can not make centerlines for %1")
+                                             .arg(GeometryUtils::getGeomTypeName(baseGeo->getGeomType())));
+
                 }
             }
         }
@@ -2200,6 +2213,10 @@ void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat
         float thinWeight = (float)TechDraw::DrawUtil::getDefaultLineWeight("Thin");
         Base::Color threadColor = _getActiveLineAttributes().getColor(); 
         _setLineAttributes(arc, solidStyle, thinWeight, threadColor);
+    } else {
+        QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw create thread circle"),
+                             QObject::tr("Can not make thread circle for %1")
+                                 .arg(GeometryUtils::getGeomTypeName(geom->getGeomType())));
     }
 }
 

--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -118,7 +118,7 @@ void execHoleCircle(Gui::Command* cmd)
             } else {
                 QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw hole circle"),
                                      QObject::tr("Can not make hole circle for %1")
-                                         .arg(GeometryUtils::getGeomTypeName(geom->getGeomType())));
+                                         .arg(QString::fromStdString(GeometryUtils::getGeomTypeName(geom->getGeomType()))));
 
             }
         }
@@ -238,7 +238,7 @@ void execCircleCenterLines(Gui::Command* cmd)
             } else {
                 QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw circle centerlines"),
                                      QObject::tr("Can not make centerlines for %1")
-                                        .arg(GeometryUtils::getGeomTypeName(geom->getGeomType())));
+                                        .arg(QString::fromStdString(GeometryUtils::getGeomTypeName(geom->getGeomType()))));
             }
         }
     }
@@ -1671,7 +1671,7 @@ void execExtendShortenLine(Gui::Command* cmd, bool extend)
                 } else {
                     QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw extend/shorten line"),
                                          QObject::tr("Can not make centerlines for %1")
-                                             .arg(GeometryUtils::getGeomTypeName(baseGeo->getGeomType())));
+                                             .arg(QString::fromStdString(GeometryUtils::getGeomTypeName(baseGeo->getGeomType()))));
 
                 }
             }
@@ -2216,7 +2216,7 @@ void _createThreadCircle(const std::string Name, TechDraw::DrawViewPart* objFeat
     } else {
         QMessageBox::warning(Gui::getMainWindow(), QObject::tr("TechDraw create thread circle"),
                              QObject::tr("Can not make thread circle for %1")
-                                 .arg(GeometryUtils::getGeomTypeName(geom->getGeomType())));
+                                 .arg(QString::fromStdString(GeometryUtils::getGeomTypeName(geom->getGeomType()))));
     }
 }
 

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -602,28 +602,12 @@ std::pair<Base::Vector3d, Base::Vector3d> DrawGuiUtil::get3DDirAndRot()
         return std::make_pair(viewDir, viewRight);
     }
 
-    // Coin is giving us a values like 0.000000134439 instead of 0.000000000000.
-    // This small difference caused circles to be projected as ellipses among other
-    // problems.
-    // Since SbVec3f is single precision floating point, it is only good to 6-9
-    // significant decimal digits, and the rest of TechDraw works with doubles
-    // that are good to 15-18 significant decimal digits.
-    // But. When a float is promoted to double the value is supposed to be unchanged!
-    // So where do the garbage digits come from???
-    // In any case, if we restrict directions to 6 digits, we avoid the problem.
-    int digits(6);
     SbVec3f dvec = viewer->getViewDirection();
-    double dvecX = roundToDigits(dvec[0], digits);
-    double dvecY = roundToDigits(dvec[1], digits);
-    double dvecZ = roundToDigits(dvec[2], digits);
-    viewDir = Base::Vector3d(dvecX, dvecY, dvecZ);
+    viewDir = Base::Vector3d(dvec[0], dvec[1], dvec[2]);
     viewDir = viewDir * (-1.0);  // Inventor dir is opposite TD projection dir
 
     SbVec3f upvec = viewer->getUpDirection();
-    double upvecX = roundToDigits(upvec[0], digits);
-    double upvecY = roundToDigits(upvec[1], digits);
-    double upvecZ = roundToDigits(upvec[2], digits);
-    viewUp = Base::Vector3d(upvecX, upvecY, upvecZ);
+    viewUp = Base::Vector3d(upvec[0], upvec[1], upvec[2]);
 
     Base::Vector3d right = viewUp.Cross(viewDir);
 


### PR DESCRIPTION
This PR implements fixes for 2 problems raised in issue #28323.

The first is in CommandExtensionPack.cpp which previously failed silently if the selected geometry was not suitable for a command (ex trying to use CircleCenterlines on an Ellipse).

<img width="864" height="559" alt="CircleCenterlinesEllipse" src="https://github.com/user-attachments/assets/a9f01040-8f7c-4dd4-9c1d-120bf17c3e6c" />



The second is a replacement for flawed code which attempts to handle projection directions that are almost a 
standard directions (+/- X, Y, Z). These directions are sometimes created when obtaining the projection direction from the current COIN camera direction.  The previous code was not selective enough in applying the correction.

<img width="857" height="561" alt="CloseToStandard" src="https://github.com/user-attachments/assets/cb91d980-f722-4d6e-8293-4520b9a6b102" />

