### PR TITLE
Measure: Better ViewProvider for Mass Properties

### DIFF
--- a/src/Mod/Measure/App/MassPropertiesResult.cpp
+++ b/src/Mod/Measure/App/MassPropertiesResult.cpp
@@ -184,41 +184,41 @@ MassPropertiesData CalculateMassProperties(
         principal = globalMassProps.PrincipalProperties();
 
         if (principal.HasSymmetryPoint()) {
-            data.principalAxisX = Base::Vector3d::UnitX;
-            data.principalAxisY = Base::Vector3d::UnitY;
-            data.principalAxisZ = Base::Vector3d::UnitZ;
+            data.principalAxis1 = Base::Vector3d::UnitX;
+            data.principalAxis2 = Base::Vector3d::UnitY;
+            data.principalAxis3 = Base::Vector3d::UnitZ;
         }
         else if (principal.HasSymmetryAxis()) {
-            gp_Vec zVec = principal.FirstAxisOfInertia();
-            Base::Vector3d zAxis {Base::convertTo<Base::Vector3d>(zVec)};
-            zAxis.Normalize();
+            gp_Vec axis3Vec = principal.FirstAxisOfInertia();
+            Base::Vector3d axis3 {Base::convertTo<Base::Vector3d>(axis3Vec)};
+            axis3.Normalize();
 
             Base::Vector3d ref {Base::Vector3d::UnitZ};
-            if (std::fabs(zAxis.z) > 0.9) {
+            if (std::fabs(axis3.z) > 0.9) {
                 ref = Base::Vector3d::UnitY;
             }
 
-            Base::Vector3d xAxis = ref.Cross(zAxis);
-            xAxis.Normalize();
+            Base::Vector3d axis1 = ref.Cross(axis3);
+            axis1.Normalize();
 
-            Base::Vector3d yAxis = zAxis.Cross(xAxis);
-            yAxis.Normalize();
+            Base::Vector3d axis2 = axis3.Cross(axis1);
+            axis2.Normalize();
 
-            data.principalAxisZ = zAxis;
-            data.principalAxisX = xAxis;
-            data.principalAxisY = yAxis;
+            data.principalAxis3 = axis3;
+            data.principalAxis1 = axis1;
+            data.principalAxis2 = axis2;
         }
         else {
             gp_Vec v1 = principal.FirstAxisOfInertia();
             gp_Vec v2 = principal.SecondAxisOfInertia();
 
-            gp_Dir Z = Base::convertTo<gp_Dir>(v1);
-            gp_Dir X = Base::convertTo<gp_Dir>(v2);
-            gp_Dir Y = Z.Crossed(X);
+            gp_Dir axis3 = Base::convertTo<gp_Dir>(v1);
+            gp_Dir axis1 = Base::convertTo<gp_Dir>(v2);
+            gp_Dir axis2 = axis3.Crossed(axis1);
 
-            data.principalAxisZ = Base::convertTo<Base::Vector3d>(Z);
-            data.principalAxisX = Base::convertTo<Base::Vector3d>(X);
-            data.principalAxisY = Base::convertTo<Base::Vector3d>(Y);
+            data.principalAxis3 = Base::convertTo<Base::Vector3d>(axis3);
+            data.principalAxis1 = Base::convertTo<Base::Vector3d>(axis1);
+            data.principalAxis2 = Base::convertTo<Base::Vector3d>(axis2);
         }
 
         auto axisMoment = [&](const Base::Vector3d& u) {
@@ -228,9 +228,9 @@ MassPropertiesData CalculateMassProperties(
         };
 
         data.inertiaJ = Base::Vector3d(
-            axisMoment(data.principalAxisX),
-            axisMoment(data.principalAxisY),
-            axisMoment(data.principalAxisZ)
+            axisMoment(data.principalAxis1),
+            axisMoment(data.principalAxis2),
+            axisMoment(data.principalAxis3)
         );
     }
     else if (mode == MassPropertiesMode::Custom) {
@@ -346,9 +346,9 @@ MassPropertiesData CalculateMassProperties(
         jacobi.Vector(2, v2);
         jacobi.Vector(3, v3);
 
-        data.principalAxisX = Base::Vector3d(v1(1), v1(2), v1(3));
-        data.principalAxisY = Base::Vector3d(v2(1), v2(2), v2(3));
-        data.principalAxisZ = Base::Vector3d(v3(1), v3(2), v3(3));
+        data.principalAxis1 = Base::Vector3d(v1(1), v1(2), v1(3));
+        data.principalAxis2 = Base::Vector3d(v2(1), v2(2), v2(3));
+        data.principalAxis3 = Base::Vector3d(v3(1), v3(2), v3(3));
     }
 
     return data;

--- a/src/Mod/Measure/App/MassPropertiesResult.h
+++ b/src/Mod/Measure/App/MassPropertiesResult.h
@@ -56,9 +56,9 @@ struct MeasureExport MassPropertiesData
     Base::Vector3d inertiaJCross {0.0, 0.0, 0.0};
     Base::Vector3d inertiaJ {0.0, 0.0, 0.0};
 
-    Base::Vector3d principalAxisX {0.0, 0.0, 0.0};
-    Base::Vector3d principalAxisY {0.0, 0.0, 0.0};
-    Base::Vector3d principalAxisZ {0.0, 0.0, 0.0};
+    Base::Vector3d principalAxis1 {0.0, 0.0, 0.0};
+    Base::Vector3d principalAxis2 {0.0, 0.0, 0.0};
+    Base::Vector3d principalAxis3 {0.0, 0.0, 0.0};
 
     double axisInertia;
 };

--- a/src/Mod/Measure/Gui/Resources/Measure.qrc
+++ b/src/Mod/Measure/Gui/Resources/Measure.qrc
@@ -13,5 +13,7 @@
         <file>icons/Measurement-Radius.svg</file>
         <file>icons/Measurement-Volume.svg</file>
         <file>icons/MassPropertiesIcon.svg</file>
+        <file>icons/COV-Icon.svg</file>
+        <file>icons/COG-Icon.svg</file>
     </qresource>
 </RCC>

--- a/src/Mod/Measure/Gui/Resources/icons/COG-Icon.svg
+++ b/src/Mod/Measure/Gui/Resources/icons/COG-Icon.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933333"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (1:1.2.2+202305151914+b0a8486541)"
+   sodipodi:docname="center_of_gravity.64px.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="true"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="9.5144352"
+     inkscape:cx="96.590074"
+     inkscape:cy="42.093933"
+     inkscape:window-width="2560"
+     inkscape:window-height="1368"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid132" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <ellipse
+       style="fill:#000000;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
+       id="path236-7"
+       cx="8.4666662"
+       cy="8.598958"
+       rx="7.9375"
+       ry="7.8052087" />
+    <ellipse
+       style="fill:#ffffff;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
+       id="path398-5"
+       cx="8.4666662"
+       cy="8.598958"
+       rx="7.4083333"
+       ry="7.2760415" />
+    <path
+       id="path398-6-3"
+       style="fill:#000000;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
+       d="m 1.5926677,8.4666667 a 6.8791671,6.7468748 0 0 0 -0.0052,0.1322916 6.8791671,6.7468748 0 0 0 6.879167,6.7468747 V 8.4666667 Z" />
+    <path
+       id="rect452-5"
+       style="fill:#000000;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
+       d="M 8.4666667,1.8520833 V 8.4666667 H 15.344283 A 6.8791671,6.7468748 0 0 0 8.4666667,1.8520833 Z" />
+  </g>
+</svg>

--- a/src/Mod/Measure/Gui/Resources/icons/COG-Icon.svg
+++ b/src/Mod/Measure/Gui/Resources/icons/COG-Icon.svg
@@ -8,7 +8,7 @@
    version="1.1"
    id="svg5"
    inkscape:version="1.2.2 (1:1.2.2+202305151914+b0a8486541)"
-   sodipodi:docname="center_of_gravity.64px.svg"
+   sodipodi:docname="COG-Icon.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="9.5144352"
-     inkscape:cx="96.590074"
-     inkscape:cy="42.093933"
+     inkscape:zoom="19.02887"
+     inkscape:cx="53.55021"
+     inkscape:cy="32.976209"
      inkscape:window-width="2560"
      inkscape:window-height="1368"
      inkscape:window-x="0"
@@ -43,27 +43,25 @@
      inkscape:label="Calque 1"
      inkscape:groupmode="layer"
      id="layer1">
-    <ellipse
+    <circle
        style="fill:#000000;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
        id="path236-7"
        cx="8.4666662"
-       cy="8.598958"
-       rx="7.9375"
-       ry="7.8052087" />
-    <ellipse
+       cy="8.4666662"
+       r="7.9375" />
+    <circle
        style="fill:#ffffff;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
        id="path398-5"
        cx="8.4666662"
-       cy="8.598958"
-       rx="7.4083333"
-       ry="7.2760415" />
+       cy="8.4666662"
+       r="6.8791666" />
     <path
        id="path398-6-3"
        style="fill:#000000;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
-       d="m 1.5926677,8.4666667 a 6.8791671,6.7468748 0 0 0 -0.0052,0.1322916 6.8791671,6.7468748 0 0 0 6.879167,6.7468747 V 8.4666667 Z" />
+       d="m 2.6502333,8.4666668 a 5.8208015,5.7088944 0 0 0 -0.0044,0.111939 A 5.8208015,5.7088944 0 0 0 8.4666346,14.2875 V 8.4666668 Z" />
     <path
        id="rect452-5"
-       style="fill:#000000;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
-       d="M 8.4666667,1.8520833 V 8.4666667 H 15.344283 A 6.8791671,6.7468748 0 0 0 8.4666667,1.8520833 Z" />
+       style="fill:#000000;stroke:none;stroke-width:0.529165;stroke-linecap:round;stroke-linejoin:round"
+       d="M 8.4666668,2.6458333 V 8.4666667 H 14.2875 A 5.822146,5.9372499 0 0 0 8.4666668,2.6458333 Z" />
   </g>
 </svg>

--- a/src/Mod/Measure/Gui/Resources/icons/COV-Icon.svg
+++ b/src/Mod/Measure/Gui/Resources/icons/COV-Icon.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="64"
+   height="64"
+   viewBox="0 0 16.933333 16.933333"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (1:1.2.2+202305151914+b0a8486541)"
+   sodipodi:docname="center_of_volume.64px.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="true"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="true"
+     inkscape:zoom="9.5144352"
+     inkscape:cx="96.590074"
+     inkscape:cy="42.093933"
+     inkscape:window-width="2560"
+     inkscape:window-height="1368"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid132" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2" />
+  <g
+     inkscape:label="Calque 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <ellipse
+       style="fill:#0000ff;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
+       id="path236-7"
+       cx="8.4666662"
+       cy="8.598958"
+       rx="7.9375"
+       ry="7.8052087" />
+    <ellipse
+       style="fill:#ffff00;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
+       id="path398-5"
+       cx="8.4666662"
+       cy="8.598958"
+       rx="7.4083333"
+       ry="7.2760415" />
+    <path
+       id="path398-6-3"
+       style="fill:#0000ff;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
+       d="m 1.5926677,8.4666667 a 6.8791671,6.7468748 0 0 0 -0.0052,0.1322916 6.8791671,6.7468748 0 0 0 6.879167,6.7468747 V 8.4666667 Z" />
+    <path
+       id="rect452-5"
+       style="fill:#0000ff;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
+       d="M 8.4666667,1.8520833 V 8.4666667 H 15.344283 A 6.8791671,6.7468748 0 0 0 8.4666667,1.8520833 Z" />
+  </g>
+</svg>

--- a/src/Mod/Measure/Gui/Resources/icons/COV-Icon.svg
+++ b/src/Mod/Measure/Gui/Resources/icons/COV-Icon.svg
@@ -8,7 +8,7 @@
    version="1.1"
    id="svg5"
    inkscape:version="1.2.2 (1:1.2.2+202305151914+b0a8486541)"
-   sodipodi:docname="center_of_volume.64px.svg"
+   sodipodi:docname="COV-Icon.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -24,9 +24,9 @@
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="mm"
      showgrid="true"
-     inkscape:zoom="9.5144352"
-     inkscape:cx="96.590074"
-     inkscape:cy="42.093933"
+     inkscape:zoom="19.02887"
+     inkscape:cx="55.389521"
+     inkscape:cy="29.66545"
      inkscape:window-width="2560"
      inkscape:window-height="1368"
      inkscape:window-x="0"
@@ -43,27 +43,33 @@
      inkscape:label="Calque 1"
      inkscape:groupmode="layer"
      id="layer1">
-    <ellipse
-       style="fill:#0000ff;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
-       id="path236-7"
-       cx="8.4666662"
-       cy="8.598958"
-       rx="7.9375"
-       ry="7.8052087" />
-    <ellipse
-       style="fill:#ffff00;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
-       id="path398-5"
-       cx="8.4666662"
-       cy="8.598958"
-       rx="7.4083333"
-       ry="7.2760415" />
-    <path
-       id="path398-6-3"
-       style="fill:#0000ff;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
-       d="m 1.5926677,8.4666667 a 6.8791671,6.7468748 0 0 0 -0.0052,0.1322916 6.8791671,6.7468748 0 0 0 6.879167,6.7468747 V 8.4666667 Z" />
-    <path
-       id="rect452-5"
-       style="fill:#0000ff;stroke:none;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round"
-       d="M 8.4666667,1.8520833 V 8.4666667 H 15.344283 A 6.8791671,6.7468748 0 0 0 8.4666667,1.8520833 Z" />
+    <rect
+       style="fill:#0000ff;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:4.23333, 2.11667"
+       id="rect290"
+       width="15.875"
+       height="15.875"
+       x="0.52916664"
+       y="0.52916664" />
+    <rect
+       style="fill:#ffff00;stroke-width:0.529166;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:4.23333, 2.11667"
+       id="rect398"
+       width="13.758333"
+       height="13.758334"
+       x="1.5875"
+       y="1.5875" />
+    <rect
+       style="fill:#0000ff;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:4.23333, 2.11667"
+       id="rect452"
+       width="5.8208332"
+       height="5.8208332"
+       x="2.6458333"
+       y="2.6458333" />
+    <rect
+       style="fill:#0000ff;stroke-width:0.529167;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:4.23333, 2.11667"
+       id="rect454"
+       width="5.8208332"
+       height="5.8208332"
+       x="8.4666662"
+       y="8.4666662" />
   </g>
 </svg>

--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -22,6 +22,7 @@
 #include "TaskMassProperties.h"
 #include "Mod/Measure/App/MassPropertiesResult.h"
 #include "Mod/Measure/App/MassPropertiesObject.h"
+#include "ViewProviderMassPropertiesResult.h"
 #include "ui_TaskMassProperties.h"
 
 #include <QtCore/QScopedValueRollback>
@@ -282,8 +283,8 @@ TaskMassProperties::TaskMassProperties()
         tr("Physical Properties"),
         panel->takePage(panel->ui.physicalPropertiesPage)
     );
-    addTaskBox("Std_Point", tr("Center of Gravity"), panel->takePage(panel->ui.centerOfGravityPage));
-    addTaskBox("Std_Point", tr("Center of Volume"), panel->takePage(panel->ui.centerOfVolumePage));
+    addTaskBox("COG-Icon", tr("Center of Gravity"), panel->takePage(panel->ui.centerOfGravityPage));
+    addTaskBox("COV-Icon", tr("Center of Volume"), panel->takePage(panel->ui.centerOfVolumePage));
     addTaskBox("Std_CoordinateSystem", tr("Inertia"), panel->takePage(panel->ui.inertiaPage));
 
     updateInertiaVisibility();
@@ -414,21 +415,13 @@ void TaskMassProperties::removeTemporaryObjects()
         return;
     }
 
