### PR TITLE
Gui: sketcher: fix number reversal on the OVP if there is no space be…

### DIFF
--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -463,8 +463,17 @@ void QuantitySpinBox::clampCursorBeforeUnit()
         return;
     }
     QLineEdit* edit = lineEdit();
+    QString text = edit->displayText();
     int cursor = edit->cursorPosition();
-    const int maxCursor = qMax(0, edit->displayText().size() - 1 /*space*/ - d->unitStr.size());
+    int suffixLength = d->unitStr.size();
+    if (suffixLength > 0 && text.endsWith(d->unitStr)) {
+        // Check if there is a space before the unit
+        int spaceIndex = text.size() - suffixLength - 1;
+        if (spaceIndex >= 0 && text.at(spaceIndex) == QLatin1Char(' ')) {
+            suffixLength += 1;
+        }
+    }
+    const int maxCursor = qMax(0, text.size() - suffixLength);
 
     if (cursor > maxCursor) {
         edit->setCursorPosition(maxCursor);


### PR DESCRIPTION
this should fix #29248

the issue happens when there is no space between the unit and and value, or there is no unit

this will now check and adjusts if there a space or not and accounts for the lack of unit