### PR TITLE
Feat slab multimaterial

### DIFF
--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -1004,11 +1004,6 @@ class _Structure(ArchComponent.Component):
                 locked=True,
             )
             obj.ArchSketchPropertySet = ["Default"]
-        if not hasattr(self, "ArchSkPropSetPickedUuid"):
-            self.ArchSkPropSetPickedUuid = ""
-        if not hasattr(self, "ArchSkPropSetListPrev"):
-            self.ArchSkPropSetListPrev = []
-
         if not "Align" in pl:
             obj.addProperty(
                 "App::PropertyEnumeration",
@@ -1016,12 +1011,43 @@ class _Structure(ArchComponent.Component):
                 "Structure",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "Vertical alignment of slab layers relative to the base face. "
-                    "Only used when IfcType is Slab.",
+                    "Global vertical alignment of the slab stack relative to its base "
+                    "face. Bottom/Center/Top. Used when Align Layer is 'None'. "
+                    "Only active when IfcType is Slab.",
                 ),
                 locked=True,
             )
             obj.Align = ["Bottom", "Center", "Top"]
+
+        if not "AlignLayer" in pl:
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "AlignLayer",
+                "Structure",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Reference layer: select a specific material layer to pin the slab "
+                    "to. When set to a layer name, overrides the global Align. "
+                    "Only active when IfcType is Slab and a multi-material is assigned.",
+                ),
+                locked=True,
+            )
+            obj.AlignLayer = ["None (use Align)"]
+
+        if not "AlignLayerMode" in pl:
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "AlignLayerMode",
+                "Structure",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Which face of the Reference Layer to pin to the base sketch: "
+                    "Bottom, Center, or Top of that specific layer. "
+                    "Only active when Align Layer is set to a layer name.",
+                ),
+                locked=True,
+            )
+            obj.AlignLayerMode = ["Bottom", "Center", "Top"]
 
         if not "Slope" in pl:
             obj.addProperty(
@@ -1049,21 +1075,6 @@ class _Structure(ArchComponent.Component):
                 locked=True,
             )
 
-        if not "AlignLayer" in pl:
-            obj.addProperty(
-                "App::PropertyEnumeration",
-                "AlignLayer",
-                "Structure",
-                QT_TRANSLATE_NOOP(
-                    "App::Property",
-                    "Fine-grain alignment: pick a specific layer face as the zero "
-                    "reference. Overrides Align when not set to 'None (use Align)'. "
-                    "Only used when IfcType is Slab and a multi-material is assigned.",
-                ),
-                locked=True,
-            )
-            obj.AlignLayer = ["None (use Align)"]
-
         if not "SlopeEdge" in pl:
             obj.addProperty(
                 "App::PropertyLinkSub",
@@ -1077,6 +1088,11 @@ class _Structure(ArchComponent.Component):
                 ),
                 locked=True,
             )
+
+        if not hasattr(self, "ArchSkPropSetPickedUuid"):
+            self.ArchSkPropSetPickedUuid = ""
+        if not hasattr(self, "ArchSkPropSetListPrev"):
+            self.ArchSkPropSetListPrev = []
 
     def dumps(self):  # Supercede Arch.Component.dumps()
         dump = super().dumps()
@@ -1118,26 +1134,154 @@ class _Structure(ArchComponent.Component):
             if hasattr(obj, "ArchSketchPropertySet"):
                 obj.setEditorMode("ArchSketchPropertySet", ["ReadOnly"])
 
-        # Restore slab-only property visibility and AlignLayer enum
+        # Restore slab-only property visibility and rebuild AlignLayer enum
         self._update_align_layer_enum(obj)
         is_slab = getattr(obj, "IfcType", "") == "Slab"
 
-        for p in ["Align", "AlignLayer", "Offset", "Slope", "SlopeEdge"]:
+        for p in ["Align", "AlignLayer", "AlignLayerMode", "Offset", "Slope", "SlopeEdge"]:
             if hasattr(obj, p):
                 obj.setEditorMode(p, 0 if is_slab else 2)
 
         if is_slab:
             align_layer = getattr(obj, "AlignLayer", "None (use Align)")
-            if align_layer and align_layer != "None (use Align)":
-                if hasattr(obj, "Align"):
-                    obj.setEditorMode("Align", ["ReadOnly"])
-            else:
-                if hasattr(obj, "Align"):
-                    obj.setEditorMode("Align", 0)
+            layer_active = bool(align_layer and align_layer != "None (use Align)")
 
+            if hasattr(obj, "Align"):
+                obj.setEditorMode("Align", ["ReadOnly"] if layer_active else 0)
+            if hasattr(obj, "AlignLayerMode"):
+                obj.setEditorMode("AlignLayerMode", 0 if layer_active else 2)
             if hasattr(obj, "Slope") and hasattr(obj, "SlopeEdge"):
                 slope_val = obj.Slope.Value if hasattr(obj.Slope, "Value") else 0.0
-                obj.setEditorMode("SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2)
+                obj.setEditorMode(
+                    "SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2
+                )
+
+    def get_layers(self, obj):
+        """Returns a list of layer thicknesses for multi-material slab support.
+        Mirrors _Wall.get_layers(), but keyed to Height instead of Width.
+        Only active when IfcType is Slab and a multi-material is assigned.
+        """
+        layers = []
+        if not (getattr(obj, "IfcType", "") == "Slab"):
+            return layers
+        height = obj.Height.Value
+        if hasattr(obj, "Material") and obj.Material:
+            if hasattr(obj.Material, "Materials"):
+                thicknesses = [abs(t) for t in obj.Material.Thicknesses]
+                restwidth = height - sum(thicknesses)
+                varwidth = 0
+                if restwidth > 0:
+                    varcount = [t for t in thicknesses if t == 0]
+                    if varcount:
+                        varwidth = restwidth / len(varcount)
+                for t in obj.Material.Thicknesses:
+                    if t:
+                        layers.append(t)
+                    elif varwidth:
+                        layers.append(varwidth)
+        return layers
+
+    def _update_align_layer_enum(self, obj):
+        """Rebuild the AlignLayer enumeration from the current multi-material.
+        Entries are plain layer names only. AlignLayerMode handles Top/Center/Bottom
+        separately. Preserves the current selection if the name still exists.
+        """
+        if not hasattr(obj, "AlignLayer"):
+            return
+        if getattr(obj, "IfcType", "") != "Slab":
+            return
+
+        entries = ["None (use Align)"]
+        layers = self.get_layers(obj)
+        if layers and hasattr(obj, "Material") and obj.Material:
+            if hasattr(obj.Material, "Materials"):
+                for i, mat in enumerate(obj.Material.Materials):
+                    if (
+                        hasattr(obj.Material, "Names")
+                        and i < len(obj.Material.Names)
+                        and obj.Material.Names[i]
+                    ):
+                        name = obj.Material.Names[i]
+                    elif hasattr(mat, "Label"):
+                        name = mat.Label
+                    else:
+                        name = f"Layer {i + 1}"
+                    entries.append(name)
+
+        # Preserve selection if still valid, else reset gracefully
+        try:
+            current = obj.AlignLayer
+        except Exception:
+            current = entries[0]
+        if current not in entries:
+            current = entries[0]
+        obj.AlignLayer = entries
+        obj.AlignLayer = current
+
+    def _align_to_z_offset(self, obj, total):
+        """Convert the global Align enum to a raw z_offset for the full stack."""
+        align = getattr(obj, "Align", "Bottom")
+        if align == "Center":
+            return -total / 2.0
+        elif align == "Top":
+            return -total
+        else:  # Bottom
+            return 0.0
+
+    def _compute_z_offset(self, obj, layers):
+        """Return the full z_offset for slab layer stacking.
+
+        Priority:
+        1. AlignLayer + AlignLayerMode (layer-specific pin) — when AlignLayer != 'None'
+        2. Align (global Bottom/Center/Top) — when AlignLayer == 'None'
+        3. Offset (manual shift) — always added on top of 1 or 2
+        """
+        total = sum(abs(l) for l in layers)
+        align_layer = getattr(obj, "AlignLayer", "None (use Align)")
+
+        if align_layer and align_layer != "None (use Align)":
+            # Resolve the layer index from its name
+            layer_idx = None
+            if hasattr(obj, "Material") and obj.Material:
+                if hasattr(obj.Material, "Materials"):
+                    for i, mat in enumerate(obj.Material.Materials):
+                        if (
+                            hasattr(obj.Material, "Names")
+                            and i < len(obj.Material.Names)
+                            and obj.Material.Names[i]
+                        ):
+                            name = obj.Material.Names[i]
+                        elif hasattr(mat, "Label"):
+                            name = mat.Label
+                        else:
+                            name = f"Layer {i + 1}"
+                        if name == align_layer:
+                            layer_idx = i
+                            break
+
+            if layer_idx is not None:
+                layer_mode = getattr(obj, "AlignLayerMode", "Bottom")
+                # Cumulative thickness of all layers before this one
+                cum = sum(abs(l) for l in layers[:layer_idx])
+                if layer_mode == "Bottom":
+                    z_offset = -cum
+                elif layer_mode == "Center":
+                    z_offset = -(cum + abs(layers[layer_idx]) / 2.0)
+                else:  # Top
+                    z_offset = -(cum + abs(layers[layer_idx]))
+            else:
+                # Layer name disappeared (material changed) — graceful fallback
+                z_offset = self._align_to_z_offset(obj, total)
+        else:
+            z_offset = self._align_to_z_offset(obj, total)
+
+        # Always apply manual Offset on top
+        manual_offset = getattr(obj, "Offset", None)
+        if manual_offset is not None:
+            val = manual_offset.Value if hasattr(manual_offset, "Value") else 0.0
+            z_offset += val
+
+        return z_offset
 
     def execute(self, obj):
         "creates the structure shape"
@@ -1537,6 +1681,8 @@ class _Structure(ArchComponent.Component):
                             slope_angle = slope_angle.Value  # degrees
                         slope_base = None
                         if abs(slope_angle) > 1e-6:
+                            import math
+
                             # Determine slope pivot axis
                             x_axis = None
 
@@ -1656,34 +1802,6 @@ class _Structure(ArchComponent.Component):
             if nodes:
                 self.nodes = [v.Point.add(offset) for v in nodes.Vertexes]
                 obj.Nodes = self.nodes
-
-        # --- Update AlignLayer enum when material or type changes ---
-        if prop in ["Material", "IfcType"]:
-            self._update_align_layer_enum(obj)
-
-        # --- Slab-only property visibility ---
-        is_slab = getattr(obj, "IfcType", "") == "Slab"
-
-        for p in ["Align", "AlignLayer", "Offset", "Slope", "SlopeEdge"]:
-            if hasattr(obj, p):
-                obj.setEditorMode(p, 0 if is_slab else 2)
-
-        if is_slab:
-            # When AlignLayer is active, Align is redundant — make read-only
-            align_layer = getattr(obj, "AlignLayer", "None (use Align)")
-            if align_layer and align_layer != "None (use Align)":
-                if hasattr(obj, "Align"):
-                    obj.setEditorMode("Align", ["ReadOnly"])
-            else:
-                if hasattr(obj, "Align"):
-                    obj.setEditorMode("Align", 0)
-
-            # Only show SlopeEdge when Slope is non-zero
-            if hasattr(obj, "Slope") and hasattr(obj, "SlopeEdge"):
-                slope_val = obj.Slope.Value if hasattr(obj.Slope, "Value") else 0.0
-                obj.setEditorMode("SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2)
-        # --- End slab-only visibility ---
-
         ArchComponent.Component.onChanged(self, obj, prop)
 
         if prop == "ArchSketchPropertySet" and Draft.getType(obj.Base) == "ArchSketch":
@@ -1705,6 +1823,38 @@ class _Structure(ArchComponent.Component):
                 obj.setEditorMode("ArchSketchEdges", 0)
             if hasattr(obj, "ArchSketchPropertySet"):
                 obj.setEditorMode("ArchSketchPropertySet", ["ReadOnly"])
+
+        # --- Update AlignLayer enum when material or type changes ---
+        if prop in ["Material", "IfcType"]:
+            self._update_align_layer_enum(obj)
+
+        # --- Slab-only property visibility ---
+        is_slab = getattr(obj, "IfcType", "") == "Slab"
+
+        for p in ["Align", "AlignLayer", "AlignLayerMode", "Offset", "Slope", "SlopeEdge"]:
+            if hasattr(obj, p):
+                obj.setEditorMode(p, 0 if is_slab else 2)
+
+        if is_slab:
+            align_layer = getattr(obj, "AlignLayer", "None (use Align)")
+            layer_active = bool(align_layer and align_layer != "None (use Align)")
+
+            # When a reference layer is active, global Align is read-only
+            # (it's overridden — no point editing it)
+            if hasattr(obj, "Align"):
+                obj.setEditorMode("Align", ["ReadOnly"] if layer_active else 0)
+
+            # AlignLayerMode only makes sense when a reference layer is chosen
+            if hasattr(obj, "AlignLayerMode"):
+                obj.setEditorMode("AlignLayerMode", 0 if layer_active else 2)
+
+            # SlopeEdge only appears when Slope is non-zero
+            if hasattr(obj, "Slope") and hasattr(obj, "SlopeEdge"):
+                slope_val = obj.Slope.Value if hasattr(obj.Slope, "Value") else 0.0
+                obj.setEditorMode(
+                    "SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2
+                )
+        # --- End slab-only visibility ---
 
     def getNodeEdges(self, obj):
         "returns a list of edges from structural nodes"
@@ -1728,138 +1878,6 @@ class _Structure(ArchComponent.Component):
                         ).toShape()
                     )
         return edges