-    if (!doc->getObject("Center_of_Gravity") && !doc->getObject("Center_of_Volume")
-        && !doc->getObject("Principal_Axes_LCS")) {
+    if (!doc->getObject("MassPropertiesPreview")) {
         return;
     }
 
-    doc->openTransaction("Remove temporary datum objects");
-
-    if (doc->getObject("Center_of_Gravity")) {
-        doc->removeObject("Center_of_Gravity");
-    }
-    if (doc->getObject("Center_of_Volume")) {
-        doc->removeObject("Center_of_Volume");
-    }
-    if (doc->getObject("Principal_Axes_LCS")) {
-        doc->removeObject("Principal_Axes_LCS");
+    doc->openTransaction("Remove temporary mass properties object");
+    if (doc->getObject("MassPropertiesPreview")) {
+        doc->removeObject("MassPropertiesPreview");
     }
 
     doc->commitTransaction();
@@ -1154,12 +1147,44 @@ void TaskMassProperties::tryUpdate()
 
     const auto infoSnapshot = currentInfo;
     QTimer::singleShot(0, this, [this, infoSnapshot, hasAxisSelection]() {
-        currentInfo = infoSnapshot;
-        createDatum(currentInfo.cog, "Center_of_Gravity");
-        createDatum(currentInfo.cov, "Center_of_Volume");
-        if (!hasAxisSelection) {
-            createLCS("Principal_Axes_LCS");
+        App::Document* doc = App::GetApplication().getActiveDocument();
+        if (!doc) {
+            return;
         }
+
+        Measure::Result::init();
+
+        App::DocumentObject* obj = doc->getObject("MassPropertiesPreview");
+        if (!obj) {
+            obj = doc->addObject("Measure::Result", "MassPropertiesPreview");
+        }
+
+        obj->Visibility.setValue(true);
+
+        auto* guiDoc = Gui::Application::Instance->activeDocument();
+        if (!guiDoc) {
+            return;
+        }
+
+        auto* view = dynamic_cast<Gui::ViewProviderDocumentObject*>(guiDoc->getViewProvider(obj));
+        if (!view) {
+            return;
+        }
+
+        if (auto* resultView = dynamic_cast<ViewProviderMassPropertiesResult*>(view)) {
+            resultView->setCenters(infoSnapshot.cog, infoSnapshot.cov);
+            resultView->setPrincipalAxes(
+                infoSnapshot.cog,
+                infoSnapshot.principalAxis1,
+                infoSnapshot.principalAxis2,
+                infoSnapshot.principalAxis3,
+                !hasAxisSelection
+            );
+        }
+
+        view->setShowable(true);
+        view->ShowInTree.setValue(false);
+        view->show();
     });
 }
 
@@ -1244,17 +1269,17 @@ void TaskMassProperties::createLCS(std::string name, bool removeExisting)
         Base::Matrix4D mat;
         mat.setToUnity();
 
-        mat[0][0] = currentInfo.principalAxisX.x;
-        mat[1][0] = currentInfo.principalAxisX.y;
-        mat[2][0] = currentInfo.principalAxisX.z;
+        mat[0][0] = currentInfo.principalAxis1.x;
+        mat[1][0] = currentInfo.principalAxis1.y;
+        mat[2][0] = currentInfo.principalAxis1.z;
 
-        mat[0][1] = currentInfo.principalAxisY.x;
-        mat[1][1] = currentInfo.principalAxisY.y;
-        mat[2][1] = currentInfo.principalAxisY.z;
+        mat[0][1] = currentInfo.principalAxis2.x;
+        mat[1][1] = currentInfo.principalAxis2.y;
+        mat[2][1] = currentInfo.principalAxis2.z;
 
-        mat[0][2] = currentInfo.principalAxisZ.x;
-        mat[1][2] = currentInfo.principalAxisZ.y;
-        mat[2][2] = currentInfo.principalAxisZ.z;
+        mat[0][2] = currentInfo.principalAxis3.x;
+        mat[1][2] = currentInfo.principalAxis3.y;
+        mat[2][2] = currentInfo.principalAxis3.z;
 
         plm.setRotation(mat);
 
@@ -1498,9 +1523,9 @@ void TaskMassProperties::saveResult()
         setQuantity("InertiaJy", "Inertia", Base::Quantity(currentInfo.inertiaJ.y, Base::Unit::Inertia));
         setQuantity("InertiaJz", "Inertia", Base::Quantity(currentInfo.inertiaJ.z, Base::Unit::Inertia));
 
-        setVector("PrincipalAxisX", "Inertia", currentInfo.principalAxisX);
-        setVector("PrincipalAxisY", "Inertia", currentInfo.principalAxisY);
-        setVector("PrincipalAxisZ", "Inertia", currentInfo.principalAxisZ);
+        setVector("PrincipalAxis1", "Inertia", currentInfo.principalAxis1);
+        setVector("PrincipalAxis2", "Inertia", currentInfo.principalAxis2);
+        setVector("PrincipalAxis3", "Inertia", currentInfo.principalAxis3);
     }
 
     if (group) {
@@ -1510,6 +1535,16 @@ void TaskMassProperties::saveResult()
 
     if (auto* guiDoc = Gui::Application::Instance->activeDocument()) {
         if (auto* view = dynamic_cast<Gui::ViewProviderDocumentObject*>(guiDoc->getViewProvider(obj))) {
+            if (auto* resultView = dynamic_cast<ViewProviderMassPropertiesResult*>(view)) {
+                resultView->setCenters(currentInfo.cog, currentInfo.cov);
+                resultView->setPrincipalAxes(
+                    currentInfo.cog,
+                    currentInfo.principalAxis1,
+                    currentInfo.principalAxis2,
+                    currentInfo.principalAxis3,
+                    !hasAxisSelection
+                );
+            }
             view->setShowable(true);
             view->show();
         }

--- a/src/Mod/Measure/Gui/TaskMassProperties.cpp
+++ b/src/Mod/Measure/Gui/TaskMassProperties.cpp
@@ -1152,8 +1152,6 @@ void TaskMassProperties::tryUpdate()
             return;
         }
 
-        Measure::Result::init();
-
         App::DocumentObject* obj = doc->getObject("MassPropertiesPreview");
         if (!obj) {
             obj = doc->addObject("Measure::Result", "MassPropertiesPreview");
@@ -1371,8 +1369,6 @@ void TaskMassProperties::saveResult()
     }
 
     doc->openTransaction("Add Mass Properties");
-
-    Measure::Result::init();
 
     auto group = freecad_cast<App::DocumentObjectGroup*>(doc->getObject("Measurements"));
 

--- a/src/Mod/Measure/Gui/TaskMassProperties.ui
+++ b/src/Mod/Measure/Gui/TaskMassProperties.ui
@@ -647,7 +647,7 @@
 		 <item>
 		  <widget class="QLabel" name="inertiaJxLabel">
 		   <property name="text">
-			<string>Jx</string>
+			<string>J1</string>
 		   </property>
 		  </widget>
 		 </item>
@@ -674,7 +674,7 @@
 		 <item>
 		  <widget class="QLabel" name="inertiaJyLabel">
 		   <property name="text">
-			<string>Jy</string>
+			<string>J2</string>
 		   </property>
 		  </widget>
 		 </item>
@@ -701,7 +701,7 @@
 		 <item>
 		  <widget class="QLabel" name="inertiaJzLabel">
 		   <property name="text">
-			<string>Jz</string>
+			<string>J3</string>
 		   </property>
 		  </widget>
 		 </item>

--- a/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.cpp
@@ -21,19 +21,284 @@
 
 #include "ViewProviderMassPropertiesResult.h"
 
+#include <QSize>
+
 #include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoAnnotation.h>
+#include <Inventor/nodes/SoBaseColor.h>
+#include <Inventor/nodes/SoCoordinate3.h>
+#include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoImage.h>
+#include <Inventor/nodes/SoIndexedLineSet.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoMaterialBinding.h>
+#include <Inventor/nodes/SoText2.h>
+#include <Inventor/nodes/SoFont.h>
 #include <Inventor/nodes/SoSwitch.h>
+#include <Inventor/nodes/SoTranslation.h>
+
+#include <Base/Precision.h>
+#include <Base/Tools.h>
+
+#include <App/Application.h>
+
+#include <Gui/BitmapFactory.h>
+#include <Gui/Inventor/SoAxisCrossKit.h>
+#include <Gui/ViewParams.h>
+#include <Gui/ViewProviderCoordinateSystem.h>
+
+#include "ViewProviderMeasureBase.h"
 
 using namespace MassPropertiesGui;
 
 PROPERTY_SOURCE(MassPropertiesGui::ViewProviderMassPropertiesResult, Gui::ViewProviderDocumentObject)
 
 ViewProviderMassPropertiesResult::ViewProviderMassPropertiesResult()
+    : displayRoot(new SoSeparator())
 {
     sPixmap = "MassPropertiesIcon";
-    getModeSwitch()->addChild(new SoSeparator());
+    displayRoot->ref();
+    getModeSwitch()->addChild(displayRoot);
     setDefaultMode(0);
     setShowable(true);
 }
 
-ViewProviderMassPropertiesResult::~ViewProviderMassPropertiesResult() = default;
+ViewProviderMassPropertiesResult::~ViewProviderMassPropertiesResult()
+{
+    displayRoot->unref();
+}
+
+void ViewProviderMassPropertiesResult::attach(App::DocumentObject* obj)
+{
+    ViewProviderDocumentObject::attach(obj);
+
+    auto* annotation = new SoAnnotation();
+    displayRoot->addChild(annotation);
+
+    lcsSwitch = new SoSwitch(SO_SWITCH_NONE);
+    annotation->addChild(lcsSwitch);
+
+    auto* seperator = new SoSeparator();
+    lcsSwitch->addChild(seperator);
+
+    lcsOriginTranslation = new SoTranslation();
+    seperator->addChild(lcsOriginTranslation);
+
+    lcsScale = new Gui::SoShapeScale();
+    seperator->addChild(lcsScale);
+
+    auto* lcsSep = new SoSeparator();
+    lcsScale->setPart("shape", lcsSep);
+
+    auto* style = new SoDrawStyle();
+
+    // There does not seem to be a property in preferences for this
+    // ViewProviderDatum.cpp also defaults to 2.0f
+    style->lineWidth = 2.0f;
+    lcsSep->addChild(style);
+
+    lcsMaterial = new SoMaterial();
+    lcsMaterial->diffuseColor.setNum(3);
+    lcsSep->addChild(lcsMaterial);
+
+    auto* lcsMaterialBinding = new SoMaterialBinding();
+    lcsMaterialBinding->value = SoMaterialBinding::PER_PART;
+    lcsSep->addChild(lcsMaterialBinding);
+
+    lcsCoords = new SoCoordinate3();
+    lcsSep->addChild(lcsCoords);
+
+    auto* lines = new SoIndexedLineSet();
+
+    static const int32_t lineIndices[9] = {0, 1, -1, 2, 3, -1, 4, 5, -1};
+    static const int32_t materialIndices[3] = {0, 1, 2};
+
+    lines->coordIndex.setValues(0, 9, lineIndices);
+    lines->materialIndex.setValues(0, 3, materialIndices);
+    lcsSep->addChild(lines);
+
+    auto* font = new SoFont();
+    // Using the preferences for the datum font size, since there is no preference for
+    // MassProperties And that this viewprovider is very close to the datum one
+    static const float size = App::GetApplication()
+                                  .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+                                  ->GetFloat("DatumFontSize", 15.0);
+    font->size = size;
+    lcsSep->addChild(font);
+
+
+    auto addAxisLabel =
+        [lcsSep](const char* text, SoBaseColor*& colorOut, SoTranslation*& translationOut) {
+            auto* labelSep = new SoSeparator();
+
+            colorOut = new SoBaseColor();
+            labelSep->addChild(colorOut);
+
+            translationOut = new SoTranslation();
+            labelSep->addChild(translationOut);
+
+            auto* labelText = new SoText2();
+            labelText->string.setValue(text);
+            labelSep->addChild(labelText);
+
+            lcsSep->addChild(labelSep);
+        };
+
+    addAxisLabel("1", lcsLabel1Color, lcsLabel1Translation);
+    addAxisLabel("2", lcsLabel2Color, lcsLabel2Translation);
+    addAxisLabel("3", lcsLabel3Color, lcsLabel3Translation);
+
+    auto addMarker = [annotation](const char* iconName, SoTranslation*& translation) {
+        auto* markerSep = new SoSeparator();
+        translation = new SoTranslation();
+        auto* image = new SoImage();
+
+        image->horAlignment = SoImage::CENTER;
+        image->vertAlignment = SoImage::HALF;
+
+        QPixmap pixmap = Gui::BitmapFactory().pixmapFromSvg(iconName, QSize(16, 16));
+        SoSFImage iconData;
+        Gui::BitmapFactory().convert(pixmap.toImage(), iconData);
+        image->image = iconData;
+
+        markerSep->addChild(translation);
+        markerSep->addChild(image);
+        annotation->addChild(markerSep);
+    };
+
+    addMarker("COV-Icon", covTranslation);
+    addMarker("COG-Icon", cogTranslation);
+
+    updateCenterMarkers();
+    updatePrincipalAxesMarker();
+}
+
+void ViewProviderMassPropertiesResult::setCenters(const Base::Vector3d& cog, const Base::Vector3d& cov)
+{
+    centerOfGravity = cog;
+    centerOfVolume = cov;
+    updateCenterMarkers();
+}
+
+void ViewProviderMassPropertiesResult::setPrincipalAxes(
+    const Base::Vector3d& origin,
+    const Base::Vector3d& axis1,
+    const Base::Vector3d& axis2,
+    const Base::Vector3d& axis3,
+    bool visible
+)
+{
+    principalOrigin = origin;
+    principalAxis1 = axis1;
+    principalAxis2 = axis2;
+    principalAxis3 = axis3;
+    showPrincipalAxes = visible;
+    updatePrincipalAxesMarker();
+}
+
+void ViewProviderMassPropertiesResult::updateCenterMarkers()
+{
+    if (cogTranslation) {
+        cogTranslation->translation.setValue(
+            MeasureGui::ViewProviderMeasureBase::toSbVec3f(centerOfGravity)
+        );
+    }
+    if (covTranslation) {
+        covTranslation->translation.setValue(
+            MeasureGui::ViewProviderMeasureBase::toSbVec3f(centerOfVolume)
+        );
+    }
+}
+
+void ViewProviderMassPropertiesResult::updatePrincipalAxesMarker()
+{
+    if (!lcsSwitch || !lcsCoords) {
+        return;
+    }
+
+    // If the user has selected an axis. The principal axes does not need to be added
+    if (!showPrincipalAxes) {
+        lcsSwitch->whichChild = SO_SWITCH_NONE;
+        return;
+    }
+
+    const auto params = Gui::ViewParams::instance();
+
+    SbColor axisColors[3];
+    float transparency = 0.0f;
+    axisColors[0].setPackedValue(static_cast<uint32_t>(params->getAxisXColor()), transparency);
+    axisColors[1].setPackedValue(static_cast<uint32_t>(params->getAxisYColor()), transparency);
+    axisColors[2].setPackedValue(static_cast<uint32_t>(params->getAxisZColor()), transparency);
+
+    if (lcsMaterial) {
+        lcsMaterial->diffuseColor.set1Value(0, axisColors[0]);
+        lcsMaterial->diffuseColor.set1Value(1, axisColors[1]);
+        lcsMaterial->diffuseColor.set1Value(2, axisColors[2]);
+    }
+
+    SoBaseColor* labelColors[3] = {
+        lcsLabel1Color,
+        lcsLabel2Color,
+        lcsLabel3Color,
+    };
+    for (int i = 0; i < 3; ++i) {
+        if (labelColors[i]) {
+            labelColors[i]->rgb.setValue(axisColors[i]);
+        }
+    }
+
+    const Base::Vector3d axes[3] = {principalAxis1, principalAxis2, principalAxis3};
+
+    double size = params->getDatumLineSize() * Base::fromPercent(params->getDatumScale());
+
+    // Again using preferences elsewhere
+    const float lcsScaleFactor = App::GetApplication()
+                                     .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+                                     ->GetFloat("LocalCoordinateSystemSize", 1.0f);
+
+    if (lcsScale) {
+        lcsScale->scaleFactor = lcsScaleFactor;
+    }
+
+    if (size < Base::Precision::Confusion()) {
+        size = Gui::ViewProviderCoordinateSystem::defaultSize();
+    }
+
+    if (lcsOriginTranslation) {
+        lcsOriginTranslation->translation.setValue(
+            MeasureGui::ViewProviderMeasureBase::toSbVec3f(principalOrigin)
+        );
+    }
+
+    // the 0.2 is so that there is a small gap in the beginning so it does not overlap with the COG
+    // marker
+    SbVec3f coords[6];
+    coords[0] = MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[0] * (0.2 * size));
+    coords[1] = MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[0] * size);
+    coords[2] = MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[1] * (0.2 * size));
+    coords[3] = MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[1] * size);
+    coords[4] = MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[2] * (0.2 * size));
+    coords[5] = MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[2] * size);
+
+    lcsCoords->point.setNum(6);
+    lcsCoords->point.setValues(0, 6, coords);
+
+    // The 1.2 factor places labels slightly beyond each axis
+    if (lcsLabel1Translation) {
+        lcsLabel1Translation->translation.setValue(
+            MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[0] * (1.2 * size))
+        );
+    }
+    if (lcsLabel2Translation) {
+        lcsLabel2Translation->translation.setValue(
+            MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[1] * (1.2 * size))
+        );
+    }
+    if (lcsLabel3Translation) {
+        lcsLabel3Translation->translation.setValue(
+            MeasureGui::ViewProviderMeasureBase::toSbVec3f(axes[2] * (1.2 * size))
+        );
+    }
+
+    lcsSwitch->whichChild = SO_SWITCH_ALL;
+}

