### PR TITLE
Draft: Avoid import of whole DraftGeomUtils module

### DIFF
--- a/src/Mod/Draft/WorkingPlane.py
+++ b/src/Mod/Draft/WorkingPlane.py
@@ -44,13 +44,13 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD
 import DraftVecUtils
 from FreeCAD import Vector
+from draftgeoutils import geometry as geo_geometry
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import utils
 from draftutils.messages import _wrn
 from draftutils.translate import translate
 
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 Part = lz.LazyLoader("Part", globals(), "Part")
 FreeCADGui = lz.LazyLoader("FreeCADGui", globals(), "FreeCADGui")
 
@@ -332,7 +332,7 @@ class PlaneBase:
 
         The center of gravity of the face defines the WP `position` and the
         normal of the face the WP `axis`. The WP `u` and `v` vectors are
-        determined by the DraftGeomUtils.uv_vectors_from_face function.
+        determined by the draftgeoutils.geometry.uv_vectors_from_face function.
         See there.
 
         Parameters
@@ -350,7 +350,7 @@ class PlaneBase:
         """
         if face.Surface.isPlanar() is False:
             return False
-        place = DraftGeomUtils.placement_from_face(face)
+        place = geo_geometry.placement_from_face(face)
         self.u, self.v, self.axis = self._axes_from_rotation(place.Rotation)
         self.position = place.Base + (self.axis * offset)
         return True
@@ -670,13 +670,13 @@ class PlaneBase:
             Direction of projection.
         force_projection: bool, optional
             Defaults to `True`.
-            See DraftGeomUtils.project_point_on_plane
+            See draftgeoutils.geometry.project_point_on_plane
 
         Returns
         -------
         Base.Vector
         """
