### PR TITLE
Base: add missing ImperialBuilding density and pressure schema entries

### DIFF
--- a/src/Base/UnitsSchemasData.h
+++ b/src/Base/UnitsSchemasData.h
@@ -671,6 +671,8 @@ inline const UnitsSchemaSpec s8
         { "Angle"    , {{ 0   , "°"               , 1.0            }}},
         { "Area"     , {{ 0   , "sqft"            , ft * ft        }}},
         { "Volume"   , {{ 0   , "cft"             , ft * ft * ft   }}},
+        { "Density"  , {{ 0   , "lb/ft^3"         , lb / (ft * ft * ft) }}},
+        { "Pressure" , {{ 0   , "psi"             , psi            }}},
         { "Velocity" , {{ 0   , "in/min"          , in / 60        }}}
     }
 };

--- a/tests/src/Base/SchemaTests.cpp
+++ b/tests/src/Base/SchemaTests.cpp
@@ -1332,36 +1332,28 @@ TEST_F(SchemaTest, sweep_imperial_building)
 
 TEST_F(SchemaTest, imperial_building_density_uses_lb_ft3)
 {
-    const auto result = set("ImperialBuilding",
-                            Unit::Density,
-                            Quantity::parse("1 lb/ft^3").getValue());
+    const auto result = set("ImperialBuilding", Unit::Density, Quantity::parse("1 lb/ft^3").getValue());
 
     EXPECT_EQ(result, "1.00 lb/ft^3");
 }
 
 TEST_F(SchemaTest, imperial_building_stress_uses_psi)
 {
-    const auto result = set("ImperialBuilding",
-                            Unit::Stress,
-                            Quantity::parse("1 psi").getValue());
+    const auto result = set("ImperialBuilding", Unit::Stress, Quantity::parse("1 psi").getValue());
 
     EXPECT_EQ(result, "1.00 psi");
 }
 
 TEST_F(SchemaTest, imperial_density_uses_lb_in3)
 {
-    const auto result = set("Imperial",
-                            Unit::Density,
-                            Quantity::parse("1 lb/in^3").getValue());
+    const auto result = set("Imperial", Unit::Density, Quantity::parse("1 lb/in^3").getValue());
 
     EXPECT_EQ(result, "1.00 lb/in^3");
 }
 
 TEST_F(SchemaTest, imperial_civil_density_uses_lb_ft3)
 {
-    const auto result = set("ImperialCivil",
-                            Unit::Density,
-                            Quantity::parse("1 lb/ft^3").getValue());
+    const auto result = set("ImperialCivil", Unit::Density, Quantity::parse("1 lb/ft^3").getValue());
 
     EXPECT_EQ(result, "1.00 lb/ft^3");
 }

--- a/tests/src/Base/SchemaTests.cpp
+++ b/tests/src/Base/SchemaTests.cpp
@@ -1330,6 +1330,42 @@ TEST_F(SchemaTest, sweep_imperial_building)
     });
 }
 
