### PR TITLE
CAM: Helix operation - HelixMaxRampAngle and HelixMaxPitch

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelixGenerator.py
@@ -26,6 +26,7 @@ import Part
 import Path
 import Path.Base.Generator.helix as generator
 import CAMTests.PathTestUtils as PathTestUtils
+import math
 
 Path.Log.setLevel(Path.Log.Level.INFO, Path.Log.thisModule())
 Path.Log.trackModule(Path.Log.thisModule())
@@ -47,6 +48,7 @@ def _resetArgs():
         "retract_height": 23,
         "direction": "CW",
         "startAt": "Inside",
+        "ramp_angle_rad": math.radians(3),
     }
 
 
@@ -55,9 +57,11 @@ class TestPathHelixGenerator(PathTestUtils.PathTestBase):
     expectedHelixGCode = "G0 Z23.000000\
 G0 X7.500000 Y5.000000\
 G1 Z20.000000\
-G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z19.500000\
-G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z19.000000\
-G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.500000\
+G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z19.666667\
+G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z19.333333\
+G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z19.000000\
+G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.666667\
+G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.333333\
 G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.000000\
 G2 I-2.500000 J0.000000 X2.500000 Y5.000000 Z18.000000\
 G2 I2.500000 J0.000000 X7.500000 Y5.000000 Z18.000000\
@@ -115,6 +119,16 @@ G0 X11.250000 Y5.000000 Z23.000000"
         args["pitch"] = 0
         self.assertRaises(ValueError, generator.generate, **args)
         args["pitch"] = -1
+        self.assertRaises(ValueError, generator.generate, **args)
+
+        args = _resetArgs()
+        args["ramp_angle_rad"] = "0.1"
+        self.assertRaises(TypeError, generator.generate, **args)
+        args["ramp_angle_rad"] = 0
+        self.assertRaises(ValueError, generator.generate, **args)
+        args["ramp_angle_rad"] = -0.1
+        self.assertRaises(ValueError, generator.generate, **args)
+        args["ramp_angle_rad"] = math.radians(90.1)
         self.assertRaises(ValueError, generator.generate, **args)
 
         # step is a length and can not be negative

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpHelixEdit.ui
@@ -115,12 +115,12 @@
       <item row="4" column="0">
         <widget class="QLabel" name="label_5">
           <property name="text">
-            <string>Helix pitch</string>
+            <string>Max pitch</string>
           </property>
         </widget>
       </item>
       <item row="4" column="1">
-        <widget class="Gui::QuantitySpinBox" name="helixPitch">
+        <widget class="Gui::QuantitySpinBox" name="helixMaxPitch">
           <property name="enabled">
             <bool>true</bool>
           </property>
@@ -128,18 +128,38 @@
             <number>0</number>
           </property>
           <property name="toolTip">
-            <string>Limit height of one complete helix turn</string>
+            <string>The maximum allowable descent in a single revolution of the helix. Set to zero to disable limitation by pitch.</string>
           </property>
         </widget>
       </item>
       <item row="5" column="0">
+        <widget class="QLabel" name="label_5">
+          <property name="text">
+            <string>Max ramp angle</string>
+          </property>
+        </widget>
+      </item>
+      <item row="5" column="1">
+        <widget class="Gui::QuantitySpinBox" name="helixMaxRampAngle">
+          <property name="enabled">
+            <bool>true</bool>
+          </property>
+          <property name="minimum">
+            <number>0</number>
+          </property>
+          <property name="toolTip">
+            <string>The maximum allowable ramp entry angle. Set to zero to disable limitation by ramp angle.</string>
+          </property>
+        </widget>
+      </item>
+      <item row="6" column="0">
        <widget class="QLabel" name="label_6">
         <property name="text">
          <string>Step over percent</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <widget class="QSpinBox" name="stepOverPercent">
         <property name="toolTip">
          <string>Specify the percent of the tool diameter each helix will be offset to the previous one. A step over of 100% means no overlap of the individual cuts.</string>
@@ -158,14 +178,14 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_7">
         <property name="text">
          <string>Stock to leave (outer radial)</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="Gui::QuantitySpinBox" name="radialStockToLeaveOuter">
         <property name="enabled">
           <bool>true</bool>