-        return DraftGeomUtils.project_point_on_plane(
+        return geo_geometry.project_point_on_plane(
             point, self.position, self.axis, direction, force_projection
         )
 
@@ -785,7 +785,7 @@ class Plane(PlaneBase):
 
         The returned value is the negative of the local Z coordinate of the point.
         """
-        return -DraftGeomUtils.distance_to_plane(point, self.position, self.axis)
+        return -geo_geometry.distance_to_plane(point, self.position, self.axis)
 
     def projectPoint(self, point, direction=None, force_projection=True):
         """See PlaneBase.project_point."""
@@ -854,7 +854,7 @@ class Plane(PlaneBase):
 
         The center of gravity of the face defines the WP `position` and the
         normal of the face the WP `axis`. The WP `u` and `v` vectors are
-        determined by the DraftGeomUtils.uv_vectors_from_face function.
+        determined by the draftgeoutils.geometry.uv_vectors_from_face function.
         See there.
 
         Parameters
@@ -874,7 +874,7 @@ class Plane(PlaneBase):
             `True` if successful.
         """
         if shape.ShapeType == "Face" and shape.Surface.isPlanar():
-            place = DraftGeomUtils.placement_from_face(shape)
+            place = geo_geometry.placement_from_face(shape)
             if parent:
                 place = parent.getGlobalPlacement() * place
             super().align_to_placement(place, offset)
@@ -961,17 +961,17 @@ class Plane(PlaneBase):
 
         normal = None
         for n in range(len(shapes)):
-            if not DraftGeomUtils.is_planar(shapes[n]):
+            if not geo_geometry.is_planar(shapes[n]):
                 _wrn(translate("draft", "'{}' object is not planar".format(names[n])) + "\n")
                 return False
             if not normal:
-                normal = DraftGeomUtils.get_normal(shapes[n])
+                normal = geo_geometry.get_normal(shapes[n])
                 shape_ref = n
 
         # test if all shapes are coplanar
         if normal:
             for n in range(len(shapes)):
-                if not DraftGeomUtils.are_coplanar(shapes[shape_ref], shapes[n]):
+                if not geo_geometry.are_coplanar(shapes[shape_ref], shapes[n]):
                     _wrn(
                         translate(
                             "draft", "{} and {} are not coplanar".format(names[shape_ref], names[n])
@@ -984,10 +984,10 @@ class Plane(PlaneBase):
             points = [vertex.Point for shape in shapes for vertex in shape.Vertexes]
             if len(points) >= 3:
                 poly = Part.makePolygon(points)
-                if not DraftGeomUtils.is_planar(poly):
+                if not geo_geometry.is_planar(poly):
                     _wrn(translate("draft", "All shapes must be coplanar") + "\n")
                     return False
-                normal = DraftGeomUtils.get_normal(poly)
+                normal = geo_geometry.get_normal(poly)
             else:
                 normal = None
 
@@ -2007,17 +2007,17 @@ if FreeCAD.GuiUp:
 def getPlacementFromPoints(points):
     """Return a placement from a list of 3 or 4 points. The 4th point is no longer used.
 
-    Calls DraftGeomUtils.placement_from_points(). See there.
+    Calls draftgeoutils.geometry.placement_from_points(). See there.
     """
     utils.use_instead("DraftGeomUtils.placement_from_points")
-    return DraftGeomUtils.placement_from_points(*points[:3])
+    return geo_geometry.placement_from_points(*points[:3])
 
 
 # Compatibility function (v1.0, 2023):
 def getPlacementFromFace(face, rotated=False):
     """Return a placement from a face.
 
-    Calls DraftGeomUtils.placement_from_face(). See there.
+    Calls draftgeoutils.geometry.placement_from_face(). See there.
     """
     utils.use_instead("DraftGeomUtils.placement_from_face")
-    return DraftGeomUtils.placement_from_face(face, rotated=rotated)
+    return geo_geometry.placement_from_face(face, rotated=rotated)

--- a/src/Mod/Draft/draftfunctions/draftify.py
+++ b/src/Mod/Draft/draftfunctions/draftify.py
@@ -38,6 +38,7 @@ from draftgeoutils import general as geo_general
 from draftmake import make_block
 from draftmake import make_wire
 from draftmake import make_circle
+
 # from draftmake import make_bspline
 # from draftmake import make_bezcurve
 from draftmake import make_arc_3points

--- a/src/Mod/Draft/draftfunctions/draftify.py
+++ b/src/Mod/Draft/draftfunctions/draftify.py
@@ -38,8 +38,8 @@ from draftgeoutils import general as geo_general
 from draftmake import make_block
 from draftmake import make_wire
 from draftmake import make_circle
-from draftmake import make_bspline
-from draftmake import make_bezcurve
+# from draftmake import make_bspline
+# from draftmake import make_bezcurve
 from draftmake import make_arc_3points
 from draftutils import gui_utils
 

--- a/src/Mod/Draft/draftfunctions/draftify.py
+++ b/src/Mod/Draft/draftfunctions/draftify.py
@@ -34,17 +34,17 @@
 import lazy_loader.lazy_loader as lz
 
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-import draftmake.make_block as make_block
-import draftmake.make_wire as make_wire
-import draftmake.make_circle as make_circle
-import draftmake.make_bspline as make_bspline
-import draftmake.make_bezcurve as make_bezcurve
-import draftmake.make_arc_3points as make_arc_3points
+from draftgeoutils import general as geo_general
+from draftmake import make_block
+from draftmake import make_wire
+from draftmake import make_circle
+from draftmake import make_bspline
+from draftmake import make_bezcurve
+from draftmake import make_arc_3points
+from draftutils import gui_utils
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 
 def draftify(objectslist, makeblock=False, delete=True):
@@ -96,10 +96,10 @@ def draftify(objectslist, makeblock=False, delete=True):
 def draftify_shape(shape):
 
     nobj = None
-    if DraftGeomUtils.hasCurves(shape):
+    if geo_general.hasCurves(shape):
         if len(shape.Edges) == 1:
             edge = shape.Edges[0]
-            edge_type = DraftGeomUtils.geomType(edge)
+            edge_type = geo_general.geomType(edge)
             if edge_type == "Circle":
                 if edge.isClosed():
                     nobj = make_circle.make_circle(edge)

--- a/src/Mod/Draft/draftfunctions/dxf.py
+++ b/src/Mod/Draft/draftfunctions/dxf.py
@@ -33,13 +33,11 @@ import lazy_loader.lazy_loader as lz
 import FreeCAD as App
 import DraftVecUtils
 import WorkingPlane
-import draftutils.utils as utils
-
+from draftutils import utils
 from draftutils.messages import _wrn
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 TechDraw = lz.LazyLoader("TechDraw", globals(), "TechDraw")
 
 

--- a/src/Mod/Draft/draftfunctions/fuse.py
+++ b/src/Mod/Draft/draftfunctions/fuse.py
@@ -31,9 +31,9 @@
 ## \addtogroup draftfunctions
 # @{
 import FreeCAD as App
-import draftutils.gui_utils as gui_utils
-
+from draftgeoutils import faces as geo_faces
 from draftmake.make_wire import Wire
+from draftutils import gui_utils
 
 if App.GuiUp:
     from draftviewproviders.view_wire import ViewProviderWire
@@ -51,7 +51,6 @@ def fuse(object1, object2):
         App.Console.PrintError("No active document. Aborting\n")
         return
     import Part
-    import DraftGeomUtils
 
     # testing if we have holes:
     holes = False
@@ -60,7 +59,7 @@ def fuse(object1, object2):
     for f in fshape.Faces:
         if len(f.Wires) > 1:
             holes = True
-    if DraftGeomUtils.isCoplanar(object1.Shape.fuse(object2.Shape).Faces) and not holes:
+    if geo_faces.is_coplanar(object1.Shape.fuse(object2.Shape).Faces) and not holes:
         obj = App.ActiveDocument.addObject("Part::FeaturePython", "Fusion")
         Wire(obj)
         if App.GuiUp:

--- a/src/Mod/Draft/draftfunctions/offset.py
+++ b/src/Mod/Draft/draftfunctions/offset.py
@@ -34,15 +34,17 @@ import math
 
 import FreeCAD as App
 import DraftVecUtils
-from draftutils import gui_utils
-from draftutils import params
-from draftutils import utils
-
+from draftgeoutils import general as geo_general
+from draftgeoutils import offsets as geo_offsets
+from draftgeoutils import wires as geo_wires
 from draftmake.make_rectangle import make_rectangle
 from draftmake.make_wire import make_wire
 from draftmake.make_polygon import make_polygon
 from draftmake.make_circle import make_circle
 from draftmake.make_bspline import make_bspline
+from draftutils import gui_utils
+from draftutils import params
+from draftutils import utils
 
 
 def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
@@ -72,7 +74,6 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
         sides, the total width being the given delta length.
     """
     import Part
-    import DraftGeomUtils
 
     newwire = None
     delete = None
@@ -128,8 +129,8 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
         if sym:
             d1 = App.Vector(delta).multiply(0.5)
             d2 = d1.negative()
-            n1 = DraftGeomUtils.offsetWire(obj.Shape, d1)
-            n2 = DraftGeomUtils.offsetWire(obj.Shape, d2)
+            n1 = geo_offsets.offsetWire(obj.Shape, d1)
+            n2 = geo_offsets.offsetWire(obj.Shape, d2)
         else:
             if isinstance(delta, float) and (len(obj.Shape.Edges) == 1):
                 # circle
@@ -142,19 +143,19 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
                 newwire = Part.Wire(nc.toShape())
                 p = []
             else:
-                newwire = DraftGeomUtils.offsetWire(obj.Shape, delta)
-                if DraftGeomUtils.hasCurves(newwire) and copy:
+                newwire = geo_offsets.offsetWire(obj.Shape, delta)
+                if geo_general.hasCurves(newwire) and copy:
                     p = []
                 else:
-                    p = DraftGeomUtils.getVerts(newwire)
+                    p = geo_general.getVerts(newwire)
     if occ:
         newobj = App.ActiveDocument.addObject("Part::Feature", "Offset")
-        newobj.Shape = DraftGeomUtils.offsetWire(obj.Shape, delta, occ=True)
+        newobj.Shape = geo_offsets.offsetWire(obj.Shape, delta, occ=True)
         gui_utils.formatObject(newobj, obj)
         if not copy:
             delete = obj.Name
     elif bind:
-        if not DraftGeomUtils.isReallyClosed(obj.Shape):
+        if not geo_wires.isReallyClosed(obj.Shape):
             if sym:
                 s1 = n1
                 s2 = n2
@@ -217,7 +218,7 @@ def offset(obj, delta, copy=False, bind=False, sym=False, occ=False):
             try:
                 if p:
                     newobj = make_wire(p)
-                    newobj.Closed = DraftGeomUtils.isReallyClosed(obj.Shape)
+                    newobj.Closed = geo_wires.isReallyClosed(obj.Shape)
             except Part.OCCError:
                 pass
             if (not newobj) and newwire:

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -37,6 +37,7 @@ import DraftVecUtils
 import WorkingPlane
 from draftfunctions import svgtext
 from draftfunctions.svgshapes import get_proj, get_circle, get_path
+# from draftgeoutils import fillets as geo_fillets
 from draftobjects import layer
 from draftutils import params
 from draftutils import utils
@@ -44,7 +45,6 @@ from draftutils.messages import _wrn, _err
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 
 ## \addtogroup draftfunctions
@@ -959,7 +959,7 @@ def get_svg(
         basewire = obj.Base.Shape.Wires[0].copy()
         # Not applying rounding because the results are not correct
         # if hasattr(obj, "Rounding") and obj.Rounding:
-        #     basewire = DraftGeomUtils.filletWire(
+        #     basewire = geo_fillets.filletWire(
         #         basewire, obj.Rounding * obj.Diameter.Value
         #     )
         wires = []

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -37,6 +37,7 @@ import DraftVecUtils
 import WorkingPlane
 from draftfunctions import svgtext
 from draftfunctions.svgshapes import get_proj, get_circle, get_path
+
 # from draftgeoutils import fillets as geo_fillets
 from draftobjects import layer
 from draftutils import params

--- a/src/Mod/Draft/draftfunctions/svgshapes.py
+++ b/src/Mod/Draft/draftfunctions/svgshapes.py
@@ -35,13 +35,14 @@ import lazy_loader.lazy_loader as lz
 import FreeCAD as App
 import DraftVecUtils
 import WorkingPlane
+from draftgeoutils import edges as geo_edges
+from draftgeoutils import general as geo_general
 from draftutils import params
 from draftutils import utils
 from draftutils.messages import _msg, _wrn
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 TechDraw = lz.LazyLoader("TechDraw", globals(), "TechDraw")
 
 ## \addtogroup draftfunctions
@@ -373,7 +374,7 @@ def get_path(
                 first = False
             else:
                 # invert further wires to create holes
-                wire = DraftGeomUtils.invert(wire)
+                wire = geo_edges.invert(wire)
 
             wire.fixWire()
             egroups.append(Part.__sortEdges__(wire.Edges))
@@ -401,8 +402,8 @@ def get_path(
                     if (verts[0].Point - previousverts[-1].Point).Length > 1e-6:
                         raise ValueError("edges not ordered")
 
-            iscircle = DraftGeomUtils.geomType(edge) == "Circle"
-            isellipse = DraftGeomUtils.geomType(edge) == "Ellipse"
+            iscircle = geo_general.geomType(edge) == "Circle"
+            isellipse = geo_general.geomType(edge) == "Ellipse"
 
             if iscircle or isellipse:
                 _type, data = _get_path_circ_ellipse(
@@ -424,7 +425,7 @@ def get_path(
 
                 # else the `edata` was properly augmented, so re-assing it
                 edata = data
-            elif DraftGeomUtils.geomType(edge) == "Line":
+            elif geo_general.geomType(edge) == "Line":
                 v = get_proj(verts[-1].Point, plane)
                 edata += "L {} {} ".format(v.x, v.y)
             else:

--- a/src/Mod/Draft/draftfunctions/upgrade.py
+++ b/src/Mod/Draft/draftfunctions/upgrade.py
@@ -38,7 +38,9 @@ import lazy_loader.lazy_loader as lz
 
 import FreeCAD as App
 from draftfunctions import draftify
-from draftgeoutils.geometry import is_straight_line
+from draftgeoutils import faces as geo_faces
+from draftgeoutils import general as geo_general
+from draftgeoutils import geometry as geo_geometry
 from draftmake import make_block
 from draftmake import make_wire
 from draftutils import gui_utils
@@ -50,7 +52,6 @@ from draftutils.translate import translate
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 Arch = lz.LazyLoader("Arch", globals(), "Arch")
 
 _DEBUG = False
@@ -138,7 +139,7 @@ def upgrade(objects, delete=False, force=None):
             return False
         if len(obj.Shape.Edges) == 1:
             return False
-        if is_straight_line(obj.Shape):
+        if geo_geometry.is_straight_line(obj.Shape):
             return False
         if utils.get_type(obj) == "Wire":
             obj.Closed = True
@@ -247,17 +248,17 @@ def upgrade(objects, delete=False, force=None):
                 done_list.append(obj)
         if not faces:
             return False
-        if not DraftGeomUtils.is_coplanar(faces, 1e-3):
+        if not geo_faces.is_coplanar(faces, 1e-3):
             return False
         fuse_face = faces.pop(0)
         for face in faces:
             fuse_face = fuse_face.fuse(face)
-        face = DraftGeomUtils.concatenate(fuse_face)
+        face = geo_faces.concatenate(fuse_face)
         # check if concatenate failed
         if face.isEqual(fuse_face):
             return False
         # several coplanar and non-curved faces, they can become a Draft Wire
-        if len(face.Wires) == 1 and not DraftGeomUtils.hasCurves(face):
+        if len(face.Wires) == 1 and not geo_general.hasCurves(face):
             newobj = make_wire.make_wire(face.Wires[0], closed=True, face=True)
         # if not possible, we do a non-parametric union
         else:
@@ -522,7 +523,7 @@ def upgrade(objects, delete=False, force=None):
         # higher value to let that function throw the exception when
         # joinFaces is called if the precision is insufficient.
         if faces:
-            faces_coplanarity = DraftGeomUtils.is_coplanar(faces, 1e-3)
+            faces_coplanarity = geo_faces.is_coplanar(faces, 1e-3)
 
         parent = get_parent(objects[0])
         same_parent = True
@@ -642,7 +643,7 @@ def upgrade(objects, delete=False, force=None):
                 and not objects[0].isDerivedFrom("Part::Part2DObjectPython")
                 and not utils.get_type(objects[0]) in ["BezCurve", "BSpline", "Wire"]
             ):
-                edge_type = DraftGeomUtils.geomType(objects[0].Shape.Edges[0])
+                edge_type = geo_general.geomType(objects[0].Shape.Edges[0])
                 # currently only support Line and Circle
                 if edge_type in ("Line", "Circle"):
                     result = _draftify(objects[0])

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -170,12 +170,16 @@ class Arc(gui_base_original.Creator):
                             self.ui.switchUi(False)
             elif self.step == 1:  # choose radius
                 if len(self.tangents) == 2:
-                    cir = geo_circles_incomplete.circleFrom2tan1pt(self.tangents[0], self.tangents[1], self.point)
+                    cir = geo_circles_incomplete.circleFrom2tan1pt(
+                        self.tangents[0], self.tangents[1], self.point
+                    )
                     _c = geo_circles.findClosestCircle(self.point, cir)
                     self.center = _c.Center
                     self.arctrack.setCenter(self.center)
                 elif self.tangents and self.tanpoints:
-                    cir = geo_circles_incomplete.circleFrom1tan2pt(self.tangents[0], self.tanpoints[0], self.point)
+                    cir = geo_circles_incomplete.circleFrom1tan2pt(
+                        self.tangents[0], self.tanpoints[0], self.point
+                    )
                     _c = geo_circles.findClosestCircle(self.point, cir)
                     self.center = _c.Center
                     self.arctrack.setCenter(self.center)
@@ -187,7 +191,9 @@ class Arc(gui_base_original.Creator):
                         num = int(info["Component"].lstrip("Edge")) - 1
                         ed = ob.Shape.Edges[num]
                         if len(self.tangents) == 2:
-                            cir = geo_circles_incomplete.circleFrom3tan(self.tangents[0], self.tangents[1], ed)
+                            cir = geo_circles_incomplete.circleFrom3tan(
+                                self.tangents[0], self.tangents[1], ed
+                            )
                             cl = geo_circles.findClosestCircle(self.point, cir)
                             self.center = cl.Center
                             self.rad = cl.Radius
@@ -433,14 +439,18 @@ class Arc(gui_base_original.Creator):
         if self.step == 1:
             self.rad = rad
             if len(self.tangents) == 2:
-                cir = geo_circles_incomplete.circleFrom2tan1rad(self.tangents[0], self.tangents[1], rad)
+                cir = geo_circles_incomplete.circleFrom2tan1rad(
+                    self.tangents[0], self.tangents[1], rad
+                )
                 if self.center:
                     _c = geo_circles.findClosestCircle(self.center, cir)
                     self.center = _c.Center
                 else:
                     self.center = cir[-1].Center
             elif self.tangents and self.tanpoints:
-                cir = geo_circles_incomplete.circleFrom1tan1pt1rad(self.tangents[0], self.tanpoints[0], rad)
+                cir = geo_circles_incomplete.circleFrom1tan1pt1rad(
+                    self.tangents[0], self.tanpoints[0], rad
+                )
                 if self.center:
                     _c = geo_circles.findClosestCircle(self.center, cir)
                     self.center = _c.Center

--- a/src/Mod/Draft/draftguitools/gui_arcs.py
+++ b/src/Mod/Draft/draftguitools/gui_arcs.py
@@ -39,6 +39,9 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import DraftVecUtils
 from FreeCAD import Units as U
+from draftgeoutils import circles as geo_circles
+from draftgeoutils import circles as geo_circles_incomplete
+from draftgeoutils import geometry as geo_geometry
 from draftguitools import gui_base
 from draftguitools import gui_base_original
 from draftguitools import gui_tool_utils
@@ -144,8 +147,6 @@ class Arc(gui_base_original.Creator):
             Dictionary with strings that indicates the type of event received
             from the 3D view.
         """
-        import DraftGeomUtils
-
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
@@ -169,17 +170,13 @@ class Arc(gui_base_original.Creator):
                             self.ui.switchUi(False)
             elif self.step == 1:  # choose radius
                 if len(self.tangents) == 2:
-                    cir = DraftGeomUtils.circleFrom2tan1pt(
-                        self.tangents[0], self.tangents[1], self.point
-                    )
-                    _c = DraftGeomUtils.findClosestCircle(self.point, cir)
+                    cir = geo_circles_incomplete.circleFrom2tan1pt(self.tangents[0], self.tangents[1], self.point)
+                    _c = geo_circles.findClosestCircle(self.point, cir)
                     self.center = _c.Center
                     self.arctrack.setCenter(self.center)
                 elif self.tangents and self.tanpoints:
-                    cir = DraftGeomUtils.circleFrom1tan2pt(
-                        self.tangents[0], self.tanpoints[0], self.point
-                    )
-                    _c = DraftGeomUtils.findClosestCircle(self.point, cir)
+                    cir = geo_circles_incomplete.circleFrom1tan2pt(self.tangents[0], self.tanpoints[0], self.point)
+                    _c = geo_circles.findClosestCircle(self.point, cir)
                     self.center = _c.Center
                     self.arctrack.setCenter(self.center)
                 if gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_alt_key()):
@@ -190,16 +187,14 @@ class Arc(gui_base_original.Creator):
                         num = int(info["Component"].lstrip("Edge")) - 1
                         ed = ob.Shape.Edges[num]
                         if len(self.tangents) == 2:
-                            cir = DraftGeomUtils.circleFrom3tan(
-                                self.tangents[0], self.tangents[1], ed
-                            )
-                            cl = DraftGeomUtils.findClosestCircle(self.point, cir)
+                            cir = geo_circles_incomplete.circleFrom3tan(self.tangents[0], self.tangents[1], ed)
+                            cl = geo_circles.findClosestCircle(self.point, cir)
                             self.center = cl.Center
                             self.rad = cl.Radius
                             self.arctrack.setCenter(self.center)
                         else:
                             self.rad = self.center.add(
-                                DraftGeomUtils.findDistance(self.center, ed).sub(self.center)
+                                geo_geometry.findDistance(self.center, ed).sub(self.center)
                             ).Length
                     else:
                         self.rad = DraftVecUtils.dist(self.point, self.center)
@@ -435,21 +430,19 @@ class Arc(gui_base_original.Creator):
         This function is called by the toolbar or taskpanel interface
         when a valid radius has been entered in the input field.
         """
-        import DraftGeomUtils
-
         if self.step == 1:
             self.rad = rad
             if len(self.tangents) == 2:
-                cir = DraftGeomUtils.circleFrom2tan1rad(self.tangents[0], self.tangents[1], rad)
+                cir = geo_circles_incomplete.circleFrom2tan1rad(self.tangents[0], self.tangents[1], rad)
                 if self.center:
-                    _c = DraftGeomUtils.findClosestCircle(self.center, cir)
+                    _c = geo_circles.findClosestCircle(self.center, cir)
                     self.center = _c.Center
                 else:
                     self.center = cir[-1].Center
             elif self.tangents and self.tanpoints:
-                cir = DraftGeomUtils.circleFrom1tan1pt1rad(self.tangents[0], self.tanpoints[0], rad)
+                cir = geo_circles_incomplete.circleFrom1tan1pt1rad(self.tangents[0], self.tanpoints[0], rad)
                 if self.center:
-                    _c = DraftGeomUtils.findClosestCircle(self.center, cir)
+                    _c = geo_circles.findClosestCircle(self.center, cir)
                     self.center = _c.Center
                 else:
                     self.center = cir[-1].Center

--- a/src/Mod/Draft/draftguitools/gui_base_original.py
+++ b/src/Mod/Draft/draftguitools/gui_base_original.py
@@ -108,9 +108,8 @@ class DraftTool:
 
         # The Part module is first initialized when using any Gui Command
         # for the first time.
-        global Part, DraftGeomUtils
+        global Part
         import Part
-        import DraftGeomUtils
 
         self.call = None
         self.commitList = []

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -46,15 +46,14 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc
 import DraftVecUtils
-import draftguitools.gui_base_original as gui_base_original
-import draftguitools.gui_tool_utils as gui_tool_utils
-import draftguitools.gui_trackers as trackers
-import draftutils.gui_utils as gui_utils
-
+from draftgeoutils import general as geo_general
+from draftgeoutils import intersections as geo_intersections
+from draftguitools import gui_base_original
+from draftguitools import gui_tool_utils
+from draftguitools import gui_trackers as trackers
+from draftutils import gui_utils
 from draftutils.translate import translate
 from draftutils.messages import _toolmsg, _msg
-
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 # The module is used to prevent complaints from code checkers (flake8)
 True if Draft_rc.__name__ else False
@@ -146,7 +145,7 @@ class Dimension(gui_base_original.Creator):
             n = int(sel_object.SubElementNames[0].lstrip("Edge")) - 1
             self.indices.append(n)
 
-            if DraftGeomUtils.geomType(edge) == "Line":
+            if geo_general.geomType(edge) == "Line":
                 self.node.extend([edge.Vertexes[0].Point, edge.Vertexes[1].Point])
 
                 # Iterate over the vertices of the parent `Object`;
@@ -162,7 +161,7 @@ class Dimension(gui_base_original.Creator):
 
                 if v1 is not None and v2 is not None:  # note that v1 or v2 can be zero
                     self.link = [sel_object.Object, v1, v2]
-            elif DraftGeomUtils.geomType(edge) == "Circle":
+            elif geo_general.geomType(edge) == "Circle":
                 self.node.extend([edge.Curve.Center, edge.Vertexes[0].Point])
                 self.edges = [edge]
                 self.arcmode = "diameter"
@@ -181,7 +180,7 @@ class Dimension(gui_base_original.Creator):
 
     def angle_dimension_normal(self, edge1, edge2):
         rot = App.Rotation(
-            DraftGeomUtils.vec(edge1), DraftGeomUtils.vec(edge2), self.wp.axis, "XYZ"
+            geo_general.vec(edge1), geo_general.vec(edge2), self.wp.axis, "XYZ"
         )
         norm = rot.multVec(App.Vector(0, 0, 1))
         vnorm = gui_utils.get_3d_view().getViewDirection()
@@ -374,7 +373,7 @@ class Dimension(gui_base_original.Creator):
                     r = self.point.sub(self.center)
                     self.arctrack.setRadius(r.Length)
                     a = self.arctrack.getAngle(self.point)
-                    pair = DraftGeomUtils.getBoundaryAngles(a, self.angles)
+                    pair = geo_general.getBoundaryAngles(a, self.angles)
                     if not (pair[0] < a < pair[1]):
                         self.angledata = [4 * math.pi - pair[0], 2 * math.pi - pair[1]]
                     else:
@@ -459,7 +458,7 @@ class Dimension(gui_base_original.Creator):
                                         self.node = [v1, v2]
                                         self.link = [ob, i1, i2]
                                         self.edges.append(ed)
-                                        if DraftGeomUtils.geomType(ed) == "Circle":
+                                        if geo_general.geomType(ed) == "Circle":
                                             # snapped edge is an arc
                                             self.arcmode = "diameter"
                                             self.link = [ob, num]
@@ -469,7 +468,7 @@ class Dimension(gui_base_original.Creator):
                                         self.edges.append(ed)
                                         # self.node now has the 4 endpoints
                                         self.node.extend([v1, v2])
-                                        c = DraftGeomUtils.findIntersection(
+                                        c = geo_intersections.findIntersection(
                                             self.node[0],
                                             self.node[1],
                                             self.node[2],

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -179,9 +179,7 @@ class Dimension(gui_base_original.Creator):
         super().finish()
 
     def angle_dimension_normal(self, edge1, edge2):
-        rot = App.Rotation(
-            geo_general.vec(edge1), geo_general.vec(edge2), self.wp.axis, "XYZ"
-        )
+        rot = App.Rotation(geo_general.vec(edge1), geo_general.vec(edge2), self.wp.axis, "XYZ")
         norm = rot.multVec(App.Vector(0, 0, 1))
         vnorm = gui_utils.get_3d_view().getViewDirection()
         if vnorm.getAngle(norm) < math.pi / 2:

--- a/src/Mod/Draft/draftguitools/gui_lines.py
+++ b/src/Mod/Draft/draftguitools/gui_lines.py
@@ -41,6 +41,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import FreeCADGui as Gui
 import DraftVecUtils
+from draftgeoutils import geometry as geo_geometry
 from draftguitools import gui_base_original
 from draftguitools import gui_tool_utils
 from draftutils import gui_utils
@@ -277,9 +278,7 @@ class Line(gui_base_original.Creator):
     def orientWP(self):
         """Orient the working plane."""
         if len(self.node) > 1 and self.obj:
-            import DraftGeomUtils
-
-            n = DraftGeomUtils.getNormal(self.obj.Shape)
+            n = geo_geometry.get_normal(self.obj.Shape)
             if not n:
                 n = self.wp.axis
             p = self.node[-1]

--- a/src/Mod/Draft/draftguitools/gui_mirror.py
+++ b/src/Mod/Draft/draftguitools/gui_mirror.py
@@ -43,12 +43,11 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc
-import DraftGeomUtils
 import DraftVecUtils
-import draftguitools.gui_base_original as gui_base_original
-import draftguitools.gui_trackers as trackers
-import draftguitools.gui_tool_utils as gui_tool_utils
-
+from draftgeoutils import geometry as geo_geometry
+from draftguitools import gui_base_original
+from draftguitools import gui_tool_utils
+from draftguitools import gui_trackers as trackers
 from draftutils.messages import _msg, _toolmsg
 from draftutils.translate import translate
 
@@ -149,7 +148,7 @@ class Mirror(gui_base_original.Modifier):
                         nor = self.point.sub(last).cross(self.wp.axis)
                         if nor.Length > tol:
                             nor.normalize()
-                            mtx = DraftGeomUtils.mirror_matrix(App.Matrix(), last, nor)
+                            mtx = geo_geometry.mirror_matrix(App.Matrix(), last, nor)
                             self.ghost.setMatrix(mtx)  # Ignores the position of the matrix.
                             self.ghost.move(App.Vector(mtx.col(3)[:3]))
             if self.extendedCopy:

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -174,9 +174,7 @@ class Offset(gui_base_original.Modifier):
                 gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_constrain_key())
                 and self.constrainSeg
             ):
-                dist = geo_geometry.findPerpendicular(
-                    self.point, self.shape, self.constrainSeg[1]
-                )
+                dist = geo_geometry.findPerpendicular(self.point, self.shape, self.constrainSeg[1])
             else:
                 dist = geo_geometry.findPerpendicular(self.point, self.shape.Edges)
             if dist:

--- a/src/Mod/Draft/draftguitools/gui_offset.py
+++ b/src/Mod/Draft/draftguitools/gui_offset.py
@@ -43,6 +43,9 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Draft_rc
 import DraftVecUtils
+from draftgeoutils import edges as geo_edges
+from draftgeoutils import geometry as geo_geometry
+from draftgeoutils import offsets as geo_offsets
 from draftguitools import gui_base_original
 from draftguitools import gui_tool_utils
 from draftguitools import gui_trackers as trackers
@@ -160,8 +163,6 @@ class Offset(gui_base_original.Modifier):
             Dictionary with strings that indicates the type of event received
             from the 3D view.
         """
-        import DraftGeomUtils
-
         if arg["Type"] == "SoKeyboardEvent":
             if arg["Key"] == "ESCAPE":
                 self.finish()
@@ -173,30 +174,30 @@ class Offset(gui_base_original.Modifier):
                 gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_constrain_key())
                 and self.constrainSeg
             ):
