### PR TITLE
Gui: FileDialog: fix Windows issues introduced in #23209

### DIFF
--- a/src/App/ExportInfo.h
+++ b/src/App/ExportInfo.h
@@ -16,7 +16,7 @@ namespace App
 struct ExportInfo {
     std::string location {};
     std::string filename {};
-    std::string filter {};
+    std::string filterName {};
     bool generatedName {false};
     App::DocumentObject* object {nullptr};
 };

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1245,9 +1245,16 @@ SET(Widget_CPP_SRCS
     FontScaledSVG.cpp
     SplitButton.cpp
 )
+if(WIN32)
+    SET(Widget_CPP_SRCS
+        ${Widget_CPP_SRCS}
+        FileDialogWin32.cpp
+    )
+endif(WIN32)
 SET(Widget_HPP_SRCS
     ComboLinks.h
     FileDialog.h
+    FileDialogInternal.h
     MainWindow.h
     MainWindowPy.h
     NotificationBox.h

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -99,17 +99,16 @@ void StdCmdOpen::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // fill the list of registered endings
-    QStringList formatList;
+    FileDialog::FilterList formatList;
 
-    QString allSupportedFormats = QObject::tr("Supported formats") + QStringLiteral(" (");
+    FileDialog::Filter allSupportedFormats {QObject::tr("Supported formats"), {}};
     // Cram all formats FreeCAD can import under one label
     const auto filetypes = App::GetApplication().getImportTypes();
     for (const auto& type : filetypes) {
-        allSupportedFormats += QStringLiteral(" *.");
-        allSupportedFormats += QString::fromStdString(type);
+        allSupportedFormats.patterns.append(QStringLiteral("*.") + QString::fromStdString(type));
     }
-    allSupportedFormats += QLatin1String(" *.FCBak)");
-    formatList += allSupportedFormats;
+    allSupportedFormats.patterns.append("*.FCBak");
+    formatList.append(allSupportedFormats);
 
     const auto importFilters = App::GetApplication().getImportFilters();
     // Make sure FCStd is the second entry in the format list
@@ -121,25 +120,25 @@ void StdCmdOpen::activated(int iMsg)
             if (!fcstdFilter.contains(QStringLiteral("*.FCBak"), Qt::CaseInsensitive)) {
                 fcstdFilter.replace(")", QStringLiteral(" *.FCBak)"));
             }
-            formatList += fcstdFilter;
+            formatList.append(FileDialog::Filter::fromFilterString(fcstdFilter));
             break;
         }
     }
     for (auto it = importFilters.cbegin(); it != importFilters.cend(); ++it) {
         if (it != fcstdIt) {
-            formatList += QString::fromStdString(it->first);
+            formatList.append(FileDialog::Filter::fromFilterString(QString::fromStdString(it->first)));
         }
     }
 
-    formatList += QObject::tr("All files") + QStringLiteral(" (*.*)");
+    formatList.append({QObject::tr("All files"), {"*.*"}});
 
-    QString selectedFilter;
+    qsizetype selectedFilterIndex = -1;
     QStringList fileList = FileDialog::getOpenFileNames(
         getMainWindow(),
         QObject::tr("Open Document"),
         QString(),
         formatList,
-        &selectedFilter
+        &selectedFilterIndex
     );
     if (fileList.isEmpty()) {
         return;
@@ -175,7 +174,8 @@ void StdCmdOpen::activated(int iMsg)
     }
 
     // load the files with the associated modules
