### PR TITLE
CAM: fix DressupArray drilling round-trip

### DIFF
--- a/src/Mod/CAM/App/Command.cpp
+++ b/src/Mod/CAM/App/Command.cpp
@@ -358,6 +358,7 @@ Command Command::transform(const Base::Placement& other)
         }
         c.Parameters[k] = v;
     }
+    c.Annotations = Annotations;
     return c;
 }
 

--- a/src/Mod/CAM/App/Path.cpp
+++ b/src/Mod/CAM/App/Path.cpp
@@ -342,47 +342,67 @@ void Toolpath::setFromGCode(const std::string instr)
     // std::string str = boost::regex_replace(instr, e, "");
     std::string str(instr);
 
-    // split input string by () or G or M commands
-    std::string mode = "command";
-    std::size_t found = str.find_first_of("(gGmM");
-    int last = -1;
+    // Split input string by () or G/M commands, but keep semicolon comments attached to the
+    // current line so annotation comments do not get mistaken for new commands.
+    enum class ParseMode
+    {
+        Command,
+        Comment,
+        LineComment
+    };
+
+    ParseMode mode = ParseMode::Command;
+    std::size_t last = std::string::npos;
     bool inches = false;
-    while (found != std::string::npos) {
-        if (str[found] == '(') {
-            // start of comment
-            if ((last > -1) && (mode == "command")) {
-                // before opening a comment, add the last found command
-                std::string gcodestr = str.substr(last, found - last);
+
+    for (std::size_t i = 0; i < str.size(); ++i) {
+        char ch = str[i];
+
+        if (mode == ParseMode::LineComment) {
+            if ((ch == '\n') || (ch == '\r')) {
+                mode = ParseMode::Command;
+            }
+            continue;
+        }
+
+        if (mode == ParseMode::Comment) {
+            if (ch == ')') {
+                std::string gcodestr = str.substr(last, i - last + 1);
+                bulkAddCommand(gcodestr, vpcCommands, inches);
+                last = std::string::npos;
+                mode = ParseMode::Command;
+            }
+            continue;
+        }
+
+        if (ch == ';') {
+            mode = ParseMode::LineComment;
+            continue;
+        }
+
+        if (ch == '(') {
+            if (last != std::string::npos) {
+                std::string gcodestr = str.substr(last, i - last);
                 bulkAddCommand(gcodestr, vpcCommands, inches);
             }
-            mode = "comment";
-            last = found;
-            found = str.find_first_of(')', found + 1);
+            last = i;
+            mode = ParseMode::Comment;
+            continue;
         }
-        else if (str[found] == ')') {
-            // end of comment
-            std::string gcodestr = str.substr(last, found - last + 1);
-            bulkAddCommand(gcodestr, vpcCommands, inches);
-            last = -1;
-            found = str.find_first_of("(gGmM", found + 1);
-            mode = "command";
-        }
-        else if (mode == "command") {
-            // command
-            if (last > -1) {
-                std::string gcodestr = str.substr(last, found - last);
+
+        if ((ch == 'g') || (ch == 'G') || (ch == 'm') || (ch == 'M')) {
+            if (last != std::string::npos) {
+                std::string gcodestr = str.substr(last, i - last);
                 bulkAddCommand(gcodestr, vpcCommands, inches);
             }
-            last = found;
-            found = str.find_first_of("(gGmM", found + 1);
+            last = i;
         }
     }
+
     // add the last command found, if any
-    if (last > -1) {
-        if (mode == "command") {
-            std::string gcodestr = str.substr(last, std::string::npos);
-            bulkAddCommand(gcodestr, vpcCommands, inches);
-        }
+    if ((last != std::string::npos) && (mode != ParseMode::Comment)) {
+        std::string gcodestr = str.substr(last, std::string::npos);
+        bulkAddCommand(gcodestr, vpcCommands, inches);
     }
     recalculate();
 }

--- a/src/Mod/CAM/CAMTests/TestPathCore.py
+++ b/src/Mod/CAM/CAMTests/TestPathCore.py
@@ -127,6 +127,24 @@ G0 Z0.500000
         p.setFromGCode(lines)
         self.assertEqual(p.toGCode(), output)
 
+    def test20(self):
+        """Test Path object parsing with semicolon annotations on drill cycles."""
+
+        gcode = "G81 F6.666667 R0.000000 X7.000000 Y9.500000 Z-3.505000 ; RetractMode:'G98'"
+
+        path = Path.Path(gcode)
+
+        self.assertEqual(len(path.Commands), 1)
+
+        command = path.Commands[0]
+        self.assertEqual(command.Name, "G81")
+        self.assertEqual(command.Annotations["RetractMode"], "G98")
+        self.assertRoughly(command.Parameters["F"], 6.666667)
+        self.assertRoughly(command.Parameters["R"], 0.0)
+        self.assertRoughly(command.Parameters["X"], 7.0)
+        self.assertRoughly(command.Parameters["Y"], 9.5)
+        self.assertRoughly(command.Parameters["Z"], -3.505)
+
     def test50(self):
         """Test Path.Length calculation"""
         commands = []

--- a/src/Mod/CAM/CAMTests/TestPathDressupArray.py
+++ b/src/Mod/CAM/CAMTests/TestPathDressupArray.py
@@ -130,9 +130,7 @@ class TestDressupArray(PathTestBase):
     def test03(self):
         """Verify array execution accepts drilling commands with semicolon annotations."""
 
-        drill = Path.Command(
-            "G81", {"F": 6.666667, "R": 0.0, "X": 7.0, "Y": 9.5, "Z": -3.505}
-        )
+        drill = Path.Command("G81", {"F": 6.666667, "R": 0.0, "X": 7.0, "Y": 9.5, "Z": -3.505})
         drill.Annotations = {"RetractMode": "G98"}
 
         base = TestEngrave([drill])

--- a/src/Mod/CAM/CAMTests/TestPathDressupArray.py
+++ b/src/Mod/CAM/CAMTests/TestPathDressupArray.py
@@ -36,6 +36,7 @@ class TestEngrave:
         self.Path = Path.Path(path)
         self.ToolController = None  # default tool 5mm
         self.CoolantMode = "None"
+        self.Active = True
         self.Name = "Engrave"
 
     def isDerivedFrom(self, type):
@@ -125,3 +126,27 @@ class TestDressupArray(PathTestBase):
 
         da.execute(obj)
         self.assertTrue(obj.Path.toGCode() == expected_gcode, "Incorrect g-code generated")
+
+    def test03(self):
+        """Verify array execution accepts drilling commands with semicolon annotations."""
+
+        drill = Path.Command(
+            "G81", {"F": 6.666667, "R": 0.0, "X": 7.0, "Y": 9.5, "Z": -3.505}
+        )
+        drill.Annotations = {"RetractMode": "G98"}
+
+        base = TestEngrave([drill])
+        obj = TestFeature()
+        da = DressupArray(obj, base, None)
+        obj.Copies = 1
+        obj.Offset = FreeCAD.Vector(21, 0, 0)
+
+        da.execute(obj)
+
+        self.assertEqual(len(obj.Path.Commands), 2)
+        self.assertEqual(obj.Path.Commands[0].Name, "G81")
+        self.assertEqual(obj.Path.Commands[1].Name, "G81")
+        self.assertEqual(obj.Path.Commands[0].Annotations["RetractMode"], "G98")
+        self.assertEqual(obj.Path.Commands[1].Annotations["RetractMode"], "G98")
+        self.assertRoughly(obj.Path.Commands[0].Parameters["X"], 7.0)
+        self.assertRoughly(obj.Path.Commands[1].Parameters["X"], 28.0)

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -37,6 +37,7 @@ from CAMTests.TestPathAdaptive import TestPathAdaptive
 from CAMTests.TestPathCommandAnnotations import TestPathCommandAnnotations
 from CAMTests.TestPathCore import TestPathCore
 from CAMTests.TestPathDepthParams import depthTestCases
+from CAMTests.TestPathDressupArray import TestDressupArray
 from CAMTests.TestPathDressupDogboneII import TestDressupDogboneII
 from CAMTests.TestPathDressupHoldingTags import TestHoldingTags
 from CAMTests.TestPathDrillable import TestPathDrillable


### PR DESCRIPTION
Fixes a CAM regression in `DressupArray` with drilling operations.

Once drilling commands started carrying semicolon annotations such as `; RetractMode:'G98'`, the array path could break when it rebuilt the result through `Path.Path(output)`. The main problem was in `Toolpath::setFromGCode()`: it was still treating `G` and `M` inside a semicolon comment as the start of a new command, so a line like `G81 ... ; RetractMode:'G98'` could be split into invalid fragments during reparse.

While tightening the regression coverage for that path, I also found that `Command::transform()` was not preserving `Annotations`, so copied drilling commands in the array could lose `RetractMode`. This patch fixes both parts of that round-trip.

## Issues
Fixes #27423

## What Changed
- keep semicolon comments attached to the current command in `Toolpath::setFromGCode()`
- preserve `Annotations` in `Command::transform()`
- add a direct parser regression test for `Path.Path("G81 ... ; RetractMode:'G98'")`
- add a `DressupArray` regression test that checks copied `G81` commands keep `RetractMode:'G98'`
- register `TestDressupArray` in `TestCAMApp`

## Before and After Images
N/A

## Validation
- reproduced the base failure
- ran `FreeCADCmd -t TestCAMApp.TestPathCore.test20`
- ran `FreeCADCmd -t TestCAMApp.TestDressupArray.test03`
- verified directly on the patched build that both arrayed `G81` commands retain `RetractMode:'G98'`
- ran `git diff --check`