-                dist = DraftGeomUtils.findPerpendicular(
+                dist = geo_geometry.findPerpendicular(
                     self.point, self.shape, self.constrainSeg[1]
                 )
             else:
-                dist = DraftGeomUtils.findPerpendicular(self.point, self.shape.Edges)
+                dist = geo_geometry.findPerpendicular(self.point, self.shape.Edges)
             if dist:
                 self.ghost.on()
                 if self.mode == "Wire":
                     d = dist[0].negative()
-                    v1 = DraftGeomUtils.getTangent(self.shape.Edges[0], self.point)
-                    v2 = DraftGeomUtils.getTangent(self.shape.Edges[dist[1]], self.point)
+                    v1 = geo_edges.getTangent(self.shape.Edges[0], self.point)
+                    v2 = geo_edges.getTangent(self.shape.Edges[dist[1]], self.point)
                     a = -DraftVecUtils.angle(v1, v2, self.wp.axis)
                     self.dvec = DraftVecUtils.rotate(d, a, self.wp.axis)
                     occmode = self.ui.occOffset.isChecked()
                     params.set_param("Offset_OCC", occmode)
-                    _wire = DraftGeomUtils.offsetWire(self.shape, self.dvec, occ=occmode)
+                    _wire = geo_offsets.offsetWire(self.shape, self.dvec, occ=occmode)
                     self.ghost.update(_wire, forceclosed=occmode)
                 elif self.mode == "BSpline":
                     d = dist[0].negative()
                     e = self.shape.Edges[0]
-                    basetan = DraftGeomUtils.getTangent(e, self.point)
+                    basetan = geo_edges.getTangent(e, self.point)
                     self.npts = []
                     for p in self.sel.Points:
-                        currtan = DraftGeomUtils.getTangent(e, p)
+                        currtan = geo_edges.getTangent(e, p)
                         a = -DraftVecUtils.angle(currtan, basetan, self.wp.axis)
                         self.dvec = DraftVecUtils.rotate(d, a, self.wp.axis)
                         self.npts.append(p.add(self.dvec))

--- a/src/Mod/Draft/draftguitools/gui_polygons.py
+++ b/src/Mod/Draft/draftguitools/gui_polygons.py
@@ -40,6 +40,9 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import FreeCAD as App
 import FreeCADGui as Gui
 import DraftVecUtils
+from draftgeoutils import circles as geo_circles
+from draftgeoutils import circles as geo_circles_incomplete
+from draftgeoutils import geometry as geo_geometry
 from draftguitools import gui_base_original
 from draftguitools import gui_tool_utils
 from draftguitools import gui_trackers as trackers
@@ -113,8 +116,6 @@ class Polygon(gui_base_original.Creator):
             Dictionary with strings that indicates the type of event received
             from the 3D view.
         """
-        import DraftGeomUtils
-
         if self.ui.numFaces.value() != self.numVertices:
             self.polygonTrack.setNumVertices(self.ui.numFaces.value())
             self.numVertices = self.ui.numFaces.value()
@@ -143,16 +144,12 @@ class Polygon(gui_base_original.Creator):
                         self.ui.switchUi(False)
             else:  # choose radius
                 if len(self.tangents) == 2:
-                    cir = DraftGeomUtils.circleFrom2tan1pt(
-                        self.tangents[0], self.tangents[1], self.point
-                    )
-                    _c = DraftGeomUtils.findClosestCircle(self.point, cir)
+                    cir = geo_circles_incomplete.circleFrom2tan1pt(self.tangents[0], self.tangents[1], self.point)
+                    _c = geo_circles.findClosestCircle(self.point, cir)
                     self.center = _c.Center
                 elif self.tangents and self.tanpoints:
-                    cir = DraftGeomUtils.circleFrom1tan2pt(
-                        self.tangents[0], self.tanpoints[0], self.point
-                    )
-                    _c = DraftGeomUtils.findClosestCircle(self.point, cir)
+                    cir = geo_circles_incomplete.circleFrom1tan2pt(self.tangents[0], self.tanpoints[0], self.point)
+                    _c = geo_circles.findClosestCircle(self.point, cir)
                     self.center = _c.Center
                 if gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_alt_key()):
                     if not self.altdown:
@@ -163,15 +160,13 @@ class Polygon(gui_base_original.Creator):
                         num = int(snapped["Component"].lstrip("Edge")) - 1
                         ed = ob.Shape.Edges[num]
                         if len(self.tangents) == 2:
-                            cir = DraftGeomUtils.circleFrom3tan(
-                                self.tangents[0], self.tangents[1], ed
-                            )
-                            cl = DraftGeomUtils.findClosestCircle(self.point, cir)
+                            cir = geo_circles_incomplete.circleFrom3tan(self.tangents[0], self.tangents[1], ed)
+                            cl = geo_circles.findClosestCircle(self.point, cir)
                             self.center = cl.Center
                             self.rad = cl.Radius
                         else:
                             self.rad = self.center.add(
-                                DraftGeomUtils.findDistance(self.center, ed).sub(self.center)
+                                geo_geometry.findDistance(self.center, ed).sub(self.center)
                             ).Length
                     else:
                         self.rad = DraftVecUtils.dist(self.point, self.center)
@@ -287,20 +282,18 @@ class Polygon(gui_base_original.Creator):
         This function is called by the toolbar or taskpanel interface
         when a valid radius has been entered in the input field.
         """
-        import DraftGeomUtils
-
         self.rad = rad
         if len(self.tangents) == 2:
-            cir = DraftGeomUtils.circleFrom2tan1rad(self.tangents[0], self.tangents[1], rad)
+            cir = geo_circles_incomplete.circleFrom2tan1rad(self.tangents[0], self.tangents[1], rad)
             if self.center:
-                _c = DraftGeomUtils.findClosestCircle(self.center, cir)
+                _c = geo_circles.findClosestCircle(self.center, cir)
                 self.center = _c.Center
             else:
                 self.center = cir[-1].Center
         elif self.tangents and self.tanpoints:
-            cir = DraftGeomUtils.circleFrom1tan1pt1rad(self.tangents[0], self.tanpoints[0], rad)
+            cir = geo_circles_incomplete.circleFrom1tan1pt1rad(self.tangents[0], self.tanpoints[0], rad)
             if self.center:
-                _c = DraftGeomUtils.findClosestCircle(self.center, cir)
+                _c = geo_circles.findClosestCircle(self.center, cir)
                 self.center = _c.Center
             else:
                 self.center = cir[-1].Center

--- a/src/Mod/Draft/draftguitools/gui_polygons.py
+++ b/src/Mod/Draft/draftguitools/gui_polygons.py
@@ -144,11 +144,15 @@ class Polygon(gui_base_original.Creator):
                         self.ui.switchUi(False)
             else:  # choose radius
                 if len(self.tangents) == 2:
-                    cir = geo_circles_incomplete.circleFrom2tan1pt(self.tangents[0], self.tangents[1], self.point)
+                    cir = geo_circles_incomplete.circleFrom2tan1pt(
+                        self.tangents[0], self.tangents[1], self.point
+                    )
                     _c = geo_circles.findClosestCircle(self.point, cir)
                     self.center = _c.Center
                 elif self.tangents and self.tanpoints:
-                    cir = geo_circles_incomplete.circleFrom1tan2pt(self.tangents[0], self.tanpoints[0], self.point)
+                    cir = geo_circles_incomplete.circleFrom1tan2pt(
+                        self.tangents[0], self.tanpoints[0], self.point
+                    )
                     _c = geo_circles.findClosestCircle(self.point, cir)
                     self.center = _c.Center
                 if gui_tool_utils.hasMod(arg, gui_tool_utils.get_mod_alt_key()):
@@ -160,7 +164,9 @@ class Polygon(gui_base_original.Creator):
                         num = int(snapped["Component"].lstrip("Edge")) - 1
                         ed = ob.Shape.Edges[num]
                         if len(self.tangents) == 2:
-                            cir = geo_circles_incomplete.circleFrom3tan(self.tangents[0], self.tangents[1], ed)
+                            cir = geo_circles_incomplete.circleFrom3tan(
+                                self.tangents[0], self.tangents[1], ed
+                            )
                             cl = geo_circles.findClosestCircle(self.point, cir)
                             self.center = cl.Center
                             self.rad = cl.Radius
@@ -291,7 +297,9 @@ class Polygon(gui_base_original.Creator):
             else:
                 self.center = cir[-1].Center
         elif self.tangents and self.tanpoints:
-            cir = geo_circles_incomplete.circleFrom1tan1pt1rad(self.tangents[0], self.tanpoints[0], rad)
+            cir = geo_circles_incomplete.circleFrom1tan1pt1rad(
+                self.tangents[0], self.tanpoints[0], rad
+            )
             if self.center:
                 _c = geo_circles.findClosestCircle(self.center, cir)
                 self.center = _c.Center

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -50,8 +50,11 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import Part
 import DraftVecUtils
-import DraftGeomUtils
 import WorkingPlane
+from draftgeoutils import edges as geo_edges
+from draftgeoutils import general as geo_general
+from draftgeoutils import geometry as geo_geometry
+from draftgeoutils import intersections as geo_intersections
 from draftguitools import gui_trackers as trackers
 from draftutils import gui_utils
 from draftutils import params
@@ -407,7 +410,7 @@ class Snapper:
                         snaps.extend(self.snapToIntersection(edge))
                         snaps.extend(self.snapToElines(edge, eline))
 
-                        et = DraftGeomUtils.geomType(edge)
+                        et = geo_general.geomType(edge)
                         if et == "Circle":
                             # the edge is an arc, we have extra options
                             snaps.extend(self.snapToAngles(edge))
@@ -628,12 +631,12 @@ class Snapper:
                                 edges.reverse()
                 if (not self.maxEdges) or (len(edges) <= self.maxEdges):
                     for e in edges:
-                        if DraftGeomUtils.geomType(e) != "Line":
+                        if geo_general.geomType(e) != "Line":
                             continue
                         np = self.getPerpendicular(e, point)
                         if (np.sub(point)).Length < self.radius:
                             if self.isEnabled("Extension"):
-                                if DraftGeomUtils.isPtOnEdge(np, e):
+                                if geo_general.isPtOnEdge(np, e):
                                     continue
                                 if np != e.Vertexes[0].Point:
                                     p0 = e.Vertexes[0].Point
@@ -652,18 +655,18 @@ class Snapper:
                                     if len(self.lastExtensions) == 0:
                                         self.lastExtensions.append(ne)
                                     elif len(self.lastExtensions) == 1:
-                                        if not DraftGeomUtils.areColinear(
+                                        if not geo_general.areColinear(
                                             ne, self.lastExtensions[0]
                                         ):
                                             self.lastExtensions.append(self.lastExtensions[0])
                                             self.lastExtensions[0] = ne
                                     else:
                                         if (
-                                            not DraftGeomUtils.areColinear(
+                                            not geo_general.areColinear(
                                                 ne, self.lastExtensions[0]
                                             )
                                         ) and (
-                                            not DraftGeomUtils.areColinear(
+                                            not geo_general.areColinear(
                                                 ne, self.lastExtensions[1]
                                             )
                                         ):
@@ -672,7 +675,7 @@ class Snapper:
                                     return np, ne
                         elif self.isEnabled("Parallel"):
                             if last:
-                                ve = DraftGeomUtils.vec(e)
+                                ve = geo_general.vec(e)
                                 if not DraftVecUtils.isNull(ve):
                                     de = Part.LineSegment(last, last.add(ve)).toShape()
                                     np = self.getPerpendicular(de, point)
@@ -689,7 +692,7 @@ class Snapper:
         """Snap to the intersection of the last 2 extension lines."""
         if self.isEnabled("Extension"):
             if len(self.lastExtensions) == 2:
-                np = DraftGeomUtils.findIntersection(
+                np = geo_intersections.findIntersection(
                     self.lastExtensions[0], self.lastExtensions[1], True, True
                 )
                 if np:
@@ -799,7 +802,7 @@ class Snapper:
         snaps = []
         if self.isEnabled("Midpoint"):
             if isinstance(shape, Part.Edge):
-                mp = DraftGeomUtils.findMidpoint(shape)
+                mp = geo_edges.findMidpoint(shape)
                 if mp:
                     snaps.append([mp, "midpoint", self.toWP(mp)])
         return snaps
@@ -883,13 +886,13 @@ class Snapper:
             if constrain:
                 if isinstance(shape, Part.Edge):
                     if last:
-                        if DraftGeomUtils.geomType(shape) == "Line":
+                        if geo_general.geomType(shape) == "Line":
                             if self.constraintAxis:
                                 tmpEdge = Part.LineSegment(
                                     last, last.add(self.constraintAxis)
                                 ).toShape()
                                 # get the intersection points
-                                pt = DraftGeomUtils.findIntersection(tmpEdge, shape, True, True)
+                                pt = geo_intersections.findIntersection(tmpEdge, shape, True, True)
                                 if pt:
                                     for p in pt:
                                         snaps.append([p, "ortho", self.toWP(p)])
@@ -902,14 +905,14 @@ class Snapper:
                 tmpEdge1 = Part.LineSegment(last, last.add(self.constraintAxis)).toShape()
                 tmpEdge2 = Part.LineSegment(self.extLine.p1(), self.extLine.p2()).toShape()
                 # get the intersection points
-                pt = DraftGeomUtils.findIntersection(tmpEdge1, tmpEdge2, True, True)
+                pt = geo_intersections.findIntersection(tmpEdge1, tmpEdge2, True, True)
                 if pt:
                     return [pt[0], "ortho", pt[0]]
             if eline:
                 try:
                     tmpEdge2 = Part.LineSegment(self.extLine.p1(), self.extLine.p2()).toShape()
                     # get the intersection points
-                    pt = DraftGeomUtils.findIntersection(eline, tmpEdge2, True, True)
+                    pt = geo_intersections.findIntersection(eline, tmpEdge2, True, True)
                     if pt:
                         return [pt[0], "ortho", pt[0]]
                 except Exception:
@@ -940,10 +943,10 @@ class Snapper:
             while len(l) > 1:
                 p1 = l.pop()
                 for p2 in l:
-                    i1 = DraftGeomUtils.findIntersection(p1, p1.add(u), p2, p2.add(v), True, True)
+                    i1 = geo_intersections.findIntersection(p1, p1.add(u), p2, p2.add(v), True, True)
                     if i1:
                         ipoints.append([p1, i1[0]])
-                    i2 = DraftGeomUtils.findIntersection(p1, p1.add(v), p2, p2.add(u), True, True)
+                    i2 = geo_intersections.findIntersection(p1, p1.add(v), p2, p2.add(u), True, True)
                     if i2:
                         ipoints.append([p1, i2[0]])
             for p in ipoints:
@@ -951,12 +954,12 @@ class Snapper:
                     return [p[0], "ortho", p[1]]
         # then try to stick to a line
         for p in self.holdPoints:
-            d = DraftGeomUtils.findDistance(point, [p, p.add(u)])
+            d = geo_geometry.findDistance(point, [p, p.add(u)])
             if d:
                 if d.Length < self.radius:
                     fp = point.add(d)
                     return [p, "extension", fp]
-            d = DraftGeomUtils.findDistance(point, [p, p.add(v)])
+            d = geo_geometry.findDistance(point, [p, p.add(v)])
             if d:
                 if d.Length < self.radius:
                     fp = point.add(d)
@@ -979,7 +982,7 @@ class Snapper:
         if self.isEnabled("Intersection") and self.isEnabled("Extension"):
             if e1 and e2:
                 # get the intersection points
-                pts = DraftGeomUtils.findIntersection(e1, e2, True, True)
+                pts = geo_intersections.findIntersection(e1, e2, True, True)
                 if pts:
                     for p in pts:
                         snaps.append([p, "intersection", self.toWP(p)])
@@ -1062,7 +1065,7 @@ class Snapper:
                     if "Face" in sub_name and shape.ShapeType == "Edge":
                         face = obj.Shape.Faces[int(sub_name[4:]) - 1]
                         try:
-                            pts = DraftGeomUtils.findIntersection(face, shape)
+                            pts = geo_intersections.findIntersection(face, shape)
                             for pt in pts:
                                 snaps.append([pt, "intersection", self.toWP(pt)])
                         except Exception:
@@ -1073,7 +1076,7 @@ class Snapper:
                     elif shape.ShapeType == "Face":
                         edge = obj.Shape.Edges[int(sub_name[4:]) - 1]
                         try:
-                            pts = DraftGeomUtils.findIntersection(edge, shape)
+                            pts = geo_intersections.findIntersection(edge, shape)
                             for pt in pts:
                                 snaps.append([pt, "intersection", self.toWP(pt)])
                         except Exception:
@@ -1096,11 +1099,11 @@ class Snapper:
                                     p2 = self.toWP(edge.Vertexes[-1].Point)
                                     p3 = self.toWP(shape.Vertexes[0].Point)
                                     p4 = self.toWP(shape.Vertexes[-1].Point)
-                                    pts = DraftGeomUtils.findIntersection(
+                                    pts = geo_intersections.findIntersection(
                                         p1, p2, p3, p4, True, True
                                     )
                                 else:
-                                    pts = DraftGeomUtils.findIntersection(edge, shape)
+                                    pts = geo_intersections.findIntersection(edge, shape)
                                 for pt in pts:
                                     snaps.append([pt, "intersection", self.toWP(pt)])
                             except Exception:
@@ -1169,7 +1172,7 @@ class Snapper:
     def getPerpendicular(self, edge, pt):
         """Return a point on an edge, perpendicular to the given point."""
         dv = pt.sub(edge.Vertexes[0].Point)
-        nv = DraftVecUtils.project(dv, DraftGeomUtils.vec(edge))
+        nv = DraftVecUtils.project(dv, geo_general.vec(edge))
         np = (edge.Vertexes[0].Point).add(nv)
         return np
 

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -655,20 +655,14 @@ class Snapper:
                                     if len(self.lastExtensions) == 0:
                                         self.lastExtensions.append(ne)
                                     elif len(self.lastExtensions) == 1:
-                                        if not geo_general.areColinear(
-                                            ne, self.lastExtensions[0]
-                                        ):
+                                        if not geo_general.areColinear(ne, self.lastExtensions[0]):
                                             self.lastExtensions.append(self.lastExtensions[0])
                                             self.lastExtensions[0] = ne
                                     else:
                                         if (
-                                            not geo_general.areColinear(
-                                                ne, self.lastExtensions[0]
-                                            )
+                                            not geo_general.areColinear(ne, self.lastExtensions[0])
                                         ) and (
-                                            not geo_general.areColinear(
-                                                ne, self.lastExtensions[1]
-                                            )
+                                            not geo_general.areColinear(ne, self.lastExtensions[1])
                                         ):
                                             self.lastExtensions[1] = self.lastExtensions[0]
                                             self.lastExtensions[0] = ne
@@ -943,10 +937,14 @@ class Snapper:
             while len(l) > 1:
                 p1 = l.pop()
                 for p2 in l:
-                    i1 = geo_intersections.findIntersection(p1, p1.add(u), p2, p2.add(v), True, True)
+                    i1 = geo_intersections.findIntersection(
+                        p1, p1.add(u), p2, p2.add(v), True, True
+                    )
                     if i1:
                         ipoints.append([p1, i1[0]])
-                    i2 = geo_intersections.findIntersection(p1, p1.add(v), p2, p2.add(u), True, True)
+                    i2 = geo_intersections.findIntersection(
+                        p1, p1.add(v), p2, p2.add(u), True, True
+                    )
                     if i2:
                         ipoints.append([p1, i2[0]])
             for p in ipoints:

--- a/src/Mod/Draft/draftguitools/gui_trackers.py
+++ b/src/Mod/Draft/draftguitools/gui_trackers.py
@@ -45,6 +45,9 @@ import FreeCAD
 import FreeCADGui
 import DraftVecUtils
 from FreeCAD import Vector
+from draftgeoutils import general as geo_general
+from draftgeoutils import geometry as geo_geometry
+from draftgeoutils import wires as geo_wires
 from draftutils import grid_observer
 from draftutils import gui_utils
 from draftutils import params
@@ -61,9 +64,8 @@ class Tracker:
     """A generic Draft Tracker, to be used by other specific trackers."""
 
     def __init__(self, dotted=False, scolor=None, swidth=None, children=[], ontop=False, name=None):
-        global Part, DraftGeomUtils
+        global Part
         import Part
-        import DraftGeomUtils
 
         self.ontop = ontop
         self.color = coin.SoBaseColor()
@@ -477,7 +479,7 @@ class dimTracker(Tracker):
                     proj = None
                 else:
                     base = Part.LineSegment(p1, p4).toShape()
-                    proj = DraftGeomUtils.findDistance(self.p3, base)
+                    proj = geo_geometry.findDistance(self.p3, base)
                 if not proj:
                     p2 = p1
                     p3 = p4
@@ -1108,7 +1110,7 @@ class wireTracker(Tracker):
 
     def __init__(self, wire):
         self.line = coin.SoLineSet()
-        self.closed = DraftGeomUtils.isReallyClosed(wire)
+        self.closed = geo_wires.isReallyClosed(wire)
         if self.closed:
             self.line.numVertices.setValue(len(wire.Vertexes) + 1)
         else:
@@ -1562,8 +1564,6 @@ class boxTracker(Tracker):
 
     def update(self, line=None, normal=None):
         """Update the tracker."""
-        import DraftGeomUtils
-
         if not normal:
             normal = self._get_wp().axis
         if line:
@@ -1571,10 +1571,10 @@ class boxTracker(Tracker):
                 bp = line[0]
                 lvec = line[1].sub(line[0])
             else:
-                lvec = DraftGeomUtils.vec(line.Shape.Edges[0])
+                lvec = geo_general.vec(line.Shape.Edges[0])
                 bp = line.Shape.Edges[0].Vertexes[0].Point
         elif self.baseline:
-            lvec = DraftGeomUtils.vec(self.baseline.Shape.Edges[0])
+            lvec = geo_general.vec(self.baseline.Shape.Edges[0])
             bp = self.baseline.Shape.Edges[0].Vertexes[0].Point
         else:
             return

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -47,6 +47,8 @@ import FreeCAD as App
 import FreeCADGui as Gui
 import DraftVecUtils
 from draftfunctions import extrude
+from draftgeoutils import general as geo_general
+from draftgeoutils import intersections as geo_intersections
 from draftguitools import gui_base_original
 from draftguitools import gui_tool_utils
 from draftguitools import gui_trackers as trackers
@@ -108,7 +110,6 @@ class Trimex(gui_base_original.Modifier):
         self.ui.trimUi(title=translate("draft", self.featureName))
         self.linetrack = trackers.lineTracker()
 
-        import DraftGeomUtils
         import Part
 
         if not hasattr(self.obj, "Shape"):
@@ -160,7 +161,7 @@ class Trimex(gui_base_original.Modifier):
             sc = (lc[0], lc[1], lc[2])
             sw = self.width
             for e in self.edges:
-                if DraftGeomUtils.geomType(e) == "Line":
+                if geo_general.geomType(e) == "Line":
                     self.ghost.append(trackers.lineTracker(scolor=sc, swidth=sw))
                 else:
                     self.ghost.append(trackers.arcTracker(scolor=sc, swidth=sw))
@@ -279,7 +280,6 @@ class Trimex(gui_base_original.Modifier):
         if real:
             newedges = []
 
-        import DraftGeomUtils
         import Part
 
         # finding the active point
@@ -290,7 +290,7 @@ class Trimex(gui_base_original.Modifier):
         if shift:
             npoint = self.activePoint
         else:
-            npoint = DraftGeomUtils.findClosest(point, vlist)
+            npoint = geo_general.findClosest(point, vlist)
         if npoint > len(self.edges) / 2:
             reverse = True
         if alt:
@@ -325,16 +325,16 @@ class Trimex(gui_base_original.Modifier):
             if shape.Edges:
                 pts = []
                 for e in shape.Edges:
-                    int = DraftGeomUtils.findIntersection(edge, e, True, True)
+                    int = geo_intersections.findIntersection(edge, e, True, True)
                     if int:
                         pts.extend(int)
                 if pts:
-                    point = pts[DraftGeomUtils.findClosest(point, pts)]
+                    point = pts[geo_general.findClosest(point, pts)]
 
         # modifying active edge
-        if DraftGeomUtils.geomType(edge) == "Line":
+        if geo_general.geomType(edge) == "Line":
             ang = None
-            ve = DraftGeomUtils.vec(edge)
+            ve = geo_general.vec(edge)
             chord = v1.sub(point)
             n = ve.cross(chord)
             if n.Length == 0:
@@ -392,7 +392,7 @@ class Trimex(gui_base_original.Modifier):
         for i in li:
             edge = self.edges[i]
             ghost = self.ghost[i]
-            if DraftGeomUtils.geomType(edge) == "Line":
+            if geo_general.geomType(edge) == "Line":
                 ghost.p1(edge.Vertexes[0].Point)
                 ghost.p2(edge.Vertexes[-1].Point)
             else:
@@ -489,7 +489,6 @@ class Trimex(gui_base_original.Modifier):
     def trimObjects(self, objectslist):
         """Attempt to trim two objects together."""
         import Part
-        import DraftGeomUtils
 
         wires = []
         for obj in objectslist:
@@ -513,7 +512,7 @@ class Trimex(gui_base_original.Modifier):
         edge2 = None
         for i1, e1 in enumerate(wires[0].Edges):
             for i2, e2 in enumerate(wires[1].Edges):
-                i = DraftGeomUtils.findIntersection(e1, e2, dts=False)
+                i = geo_intersections.findIntersection(e1, e2, dts=False)
                 if len(i) == 1:
                     ints.append(i[0])
                     edge1 = i1

--- a/src/Mod/Draft/draftmake/make_circle.py
+++ b/src/Mod/Draft/draftmake/make_circle.py
@@ -34,12 +34,11 @@ import math
 
 import FreeCAD as App
 import Part
-import DraftGeomUtils
 import DraftVecUtils
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
+from draftgeoutils import general as geo_general
 from draftobjects.circle import Circle
+from draftutils import utils
+from draftutils import gui_utils
 
 if App.GuiUp:
     from draftviewproviders.view_base import ViewProviderDraft
@@ -121,7 +120,7 @@ def make_circle(radius, placement=None, face=None, startangle=None, endangle=Non
     if face is not None:
         obj.MakeFace = face
 
-    if isinstance(radius, Part.Edge) and DraftGeomUtils.geomType(radius) == "Circle":
+    if isinstance(radius, Part.Edge) and geo_general.geomType(radius) == "Circle":
         edge = radius
         obj.Radius = edge.Curve.Radius
         axis = edge.Curve.Axis

--- a/src/Mod/Draft/draftmake/make_fillet.py
+++ b/src/Mod/Draft/draftmake/make_fillet.py
@@ -37,7 +37,6 @@ import FreeCAD as App
 from draftgeoutils import fillets as geo_fillets
 from draftobjects import fillet
 from draftutils import gui_utils
-from draftutils import utils
 from draftutils.messages import _err
 from draftutils.translate import translate
 

--- a/src/Mod/Draft/draftmake/make_fillet.py
+++ b/src/Mod/Draft/draftmake/make_fillet.py
@@ -34,10 +34,10 @@ This creates a `Part::Part2DObjectPython`, and then assigns the Proxy class
 import lazy_loader.lazy_loader as lz
 
 import FreeCAD as App
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-import draftobjects.fillet as fillet
-
+from draftgeoutils import fillets as geo_fillets
+from draftobjects import fillet
+from draftutils import gui_utils
+from draftutils import utils
 from draftutils.messages import _err
 from draftutils.translate import translate
 
@@ -46,7 +46,6 @@ if App.GuiUp:
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 ## \addtogroup draftmake
 # @{
@@ -78,7 +77,7 @@ def _preprocess(objs, radius, chamfer):
         _err(translate("draft", "2 edges are needed"))
         return None, None
 
-    edges = DraftGeomUtils.fillet(edges, radius, chamfer)
+    edges = geo_fillets.fillet(edges, radius, chamfer)
     if len(edges) < 3:
         _err(translate("draft", "Edges are not connected or radius is too large"))
         return None, None

--- a/src/Mod/Draft/draftmake/make_sketch.py
+++ b/src/Mod/Draft/draftmake/make_sketch.py
@@ -35,7 +35,9 @@ import math
 
 import FreeCAD as App
 import DraftVecUtils
-import DraftGeomUtils
+from draftgeoutils import edges as geo_edges
+from draftgeoutils import general as geo_general
+from draftgeoutils import geometry as geo_geometry
 from draftutils import gui_utils
 from draftutils import utils
 from draftutils.translate import translate
@@ -104,11 +106,11 @@ def make_sketch(
         else:
             shape = obj.Shape
 
-        if not DraftGeomUtils.is_planar(shape, tol):
+        if not geo_geometry.is_planar(shape, tol):
             App.Console.PrintError(translate("draft", "All shapes must be planar") + "\n")
             return None
 
-        if DraftGeomUtils.get_normal(shape, tol):
+        if geo_geometry.get_normal(shape, tol):
             shape_norm_yes.append(shape)
         else:
             shape_norm_no.append(shape)
@@ -118,11 +120,11 @@ def make_sketch(
     # test if all shapes are coplanar
     if len(shape_norm_yes) >= 1:
         for shape in shapes_list[1:]:
-            if not DraftGeomUtils.are_coplanar(shapes_list[0], shape, tol):
+            if not geo_geometry.are_coplanar(shapes_list[0], shape, tol):
                 App.Console.PrintError(translate("draft", "All shapes must be coplanar") + "\n")
                 return None
         # define sketch normal
-        normal = DraftGeomUtils.get_normal(shapes_list[0], tol)
+        normal = geo_geometry.get_normal(shapes_list[0], tol)
 
     else:
         # suppose all geometries are straight lines or points
@@ -134,10 +136,10 @@ def make_sketch(
                 # all points coincide
                 normal = App.Vector(0, 0, 1)
             else:
-                if not DraftGeomUtils.is_planar(poly, tol):
+                if not geo_geometry.is_planar(poly, tol):
                     App.Console.PrintError(translate("draft", "All shapes must be coplanar") + "\n")
                     return None
-                normal = DraftGeomUtils.get_shape_normal(poly)
+                normal = geo_geometry.get_shape_normal(poly)
         else:
             # only one point
             normal = App.Vector(0, 0, 1)
@@ -167,7 +169,7 @@ def make_sketch(
             pass
 
     def convertBezier(edge):
-        if DraftGeomUtils.geomType(edge) == "BezierCurve":
+        if geo_general.geomType(edge) == "BezierCurve":
             return edge.Curve.toBSpline(edge.FirstParameter, edge.LastParameter).toShape()
         else:
             return edge
@@ -209,7 +211,7 @@ def make_sketch(
             shape = obj if tp == "Shape" else obj.Shape
             for e in shape.Edges:
                 newedge = convertBezier(e)
-                nobj.addGeometry(DraftGeomUtils.orientEdge(newedge, normal, make_arc=True))
+                nobj.addGeometry(geo_edges.orientEdge(newedge, normal, make_arc=True))
                 addRadiusConstraint(newedge)
             ok = True
 

--- a/src/Mod/Draft/draftmake/make_wire.py
+++ b/src/Mod/Draft/draftmake/make_wire.py
@@ -30,11 +30,10 @@
 ## \addtogroup draftmake
 # @{
 import FreeCAD as App
-import DraftGeomUtils
-import draftutils.utils as utils
-import draftutils.gui_utils as gui_utils
-
+from draftgeoutils import geometry as geo_geometry
 from draftobjects.wire import Wire
+from draftutils import utils
+from draftutils import gui_utils
 
 if App.GuiUp:
     from draftviewproviders.view_wire import ViewProviderWire
@@ -85,7 +84,7 @@ def make_wire(pointslist, closed=False, placement=None, face=None, support=None,
 
     elif isinstance(pointslist, Part.Wire):
         for edge in pointslist.Edges:
-            if not DraftGeomUtils.is_straight_line(edge):
+            if not geo_geometry.is_straight_line(edge):
                 App.Console.PrintError("All edges must be straight lines\n")
                 return None
         closed = pointslist.isClosed()

--- a/src/Mod/Draft/draftobjects/dimension.py
+++ b/src/Mod/Draft/draftobjects/dimension.py
@@ -107,8 +107,8 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import DraftVecUtils
-import DraftGeomUtils
 import WorkingPlane
+from draftgeoutils import general as geo_general
 from draftobjects.draft_annotation import DraftAnnotation
 from draftutils import gui_utils
 from draftutils import utils
@@ -395,10 +395,10 @@ def measure_one_obj_edge(obj, subelement, dim_point, diameter=False):
         n = int(subelement[4:]) - 1
         edge = obj.Shape.Edges[n]
 
-        if DraftGeomUtils.geomType(edge) == "Line":
+        if geo_general.geomType(edge) == "Line":
             start = edge.Vertexes[0].Point
             end = edge.Vertexes[-1].Point
-        elif DraftGeomUtils.geomType(edge) == "Circle":
+        elif geo_general.geomType(edge) == "Circle":
             center = edge.Curve.Center
             radius = edge.Curve.Radius
             axis = edge.Curve.Axis

--- a/src/Mod/Draft/draftobjects/draftlink.py
+++ b/src/Mod/Draft/draftobjects/draftlink.py
@@ -41,14 +41,13 @@ import lazy_loader.lazy_loader as lz
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
+from draftgeoutils import general as geo_general
+from draftobjects.base import DraftObject
 from draftutils import gui_utils
 from draftutils.messages import _log
 
-from draftobjects.base import DraftObject
-
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 ## \addtogroup draftobjects
 # @{
@@ -229,7 +228,7 @@ class DraftLink(DraftObject):
                 else:
                     obj.Shape = Part.makeCompound(base)
 
-                if not DraftGeomUtils.isNull(pl):
+                if not geo_general.isNull(pl):
                     obj.Placement = pl
 
         if self.use_link:

--- a/src/Mod/Draft/draftobjects/patharray.py
+++ b/src/Mod/Draft/draftobjects/patharray.py
@@ -66,24 +66,20 @@ a single property of type `App::PropertyLinkSub`.
 # \ingroup draftobjects
 # \brief Provides the object code for the PathArray object.
 
+import lazy_loader.lazy_loader as lz
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
 import FreeCAD as App
 import DraftVecUtils
-import lazy_loader.lazy_loader as lz
-
+from draftgeoutils import geometry as geo_geometry
+from draftgeoutils import wires as geo_wires
+from draftobjects.base import DraftObject
+from draftobjects.draftlink import DraftLink
 from draftutils.messages import _err, _log, _wrn
 from draftutils.translate import translate
 
-
-def QT_TRANSLATE_NOOP(ctx, txt):
-    return txt
-
-
-from draftobjects.base import DraftObject
-from draftobjects.draftlink import DraftLink
-
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 ## \addtogroup draftobjects
 # @{
@@ -605,7 +601,7 @@ def placements_on_path(
     if forceNormal and normalOverride:
         normal = normalOverride
     else:
-        normal = DraftGeomUtils.get_shape_normal(pathwire)
+        normal = geo_geometry.get_shape_normal(pathwire)
         if normal is None:
             normal = App.Vector(0, 0, 1)
 
@@ -661,7 +657,7 @@ def placements_on_path(
     if sum(spacingPattern) == 0:
         spacingPattern = [spacingUnit]
 
-    isClosedPath = DraftGeomUtils.isReallyClosed(pathwire) and not (startOffset or endOffset)
+    isClosedPath = geo_wires.isReallyClosed(pathwire) and not (startOffset or endOffset)
 
     count = max(count, 1)
 

--- a/src/Mod/Draft/draftobjects/polygon.py
+++ b/src/Mod/Draft/draftobjects/polygon.py
@@ -34,7 +34,7 @@ import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-import DraftGeomUtils
+from draftgeoutils import fillets as geo_fillets
 from draftobjects.base import DraftObject
 from draftutils import gui_utils
 from draftutils import params
@@ -101,12 +101,12 @@ class Polygon(DraftObject):
             shape = Part.makePolygon(pts)
             if "ChamferSize" in obj.PropertiesList:
                 if obj.ChamferSize.Value != 0:
-                    w = DraftGeomUtils.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
+                    w = geo_geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
                     if w:
                         shape = w
             if "FilletRadius" in obj.PropertiesList:
                 if obj.FilletRadius.Value != 0:
-                    w = DraftGeomUtils.filletWire(shape, obj.FilletRadius.Value)
+                    w = geo_geo_fillets.filletWire(shape, obj.FilletRadius.Value)
                     if w:
                         shape = w
             if hasattr(obj, "MakeFace"):

--- a/src/Mod/Draft/draftobjects/polygon.py
+++ b/src/Mod/Draft/draftobjects/polygon.py
@@ -101,12 +101,12 @@ class Polygon(DraftObject):
             shape = Part.makePolygon(pts)
             if "ChamferSize" in obj.PropertiesList:
                 if obj.ChamferSize.Value != 0:
-                    w = geo_geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
+                    w = geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
                     if w:
                         shape = w
             if "FilletRadius" in obj.PropertiesList:
                 if obj.FilletRadius.Value != 0:
-                    w = geo_geo_fillets.filletWire(shape, obj.FilletRadius.Value)
+                    w = geo_fillets.filletWire(shape, obj.FilletRadius.Value)
                     if w:
                         shape = w
             if hasattr(obj, "MakeFace"):

--- a/src/Mod/Draft/draftobjects/rectangle.py
+++ b/src/Mod/Draft/draftobjects/rectangle.py
@@ -123,14 +123,14 @@ class Rectangle(DraftObject):
                         p = Part.makePolygon([p1, p2, p3, p4, p1])
                         if "ChamferSize" in obj.PropertiesList:
                             if obj.ChamferSize.Value != 0:
-                                w = geo_geo_fillets.filletWire(
+                                w = geo_fillets.filletWire(
                                     p, obj.ChamferSize.Value, chamfer=True
                                 )
                                 if w:
                                     p = w
                         if "FilletRadius" in obj.PropertiesList:
                             if obj.FilletRadius.Value != 0:
-                                w = geo_geo_fillets.filletWire(p, obj.FilletRadius.Value)
+                                w = geo_fillets.filletWire(p, obj.FilletRadius.Value)
                                 if w:
                                     p = w
                         if hasattr(obj, "MakeFace"):
@@ -148,12 +148,12 @@ class Rectangle(DraftObject):
             shape = Part.makePolygon([p1, p2, p3, p4, p1])
             if "ChamferSize" in obj.PropertiesList:
                 if obj.ChamferSize.Value != 0:
-                    w = geo_geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
+                    w = geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
                     if w:
                         shape = w
             if "FilletRadius" in obj.PropertiesList:
                 if obj.FilletRadius.Value != 0:
-                    w = geo_geo_fillets.filletWire(shape, obj.FilletRadius.Value)
+                    w = geo_fillets.filletWire(shape, obj.FilletRadius.Value)
                     if w:
                         shape = w
             if hasattr(obj, "MakeFace"):

--- a/src/Mod/Draft/draftobjects/rectangle.py
+++ b/src/Mod/Draft/draftobjects/rectangle.py
@@ -123,9 +123,7 @@ class Rectangle(DraftObject):
                         p = Part.makePolygon([p1, p2, p3, p4, p1])
                         if "ChamferSize" in obj.PropertiesList:
                             if obj.ChamferSize.Value != 0:
-                                w = geo_fillets.filletWire(
-                                    p, obj.ChamferSize.Value, chamfer=True
-                                )
+                                w = geo_fillets.filletWire(p, obj.ChamferSize.Value, chamfer=True)
                                 if w:
                                     p = w
                         if "FilletRadius" in obj.PropertiesList:

--- a/src/Mod/Draft/draftobjects/rectangle.py
+++ b/src/Mod/Draft/draftobjects/rectangle.py
@@ -33,7 +33,7 @@
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-import DraftGeomUtils
+from draftgeoutils import fillets as geo_fillets
 from draftobjects.base import DraftObject
 from draftutils import gui_utils
 from draftutils import params
@@ -123,14 +123,14 @@ class Rectangle(DraftObject):
                         p = Part.makePolygon([p1, p2, p3, p4, p1])
                         if "ChamferSize" in obj.PropertiesList:
                             if obj.ChamferSize.Value != 0:
-                                w = DraftGeomUtils.filletWire(
+                                w = geo_geo_fillets.filletWire(
                                     p, obj.ChamferSize.Value, chamfer=True
                                 )
                                 if w:
                                     p = w
                         if "FilletRadius" in obj.PropertiesList:
                             if obj.FilletRadius.Value != 0:
-                                w = DraftGeomUtils.filletWire(p, obj.FilletRadius.Value)
+                                w = geo_geo_fillets.filletWire(p, obj.FilletRadius.Value)
                                 if w:
                                     p = w
                         if hasattr(obj, "MakeFace"):
@@ -148,12 +148,12 @@ class Rectangle(DraftObject):
             shape = Part.makePolygon([p1, p2, p3, p4, p1])
             if "ChamferSize" in obj.PropertiesList:
                 if obj.ChamferSize.Value != 0:
-                    w = DraftGeomUtils.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
+                    w = geo_geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
                     if w:
                         shape = w
             if "FilletRadius" in obj.PropertiesList:
                 if obj.FilletRadius.Value != 0:
-                    w = DraftGeomUtils.filletWire(shape, obj.FilletRadius.Value)
+                    w = geo_geo_fillets.filletWire(shape, obj.FilletRadius.Value)
                     if w:
                         shape = w
             if hasattr(obj, "MakeFace"):

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -34,6 +34,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import DraftVecUtils
+from draftgeoutils import wires as geo_wires
 from draftobjects.base import DraftObject
 from draftutils import groups
 from draftutils import gui_utils
@@ -156,7 +157,6 @@ class Shape2DView(DraftObject):
         "returns projected edges from a shape and a direction"
         import Part
         import TechDraw
-        import DraftGeomUtils
 
         edges = []
         _groups = TechDraw.projectEx(shape, direction)
@@ -169,7 +169,7 @@ class Shape2DView(DraftObject):
                     edges.append(g)
         edges = self.cleanExcluded(obj, edges)
         if getattr(obj, "Tessellation", False):
-            return DraftGeomUtils.cleanProjection(
+            return geo_wires.cleanProjection(
                 Part.makeCompound(edges), obj.Tessellation, obj.SegmentLength
             )
         else:
@@ -221,7 +221,6 @@ class Shape2DView(DraftObject):
             return
 
         import Part
-        import DraftGeomUtils
 
         pl = obj.Placement
         if obj.Base:
@@ -386,7 +385,7 @@ class Shape2DView(DraftObject):
                                         c = self.getProjected(obj, c, proj)
                             # faces = []
                             # if (obj.ProjectionMode == "Cutfaces") and (sh.ShapeType == "Solid"):
-                            #    wires = DraftGeomUtils.findWires(c.Edges)
+                            #    wires = geo_wires.findWires(c.Edges)
                             #    for w in wires:
                             #        if w.isClosed():
                             #            faces.append(Part.Face(w))

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -34,8 +34,9 @@ import math
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
-import DraftGeomUtils
 import DraftVecUtils
+from draftgeoutils import faces as geo_faces
+from draftgeoutils import fillets as geo_fillets
 from draftobjects.base import DraftObject
 from draftutils import gui_utils
 from draftutils import params
@@ -145,8 +146,8 @@ class Wire(DraftObject):
                     sh1 = obj.Base.Shape.copy()
                     sh2 = obj.Tool.Shape.copy()
                     shape = sh1.fuse(sh2)
-                    if DraftGeomUtils.isCoplanar(shape.Faces):
-                        shape = DraftGeomUtils.concatenate(shape)
+                    if geo_faces.is_coplanar(shape.Faces):
+                        shape = geo_faces.concatenate(shape)
                         obj.Shape = shape
                         p = []
                         for v in shape.Vertexes:
@@ -177,12 +178,12 @@ class Wire(DraftObject):
                 shape = Part.makePolygon(pts + [pts[0]])
                 if "ChamferSize" in obj.PropertiesList:
                     if obj.ChamferSize.Value != 0:
-                        w = DraftGeomUtils.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
+                        w = geo_geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
                         if w:
                             shape = w
                 if "FilletRadius" in obj.PropertiesList:
                     if obj.FilletRadius.Value != 0:
-                        w = DraftGeomUtils.filletWire(shape, obj.FilletRadius.Value)
+                        w = geo_geo_fillets.filletWire(shape, obj.FilletRadius.Value)
                         if w:
                             shape = w
                 try:
@@ -215,12 +216,12 @@ class Wire(DraftObject):
                     shape = None
                 if "ChamferSize" in obj.PropertiesList:
                     if obj.ChamferSize.Value != 0:
-                        w = DraftGeomUtils.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
+                        w = geo_geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
                         if w:
                             shape = w
                 if "FilletRadius" in obj.PropertiesList:
                     if obj.FilletRadius.Value != 0:
-                        w = DraftGeomUtils.filletWire(shape, obj.FilletRadius.Value)
+                        w = geo_geo_fillets.filletWire(shape, obj.FilletRadius.Value)
                         if w:
                             shape = w
             if shape:

--- a/src/Mod/Draft/draftobjects/wire.py
+++ b/src/Mod/Draft/draftobjects/wire.py
@@ -178,12 +178,12 @@ class Wire(DraftObject):
                 shape = Part.makePolygon(pts + [pts[0]])
                 if "ChamferSize" in obj.PropertiesList:
                     if obj.ChamferSize.Value != 0:
-                        w = geo_geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
+                        w = geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
                         if w:
                             shape = w
                 if "FilletRadius" in obj.PropertiesList:
                     if obj.FilletRadius.Value != 0:
-                        w = geo_geo_fillets.filletWire(shape, obj.FilletRadius.Value)
+                        w = geo_fillets.filletWire(shape, obj.FilletRadius.Value)
                         if w:
                             shape = w
                 try:
@@ -216,12 +216,12 @@ class Wire(DraftObject):
                     shape = None
                 if "ChamferSize" in obj.PropertiesList:
                     if obj.ChamferSize.Value != 0:
-                        w = geo_geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
+                        w = geo_fillets.filletWire(shape, obj.ChamferSize.Value, chamfer=True)
                         if w:
                             shape = w
                 if "FilletRadius" in obj.PropertiesList:
                     if obj.FilletRadius.Value != 0:
-                        w = geo_geo_fillets.filletWire(shape, obj.FilletRadius.Value)
+                        w = geo_fillets.filletWire(shape, obj.FilletRadius.Value)
                         if w:
                             shape = w
             if shape:

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -42,6 +42,7 @@ import os
 import PySide.QtCore as QtCore
 
 import FreeCAD as App
+from draftgeoutils import general as geo_general
 from draftutils import params
 from draftutils.messages import _wrn, _err, _log
 from draftutils.translate import translate
@@ -542,9 +543,7 @@ def shapify(obj, delete=True):
     elif len(shape.Wires) == 1:
         name = "Wire"
     elif len(shape.Edges) == 1:
-        import DraftGeomUtils
-
-        if DraftGeomUtils.geomType(shape.Edges[0]) == "Line":
+        if geo_general.geomType(shape.Edges[0]) == "Line":
             name = "Line"
         else:
             name = "Circle"

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -42,7 +42,6 @@ import os
 import PySide.QtCore as QtCore
 
 import FreeCAD as App
-from draftgeoutils import general as geo_general
 from draftutils import params
 from draftutils.messages import _wrn, _err, _log
 from draftutils.translate import translate
@@ -543,12 +542,9 @@ def shapify(obj, delete=True):
     elif len(shape.Wires) == 1:
         name = "Wire"
     elif len(shape.Edges) == 1:
-        if geo_general.geomType(shape.Edges[0]) == "Line":
-            name = "Line"
-        else:
-            name = "Circle"
+        name = "Edge"
     else:
-        name = getRealName(obj.Name)
+        name = get_real_name(obj.Name)
 
     if delete:
         App.ActiveDocument.removeObject(obj.Name)

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -43,6 +43,9 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import FreeCAD as App
 import DraftVecUtils
+from draftgeoutils import edges as geo_edges
+from draftgeoutils import general as geo_general
+from draftgeoutils import geometry as geo_geometry
 from draftutils import gui_utils
 from draftutils import params
 from draftutils import units
@@ -51,7 +54,6 @@ from draftviewproviders.view_draft_annotation import ViewProviderDraftAnnotation
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
-DraftGeomUtils = lz.LazyLoader("DraftGeomUtils", globals(), "DraftGeomUtils")
 
 ## \addtogroup draftviewproviders
 # @{
@@ -378,7 +380,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
                 proj = None
             else:
                 base = Part.LineSegment(self.p2, self.p3).toShape()
-                proj = DraftGeomUtils.findDistance(self.p1, base)
+                proj = geo_geometry.findDistance(self.p1, base)
                 if proj:
                     proj = proj.negative()
 
@@ -388,7 +390,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
                 proj = None
             else:
                 base = Part.LineSegment(self.p1, self.p4).toShape()
-                proj = DraftGeomUtils.findDistance(obj.Dimline, base)
+                proj = geo_geometry.findDistance(obj.Dimline, base)
 
             if proj:
                 self.p2 = self.p1 + proj.negative()
@@ -790,7 +792,7 @@ class ViewProviderLinearDimension(ViewProviderDimensionBase):
                 sub = subelements[0]
                 index = int(sub[4:]) - 1
                 edge = linked_obj.Shape.Edges[index]
-                if DraftGeomUtils.geomType(edge) == "Circle":
+                if geo_general.geomType(edge) == "Circle":
                     return True
         return False
 
@@ -922,7 +924,7 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
         )
         self.p2 = self.circle.Vertexes[0].Point
         self.p3 = self.circle.Vertexes[-1].Point
-        midp = DraftGeomUtils.findMidpoint(self.circle)
+        midp = geo_edges.findMidpoint(self.circle)
         ray = midp - obj.Center
 
         proj1 = obj.Center - self.p2

--- a/src/Mod/Draft/importDXF.py
+++ b/src/Mod/Draft/importDXF.py
@@ -60,10 +60,13 @@ import time
 import FreeCAD
 import Part
 import DraftVecUtils
-import DraftGeomUtils
 import WorkingPlane
 from FreeCAD import Vector
 from FreeCAD import Console as FCC
+from draftgeoutils import circles as geo_circles
+from draftgeoutils import general as geo_general
+from draftgeoutils import geometry as geo_geometry
+from draftgeoutils import wires as geo_wires
 from draftfunctions import dxf
 from draftfunctions import rotate
 from draftmake import make_bezcurve
@@ -2442,7 +2445,7 @@ def processdxf(document, filename, getShapes=False, reComputeFlag=True):
                 if res == QtWidgets.QMessageBox.Cancel:
                     FCC.PrintMessage("Aborted\n")
                     return
-        shapes = DraftGeomUtils.findWires(edges)
+        shapes = geo_wires.findWires(edges)
         for s in shapes:
             newob = addObject(s)
 
@@ -3028,7 +3031,7 @@ def projectShape(shape, direction, tess=None):
     tess : list, optional
         It defaults to `None`. If it is available, it is a list with
         two elements, `[True, segment_length]` which are used by
-        `DraftGeomUtils.cleanProjection(compound, tess[0], tess[1])`
+        `draftgeoutils.wires.cleanProjection(compound, tess[0], tess[1])`
         to create a valid compound of edges.
 
         Otherwise, a simple `Part.Compound` is produced.
@@ -3043,7 +3046,7 @@ def projectShape(shape, direction, tess=None):
 
     See also
     --------
-    TechDraw.projectEx, DraftGeomUtils.cleanProjection
+    TechDraw.projectEx, draftgeoutils.wires.cleanProjection
     """
     import TechDraw
 
@@ -3057,12 +3060,12 @@ def projectShape(shape, direction, tess=None):
         for g in groups[0:5]:
             if g:
                 edges.append(g)
-        # return DraftGeomUtils.cleanProjection(Part.makeCompound(edges))
+        # return geo_wires.cleanProjection(Part.makeCompound(edges))
         if tess:
-            return DraftGeomUtils.cleanProjection(Part.makeCompound(edges), tess[0], tess[1])
+            return geo_wires.cleanProjection(Part.makeCompound(edges), tess[0], tess[1])
         else:
             return Part.makeCompound(edges)
-            # return DraftGeomUtils.cleanProjection(Part.makeCompound(edges))
+            # return geo_wires.cleanProjection(Part.makeCompound(edges))
 
 
 def getArcData(edge):
@@ -3240,7 +3243,7 @@ def getWire(wire, nospline=False, lw=True, asis=False):
         # print("processing wire ",wire.Edges)
         for edge in edges:
             v1 = edge.Vertexes[0].Point
-            if DraftGeomUtils.geomType(edge) == "Circle":
+            if geo_general.geomType(edge) == "Circle":
                 # polyline bulge -> negative makes the arc go clockwise
                 angle = edge.LastParameter - edge.FirstParameter
                 bul = math.tan(angle / 4)
@@ -3250,7 +3253,7 @@ def getWire(wire, nospline=False, lw=True, asis=False):
                 if edge.Curve.Axis.dot(Vector(0, 0, 1)) < 0:
                     bul = -bul
                 points.append(fmt(v1, bul))
-            elif (DraftGeomUtils.geomType(edge) in ["BSplineCurve", "BezierCurve", "Ellipse"]) and (
+            elif (geo_general.geomType(edge) in ["BSplineCurve", "BezierCurve", "Ellipse"]) and (
                 not nospline
             ):
                 spline = getSplineSegs(edge)
@@ -3259,7 +3262,7 @@ def getWire(wire, nospline=False, lw=True, asis=False):
                     points.append(fmt(p))
             else:
                 points.append(fmt(v1))
-        if not DraftGeomUtils.isReallyClosed(wire):
+        if not geo_wires.isReallyClosed(wire):
             v = edges[-1].Vertexes[-1].Point
             points.append(fmt(v))
         # print("wire verts: ",points)
@@ -3379,7 +3382,7 @@ def writeShape(sh, ob, dxfobject, nospline=False, lwPoly=False, layer=None, colo
             edges = Part.__sortEdges__(wire.Edges)
         for e in edges:
             processededges.append(e.hashCode())
-        if (len(wire.Edges) == 1) and (DraftGeomUtils.geomType(wire.Edges[0]) == "Circle"):
+        if (len(wire.Edges) == 1) and (geo_general.geomType(wire.Edges[0]) == "Circle"):
             center, radius, ang1, ang2 = getArcData(wire.Edges[0])
             if center is not None:
                 if len(wire.Edges[0].Vertexes) == 1:  # circle
@@ -3395,7 +3398,7 @@ def writeShape(sh, ob, dxfobject, nospline=False, lwPoly=False, layer=None, colo
                         dxfLibrary.LwPolyLine(
                             getWire(wire, nospline, asis=asis),
                             [0.0, 0.0],
-                            int(DraftGeomUtils.isReallyClosed(wire)),
+                            int(geo_wires.isReallyClosed(wire)),
                             color=color,
                             layer=layer,
                         )
@@ -3412,7 +3415,7 @@ def writeShape(sh, ob, dxfobject, nospline=False, lwPoly=False, layer=None, colo
                     dxfLibrary.PolyLine(
                         getWire(wire, nospline, lw=False, asis=asis),
                         [0.0, 0.0, 0.0],
-                        int(DraftGeomUtils.isReallyClosed(wire)),
+                        int(geo_wires.isReallyClosed(wire)),
                         color=color,
                         layer=layer,
                     )
@@ -3425,10 +3428,10 @@ def writeShape(sh, ob, dxfobject, nospline=False, lwPoly=False, layer=None, colo
         # print("lone edges ", loneedges)
         for edge in loneedges:
             # splines
-            if DraftGeomUtils.geomType(edge) in ["BSplineCurve", "BezierCurve"]:
+            if geo_general.geomType(edge) in ["BSplineCurve", "BezierCurve"]:
                 if (len(edge.Vertexes) == 1) and (edge.Curve.isClosed()) and (edge.Area > 0):
                     # special case: 1-vert closed spline, approximate as a circle
-                    c = DraftGeomUtils.getCircleFromSpline(edge)
+                    c = geo_circles.getCircleFromSpline(edge)
                     if c:
                         dxfobject.append(
                             dxfLibrary.Circle(
@@ -3446,7 +3449,7 @@ def writeShape(sh, ob, dxfobject, nospline=False, lwPoly=False, layer=None, colo
                     dxfobject.append(
                         dxfLibrary.PolyLine(points, [0.0, 0.0, 0.0], 0, color=color, layer=layer)
                     )
-            elif DraftGeomUtils.geomType(edge) == "Circle":  # curves
+            elif geo_general.geomType(edge) == "Circle":  # curves
                 center, radius, ang1, ang2 = getArcData(edge)
                 if center is not None:
                     if not isinstance(center, tuple):
@@ -3461,7 +3464,7 @@ def writeShape(sh, ob, dxfobject, nospline=False, lwPoly=False, layer=None, colo
                                 center, radius, ang1, ang2, color=getACI(ob), layer=layer
                             )
                         )
-            elif DraftGeomUtils.geomType(edge) == "Ellipse":  # ellipses:
+            elif geo_general.geomType(edge) == "Ellipse":  # ellipses:
                 if params.get_param("DiscretizeEllipses"):
                     points = []
                     spline = getSplineSegs(edge)
@@ -4055,7 +4058,7 @@ def export(objectslist, filename, nospline=False, lwPoly=False):
                     p1 = DraftVecUtils.tup(ob.Start)
                     p2 = DraftVecUtils.tup(ob.End)
                     base = Part.LineSegment(ob.Start, ob.End).toShape()
-                    proj = DraftGeomUtils.findDistance(ob.Dimline, base)
+                    proj = geo_geometry.findDistance(ob.Dimline, base)
                     if not proj:
                         pbase = DraftVecUtils.tup(ob.End)
                     else:


### PR DESCRIPTION
Another step to (hopefully) prevent some of the circular import warnings that we get with Draft and BIM code on GitHub.

Related: #25386.