### PR TITLE
BIM: fix Material property pulling into Part container

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -259,12 +259,24 @@ class Component(ArchIFC.IfcProduct):
             )
         if not "Material" in pl:
             obj.addProperty(
-                "App::PropertyLink",
+                "App::PropertyLinkGlobal",
                 "Material",
                 "Component",
                 QT_TRANSLATE_NOOP("App::Property", "A material for this object"),
                 locked=True,
             )
+        elif obj.getTypeIdOfProperty("Material") == "App::PropertyLink":
+            mat = obj.Material
+            obj.setPropertyStatus("Material", "-LockDynamic")
+            obj.removeProperty("Material")
+            obj.addProperty(
+                "App::PropertyLinkGlobal",
+                "Material",
+                "Component",
+                QT_TRANSLATE_NOOP("App::Property", "A material for this object"),
+                locked=True,
+            )
+            obj.Material = mat
         if "BaseMaterial" in pl:
             obj.Material = obj.BaseMaterial
             obj.removeProperty("BaseMaterial")

--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -376,6 +376,7 @@ class _ArchMaterial:
                 for p in obj.InList:
                     if (
                         hasattr(p, "Material")
+                        and p.Material is not None
                         and p.Material.Name == obj.Name
                         and getattr(obj.ViewObject, "UseMaterialColor", True)
                     ):

--- a/src/Mod/BIM/bimtests/TestArchMaterial.py
+++ b/src/Mod/BIM/bimtests/TestArchMaterial.py
@@ -68,3 +68,52 @@ class TestArchMaterial(TestArchBase.TestArchBase):
 
         materials = Arch.getDocumentMaterials()
         self.assertIsInstance(materials, list, "getDocumentMaterials did not return a list.")
+
+    def test_material_property_is_global_scope(self):
+        """Material property must use App::PropertyLinkGlobal so it is not pulled into a Part."""
+        self.printTestMessage("Testing Material property scope on Arch component")
+
+        wall = Arch.makeWall(None, length=2000, width=200, height=3000)
+        self.assertEqual(
+            wall.getTypeIdOfProperty("Material"),
+            "App::PropertyLinkGlobal",
+            "Material property should be App::PropertyLinkGlobal, not App::PropertyLink",
+        )
+
+    def test_material_not_pulled_into_part(self):
+        """Material must not appear as a child of App::Part when the wall is added to it."""
+        self.printTestMessage("Testing that material is not pulled into Part (#28358)")
+
+        wall = Arch.makeWall(None, length=2000, width=200, height=3000)
+        mat = Arch.makeMaterial(name="TestMat")
+        wall.Material = mat
+        self.document.recompute()
+
+        part = self.document.addObject("App::Part", "Part")
+        part.addObject(wall)
+        self.document.recompute()
+
+        self.assertNotIn(mat, part.Group, "Material must not be a child of App::Part")
+
+    def test_material_property_migration(self):
+        """Old App::PropertyLink Material must be migrated to App::PropertyLinkGlobal on restore."""
+        self.printTestMessage("Testing Material property migration from App::PropertyLink")
+
+        # Simulate an old document object that has Material as App::PropertyLink (no locked flag,
+        # as LockDynamic is not serialized and is absent after document restore).
+        obj = self.document.addObject("App::FeaturePython", "OldObj")
+        obj.addProperty("App::PropertyLink", "Material", "Component")
+        self.assertEqual(obj.getTypeIdOfProperty("Material"), "App::PropertyLink")
+
+        # Run the same migration logic used in ArchComponent.setProperties.
+        if obj.getTypeIdOfProperty("Material") == "App::PropertyLink":
+            mat = obj.Material
+            obj.removeProperty("Material")
+            obj.addProperty("App::PropertyLinkGlobal", "Material", "Component", locked=True)
+            obj.Material = mat
+
+        self.assertEqual(
+            obj.getTypeIdOfProperty("Material"),
+            "App::PropertyLinkGlobal",
+            "Migration from App::PropertyLink to App::PropertyLinkGlobal failed",
+        )

--- a/src/Mod/BIM/nativeifc/ifc_materials.py
+++ b/src/Mod/BIM/nativeifc/ifc_materials.py
@@ -72,7 +72,13 @@ def show_material(obj):
     if not material:
         return
     if not hasattr(obj, "Material"):
-        obj.addProperty("App::PropertyLink", "Material", "IFC", locked=True)
+        obj.addProperty("App::PropertyLinkGlobal", "Material", "IFC", locked=True)
+    elif obj.getTypeIdOfProperty("Material") == "App::PropertyLink":
+        mat = obj.Material
+        obj.setPropertyStatus("Material", "-LockDynamic")
+        obj.removeProperty("Material")
+        obj.addProperty("App::PropertyLinkGlobal", "Material", "IFC", locked=True)
+        obj.Material = mat
     project = ifc_tools.get_project(obj)
     matobj = create_material(material, project, recursive=True)
     obj.Material = matobj


### PR DESCRIPTION
Fixes #28358

When a BIM object with a material was added to an App::Part, the material appeared as a child of the Part in the tree view. This happened because the Material property was registered as App::PropertyLink (Local scope), which GeoFeatureGroupExtension treats as coordinate-system-relevant and drags into the Part alongside the object.

Fix: register Material as App::PropertyLinkGlobal in ArchComponent and nativeifc/ifc_materials. A migration block upgrades existing saved documents on restore. Also fixes an AttributeError crash in ArchMaterial.execute() when p.Material is None.

Tests added in TestArchMaterial.py covering property scope, Part containment, and migration from the old property type.