-
-    def get_layers(self, obj):
-        """Returns a list of layer thicknesses for multi-material slab support.
-        Mirrors _Wall.get_layers(), but keyed to Height instead of Width.
-        Only active when IfcType is Slab and a multi-material is assigned.
-        """
-        layers = []
-        if not (getattr(obj, "IfcType", "") == "Slab"):
-            return layers
-        height = obj.Height.Value
-        if hasattr(obj, "Material") and obj.Material:
-            if hasattr(obj.Material, "Materials"):
-                thicknesses = [abs(t) for t in obj.Material.Thicknesses]
-                restwidth = height - sum(thicknesses)
-                varwidth = 0
-                if restwidth > 0:
-                    varcount = [t for t in thicknesses if t == 0]
-                    if varcount:
-                        varwidth = restwidth / len(varcount)
-                for t in obj.Material.Thicknesses:
-                    if t:
-                        layers.append(t)
-                    elif varwidth:
-                        layers.append(varwidth)
-        return layers
-
-    def _update_align_layer_enum(self, obj):
-        """Rebuild the AlignLayer enumeration from the current multi-material.
-        Called whenever Material or IfcType changes.
-        Preserves the current selection if still valid.
-        """
-        if not hasattr(obj, "AlignLayer"):
-            return
-        if getattr(obj, "IfcType", "") != "Slab":
-            return
-
-        entries = ["None (use Align)"]
-        layers = self.get_layers(obj)
-        if layers and hasattr(obj, "Material") and obj.Material:
-            if hasattr(obj.Material, "Materials"):
-                for i, mat in enumerate(obj.Material.Materials):
-                    # Prefer Material.Names, then Label, then fallback index
-                    if (
-                        hasattr(obj.Material, "Names")
-                        and i < len(obj.Material.Names)
-                        and obj.Material.Names[i]
-                    ):
-                        name = obj.Material.Names[i]
-                    elif hasattr(mat, "Label"):
-                        name = mat.Label
-                    else:
-                        name = f"Layer {i + 1}"
-                    entries.append(f"Bot: {name}")
-                    entries.append(f"Ctr: {name}")
-                    entries.append(f"Top: {name}")
-
-        # Preserve selection if still valid, else reset
-        try:
-            current = obj.AlignLayer
-        except Exception:
-            current = entries[0]
-        if current not in entries:
-            current = entries[0]
-        obj.AlignLayer = entries
-        obj.AlignLayer = current
-
-    def _align_to_z_offset(self, obj, total):
-        """Convert the Align enum (Bottom/Center/Top) to a raw z_offset for the stack."""
-        align = getattr(obj, "Align", "Bottom")
-        if align == "Center":
-            return -total / 2.0
-        elif align == "Top":
-            return -total
-        else:  # Bottom
-            return 0.0
-
-    def _compute_z_offset(self, obj, layers):
-        """Return the full z_offset for slab layer stacking.
-
-        Priority order:
-        1. AlignLayer (layer-specific reference face) — overrides Align when set
-        2. Align (Bottom / Center / Top of full stack) — used when AlignLayer is None
-        3. Offset (manual shift) — always applied on top of 1 or 2
-        """
-        total = sum(abs(l) for l in layers)
-        align_layer = getattr(obj, "AlignLayer", "None (use Align)")
-
-        if align_layer and align_layer != "None (use Align)":
-            # Format is "Bot: name", "Ctr: name", or "Top: name"
-            face_code = align_layer[:3]   # "Bot", "Ctr", "Top"
-            layer_name = align_layer[5:]  # everything after "Bot: " / "Ctr: " / "Top: "
-
-            # Resolve layer index by matching name
-            layer_idx = None
-            if hasattr(obj, "Material") and obj.Material:
-                if hasattr(obj.Material, "Materials"):
-                    for i, mat in enumerate(obj.Material.Materials):
-                        if (
-                            hasattr(obj.Material, "Names")
-                            and i < len(obj.Material.Names)
-                            and obj.Material.Names[i]
-                        ):
-                            name = obj.Material.Names[i]
-                        elif hasattr(mat, "Label"):
-                            name = mat.Label
-                        else:
-                            name = f"Layer {i + 1}"
-                        if name == layer_name:
-                            layer_idx = i
-                            break
-
-            if layer_idx is not None:
-                cum = sum(abs(l) for l in layers[:layer_idx])
-                if face_code == "Bot":
-                    z_offset = -cum
-                elif face_code == "Ctr":
-                    z_offset = -(cum + abs(layers[layer_idx]) / 2.0)
-                else:  # "Top"
-                    z_offset = -(cum + abs(layers[layer_idx]))
-            else:
-                # Layer name not found (material changed), graceful fallback
-                z_offset = self._align_to_z_offset(obj, total)
-        else:
-            z_offset = self._align_to_z_offset(obj, total)
-
-        # Apply manual Offset on top of everything
-        manual_offset = getattr(obj, "Offset", None)
-        if manual_offset is not None:
-            val = manual_offset.Value if hasattr(manual_offset, "Value") else 0.0
-            z_offset += val
-
-        return z_offset
 
 
 class _ViewProviderStructure(ArchComponent.ViewProviderComponent):

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -37,6 +37,7 @@ __url__ = "https://www.freecad.org"
 #  elements that have a structural function, that is, that
 #  support other parts of the building.
 
+import enum
 import FreeCAD
 import ArchComponent
 import ArchCommands
@@ -47,6 +48,18 @@ import DraftVecUtils
 from FreeCAD import Vector
 from draftutils import params
 from draftutils import gui_utils
+
+
+class StructureMode(enum.Enum):
+    """Placement mode for the interactive Structure command.
+
+    COLUMN: single-point placement, extrusion along the working plane normal.
+    BEAM:   two-point placement, extrusion along the edge between the two points.
+    """
+
+    COLUMN = "Column"
+    BEAM = "Beam"
+
 
 if FreeCAD.GuiUp:
     from PySide import QtCore, QtGui
@@ -72,127 +85,6 @@ Presets = ArchProfile.readPresets()
 for pre in Presets:
     if pre[1] not in Categories:
         Categories.append(pre[1])
-
-
-def makeStructure(baseobj=None, length=None, width=None, height=None, name=None):
-    """makeStructure([baseobj],[length],[width],[height],[name]): creates a
-    structure element based on the given profile object and the given
-    extrusion height. If no base object is given, you can also specify
-    length and width for a cubic object."""
-
-    if not FreeCAD.ActiveDocument:
-        FreeCAD.Console.PrintError("No active document. Aborting\n")
-        return
-    obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Structure")
-    _Structure(obj)
-    if FreeCAD.GuiUp:
-        _ViewProviderStructure(obj.ViewObject)
-    if baseobj:
-        obj.Base = baseobj
-        if FreeCAD.GuiUp:
-            obj.Base.ViewObject.hide()
-    if width:
-        obj.Width = width
-    else:
-        obj.Width = params.get_param_arch("StructureWidth")
-    if height:
-        obj.Height = height
-    else:
-        if not length:
-            obj.Height = params.get_param_arch("StructureHeight")
-    if length:
-        obj.Length = length
-    else:
-        if not baseobj:
-            # don't set the length if we have a base object, otherwise the length X height calc
-            # gets wrong
-            obj.Length = params.get_param_arch("StructureLength")
-    if baseobj:
-        w = 0
-        h = 0
-        if hasattr(baseobj, "Width") and hasattr(baseobj, "Height"):
-            w = baseobj.Width.Value
-            h = baseobj.Height.Value
-        elif hasattr(baseobj, "Length") and hasattr(baseobj, "Width"):
-            w = baseobj.Length.Value
-            h = baseobj.Width.Value
-        elif hasattr(baseobj, "Length") and hasattr(baseobj, "Height"):
-            w = baseobj.Length.Value
-            h = baseobj.Height.Value
-        if w and h:
-            if length and not height:
-                obj.Width = w
-                obj.Height = h
-            elif height and not length:
-                obj.Width = w
-                obj.Length = h
-
-    if obj.Length > obj.Height:
-        obj.IfcType = "Beam"
-        obj.Label = name if name else translate("Arch", "Beam")
-    elif obj.Height > obj.Length:
-        obj.IfcType = "Column"
-        obj.Label = name if name else translate("Arch", "Column")
-    return obj
-
-
-def makeStructuralSystem(objects=[], axes=[], name=None):
-    """makeStructuralSystem([objects],[axes],[name]): makes a structural system
-    based on the given objects and axes"""
-
-    if not FreeCAD.ActiveDocument:
-        FreeCAD.Console.PrintError("No active document. Aborting\n")
-        return
-    result = []
-    if not axes:
-        print("At least one axis must be given")
-        return
-    if objects:
-        if not isinstance(objects, list):
-            objects = [objects]
-    else:
-        objects = [None]
-    for o in objects:
-        obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "StructuralSystem")
-        obj.Label = name if name else translate("Arch", "StructuralSystem")
-        _StructuralSystem(obj)
-        if FreeCAD.GuiUp:
-            _ViewProviderStructuralSystem(obj.ViewObject)
-        if o:
-            obj.Base = o
-        obj.Axes = axes
-        result.append(obj)
-        if FreeCAD.GuiUp and o:
-            o.ViewObject.hide()
-            Draft.formatObject(obj, o)
-    FreeCAD.ActiveDocument.recompute()
-    if len(result) == 1:
-        return result[0]
-    else:
-        return result
-
-
-def placeAlongEdge(p1, p2, horizontal=False):
-    """placeAlongEdge(p1,p2,[horizontal]): returns a Placement positioned at p1, with Z axis oriented towards p2.
-    If horizontal is True, then the X axis is oriented towards p2, not the Z axis"""
-
-    pl = FreeCAD.Placement()
-    pl.Base = p1
-    import WorkingPlane
-
-    up = WorkingPlane.get_working_plane(update=False).axis
-    zaxis = p2.sub(p1)
-    yaxis = up.cross(zaxis)
-    if yaxis.Length > 0:
-        xaxis = zaxis.cross(yaxis)
-        if horizontal:
-            pl.Rotation = FreeCAD.Rotation(zaxis, yaxis, xaxis, "ZXY")
-        else:
-            pl.Rotation = FreeCAD.Rotation(xaxis, yaxis, zaxis, "ZXY")
-            pl.Rotation = FreeCAD.Rotation(
-                pl.Rotation.multVec(FreeCAD.Vector(0, 0, 1)), 90
-            ).multiply(pl.Rotation)
-    return pl
 
 
 class CommandStructuresFromSelection:
@@ -320,37 +212,29 @@ class _CommandStructure:
 
     def __init__(self):
 
-        self.beammode = False
-
-    def GetResources(self):
-
-        return {
-            "Pixmap": "Arch_Structure",
-            "MenuText": QT_TRANSLATE_NOOP("Arch_Structure", "Structure"),
-            "Accel": "S, T",
-            "ToolTip": QT_TRANSLATE_NOOP(
-                "Arch_Structure",
-                "Creates a structure from scratch or from a selected object (sketch, wire, face or solid)",
-            ),
-        }
+        self.mode = StructureMode.COLUMN
 
     def IsActive(self):
 
         return not FreeCAD.ActiveDocument is None
 
+    def _loadDimensions(self):
+        """Load Width/Height/Length from mode-specific params.
+
+        Each mode persists its own set of dimensions so that switching between beam and column
+        doesn't pollute one mode's values with the other's.
+        """
+        prefix = "Beam" if self.mode == StructureMode.BEAM else "Column"
+        self.Width = params.get_param_arch(prefix + "Width")
+        self.Height = params.get_param_arch(prefix + "Height")
+        self.Length = params.get_param_arch(prefix + "Length")
+
     def Activated(self):
 
         self.doc = FreeCAD.ActiveDocument
-        self.Width = params.get_param_arch("StructureWidth")
-        if self.beammode:
-            self.Height = params.get_param_arch("StructureLength")
-            self.Length = params.get_param_arch("StructureHeight")
-        else:
-            self.Length = params.get_param_arch("StructureLength")
-            self.Height = params.get_param_arch("StructureHeight")
+        self._loadDimensions()
         self.Profile = None
         self.bpoint = None
-        self.bmode = False
         self.precastvalues = None
         self.wp = None
         sel = FreeCADGui.Selection.getSelection()
@@ -388,10 +272,10 @@ class _CommandStructure:
         self.precast = ArchPrecast._PrecastTaskPanel()
         self.dents = ArchPrecast._DentsTaskPanel()
         self.precast.Dents = self.dents
-        if self.beammode:
-            title = translate("Arch", "First point of the beam")
+        if self.mode == StructureMode.BEAM:
+            title = translate("Arch", "First Point of Beam")
         else:
