### PR TITLE
Draft: honor overshoot settings in angular dimensions

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(Draft_tests
     drafttests/test_array.py
     drafttests/test_base.py
     drafttests/test_creation.py
+    drafttests/test_dimension_gui.py
     drafttests/test_draftgeomutils.py
     drafttests/test_dwg.py
     drafttests/test_dxf.py

--- a/src/Mod/Draft/TestDraftGui.py
+++ b/src/Mod/Draft/TestDraftGui.py
@@ -100,8 +100,10 @@ For the non-GUI tests see TestDraft.
 from drafttests.test_import_gui import DraftGuiImport as DraftTestGui01
 from drafttests.test_import_tools import DraftImportTools as DraftTestGui02
 from drafttests.test_pivy import DraftPivy as DraftTestGui03
+from drafttests.test_dimension_gui import DraftGuiDimension as DraftTestGui04
 
 # Use the modules so that code checkers don't complain (flake8)
 True if DraftTestGui01 else False
 True if DraftTestGui02 else False
 True if DraftTestGui03 else False
+True if DraftTestGui04 else False

--- a/src/Mod/Draft/draftfunctions/svg.py
+++ b/src/Mod/Draft/draftfunctions/svg.py
@@ -646,6 +646,10 @@ def get_svg(
             if vobj.Proxy:
                 if hasattr(vobj.Proxy, "circle"):
                     prx = vobj.Proxy
+                    p1 = get_proj(prx.p1, plane)
+                    p2 = get_proj(prx.p2, plane)
+                    p3 = get_proj(prx.p3, plane)
+                    p4 = get_proj(prx.p4, plane)
 
                     # drawing arc
                     fill = "none"
@@ -662,12 +666,38 @@ def get_svg(
                         obj, plane, fill, pathdata, stroke, linewidth, lstyle, edges=edges
                     )
 
+                    if hasattr(vobj, "DimOvershoot") and vobj.DimOvershoot.Value:
+                        shootsize = vobj.DimOvershoot.Value / pointratio
+                        tangent1 = get_proj(prx.circle.tangentAt(prx.circle.FirstParameter), plane)
+                        tangent2 = get_proj(prx.circle.tangentAt(prx.circle.LastParameter), plane)
+                        if not DraftVecUtils.isNull(tangent1):
+                            svg += get_overshoot(
+                                p2, shootsize, stroke, linewidth, -DraftVecUtils.angle(tangent1)
+                            )
+                        if not DraftVecUtils.isNull(tangent2):
+                            svg += get_overshoot(
+                                p3,
+                                shootsize,
+                                stroke,
+                                linewidth,
+                                -DraftVecUtils.angle(tangent2) + math.pi,
+                            )
+
+                    if hasattr(vobj, "ExtOvershoot") and vobj.ExtOvershoot.Value:
+                        shootsize = vobj.ExtOvershoot.Value / pointratio
+                        ext1 = p1 - p2
+                        ext2 = p4 - p3
+                        if not DraftVecUtils.isNull(ext1):
+                            svg += get_overshoot(
+                                p2, shootsize, stroke, linewidth, -DraftVecUtils.angle(ext1)
+                            )
+                        if not DraftVecUtils.isNull(ext2):
+                            svg += get_overshoot(
+                                p3, shootsize, stroke, linewidth, -DraftVecUtils.angle(ext2)
+                            )
+
                     # draw extlines
                     if hasattr(vobj, "ExtLines") and vobj.ExtLines:
-                        p1 = get_proj(prx.p1, plane)
-                        p2 = get_proj(prx.p2, plane)
-                        p3 = get_proj(prx.p3, plane)
-                        p4 = get_proj(prx.p4, plane)
                         d1 = (
                             "M " + str(p1.x) + " " + str(p1.y) + " L " + str(p2.x) + " " + str(p2.y)
                         )
@@ -700,8 +730,6 @@ def get_svg(
                         and hasattr(vobj, "ArrowSizeStart")
                         and hasattr(vobj, "ArrowSizeEnd")
                     ):
-                        p2 = get_proj(prx.p2, plane)
-                        p3 = get_proj(prx.p3, plane)
                         arrowsizestart = vobj.ArrowSizeStart.Value / pointratio
                         halfstartarrowlength = 2 * arrowsizestart
                         startarrowangle = 2 * math.asin(

--- a/src/Mod/Draft/drafttests/test_dimension_gui.py
+++ b/src/Mod/Draft/drafttests/test_dimension_gui.py
@@ -115,9 +115,7 @@ class DraftGuiDimension(test_base.DraftTestCaseDoc):
 
     def extractOvershootLines(self, svg_text):
         """Extract overshoot line transforms from Draft SVG output."""
-        root = ET.fromstring(
-            f'<svg xmlns:freecad="{self.FREECAD_NAMESPACE}">{svg_text}</svg>'
-        )
+        root = ET.fromstring(f'<svg xmlns:freecad="{self.FREECAD_NAMESPACE}">{svg_text}</svg>')
         lines = []
         for element in root.iter():
             if not element.tag.endswith("line"):
@@ -253,7 +251,9 @@ class DraftGuiDimension(test_base.DraftTestCaseDoc):
         """Create a TechDraw DraftView for the provided angular dimension."""
         page = doc.addObject("TechDraw::DrawPage")
         template = doc.addObject("TechDraw::DrawSVGTemplate")
-        template.Template = App.getResourceDir() + "Mod/TechDraw/Templates/ISO/A3_Landscape_blank.svg"
+        template.Template = (
+            App.getResourceDir() + "Mod/TechDraw/Templates/ISO/A3_Landscape_blank.svg"
+        )
         page.Template = template
         view = doc.addObject("TechDraw::DrawViewDraft")
         view.Source = source

--- a/src/Mod/Draft/drafttests/test_dimension_gui.py
+++ b/src/Mod/Draft/drafttests/test_dimension_gui.py
@@ -99,9 +99,13 @@ class DraftGuiDimension(test_base.DraftTestCaseDoc):
             self.assertEqual(state["dim_scale_end"], expected_state["dim_scale_end"])
             self.assertEqual(state["ext_scale_start"], expected_state["ext_scale_start"])
             self.assertEqual(state["ext_scale_end"], expected_state["ext_scale_end"])
-            self.assertEqual(state["dim_translation_start"], expected_state["dim_translation_start"])
+            self.assertEqual(
+                state["dim_translation_start"], expected_state["dim_translation_start"]
+            )
             self.assertEqual(state["dim_translation_end"], expected_state["dim_translation_end"])
-            self.assertEqual(state["ext_translation_start"], expected_state["ext_translation_start"])
+            self.assertEqual(
+                state["ext_translation_start"], expected_state["ext_translation_start"]
+            )
             self.assertEqual(state["ext_translation_end"], expected_state["ext_translation_end"])
             self.assertRotationAlmostEqual(
                 state["dim_rotation_start"], expected_state["dim_rotation_start"]

--- a/src/Mod/Draft/drafttests/test_dimension_gui.py
+++ b/src/Mod/Draft/drafttests/test_dimension_gui.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+# ***************************************************************************
+# *   Copyright (c) 2026 FreeCAD Project Association                        *
+# *                                                                         *
+# *   This file is part of the FreeCAD CAx development system.              *
+# *                                                                         *
+# *   This program is free software; you can redistribute it and/or modify  *
+# *   it under the terms of the GNU Lesser General Public License (LGPL)    *
+# *   as published by the Free Software Foundation; either version 2 of     *
+# *   the License, or (at your option) any later version.                   *
+# *   for detail see the LICENCE text file.                                 *
+# *                                                                         *
+# *   FreeCAD is distributed in the hope that it will be useful,            *
+# *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+# *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+# *   GNU Library General Public License for more details.                  *
+# *                                                                         *
+# *   You should have received a copy of the GNU Library General Public     *
+# *   License along with FreeCAD; if not, write to the Free Software        *
+# *   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  *
+# *   USA                                                                   *
+# *                                                                         *
+# ***************************************************************************
+
+"""Unit tests for the Draft Workbench, GUI dimension tests."""
+
+import os
+import tempfile
+
+import Draft
+import FreeCAD as App
+import FreeCADGui as Gui
+from FreeCAD import Vector
+
+from drafttests import test_base
+
+
+class DraftGuiDimension(test_base.DraftTestCaseDoc):
+    """GUI regressions for Draft dimensions."""
+
+    def setUp(self):
+        """Set up a temporary Draft document and keep a stable name for teardown."""
+        super().setUp()
+        self.doc_name = self.doc.Name
+
+    def tearDown(self):
+        """Close the temporary document even if save/reopen invalidated the Python wrapper."""
+        if self.doc_name in App.listDocuments():
+            App.closeDocument(self.doc_name)
+
+    def getAngularOvershootState(self, dimension):
+        """Return the angular overshoot scenegraph state used by the regression checks."""
+        vobj = dimension.ViewObject
+        proxy = vobj.Proxy
+        return {
+            "dim_children": proxy.marksDimOvershoot.getNumChildren(),
+            "ext_children": proxy.marksExtOvershoot.getNumChildren(),
+            "dim_scale_start": tuple(proxy.transDimOvershoot1.scaleFactor.getValue()),
+            "dim_scale_end": tuple(proxy.transDimOvershoot2.scaleFactor.getValue()),
+            "ext_scale_start": tuple(proxy.transExtOvershoot1.scaleFactor.getValue()),
+            "ext_scale_end": tuple(proxy.transExtOvershoot2.scaleFactor.getValue()),
+            "dim_translation_start": tuple(proxy.transDimOvershoot1.translation.getValue()),
+            "dim_translation_end": tuple(proxy.transDimOvershoot2.translation.getValue()),
+            "ext_translation_start": tuple(proxy.transExtOvershoot1.translation.getValue()),
+            "ext_translation_end": tuple(proxy.transExtOvershoot2.translation.getValue()),
+            "coord_start": tuple(proxy.coord1.point.getValues()[0].getValue()),
+            "coord_end": tuple(proxy.coord2.point.getValues()[0].getValue()),
+            "dim_rotation_start": tuple(proxy.transDimOvershoot1.rotation.getValue().getValue()),
+            "dim_rotation_end": tuple(proxy.transDimOvershoot2.rotation.getValue().getValue()),
+            "ext_rotation_start": tuple(proxy.transExtOvershoot1.rotation.getValue().getValue()),
+            "ext_rotation_end": tuple(proxy.transExtOvershoot2.rotation.getValue().getValue()),
+        }
+
+    def assertRotationAlmostEqual(self, actual, expected):
+        """Compare Coin quaternion values with a tolerance."""
+        for actual_component, expected_component in zip(actual, expected):
+            self.assertAlmostEqual(actual_component, expected_component, places=6)
+
+    def assertAngularOvershoots(self, dimension, expected_state=None):
+        """Assert that the angular dimension view provider drew both overshoot marks."""
+        Gui.updateGui()
+        state = self.getAngularOvershootState(dimension)
+        self.assertEqual(state["dim_children"], 3)
+        self.assertEqual(state["ext_children"], 3)
+        self.assertEqual(state["dim_scale_start"], (1.0, 1.0, 1.0))
+        self.assertEqual(state["dim_scale_end"], (1.0, 1.0, 1.0))
+        self.assertEqual(state["ext_scale_start"], (2.0, 2.0, 2.0))
+        self.assertEqual(state["ext_scale_end"], (2.0, 2.0, 2.0))
+        self.assertEqual(state["dim_translation_start"], state["coord_start"])
+        self.assertEqual(state["dim_translation_end"], state["coord_end"])
+        self.assertEqual(state["ext_translation_start"], state["coord_start"])
+        self.assertEqual(state["ext_translation_end"], state["coord_end"])
+
+        if expected_state is not None:
+            self.assertEqual(state["dim_children"], expected_state["dim_children"])
+            self.assertEqual(state["ext_children"], expected_state["ext_children"])
+            self.assertEqual(state["dim_scale_start"], expected_state["dim_scale_start"])
+            self.assertEqual(state["dim_scale_end"], expected_state["dim_scale_end"])
+            self.assertEqual(state["ext_scale_start"], expected_state["ext_scale_start"])
+            self.assertEqual(state["ext_scale_end"], expected_state["ext_scale_end"])
+            self.assertEqual(state["dim_translation_start"], expected_state["dim_translation_start"])
+            self.assertEqual(state["dim_translation_end"], expected_state["dim_translation_end"])
+            self.assertEqual(state["ext_translation_start"], expected_state["ext_translation_start"])
+            self.assertEqual(state["ext_translation_end"], expected_state["ext_translation_end"])
+            self.assertRotationAlmostEqual(
+                state["dim_rotation_start"], expected_state["dim_rotation_start"]
+            )
+            self.assertRotationAlmostEqual(
+                state["dim_rotation_end"], expected_state["dim_rotation_end"]
+            )
+            self.assertRotationAlmostEqual(
+                state["ext_rotation_start"], expected_state["ext_rotation_start"]
+            )
+            self.assertRotationAlmostEqual(
+                state["ext_rotation_end"], expected_state["ext_rotation_end"]
+            )
+
+    def test_angular_dimension_draws_overshoots_after_restore(self):
+        """Angular dimensions keep both overshoot marks after saving and reopening a document."""
+        original_name = self.doc.Name
+        dimension = Draft.make_angular_dimension(Vector(0, 0, 0), [20, 70], Vector(3, 1, 0))
+        vobj = dimension.ViewObject
+        vobj.DisplayMode = "World"
+        vobj.DimOvershoot = 1
+        vobj.ExtOvershoot = 2
+
+        self.doc.recompute()
+        self.assertAngularOvershoots(dimension)
+        expected_state = self.getAngularOvershootState(dimension)
+
+        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".FCStd")
+        temp_file.close()
+        reopened = None
+        try:
+            self.doc.saveAs(temp_file.name)
+            self.doc = App.getDocument(original_name)
+            reopened = App.openDocument(temp_file.name)
+            Gui.updateGui()
+
+            restored = reopened.getObject(dimension.Name)
+            self.assertIsNotNone(restored)
+            self.assertAngularOvershoots(restored, expected_state)
+
+            reopened.recompute()
+            self.assertAngularOvershoots(restored, expected_state)
+        finally:
+            if reopened is not None:
+                App.closeDocument(reopened.Name)
+            if original_name in App.listDocuments():
+                self.doc = App.getDocument(original_name)
+            os.unlink(temp_file.name)

--- a/src/Mod/Draft/drafttests/test_dimension_gui.py
+++ b/src/Mod/Draft/drafttests/test_dimension_gui.py
@@ -25,10 +25,14 @@
 
 """Unit tests for the Draft Workbench, GUI dimension tests."""
 
+import math
 import os
+import re
 import tempfile
+import xml.etree.ElementTree as ET
 
 import Draft
+import DraftVecUtils
 import FreeCAD as App
 import FreeCADGui as Gui
 from FreeCAD import Vector
@@ -38,6 +42,12 @@ from drafttests import test_base
 
 class DraftGuiDimension(test_base.DraftTestCaseDoc):
     """GUI regressions for Draft dimensions."""
+
+    FREECAD_NAMESPACE = "https://www.freecad.org/ns"
+    OVERSHOOT_TRANSFORM_RE = re.compile(
+        r"rotate\((?P<angle>[-+0-9.eE]+),(?P<rot_x>[-+0-9.eE]+),(?P<rot_y>[-+0-9.eE]+)\)\s+"
+        r"translate\((?P<tx>[-+0-9.eE]+),(?P<ty>[-+0-9.eE]+)\)"
+    )
 
     def setUp(self):
         """Set up a temporary Draft document and keep a stable name for teardown."""
@@ -76,6 +86,180 @@ class DraftGuiDimension(test_base.DraftTestCaseDoc):
         """Compare Coin quaternion values with a tolerance."""
         for actual_component, expected_component in zip(actual, expected):
             self.assertAlmostEqual(actual_component, expected_component, places=6)
+
+    def normalizeAngleDegrees(self, angle):
+        """Normalize an SVG rotation angle so wraparound is easy to compare."""
+        normalized = math.fmod(angle, 360.0)
+        if normalized < 0:
+            normalized += 360.0
+        return normalized
+
+    def angleDeltaDegrees(self, actual, expected):
+        """Return the shortest distance between two rotation angles."""
+        delta = abs(self.normalizeAngleDegrees(actual) - self.normalizeAngleDegrees(expected))
+        return min(delta, 360.0 - delta)
+
+    def makeAngularDimension(self):
+        """Create a stable angular dimension setup shared by the GUI regressions."""
+        dimension = Draft.make_angular_dimension(Vector(0, 0, 0), [20, 70], Vector(3, 1, 0))
+        vobj = dimension.ViewObject
+        vobj.DisplayMode = "World"
+        vobj.ArrowTypeStart = "Dot"
+        vobj.ArrowTypeEnd = "Dot"
+        return dimension
+
+    def getAngularSvg(self, dimension):
+        """Return the Draft SVG body used by TechDraw DraftView for this dimension."""
+        Gui.updateGui()
+        return Draft.get_svg(dimension, direction=Vector(0, 0, 1), techdraw=True)
+
+    def extractOvershootLines(self, svg_text):
+        """Extract overshoot line transforms from Draft SVG output."""
+        root = ET.fromstring(
+            f'<svg xmlns:freecad="{self.FREECAD_NAMESPACE}">{svg_text}</svg>'
+        )
+        lines = []
+        for element in root.iter():
+            if not element.tag.endswith("line"):
+                continue
+            skip_value = next(
+                (
+                    value
+                    for key, value in element.attrib.items()
+                    if key == "freecad:skip" or key == "skip" or key.endswith("}skip")
+                ),
+                None,
+            )
+            if skip_value != "1":
+                continue
+
+            x1 = float(element.attrib.get("x1", "nan"))
+            y1 = float(element.attrib.get("y1", "nan"))
+            x2 = float(element.attrib.get("x2", "nan"))
+            y2 = float(element.attrib.get("y2", "nan"))
+            if abs(x1) > 1e-9 or abs(y1) > 1e-9 or abs(y2) > 1e-9 or x2 >= 0:
+                continue
+
+            transform = element.attrib.get("transform", "")
+            match = self.OVERSHOOT_TRANSFORM_RE.fullmatch(transform)
+            self.assertIsNotNone(match, msg=f"unexpected overshoot transform: {transform}")
+
+            tx = float(match.group("tx"))
+            ty = float(match.group("ty"))
+            rot_x = float(match.group("rot_x"))
+            rot_y = float(match.group("rot_y"))
+            self.assertAlmostEqual(tx, rot_x, places=6)
+            self.assertAlmostEqual(ty, rot_y, places=6)
+
+            lines.append(
+                {
+                    "anchor": (tx, ty),
+                    "angle": self.normalizeAngleDegrees(float(match.group("angle"))),
+                    "length": abs(x2),
+                }
+            )
+        return lines
+
+    def getExpectedAngularSvgOvershoots(self, dimension):
+        """Compute the expected TechDraw overshoot lines from the angular geometry."""
+        vobj = dimension.ViewObject
+        proxy = vobj.Proxy
+        pointratio = 0.75
+        expected = []
+
+        if vobj.DimOvershoot.Value:
+            shootsize = vobj.DimOvershoot.Value / pointratio
+            tangent1 = proxy.circle.tangentAt(proxy.circle.FirstParameter)
+            tangent2 = proxy.circle.tangentAt(proxy.circle.LastParameter)
+            if not DraftVecUtils.isNull(tangent1):
+                expected.append(
+                    {
+                        "anchor": (float(proxy.p2.x), float(proxy.p2.y)),
+                        "angle": self.normalizeAngleDegrees(
+                            math.degrees(-DraftVecUtils.angle(tangent1))
+                        ),
+                        "length": shootsize,
+                    }
+                )
+            if not DraftVecUtils.isNull(tangent2):
+                expected.append(
+                    {
+                        "anchor": (float(proxy.p3.x), float(proxy.p3.y)),
+                        "angle": self.normalizeAngleDegrees(
+                            math.degrees(-DraftVecUtils.angle(tangent2) + math.pi)
+                        ),
+                        "length": shootsize,
+                    }
+                )
+
+        if vobj.ExtOvershoot.Value:
+            shootsize = vobj.ExtOvershoot.Value / pointratio
+            ext1 = proxy.p1 - proxy.p2
+            ext2 = proxy.p4 - proxy.p3
+            if not DraftVecUtils.isNull(ext1):
+                expected.append(
+                    {
+                        "anchor": (float(proxy.p2.x), float(proxy.p2.y)),
+                        "angle": self.normalizeAngleDegrees(
+                            math.degrees(-DraftVecUtils.angle(ext1))
+                        ),
+                        "length": shootsize,
+                    }
+                )
+            if not DraftVecUtils.isNull(ext2):
+                expected.append(
+                    {
+                        "anchor": (float(proxy.p3.x), float(proxy.p3.y)),
+                        "angle": self.normalizeAngleDegrees(
+                            math.degrees(-DraftVecUtils.angle(ext2))
+                        ),
+                        "length": shootsize,
+                    }
+                )
+
+        return expected
+
+    def assertOvershootLinesMatch(self, actual_lines, expected_lines):
+        """Match SVG overshoot lines by anchor, angle, and length."""
+        self.assertEqual(len(actual_lines), len(expected_lines))
+        remaining = list(actual_lines)
+        for expected in expected_lines:
+            match_index = None
+            for index, actual in enumerate(remaining):
+                same_anchor = (
+                    abs(actual["anchor"][0] - expected["anchor"][0]) < 1e-6
+                    and abs(actual["anchor"][1] - expected["anchor"][1]) < 1e-6
+                )
+                same_angle = self.angleDeltaDegrees(actual["angle"], expected["angle"]) < 1e-6
+                same_length = abs(actual["length"] - expected["length"]) < 1e-6
+                if same_anchor and same_angle and same_length:
+                    match_index = index
+                    break
+
+            self.assertIsNotNone(match_index, msg=f"missing overshoot line {expected}")
+            remaining.pop(match_index)
+
+        self.assertEqual(remaining, [])
+
+    def assertAngularSvgOvershoots(self, dimension, expected_lines=None, svg_text=None):
+        """Assert the Draft SVG path exposes the angular overshoot lines."""
+        if svg_text is None:
+            svg_text = self.getAngularSvg(dimension)
+        if expected_lines is None:
+            expected_lines = self.getExpectedAngularSvgOvershoots(dimension)
+        self.assertOvershootLinesMatch(self.extractOvershootLines(svg_text), expected_lines)
+
+    def createTechDrawDraftView(self, doc, source):
+        """Create a TechDraw DraftView for the provided angular dimension."""
+        page = doc.addObject("TechDraw::DrawPage")
+        template = doc.addObject("TechDraw::DrawSVGTemplate")
+        template.Template = App.getResourceDir() + "Mod/TechDraw/Templates/ISO/A3_Landscape_blank.svg"
+        page.Template = template
+        view = doc.addObject("TechDraw::DrawViewDraft")
+        view.Source = source
+        view.Direction = Vector(0, 0, 1)
+        page.addView(view)
+        return view
 
     def assertAngularOvershoots(self, dimension, expected_state=None):
         """Assert that the angular dimension view provider drew both overshoot marks."""
@@ -123,9 +307,8 @@ class DraftGuiDimension(test_base.DraftTestCaseDoc):
     def test_angular_dimension_draws_overshoots_after_restore(self):
         """Angular dimensions keep both overshoot marks after saving and reopening a document."""
         original_name = self.doc.Name
-        dimension = Draft.make_angular_dimension(Vector(0, 0, 0), [20, 70], Vector(3, 1, 0))
+        dimension = self.makeAngularDimension()
         vobj = dimension.ViewObject
-        vobj.DisplayMode = "World"
         vobj.DimOvershoot = 1
         vobj.ExtOvershoot = 2
 
@@ -148,6 +331,50 @@ class DraftGuiDimension(test_base.DraftTestCaseDoc):
 
             reopened.recompute()
             self.assertAngularOvershoots(restored, expected_state)
+        finally:
+            if reopened is not None:
+                App.closeDocument(reopened.Name)
+            if original_name in App.listDocuments():
+                self.doc = App.getDocument(original_name)
+            os.unlink(temp_file.name)
+
+    def test_angular_dimension_svg_overshoots_after_restore_and_in_techdraw(self):
+        """Angular dimension overshoots survive restore in SVG and propagate into TechDraw DraftView."""
+        original_name = self.doc.Name
+        dimension = self.makeAngularDimension()
+        vobj = dimension.ViewObject
+
+        vobj.DimOvershoot = 0
+        vobj.ExtOvershoot = 0
+        self.doc.recompute()
+        self.assertEqual(self.extractOvershootLines(self.getAngularSvg(dimension)), [])
+
+        vobj.DimOvershoot = 1
+        vobj.ExtOvershoot = 2
+        self.doc.recompute()
+        expected_lines = self.getExpectedAngularSvgOvershoots(dimension)
+        self.assertAngularSvgOvershoots(dimension, expected_lines)
+
+        temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".FCStd")
+        temp_file.close()
+        reopened = None
+        try:
+            self.doc.saveAs(temp_file.name)
+            self.doc = App.getDocument(original_name)
+            reopened = App.openDocument(temp_file.name)
+            Gui.updateGui()
+
+            restored = reopened.getObject(dimension.Name)
+            self.assertIsNotNone(restored)
+            self.assertAngularSvgOvershoots(restored, expected_lines)
+
+            reopened.recompute()
+            self.assertAngularSvgOvershoots(restored, expected_lines)
+
+            view = self.createTechDrawDraftView(reopened, restored)
+            reopened.recompute()
+            Gui.updateGui()
+            self.assertAngularSvgOvershoots(restored, expected_lines, view.Symbol)
         finally:
             if reopened is not None:
                 App.closeDocument(reopened.Name)

--- a/src/Mod/Draft/draftviewproviders/view_dimension.py
+++ b/src/Mod/Draft/draftviewproviders/view_dimension.py
@@ -848,6 +848,10 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
         self.trans1 = coin.SoTransform()
         self.coord2 = coin.SoCoordinate3()
         self.trans2 = coin.SoTransform()
+        self.transDimOvershoot1 = coin.SoTransform()
+        self.transDimOvershoot2 = coin.SoTransform()
+        self.transExtOvershoot1 = coin.SoTransform()
+        self.transExtOvershoot2 = coin.SoTransform()
 
         self.linecolor = coin.SoBaseColor()
         self.drawstyle = coin.SoDrawStyle()
@@ -856,6 +860,8 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
 
         self.arc = coin.SoType.fromName("SoBrepEdgeSet").createInstance()
         self.marks = coin.SoSeparator()
+        self.marksDimOvershoot = coin.SoSeparator()
+        self.marksExtOvershoot = coin.SoSeparator()
 
         self.node_wld = coin.SoGroup()
         self.node_wld.addChild(self.linecolor)
@@ -863,6 +869,8 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
         self.node_wld.addChild(self.coords)
         self.node_wld.addChild(self.arc)
         self.node_wld.addChild(self.marks)
+        self.node_wld.addChild(self.marksDimOvershoot)
+        self.node_wld.addChild(self.marksExtOvershoot)
         self.node_wld.addChild(label_wld)
 
         self.node_scr = coin.SoGroup()
@@ -871,6 +879,8 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
         self.node_scr.addChild(self.coords)
         self.node_scr.addChild(self.arc)
         self.node_scr.addChild(self.marks)
+        self.node_scr.addChild(self.marksDimOvershoot)
+        self.node_scr.addChild(self.marksExtOvershoot)
         self.node_scr.addChild(label_scr)
 
         vobj.addDisplayMode(self.node_wld, "World")
@@ -882,6 +892,9 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
         self.onChanged(vobj, "ArrowTypeStart")
         self.onChanged(vobj, "ArrowTypeEnd")
         self.onChanged(vobj, "LineColor")
+        self.onChanged(vobj, "DimOvershoot")
+        self.onChanged(vobj, "ExtOvershoot")
+        self.onChanged(vobj, "LineWidth")
 
     def updateData(self, obj, prop):
         """Execute when a property from the Proxy class is changed."""
@@ -1036,6 +1049,10 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
         self.coord1.point.setValue(p2)
         self.trans2.translation.setValue(p3)
         self.coord2.point.setValue(p3)
+        self.transDimOvershoot1.translation.setValue(p2)
+        self.transDimOvershoot2.translation.setValue(p3)
+        self.transExtOvershoot1.translation.setValue(p2)
+        self.transExtOvershoot2.translation.setValue(p3)
 
         # Calculate small chords to make arrows look better
         if (
@@ -1074,6 +1091,38 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
 
             self.trans1.rotation.setValue((q1[0], q1[1], q1[2], q1[3]))
             self.trans2.rotation.setValue((q2[0], q2[1], q2[2], q2[3]))
+
+        tangent1 = self.circle.tangentAt(self.circle.FirstParameter)
+        tangent2 = self.circle.tangentAt(self.circle.LastParameter)
+        if not DraftVecUtils.isNull(tangent1):
+            tangent1.normalize()
+            plane_rot = DraftVecUtils.getPlaneRotation(tangent1, norm.cross(tangent1), norm)
+            if plane_rot is not None:
+                q = App.Placement(plane_rot).Rotation.Q
+                self.transDimOvershoot1.rotation.setValue((q[0], q[1], q[2], q[3]))
+
+        if not DraftVecUtils.isNull(tangent2):
+            tangent2.normalize()
+            plane_rot = DraftVecUtils.getPlaneRotation(tangent2, norm.cross(tangent2), norm)
+            if plane_rot is not None:
+                q = App.Placement(plane_rot).Rotation.Q
+                self.transDimOvershoot2.rotation.setValue((q[0], q[1], q[2], q[3]))
+
+        ext1 = self.p1 - self.p2
+        ext2 = self.p4 - self.p3
+        if not DraftVecUtils.isNull(ext1):
+            ext1.normalize()
+            plane_rot = DraftVecUtils.getPlaneRotation(ext1, norm.cross(ext1), norm)
+            if plane_rot is not None:
+                q = App.Placement(plane_rot).Rotation.Q
+                self.transExtOvershoot1.rotation.setValue((q[0], q[1], q[2], q[3]))
+
+        if not DraftVecUtils.isNull(ext2):
+            ext2.normalize()
+            plane_rot = DraftVecUtils.getPlaneRotation(ext2, norm.cross(ext2), norm)
+            if plane_rot is not None:
+                q = App.Placement(plane_rot).Rotation.Q
+                self.transExtOvershoot2.rotation.setValue((q[0], q[1], q[2], q[3]))
 
         # Set text position and rotation
         self.tbase = midp
@@ -1131,6 +1180,12 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
             ):
                 self.remove_dim_arrows()
                 self.draw_dim_arrows(vobj)
+            if "DimOvershoot" in properties:
+                self.remove_dim_overshoot()
+                self.draw_dim_overshoot(vobj)
+            if "ExtOvershoot" in properties:
+                self.remove_ext_overshoot()
+                self.draw_ext_overshoot(vobj)
 
             self.updateData(obj, None)
 
@@ -1151,6 +1206,22 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
 
         elif prop == "LineWidth" and hasattr(self, "drawstyle"):
             self.drawstyle.lineWidth = vobj.LineWidth
+
+        elif (
+            prop == "DimOvershoot"
+            and "DimOvershoot" in properties
+            and "ScaleMultiplier" in properties
+        ):
+            self.remove_dim_overshoot()
+            self.draw_dim_overshoot(vobj)
+
+        elif (
+            prop == "ExtOvershoot"
+            and "ExtOvershoot" in properties
+            and "ScaleMultiplier" in properties
+        ):
+            self.remove_ext_overshoot()
+            self.draw_ext_overshoot(vobj)
 
         elif (
             prop in ("ArrowSizeStart", "ArrowTypeStart", "ArrowSizeEnd", "ArrowTypeEnd")
@@ -1213,6 +1284,62 @@ class ViewProviderAngularDimension(ViewProviderDimensionBase):
 
         self.node_wld.insertChild(self.marks, 2)
         self.node_scr.insertChild(self.marks, 2)
+
+    def remove_dim_overshoot(self):
+        """Remove the dimension overshoot lines."""
+        self.node_wld.removeChild(self.marksDimOvershoot)
+        self.node_scr.removeChild(self.marksDimOvershoot)
+
+    def draw_dim_overshoot(self, vobj):
+        """Draw dimension overshoot lines."""
+        s = vobj.DimOvershoot.Value * vobj.ScaleMultiplier
+        self.transDimOvershoot1.scaleFactor.setValue((s, s, s))
+        self.transDimOvershoot2.scaleFactor.setValue((s, s, s))
+
+        self.marksDimOvershoot = coin.SoSeparator()
+        if vobj.DimOvershoot.Value:
+            self.marksDimOvershoot.addChild(self.linecolor)
+
+            s1 = coin.SoSeparator()
+            s1.addChild(self.transDimOvershoot1)
+            s1.addChild(gui_utils.dimDash((-1, 0, 0), (0, 0, 0)))
+            self.marksDimOvershoot.addChild(s1)
+
+            s2 = coin.SoSeparator()
+            s2.addChild(self.transDimOvershoot2)
+            s2.addChild(gui_utils.dimDash((0, 0, 0), (1, 0, 0)))
+            self.marksDimOvershoot.addChild(s2)
+
+        self.node_wld.insertChild(self.marksDimOvershoot, 5)
+        self.node_scr.insertChild(self.marksDimOvershoot, 5)
+
+    def remove_ext_overshoot(self):
+        """Remove dimension extension overshoot lines."""
+        self.node_wld.removeChild(self.marksExtOvershoot)
+        self.node_scr.removeChild(self.marksExtOvershoot)
+
+    def draw_ext_overshoot(self, vobj):
+        """Draw dimension extension overshoot lines."""
+        s = vobj.ExtOvershoot.Value * vobj.ScaleMultiplier
+        self.transExtOvershoot1.scaleFactor.setValue((s, s, s))
+        self.transExtOvershoot2.scaleFactor.setValue((s, s, s))
+
+        self.marksExtOvershoot = coin.SoSeparator()
+        if vobj.ExtOvershoot.Value:
+            self.marksExtOvershoot.addChild(self.linecolor)
+
+            s1 = coin.SoSeparator()
+            s1.addChild(self.transExtOvershoot1)
+            s1.addChild(gui_utils.dimDash((0, 0, 0), (-1, 0, 0)))
+            self.marksExtOvershoot.addChild(s1)
+
+            s2 = coin.SoSeparator()
+            s2.addChild(self.transExtOvershoot2)
+            s2.addChild(gui_utils.dimDash((0, 0, 0), (-1, 0, 0)))
+            self.marksExtOvershoot.addChild(s2)
+
+        self.node_wld.insertChild(self.marksExtOvershoot, 6)
+        self.node_scr.insertChild(self.marksExtOvershoot, 6)
 
     def getIcon(self):
         """Return the path to the icon used by the viewprovider."""


### PR DESCRIPTION
Angular Draft dimensions exposed `DimOvershoot` and `ExtOvershoot`, but `ViewProviderAngularDimension` did not create or update the overshoot scenegraph used to render those settings. The properties were present in the UI and stored in documents, but they had no visible effect on angular dimensions.

This change adds the missing angular overshoot scenegraph setup and update path, and adds a Draft GUI regression that saves and reopens an angular dimension document before checking the restored overshoot state.

Validation:
- reproduced the reporter file before and after the patch with a FreeCAD 1.1.0 AppImage
- ran the relevant Draft GUI regression coverage for the restore path

## Issues
Closes #27297

## Before and After Images

<img width="1500" height="1000" alt="image" src="https://github.com/user-attachments/assets/f8ae6b4b-955b-4d1f-8a23-50cb39926256" />

<img width="1500" height="1000" alt="image" src="https://github.com/user-attachments/assets/aa864626-0ab3-47be-9151-c8b211152061" />


