### PR TITLE
PartDesign: fix Chamfer tool not starting in selection mode

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskChamferParameters.cpp
@@ -115,14 +115,14 @@ TaskChamferParameters::TaskChamferParameters(ViewProviderDressUp* DressUpView, Q
             this, &TaskChamferParameters::doubleClicked);
     // clang-format on
 
+    setupGizmos(DressUpView);
+
     if (strings.size() == 0) {
         setSelectionMode(refSel);
     }
     else {
         hideOnError();
     }
-
-    setupGizmos(DressUpView);
 }
 
 void TaskChamferParameters::setUpUI(PartDesign::Chamfer* pcChamfer)


### PR DESCRIPTION
Fixes #29306

setupGizmos() emits currentIndexChanged on the type combobox, which triggers onTypeChanged() then setSelectionMode(none), overriding the setSelectionMode(refSel) that was called just before it. Moving the selection mode initialization after setupGizmos() fixes this.