-            title = translate("Arch", "Base point of column")
+            title = translate("Arch", "Base Point of Column")
         FreeCADGui.Snapper.getPoint(
             callback=self.getPoint,
             movecallback=self.update,
@@ -403,20 +287,25 @@ class _CommandStructure:
     def getPoint(self, point=None, obj=None):
         "this function is called by the snapper when it has a 3D point"
 
-        self.bmode = self.modeb.isChecked()
+        self.mode = StructureMode.BEAM if self.modeb.isChecked() else StructureMode.COLUMN
         if point is None:
             FreeCAD.activeDraftCommand = None
             FreeCADGui.Snapper.off()
             self.tracker.finalize()
             return
-        if self.bmode and (self.bpoint is None):
+        if self.mode == StructureMode.BEAM and (self.bpoint is None):
             self.bpoint = point
+            # Recreate precast/dents task boxes. The getPoint() call below replaces the task panel,
+            # destroying the task boxes that were embedded via extradlg by the first call.
+            self.precast = ArchPrecast._PrecastTaskPanel()
+            self.dents = ArchPrecast._DentsTaskPanel()
+            self.precast.Dents = self.dents
             FreeCADGui.Snapper.getPoint(
                 last=point,
                 callback=self.getPoint,
                 movecallback=self.update,
                 extradlg=[self.taskbox(), self.precast.form, self.dents.form],
-                title=translate("Arch", "Next point") + ":",
+                title=translate("Arch", "Next Point") + ":",
                 mode="line",
             )
             return
@@ -427,9 +316,9 @@ class _CommandStructure:
         self.doc.openTransaction(translate("Arch", "Create Structure"))
         FreeCADGui.addModule("Arch")
         FreeCADGui.addModule("WorkingPlane")
-        if self.bmode:
+        if self.mode == StructureMode.BEAM:
             self.Length = point.sub(self.bpoint).Length
-            params.set_param_arch("StructureHeight", self.Length)
+            params.set_param_arch("BeamLength", self.Length)
         if self.Profile is not None:
             try:  # try to update latest precast values - fails if dialog has been destroyed already
                 self.precastvalues = self.precast.getValues()
@@ -443,7 +332,7 @@ class _CommandStructure:
                 self.precastvalues["Height"] = self.Height
                 argstring = ""
                 # fix for precast placement, since their (0,0) point is the lower left corner
-                if self.bmode:
+                if self.mode == StructureMode.BEAM:
                     delta = FreeCAD.Vector(0, 0 - self.Width / 2, 0)
                 else:
                     delta = FreeCAD.Vector(-self.Length / 2, -self.Width / 2, 0)
@@ -463,9 +352,7 @@ class _CommandStructure:
             else:
                 # metal profile
                 FreeCADGui.doCommand("p = Arch.makeProfile(" + str(self.Profile) + ")")
-                if (
-                    abs(self.Length - self.Profile[4]) >= 0.1
-                ) or self.bmode:  # forgive rounding errors
+                if self.mode == StructureMode.BEAM:
                     # horizontal
                     FreeCADGui.doCommand(
                         "s = Arch.makeStructure(p,length=" + str(self.Length) + ")"
@@ -476,9 +363,7 @@ class _CommandStructure:
                     FreeCADGui.doCommand(
                         "s = Arch.makeStructure(p,height=" + str(self.Height) + ")"
                     )
-                    # if not self.bmode:
-                    #    FreeCADGui.doCommand('s.Placement.Rotation = FreeCAD.Rotation(-0.5,0.5,-0.5,0.5)')
-                FreeCADGui.doCommand('s.Profile = "' + self.Profile[2] + '"')
+                FreeCADGui.doCommand("s.Profile = " + repr(self.Profile[2]))
         else:
             FreeCADGui.doCommand(
                 "s = Arch.makeStructure(length="
@@ -491,7 +376,7 @@ class _CommandStructure:
             )
 
         # calculate rotation
-        if self.bmode and self.bpoint:
+        if self.mode == StructureMode.BEAM and self.bpoint:
             FreeCADGui.doCommand(
                 "s.Placement = Arch.placeAlongEdge("
                 + DraftVecUtils.toString(self.bpoint)
@@ -535,14 +420,14 @@ class _CommandStructure:
 
         w = QtGui.QWidget()
         ui = FreeCADGui.UiLoader()
-        w.setWindowTitle(translate("Arch", "Structure options"))
+        w.setWindowTitle(translate("Arch", "Structure Options"))
         grid = QtGui.QGridLayout(w)
 
         # mode box
         labelmode = QtGui.QLabel(translate("Arch", "Parameters of the structure") + ":")
         self.modeb = QtGui.QRadioButton(translate("Arch", "Beam"))
         self.modec = QtGui.QRadioButton(translate("Arch", "Column"))
-        if self.bpoint or self.beammode:
+        if self.bpoint or self.mode == StructureMode.BEAM:
             self.modeb.setChecked(True)
         else:
             self.modec.setChecked(True)
@@ -569,14 +454,7 @@ class _CommandStructure:
         # length
         label1 = QtGui.QLabel(translate("Arch", "Length"))
         self.vLength = ui.createWidget("Gui::InputField")
-        if self.modeb.isChecked():
-            self.vLength.setText(
-                FreeCAD.Units.Quantity(self.Height, FreeCAD.Units.Length).UserString
-            )
-        else:
-            self.vLength.setText(
-                FreeCAD.Units.Quantity(self.Length, FreeCAD.Units.Length).UserString
-            )
+        self.vLength.setText(FreeCAD.Units.Quantity(self.Length, FreeCAD.Units.Length).UserString)
         grid.addWidget(label1, 4, 0, 1, 1)
         grid.addWidget(self.vLength, 4, 1, 1, 1)
 
@@ -590,14 +468,7 @@ class _CommandStructure:
         # height
         label3 = QtGui.QLabel(translate("Arch", "Height"))
         self.vHeight = ui.createWidget("Gui::InputField")
-        if self.modeb.isChecked():
-            self.vHeight.setText(
-                FreeCAD.Units.Quantity(self.Length, FreeCAD.Units.Length).UserString
-            )
-        else:
-            self.vHeight.setText(
-                FreeCAD.Units.Quantity(self.Height, FreeCAD.Units.Length).UserString
-            )
+        self.vHeight.setText(FreeCAD.Units.Quantity(self.Height, FreeCAD.Units.Length).UserString)
         grid.addWidget(label3, 6, 0, 1, 1)
         grid.addWidget(self.vHeight, 6, 1, 1, 1)
 
@@ -652,7 +523,7 @@ class _CommandStructure:
             else:
                 delta = Vector(self.Length / 2, 0, 0)
             delta = self.wp.get_global_coords(delta, as_vector=True)
-            if self.modec.isChecked():
+            if self.mode == StructureMode.COLUMN:
                 self.tracker.pos(point.add(delta))
                 self.tracker.on()
             else:
@@ -666,29 +537,26 @@ class _CommandStructure:
                 else:
                     self.tracker.off()
 
+    def _paramPrefix(self):
+        return "Beam" if self.mode == StructureMode.BEAM else "Column"
+
     def setWidth(self, d):
 
         self.Width = d
         self.tracker.width(d)
-        params.set_param_arch("StructureWidth", d)
+        params.set_param_arch(self._paramPrefix() + "Width", d)
 
     def setHeight(self, d):
 
         self.Height = d
         self.tracker.height(d)
-        if self.modeb.isChecked():
-            params.set_param_arch("StructureLength", d)
-        else:
-            params.set_param_arch("StructureHeight", d)
+        params.set_param_arch(self._paramPrefix() + "Height", d)
 
     def setLength(self, d):
 
         self.Length = d
         self.tracker.length(d)
-        if self.modeb.isChecked():
-            params.set_param_arch("StructureHeight", d)
-        else:
-            params.set_param_arch("StructureLength", d)
+        params.set_param_arch(self._paramPrefix() + "Length", d)
 
     def setCategory(self, i):
 
@@ -726,26 +594,37 @@ class _CommandStructure:
                     self.dents.form.hide()
                 params.set_param_arch("StructurePreset", self.Profile)
             else:
-                self.vLength.setText(
-                    FreeCAD.Units.Quantity(float(elt[4]), FreeCAD.Units.Length).UserString
-                )
-                self.vWidth.setText(
-                    FreeCAD.Units.Quantity(float(elt[5]), FreeCAD.Units.Length).UserString
-                )
+                # elt[4] is the cross-section depth, elt[5] is the cross-section width.
+                # For beams the cross-section depth is Height; for columns it is Length.
+                depth = float(elt[4])
+                width = float(elt[5])
+                if self.mode == StructureMode.BEAM:
+                    self.vHeight.setText(
+                        FreeCAD.Units.Quantity(depth, FreeCAD.Units.Length).UserString
+                    )
+                    self.setHeight(depth)
+                else:
+                    self.vLength.setText(
+                        FreeCAD.Units.Quantity(depth, FreeCAD.Units.Length).UserString
+                    )
+                    self.setLength(depth)
+                self.vWidth.setText(FreeCAD.Units.Quantity(width, FreeCAD.Units.Length).UserString)
+                self.setWidth(width)
                 self.Profile = elt
                 params.set_param_arch("StructurePreset", ";".join([str(i) for i in self.Profile]))
 
-    def switchLH(self, bmode):
+    def switchLH(self, beam_toggled):
 
-        if bmode:
-            self.bmode = True
-            if self.Height > self.Length:
-                self.rotateLH()
-        else:
-            self.bmode = False
-            if self.Length > self.Height:
-                self.rotateLH()
-                self.tracker.setRotation(FreeCAD.Rotation())
+        self.mode = StructureMode.BEAM if beam_toggled else StructureMode.COLUMN
+        self._loadDimensions()
+        self.vWidth.setText(FreeCAD.Units.Quantity(self.Width, FreeCAD.Units.Length).UserString)
+        self.vHeight.setText(FreeCAD.Units.Quantity(self.Height, FreeCAD.Units.Length).UserString)
+        self.vLength.setText(FreeCAD.Units.Quantity(self.Length, FreeCAD.Units.Length).UserString)
+        self.tracker.width(self.Width)
+        self.tracker.height(self.Height)
+        self.tracker.length(self.Length)
+        if self.mode == StructureMode.COLUMN:
+            self.tracker.setRotation(FreeCAD.Rotation())
 
     def rotateLH(self):
 
@@ -1004,6 +883,8 @@ class _Structure(ArchComponent.Component):
                 locked=True,
             )
             obj.ArchSketchPropertySet = ["Default"]
+
+        # Slab multi-material properties
         if not "Align" in pl:
             obj.addProperty(
                 "App::PropertyEnumeration",
@@ -1012,7 +893,7 @@ class _Structure(ArchComponent.Component):
                 QT_TRANSLATE_NOOP(
                     "App::Property",
                     "Global vertical alignment of the slab stack relative to its base "
-                    "face. Bottom/Center/Top. Used when Align Layer is 'None'. "
+                    "face. Bottom/Center/Top. Used when Align Layer is None. "
                     "Only active when IfcType is Slab.",
                 ),
                 locked=True,
@@ -1152,136 +1033,16 @@ class _Structure(ArchComponent.Component):
                 obj.setEditorMode("AlignLayerMode", 0 if layer_active else 2)
             if hasattr(obj, "Slope") and hasattr(obj, "SlopeEdge"):
                 slope_val = obj.Slope.Value if hasattr(obj.Slope, "Value") else 0.0
-                obj.setEditorMode(
-                    "SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2
-                )
-
-    def get_layers(self, obj):
-        """Returns a list of layer thicknesses for multi-material slab support.
-        Mirrors _Wall.get_layers(), but keyed to Height instead of Width.
-        Only active when IfcType is Slab and a multi-material is assigned.
-        """
-        layers = []
-        if not (getattr(obj, "IfcType", "") == "Slab"):
-            return layers
-        height = obj.Height.Value
-        if hasattr(obj, "Material") and obj.Material:
-            if hasattr(obj.Material, "Materials"):
-                thicknesses = [abs(t) for t in obj.Material.Thicknesses]
-                restwidth = height - sum(thicknesses)
-                varwidth = 0
-                if restwidth > 0:
-                    varcount = [t for t in thicknesses if t == 0]
-                    if varcount:
-                        varwidth = restwidth / len(varcount)
-                for t in obj.Material.Thicknesses:
-                    if t:
-                        layers.append(t)
-                    elif varwidth:
-                        layers.append(varwidth)
-        return layers
-
-    def _update_align_layer_enum(self, obj):
-        """Rebuild the AlignLayer enumeration from the current multi-material.
-        Entries are plain layer names only. AlignLayerMode handles Top/Center/Bottom
-        separately. Preserves the current selection if the name still exists.
-        """
-        if not hasattr(obj, "AlignLayer"):
-            return
-        if getattr(obj, "IfcType", "") != "Slab":
-            return
-
-        entries = ["None (use Align)"]
-        layers = self.get_layers(obj)
-        if layers and hasattr(obj, "Material") and obj.Material:
-            if hasattr(obj.Material, "Materials"):
-                for i, mat in enumerate(obj.Material.Materials):
-                    if (
-                        hasattr(obj.Material, "Names")
-                        and i < len(obj.Material.Names)
-                        and obj.Material.Names[i]
-                    ):
-                        name = obj.Material.Names[i]
-                    elif hasattr(mat, "Label"):
-                        name = mat.Label
-                    else:
-                        name = f"Layer {i + 1}"
-                    entries.append(name)
-
-        # Preserve selection if still valid, else reset gracefully
-        try:
-            current = obj.AlignLayer
-        except Exception:
-            current = entries[0]
-        if current not in entries:
-            current = entries[0]
-        obj.AlignLayer = entries
-        obj.AlignLayer = current
-
-    def _align_to_z_offset(self, obj, total):
-        """Convert the global Align enum to a raw z_offset for the full stack."""
-        align = getattr(obj, "Align", "Bottom")
-        if align == "Center":
-            return -total / 2.0
-        elif align == "Top":
-            return -total
-        else:  # Bottom
-            return 0.0
-
-    def _compute_z_offset(self, obj, layers):
-        """Return the full z_offset for slab layer stacking.
-
-        Priority:
-        1. AlignLayer + AlignLayerMode (layer-specific pin) — when AlignLayer != 'None'
-        2. Align (global Bottom/Center/Top) — when AlignLayer == 'None'
-        3. Offset (manual shift) — always added on top of 1 or 2
-        """
-        total = sum(abs(l) for l in layers)
-        align_layer = getattr(obj, "AlignLayer", "None (use Align)")
-
-        if align_layer and align_layer != "None (use Align)":
-            # Resolve the layer index from its name
-            layer_idx = None
-            if hasattr(obj, "Material") and obj.Material:
-                if hasattr(obj.Material, "Materials"):
-                    for i, mat in enumerate(obj.Material.Materials):
-                        if (
-                            hasattr(obj.Material, "Names")
-                            and i < len(obj.Material.Names)
-                            and obj.Material.Names[i]
-                        ):
-                            name = obj.Material.Names[i]
-                        elif hasattr(mat, "Label"):
-                            name = mat.Label
+                obj.setEditorMode("SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2)
+            # Restore Height read-only state
+            layers = self.get_layers(obj)
+            if layers:
+                if hasattr(obj, "Material") and obj.Material:
+                    if hasattr(obj.Material, "Thicknesses"):
+                        if 0 not in obj.Material.Thicknesses:
+                            obj.setEditorMode("Height", ["ReadOnly"])
                         else:
-                            name = f"Layer {i + 1}"
-                        if name == align_layer:
-                            layer_idx = i
-                            break
-
-            if layer_idx is not None:
-                layer_mode = getattr(obj, "AlignLayerMode", "Bottom")
-                # Cumulative thickness of all layers before this one
-                cum = sum(abs(l) for l in layers[:layer_idx])
-                if layer_mode == "Bottom":
-                    z_offset = -cum
-                elif layer_mode == "Center":
-                    z_offset = -(cum + abs(layers[layer_idx]) / 2.0)
-                else:  # Top
-                    z_offset = -(cum + abs(layers[layer_idx]))
-            else:
-                # Layer name disappeared (material changed) — graceful fallback
-                z_offset = self._align_to_z_offset(obj, total)
-        else:
-            z_offset = self._align_to_z_offset(obj, total)
-
-        # Always apply manual Offset on top
-        manual_offset = getattr(obj, "Offset", None)
-        if manual_offset is not None:
-            val = manual_offset.Value if hasattr(manual_offset, "Value") else 0.0
-            z_offset += val
-
-        return z_offset
+                            obj.setEditorMode("Height", 0)
 
     def execute(self, obj):
         "creates the structure shape"
@@ -1297,14 +1058,12 @@ class _Structure(ArchComponent.Component):
         # --- Slab: sync Height with multi-material total, manage read-only,
         #     and keep AlignLayer enum up to date ---
         if getattr(obj, "IfcType", "") == "Slab":
-            # Always keep the AlignLayer dropdown in sync with current material
             self._update_align_layer_enum(obj)
             layers = self.get_layers(obj)
             if layers:
                 total = sum([abs(l) for l in layers])
                 if obj.Height.Value != total:
                     obj.Height = total
-                # Lock Height when material fully defines thickness (no zero entry)
                 if hasattr(obj, "Material") and obj.Material:
                     if hasattr(obj.Material, "Thicknesses"):
                         if 0 not in obj.Material.Thicknesses:
@@ -1429,6 +1188,135 @@ class _Structure(ArchComponent.Component):
 
         base = self.processSubShapes(obj, base, pl)
         self.applyShape(obj, base, pl)
+
+    def get_layers(self, obj):
+        """Returns a list of layer thicknesses for multi-material slab support.
+        Only active when IfcType is Slab and a multi-material is assigned.
+        """
+        layers = []
+        if not (getattr(obj, "IfcType", "") == "Slab"):
+            return layers
+        height = obj.Height.Value
+        if hasattr(obj, "Material") and obj.Material:
+            if hasattr(obj.Material, "Materials"):
+                thicknesses = [abs(t) for t in obj.Material.Thicknesses]
+                restwidth = height - sum(thicknesses)
+                varwidth = 0
+                if restwidth > 0:
+                    varcount = [t for t in thicknesses if t == 0]
+                    if varcount:
+                        varwidth = restwidth / len(varcount)
+                for t in obj.Material.Thicknesses:
+                    if t:
+                        layers.append(t)
+                    elif varwidth:
+                        layers.append(varwidth)
+        return layers
+
+    def _update_align_layer_enum(self, obj):
+        """Rebuild the AlignLayer enumeration from the current multi-material.
+        Guarded against re-entrancy. Preserves selection if name still exists.
+        """
+        if getattr(self, "_updating_align_layer", False):
+            return
+        if not hasattr(obj, "AlignLayer"):
+            return
+        if getattr(obj, "IfcType", "") != "Slab":
+            return
+        self._updating_align_layer = True
+        try:
+            entries = ["None (use Align)"]
+            layers = self.get_layers(obj)
+            if layers and hasattr(obj, "Material") and obj.Material:
+                if hasattr(obj.Material, "Materials"):
+                    for i, mat in enumerate(obj.Material.Materials):
+                        if (
+                            hasattr(obj.Material, "Names")
+                            and i < len(obj.Material.Names)
+                            and obj.Material.Names[i]
+                        ):
+                            name = obj.Material.Names[i]
+                        elif hasattr(mat, "Label"):
+                            name = mat.Label
+                        else:
+                            name = "Layer {}".format(i + 1)
+                        entries.append(name)
+            try:
+                current = obj.AlignLayer
+            except Exception:
+                current = entries[0]
+            if current not in entries:
+                current = entries[0]
+            try:
+                existing = list(obj.getEnumerationsOfProperty("AlignLayer"))
+            except Exception:
+                existing = []
+            if existing != entries:
+                obj.AlignLayer = entries
+            obj.AlignLayer = current
+        finally:
+            self._updating_align_layer = False
+
+    def _align_to_z_offset(self, obj, total):
+        """Convert the global Align enum to a raw z_offset for the full stack."""
+        align = getattr(obj, "Align", "Bottom")
+        if align == "Center":
+            return -total / 2.0
+        elif align == "Top":
+            return -total
+        else:  # Bottom
+            return 0.0
+
+    def _compute_z_offset(self, obj, layers):
+        """Return the full z_offset for slab layer stacking.
+
+        Priority:
+        1. AlignLayer + AlignLayerMode (layer-specific pin)
+        2. Align (global Bottom/Center/Top)
+        3. Offset (manual shift) — always added on top
+        """
+        total = sum(abs(l) for l in layers)
+        align_layer = getattr(obj, "AlignLayer", "None (use Align)")
+
+        if align_layer and align_layer != "None (use Align)":
+            layer_idx = None
+            if hasattr(obj, "Material") and obj.Material:
+                if hasattr(obj.Material, "Materials"):
+                    for i, mat in enumerate(obj.Material.Materials):
+                        if (
+                            hasattr(obj.Material, "Names")
+                            and i < len(obj.Material.Names)
+                            and obj.Material.Names[i]
+                        ):
+                            name = obj.Material.Names[i]
+                        elif hasattr(mat, "Label"):
+                            name = mat.Label
+                        else:
+                            name = "Layer {}".format(i + 1)
+                        if name == align_layer:
+                            layer_idx = i
+                            break
+
+            if layer_idx is not None:
+                layer_mode = getattr(obj, "AlignLayerMode", "Bottom")
+                cum = sum(abs(l) for l in layers[:layer_idx])
+                if layer_mode == "Bottom":
+                    z_offset = -cum
+                elif layer_mode == "Center":
+                    z_offset = -(cum + abs(layers[layer_idx]) / 2.0)
+                else:  # Top
+                    z_offset = -(cum + abs(layers[layer_idx]))
+            else:
+                z_offset = self._align_to_z_offset(obj, total)
+        else:
+            z_offset = self._align_to_z_offset(obj, total)
+
+        manual_offset = getattr(obj, "Offset", None)
+        if manual_offset is not None:
+            val = manual_offset.Value if hasattr(manual_offset, "Value") else 0.0
+            z_offset += val
+
+        return z_offset
 
     def getExtrusionData(self, obj):
         """returns (shape,extrusion vector or path,placement) or None"""
@@ -1678,15 +1566,12 @@ class _Structure(ArchComponent.Component):
                         # --- Slope with SlopeEdge direction ---
                         slope_angle = getattr(obj, "Slope", 0)
                         if hasattr(slope_angle, "Value"):
-                            slope_angle = slope_angle.Value  # degrees
+                            slope_angle = slope_angle.Value
                         slope_base = None
                         if abs(slope_angle) > 1e-6:
                             import math
 
-                            # Determine slope pivot axis
                             x_axis = None
-
-                            # 1. Try SlopeEdge property first
                             slope_edge_link = getattr(obj, "SlopeEdge", None)
                             if (
                                 slope_edge_link
@@ -1706,7 +1591,6 @@ class _Structure(ArchComponent.Component):
                                 except Exception:
                                     x_axis = None
 
-                            # 2. Fall back to first edge of base face
                             if x_axis is None:
                                 try:
                                     outer_wire = base.Wires[0]
@@ -1716,7 +1600,6 @@ class _Structure(ArchComponent.Component):
                                 except Exception:
                                     x_axis = FreeCAD.Vector(1, 0, 0)
 
-                            # Apply slope rotation around x_axis through the face centroid
                             try:
                                 pivot = base.CenterOfMass
                                 rot = FreeCAD.Rotation(x_axis, slope_angle)
@@ -1732,7 +1615,6 @@ class _Structure(ArchComponent.Component):
 
                         working_base = slope_base if slope_base is not None else base
 
-                        # Build per-layer face/extrusion/placement lists
                         bases_list, extrusions_list, placements_list = [], [], []
                         cum_offset = z_offset
 
@@ -1802,6 +1684,32 @@ class _Structure(ArchComponent.Component):
             if nodes:
                 self.nodes = [v.Point.add(offset) for v in nodes.Vertexes]
                 obj.Nodes = self.nodes
+
+        # --- Update AlignLayer enum when material or type changes ---
+        if prop in ["Material", "IfcType"]:
+            self._update_align_layer_enum(obj)
+
+        # --- Slab-only property visibility ---
+        is_slab = getattr(obj, "IfcType", "") == "Slab"
+
+        for p in ["Align", "AlignLayer", "AlignLayerMode", "Offset", "Slope", "SlopeEdge"]:
+            if hasattr(obj, p):
+                obj.setEditorMode(p, 0 if is_slab else 2)
+
+        if is_slab:
+            align_layer = getattr(obj, "AlignLayer", "None (use Align)")
+            layer_active = bool(align_layer and align_layer != "None (use Align)")
+
+            if hasattr(obj, "Align"):
+                obj.setEditorMode("Align", ["ReadOnly"] if layer_active else 0)
+            if hasattr(obj, "AlignLayerMode"):
+                obj.setEditorMode("AlignLayerMode", 0 if layer_active else 2)
+
+            if hasattr(obj, "Slope") and hasattr(obj, "SlopeEdge"):
+                slope_val = obj.Slope.Value if hasattr(obj.Slope, "Value") else 0.0
+                obj.setEditorMode("SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2)
+        # --- End slab-only visibility ---
+
         ArchComponent.Component.onChanged(self, obj, prop)
 
         if prop == "ArchSketchPropertySet" and Draft.getType(obj.Base) == "ArchSketch":
@@ -1823,38 +1731,6 @@ class _Structure(ArchComponent.Component):
                 obj.setEditorMode("ArchSketchEdges", 0)
             if hasattr(obj, "ArchSketchPropertySet"):
                 obj.setEditorMode("ArchSketchPropertySet", ["ReadOnly"])
-
-        # --- Update AlignLayer enum when material or type changes ---
-        if prop in ["Material", "IfcType"]:
-            self._update_align_layer_enum(obj)
-
-        # --- Slab-only property visibility ---
-        is_slab = getattr(obj, "IfcType", "") == "Slab"
-
-        for p in ["Align", "AlignLayer", "AlignLayerMode", "Offset", "Slope", "SlopeEdge"]:
-            if hasattr(obj, p):
-                obj.setEditorMode(p, 0 if is_slab else 2)
-
-        if is_slab:
-            align_layer = getattr(obj, "AlignLayer", "None (use Align)")
-            layer_active = bool(align_layer and align_layer != "None (use Align)")
-
-            # When a reference layer is active, global Align is read-only
-            # (it's overridden — no point editing it)
-            if hasattr(obj, "Align"):
-                obj.setEditorMode("Align", ["ReadOnly"] if layer_active else 0)
-
-            # AlignLayerMode only makes sense when a reference layer is chosen
-            if hasattr(obj, "AlignLayerMode"):
-                obj.setEditorMode("AlignLayerMode", 0 if layer_active else 2)
-
-            # SlopeEdge only appears when Slope is non-zero
-            if hasattr(obj, "Slope") and hasattr(obj, "SlopeEdge"):
-                slope_val = obj.Slope.Value if hasattr(obj.Slope, "Value") else 0.0
-                obj.setEditorMode(
-                    "SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2
-                )
-        # --- End slab-only visibility ---
 
     def getNodeEdges(self, obj):
         "returns a list of edges from structural nodes"
@@ -2098,17 +1974,33 @@ class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
             return None
 
         taskd = StructureTaskPanel(vobj.Object)
-        taskd.obj = self.Object
-        taskd.update()
         FreeCADGui.Control.showDialog(taskd)
         return True
 
 
-class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
+class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
+    """A task panel for Arch Structures that combines generic dimensions with node tools"""
 
     def __init__(self, obj):
+        # Define properties based on the IfcType
+        if getattr(obj, "IfcType", "Beam") == "Slab":
+            property_definitions = [
+                {"prop": "Height", "label": translate("Arch", "Thickness")},
+            ]
+        else:
+            # For Beams and Columns
+            property_definitions = [
+                {"prop": "Length", "label": translate("Arch", "Length")},
+                {"prop": "Width", "label": translate("Arch", "Width")},
+                {"prop": "Height", "label": translate("Arch", "Height")},
+            ]
 
-        ArchComponent.ComponentTaskPanel.__init__(self)
+        #  Initialize generic parent (creates self.options_widget and self.baseform)
+        super().__init__(obj, property_definitions)
+
+        # Alias for compatibility with node/tool methods
+        self.Object = self.obj
+
         self.nodes_widget = QtGui.QWidget()
         self.nodes_widget.setWindowTitle(QtGui.QApplication.translate("Arch", "Node Tools", None))
         lay = QtGui.QVBoxLayout(self.nodes_widget)
@@ -2116,15 +2008,14 @@ class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
         self.resetButton = QtGui.QPushButton(self.nodes_widget)
         self.resetButton.setIcon(QtGui.QIcon(":/icons/edit-undo.svg"))
         self.resetButton.setText(QtGui.QApplication.translate("Arch", "Reset Nodes", None))
-
         lay.addWidget(self.resetButton)
-        QtCore.QObject.connect(self.resetButton, QtCore.SIGNAL("clicked()"), self.resetNodes)
+        self.resetButton.clicked.connect(self.resetNodes)
 
         self.editButton = QtGui.QPushButton(self.nodes_widget)
         self.editButton.setIcon(QtGui.QIcon(":/icons/Draft_Edit.svg"))
         self.editButton.setText(QtGui.QApplication.translate("Arch", "Edit Nodes", None))
         lay.addWidget(self.editButton)
-        QtCore.QObject.connect(self.editButton, QtCore.SIGNAL("clicked()"), self.editNodes)
+        self.editButton.clicked.connect(self.editNodes)
 
         self.extendButton = QtGui.QPushButton(self.nodes_widget)
         self.extendButton.setIcon(QtGui.QIcon(":/icons/Snap_Perpendicular.svg"))
@@ -2137,7 +2028,7 @@ class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
             )
         )
         lay.addWidget(self.extendButton)
-        QtCore.QObject.connect(self.extendButton, QtCore.SIGNAL("clicked()"), self.extendNodes)
+        self.extendButton.clicked.connect(self.extendNodes)
 
         self.connectButton = QtGui.QPushButton(self.nodes_widget)
         self.connectButton.setIcon(QtGui.QIcon(":/icons/Snap_Intersection.svg"))
@@ -2148,7 +2039,7 @@ class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
             )
         )
         lay.addWidget(self.connectButton)
-        QtCore.QObject.connect(self.connectButton, QtCore.SIGNAL("clicked()"), self.connectNodes)
+        self.connectButton.clicked.connect(self.connectNodes)
 
         self.toggleButton = QtGui.QPushButton(self.nodes_widget)
         self.toggleButton.setIcon(QtGui.QIcon(":/icons/dagViewVisible.svg"))
@@ -2159,7 +2050,7 @@ class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
             )
         )
         lay.addWidget(self.toggleButton)
