### PR TITLE
Gui: FileDialog: enforce having an extension on save (fixes #29212)

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -21,6 +21,9 @@
  ***************************************************************************/
 
 
+#ifndef NDEBUG
+# include <cassert>
+#endif
 #include <memory>
 
 #include <FCConfig.h>
@@ -364,6 +367,17 @@ struct FilterSpec
         return getDisplayName(showPatterns) + QStringLiteral(" (") + patterns.join(QLatin1Char(' '))
             + QLatin1Char(')');
     }
+
+    /// @returns Whether the filter is a full wildcard (i.e. accepts "*" or "*.*")
+    bool isWildcard() const
+    {
+        for (const auto& pat : patterns) {
+            if (pat != "*" || pat != "*.*") {
+                return false;
+            }
+        }
+        return true;
+    }
 };
 
 class FilterSpecList: public QList<FilterSpec>
@@ -556,6 +570,144 @@ static QStringList nativeFileDialog(
 }
 #endif
 
+static void normalizeSavePath(QString& path, const FilterSpec& selectedFilterSpec)
+{
+    // Wildcards have no rule by definition.
+    if (selectedFilterSpec.isWildcard()) {
+        return;
+    }
+
+    // As it stands, much of FreeCAD relies on an extension always being present, so
+    // enforce extension according to selected filter if none is specified.
+    // Ideally code should be migrated to discriminating on the returned selected
+    // filter instead.
+
+    // Platform dialogs can have a variety of behaviors:
+    // * Qt/KDE changes the filter to a matching one if applicable when the user
+    //   types an extension in the file name explicitly, and some of the dialogs
+    //   feature a checkbox to auto-append an extension if absent.
+    // * Windows will never change the selected filter on its own.
+    //   1. Modern dialogs (IFileDialog and Windows::Storage::Pickers) keep typed
+    //      filenames intact *if* they have an extension 1-3 characters long, known
+    //      to HKEY_CLASSES_ROOT, or present in the filters.
+    //      Otherwise, appends the first extension of the selected filter.
+    //   2. Legacy GetSaveFileName() always keeps typed filenames intact.
+    //      However, we use it and want the modern behavior instead.
+
+    // This function uniformizes some of that.
+
+    // Discard everything up to and including directory separator.
+    const auto typedName = QStringView(path).mid(path.lastIndexOf('/') + 1);
+
+    // Check for any full-name filters first.
+    for (const auto& pat : selectedFilterSpec.patterns) {
+        if (!pat.startsWith("*.") && typedName == pat) {
+            return;
+        }
+    }
+
+    const auto lastDot = typedName.lastIndexOf('.');
+    // typedExt includes the last dot and everything after it,
+    // as a stray dot ("abc.") may have been typed. Won't fail
+    // even in the improbable case of only "." being passed.
+    const auto typedExt = lastDot == -1 ? QStringView() : typedName.mid(lastDot);
+
+    if (typedExt.isEmpty()) {
+        // No extension, move directly to append.
+    }
+    else if (typedExt.size() == 1) {
+        // Remove stray dot then append.
+        path.chop(1);
+    }
+    else /* size() > 1 */ {
+        for (const auto& pat : selectedFilterSpec.patterns) {
+            if (pat.startsWith("*.") && typedExt == QStringView(pat).mid(1)) {
+                // Valid extension found for the selected filter.
+                return;
+            }
+        }
+    }
+
+    // Append extension from first *.xyz-style pattern.
+    for (const auto& pat : selectedFilterSpec.patterns) {
+        if (pat.startsWith("*.")) {
+            path.append(QStringView(pat).mid(1));
+            break;
+        }
+    }
+}
+
+#ifndef NDEBUG
+static void testNormalizeSavePath()
+{
+    const auto spec = FilterSpec::fromFilterString(
+        QStringLiteral("Whatever files (what ev.er *.abc *.xyz)")
+    );
+    const auto nspEq = [spec](QString path, const QString& desired) -> bool {
+        normalizeSavePath(path, spec);
+        const auto firstPassResult = path;
+        normalizeSavePath(path, spec);
+        const bool idempotent = firstPassResult == path;
+        return idempotent && path == desired;
+    };
+    for (const auto& root :
+         {QStringLiteral(""),
+          QStringLiteral("/root/.trash/"),
+          QStringLiteral("C:/$Recycle.bin/"),
+          QStringLiteral("//net.worked:123/"),
+          QStringLiteral("//?/o:/ntpath/"),
+          QStringLiteral("/\x3F?/z:/evil/")}) {
+        assert(nspEq(root + "", root + ".abc"));
+        assert(nspEq(root + "hello", root + "hello.abc"));
+
+        // Dots handling
+        assert(nspEq(root + "dotty.", root + "dotty.abc"));
+        assert(nspEq(root + "dotty2..", root + "dotty2..abc"));
+        assert(nspEq(root + "dotty3...", root + "dotty3...abc"));
+        assert(nspEq(root + ".hidden", root + ".hidden.abc"));
+        assert(nspEq(root + ".1dotty1.", root + ".1dotty1.abc"));
+        assert(nspEq(root + ".1dotty2..", root + ".1dotty2..abc"));
+        assert(nspEq(root + "..2dotty2..", root + "..2dotty2..abc"));
+
+        // Extension not in filter
+        assert(nspEq(root + "ascii.txt", root + "ascii.txt.abc"));
+        assert(nspEq(root + "asciidot.txt.", root + "asciidot.txt.abc"));
+
+        // Empty stems but valid extensions
+        assert(nspEq(root + ".abc", root + ".abc"));
+        assert(nspEq(root + ".xyz", root + ".xyz"));
+
+        // Regular cases with extension
+        assert(nspEq(root + "ext.abc", root + "ext.abc"));
+        assert(nspEq(root + "ext.parts.abc", root + "ext.parts.abc"));
+        assert(nspEq(root + ".hidden.ext.abc", root + ".hidden.ext.abc"));
+        assert(nspEq(root + "ext.xyz", root + "ext.xyz"));
+        assert(nspEq(root + "ext.parts.xyz", root + "ext.parts.xyz"));
+        assert(nspEq(root + ".hidden.ext.xyz", root + ".hidden.ext.xyz"));
+
+        // Non-wildcard pattern without ext
+        assert(nspEq(root + "what", root + "what"));
+        assert(nspEq(root + "what.", root + "what.abc"));
+        assert(nspEq(root + ".what", root + ".what.abc"));
+        assert(nspEq(root + ".what.", root + ".what.abc"));
+
+        // Non-wildcard pattern with ext
+        assert(nspEq(root + "ev.er", root + "ev.er"));
+        assert(nspEq(root + "ev.er.", root + "ev.er.abc"));
+        assert(nspEq(root + ".ev.er", root + ".ev.er.abc"));
+        assert(nspEq(root + ".ev.er.", root + ".ev.er.abc"));
+        // Check for mixed up extension matching
+        assert(nspEq(root + "notev.er", root + "notev.er.abc"));
+
+        // The following two should never be encountered in the wild as they refer to
+        // the current or upper directories, but still should be handled gracefully as
+        // if they were just user input tacked on after some directory path.
+        assert(nspEq(root + ".", root + ".abc"));
+        assert(nspEq(root + "..", root + "..abc"));
+    }
+}
+#endif  // NDEBUG
+
 /**
  * This is a convenience static function that will return a file name selected by the user. The file
  * does not have to exist.
@@ -686,16 +838,22 @@ QString FileDialog::getSaveFileName(
         if (selectedFilter && selectedFilterIndex >= 0) {
             *selectedFilter = filters[selectedFilterIndex];
         }
-        file = QDir::fromNativeSeparators(file);
     }
 
-    if (!file.isEmpty()) {
-        setWorkingDirectory(file);
-        return file;
-    }
-    else {
+    if (file.isEmpty()) {
         return {};
     }
+
+    // All directory separators become "/" from here on out.
+    file = QDir::fromNativeSeparators(file);
+
+#ifndef NDEBUG
+    testNormalizeSavePath();
+#endif  // NDEBUG
+    normalizeSavePath(file, filterSpecList[selectedFilterIndex]);
+
+    setWorkingDirectory(file);
+    return file;
 }
 
 /**

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -274,7 +274,7 @@ static void getSuffixesDescription(QStringList& suffixes, const QString& suffixD
     }
 }
 
-static bool getPreferShowFilterExtensions()
+static bool getPreferShowFilterPatterns()
 {
     bool show = true;
 #ifdef FC_OS_WIN32
@@ -288,17 +288,19 @@ static bool getPreferShowFilterExtensions()
                                      .GetGroup("BaseApp")
                                      ->GetGroup("Preferences")
                                      ->GetGroup("Dialog");
-    return group->GetBool("ShowFilterExtensions", show);
+    return group->GetBool("ShowFilterPatterns", show);
 }
 
 struct FilterSpec
 {
     QString name;
-    QStringList extensions;
+    /// List of patterns matched by this filter. Note that extensions are
+    /// just a subset of patterns in the form of "*.ext".
+    QStringList patterns;
 
     bool operator==(const FilterSpec& rhs) const
     {
-        return name == rhs.name && extensions == rhs.extensions;
+        return name == rhs.name && patterns == rhs.patterns;
     }
 
     static FilterSpec fromFilterString(const QString& filter)
@@ -306,61 +308,61 @@ struct FilterSpec
         const auto start = filter.lastIndexOf(QLatin1Char('('));
         const auto end = filter.lastIndexOf(QLatin1Char(')'));
         const auto name = filter.left(start).trimmed();
-        const auto extensionsPart = filter.mid(start + 1, end - start - 1);
-        return {name, extensionsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
+        const auto patternsPart = filter.mid(start + 1, end - start - 1);
+        return {name, patternsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
     }
 
-    QString getDisplayName(bool showExtensions) const
+    QString getDisplayName(bool showPatterns) const
     {
         // Avoid overflowing the screen with an excessively long filter list (see #23139).
         const qsizetype MaxFiltersLength = 128;
-        const qsizetype TypicalMaxExtensionLength = 12;
+        const qsizetype TypicalMaxPatternLength = 12;
 
-        if (!showExtensions) {
+        if (!showPatterns) {
             return name;
         }
 
         QString formatted(name);
         formatted += QLatin1Char(' ');
 
-        // Deduplicate the extensions which usually come in both *.ext & *.EXT variants.
-        // Keeps the first case encountered for a given extension set.
-        // O(n^2) in complexity but the extension lists are usually short.
+        // Deduplicate the patterns which usually come in both uppercase and lowercase variants.
+        // Keeps the first case encountered for a given pattern set.
+        // O(n^2) in complexity but the pattern lists are usually short.
         QList<QStringView> seen;
-        seen.reserve(extensions.size());
-        const auto wasSeen = [&seen](QStringView ext) -> bool {
-            for (QStringView extSeen : seen) {
-                if (extSeen.compare(ext, Qt::CaseInsensitive) == 0) {
+        seen.reserve(patterns.size());
+        const auto wasSeen = [&seen](QStringView pat) -> bool {
+            for (QStringView patSeen : seen) {
+                if (patSeen.compare(pat, Qt::CaseInsensitive) == 0) {
                     return true;
                 }
             }
             return false;
         };
-        QString dedupExtensions;
-        dedupExtensions.reserve(extensions.length() * TypicalMaxExtensionLength);
-        for (auto it = extensions.cbegin(); it != extensions.cend(); ++it) {
+        QString dedupPatterns;
+        dedupPatterns.reserve(patterns.length() * TypicalMaxPatternLength);
+        for (auto it = patterns.cbegin(); it != patterns.cend(); ++it) {
             if (!wasSeen(*it)) {
                 seen.append(*it);
-                if (it != extensions.cbegin()) {
-                    dedupExtensions += QLatin1Char(' ');
+                if (it != patterns.cbegin()) {
+                    dedupPatterns += QLatin1Char(' ');
                 }
-                dedupExtensions += *it;
+                dedupPatterns += *it;
             }
         }
 
-        if (dedupExtensions.size() <= MaxFiltersLength) {
+        if (dedupPatterns.size() <= MaxFiltersLength) {
             formatted += QLatin1Char('(');
-            formatted += dedupExtensions;
+            formatted += dedupPatterns;
             formatted += QLatin1Char(')');
         }
 
         return formatted;
     }
 
-    QString toQtFilter(bool showExtensions) const
+    QString toQtFilter(bool showPatterns) const
     {
-        return getDisplayName(showExtensions) + QStringLiteral(" (")
-            + extensions.join(QLatin1Char(' ')) + QLatin1Char(')');
+        return getDisplayName(showPatterns) + QStringLiteral(" (") + patterns.join(QLatin1Char(' '))
+            + QLatin1Char(')');
     }
 };
 
@@ -377,11 +379,11 @@ public:
         return specs;
     }
 
-    QStringList toQtFilterList(bool showExtensions) const
+    QStringList toQtFilterList(bool showPatterns) const
     {
         QStringList qtFilters;
         for (const auto& filterSpec : *this) {
-            qtFilters += filterSpec.toQtFilter(showExtensions);
+            qtFilters += filterSpec.toQtFilter(showPatterns);
         }
         return qtFilters;
     }
@@ -410,7 +412,7 @@ static std::unique_ptr<wchar_t[]> qStringToWCharArray(const QString& s, size_t r
 }
 
 /* Use the legacy Get{Open,Save}FileNameW functions as the Vista+ IFileDialog forces
- * extension display in filter lists, leading to exceedingly long entries as seen in
+ * pattern/extension display in filter lists, leading to exceedingly long entries as seen in
  * issue #23139.
  * Note neither this legacy function set nor IFileDialog are valid for UWP WinRT,
  * for which Windows::Storage::Pickers::FileOpenPicker will have to be used instead.
@@ -425,7 +427,7 @@ static QStringList nativeFileDialog(
     FileDialog::Options options
 )
 {
-    const bool showExtensions = getPreferShowFilterExtensions();
+    const bool showPatterns = getPreferShowFilterPatterns();
 
     OPENFILENAMEW ofn;
     memset(&ofn, 0, sizeof(OPENFILENAMEW));
@@ -436,9 +438,9 @@ static QStringList nativeFileDialog(
 
     QString flatFilter;
     for (const auto& filterSpec : filterSpecs) {
-        flatFilter += filterSpec.getDisplayName(showExtensions);
+        flatFilter += filterSpec.getDisplayName(showPatterns);
         flatFilter += QLatin1Char('\0');
-        flatFilter += filterSpec.extensions.join(QLatin1Char(';'));
+        flatFilter += filterSpec.patterns.join(QLatin1Char(';'));
         flatFilter += QLatin1Char('\0');
     }
     flatFilter += QLatin1Char('\0');
@@ -511,8 +513,8 @@ static QStringList nativeFileDialog(
     FileDialog::Options options
 )
 {
-    const bool showExtensions = getPreferShowFilterExtensions();
-    const auto qtFilterList = filterSpecs.toQtFilterList(showExtensions);
+    const bool showPatterns = getPreferShowFilterPatterns();
+    const auto qtFilterList = filterSpecs.toQtFilterList(showPatterns);
     QString selectedQtFilter = (selectedFilterIndex != nullptr && *selectedFilterIndex >= 0)
         ? qtFilterList[*selectedFilterIndex]
         : "";
@@ -640,8 +642,8 @@ QString FileDialog::getSaveFileName(
     // and append it before showing the file dialog.
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -660,7 +662,7 @@ QString FileDialog::getSaveFileName(
         }
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         dlg.onSelectedFilter(dlg.selectedNameFilter());
         dlg.setOption(QFileDialog::DontConfirmOverwrite, false);
@@ -771,8 +773,8 @@ QString FileDialog::getOpenFileName(
 
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -788,7 +790,7 @@ QString FileDialog::getOpenFileName(
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
@@ -871,8 +873,8 @@ QStringList FileDialog::getOpenFileNames(
 
     QStringList files;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -888,7 +890,7 @@ QStringList FileDialog::getOpenFileNames(
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {


### PR DESCRIPTION
Fixes #29212 and #29183

As it stands, much of FreeCAD relies on an extension always being present, so enforce extension according to selected filter if none is specified.

This was not guaranteed on Linux depending on exact configuration and Qt version in use, and was also broken on Windows by my FileDialog rework in 46125f1b753bc0443e1e1c0d2960adbd4b780ec0

Introduces a `normalizeSavePath()` function to make file naming behavior more consistent across the board.

## Testing

I did rudimentary testing on both Linux Qt6.10.2 under KDE, as well as Windows 11, with a few export formats selected like IGES but certainly not all. Plus a lot more save/export dialogs exist, if any sound breakage-prone to you please do test them with these changes.

## Code review

There's a disabled by default `testNormalizeSavePath()` function in `FileDialog.cpp` unit testing the behavior of `normalizeSavePath()` but since the function is both private/`static` and the `FilterSpec` type it relies on is not to be exposed (yet) I'm unaware of any better spot to put it. Ideas welcome.