-    SelectModule::Dict dict = SelectModule::importHandler(fileList, selectedFilter);
+    SelectModule::Dict dict
+        = SelectModule::importHandler(fileList, formatList[selectedFilterIndex].toFilterString());
     if (dict.isEmpty()) {
         QMessageBox::critical(
             getMainWindow(),
@@ -225,44 +225,52 @@ void StdCmdImport::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // fill the list of registered endings
-    QStringList formatList;
+    FileDialog::FilterList formatList;
 
-    QString allSupportedFormats = QObject::tr("Supported formats") + QStringLiteral(" (");
+    FileDialog::Filter allSupportedFormats {QObject::tr("Supported formats"), {}};
     const auto filetypes = App::GetApplication().getImportTypes();
     for (const auto& type : filetypes) {
         if (type != "FCStd") {
-            allSupportedFormats += QStringLiteral(" *.");
-            allSupportedFormats += QString::fromStdString(type);
+            allSupportedFormats.patterns.append(QStringLiteral("*.") + QString::fromStdString(type));
         }
     }
-    allSupportedFormats += QLatin1Char(')');
-    formatList += allSupportedFormats;
+    formatList.append(allSupportedFormats);
 
     const auto importFilters = App::GetApplication().getImportFilters();
     for (auto it = importFilters.cbegin(); it != importFilters.cend(); ++it) {
         if (it->first.find("*.FCStd") == std::string::npos) {
-            formatList += QString::fromStdString(it->first);
+            formatList.append(FileDialog::Filter::fromFilterString(QString::fromStdString(it->first)));
         }
     }
 
-    formatList += QObject::tr("All files") + QStringLiteral(" (*.*)");
+    formatList.append({QObject::tr("All files"), {"*.*"}});
 
     Base::Reference<ParameterGrp> hPath = App::GetApplication()
                                               .GetUserParameter()
                                               .GetGroup("BaseApp")
                                               ->GetGroup("Preferences")
                                               ->GetGroup("General");
-    QString selectedFilter = QString::fromStdString(hPath->GetASCII("FileImportFilter"));
+    const auto lastImportFilterName = QString::fromStdString(hPath->GetASCII("FileImportFilter"));
+    qsizetype selectedFilterIndex = -1;
+    for (qsizetype i = 0; i < formatList.size(); ++i) {
+        if (formatList[i].name == lastImportFilterName) {
+            selectedFilterIndex = i;
+            break;
+        }
+    }
+
     QStringList fileList = FileDialog::getOpenFileNames(
         getMainWindow(),
         QObject::tr("Import File"),
         QString(),
         formatList,
-        &selectedFilter
+        &selectedFilterIndex
     );
     if (!fileList.isEmpty()) {
-        hPath->SetASCII("FileImportFilter", selectedFilter.toLatin1().constData());
-        SelectModule::Dict dict = SelectModule::importHandler(fileList, selectedFilter);
+        const auto& selectedFilter = formatList[selectedFilterIndex];
+        hPath->SetASCII("FileImportFilter", selectedFilter.name.toLatin1().constData());
+        SelectModule::Dict dict
+            = SelectModule::importHandler(fileList, selectedFilter.toFilterString());
 
         bool emptyDoc = (getActiveGuiDocument()->getDocument()->countObjects() == 0);
         // load the files with the associated modules
@@ -468,12 +476,14 @@ void StdCmdExport::activated(int iMsg)
     bool filenameWasGenerated = false;
 
     // fill the list of registered suffixes
-    QStringList filterList;
+    FileDialog::FilterList filterList;
     std::map<std::string, std::string> filterMap = App::GetApplication().getExportFilters();
     for (const auto& filter : filterMap) {
         // ignore the project file format
-        if (filter.first.find("(*.FCStd)") == std::string::npos) {
-            filterList << QString::fromStdString(filter.first);
+        if (filter.first.find("*.FCStd") == std::string::npos) {
+            filterList.append(
+                FileDialog::Filter::fromFilterString(QString::fromStdString(filter.first))
+            );
         }
     }
     Base::Reference<ParameterGrp> hPath = App::GetApplication()
@@ -481,13 +491,15 @@ void StdCmdExport::activated(int iMsg)
                                               .GetGroup("BaseApp")
                                               ->GetGroup("Preferences")
                                               ->GetGroup("General");
-    QString selectedFilter;
-
-    if (!exportInfo.filter.empty()) {
-        selectedFilter = QString::fromStdString(exportInfo.filter);
-    }
-    else {
-        selectedFilter = QString::fromStdString(hPath->GetASCII("FileExportFilter"));
+    const auto lastExportFilterName = QString::fromStdString(
+        !exportInfo.filterName.empty() ? exportInfo.filterName : hPath->GetASCII("FileExportFilter")
+    );
+    qsizetype selectedFilterIndex = -1;
+    for (qsizetype i = 0; i < filterList.size(); ++i) {
+        if (filterList[i].name == lastExportFilterName) {
+            selectedFilterIndex = i;
+            break;
+        }
     }
 
     // Create a default filename for the export
@@ -539,12 +551,14 @@ void StdCmdExport::activated(int iMsg)
         QObject::tr("Export File"),
         defaultFilename,
         filterList,
-        &selectedFilter
+        &selectedFilterIndex
     );
     if (!filename.isEmpty()) {
-        hPath->SetASCII("FileExportFilter", selectedFilter.toLatin1().constData());
+        const auto& selectedFilter = filterList[selectedFilterIndex];
+        hPath->SetASCII("FileExportFilter", selectedFilter.name.toLatin1().constData());
 
-        SelectModule::Dict dict = SelectModule::exportHandler(filename, selectedFilter);
+        SelectModule::Dict dict
+            = SelectModule::exportHandler(filename, selectedFilter.toFilterString());
         // export the files with the associated modules
         for (SelectModule::Dict::iterator it = dict.begin(); it != dict.end(); ++it) {
             getGuiApplication()->exportTo(it.key().toUtf8(), doc->getName(), it.value().toLatin1());
@@ -563,7 +577,7 @@ void StdCmdExport::activated(int iMsg)
 
         exportInfo.filename = filename.toStdString();
         exportInfo.object = toExport;
-        exportInfo.filter = selectedFilter.toStdString();
+        exportInfo.filterName = selectedFilter.name.toStdString();
         exportInfo.generatedName = filenameWasGenerated;
 
         doc->setExportInfo(exportInfo);
@@ -604,7 +618,7 @@ void StdCmdMergeProjects::activated(int iMsg)
         Gui::getMainWindow(),
         QString::fromUtf8(QT_TR_NOOP("Merge Document")),
         FileDialog::getWorkingDirectory(),
-        QStringList(QString::fromUtf8(QT_TR_NOOP("%1 document (*.FCStd)")).arg(exe))
+        FileDialog::FilterList {{QString::fromUtf8(QT_TR_NOOP("%1 document")).arg(exe), {"*.FCStd"}}}
     );
     if (!project.isEmpty()) {
         FileDialog::setWorkingDirectory(project);
@@ -691,12 +705,11 @@ void StdCmdExportDependencyGraph::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     App::Document* doc = App::GetApplication().getActiveDocument();
-    QString format = QStringLiteral("%1 (*.gv)").arg(Gui::GraphvizView::tr("Graphviz format"));
     QString fn = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),
         Gui::GraphvizView::tr("Export Graph"),
         QString(),
-        QStringList(format)
+        FileDialog::FilterList {{Gui::GraphvizView::tr("Graphviz format"), {"*.gv"}}}
     );
     if (!fn.isEmpty()) {
         QFile file(fn);

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -130,7 +130,7 @@ void StdCmdOpen::activated(int iMsg)
         }
     }
 
-    formatList.append({QObject::tr("All files"), {"*.*"}});
+    formatList.append(FileDialog::Filter::AllFiles());
 
     qsizetype selectedFilterIndex = -1;
     QStringList fileList = FileDialog::getOpenFileNames(
@@ -243,7 +243,7 @@ void StdCmdImport::activated(int iMsg)
         }
     }
 
-    formatList.append({QObject::tr("All files"), {"*.*"}});
+    formatList.append(FileDialog::Filter::AllFiles());
 
     Base::Reference<ParameterGrp> hPath = App::GetApplication()
                                               .GetUserParameter()
@@ -616,9 +616,9 @@ void StdCmdMergeProjects::activated(int iMsg)
     QString exe = qApp->applicationName();
     QString project = FileDialog::getOpenFileName(
         Gui::getMainWindow(),
-        QString::fromUtf8(QT_TR_NOOP("Merge Document")),
+        QObject::tr("Merge Document"),
         FileDialog::getWorkingDirectory(),
-        FileDialog::FilterList {{QString::fromUtf8(QT_TR_NOOP("%1 document")).arg(exe), {"*.FCStd"}}}
+        FileDialog::FilterList {{QObject::tr("%1 document").arg(exe), {"*.FCStd"}}}
     );
     if (!project.isEmpty()) {
         FileDialog::setWorkingDirectory(project);
@@ -628,8 +628,8 @@ void StdCmdMergeProjects::activated(int iMsg)
         if (proj == info) {
             QMessageBox::critical(
                 Gui::getMainWindow(),
-                QString::fromUtf8(QT_TR_NOOP("Merge Document")),
-                QString::fromUtf8(QT_TR_NOOP("Cannot merge document with itself."))
+                QObject::tr("Merge Document"),
+                QObject::tr("Cannot merge document with itself.")
             );
             return;
         }
@@ -709,7 +709,7 @@ void StdCmdExportDependencyGraph::activated(int iMsg)
         Gui::getMainWindow(),
         Gui::GraphvizView::tr("Export Graph"),
         QString(),
-        FileDialog::FilterList {{Gui::GraphvizView::tr("Graphviz format"), {"*.gv"}}}
+        FileDialog::FilterList {{QStringLiteral("Graphviz"), {"*.gv"}}}
     );
     if (!fn.isEmpty()) {
         QFile file(fn);

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2152,8 +2152,7 @@ void StdViewScreenShot::activated(int iMsg)
         QStringList filter;
         QString selFilter;
         for (QStringList::Iterator it = formats.begin(); it != formats.end(); ++it) {
-            filter << QStringLiteral("%1 %2 (*.%3)")
-                          .arg((*it).toUpper(), QObject::tr("files"), (*it).toLower());
+            filter << QStringLiteral("%1 files (*.%2)").arg(it->toUpper(), it->toLower());
             if (ext == *it) {
                 selFilter = filter.last();
             }

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -454,7 +454,7 @@ void StdCmdFreezeViews::onSaveViews()
         getMainWindow(),
         QObject::tr("Save Frozen Views"),
         QString(),
-        QStringList(QStringLiteral("%1 (*.cam)").arg(QObject::tr("Frozen views")))
+        FileDialog::FilterList {{QObject::tr("Frozen views"), {"*.cam"}}}
     );
     if (fn.isEmpty()) {
         return;
@@ -516,7 +516,7 @@ void StdCmdFreezeViews::onRestoreViews()
         getMainWindow(),
         QObject::tr("Restore Frozen Views"),
         QString(),
-        QStringList(QStringLiteral("%1 (*.cam)").arg(QObject::tr("Frozen views")))
+        FileDialog::FilterList {{QObject::tr("Frozen views"), {"*.cam"}}}
     );
     if (fn.isEmpty()) {
         return;

--- a/src/Gui/Dialogs/DlgParameterImp.cpp
+++ b/src/Gui/Dialogs/DlgParameterImp.cpp
@@ -609,7 +609,7 @@ void ParameterGroup::onExportToFile()
         this,
         tr("Export Parameter to File"),
         QString(),
-        QStringList(QStringLiteral("XML (*.FCParam)"))
+        FileDialog::FilterList {{"XML", {"*.FCParam"}}}
     );
     if (!file.isEmpty()) {
         QTreeWidgetItem* item = currentItem();
@@ -627,7 +627,7 @@ void ParameterGroup::onImportFromFile()
         this,
         tr("Import Parameter From File"),
         QString(),
-        QStringList(QStringLiteral("XML (*.FCParam)"))
+        FileDialog::FilterList {{"XML", {"*.FCParam"}}}
     );
     if (!file.isEmpty()) {
         QTreeWidgetItem* item = currentItem();

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1618,7 +1618,7 @@ bool Document::saveAs()
         getMainWindow(),
         QObject::tr("Save %1 Document").arg(exe),
         name,
-        FileDialog::FilterList {{QStringLiteral("%1 %2").arg(exe, QObject::tr("Document")), {"*.FCStd"}}}
+        FileDialog::FilterList {{QObject::tr("%1 document").arg(exe), {"*.FCStd"}}}
     );
 
     if (!fn.isEmpty()) {

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1618,7 +1618,7 @@ bool Document::saveAs()
         getMainWindow(),
         QObject::tr("Save %1 Document").arg(exe),
         name,
-        QStringList(QStringLiteral("%1 %2 (*.FCStd)").arg(exe, QObject::tr("Document")))
+        FileDialog::FilterList {{QStringLiteral("%1 %2").arg(exe, QObject::tr("Document")), {"*.FCStd"}}}
     );
 
     if (!fn.isEmpty()) {
@@ -1748,7 +1748,7 @@ bool Document::saveCopy()
         getMainWindow(),
         QObject::tr("Save %1 Document").arg(exe),
         name,
-        QStringList(QObject::tr("%1 document (*.FCStd)").arg(exe))
+        FileDialog::FilterList {{QObject::tr("%1 document").arg(exe), {"*.FCStd"}}}
     );
     if (!fn.isEmpty()) {
         const char* DocName = App::GetApplication().getDocumentName(getDocument());

--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -508,7 +508,7 @@ void EditorView::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        FileDialog::FilterList {{tr("PDF file"), {"*.pdf"}}}
+        FileDialog::FilterList {{QStringLiteral("PDF"), {"*.pdf"}}}
     );
     if (!filename.isEmpty()) {
         QPrinter printer(QPrinter::ScreenResolution);

--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -377,7 +377,7 @@ bool EditorView::saveAs()
         this,
         QObject::tr("Save Macro"),
         QString(),
-        QStringList(QStringLiteral("%1 (*.FCMacro);;Python (*.py)").arg(tr("FreeCAD macro")))
+        FileDialog::FilterList {{tr("FreeCAD macro"), {"*.FCMacro"}}, {"Python", {"*.py"}}}
     );
     if (fn.isEmpty()) {
         return false;
@@ -508,7 +508,7 @@ void EditorView::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        QStringList(QStringLiteral("%1 (*.pdf)").arg(tr("PDF file")))
+        FileDialog::FilterList {{tr("PDF file"), {"*.pdf"}}}
     );
     if (!filename.isEmpty()) {
         QPrinter printer(QPrinter::ScreenResolution);

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -261,22 +261,6 @@ void FileDialog::accept()
     QFileDialog::accept();
 }
 
-static void getSuffixesDescription(QStringList& suffixes, const QString& suffixDescriptions)
-{
-    QRegularExpression rx;
-    // start the raw string with a (
-    // match a *, a . and at least one word character (a-z, A-Z, 0-9, _) with \*\.\w+
-    // end the raw string with a )
-    rx.setPattern(QStringLiteral(R"(\*\.\w+)"));
-
-    QRegularExpressionMatchIterator i = rx.globalMatch(suffixDescriptions);
-    while (i.hasNext()) {
-        QRegularExpressionMatch match = i.next();
-        QString suffix = match.captured(0);
-        suffixes << suffix;
-    }
-}
-
 static bool getPreferShowFilterPatterns()
 {
     bool show = true;
@@ -300,7 +284,14 @@ FileDialog::Filter FileDialog::Filter::fromFilterString(const QString& filter)
     const auto end = filter.lastIndexOf(QLatin1Char(')'));
     const auto name = filter.left(start).trimmed();
     const auto patternsPart = filter.mid(start + 1, end - start - 1);
+    // ";" separators are explicitly not supported as this could
+    // encourage having more than one canonical string represenation.
     return {name, patternsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
+}
+
+QString FileDialog::Filter::toFilterString() const
+{
+    return name + QStringLiteral(" (") + patterns.join(QLatin1Char(' ')) + QLatin1Char(')');
 }
 
 bool FileDialog::Filter::isWildcard() const
@@ -366,19 +357,6 @@ static QString toQtFilter(const FileDialog::Filter& filter, bool showPatterns)
         + filter.patterns.join(QLatin1Char(' ')) + QLatin1Char(')');
 }
 
-// This function is intentionally not exposed as code using `FilterList`s
-// should be using them natively as intended, not converted from strings
-// at the last minute.
-static FileDialog::FilterList filterListFromStringList(const QStringList& filterStringList)
-{
-    FileDialog::FilterList filters;
-    filters.reserve(filterStringList.length());
-    for (const auto& filterString : filterStringList) {
-        filters += FileDialog::Filter::fromFilterString(filterString);
-    }
-    return filters;
-}
-
 QStringList toQtFilterList(const FileDialog::FilterList& filterList, bool showPatterns)
 {
     QStringList qtFilters;
@@ -420,9 +398,9 @@ static QStringList nativeFileDialog(
     NativeFileDialogMode mode,
     QWidget* parent,
     const QString& caption,
-    const QString& dir,
+    const QString& startPath,
     const FileDialog::FilterList& filters,
-    qsizetype* selectedFilterIndex,
+    qsizetype& selectedFilterIndex,
     FileDialog::Options options
 )
 {
@@ -446,8 +424,8 @@ static QStringList nativeFileDialog(
     auto ofnFilter = qStringToWCharArray(flatFilter);
     ofn.lpstrFilter = ofnFilter.get();
 
-    if (selectedFilterIndex && *selectedFilterIndex >= 0) {
-        ofn.nFilterIndex = *selectedFilterIndex + 1;  // OPENFILENAMEW index is 1-based
+    if (selectedFilterIndex >= 0) {
+        ofn.nFilterIndex = selectedFilterIndex + 1;  // OPENFILENAMEW index is 1-based
     }
 
     constexpr const DWORD SelectionBufferSize = 65535;
@@ -456,7 +434,7 @@ static QStringList nativeFileDialog(
     ofn.nMaxFile = SelectionBufferSize;
     ofn.lpstrFile = selectedFile.get();
 
-    auto initialDir = qStringToWCharArray(QDir::toNativeSeparators(dir));
+    auto initialDir = qStringToWCharArray(QDir::toNativeSeparators(startPath));
     ofn.lpstrInitialDir = initialDir.get();
 
     auto title = qStringToWCharArray(caption);
@@ -481,9 +459,7 @@ static QStringList nativeFileDialog(
 
     QStringList selected;
     if (ok) {
-        if (selectedFilterIndex) {
-            *selectedFilterIndex = ofn.nFilterIndex - 1;
-        }
+        selectedFilterIndex = ofn.nFilterIndex - 1;
         const QString dir = QDir::cleanPath(QString::fromWCharArray(ofn.lpstrFile));
         selected += dir;
         if (ofn.Flags & OFN_ALLOWMULTISELECT) {
@@ -506,23 +482,21 @@ static QStringList nativeFileDialog(
     NativeFileDialogMode mode,
     QWidget* parent,
     const QString& caption,
-    const QString& dir,
+    const QString& startPath,
     const FileDialog::FilterList& filters,
-    qsizetype* selectedFilterIndex,
+    qsizetype& selectedFilterIndex,
     FileDialog::Options options
 )
 {
     const bool showPatterns = getPreferShowFilterPatterns();
     const auto qtFilterList = toQtFilterList(filters, showPatterns);
-    QString selectedQtFilter = (selectedFilterIndex != nullptr && *selectedFilterIndex >= 0)
-        ? qtFilterList[*selectedFilterIndex]
-        : "";
+    QString selectedQtFilter = (selectedFilterIndex >= 0) ? qtFilterList[selectedFilterIndex] : "";
     QStringList selected;
     if (mode == NativeFileDialogMode::OpenSingle) {
         selected << QFileDialog::getOpenFileName(
             parent,
             caption,
-            dir,
+            startPath,
             qtFilterList.join(QStringLiteral(";;")),
             &selectedQtFilter,
             options
@@ -532,7 +506,7 @@ static QStringList nativeFileDialog(
         selected << QFileDialog::getOpenFileNames(
             parent,
             caption,
-            dir,
+            startPath,
             qtFilterList.join(QStringLiteral(";;")),
             &selectedQtFilter,
             options
@@ -542,15 +516,13 @@ static QStringList nativeFileDialog(
         selected << QFileDialog::getSaveFileName(
             parent,
             caption,
-            dir,
+            startPath,
             qtFilterList.join(QStringLiteral(";;")),
             &selectedQtFilter,
             options
         );
     }
-    if (selectedFilterIndex != nullptr) {
-        *selectedFilterIndex = qtFilterList.indexOf(selectedQtFilter);
-    }
+    selectedFilterIndex = qtFilterList.indexOf(selectedQtFilter);
     return selected;
 }
 #endif
@@ -633,48 +605,36 @@ void detail::normalizeSavePath(QString& path, const FileDialog::Filter& selected
 QString FileDialog::getSaveFileName(
     QWidget* parent,
     const QString& caption,
-    const QString& dir,
-    const QStringList& filters,
-    QString* selectedFilter,
+    const QString& startPath,
+    const FilterList& filters,
+    qsizetype* selectedFilterIndex,
     Options options
 )
 {
     ActionDisabler actionDisabler {};
-    QString dirName = dir;
+    qsizetype actuallySelectedFilterIndex = selectedFilterIndex != nullptr ? *selectedFilterIndex
+                                                                           : -1;
+    QString suggestedPath = startPath;
     bool hasFilename = false;
-    if (dirName.isEmpty()) {
-        dirName = getPreferredDialogDirectory();
+    if (suggestedPath.isEmpty()) {
+        suggestedPath = getPreferredDialogDirectory();
     }
     else {
-        QFileInfo fi(dir);
+        QFileInfo fi(suggestedPath);
         if (fi.isRelative()) {
-            dirName = getPreferredDialogDirectory();
-            dirName += QStringLiteral("/");
-            dirName += fi.fileName();
+            suggestedPath = getPreferredDialogDirectory();
+            suggestedPath += QStringLiteral("/");
+            suggestedPath += fi.fileName();
+            fi.setFile(suggestedPath);
         }
-        if (!fi.fileName().isEmpty()) {
+        // If the startPath points to a directory (path ends with separator, or points
+        // to existing dir), don't touch it and don't use QFileDialog::selectFile() later.
+        if (!(fi.fileName().isEmpty() || fi.isDir())) {
+            // If there is a file name at the end, make sure it matches one of the patterns
+            // of the pre-selected filter, if applicable.
             hasFilename = true;
-        }
-
-        // get the suffix for the filter: use the selected filter if there is one,
-        // otherwise find the first valid suffix in the complete list of filters
-        QString filterToSearch;
-        if (selectedFilter && !selectedFilter->isEmpty()) {
-            filterToSearch = *selectedFilter;
-        }
-        else {
-            filterToSearch = filters.join(QLatin1Char(';'));
-        }
-
-        QStringList filterSuffixes;
-        getSuffixesDescription(filterSuffixes, filterToSearch);
-        const QString fiSuffix = fi.suffix();
-        const QString dotSuffix = QLatin1String("*.") + fiSuffix;  // To match with filterSuffixes
-        if (fiSuffix.isEmpty() || !filterSuffixes.contains(dotSuffix)) {
-            // there is no suffix or not a suffix that matches the filter, so
-            // default to the first suffix of the filter
-            if (!filterSuffixes.isEmpty()) {
-                dirName += filterSuffixes[0].mid(1);
+            if (actuallySelectedFilterIndex >= 0) {
+                detail::normalizeSavePath(suggestedPath, filters[actuallySelectedFilterIndex]);
             }
         }
     }
@@ -684,20 +644,12 @@ QString FileDialog::getSaveFileName(
         windowTitle = FileDialog::tr("Save As");
     }
 
-    const auto filterList = filterListFromStringList(filters);
-    qsizetype selectedFilterIndex = (selectedFilter != nullptr && !selectedFilter->isEmpty())
-        ? indexOfFilterString(filterList, *selectedFilter)
-        : -1;
-
     options |= QFileDialog::HideNameFilterDetails;
 
-    // NOTE: We must not change the specified file name afterwards as we may return the name of an
-    // already existing file. Hence we must extract the first matching suffix from the filter list
-    // and append it before showing the file dialog.
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
         const bool showPatterns = getPreferShowFilterPatterns();
-        const auto qtFilterList = toQtFilterList(filterList, showPatterns);
+        const auto qtFilterList = toQtFilterList(filters, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -710,36 +662,39 @@ QString FileDialog::getSaveFileName(
         dlg.setIconProvider(iconprov.get());
         dlg.setFileMode(QFileDialog::AnyFile);
         dlg.setAcceptMode(QFileDialog::AcceptSave);
-        dlg.setDirectory(dirName);
+        dlg.setDirectory(suggestedPath);
         if (hasFilename) {
-            dlg.selectFile(dirName);
+            dlg.selectFile(suggestedPath);
         }
         dlg.setNameFilters(qtFilterList);
-        if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(toQtFilter(filterList[selectedFilterIndex], showPatterns));
+        if (actuallySelectedFilterIndex >= 0) {
+            dlg.selectNameFilter(toQtFilter(filters[actuallySelectedFilterIndex], showPatterns));
         }
         dlg.onSelectedFilter(dlg.selectedNameFilter());
         dlg.setOption(QFileDialog::DontConfirmOverwrite, false);
         if (dlg.exec() == QDialog::Accepted) {
-            if (selectedFilter) {
-                *selectedFilter = filters[qtFilterList.indexOf(dlg.selectedNameFilter())];
-            }
             file = dlg.selectedFiles().constFirst();
         }
+        // Non-native QFileDialog::selectedNameFilter() always returns a filter, even if
+        // the user cancelled or the dialog wasn't shown at all.
+        // https://github.com/qt/qtbase/blob/53ff8897c5c8bc6175cf94ed24e2d2c5fa17365b/
+        // src/widgets/dialogs/qfiledialog.cpp#L1484
+        actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
     }
     else {
         file = nativeFileDialog(
             NativeFileDialogMode::Save,
             parent,
             windowTitle,
-            dirName,
-            filterList,
-            &selectedFilterIndex,
+            suggestedPath,
+            filters,
+            actuallySelectedFilterIndex,
             options
         )[0];
-        if (selectedFilter && selectedFilterIndex >= 0) {
-            *selectedFilter = filters[selectedFilterIndex];
-        }
+    }
+
+    if (selectedFilterIndex != nullptr) {
+        *selectedFilterIndex = actuallySelectedFilterIndex;
     }
 
     if (file.isEmpty()) {
@@ -749,7 +704,14 @@ QString FileDialog::getSaveFileName(
     // All directory separators become "/" from here on out.
     file = QDir::fromNativeSeparators(file);
 
-    detail::normalizeSavePath(file, filterList[selectedFilterIndex]);
+    // Changing the file path after selection is risky as we may as well land on an existing
+    // file if the platform dialog didn't enforce pattern matching and prompt the user
+    // upon overwrite. Take the path of least destruction.
+    const QString pristineUserInput(file);
+    detail::normalizeSavePath(file, filters[actuallySelectedFilterIndex]);
+    if (file != pristineUserInput && QFileInfo::exists(file)) {
+        file = pristineUserInput;
+    }
 
     setWorkingDirectory(file);
     return file;
@@ -789,8 +751,8 @@ QString FileDialog::getOpenFileName(
     QWidget* parent,
     const QString& caption,
     const QString& dir,
-    const QStringList& filters,
-    QString* selectedFilter,
+    const FilterList& filters,
+    qsizetype* selectedFilterIndex,
     Options options
 )
 {
@@ -805,17 +767,15 @@ QString FileDialog::getOpenFileName(
         windowTitle = FileDialog::tr("Open");
     }
 
-    const auto filterList = filterListFromStringList(filters);
-    qsizetype selectedFilterIndex = (selectedFilter && !selectedFilter->isEmpty())
-        ? indexOfFilterString(filterList, *selectedFilter)
-        : -1;
-
     options |= QFileDialog::HideNameFilterDetails;
+
+    qsizetype actuallySelectedFilterIndex = selectedFilterIndex != nullptr ? *selectedFilterIndex
+                                                                           : -1;
 
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
         const bool showPatterns = getPreferShowFilterPatterns();
-        const auto qtFilterList = toQtFilterList(filterList, showPatterns);
+        const auto qtFilterList = toQtFilterList(filters, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -830,15 +790,15 @@ QString FileDialog::getOpenFileName(
         dlg.setAcceptMode(QFileDialog::AcceptOpen);
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
-        if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(toQtFilter(filterList[selectedFilterIndex], showPatterns));
+        if (actuallySelectedFilterIndex >= 0) {
+            dlg.selectNameFilter(toQtFilter(filters[actuallySelectedFilterIndex], showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
-            if (selectedFilter) {
-                *selectedFilter = filters[qtFilterList.indexOf(dlg.selectedNameFilter())];
-            }
             file = dlg.selectedFiles().constFirst();
         }
+        // Non-native QFileDialog::selectedNameFilter() always returns a filter, even if
+        // the user cancelled or the dialog wasn't shown at all.
+        actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
     }
     else {
         file = nativeFileDialog(
@@ -846,23 +806,24 @@ QString FileDialog::getOpenFileName(
             parent,
             windowTitle,
             dirName,
-            filterList,
-            &selectedFilterIndex,
+            filters,
+            actuallySelectedFilterIndex,
             options
         )[0];
-        if (selectedFilter && selectedFilterIndex >= 0) {
-            *selectedFilter = filters[selectedFilterIndex];
-        }
-        file = QDir::fromNativeSeparators(file);
     }
 
-    if (!file.isEmpty()) {
-        setWorkingDirectory(file);
-        return file;
+    if (selectedFilterIndex != nullptr) {
+        *selectedFilterIndex = actuallySelectedFilterIndex;
     }
-    else {
+
+    if (file.isEmpty()) {
         return {};
     }
+
+    file = QDir::fromNativeSeparators(file);
+
+    setWorkingDirectory(file);
+    return file;
 }
 
 /**
@@ -873,8 +834,8 @@ QStringList FileDialog::getOpenFileNames(
     QWidget* parent,
     const QString& caption,
     const QString& dir,
-    const QStringList& filters,
-    QString* selectedFilter,
+    const FilterList& filters,
+    qsizetype* selectedFilterIndex,
     Options options
 )
 {
@@ -889,17 +850,15 @@ QStringList FileDialog::getOpenFileNames(
         windowTitle = FileDialog::tr("Open");
     }
 
-    const auto filterList = filterListFromStringList(filters);
-    qsizetype selectedFilterIndex = (selectedFilter != nullptr && !selectedFilter->isEmpty())
-        ? indexOfFilterString(filterList, *selectedFilter)
-        : -1;
-
     options |= QFileDialog::HideNameFilterDetails;
+
+    qsizetype actuallySelectedFilterIndex = selectedFilterIndex != nullptr ? *selectedFilterIndex
+                                                                           : -1;
 
     QStringList files;
     if (DialogOptions::dontUseNativeFileDialog()) {
         const bool showPatterns = getPreferShowFilterPatterns();
-        const auto qtFilterList = toQtFilterList(filterList, showPatterns);
+        const auto qtFilterList = toQtFilterList(filters, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -914,15 +873,15 @@ QStringList FileDialog::getOpenFileNames(
         dlg.setAcceptMode(QFileDialog::AcceptOpen);
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
-        if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(toQtFilter(filterList[selectedFilterIndex], showPatterns));
+        if (actuallySelectedFilterIndex >= 0) {
+            dlg.selectNameFilter(toQtFilter(filters[actuallySelectedFilterIndex], showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
-            if (selectedFilter) {
-                *selectedFilter = filters[qtFilterList.indexOf(dlg.selectedNameFilter())];
-            }
             files = dlg.selectedFiles();
         }
+        // Non-native QFileDialog::selectedNameFilter() always returns a filter, even if
+        // the user cancelled or the dialog wasn't shown at all.
+        actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
     }
     else {
         files = nativeFileDialog(
@@ -930,16 +889,17 @@ QStringList FileDialog::getOpenFileNames(
             parent,
             windowTitle,
             dirName,
-            filterList,
-            &selectedFilterIndex,
+            filters,
+            actuallySelectedFilterIndex,
             options
         );
-        if (selectedFilter && selectedFilterIndex >= 0) {
-            *selectedFilter = filters[selectedFilterIndex];
-        }
         for (auto& file : files) {
             file = QDir::fromNativeSeparators(file);
         }
+    }
+
+    if (selectedFilterIndex != nullptr) {
+        *selectedFilterIndex = actuallySelectedFilterIndex;
     }
 
     if (!files.isEmpty()) {

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -428,9 +428,13 @@ static QStringList nativeFileDialog(
         ofn.nFilterIndex = selectedFilterIndex + 1;  // OPENFILENAMEW index is 1-based
     }
 
+    const QFileInfo startPathInfo(startPath);
+
     constexpr const DWORD SelectionBufferSize = 65535;
     auto selectedFile = std::make_unique<wchar_t[]>(SelectionBufferSize);
-    selectedFile[0] = L'\0';
+    startPathInfo.fileName().toWCharArray(selectedFile.get());
+    selectedFile[startPathInfo.fileName().size()] = L'\0';
+
     ofn.nMaxFile = SelectionBufferSize;
     ofn.lpstrFile = selectedFile.get();
 
@@ -468,7 +472,7 @@ static QStringList nativeFileDialog(
             const wchar_t* ptr = ofn.lpstrFile + dir.size() + 1;
             if (*ptr) {
                 selected.clear();
-                const QString path = dir + u'/';
+                const QString path = dir + L'/';
                 while (*ptr) {
                     const QString fileName = QString::fromWCharArray(ptr);
                     selected += path + fileName;

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -21,6 +21,9 @@
  ***************************************************************************/
 
 
+#ifndef NDEBUG
+# include <cassert>
+#endif
 #include <memory>
 
 #include <FCConfig.h>
@@ -364,6 +367,17 @@ struct FilterSpec
         return getDisplayName(showPatterns) + QStringLiteral(" (") + patterns.join(QLatin1Char(' '))
             + QLatin1Char(')');
     }
+
+    /// @returns Whether the filter is a full wildcard (i.e. accepts "*" or "*.*")
+    bool isWildcard() const
+    {
+        for (const auto& pat : patterns) {
+            if (pat != "*" || pat != "*.*") {
+                return false;
+            }
+        }
+        return true;
+    }
 };
 
 class FilterSpecList: public QList<FilterSpec>
@@ -557,6 +571,148 @@ static QStringList nativeFileDialog(
 #endif
 
 /**
+ * Modifies a path obtained as a result of a save file dialog to ensure the file
+ * name matches the selected file filter.
+ */
+static void normalizeSavePath(QString& path, const FilterSpec& selectedFilterSpec)
+{
+    // Wildcards have no rule by definition.
+    if (selectedFilterSpec.isWildcard()) {
+        return;
+    }
+
+    // As it stands, much of FreeCAD relies on an extension always being present, so
+    // enforce extension according to selected filter if none is specified.
+    // Ideally code should be migrated to discriminating on the returned selected
+    // filter instead.
+
+    // Platform dialogs can have a variety of behaviors:
+    // * Qt/KDE changes the filter to a matching one if applicable when the user
+    //   types an extension in the file name explicitly, and some of the dialogs
+    //   feature a checkbox to auto-append an extension if absent.
+    // * Windows will never change the selected filter on its own.
+    //   1. Modern dialogs (IFileDialog and Windows::Storage::Pickers) keep typed
+    //      filenames intact *if* they have an extension 1-3 characters long, known
+    //      to HKEY_CLASSES_ROOT, or present in the filters.
+    //      Otherwise, appends the first extension of the selected filter.
+    //   2. Legacy GetSaveFileName() always keeps typed filenames intact.
+    //      However, we use it and want the modern behavior instead.
+
+    // This function uniformizes some of that.
+
+    // Discard everything up to and including directory separator.
+    const auto typedName = QStringView(path).mid(path.lastIndexOf('/') + 1);
+
+    // Check for any full-name filters first.
+    for (const auto& pat : selectedFilterSpec.patterns) {
+        if (!pat.startsWith("*.") && typedName == pat) {
+            return;
+        }
+    }
+
+    const auto lastDot = typedName.lastIndexOf('.');
+    // typedExt includes the last dot and everything after it,
+    // as a stray dot ("abc.") may have been typed. Won't fail
+    // even in the improbable case of only "." being passed.
+    const auto typedExt = lastDot == -1 ? QStringView() : typedName.mid(lastDot);
+
+    if (typedExt.isEmpty()) {
+        // No extension, move directly to append.
+    }
+    else if (typedExt.size() == 1) {
+        // Remove stray dot then append.
+        path.chop(1);
+    }
+    else /* size() > 1 */ {
+        for (const auto& pat : selectedFilterSpec.patterns) {
+            if (pat.startsWith("*.") && typedExt == QStringView(pat).mid(1)) {
+                // Valid extension found for the selected filter.
+                return;
+            }
+        }
+    }
+
+    // Append extension from first *.xyz-style pattern.
+    for (const auto& pat : selectedFilterSpec.patterns) {
+        if (pat.startsWith("*.")) {
+            path.append(QStringView(pat).mid(1));
+            break;
+        }
+    }
+}
+
+#ifndef NDEBUG
+static void testNormalizeSavePath()
+{
+    const auto spec = FilterSpec::fromFilterString(
+        QStringLiteral("Whatever files (what ev.er *.abc *.xyz)")
+    );
+    const auto nspEq = [spec](QString path, const QString& desired) -> bool {
+        normalizeSavePath(path, spec);
+        const auto firstPassResult = path;
+        normalizeSavePath(path, spec);
+        const bool idempotent = firstPassResult == path;
+        return idempotent && path == desired;
+    };
+    for (const auto& root :
+         {QStringLiteral(""),
+          QStringLiteral("/root/.trash/"),
+          QStringLiteral("C:/$Recycle.bin/"),
+          QStringLiteral("//net.worked:123/"),
+          QStringLiteral("//?/o:/ntpath/"),
+          QStringLiteral("/\x3F?/z:/evil/")}) {
+        assert(nspEq(root + "", root + ".abc"));
+        assert(nspEq(root + "hello", root + "hello.abc"));
+
+        // Dots handling
+        assert(nspEq(root + "dotty.", root + "dotty.abc"));
+        assert(nspEq(root + "dotty2..", root + "dotty2..abc"));
+        assert(nspEq(root + "dotty3...", root + "dotty3...abc"));
+        assert(nspEq(root + ".hidden", root + ".hidden.abc"));
+        assert(nspEq(root + ".1dotty1.", root + ".1dotty1.abc"));
+        assert(nspEq(root + ".1dotty2..", root + ".1dotty2..abc"));
+        assert(nspEq(root + "..2dotty2..", root + "..2dotty2..abc"));
+
+        // Extension not in filter
+        assert(nspEq(root + "ascii.txt", root + "ascii.txt.abc"));
+        assert(nspEq(root + "asciidot.txt.", root + "asciidot.txt.abc"));
+
+        // Empty stems but valid extensions
+        assert(nspEq(root + ".abc", root + ".abc"));
+        assert(nspEq(root + ".xyz", root + ".xyz"));
+
+        // Regular cases with extension
+        assert(nspEq(root + "ext.abc", root + "ext.abc"));
+        assert(nspEq(root + "ext.parts.abc", root + "ext.parts.abc"));
+        assert(nspEq(root + ".hidden.ext.abc", root + ".hidden.ext.abc"));
+        assert(nspEq(root + "ext.xyz", root + "ext.xyz"));
+        assert(nspEq(root + "ext.parts.xyz", root + "ext.parts.xyz"));
+        assert(nspEq(root + ".hidden.ext.xyz", root + ".hidden.ext.xyz"));
+
+        // Non-wildcard pattern without ext
+        assert(nspEq(root + "what", root + "what"));
+        assert(nspEq(root + "what.", root + "what.abc"));
+        assert(nspEq(root + ".what", root + ".what.abc"));
+        assert(nspEq(root + ".what.", root + ".what.abc"));
+
+        // Non-wildcard pattern with ext
+        assert(nspEq(root + "ev.er", root + "ev.er"));
+        assert(nspEq(root + "ev.er.", root + "ev.er.abc"));
+        assert(nspEq(root + ".ev.er", root + ".ev.er.abc"));
+        assert(nspEq(root + ".ev.er.", root + ".ev.er.abc"));
+        // Check for mixed up extension matching
+        assert(nspEq(root + "notev.er", root + "notev.er.abc"));
+
+        // The following two should never be encountered in the wild as they refer to
+        // the current or upper directories, but still should be handled gracefully as
+        // if they were just user input tacked on after some directory path.
+        assert(nspEq(root + ".", root + ".abc"));
+        assert(nspEq(root + "..", root + "..abc"));
+    }
+}
+#endif  // NDEBUG
+
+/**
  * This is a convenience static function that will return a file name selected by the user. The file
  * does not have to exist.
  */
@@ -670,16 +826,22 @@ QString FileDialog::getSaveFileName(
         if (selectedFilter && selectedFilterIndex >= 0) {
             *selectedFilter = filters[selectedFilterIndex];
         }
-        file = QDir::fromNativeSeparators(file);
     }
 
-    if (!file.isEmpty()) {
-        setWorkingDirectory(file);
-        return file;
-    }
-    else {
+    if (file.isEmpty()) {
         return {};
     }
+
+    // All directory separators become "/" from here on out.
+    file = QDir::fromNativeSeparators(file);
+
+#ifndef NDEBUG
+    testNormalizeSavePath();
+#endif  // NDEBUG
+    normalizeSavePath(file, filterSpecList[selectedFilterIndex]);
+
+    setWorkingDirectory(file);
+    return file;
 }
 
 /**

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -274,7 +274,7 @@ static void getSuffixesDescription(QStringList& suffixes, const QString& suffixD
     }
 }
 
-static bool getPreferShowFilterExtensions()
+static bool getPreferShowFilterPatterns()
 {
     bool show = true;
 #ifdef FC_OS_WIN32
@@ -288,17 +288,19 @@ static bool getPreferShowFilterExtensions()
                                      .GetGroup("BaseApp")
                                      ->GetGroup("Preferences")
                                      ->GetGroup("Dialog");
-    return group->GetBool("ShowFilterExtensions", show);
+    return group->GetBool("ShowFilterPatterns", show);
 }
 
 struct FilterSpec
 {
     QString name;
-    QStringList extensions;
+    /// List of patterns matched by this filter. Note that extensions are
+    /// just a subset of patterns in the form of "*.ext".
+    QStringList patterns;
 
     bool operator==(const FilterSpec& rhs) const
     {
-        return name == rhs.name && extensions == rhs.extensions;
+        return name == rhs.name && patterns == rhs.patterns;
     }
 
     static FilterSpec fromFilterString(const QString& filter)
@@ -306,61 +308,61 @@ struct FilterSpec
         const auto start = filter.lastIndexOf(QLatin1Char('('));
         const auto end = filter.lastIndexOf(QLatin1Char(')'));
         const auto name = filter.left(start).trimmed();
-        const auto extensionsPart = filter.mid(start + 1, end - start - 1);
-        return {name, extensionsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
+        const auto patternsPart = filter.mid(start + 1, end - start - 1);
+        return {name, patternsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
     }
 
-    QString getDisplayName(bool showExtensions) const
+    QString getDisplayName(bool showPatterns) const
     {
         // Avoid overflowing the screen with an excessively long filter list (see #23139).
         const qsizetype MaxFiltersLength = 128;
-        const qsizetype TypicalMaxExtensionLength = 12;
+        const qsizetype TypicalMaxPatternLength = 12;
 
-        if (!showExtensions) {
+        if (!showPatterns) {
             return name;
         }
 
         QString formatted(name);
         formatted += QLatin1Char(' ');
 
-        // Deduplicate the extensions which usually come in both *.ext & *.EXT variants.
-        // Keeps the first case encountered for a given extension set.
-        // O(n^2) in complexity but the extension lists are usually short.
+        // Deduplicate the patterns which usually come in both uppercase and lowercase variants.
+        // Keeps the first case encountered for a given pattern set.
+        // O(n^2) in complexity but the pattern lists are usually short.
         QList<QStringView> seen;
-        seen.reserve(extensions.size());
-        const auto wasSeen = [&seen](QStringView ext) -> bool {
-            for (QStringView extSeen : seen) {
-                if (extSeen.compare(ext, Qt::CaseInsensitive) == 0) {
+        seen.reserve(patterns.size());
+        const auto wasSeen = [&seen](QStringView pat) -> bool {
+            for (QStringView patSeen : seen) {
+                if (patSeen.compare(pat, Qt::CaseInsensitive) == 0) {
                     return true;
                 }
             }
             return false;
         };
-        QString dedupExtensions;
-        dedupExtensions.reserve(extensions.length() * TypicalMaxExtensionLength);
-        for (auto it = extensions.cbegin(); it != extensions.cend(); ++it) {
+        QString dedupPatterns;
+        dedupPatterns.reserve(patterns.length() * TypicalMaxPatternLength);
+        for (auto it = patterns.cbegin(); it != patterns.cend(); ++it) {
             if (!wasSeen(*it)) {
                 seen.append(*it);
-                if (it != extensions.cbegin()) {
-                    dedupExtensions += QLatin1Char(' ');
+                if (it != patterns.cbegin()) {
+                    dedupPatterns += QLatin1Char(' ');
                 }
-                dedupExtensions += *it;
+                dedupPatterns += *it;
             }
         }
 
-        if (dedupExtensions.size() <= MaxFiltersLength) {
+        if (dedupPatterns.size() <= MaxFiltersLength) {
             formatted += QLatin1Char('(');
-            formatted += dedupExtensions;
+            formatted += dedupPatterns;
             formatted += QLatin1Char(')');
         }
 
         return formatted;
     }
 
-    QString toQtFilter(bool showExtensions) const
+    QString toQtFilter(bool showPatterns) const
     {
-        return getDisplayName(showExtensions) + QStringLiteral(" (")
-            + extensions.join(QLatin1Char(' ')) + QLatin1Char(')');
+        return getDisplayName(showPatterns) + QStringLiteral(" (") + patterns.join(QLatin1Char(' '))
+            + QLatin1Char(')');
     }
 };
 
@@ -377,11 +379,11 @@ public:
         return specs;
     }
 
-    QStringList toQtFilterList(bool showExtensions) const
+    QStringList toQtFilterList(bool showPatterns) const
     {
         QStringList qtFilters;
         for (const auto& filterSpec : *this) {
-            qtFilters += filterSpec.toQtFilter(showExtensions);
+            qtFilters += filterSpec.toQtFilter(showPatterns);
         }
         return qtFilters;
     }
@@ -410,7 +412,7 @@ static std::unique_ptr<wchar_t[]> qStringToWCharArray(const QString& s, size_t r
 }
 
 /* Use the legacy Get{Open,Save}FileNameW functions as the Vista+ IFileDialog forces
- * extension display in filter lists, leading to exceedingly long entries as seen in
+ * pattern/extension display in filter lists, leading to exceedingly long entries as seen in
  * issue #23139.
  * Note neither this legacy function set nor IFileDialog are valid for UWP WinRT,
  * for which Windows::Storage::Pickers::FileOpenPicker will have to be used instead.
@@ -425,7 +427,7 @@ static QStringList nativeFileDialog(
     FileDialog::Options options
 )
 {
-    const bool showExtensions = getPreferShowFilterExtensions();
+    const bool showPatterns = getPreferShowFilterPatterns();
 
     OPENFILENAMEW ofn;
     memset(&ofn, 0, sizeof(OPENFILENAMEW));
@@ -436,9 +438,9 @@ static QStringList nativeFileDialog(
 
     QString flatFilter;
     for (const auto& filterSpec : filterSpecs) {
-        flatFilter += filterSpec.getDisplayName(showExtensions);
+        flatFilter += filterSpec.getDisplayName(showPatterns);
         flatFilter += QLatin1Char('\0');
-        flatFilter += filterSpec.extensions.join(QLatin1Char(';'));
+        flatFilter += filterSpec.patterns.join(QLatin1Char(';'));
         flatFilter += QLatin1Char('\0');
     }
     flatFilter += QLatin1Char('\0');
@@ -511,8 +513,8 @@ static QStringList nativeFileDialog(
     FileDialog::Options options
 )
 {
-    const bool showExtensions = getPreferShowFilterExtensions();
-    const auto qtFilterList = filterSpecs.toQtFilterList(showExtensions);
+    const bool showPatterns = getPreferShowFilterPatterns();
+    const auto qtFilterList = filterSpecs.toQtFilterList(showPatterns);
     QString selectedQtFilter = (selectedFilterIndex != nullptr && *selectedFilterIndex >= 0)
         ? qtFilterList[*selectedFilterIndex]
         : "";
@@ -624,8 +626,8 @@ QString FileDialog::getSaveFileName(
     // and append it before showing the file dialog.
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -644,7 +646,7 @@ QString FileDialog::getSaveFileName(
         }
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         dlg.onSelectedFilter(dlg.selectedNameFilter());
         dlg.setOption(QFileDialog::DontConfirmOverwrite, false);
@@ -739,8 +741,8 @@ QString FileDialog::getOpenFileName(
 
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -756,7 +758,7 @@ QString FileDialog::getOpenFileName(
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
@@ -823,8 +825,8 @@ QStringList FileDialog::getOpenFileNames(
 
     QStringList files;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -840,7 +842,7 @@ QStringList FileDialog::getOpenFileNames(
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -274,7 +274,14 @@ bool FileDialogInternal::getPreferShowFilterPatterns()
     return group->GetBool("ShowFilterPatterns", show);
 }
 
-FileDialog::Filter FileDialog::Filter::fromFilterString(const QString& filter)
+using Filter = FileDialog::Filter;
+
+Filter Filter::AllFiles()
+{
+    return {QObject::tr("All Files"), {"*.*"}};
+}
+
+Filter Filter::fromFilterString(const QString& filter)
 {
     const auto start = filter.lastIndexOf(QLatin1Char('('));
     const auto end = filter.lastIndexOf(QLatin1Char(')'));
@@ -285,12 +292,12 @@ FileDialog::Filter FileDialog::Filter::fromFilterString(const QString& filter)
     return {name, patternsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
 }
 
-QString FileDialog::Filter::toFilterString() const
+QString Filter::toFilterString() const
 {
     return name + QStringLiteral(" (") + patterns.join(QLatin1Char(' ')) + QLatin1Char(')');
 }
 
-bool FileDialog::Filter::isWildcard() const
+bool Filter::isWildcard() const
 {
     for (const auto& pat : patterns) {
         if (pat == "*" || pat == "*.*") {
@@ -300,7 +307,7 @@ bool FileDialog::Filter::isWildcard() const
     return false;
 }
 
-QString FileDialogInternal::getFilterDisplayName(const FileDialog::Filter& filter, bool showPatterns)
+QString FileDialogInternal::getFilterDisplayName(const Filter& filter, bool showPatterns)
 {
     // Avoid overflowing the screen with an excessively long filter list (see #23139).
     const qsizetype MaxFiltersLength = 128;
@@ -346,7 +353,7 @@ QString FileDialogInternal::getFilterDisplayName(const FileDialog::Filter& filte
     return formatted;
 }
 
-static QString toQtFilter(const FileDialog::Filter& filter, bool showPatterns)
+static QString toQtFilter(const Filter& filter, bool showPatterns)
 {
     return FileDialogInternal::getFilterDisplayName(filter, showPatterns) + QStringLiteral(" (")
         + filter.patterns.join(QLatin1Char(' ')) + QLatin1Char(')');

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -315,7 +315,6 @@ QString FileDialogInternal::getFilterDisplayName(const FileDialog::Filter& filte
     }
 
     QString formatted(filter.name);
-    formatted += QLatin1Char(' ');
 
     // Deduplicate the patterns which usually come in both uppercase and lowercase variants.
     // Keeps the first case encountered for a given pattern set.
@@ -343,7 +342,7 @@ QString FileDialogInternal::getFilterDisplayName(const FileDialog::Filter& filte
     }
 
     if (dedupPatterns.size() <= MaxFiltersLength) {
-        formatted += QLatin1Char('(');
+        formatted += QStringLiteral(" (");
         formatted += dedupPatterns;
         formatted += QLatin1Char(')');
     }
@@ -417,6 +416,13 @@ QStringList FileDialogInternal::nativeFileDialog(
         );
     }
     selectedFilterIndex = qtFilterList.indexOf(selectedQtFilter);
+    if (selectedFilterIndex < 0) {
+        Base::Console().error(
+            "Qt-backed nativeFileDialog returned a selected filter that wasn't in the original "
+            "list, defaulting to index 0"
+        );
+        selectedFilterIndex = 0;
+    }
     return selected;
 }
 #endif
@@ -577,6 +583,12 @@ QString FileDialog::getSaveFileName(
         // https://github.com/qt/qtbase/blob/53ff8897c5c8bc6175cf94ed24e2d2c5fa17365b/
         // src/widgets/dialogs/qfiledialog.cpp#L1484
         actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
+        if (actuallySelectedFilterIndex < 0) {
+            // Log an error since this happening means the code is incorrect
+            Base::Console()
+                .error("FileDialog returned a selected filter that wasn't in the original list, defaulting to index 0");
+            actuallySelectedFilterIndex = 0;
+        }
     }
     else {
         const auto files = nativeFileDialog(
@@ -699,6 +711,12 @@ QString FileDialog::getOpenFileName(
         // Non-native QFileDialog::selectedNameFilter() always returns a filter, even if
         // the user cancelled or the dialog wasn't shown at all.
         actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
+        if (actuallySelectedFilterIndex < 0) {
+            // Log an error since this happening means the code is incorrect
+            Base::Console()
+                .error("FileDialog returned a selected filter that wasn't in the original list, defaulting to index 0");
+            actuallySelectedFilterIndex = 0;
+        }
     }
     else {
         const auto files = nativeFileDialog(
@@ -785,6 +803,12 @@ QStringList FileDialog::getOpenFileNames(
         // Non-native QFileDialog::selectedNameFilter() always returns a filter, even if
         // the user cancelled or the dialog wasn't shown at all.
         actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
+        if (actuallySelectedFilterIndex < 0) {
+            // Log an error since this happening means the code is incorrect
+            Base::Console()
+                .error("FileDialog returned a selected filter that wasn't in the original list, defaulting to index 0");
+            actuallySelectedFilterIndex = 0;
+        }
     }
     else {
         files = nativeFileDialog(

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -1,29 +1,25 @@
-/***************************************************************************
- *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 51 Franklin Street,      *
- *   Fifth Floor, Boston, MA  02110-1301, USA                              *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2004 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
 
 
-#ifndef NDEBUG
-# include <cassert>
-#endif
 #include <memory>
 
 #include <FCConfig.h>

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -559,7 +559,7 @@ static QStringList nativeFileDialog(
  * Modifies a path obtained as a result of a save file dialog to ensure the file
  * name matches the selected file filter.
  */
-static void normalizeSavePath(QString& path, const FileDialog::Filter& selectedFilter)
+void detail::normalizeSavePath(QString& path, const FileDialog::Filter& selectedFilter)
 {
     // Wildcards have no rule by definition.
     if (selectedFilter.isWildcard()) {
@@ -625,77 +625,6 @@ static void normalizeSavePath(QString& path, const FileDialog::Filter& selectedF
         }
     }
 }
-
-#ifndef NDEBUG
-static void testNormalizeSavePath()
-{
-    const auto filt = Filter::fromFilterString(
-        QStringLiteral("Whatever files (what ev.er *.abc *.xyz)")
-    );
-    const auto nspEq = [filt](QString path, const QString& desired) -> bool {
-        normalizeSavePath(path, filt);
-        const auto firstPassResult = path;
-        normalizeSavePath(path, filt);
-        const bool idempotent = firstPassResult == path;
-        return idempotent && path == desired;
-    };
-    for (const auto& root :
-         {QStringLiteral(""),
-          QStringLiteral("/root/.trash/"),
-          QStringLiteral("C:/$Recycle.bin/"),
-          QStringLiteral("//net.worked:123/"),
-          QStringLiteral("//?/o:/ntpath/"),
-          QStringLiteral("/\x3F?/z:/evil/")}) {
-        assert(nspEq(root + "", root + ".abc"));
-        assert(nspEq(root + "hello", root + "hello.abc"));
-
-        // Dots handling
-        assert(nspEq(root + "dotty.", root + "dotty.abc"));
-        assert(nspEq(root + "dotty2..", root + "dotty2..abc"));
-        assert(nspEq(root + "dotty3...", root + "dotty3...abc"));
-        assert(nspEq(root + ".hidden", root + ".hidden.abc"));
-        assert(nspEq(root + ".1dotty1.", root + ".1dotty1.abc"));
-        assert(nspEq(root + ".1dotty2..", root + ".1dotty2..abc"));
-        assert(nspEq(root + "..2dotty2..", root + "..2dotty2..abc"));
-
-        // Extension not in filter
-        assert(nspEq(root + "ascii.txt", root + "ascii.txt.abc"));
-        assert(nspEq(root + "asciidot.txt.", root + "asciidot.txt.abc"));
-
-        // Empty stems but valid extensions
-        assert(nspEq(root + ".abc", root + ".abc"));
-        assert(nspEq(root + ".xyz", root + ".xyz"));
-
-        // Regular cases with extension
-        assert(nspEq(root + "ext.abc", root + "ext.abc"));
-        assert(nspEq(root + "ext.parts.abc", root + "ext.parts.abc"));
-        assert(nspEq(root + ".hidden.ext.abc", root + ".hidden.ext.abc"));
-        assert(nspEq(root + "ext.xyz", root + "ext.xyz"));
-        assert(nspEq(root + "ext.parts.xyz", root + "ext.parts.xyz"));
-        assert(nspEq(root + ".hidden.ext.xyz", root + ".hidden.ext.xyz"));
-
-        // Non-wildcard pattern without ext
-        assert(nspEq(root + "what", root + "what"));
-        assert(nspEq(root + "what.", root + "what.abc"));
-        assert(nspEq(root + ".what", root + ".what.abc"));
-        assert(nspEq(root + ".what.", root + ".what.abc"));
-
-        // Non-wildcard pattern with ext
-        assert(nspEq(root + "ev.er", root + "ev.er"));
-        assert(nspEq(root + "ev.er.", root + "ev.er.abc"));
-        assert(nspEq(root + ".ev.er", root + ".ev.er.abc"));
-        assert(nspEq(root + ".ev.er.", root + ".ev.er.abc"));
-        // Check for mixed up extension matching
-        assert(nspEq(root + "notev.er", root + "notev.er.abc"));
-
-        // The following two should never be encountered in the wild as they refer to
-        // the current or upper directories, but still should be handled gracefully as
-        // if they were just user input tacked on after some directory path.
-        assert(nspEq(root + ".", root + ".abc"));
-        assert(nspEq(root + "..", root + "..abc"));
-    }
-}
-#endif  // NDEBUG
 
 /**
  * This is a convenience static function that will return a file name selected by the user. The file
@@ -820,10 +749,7 @@ QString FileDialog::getSaveFileName(
     // All directory separators become "/" from here on out.
     file = QDir::fromNativeSeparators(file);
 
-#ifndef NDEBUG
-    testNormalizeSavePath();
-#endif  // NDEBUG
-    normalizeSavePath(file, filterList[selectedFilterIndex]);
+    detail::normalizeSavePath(file, filterList[selectedFilterIndex]);
 
     setWorkingDirectory(file);
     return file;

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -294,119 +294,104 @@ static bool getPreferShowFilterPatterns()
     return group->GetBool("ShowFilterPatterns", show);
 }
 
-struct FilterSpec
+FileDialog::Filter FileDialog::Filter::fromFilterString(const QString& filter)
 {
-    QString name;
-    /// List of patterns matched by this filter. Note that extensions are
-    /// just a subset of patterns in the form of "*.ext".
-    QStringList patterns;
+    const auto start = filter.lastIndexOf(QLatin1Char('('));
+    const auto end = filter.lastIndexOf(QLatin1Char(')'));
+    const auto name = filter.left(start).trimmed();
+    const auto patternsPart = filter.mid(start + 1, end - start - 1);
+    return {name, patternsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
+}
 
-    bool operator==(const FilterSpec& rhs) const
-    {
-        return name == rhs.name && patterns == rhs.patterns;
-    }
-
-    static FilterSpec fromFilterString(const QString& filter)
-    {
-        const auto start = filter.lastIndexOf(QLatin1Char('('));
-        const auto end = filter.lastIndexOf(QLatin1Char(')'));
-        const auto name = filter.left(start).trimmed();
-        const auto patternsPart = filter.mid(start + 1, end - start - 1);
-        return {name, patternsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
-    }
-
-    QString getDisplayName(bool showPatterns) const
-    {
-        // Avoid overflowing the screen with an excessively long filter list (see #23139).
-        const qsizetype MaxFiltersLength = 128;
-        const qsizetype TypicalMaxPatternLength = 12;
-
-        if (!showPatterns) {
-            return name;
-        }
-
-        QString formatted(name);
-        formatted += QLatin1Char(' ');
-
-        // Deduplicate the patterns which usually come in both uppercase and lowercase variants.
-        // Keeps the first case encountered for a given pattern set.
-        // O(n^2) in complexity but the pattern lists are usually short.
-        QList<QStringView> seen;
-        seen.reserve(patterns.size());
-        const auto wasSeen = [&seen](QStringView pat) -> bool {
-            for (QStringView patSeen : seen) {
-                if (patSeen.compare(pat, Qt::CaseInsensitive) == 0) {
-                    return true;
-                }
-            }
-            return false;
-        };
-        QString dedupPatterns;
-        dedupPatterns.reserve(patterns.length() * TypicalMaxPatternLength);
-        for (auto it = patterns.cbegin(); it != patterns.cend(); ++it) {
-            if (!wasSeen(*it)) {
-                seen.append(*it);
-                if (it != patterns.cbegin()) {
-                    dedupPatterns += QLatin1Char(' ');
-                }
-                dedupPatterns += *it;
-            }
-        }
-
-        if (dedupPatterns.size() <= MaxFiltersLength) {
-            formatted += QLatin1Char('(');
-            formatted += dedupPatterns;
-            formatted += QLatin1Char(')');
-        }
-
-        return formatted;
-    }
-
-    QString toQtFilter(bool showPatterns) const
-    {
-        return getDisplayName(showPatterns) + QStringLiteral(" (") + patterns.join(QLatin1Char(' '))
-            + QLatin1Char(')');
-    }
-
-    /// @returns Whether the filter is a full wildcard (i.e. accepts "*" or "*.*")
-    bool isWildcard() const
-    {
-        for (const auto& pat : patterns) {
-            if (pat != "*" || pat != "*.*") {
-                return false;
-            }
-        }
-        return true;
-    }
-};
-
-class FilterSpecList: public QList<FilterSpec>
+bool FileDialog::Filter::isWildcard() const
 {
-public:
-    static FilterSpecList fromFilterStringList(const QStringList& filterStringList)
-    {
-        FilterSpecList specs;
-        specs.reserve(filterStringList.length());
-        for (const auto& filterString : filterStringList) {
-            specs += FilterSpec::fromFilterString(filterString);
+    for (const auto& pat : patterns) {
+        if (pat == "*" || pat == "*.*") {
+            return true;
         }
-        return specs;
+    }
+    return false;
+}
+
+static QString getFilterDisplayName(const FileDialog::Filter& filter, bool showPatterns)
+{
+    // Avoid overflowing the screen with an excessively long filter list (see #23139).
+    const qsizetype MaxFiltersLength = 128;
+    const qsizetype TypicalMaxPatternLength = 12;
+
+    if (!showPatterns) {
+        return filter.name;
     }
 
-    QStringList toQtFilterList(bool showPatterns) const
-    {
-        QStringList qtFilters;
-        for (const auto& filterSpec : *this) {
-            qtFilters += filterSpec.toQtFilter(showPatterns);
+    QString formatted(filter.name);
+    formatted += QLatin1Char(' ');
+
+    // Deduplicate the patterns which usually come in both uppercase and lowercase variants.
+    // Keeps the first case encountered for a given pattern set.
+    // O(n^2) in complexity but the pattern lists are usually short.
+    QList<QStringView> seen;
+    seen.reserve(filter.patterns.size());
+    const auto wasSeen = [&seen](QStringView pat) -> bool {
+        for (QStringView patSeen : seen) {
+            if (patSeen.compare(pat, Qt::CaseInsensitive) == 0) {
+                return true;
+            }
         }
-        return qtFilters;
+        return false;
+    };
+    QString dedupPatterns;
+    dedupPatterns.reserve(filter.patterns.length() * TypicalMaxPatternLength);
+    for (auto it = filter.patterns.cbegin(); it != filter.patterns.cend(); ++it) {
+        if (!wasSeen(*it)) {
+            seen.append(*it);
+            if (it != filter.patterns.cbegin()) {
+                dedupPatterns += QLatin1Char(' ');
+            }
+            dedupPatterns += *it;
+        }
     }
 
-    qsizetype indexOfFilterString(const QString& filterString) const
-    {
-        return indexOf(FilterSpec::fromFilterString(filterString));
+    if (dedupPatterns.size() <= MaxFiltersLength) {
+        formatted += QLatin1Char('(');
+        formatted += dedupPatterns;
+        formatted += QLatin1Char(')');
     }
-};
+
+    return formatted;
+}
+
+static QString toQtFilter(const FileDialog::Filter& filter, bool showPatterns)
+{
+    return getFilterDisplayName(filter, showPatterns) + QStringLiteral(" (")
+        + filter.patterns.join(QLatin1Char(' ')) + QLatin1Char(')');
+}
+
+// This function is intentionally not exposed as code using `FilterList`s
+// should be using them natively as intended, not converted from strings
+// at the last minute.
+static FileDialog::FilterList filterListFromStringList(const QStringList& filterStringList)
+{
+    FileDialog::FilterList filters;
+    filters.reserve(filterStringList.length());
+    for (const auto& filterString : filterStringList) {
+        filters += FileDialog::Filter::fromFilterString(filterString);
+    }
+    return filters;
+}
+
+QStringList toQtFilterList(const FileDialog::FilterList& filterList, bool showPatterns)
+{
+    QStringList qtFilters;
+    for (const auto& filter : filterList) {
+        qtFilters += toQtFilter(filter, showPatterns);
+    }
+    return qtFilters;
+}
+
+qsizetype indexOfFilterString(const FileDialog::FilterList& filterList, const QString& filterString)
+{
+    return filterList.indexOf(FileDialog::Filter::fromFilterString(filterString));
+}
 
 enum class NativeFileDialogMode
 {
@@ -435,8 +420,8 @@ static QStringList nativeFileDialog(
     NativeFileDialogMode mode,
     QWidget* parent,
     const QString& caption,
-    QString& dir,
-    const FilterSpecList& filterSpecs,
+    const QString& dir,
+    const FileDialog::FilterList& filters,
     qsizetype* selectedFilterIndex,
     FileDialog::Options options
 )
@@ -451,10 +436,10 @@ static QStringList nativeFileDialog(
     }
 
     QString flatFilter;
-    for (const auto& filterSpec : filterSpecs) {
-        flatFilter += filterSpec.getDisplayName(showPatterns);
+    for (const auto& filter : filters) {
+        flatFilter += getFilterDisplayName(filter, showPatterns);
         flatFilter += QLatin1Char('\0');
-        flatFilter += filterSpec.patterns.join(QLatin1Char(';'));
+        flatFilter += filter.patterns.join(QLatin1Char(';'));
         flatFilter += QLatin1Char('\0');
     }
     flatFilter += QLatin1Char('\0');
@@ -521,14 +506,14 @@ static QStringList nativeFileDialog(
     NativeFileDialogMode mode,
     QWidget* parent,
     const QString& caption,
-    QString& dir,
-    const FilterSpecList& filterSpecs,
+    const QString& dir,
+    const FileDialog::FilterList& filters,
     qsizetype* selectedFilterIndex,
     FileDialog::Options options
 )
 {
     const bool showPatterns = getPreferShowFilterPatterns();
-    const auto qtFilterList = filterSpecs.toQtFilterList(showPatterns);
+    const auto qtFilterList = toQtFilterList(filters, showPatterns);
     QString selectedQtFilter = (selectedFilterIndex != nullptr && *selectedFilterIndex >= 0)
         ? qtFilterList[*selectedFilterIndex]
         : "";
@@ -574,10 +559,10 @@ static QStringList nativeFileDialog(
  * Modifies a path obtained as a result of a save file dialog to ensure the file
  * name matches the selected file filter.
  */
-static void normalizeSavePath(QString& path, const FilterSpec& selectedFilterSpec)
+static void normalizeSavePath(QString& path, const FileDialog::Filter& selectedFilter)
 {
     // Wildcards have no rule by definition.
-    if (selectedFilterSpec.isWildcard()) {
+    if (selectedFilter.isWildcard()) {
         return;
     }
 
@@ -604,7 +589,7 @@ static void normalizeSavePath(QString& path, const FilterSpec& selectedFilterSpe
     const auto typedName = QStringView(path).mid(path.lastIndexOf('/') + 1);
 
     // Check for any full-name filters first.
-    for (const auto& pat : selectedFilterSpec.patterns) {
+    for (const auto& pat : selectedFilter.patterns) {
         if (!pat.startsWith("*.") && typedName == pat) {
             return;
         }
@@ -624,7 +609,7 @@ static void normalizeSavePath(QString& path, const FilterSpec& selectedFilterSpe
         path.chop(1);
     }
     else /* size() > 1 */ {
-        for (const auto& pat : selectedFilterSpec.patterns) {
+        for (const auto& pat : selectedFilter.patterns) {
             if (pat.startsWith("*.") && typedExt == QStringView(pat).mid(1)) {
                 // Valid extension found for the selected filter.
                 return;
@@ -633,7 +618,7 @@ static void normalizeSavePath(QString& path, const FilterSpec& selectedFilterSpe
     }
 
     // Append extension from first *.xyz-style pattern.
-    for (const auto& pat : selectedFilterSpec.patterns) {
+    for (const auto& pat : selectedFilter.patterns) {
         if (pat.startsWith("*.")) {
             path.append(QStringView(pat).mid(1));
             break;
@@ -644,13 +629,13 @@ static void normalizeSavePath(QString& path, const FilterSpec& selectedFilterSpe
 #ifndef NDEBUG
 static void testNormalizeSavePath()
 {
-    const auto spec = FilterSpec::fromFilterString(
+    const auto filt = Filter::fromFilterString(
         QStringLiteral("Whatever files (what ev.er *.abc *.xyz)")
     );
-    const auto nspEq = [spec](QString path, const QString& desired) -> bool {
-        normalizeSavePath(path, spec);
+    const auto nspEq = [filt](QString path, const QString& desired) -> bool {
+        normalizeSavePath(path, filt);
         const auto firstPassResult = path;
-        normalizeSavePath(path, spec);
+        normalizeSavePath(path, filt);
         const bool idempotent = firstPassResult == path;
         return idempotent && path == desired;
     };
@@ -770,9 +755,9 @@ QString FileDialog::getSaveFileName(
         windowTitle = FileDialog::tr("Save As");
     }
 
-    const auto filterSpecList = FilterSpecList::fromFilterStringList(filters);
+    const auto filterList = filterListFromStringList(filters);
     qsizetype selectedFilterIndex = (selectedFilter != nullptr && !selectedFilter->isEmpty())
-        ? filterSpecList.indexOfFilterString(*selectedFilter)
+        ? indexOfFilterString(filterList, *selectedFilter)
         : -1;
 
     options |= QFileDialog::HideNameFilterDetails;
@@ -783,7 +768,7 @@ QString FileDialog::getSaveFileName(
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
         const bool showPatterns = getPreferShowFilterPatterns();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
+        const auto qtFilterList = toQtFilterList(filterList, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -802,7 +787,7 @@ QString FileDialog::getSaveFileName(
         }
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
+            dlg.selectNameFilter(toQtFilter(filterList[selectedFilterIndex], showPatterns));
         }
         dlg.onSelectedFilter(dlg.selectedNameFilter());
         dlg.setOption(QFileDialog::DontConfirmOverwrite, false);
@@ -819,7 +804,7 @@ QString FileDialog::getSaveFileName(
             parent,
             windowTitle,
             dirName,
-            filterSpecList,
+            filterList,
             &selectedFilterIndex,
             options
         )[0];
@@ -838,7 +823,7 @@ QString FileDialog::getSaveFileName(
 #ifndef NDEBUG
     testNormalizeSavePath();
 #endif  // NDEBUG
-    normalizeSavePath(file, filterSpecList[selectedFilterIndex]);
+    normalizeSavePath(file, filterList[selectedFilterIndex]);
 
     setWorkingDirectory(file);
     return file;
@@ -894,9 +879,9 @@ QString FileDialog::getOpenFileName(
         windowTitle = FileDialog::tr("Open");
     }
 
-    const auto filterSpecList = FilterSpecList::fromFilterStringList(filters);
+    const auto filterList = filterListFromStringList(filters);
     qsizetype selectedFilterIndex = (selectedFilter && !selectedFilter->isEmpty())
-        ? filterSpecList.indexOfFilterString(*selectedFilter)
+        ? indexOfFilterString(filterList, *selectedFilter)
         : -1;
 
     options |= QFileDialog::HideNameFilterDetails;
@@ -904,7 +889,7 @@ QString FileDialog::getOpenFileName(
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
         const bool showPatterns = getPreferShowFilterPatterns();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
+        const auto qtFilterList = toQtFilterList(filterList, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -920,7 +905,7 @@ QString FileDialog::getOpenFileName(
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
+            dlg.selectNameFilter(toQtFilter(filterList[selectedFilterIndex], showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
@@ -935,7 +920,7 @@ QString FileDialog::getOpenFileName(
             parent,
             windowTitle,
             dirName,
-            filterSpecList,
+            filterList,
             &selectedFilterIndex,
             options
         )[0];
@@ -978,9 +963,9 @@ QStringList FileDialog::getOpenFileNames(
         windowTitle = FileDialog::tr("Open");
     }
 
-    const auto filterSpecList = FilterSpecList::fromFilterStringList(filters);
+    const auto filterList = filterListFromStringList(filters);
     qsizetype selectedFilterIndex = (selectedFilter != nullptr && !selectedFilter->isEmpty())
-        ? filterSpecList.indexOfFilterString(*selectedFilter)
+        ? indexOfFilterString(filterList, *selectedFilter)
         : -1;
 
     options |= QFileDialog::HideNameFilterDetails;
@@ -988,7 +973,7 @@ QStringList FileDialog::getOpenFileNames(
     QStringList files;
     if (DialogOptions::dontUseNativeFileDialog()) {
         const bool showPatterns = getPreferShowFilterPatterns();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
+        const auto qtFilterList = toQtFilterList(filterList, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -1004,7 +989,7 @@ QStringList FileDialog::getOpenFileNames(
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
+            dlg.selectNameFilter(toQtFilter(filterList[selectedFilterIndex], showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
@@ -1019,7 +1004,7 @@ QStringList FileDialog::getOpenFileNames(
             parent,
             windowTitle,
             dirName,
-            filterSpecList,
+            filterList,
             &selectedFilterIndex,
             options
         );

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -458,8 +458,10 @@ static QStringList nativeFileDialog(
     }
 
     QStringList selected;
-    if (ok) {
-        selectedFilterIndex = ofn.nFilterIndex - 1;
+    // Always return a selected filter index >= 0, but
+    // ofn.nFilterIndex, while 1-based, might be 0 if the user cancelled.
+    selectedFilterIndex = ofn.nFilterIndex == 0 ? 0 : (ofn.nFilterIndex - 1);
+    if (ok != FALSE) {
         const QString dir = QDir::cleanPath(QString::fromWCharArray(ofn.lpstrFile));
         selected += dir;
         if (ofn.Flags & OFN_ALLOWMULTISELECT) {
@@ -682,7 +684,7 @@ QString FileDialog::getSaveFileName(
         actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
     }
     else {
-        file = nativeFileDialog(
+        const auto files = nativeFileDialog(
             NativeFileDialogMode::Save,
             parent,
             windowTitle,
@@ -690,7 +692,10 @@ QString FileDialog::getSaveFileName(
             filters,
             actuallySelectedFilterIndex,
             options
-        )[0];
+        );
+        if (!files.isEmpty()) {
+            file = files.constFirst();
+        }
     }
 
     if (selectedFilterIndex != nullptr) {
@@ -801,7 +806,7 @@ QString FileDialog::getOpenFileName(
         actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
     }
     else {
-        file = nativeFileDialog(
+        const auto files = nativeFileDialog(
             NativeFileDialogMode::OpenSingle,
             parent,
             windowTitle,
@@ -809,7 +814,11 @@ QString FileDialog::getOpenFileName(
             filters,
             actuallySelectedFilterIndex,
             options
-        )[0];
+        );
+        if (!files.isEmpty())
+        {
+            file = files.constFirst();
+        }
     }
 
     if (selectedFilterIndex != nullptr) {

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -55,12 +55,12 @@
 #include <QStyle>
 #include <QUrl>
 
-
 #include <Base/Parameter.h>
 #include <App/Application.h>
 #include <App/Document.h>
 
 #include "FileDialog.h"
+#include "FileDialogInternal.h"
 #include "MainWindow.h"
 #include "Tools.h"
 
@@ -261,7 +261,7 @@ void FileDialog::accept()
     QFileDialog::accept();
 }
 
-static bool getPreferShowFilterPatterns()
+bool FileDialogInternal::getPreferShowFilterPatterns()
 {
     bool show = true;
 #ifdef FC_OS_WIN32
@@ -304,7 +304,7 @@ bool FileDialog::Filter::isWildcard() const
     return false;
 }
 
-static QString getFilterDisplayName(const FileDialog::Filter& filter, bool showPatterns)
+QString FileDialogInternal::getFilterDisplayName(const FileDialog::Filter& filter, bool showPatterns)
 {
     // Avoid overflowing the screen with an excessively long filter list (see #23139).
     const qsizetype MaxFiltersLength = 128;
@@ -353,7 +353,7 @@ static QString getFilterDisplayName(const FileDialog::Filter& filter, bool showP
 
 static QString toQtFilter(const FileDialog::Filter& filter, bool showPatterns)
 {
-    return getFilterDisplayName(filter, showPatterns) + QStringLiteral(" (")
+    return FileDialogInternal::getFilterDisplayName(filter, showPatterns) + QStringLiteral(" (")
         + filter.patterns.join(QLatin1Char(' ')) + QLatin1Char(')');
 }
 
@@ -371,120 +371,8 @@ qsizetype indexOfFilterString(const FileDialog::FilterList& filterList, const QS
     return filterList.indexOf(FileDialog::Filter::fromFilterString(filterString));
 }
 
-enum class NativeFileDialogMode
-{
-    OpenSingle,
-    OpenMultiple,
-    Save,
-};
-
-#ifdef FC_OS_WIN32
-static std::unique_ptr<wchar_t[]> qStringToWCharArray(const QString& s, size_t reserveSize = 0)
-{
-    const size_t stringSize = s.size();
-    wchar_t* result = new wchar_t[qMax(stringSize + 1, reserveSize)];
-    s.toWCharArray(result);
-    result[stringSize] = 0;
-    return std::unique_ptr<wchar_t[]>(result);
-}
-
-/* Use the legacy Get{Open,Save}FileNameW functions as the Vista+ IFileDialog forces
- * pattern/extension display in filter lists, leading to exceedingly long entries as seen in
- * issue #23139.
- * Note neither this legacy function set nor IFileDialog are valid for UWP WinRT,
- * for which Windows::Storage::Pickers::FileOpenPicker will have to be used instead.
- */
-static QStringList nativeFileDialog(
-    NativeFileDialogMode mode,
-    QWidget* parent,
-    const QString& caption,
-    const QString& startPath,
-    const FileDialog::FilterList& filters,
-    qsizetype& selectedFilterIndex,
-    FileDialog::Options options
-)
-{
-    const bool showPatterns = getPreferShowFilterPatterns();
-
-    OPENFILENAMEW ofn;
-    memset(&ofn, 0, sizeof(OPENFILENAMEW));
-    ofn.lStructSize = sizeof(OPENFILENAMEW);
-    if (parent) {
-        ofn.hwndOwner = HWND(parent->winId());
-    }
-
-    QString flatFilter;
-    for (const auto& filter : filters) {
-        flatFilter += getFilterDisplayName(filter, showPatterns);
-        flatFilter += QLatin1Char('\0');
-        flatFilter += filter.patterns.join(QLatin1Char(';'));
-        flatFilter += QLatin1Char('\0');
-    }
-    flatFilter += QLatin1Char('\0');
-    auto ofnFilter = qStringToWCharArray(flatFilter);
-    ofn.lpstrFilter = ofnFilter.get();
-
-    if (selectedFilterIndex >= 0) {
-        ofn.nFilterIndex = selectedFilterIndex + 1;  // OPENFILENAMEW index is 1-based
-    }
-
-    const QFileInfo startPathInfo(startPath);
-
-    constexpr const DWORD SelectionBufferSize = 65535;
-    auto selectedFile = std::make_unique<wchar_t[]>(SelectionBufferSize);
-    startPathInfo.fileName().toWCharArray(selectedFile.get());
-    selectedFile[startPathInfo.fileName().size()] = L'\0';
-
-    ofn.nMaxFile = SelectionBufferSize;
-    ofn.lpstrFile = selectedFile.get();
-
-    auto initialDir = qStringToWCharArray(QDir::toNativeSeparators(startPath));
-    ofn.lpstrInitialDir = initialDir.get();
-
-    auto title = qStringToWCharArray(caption);
-    ofn.lpstrTitle = title.get();
-
-    ofn.Flags = OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_PATHMUSTEXIST;
-    if (mode == NativeFileDialogMode::OpenSingle || mode == NativeFileDialogMode::OpenMultiple) {
-        ofn.Flags |= OFN_FILEMUSTEXIST;
-    }
-
-    BOOL ok = FALSE;
-    if (mode == NativeFileDialogMode::OpenSingle) {
-        ok = ::GetOpenFileNameW(&ofn);
-    }
-    else if (mode == NativeFileDialogMode::OpenMultiple) {
-        ofn.Flags |= OFN_ALLOWMULTISELECT;
-        ok = ::GetOpenFileNameW(&ofn);
-    }
-    else /* (mode == NativeFileDialogMode::Save) */ {
-        ok = ::GetSaveFileNameW(&ofn);
-    }
-
-    QStringList selected;
-    // Always return a selected filter index >= 0, but
-    // ofn.nFilterIndex, while 1-based, might be 0 if the user cancelled.
-    selectedFilterIndex = ofn.nFilterIndex == 0 ? 0 : (ofn.nFilterIndex - 1);
-    if (ok != FALSE) {
-        const QString dir = QDir::cleanPath(QString::fromWCharArray(ofn.lpstrFile));
-        selected += dir;
-        if (ofn.Flags & OFN_ALLOWMULTISELECT) {
-            const wchar_t* ptr = ofn.lpstrFile + dir.size() + 1;
-            if (*ptr) {
-                selected.clear();
-                const QString path = dir + L'/';
-                while (*ptr) {
-                    const QString fileName = QString::fromWCharArray(ptr);
-                    selected += path + fileName;
-                    ptr += fileName.size() + 1;
-                }
-            }
-        }
-    }
-    return selected;
-}
-#else
-static QStringList nativeFileDialog(
+#ifndef FC_OS_WIN32
+QStringList FileDialogInternal::nativeFileDialog(
     NativeFileDialogMode mode,
     QWidget* parent,
     const QString& caption,
@@ -537,7 +425,7 @@ static QStringList nativeFileDialog(
  * Modifies a path obtained as a result of a save file dialog to ensure the file
  * name matches the selected file filter.
  */
-void detail::normalizeSavePath(QString& path, const FileDialog::Filter& selectedFilter)
+void FileDialogInternal::normalizeSavePath(QString& path, const FileDialog::Filter& selectedFilter)
 {
     // Wildcards have no rule by definition.
     if (selectedFilter.isWildcard()) {
@@ -640,7 +528,10 @@ QString FileDialog::getSaveFileName(
             // of the pre-selected filter, if applicable.
             hasFilename = true;
             if (actuallySelectedFilterIndex >= 0) {
-                detail::normalizeSavePath(suggestedPath, filters[actuallySelectedFilterIndex]);
+                FileDialogInternal::normalizeSavePath(
+                    suggestedPath,
+                    filters[actuallySelectedFilterIndex]
+                );
             }
         }
     }
@@ -654,7 +545,7 @@ QString FileDialog::getSaveFileName(
 
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showPatterns = getPreferShowFilterPatterns();
+        const bool showPatterns = FileDialogInternal::getPreferShowFilterPatterns();
         const auto qtFilterList = toQtFilterList(filters, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
@@ -689,7 +580,7 @@ QString FileDialog::getSaveFileName(
     }
     else {
         const auto files = nativeFileDialog(
-            NativeFileDialogMode::Save,
+            FileDialogInternal::NativeFileDialogMode::Save,
             parent,
             windowTitle,
             suggestedPath,
@@ -717,7 +608,7 @@ QString FileDialog::getSaveFileName(
     // file if the platform dialog didn't enforce pattern matching and prompt the user
     // upon overwrite. Take the path of least destruction.
     const QString pristineUserInput(file);
-    detail::normalizeSavePath(file, filters[actuallySelectedFilterIndex]);
+    FileDialogInternal::normalizeSavePath(file, filters[actuallySelectedFilterIndex]);
     if (file != pristineUserInput && QFileInfo::exists(file)) {
         file = pristineUserInput;
     }
@@ -783,7 +674,7 @@ QString FileDialog::getOpenFileName(
 
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showPatterns = getPreferShowFilterPatterns();
+        const bool showPatterns = FileDialogInternal::getPreferShowFilterPatterns();
         const auto qtFilterList = toQtFilterList(filters, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
@@ -811,7 +702,7 @@ QString FileDialog::getOpenFileName(
     }
     else {
         const auto files = nativeFileDialog(
-            NativeFileDialogMode::OpenSingle,
+            FileDialogInternal::NativeFileDialogMode::OpenSingle,
             parent,
             windowTitle,
             dirName,
@@ -819,8 +710,7 @@ QString FileDialog::getOpenFileName(
             actuallySelectedFilterIndex,
             options
         );
-        if (!files.isEmpty())
-        {
+        if (!files.isEmpty()) {
             file = files.constFirst();
         }
     }
@@ -870,7 +760,7 @@ QStringList FileDialog::getOpenFileNames(
 
     QStringList files;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showPatterns = getPreferShowFilterPatterns();
+        const bool showPatterns = FileDialogInternal::getPreferShowFilterPatterns();
         const auto qtFilterList = toQtFilterList(filters, showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
@@ -898,7 +788,7 @@ QStringList FileDialog::getOpenFileNames(
     }
     else {
         files = nativeFileDialog(
-            NativeFileDialogMode::OpenMultiple,
+            FileDialogInternal::NativeFileDialogMode::OpenMultiple,
             parent,
             windowTitle,
             dirName,

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -274,7 +274,7 @@ static void getSuffixesDescription(QStringList& suffixes, const QString& suffixD
     }
 }
 
-static bool getPreferShowFilterExtensions()
+static bool getPreferShowFilterPatterns()
 {
     bool show = true;
 #ifdef FC_OS_WIN32
@@ -288,17 +288,19 @@ static bool getPreferShowFilterExtensions()
                                      .GetGroup("BaseApp")
                                      ->GetGroup("Preferences")
                                      ->GetGroup("Dialog");
-    return group->GetBool("ShowFilterExtensions", show);
+    return group->GetBool("ShowFilterPatterns", show);
 }
 
 struct FilterSpec
 {
     QString name;
-    QStringList extensions;
+    /// List of patterns matched by this filter. Note that extensions are
+    /// just a subset of patterns in the form of "*.ext".
+    QStringList patterns;
 
     bool operator==(const FilterSpec& rhs) const
     {
-        return name == rhs.name && extensions == rhs.extensions;
+        return name == rhs.name && patterns == rhs.patterns;
     }
 
     static FilterSpec fromFilterString(const QString& filter)
@@ -306,61 +308,61 @@ struct FilterSpec
         const auto start = filter.lastIndexOf(QLatin1Char('('));
         const auto end = filter.lastIndexOf(QLatin1Char(')'));
         const auto name = filter.left(start).trimmed();
-        const auto extensionsPart = filter.mid(start + 1, end - start - 1);
-        return {name, extensionsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
+        const auto patternsPart = filter.mid(start + 1, end - start - 1);
+        return {name, patternsPart.split(QLatin1Char(' '), Qt::SkipEmptyParts)};
     }
 
-    QString getDisplayName(bool showExtensions) const
+    QString getDisplayName(bool showPatterns) const
     {
         // Avoid overflowing the screen with an excessively long filter list (see #23139).
         const qsizetype MaxFiltersLength = 128;
-        const qsizetype TypicalMaxExtensionLength = 12;
+        const qsizetype TypicalMaxPatternLength = 12;
 
-        if (!showExtensions) {
+        if (!showPatterns) {
             return name;
         }
 
         QString formatted(name);
         formatted += QLatin1Char(' ');
 
-        // Deduplicate the extensions which usually come in both *.ext & *.EXT variants.
-        // Keeps the first case encountered for a given extension set.
-        // O(n^2) in complexity but the extension lists are usually short.
+        // Deduplicate the patterns which usually come in both uppercase and lowercase variants.
+        // Keeps the first case encountered for a given pattern set.
+        // O(n^2) in complexity but the pattern lists are usually short.
         QList<QStringView> seen;
-        seen.reserve(extensions.size());
-        const auto wasSeen = [&seen](QStringView ext) -> bool {
-            for (QStringView extSeen : seen) {
-                if (extSeen.compare(ext, Qt::CaseInsensitive) == 0) {
+        seen.reserve(patterns.size());
+        const auto wasSeen = [&seen](QStringView pat) -> bool {
+            for (QStringView patSeen : seen) {
+                if (patSeen.compare(pat, Qt::CaseInsensitive) == 0) {
                     return true;
                 }
             }
             return false;
         };
-        QString dedupExtensions;
-        dedupExtensions.reserve(extensions.length() * TypicalMaxExtensionLength);
-        for (auto it = extensions.cbegin(); it != extensions.cend(); ++it) {
+        QString dedupPatterns;
+        dedupPatterns.reserve(patterns.length() * TypicalMaxPatternLength);
+        for (auto it = patterns.cbegin(); it != patterns.cend(); ++it) {
             if (!wasSeen(*it)) {
                 seen.append(*it);
-                if (it != extensions.cbegin()) {
-                    dedupExtensions += QLatin1Char(' ');
+                if (it != patterns.cbegin()) {
+                    dedupPatterns += QLatin1Char(' ');
                 }
-                dedupExtensions += *it;
+                dedupPatterns += *it;
             }
         }
 
-        if (dedupExtensions.size() <= MaxFiltersLength) {
+        if (dedupPatterns.size() <= MaxFiltersLength) {
             formatted += QLatin1Char('(');
-            formatted += dedupExtensions;
+            formatted += dedupPatterns;
             formatted += QLatin1Char(')');
         }
 
         return formatted;
     }
 
-    QString toQtFilter(bool showExtensions) const
+    QString toQtFilter(bool showPatterns) const
     {
-        return getDisplayName(showExtensions) + QStringLiteral(" (")
-            + extensions.join(QLatin1Char(' ')) + QLatin1Char(')');
+        return getDisplayName(showPatterns) + QStringLiteral(" (") + patterns.join(QLatin1Char(' '))
+            + QLatin1Char(')');
     }
 };
 
@@ -377,11 +379,11 @@ public:
         return specs;
     }
 
-    QStringList toQtFilterList(bool showExtensions) const
+    QStringList toQtFilterList(bool showPatterns) const
     {
         QStringList qtFilters;
         for (const auto& filterSpec : *this) {
-            qtFilters += filterSpec.toQtFilter(showExtensions);
+            qtFilters += filterSpec.toQtFilter(showPatterns);
         }
         return qtFilters;
     }
@@ -410,7 +412,7 @@ static std::unique_ptr<wchar_t[]> qStringToWCharArray(const QString& s, size_t r
 }
 
 /* Use the legacy Get{Open,Save}FileNameW functions as the Vista+ IFileDialog forces
- * extension display in filter lists, leading to exceedingly long entries as seen in
+ * pattern/extension display in filter lists, leading to exceedingly long entries as seen in
  * issue #23139.
  * Note neither this legacy function set nor IFileDialog are valid for UWP WinRT,
  * for which Windows::Storage::Pickers::FileOpenPicker will have to be used instead.
@@ -425,7 +427,7 @@ static QStringList nativeFileDialog(
     FileDialog::Options options
 )
 {
-    const bool showExtensions = getPreferShowFilterExtensions();
+    const bool showPatterns = getPreferShowFilterPatterns();
 
     OPENFILENAMEW ofn;
     memset(&ofn, 0, sizeof(OPENFILENAMEW));
@@ -436,9 +438,9 @@ static QStringList nativeFileDialog(
 
     QString flatFilter;
     for (const auto& filterSpec : filterSpecs) {
-        flatFilter += filterSpec.getDisplayName(showExtensions);
+        flatFilter += filterSpec.getDisplayName(showPatterns);
         flatFilter += QLatin1Char('\0');
-        flatFilter += filterSpec.extensions.join(QLatin1Char(';'));
+        flatFilter += filterSpec.patterns.join(QLatin1Char(';'));
         flatFilter += QLatin1Char('\0');
     }
     flatFilter += QLatin1Char('\0');
@@ -511,8 +513,8 @@ static QStringList nativeFileDialog(
     FileDialog::Options options
 )
 {
-    const bool showExtensions = getPreferShowFilterExtensions();
-    const auto qtFilterList = filterSpecs.toQtFilterList(showExtensions);
+    const bool showPatterns = getPreferShowFilterPatterns();
+    const auto qtFilterList = filterSpecs.toQtFilterList(showPatterns);
     QString selectedQtFilter = (selectedFilterIndex != nullptr && *selectedFilterIndex >= 0)
         ? qtFilterList[*selectedFilterIndex]
         : "";
@@ -640,8 +642,8 @@ QString FileDialog::getSaveFileName(
     // and append it before showing the file dialog.
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -660,7 +662,7 @@ QString FileDialog::getSaveFileName(
         }
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         dlg.onSelectedFilter(dlg.selectedNameFilter());
         dlg.setOption(QFileDialog::DontConfirmOverwrite, false);
@@ -771,8 +773,8 @@ QString FileDialog::getOpenFileName(
 
     QString file;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -788,7 +790,7 @@ QString FileDialog::getOpenFileName(
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {
@@ -871,8 +873,8 @@ QStringList FileDialog::getOpenFileNames(
 
     QStringList files;
     if (DialogOptions::dontUseNativeFileDialog()) {
-        const bool showExtensions = getPreferShowFilterExtensions();
-        const auto qtFilterList = filterSpecList.toQtFilterList(showExtensions);
+        const bool showPatterns = getPreferShowFilterPatterns();
+        const auto qtFilterList = filterSpecList.toQtFilterList(showPatterns);
         QList<QUrl> urls = fetchSidebarUrls();
 
         options |= QFileDialog::DontUseNativeDialog;
@@ -888,7 +890,7 @@ QStringList FileDialog::getOpenFileNames(
         dlg.setDirectory(dirName);
         dlg.setNameFilters(qtFilterList);
         if (selectedFilterIndex >= 0) {
-            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showExtensions));
+            dlg.selectNameFilter(filterSpecList[selectedFilterIndex].toQtFilter(showPatterns));
         }
         if (dlg.exec() == QDialog::Accepted) {
             if (selectedFilter) {

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -147,11 +147,6 @@ private:
     static QString workingDirectory;
 };
 
-namespace detail
-{
-GuiExport void normalizeSavePath(QString&, const FileDialog::Filter&);
-}  // namespace detail
-
 // ----------------------------------------------------------------------
 
 /**

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -66,6 +66,9 @@ public:
      */
     struct GuiExport Filter
     {
+        /** Predefined "All files (*.*)" filter. */
+        static Filter AllFiles();
+
         /** Text displayed for this filter. Translatable. */
         QString name;
 

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -83,6 +83,8 @@ public:
          */
         static Filter fromFilterString(const QString& filter);
 
+        QString toFilterString() const;
+
         bool operator==(const Filter& rhs) const
         {
             return name == rhs.name && patterns == rhs.patterns;
@@ -96,31 +98,31 @@ public:
     static QString getOpenFileName(
         QWidget* parent = nullptr,
         const QString& caption = QString(),
-        const QString& dir = QString(),
-        const QStringList& filters = QStringList(),
-        QString* selectedFilter = nullptr,
+        const QString& startPath = QString(),
+        const FilterList& filters = {},
+        qsizetype* selectedFilterIndex = nullptr,
         Options options = Options()
     );
     static QString getSaveFileName(
         QWidget* parent = nullptr,
         const QString& caption = QString(),
-        const QString& dir = QString(),
-        const QStringList& filters = QStringList(),
-        QString* selectedFilter = nullptr,
+        const QString& startPath = QString(),
+        const FilterList& filters = {},
+        qsizetype* selectedFilterIndex = nullptr,
         Options options = Options()
     );
     static QString getExistingDirectory(
         QWidget* parent = nullptr,
         const QString& caption = QString(),
-        const QString& dir = QString(),
+        const QString& startPath = QString(),
         Options options = ShowDirsOnly
     );
     static QStringList getOpenFileNames(
         QWidget* parent = nullptr,
         const QString& caption = QString(),
-        const QString& dir = QString(),
-        const QStringList& filters = QStringList(),
-        QString* selectedFilter = nullptr,
+        const QString& startPath = QString(),
+        const FilterList& filters = {},
+        qsizetype* selectedFilterIndex = nullptr,
         Options options = Options()
     );
 

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -1,24 +1,23 @@
-/***************************************************************************
- *   Copyright (c) 2004 Werner Mayer <wmayer[at]users.sourceforge.net>     *
- *                                                                         *
- *   This file is part of the FreeCAD CAx development system.              *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2004 Werner Mayer <wmayer[at]users.sourceforge.net>
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
 
 
 #pragma once

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -145,6 +145,11 @@ private:
     static QString workingDirectory;
 };
 
+namespace detail
+{
+GuiExport void normalizeSavePath(QString&, const FileDialog::Filter&);
+}  // namespace detail
+
 // ----------------------------------------------------------------------
 
 /**

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -61,6 +61,38 @@ class GuiExport FileDialog: public QFileDialog
     Q_OBJECT
 
 public:
+    /**
+     * File name filter specification for narrowing down the choice of
+     * files in open/save dialogs.
+     */
+    struct GuiExport Filter
+    {
+        /** Text displayed for this filter. Translatable. */
+        QString name;
+
+        /**
+         * List of patterns matched by this filter. Note that extensions are
+         * just a subset of patterns in the form of "*.ext".
+         * For example, `{"*.so", "*.exe", "*.dyld", "a.out"}`.
+         */
+        QStringList patterns;
+
+        /**
+         * Create a filter from its string form.
+         * These take the form of `Filter name (*.ext1 *.ext2)`.
+         */
+        static Filter fromFilterString(const QString& filter);
+
+        bool operator==(const Filter& rhs) const
+        {
+            return name == rhs.name && patterns == rhs.patterns;
+        }
+
+        /** Checks if the filter is a full wildcard, i.e. accepts "*" or "*.*". */
+        bool isWildcard() const;
+    };
+    using FilterList = QList<Filter>;
+
     static QString getOpenFileName(
         QWidget* parent = nullptr,
         const QString& caption = QString(),

--- a/src/Gui/FileDialog.h
+++ b/src/Gui/FileDialog.h
@@ -79,6 +79,13 @@ public:
          */
         QStringList patterns;
 
+        Filter() = default;
+        ~Filter() = default;
+        Filter(QString name, QStringList patterns)
+            : name(std::move(name))
+            , patterns(std::move(patterns))
+        {}
+
         /**
          * Create a filter from its string form.
          * These take the form of `Filter name (*.ext1 *.ext2)`.

--- a/src/Gui/FileDialogInternal.h
+++ b/src/Gui/FileDialogInternal.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *   Copyright (c) 2026 The FreeCAD Project Association AISBL              *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#pragma once
+
+#include "FileDialog.h"
+
+
+namespace Gui::FileDialogInternal
+{
+
+enum class NativeFileDialogMode : uint8_t
+{
+    OpenSingle,
+    OpenMultiple,
+    Save,
+};
+
+QString getFilterDisplayName(const FileDialog::Filter&, bool);
+
+QStringList nativeFileDialog(
+    NativeFileDialogMode mode,
+    QWidget* parent,
+    const QString& caption,
+    const QString& startPath,
+    const FileDialog::FilterList& filters,
+    qsizetype& selectedFilterIndex,
+    FileDialog::Options options
+);
+
+bool getPreferShowFilterPatterns();
+
+GuiExport void normalizeSavePath(QString&, const FileDialog::Filter&);
+
+}  // namespace Gui::FileDialogInternal

--- a/src/Gui/FileDialogInternal.h
+++ b/src/Gui/FileDialogInternal.h
@@ -1,24 +1,23 @@
-/***************************************************************************
- *   Copyright (c) 2026 The FreeCAD Project Association AISBL              *
- *                                                                         *
- *   This file is part of FreeCAD.                                         *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
- *   Suite 330, Boston, MA  02111-1307, USA                                *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Céleste Wouters <foss@elementw.net>
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
 
 
 #pragma once

--- a/src/Gui/FileDialogWin32.cpp
+++ b/src/Gui/FileDialogWin32.cpp
@@ -1,0 +1,143 @@
+/***************************************************************************
+ *   Copyright (c) 2026 The FreeCAD Project Association AISBL              *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 51 Franklin Street,      *
+ *   Fifth Floor, Boston, MA  02110-1301, USA                              *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <cstddef>
+#include <memory>
+
+// windows.h must be kept above commdlg.h and shlobj.h
+#include <windows.h>
+#include <commdlg.h>
+#include <shlobj.h>
+
+#include <QDir>
+#include <QFileInfo>
+#include <QString>
+
+#include "FileDialogInternal.h"
+
+
+using namespace Gui;
+
+static std::unique_ptr<wchar_t[]> qStringToWCharArray(const QString& s, size_t reserveSize = 0)
+{
+    const size_t stringSize = s.size();
+    wchar_t* result = new wchar_t[qMax(stringSize + 1, reserveSize)];
+    s.toWCharArray(result);
+    result[stringSize] = 0;
+    return std::unique_ptr<wchar_t[]>(result);
+}
+
+/* Use the legacy Get{Open,Save}FileNameW functions as the Vista+ IFileDialog forces
+ * pattern/extension display in filter lists, leading to exceedingly long entries as seen in
+ * issue #23139.
+ * Note neither this legacy function set nor IFileDialog are valid for UWP WinRT,
+ * for which Windows::Storage::Pickers::FileOpenPicker will have to be used instead.
+ */
+QStringList FileDialogInternal::nativeFileDialog(
+    NativeFileDialogMode mode,
+    QWidget* parent,
+    const QString& caption,
+    const QString& startPath,
+    const FileDialog::FilterList& filters,
+    qsizetype& selectedFilterIndex,
+    FileDialog::Options options
+)
+{
+    const bool showPatterns = getPreferShowFilterPatterns();
+
+    OPENFILENAMEW ofn;
+    memset(&ofn, 0, sizeof(OPENFILENAMEW));
+    ofn.lStructSize = sizeof(OPENFILENAMEW);
+    if (parent) {
+        ofn.hwndOwner = HWND(parent->winId());
+    }
+
+    QString flatFilter;
+    for (const auto& filter : filters) {
+        flatFilter += getFilterDisplayName(filter, showPatterns);
+        flatFilter += QLatin1Char('\0');
+        flatFilter += filter.patterns.join(QLatin1Char(';'));
+        flatFilter += QLatin1Char('\0');
+    }
+    flatFilter += QLatin1Char('\0');
+    auto ofnFilter = qStringToWCharArray(flatFilter);
+    ofn.lpstrFilter = ofnFilter.get();
+
+    if (selectedFilterIndex >= 0) {
+        ofn.nFilterIndex = selectedFilterIndex + 1;  // OPENFILENAMEW index is 1-based
+    }
+
+    const QFileInfo startPathInfo(startPath);
+
+    constexpr const DWORD SelectionBufferSize = 65535;
+    auto selectedFile = std::make_unique<wchar_t[]>(SelectionBufferSize);
+    startPathInfo.fileName().toWCharArray(selectedFile.get());
+    selectedFile[startPathInfo.fileName().size()] = L'\0';
+
+    ofn.nMaxFile = SelectionBufferSize;
+    ofn.lpstrFile = selectedFile.get();
+
+    auto initialDir = qStringToWCharArray(QDir::toNativeSeparators(startPath));
+    ofn.lpstrInitialDir = initialDir.get();
+
+    auto title = qStringToWCharArray(caption);
+    ofn.lpstrTitle = title.get();
+
+    ofn.Flags = OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_PATHMUSTEXIST;
+    if (mode == NativeFileDialogMode::OpenSingle || mode == NativeFileDialogMode::OpenMultiple) {
+        ofn.Flags |= OFN_FILEMUSTEXIST;
+    }
+
+    BOOL ok = FALSE;
+    if (mode == NativeFileDialogMode::OpenSingle) {
+        ok = ::GetOpenFileNameW(&ofn);
+    }
+    else if (mode == NativeFileDialogMode::OpenMultiple) {
+        ofn.Flags |= OFN_ALLOWMULTISELECT;
+        ok = ::GetOpenFileNameW(&ofn);
+    }
+    else /* (mode == NativeFileDialogMode::Save) */ {
+        ok = ::GetSaveFileNameW(&ofn);
+    }
+
+    QStringList selected;
+    // Always return a selected filter index >= 0, but
+    // ofn.nFilterIndex, while 1-based, might be 0 if the user cancelled.
+    selectedFilterIndex = ofn.nFilterIndex == 0 ? 0 : (ofn.nFilterIndex - 1);
+    if (ok != FALSE) {
+        const QString dir = QDir::cleanPath(QString::fromWCharArray(ofn.lpstrFile));
+        selected += dir;
+        if (ofn.Flags & OFN_ALLOWMULTISELECT) {
+            const wchar_t* ptr = ofn.lpstrFile + dir.size() + 1;
+            if (*ptr) {
+                selected.clear();
+                const QString path = dir + L'/';
+                while (*ptr) {
+                    const QString fileName = QString::fromWCharArray(ptr);
+                    selected += path + fileName;
+                    ptr += fileName.size() + 1;
+                }
+            }
+        }
+    }
+    return selected;
+}

--- a/src/Gui/FileDialogWin32.cpp
+++ b/src/Gui/FileDialogWin32.cpp
@@ -1,24 +1,23 @@
-/***************************************************************************
- *   Copyright (c) 2026 The FreeCAD Project Association AISBL              *
- *                                                                         *
- *   This file is part of FreeCAD.                                         *
- *                                                                         *
- *   This library is free software; you can redistribute it and/or         *
- *   modify it under the terms of the GNU Library General Public           *
- *   License as published by the Free Software Foundation; either          *
- *   version 2 of the License, or (at your option) any later version.      *
- *                                                                         *
- *   This library  is distributed in the hope that it will be useful,      *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
- *   GNU Library General Public License for more details.                  *
- *                                                                         *
- *   You should have received a copy of the GNU Library General Public     *
- *   License along with this library; see the file COPYING.LIB. If not,    *
- *   write to the Free Software Foundation, Inc., 51 Franklin Street,      *
- *   Fifth Floor, Boston, MA  02110-1301, USA                              *
- *                                                                         *
- ***************************************************************************/
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Céleste Wouters <foss@elementw.net>
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
 
 #include <cstddef>
 #include <memory>

--- a/src/Gui/FileDialogWin32.cpp
+++ b/src/Gui/FileDialogWin32.cpp
@@ -22,6 +22,8 @@
 
 #include <cstddef>
 #include <memory>
+#include <utility>
+#include <vector>
 
 // windows.h must be kept above commdlg.h and shlobj.h
 #include <windows.h>
@@ -30,12 +32,63 @@
 
 #include <QDir>
 #include <QFileInfo>
+#include <QList>
+#include <QPair>
 #include <QString>
+
+#include <Base/Console.h>
 
 #include "FileDialogInternal.h"
 
 
+/* The enum & structs below are part of Win32 private APIs, which are the only
+ * way to force hiding the patterns on file dialog filters.
+ * See https://elementw.net/posts/microsoft-bs-ifiledialog/ for the investigation
+ * that led to the discovery of those.
+ */
+
+using FileDialogPrivateOptions = DWORD;
+static constexpr const FileDialogPrivateOptions FDPO_DONT_FORCE_SHOW_EXTS = 0x10;
+
+struct IFileDialogPrivate_W7Vtbl;
+struct IFileDialogPrivate_W7
+{
+    IFileDialogPrivate_W7Vtbl* lpVtbl;
+};
+struct IFileDialogPrivate_W7Vtbl
+{
+    HRESULT (*QueryInterface)(IFileDialogPrivate_W7*, IID*, void**);
+    ULONG (*AddRef)(IFileDialogPrivate_W7*);
+    ULONG (*Release)(IFileDialogPrivate_W7*);
+    HRESULT (*GetPrivateOptions)(IFileDialogPrivate_W7*, FileDialogPrivateOptions*);
+    HRESULT (*SetPrivateOptions)(IFileDialogPrivate_W7*, FileDialogPrivateOptions);
+};
+
+struct IFileDialogPrivate_W10Vtbl;
+struct IFileDialogPrivate_W10
+{
+    IFileDialogPrivate_W10Vtbl* lpVtbl;
+};
+struct IFileDialogPrivate_W10Vtbl
+{
+    HRESULT (*QueryInterface)(IFileDialogPrivate_W10*, IID*, void**);
+    ULONG (*AddRef)(IFileDialogPrivate_W10*);
+    ULONG (*Release)(IFileDialogPrivate_W10*);
+    HRESULT (*HideControlsForHostedPickerProviderApp)(IFileDialogPrivate_W10*);
+    HRESULT (*EnableControlsForHostedPickerProviderApp)(IFileDialogPrivate_W10*);
+    HRESULT (*GetPrivateOptions)(IFileDialogPrivate_W10*, FileDialogPrivateOptions*);
+    HRESULT (*SetPrivateOptions)(IFileDialogPrivate_W10*, FileDialogPrivateOptions);
+};
+
+#define INITGUID
+#include <initguid.h>
+// clang-format off
+DEFINE_GUID(IID_IFileDialogPrivate_W7, 0xAC92FFC5, 0xF0E9, 0x455A, 0x90, 0x6B, 0x4A, 0x83, 0xE7, 0x4A, 0x80, 0x3B);
+DEFINE_GUID(IID_IFileDialogPrivate_W10, 0x9EA5491C, 0x89C8, 0x4BEF, 0x93, 0xD3, 0x7F, 0x66, 0x5F, 0xB8, 0x2A, 0x33);
+// clang-format on
+
 using namespace Gui;
+using namespace Gui::FileDialogInternal;
 
 static std::unique_ptr<wchar_t[]> qStringToWCharArray(const QString& s, size_t reserveSize = 0)
 {
@@ -46,13 +99,10 @@ static std::unique_ptr<wchar_t[]> qStringToWCharArray(const QString& s, size_t r
     return std::unique_ptr<wchar_t[]>(result);
 }
 
-/* Use the legacy Get{Open,Save}FileNameW functions as the Vista+ IFileDialog forces
- * pattern/extension display in filter lists, leading to exceedingly long entries as seen in
- * issue #23139.
- * Note neither this legacy function set nor IFileDialog are valid for UWP WinRT,
- * for which Windows::Storage::Pickers::FileOpenPicker will have to be used instead.
+/* The legacy Get{Open,Save}FileNameW() functions never change how the file filters are
+ * displayed, inherently avoiding the problem in issue #23139.
  */
-QStringList FileDialogInternal::nativeFileDialog(
+static QStringList legacyNativeFileDialog(
     NativeFileDialogMode mode,
     QWidget* parent,
     const QString& caption,
@@ -62,8 +112,6 @@ QStringList FileDialogInternal::nativeFileDialog(
     FileDialog::Options options
 )
 {
-    const bool showPatterns = getPreferShowFilterPatterns();
-
     OPENFILENAMEW ofn;
     memset(&ofn, 0, sizeof(OPENFILENAMEW));
     ofn.lStructSize = sizeof(OPENFILENAMEW);
@@ -71,6 +119,8 @@ QStringList FileDialogInternal::nativeFileDialog(
         ofn.hwndOwner = HWND(parent->winId());
     }
 
+    // Populate file filters
+    const bool showPatterns = getPreferShowFilterPatterns();
     QString flatFilter;
     for (const auto& filter : filters) {
         flatFilter += getFilterDisplayName(filter, showPatterns);
@@ -82,31 +132,37 @@ QStringList FileDialogInternal::nativeFileDialog(
     auto ofnFilter = qStringToWCharArray(flatFilter);
     ofn.lpstrFilter = ofnFilter.get();
 
+    // Select active filter
     if (selectedFilterIndex >= 0) {
         ofn.nFilterIndex = selectedFilterIndex + 1;  // OPENFILENAMEW index is 1-based
     }
 
-    const QFileInfo startPathInfo(startPath);
-
+    // Pre-select file name, if any
     constexpr const DWORD SelectionBufferSize = 65535;
     auto selectedFile = std::make_unique<wchar_t[]>(SelectionBufferSize);
+
+    const QFileInfo startPathInfo(startPath);
     startPathInfo.fileName().toWCharArray(selectedFile.get());
     selectedFile[startPathInfo.fileName().size()] = L'\0';
 
     ofn.nMaxFile = SelectionBufferSize;
     ofn.lpstrFile = selectedFile.get();
 
+    // Select starting directory, if any
     auto initialDir = qStringToWCharArray(QDir::toNativeSeparators(startPath));
     ofn.lpstrInitialDir = initialDir.get();
 
+    // Set title
     auto title = qStringToWCharArray(caption);
     ofn.lpstrTitle = title.get();
 
+    // Mode flags
     ofn.Flags = OFN_NOCHANGEDIR | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_PATHMUSTEXIST;
     if (mode == NativeFileDialogMode::OpenSingle || mode == NativeFileDialogMode::OpenMultiple) {
         ofn.Flags |= OFN_FILEMUSTEXIST;
     }
 
+    // Show the dialog
     BOOL ok = FALSE;
     if (mode == NativeFileDialogMode::OpenSingle) {
         ok = ::GetOpenFileNameW(&ofn);
@@ -140,4 +196,238 @@ QStringList FileDialogInternal::nativeFileDialog(
         }
     }
     return selected;
+}
+
+struct ComRuntime
+{
+    ComRuntime()
+    {
+        CoInitialize(nullptr);
+    }
+    ~ComRuntime()
+    {
+        CoUninitialize();
+    }
+};
+
+// WRL ComPtr-like wrapper, without the need for WRL
+template<typename T>
+struct ComPointer
+{
+    T* ptr;
+    ComPointer()
+        : ptr(nullptr)
+    {}
+    ~ComPointer()
+    {
+        if (ptr) {
+            ptr->Release();
+        }
+    }
+    T* operator->() const
+    {
+        return ptr;
+    }
+    operator bool() const
+    {
+        return ptr != nullptr;
+    }
+    operator T*() const
+    {
+        return ptr;
+    }
+    void** ppvObject()
+    {
+        return reinterpret_cast<void**>(&ptr);
+    }
+    // An `operator T**` would exist here if type conversion rules to bool
+    // did not make them ambiguous even in the presence of `operator bool`.
+};
+
+/* Try using the Vista+ IFileDialog APIs first with the private interfaces,
+ * falling back to legacy functions if said private APIs aren't available.
+ *
+ * Note neither IFileDialog or the legacy functions are valid for UWP WinRT,
+ * for which Windows::Storage::Pickers::FileOpenPicker will have to be used instead.
+ */
+QStringList FileDialogInternal::nativeFileDialog(
+    NativeFileDialogMode mode,
+    QWidget* parent,
+    const QString& caption,
+    const QString& startPath,
+    const FileDialog::FilterList& filters,
+    qsizetype& selectedFilterIndex,
+    FileDialog::Options options
+)
+{
+    ComRuntime com;
+    const bool isOpen = mode == NativeFileDialogMode::OpenSingle
+        || mode == NativeFileDialogMode::OpenMultiple;
+
+    ComPointer<IFileDialog> fileDialog;
+    if (FAILED(CoCreateInstance(
+            isOpen ? CLSID_FileOpenDialog : CLSID_FileSaveDialog,
+            nullptr,
+            CLSCTX_INPROC_SERVER,
+            isOpen ? IID_IFileOpenDialog : IID_IFileSaveDialog,
+            fileDialog.ppvObject()
+        ))) {
+        Base::Console().warning("Failed to create IFileDialog, falling back on GetOpen/SaveFileNameW");
+        return legacyNativeFileDialog(mode, parent, caption, startPath, filters, selectedFilterIndex, options);
+    }
+
+    // These aren't wrapped interfaces, can't use ComPointer on them
+    IFileDialogPrivate_W10* w10;
+    IFileDialogPrivate_W7* w7;
+    // Set the private flag to hide filter patterns
+    if (SUCCEEDED(
+            fileDialog->QueryInterface(IID_IFileDialogPrivate_W10, reinterpret_cast<void**>(&w10))
+        )) {
+        FileDialogPrivateOptions flags;
+        w10->lpVtbl->GetPrivateOptions(w10, &flags);
+        w10->lpVtbl->SetPrivateOptions(w10, flags | FDPO_DONT_FORCE_SHOW_EXTS);
+        w10->lpVtbl->Release(w10);
+    }
+    else if (
+        SUCCEEDED(fileDialog->QueryInterface(IID_IFileDialogPrivate_W7, reinterpret_cast<void**>(&w7)))
+    ) {
+        FileDialogPrivateOptions flags;
+        w7->lpVtbl->GetPrivateOptions(w7, &flags);
+        w7->lpVtbl->SetPrivateOptions(w7, flags | FDPO_DONT_FORCE_SHOW_EXTS);
+        w7->lpVtbl->Release(w7);
+    }
+    else {
+        // No private API, fall back to legacy and emit warning
+        Base::Console()
+            .warning("FileDialog fell back on legacy GetOpen/SaveFileNameW, the IFileDialog private API needs to be updated");
+        return legacyNativeFileDialog(mode, parent, caption, startPath, filters, selectedFilterIndex, options);
+    }
+
+    // Populate file filters
+    const bool showPatterns = getPreferShowFilterPatterns();
+    std::vector<std::pair<QString, QString>> qstringFilterSpecs;
+    qstringFilterSpecs.reserve(filters.size());
+    qsizetype totalStringLength = 0;
+    for (const auto& filter : filters) {
+        const auto display = getFilterDisplayName(filter, showPatterns);
+        totalStringLength += display.size() + 1;
+        const auto patterns = filter.patterns.join(QLatin1Char(';'));
+        totalStringLength += patterns.size() + 1;
+        qstringFilterSpecs.emplace_back(std::move(display), std::move(patterns));
+    }
+    auto comFilterSpecs = std::make_unique<COMDLG_FILTERSPEC[]>(filters.size());
+    auto comFilterBuffer = std::make_unique<wchar_t[]>(totalStringLength);
+    auto ptr = comFilterBuffer.get();
+    for (qsizetype i = 0; i < filters.size(); ++i) {
+        comFilterSpecs[i].pszName = ptr;
+        ptr += qstringFilterSpecs[i].first.toWCharArray(ptr);
+        *ptr++ = 0;
+        comFilterSpecs[i].pszSpec = ptr;
+        ptr += qstringFilterSpecs[i].second.toWCharArray(ptr);
+        *ptr++ = 0;
+    }
+    fileDialog->SetFileTypes(filters.size(), comFilterSpecs.get());
+
+    // Enable appending extension of currently selected filter
+    fileDialog->SetDefaultExtension(L"");
+
+    // Select active filter
+    if (selectedFilterIndex >= 0) {
+        fileDialog->SetFileTypeIndex(selectedFilterIndex + 1);  // FileTypeIndex is 1-based
+    }
+
+    // Pre-select file name, if any
+    const QFileInfo startPathInfo(startPath);
+    const auto startFileName = qStringToWCharArray(startPathInfo.fileName());
+    fileDialog->SetFileName(startFileName.get());
+
+    // Select starting directory, if any
+    if (startPathInfo.isAbsolute()) {
+        const auto startFolder = qStringToWCharArray(startPathInfo.absoluteDir().path());
+        ComPointer<IShellItem> shellStartFolder;
+        if (SUCCEEDED(SHCreateItemFromParsingName(
+                startFolder.get(),
+                nullptr,
+                IID_IShellItem,
+                shellStartFolder.ppvObject()
+            ))) {
+            fileDialog->SetFolder(shellStartFolder);
+        }
+    }
+
+    // Set title
+    auto title = qStringToWCharArray(caption);
+    fileDialog->SetTitle(title.get());
+
+    // Mode flags
+    FILEOPENDIALOGOPTIONS fos = FOS_NOCHANGEDIR | FOS_PATHMUSTEXIST;
+    if (mode == NativeFileDialogMode::OpenSingle) {
+        fos |= FOS_FILEMUSTEXIST;
+    }
+    else if (mode == NativeFileDialogMode::OpenMultiple) {
+        fos |= FOS_FILEMUSTEXIST | FOS_ALLOWMULTISELECT;
+    }
+    else /* (mode == NativeFileDialogMode::Save) */ {
+        fos |= FOS_NOREADONLYRETURN | FOS_OVERWRITEPROMPT;
+    }
+    fileDialog->SetOptions(fos);
+
+    // Show the dialog
+    if (FAILED(fileDialog->Show(HWND(parent ? parent->winId() : 0)))) {
+        return {};
+    }
+
+    // Always return a selected filter index >= 0, but
+    // FileTypeIndex, while 1-based, might be 0 if the user cancelled.
+    UINT fileTypeIndex;
+    fileDialog->GetFileTypeIndex(&fileTypeIndex);
+    selectedFilterIndex = fileTypeIndex == 0 ? 0 : (fileTypeIndex - 1);
+
+    QStringList selectedFiles;
+    if (isOpen) {
+        const auto openFileDialog = reinterpret_cast<IFileOpenDialog*>(fileDialog.ptr);
+        ComPointer<IShellItemArray> results;
+        if (SUCCEEDED(openFileDialog->GetResults(&results.ptr)) && results) {
+            DWORD itemCount;
+            if (FAILED(results->GetCount(&itemCount))) {
+                Base::Console().error("Failed to enumerate IShellItemArray");
+                return selectedFiles;
+            }
+            for (DWORD i = 0; i < itemCount; ++i) {
+                ComPointer<IShellItem> item;
+                if (FAILED(results->GetItemAt(i, &item.ptr))) {
+                    Base::Console().error("Failed to get IShellItemArray item #%d", i);
+                    return selectedFiles;
+                }
+                PWSTR itemPath;
+                if (FAILED(item->GetDisplayName(SIGDN_FILESYSPATH, &itemPath))) {
+                    Base::Console().error("Failed to get path of IShellItemArray item #%d", i);
+                    return selectedFiles;
+                }
+                selectedFiles.append(QDir::cleanPath(QString::fromWCharArray(itemPath)));
+                CoTaskMemFree(itemPath);
+            }
+        }
+        else {
+            Base::Console().error("Failed to get file picker IShellItemArray results");
+        }
+    }
+    else {
+        ComPointer<IShellItem> item;
+        if (SUCCEEDED(fileDialog->GetResult(&item.ptr)) && item) {
+            PWSTR itemPath = nullptr;
+            if (SUCCEEDED(item->GetDisplayName(SIGDN_FILESYSPATH, &itemPath))) {
+                selectedFiles.append(QDir::cleanPath(QString::fromWCharArray(itemPath)));
+                CoTaskMemFree(itemPath);
+            }
+            else {
+                Base::Console().error("Failed to get path of IShellItem");
+            }
+        }
+        else {
+            Base::Console().error("Failed to get file picker IShellItem result");
+        }
+    }
+
+    return selectedFiles;
 }

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -476,18 +476,30 @@ bool GraphvizView::onMsg(const char* pMsg)
     if (strcmp("Save", pMsg) == 0 || strcmp("SaveAs", pMsg) == 0) {
         QList<QPair<FileDialog::Filter, QString>> formatMap;
         formatMap << qMakePair(
-            FileDialog::Filter {tr("Graphviz format"), {"*.gv"}},
+            FileDialog::Filter {QStringLiteral("Graphviz"), {"*.gv"}},
             QStringLiteral("gv")
         );
-        formatMap << qMakePair(FileDialog::Filter {tr("PNG format"), {"*.png"}}, QStringLiteral("png"));
         formatMap << qMakePair(
-            FileDialog::Filter {tr("Bitmap format"), {"*.bmp"}},
-            QStringLiteral("bmp")
+            FileDialog::Filter {QStringLiteral("PNG"), {"*.png"}},
+            QStringLiteral("png")
         );
-        formatMap << qMakePair(FileDialog::Filter {tr("GIF format"), {"*.gif"}}, QStringLiteral("gif"));
-        formatMap << qMakePair(FileDialog::Filter {tr("JPG format"), {"*.jpg"}}, QStringLiteral("jpg"));
-        formatMap << qMakePair(FileDialog::Filter {tr("SVG format"), {"*.svg"}}, QStringLiteral("svg"));
-        formatMap << qMakePair(FileDialog::Filter {tr("PDF format"), {"*.pdf"}}, QStringLiteral("pdf"));
+        formatMap << qMakePair(FileDialog::Filter {tr("Bitmap"), {"*.bmp"}}, QStringLiteral("bmp"));
+        formatMap << qMakePair(
+            FileDialog::Filter {QStringLiteral("GIF"), {"*.gif"}},
+            QStringLiteral("gif")
+        );
+        formatMap << qMakePair(
+            FileDialog::Filter {QStringLiteral("JPG"), {"*.jpg"}},
+            QStringLiteral("jpg")
+        );
+        formatMap << qMakePair(
+            FileDialog::Filter {QStringLiteral("SVG"), {"*.svg"}},
+            QStringLiteral("svg")
+        );
+        formatMap << qMakePair(
+            FileDialog::Filter {QStringLiteral("PDF"), {"*.pdf"}},
+            QStringLiteral("pdf")
+        );
 
         FileDialog::FilterList filterList;
         for (const auto& it : std::as_const(formatMap)) {
@@ -505,7 +517,7 @@ bool GraphvizView::onMsg(const char* pMsg)
         if (!fn.isEmpty()) {
             const auto& format = formatMap[selectedFilterIndex].second;
             QByteArray buffer;
-            if (format == QLatin1String("gv")) {
+            if (format == QStringLiteral("gv")) {
                 std::stringstream str;
                 doc.exportGraphviz(str);
                 buffer = QByteArray::fromStdString(str.str());
@@ -591,7 +603,7 @@ void GraphvizView::printPdf()
         this,
         tr("Export graph"),
         QString(),
-        FileDialog::FilterList {{tr("PDF format"), {"*.pdf"}}}
+        FileDialog::FilterList {{QStringLiteral("PDF"), {"*.pdf"}}}
     );
     if (!fn.isEmpty()) {
         QByteArray buffer = exportGraph("pdf");

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -474,47 +474,36 @@ QByteArray GraphvizView::exportGraph(const QString& format)
 bool GraphvizView::onMsg(const char* pMsg)
 {
     if (strcmp("Save", pMsg) == 0 || strcmp("SaveAs", pMsg) == 0) {
-        QList<QPair<QString, QString>> formatMap;
+        QList<QPair<FileDialog::Filter, QString>> formatMap;
         formatMap << qMakePair(
-            QStringLiteral("%1 (*.gv)").arg(tr("Graphviz format")),
+            FileDialog::Filter {tr("Graphviz format"), {"*.gv"}},
             QStringLiteral("gv")
         );
-        formatMap
-            << qMakePair(QStringLiteral("%1 (*.png)").arg(tr("PNG format")), QStringLiteral("png"));
+        formatMap << qMakePair(FileDialog::Filter {tr("PNG format"), {"*.png"}}, QStringLiteral("png"));
         formatMap << qMakePair(
-            QStringLiteral("%1 (*.bmp)").arg(tr("Bitmap format")),
+            FileDialog::Filter {tr("Bitmap format"), {"*.bmp"}},
             QStringLiteral("bmp")
         );
-        formatMap
-            << qMakePair(QStringLiteral("%1 (*.gif)").arg(tr("GIF format")), QStringLiteral("gif"));
-        formatMap
-            << qMakePair(QStringLiteral("%1 (*.jpg)").arg(tr("JPG format")), QStringLiteral("jpg"));
-        formatMap
-            << qMakePair(QStringLiteral("%1 (*.svg)").arg(tr("SVG format")), QStringLiteral("svg"));
-        formatMap
-            << qMakePair(QStringLiteral("%1 (*.pdf)").arg(tr("PDF format")), QStringLiteral("pdf"));
+        formatMap << qMakePair(FileDialog::Filter {tr("GIF format"), {"*.gif"}}, QStringLiteral("gif"));
+        formatMap << qMakePair(FileDialog::Filter {tr("JPG format"), {"*.jpg"}}, QStringLiteral("jpg"));
+        formatMap << qMakePair(FileDialog::Filter {tr("SVG format"), {"*.svg"}}, QStringLiteral("svg"));
+        formatMap << qMakePair(FileDialog::Filter {tr("PDF format"), {"*.pdf"}}, QStringLiteral("pdf"));
 
-        QStringList filter;
+        FileDialog::FilterList filterList;
         for (const auto& it : std::as_const(formatMap)) {
-            filter << it.first;
+            filterList.append(it.first);
         }
 
-        QString selectedFilter;
+        qsizetype selectedFilterIndex = -1;
         QString fn = Gui::FileDialog::getSaveFileName(
             this,
             tr("Export Graph"),
             QString(),
-            filter,
-            &selectedFilter
+            filterList,
+            &selectedFilterIndex
         );
         if (!fn.isEmpty()) {
-            QString format;
-            for (const auto& it : std::as_const(formatMap)) {
-                if (selectedFilter == it.first) {
-                    format = it.second;
-                    break;
-                }
-            }
+            const auto& format = formatMap[selectedFilterIndex].second;
             QByteArray buffer;
             if (format == QLatin1String("gv")) {
                 std::stringstream str;
@@ -598,14 +587,14 @@ void GraphvizView::print()
 
 void GraphvizView::printPdf()
 {
-    QStringList filter;
-    filter << QStringLiteral("%1 (*.pdf)").arg(tr("PDF format"));
-
-    QString selectedFilter;
-    QString fn
-        = Gui::FileDialog::getSaveFileName(this, tr("Export graph"), QString(), filter, &selectedFilter);
+    QString fn = Gui::FileDialog::getSaveFileName(
+        this,
+        tr("Export graph"),
+        QString(),
+        FileDialog::FilterList {{tr("PDF format"), {"*.pdf"}}}
+    );
     if (!fn.isEmpty()) {
-        QByteArray buffer = exportGraph(selectedFilter);
+        QByteArray buffer = exportGraph("pdf");
         if (buffer.isEmpty()) {
             return;
         }

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -284,7 +284,7 @@ void MDIView::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        QStringList(QStringLiteral("%1 (*.pdf)").arg(tr("PDF file")))
+        FileDialog::FilterList {{tr("PDF file"), {"*.pdf"}}}
     );
     if (!filename.isEmpty()) {
         QPrinter printer(QPrinter::ScreenResolution);

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -284,7 +284,7 @@ void MDIView::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        FileDialog::FilterList {{tr("PDF file"), {"*.pdf"}}}
+        FileDialog::FilterList {{QStringLiteral("PDF"), {"*.pdf"}}}
     );
     if (!filename.isEmpty()) {
         QPrinter printer(QPrinter::ScreenResolution);

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -1405,7 +1405,7 @@ void PythonConsole::onSaveHistoryAs()
         this,
         tr("Save History"),
         cMacroPath,
-        QStringList(QStringLiteral("%1 (*.FCMacro *.py)").arg(tr("Macro Files")))
+        FileDialog::FilterList {{tr("Macro Files"), {"*.FCMacro", "*.py"}}}
     );
     if (!fn.isEmpty()) {
         int dot = fn.indexOf(QLatin1Char('.'));
@@ -1429,7 +1429,7 @@ void PythonConsole::onInsertFileName()
         Gui::getMainWindow(),
         tr("Insert file name"),
         QString(),
-        QStringList(QStringLiteral("%1 (*.*)").arg(tr("All Files")))
+        FileDialog::FilterList {{tr("All Files"), {"*.*"}}}
     );
     if (!fn.isEmpty()) {
         insertPlainText(fn);

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -1429,7 +1429,7 @@ void PythonConsole::onInsertFileName()
         Gui::getMainWindow(),
         tr("Insert file name"),
         QString(),
-        FileDialog::FilterList {{tr("All Files"), {"*.*"}}}
+        FileDialog::FilterList {FileDialog::Filter::AllFiles()}
     );
     if (!fn.isEmpty()) {
         insertPlainText(fn);

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -288,7 +288,7 @@ void View3DInventor::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        QStringList(QStringLiteral("%1 (*.pdf)").arg(tr("PDF file")))
+        FileDialog::FilterList {{tr("PDF file"), {"*.pdf"}}}
     );
     if (!filename.isEmpty()) {
         Gui::WaitCursor wc;

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -288,7 +288,7 @@ void View3DInventor::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        FileDialog::FilterList {{tr("PDF file"), {"*.pdf"}}}
+        FileDialog::FilterList {{QStringLiteral("PDF"), {"*.pdf"}}}
     );
     if (!filename.isEmpty()) {
         Gui::WaitCursor wc;

--- a/src/Mod/Import/Gui/Command.cpp
+++ b/src/Mod/Import/Gui/Command.cpp
@@ -58,7 +58,7 @@ void FCCmdImportReadBREP::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        Gui::FileDialog::FilterList {{QLatin1String("BREP"), {"*.brep", "*.rle"}}}
+        Gui::FileDialog::FilterList {{QStringLiteral("BREP"), {"*.brep", "*.rle"}}}
     );
     if (fn.isEmpty()) {
         abortCommand();
@@ -103,7 +103,7 @@ void ImportStep::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        Gui::FileDialog::FilterList {{QLatin1String("STEP"), {"*.stp", "*.step"}}}
+        Gui::FileDialog::FilterList {{QStringLiteral("STEP"), {"*.stp", "*.step"}}}
     );
     if (!fn.isEmpty()) {
         openCommand(QT_TRANSLATE_NOOP("Command", "Part ImportSTEP Create"));
@@ -153,7 +153,7 @@ void ImportIges::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        Gui::FileDialog::FilterList {{QLatin1String("IGES"), {"*.igs", "*.iges"}}}
+        Gui::FileDialog::FilterList {{QStringLiteral("IGES"), {"*.igs", "*.iges"}}}
     );
     if (!fn.isEmpty()) {
         openCommand(QT_TRANSLATE_NOOP("Command", "ImportIGES Create"));

--- a/src/Mod/Import/Gui/Command.cpp
+++ b/src/Mod/Import/Gui/Command.cpp
@@ -58,7 +58,7 @@ void FCCmdImportReadBREP::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        QStringList(QLatin1String("BREP (*.brep *.rle)"))
+        Gui::FileDialog::FilterList {{QLatin1String("BREP"), {"*.brep", "*.rle"}}}
     );
     if (fn.isEmpty()) {
         abortCommand();
@@ -103,7 +103,7 @@ void ImportStep::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        QStringList(QLatin1String("STEP (*.stp *.step)"))
+        Gui::FileDialog::FilterList {{QLatin1String("STEP"), {"*.stp", "*.step"}}}
     );
     if (!fn.isEmpty()) {
         openCommand(QT_TRANSLATE_NOOP("Command", "Part ImportSTEP Create"));
@@ -153,7 +153,7 @@ void ImportIges::activated(int iMsg)
         Gui::getMainWindow(),
         QString(),
         QString(),
-        QStringList(QLatin1String("IGES (*.igs *.iges)"))
+        Gui::FileDialog::FilterList {{QLatin1String("IGES"), {"*.igs", "*.iges"}}}
     );
     if (!fn.isEmpty()) {
         openCommand(QT_TRANSLATE_NOOP("Command", "ImportIGES Create"));

--- a/src/Mod/Material/Gui/ImageEdit.cpp
+++ b/src/Mod/Material/Gui/ImageEdit.cpp
@@ -183,7 +183,7 @@ void ImageEdit::onFileSelect(bool checked)
     }
 }
 
-QString ImageEdit::selectFile(const QStringList& filePatterns)
+QString ImageEdit::selectFile(const Gui::FileDialog::FilterList& filters)
 {
     QFileDialog::Options dlgOpt;
     if (Gui::DialogOptions::dontUseNativeFileDialog()) {
@@ -194,7 +194,7 @@ QString ImageEdit::selectFile(const QStringList& filePatterns)
     QString fn = Gui::FileDialog::getOpenFileName(this,
                                                   tr("Select an image"),
                                                   directory,
-                                                  filePatterns,
+                                                  filters,
                                                   nullptr,
                                                   dlgOpt);
 
@@ -203,9 +203,10 @@ QString ImageEdit::selectFile(const QStringList& filePatterns)
 
 void ImageEdit::onFileSelectImage()
 {
-    QStringList filterList;
-    filterList << tr("Image files (*.jpg *.jpeg *.png *.bmp)");
-    filterList << tr("All files (*)");
+    const Gui::FileDialog::FilterList filterList {
+        {tr("Image files"), {"*.jpg", "*.jpeg", "*.png", "*.bmp"}},
+        {tr("All files"), {"(*)"}}
+    };
     QString fn = selectFile(filterList);
     if (!fn.isEmpty()) {
         fn = QDir::fromNativeSeparators(fn);
@@ -218,9 +219,10 @@ void ImageEdit::onFileSelectImage()
 
 void ImageEdit::onFileSelectSVG()
 {
-    QStringList filterList;
-    filterList << tr("Image files (*.svg)");
-    filterList << tr("All files (*)");
+    const Gui::FileDialog::FilterList filterList {
+        {tr("Image files"), {"*.svg"}},
+        {tr("All files"), {"(*)"}}
+    };
     QString fn = selectFile(filterList);
     if (!fn.isEmpty()) {
         fn = QDir::fromNativeSeparators(fn);

--- a/src/Mod/Material/Gui/ImageEdit.h
+++ b/src/Mod/Material/Gui/ImageEdit.h
@@ -36,6 +36,8 @@
 #include <QStandardItemModel>
 #include <QVariant>
 
+#include <Gui/FileDialog.h>
+
 #include <Mod/Material/App/Model.h>
 
 #include "ListModel.h"
@@ -93,7 +95,7 @@ private:
     void showPixmap();
     void showSVG();
 
-    QString selectFile(const QStringList& filePatterns);
+    QString selectFile(const Gui::FileDialog::FilterList& filters);
     void onFileSelectImage();
     void onFileSelectSVG();
 };

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -352,18 +352,20 @@ CmdMeshImport::CmdMeshImport()
 void CmdMeshImport::activated(int)
 {
     // use current path as default
-    QStringList filter;
-    filter << QStringLiteral("%1 (*.stl *.ast *.bms *.obj *.off *.iv *.ply *.nas *.bdf)")
-                  .arg(QObject::tr("All Mesh Files"));
-    filter << QStringLiteral("%1 (*.stl)").arg(QObject::tr("Binary STL"));
-    filter << QStringLiteral("%1 (*.ast)").arg(QObject::tr("ASCII STL"));
-    filter << QStringLiteral("%1 (*.bms)").arg(QObject::tr("Binary Mesh"));
-    filter << QStringLiteral("%1 (*.obj)").arg(QObject::tr("Alias Mesh"));
-    filter << QStringLiteral("%1 (*.off)").arg(QObject::tr("Object File Format"));
-    filter << QStringLiteral("%1 (*.iv)").arg(QObject::tr("Inventor V2.1 ASCII"));
-    filter << QStringLiteral("%1 (*.ply)").arg(QObject::tr("Stanford Polygon"));
-    filter << QStringLiteral("%1 (*.nas *.bdf)").arg(QObject::tr("NASTRAN"));
-    filter << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+
+    const Gui::FileDialog::FilterList filter {
+        {QObject::tr("All Mesh Files"),
+         {"*.stl", "*.ast", "*.bms", "*.obj", "*.off", "*.iv", "*.ply", "*.nas", "*.bdf"}},
+        {QObject::tr("Binary STL"), {"*.stl"}},
+        {QObject::tr("ASCII STL"), {"*.ast"}},
+        {QObject::tr("Binary Mesh"), {"*.bms"}},
+        {QObject::tr("Alias Mesh"), {"*.obj"}},
+        {QObject::tr("Object File Format"), {"*.off"}},
+        {QObject::tr("Inventor V2.1 ASCII"), {"*.iv"}},
+        {QObject::tr("Stanford Polygon"), {"*.ply"}},
+        {QObject::tr("NASTRAN"), {"*.nas", "*.bdf"}},
+        {QObject::tr("All Files"), {"*.*"}},
+    };
 
     // Allow multi selection
     QStringList fn = Gui::FileDialog::getOpenFileNames(
@@ -417,49 +419,43 @@ void CmdMeshExport::activated(int)
 
     // clang-format off
     QString dir = QString::fromUtf8(docObj->Label.getValue());
-    QList<QPair<QString, QByteArray> > ext;
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.stl)").arg(QObject::tr("Binary STL")), "STL");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.stl)").arg(QObject::tr("ASCII STL")), "AST");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.ast)").arg(QObject::tr("ASCII STL")), "AST");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.bms)").arg(QObject::tr("Binary Mesh")), "BMS");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.obj)").arg(QObject::tr("Alias Mesh")), "OBJ");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.smf)").arg(QObject::tr("Simple Model Format")), "SMF");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.off)").arg(QObject::tr("Object File Format")), "OFF");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.iv)").arg(QObject::tr("Inventor V2.1 ascii")), "IV");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.x3d)").arg(QObject::tr("X3D Extensible 3D")), "X3D");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.x3dz)").arg(QObject::tr("Compressed X3D")), "X3DZ");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.xhtml)").arg(QObject::tr("WebGL/X3D")), "X3DOM");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.ply)").arg(QObject::tr("Stanford Polygon")), "PLY");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.wrl *.vrml)").arg(QObject::tr("VRML V2.0")), "VRML");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.wrz)").arg(QObject::tr("Compressed VRML 2.0")), "WRZ");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.nas *.bdf)").arg(QObject::tr("Nastran")), "NAS");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.py)").arg(QObject::tr("Python module def")), "PY");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.asy)").arg(QObject::tr("Asymptote Format")), "ASY");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.3mf)").arg(QObject::tr("3D Manufacturing Format")), "3MF");
-    ext << qMakePair<QString, QByteArray>(QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files")), ""); // Undefined
+    using Filter = Gui::FileDialog::Filter;
+    QList<QPair<Filter, QByteArray> > ext;
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Binary STL"), {"*.stl"}}, "STL");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("ASCII STL"), {"*.stl"}}, "AST");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("ASCII STL"), {"*.ast"}}, "AST");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Binary Mesh"), {"*.bms"}}, "BMS");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Alias Mesh"), {"*.obj"}}, "OBJ");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Simple Model Format"), {"*.smf"}}, "SMF");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Object File Format"), {"*.off"}}, "OFF");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Inventor V2.1 ascii"), {"*.iv"}}, "IV");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("X3D Extensible 3D"), {"*.x3d"}}, "X3D");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Compressed X3D"), {"*.x3dz"}}, "X3DZ");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("WebGL/X3D"), {"*.xhtml"}}, "X3DOM");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Stanford Polygon"), {"*.ply"}}, "PLY");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("VRML V2.0"), {"*.wrl *.vrml"}}, "VRML");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Compressed VRML 2.0"), {"*.wrz"}}, "WRZ");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Nastran"), {"*.nas *.bdf"}}, "NAS");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Python module def"), {"*.py"}}, "PY");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("Asymptote Format"), {"*.asy"}}, "ASY");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("3D Manufacturing Format"), {"*.3mf"}}, "3MF");
+    ext << qMakePair<Filter, QByteArray>({QObject::tr("All Files"), {"*.*"}}, ""); // Undefined
     // clang-format on
-    QStringList filter;
+    Gui::FileDialog::FilterList filter;
     for (const auto& it : ext) {
         filter << it.first;
     }
 
-    QString format;
+    qsizetype formatIndex;
     QString fn = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),
         QObject::tr("Export Mesh"),
         dir,
         filter,
-        &format
+        &formatIndex
     );
     if (!fn.isEmpty()) {
-        QFileInfo fi(fn);
-        QByteArray extension = fi.suffix().toLatin1();
-        for (const auto& it : ext) {
-            if (it.first == format) {
-                extension = it.second;
-                break;
-            }
-        }
+        QByteArray extension = ext[formatIndex].second;
 
         MeshGui::ViewProviderMesh* vp = dynamic_cast<MeshGui::ViewProviderMesh*>(
             Gui::Application::Instance->getViewProvider(docObj)

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -363,8 +363,8 @@ void CmdMeshImport::activated(int)
         {QObject::tr("Object File Format"), {"*.off"}},
         {QObject::tr("Inventor V2.1 ASCII"), {"*.iv"}},
         {QObject::tr("Stanford Polygon"), {"*.ply"}},
-        {QObject::tr("NASTRAN"), {"*.nas", "*.bdf"}},
-        {QObject::tr("All Files"), {"*.*"}},
+        {QStringLiteral("NASTRAN"), {"*.nas", "*.bdf"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
 
     // Allow multi selection
@@ -435,11 +435,11 @@ void CmdMeshExport::activated(int)
     ext << qMakePair<Filter, QByteArray>({QObject::tr("Stanford Polygon"), {"*.ply"}}, "PLY");
     ext << qMakePair<Filter, QByteArray>({QObject::tr("VRML V2.0"), {"*.wrl *.vrml"}}, "VRML");
     ext << qMakePair<Filter, QByteArray>({QObject::tr("Compressed VRML 2.0"), {"*.wrz"}}, "WRZ");
-    ext << qMakePair<Filter, QByteArray>({QObject::tr("Nastran"), {"*.nas *.bdf"}}, "NAS");
+    ext << qMakePair<Filter, QByteArray>({QStringLiteral("NASTRAN"), {"*.nas *.bdf"}}, "NAS");
     ext << qMakePair<Filter, QByteArray>({QObject::tr("Python module def"), {"*.py"}}, "PY");
     ext << qMakePair<Filter, QByteArray>({QObject::tr("Asymptote Format"), {"*.asy"}}, "ASY");
     ext << qMakePair<Filter, QByteArray>({QObject::tr("3D Manufacturing Format"), {"*.3mf"}}, "3MF");
-    ext << qMakePair<Filter, QByteArray>({QObject::tr("All Files"), {"*.*"}}, ""); // Undefined
+    ext << qMakePair<Filter, QByteArray>(Filter::AllFiles(), ""); // Undefined
     // clang-format on
     Gui::FileDialog::FilterList filter;
     for (const auto& it : ext) {

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1077,9 +1077,9 @@ void CmdPartImport::activated(int iMsg)
     Q_UNUSED(iMsg);
     const Gui::FileDialog::FilterList filter {
         {QStringLiteral("STEP"), {"*.stp", "*.step"}},
-        {QStringLiteral("STEP with colors"), {"*.stp", "*.step"}},
+        {QObject::tr("STEP with colors"), {"*.stp", "*.step"}},
         {QStringLiteral("IGES"), {"*.igs", "*.iges"}},
-        {QStringLiteral("IGES with colors"), {"*.igs", "*.iges"}},
+        {QObject::tr("IGES with colors"), {"*.igs", "*.iges"}},
         {QStringLiteral("BREP"), {"*.brp", "*.brep"}},
     };
 
@@ -1147,9 +1147,9 @@ void CmdPartExport::activated(int iMsg)
     Q_UNUSED(iMsg);
     const Gui::FileDialog::FilterList filter {
         {QStringLiteral("STEP"), {"*.stp", "*.step"}},
-        {QStringLiteral("STEP with colors"), {"*.stp", "*.step"}},
+        {QObject::tr("STEP with colors"), {"*.stp", "*.step"}},
         {QStringLiteral("IGES"), {"*.igs", "*.iges"}},
-        {QStringLiteral("IGES with colors"), {"*.igs", "*.iges"}},
+        {QObject::tr("IGES with colors"), {"*.igs", "*.iges"}},
         {QStringLiteral("BREP"), {"*.brp", "*.brep"}},
     };
 
@@ -1202,7 +1202,7 @@ void CmdPartImportCurveNet::activated(int iMsg)
         {QStringLiteral("STEP"), {"*.stp", "*.step"}},
         {QStringLiteral("IGES"), {"*.igs", "*.iges"}},
         {QStringLiteral("BREP"), {"*.brp", "*.brep"}},
-        {QObject::tr("All Files"), {"*.*"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
 
     QString fn = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filter);

--- a/src/Mod/Part/Gui/Command.cpp
+++ b/src/Mod/Part/Gui/Command.cpp
@@ -1075,14 +1075,15 @@ CmdPartImport::CmdPartImport()
 void CmdPartImport::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QStringList filter;
-    filter << QStringLiteral("STEP (*.stp *.step)");
-    filter << QStringLiteral("STEP with colors (*.stp *.step)");
-    filter << QStringLiteral("IGES (*.igs *.iges)");
-    filter << QStringLiteral("IGES with colors (*.igs *.iges)");
-    filter << QStringLiteral("BREP (*.brp *.brep)");
+    const Gui::FileDialog::FilterList filter {
+        {QStringLiteral("STEP"), {"*.stp", "*.step"}},
+        {QStringLiteral("STEP with colors"), {"*.stp", "*.step"}},
+        {QStringLiteral("IGES"), {"*.igs", "*.iges"}},
+        {QStringLiteral("IGES with colors"), {"*.igs", "*.iges"}},
+        {QStringLiteral("BREP"), {"*.brp", "*.brep"}},
+    };
 
-    QString select;
+    qsizetype select;
     QString fn
         = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filter, &select);
     if (!fn.isEmpty()) {
@@ -1094,7 +1095,7 @@ void CmdPartImport::activated(int iMsg)
 
         const std::string fnEscapedUtf8 = Base::Tools::escapeEncodeFilename(fn.toUtf8().constData());
         openCommand(QT_TRANSLATE_NOOP("Command", "Import Part"));
-        if (select == filter[1] || select == filter[3]) {
+        if (select == 1 || select == 3) {
             doCommand(Doc, "import ImportGui");
             doCommand(Doc, "ImportGui.insert(\"%s\",\"%s\")", fnEscapedUtf8.c_str(), pDoc->getName());
         }
@@ -1144,14 +1145,15 @@ CmdPartExport::CmdPartExport()
 void CmdPartExport::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QStringList filter;
-    filter << QStringLiteral("STEP (*.stp *.step)");
-    filter << QStringLiteral("STEP with colors (*.stp *.step)");
-    filter << QStringLiteral("IGES (*.igs *.iges)");
-    filter << QStringLiteral("IGES with colors (*.igs *.iges)");
-    filter << QStringLiteral("BREP (*.brp *.brep)");
+    const Gui::FileDialog::FilterList filter {
+        {QStringLiteral("STEP"), {"*.stp", "*.step"}},
+        {QStringLiteral("STEP with colors"), {"*.stp", "*.step"}},
+        {QStringLiteral("IGES"), {"*.igs", "*.iges"}},
+        {QStringLiteral("IGES with colors"), {"*.igs", "*.iges"}},
+        {QStringLiteral("BREP"), {"*.brp", "*.brep"}},
+    };
 
-    QString select;
+    qsizetype select;
     QString fn
         = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QString(), QString(), filter, &select);
     if (!fn.isEmpty()) {
@@ -1159,7 +1161,7 @@ void CmdPartExport::activated(int iMsg)
         if (!pDoc) {  // no document
             return;
         }
-        if (select == filter[1] || select == filter[3]) {
+        if (select == 1 || select == 3) {
             Gui::Application::Instance->exportTo((const char*)fn.toUtf8(), pDoc->getName(), "ImportGui");
         }
         else {
@@ -1195,13 +1197,13 @@ CmdPartImportCurveNet::CmdPartImportCurveNet()
 void CmdPartImportCurveNet::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QStringList filter;
-    filter << QStringLiteral("%1 (*.stp *.step *.igs *.iges *.brp *.brep)")
-                  .arg(QObject::tr("All CAD Files"));
-    filter << QStringLiteral("STEP (*.stp *.step)");
-    filter << QStringLiteral("IGES (*.igs *.iges)");
-    filter << QStringLiteral("BREP (*.brp *.brep)");
-    filter << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+    const Gui::FileDialog::FilterList filter {
+        {QObject::tr("All CAD Files"), {"*.stp", "*.step", "*.igs", "*.iges", "*.brp", "*.brep"}},
+        {QStringLiteral("STEP"), {"*.stp", "*.step"}},
+        {QStringLiteral("IGES"), {"*.igs", "*.iges"}},
+        {QStringLiteral("BREP"), {"*.brp", "*.brep"}},
+        {QObject::tr("All Files"), {"*.*"}},
+    };
 
     QString fn = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filter);
     if (!fn.isEmpty()) {

--- a/src/Mod/Part/Gui/DlgPartImportIgesImp.cpp
+++ b/src/Mod/Part/Gui/DlgPartImportIgesImp.cpp
@@ -64,8 +64,8 @@ void DlgPartImportIgesImp::OnApply()
 void DlgPartImportIgesImp::onChooseFileName()
 {
     const Gui::FileDialog::FilterList filterList {
-        {QLatin1String("IGES"), {"*.igs", "*.iges"}},
-        {tr("All Files"), {"*.*"}},
+        {QStringLiteral("IGES"), {"*.igs", "*.iges"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fn
         = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filterList);

--- a/src/Mod/Part/Gui/DlgPartImportIgesImp.cpp
+++ b/src/Mod/Part/Gui/DlgPartImportIgesImp.cpp
@@ -63,9 +63,10 @@ void DlgPartImportIgesImp::OnApply()
 
 void DlgPartImportIgesImp::onChooseFileName()
 {
-    QStringList filterList;
-    filterList << QStringLiteral("%1 (*.igs *.iges)").arg(QLatin1String("IGES"));
-    filterList << QStringLiteral("%1 (*.*)").arg(tr("All Files"));
+    const Gui::FileDialog::FilterList filterList {
+        {QLatin1String("IGES"), {"*.igs", "*.iges"}},
+        {tr("All Files"), {"*.*"}},
+    };
     QString fn
         = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filterList);
     if (!fn.isEmpty()) {

--- a/src/Mod/Part/Gui/DlgPartImportStepImp.cpp
+++ b/src/Mod/Part/Gui/DlgPartImportStepImp.cpp
@@ -63,9 +63,10 @@ void DlgPartImportStepImp::OnApply()
 
 void DlgPartImportStepImp::onChooseFileName()
 {
-    QStringList filterList;
-    filterList << QStringLiteral("%1 (*.stp *.step)").arg(QLatin1String("STEP"));
-    filterList << QStringLiteral("%1 (*.*)").arg(tr("All Files"));
+    const Gui::FileDialog::FilterList filterList {
+        {QLatin1String("STEP"), {"*.stp", "*.step"}},
+        {tr("All Files"), {"*.*"}},
+    };
     QString fn
         = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filterList);
     if (!fn.isEmpty()) {

--- a/src/Mod/Part/Gui/DlgPartImportStepImp.cpp
+++ b/src/Mod/Part/Gui/DlgPartImportStepImp.cpp
@@ -64,8 +64,8 @@ void DlgPartImportStepImp::OnApply()
 void DlgPartImportStepImp::onChooseFileName()
 {
     const Gui::FileDialog::FilterList filterList {
-        {QLatin1String("STEP"), {"*.stp", "*.step"}},
-        {tr("All Files"), {"*.*"}},
+        {QStringLiteral("STEP"), {"*.stp", "*.step"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fn
         = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), filterList);

--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -79,7 +79,7 @@ void CmdPointsImport::activated(int iMsg)
 
     const Gui::FileDialog::FilterList formatList {
         {QObject::tr("Point formats"), {"*.asc", "*.pcd", "*.ply", "*.e57"}},
-        {QObject::tr("All Files"), {"*.*"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fn
         = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), formatList);
@@ -166,7 +166,7 @@ void CmdPointsExport::activated(int iMsg)
     for (auto point : points) {
         const Gui::FileDialog::FilterList formatList {
             {QObject::tr("Point formats"), {"*.asc", "*.pcd", "*.ply"}},
-            {QObject::tr("All Files"), {"*.*"}}
+            Gui::FileDialog::Filter::AllFiles(),
         };
         QString fn
             = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QString(), QString(), formatList);

--- a/src/Mod/Points/Gui/Command.cpp
+++ b/src/Mod/Points/Gui/Command.cpp
@@ -77,9 +77,10 @@ void CmdPointsImport::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
 
-    QStringList formatList;
-    formatList << QStringLiteral("%1 (*.asc *.pcd *.ply *.e57)").arg(QObject::tr("Point formats"));
-    formatList << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+    const Gui::FileDialog::FilterList formatList {
+        {QObject::tr("Point formats"), {"*.asc", "*.pcd", "*.ply", "*.e57"}},
+        {QObject::tr("All Files"), {"*.*"}},
+    };
     QString fn
         = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(), QString(), QString(), formatList);
     if (fn.isEmpty()) {
@@ -163,9 +164,10 @@ void CmdPointsExport::activated(int iMsg)
         Points::Feature::getClassTypeId()
     );
     for (auto point : points) {
-        QStringList formatList;
-        formatList << QStringLiteral("%1 (*.asc *.pcd *.ply)").arg(QObject::tr("Point formats"));
-        formatList << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+        const Gui::FileDialog::FilterList formatList {
+            {QObject::tr("Point formats"), {"*.asc", "*.pcd", "*.ply"}},
+            {QObject::tr("All Files"), {"*.*"}}
+        };
         QString fn
             = Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QString(), QString(), formatList);
         if (fn.isEmpty()) {

--- a/src/Mod/Robot/Gui/CommandExport.cpp
+++ b/src/Mod/Robot/Gui/CommandExport.cpp
@@ -89,7 +89,7 @@ void CmdRobotExportKukaCompact::activated(int)
 
     const Gui::FileDialog::FilterList filter {
         {QObject::tr("KRL file"), {"*.src"}},
-        {QObject::tr("All Files"), {"*.*"}}
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fn = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),
@@ -171,7 +171,7 @@ void CmdRobotExportKukaFull::activated(int)
 
     const Gui::FileDialog::FilterList filter {
         {QObject::tr("KRL file"), {"*.src"}},
-        {QObject::tr("All Files"), {"*.*"}}
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fn = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),

--- a/src/Mod/Robot/Gui/CommandExport.cpp
+++ b/src/Mod/Robot/Gui/CommandExport.cpp
@@ -87,9 +87,10 @@ void CmdRobotExportKukaCompact::activated(int)
     }
     // std::string TrakName = pcTrajectoryObject->getNameInDocument();
 
-    QStringList filter;
-    filter << QStringLiteral("%1 (*.src)").arg(QObject::tr("KRL file"));
-    filter << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+    const Gui::FileDialog::FilterList filter {
+        {QObject::tr("KRL file"), {"*.src"}},
+        {QObject::tr("All Files"), {"*.*"}}
+    };
     QString fn = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),
         QObject::tr("Export program"),
@@ -168,9 +169,10 @@ void CmdRobotExportKukaFull::activated(int)
     }
     // std::string TrakName = pcTrajectoryObject->getNameInDocument();
 
-    QStringList filter;
-    filter << QStringLiteral("%1 (*.src)").arg(QObject::tr("KRL file"));
-    filter << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+    const Gui::FileDialog::FilterList filter {
+        {QObject::tr("KRL file"), {"*.src"}},
+        {QObject::tr("All Files"), {"*.*"}}
+    };
     QString fn = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),
         QObject::tr("Export program"),

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -194,9 +194,10 @@ CmdSpreadsheetImport::CmdSpreadsheetImport()
 void CmdSpreadsheetImport::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    Gui::FileDialog::FilterList formatList;
-    formatList.append({QObject::tr("CSV"), {"*.csv", "*.CSV"}});
-    formatList.append({QObject::tr("All"), {"*"}});
+    const Gui::FileDialog::FilterList formatList {
+        {QStringLiteral("CSV"), {"*.csv"}},
+        Gui::FileDialog::Filter::AllFiles(),
+    };
     QString fileName = Gui::FileDialog::getOpenFileName(
         Gui::getMainWindow(),
         QObject::tr("Import file"),

--- a/src/Mod/Spreadsheet/Gui/Command.cpp
+++ b/src/Mod/Spreadsheet/Gui/Command.cpp
@@ -194,16 +194,14 @@ CmdSpreadsheetImport::CmdSpreadsheetImport()
 void CmdSpreadsheetImport::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    QString selectedFilter;
-    QStringList formatList;
-    formatList << QObject::tr("CSV (*.csv *.CSV)");
-    formatList << QObject::tr("All (*)");
+    Gui::FileDialog::FilterList formatList;
+    formatList.append({QObject::tr("CSV"), {"*.csv", "*.CSV"}});
+    formatList.append({QObject::tr("All"), {"*"}});
     QString fileName = Gui::FileDialog::getOpenFileName(
         Gui::getMainWindow(),
         QObject::tr("Import file"),
         QString(),
-        formatList,
-        &selectedFilter
+        formatList
     );
     if (!fileName.isEmpty()) {
         std::string FeatName = getUniqueObjectName("Spreadsheet");

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -283,7 +283,7 @@ void SheetView::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        FileDialog::FilterList {{tr("PDF file"), {"*.pdf"}}}
+        FileDialog::FilterList {{QStringLiteral("PDF"), {"*.pdf"}}}
     );
     if (!filename.isEmpty()) {
         QPrinter printer(QPrinter::ScreenResolution);

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -283,7 +283,7 @@ void SheetView::printPdf()
         this,
         tr("Export PDF"),
         QString(),
-        QStringList(QStringLiteral("%1 (*.pdf)").arg(tr("PDF file")))
+        FileDialog::FilterList {{tr("PDF file"), {"*.pdf"}}}
     );
     if (!filename.isEmpty()) {
         QPrinter printer(QPrinter::ScreenResolution);

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -104,8 +104,8 @@ void ViewProviderSheet::exportAsFile()
 {
     auto* sheet = getObject<Spreadsheet::Sheet>();
     const Gui::FileDialog::FilterList formatList {
-        {QObject::tr("CSV"), {"*.csv", "*.CSV"}},
-        {QObject::tr("All"), {"(*)"}}
+        {QStringLiteral("CSV"), {"*.csv", "*.CSV"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fileName = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -103,16 +103,15 @@ void ViewProviderSheet::showSheetMdi()
 void ViewProviderSheet::exportAsFile()
 {
     auto* sheet = getObject<Spreadsheet::Sheet>();
-    QString selectedFilter;
-    QStringList formatList;
-    formatList << QObject::tr("CSV (*.csv *.CSV)");
-    formatList << QObject::tr("All (*)");
+    const Gui::FileDialog::FilterList formatList {
+        {QObject::tr("CSV"), {"*.csv", "*.CSV"}},
+        {QObject::tr("All"), {"(*)"}}
+    };
     QString fileName = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(),
         QObject::tr("Export File"),
         QString(),
-        formatList,
-        &selectedFilter
+        formatList
     );
     if (!fileName.isEmpty()) {
         if (sheet) {

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -178,8 +178,8 @@ void CmdTechDrawPageTemplate::activated(int iMsg)
     QString work_dir = Gui::FileDialog::getWorkingDirectory();
     QString templateDir = Preferences::defaultTemplateDir();
     QString templateFileName = Gui::FileDialog::getOpenFileName(
-        Gui::getMainWindow(), QString::fromUtf8(QT_TR_NOOP("Select a template file")), templateDir,
-        Gui::FileDialog::FilterList{{QString::fromUtf8(QT_TR_NOOP("Template")), {"*.svg"}}});
+        Gui::getMainWindow(), QObject::tr("Select a template file"), templateDir,
+        Gui::FileDialog::FilterList{{QObject::tr("Template"), {"*.svg"}}});
     Gui::FileDialog::setWorkingDirectory(work_dir);// Don't overwrite WD with templateDir
 
     if (templateFileName.isEmpty()) {
@@ -442,7 +442,7 @@ void CmdTechDrawView::activated(int iMsg)
 
             const Gui::FileDialog::FilterList filterList {
                 {QObject::tr("SVG or Image files"), {"*.svg", "*.svgz", "*.jpg", "*.jpeg", "*.png", "*.bmp"}},
-                {QObject::tr("All Files"), {"*.*"}},
+                Gui::FileDialog::Filter::AllFiles(),
             };
             QString filename = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(),
                 QObject::tr("Select a SVG or Image file to open"),
@@ -1551,8 +1551,8 @@ void CmdTechDrawSymbol::activated(int iMsg)
 
     // Reading an image
     const Gui::FileDialog::FilterList filterList {
-        {QObject::tr("Scalable vector graphic"), {"*.svg", "*.svgz"}},
-        {QObject::tr("All files"), {"*.*"}}
+        {QStringLiteral("SVG"), {"*.svg", "*.svgz"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString filename = Gui::FileDialog::getOpenFileName(
         Gui::getMainWindow(), QObject::tr("Choose an SVG file to open"),
@@ -1888,8 +1888,8 @@ void CmdTechDrawExportPageDXF::activated(int iMsg)
     //WF? allow more than one TD Page per Dxf file??  1 TD page = 1 DXF file = 1 drawing?
     QString defaultDir;
     QString fileName = Gui::FileDialog::getSaveFileName(
-        Gui::getMainWindow(), QString::fromUtf8(QT_TR_NOOP("Save DXF file")), defaultDir,
-        Gui::FileDialog::FilterList{{"DXF", {"*.dxf"}}});
+        Gui::getMainWindow(), QObject::tr("Save DXF file"), defaultDir,
+        Gui::FileDialog::FilterList{{QStringLiteral("DXF"), {"*.dxf"}}});
 
     if (fileName.isEmpty()) {
         return;

--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -179,7 +179,7 @@ void CmdTechDrawPageTemplate::activated(int iMsg)
     QString templateDir = Preferences::defaultTemplateDir();
     QString templateFileName = Gui::FileDialog::getOpenFileName(
         Gui::getMainWindow(), QString::fromUtf8(QT_TR_NOOP("Select a template file")), templateDir,
-        QStringList(QString::fromUtf8(QT_TR_NOOP("Template (*.svg)"))));
+        Gui::FileDialog::FilterList{{QString::fromUtf8(QT_TR_NOOP("Template")), {"*.svg"}}});
     Gui::FileDialog::setWorkingDirectory(work_dir);// Don't overwrite WD with templateDir
 
     if (templateFileName.isEmpty()) {
@@ -440,9 +440,10 @@ void CmdTechDrawView::activated(int iMsg)
                 }
             }
 
-            QStringList filterList;
-            filterList << QStringLiteral("%1 (*.svg *.svgz *.jpg *.jpeg *.png *.bmp)").arg(QObject::tr("SVG or Image files"));
-            filterList << QStringLiteral("%1 (*.*)").arg(QObject::tr("All Files"));
+            const Gui::FileDialog::FilterList filterList {
+                {QObject::tr("SVG or Image files"), {"*.svg", "*.svgz", "*.jpg", "*.jpeg", "*.png", "*.bmp"}},
+                {QObject::tr("All Files"), {"*.*"}},
+            };
             QString filename = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(),
                 QObject::tr("Select a SVG or Image file to open"),
                 Preferences::defaultSymbolDir(),
@@ -1549,9 +1550,10 @@ void CmdTechDrawSymbol::activated(int iMsg)
     std::string PageName = page->getNameInDocument();
 
     // Reading an image
-    QStringList filterList;
-    filterList << QStringLiteral("%1 (*.svg *.svgz)").arg(QObject::tr("Scalable vector graphic"));
-    filterList << QStringLiteral("%1 (*.*)").arg(QObject::tr("All files"));
+    const Gui::FileDialog::FilterList filterList {
+        {QObject::tr("Scalable vector graphic"), {"*.svg", "*.svgz"}},
+        {QObject::tr("All files"), {"*.*"}}
+    };
     QString filename = Gui::FileDialog::getOpenFileName(
         Gui::getMainWindow(), QObject::tr("Choose an SVG file to open"),
         Preferences::defaultSymbolDir(),
@@ -1887,7 +1889,7 @@ void CmdTechDrawExportPageDXF::activated(int iMsg)
     QString defaultDir;
     QString fileName = Gui::FileDialog::getSaveFileName(
         Gui::getMainWindow(), QString::fromUtf8(QT_TR_NOOP("Save DXF file")), defaultDir,
-        QStringList(QStringLiteral("DXF (*.dxf)")));
+        Gui::FileDialog::FilterList{{"DXF", {"*.dxf"}}});
 
     if (fileName.isEmpty()) {
         return;

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -356,11 +356,11 @@ void CmdTechDrawImage::activated(int iMsg)
 
     // Reading an image
     const Gui::FileDialog::FilterList filterList {
-        {QString::fromUtf8(QT_TR_NOOP("Image files")), {"*.jpg", "*.jpeg", "*.png", "*.bmp"}},
-        {QString::fromUtf8(QT_TR_NOOP("All files")), {"*"}},
+        {QObject::tr("Image files"), {"*.jpg", "*.jpeg", "*.png", "*.bmp"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fileName = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(),
-        QString::fromUtf8(QT_TR_NOOP("Select an image file")),
+        QObject::tr("Select an image file"),
         Preferences::defaultSymbolDir(),
         filterList);
     if (fileName.isEmpty()) {

--- a/src/Mod/TechDraw/Gui/CommandDecorate.cpp
+++ b/src/Mod/TechDraw/Gui/CommandDecorate.cpp
@@ -355,9 +355,10 @@ void CmdTechDrawImage::activated(int iMsg)
     std::string PageName = page->getNameInDocument();
 
     // Reading an image
-    QStringList filterList;
-    filterList << QString::fromUtf8(QT_TR_NOOP("Image files (*.jpg *.jpeg *.png *.bmp)"));
-    filterList << QString::fromUtf8(QT_TR_NOOP("All files (*)"));
+    const Gui::FileDialog::FilterList filterList {
+        {QString::fromUtf8(QT_TR_NOOP("Image files")), {"*.jpg", "*.jpeg", "*.png", "*.bmp"}},
+        {QString::fromUtf8(QT_TR_NOOP("All files")), {"*"}},
+    };
     QString fileName = Gui::FileDialog::getOpenFileName(Gui::getMainWindow(),
         QString::fromUtf8(QT_TR_NOOP("Select an image file")),
         Preferences::defaultSymbolDir(),

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -511,9 +511,10 @@ void MDIViewPage::saveSVG(std::string filename)
 
 void MDIViewPage::saveSVG()
 {
-    QStringList filter;
-    filter << QStringLiteral("SVG (*.svg)");
-    filter << QObject::tr("All files (*.*)");
+    const Gui::FileDialog::FilterList filter {
+        {QStringLiteral("SVG"), {"*.svg"}},
+        {QObject::tr("All files"), {"*.*"}}
+    };
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export page as SVG"),
 
@@ -533,9 +534,10 @@ void MDIViewPage::saveDXF(std::string filename)
 
 void MDIViewPage::saveDXF()
 {
-    QStringList filter;
-    filter << QStringLiteral("DXF (*.dxf)");
-    filter << QObject::tr("All files (*.*)");
+    const Gui::FileDialog::FilterList filter {
+        {QStringLiteral("DXF"), {"*.dxf"}},
+        {QObject::tr("All files"), {"*.*"}}
+    };
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export page as DXF"),
 
@@ -589,9 +591,10 @@ void MDIViewPage::exportAsPdf() const
 
 QString MDIViewPage::getPdfFileName() const
 {
-    QStringList filter;
-    filter << QObject::tr("PDF (*.pdf)");
-    filter << QObject::tr("All Files (*.*)");
+    const Gui::FileDialog::FilterList filter {
+        {QObject::tr("PDF"), {"*.pdf"}},
+        {QObject::tr("All files"), {"*.*"}}
+    };
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(),
                                          QObject::tr("Export Page as PDF"),

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -513,7 +513,7 @@ void MDIViewPage::saveSVG()
 {
     const Gui::FileDialog::FilterList filter {
         {QStringLiteral("SVG"), {"*.svg"}},
-        {QObject::tr("All files"), {"*.*"}}
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export page as SVG"),
@@ -536,7 +536,7 @@ void MDIViewPage::saveDXF()
 {
     const Gui::FileDialog::FilterList filter {
         {QStringLiteral("DXF"), {"*.dxf"}},
-        {QObject::tr("All files"), {"*.*"}}
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(), QObject::tr("Export page as DXF"),
@@ -592,8 +592,8 @@ void MDIViewPage::exportAsPdf() const
 QString MDIViewPage::getPdfFileName() const
 {
     const Gui::FileDialog::FilterList filter {
-        {QObject::tr("PDF"), {"*.pdf"}},
-        {QObject::tr("All files"), {"*.*"}}
+        {"PDF", {"*.pdf"}},
+        Gui::FileDialog::Filter::AllFiles(),
     };
     QString fn =
         Gui::FileDialog::getSaveFileName(Gui::getMainWindow(),

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(propertyeditor)
 add_executable(Gui_tests_run
         Assistant.cpp
         Camera.cpp
+        FileDialog.cpp
         StyleParameters/StyleParametersApplicationTest.cpp
         StyleParameters/ParserTest.cpp
         StyleParameters/ParameterManagerTest.cpp

--- a/tests/src/Gui/FileDialog.cpp
+++ b/tests/src/Gui/FileDialog.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <Gui/FileDialog.h>
+#include <Gui/FileDialogInternal.h>
 
 
 using namespace Gui;
@@ -14,9 +15,9 @@ TEST(FileDialog, testNormalizeSavePath)
         QStringLiteral("Whatever files (what ev.er *.abc *.xyz)")
     );
     const auto test = [filt](QString path, const QString& desired) {
-        detail::normalizeSavePath(path, filt);
+        FileDialogInternal::normalizeSavePath(path, filt);
         const auto firstPassResult = path;
-        detail::normalizeSavePath(path, filt);
+        FileDialogInternal::normalizeSavePath(path, filt);
         EXPECT_EQ(firstPassResult, path) << "not idempotent";
         EXPECT_EQ(path, desired);
     };

--- a/tests/src/Gui/FileDialog.cpp
+++ b/tests/src/Gui/FileDialog.cpp
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <Gui/FileDialog.h>
+
+
+using namespace Gui;
+
+TEST(FileDialog, testNormalizeSavePath)
+{
+    const auto filt = FileDialog::Filter::fromFilterString(
+        QStringLiteral("Whatever files (what ev.er *.abc *.xyz)")
+    );
+    const auto test = [filt](QString path, const QString& desired) {
+        detail::normalizeSavePath(path, filt);
+        const auto firstPassResult = path;
+        detail::normalizeSavePath(path, filt);
+        EXPECT_EQ(firstPassResult, path) << "not idempotent";
+        EXPECT_EQ(path, desired);
+    };
+    for (const auto& root :
+         {QStringLiteral(""),
+          QStringLiteral("/root/.trash/"),
+          QStringLiteral("C:/$Recycle.bin/"),
+          QStringLiteral("//net.worked:123/"),
+          QStringLiteral("//?/o:/ntpath/"),
+          QStringLiteral("/\x3F?/z:/evil/")}) {
+        test(root + "", root + ".abc");
+        test(root + "hello", root + "hello.abc");
+
+        // Dots handling
+        test(root + "dotty.", root + "dotty.abc");
+        test(root + "dotty2..", root + "dotty2..abc");
+        test(root + "dotty3...", root + "dotty3...abc");
+        test(root + ".hidden", root + ".hidden.abc");
+        test(root + ".1dotty1.", root + ".1dotty1.abc");
+        test(root + ".1dotty2..", root + ".1dotty2..abc");
+        test(root + "..2dotty2..", root + "..2dotty2..abc");
+
+        // Extension not in filter
+        test(root + "ascii.txt", root + "ascii.txt.abc");
+        test(root + "asciidot.txt.", root + "asciidot.txt.abc");
+
+        // Empty stems but valid extensions
+        test(root + ".abc", root + ".abc");
+        test(root + ".xyz", root + ".xyz");
+
+        // Regular cases with extension
+        test(root + "ext.abc", root + "ext.abc");
+        test(root + "ext.parts.abc", root + "ext.parts.abc");
+        test(root + ".hidden.ext.abc", root + ".hidden.ext.abc");
+        test(root + "ext.xyz", root + "ext.xyz");
+        test(root + "ext.parts.xyz", root + "ext.parts.xyz");
+        test(root + ".hidden.ext.xyz", root + ".hidden.ext.xyz");
+
+        // Non-wildcard pattern without ext
+        test(root + "what", root + "what");
+        test(root + "what.", root + "what.abc");
+        test(root + ".what", root + ".what.abc");
+        test(root + ".what.", root + ".what.abc");
+
+        // Non-wildcard pattern with ext
+        test(root + "ev.er", root + "ev.er");
+        test(root + "ev.er.", root + "ev.er.abc");
+        test(root + ".ev.er", root + ".ev.er.abc");
+        test(root + ".ev.er.", root + ".ev.er.abc");
+        // Check for mixed up extension matching
+        test(root + "notev.er", root + "notev.er.abc");
+
+        // The following two should never be encountered in the wild as they refer to
+        // the current or upper directories, but still should be handled gracefully as
+        // if they were just user input tacked on after some directory path.
+        test(root + ".", root + ".abc");
+        test(root + "..", root + "..abc");
+    }
+}
+
+TEST(FileDialog, testFilterWildcard)
+{
+    using F = FileDialog::Filter;
+    EXPECT_TRUE(F("Single wildcard", {"*"}).isWildcard());
+    EXPECT_TRUE(F("Dotted wildcard", {"*.*"}).isWildcard());
+    EXPECT_TRUE(F("Ext & Single wildcard", {"*.abc", "*"}).isWildcard());
+    EXPECT_TRUE(F("Ext & Dotted wildcard", {"*.abc", "*.*"}).isWildcard());
+
+    EXPECT_FALSE(F("Empty", {}).isWildcard());
+    EXPECT_FALSE(F("Empty string", {""}).isWildcard());
+    EXPECT_FALSE(F("Text", {"*.txt"}).isWildcard());
+    EXPECT_FALSE(F("Not single wildcard", {"*def"}).isWildcard());
+    EXPECT_FALSE(F("Not single wildcard 2", {"def*"}).isWildcard());
+    EXPECT_FALSE(F("Not single wildcard 2", {"def*ghi"}).isWildcard());
+    EXPECT_FALSE(F("Not dotted wildcard", {"*.*def"}).isWildcard());
+    EXPECT_FALSE(F("Not dotted wildcard 2", {"def*.*"}).isWildcard());
+    EXPECT_FALSE(F("Not dotted wildcard 3", {"def*.*ghi"}).isWildcard());
+    EXPECT_FALSE(F("Ext & Not single wildcard", {"*.abc", "*def"}).isWildcard());
+    EXPECT_FALSE(F("Ext & Not single wildcard 2", {"*.abc", "def*"}).isWildcard());
+    EXPECT_FALSE(F("Ext & Not single wildcard 3", {"*.abc", "def*ghi"}).isWildcard());
+    EXPECT_FALSE(F("Ext & Not dotted wildcard", {"*.abc", "*.*def"}).isWildcard());
+    EXPECT_FALSE(F("Ext & Not dotted wildcard 2", {"*.abc", "def*.*"}).isWildcard());
+    EXPECT_FALSE(F("Ext & Not dotted wildcard 3", {"*.abc", "def*.*ghi"}).isWildcard());
+}

--- a/tests/src/Gui/FileDialog.cpp
+++ b/tests/src/Gui/FileDialog.cpp
@@ -6,6 +6,7 @@
 
 
 using namespace Gui;
+using Filter = FileDialog::Filter;
 
 TEST(FileDialog, testNormalizeSavePath)
 {
@@ -74,6 +75,26 @@ TEST(FileDialog, testNormalizeSavePath)
         test(root + ".", root + ".abc");
         test(root + "..", root + "..abc");
     }
+}
+
+TEST(FileDialog, testFilterFromFilterString)
+{
+    const auto eq =
+        [](bool positive, const QString& string, const QString& name, const QStringList& patterns) {
+            const auto fromString = Filter::fromFilterString(string);
+            const Filter expected {name, patterns};
+            if (positive) {
+                EXPECT_EQ(fromString, expected);
+            }
+            else {
+                EXPECT_NE(fromString, expected);
+            }
+        };
+    eq(true, "A (*.a)", "A", {"*.a"});
+    eq(true, "A (*.a *.b)", "A", {"*.a", "*.b"});
+    eq(true, "A ( *.a  *.b )", "A", {"*.a", "*.b"});
+    eq(false, "A (*.a;*.b)", "A", {"*.a", "*.b"});
+    eq(true, "L (*.averylongname)", "L", {"*.averylongname"});
 }
 
 TEST(FileDialog, testFilterWildcard)


### PR DESCRIPTION
* Supersedes #29268
* Supersedes #29240
* Fixes #29212
* Fixes #29183
* Fixes #29302
* Fixes #29451
* Fixes #29238
* Fixes #29453
* Fixes name field not being populated with suggested file name
* Fixes Windows dialog not picking an extension if you did not specify one

My first FileDialog rework broke Windows support around the edges because the legacy file dialog APIs there simply do not behave like the modern `IFileDialog` ones used by Qt in ways that are either:
1. completely undocumented, or
2. badly expressed
   * Looking at you [need to call `IFileDialog::SetDefaultExtension()` even with an empty string to instruct the file dialog to append an extension on its own](https://learn.microsoft.com/en-us/windows/win32/api/shobjidl_core/nf-shobjidl_core-ifiledialog-setdefaultextension) for which no equivalent exist in the legacy API

This commit sequence (re-)introduces `IFileDialog` use into FreeCAD inherently fixing some of the observed differences. Doing this without reintroducing #23139 comes at the cost of using [undocumented APIs I have discovered](https://elementw.net/posts/microsoft-bs-ifiledialog/).

This required putting said impl in its own file as to not pollute the rest, which needed headers for sharing some of the FC `FileDialog` internal details, in turn meaning I might as well expose the `Filter` struct (name + patterns) and migrate `FileDialog` call sites to it; hence the large amount of files touched like last time[^1].

Also adds (from #29268) some amount of file naming enforcement should the platform APIs not append extensions/match patterns on their own—e.g. Qt/KDE dialogs that have a checkbox for that—but FC currently *depends* on extensions just about everywhere. Hopefully this enforcement can be lifted at some later date as said code would be reworked.

### Testing

Tested on both Linux (KDE) and Windows 11.
In the latter case, typing a name without extension but file filter correctly selected returns a filename with corresponding extension, and the system prompts the user on overwrite (e.g. on IGES filter selected, `abc` typed, `abc.iges` already exists).

Obviously I have not tested every dialog that exists in FC or every possible case with files and their naming, so more is needed.

[^1]: And mind you this is only batch 2 out of 3. Should time and motivation permit, I will attempt migrating most if not all raw pattern filters to a MIME-based system instead, eliminating a lot of the variation in filtering and format handling.