-        QtCore.QObject.connect(self.toggleButton, QtCore.SIGNAL("clicked()"), self.toggleNodes)
+        self.toggleButton.clicked.connect(self.toggleNodes)
 
         self.extrusion_widget = QtGui.QWidget()
         self.extrusion_widget.setWindowTitle(
@@ -2176,12 +2067,11 @@ class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
             )
         )
         lay.addWidget(self.selectToolButton)
-        QtCore.QObject.connect(
-            self.selectToolButton, QtCore.SIGNAL("clicked()"), self.setSelectionFromTool
-        )
+        self.selectToolButton.clicked.connect(self.setSelectionFromTool)
 
-        self.form = [self.form, self.nodes_widget, self.extrusion_widget]
-        self.Object = obj
+        # Build the final form list: Options box, Node Tools box, Extrusion box, Components box
+        self.form = [self.options_widget, self.nodes_widget, self.extrusion_widget, self.baseform]
+
         self.observer = None
         self.nodevis = None
 
@@ -2374,14 +2264,13 @@ class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
         self.selectToolButton.setText(QtGui.QApplication.translate("Arch", "Select Tool", None))
 
     def accept(self):
-
         if self.observer:
             FreeCADGui.Selection.removeObserver(self.observer)
         if self.nodevis:
             self.toggleNodes()
