### PR TITLE
Sketcher: preserve local overlay depth for dimensions and grid

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1191,11 +1191,9 @@ void SoDatumLabel::GLRender(SoGLRenderAction* action)
     glDisable(GL_LIGHTING);
     glDisable(GL_CULL_FACE);
 
-    // Explicitly enable depth testing for constraint lines. This is needed because the
-    // constraint group may have depth testing disabled (to allow icons to render on top),
-    // but we want constraint LINES to render BELOW geometry lines.
-    // Arrowheads are drawn at elevated Z (ZARROW_TEXT_OFFSET) so they render on top.
-    // Text rendering disables depth testing separately.
+    // Enable depth testing so constraint lines use the sketch-local Z carried by their
+    // input points. That keeps them above coplanar model geometry while still rendering
+    // below sketch elements in the normal scene.
     glEnable(GL_DEPTH_TEST);
 
     // Enable Anti-alias
@@ -1289,18 +1287,18 @@ void SoDatumLabel::drawDistance(const SbVec3f* points, float& angle, SbVec3f& te
     // Perp Lines
     glBegin(GL_LINES);
     if (this->param1.getValue() != 0.) {
-        glVertex2f(geom.p1[0], geom.p1[1]);
-        glVertex2f(geom.perp1[0], geom.perp1[1]);
+        glVertex(geom.p1);
+        glVertex(geom.perp1);
 
-        glVertex2f(geom.p2[0], geom.p2[1]);
-        glVertex2f(geom.perp2[0], geom.perp2[1]);
+        glVertex(geom.p2);
+        glVertex(geom.perp2);
     }
 
-    glVertex2f(geom.par1[0], geom.par1[1]);
-    glVertex2f(geom.par2[0], geom.par2[1]);
+    glVertex(geom.par1);
+    glVertex(geom.par2);
 
-    glVertex2f(geom.par3[0], geom.par3[1]);
-    glVertex2f(geom.par4[0], geom.par4[1]);
+    glVertex(geom.par3);
+    glVertex(geom.par4);
     glEnd();
 
     // Draw the arrowheads at elevated Z to render ON TOP of geometry lines
@@ -1349,11 +1347,11 @@ void SoDatumLabel::drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbV
 
     // Draw the Lines
     glBegin(GL_LINES);
-    glVertex2f(geom.p1[0], geom.p1[1]);
-    glVertex2f(geom.pnt1[0], geom.pnt1[1]);
+    glVertex(geom.p1);
+    glVertex(geom.pnt1);
 
-    glVertex2f(geom.pnt2[0], geom.pnt2[1]);
-    glVertex2f(geom.p2[0], geom.p2[1]);
+    glVertex(geom.pnt2);
+    glVertex(geom.p2);
     glEnd();
 
     // Draw arrowhead at elevated Z to render ON TOP of geometry lines

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -24,6 +24,7 @@
 
 #include <limits>
 
+#include <Inventor/nodes/SoCamera.h>
 #include <Inventor/nodes/SoDepthBuffer.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoLineSet.h>
@@ -63,6 +64,11 @@ App::PropertyQuantityConstraint::Constraints ViewProviderGridExtension::GridSize
 
 namespace PartGui
 {
+
+namespace
+{
+constexpr float GRID_Z_OFFSET {0.002F};
+}
 
 class GridExtensionP
 {
@@ -111,6 +117,8 @@ private:
     void createEditModeInventorNodes();
 
     Base::Vector3d getCamCenterInSketchCoordinates() const;
+    Base::Vector3d getPointInSketchCoordinates(const SbVec3f& point) const;
+    int getViewOrientationFactor() const;
 
     SbVec3f camCenterPointOnFocalPlane;
     float camMaxDimension;
@@ -307,6 +315,8 @@ void GridExtensionP::createGridPart(
     int lineWidth
 )
 {
+    float gridZ = getViewOrientationFactor() * GRID_Z_OFFSET;
+
     auto* parent = new Gui::SoSkipBoundingGroup();
     parent->mode = Gui::SoSkipBoundingGroup::EXCLUDE_BBOX;
 
@@ -379,8 +389,8 @@ void GridExtensionP::createGridPart(
         int iStep = (i + i_offset_x);
         if (((iStep % numberSubdiv == 0) && divLines)
             || ((iStep % numberSubdiv != 0) && subDivLines)) {
-            vertex_coords[2 * i].setValue(iStep * computedGridValue, minY, 0);
-            vertex_coords[2 * i + 1].setValue(iStep * computedGridValue, maxY, 0);
+            vertex_coords[2 * i].setValue(iStep * computedGridValue, minY, gridZ);
+            vertex_coords[2 * i + 1].setValue(iStep * computedGridValue, maxY, gridZ);
         }
         else {
             /*the number of vertices is defined before. To know the number of vertices ahead it would
@@ -397,8 +407,8 @@ void GridExtensionP::createGridPart(
         int iStep = (i + i_offset_y);
         if (((iStep % numberSubdiv == 0) && divLines)
             || ((iStep % numberSubdiv != 0) && subDivLines)) {
-            vertex_coords[2 * i].setValue(minX, iStep * computedGridValue, 0);
-            vertex_coords[2 * i + 1].setValue(maxX, iStep * computedGridValue, 0);
+            vertex_coords[2 * i].setValue(minX, iStep * computedGridValue, gridZ);
+            vertex_coords[2 * i + 1].setValue(maxX, iStep * computedGridValue, gridZ);
         }
         else {
             vertex_coords[2 * i].setValue(0, 0, 0);
@@ -413,19 +423,43 @@ void GridExtensionP::createGridPart(
 
 Base::Vector3d GridExtensionP::getCamCenterInSketchCoordinates() const
 {
+    return getPointInSketchCoordinates(camCenterPointOnFocalPlane);
+}
+
+Base::Vector3d GridExtensionP::getPointInSketchCoordinates(const SbVec3f& point) const
+{
     Base::Vector3d xaxis(1, 0, 0), yaxis(0, 1, 0);
 
     gridRotation.multVec(xaxis, xaxis);
     gridRotation.multVec(yaxis, yaxis);
 
     float x, y, z;
-    camCenterPointOnFocalPlane.getValue(x, y, z);
+    point.getValue(x, y, z);
 
-    Base::Vector3d center(x, y, z);
+    Base::Vector3d result(x, y, z);
+    result.TransformToCoordinateSystem(gridOrigin, xaxis, yaxis);
 
-    center.TransformToCoordinateSystem(gridOrigin, xaxis, yaxis);
+    return result;
+}
 
-    return center;
+int GridExtensionP::getViewOrientationFactor() const
+{
+    if (!view) {
+        return 1;
+    }
+
+    auto* viewer = view->getViewer();
+    if (!viewer) {
+        return 1;
+    }
+
+    auto* camera = viewer->getSoRenderManager()->getCamera();
+    if (!camera) {
+        return 1;
+    }
+
+    auto cameraPosition = getPointInSketchCoordinates(camera->position.getValue());
+    return cameraPosition.z < 0 ? -1 : 1;
 }
 
 void GridExtensionP::setEnabled(Gui::View3DInventor* view_)


### PR DESCRIPTION
This fixes depth layering for face-attached sketches in edit mode.

The branch does two things:

1. Preserve the local Sketcher overlay Z for dimension/helper lines.
2. Lift the Sketcher grid slightly off the support face so it remains visible.

## Problem

When editing a sketch attached to a face, dimension/helper lines could disappear behind the model geometry.

The underlying issue was that some `SoDatumLabel` drawing paths used `glVertex2f(...)`, which discards the incoming Z coordinate. That flattened those lines onto the sketch plane instead of using the local Sketcher overlay depth that had already been assigned upstream.

With depth testing enabled, those lines could then lose against the support face.

After correcting that, the grid exposed the same problem from the opposite direction: it was still generated directly on the support plane, so it rendered behind the face while dimensions were correctly using their local overlay depth.

## Fix

### Preserve local Z for dimension lines

In `src/Gui/SoDatumLabel.cpp`, the affected dimension/helper line paths now use the full 3D input points instead of dropping Z.

This makes those lines render at the same local Sketcher overlay depth they already receive from the constraint code, including the correct front/back behavior.

### Lift the grid off the support face

In `src/Mod/Part/Gui/ViewProviderGridExtension.cpp`, the grid is now emitted with a small local Z offset toward the active viewing side instead of being placed directly on the support plane.

This keeps the grid visible while still leaving it below the rest of the sketch overlay.

## Result

- dimension lines no longer disappear behind the support geometry
- the Sketcher grid remains visible
- both now follow the existing local Sketcher depth layering instead of using conflicting plane-level depth

Fixes https://github.com/FreeCAD/FreeCAD/issues/27924