### PR TITLE
core: selection: fixes #29024 select objects with clarify selection menu with assemblies

### DIFF
--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -1074,7 +1074,12 @@ void SelectionMenu::addWholeObjectSelection(
 
                 if (!subObjName.empty()) {
                     wholeObjKey = std::string(sel.objName) + "." + subObjName + ".";
-                    wholeObjSubName = subObjName + ".";
+                    // use the full sub-object path up to and including the
+                    // last dot, not just the final segment. this preserves
+                    // the correct chain ie. "Cone001.Cone." instead of
+                    // just "Cone.") for objects inside assembly links.
+                    // see github issue: https://github.com/freecad/freecad/issues/29024
+                    wholeObjSubName = subNameStr.substr(0, lastDot + 1);
                 }
             }
         }

--- a/src/Mod/Fem/femguiutils/selection_widgets.py
+++ b/src/Mod/Fem/femguiutils/selection_widgets.py
@@ -625,13 +625,15 @@ class FemSelectionObserver:
 
     def addSelection(self, docName, objName, sub, pos):
         selected_object = FreeCAD.getDocument(docName).getObject(objName)  # get the obj objName
-        if FreeCADGui.editDocument().getInEdit().Object.Document != selected_object.Document:
-            QtGui.QMessageBox.critical(
-                None, "Selection error", "External object selection is not supported"
-            )
-            FreeCADGui.Selection.clearSelection()
-            return
-
+        edit_doc = FreeCADGui.editDocument()
+        in_edit = edit_doc.getInEdit() if edit_doc else None
+        if in_edit is not None and hasattr(in_edit, "Object"):
+            if in_edit.Object.Document != selected_object.Document:
+                QtGui.QMessageBox.critical(
+                    None, "Selection error", "External object selection is not supported"
+                )
+                FreeCADGui.Selection.clearSelection()
+                return
         self.added_obj = (selected_object, sub)
         # on double click on a vertex of a solid sub is None and obj is the solid
         self.parseSelectionFunction(self.added_obj)


### PR DESCRIPTION
fixes #29024 ie. allow clarify menu to pick proper objects in assemblies when those objects reference other objects. left a descriptive comment in the diff for fix #1. the above mentioned issue is really two separate issues thus the changes to two separate files.

## Issues

- https://github.com/freecad/freecad/issues/29024

## Before and After Images

- [x] will post some pics after editing pr in neovim via gh.

- issue 1a.

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/f389b414-63ba-46c3-870b-f2503525d116" />

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/40a4d2ce-03d6-4d62-9236-d89911d20932" />

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/2f1def89-4626-42e8-ba66-e6ab193b3dad" />

---

1b.

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/fa935499-5ee6-42f4-908b-271305ea7598" />

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/c6ad5fbc-35cb-480d-b015-2717e960a37b" />