--- a/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.cpp
@@ -25,6 +25,7 @@
 
 #include <Inventor/nodes/SoSeparator.h>
 #include <Inventor/nodes/SoAnnotation.h>
+#include <Inventor/nodes/SoAlphaTest.h>
 #include <Inventor/nodes/SoBaseColor.h>
 #include <Inventor/nodes/SoCoordinate3.h>
 #include <Inventor/nodes/SoDepthBuffer.h>
@@ -74,13 +75,13 @@ void ViewProviderMassPropertiesResult::attach(App::DocumentObject* obj)
     auto* annotation = new SoAnnotation();
     displayRoot->addChild(annotation);
 
+    auto* depth = new SoDepthBuffer();
+    depth->function = SoDepthBufferElement::LESS;
+    depth->range = SbVec2f(0.0f, 0.001f);
+    annotation->addChild(depth);
+
     lcsSwitch = new SoSwitch(SO_SWITCH_NONE);
     annotation->addChild(lcsSwitch);
-
-    auto* markerDepth = new SoDepthBuffer();
-    markerDepth->function = SoDepthBufferElement::LESS;
-    markerDepth->range = SbVec2f(0.0f, 0.001f);
-    annotation->addChild(markerDepth);
 
     auto* seperator = new SoSeparator();
     lcsSwitch->addChild(seperator);