--- a/src/Mod/CAM/Path/Base/Generator/helix.py
+++ b/src/Mod/CAM/Path/Base/Generator/helix.py
@@ -52,6 +52,7 @@ def generate(
     finish_circle=True,
     cone_angle_rad=0,
     dir_angle_rad=0,
+    ramp_angle_rad=math.pi / 2,
 ):
     """
     Example of use in Mod/CAM/Path/Op/Helix.py
@@ -78,14 +79,21 @@ def generate(
         raise TypeError("Invalid type for edge")
     topCenterPoint = edge.Vertexes[0].Point
     bottomCenterPoint = edge.Vertexes[1].Point
+    helixHeight = topCenterPoint.z - bottomCenterPoint.z
 
     if not isinstance(edge.Curve, Part.Line):
         raise TypeError("Invalid type for edge curve")
 
+    if not Path.Geom.isVertical(edge):
+        raise ValueError("edge is not aligned with Z axis")
+
+    if topCenterPoint.z < bottomCenterPoint.z:
+        raise ValueError("start point is below end point")
+
     if not isinstance(outer_radius, (float, int)):
         raise TypeError("Invalid type for outer radius")
 
-    if outer_radius <= 0:
+    if outer_radius < 0 or Path.Geom.isRoughly(outer_radius, 0):
         raise ValueError("outer_radius <= 0")
 
     if not isinstance(pitch, (float, int)):
@@ -93,6 +101,15 @@ def generate(
 
     if pitch < 0 or Path.Geom.isRoughly(pitch, 0):
         raise ValueError("pitch <= 0")
+
+    if not isinstance(ramp_angle_rad, (float, int)):
+        raise TypeError("Invalid type for 'ramp_angle_rad'")
+
+    if ramp_angle_rad < 0 or Path.Geom.isRoughly(ramp_angle_rad, 0):
+        raise ValueError("ramp_angle_rad <= 0")
+
+    if ramp_angle_rad > math.pi / 2:
+        raise ValueError("ramp_angle > 90")
 
     if not isinstance(step, (float, int)):
         raise TypeError("Invalid value for parameter 'step'")
@@ -146,12 +163,6 @@ def generate(
     if not isinstance(dir_angle_rad, (float, int)):
         raise TypeError("Invalid value for parameter 'dir_angle_rad'")
 
-    if not Path.Geom.isVertical(edge):
-        raise ValueError("edge is not aligned with Z axis")
-
-    if topCenterPoint.z < bottomCenterPoint.z:
-        raise ValueError("start point is below end point")
-
     Path.Log.track(
         "(helix: <{}, {}>\n outer radius {}\n inner radius {}\n retract height {}\n step {}\n start point {}\n end point {}\n pitch {}\n tool diameter {}\n direction {}\n startAt {})".format(
             topCenterPoint.x,
@@ -175,7 +186,7 @@ def generate(
     else:
         Path.Log.debug("(annulus mode)\n")
         work_distance = outer_radius - inner_radius
-        nr = math.ceil(work_distance / step) + 1
+        nr = math.ceil(round(work_distance / step, 6)) + 1
         radii = linspace(outer_radius, inner_radius, nr)
 
     if startAt == "Inside":
@@ -183,16 +194,17 @@ def generate(
         radii = radii[::-1]
 
     Path.Log.debug("Radii: {}".format(radii))
-    """Calculate the number of full and partial turns required
-    Each full turn is two 180 degree arcs
-    zsteps is equally spaced pitch values"""
-    helixHeight = topCenterPoint.z - bottomCenterPoint.z
-    turncount = math.ceil(helixHeight / pitch)
-    zsteps = linspace(topCenterPoint.z, bottomCenterPoint.z, 2 * turncount + 1)
 
     def helix_vertical(r):
-        """helix_vertical(r) ... returns list of commands, which forms simple helix"""
+        """helix_vertical(r) ... returns list of commands, which forms simple helix
+        Each full turn is two 180 degrees arcs"""
         commandlist = []
+
+        lengthOneTurn = math.tau * r
+        depthPerOneCircle = min(lengthOneTurn * math.tan(ramp_angle_rad), pitch)
+        turncount = math.ceil(round(helixHeight / depthPerOneCircle, 6))
+        zsteps = linspace(topCenterPoint.z, bottomCenterPoint.z, 2 * turncount + 1)
+
         arc_cmd = "G2" if direction == "CW" else "G3"
         dx = r * math.cos(dir_angle_rad)
         dy = r * math.sin(dir_angle_rad)
@@ -258,19 +270,27 @@ def generate(
 
     def helix_cone(bottomRadius):
         """helix_cone(bottomRadius) ... returns list of moves,