+TEST_F(SchemaTest, imperial_building_density_uses_lb_ft3)
+{
+    const auto result = set("ImperialBuilding",
+                            Unit::Density,
+                            Quantity::parse("1 lb/ft^3").getValue());
+
+    EXPECT_EQ(result, "1.00 lb/ft^3");
+}
+
+TEST_F(SchemaTest, imperial_building_stress_uses_psi)
+{
+    const auto result = set("ImperialBuilding",
+                            Unit::Stress,
+                            Quantity::parse("1 psi").getValue());
+
+    EXPECT_EQ(result, "1.00 psi");
+}
+
+TEST_F(SchemaTest, imperial_density_uses_lb_in3)
+{
+    const auto result = set("Imperial",
+                            Unit::Density,
+                            Quantity::parse("1 lb/in^3").getValue());
+
+    EXPECT_EQ(result, "1.00 lb/in^3");
+}
+
+TEST_F(SchemaTest, imperial_civil_density_uses_lb_ft3)
+{
+    const auto result = set("ImperialCivil",
+                            Unit::Density,
+                            Quantity::parse("1 lb/ft^3").getValue());
+
+    EXPECT_EQ(result, "1.00 lb/ft^3");
+}
+
 TEST_F(SchemaTest, sweep_imperial_civil)
 {
     UnitsApi::setSchema("ImperialCivil");

--- a/tests/src/Base/SchemaTests.cpp
+++ b/tests/src/Base/SchemaTests.cpp
@@ -1360,12 +1360,8 @@ TEST_F(SchemaTest, imperial_density_uses_lb_in3)
 
 TEST_F(SchemaTest, imperial_civil_density_uses_lb_ft3)
 {
-    const auto result = setWithPrecision(
-        "ImperialCivil",
-        Quantity::parse("1 lb/ft^3").getValue(),
-        Unit::Density,
-        6
-    );
+    const auto result
+        = setWithPrecision("ImperialCivil", Quantity::parse("1 lb/ft^3").getValue(), Unit::Density, 6);
 
     EXPECT_EQ(result, "1.000000 lb/ft^3");
 }

--- a/tests/src/Base/SchemaTests.cpp
+++ b/tests/src/Base/SchemaTests.cpp
@@ -1332,30 +1332,42 @@ TEST_F(SchemaTest, sweep_imperial_building)
 
 TEST_F(SchemaTest, imperial_building_density_uses_lb_ft3)
 {
-    const auto result = set("ImperialBuilding", Unit::Density, Quantity::parse("1 lb/ft^3").getValue());
+    const auto result = setWithPrecision(
+        "ImperialBuilding",
+        Quantity::parse("1 lb/ft^3").getValue(),
+        Unit::Density,
+        6
+    );
 
-    EXPECT_EQ(result, "1.00 lb/ft^3");
+    EXPECT_EQ(result, "1.000000 lb/ft^3");
 }
 
 TEST_F(SchemaTest, imperial_building_stress_uses_psi)
 {
-    const auto result = set("ImperialBuilding", Unit::Stress, Quantity::parse("1 psi").getValue());
+    const auto result
+        = setWithPrecision("ImperialBuilding", Quantity::parse("1 psi").getValue(), Unit::Stress, 6);
 
-    EXPECT_EQ(result, "1.00 psi");
+    EXPECT_EQ(result, "1.000000 psi");
 }
 
 TEST_F(SchemaTest, imperial_density_uses_lb_in3)
 {
-    const auto result = set("Imperial", Unit::Density, Quantity::parse("1 lb/in^3").getValue());
+    const auto result
+        = setWithPrecision("Imperial", Quantity::parse("1 lb/in^3").getValue(), Unit::Density, 6);
 
-    EXPECT_EQ(result, "1.00 lb/in^3");
+    EXPECT_EQ(result, "1.000000 lb/in^3");
 }
 
 TEST_F(SchemaTest, imperial_civil_density_uses_lb_ft3)
 {
-    const auto result = set("ImperialCivil", Unit::Density, Quantity::parse("1 lb/ft^3").getValue());
+    const auto result = setWithPrecision(
+        "ImperialCivil",
+        Quantity::parse("1 lb/ft^3").getValue(),
+        Unit::Density,
+        6
+    );
 
-    EXPECT_EQ(result, "1.00 lb/ft^3");
+    EXPECT_EQ(result, "1.000000 lb/ft^3");
 }
 
 TEST_F(SchemaTest, sweep_imperial_civil)


### PR DESCRIPTION
Add the missing `ImperialBuilding` schema entries for `Density` and `Pressure`.

`PropertyStress` translates through `Pressure`, so this fixes both reported Building US cases by preventing fallback to internal units.

Also add focused regression tests for Building US density/stress and adjacent imperial density behavior.

Validation:
- focused Base schema tests fail before the change and pass after it

## Issues

Related to #26456

## Before and After Images

N/A - no GUI changes