@@ -130,6 +131,11 @@ void ViewProviderMassPropertiesResult::attach(App::DocumentObject* obj)
 
             translationOut = new SoTranslation();
             labelSep->addChild(translationOut);
+
+            auto* labelAlpha = new SoAlphaTest();
+            labelAlpha->function = SoAlphaTest::GREATER;
+            labelAlpha->value = 0.0f;
+            labelSep->addChild(labelAlpha);
 
             auto* labelText = new Gui::SoFrameLabel();
             labelText->string.setValue(text);

--- a/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.cpp
@@ -33,8 +33,6 @@
 #include <Inventor/nodes/SoIndexedLineSet.h>
 #include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoMaterialBinding.h>
-#include <Inventor/nodes/SoText2.h>
-#include <Inventor/nodes/SoFont.h>
 #include <Inventor/nodes/SoSwitch.h>
 #include <Inventor/nodes/SoTranslation.h>
 
@@ -123,16 +121,6 @@ void ViewProviderMassPropertiesResult::attach(App::DocumentObject* obj)
     lines->materialIndex.setValues(0, 3, materialIndices);
     lcsSep->addChild(lines);
 
-    auto* font = new SoFont();
-    // Using the preferences for the datum font size, since there is no preference for
-    // MassProperties And that this viewprovider is very close to the datum one
-    static const float size = App::GetApplication()
-                                  .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
-                                  ->GetFloat("DatumFontSize", 15.0);
-    font->size = size;
-    lcsSep->addChild(font);
-
-
     auto addAxisLabel =
         [lcsSep](const char* text, SoBaseColor*& colorOut, SoTranslation*& translationOut) {
             auto* labelSep = new SoSeparator();
@@ -143,8 +131,14 @@ void ViewProviderMassPropertiesResult::attach(App::DocumentObject* obj)
             translationOut = new SoTranslation();
             labelSep->addChild(translationOut);
 
-            auto* labelText = new SoText2();
+            auto* labelText = new Gui::SoFrameLabel();
             labelText->string.setValue(text);
+            labelText->horAlignment = SoImage::CENTER;
+            labelText->vertAlignment = SoImage::HALF;
+            labelText->border = false;
+            labelText->frame = false;
+            labelText->textUseBaseColor = true;
+            labelText->size = 8;
             labelSep->addChild(labelText);
 
             lcsSep->addChild(labelSep);

--- a/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.cpp
@@ -27,6 +27,7 @@
 #include <Inventor/nodes/SoAnnotation.h>
 #include <Inventor/nodes/SoBaseColor.h>
 #include <Inventor/nodes/SoCoordinate3.h>
+#include <Inventor/nodes/SoDepthBuffer.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoImage.h>
 #include <Inventor/nodes/SoIndexedLineSet.h>
@@ -77,6 +78,11 @@ void ViewProviderMassPropertiesResult::attach(App::DocumentObject* obj)
 
     lcsSwitch = new SoSwitch(SO_SWITCH_NONE);
     annotation->addChild(lcsSwitch);
+
+    auto* markerDepth = new SoDepthBuffer();
+    markerDepth->function = SoDepthBufferElement::LESS;
+    markerDepth->range = SbVec2f(0.0f, 0.001f);
+    annotation->addChild(markerDepth);
 
     auto* seperator = new SoSeparator();
     lcsSwitch->addChild(seperator);
@@ -166,8 +172,8 @@ void ViewProviderMassPropertiesResult::attach(App::DocumentObject* obj)
         annotation->addChild(markerSep);
     };
 