-        which forms cone helix inclined by angle"""
+        which forms cone helix inclined by angle
+        Each full turn is three 120 degrees arcs"""
+
         topRadius = bottomRadius + math.tan(cone_angle_rad) * helixHeight
-        commandlist = []
-        arcCmdName = "G2" if direction == "CW" else "G3"
         dx = topRadius * math.cos(dir_angle_rad)
         dy = topRadius * math.sin(dir_angle_rad)
+
+        commandlist = []
+        arcCmdName = "G2" if direction == "CW" else "G3"
         commandlist.append(
             Path.Command("G0", {"X": topCenterPoint.x + dx, "Y": topCenterPoint.y + dy})
         )
         commandlist.append(Path.Command("G1", {"Z": topCenterPoint.z}))
-        stepRotate = math.pi / 3  # step size for rotate
+
+        lengthOneTurn = math.tau * bottomRadius
+        depthPerOneCircle = min(lengthOneTurn * math.tan(ramp_angle_rad), pitch)
+        turncount = math.ceil(round(helixHeight / depthPerOneCircle, 6))
+        stepsPerRev = 6
+        stepRotate = math.tau / stepsPerRev  # step angle for rotate
         stepRotate = -stepRotate if direction == "CCW" else stepRotate
-        iters = int(math.tau * turncount / abs(stepRotate))
+        iters = turncount * stepsPerRev
         stepRadius = (topRadius - bottomRadius) / iters  # step size for spiral radius
         stepZ = helixHeight / iters
         count = 0