-        FreeCAD.ActiveDocument.recompute()
-        FreeCADGui.ActiveDocument.resetEdit()
-        return True
+
+        # Trigger the generic property-saving logic in ComponentOptionsTaskPanel
+        return super().accept()
 
 
 class StructSelectionObserver:
@@ -2537,14 +2426,13 @@ class _ViewProviderStructuralSystem(ArchComponent.ViewProviderComponent):
 
 
 if FreeCAD.GuiUp:
-    FreeCADGui.addCommand("Arch_Structure", _CommandStructure())
     FreeCADGui.addCommand("Arch_StructuralSystem", CommandStructuralSystem())
     FreeCADGui.addCommand("Arch_StructuresFromSelection", CommandStructuresFromSelection())
 
     class _ArchStructureGroupCommand:
 
         def GetCommands(self):
-            return ("Arch_Structure", "Arch_StructuralSystem", "Arch_StructuresFromSelection")
+            return ("Arch_StructuralSystem", "Arch_StructuresFromSelection")
 
         def GetResources(self):
             return {

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -1585,18 +1585,18 @@ class _Structure(ArchComponent.Component):
                                     sub_name = sub_names[0] if sub_names else None
                                     if sub_name and hasattr(linked_obj, "Shape"):
                                         edge = linked_obj.Shape.getElement(sub_name)
-                                        x_axis = edge.tangentAt(
-                                            edge.FirstParameter
-                                        ).normalize()
+                                        x_axis = edge.tangentAt(edge.FirstParameter).normalize()
                                 except Exception:
                                     x_axis = None
 
                             if x_axis is None:
                                 try:
                                     outer_wire = base.Wires[0]
-                                    x_axis = outer_wire.Edges[0].tangentAt(
-                                        outer_wire.Edges[0].FirstParameter
-                                    ).normalize()
+                                    x_axis = (
+                                        outer_wire.Edges[0]
+                                        .tangentAt(outer_wire.Edges[0].FirstParameter)
+                                        .normalize()
+                                    )
                                 except Exception:
                                     x_axis = FreeCAD.Vector(1, 0, 0)
 
@@ -1900,9 +1900,7 @@ class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
                                         c[2],
                                         1.0 - float(mat.Material["Transparency"]),
                                     )
-                                cols.extend(
-                                    [c for _ in range(len(obj.Shape.Solids[i].Faces))]
-                                )
+                                cols.extend([c for _ in range(len(obj.Shape.Solids[i].Faces))])
                             obj.ViewObject.DiffuseColor = cols
             ArchComponent.ViewProviderComponent.updateData(self, obj, prop)
             if len(obj.ViewObject.DiffuseColor) > 1:

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -1036,6 +1036,48 @@ class _Structure(ArchComponent.Component):
                 locked=True,
             )
 
+        if not "Offset" in pl:
+            obj.addProperty(
+                "App::PropertyDistance",
+                "Offset",
+                "Structure",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Vertical offset of the slab from its base face along the extrusion "
+                    "normal. Applied after Align / AlignLayer. Only used when IfcType is Slab.",
+                ),
+                locked=True,
+            )
+
+        if not "AlignLayer" in pl:
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "AlignLayer",
+                "Structure",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Fine-grain alignment: pick a specific layer face as the zero "
+                    "reference. Overrides Align when not set to 'None (use Align)'. "
+                    "Only used when IfcType is Slab and a multi-material is assigned.",
+                ),
+                locked=True,
+            )
+            obj.AlignLayer = ["None (use Align)"]
+
+        if not "SlopeEdge" in pl:
+            obj.addProperty(
+                "App::PropertyLinkSub",
+                "SlopeEdge",
+                "Structure",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Edge to use as the slope direction pivot. If not set, the first "
+                    "edge of the base face is used. Only active when Slope != 0 and "
+                    "IfcType is Slab.",
+                ),
+                locked=True,
+            )
+
     def dumps(self):  # Supercede Arch.Component.dumps()
         dump = super().dumps()
         if not isinstance(dump, tuple):
@@ -1076,12 +1118,26 @@ class _Structure(ArchComponent.Component):
             if hasattr(obj, "ArchSketchPropertySet"):
                 obj.setEditorMode("ArchSketchPropertySet", ["ReadOnly"])
 
-        # Restore slab-only property visibility
+        # Restore slab-only property visibility and AlignLayer enum
+        self._update_align_layer_enum(obj)
         is_slab = getattr(obj, "IfcType", "") == "Slab"
