### PR TITLE
Gui: use Windows user locale for OS formatting

### DIFF
--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <array>
 #include <QApplication>
 #include <QDir>
 #include <QDirListing>
@@ -38,6 +39,9 @@
 #include <Gui/TextEdit.h>
 #include "Translator.h"
 
+#ifdef FC_OS_WIN32
+# include <windows.h>
+#endif
 
 using namespace Gui;
 
@@ -59,6 +63,19 @@ Translator::LocaleFormattingPreference toLocaleFormattingPreference(const int fo
             );
     }
 }
+
+#ifdef FC_OS_WIN32
+QString getWindowsUserDefaultLocaleName()
+{
+    std::array<wchar_t, LOCALE_NAME_MAX_LENGTH> buffer {};
+    const int written = GetUserDefaultLocaleName(buffer.data(), static_cast<int>(buffer.size()));
+    if (written <= 0) {
+        return {};
+    }
+
+    return QString::fromWCharArray(buffer.data());
+}
+#endif
 }  // namespace
 
 /** \defgroup i18n Internationalization with FreeCAD
@@ -357,6 +374,16 @@ void Translator::setLocale(const std::string& language) const
     const bool isCLocale = Base::Tools::isCLocaleName(language);
 
     auto loc = QLocale::system();  // Defaulting to OS locale
+#ifdef FC_OS_WIN32
+    if (language.empty()) {
+        // Local Windows development runs can inherit shell state that makes Qt resolve the
+        // system locale differently from the user's regional format.
+        const auto operatingSystemLocale = getWindowsUserDefaultLocaleName();
+        if (!operatingSystemLocale.isEmpty()) {
+            loc = QLocale(operatingSystemLocale);
+        }
+    }
+#endif
     if (isCLocale) {
         loc = QLocale::c();
     }


### PR DESCRIPTION
## Summary

Use the Windows user locale directly for `UseLocaleFormatting=Operating system` instead of relying only on `QLocale::system()`.

Fixes #29243.

## Problem

A local Windows build launched via `pixi run freecad` could inherit `LANG=en_US.UTF-8`, causing Qt to resolve `QLocale::system()` as `en_US` even when the actual Windows regional format was `de-DE`.

That left `Operating system` formatting stuck on English separators in local builds.

The reporter confirmed the fix using a local `pixi` build, and the temporary diagnostics branch showed:

- `Qt system locale: English/United States (en_US)`
- `Win user default locale: de-DE`
- `Env LANG: en_US.UTF-8`

## Changes

- On Windows, when locale formatting is set to `Operating system`, resolve the locale from `GetUserDefaultLocaleName()` before falling back to Qt's system locale.
- Keep the existing behavior for `Selected language` and `C/POSIX` unchanged.
- Leave the Linux/BSD numeric-locale preservation path untouched.

## Validation

- Reporter tested the diagnostic branch on Windows 11 and confirmed the fix resolves the issue.

