### PR TITLE
CAM Tests: fix job.addObject() misuse exposed by stricter findParentJob

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathPocket.py
+++ b/src/Mod/CAM/CAMTests/TestPathPocket.py
@@ -131,11 +131,11 @@ class TestPathPocket(PathTestBase):
 
         _addViewProvider(pocket)
 
-        # Add pocket to job's operations
-        job.addObject(pocket)
-
         # Generate the toolpath
-        pocket.recompute()
+        # Note: PathPocket.Create() with parentJob already adds the operation
+        # to job.Operations.Group via PathUtils.addToJob, so no need to call
+        # job.addObject() here (which would move it out of Operations).
+        self.doc.recompute()
 
         return pocket
 

--- a/src/Mod/CAM/CAMTests/TestPostCore.py
+++ b/src/Mod/CAM/CAMTests/TestPostCore.py
@@ -931,7 +931,7 @@ class TestJobPropertyOverrides(unittest.TestCase):
 
         tc = PathToolController.Create("TC_Test_Tool", tool, 1)
         tc.Label = "TC: 6mm Endmill"
-        cls.job.addObject(tc)
+        cls.job.Proxy.addToolController(tc)
 
         # Create operation
         profile_op = cls.doc.addObject("Path::FeaturePython", "TestProfile")

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -136,7 +136,7 @@ class TestFileNameGenerator(unittest.TestCase):
 
         tc = PathToolController.Create("TC_Test_Tool", tool, 5)
         tc.Label = "TC: 6mm Endmill"
-        cls.job.addObject(tc)
+        cls.job.Proxy.addToolController(tc)
 
         # Create a simple mock operation for testing operation-related substitutions
         profile_op = cls.doc.addObject("Path::FeaturePython", "TestProfile")
@@ -455,7 +455,7 @@ class TestExport2Integration(unittest.TestCase):
 
         tc = PathToolController.Create("TC_Test_Tool", tool, 1)
         tc.Label = "TC: 6mm Endmill"
-        cls.job.addObject(tc)
+        cls.job.Proxy.addToolController(tc)
 
         profile_op = cls.doc.addObject("Path::FeaturePython", "TestProfile")
         profile_op.Label = "TestProfile"

--- a/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
+++ b/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
@@ -279,7 +279,7 @@ class TestToolProcessing(unittest.TestCase):
 
         tc2 = PathToolController.Create("TC_Test_Tool2", tool2, 2)
         tc2.Label = "TC: 3mm Endmill"
-        self.job.addObject(tc2)
+        self.job.Proxy.addToolController(tc2)
 
         # Create a second operation using the second tool
         # First move after tool change has X, Y, and Z components
@@ -357,7 +357,7 @@ class TestToolProcessing(unittest.TestCase):
 
         tc2 = PathToolController.Create("TC_Test_Tool2", tool2, 2)
         tc2.Label = "TC: 3mm Endmill"
-        self.job.addObject(tc2)
+        self.job.Proxy.addToolController(tc2)
 
         # Create a second operation using the second tool
         profile_op2 = self.doc.addObject("Path::FeaturePython", "TestProfile2")
@@ -452,7 +452,7 @@ class TestToolProcessing(unittest.TestCase):
 
         tc2 = PathToolController.Create("TC_Second_Tool", tool, 2)
         tc2.Label = "TC: 3mm Endmill"
-        self.job.addObject(tc2)
+        self.job.Proxy.addToolController(tc2)
 
         # Create a second operation using the second tool
         profile_op2 = self.doc.addObject("Path::FeaturePython", "TestProfile2")


### PR DESCRIPTION
Commit 91aa3c9 tightened findParentJob() to require operations and tool controllers to be in their proper sub-groups (job.Operations.Group and job.Tools.Group) rather than accepting any direct child of the Job.

Several tests were using job.addObject() which adds objects to the Job's flat Group via App::GroupExtension, bypassing the structured hierarchy. This was silently tolerated by the old loose lookup but broke with the stricter traversal.

- TestPathPocket: remove redundant job.addObject(pocket) since PathPocket.Create(parentJob=job) already calls job.Proxy.addOperation() via PathUtils.addToJob()
- TestPostToolProcessing, TestPostOutput, TestPostCore: replace job.addObject(tc) with job.Proxy.addToolController(tc) to properly add TCs to job.Tools.Group