-        if hasattr(obj, "Align"):
-            obj.setEditorMode("Align", 0 if is_slab else 2)
-        if hasattr(obj, "Slope"):
-            obj.setEditorMode("Slope", 0 if is_slab else 2)
+
+        for p in ["Align", "AlignLayer", "Offset", "Slope", "SlopeEdge"]:
+            if hasattr(obj, p):
+                obj.setEditorMode(p, 0 if is_slab else 2)
+
+        if is_slab:
+            align_layer = getattr(obj, "AlignLayer", "None (use Align)")
+            if align_layer and align_layer != "None (use Align)":
+                if hasattr(obj, "Align"):
+                    obj.setEditorMode("Align", ["ReadOnly"])
+            else:
+                if hasattr(obj, "Align"):
+                    obj.setEditorMode("Align", 0)
+
+            if hasattr(obj, "Slope") and hasattr(obj, "SlopeEdge"):
+                slope_val = obj.Slope.Value if hasattr(obj.Slope, "Value") else 0.0
+                obj.setEditorMode("SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2)
 
     def execute(self, obj):
         "creates the structure shape"
@@ -1094,14 +1150,17 @@ class _Structure(ArchComponent.Component):
         if obj.Base and not self.ensureBase(obj):
             return
 
-        # --- Slab: sync Height with multi-material total, manage read-only ---
+        # --- Slab: sync Height with multi-material total, manage read-only,
+        #     and keep AlignLayer enum up to date ---
         if getattr(obj, "IfcType", "") == "Slab":
+            # Always keep the AlignLayer dropdown in sync with current material
+            self._update_align_layer_enum(obj)
             layers = self.get_layers(obj)
             if layers:
                 total = sum([abs(l) for l in layers])
                 if obj.Height.Value != total:
                     obj.Height = total
-                # If no zero-thickness entry exists, the material fully drives Height
+                # Lock Height when material fully defines thickness (no zero entry)
                 if hasattr(obj, "Material") and obj.Material:
                     if hasattr(obj.Material, "Thicknesses"):
                         if 0 not in obj.Material.Thicknesses:
@@ -1109,7 +1168,6 @@ class _Structure(ArchComponent.Component):
                         else:
                             obj.setEditorMode("Height", 0)
             else:
-                # No multi-material: Height is always user-editable
                 obj.setEditorMode("Height", 0)
         # --- End slab Height sync ---
 
@@ -1458,7 +1516,6 @@ class _Structure(ArchComponent.Component):
                 else:
                     if height:
                         extrusion = normal.multiply(height)
-
             if extrusion:
                 # --- Multi-material layer support for slabs ---
                 if (
@@ -1471,36 +1528,52 @@ class _Structure(ArchComponent.Component):
                     if layers:
                         unit_n = FreeCAD.Vector(extrusion).normalize()
 
-                        # --- Align offset ---
-                        align = getattr(obj, "Align", "Bottom")
-                        total = sum(abs(l) for l in layers)
-                        if align == "Center":
-                            z_offset = -total / 2
-                        elif align == "Top":
-                            z_offset = -total
-                        else:  # Bottom
-                            z_offset = 0.0
+                        # Resolve z_offset via AlignLayer > Align > Offset
+                        z_offset = self._compute_z_offset(obj, layers)
 
-                        # --- Slope: rotate base face around its local X axis ---
+                        # --- Slope with SlopeEdge direction ---
                         slope_angle = getattr(obj, "Slope", 0)
                         if hasattr(slope_angle, "Value"):
                             slope_angle = slope_angle.Value  # degrees
                         slope_base = None
                         if abs(slope_angle) > 1e-6:
-                            import math
-                            # Determine the local X axis of the base face
-                            # (first edge direction of the face's outer wire)
+                            # Determine slope pivot axis
+                            x_axis = None
+
+                            # 1. Try SlopeEdge property first
+                            slope_edge_link = getattr(obj, "SlopeEdge", None)
+                            if (
+                                slope_edge_link
+                                and len(slope_edge_link) >= 2
+                                and slope_edge_link[0]
+                                and slope_edge_link[1]
+                            ):
+                                try:
+                                    linked_obj = slope_edge_link[0]
+                                    sub_names = slope_edge_link[1]
+                                    sub_name = sub_names[0] if sub_names else None
+                                    if sub_name and hasattr(linked_obj, "Shape"):
+                                        edge = linked_obj.Shape.getElement(sub_name)
+                                        x_axis = edge.tangentAt(
+                                            edge.FirstParameter
+                                        ).normalize()
+                                except Exception:
+                                    x_axis = None
+
+                            # 2. Fall back to first edge of base face
+                            if x_axis is None:
+                                try:
+                                    outer_wire = base.Wires[0]
+                                    x_axis = outer_wire.Edges[0].tangentAt(
+                                        outer_wire.Edges[0].FirstParameter
+                                    ).normalize()
+                                except Exception:
+                                    x_axis = FreeCAD.Vector(1, 0, 0)
+
+                            # Apply slope rotation around x_axis through the face centroid
                             try:
-                                outer_wire = base.Wires[0]
-                                x_axis = outer_wire.Edges[0].tangentAt(
-                                    outer_wire.Edges[0].FirstParameter
-                                )
-                                x_axis.normalize()
-                                # Pivot point: centroid of base face
                                 pivot = base.CenterOfMass
                                 rot = FreeCAD.Rotation(x_axis, slope_angle)
-                                slope_mat = FreeCAD.Matrix()
-                                # Translate to pivot, rotate, translate back
                                 t1 = FreeCAD.Matrix()
                                 t1.move(-pivot)
                                 r = rot.toMatrix()
@@ -1509,12 +1582,11 @@ class _Structure(ArchComponent.Component):
                                 slope_mat = t2.multiply(r.multiply(t1))
                                 slope_base = base.transformGeometry(slope_mat)
                             except Exception:
-                                # If slope geometry fails for any reason, fall through
-                                # to the flat slab path without crashing
                                 slope_base = None
 
                         working_base = slope_base if slope_base is not None else base
 
+                        # Build per-layer face/extrusion/placement lists
                         bases_list, extrusions_list, placements_list = [], [], []
                         cum_offset = z_offset
 
@@ -1585,13 +1657,32 @@ class _Structure(ArchComponent.Component):
                 self.nodes = [v.Point.add(offset) for v in nodes.Vertexes]
                 obj.Nodes = self.nodes
 
-        # --- Show/hide slab-only properties ---
+        # --- Update AlignLayer enum when material or type changes ---
+        if prop in ["Material", "IfcType"]:
+            self._update_align_layer_enum(obj)
+
+        # --- Slab-only property visibility ---
         is_slab = getattr(obj, "IfcType", "") == "Slab"
-        if hasattr(obj, "Align"):
-            obj.setEditorMode("Align", 0 if is_slab else 2)
-        if hasattr(obj, "Slope"):
-            obj.setEditorMode("Slope", 0 if is_slab else 2)
-        # --- End slab-only properties ---
+
+        for p in ["Align", "AlignLayer", "Offset", "Slope", "SlopeEdge"]:
+            if hasattr(obj, p):
+                obj.setEditorMode(p, 0 if is_slab else 2)
+
+        if is_slab:
+            # When AlignLayer is active, Align is redundant — make read-only
+            align_layer = getattr(obj, "AlignLayer", "None (use Align)")
+            if align_layer and align_layer != "None (use Align)":
+                if hasattr(obj, "Align"):
+                    obj.setEditorMode("Align", ["ReadOnly"])
+            else:
+                if hasattr(obj, "Align"):
+                    obj.setEditorMode("Align", 0)
+
+            # Only show SlopeEdge when Slope is non-zero
+            if hasattr(obj, "Slope") and hasattr(obj, "SlopeEdge"):
+                slope_val = obj.Slope.Value if hasattr(obj.Slope, "Value") else 0.0
+                obj.setEditorMode("SlopeEdge", 0 if abs(slope_val) > 1e-6 else 2)
+        # --- End slab-only visibility ---
 
         ArchComponent.Component.onChanged(self, obj, prop)
 
@@ -1662,6 +1753,113 @@ class _Structure(ArchComponent.Component):
                     elif varwidth:
                         layers.append(varwidth)
         return layers
+
+    def _update_align_layer_enum(self, obj):
+        """Rebuild the AlignLayer enumeration from the current multi-material.
+        Called whenever Material or IfcType changes.
+        Preserves the current selection if still valid.
+        """
+        if not hasattr(obj, "AlignLayer"):
+            return
+        if getattr(obj, "IfcType", "") != "Slab":
+            return
+
+        entries = ["None (use Align)"]
+        layers = self.get_layers(obj)
+        if layers and hasattr(obj, "Material") and obj.Material:
+            if hasattr(obj.Material, "Materials"):
+                for i, mat in enumerate(obj.Material.Materials):
+                    # Prefer Material.Names, then Label, then fallback index
+                    if (
+                        hasattr(obj.Material, "Names")
+                        and i < len(obj.Material.Names)
+                        and obj.Material.Names[i]
+                    ):
+                        name = obj.Material.Names[i]
+                    elif hasattr(mat, "Label"):
+                        name = mat.Label
+                    else:
+                        name = f"Layer {i + 1}"
+                    entries.append(f"Bot: {name}")
+                    entries.append(f"Ctr: {name}")
+                    entries.append(f"Top: {name}")
+
+        # Preserve selection if still valid, else reset
+        try:
+            current = obj.AlignLayer
+        except Exception:
+            current = entries[0]
+        if current not in entries:
+            current = entries[0]
+        obj.AlignLayer = entries
+        obj.AlignLayer = current
+
+    def _align_to_z_offset(self, obj, total):
+        """Convert the Align enum (Bottom/Center/Top) to a raw z_offset for the stack."""
+        align = getattr(obj, "Align", "Bottom")
+        if align == "Center":
+            return -total / 2.0
+        elif align == "Top":
+            return -total
+        else:  # Bottom
+            return 0.0
+
+    def _compute_z_offset(self, obj, layers):
+        """Return the full z_offset for slab layer stacking.
+
+        Priority order:
+        1. AlignLayer (layer-specific reference face) — overrides Align when set
+        2. Align (Bottom / Center / Top of full stack) — used when AlignLayer is None
+        3. Offset (manual shift) — always applied on top of 1 or 2
+        """
+        total = sum(abs(l) for l in layers)
+        align_layer = getattr(obj, "AlignLayer", "None (use Align)")
+
+        if align_layer and align_layer != "None (use Align)":
+            # Format is "Bot: name", "Ctr: name", or "Top: name"
+            face_code = align_layer[:3]   # "Bot", "Ctr", "Top"
+            layer_name = align_layer[5:]  # everything after "Bot: " / "Ctr: " / "Top: "
+
+            # Resolve layer index by matching name
+            layer_idx = None
+            if hasattr(obj, "Material") and obj.Material:
+                if hasattr(obj.Material, "Materials"):
+                    for i, mat in enumerate(obj.Material.Materials):
+                        if (
+                            hasattr(obj.Material, "Names")
+                            and i < len(obj.Material.Names)
+                            and obj.Material.Names[i]
+                        ):
+                            name = obj.Material.Names[i]
+                        elif hasattr(mat, "Label"):
+                            name = mat.Label
+                        else:
+                            name = f"Layer {i + 1}"
+                        if name == layer_name:
+                            layer_idx = i
+                            break
+
+            if layer_idx is not None:
+                cum = sum(abs(l) for l in layers[:layer_idx])
+                if face_code == "Bot":
+                    z_offset = -cum
+                elif face_code == "Ctr":
+                    z_offset = -(cum + abs(layers[layer_idx]) / 2.0)
+                else:  # "Top"
+                    z_offset = -(cum + abs(layers[layer_idx]))
+            else:
+                # Layer name not found (material changed), graceful fallback
+                z_offset = self._align_to_z_offset(obj, total)
+        else:
+            z_offset = self._align_to_z_offset(obj, total)
+
+        # Apply manual Offset on top of everything
+        manual_offset = getattr(obj, "Offset", None)
+        if manual_offset is not None:
+            val = manual_offset.Value if hasattr(manual_offset, "Value") else 0.0
+            z_offset += val
+
+        return z_offset
 
 
 class _ViewProviderStructure(ArchComponent.ViewProviderComponent):

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -37,7 +37,6 @@ __url__ = "https://www.freecad.org"
 #  elements that have a structural function, that is, that
 #  support other parts of the building.
 
-import enum
 import FreeCAD
 import ArchComponent
 import ArchCommands
@@ -48,18 +47,6 @@ import DraftVecUtils
 from FreeCAD import Vector
 from draftutils import params
 from draftutils import gui_utils
-
-
-class StructureMode(enum.Enum):
-    """Placement mode for the interactive Structure command.
-
-    COLUMN: single-point placement, extrusion along the working plane normal.
-    BEAM:   two-point placement, extrusion along the edge between the two points.
-    """
-
-    COLUMN = "Column"
-    BEAM = "Beam"
-
 
 if FreeCAD.GuiUp:
     from PySide import QtCore, QtGui
@@ -85,6 +72,127 @@ Presets = ArchProfile.readPresets()
 for pre in Presets:
     if pre[1] not in Categories:
         Categories.append(pre[1])
+
+
+def makeStructure(baseobj=None, length=None, width=None, height=None, name=None):
+    """makeStructure([baseobj],[length],[width],[height],[name]): creates a
+    structure element based on the given profile object and the given
+    extrusion height. If no base object is given, you can also specify
+    length and width for a cubic object."""
+
+    if not FreeCAD.ActiveDocument:
+        FreeCAD.Console.PrintError("No active document. Aborting\n")
+        return
+    obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "Structure")
+    _Structure(obj)
+    if FreeCAD.GuiUp:
+        _ViewProviderStructure(obj.ViewObject)
+    if baseobj:
+        obj.Base = baseobj
+        if FreeCAD.GuiUp:
+            obj.Base.ViewObject.hide()
+    if width:
+        obj.Width = width
+    else:
+        obj.Width = params.get_param_arch("StructureWidth")
+    if height:
+        obj.Height = height
+    else:
+        if not length:
+            obj.Height = params.get_param_arch("StructureHeight")
+    if length:
+        obj.Length = length
+    else:
+        if not baseobj:
+            # don't set the length if we have a base object, otherwise the length X height calc
+            # gets wrong
+            obj.Length = params.get_param_arch("StructureLength")
+    if baseobj:
+        w = 0
+        h = 0
+        if hasattr(baseobj, "Width") and hasattr(baseobj, "Height"):
+            w = baseobj.Width.Value
+            h = baseobj.Height.Value
+        elif hasattr(baseobj, "Length") and hasattr(baseobj, "Width"):
+            w = baseobj.Length.Value
+            h = baseobj.Width.Value
+        elif hasattr(baseobj, "Length") and hasattr(baseobj, "Height"):
+            w = baseobj.Length.Value
+            h = baseobj.Height.Value
+        if w and h:
+            if length and not height:
+                obj.Width = w
+                obj.Height = h
+            elif height and not length:
+                obj.Width = w
+                obj.Length = h
+
+    if obj.Length > obj.Height:
+        obj.IfcType = "Beam"
+        obj.Label = name if name else translate("Arch", "Beam")
+    elif obj.Height > obj.Length:
+        obj.IfcType = "Column"
+        obj.Label = name if name else translate("Arch", "Column")
+    return obj
+
+
+def makeStructuralSystem(objects=[], axes=[], name=None):
+    """makeStructuralSystem([objects],[axes],[name]): makes a structural system
+    based on the given objects and axes"""
+
+    if not FreeCAD.ActiveDocument:
+        FreeCAD.Console.PrintError("No active document. Aborting\n")
+        return
+    result = []
+    if not axes:
+        print("At least one axis must be given")
+        return
+    if objects:
+        if not isinstance(objects, list):
+            objects = [objects]
+    else:
+        objects = [None]
+    for o in objects:
+        obj = FreeCAD.ActiveDocument.addObject("Part::FeaturePython", "StructuralSystem")
+        obj.Label = name if name else translate("Arch", "StructuralSystem")
+        _StructuralSystem(obj)
+        if FreeCAD.GuiUp:
+            _ViewProviderStructuralSystem(obj.ViewObject)
+        if o:
+            obj.Base = o
+        obj.Axes = axes
+        result.append(obj)
+        if FreeCAD.GuiUp and o:
+            o.ViewObject.hide()
+            Draft.formatObject(obj, o)
+    FreeCAD.ActiveDocument.recompute()
+    if len(result) == 1:
+        return result[0]
+    else:
+        return result
+
+
+def placeAlongEdge(p1, p2, horizontal=False):
+    """placeAlongEdge(p1,p2,[horizontal]): returns a Placement positioned at p1, with Z axis oriented towards p2.
+    If horizontal is True, then the X axis is oriented towards p2, not the Z axis"""
+
+    pl = FreeCAD.Placement()
+    pl.Base = p1
+    import WorkingPlane
+
+    up = WorkingPlane.get_working_plane(update=False).axis
+    zaxis = p2.sub(p1)
+    yaxis = up.cross(zaxis)
+    if yaxis.Length > 0:
+        xaxis = zaxis.cross(yaxis)
+        if horizontal:
+            pl.Rotation = FreeCAD.Rotation(zaxis, yaxis, xaxis, "ZXY")
+        else:
+            pl.Rotation = FreeCAD.Rotation(xaxis, yaxis, zaxis, "ZXY")
+            pl.Rotation = FreeCAD.Rotation(
+                pl.Rotation.multVec(FreeCAD.Vector(0, 0, 1)), 90
+            ).multiply(pl.Rotation)
+    return pl
 
 
 class CommandStructuresFromSelection:
@@ -212,29 +320,37 @@ class _CommandStructure:
 
     def __init__(self):
 
-        self.mode = StructureMode.COLUMN
+        self.beammode = False
+
+    def GetResources(self):
+
+        return {
+            "Pixmap": "Arch_Structure",
+            "MenuText": QT_TRANSLATE_NOOP("Arch_Structure", "Structure"),
+            "Accel": "S, T",
+            "ToolTip": QT_TRANSLATE_NOOP(
+                "Arch_Structure",
+                "Creates a structure from scratch or from a selected object (sketch, wire, face or solid)",
+            ),
+        }
 
     def IsActive(self):
 
         return not FreeCAD.ActiveDocument is None
 
-    def _loadDimensions(self):
-        """Load Width/Height/Length from mode-specific params.
-
-        Each mode persists its own set of dimensions so that switching between beam and column
-        doesn't pollute one mode's values with the other's.
-        """
-        prefix = "Beam" if self.mode == StructureMode.BEAM else "Column"
-        self.Width = params.get_param_arch(prefix + "Width")
-        self.Height = params.get_param_arch(prefix + "Height")
-        self.Length = params.get_param_arch(prefix + "Length")
-
     def Activated(self):
 
         self.doc = FreeCAD.ActiveDocument
-        self._loadDimensions()
+        self.Width = params.get_param_arch("StructureWidth")
+        if self.beammode:
+            self.Height = params.get_param_arch("StructureLength")
+            self.Length = params.get_param_arch("StructureHeight")
+        else:
+            self.Length = params.get_param_arch("StructureLength")
+            self.Height = params.get_param_arch("StructureHeight")
         self.Profile = None
         self.bpoint = None
+        self.bmode = False
         self.precastvalues = None
         self.wp = None
         sel = FreeCADGui.Selection.getSelection()
@@ -272,10 +388,10 @@ class _CommandStructure:
         self.precast = ArchPrecast._PrecastTaskPanel()
         self.dents = ArchPrecast._DentsTaskPanel()
         self.precast.Dents = self.dents
-        if self.mode == StructureMode.BEAM:
-            title = translate("Arch", "First Point of Beam")
+        if self.beammode:
+            title = translate("Arch", "First point of the beam")
         else:
-            title = translate("Arch", "Base Point of Column")
+            title = translate("Arch", "Base point of column")
         FreeCADGui.Snapper.getPoint(
             callback=self.getPoint,
             movecallback=self.update,
@@ -287,25 +403,20 @@ class _CommandStructure:
     def getPoint(self, point=None, obj=None):
         "this function is called by the snapper when it has a 3D point"
 
-        self.mode = StructureMode.BEAM if self.modeb.isChecked() else StructureMode.COLUMN
+        self.bmode = self.modeb.isChecked()
         if point is None:
             FreeCAD.activeDraftCommand = None
             FreeCADGui.Snapper.off()
             self.tracker.finalize()
             return
-        if self.mode == StructureMode.BEAM and (self.bpoint is None):
+        if self.bmode and (self.bpoint is None):
             self.bpoint = point
-            # Recreate precast/dents task boxes. The getPoint() call below replaces the task panel,
-            # destroying the task boxes that were embedded via extradlg by the first call.
-            self.precast = ArchPrecast._PrecastTaskPanel()
-            self.dents = ArchPrecast._DentsTaskPanel()
-            self.precast.Dents = self.dents
             FreeCADGui.Snapper.getPoint(
                 last=point,
                 callback=self.getPoint,
                 movecallback=self.update,
                 extradlg=[self.taskbox(), self.precast.form, self.dents.form],
-                title=translate("Arch", "Next Point") + ":",
+                title=translate("Arch", "Next point") + ":",
                 mode="line",
             )
             return
@@ -316,9 +427,9 @@ class _CommandStructure:
         self.doc.openTransaction(translate("Arch", "Create Structure"))
         FreeCADGui.addModule("Arch")
         FreeCADGui.addModule("WorkingPlane")
-        if self.mode == StructureMode.BEAM:
+        if self.bmode:
             self.Length = point.sub(self.bpoint).Length
-            params.set_param_arch("BeamLength", self.Length)
+            params.set_param_arch("StructureHeight", self.Length)
         if self.Profile is not None:
             try:  # try to update latest precast values - fails if dialog has been destroyed already
                 self.precastvalues = self.precast.getValues()
@@ -332,7 +443,7 @@ class _CommandStructure:
                 self.precastvalues["Height"] = self.Height
                 argstring = ""
                 # fix for precast placement, since their (0,0) point is the lower left corner
-                if self.mode == StructureMode.BEAM:
+                if self.bmode:
                     delta = FreeCAD.Vector(0, 0 - self.Width / 2, 0)
                 else:
                     delta = FreeCAD.Vector(-self.Length / 2, -self.Width / 2, 0)
@@ -352,7 +463,9 @@ class _CommandStructure:
             else:
                 # metal profile
                 FreeCADGui.doCommand("p = Arch.makeProfile(" + str(self.Profile) + ")")
-                if self.mode == StructureMode.BEAM:
+                if (
+                    abs(self.Length - self.Profile[4]) >= 0.1
+                ) or self.bmode:  # forgive rounding errors
                     # horizontal
                     FreeCADGui.doCommand(
                         "s = Arch.makeStructure(p,length=" + str(self.Length) + ")"
@@ -363,7 +476,9 @@ class _CommandStructure:
                     FreeCADGui.doCommand(
                         "s = Arch.makeStructure(p,height=" + str(self.Height) + ")"
                     )
-                FreeCADGui.doCommand("s.Profile = " + repr(self.Profile[2]))
+                    # if not self.bmode:
+                    #    FreeCADGui.doCommand('s.Placement.Rotation = FreeCAD.Rotation(-0.5,0.5,-0.5,0.5)')
+                FreeCADGui.doCommand('s.Profile = "' + self.Profile[2] + '"')
         else:
             FreeCADGui.doCommand(
                 "s = Arch.makeStructure(length="
@@ -376,7 +491,7 @@ class _CommandStructure:
             )
 
         # calculate rotation
-        if self.mode == StructureMode.BEAM and self.bpoint:
+        if self.bmode and self.bpoint:
             FreeCADGui.doCommand(
                 "s.Placement = Arch.placeAlongEdge("
                 + DraftVecUtils.toString(self.bpoint)
@@ -420,14 +535,14 @@ class _CommandStructure:
 
         w = QtGui.QWidget()
         ui = FreeCADGui.UiLoader()
-        w.setWindowTitle(translate("Arch", "Structure Options"))
+        w.setWindowTitle(translate("Arch", "Structure options"))
         grid = QtGui.QGridLayout(w)
 
         # mode box
         labelmode = QtGui.QLabel(translate("Arch", "Parameters of the structure") + ":")
         self.modeb = QtGui.QRadioButton(translate("Arch", "Beam"))
         self.modec = QtGui.QRadioButton(translate("Arch", "Column"))
-        if self.bpoint or self.mode == StructureMode.BEAM:
+        if self.bpoint or self.beammode:
             self.modeb.setChecked(True)
         else:
             self.modec.setChecked(True)
@@ -454,7 +569,14 @@ class _CommandStructure:
         # length
         label1 = QtGui.QLabel(translate("Arch", "Length"))
         self.vLength = ui.createWidget("Gui::InputField")
-        self.vLength.setText(FreeCAD.Units.Quantity(self.Length, FreeCAD.Units.Length).UserString)
+        if self.modeb.isChecked():
+            self.vLength.setText(
+                FreeCAD.Units.Quantity(self.Height, FreeCAD.Units.Length).UserString
+            )
+        else:
+            self.vLength.setText(
+                FreeCAD.Units.Quantity(self.Length, FreeCAD.Units.Length).UserString
+            )
         grid.addWidget(label1, 4, 0, 1, 1)
         grid.addWidget(self.vLength, 4, 1, 1, 1)
 
@@ -468,7 +590,14 @@ class _CommandStructure:
         # height
         label3 = QtGui.QLabel(translate("Arch", "Height"))
         self.vHeight = ui.createWidget("Gui::InputField")
-        self.vHeight.setText(FreeCAD.Units.Quantity(self.Height, FreeCAD.Units.Length).UserString)
+        if self.modeb.isChecked():
+            self.vHeight.setText(
+                FreeCAD.Units.Quantity(self.Length, FreeCAD.Units.Length).UserString
+            )
+        else:
+            self.vHeight.setText(
+                FreeCAD.Units.Quantity(self.Height, FreeCAD.Units.Length).UserString
+            )
         grid.addWidget(label3, 6, 0, 1, 1)
         grid.addWidget(self.vHeight, 6, 1, 1, 1)
 
@@ -523,7 +652,7 @@ class _CommandStructure:
             else:
                 delta = Vector(self.Length / 2, 0, 0)
             delta = self.wp.get_global_coords(delta, as_vector=True)
-            if self.mode == StructureMode.COLUMN:
+            if self.modec.isChecked():
                 self.tracker.pos(point.add(delta))
                 self.tracker.on()
             else:
@@ -537,26 +666,29 @@ class _CommandStructure:
                 else:
                     self.tracker.off()
 
-    def _paramPrefix(self):
-        return "Beam" if self.mode == StructureMode.BEAM else "Column"
-
     def setWidth(self, d):
 
         self.Width = d
         self.tracker.width(d)
-        params.set_param_arch(self._paramPrefix() + "Width", d)
+        params.set_param_arch("StructureWidth", d)
 
     def setHeight(self, d):
 
         self.Height = d
         self.tracker.height(d)
-        params.set_param_arch(self._paramPrefix() + "Height", d)
+        if self.modeb.isChecked():
+            params.set_param_arch("StructureLength", d)
+        else:
+            params.set_param_arch("StructureHeight", d)
 
     def setLength(self, d):
 
         self.Length = d
         self.tracker.length(d)
-        params.set_param_arch(self._paramPrefix() + "Length", d)
+        if self.modeb.isChecked():
+            params.set_param_arch("StructureHeight", d)
+        else:
+            params.set_param_arch("StructureLength", d)
 
     def setCategory(self, i):
 
@@ -594,37 +726,26 @@ class _CommandStructure:
                     self.dents.form.hide()
                 params.set_param_arch("StructurePreset", self.Profile)
             else:
-                # elt[4] is the cross-section depth, elt[5] is the cross-section width.
-                # For beams the cross-section depth is Height; for columns it is Length.
-                depth = float(elt[4])
-                width = float(elt[5])
-                if self.mode == StructureMode.BEAM:
-                    self.vHeight.setText(
-                        FreeCAD.Units.Quantity(depth, FreeCAD.Units.Length).UserString
-                    )
-                    self.setHeight(depth)
-                else:
-                    self.vLength.setText(
-                        FreeCAD.Units.Quantity(depth, FreeCAD.Units.Length).UserString
-                    )
-                    self.setLength(depth)
-                self.vWidth.setText(FreeCAD.Units.Quantity(width, FreeCAD.Units.Length).UserString)
-                self.setWidth(width)
+                self.vLength.setText(
+                    FreeCAD.Units.Quantity(float(elt[4]), FreeCAD.Units.Length).UserString
+                )
+                self.vWidth.setText(
+                    FreeCAD.Units.Quantity(float(elt[5]), FreeCAD.Units.Length).UserString
+                )
                 self.Profile = elt
                 params.set_param_arch("StructurePreset", ";".join([str(i) for i in self.Profile]))
 
-    def switchLH(self, beam_toggled):
+    def switchLH(self, bmode):
 
-        self.mode = StructureMode.BEAM if beam_toggled else StructureMode.COLUMN
-        self._loadDimensions()
-        self.vWidth.setText(FreeCAD.Units.Quantity(self.Width, FreeCAD.Units.Length).UserString)
-        self.vHeight.setText(FreeCAD.Units.Quantity(self.Height, FreeCAD.Units.Length).UserString)
-        self.vLength.setText(FreeCAD.Units.Quantity(self.Length, FreeCAD.Units.Length).UserString)
-        self.tracker.width(self.Width)
-        self.tracker.height(self.Height)
-        self.tracker.length(self.Length)
-        if self.mode == StructureMode.COLUMN:
-            self.tracker.setRotation(FreeCAD.Rotation())
+        if bmode:
+            self.bmode = True
+            if self.Height > self.Length:
+                self.rotateLH()
+        else:
+            self.bmode = False
+            if self.Length > self.Height:
+                self.rotateLH()
+                self.tracker.setRotation(FreeCAD.Rotation())
 
     def rotateLH(self):
 
@@ -888,6 +1009,33 @@ class _Structure(ArchComponent.Component):
         if not hasattr(self, "ArchSkPropSetListPrev"):
             self.ArchSkPropSetListPrev = []
 
+        if not "Align" in pl:
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "Align",
+                "Structure",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Vertical alignment of slab layers relative to the base face. "
+                    "Only used when IfcType is Slab.",
+                ),
+                locked=True,
+            )
+            obj.Align = ["Bottom", "Center", "Top"]
+
+        if not "Slope" in pl:
+            obj.addProperty(
+                "App::PropertyAngle",
+                "Slope",
+                "Structure",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Drainage slope angle applied to the slab along its local X axis. "
+                    "Only used when IfcType is Slab. Keep 0 for flat.",
+                ),
+                locked=True,
+            )
+
     def dumps(self):  # Supercede Arch.Component.dumps()
         dump = super().dumps()
         if not isinstance(dump, tuple):
@@ -928,7 +1076,12 @@ class _Structure(ArchComponent.Component):
             if hasattr(obj, "ArchSketchPropertySet"):
                 obj.setEditorMode("ArchSketchPropertySet", ["ReadOnly"])
 
-        # set a flag to indicate onDocumentRestored() is run
+        # Restore slab-only property visibility
+        is_slab = getattr(obj, "IfcType", "") == "Slab"
+        if hasattr(obj, "Align"):
+            obj.setEditorMode("Align", 0 if is_slab else 2)
+        if hasattr(obj, "Slope"):
+            obj.setEditorMode("Slope", 0 if is_slab else 2)
 
     def execute(self, obj):
         "creates the structure shape"
@@ -940,6 +1093,25 @@ class _Structure(ArchComponent.Component):
             return
         if obj.Base and not self.ensureBase(obj):
             return
+
+        # --- Slab: sync Height with multi-material total, manage read-only ---
+        if getattr(obj, "IfcType", "") == "Slab":
+            layers = self.get_layers(obj)
+            if layers:
+                total = sum([abs(l) for l in layers])
+                if obj.Height.Value != total:
+                    obj.Height = total
+                # If no zero-thickness entry exists, the material fully drives Height
+                if hasattr(obj, "Material") and obj.Material:
+                    if hasattr(obj.Material, "Thicknesses"):
+                        if 0 not in obj.Material.Thicknesses:
+                            obj.setEditorMode("Height", ["ReadOnly"])
+                        else:
+                            obj.setEditorMode("Height", 0)
+            else:
+                # No multi-material: Height is always user-editable
+                obj.setEditorMode("Height", 0)
+        # --- End slab Height sync ---
 
         base = None
         pl = obj.Placement
@@ -1286,7 +1458,79 @@ class _Structure(ArchComponent.Component):
                 else:
                     if height:
                         extrusion = normal.multiply(height)
+
             if extrusion:
+                # --- Multi-material layer support for slabs ---
+                if (
+                    getattr(obj, "IfcType", "") == "Slab"
+                    and not isinstance(base, list)
+                    and isinstance(extrusion, FreeCAD.Vector)
+                    and not (hasattr(obj, "Tool") and obj.Tool)
+                ):
+                    layers = self.get_layers(obj)
+                    if layers:
+                        unit_n = FreeCAD.Vector(extrusion).normalize()
+
+                        # --- Align offset ---
+                        align = getattr(obj, "Align", "Bottom")
+                        total = sum(abs(l) for l in layers)
+                        if align == "Center":
+                            z_offset = -total / 2
+                        elif align == "Top":
+                            z_offset = -total
+                        else:  # Bottom
+                            z_offset = 0.0
+
+                        # --- Slope: rotate base face around its local X axis ---
+                        slope_angle = getattr(obj, "Slope", 0)
+                        if hasattr(slope_angle, "Value"):
+                            slope_angle = slope_angle.Value  # degrees
+                        slope_base = None
+                        if abs(slope_angle) > 1e-6:
+                            import math
+                            # Determine the local X axis of the base face
+                            # (first edge direction of the face's outer wire)
+                            try:
+                                outer_wire = base.Wires[0]
+                                x_axis = outer_wire.Edges[0].tangentAt(
+                                    outer_wire.Edges[0].FirstParameter
+                                )
+                                x_axis.normalize()
+                                # Pivot point: centroid of base face
+                                pivot = base.CenterOfMass
+                                rot = FreeCAD.Rotation(x_axis, slope_angle)
+                                slope_mat = FreeCAD.Matrix()
+                                # Translate to pivot, rotate, translate back
+                                t1 = FreeCAD.Matrix()
+                                t1.move(-pivot)
+                                r = rot.toMatrix()
+                                t2 = FreeCAD.Matrix()
+                                t2.move(pivot)
+                                slope_mat = t2.multiply(r.multiply(t1))
+                                slope_base = base.transformGeometry(slope_mat)
+                            except Exception:
+                                # If slope geometry fails for any reason, fall through
+                                # to the flat slab path without crashing
+                                slope_base = None
+
+                        working_base = slope_base if slope_base is not None else base
+
+                        bases_list, extrusions_list, placements_list = [], [], []
+                        cum_offset = z_offset
+
+                        for layer in layers:
+                            if layer > 0:
+                                layer_face = working_base.copy()
+                                layer_face.translate(unit_n * cum_offset)
+                                bases_list.append(layer_face)
+                                extrusions_list.append(unit_n * layer)
+                                placements_list.append(placement)
+                            cum_offset += abs(layer)
+
+                        if bases_list:
+                            return (bases_list, extrusions_list, placements_list)
+                # --- End multi-material layer block ---
+
                 return (base, extrusion, placement)
         return None
 
@@ -1340,6 +1584,15 @@ class _Structure(ArchComponent.Component):
             if nodes:
                 self.nodes = [v.Point.add(offset) for v in nodes.Vertexes]
                 obj.Nodes = self.nodes
+
+        # --- Show/hide slab-only properties ---
+        is_slab = getattr(obj, "IfcType", "") == "Slab"
+        if hasattr(obj, "Align"):
+            obj.setEditorMode("Align", 0 if is_slab else 2)
+        if hasattr(obj, "Slope"):
+            obj.setEditorMode("Slope", 0 if is_slab else 2)
+        # --- End slab-only properties ---
+
         ArchComponent.Component.onChanged(self, obj, prop)
 
         if prop == "ArchSketchPropertySet" and Draft.getType(obj.Base) == "ArchSketch":
@@ -1384,6 +1637,31 @@ class _Structure(ArchComponent.Component):
                         ).toShape()
                     )
         return edges
