### PR TITLE
Gui: make UseVBO checkbox do and say what it should

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -491,12 +491,12 @@ Application::Application(bool GUIenabled)
             hPGrp->GetASCII("Language", (const char*)lang.toLatin1()).c_str());
         GetWidgetFactorySupplier();
 
-        // Coin3d disabled VBO support for all Intel drivers but in the meantime they have improved
-        // so we can try to override the workaround by setting COIN_VBO
+        // Coin3d disables VBO support for some (typically very old) drivers and hardware.
+        // Force it on if the preference says to.
         ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/View");
         if (hViewGrp->GetBool("UseVBO", false)) {
-            (void)coin_setenv("COIN_VBO", "0", true);
+            (void)coin_setenv("COIN_VBO", "1", true);
         }
 
         // Check for the symbols for group separator and decimal point. They must be different

--- a/src/Gui/PreferencePages/DlgSettings3DView.ui
+++ b/src/Gui/PreferencePages/DlgSettings3DView.ui
@@ -300,19 +300,18 @@ Changing this option requires a restart of the application.</string>
       <item>
        <widget class="Gui::PrefCheckBox" name="CheckBox_useVBO">
         <property name="toolTip">
-         <string>If selected, Vertex Buffer Objects (VBO) will be used.
-A VBO is an OpenGL feature that provides methods for uploading
-vertex data (position, normal vector, color, etc.) to the graphics card.
-VBOs offer substantial performance gains because the data resides
-in the graphics memory rather than the system memory and so it
-can be rendered directly by the GPU.
+         <string>A VBO is an OpenGL feature that enables uploading geometry data
+to the graphics card, and is how efficient 3D rendering is done
+on modern hardware.
+This feature might not be used by default if you are running old
+hardware or drivers. By selecting this option its usage will be
+forcibly enabled.
 
-Note: Sometimes this feature may lead to a host of different
-issues ranging from graphical anomalies to GPU crash bugs. Remember to
-report this setting as enabled when seeking support.</string>
+Note: Turning this on is typically not required. If you do,
+remember to report this setting as enabled when seeking support.</string>
         </property>
         <property name="text">
-         <string>Use OpenGL VBO (Vertex Buffer Object)</string>
+         <string>Force use of OpenGL VBO (Vertex Buffer Object)</string>
         </property>
         <property name="prefEntry" stdset="0">
          <cstring>UseVBO</cstring>

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -426,8 +426,11 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     }
     else if (strcmp(Reason, "UseVBO") == 0) {
         if (!ignoreVBO) {
+            // Assume no value means "on" as Coin only disables
+            // VBOs for some (very old) drivers and hardware.
+            const auto useVbo = rGrp.GetBool("UseVBO", true);
             for (auto _viewer : _viewers) {
-                _viewer->setEnabledVBO(rGrp.GetBool("UseVBO", false));
+                _viewer->setEnabledVBO(useVbo);
             }
         }
     }


### PR DESCRIPTION
@wwmayer messed up all the way back in 2018 with commit acbbcbcb00e3ce9d0f6c0bdf0e6ab4f983e53234 where the function of the UseVBO checkbox/preference is flipped and forcibly *disables* the use of VBOs instead.

Revert this blunder, and change the checkbox's text to state what actually happens.

See [coin3d:src/rendering/SoVBO.cpp:179-185](https://github.com/coin3d/coin/blob/master/src/rendering/SoVBO.cpp#L179-L185) if you have any doubts on how the `COIN_VBO` env var works.

## Before

<img width="484" height="214" alt="image" src="https://github.com/user-attachments/assets/d07bc3b9-e93f-4af6-aaec-04a8be8dd6f7" />

No VBO if checked, bamboozled ☹️

## After

<img width="484" height="214" alt="image" src="https://github.com/user-attachments/assets/6f3ab53a-3360-4c82-99d7-3721159f7d03" />

VBOs forced on if checked, joy