### PR TITLE
Assembly: Fix sketcher external edit

### DIFF
--- a/src/Gui/TaskView/TaskDialog.cpp
+++ b/src/Gui/TaskView/TaskDialog.cpp
@@ -106,7 +106,7 @@ void TaskDialog::associateToObject3dView(App::DocumentObject* obj)
         return;
     }
 
-    Gui::Document* guiDoc = Gui::Application::Instance->getDocument(obj->getDocument());
+    Gui::Document* guiDoc = Gui::Application::Instance->activeDocument();
     auto* vp = Gui::Application::Instance->getViewProvider(obj);
     auto* vpdo = static_cast<Gui::ViewProviderDocumentObject*>(vp);
     auto* view = guiDoc->openEditingView3D(vpdo);

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -297,7 +297,8 @@ bool ViewProviderAssembly::setEdit(int mode)
             this->getObject()->getNameInDocument()
         );
 
-        setupActiveAndInEdit();
+        setDragger();
+        attachSelection();
 
         updateTaskPanel(true);
 
@@ -335,7 +336,8 @@ void ViewProviderAssembly::unsetEdit(int mode)
         partMoving = false;
         docsToMove.clear();
 
-        unsetupActiveAndInEdit();
+        unsetDragger();
+        detachSelection();
 
         // Check if the view is still active before trying to deactivate the assembly.
         auto activeView = getDocument()->getActiveView();
@@ -419,26 +421,6 @@ bool ViewProviderAssembly::isInEditMode() const
 {
     return asmDragger != nullptr;
 }
-void ViewProviderAssembly::setupActiveAndInEdit()
-{
-    setDragger();
-    attachSelection();
-}
-void ViewProviderAssembly::unsetupActiveAndInEdit()
-{
-    unsetDragger();
-    detachSelection();
-}
-void ViewProviderAssembly::setActive(bool active)
-{
-    if (active) {
-        setupActiveAndInEdit();
-    }
-    else {
-        unsetupActiveAndInEdit();
-    }
-}
-
 
 App::DocumentObject* ViewProviderAssembly::getActivePart() const
 {

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.h
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.h
@@ -127,10 +127,6 @@ public:
     void setEditViewer(Gui::View3DInventorViewer*, int ModNum) override;
     bool isInEditMode() const;
 
-    void setActive(bool active) override;
-    void setupActiveAndInEdit();
-    void unsetupActiveAndInEdit();
-
     /// Ask the view provider if it accepts object deletions while in edit
     bool acceptDeletionsInEdit() override
     {


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

The sketcher's TaskDialog would get it's associated view from the sketch object in the sketch's source document, which made the sketcher's source document the active document for a fraction of a second, just in time to get bound to the sketcher' taskview

The assembly deactivation pattern was wrongly refactored and would do a use after free in that situation

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues

Fix #28989 
Fix #29148
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
