### PR TITLE
BIM: fix baseless wall ignoring Offset property

### DIFF
--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1772,6 +1772,7 @@ class _Wall(ArchComponent.Component):
         layers = self.get_layers(obj)
         width = self.get_width(obj, widths=False)
         align = obj.Align
+        wall_offset = obj.Offset.Value
 
         # Use a small default for zero dimensions to ensure a valid shape can be created.
         safe_length = obj.Length.Value or 0.5
@@ -1792,7 +1793,9 @@ class _Wall(ArchComponent.Component):
             offset = -totalwidth / 2
         elif align == "Left":
             # Per convention, 'Left' is on the geometric right (-Y direction).
-            offset = -totalwidth
+            offset = -totalwidth - wall_offset
+        elif align == "Right":
+            offset = wall_offset
 
         # Loop through all layers and create a face for each.
         for layer in layers:

--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -567,3 +567,36 @@ class TestArchWall(TestArchBase.TestArchBase):
         # Final verification that the wall itself was correctly debased
         self.assertIsNone(wall.Base, "Wall was not successfully debased (Base still exists).")
         self.assertAlmostEqual(wall.Placement.Base.x, 6000.0, places=3)
+
+    def test_baseless_wall_offset(self):
+        """Test that the Offset property shifts the geometry of a baseless wall.
+
+        Regression test for https://github.com/FreeCAD/FreeCAD/issues/29256.
+        """
+        self.printTestMessage("Checking baseless wall Offset property...")
+
+        length, width, height, offset = 2000.0, 200.0, 3000.0, 1000.0
+
+        # Left alignment: wall body is in -Y direction. Offset shifts it further in -Y.
+        wall_left = Arch.makeWall(
+            length=length, width=width, height=height, align="Left", offset=offset
+        )
+        self.assertIsNone(wall_left.Base, "Left: wall should be baseless")
+        self.document.recompute()
+        bb = wall_left.Shape.BoundBox
+        self.assertAlmostEqual(bb.YMax, -offset, delta=1e-6, msg="Left: YMax should be -offset")
+        self.assertAlmostEqual(
+            bb.YMin, -width - offset, delta=1e-6, msg="Left: YMin should be -(width+offset)"
+        )
+
+        # Right alignment: wall body is in +Y direction. Offset shifts it further in +Y.
+        wall_right = Arch.makeWall(
+            length=length, width=width, height=height, align="Right", offset=offset
+        )
+        self.assertIsNone(wall_right.Base, "Right: wall should be baseless")
+        self.document.recompute()
+        bb = wall_right.Shape.BoundBox
+        self.assertAlmostEqual(bb.YMin, offset, delta=1e-6, msg="Right: YMin should be offset")
+        self.assertAlmostEqual(
+            bb.YMax, width + offset, delta=1e-6, msg="Right: YMax should be width+offset"
+        )


### PR DESCRIPTION
Fixes #29256

Baseless walls (no baseline, length-defined) ignored the `Offset` property when
building their geometry. The offset was stored on the object but never applied in
`build_base_from_scratch()`.

Fix: shift the starting Y position by `obj.Offset.Value` for Left and Right
alignments, matching the existing preview behavior in `BimWall.py`.

- Left: `offset = -totalwidth - wall_offset`
- Right: `offset = wall_offset`
- Center: unchanged (offset widget is disabled for Center in the GUI)