+
+    def get_layers(self, obj):
+        """Returns a list of layer thicknesses for multi-material slab support.
+        Mirrors _Wall.get_layers(), but keyed to Height instead of Width.
+        Only active when IfcType is Slab and a multi-material is assigned.
+        """
+        layers = []
+        if not (getattr(obj, "IfcType", "") == "Slab"):
+            return layers
+        height = obj.Height.Value
+        if hasattr(obj, "Material") and obj.Material:
+            if hasattr(obj.Material, "Materials"):
+                thicknesses = [abs(t) for t in obj.Material.Thicknesses]
+                restwidth = height - sum(thicknesses)
+                varwidth = 0
+                if restwidth > 0:
+                    varcount = [t for t in thicknesses if t == 0]
+                    if varcount:
+                        varwidth = restwidth / len(varcount)
+                for t in obj.Material.Thicknesses:
+                    if t:
+                        layers.append(t)
+                    elif varwidth:
+                        layers.append(varwidth)
+        return layers
 
 
 class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
@@ -1496,7 +1774,47 @@ class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
                 else:
                     obj.ViewObject.NodeType = "Linear"
         else:
+            # Per-layer material colors for slabs (mirrors _ViewProviderWall)
+            if prop in ["Placement", "Shape", "Material"]:
+                if hasattr(obj, "Material") and obj.Material and obj.Shape:
+                    if hasattr(obj.Material, "Materials"):
+                        activematerials = [
+                            obj.Material.Materials[i]
+                            for i in range(len(obj.Material.Materials))
+                            if obj.Material.Thicknesses[i] >= 0
+                        ]
+                        if len(activematerials) == len(obj.Shape.Solids):
+                            cols = []
+                            for i, mat in enumerate(activematerials):
+                                c = obj.ViewObject.ShapeColor
+                                c = (
+                                    c[0],
+                                    c[1],
+                                    c[2],
+                                    1.0 - obj.ViewObject.Transparency / 100.0,
+                                )
+                                if "DiffuseColor" in mat.Material:
+                                    if "(" in mat.Material["DiffuseColor"]:
+                                        c = tuple(
+                                            float(f)
+                                            for f in mat.Material["DiffuseColor"]
+                                            .strip("()")
+                                            .split(",")
+                                        )
+                                if "Transparency" in mat.Material:
+                                    c = (
+                                        c[0],
+                                        c[1],
+                                        c[2],
+                                        1.0 - float(mat.Material["Transparency"]),
+                                    )
+                                cols.extend(
+                                    [c for _ in range(len(obj.Shape.Solids[i].Faces))]
+                                )
+                            obj.ViewObject.DiffuseColor = cols
             ArchComponent.ViewProviderComponent.updateData(self, obj, prop)
