### PR TITLE
Gui: sketcher: fix OVP cursor movement issues

### DIFF
--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -191,7 +191,9 @@ void EditableDatumLabel::startEdit(double val, QObject* eventFilteringObj, bool 
     }
 
     spinBox->show();
-    updateGeometry();
+    if (auto* edit = spinBox->findChild<QLineEdit*>()) {
+        updateGeometry(edit);
+    }
     setFocusToSpinbox();
 
     const auto validateAndFinish = [this]() {
@@ -221,7 +223,9 @@ void EditableDatumLabel::startEdit(double val, QObject* eventFilteringObj, bool 
 
     connect(spinBox, qOverload<double>(&QuantitySpinBox::valueChanged), this, validateAndFinish);
     if (auto* edit = spinBox->findChild<QLineEdit*>()) {
-        connect(edit, &QLineEdit::textChanged, this, &EditableDatumLabel::updateGeometry);
+        connect(edit, &QLineEdit::textChanged, this, [this, edit](const QString &text) {
+            this->updateGeometry(edit);
+        });
     }
 }
 
@@ -431,12 +435,14 @@ void EditableDatumLabel::setPlacement(const Base::Placement& plc)
     label->norm.setValue(SbVec3f(float(RN.x), float(RN.y), float(RN.z)));
 }
 
-void EditableDatumLabel::updateGeometry()
+void EditableDatumLabel::updateGeometry(QLineEdit* edit)
 {
-    if (!spinBox) {
+    if (!spinBox || !edit) {
         return;
     }
+    int pos = edit->cursorPosition();
     spinBox->adjustSize();
+    edit->setCursorPosition(pos);
 }
 
 // NOLINTNEXTLINE

--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -223,7 +223,7 @@ void EditableDatumLabel::startEdit(double val, QObject* eventFilteringObj, bool 
 
     connect(spinBox, qOverload<double>(&QuantitySpinBox::valueChanged), this, validateAndFinish);
     if (auto* edit = spinBox->findChild<QLineEdit*>()) {
-        connect(edit, &QLineEdit::textChanged, this, [this, edit](const QString &text) {
+        connect(edit, &QLineEdit::textChanged, this, [this, edit](const QString& text) {
             this->updateGeometry(edit);
         });
     }

--- a/src/Gui/EditableDatumLabel.h
+++ b/src/Gui/EditableDatumLabel.h
@@ -92,7 +92,7 @@ public:
     void setLockedAppearance(bool locked);  ///< Sets visual appearance to indicate locked state
                                             ///< (finished editing)
     void resetLockedState();  ///< Resets both hasFinishedEditing flag and locked appearance
-    void updateGeometry();
+    void updateGeometry(QLineEdit* edit);
 
     Function getFunction();
 

--- a/src/Gui/QuantitySpinBox.cpp
+++ b/src/Gui/QuantitySpinBox.cpp
@@ -453,22 +453,6 @@ void QuantitySpinBox::resizeEvent(QResizeEvent* event)
 {
     QAbstractSpinBox::resizeEvent(event);
     resizeWidget();
-    clampCursorBeforeUnit();
-}
-
-void QuantitySpinBox::clampCursorBeforeUnit()
-{
-    Q_D(QuantitySpinBox);
-    if (!d->adjustableWidth) {
-        return;
-    }
-    QLineEdit* edit = lineEdit();
-    int cursor = edit->cursorPosition();
-    const int maxCursor = qMax(0, edit->displayText().size() - 1 /*space*/ - d->unitStr.size());
-
-    if (cursor > maxCursor) {
-        edit->setCursorPosition(maxCursor);
-    }
 }
 
 void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent* event)
@@ -491,9 +475,6 @@ void Gui::QuantitySpinBox::keyPressEvent(QKeyEvent* event)
 
     if (isEnter) {
         returnPressed();
-    }
-    else {
-        clampCursorBeforeUnit();
     }
 }
 
@@ -521,7 +502,6 @@ void QuantitySpinBox::updateEdit(const QString& text)
 
     QLineEdit* edit = lineEdit();
 
-    bool empty = edit->text().isEmpty();
     int cursor = edit->cursorPosition();
     int selsize = edit->selectedText().size();
 
@@ -530,9 +510,6 @@ void QuantitySpinBox::updateEdit(const QString& text)
     cursor = qBound(0, cursor, qMax(0, edit->displayText().size() - d->unitStr.size()));
     if (selsize > 0) {
         edit->setSelection(0, cursor);
-    }
-    else {
-        clampCursorBeforeUnit();
     }
 }
 

--- a/src/Gui/QuantitySpinBox.h
+++ b/src/Gui/QuantitySpinBox.h
@@ -198,7 +198,6 @@ protected:
     void paintEvent(QPaintEvent* event) override;
 
 private:
-    void clampCursorBeforeUnit();
     void validateInput() override;
     void updateText(const Base::Quantity&);
     void updateEdit(const QString& text);


### PR DESCRIPTION
this should fix https://github.com/FreeCAD/FreeCAD/issues/29248 with a completely different approach than #29263

basically i've simplified the logic to the maximum, we don't need to calculate or clamp anything, we just save the cursor before resizing and restore it afterwards, much simpler than the current code

@ElementW 