-    addMarker("COV-Icon", covTranslation);
     addMarker("COG-Icon", cogTranslation);
+    addMarker("COV-Icon", covTranslation);
 
     updateCenterMarkers();
     updatePrincipalAxesMarker();

--- a/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.h
+++ b/src/Mod/Measure/Gui/ViewProviderMassPropertiesResult.h
@@ -22,6 +22,20 @@
 #pragma once
 
 #include <Gui/ViewProviderDocumentObject.h>
+#include <Gui/ParamHandler.h>
+#include <Base/Vector3D.h>
+
+class SoSeparator;
+class SoTranslation;
+class SoSwitch;
+class SoCoordinate3;
+class SoMaterial;
+class SoBaseColor;
+
+namespace Gui
+{
+class SoShapeScale;
+}
 
 namespace MassPropertiesGui
 {
@@ -34,10 +48,47 @@ public:
     ViewProviderMassPropertiesResult();
     ~ViewProviderMassPropertiesResult() override;
 
+    void attach(App::DocumentObject*) override;
+    void setCenters(const Base::Vector3d& cog, const Base::Vector3d& cov);
+    void setPrincipalAxes(
+        const Base::Vector3d& origin,
+        const Base::Vector3d& axis1,
+        const Base::Vector3d& axis2,
+        const Base::Vector3d& axis3,
+        bool visible = true
+    );
+
     bool allowOverride(const App::DocumentObject&) const override
     {
         return true;
     }
+
+private:
+    void updateCenterMarkers();
+    void updatePrincipalAxesMarker();
+
+    SoSeparator* displayRoot = nullptr;
+    SoTranslation* cogTranslation = nullptr;
+    SoTranslation* covTranslation = nullptr;
+    SoSwitch* lcsSwitch = nullptr;
+    SoTranslation* lcsOriginTranslation = nullptr;
+    Gui::SoShapeScale* lcsScale = nullptr;
+    SoMaterial* lcsMaterial = nullptr;
+    SoCoordinate3* lcsCoords = nullptr;
+    SoBaseColor* lcsLabel1Color = nullptr;
+    SoBaseColor* lcsLabel2Color = nullptr;
+    SoBaseColor* lcsLabel3Color = nullptr;
+    SoTranslation* lcsLabel1Translation = nullptr;
+    SoTranslation* lcsLabel2Translation = nullptr;
+    SoTranslation* lcsLabel3Translation = nullptr;
+    Base::Vector3d centerOfGravity {};
+    Base::Vector3d centerOfVolume {};
+    Base::Vector3d principalOrigin {};
+    Base::Vector3d principalAxis1 {};
+    Base::Vector3d principalAxis2 {};
+    Base::Vector3d principalAxis3 {};
+    bool showPrincipalAxes = false;
+    Gui::ParamHandlers handlers;
 };
 
 }  // namespace MassPropertiesGui


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
The PR adds some icons at the center of gravity and center of volume. This makes it easier to see instead of datum points
It also changes the labvels from xyz to 123, which is how it is in most other CAD programs.

However It does not use the viewprovider from Part, as this will put a dependency on part from measure. It does use the same preferences as the Part coordinatesystem. This might be a bit of a problem or up for discussion as this is a bit like reinventing the wheel.

The icons used was chosen by the DWG. 

The rest of the changes is changing the variables in the code to use the new 1, 2, 3 naming. 

<img width="410" height="308" alt="image" src="https://github.com/user-attachments/assets/e3d4b18f-0037-4eaf-a25e-2a001c69a154" />

In the case that the COG and COV are at the same point the COG is on top
<img width="222" height="265" alt="image" src="https://github.com/user-attachments/assets/adabf5fb-c5e1-4ba5-91f3-1099ecae1809" />


## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
closes #28923
closes #28925