@@ -290,6 +310,7 @@ def generate(
             count += 1
 
         i = 0
+        assert (len(arcPoints) - 3) % 2 == 0
         while i <= len(arcPoints) - 3:
             arcEnd = arcPoints[i + 2]
             arcCenter = getArcCenter(arcPoints[i], arcPoints[i + 1], arcPoints[i + 2])

--- a/src/Mod/CAM/Path/Base/Generator/spiral.py
+++ b/src/Mod/CAM/Path/Base/Generator/spiral.py
@@ -167,7 +167,7 @@ def generate(
     stepAngle = math.tau / turnDivider  # step angle for rotate
     stepAngle = -stepAngle if direction == "CCW" else stepAngle
     turns = math.ceil(round((outer_radius - inner_radius) / step, 6))  # amount of spiral turns
-    iters = round(math.tau * turns / abs(stepAngle))
+    iters = turns * turnDivider
     stepRadius = (outer_radius - inner_radius) / iters  # changes spiral radius on each step
     stepRadius = -stepRadius if startAt == "Outside" else stepRadius
     angle = math.pi / 2 - dir_angle_rad
@@ -193,6 +193,7 @@ def generate(
         count += 1
 
     i = 0
+    assert (len(arcPoints) - 3) % 2 == 0
     while i <= len(arcPoints) - 3:
         arcEnd = arcPoints[i + 2]
         arcCenter = getArcCenter(arcPoints[i], arcPoints[i + 1], arcPoints[i + 2])

--- a/src/Mod/CAM/Path/Op/Gui/Helix.py
+++ b/src/Mod/CAM/Path/Op/Gui/Helix.py
@@ -47,8 +47,11 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
     """Page controller class for Helix operations."""
 
     def initPage(self, obj):
-        self.helixPitchSpinBox = PathGuiUtil.QuantitySpinBox(
-            self.form.helixPitch, obj, "HelixPitch"
+        self.helixMaxPitchSpinBox = PathGuiUtil.QuantitySpinBox(
+            self.form.helixMaxPitch, obj, "HelixMaxPitch"
+        )
+        self.helixMaxRampAngleSpinBox = PathGuiUtil.QuantitySpinBox(
+            self.form.helixMaxRampAngle, obj, "HelixMaxRampAngle"
         )
         self.radialStockToLeaveOuterSpinBox = PathGuiUtil.QuantitySpinBox(
             self.form.radialStockToLeaveOuter, obj, "RadialStockToLeaveOuter"
@@ -65,13 +68,15 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         return form
 
     def updateQuantitySpinBoxes(self, index=None):
-        self.helixPitchSpinBox.updateWidget()
+        self.helixMaxPitchSpinBox.updateWidget()
+        self.helixMaxRampAngleSpinBox.updateWidget()
         self.radialStockToLeaveOuterSpinBox.updateWidget()
 
     def getFields(self, obj):
         """getFields(obj) ... transfers values from UI to obj's properties"""
         Path.Log.track()
-        self.helixPitchSpinBox.updateProperty()
+        self.helixMaxPitchSpinBox.updateProperty()
+        self.helixMaxRampAngleSpinBox.updateProperty()
         self.radialStockToLeaveOuterSpinBox.updateProperty()
 
         if obj.CutMode != str(self.form.cutMode.currentData()):
@@ -102,7 +107,8 @@ class TaskPanelOpPage(PathCircularHoleBaseGui.TaskPanelOpPage):
         """getSignalsForUpdate(obj) ... return list of signals for updating obj"""
         signals = []
 
-        signals.append(self.form.helixPitch.editingFinished)
+        signals.append(self.form.helixMaxPitch.editingFinished)
+        signals.append(self.form.helixMaxRampAngle.editingFinished)
         signals.append(self.form.radialStockToLeaveOuter.editingFinished)
         signals.append(self.form.stepOverPercent.editingFinished)
 

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -279,11 +279,22 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         )
         obj.addProperty(
             "App::PropertyLength",
-            "HelixPitch",
+            "HelixMaxPitch",
             "Helix Drill",
             QT_TRANSLATE_NOOP(
                 "App::Property",
-                "Limit height of one complete helix turn",
+                "The maximum allowable descent in a single revolution of the helix"
+                "\nSet to zero to disable limitation by pitch",
+            ),
+        )
+        obj.addProperty(
+            "App::PropertyAngle",
+            "HelixMaxRampAngle",
+            "Helix Drill",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "The maximum allowable ramp entry angle"
+                "\nSet to zero to disable limitation by ramp angle",
             ),
         )
 
@@ -317,7 +328,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         obj.RotationAngle = -1
         obj.StepOver = 50
 
-        obj.setExpression("HelixPitch", job.SetupSheet.StepDownExpression)
+        obj.setExpression("HelixMaxPitch", job.SetupSheet.StepDownExpression)
         obj.setExpression("StepDown", "StartDepth - FinalDepth")
 
     def opCheckParameters(self, obj):
@@ -336,6 +347,11 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
             if obj.Side == "Inside" and obj.RadialStockToLeaveInner.Value < -tooldiam / 2:
                 obj.RadialStockToLeaveInner = -tooldiam / 2
+
+        if obj.HelixMaxRampAngle < 0:
+            obj.HelixMaxRampAngle = 0
+        elif obj.HelixMaxRampAngle > 90:
+            obj.HelixMaxRampAngle = 90
 
     def opOnDocumentRestored(self, obj):
         if hasattr(obj, "StartSide") and not hasattr(obj, "StartAt"):
@@ -477,24 +493,37 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
                 ),
             )
             obj.RotationAngle = -1
-        if not hasattr(obj, "HelixPitch"):
+        if hasattr(obj, "HelixPitch"):
+            obj.renameProperty("HelixPitch", "HelixMaxPitch")
+        if not hasattr(obj, "HelixMaxPitch"):
             obj.addProperty(
                 "App::PropertyLength",
-                "HelixPitch",
+                "HelixMaxPitch",
                 "Helix Drill",
                 QT_TRANSLATE_NOOP(
                     "App::Property",
-                    "Limit height of one complete helix turn",
+                    "The maximum allowable descent in a single revolution of the helix"
+                    "\nSet to zero to disable limitation by pitch",
                 ),
             )
             expressions = dict(obj.ExpressionEngine)
             stepDownExpr = expressions.get("StepDown")
             if stepDownExpr:
-                obj.setExpression("HelixPitch", stepDownExpr)
+                obj.setExpression("HelixMaxPitch", stepDownExpr)
             else:
                 obj.StepDown
             obj.setExpression("StepDown", "StartDepth - FinalDepth")
-
+        if not hasattr(obj, "HelixMaxRampAngle"):
+            obj.addProperty(
+                "App::PropertyAngle",
+                "HelixMaxRampAngle",
+                "Helix Drill",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "The maximum allowable ramp entry angle"
+                    "\nSet to zero to disable limitation by ramp angle",
+                ),
+            )
         if not hasattr(obj, "CutMode"):
             obj.addProperty(
                 "App::PropertyEnumeration",
@@ -547,6 +576,9 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         # validate that SafeHeight doesn't exceed ClearanceHeight
         safeHeight = obj.SafeHeight.Value
         clearanceHeight = obj.ClearanceHeight.Value
+        tooldiameter = obj.ToolController.Tool.Diameter.Value
+        toolradius = tooldiameter / 2
+
         if safeHeight > clearanceHeight:
             Path.Log.warning(
                 f"SafeHeight ({safeHeight}) is above ClearanceHeight ({clearanceHeight}). "
@@ -566,18 +598,15 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "global_clearance": clearanceHeight,
             "solids": solids,
             "tool_shape": self.tool.Shape,
-            "tolerance": safeHeight - obj.StartDepth.Value,
+            "tolerance": abs(safeHeight - obj.StartDepth.Value),
         }
 
         obj.Direction = _caclulatePathDirection(obj)
 
-        tooldiameter = obj.ToolController.Tool.Diameter.Value
-        toolradius = tooldiameter / 2
-
         args = {
             "edge": None,
             "outer_radius": None,
-            "pitch": obj.HelixPitch.Value,
+            "pitch": obj.HelixMaxPitch.Value or safeHeight - obj.FinalDepth.Value,
             "step": obj.StepOver * tooldiameter / 100,
             "inner_radius": None,
             "retract_height": safeHeight,
@@ -586,6 +615,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
             "finish_circle": obj.FinishHelixCircle,
             "cone_angle_rad": None,
             "dir_angle_rad": None,
+            "ramp_angle_rad": math.radians(obj.HelixMaxRampAngle) or math.pi / 2,
         }
 
         if obj.RetractFromWall:
@@ -655,7 +685,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
             # Split depth by step down
             work_distance = obj.StartDepth.Value - obj.FinalDepth.Value
-            iters = math.ceil(work_distance / obj.StepDown.Value)
+            iters = math.ceil(round(work_distance / obj.StepDown.Value, 6))
             centerTop = FreeCAD.Vector(hole["x"], hole["y"], obj.StartDepth.Value)
             centerBottom = FreeCAD.Vector(hole["x"], hole["y"], obj.StartDepth.Value)
             retractDistance = safeHeight - obj.StartDepth.Value


### PR DESCRIPTION
Step **1/2** of changes to get identical names and behavior of helix ramp entry in **Helix** and **Adaptive** operations
https://github.com/FreeCAD/FreeCAD/pull/22357#issuecomment-4225254804

This PR touch **Helix** operation
PR #22357 will touch **Adaptive** operation 

---
## Changes

### Helix generator
- Added argument `rap_angle_rad`
Now pitch calculates for each helix radius

### Helix operation
- Added property `HelixMaxRampAngle` (degrees)
Default value is 0, which get old behavior
Set non zero value to limit ramp entry by angle
- Property `HelixPitch` renamed to `HelixMaxPitch` (mm/inch)
Set non zero value to limit helix pitch

<img width="1380" height="478" alt="Screenshot_20260417_214822_hor" src="https://github.com/user-attachments/assets/d3ce7900-503f-4f73-bf80-bd2740e25e90" />