+            if len(obj.ViewObject.DiffuseColor) > 1:
+                obj.ViewObject.DiffuseColor = obj.ViewObject.DiffuseColor
 
     def onChanged(self, vobj, prop):
 
@@ -1564,33 +1882,17 @@ class _ViewProviderStructure(ArchComponent.ViewProviderComponent):
             return None
 
         taskd = StructureTaskPanel(vobj.Object)
+        taskd.obj = self.Object
+        taskd.update()
         FreeCADGui.Control.showDialog(taskd)
         return True
 
 
-class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
-    """A task panel for Arch Structures that combines generic dimensions with node tools"""
+class StructureTaskPanel(ArchComponent.ComponentTaskPanel):
 
     def __init__(self, obj):
-        # Define properties based on the IfcType
-        if getattr(obj, "IfcType", "Beam") == "Slab":
-            property_definitions = [
-                {"prop": "Height", "label": translate("Arch", "Thickness")},
-            ]
-        else:
-            # For Beams and Columns
-            property_definitions = [
-                {"prop": "Length", "label": translate("Arch", "Length")},
-                {"prop": "Width", "label": translate("Arch", "Width")},
-                {"prop": "Height", "label": translate("Arch", "Height")},
-            ]
 
-        #  Initialize generic parent (creates self.options_widget and self.baseform)
-        super().__init__(obj, property_definitions)
-
-        # Alias for compatibility with node/tool methods
-        self.Object = self.obj
-
+        ArchComponent.ComponentTaskPanel.__init__(self)
         self.nodes_widget = QtGui.QWidget()
         self.nodes_widget.setWindowTitle(QtGui.QApplication.translate("Arch", "Node Tools", None))
         lay = QtGui.QVBoxLayout(self.nodes_widget)
@@ -1598,14 +1900,15 @@ class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
         self.resetButton = QtGui.QPushButton(self.nodes_widget)
         self.resetButton.setIcon(QtGui.QIcon(":/icons/edit-undo.svg"))
         self.resetButton.setText(QtGui.QApplication.translate("Arch", "Reset Nodes", None))
+
         lay.addWidget(self.resetButton)
-        self.resetButton.clicked.connect(self.resetNodes)
+        QtCore.QObject.connect(self.resetButton, QtCore.SIGNAL("clicked()"), self.resetNodes)
 
         self.editButton = QtGui.QPushButton(self.nodes_widget)
         self.editButton.setIcon(QtGui.QIcon(":/icons/Draft_Edit.svg"))
         self.editButton.setText(QtGui.QApplication.translate("Arch", "Edit Nodes", None))
         lay.addWidget(self.editButton)
-        self.editButton.clicked.connect(self.editNodes)
+        QtCore.QObject.connect(self.editButton, QtCore.SIGNAL("clicked()"), self.editNodes)
 
         self.extendButton = QtGui.QPushButton(self.nodes_widget)
         self.extendButton.setIcon(QtGui.QIcon(":/icons/Snap_Perpendicular.svg"))
@@ -1618,7 +1921,7 @@ class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
             )
         )
         lay.addWidget(self.extendButton)
-        self.extendButton.clicked.connect(self.extendNodes)
+        QtCore.QObject.connect(self.extendButton, QtCore.SIGNAL("clicked()"), self.extendNodes)
 
         self.connectButton = QtGui.QPushButton(self.nodes_widget)
         self.connectButton.setIcon(QtGui.QIcon(":/icons/Snap_Intersection.svg"))
@@ -1629,7 +1932,7 @@ class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
             )
         )
         lay.addWidget(self.connectButton)
-        self.connectButton.clicked.connect(self.connectNodes)
+        QtCore.QObject.connect(self.connectButton, QtCore.SIGNAL("clicked()"), self.connectNodes)
 
         self.toggleButton = QtGui.QPushButton(self.nodes_widget)
         self.toggleButton.setIcon(QtGui.QIcon(":/icons/dagViewVisible.svg"))
@@ -1640,7 +1943,7 @@ class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
             )
         )
         lay.addWidget(self.toggleButton)
-        self.toggleButton.clicked.connect(self.toggleNodes)
+        QtCore.QObject.connect(self.toggleButton, QtCore.SIGNAL("clicked()"), self.toggleNodes)
 
         self.extrusion_widget = QtGui.QWidget()
         self.extrusion_widget.setWindowTitle(
@@ -1657,11 +1960,12 @@ class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
             )
         )
         lay.addWidget(self.selectToolButton)
-        self.selectToolButton.clicked.connect(self.setSelectionFromTool)
+        QtCore.QObject.connect(
+            self.selectToolButton, QtCore.SIGNAL("clicked()"), self.setSelectionFromTool
+        )
 
-        # Build the final form list: Options box, Node Tools box, Extrusion box, Components box
-        self.form = [self.options_widget, self.nodes_widget, self.extrusion_widget, self.baseform]
-
+        self.form = [self.form, self.nodes_widget, self.extrusion_widget]
+        self.Object = obj
         self.observer = None
         self.nodevis = None
 
@@ -1854,13 +2158,14 @@ class StructureTaskPanel(ArchComponent.ComponentOptionsTaskPanel):
         self.selectToolButton.setText(QtGui.QApplication.translate("Arch", "Select Tool", None))
 
     def accept(self):
+
         if self.observer:
             FreeCADGui.Selection.removeObserver(self.observer)
         if self.nodevis:
             self.toggleNodes()
-
-        # Trigger the generic property-saving logic in ComponentOptionsTaskPanel
-        return super().accept()
+        FreeCAD.ActiveDocument.recompute()
+        FreeCADGui.ActiveDocument.resetEdit()
+        return True
 
 
 class StructSelectionObserver:
@@ -2016,13 +2321,14 @@ class _ViewProviderStructuralSystem(ArchComponent.ViewProviderComponent):
 
 
 if FreeCAD.GuiUp:
+    FreeCADGui.addCommand("Arch_Structure", _CommandStructure())
     FreeCADGui.addCommand("Arch_StructuralSystem", CommandStructuralSystem())
     FreeCADGui.addCommand("Arch_StructuresFromSelection", CommandStructuresFromSelection())
 
     class _ArchStructureGroupCommand:
 
         def GetCommands(self):
-            return ("Arch_StructuralSystem", "Arch_StructuresFromSelection")
+            return ("Arch_Structure", "Arch_StructuralSystem", "Arch_StructuresFromSelection")
 
         def GetResources(self):
             return {


### PR DESCRIPTION
## Summary
This Pull Request introduces comprehensive multi-material layer support, advanced alignment controls, and a professional drainage slope system for BIM Structures, specifically when the `IfcType` is set to **Slab**. It also refactors the `StructureTaskPanel` to use the modern `ComponentOptionsTaskPanel` base class, unifying the UI with other BIM tools.

### Key Changes:
- **Multi-material Layer Support:** Slabs now generate multiple solids based on assigned Multi-Materials. The `Height` (Thickness) property is automatically synchronized with the total thickness of the material stack.
- **Advanced Alignment System:**
    - **Global Alignment:** Pin the full slab stack (Bottom/Center/Top) to the base sketch.
    - **Layer-based Alignment:** Pin a specific material layer (e.g., the structural core) to the base sketch. Includes a dynamic `Align Layer` dropdown that rebuilds based on material names and an `Align Layer Mode` to choose the specific face of that layer.
- **Manual Offset:** Added an `Offset` property to shift the entire slab vertically along its normal, applied after alignment logic.
- **Professional Drainage Slope:**
    - Enhanced the `Slope` tool to include a `Slope Edge` pivot. 
    - Users can pick a specific edge (from a sketch or other geometry) to act as the "hinge" for the drainage tilt. 
    - All material layers tilt perfectly parallel to each other.
- **UI Refactoring:** Refactored the `StructureTaskPanel` to use `ComponentOptionsTaskPanel`. This provides a cleaner, more consistent editing experience in the Task tab and simplifies future maintenance.

## Issues
<!-- If there was a specific issue number on the FreeCAD tracker, link it here. If not, you can leave it blank or say "Feature request from forum/community" -->
Relates to standardizing BIM Slab behavior to match BIM Walls regarding multi-layer materials.

## Before and After Images
**Before:** Structures were limited to a single solid, even when a multi-material was assigned. Alignment was limited to a simple Z-shift, and slopes tilted around the global axis.

**After:** Slabs now show distinct solids for every material layer. The Properties panel dynamically updates to show alignment and slope tools only when applicable, and the Task panel is unified with the modern BIM workflow.

## Detailed Property Logic
| Property | Behavior |
|---|---|
| **Align** | Global alignment of the full stack. Becomes Read-Only when a specific "Align Layer" is chosen. |
| **Align Layer** | Dynamic dropdown listing all layers in the material. Allows pinning the slab based on a specific material (e.g., the Concrete slab) rather than the finish. |
| **Align Layer Mode** | Choose if the Bottom, Center, or Top of the chosen layer aligns with the sketch. |
| **Offset** | A manual Z-offset applied after all other alignment is calculated. |
| **Slope** | Tilt angle for drainage. |
| **Slope Edge** | User-selected edge to define the tilt pivot axis. Defaults to the first edge of the base face if unset. |
<img width="1920" height="1020" alt="Snipaste_2026-04-10_16-55-47" src="https://github.com/user-attachments/assets/ba339f39-fa3a-4d30-9e23-8fa2a80fecf3" />

<img width="1920" height="1020" alt="Snipaste_2026-04-10_16-56-40" src="https://github.com/user-attachments/assets/f0adc836-11e2-4f40-b200-5c377b353448" />

<img width="1920" height="1020" alt="Snipaste_2026-04-10_16-57-36" src="https://github.com/user-attachments/assets/bb98c1fa-3f7b-4f44-b976-270583df4ee4" />

<img width="1920" height="1020" alt="Snipaste_2026-04-10_16-58-33" src="https://github.com/user-attachments/assets/246b352c-365a-4156-ac9a-c85de13a0e23" />

<img width="1920" height="1020" alt="Snipaste_2026-04-10_16-59-47" src="https://github.com/user-attachments/assets/d3bc139b-6d3f-4a60-bded-656d428cde98" />

<img width="1920" height="1020" alt="Snipaste_2026-04-10_17-00-36" src="https://github.com/user-attachments/assets/a035ae63-2dbb-42bb-8f15-c9be2b0e1e48" />

<img width="1919" height="1020" alt="Snipaste_2026-04-10_17-01-42" src="https://github.com/user-attachments/assets/11e3e054-0732-4870-b2c5-e2399a7ebc7b" />

<img width="1920" height="1020" alt="Snipaste_2026-04-10_17-02-59" src="https://github.com/user-attachments/assets/c7e28aed-5324-4a66-b52c-2d3686086de7" />

<img width="1920" height="1020" alt="Snipaste_2026-04-10_16-51-27" src="https://github.com/user-attachments/assets/7ca87f4d-1bc2-44a1-9e5b-4a62da4357e0" />

<img width="1920" height="1018" alt="Snipaste_2026-04-10_16-53-04" src="https://github.com/user-attachments/assets/6ca452da-f5c0-4fab-bc26-711434a198b9" />
