### PR TITLE
Part: Default `Refine=false` for pre-0.17 files

### DIFF
--- a/src/Mod/Part/App/FeaturePartBoolean.cpp
+++ b/src/Mod/Part/App/FeaturePartBoolean.cpp
@@ -33,6 +33,7 @@
 #include <App/Application.h>
 #include <Base/Exception.h>
 #include <Base/Parameter.h>
+#include <Base/ProgramVersion.h>
 
 #include "FeaturePartBoolean.h"
 #include "TopoShapeOpCode.h"
@@ -181,5 +182,16 @@ App::DocumentObjectExecReturn* Boolean::execute()
         return new App::DocumentObjectExecReturn(
             "A fatal error occurred when running boolean operation"
         );
+    }
+}
+
+void Boolean::Restore(Base::XMLReader& reader)
+{
+    ExtensionContainer::Restore(reader);
+
+    // The Refine property was added in FreeCAD 0.17, so any file before that will not have it set.
+    // For these files, the appropriate default value is false.
+    if (Base::getVersion(reader.ProgramVersion) < Base::Version::v0_17) {
+        Refine.setValue(false);
     }
 }

--- a/src/Mod/Part/App/FeaturePartBoolean.h
+++ b/src/Mod/Part/App/FeaturePartBoolean.h
@@ -55,6 +55,8 @@ public:
     short mustExecute() const override;
     //@}
 
+    void Restore(Base::XMLReader& reader) override;
+
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {

--- a/src/Mod/Part/App/FeaturePartCommon.cpp
+++ b/src/Mod/Part/App/FeaturePartCommon.cpp
@@ -117,6 +117,12 @@ void MultiCommon::Restore(Base::XMLReader& reader)
     if (Base::getVersion(reader.ProgramVersion) == Base::Version::v1_0) {
         Behavior.setValue(CommonOfFirstAndRest);
     }
+
+    // The Refine property was added in FreeCAD 0.17, so any file before that will not have it set.
+    // For these files, the appropriate default value is false.
+    if (Base::getVersion(reader.ProgramVersion) < Base::Version::v0_17) {
+        Refine.setValue(false);
+    }
 }
 
 App::DocumentObjectExecReturn* MultiCommon::execute()

--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -35,6 +35,9 @@
 #include "modelRefine.h"
 #include "TopoShapeOpCode.h"
 
+#include <Base/ProgramVersion.h>
+
+
 FC_LOG_LEVEL_INIT("Part", true, true);
 
 using namespace Part;
@@ -225,5 +228,16 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
     }
     else {
         throw Base::CADKernelError("Not enough shape objects linked");
+    }
+}
+
+void MultiFuse::Restore(Base::XMLReader& reader)
+{
+    ExtensionContainer::Restore(reader);
+
+    // The Refine property was added in FreeCAD 0.17, so any file before that will not have it set.
+    // For these files, the appropriate default value is false.
+    if (Base::getVersion(reader.ProgramVersion) < Base::Version::v0_17) {
+        Refine.setValue(false);
     }
 }

--- a/src/Mod/Part/App/FeaturePartFuse.h
+++ b/src/Mod/Part/App/FeaturePartFuse.h
@@ -65,6 +65,9 @@ public:
     App::DocumentObjectExecReturn* execute() override;
     short mustExecute() const override;
     //@}
+
+    void Restore(Base::XMLReader& reader) override;
+
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override
     {


### PR DESCRIPTION
The `Refine` parameter was added to our Part boolean operations in FreeCAD 0.17 (478611371b) -- any file prior to that lacks Refine entirely, though our loading system doesn't care, it simply leaves the value at its default. Prior to e77f181393b93ba72bce3704771b7f3d0d70b684 (2025-09-27) it defaulted to `false`, as appropriate for files that pre-dated its existence. However, once the default value changed, old files that didn't have the parameter at all were broken. See for example [xtal-through-hole.fcstd](https://github.com/FreeCAD/FreeCAD-library/raw/refs/heads/master/Electronics%20Parts/Crystals/xtal-through-hole.fcstd) from the Parts library. That file will fail to recompute without this PR. This fixes the recompute state of 213 files in the Parts library (6.7% of the library, if you're keeping score 😁 ).