### PR TITLE
CAM: MachineState for Post/Processor.py (and post-processors)

### DIFF
--- a/src/Mod/CAM/CAMTests/PostTestMocks.py
+++ b/src/Mod/CAM/CAMTests/PostTestMocks.py
@@ -33,6 +33,8 @@ class MockTool:
         self.ShapeType = "endmill"
 
 
+from Path.Base.Generator import toolchange
+
 class MockToolController:
     """Mock ToolController for operations."""
 
@@ -41,7 +43,7 @@ class MockToolController:
         tool_number=1,
         label="TC: Default Tool",
         spindle_speed=1000,
-        spindle_dir="Forward",
+        spindle_dir= toolchange.SpindleDirection.CW,
     ):
         self.Tool = MockTool()
         self.ToolNumber = tool_number
@@ -52,8 +54,15 @@ class MockToolController:
 
         # Create a simple path with tool change commands
         self.Path = Path.Path()
+
         self.Path.addCommands(
-            [Path.Command(f"M6 T{tool_number}"), Path.Command(f"M3 S{spindle_speed}")]
+            #[Path.Command(f"M6 T{tool_number}"), Path.Command(f"M3 S{spindle_speed}")] # FIXME: force m3?
+            toolchange.generate(
+                toolnumber=tool_number,
+                toollabel=label,
+                spindlespeed=spindle_speed,
+                spindledirection=spindle_dir,
+            )
         )
 
     @property

--- a/src/Mod/CAM/CAMTests/PostTestMocks.py
+++ b/src/Mod/CAM/CAMTests/PostTestMocks.py
@@ -35,6 +35,7 @@ class MockTool:
 
 from Path.Base.Generator import toolchange
 
+
 class MockToolController:
     """Mock ToolController for operations."""
 
@@ -43,7 +44,7 @@ class MockToolController:
         tool_number=1,
         label="TC: Default Tool",
         spindle_speed=1000,
-        spindle_dir= toolchange.SpindleDirection.CW,
+        spindle_dir=toolchange.SpindleDirection.CW,
     ):
         self.Tool = MockTool()
         self.ToolNumber = tool_number
@@ -56,7 +57,7 @@ class MockToolController:
         self.Path = Path.Path()
 
         self.Path.addCommands(
-            #[Path.Command(f"M6 T{tool_number}"), Path.Command(f"M3 S{spindle_speed}")] # FIXME: force m3?
+            # [Path.Command(f"M6 T{tool_number}"), Path.Command(f"M3 S{spindle_speed}")] # FIXME: force m3?
             toolchange.generate(
                 toolnumber=tool_number,
                 toollabel=label,

--- a/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
+++ b/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
@@ -27,6 +27,7 @@ Test suite for DrillCycleExpander class.
 import unittest
 import Path
 from Path.Post.DrillCycleExpander import DrillCycleExpander
+from Path.Base.MachineState import MachineState
 
 
 class TestDrillCycleExpander(unittest.TestCase):
@@ -35,11 +36,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_00_error_r_less_than_z(self):
         """Test error condition when R < Z."""
 
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 10.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         # Invalid: retract height below drill depth
         cmd = Path.Command("G81", {"X": 5.0, "Y": 5.0, "Z": -3.0, "R": -5.0, "F": 100.0})
@@ -50,11 +48,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_01_modal_retract_mode(self):
         """Test that G98/G99 modal commands are processed and filtered out"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 10.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         # Test G99 processing
         cmd = Path.Command("G99", {})
@@ -64,7 +59,7 @@ class TestDrillCycleExpander(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
         # Expander should track the mode
-        self.assertEqual(expander.retract_mode, "G99")
+        self.assertEqual(expander.machine_state.ReturnMode, "R")
 
         # Test G98 processing
         cmd = Path.Command("G98", {})
@@ -74,35 +69,30 @@ class TestDrillCycleExpander(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
         # Expander should track the mode
-        self.assertEqual(expander.retract_mode, "G98")
+        self.assertEqual(expander.machine_state.ReturnMode, "Z")
 
     def test_02_position_tracking(self):
         """Test that position is tracked correctly"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 10.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state )
 
         commands = [
-            Path.Command("G0", {"X": 5.0, "Y": 10.0, "Z": 15.0}),
-            Path.Command("G81", {"Z": -5.0, "R": 2.0, "F": 100.0}),  # No X/Y, should use current
+            Path.Command("G0 X5 Y10 Z15" ),
+            Path.Command("G81 X2 Y2.1 Z-5.0 R2.0 F100.0"),
         ]
 
         # Expand commands to update position tracking
         expander.expand_commands(commands)
 
         # Position should be updated from first move
-        self.assertEqual(expander.current_position["X"], 5.0)
-        self.assertEqual(expander.current_position["Y"], 10.0)
+        self.assertEqual(expander.machine_state.X, 2.0)
+        self.assertEqual(expander.machine_state.Y, 2.1)
+        # self.assertEqual(expander.machine_state.Z, -5.0) # FIXME: not tracking Z based on retract
 
     def test_03_expand_path_object(self):
         """Test expanding a complete Path object"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 10.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         commands = [
             Path.Command("G0", {"X": 10.0, "Y": 10.0, "Z": 30.0}),
@@ -127,33 +117,21 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_04_g81_with_g98(self):
         """Test 1: Basic G81 (simple drill) with G98 retract"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 30.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":30.0, "ReturnMode":"Z", "G0F":110} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
         ]
 
         result = expander.expand_commands(input_cmds)
-
-        print("\n")
-        print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
-        print(Path.Path(input_cmds).toGCode())
-        print("#### Result ####")
-        print(Path.Path(result).toGCode())
-        print("##########")
 
         self.assertEqual(len(result), len(expected_cmds))
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
@@ -162,30 +140,27 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_05_g81_with_g99(self):
         """Test 2: G81 with G99 retract (retract to R instead of initial Z)"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 30.0}
-        retract_mode = "G99"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":30.0, "ReturnMode":"R", "G0F":110} ) # G99
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110 }),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110 }),
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110 }),
         ]
-
-        result = expander.expand_commands(input_cmds)
 
         print("\n")
         print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
+        print(f"starting position: {machine_state}")
         print(Path.Path(input_cmds).toGCode())
+
+        result = expander.expand_commands(input_cmds)
+
         print("#### Result ####")
         print(Path.Path(result).toGCode())
         print("##########")
@@ -198,35 +173,32 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_06_g82(self):
         """Test 3: G82 (drill with dwell)"""
         # Initialize expander with G98 retract mode
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 0.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
-            Path.Command("G0", {"Z": 1.0}),
+            Path.Command("G0", {"Z": 1.0, "F":110}),
             Path.Command("G82", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "P": 1.5, "F": 10.0}),
             Path.Command("G80", {}),  # This should be filtered out
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"Z": 1.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),  # Z to R position
+            Path.Command("G0", {"Z": 1.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
             Path.Command("G4", {"P": 1.5}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # Retract to initial Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":11, "F":110}),  # Retract to initial Z
             # G80 is filtered out
         ]
 
-        result = expander.expand_commands(input_cmds)
-
         print("\n")
         print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
+        print(f"starting position: {machine_state}")
         print(Path.Path(input_cmds).toGCode())
+
+        result = expander.expand_commands(input_cmds)
+
         print("#### Result ####")
         print(Path.Path(result).toGCode())
         print("##########")
@@ -239,11 +211,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_07_g83(self):
         """Test 4: G83 (peck drill) with 3 pecks"""
         # Initialize expander with G98 retract mode
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 0.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -255,10 +224,10 @@ class TestDrillCycleExpander(unittest.TestCase):
             Path.Command("G0", {"Z": 1.0}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # XY move at current Z
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),  # Z to R position
-            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.1, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.09}),
-            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.3, "F": 10.0}),
+            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.1, "F": 10.0}), # drill
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}), # retract
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.09}), # back to bottom
+            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.3, "F": 10.0}), # drill...
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.29}),
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
@@ -269,13 +238,13 @@ class TestDrillCycleExpander(unittest.TestCase):
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # Retract to initial Z
         ]
 
-        result = expander.expand_commands(input_cmds)
-
         print("\n")
         print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
+        print(f"starting position: {machine_state}")
         print(Path.Path(input_cmds).toGCode())
+
+        result = expander.expand_commands(input_cmds)
+
         print("#### Result ####")
         print(Path.Path(result).toGCode())
         print("##########")
@@ -294,11 +263,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_08_preliminary_moves(self):
         """Test preliminary motion according to LinuxCNC specification"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 30.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":30, "ReturnMode":"Z", "G0F":110} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
@@ -311,10 +277,10 @@ class TestDrillCycleExpander(unittest.TestCase):
         # 4. Drill
         # 5. Retract to initial Z (30) for G98
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # Drill
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),  # Retract to initial Z (G98)
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),  # Retract to initial Z (G98)
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -326,11 +292,9 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_09_preliminary_moves_z_below_r(self):
         """Test preliminary motion when Z starts below R"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 5.0}  # Below R=10
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        # Below R=10
+        machine_state = MachineState( {"Z":5, "ReturnMode":"Z", "G0F":110} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
@@ -343,11 +307,11 @@ class TestDrillCycleExpander(unittest.TestCase):
         # 4. Drill
         # 5. Retract to initial Z (5) for G98, but initial Z < R, so retract to R
         expected_cmds = [
-            Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 10.0}),  # Preliminary Z to R
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),  # XY move at R
+            Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 10.0, "F":110}),  # Preliminary Z to R
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # XY move at R
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # Drill
             Path.Command(
-                "G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}
+                "G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}
             ),  # Retract to R (max of initial Z=5 and R=10)
         ]
 
@@ -361,11 +325,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_10_g73(self):
         """Test 6: G73 (chip breaking drill) with small retracts"""
         # Initialize expander with G98 retract mode
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 0.0}  # Below R=10
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -389,12 +350,13 @@ class TestDrillCycleExpander(unittest.TestCase):
             # G80 is filtered out
         ]
 
-        result = expander.expand_commands(input_cmds)
         print("\n")
         print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
+        print(f"starting position: {machine_state}")
         print(Path.Path(input_cmds).toGCode())
+        
+        result = expander.expand_commands(input_cmds)
+
         print("#### Result ####")
         print(Path.Path(result).toGCode())
         print("##########")
@@ -414,13 +376,12 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_11_cycle_multiple_positions(self):
         """Test 5: Modal cycle with multiple positions (G81)"""
         # Initialize expander with G98 retract mode
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 0.0}  # Below R=10
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        # Below R=10
+        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
+
         input_cmds = [
-            Path.Command("G0", {"Z": 1.0}),
+            Path.Command("G0", {"Z": 1.0, "F":110}),
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 2.0, "Y": 2.0}),  # Modal - reuses Z, R, F
             Path.Command("G81", {"X": 3.0, "Y": 3.0}),  # Modal - reuses Z, R, F
@@ -431,7 +392,7 @@ class TestDrillCycleExpander(unittest.TestCase):
         # For now, we'll test with explicit parameters since modal parameter tracking
         # is a more complex feature that may need to be added
         input_cmds_explicit = [
-            Path.Command("G0", {"Z": 1.0}),
+            Path.Command("G0", {"Z": 1.0, "F":110}),
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 2.0, "Y": 2.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 3.0, "Y": 3.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
@@ -439,29 +400,29 @@ class TestDrillCycleExpander(unittest.TestCase):
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"Z": 1.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),  # Z to R position
+            Path.Command("G0", {"Z": 1.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # Retract to initial Z
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 0.1}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # Retract to initial Z
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F":110}),  # XY move at current Z
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 0.1, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 2.0, "Y": 2.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0}),  # Retract to initial Z
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 0.1}),  # Z to R position
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F":110}),  # Retract to initial Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F":110}),  # XY move at current Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 0.1, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 3.0, "Y": 3.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0}),  # Retract to initial Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F":110}),  # Retract to initial Z
             # G80 is filtered out
         ]
 
-        result = expander.expand_commands(input_cmds_explicit)
-
         print("\n")
         print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
+        print(f"starting position: {machine_state}")
         print(Path.Path(input_cmds).toGCode())
+
+        result = expander.expand_commands(input_cmds_explicit)
+
         print("#### Result ####")
         print(Path.Path(result).toGCode())
         print("##########")
@@ -470,3 +431,67 @@ class TestDrillCycleExpander(unittest.TestCase):
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
             self.assertEqual(res.Name, exp.Name, f"Command {i}: name mismatch")
             self.assertEqual(res.Parameters, exp.Parameters, f"Command {i}: parameters mismatch")
+
+
+    # nb: DrillCycleExpander and UtilsParse.drill_translate are NOT identical. see issue #28984
+    # So, we don't test for that.
+
+    def test_G98_vs_G99(self):
+        """Check that G98 and G99 is consistently applied: G73 is special case"""
+
+        # try to excercise all code-paths
+        for retract in ["G98", "G99"]:
+            # nb: g73 has a different code path too
+            command = Path.Command("G83 X10.0 Y10.0 Z0 F100 R9.0 Q4")
+
+            machine_state = MachineState( {"Z":20, "G0F":110} )
+            machine_state.addCommand(Path.Command(retract))
+            expander = DrillCycleExpander( machine_state)
+
+            result = expander.expand_command( command )
+
+            self.maxDiff = None
+
+            # We have to test stringified because Path.Command doesn't implement __eq__
+
+            # Expected, new algorithm
+
+            final_z = machine_state.Z if retract == "G98" else command.Parameters["R"]
+            expected = [ Path.Command(g) for g in [
+                # (tracking current.Z):
+                # No prelim Z, Z>R
+                "G0 X10 Y10 Z20 F110", # prelim move, Z unchanged
+                "G0 X10 Y10 Z9 F110", # start: to R if != Z
+                "G1 X10 Y10 Z5 F100", # drill
+                "G0 X10 Y10 Z9 F110", # retract
+                f"G0 X10 Y10 Z{5 + 4*0.05} F110", # back to bottom
+                "G1 X10 Y10 Z1 F100", # drill
+                "G0 X10 Y10 Z9 F110", # retract
+                f"G0 X10 Y10 Z{1 + 4*0.05} F110", # back to bottom
+                "G1 X10 Y10 Z0 F100", # drill
+                "G0 X10 Y10 Z9 F110", # retract
+                ]
+            ]
+            if retract == "G98":
+                expected.append( Path.Command(f"G0 X10 Y10 Z{final_z} F110") ) # back to original-Z|R
+
+            eol="\n"
+
+            result = [ Path.Command(c.Name, c.Parameters) for c in result ]
+            as_strings = [x.toGCode() for x in result]
+            lines = "\n".join(as_strings)
+
+            self.assertEqual(
+                lines,
+                "\n".join([x.toGCode() for x in expected]),
+                f"For retract {retract}, {command.toGCode()}"
+            )
+
+    @unittest.expectedFailure
+    def test_bad_values(self):
+        """Examples
+            r < Z
+            etc.
+        """
+        assertTrue(False, "FIXME: DrillCycleExpander returns [] on bad values, no way of reporting the issue")
+

--- a/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
+++ b/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
@@ -36,8 +36,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_00_error_r_less_than_z(self):
         """Test error condition when R < Z."""
 
-        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 10.0, "ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         # Invalid: retract height below drill depth
         cmd = Path.Command("G81", {"X": 5.0, "Y": 5.0, "Z": -3.0, "R": -5.0, "F": 100.0})
@@ -48,8 +48,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_01_modal_retract_mode(self):
         """Test that G98/G99 modal commands are processed and filtered out"""
-        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 10.0, "ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         # Test G99 processing
         cmd = Path.Command("G99", {})
@@ -73,11 +73,11 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_02_position_tracking(self):
         """Test that position is tracked correctly"""
-        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state )
+        machine_state = MachineState({"Z": 10.0, "ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         commands = [
-            Path.Command("G0 X5 Y10 Z15" ),
+            Path.Command("G0 X5 Y10 Z15"),
             Path.Command("G81 X2 Y2.1 Z-5.0 R2.0 F100.0"),
         ]
 
@@ -91,8 +91,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_03_expand_path_object(self):
         """Test expanding a complete Path object"""
-        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 10.0, "ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         commands = [
             Path.Command("G0", {"X": 10.0, "Y": 10.0, "Z": 30.0}),
@@ -117,18 +117,18 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_04_g81_with_g98(self):
         """Test 1: Basic G81 (simple drill) with G98 retract"""
-        machine_state = MachineState( {"Z":30.0, "ReturnMode":"Z", "G0F":110} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 30.0, "ReturnMode": "Z", "G0F": 110})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}),
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -140,18 +140,18 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_05_g81_with_g99(self):
         """Test 2: G81 with G99 retract (retract to R instead of initial Z)"""
-        machine_state = MachineState( {"Z":30.0, "ReturnMode":"R", "G0F":110} ) # G99
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 30.0, "ReturnMode": "R", "G0F": 110})  # G99
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110 }),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110 }),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110 }),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),
         ]
 
         print("\n")
@@ -173,22 +173,24 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_06_g82(self):
         """Test 3: G82 (drill with dwell)"""
         # Initialize expander with G98 retract mode
-        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
-            Path.Command("G0", {"Z": 1.0, "F":110}),
+            Path.Command("G0", {"Z": 1.0, "F": 110}),
             Path.Command("G82", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "P": 1.5, "F": 10.0}),
             Path.Command("G80", {}),  # This should be filtered out
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"Z": 1.0, "F":110}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F":110}),  # Z to R position
+            Path.Command("G0", {"Z": 1.0, "F": 110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F": 110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
             Path.Command("G4", {"P": 1.5}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":11, "F":110}),  # Retract to initial Z
+            Path.Command(
+                "G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F": 11, "F": 110}
+            ),  # Retract to initial Z
             # G80 is filtered out
         ]
 
@@ -211,8 +213,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_07_g83(self):
         """Test 4: G83 (peck drill) with 3 pecks"""
         # Initialize expander with G98 retract mode
-        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -224,10 +226,10 @@ class TestDrillCycleExpander(unittest.TestCase):
             Path.Command("G0", {"Z": 1.0}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # XY move at current Z
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),  # Z to R position
-            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.1, "F": 10.0}), # drill
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}), # retract
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.09}), # back to bottom
-            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.3, "F": 10.0}), # drill...
+            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.1, "F": 10.0}),  # drill
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),  # retract
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.09}),  # back to bottom
+            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.3, "F": 10.0}),  # drill...
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.29}),
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
@@ -263,8 +265,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_08_preliminary_moves(self):
         """Test preliminary motion according to LinuxCNC specification"""
-        machine_state = MachineState( {"Z":30, "ReturnMode":"Z", "G0F":110} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 30, "ReturnMode": "Z", "G0F": 110})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
@@ -277,10 +279,12 @@ class TestDrillCycleExpander(unittest.TestCase):
         # 4. Drill
         # 5. Retract to initial Z (30) for G98
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # Drill
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),  # Retract to initial Z (G98)
+            Path.Command(
+                "G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}
+            ),  # Retract to initial Z (G98)
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -293,8 +297,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_09_preliminary_moves_z_below_r(self):
         """Test preliminary motion when Z starts below R"""
         # Below R=10
-        machine_state = MachineState( {"Z":5, "ReturnMode":"Z", "G0F":110} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 5, "ReturnMode": "Z", "G0F": 110})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
@@ -307,11 +311,11 @@ class TestDrillCycleExpander(unittest.TestCase):
         # 4. Drill
         # 5. Retract to initial Z (5) for G98, but initial Z < R, so retract to R
         expected_cmds = [
-            Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 10.0, "F":110}),  # Preliminary Z to R
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # XY move at R
+            Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 10.0, "F": 110}),  # Preliminary Z to R
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),  # XY move at R
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # Drill
             Path.Command(
-                "G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}
+                "G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}
             ),  # Retract to R (max of initial Z=5 and R=10)
         ]
 
@@ -325,8 +329,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_10_g73(self):
         """Test 6: G73 (chip breaking drill) with small retracts"""
         # Initialize expander with G98 retract mode
-        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -354,7 +358,7 @@ class TestDrillCycleExpander(unittest.TestCase):
         print("#### Input ####")
         print(f"starting position: {machine_state}")
         print(Path.Path(input_cmds).toGCode())
-        
+
         result = expander.expand_commands(input_cmds)
 
         print("#### Result ####")
@@ -377,11 +381,11 @@ class TestDrillCycleExpander(unittest.TestCase):
         """Test 5: Modal cycle with multiple positions (G81)"""
         # Initialize expander with G98 retract mode
         # Below R=10
-        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
-            Path.Command("G0", {"Z": 1.0, "F":110}),
+            Path.Command("G0", {"Z": 1.0, "F": 110}),
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 2.0, "Y": 2.0}),  # Modal - reuses Z, R, F
             Path.Command("G81", {"X": 3.0, "Y": 3.0}),  # Modal - reuses Z, R, F
@@ -392,7 +396,7 @@ class TestDrillCycleExpander(unittest.TestCase):
         # For now, we'll test with explicit parameters since modal parameter tracking
         # is a more complex feature that may need to be added
         input_cmds_explicit = [
-            Path.Command("G0", {"Z": 1.0, "F":110}),
+            Path.Command("G0", {"Z": 1.0, "F": 110}),
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 2.0, "Y": 2.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 3.0, "Y": 3.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
@@ -400,19 +404,19 @@ class TestDrillCycleExpander(unittest.TestCase):
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"Z": 1.0, "F":110}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F":110}),  # Z to R position
+            Path.Command("G0", {"Z": 1.0, "F": 110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F": 110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # Retract to initial Z
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F":110}),  # XY move at current Z
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 0.1, "F":110}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F": 110}),  # Retract to initial Z
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F": 110}),  # XY move at current Z
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 0.1, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 2.0, "Y": 2.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F":110}),  # Retract to initial Z
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F":110}),  # XY move at current Z
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 0.1, "F":110}),  # Z to R position
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F": 110}),  # Retract to initial Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F": 110}),  # XY move at current Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 0.1, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 3.0, "Y": 3.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F":110}),  # Retract to initial Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F": 110}),  # Retract to initial Z
             # G80 is filtered out
         ]
 
@@ -432,7 +436,6 @@ class TestDrillCycleExpander(unittest.TestCase):
             self.assertEqual(res.Name, exp.Name, f"Command {i}: name mismatch")
             self.assertEqual(res.Parameters, exp.Parameters, f"Command {i}: parameters mismatch")
 
-
     # nb: DrillCycleExpander and UtilsParse.drill_translate are NOT identical. see issue #28984
     # So, we don't test for that.
 
@@ -444,11 +447,11 @@ class TestDrillCycleExpander(unittest.TestCase):
             # nb: g73 has a different code path too
             command = Path.Command("G83 X10.0 Y10.0 Z0 F100 R9.0 Q4")
 
-            machine_state = MachineState( {"Z":20, "G0F":110} )
+            machine_state = MachineState({"Z": 20, "G0F": 110})
             machine_state.addCommand(Path.Command(retract))
-            expander = DrillCycleExpander( machine_state)
+            expander = DrillCycleExpander(machine_state)
 
-            result = expander.expand_command( command )
+            result = expander.expand_command(command)
 
             self.maxDiff = None
 
@@ -457,41 +460,45 @@ class TestDrillCycleExpander(unittest.TestCase):
             # Expected, new algorithm
 
             final_z = machine_state.Z if retract == "G98" else command.Parameters["R"]
-            expected = [ Path.Command(g) for g in [
-                # (tracking current.Z):
-                # No prelim Z, Z>R
-                "G0 X10 Y10 Z20 F110", # prelim move, Z unchanged
-                "G0 X10 Y10 Z9 F110", # start: to R if != Z
-                "G1 X10 Y10 Z5 F100", # drill
-                "G0 X10 Y10 Z9 F110", # retract
-                f"G0 X10 Y10 Z{5 + 4*0.05} F110", # back to bottom
-                "G1 X10 Y10 Z1 F100", # drill
-                "G0 X10 Y10 Z9 F110", # retract
-                f"G0 X10 Y10 Z{1 + 4*0.05} F110", # back to bottom
-                "G1 X10 Y10 Z0 F100", # drill
-                "G0 X10 Y10 Z9 F110", # retract
+            expected = [
+                Path.Command(g)
+                for g in [
+                    # (tracking current.Z):
+                    # No prelim Z, Z>R
+                    "G0 X10 Y10 Z20 F110",  # prelim move, Z unchanged
+                    "G0 X10 Y10 Z9 F110",  # start: to R if != Z
+                    "G1 X10 Y10 Z5 F100",  # drill
+                    "G0 X10 Y10 Z9 F110",  # retract
+                    f"G0 X10 Y10 Z{5 + 4*0.05} F110",  # back to bottom
+                    "G1 X10 Y10 Z1 F100",  # drill
+                    "G0 X10 Y10 Z9 F110",  # retract
+                    f"G0 X10 Y10 Z{1 + 4*0.05} F110",  # back to bottom
+                    "G1 X10 Y10 Z0 F100",  # drill
+                    "G0 X10 Y10 Z9 F110",  # retract
                 ]
             ]
             if retract == "G98":
-                expected.append( Path.Command(f"G0 X10 Y10 Z{final_z} F110") ) # back to original-Z|R
+                expected.append(Path.Command(f"G0 X10 Y10 Z{final_z} F110"))  # back to original-Z|R
 
-            eol="\n"
+            eol = "\n"
 
-            result = [ Path.Command(c.Name, c.Parameters) for c in result ]
+            result = [Path.Command(c.Name, c.Parameters) for c in result]
             as_strings = [x.toGCode() for x in result]
             lines = "\n".join(as_strings)
 
             self.assertEqual(
                 lines,
                 "\n".join([x.toGCode() for x in expected]),
-                f"For retract {retract}, {command.toGCode()}"
+                f"For retract {retract}, {command.toGCode()}",
             )
 
     @unittest.expectedFailure
     def test_bad_values(self):
         """Examples
-            r < Z
-            etc.
+        r < Z
+        etc.
         """
-        assertTrue(False, "FIXME: DrillCycleExpander returns [] on bad values, no way of reporting the issue")
-
+        assertTrue(
+            False,
+            "FIXME: DrillCycleExpander returns [] on bad values, no way of reporting the issue",
+        )

--- a/src/Mod/CAM/CAMTests/TestFanucPost.py
+++ b/src/Mod/CAM/CAMTests/TestFanucPost.py
@@ -21,6 +21,8 @@
 # *                                                                         *
 # ***************************************************************************
 
+import re
+
 import FreeCAD
 import Part
 import Path
@@ -93,7 +95,7 @@ class TestFanucPost(PathTestUtils.PathTestBase):
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         gcode = self.post.export()[0][1]
-        self.assertEqual(27, len(gcode.splitlines()))
+        self.assertEqual(28, len(gcode.splitlines()))
         # Test without header
         expected = """%
 (BEGIN PREAMBLE)
@@ -101,6 +103,7 @@ G17 G54 G40 G49 G80 G90 G94
 G21
 (BEGIN OPERATION: TC: DEFAULT TOOL)
 (MACHINE UNITS: MM/MIN)
+(TC: DEFAULT TOOL)
 M05
 G28 G91 Z0
 M6 T1
@@ -166,7 +169,7 @@ M30
         # Header contains a time stamp that messes up unit testing.
         # Only test length of result.
         gcode = self.post.export()[0][1]
-        self.assertEqual(31, len(gcode.splitlines()))
+        self.assertEqual(32, len(gcode.splitlines()))
         # Test without header
         expected = """%
 (BEGIN PREAMBLE)
@@ -174,6 +177,7 @@ G17 G54 G40 G49 G80 G90 G94
 G21
 (BEGIN OPERATION: TC: DEFAULT TOOL)
 (MACHINE UNITS: MM/MIN)
+(TC: DEFAULT TOOL)
 M05
 G28 G91 Z0
 M6 T1
@@ -243,15 +247,15 @@ M30
         self.profile_op.Path = Path.Path([c])
         self.job.PostProcessorArgs = "--no-header --no-show-editor"
         gcode = self.post.export()[0][1]
-        result = gcode.splitlines()[19]
+        result = gcode.splitlines()
         expected = "G0 X10.000 Y20.000 Z30.000"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
         self.job.PostProcessorArgs = "--no-header --precision=2 --no-show-editor"
         gcode = self.post.export()[0][1]
-        result = gcode.splitlines()[19]
+        result = gcode.splitlines()
         expected = "G0 X10.00 Y20.00 Z30.00"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
     def test_line_numbers(self):
         """
@@ -262,9 +266,9 @@ M30
         self.profile_op.Path = Path.Path([c])
         self.job.PostProcessorArgs = "--no-header --line-numbers --no-show-editor"
         gcode = self.post.export()[0][1]
-        result = gcode.splitlines()[19]
-        expected = "N290  G0 X10.000 Y20.000 Z30.000"
-        self.assertEqual(result, expected)
+        result = gcode.splitlines()
+        expected = "G0 X10.000 Y20.000 Z30.000"
+        self.assertTrue( re.search(r'^N\d+ +'+expected, gcode, flags=re.M), gcode)
 
     def test_pre_amble(self):
         """
@@ -302,15 +306,15 @@ M30
         gcode = self.post.export()[0][1]
         self.assertEqual(gcode.splitlines()[3], "G20")
 
-        result = gcode.splitlines()[19]
+        result = gcode.splitlines()
         expected = "G0 X0.3937 Y0.7874 Z1.1811"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
         self.job.PostProcessorArgs = "--no-header --inches --precision=2 --no-show-editor"
         gcode = self.post.export()[0][1]
-        result = gcode.splitlines()[19]
+        result = gcode.splitlines()
         expected = "G0 X0.39 Y0.79 Z1.18"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
     def test_tool_change(self):
         """
@@ -321,17 +325,17 @@ M30
         self.profile_op.Path = Path.Path([c, c2])
         self.job.PostProcessorArgs = "--no-header --no-show-editor"
         gcode = self.post.export()[0][1]
-        self.assertEqual(gcode.splitlines()[19], "M05")
-        self.assertEqual(gcode.splitlines()[20], "G28 G91 Z0")
-        self.assertEqual(gcode.splitlines()[21], "M6 T1")
-        self.assertEqual(gcode.splitlines()[22], "G91 G0 G43 G54 Z-[#[2000+#4120]] H#4120")
-        self.assertEqual(gcode.splitlines()[23], "G90")
-        self.assertEqual(gcode.splitlines()[24], "M3 S3000")
+        self.assertIn("M05", gcode.splitlines())
+        self.assertIn("G28 G91 Z0", gcode.splitlines())
+        self.assertIn("M6 T1", gcode.splitlines())
+        self.assertIn("G91 G0 G43 G54 Z-[#[2000+#4120]] H#4120", gcode.splitlines())
+        self.assertIn("G90", gcode.splitlines())
+        self.assertIn("M3 S3000", gcode.splitlines())
 
         # suppress TLO
         self.job.PostProcessorArgs = "--no-header --no-tlo --no-show-editor"
         gcode = self.post.export()[0][1]
-        self.assertEqual(gcode.splitlines()[20], "M3 S3000")
+        self.assertIn("M3 S3000", gcode.splitlines())
 
     def test_thread_tap(self):
         """
@@ -344,10 +348,10 @@ M30
         self.profile_op.Path = Path.Path([c, c2])
         self.job.PostProcessorArgs = "--no-header --no-show-editor"
         gcode = self.post.export()[0][1]
-        self.assertEqual(gcode.splitlines()[18], "G0 X10.000 Y10.000")
-        self.assertEqual(gcode.splitlines()[19], "M29 S1000")
-        self.assertEqual(gcode.splitlines()[20], "G84 Z-10.000 R20.000 F1000.000 P1.000 Q1.000")
-        self.assertEqual(gcode.splitlines()[21], "G80")
+        self.assertIn("G0 X10.000 Y10.000", gcode.splitlines())
+        self.assertIn("M29 S1000", gcode.splitlines())
+        self.assertIn("G84 Z-10.000 R20.000 F1000.000 P1.000 Q1.000", gcode.splitlines())
+        self.assertIn("G80", gcode.splitlines())
 
     def test_comment(self):
         """
@@ -359,9 +363,9 @@ M30
         self.profile_op.Path = Path.Path([c])
         self.job.PostProcessorArgs = "--no-header --no-show-editor"
         gcode = self.post.export()[0][1]
-        result = gcode.splitlines()[19]
+        result = gcode.splitlines()
         expected = "(COMMENT)"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
     def test_drilling_peck(self):
         """
@@ -400,17 +404,17 @@ M30
         print("Testing drilling")
         print(gcode)
         expected = "G0 X0.000 Y0.000"
-        self.assertEqual(glines[19], expected)
+        self.assertIn(expected, glines)
         expected = "G83 Z0.000 F6000.000 Q2.000 R10.000"
-        self.assertEqual(glines[20], expected)
+        self.assertIn(expected, glines)
         expected = "G0 X20.000"
-        self.assertEqual(glines[21], expected)
+        self.assertIn(expected, glines)
         expected = "G83 Z0.000 Q2.000 R10.000"
-        self.assertEqual(glines[22], expected)
+        self.assertIn(expected, glines)
         expected = "G0 X40.000"
-        self.assertEqual(glines[23], expected)
+        self.assertIn(expected, glines)
         expected = "G83 Z0.000 Q2.000 R10.000"
-        self.assertEqual(glines[24], expected)
+        self.assertIn(expected, glines)
 
     def test_drilling_peck_chipbreak(self):
         """
@@ -449,14 +453,14 @@ M30
         print("Testing drilling")
         print(gcode)
         expected = "G0 X0.000 Y0.000"
-        self.assertEqual(glines[19], expected)
+        self.assertIn(expected, glines)
         expected = "G73 Z0.000 F6000.000 Q2.000 R10.000"
-        self.assertEqual(glines[20], expected)
+        self.assertIn(expected, glines)
         expected = "G0 X20.000"
-        self.assertEqual(glines[21], expected)
+        self.assertIn(expected, glines)
         expected = "G73 Z0.000 Q2.000 R10.000"
-        self.assertEqual(glines[22], expected)
+        self.assertIn(expected, glines)
         expected = "G0 X40.000"
-        self.assertEqual(glines[23], expected)
+        self.assertIn(expected, glines)
         expected = "G73 Z0.000 Q2.000 R10.000"
-        self.assertEqual(glines[24], expected)
+        self.assertIn(expected, glines)

--- a/src/Mod/CAM/CAMTests/TestFanucPost.py
+++ b/src/Mod/CAM/CAMTests/TestFanucPost.py
@@ -268,7 +268,7 @@ M30
         gcode = self.post.export()[0][1]
         result = gcode.splitlines()
         expected = "G0 X10.000 Y20.000 Z30.000"
-        self.assertTrue( re.search(r'^N\d+ +'+expected, gcode, flags=re.M), gcode)
+        self.assertTrue(re.search(r"^N\d+ +" + expected, gcode, flags=re.M), gcode)
 
     def test_pre_amble(self):
         """

--- a/src/Mod/CAM/CAMTests/TestGenericPost.py
+++ b/src/Mod/CAM/CAMTests/TestGenericPost.py
@@ -23,6 +23,8 @@
 # ***************************************************************************
 
 
+import re
+
 import FreeCAD
 
 import Path
@@ -105,7 +107,7 @@ class TestGenericPost(PathTestUtils.PathTestBase):
         self.job.PostProcessorArgs = "--no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}Actual line count: {len(gcode.splitlines())}{nl}{gcode}--------{nl}")
-        self.assertTrue(len(gcode.splitlines()) == 23)
+        self.assertEqual(len(gcode.splitlines()), 24, gcode)
 
         # Test without header
         expected = """(Begin preamble)
@@ -113,6 +115,7 @@ G90
 G21
 (Begin operation: TC: Default Tool)
 (Machine units: mm/min)
+(TC: Default Tool)
 (Begin toolchange)
 M5
 M6 T1
@@ -166,16 +169,16 @@ G54
         self.job.PostProcessorArgs = "--no-header --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        result = gcode.splitlines()[17]
+        result = gcode.splitlines()
         expected = "G0 X10.000 Y20.000 Z30.000"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
         self.job.PostProcessorArgs = "--no-header --precision=2 --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        result = gcode.splitlines()[17]
+        result = gcode.splitlines()
         expected = "G0 X10.00 Y20.00 Z30.00"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
     def test020(self):
         """
@@ -190,9 +193,8 @@ G54
         self.job.PostProcessorArgs = "--no-header --line-numbers --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        result = gcode.splitlines()[17]
-        expected = "N270 G0 X10.000 Y20.000 Z30.000"
-        self.assertEqual(result, expected)
+        expected = r"^N\d+ +G0 X10.000 Y20.000 Z30.000"
+        self.assertTrue( re.search(expected, gcode, flags=re.M), f"Expected {expected} in\n{gcode}")
 
     def test030(self):
         """
@@ -243,16 +245,16 @@ G54
         # print(f"--------{nl}{gcode}--------{nl}")
         self.assertEqual(gcode.splitlines()[2], "G20")
 
-        result = gcode.splitlines()[17]
+        result = gcode.splitlines()
         expected = "G0 X0.3937 Y0.7874 Z1.1811"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
         self.job.PostProcessorArgs = "--no-header --inches --precision=2 --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        result = gcode.splitlines()[17]
+        result = gcode.splitlines()
         expected = "G0 X0.39 Y0.79 Z1.18"
-        self.assertEqual(result, expected)
+        self.assertIn(expected,result)
 
     def test060(self):
         """
@@ -269,9 +271,9 @@ G54
         self.job.PostProcessorArgs = "--no-header --modal --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        result = gcode.splitlines()[18]
+        result = gcode.splitlines()
         expected = "X10.000 Y30.000 Z30.000"
-        self.assertEqual(result, expected)
+        self.assertEqual(len([l for l in result if l==expected]),1,"Only expected one G0 X10..., in\n{gcode}")
 
     def test070(self):
         """
@@ -288,9 +290,9 @@ G54
         self.job.PostProcessorArgs = "--no-header --axis-modal --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        result = gcode.splitlines()[18]
+        result = gcode.splitlines()
         expected = "G0 Y30.000"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result)
 
     def test080(self):
         """
@@ -305,18 +307,21 @@ G54
 
         self.job.PostProcessorArgs = "--no-header --no-show-editor"
         gcode = self.post.export()[0][1]
-        # print(f"--------{nl}{gcode}--------{nl}")
+        print(f"--------{nl}{gcode}--------{nl}")
         split_gcode = gcode.splitlines()
-        self.assertEqual(split_gcode[18], "M5")
-        self.assertEqual(split_gcode[19], "M6 T2")
-        self.assertEqual(split_gcode[20], "G43 H2")
-        self.assertEqual(split_gcode[21], "M3 S3000")
+        self.assertIn("""
+M5
+M6 T2
+G43 H2
+M3 S3000
+""", gcode, f"for\n{gcode}")
 
         # suppress TLO
         self.job.PostProcessorArgs = "--no-header --no-tlo --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        self.assertEqual(gcode.splitlines()[19], "M3 S3000")
+        expected = "M3 S3000"
+        self.assertIn(expected, gcode.splitlines())
 
     def test090(self):
         """
@@ -331,6 +336,6 @@ G54
         self.job.PostProcessorArgs = "--no-header --no-show-editor"
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
-        result = gcode.splitlines()[17]
+        result = gcode.splitlines()
         expected = "(comment)"
-        self.assertEqual(result, expected)
+        self.assertIn(expected, result, f"In\n{gcode}")

--- a/src/Mod/CAM/CAMTests/TestGenericPost.py
+++ b/src/Mod/CAM/CAMTests/TestGenericPost.py
@@ -194,7 +194,7 @@ G54
         gcode = self.post.export()[0][1]
         # print(f"--------{nl}{gcode}--------{nl}")
         expected = r"^N\d+ +G0 X10.000 Y20.000 Z30.000"
-        self.assertTrue( re.search(expected, gcode, flags=re.M), f"Expected {expected} in\n{gcode}")
+        self.assertTrue(re.search(expected, gcode, flags=re.M), f"Expected {expected} in\n{gcode}")
 
     def test030(self):
         """
@@ -254,7 +254,7 @@ G54
         # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()
         expected = "G0 X0.39 Y0.79 Z1.18"
-        self.assertIn(expected,result)
+        self.assertIn(expected, result)
 
     def test060(self):
         """
@@ -273,7 +273,9 @@ G54
         # print(f"--------{nl}{gcode}--------{nl}")
         result = gcode.splitlines()
         expected = "X10.000 Y30.000 Z30.000"
-        self.assertEqual(len([l for l in result if l==expected]),1,"Only expected one G0 X10..., in\n{gcode}")
+        self.assertEqual(
+            len([l for l in result if l == expected]), 1, "Only expected one G0 X10..., in\n{gcode}"
+        )
 
     def test070(self):
         """
@@ -309,12 +311,16 @@ G54
         gcode = self.post.export()[0][1]
         print(f"--------{nl}{gcode}--------{nl}")
         split_gcode = gcode.splitlines()
-        self.assertIn("""
+        self.assertIn(
+            """
 M5
 M6 T2
 G43 H2
 M3 S3000
-""", gcode, f"for\n{gcode}")
+""",
+            gcode,
+            f"for\n{gcode}",
+        )
 
         # suppress TLO
         self.job.PostProcessorArgs = "--no-header --no-tlo --no-show-editor"

--- a/src/Mod/CAM/CAMTests/TestPathToolLibrarySerializer.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolLibrarySerializer.py
@@ -139,16 +139,38 @@ class TestLinuxCNCLibrarySerializer(TestPathToolLibrarySerializerBase):
     """Tests for the LinuxCNCLibrarySerializer."""
 
     def test_linuxcnc_serialize(self):
+        # TODO: this test uses the user-preferences for the tester's installed version of FreeCAD
+        # i.e., it depends on what the developer happened to set last.
+        # it probably shouldn't: set the pref, and or test several unit-systems
         serializer = LinuxCNCSerializer
         serialized_data = serializer.serialize(self.test_library)
         self.assertIsInstance(serialized_data, bytes)
 
+        decimals = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
+            "Decimals", 2
+        )
+
+        def format_D(v):
+            # Convert and format to userPreferred
+            # It is important to get the units for userPreferred from the actual `v`, 
+            # because the units are dependant on the order-of-magnitude of v
+            # for some user-preference unit-systems.
+            # E.g. U.S. Customary will give `thous` for 1mm, `"` (inch) for 6mm, etc.
+            as_quantity = FreeCAD.Units.Quantity(v)
+            units = as_quantity.getUserPreferred()[2]
+            in_user_units = as_quantity.getValueAs(units).Value
+            return f"{in_user_units:.{decimals}f}"
+
         # Verify the content format (basic check)
         lines = serialized_data.decode("ascii", "ignore").strip().split("\n")
         self.assertEqual(len(lines), 3)
-        self.assertEqual(lines[0], "T1 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D6.00 I0 J0 Q0 ;Endmill 6mm")
-        self.assertEqual(lines[1], "T2 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D3.00 I0 J0 Q0 ;Endmill 3mm")
-        self.assertEqual(lines[2], "T3 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D5.00 I0 J0 Q0 ;Ballend 5mm")
+
+        # D values from setUp()
+        # TODO: this will fail when Tool/library/serializers/linuxcnc.py serialize() uses MBPP, as noted in its TODO
+        # and the test will have to use MBPP in place of the userPreferred stuff above
+        self.assertEqual(lines[0], f"T1 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('6mm')} I0 J0 Q0 ;Endmill 6mm")
+        self.assertEqual(lines[1], f"T2 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('3mm')} I0 J0 Q0 ;Endmill 3mm")
+        self.assertEqual(lines[2], f"T3 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('5mm')} I0 J0 Q0 ;Ballend 5mm")
 
     def test_linuxcnc_deserialize_not_implemented(self):
         serializer = LinuxCNCSerializer

--- a/src/Mod/CAM/CAMTests/TestPathToolLibrarySerializer.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolLibrarySerializer.py
@@ -152,7 +152,7 @@ class TestLinuxCNCLibrarySerializer(TestPathToolLibrarySerializerBase):
 
         def format_D(v):
             # Convert and format to userPreferred
-            # It is important to get the units for userPreferred from the actual `v`, 
+            # It is important to get the units for userPreferred from the actual `v`,
             # because the units are dependant on the order-of-magnitude of v
             # for some user-preference unit-systems.
             # E.g. U.S. Customary will give `thous` for 1mm, `"` (inch) for 6mm, etc.
@@ -168,9 +168,15 @@ class TestLinuxCNCLibrarySerializer(TestPathToolLibrarySerializerBase):
         # D values from setUp()
         # TODO: this will fail when Tool/library/serializers/linuxcnc.py serialize() uses MBPP, as noted in its TODO
         # and the test will have to use MBPP in place of the userPreferred stuff above
-        self.assertEqual(lines[0], f"T1 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('6mm')} I0 J0 Q0 ;Endmill 6mm")
-        self.assertEqual(lines[1], f"T2 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('3mm')} I0 J0 Q0 ;Endmill 3mm")
-        self.assertEqual(lines[2], f"T3 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('5mm')} I0 J0 Q0 ;Ballend 5mm")
+        self.assertEqual(
+            lines[0], f"T1 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('6mm')} I0 J0 Q0 ;Endmill 6mm"
+        )
+        self.assertEqual(
+            lines[1], f"T2 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('3mm')} I0 J0 Q0 ;Endmill 3mm"
+        )
+        self.assertEqual(
+            lines[2], f"T3 P0 X0 Y0 Z0 A0 B0 C0 U0 V0 W0 D{format_D('5mm')} I0 J0 Q0 ;Ballend 5mm"
+        )
 
     def test_linuxcnc_deserialize_not_implemented(self):
         serializer = LinuxCNCSerializer

--- a/src/Mod/CAM/CAMTests/TestPostCore.py
+++ b/src/Mod/CAM/CAMTests/TestPostCore.py
@@ -931,7 +931,7 @@ class TestJobPropertyOverrides(unittest.TestCase):
 
         tc = PathToolController.Create("TC_Test_Tool", tool, 1)
         tc.Label = "TC: 6mm Endmill"
-        cls.job.Proxy.addToolController(tc)
+        cls.job.addObject(tc)
 
         # Create operation
         profile_op = cls.doc.addObject("Path::FeaturePython", "TestProfile")
@@ -1078,7 +1078,7 @@ class TestJobPropertyOverrides(unittest.TestCase):
         # Add M3/M4 commands to trigger plasma behavior
         plasma_commands = [
             Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),
-            Path.Command("M3", {}),  # Torch on - should trigger pierce delay
+            Path.Command("M3", {"S":1}),  # Torch on - should trigger pierce delay
             Path.Command("G1", {"X": 100.0, "Y": 0.0, "Z": -5.0, "F": 100.0}),
             Path.Command("M5", {}),  # Torch off
             Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),

--- a/src/Mod/CAM/CAMTests/TestPostCore.py
+++ b/src/Mod/CAM/CAMTests/TestPostCore.py
@@ -1078,7 +1078,7 @@ class TestJobPropertyOverrides(unittest.TestCase):
         # Add M3/M4 commands to trigger plasma behavior
         plasma_commands = [
             Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),
-            Path.Command("M3", {"S":1}),  # Torch on - should trigger pierce delay
+            Path.Command("M3", {"S": 1}),  # Torch on - should trigger pierce delay
             Path.Command("G1", {"X": 100.0, "Y": 0.0, "Z": -5.0, "F": 100.0}),
             Path.Command("M5", {}),  # Torch off
             Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -1385,7 +1385,9 @@ class TestExport2Integration(unittest.TestCase):
             line.strip() for line in gcode.split("\n") if line.strip().startswith("N")
         ]
 
-        self.assertGreaterEqual(len(numbered_lines), 2, "Should have at least 2 numbered lines in\n{gcode}")
+        self.assertGreaterEqual(
+            len(numbered_lines), 2, "Should have at least 2 numbered lines in\n{gcode}"
+        )
         self.assertTrue(
             numbered_lines[0].startswith("N50"),
             f"First line should be N50, got: {numbered_lines[0]} in\n{gcode}",
@@ -1579,17 +1581,17 @@ class TestExport2Integration(unittest.TestCase):
         """Does an entire gcode get removed if redundant"""
         with self._modify_operation_path(
             [
-            Path.Command("G0 X1 Y1 Z1 F50"), # 
-            Path.Command("G0 X1 Y1 Z1 F50"), # elided
+                Path.Command("G0 X1 Y1 Z1 F50"),  #
+                Path.Command("G0 X1 Y1 Z1 F50"),  # elided
             ]
         ):
             machine = self._create_machine(commands=False, parameters=True, header=True)
             results = self._run_export2(machine)
             gcode = self._get_all_gcode(results)
             lines = gcode.split("\n")
-            
-            g0s = [ l for l in lines if l.startswith("G0 ") ]
-            self.assertEqual( ['G0 X1.000 Y1.000 Z1.000 F3000.000'], g0s )
+
+            g0s = [l for l in lines if l.startswith("G0 ")]
+            self.assertEqual(["G0 X1.000 Y1.000 Z1.000 F3000.000"], g0s)
 
     def test129_duplicate_commands_suppressed(self):
         """

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -136,7 +136,7 @@ class TestFileNameGenerator(unittest.TestCase):
 
         tc = PathToolController.Create("TC_Test_Tool", tool, 5)
         tc.Label = "TC: 6mm Endmill"
-        cls.job.Proxy.addToolController(tc)
+        cls.job.addObject(tc)
 
         # Create a simple mock operation for testing operation-related substitutions
         profile_op = cls.doc.addObject("Path::FeaturePython", "TestProfile")
@@ -455,7 +455,7 @@ class TestExport2Integration(unittest.TestCase):
 
         tc = PathToolController.Create("TC_Test_Tool", tool, 1)
         tc.Label = "TC: 6mm Endmill"
-        cls.job.Proxy.addToolController(tc)
+        cls.job.addObject(tc)
 
         profile_op = cls.doc.addObject("Path::FeaturePython", "TestProfile")
         profile_op.Label = "TestProfile"
@@ -481,7 +481,7 @@ class TestExport2Integration(unittest.TestCase):
 
     def _create_machine(self, **output_options):
         """Helper to create a machine with specified output options."""
-        from Machine.models.machine import Machine, OutputUnits, Toolhead, ToolheadType
+        from Machine.models.machine import OutputUnits, Toolhead, ToolheadType
 
         machine = Machine.create_3axis_config()
         machine.name = "TestMachine"
@@ -751,11 +751,11 @@ class TestExport2Integration(unittest.TestCase):
 
     def test010_export2_returns_gcode_sections(self):
         """Test that export2() returns a non-empty list of (name, gcode) tuples."""
-        from Path.Post.Processor import PostProcessor
 
-        post = PostProcessor(self.job, "", "", "mm")
-        post._machine = Machine("Test Machine")
-        results = post.export2()
+        machine = self._create_machine(
+            output_header=True, include_machine_name=True, line_numbers=False
+        )
+        results = self._run_export2(machine)
 
         self.assertIsNotNone(results, "export2 should return results")
         self.assertIsInstance(results, list)
@@ -1385,14 +1385,14 @@ class TestExport2Integration(unittest.TestCase):
             line.strip() for line in gcode.split("\n") if line.strip().startswith("N")
         ]
 
-        self.assertGreaterEqual(len(numbered_lines), 2, "Should have at least 2 numbered lines")
+        self.assertGreaterEqual(len(numbered_lines), 2, "Should have at least 2 numbered lines in\n{gcode}")
         self.assertTrue(
             numbered_lines[0].startswith("N50"),
-            f"First line should be N50, got: {numbered_lines[0]}",
+            f"First line should be N50, got: {numbered_lines[0]} in\n{gcode}",
         )
         self.assertTrue(
             numbered_lines[1].startswith("N55"),
-            f"Second line should be N55, got: {numbered_lines[1]}",
+            f"Second line should be N55, got: {numbered_lines[1]} in\n{gcode}",
         )
 
     def test122_precision_from_config(self):
@@ -1575,9 +1575,26 @@ class TestExport2Integration(unittest.TestCase):
             self.assertNotIn("Y", second_commands[0], "Y should be suppressed (unchanged)")
             self.assertNotIn("Z", second_commands[0], "Z should be suppressed (unchanged)")
 
+    def test128_1_redundant_commands(self):
+        """Does an entire gcode get removed if redundant"""
+        with self._modify_operation_path(
+            [
+            Path.Command("G0 X1 Y1 Z1 F50"), # 
+            Path.Command("G0 X1 Y1 Z1 F50"), # elided
+            ]
+        ):
+            machine = self._create_machine(commands=False, parameters=True, header=True)
+            results = self._run_export2(machine)
+            gcode = self._get_all_gcode(results)
+            lines = gcode.split("\n")
+            
+            g0s = [ l for l in lines if l.startswith("G0 ") ]
+            self.assertEqual( ['G0 X1.000 Y1.000 Z1.000 F3000.000'], g0s )
+
     def test129_duplicate_commands_suppressed(self):
         """
         Test that duplicate G-code commands are suppressed when duplicates.commands=False.
+        This is traditional "modal": can suppress the gcode-name
 
         Expected:
             BEFORE: G1 X10 Y10
@@ -1670,8 +1687,8 @@ class TestExport2Integration(unittest.TestCase):
             results = self._run_export2(machine)
             gcode = "\n".join(g for _, g in results)
 
-            self.assertIn("(prerotary)", gcode, "Pre-rotary block should appear")
-            self.assertIn("(Postrotary)", gcode, "Post-rotary block should appear")
+            self.assertIn("(prerotary)", gcode, f"Pre-rotary block should appear\n{gcode}")
+            self.assertIn("(Postrotary)", gcode, f"Post-rotary block should appear\n{gcode}")
 
             self.assertEqual(
                 gcode.count("(prerotary)"),

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -754,6 +754,7 @@ class TestExport2Integration(unittest.TestCase):
         from Path.Post.Processor import PostProcessor
 
         post = PostProcessor(self.job, "", "", "mm")
+        post._machine = Machine("Test Machine")
         results = post.export2()
 
         self.assertIsNotNone(results, "export2 should return results")

--- a/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
+++ b/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
@@ -29,9 +29,6 @@ from Machine.models.machine import Machine
 import Path.Tool.Controller as PathToolController
 from Path.Tool.toolbit import ToolBit
 import Path.Main.Job as PathJob
-import CAMTests.PostTestMocks as PostTestMocks
-from Path.Post.Processor import PostProcessorFactory
-
 
 
 class TestToolLengthOffset(unittest.TestCase):
@@ -51,6 +48,9 @@ class TestToolLengthOffset(unittest.TestCase):
         machine = Machine("Test Machine")
         machine.output.output_tool_length_offset = False
 
+        import CAMTests.PostTestMocks as PostTestMocks
+        from Path.Post.Processor import PostProcessorFactory
+
         job, profile_op, tool_controller = (
             PostTestMocks.create_default_job_with_operation()
         )
@@ -63,12 +63,11 @@ class TestToolLengthOffset(unittest.TestCase):
         profile_op.Path = Path.Path( [ Path.Command("G43", {"H": 1}) ] )
 
         # Convert G43 command
-        processor._machine.output.output_tool_length_offset = False
         result = processor.export2()[0][1]
 
         # Should return None (suppressed)
         self.assertNotIn(
-            "G43", result, f"G43 command should be suppressed when output_tool_length_offset is False in\n{result}"
+            "G43", result, f"G43 command should be suppressed when output_tool_length_offset is False\n{result}"
         )
 
     def test_g43_output_enabled(self):
@@ -77,6 +76,9 @@ class TestToolLengthOffset(unittest.TestCase):
         machine = Machine("Test Machine")
         machine.output.output_tool_length_offset = True
 
+        import CAMTests.PostTestMocks as PostTestMocks
+        from Path.Post.Processor import PostProcessorFactory
+
         job, profile_op, tool_controller = (
             PostTestMocks.create_default_job_with_operation()
         )
@@ -91,6 +93,7 @@ class TestToolLengthOffset(unittest.TestCase):
         # Convert G43 command
         result = processor.export2()[0][1]
 
+        # Should return the G43 command
         self.assertIn("G43", result, "Result should contain G43 command")
         self.assertIn("H1", result, "Result should contain H parameter")
 
@@ -281,7 +284,7 @@ class TestToolProcessing(unittest.TestCase):
 
         tc2 = PathToolController.Create("TC_Test_Tool2", tool2, 2)
         tc2.Label = "TC: 3mm Endmill"
-        self.job.Proxy.addToolController(tc2)
+        self.job.addObject(tc2)
 
         # Create a second operation using the second tool
         # First move after tool change has X, Y, and Z components
@@ -359,7 +362,7 @@ class TestToolProcessing(unittest.TestCase):
 
         tc2 = PathToolController.Create("TC_Test_Tool2", tool2, 2)
         tc2.Label = "TC: 3mm Endmill"
-        self.job.Proxy.addToolController(tc2)
+        self.job.addObject(tc2)
 
         # Create a second operation using the second tool
         profile_op2 = self.doc.addObject("Path::FeaturePython", "TestProfile2")
@@ -454,7 +457,7 @@ class TestToolProcessing(unittest.TestCase):
 
         tc2 = PathToolController.Create("TC_Second_Tool", tool, 2)
         tc2.Label = "TC: 3mm Endmill"
-        self.job.Proxy.addToolController(tc2)
+        self.job.addObject(tc2)
 
         # Create a second operation using the second tool
         profile_op2 = self.doc.addObject("Path::FeaturePython", "TestProfile2")
@@ -479,7 +482,7 @@ class TestToolProcessing(unittest.TestCase):
             self.assertGreater(len(all_output), 0, "Should have non-empty output")
 
             self.assertIn(
-                "(pretoolchange)", all_output, "Pre-tool-change block should appear in output"
+                "(pretoolchange)", all_output, f"Pre-tool-change block should appear in output\n{all_output}"
             )
             self.assertIn(
                 "(posttoolchange)", all_output, "Post-tool-change block should appear in output"

--- a/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
+++ b/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
@@ -29,6 +29,9 @@ from Machine.models.machine import Machine
 import Path.Tool.Controller as PathToolController
 from Path.Tool.toolbit import ToolBit
 import Path.Main.Job as PathJob
+import CAMTests.PostTestMocks as PostTestMocks
+from Path.Post.Processor import PostProcessorFactory
+
 
 
 class TestToolLengthOffset(unittest.TestCase):
@@ -48,22 +51,24 @@ class TestToolLengthOffset(unittest.TestCase):
         machine = Machine("Test Machine")
         machine.output.output_tool_length_offset = False
 
-        # Create a simple path with G43 command
-        path = Path.Path()
-        g43_cmd = Path.Command("G43", {"H": 1})
-        path.addCommands(g43_cmd)
+        job, profile_op, tool_controller = (
+            PostTestMocks.create_default_job_with_operation()
+        )
 
         # Create post processor
-        processor = PostProcessor(None, tooltip=None, tooltipargs=None, units=None)
+        processor = PostProcessorFactory.get_post_processor(job, "test")
         processor._machine = machine
-        processor.values["OUTPUT_TOOL_LENGTH_OFFSET"] = False
+
+        # Create a simple path with G43 command
+        profile_op.Path = Path.Path( [ Path.Command("G43", {"H": 1}) ] )
 
         # Convert G43 command
-        result = processor.convert_command_to_gcode(g43_cmd)
+        processor._machine.output.output_tool_length_offset = False
+        result = processor.export2()[0][1]
 
         # Should return None (suppressed)
-        self.assertIsNone(
-            result, "G43 command should be suppressed when output_tool_length_offset is False"
+        self.assertNotIn(
+            "G43", result, f"G43 command should be suppressed when output_tool_length_offset is False in\n{result}"
         )
 
     def test_g43_output_enabled(self):
@@ -72,23 +77,20 @@ class TestToolLengthOffset(unittest.TestCase):
         machine = Machine("Test Machine")
         machine.output.output_tool_length_offset = True
 
-        # Create a simple path with G43 command
-        path = Path.Path()
-        g43_cmd = Path.Command("G43", {"H": 1})
-        path.addCommands(g43_cmd)
+        job, profile_op, tool_controller = (
+            PostTestMocks.create_default_job_with_operation()
+        )
 
         # Create post processor
-        processor = PostProcessor(None, tooltip=None, tooltipargs=None, units=None)
+        processor = PostProcessorFactory.get_post_processor(job, "test")
         processor._machine = machine
-        processor.values["OUTPUT_TOOL_LENGTH_OFFSET"] = True
+
+        # Create a simple path with G43 command
+        profile_op.Path = Path.Path( [ Path.Command("G43", {"H": 1}) ] )
 
         # Convert G43 command
-        result = processor.convert_command_to_gcode(g43_cmd)
+        result = processor.export2()[0][1]
 
-        # Should return the G43 command
-        self.assertIsNotNone(
-            result, "G43 command should be output when output_tool_length_offset is True"
-        )
         self.assertIn("G43", result, "Result should contain G43 command")
         self.assertIn("H1", result, "Result should contain H parameter")
 

--- a/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
+++ b/src/Mod/CAM/CAMTests/TestPostToolProcessing.py
@@ -51,23 +51,23 @@ class TestToolLengthOffset(unittest.TestCase):
         import CAMTests.PostTestMocks as PostTestMocks
         from Path.Post.Processor import PostProcessorFactory
 
-        job, profile_op, tool_controller = (
-            PostTestMocks.create_default_job_with_operation()
-        )
+        job, profile_op, tool_controller = PostTestMocks.create_default_job_with_operation()
 
         # Create post processor
         processor = PostProcessorFactory.get_post_processor(job, "test")
         processor._machine = machine
 
         # Create a simple path with G43 command
-        profile_op.Path = Path.Path( [ Path.Command("G43", {"H": 1}) ] )
+        profile_op.Path = Path.Path([Path.Command("G43", {"H": 1})])
 
         # Convert G43 command
         result = processor.export2()[0][1]
 
         # Should return None (suppressed)
         self.assertNotIn(
-            "G43", result, f"G43 command should be suppressed when output_tool_length_offset is False\n{result}"
+            "G43",
+            result,
+            f"G43 command should be suppressed when output_tool_length_offset is False\n{result}",
         )
 
     def test_g43_output_enabled(self):
@@ -79,16 +79,14 @@ class TestToolLengthOffset(unittest.TestCase):
         import CAMTests.PostTestMocks as PostTestMocks
         from Path.Post.Processor import PostProcessorFactory
 
-        job, profile_op, tool_controller = (
-            PostTestMocks.create_default_job_with_operation()
-        )
+        job, profile_op, tool_controller = PostTestMocks.create_default_job_with_operation()
 
         # Create post processor
         processor = PostProcessorFactory.get_post_processor(job, "test")
         processor._machine = machine
 
         # Create a simple path with G43 command
-        profile_op.Path = Path.Path( [ Path.Command("G43", {"H": 1}) ] )
+        profile_op.Path = Path.Path([Path.Command("G43", {"H": 1})])
 
         # Convert G43 command
         result = processor.export2()[0][1]
@@ -482,7 +480,9 @@ class TestToolProcessing(unittest.TestCase):
             self.assertGreater(len(all_output), 0, "Should have non-empty output")
 
             self.assertIn(
-                "(pretoolchange)", all_output, f"Pre-tool-change block should appear in output\n{all_output}"
+                "(pretoolchange)",
+                all_output,
+                f"Pre-tool-change block should appear in output\n{all_output}",
             )
             self.assertIn(
                 "(posttoolchange)", all_output, "Post-tool-change block should appear in output"

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -34,8 +34,14 @@ GCODE_MOVE_CCW = ["G3", "G03"]
 GCODE_MOVE_ARC = GCODE_MOVE_CW + GCODE_MOVE_CCW
 
 # Canned drilling cycles
-GCODE_MOVE_DRILL = ["G73", "G81", "G82", "G83", "G85"] # FIXME: G85 not supported in Post/Processor.py
-GCODE_EXPANDABLE_DRILL = [ "G73", "G81", "G82", "G83" ]
+GCODE_MOVE_DRILL = [
+    "G73",
+    "G81",
+    "G82",
+    "G83",
+    "G85",
+]  # FIXME: G85 not supported in Post/Processor.py
+GCODE_EXPANDABLE_DRILL = ["G73", "G81", "G82", "G83"]
 
 # Cutting moves (feed moves and arcs)
 GCODE_MOVE_MILL = GCODE_MOVE_STRAIGHT + GCODE_MOVE_ARC
@@ -64,7 +70,7 @@ GCODE_CUTTER_COMPENSATION = ["G40", "G41", "G42"]
 GCODE_CYCLE_CANCEL = ["G80"]
 
 # Additional drilling cycles
-GCODE_DRILL_EXTENDED = ["G74", "G84", "G88", "G89"] # FIXME: G86 G87 are mentioned in other code
+GCODE_DRILL_EXTENDED = ["G74", "G84", "G88", "G89"]  # FIXME: G86 G87 are mentioned in other code
 
 # Probing
 GCODE_PROBE = ["G38.2"]

--- a/src/Mod/CAM/Constants.py
+++ b/src/Mod/CAM/Constants.py
@@ -9,6 +9,8 @@ This module contains centralized constants used throughout the CAM workbench,
 including G-code commands, M-codes, and other standardized values.
 """
 
+PARAMETER_ORDER = ["X", "Y", "Z", "F", "I", "J", "K", "R", "Q", "P", "S"]
+
 # =============================================================================
 # G-Code Motion Commands
 # =============================================================================
@@ -32,7 +34,8 @@ GCODE_MOVE_CCW = ["G3", "G03"]
 GCODE_MOVE_ARC = GCODE_MOVE_CW + GCODE_MOVE_CCW
 
 # Canned drilling cycles
-GCODE_MOVE_DRILL = ["G73", "G81", "G82", "G83", "G85"]
+GCODE_MOVE_DRILL = ["G73", "G81", "G82", "G83", "G85"] # FIXME: G85 not supported in Post/Processor.py
+GCODE_EXPANDABLE_DRILL = [ "G73", "G81", "G82", "G83" ]
 
 # Cutting moves (feed moves and arcs)
 GCODE_MOVE_MILL = GCODE_MOVE_STRAIGHT + GCODE_MOVE_ARC
@@ -48,9 +51,9 @@ GCODE_MOVE_ALL = GCODE_MOVE_LINE + GCODE_MOVE_ARC + GCODE_MOVE_DRILL
 # =============================================================================
 
 # Units mode
-GCODE_UNITS = ["G20", "G21"]
 GCODE_UNITS_METRIC = ["G21"]
 GCODE_UNITS_INCHES = ["G20"]
+GCODE_UNITS = GCODE_UNITS_METRIC + GCODE_UNITS_INCHES
 
 # Dwell
 GCODE_DWELL = ["G4", "G04"]
@@ -61,7 +64,7 @@ GCODE_CUTTER_COMPENSATION = ["G40", "G41", "G42"]
 GCODE_CYCLE_CANCEL = ["G80"]
 
 # Additional drilling cycles
-GCODE_DRILL_EXTENDED = ["G74", "G84", "G88", "G89"]
+GCODE_DRILL_EXTENDED = ["G74", "G84", "G88", "G89"] # FIXME: G86 G87 are mentioned in other code
 
 # Probing
 GCODE_PROBE = ["G38.2"]
@@ -76,13 +79,17 @@ GCODE_OFFSET = ["G92"]
 
 # Tool length offset
 GCODE_TOOL_LENGTH_OFFSET = ["G43"]
+GCODE_TOOL_LENGTH_OFFSET_CANCEL = ["G49"]
 
 # Feed rate modes
+# FIXME: are these ever used?
 GCODE_FEED_INVERSE_TIME = ["G93"]
 GCODE_FEED_UNITS_PER_MIN = ["G94"]
 GCODE_FEED_UNITS_PER_REV = ["G95"]
 
 # Spindle control modes
+# FIXME: are these ever used?
+GCODE_FEED_INVERSE_TIME = ["G93"]
 GCODE_SPINDLE_CSS = ["G96"]  # Constant surface speed
 GCODE_SPINDLE_RPM = ["G97"]  # RPM mode
 
@@ -163,6 +170,8 @@ GCODE_SUPPORTED = (
     + GCODE_RETURN_INITIAL
     + GCODE_RETURN_R
     + GCODE_TOOL_LENGTH_OFFSET
+    + GCODE_FIXTURES
+    # FIXME: MCODE_END_RESET & MCODE_END?
 )
 
 # All supported M-codes for generic post processor
@@ -175,6 +184,8 @@ MCODE_SUPPORTED = (
     + MCODE_COOLANT_MIST
     + MCODE_COOLANT_FLOOD
     + MCODE_COOLANT_OFF
+    + MCODE_SPINDLE_ON
+    + MCODE_SPINDLE_OFF
 )
 
 # All coolant M-codes

--- a/src/Mod/CAM/Path/Base/Generator/toolchange.py
+++ b/src/Mod/CAM/Path/Base/Generator/toolchange.py
@@ -64,9 +64,11 @@ def generate(toolnumber, toollabel, spindlespeed=0, spindledirection=SpindleDire
 
     commands.append(Path.Command(f"({toollabel})"))
     tc = Path.Command("M6", {"T": int(toolnumber)})
-    tc.addAnnotations({
-        "label": toollabel, # FIXME: want the Tool name (not tc name)
-    })
+    tc.addAnnotations(
+        {
+            "label": toollabel,  # FIXME: want the Tool name (not tc name)
+        }
+    )
 
     commands.append(tc)
 

--- a/src/Mod/CAM/Path/Base/Generator/toolchange.py
+++ b/src/Mod/CAM/Path/Base/Generator/toolchange.py
@@ -63,12 +63,19 @@ def generate(toolnumber, toollabel, spindlespeed=0, spindledirection=SpindleDire
     commands = []
 
     commands.append(Path.Command(f"({toollabel})"))
-    commands.append(Path.Command("M6", {"T": int(toolnumber)}))
+    tc = Path.Command("M6", {"T": int(toolnumber)})
+    tc.addAnnotations({
+        "label": toollabel, # FIXME: want the Tool name (not tc name)
+    })
 
+    commands.append(tc)
+
+    # FIXME: test both branches
     if spindledirection is SpindleDirection.OFF:
         return commands
     else:
-        commands.append(Path.Command(spindledirection.value, {"S": spindlespeed}))
+        spindle_on = "M3" if spindledirection == SpindleDirection.CW else "M4"
+        commands.append(Path.Command(spindle_on, {"S": spindlespeed}))
 
     Path.Log.track(commands)
     return commands

--- a/src/Mod/CAM/Path/Base/MachineState.py
+++ b/src/Mod/CAM/Path/Base/MachineState.py
@@ -37,7 +37,17 @@ else:
 
 
 class MachineState:
-    def __init__(self):
+    Tracked = [
+        "X", "Y", "Z", "A", "B", "C", "F", "S", "T",
+        "Coolant", # true/false for on/off
+        "WCS", # work-coordinate system Gcode
+        "Spindle", # rpms
+        "ReturnMode", # Z(G98) or R(G99) for drills
+        "G0F", # F for G0's, distinct from all other move F. all G0's should have an F now.
+    ]
+
+    def __init__(self, initial : None|dict = None):
+        """an initial state is optional, and doesn't have to set all Tracked properties"""
         self.WCSLIST = [
             "G53",
             "G54",
@@ -67,8 +77,15 @@ class MachineState:
         self.Coolant = False  #: bool = field(default=False)
         self.WCS = "G54"  #: str = field(default="G54")
         self.Spindle = "off"  #: str = field(default="off")
+        self.ReturnMode = "Z"  #: str = Z|R for G98/G99, for drill cycles
+        self.G0F = 0.0 #: float = field(default=None)
         self.S = 0  #: int = field(default=0)
         self.T = None  #: int = field(default=None)
+        if missing:=[ k for k in self.Tracked if k not in dir(self) ]:
+            raise Exception(f"Internal: didn't initialize a Tracked Parameter {missing}")
+
+        if initial:
+            self.setState(initial)
 
     def addCommand(self, command):
         """Processes a command and updates the internal state of the machine.
@@ -83,6 +100,10 @@ class MachineState:
             self.Spindle = "CW" if command.Name == "M3" else "CCW"
             return not oldstate == self.getState()
 
+        if command.Name in ["G98", "G99"]:
+            self.ReturnMode = "R" if command.Name=="G99" else "Z"
+            return not oldstate == self.getState()
+
         if command.Name in ["M2", "M5"]:
             self.S = 0
             self.Spindle = "off"
@@ -93,14 +114,41 @@ class MachineState:
             return not oldstate == self.getState()
 
         if command.Name in Path.Geom.CmdMoveDrill:
-            oldZ = self.Z
+            # Special logic for drill: old-Z or R
             for p in command.Parameters:
-                self.__setattr__(p, command.Parameters[p])
-            self.__setattr__("Z", oldZ)
+
+                # Z depends on ReturnMode
+                if p == "Z":
+                    continue
+
+                if p in self.Tracked:
+                    self.__setattr__(p, command.Parameters[p])
+
+            if self.ReturnMode == "R":
+                self.Z = command.Parameters["R"]
+            else: # Z/G98 mode
+                oldZ = self.Z
+                r = command.Parameters.get("R", None)
+                if oldZ is None or r is None:
+                    # can't test R vs old Z
+                    # You need to establish an old Z, and specify an R
+                    # Which shouldn't happen unless testing
+                    self.Z = oldZ
+                else:
+                    self.Z = max( oldZ, r )
+
             return not oldstate == self.getState()
 
-        for p in command.Parameters:
-            self.__setattr__(p, command.Parameters[p])
+        # just the usual GCode Parameters (except G0's F)
+        for p in self.Tracked:
+            if p not in command.Parameters:
+                continue
+
+            # G0's F is distinct
+            if command.Name in ["G0","G00"] and p == "F":
+                self.G0F = command.Parameters[p]
+            else:
+                self.__setattr__(p, command.Parameters[p])
 
         return not oldstate == self.getState()
 
@@ -114,25 +162,20 @@ class MachineState:
 
         return False
 
+    def copy(self):
+        return MachineState( self.getState() )
+
+    def setState(self, state : dict):
+        """Set the state from a dict"""
+        for s in self.Tracked:
+            if s in state:
+                setattr(self, s, state[s])
+
     def getState(self):
         """
         Returns a dictionary of the current machine state
         """
-        state = {}
-        state["X"] = self.X
-        state["Y"] = self.Y
-        state["Z"] = self.Z
-        state["A"] = self.A
-        state["B"] = self.B
-        state["C"] = self.C
-        state["F"] = self.F
-        state["Coolant"] = self.Coolant
-        state["WCS"] = self.WCS
-        state["Spindle"] = self.Spindle
-        state["S"] = self.S
-        state["T"] = self.T
-
-        return state
+        return { k: getattr(self,k) for k in self.Tracked }
 
     def getPosition(self):
         """
@@ -142,3 +185,6 @@ class MachineState:
         # This is technical debt.  The actual position may include a rotation
         # component as well.  We should probably be returning a placement
         return FreeCAD.Vector(self.X, self.Y, self.Z)
+
+    def __str__(self):
+        return f"MachineState({self.getState()})"

--- a/src/Mod/CAM/Path/Base/MachineState.py
+++ b/src/Mod/CAM/Path/Base/MachineState.py
@@ -38,15 +38,23 @@ else:
 
 class MachineState:
     Tracked = [
-        "X", "Y", "Z", "A", "B", "C", "F", "S", "T",
-        "Coolant", # true/false for on/off
-        "WCS", # work-coordinate system Gcode
-        "Spindle", # rpms
-        "ReturnMode", # Z(G98) or R(G99) for drills
-        "G0F", # F for G0's, distinct from all other move F. all G0's should have an F now.
+        "X",
+        "Y",
+        "Z",
+        "A",
+        "B",
+        "C",
+        "F",
+        "S",
+        "T",
+        "Coolant",  # true/false for on/off
+        "WCS",  # work-coordinate system Gcode
+        "Spindle",  # rpms
+        "ReturnMode",  # Z(G98) or R(G99) for drills
+        "G0F",  # F for G0's, distinct from all other move F. all G0's should have an F now.
     ]
 
-    def __init__(self, initial : None|dict = None):
+    def __init__(self, initial: None | dict = None):
         """an initial state is optional, and doesn't have to set all Tracked properties"""
         self.WCSLIST = [
             "G53",
@@ -78,10 +86,10 @@ class MachineState:
         self.WCS = "G54"  #: str = field(default="G54")
         self.Spindle = "off"  #: str = field(default="off")
         self.ReturnMode = "Z"  #: str = Z|R for G98/G99, for drill cycles
-        self.G0F = 0.0 #: float = field(default=None)
+        self.G0F = 0.0  #: float = field(default=None)
         self.S = 0  #: int = field(default=0)
         self.T = None  #: int = field(default=None)
-        if missing:=[ k for k in self.Tracked if k not in dir(self) ]:
+        if missing := [k for k in self.Tracked if k not in dir(self)]:
             raise Exception(f"Internal: didn't initialize a Tracked Parameter {missing}")
 
         if initial:
@@ -101,7 +109,7 @@ class MachineState:
             return not oldstate == self.getState()
 
         if command.Name in ["G98", "G99"]:
-            self.ReturnMode = "R" if command.Name=="G99" else "Z"
+            self.ReturnMode = "R" if command.Name == "G99" else "Z"
             return not oldstate == self.getState()
 
         if command.Name in ["M2", "M5"]:
@@ -126,7 +134,7 @@ class MachineState:
 
             if self.ReturnMode == "R":
                 self.Z = command.Parameters["R"]
-            else: # Z/G98 mode
+            else:  # Z/G98 mode
                 oldZ = self.Z
                 r = command.Parameters.get("R", None)
                 if oldZ is None or r is None:
@@ -135,7 +143,7 @@ class MachineState:
                     # Which shouldn't happen unless testing
                     self.Z = oldZ
                 else:
-                    self.Z = max( oldZ, r )
+                    self.Z = max(oldZ, r)
 
             return not oldstate == self.getState()
 
@@ -145,7 +153,7 @@ class MachineState:
                 continue
 
             # G0's F is distinct
-            if command.Name in ["G0","G00"] and p == "F":
+            if command.Name in ["G0", "G00"] and p == "F":
                 self.G0F = command.Parameters[p]
             else:
                 self.__setattr__(p, command.Parameters[p])
@@ -163,9 +171,9 @@ class MachineState:
         return False
 
     def copy(self):
-        return MachineState( self.getState() )
+        return MachineState(self.getState())
 
-    def setState(self, state : dict):
+    def setState(self, state: dict):
         """Set the state from a dict"""
         for s in self.Tracked:
             if s in state:
@@ -175,7 +183,7 @@ class MachineState:
         """
         Returns a dictionary of the current machine state
         """
-        return { k: getattr(self,k) for k in self.Tracked }
+        return {k: getattr(self, k) for k in self.Tracked}
 
     def getPosition(self):
         """

--- a/src/Mod/CAM/Path/Post/DrillCycleExpander.py
+++ b/src/Mod/CAM/Path/Post/DrillCycleExpander.py
@@ -32,7 +32,6 @@ import Path
 from Path.Base.MachineState import MachineState
 from Constants import GCODE_EXPANDABLE_DRILL
 
-
 debug = True
 if debug:
     Path.Log.setLevel(Path.Log.Level.DEBUG, Path.Log.thisModule())
@@ -49,8 +48,8 @@ class DrillCycleExpander:
 
     def __init__(
         self,
-        machine_state : MachineState, # we mutate
-        chipbreaking_amount : None|float = None, # only G73, default 5%, a distance
+        machine_state: MachineState,  # we mutate
+        chipbreaking_amount: None | float = None,  # only G73, default 5%, a distance
     ):
         """
         Initialize the expander.
@@ -76,7 +75,7 @@ class DrillCycleExpander:
 
         # Handle modal commands - filter them out after processing
         if cmd_name in ["G98", "G99"]:
-            self.machine_state.addCommand( command )
+            self.machine_state.addCommand(command)
             return []  # Filter out after processing
         elif cmd_name == "G90":
             return []  # Filter out after processing
@@ -95,7 +94,7 @@ class DrillCycleExpander:
             return result
 
         # Update position for non-drill commands
-        self.machine_state.addCommand( command )
+        self.machine_state.addCommand(command)
 
         # Pass through other commands unchanged
         Path.Log.debug(f"Passing through command: {command}")
@@ -119,23 +118,33 @@ class DrillCycleExpander:
 
         # Required parameters
 
-        missing_state = [ a for a in ("Z","ReturnMode", "G0F") if getattr(self.machine_state, a) is None ]
+        missing_state = [
+            a for a in ("Z", "ReturnMode", "G0F") if getattr(self.machine_state, a) is None
+        ]
         if missing_state:
             # should be an internal error only
-            raise Exception(f"Drill-cycle-expand.machine_state (starting state) requires Z, G0F, and ReturnMode: {command}, {self.machine_state} missing {missing_state}")
+            raise Exception(
+                f"Drill-cycle-expand.machine_state (starting state) requires Z, G0F, and ReturnMode: {command}, {self.machine_state} missing {missing_state}"
+            )
 
-        missing_axis = [ a for a in "XYZ" if a not in command.Parameters or command.Parameters[a] is None ]
+        missing_axis = [
+            a for a in "XYZ" if a not in command.Parameters or command.Parameters[a] is None
+        ]
         if missing_axis:
             # should be an internal error only
-            raise Exception(f"Drill-cycle-expand requires X,Y & Z axis: {command}, missing {missing_axis}")
-        missing_param = [ p for p in "RF" if command.Parameters.get(p, None) is None ]
-        if command.Name in ["G83","G73"] and command.Parameters.get("Q", None) is None:
-            missing_param.append('Q')
+            raise Exception(
+                f"Drill-cycle-expand requires X,Y & Z axis: {command}, missing {missing_axis}"
+            )
+        missing_param = [p for p in "RF" if command.Parameters.get(p, None) is None]
+        if command.Name in ["G83", "G73"] and command.Parameters.get("Q", None) is None:
+            missing_param.append("Q")
         if command.Name in ["G82"] and command.Parameters.get("P", None) is None:
-            missing_param.append('P')
+            missing_param.append("P")
         if missing_param:
             # should be an internal error only
-            raise Exception(f"Drill-cycle-expand requires {' & '.join(missing_param)} parameter: {command}")
+            raise Exception(
+                f"Drill-cycle-expand requires {' & '.join(missing_param)} parameter: {command}"
+            )
 
         # DEBUG to be removed in next PR
         def bad(param, *which_commands):
@@ -143,7 +152,8 @@ class DrillCycleExpander:
                 return param
             else:
                 return None
-        if b:=(bad('Q', "G81","G82") or bad('P', "G73","G81","G83")):
+
+        if b := (bad("Q", "G81", "G82") or bad("P", "G73", "G81", "G83")):
             raise Exception(f"Unexpected param {b} for {command}")
 
         # Extract parameters
@@ -183,22 +193,22 @@ class DrillCycleExpander:
                     "F": self.machine_state.G0F,
                 },
             )
-            expanded.append( prelim )
-            self.machine_state.addCommand( prelim )
+            expanded.append(prelim)
+            self.machine_state.addCommand(prelim)
 
         # Move to XY position at current Z height (which should be R)
         if drill_x != self.machine_state.X or drill_y != self.machine_state.Y:
             prelim = Path.Command(
-                "G0", 
+                "G0",
                 {
-                    "X": drill_x, 
-                    "Y": drill_y, 
+                    "X": drill_x,
+                    "Y": drill_y,
                     "Z": self.machine_state.Z,
                     "F": self.machine_state.G0F,
                 },
             )
-            expanded.append( prelim )
-            self.machine_state.addCommand( prelim )
+            expanded.append(prelim)
+            self.machine_state.addCommand(prelim)
 
         # Ensure Z is at R position (might already be there from preliminary motion)
         if self.machine_state.Z != retract_z:
@@ -211,15 +221,13 @@ class DrillCycleExpander:
                     "F": self.machine_state.G0F,
                 },
             )
-            expanded.append( prelim )
-            self.machine_state.addCommand( prelim )
+            expanded.append(prelim)
+            self.machine_state.addCommand(prelim)
 
         # Perform the drilling operation
         # machine_state is tracked inside these two
         if cmd_name in ("G81", "G82"):
-            expanded.extend(
-                self._expand_g81_g82(command, drill_z, final_retract, feedrate)
-            )
+            expanded.extend(self._expand_g81_g82(command, drill_z, final_retract, feedrate))
         elif cmd_name in ("G73", "G83"):
             expanded.extend(
                 self._expand_g73_g83(command, drill_z, retract_z, final_retract, feedrate)
@@ -229,7 +237,7 @@ class DrillCycleExpander:
 
     def _expand_g81_g82(
         self,
-        command : Path.Command,
+        command: Path.Command,
         drill_z: float,
         final_retract: float,
         feedrate: Optional[float],
@@ -249,14 +257,14 @@ class DrillCycleExpander:
         if feedrate:
             move_params["F"] = feedrate
         new_command = Path.Command("G1", move_params)
-        expanded.append( new_command )
-        self.machine_state.addCommand( new_command )
+        expanded.append(new_command)
+        self.machine_state.addCommand(new_command)
 
         # Dwell for G82
         if cmd_name == "G82" and "P" in params:
             dwell_command = Path.Command("G4", {"P": params["P"]})
-            expanded.append( dwell_command )
-            self.machine_state.addCommand( dwell_command )
+            expanded.append(dwell_command)
+            self.machine_state.addCommand(dwell_command)
 
         # Retract
         retract_command = Path.Command(
@@ -268,14 +276,14 @@ class DrillCycleExpander:
                 "F": self.machine_state.G0F,
             },
         )
-        expanded.append( retract_command )
-        self.machine_state.addCommand( retract_command )
+        expanded.append(retract_command)
+        self.machine_state.addCommand(retract_command)
 
         return expanded
 
     def _expand_g73_g83(
         self,
-        command : Path.Command,
+        command: Path.Command,
         drill_z: float,
         retract_z: float,
         final_retract: float,
@@ -287,10 +295,14 @@ class DrillCycleExpander:
         cmd_name = command.Name
         params = command.Parameters
 
-        peck_depth = params.get("Q", abs(drill_z - retract_z)) # G81/G82 have no Q
+        peck_depth = params.get("Q", abs(drill_z - retract_z))  # G81/G82 have no Q
         current_depth = retract_z
         # for G73, Explicit or Small clearance amount
-        clearance = (current_depth + self.chipbreaking_amount) if self.chipbreaking_amount is not None else (peck_depth * 0.05)
+        clearance = (
+            (current_depth + self.chipbreaking_amount)
+            if self.chipbreaking_amount is not None
+            else (peck_depth * 0.05)
+        )
 
         while current_depth > drill_z:
             # Calculate next peck depth
@@ -308,8 +320,8 @@ class DrillCycleExpander:
                         "F": self.machine_state.G0F,
                     },
                 )
-                expanded.append( down_command )
-                self.machine_state.addCommand( down_command )
+                expanded.append(down_command)
+                self.machine_state.addCommand(down_command)
 
             # Feed to next depth
             move_params = {
@@ -320,12 +332,12 @@ class DrillCycleExpander:
             if feedrate:
                 move_params["F"] = feedrate
             feed_command = Path.Command("G1", move_params)
-            expanded.append( feed_command )
-            self.machine_state.addCommand( feed_command )
+            expanded.append(feed_command)
+            self.machine_state.addCommand(feed_command)
 
             # Retract based on cycle type
             if cmd_name == "G73":
-                if next_depth == drill_z: # should be covered by final retract after if/else
+                if next_depth == drill_z:  # should be covered by final retract after if/else
                     # Final peck - retract to R
                     retract_command = Path.Command(
                         "G0",
@@ -336,8 +348,8 @@ class DrillCycleExpander:
                             "F": self.machine_state.G0F,
                         },
                     )
-                    expanded.append( retract_command )
-                    self.machine_state.addCommand( retract_command )
+                    expanded.append(retract_command)
+                    self.machine_state.addCommand(retract_command)
                 else:
                     # Chip breaking - small retract
                     chip_break_height = next_depth + clearance
@@ -350,8 +362,8 @@ class DrillCycleExpander:
                             "F": self.machine_state.G0F,
                         },
                     )
-                    expanded.append( chip_command )
-                    self.machine_state.addCommand( chip_command )
+                    expanded.append(chip_command)
+                    self.machine_state.addCommand(chip_command)
 
             elif cmd_name == "G83":
                 # Full retract to R plane
@@ -364,8 +376,8 @@ class DrillCycleExpander:
                         "F": self.machine_state.G0F,
                     },
                 )
-                expanded.append( retract_command )
-                self.machine_state.addCommand( retract_command )
+                expanded.append(retract_command)
+                self.machine_state.addCommand(retract_command)
 
             current_depth = next_depth
 
@@ -380,8 +392,8 @@ class DrillCycleExpander:
                     "F": self.machine_state.G0F,
                 },
             )
-            expanded.append( final_command )
-            self.machine_state.addCommand( final_command )
+            expanded.append(final_command)
+            self.machine_state.addCommand(final_command)
 
         return expanded
 

--- a/src/Mod/CAM/Path/Post/DrillCycleExpander.py
+++ b/src/Mod/CAM/Path/Post/DrillCycleExpander.py
@@ -26,10 +26,11 @@ This module provides a clean API for expanding canned drill cycles without
 coupling to the postprocessing infrastructure.
 """
 
-import Path
 from typing import List, Optional
 
-EXPANDABLE_DRILL_CYCLES = {"G81", "G82", "G83", "G73"}
+import Path
+from Path.Base.MachineState import MachineState
+from Constants import GCODE_EXPANDABLE_DRILL
 
 
 debug = True
@@ -43,27 +44,22 @@ else:
 class DrillCycleExpander:
     """Expands canned drill cycles (Path.Command) into basic G-code movements."""
 
-    EXPANDABLE_CYCLES = EXPANDABLE_DRILL_CYCLES
+    # We might have a different list
+    EXPANDABLE_CYCLES = GCODE_EXPANDABLE_DRILL
 
     def __init__(
         self,
-        retract_mode: str = "G98",
-        motion_mode: str = "G90",
-        initial_position: Optional[dict] = None,
+        machine_state : MachineState, # we mutate
+        chipbreaking_amount : None|float = None, # only G73, default 5%, a distance
     ):
         """
         Initialize the expander.
 
         Args:
-            retract_mode: "G98" (return to initial Z) or "G99" (return to R plane)
-            motion_mode: "G90" (absolute) or "G91" (incremental)
-            initial_position: Initial position dict with X, Y, Z keys
+            MachineState, including ReturnMode (G98/G99), and required initial axis XYZ, and F and G0F
         """
-        self.retract_mode = retract_mode
-        self.motion_mode = motion_mode
-        self.current_position = (
-            initial_position if initial_position else {"X": 0.0, "Y": 0.0, "Z": 0.0}
-        )
+        self.machine_state = machine_state
+        self.chipbreaking_amount = chipbreaking_amount
 
     def expand_command(self, command: Path.Command) -> List[Path.Command]:
         """
@@ -79,60 +75,91 @@ class DrillCycleExpander:
         params = command.Parameters
 
         # Handle modal commands - filter them out after processing
-        if cmd_name == "G98":
-            self.retract_mode = "G98"
-            return []  # Filter out after processing
-        elif cmd_name == "G99":
-            self.retract_mode = "G99"
+        if cmd_name in ["G98", "G99"]:
+            self.machine_state.addCommand( command )
             return []  # Filter out after processing
         elif cmd_name == "G90":
-            self.motion_mode = "G90"
-            return []  # Filter out after processing
-        elif cmd_name == "G91":
-            self.motion_mode = "G91"
             return []  # Filter out after processing
         elif cmd_name == "G80":
             # Cancel drill cycle - filter out since cycles are already expanded
             return []
 
         # Handle drill cycles
-        if cmd_name in ("G81", "G82", "G73", "G83"):
-            result = self._expand_drill_cycle(command)
+        if cmd_name in self.EXPANDABLE_CYCLES:
+            try:
+                result = self._expand_drill_cycle(command)
+            except Exception as e:
+                raise Exception(f"During {command}") from e
+
             Path.Log.debug(f"Expanded drill cycle: {command} -> {result}")
             return result
 
         # Update position for non-drill commands
-        if cmd_name in ("G0", "G00", "G1", "G01"):
-            for axis in ("X", "Y", "Z"):
-                if axis in params:
-                    if self.motion_mode == "G90":
-                        self.current_position[axis] = params[axis]
-                    else:  # G91
-                        self.current_position[axis] += params[axis]
+        self.machine_state.addCommand( command )
 
         # Pass through other commands unchanged
         Path.Log.debug(f"Passing through command: {command}")
         return [command]
 
     def _expand_drill_cycle(self, command: Path.Command) -> List[Path.Command]:
-        """Expand a drill cycle into basic movements."""
+        """Expand a drill cycle into basic movements.
+        As per ADR-002, we are in Path.Command world, so no G91, and not modal
+        Does not support repeat-on-move-till-G80 (modal repeat drill)
+        Does not support L
+        Needs a Z-start position
+        Q is peck amount, a distance not position
+        R is a position
+            R must always be above surface: initial move is a G0
+        Z is a position
+        P is dwell
+        chip-break is a position (R), or chipbreaking_amount|5% for G73
+        peck-return-to-bottom-clearance (fast-move) is hard-coded delta.
+        """
         cmd_name = command.Name.upper()
-        params = command.Parameters
+
+        # Required parameters
+
+        missing_state = [ a for a in ("Z","ReturnMode", "G0F") if getattr(self.machine_state, a) is None ]
+        if missing_state:
+            # should be an internal error only
+            raise Exception(f"Drill-cycle-expand.machine_state (starting state) requires Z, G0F, and ReturnMode: {command}, {self.machine_state} missing {missing_state}")
+
+        missing_axis = [ a for a in "XYZ" if a not in command.Parameters or command.Parameters[a] is None ]
+        if missing_axis:
+            # should be an internal error only
+            raise Exception(f"Drill-cycle-expand requires X,Y & Z axis: {command}, missing {missing_axis}")
+        missing_param = [ p for p in "RF" if command.Parameters.get(p, None) is None ]
+        if command.Name in ["G83","G73"] and command.Parameters.get("Q", None) is None:
+            missing_param.append('Q')
+        if command.Name in ["G82"] and command.Parameters.get("P", None) is None:
+            missing_param.append('P')
+        if missing_param:
+            # should be an internal error only
+            raise Exception(f"Drill-cycle-expand requires {' & '.join(missing_param)} parameter: {command}")
+
+        # DEBUG to be removed in next PR
+        def bad(param, *which_commands):
+            if command.Name in which_commands and param in command.Parameters:
+                return param
+            else:
+                return None
+        if b:=(bad('Q', "G81","G82") or bad('P', "G73","G81","G83")):
+            raise Exception(f"Unexpected param {b} for {command}")
 
         # Extract parameters
-        drill_x = params.get("X", self.current_position["X"])
-        drill_y = params.get("Y", self.current_position["Y"])
-        drill_z = params["Z"]
-        retract_z = params["R"]
-        feedrate = params.get("F")
+        drill_x = command.Parameters["X"]
+        drill_y = command.Parameters["Y"]
+        drill_z = command.Parameters["Z"]
+        retract_z = command.Parameters["R"]
+        feedrate = command.Parameters["F"]
 
-        # Store initial Z for G98 mode
-        initial_z = self.current_position["Z"]
+        # Store initial Z for G98 (Z-return) mode
+        initial_z = self.machine_state.Z
 
         # Determine final retract height
-        if self.retract_mode == "G98":
+        if self.machine_state.ReturnMode == "Z":
             final_retract = max(initial_z, retract_z)
-        else:  # G99
+        else:  # G99 (R)
             final_retract = retract_z
 
         # Error check
@@ -146,57 +173,63 @@ class DrillCycleExpander:
         expanded = []
 
         # Preliminary motion: If Z < R, move Z to R once (LinuxCNC spec)
-        if self.current_position["Z"] < retract_z:
-            expanded.append(
-                Path.Command(
-                    "G0",
-                    {
-                        "X": self.current_position["X"],
-                        "Y": self.current_position["Y"],
-                        "Z": retract_z,
-                    },
-                )
+        if self.machine_state.Z < retract_z:
+            prelim = Path.Command(
+                "G0",
+                {
+                    "X": self.machine_state.X,
+                    "Y": self.machine_state.Y,
+                    "Z": retract_z,
+                    "F": self.machine_state.G0F,
+                },
             )
-            self.current_position["Z"] = retract_z
+            expanded.append( prelim )
+            self.machine_state.addCommand( prelim )
 
         # Move to XY position at current Z height (which should be R)
-        if drill_x != self.current_position["X"] or drill_y != self.current_position["Y"]:
-            expanded.append(
-                Path.Command("G0", {"X": drill_x, "Y": drill_y, "Z": self.current_position["Z"]})
+        if drill_x != self.machine_state.X or drill_y != self.machine_state.Y:
+            prelim = Path.Command(
+                "G0", 
+                {
+                    "X": drill_x, 
+                    "Y": drill_y, 
+                    "Z": self.machine_state.Z,
+                    "F": self.machine_state.G0F,
+                },
             )
-            self.current_position["X"] = drill_x
-            self.current_position["Y"] = drill_y
+            expanded.append( prelim )
+            self.machine_state.addCommand( prelim )
 
-        # Ensure Z is at R position (should already be there from preliminary motion)
-        if self.current_position["Z"] != retract_z:
-            expanded.append(
-                Path.Command(
-                    "G0",
-                    {
-                        "X": self.current_position["X"],
-                        "Y": self.current_position["Y"],
-                        "Z": retract_z,
-                    },
-                )
+        # Ensure Z is at R position (might already be there from preliminary motion)
+        if self.machine_state.Z != retract_z:
+            prelim = Path.Command(
+                "G0",
+                {
+                    "X": self.machine_state.X,
+                    "Y": self.machine_state.Y,
+                    "Z": retract_z,
+                    "F": self.machine_state.G0F,
+                },
             )
-            self.current_position["Z"] = retract_z
+            expanded.append( prelim )
+            self.machine_state.addCommand( prelim )
 
         # Perform the drilling operation
+        # machine_state is tracked inside these two
         if cmd_name in ("G81", "G82"):
             expanded.extend(
-                self._expand_g81_g82(cmd_name, params, drill_z, final_retract, feedrate)
+                self._expand_g81_g82(command, drill_z, final_retract, feedrate)
             )
         elif cmd_name in ("G73", "G83"):
             expanded.extend(
-                self._expand_g73_g83(cmd_name, params, drill_z, retract_z, final_retract, feedrate)
+                self._expand_g73_g83(command, drill_z, retract_z, final_retract, feedrate)
             )
 
         return expanded
 
     def _expand_g81_g82(
         self,
-        cmd_name: str,
-        params: dict,
+        command : Path.Command,
         drill_z: float,
         final_retract: float,
         feedrate: Optional[float],
@@ -204,40 +237,45 @@ class DrillCycleExpander:
         """Expand G81 (simple drill) or G82 (drill with dwell)."""
         expanded = []
 
+        cmd_name = command.Name
+        params = command.Parameters
+
         # Feed to depth
         move_params = {
-            "X": self.current_position["X"],
-            "Y": self.current_position["Y"],
+            "X": self.machine_state.X,
+            "Y": self.machine_state.Y,
             "Z": drill_z,
         }
         if feedrate:
             move_params["F"] = feedrate
-        expanded.append(Path.Command("G1", move_params))
-        self.current_position["Z"] = drill_z
+        new_command = Path.Command("G1", move_params)
+        expanded.append( new_command )
+        self.machine_state.addCommand( new_command )
 
         # Dwell for G82
         if cmd_name == "G82" and "P" in params:
-            expanded.append(Path.Command("G4", {"P": params["P"]}))
+            dwell_command = Path.Command("G4", {"P": params["P"]})
+            expanded.append( dwell_command )
+            self.machine_state.addCommand( dwell_command )
 
         # Retract
-        expanded.append(
-            Path.Command(
-                "G0",
-                {
-                    "X": self.current_position["X"],
-                    "Y": self.current_position["Y"],
-                    "Z": final_retract,
-                },
-            )
+        retract_command = Path.Command(
+            "G0",
+            {
+                "X": self.machine_state.X,
+                "Y": self.machine_state.Y,
+                "Z": final_retract,
+                "F": self.machine_state.G0F,
+            },
         )
-        self.current_position["Z"] = final_retract
+        expanded.append( retract_command )
+        self.machine_state.addCommand( retract_command )
 
         return expanded
 
     def _expand_g73_g83(
         self,
-        cmd_name: str,
-        params: dict,
+        command : Path.Command,
         drill_z: float,
         retract_z: float,
         final_retract: float,
@@ -246,9 +284,13 @@ class DrillCycleExpander:
         """Expand G73 (chip breaking) or G83 (peck drilling)."""
         expanded = []
 
-        peck_depth = params.get("Q", abs(drill_z - retract_z))
+        cmd_name = command.Name
+        params = command.Parameters
+
+        peck_depth = params.get("Q", abs(drill_z - retract_z)) # G81/G82 have no Q
         current_depth = retract_z
-        clearance = peck_depth * 0.05  # Small clearance amount
+        # for G73, Explicit or Small clearance amount
+        clearance = (current_depth + self.chipbreaking_amount) if self.chipbreaking_amount is not None else (peck_depth * 0.05)
 
         while current_depth > drill_z:
             # Calculate next peck depth
@@ -257,99 +299,91 @@ class DrillCycleExpander:
             # If not first peck, rapid to clearance above previous depth
             if current_depth != retract_z and cmd_name == "G83":
                 clearance_depth = current_depth + clearance
-                expanded.append(
-                    Path.Command(
-                        "G0",
-                        {
-                            "X": self.current_position["X"],
-                            "Y": self.current_position["Y"],
-                            "Z": clearance_depth,
-                        },
-                    )
+                down_command = Path.Command(
+                    "G0",
+                    {
+                        "X": self.machine_state.X,
+                        "Y": self.machine_state.Y,
+                        "Z": clearance_depth,
+                        "F": self.machine_state.G0F,
+                    },
                 )
+                expanded.append( down_command )
+                self.machine_state.addCommand( down_command )
 
             # Feed to next depth
             move_params = {
-                "X": self.current_position["X"],
-                "Y": self.current_position["Y"],
+                "X": self.machine_state.X,
+                "Y": self.machine_state.Y,
                 "Z": next_depth,
             }
             if feedrate:
                 move_params["F"] = feedrate
-            expanded.append(Path.Command("G1", move_params))
-            self.current_position["Z"] = next_depth
+            feed_command = Path.Command("G1", move_params)
+            expanded.append( feed_command )
+            self.machine_state.addCommand( feed_command )
 
             # Retract based on cycle type
             if cmd_name == "G73":
-                if next_depth == drill_z:
+                if next_depth == drill_z: # should be covered by final retract after if/else
                     # Final peck - retract to R
-                    expanded.append(
-                        Path.Command(
-                            "G0",
-                            {
-                                "X": self.current_position["X"],
-                                "Y": self.current_position["Y"],
-                                "Z": retract_z,
-                            },
-                        )
+                    retract_command = Path.Command(
+                        "G0",
+                        {
+                            "X": self.machine_state.X,
+                            "Y": self.machine_state.Y,
+                            "Z": retract_z,
+                            "F": self.machine_state.G0F,
+                        },
                     )
+                    expanded.append( retract_command )
+                    self.machine_state.addCommand( retract_command )
                 else:
                     # Chip breaking - small retract
                     chip_break_height = next_depth + clearance
-                    expanded.append(
-                        Path.Command(
-                            "G0",
-                            {
-                                "X": self.current_position["X"],
-                                "Y": self.current_position["Y"],
-                                "Z": chip_break_height,
-                            },
-                        )
-                    )
-            elif cmd_name == "G83":
-                # Full retract to R plane
-                expanded.append(
-                    Path.Command(
+                    chip_command = Path.Command(
                         "G0",
                         {
-                            "X": self.current_position["X"],
-                            "Y": self.current_position["Y"],
-                            "Z": retract_z,
+                            "X": self.machine_state.X,
+                            "Y": self.machine_state.Y,
+                            "Z": chip_break_height,
+                            "F": self.machine_state.G0F,
                         },
                     )
+                    expanded.append( chip_command )
+                    self.machine_state.addCommand( chip_command )
+
+            elif cmd_name == "G83":
+                # Full retract to R plane
+                retract_command = Path.Command(
+                    "G0",
+                    {
+                        "X": self.machine_state.X,
+                        "Y": self.machine_state.Y,
+                        "Z": retract_z,
+                        "F": self.machine_state.G0F,
+                    },
                 )
+                expanded.append( retract_command )
+                self.machine_state.addCommand( retract_command )
 
             current_depth = next_depth
 
         # Final retract
-        if self.current_position["Z"] != final_retract:
-            expanded.append(
-                Path.Command(
-                    "G0",
-                    {
-                        "X": self.current_position["X"],
-                        "Y": self.current_position["Y"],
-                        "Z": final_retract,
-                    },
-                )
+        if self.machine_state.Z != final_retract:
+            final_command = Path.Command(
+                "G0",
+                {
+                    "X": self.machine_state.X,
+                    "Y": self.machine_state.Y,
+                    "Z": final_retract,
+                    "F": self.machine_state.G0F,
+                },
             )
-            self.current_position["Z"] = final_retract
+            expanded.append( final_command )
+            self.machine_state.addCommand( final_command )
 
         return expanded
-
-    def _update_position(self, cmd: Path.Command) -> None:
-        """
-        Update the current position based on a movement command.
-
-        Args:
-            cmd: The command to update position from
-        """
-        if "X" in cmd.Parameters:
-            self.current_position["X"] = cmd.Parameters["X"]
-        if "Y" in cmd.Parameters:
-            self.current_position["Y"] = cmd.Parameters["Y"]
-        if "Z" in cmd.Parameters:
-            self.current_position["Z"] = cmd.Parameters["Z"]
 
     def expand_commands(self, commands: List[Path.Command]) -> List[Path.Command]:
         """

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -197,19 +197,21 @@ class _HeaderBuilder:
 
         return Path.Path(commands)
 
+
 class PPMachineState(MachineState):
     """Tracks a little more:
-        Units (G21/G20)
+    Units (G21/G20)
     """
-    Tracked = MachineState.Tracked + [ "Units" ]
 
-    def __init__(self, initial : None|dict = None):
-        self.Units = "G21" # mm, default internal
+    Tracked = MachineState.Tracked + ["Units"]
+
+    def __init__(self, initial: None | dict = None):
+        self.Units = "G21"  # mm, default internal
         super().__init__(initial)
 
-    def addCommand(self, command: Path.Command) :
+    def addCommand(self, command: Path.Command):
         oldstate = self.getState()
-        if command.Name in ["G21","G20" ]:
+        if command.Name in ["G21", "G20"]:
             self.Units = command.Name
             return not oldstate == self.getState()
 
@@ -971,7 +973,9 @@ class PostProcessor:
         Subclasses can override to customize.
         """
 
-        do_line_numbers = getattr(getattr(self._machine.output, "formatting", None),"line_numbers", None)
+        do_line_numbers = getattr(
+            getattr(self._machine.output, "formatting", None), "line_numbers", None
+        )
         if not do_line_numbers:
             return
 
@@ -992,13 +996,13 @@ class PostProcessor:
             for item in sublist:
 
                 # count 'str' lines, because it might be gcode/commands
-                if item.item_type == 'str':
-                    str_lines = item.data['str'].count("\n")
-                    if item.data['str'] != "" and not item.data['str'].endswith("\n"):
+                if item.item_type == "str":
+                    str_lines = item.data["str"].count("\n")
+                    if item.data["str"] != "" and not item.data["str"].endswith("\n"):
                         # count last line
                         str_lines += 1
-                    for _ in range(0, item.data['str'].count("\n")):
-                        next( line_number )
+                    for _ in range(0, item.data["str"].count("\n")):
+                        next(line_number)
 
                 # number Path.Command's
                 elif item.Path:
@@ -1007,13 +1011,15 @@ class PostProcessor:
 
                         # don't count comments
                         if command.Name.startswith("("):
-                            new_commands.append( command )
+                            new_commands.append(command)
                             continue
 
                         # Have to remake, because we change Parameters
-                        new_params = {"N":next(line_number)}
-                        new_params.update( command.Parameters )
-                        new_commands.append( Path.Command( command.Name, new_params, command.Annotations) )
+                        new_params = {"N": next(line_number)}
+                        new_params.update(command.Parameters)
+                        new_commands.append(
+                            Path.Command(command.Name, new_params, command.Annotations)
+                        )
                     item.path = Path.Path(new_commands)
 
     def _expand_canned_cycles(self, postables):
@@ -1031,10 +1037,11 @@ class PostProcessor:
                 has_drill_cycles = False
                 if item.path:
                     drill_commands = (
-                        Constants.GCODE_DRILL_EXTENDED + Constants.GCODE_MOVE_DRILL
+                        Constants.GCODE_DRILL_EXTENDED
+                        + Constants.GCODE_MOVE_DRILL
                         + [
-                        "G86",  # FIXME: not in Constants
-                        "G87",  # FIXME: not in Constants
+                            "G86",  # FIXME: not in Constants
+                            "G87",  # FIXME: not in Constants
                         ]
                     )
                     has_drill_cycles = any(cmd.Name in drill_commands for cmd in item.path.Commands)
@@ -1152,27 +1159,28 @@ class PostProcessor:
         """
 
         Path.Log.track("Translating drill cycles")
-        if not ( self._machine.processing.translate_drill_cycles ):
+        if not (self._machine.processing.translate_drill_cycles):
             Path.Log.debug("Drill cycle translation disabled")
             return
 
         # We do NOT start at axis 0, we start undefined
-        machine_state = MachineState( {k:None for k in MachineState.Tracked} )
+        machine_state = MachineState({k: None for k in MachineState.Tracked})
 
         # only used by G73
-        if "CHIPBREAKING_AMOUNT" in self.values: # FIXME: add to Machine, Units.Quantity
+        if "CHIPBREAKING_AMOUNT" in self.values:  # FIXME: add to Machine, Units.Quantity
             v_chipbreak = self.values["CHIPBREAKING_AMOUNT"]
             # pre-MBPP (args --chipbreaking_amount) can be string values e.g. "0.02 mm"
             if isinstance(v_chipbreak, FreeCAD.Units.Quantity):
                 chipbreaking_amount = v_chipbreak.Value
             else:
-                chipbreaking_amount = FreeCAD.Units.Quantity( v_chipbreak, FreeCAD.Units.Length).Value
+                chipbreaking_amount = FreeCAD.Units.Quantity(
+                    v_chipbreak, FreeCAD.Units.Length
+                ).Value
         else:
             chipbreaking_amount = None
 
         expander = DrillCycleExpander(
-                    machine_state, # it mutates this
-                    chipbreaking_amount = chipbreaking_amount
+            machine_state, chipbreaking_amount=chipbreaking_amount  # it mutates this
         )
 
         for section_name, sublist in postables:
@@ -1187,7 +1195,7 @@ class PostProcessor:
                         Path.Log.debug(f"Translating drill cycles for {item.label}")
                         item.path = expander.expand_path(item.path)
 
-                    machine_state.addCommands( item.path )
+                    machine_state.addCommands(item.path)
 
     def _expand_xy_before_z(self, postables):
         """Decompose first move after tool change into XY then Z.
@@ -1384,7 +1392,7 @@ class PostProcessor:
                         if cmd.Name in ("M6", "M06") and "T" in cmd.Parameters:
                             tool_num = cmd.Parameters["T"]
                             g43_cmd = Path.Command("G43", {"H": tool_num})
-                            g43_cmd.Annotations = {"tool_length_offset": True} # FIXME: not used
+                            g43_cmd.Annotations = {"tool_length_offset": True}  # FIXME: not used
                             commands_with_g43.append(g43_cmd)
                             Path.Log.debug(
                                 f"Added G43 H{tool_num} after M6 in operation {item.label}"
@@ -1436,7 +1444,7 @@ class PostProcessor:
         gcode_lines.extend(pre_job_lines)
         return gcode_lines
 
-    def _item_pre_block(self, item) -> None|list[str]|list[Path.Command]:
+    def _item_pre_block(self, item) -> None | list[str] | list[Path.Command]:
         """Emit pre-block None|[str]|[Path.Command] for a postable item based on its type.
 
         Handles tool_controller, fixture, and operation item types.
@@ -1468,10 +1476,10 @@ class PostProcessor:
         if item.item_type == "str":
 
             # "gcode" could be in there, so our state is invalid
-            self.machine_state.setState( {k:None for k in MachineState.Tracked} )
+            self.machine_state.setState({k: None for k in MachineState.Tracked})
 
             # append the output & done
-            output_lines.extend( item.data["str"].split("\n") )
+            output_lines.extend(item.data["str"].split("\n"))
 
             return
 
@@ -1494,24 +1502,24 @@ class PostProcessor:
                     in_rotary_group = False
 
                 # we need Path.Command w/full params for MachineState
-                was_cmd = Path.Command(
-                    cmd.Name,
-                    cmd.Parameters,
-                    cmd.Annotations
-                )
+                was_cmd = Path.Command(cmd.Name, cmd.Parameters, cmd.Annotations)
 
                 try:
                     gcode = self.convert_command_to_gcode(cmd)
                 except Exception as e:
-                    raise Exception(f"During '{item.item_type}' item '{item.label}', gcode[{cmd_i}]: {cmd}") from e
+                    raise Exception(
+                        f"During '{item.item_type}' item '{item.label}', gcode[{cmd_i}]: {cmd}"
+                    ) from e
 
                 # NB: .machine_state can only reflect Path.Command's
                 #     subclasses must update it if they've made a change that affects the state
                 # NB: .machine_state can NOT reflect gcode in string blocks (e.g. safety_block, etc.)
                 try:
-                    self.machine_state.addCommand( was_cmd )
+                    self.machine_state.addCommand(was_cmd)
                 except Exception as e:
-                    raise Exception(f"During '{item.item_type}' {item.label}, command [{cmd_i}]: {cmd}") from e
+                    raise Exception(
+                        f"During '{item.item_type}' {item.label}, command [{cmd_i}]: {cmd}"
+                    ) from e
 
                 if gcode is not None and gcode.strip():
                     # pp's can return multiple lines for a gcode convert
@@ -1520,14 +1528,13 @@ class PostProcessor:
             finally:
                 pass
                 # FIXME: silent consumption of coding errors
-                #except (ValueError, AttributeError) as e:
+                # except (ValueError, AttributeError) as e:
                 #    Path.Log.debug(f"Skipping command {cmd.Name}: {e}")
 
         if in_rotary_group:
             output_lines.extend(self._get_property_lines("post_rotary_move"))
 
-
-    def _item_post_block(self, item) -> None|list[str]|list[Path.Command]:
+    def _item_post_block(self, item) -> None | list[str] | list[Path.Command]:
         """Emit post-block None|[str]|[Path.Command] for a postable item based on its type.
 
         Handles tool_controller, fixture, and operation item types.
@@ -1587,12 +1594,11 @@ class PostProcessor:
     def _collect_trailing_lines(self) -> str:
         """post_job and postamble lines for a gcode section."""
         lines = []
-        if l:=self._get_property_lines("post_job"):
-            lines.append( self._smart_postable("Post: post_job",l) )
-        if l:=self._get_property_lines("postamble"):
-            lines.append(self._smart_postable("Post: postamble", l) )
+        if l := self._get_property_lines("post_job"):
+            lines.append(self._smart_postable("Post: post_job", l))
+        if l := self._get_property_lines("postamble"):
+            lines.append(self._smart_postable("Post: postamble", l))
         return lines
-
 
     def _collect_bcnc_postamble(self) -> None:
         """Append bCNC postamble after the last section, just before safety_block
@@ -1602,85 +1608,93 @@ class PostProcessor:
         tracking (future work).
         """
         cleaned = None
-        if (
-            hasattr(self, "_bcnc_postamble_commands")
-            and self._bcnc_postamble_commands is not None
-        ):
+        if hasattr(self, "_bcnc_postamble_commands") and self._bcnc_postamble_commands is not None:
             Path.Log.debug(
                 f"Processing {len(self._bcnc_postamble_commands)}" " bCNC postamble commands"
             )
             if self._bcnc_postamble_commands:
-                cleaned = [ c for c in self._bcnc_postamble_commands if c is not None ]
+                cleaned = [c for c in self._bcnc_postamble_commands if c is not None]
         else:
             Path.Log.debug("No bCNC postamble commands to process")
 
         return cleaned
 
-    def _tool_change_filter(self, item: Postable): # -> None|[str]|[Path.Command]:
+    def _tool_change_filter(self, item: Postable):  # -> None|[str]|[Path.Command]:
         """Suppress tool-changes if option is on.
         See _filter_item()
         """
-        if item.item_type == 'tool_controller':
+        if item.item_type == "tool_controller":
             allow = self._machine.processing.tool_change
             if allow is None or allow is False:
                 tool_num = item.data["tool_number"]
-                return [ Path.Command(f"(Tool change suppressed: M6 T{tool_num})") ]
+                return [Path.Command(f"(Tool change suppressed: M6 T{tool_num})")]
 
         return None
 
-    def _filter_item(self, item: Postable): # -> None|[str]|[Path.Command]:
+    def _filter_item(self, item: Postable):  # -> None|[str]|[Path.Command]:
         """Runs the built in list of filter predicates during _filter_for_items().
-            We, and each predicate, returns:
-                None : leave item in place
-                [] : drop item
-                [str]|[Path.Command] : replace item, preferably with just a comment
-            The first predicate that returns not None
-                has it's result returned.
-            Subclasses can override, typically doing their predicates before or after ours.
+        We, and each predicate, returns:
+            None : leave item in place
+            [] : drop item
+            [str]|[Path.Command] : replace item, preferably with just a comment
+        The first predicate that returns not None
+            has it's result returned.
+        Subclasses can override, typically doing their predicates before or after ours.
         """
-        for pred in (
-            self._tool_change_filter,
-        ):
+        for pred in (self._tool_change_filter,):
             rez = pred(item)
             if rez is not None:
                 return rez
         return None
 
-    def _smart_postable(self,
-        label:str,
-        contents: str|list[str]|Path.Command|list[Path.Command]|list[Any],
-        extra_data = {},
+    def _smart_postable(
+        self,
+        label: str,
+        contents: str | list[str] | Path.Command | list[Path.Command] | list[Any],
+        extra_data={},
     ) -> Postable:
         """Makes a Postable with the right kind of args and item_type
-            for the supported inputs.
-            A postable contents=[] is fine, it's just a marker with no content
-            extra_data is added to the `data`
+        for the supported inputs.
+        A postable contents=[] is fine, it's just a marker with no content
+        extra_data is added to the `data`
         """
-        if isinstance( contents, str ):
-            args = { "item_type" : "str", "data" : {"str": contents}, "path":None, "source":None }
-        elif isinstance( contents, Path.Command ):
-            args = { "item_type" : "command", "data" : {}, "path" : Path.Path( [contents] ), "source":None}
-        elif contents == [] or isinstance( contents[0], Path.Command ):
+        if isinstance(contents, str):
+            args = {"item_type": "str", "data": {"str": contents}, "path": None, "source": None}
+        elif isinstance(contents, Path.Command):
+            args = {
+                "item_type": "command",
+                "data": {},
+                "path": Path.Path([contents]),
+                "source": None,
+            }
+        elif contents == [] or isinstance(contents[0], Path.Command):
             # A postable of "command" with empty .path is fine, it's just a marker with no content
-            args = { "item_type" : "command", "data" : {}, "path" : Path.Path( contents ), "source":None}
-        elif isinstance( contents[0], str ):
-            args = { "item_type" : "str", "data" : {"str": "\n".join(contents)}, "path":None, "source":None }
+            args = {"item_type": "command", "data": {}, "path": Path.Path(contents), "source": None}
+        elif isinstance(contents[0], str):
+            args = {
+                "item_type": "str",
+                "data": {"str": "\n".join(contents)},
+                "path": None,
+                "source": None,
+            }
         else:
-            raise Exception(f"Can't smartly make a Postable for label '{label}'\n\tfor contents: {contents}")
+            raise Exception(
+                f"Can't smartly make a Postable for label '{label}'\n\tfor contents: {contents}"
+            )
 
-        args['data'].update(extra_data)
-        return Postable( label=label, **args )
+        args["data"].update(extra_data)
+        return Postable(label=label, **args)
 
     def _filter_for_items(self, postables):
         """Remove/Replace items as wanted (filter list in _filter_item())
         Returns a new list of postables
         """
-        filter_ct = 0 # need a unique label
+        filter_ct = 0  # need a unique label
         new_sections = []
         for section_name, sublist in postables:
             new_sublist = []
             for item in sublist:
-                if item.data.get('noedit', False):
+                if item.data.get("noedit", False):
                     # marked block, don't change
                     new_sublist.append(item)
                     continue
@@ -1688,7 +1702,7 @@ class PostProcessor:
                 # None means leave alone
                 # [] means drop
                 # [str|Path.Command] means replace
-                replace  = self._filter_item(item)
+                replace = self._filter_item(item)
 
                 if replace is None:
                     new_sublist.append(item)
@@ -1701,10 +1715,13 @@ class PostProcessor:
                         continue
                     else:
                         new_sublist.append(
-                            self._smart_postable(f"Post: {section_name} {item.item_type} {item.label}{filter_ct} filtered", replace)
+                            self._smart_postable(
+                                f"Post: {section_name} {item.item_type} {item.label}{filter_ct} filtered",
+                                replace,
+                            )
                         )
 
-            new_sections.append( (section_name, new_sublist.copy()) ) # FIXME: no copy?
+            new_sections.append((section_name, new_sublist.copy()))  # FIXME: no copy?
 
         return new_sections
 
@@ -1721,7 +1738,7 @@ class PostProcessor:
         if post_blocks is None:
             post_blocks = self._item_post_block
 
-        pre_ct = 0 # pre-blocks need a unique label
+        pre_ct = 0  # pre-blocks need a unique label
         post_ct = 0
         new_sections = []
         for section_name, sublist in postables:
@@ -1731,7 +1748,10 @@ class PostProcessor:
                 if pre:
                     pre_ct += 1
                     new_sublist.append(
-                        self._smart_postable(f"Post: {section_name} {item.item_type} {item.label} pre-block{pre_ct}", pre)
+                        self._smart_postable(
+                            f"Post: {section_name} {item.item_type} {item.label} pre-block{pre_ct}",
+                            pre,
+                        )
                     )
 
                 new_sublist.append(item)
@@ -1740,19 +1760,22 @@ class PostProcessor:
                 if post:
                     post_ct += 1
                     new_sublist.append(
-                        self._smart_postable(f"Post: {section_name} {item.item_type} {item.label} post-block{post_ct}", post)
+                        self._smart_postable(
+                            f"Post: {section_name} {item.item_type} {item.label} post-block{post_ct}",
+                            post,
+                        )
                     )
 
-            new_sections.append( (section_name, new_sublist.copy()) )
+            new_sections.append((section_name, new_sublist.copy()))
 
         return new_sections
 
-    def _suppress_redundant_axes_words(self, postables : list[Postable] ):
-        self._filter_for_commands(postables, self._suppress_redundant_axes_words_in_command )
+    def _suppress_redundant_axes_words(self, postables: list[Postable]):
+        self._filter_for_commands(postables, self._suppress_redundant_axes_words_in_command)
 
-    def _suppress_redundant_axes_words_in_command(self, command : Path.Command):
+    def _suppress_redundant_axes_words_in_command(self, command: Path.Command):
         """example of an optimization in Path.Command world
-            Will not operate on strings from blocks
+        Will not operate on strings from blocks
         """
 
         # self.machine_state is being tracked
@@ -1760,21 +1783,39 @@ class PostProcessor:
         Actionable = {
             # These should have no side-effects (cf. a drill-cycle)
             # And not have hidden state (cf. plasma's turn off on -Z)
-            "G0", "G1", "G2", "G3",
-            "G20", "G21",
+            "G0",
+            "G1",
+            "G2",
+            "G3",
+            "G20",
+            "G21",
             "G43",
             *Constants.GCODE_FIXTURES,
-            "M2", "M3", "M4", "M5", "M6", "M7", "M8", "M9", # m1 could have side effects.
+            "M2",
+            "M3",
+            "M4",
+            "M5",
+            "M6",
+            "M7",
+            "M8",
+            "M9",  # m1 could have side effects.
         }
         Axes = "XYZABCF"
 
         if self._machine.output.duplicates.parameters:
-            return [ command ]
+            return [command]
 
         if not command.Name in Actionable:
-            return [ command ]
+            return [command]
 
-        remove_params = { p for p,v in self.machine_state.getState().items() if p in Axes and v is not None and p in command.Parameters and v == command.Parameters[p] }
+        remove_params = {
+            p
+            for p, v in self.machine_state.getState().items()
+            if p in Axes
+            and v is not None
+            and p in command.Parameters
+            and v == command.Parameters[p]
+        }
         if remove_params:
             # G1/G0 F fixup
             if command.Name == "G0":
@@ -1786,41 +1827,52 @@ class PostProcessor:
 
             new_command = Path.Command(
                 command.Name,
-                { p:v for p,v in command.Parameters.items() if p not in remove_params },
-                command.Annotations
+                {p: v for p, v in command.Parameters.items() if p not in remove_params},
+                command.Annotations,
             )
-            return [ new_command ]
+            return [new_command]
         else:
-            return [ command ]
+            return [command]
 
     def _remove_redundant_commands(self, postables):
         """example of an optimization in Path.Command world
-            Can not operate on strings from blocks
+        Can not operate on strings from blocks
         """
         Actionable = {
             # These should have no side-effects (cf. a drill-cycle)
             # And not have hidden state (cf. plasma's turn off on -Z)
-            "G0", "G1", "G2", "G3",
-            "G20", "G21",
+            "G0",
+            "G1",
+            "G2",
+            "G3",
+            "G20",
+            "G21",
             "G43",
             *Constants.GCODE_FIXTURES,
-            "M2", "M3", "M4", "M5", "M6", "M7", "M8", "M9", # m1 could have side effects.
+            "M2",
+            "M3",
+            "M4",
+            "M5",
+            "M6",
+            "M7",
+            "M8",
+            "M9",  # m1 could have side effects.
         }
 
         if self._machine.output.duplicates.commands:
             return
 
-        machine_state = MachineState( {k:None for k in MachineState.Tracked} )
-        last_command = Path.Command() # empty
+        machine_state = MachineState({k: None for k in MachineState.Tracked})
+        last_command = Path.Command()  # empty
         for section_name, sublist in postables:
             for item in sublist:
-                if item.data.get('noedit', False):
+                if item.data.get("noedit", False):
                     # marked block, don't change
                     continue
 
                 if item.item_type == "str":
                     # "gcode" could be in there, so our state is invalid
-                    machine_state.setState( {k:None for k in MachineState.Tracked} )
+                    machine_state.setState({k: None for k in MachineState.Tracked})
                     last_command = Path.Command
 
                 if item.path:
@@ -1837,7 +1889,7 @@ class PostProcessor:
                             continue
 
                         machine_state.addCommand(cmd)
-                        new_commands.append( cmd )
+                        new_commands.append(cmd)
                         if not cmd.Name.startswith("("):
                             last_command = cmd
 
@@ -1845,29 +1897,23 @@ class PostProcessor:
 
     def _collect_frontmatter(self) -> [Postable]:
         """front-matter for each section
-            Each Postable might be 'str' or 'command'
+        Each Postable might be 'str' or 'command'
         """
         front_matter = []
 
         preamble_lines = self._collect_preamble_lines()
         if preamble_lines:
-            front_matter.append(
-                self._smart_postable("Post: preamble", preamble_lines)
-            )
+            front_matter.append(self._smart_postable("Post: preamble", preamble_lines))
 
         unit_command = self._collect_unit_command()
         if unit_command:
-            front_matter.append(
-                self._smart_postable("Post: unit", unit_command)
-            )
+            front_matter.append(self._smart_postable("Post: unit", unit_command))
 
         pre_job_lines = self._collect_pre_job_lines()
         if pre_job_lines:
-            front_matter.append(
-                self._smart_postable("Post: pre_job", pre_job_lines)
-            )
+            front_matter.append(self._smart_postable("Post: pre_job", pre_job_lines))
 
-        front_matter.append( self._smart_postable("Post: endfrontmatter", [] ) )
+        front_matter.append(self._smart_postable("Post: endfrontmatter", []))
         return front_matter
 
     def _header_object_to_commands(self, gcodeheader):
@@ -1891,51 +1937,54 @@ class PostProcessor:
             if header_commands:
                 new_sublist.append(
                     self._smart_postable(
-                        "Post: header", self._header_object_to_commands(gcodeheader),
-                        extra_data={"noedit":True}
+                        "Post: header",
+                        self._header_object_to_commands(gcodeheader),
+                        extra_data={"noedit": True},
                     )
                 )
 
-            new_sublist.extend( frontmatter )
+            new_sublist.extend(frontmatter)
 
             new_sublist += sublist
-            new_sections.append( ( section_name, new_sublist.copy() ) )
+            new_sections.append((section_name, new_sublist.copy()))
         return new_sections
 
     def _append_endmatter(self, postables, endmatter):
         """Append endmatter at each section"""
         for section_name, sublist in postables:
-            sublist.extend( endmatter )
+            sublist.extend(endmatter)
 
-    def _append_bcnc_postamble(self, postables ):
+    def _append_bcnc_postamble(self, postables):
         """at section[-1] only, after all other items"""
         if not postables:
             return
-        if commands:=self._bcnc_postamble_commands:
-            _,sublist = postables[-1]
-            bcnc_postable = self._smart_postable("Post: bcnc postamble", commands, extra_data={"noedit":True})
-            sublist.append( bcnc_postable )
-
+        if commands := self._bcnc_postamble_commands:
+            _, sublist = postables[-1]
+            bcnc_postable = self._smart_postable(
+                "Post: bcnc postamble", commands, extra_data={"noedit": True}
+            )
+            sublist.append(bcnc_postable)
 
     def _add_safety_block(self, postables):
         """at section[0] only, before other items"""
         if not postables:
             return
-        if safety_lines:=self._get_property_lines("safetyblock"):
-            bcnc_postable = self._smart_postable("Post: safetyblock", safety_lines, extra_data={"noedit":True})
+        if safety_lines := self._get_property_lines("safetyblock"):
+            bcnc_postable = self._smart_postable(
+                "Post: safetyblock", safety_lines, extra_data={"noedit": True}
+            )
             _, sublist = postables[0]
             sublist.insert(0, bcnc_postable)
 
-
-    def _filter_command(self, command : Path.Command) -> None|list[Path.Command]:
+    def _filter_command(self, command: Path.Command) -> None | list[Path.Command]:
         """Runs the built in list of filter predicates during _filter_for_command().
-            We, and each predicate, returns:
-                None : leave command in place
-                [] : drop command
-                [Path.Command] : replace command, preferably with just a comment
-            The first predicate that returns not None
-                has it's result returned.
-            Subclasses can override, typically doing their predicates before or after ours.
+        We, and each predicate, returns:
+            None : leave command in place
+            [] : drop command
+            [Path.Command] : replace command, preferably with just a comment
+        The first predicate that returns not None
+            has it's result returned.
+        Subclasses can override, typically doing their predicates before or after ours.
         """
         for pred in (
             self._comment_filter,
@@ -1974,21 +2023,25 @@ class PostProcessor:
         if getattr(self._machine.processing, "tool_change", True):
             return None
         else:
-            return [Path.Command(f"(Tool change suppressed: {command.toGCode()})")] if command.Name in ["M6","M06"] else None
+            return (
+                [Path.Command(f"(Tool change suppressed: {command.toGCode()})")]
+                if command.Name in ["M6", "M06"]
+                else None
+            )
 
     def _filter_for_commands(self, postables, filter=None):
         """Remove/Replace commands as wanted
-            Using filter list in _filter_command()
-            OR the specified filter (see _filter_command for return types)
+        Using filter list in _filter_command()
+        OR the specified filter (see _filter_command for return types)
         """
 
         if filter is None:
             filter = self._filter_command
 
         for section_name, sublist in postables:
-            self.machine_state = PPMachineState( {k:None for k in PPMachineState.Tracked} )
+            self.machine_state = PPMachineState({k: None for k in PPMachineState.Tracked})
             for item in sublist:
-                if item.data.get('noedit', False):
+                if item.data.get("noedit", False):
                     # marked block, don't change
                     continue
 
@@ -1999,7 +2052,7 @@ class PostProcessor:
                         # None means leave alone
                         # [] means drop
                         # [Path.Command] means replace
-                        replace  = filter(cmd)
+                        replace = filter(cmd)
 
                         if replace is None:
                             new_commands.append(cmd)
@@ -2009,36 +2062,41 @@ class PostProcessor:
                                 # just drop it
                                 continue
                             else:
-                                new_commands.extend( replace )
+                                new_commands.extend(replace)
                     item.path = Path.Path(new_commands)
 
             self.machine_state = None
 
-
     def _convert_job_sections(self, postables):
         """Convert each section to output-code"""
 
-        job_sections = [] # output chunks
-        header_last_line = -1 # updated when we process Postable.label == "Post: endfrontmatter"
+        job_sections = []  # output chunks
+        header_last_line = -1  # updated when we process Postable.label == "Post: endfrontmatter"
         for section_name, sublist in postables:
-            #print(f"#-- Section '{section_name}'")
+            # print(f"#-- Section '{section_name}'")
 
             # We do NOT start at axis 0, we start undefined
-            self.machine_state = PPMachineState( {k:None for k in PPMachineState.Tracked} )
+            self.machine_state = PPMachineState({k: None for k in PPMachineState.Tracked})
 
             output_lines = []
 
             seen_items = set()
             for item_i, item in enumerate(sublist):
                 # DEBUG
-                #print(f"#----  Postable <{item.label}> {item.item_type}: {item}")
-                if item.path and len(item.path.Commands) < 10: # DEBUG
-                    paths = [i.toGCode() for i in item.path.Commands] if item.path and item.path.Commands else []
-                    #print(f"#--     paths {paths}")
+                # print(f"#----  Postable <{item.label}> {item.item_type}: {item}")
+                if item.path and len(item.path.Commands) < 10:  # DEBUG
+                    paths = (
+                        [i.toGCode() for i in item.path.Commands]
+                        if item.path and item.path.Commands
+                        else []
+                    )
+                    # print(f"#--     paths {paths}")
 
                 if item.label in seen_items:
-                    Path.Log.debug( f"Internal: Postables, in a section ('{section_name}'), should have unique .label. Saw .label twice <{item.label}>. Second looks like '{item.item_type}': {item}")
-                seen_items.add( item.label )
+                    Path.Log.debug(
+                        f"Internal: Postables, in a section ('{section_name}'), should have unique .label. Saw .label twice <{item.label}>. Second looks like '{item.item_type}': {item}"
+                    )
+                seen_items.add(item.label)
 
                 # FIXME: skip "noedit" Postables? or let pp see them?
 
@@ -2067,7 +2125,7 @@ class PostProcessor:
             if output_string:
                 job_sections.append((section_name, output_string))
 
-        self.machine_state = None # FIXME: with machine_state...
+        self.machine_state = None  # FIXME: with machine_state...
         return job_sections
 
     def export2(self) -> Union[None, GCodeSections]:
@@ -2108,7 +2166,7 @@ class PostProcessor:
         # ===== STAGE 2: COMMAND EXPANSION =====
         # We want to collect header-info before any more changes
         # used later to insert actual header into each section
-        gcodeheader = self._collect_header_info(postables) # a _HeaderBuilder
+        gcodeheader = self._collect_header_info(postables)  # a _HeaderBuilder
 
         self._expand_translate_drill_cycles(postables)
         self._expand_canned_cycles(postables)
@@ -2135,18 +2193,18 @@ class PostProcessor:
         # Add some blocks, that we didn't want the above messing with
 
         frontmatter = self._collect_frontmatter()
-        postables = self._prefix_header_and_frontmatter( postables, gcodeheader, frontmatter)
+        postables = self._prefix_header_and_frontmatter(postables, gcodeheader, frontmatter)
 
-        endmatter = self._collect_trailing_lines() # FIXME: test
-        self._append_endmatter( postables, endmatter )
+        endmatter = self._collect_trailing_lines()  # FIXME: test
+        self._append_endmatter(postables, endmatter)
 
         self._remove_redundant_commands(postables)
 
         # all appending must be done, so:
-        self._append_bcnc_postamble( postables ) # section[-1] only, after all other items
+        self._append_bcnc_postamble(postables)  # section[-1] only, after all other items
 
         # all prefixing must be done, so:
-        self._add_safety_block(postables) # section[0] only, before other items
+        self._add_safety_block(postables)  # section[0] only, before other items
 
         self._suppress_redundant_axes_words(postables)
 
@@ -2156,7 +2214,7 @@ class PostProcessor:
         # FIXME: post to gcode processors: pre-output
 
         # To output strings per section
-        all_job_sections = self._convert_job_sections( postables )
+        all_job_sections = self._convert_job_sections(postables)
 
         # ===== STAGE 5: OUTPUT PRODUCTION =====
 
@@ -2170,12 +2228,14 @@ class PostProcessor:
             Path.Log.error(f"Remote posting failed: {e}")
 
         # Only have to do line_ending in one place
-        line_ending = getattr(getattr(self._machine.output, "formatting", None),"end_of_line_chars", None)
+        line_ending = getattr(
+            getattr(self._machine.output, "formatting", None), "end_of_line_chars", None
+        )
         if line_ending and line_ending != "\n":
             all_job_sections = [
-                (section_name, section.replace("\n", line_ending) )
+                (section_name, section.replace("\n", line_ending))
                 for section_name, section in all_job_sections
-                ]
+            ]
 
         return all_job_sections
 
@@ -2477,7 +2537,7 @@ class PostProcessor:
                 return super()._convert_drill_cycle(command)
         """
 
-        if not command.Name: # DEBUG
+        if not command.Name:  # DEBUG
             raise Exception("No command.Name")
 
         # Validate command is supported
@@ -2491,10 +2551,7 @@ class PostProcessor:
                 + Constants.GCODE_NON_CONFORMING
             )
 
-        if (
-            command.Name not in supported
-            and not command.Name.startswith("(")
-        ):
+        if command.Name not in supported and not command.Name.startswith("("):
             raise ValueError(f"Unsupported command: {command.Name}")
 
         # Dispatch to appropriate hook method based on command type
@@ -2649,7 +2706,7 @@ class PostProcessor:
             feed_value = _convert_axis_param(feed_value)
 
             # There are actually oddball controls that use {units}/second feedrate.
-            if not ( self._machine and hasattr(self._machine, "feedrate_per_second") ):
+            if not (self._machine and hasattr(self._machine, "feedrate_per_second")):
                 # Convert from mm/sec to mm/min (multiply by 60)
                 feed_value = feed_value * 60.0
 
@@ -2724,16 +2781,16 @@ class PostProcessor:
 
         # line numbers
         if params.get("N", None) is not None:
-            prefix = getattr(getattr(self._machine.output, "formatting", None), "line_number_prefix", "N")
-            command_line.append( f"{prefix}{ int(params['N']):d}" )
+            prefix = getattr(
+                getattr(self._machine.output, "formatting", None), "line_number_prefix", "N"
+            )
+            command_line.append(f"{prefix}{ int(params['N']):d}")
 
         # GCode name
         command_line.append(command_name)
 
         # Format parameters with clean, stateless implementation
-        parameter_order = self.values.get(
-            "PARAMETER_ORDER", Constants.PARAMETER_ORDER
-        )
+        parameter_order = self.values.get("PARAMETER_ORDER", Constants.PARAMETER_ORDER)
 
         for parameter in parameter_order:
             if parameter in params:
@@ -2891,7 +2948,6 @@ class WrapperPost(PostProcessor):
         self._units = "Metric" if getattr(self.script_module, "UNITS", "G21") == "G21" else "Inch"
         self._tooltip = getattr(self.script_module, "TOOLTIP", "No tooltip provided")
         self._tooltipargs = getattr(self.script_module, "TOOLTIP_ARGS", [])
-
 
     def export(self):
         """Dynamically reload the module for the export to ensure up-to-date usage."""

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -31,6 +31,7 @@ import json
 import os
 import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
+import itertools
 
 import FreeCAD
 import Constants
@@ -195,6 +196,25 @@ class _HeaderBuilder:
             commands.append(Path.Command(f"(Note: {sanitized})"))
 
         return Path.Path(commands)
+
+class PPMachineState(MachineState):
+    """Tracks a little more:
+        Units (G21/G20)
+    """
+    Tracked = MachineState.Tracked + [ "Units" ]
+
+    def __init__(self, initial : None|dict = None):
+        self.Units = "G21" # mm, default internal
+        super().__init__(initial)
+
+    def addCommand(self, command: Path.Command) :
+        oldstate = self.getState()
+        if command.Name in ["G21","G20" ]:
+            self.Units = command.Name
+            return not oldstate == self.getState()
+
+        return super().addCommand(command)
+
 
 #
 # Define some types that are used throughout this file.
@@ -966,12 +986,11 @@ class PostProcessor:
         ):
             start = self._machine.output.formatting.line_number_start
             increment = self._machine.output.formatting.line_increment
-        import itertools
         line_number = itertools.count(start, increment)
 
         for section_name, sublist in postables:
             for item in sublist:
-                
+
                 # count 'str' lines, because it might be gcode/commands
                 if item.item_type == 'str':
                     str_lines = item.data['str'].count("\n")
@@ -1131,14 +1150,30 @@ class PostProcessor:
 
         Subclasses can override to customize drill cycle translation.
         """
+
         Path.Log.track("Translating drill cycles")
-        if not (
-            self._machine
-            and hasattr(self._machine, "processing")
-            and self._machine.processing.translate_drill_cycles
-        ):
+        if not ( self._machine.processing.translate_drill_cycles ):
             Path.Log.debug("Drill cycle translation disabled")
             return
+
+        # We do NOT start at axis 0, we start undefined
+        machine_state = MachineState( {k:None for k in MachineState.Tracked} )
+
+        # only used by G73
+        if "CHIPBREAKING_AMOUNT" in self.values: # FIXME: add to Machine, Units.Quantity
+            v_chipbreak = self.values["CHIPBREAKING_AMOUNT"]
+            # pre-MBPP (args --chipbreaking_amount) can be string values e.g. "0.02 mm"
+            if isinstance(v_chipbreak, FreeCAD.Units.Quantity):
+                chipbreaking_amount = v_chipbreak.Value
+            else:
+                chipbreaking_amount = FreeCAD.Units.Quantity( v_chipbreak, FreeCAD.Units.Length).Value
+        else:
+            chipbreaking_amount = None
+
+        expander = DrillCycleExpander(
+                    machine_state, # it mutates this
+                    chipbreaking_amount = chipbreaking_amount
+        )
 
         for section_name, sublist in postables:
             for item in sublist:
@@ -1150,8 +1185,9 @@ class PostProcessor:
                     )
                     if has_drill:
                         Path.Log.debug(f"Translating drill cycles for {item.label}")
-                        expander = DrillCycleExpander()
                         item.path = expander.expand_path(item.path)
+
+                    machine_state.addCommands( item.path )
 
     def _expand_xy_before_z(self, postables):
         """Decompose first move after tool change into XY then Z.
@@ -1427,10 +1463,12 @@ class PostProcessor:
         """Convert Path.Commands to output code-strings for a single item.
 
         Tracks rotary move groups and inserts pre/post rotary blocks.
-        Handles M6 tool change suppression when tool_change is disabled.
         """
 
         if item.item_type == "str":
+
+            # "gcode" could be in there, so our state is invalid
+            self.machine_state.setState( {k:None for k in MachineState.Tracked} )
 
             # append the output & done
             output_lines.extend( item.data["str"].split("\n") )
@@ -1438,6 +1476,7 @@ class PostProcessor:
             return
 
         if not item.path:
+            # you can have "empty" Postable's, as markers
             return
 
         in_rotary_group = False
@@ -1445,7 +1484,6 @@ class PostProcessor:
         for cmd_i, cmd in enumerate(item.path.Commands):
 
             try:
-                # FIXME: factor rotary stuff
                 has_rotary = any(param in cmd.Parameters for param in ["A", "B", "C"])
 
                 if has_rotary and not in_rotary_group:
@@ -1467,6 +1505,14 @@ class PostProcessor:
                 except Exception as e:
                     raise Exception(f"During '{item.item_type}' item '{item.label}', gcode[{cmd_i}]: {cmd}") from e
 
+                # NB: .machine_state can only reflect Path.Command's
+                #     subclasses must update it if they've made a change that affects the state
+                # NB: .machine_state can NOT reflect gcode in string blocks (e.g. safety_block, etc.)
+                try:
+                    self.machine_state.addCommand( was_cmd )
+                except Exception as e:
+                    raise Exception(f"During '{item.item_type}' {item.label}, command [{cmd_i}]: {cmd}") from e
+
                 if gcode is not None and gcode.strip():
                     # pp's can return multiple lines for a gcode convert
                     output_lines.extend(gcode.split("\n"))
@@ -1478,8 +1524,8 @@ class PostProcessor:
                 #    Path.Log.debug(f"Skipping command {cmd.Name}: {e}")
 
         if in_rotary_group:
-            # FIXME: lift
             output_lines.extend(self._get_property_lines("post_rotary_move"))
+
 
     def _item_post_block(self, item) -> None|list[str]|list[Path.Command]:
         """Emit post-block None|[str]|[Path.Command] for a postable item based on its type.
@@ -1600,8 +1646,8 @@ class PostProcessor:
                 return rez
         return None
 
-    def _smart_postable(self, 
-        label:str, 
+    def _smart_postable(self,
+        label:str,
         contents: str|list[str]|Path.Command|list[Path.Command]|list[Any],
         extra_data = {},
     ) -> Postable:
@@ -1662,15 +1708,26 @@ class PostProcessor:
 
         return new_sections
 
-    def _add_per_item_blocks(self, postables):
-        """Insert item_pre_block before, and item_post_block after it's item"""
+    def _add_per_item_blocks(self, postables, pre_blocks=None, post_blocks=None):
+        """Insert _item_pre_block before, and _item_post_block after it's item.
+        OR provide your own pre/post_blocks function:
+            rez = yourfn(item:Postable) -> str|list[str]|Path.Command|list[Path.Command] | []|None
+            # str|list[str] will become a Postable.item_type="str" with data["str"]
+            # Path.Command|list[Path.Command] becomes a Postable.item_type="command"
+            # []|None becomes nothing
+        """
+        if pre_blocks is None:
+            pre_blocks = self._item_pre_block
+        if post_blocks is None:
+            post_blocks = self._item_post_block
+
         pre_ct = 0 # pre-blocks need a unique label
         post_ct = 0
         new_sections = []
         for section_name, sublist in postables:
             new_sublist = []
             for item in sublist:
-                pre = self._item_pre_block(item)
+                pre = pre_blocks(item)
                 if pre:
                     pre_ct += 1
                     new_sublist.append(
@@ -1679,7 +1736,7 @@ class PostProcessor:
 
                 new_sublist.append(item)
 
-                post = self._item_post_block(item)
+                post = post_blocks(item)
                 if post:
                     post_ct += 1
                     new_sublist.append(
@@ -1689,6 +1746,102 @@ class PostProcessor:
             new_sections.append( (section_name, new_sublist.copy()) )
 
         return new_sections
+
+    def _suppress_redundant_axes_words(self, postables : list[Postable] ):
+        self._filter_for_commands(postables, self._suppress_redundant_axes_words_in_command )
+
+    def _suppress_redundant_axes_words_in_command(self, command : Path.Command):
+        """example of an optimization in Path.Command world
+            Will not operate on strings from blocks
+        """
+
+        # self.machine_state is being tracked
+
+        Actionable = {
+            # These should have no side-effects (cf. a drill-cycle)
+            # And not have hidden state (cf. plasma's turn off on -Z)
+            "G0", "G1", "G2", "G3",
+            "G20", "G21",
+            "G43",
+            *Constants.GCODE_FIXTURES,
+            "M2", "M3", "M4", "M5", "M6", "M7", "M8", "M9", # m1 could have side effects.
+        }
+        Axes = "XYZABCF"
+
+        if self._machine.output.duplicates.parameters:
+            return [ command ]
+
+        if not command.Name in Actionable:
+            return [ command ]
+
+        remove_params = { p for p,v in self.machine_state.getState().items() if p in Axes and v is not None and p in command.Parameters and v == command.Parameters[p] }
+        if remove_params:
+            # G1/G0 F fixup
+            if command.Name == "G0":
+                state_g0f = self.machine_state.G0F
+                if "F" in command.Parameters and state_g0f == command.Parameters["F"]:
+                    remove_params &= {"F"}
+                else:
+                    remove_params -= {"F"}
+
+            new_command = Path.Command(
+                command.Name,
+                { p:v for p,v in command.Parameters.items() if p not in remove_params },
+                command.Annotations
+            )
+            return [ new_command ]
+        else:
+            return [ command ]
+
+    def _remove_redundant_commands(self, postables):
+        """example of an optimization in Path.Command world
+            Can not operate on strings from blocks
+        """
+        Actionable = {
+            # These should have no side-effects (cf. a drill-cycle)
+            # And not have hidden state (cf. plasma's turn off on -Z)
+            "G0", "G1", "G2", "G3",
+            "G20", "G21",
+            "G43",
+            *Constants.GCODE_FIXTURES,
+            "M2", "M3", "M4", "M5", "M6", "M7", "M8", "M9", # m1 could have side effects.
+        }
+
+        if self._machine.output.duplicates.commands:
+            return
+
+        machine_state = MachineState( {k:None for k in MachineState.Tracked} )
+        last_command = Path.Command() # empty
+        for section_name, sublist in postables:
+            for item in sublist:
+                if item.data.get('noedit', False):
+                    # marked block, don't change
+                    continue
+
+                if item.item_type == "str":
+                    # "gcode" could be in there, so our state is invalid
+                    machine_state.setState( {k:None for k in MachineState.Tracked} )
+                    last_command = Path.Command
+
+                if item.path:
+                    new_commands = []
+                    for cmd in item.path.Commands:
+
+                        if (
+                            cmd.Name in Actionable
+                            and cmd.Name == last_command.Name
+                            and cmd.Parameters == last_command.Parameters
+                            and cmd.Annotations == last_command.Annotations
+                        ):
+                            # skip it!
+                            continue
+
+                        machine_state.addCommand(cmd)
+                        new_commands.append( cmd )
+                        if not cmd.Name.startswith("("):
+                            last_command = cmd
+
+                    item.path = Path.Path(new_commands)
 
     def _collect_frontmatter(self) -> [Postable]:
         """front-matter for each section
@@ -1736,9 +1889,9 @@ class PostProcessor:
 
             header_commands = self._header_object_to_commands(gcodeheader)
             if header_commands:
-                new_sublist.append( 
+                new_sublist.append(
                     self._smart_postable(
-                        "Post: header", self._header_object_to_commands(gcodeheader), 
+                        "Post: header", self._header_object_to_commands(gcodeheader),
                         extra_data={"noedit":True}
                     )
                 )
@@ -1795,10 +1948,10 @@ class PostProcessor:
         return None
 
     def _tlo_filter(self, command):
-        """Remove comments if option says to
+        """Remove tool-length-offset if option says to
         see _filter_command
         """
-        if getattr(self._machine.output, "output_tool_length_offset", False):
+        if getattr(self._machine.output, "output_tool_length_offset", True):
             return None
         else:
             return [] if command.Name == "G43" else None
@@ -1823,11 +1976,17 @@ class PostProcessor:
         else:
             return [Path.Command(f"(Tool change suppressed: {command.toGCode()})")] if command.Name in ["M6","M06"] else None
 
-    def _filter_for_commands(self, postables):
-        """Remove/Replace commands as wanted (filter list in _filter_command())
+    def _filter_for_commands(self, postables, filter=None):
+        """Remove/Replace commands as wanted
+            Using filter list in _filter_command()
+            OR the specified filter (see _filter_command for return types)
         """
 
+        if filter is None:
+            filter = self._filter_command
+
         for section_name, sublist in postables:
+            self.machine_state = PPMachineState( {k:None for k in PPMachineState.Tracked} )
             for item in sublist:
                 if item.data.get('noedit', False):
                     # marked block, don't change
@@ -1840,7 +1999,7 @@ class PostProcessor:
                         # None means leave alone
                         # [] means drop
                         # [Path.Command] means replace
-                        replace  = self._filter_command(cmd)
+                        replace  = filter(cmd)
 
                         if replace is None:
                             new_commands.append(cmd)
@@ -1853,6 +2012,8 @@ class PostProcessor:
                                 new_commands.extend( replace )
                     item.path = Path.Path(new_commands)
 
+            self.machine_state = None
+
 
     def _convert_job_sections(self, postables):
         """Convert each section to output-code"""
@@ -1861,6 +2022,9 @@ class PostProcessor:
         header_last_line = -1 # updated when we process Postable.label == "Post: endfrontmatter"
         for section_name, sublist in postables:
             #print(f"#-- Section '{section_name}'")
+
+            # We do NOT start at axis 0, we start undefined
+            self.machine_state = PPMachineState( {k:None for k in PPMachineState.Tracked} )
 
             output_lines = []
 
@@ -1903,6 +2067,7 @@ class PostProcessor:
             if output_string:
                 job_sections.append((section_name, output_string))
 
+        self.machine_state = None # FIXME: with machine_state...
         return job_sections
 
     def export2(self) -> Union[None, GCodeSections]:
@@ -1933,7 +2098,6 @@ class PostProcessor:
             self.apply_configuration_bundle()
 
         # ===== STAGE 1: ORDERING =====
-        all_job_sections = []
 
         # Build ordered postables for this job
         postables = self._buildPostList()
@@ -1946,7 +2110,7 @@ class PostProcessor:
         # used later to insert actual header into each section
         gcodeheader = self._collect_header_info(postables) # a _HeaderBuilder
 
-        self._expand_translate_drill_cycles(postables) # FIXME: redundant now, but check "if"
+        self._expand_translate_drill_cycles(postables)
         self._expand_canned_cycles(postables)
         self._expand_split_arcs(postables)
         self._expand_spindle_wait(postables)
@@ -1976,20 +2140,23 @@ class PostProcessor:
         endmatter = self._collect_trailing_lines() # FIXME: test
         self._append_endmatter( postables, endmatter )
 
+        self._remove_redundant_commands(postables)
+
         # all appending must be done, so:
         self._append_bcnc_postamble( postables ) # section[-1] only, after all other items
 
         # all prefixing must be done, so:
         self._add_safety_block(postables) # section[0] only, before other items
 
-        # Add line-numbers to all Path.Command's (if option is on)
+        self._suppress_redundant_axes_words(postables)
+
+        # line-numbers should be last, before output
         self._add_line_numbers(postables)
 
         # FIXME: post to gcode processors: pre-output
 
-        job_sections = self._convert_job_sections( postables )
-
-        all_job_sections.extend(job_sections)
+        # To output strings per section
+        all_job_sections = self._convert_job_sections( postables )
 
         # ===== STAGE 5: OUTPUT PRODUCTION =====
 
@@ -2005,9 +2172,9 @@ class PostProcessor:
         # Only have to do line_ending in one place
         line_ending = getattr(getattr(self._machine.output, "formatting", None),"end_of_line_chars", None)
         if line_ending and line_ending != "\n":
-            all_job_sections = [ 
+            all_job_sections = [
                 (section_name, section.replace("\n", line_ending) )
-                for section_name, section in all_job_sections 
+                for section_name, section in all_job_sections
                 ]
 
         return all_job_sections
@@ -2367,6 +2534,20 @@ class PostProcessor:
 
         # Spindle control
         if command_name in Constants.MCODE_SPINDLE_ON + Constants.MCODE_SPINDLE_OFF:
+            return self._convert_spindle_command(command)
+
+        # Coolant control
+        if command_name in Constants.MCODE_COOLANT:
+            return self._convert_coolant_command(command)
+
+        # Program control
+        if (
+            command_name
+            in Constants.MCODE_STOP
+            + Constants.MCODE_OPTIONAL_STOP
+            + Constants.MCODE_END
+            + Constants.MCODE_END_RESET
+        ):
             return self._convert_program_control(command)
 
         # Fixtures
@@ -2446,8 +2627,6 @@ class PostProcessor:
             # Apply unit conversion based on machine units setting
             is_imperial = False
             if self._machine and hasattr(self._machine, "output"):
-                from Machine.models.machine import OutputUnits
-
                 is_imperial = self._machine.output.units == OutputUnits.IMPERIAL
             else:
                 # Fallback to legacy UNITS value

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -29,24 +29,22 @@ import argparse
 import importlib.util
 import json
 import os
-from PySide import QtCore, QtGui
-import re
 import sys
 from typing import Any, Dict, List, Optional, Tuple, Union
-import Constants
-
-import Path.Base.Util as PathUtil
-import Path.Post.UtilsArguments as PostUtilsArguments
-import Path.Post.UtilsExport as PostUtilsExport
-import Path.Post.PostList as PostList
 
 import FreeCAD
+import Constants
 import Path
-
 import Path.Post.Utils as PostUtils
-from Machine.models.machine import (
-    MachineFactory,
-)
+import Path.Post.UtilsArguments as PostUtilsArguments
+import Path.Post.UtilsExport as PostUtilsExport
+from Path.Base.MachineState import MachineState
+from Path.Post import PostList
+from Path.Post.UtilsParse import format_command_line
+from Path.Post.DrillCycleExpander import DrillCycleExpander
+from Path.Post.PostList import Postable
+from Machine.models.machine import MachineFactory
+from Machine.models.machine import OutputUnits
 
 translate = FreeCAD.Qt.translate
 
@@ -79,6 +77,7 @@ class _HeaderBuilder:
         self._fixtures = []  # List of fixture names
         self._notes = []  # list of notes
 
+    # FIXME: some of these add_*() are not used
     def add_exporter_info(self, exporter: str = "FreeCAD"):
         """Add exporter information to the header."""
         self._exporter = exporter
@@ -196,7 +195,6 @@ class _HeaderBuilder:
             commands.append(Path.Command(f"(Note: {sanitized})"))
 
         return Path.Path(commands)
-
 
 #
 # Define some types that are used throughout this file.
@@ -342,11 +340,11 @@ class PostProcessor:
                 "name": "drill_cycles_to_translate",
                 "type": "text",
                 "label": translate("CAM", "Drill Cycles to Translate"),
-                "default": "\n".join(Constants.GCODE_MOVE_DRILL),
+                "default": "",
                 "help": translate(
                     "CAM",
                     "List of drill cycle commands to translate to G0/G1 moves (one per line). "
-                    f"Standard drill cycles: {', '.join(Constants.GCODE_MOVE_DRILL)}. "
+                    f"Standard drill cycles: {', '.join(Constants.GCODE_EXPANDABLE_DRILL)}. "
                     "Leave empty if postprocessor supports drill cycles natively.",
                 ),
             },
@@ -472,8 +470,8 @@ class PostProcessor:
             # Validate all jobs have the same machine (if Machine attribute exists)
             if hasattr(self._jobs[0], "Machine"):
                 machine_name = self._jobs[0].Machine
-                for job in self._jobs[1:]:
-                    if hasattr(job, "Machine") and job.Machine != machine_name:
+                for a_job in self._jobs[1:]:
+                    if hasattr(a_job, "Machine") and job.Machine != machine_name:
                         raise ValueError("All jobs must have the same machine")
             # For now, only single job supported
             if len(self._jobs) > 1:
@@ -842,8 +840,8 @@ class PostProcessor:
     def _apply_overrides(self, overrides):
         self.apply_configuration_bundle(overrides)
 
-    def _build_header(self, postables):
-        """Build the G-code header from job/machine metadata.
+    def _collect_header_info(self, postables):
+        """Collect the G-code header info from job/machine metadata.
 
         Creates a _HeaderBuilder populated with machine name, project file,
         document name, description, author, and timestamp based on machine
@@ -935,13 +933,69 @@ class PostProcessor:
                                 gcodeheader.add_tool(tool_key, item.label)
                     elif item.item_type == "fixture":
                         if list_fixtures:
-                            if item.path and item.path.Commands:
+                            if item.path:
                                 fixture_name = item.path.Commands[0].Name
                                 if fixture_name not in seen_fixtures:
                                     seen_fixtures.add(fixture_name)
                                     gcodeheader.add_fixture(fixture_name)
 
         return gcodeheader
+
+    def _add_line_numbers(self, postables):
+        """Add N word if we are line-numbering
+        Subclasses are expected to render N as line-number (if present)
+            the default _convert_move() will do that
+        Numbering does not know about the subclass inserting/removing commands/lines,
+            so is NOT the physical line-number.
+
+        Subclasses can override to customize.
+        """
+
+        do_line_numbers = getattr(getattr(self._machine.output, "formatting", None),"line_numbers", None)
+        if not do_line_numbers:
+            return
+
+        Path.Log.track("Line numbering")
+
+        start = 10
+        increment = 10
+        if (
+            self._machine
+            and hasattr(self._machine, "output")
+            and hasattr(self._machine.output, "formatting")
+        ):
+            start = self._machine.output.formatting.line_number_start
+            increment = self._machine.output.formatting.line_increment
+        import itertools
+        line_number = itertools.count(start, increment)
+
+        for section_name, sublist in postables:
+            for item in sublist:
+                
+                # count 'str' lines, because it might be gcode/commands
+                if item.item_type == 'str':
+                    str_lines = item.data['str'].count("\n")
+                    if item.data['str'] != "" and not item.data['str'].endswith("\n"):
+                        # count last line
+                        str_lines += 1
+                    for _ in range(0, item.data['str'].count("\n")):
+                        next( line_number )
+
+                # number Path.Command's
+                elif item.Path:
+                    new_commands = []
+                    for command in item.Path.Commands:
+
+                        # don't count comments
+                        if command.Name.startswith("("):
+                            new_commands.append( command )
+                            continue
+
+                        # Have to remake, because we change Parameters
+                        new_params = {"N":next(line_number)}
+                        new_params.update( command.Parameters )
+                        new_commands.append( Path.Command( command.Name, new_params, command.Annotations) )
+                    item.path = Path.Path(new_commands)
 
     def _expand_canned_cycles(self, postables):
         """Terminate canned drill cycles in postable paths.
@@ -957,19 +1011,13 @@ class PostProcessor:
             for item in sublist:
                 has_drill_cycles = False
                 if item.path:
-                    drill_commands = [
-                        "G73",
-                        "G74",
-                        "G81",
-                        "G82",
-                        "G83",
-                        "G84",
-                        "G85",
-                        "G86",
-                        "G87",
-                        "G88",
-                        "G89",
-                    ]
+                    drill_commands = (
+                        Constants.GCODE_DRILL_EXTENDED + Constants.GCODE_MOVE_DRILL
+                        + [
+                        "G86",  # FIXME: not in Constants
+                        "G87",  # FIXME: not in Constants
+                        ]
+                    )
                     has_drill_cycles = any(cmd.Name in drill_commands for cmd in item.path.Commands)
 
                 if has_drill_cycles:
@@ -1091,8 +1139,6 @@ class PostProcessor:
         ):
             Path.Log.debug("Drill cycle translation disabled")
             return
-
-        from Path.Post.DrillCycleExpander import DrillCycleExpander
 
         for section_name, sublist in postables:
             for item in sublist:
@@ -1302,7 +1348,7 @@ class PostProcessor:
                         if cmd.Name in ("M6", "M06") and "T" in cmd.Parameters:
                             tool_num = cmd.Parameters["T"]
                             g43_cmd = Path.Command("G43", {"H": tool_num})
-                            g43_cmd.Annotations = {"tool_length_offset": True}
+                            g43_cmd.Annotations = {"tool_length_offset": True} # FIXME: not used
                             commands_with_g43.append(g43_cmd)
                             Path.Log.debug(
                                 f"Added G43 H{tool_num} after M6 in operation {item.label}"
@@ -1321,33 +1367,6 @@ class PostProcessor:
             ]
         return []
 
-    def _collect_header_lines(self, gcodeheader) -> list:
-        """Build header comment lines from the gcodeheader object.
-
-        Gated on machine.output.output_header. Returns formatted comment
-        strings using the configured COMMENT_SYMBOL.
-        """
-        header_enabled = True
-        if self._machine and hasattr(self._machine, "output"):
-            header_enabled = self._machine.output.output_header
-
-        header_lines = []
-        if header_enabled:
-            header_commands = gcodeheader.Path.Commands if hasattr(gcodeheader, "Path") else []
-            comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
-            for cmd in header_commands:
-                if cmd.Name.startswith("("):
-                    comment_text = (
-                        cmd.Name[1:-1]
-                        if cmd.Name.startswith("(") and cmd.Name.endswith(")")
-                        else cmd.Name[1:]
-                    )
-                    if comment_symbol == "(":
-                        header_lines.append(f"({comment_text})")
-                    else:
-                        header_lines.append(f"{comment_symbol} {comment_text}")
-        return header_lines
-
     def _collect_preamble_lines(self) -> list:
         """Return preamble lines from machine configuration."""
         return self._get_property_lines("preamble")
@@ -1355,12 +1374,11 @@ class PostProcessor:
     def _collect_unit_command(self) -> list:
         """Return G20/G21 unit command based on output_units setting."""
         if self._machine and hasattr(self._machine, "output"):
-            from Machine.models.machine import OutputUnits
 
             if self._machine.output.units == OutputUnits.METRIC:
-                return ["G21"]
+                return Path.Command("G21")
             elif self._machine.output.units == OutputUnits.IMPERIAL:
-                return ["G20"]
+                return Path.Command("G20")
         return []
 
     def _collect_pre_job_lines(self) -> list:
@@ -1382,100 +1400,109 @@ class PostProcessor:
         gcode_lines.extend(pre_job_lines)
         return gcode_lines
 
-    def _emit_item_pre_block(self, item, gcode_lines) -> bool:
-        """Emit pre-block lines for a postable item based on its type.
+    def _item_pre_block(self, item) -> None|list[str]|list[Path.Command]:
+        """Emit pre-block None|[str]|[Path.Command] for a postable item based on its type.
 
         Handles tool_controller, fixture, and operation item types.
         Derived postprocessors can override to customize pre-block
         behavior.
 
-        Returns True if the item should be skipped (no further
-        processing), False to continue with command conversion and
+        Returns
+            str|[Path.Command] if add
+            None if nothing to add
         post-blocks.
         """
         if item.item_type == "tool_controller":
-            if self._machine and hasattr(self._machine, "processing"):
-                if not self._machine.processing.tool_change:
-                    comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
-                    tool_num = item.data["tool_number"]
-                    if comment_symbol == "(":
-                        gcode_lines.append(f"(Tool change suppressed: M6 T{tool_num})")
-                    else:
-                        gcode_lines.append(
-                            f"{comment_symbol} Tool change suppressed:" f" M6 T{tool_num}"
-                        )
-                    return True
-            gcode_lines.extend(self._get_property_lines("pre_tool_change"))
+            return self._get_property_lines("pre_tool_change")
 
         elif item.item_type == "fixture":
-            gcode_lines.extend(self._get_property_lines("pre_fixture_change"))
+            return self._get_property_lines("pre_fixture_change")
 
         elif item.item_type == "operation":
-            gcode_lines.extend(self._get_property_lines("pre_operation"))
+            return self._get_property_lines("pre_operation")
 
-        return False
+        return None
 
-    def _convert_item_commands(self, item, gcode_lines) -> None:
-        """Convert Path.Commands to G-code strings for a single item.
+    def _convert_item_commands(self, item, output_lines) -> None:
+        """Convert Path.Commands to output code-strings for a single item.
 
         Tracks rotary move groups and inserts pre/post rotary blocks.
         Handles M6 tool change suppression when tool_change is disabled.
         """
+
+        if item.item_type == "str":
+
+            # append the output & done
+            output_lines.extend( item.data["str"].split("\n") )
+
+            return
+
         if not item.path:
             return
 
         in_rotary_group = False
 
-        for cmd in item.path.Commands:
+        for cmd_i, cmd in enumerate(item.path.Commands):
+
             try:
+                # FIXME: factor rotary stuff
                 has_rotary = any(param in cmd.Parameters for param in ["A", "B", "C"])
 
                 if has_rotary and not in_rotary_group:
-                    gcode_lines.extend(self._get_property_lines("pre_rotary_move"))
+                    output_lines.extend(self._get_property_lines("pre_rotary_move"))
                     in_rotary_group = True
                 elif not has_rotary and in_rotary_group:
-                    gcode_lines.extend(self._get_property_lines("post_rotary_move"))
+                    output_lines.extend(self._get_property_lines("post_rotary_move"))
                     in_rotary_group = False
 
-                gcode = self.convert_command_to_gcode(cmd)
+                # we need Path.Command w/full params for MachineState
+                was_cmd = Path.Command(
+                    cmd.Name,
+                    cmd.Parameters,
+                    cmd.Annotations
+                )
 
-                if cmd.Name in ("M6", "M06"):
-                    if (
-                        self._machine
-                        and hasattr(self._machine, "processing")
-                        and not self._machine.processing.tool_change
-                    ):
-                        comment_symbol = self.values.get("COMMENT_SYMBOL", "(")
-                        if comment_symbol == "(":
-                            gcode = f"(Tool change suppressed: {gcode})"
-                        else:
-                            gcode = f"{comment_symbol} Tool change" f" suppressed: {gcode}"
+                try:
+                    gcode = self.convert_command_to_gcode(cmd)
+                except Exception as e:
+                    raise Exception(f"During '{item.item_type}' item '{item.label}', gcode[{cmd_i}]: {cmd}") from e
 
                 if gcode is not None and gcode.strip():
-                    gcode_lines.append(gcode)
+                    # pp's can return multiple lines for a gcode convert
+                    output_lines.extend(gcode.split("\n"))
 
-            except (ValueError, AttributeError) as e:
-                Path.Log.debug(f"Skipping command {cmd.Name}: {e}")
+            finally:
+                pass
+                # FIXME: silent consumption of coding errors
+                #except (ValueError, AttributeError) as e:
+                #    Path.Log.debug(f"Skipping command {cmd.Name}: {e}")
 
         if in_rotary_group:
-            gcode_lines.extend(self._get_property_lines("post_rotary_move"))
+            # FIXME: lift
+            output_lines.extend(self._get_property_lines("post_rotary_move"))
 
-    def _emit_item_post_block(self, item, gcode_lines) -> None:
-        """Emit post-block lines for a postable item based on its type.
+    def _item_post_block(self, item) -> None|list[str]|list[Path.Command]:
+        """Emit post-block None|[str]|[Path.Command] for a postable item based on its type.
 
         Handles tool_controller, fixture, and operation item types.
         Derived postprocessors can override to customize post-block
         behavior.
         """
+        output_lines = []
         if item.item_type == "tool_controller":
-            gcode_lines.extend(self._get_property_lines("post_tool_change"))
-            gcode_lines.extend(self._get_property_lines("tool_return"))
+            output_lines.extend(self._get_property_lines("post_tool_change"))
+            output_lines.extend(self._get_property_lines("tool_return"))
+            return output_lines
         elif item.item_type == "fixture":
-            gcode_lines.extend(self._get_property_lines("post_fixture_change"))
+            output_lines.extend(self._get_property_lines("post_fixture_change"))
+            return output_lines
         elif item.item_type == "operation":
-            gcode_lines.extend(self._get_property_lines("post_operation"))
+            output_lines.extend(self._get_property_lines("post_operation"))
+            return output_lines
 
-    def _optimize_gcode(self, header_lines, gcode_lines) -> str:
+        return None
+
+    def _optimize_gcode(self, last_header_line, output_lines) -> str:
         """Apply G-code optimizations and produce a final string.
 
         Separates header comments from body, applies deduplication,
@@ -1487,20 +1514,19 @@ class PostProcessor:
             deduplicate_repeated_commands,
             suppress_redundant_axes_words,
             filter_inefficient_moves,
-            insert_line_numbers,
         )
 
-        if not gcode_lines:
+        if not output_lines:
             return ""
 
-        num_header_lines = len(header_lines)
-        header_part = gcode_lines[:num_header_lines]
-        body_part = gcode_lines[num_header_lines:]
+        num_header_lines = last_header_line + 1
+        header_part = output_lines[:num_header_lines]
+        body_part = output_lines[num_header_lines:]
 
         if body_part:
-            if not self.values.get("OUTPUT_DUPLICATE_COMMANDS", True):
+            if not self._machine.output.duplicates.commands:
                 body_part = deduplicate_repeated_commands(body_part)
-            if not self.values.get("OUTPUT_DOUBLES", True):
+            if not self._machine.output.duplicates.parameters:
                 body_part = suppress_redundant_axes_words(body_part)
 
         if body_part and self._machine and hasattr(self._machine, "processing"):
@@ -1508,98 +1534,376 @@ class PostProcessor:
                 if self._machine.processing.filter_inefficient_moves:
                     body_part = filter_inefficient_moves(body_part)
 
-        if body_part and self.values.get("OUTPUT_LINE_NUMBERS", False):
-            start = 10
-            increment = 10
-            if (
-                self._machine
-                and hasattr(self._machine, "output")
-                and hasattr(self._machine.output, "formatting")
-            ):
-                start = self._machine.output.formatting.line_number_start
-                increment = self._machine.output.formatting.line_increment
-            body_part = insert_line_numbers(body_part, start=start, increment=increment)
-
         final_lines = header_part + body_part
-        gcode_with_newlines = "\n".join(final_lines)
 
-        line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
-        if line_ending == "\n":
-            return gcode_with_newlines
-        else:
-            return gcode_with_newlines.replace("\n", line_ending)
+        return final_lines
 
-    def _append_trailing_lines(self, gcode_string) -> str:
-        """Append post_job and postamble lines to a gcode section."""
-        trailing = []
-        trailing.extend(self._get_property_lines("post_job"))
-        trailing.extend(self._get_property_lines("postamble"))
+    def _collect_trailing_lines(self) -> str:
+        """post_job and postamble lines for a gcode section."""
+        lines = []
+        if l:=self._get_property_lines("post_job"):
+            lines.append( self._smart_postable("Post: post_job",l) )
+        if l:=self._get_property_lines("postamble"):
+            lines.append(self._smart_postable("Post: postamble", l) )
+        return lines
 
-        if trailing:
-            trailing_str = "\n".join(trailing)
-            line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
-            if line_ending == "\n":
-                gcode_string = gcode_string + "\n" + trailing_str
-            else:
-                gcode_string = gcode_string + line_ending + trailing_str.replace("\n", line_ending)
-        return gcode_string
 
-    def _append_bcnc_postamble(self, job_sections) -> None:
-        """Append bCNC postamble to the last section only.
+    def _collect_bcnc_postamble(self) -> None:
+        """Append bCNC postamble after the last section, just before safety_block
 
         bCNC postamble tracks global state across all sections; proper
         per-section bCNC support in split mode requires per-section
         tracking (future work).
         """
+        cleaned = None
         if (
-            job_sections
-            and hasattr(self, "_bcnc_postamble_commands")
+            hasattr(self, "_bcnc_postamble_commands")
             and self._bcnc_postamble_commands is not None
         ):
             Path.Log.debug(
                 f"Processing {len(self._bcnc_postamble_commands)}" " bCNC postamble commands"
             )
-            bcnc_lines = []
-            for cmd in self._bcnc_postamble_commands:
-                gcode = self.convert_command_to_gcode(cmd)
-                if gcode is not None and gcode.strip():
-                    bcnc_lines.append(gcode)
-            if bcnc_lines:
-                last_name, last_gcode = job_sections[-1]
-                line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
-                bcnc_gcode = "\n".join(bcnc_lines)
-                if line_ending == "\n":
-                    job_sections[-1] = (
-                        last_name,
-                        last_gcode + "\n" + bcnc_gcode,
-                    )
-                else:
-                    job_sections[-1] = (
-                        last_name,
-                        last_gcode + line_ending + bcnc_gcode.replace("\n", line_ending),
-                    )
+            if self._bcnc_postamble_commands:
+                cleaned = [ c for c in self._bcnc_postamble_commands if c is not None ]
         else:
             Path.Log.debug("No bCNC postamble commands to process")
 
-    def _prepend_safety_block(self, all_job_sections) -> None:
-        """Prepend safetyblock to the first section if configured."""
-        if not all_job_sections:
-            return
+        return cleaned
 
-        safety_lines = self._get_property_lines("safetyblock")
-        if not safety_lines:
-            return
+    def _tool_change_filter(self, item: Postable): # -> None|[str]|[Path.Command]:
+        """Suppress tool-changes if option is on.
+        See _filter_item()
+        """
+        if item.item_type == 'tool_controller':
+            allow = self._machine.processing.tool_change
+            if allow is None or allow is False:
+                tool_num = item.data["tool_number"]
+                return [ Path.Command(f"(Tool change suppressed: M6 T{tool_num})") ]
 
-        safety_gcode_newlines = "\n".join(safety_lines)
-        line_ending = self.values.get("END_OF_LINE_CHARS", "\n")
+        return None
 
-        if line_ending == "\n":
-            safety_gcode = safety_gcode_newlines + "\n"
+    def _filter_item(self, item: Postable): # -> None|[str]|[Path.Command]:
+        """Runs the built in list of filter predicates during _filter_for_items().
+            We, and each predicate, returns:
+                None : leave item in place
+                [] : drop item
+                [str]|[Path.Command] : replace item, preferably with just a comment
+            The first predicate that returns not None
+                has it's result returned.
+            Subclasses can override, typically doing their predicates before or after ours.
+        """
+        for pred in (
+            self._tool_change_filter,
+        ):
+            rez = pred(item)
+            if rez is not None:
+                return rez
+        return None
+
+    def _smart_postable(self, 
+        label:str, 
+        contents: str|list[str]|Path.Command|list[Path.Command]|list[Any],
+        extra_data = {},
+    ) -> Postable:
+        """Makes a Postable with the right kind of args and item_type
+            for the supported inputs.
+            A postable contents=[] is fine, it's just a marker with no content
+            extra_data is added to the `data`
+        """
+        if isinstance( contents, str ):
+            args = { "item_type" : "str", "data" : {"str": contents}, "path":None, "source":None }
+        elif isinstance( contents, Path.Command ):
+            args = { "item_type" : "command", "data" : {}, "path" : Path.Path( [contents] ), "source":None}
+        elif contents == [] or isinstance( contents[0], Path.Command ):
+            # A postable of "command" with empty .path is fine, it's just a marker with no content
+            args = { "item_type" : "command", "data" : {}, "path" : Path.Path( contents ), "source":None}
+        elif isinstance( contents[0], str ):
+            args = { "item_type" : "str", "data" : {"str": "\n".join(contents)}, "path":None, "source":None }
         else:
-            safety_gcode = safety_gcode_newlines.replace("\n", line_ending) + line_ending
+            raise Exception(f"Can't smartly make a Postable for label '{label}'\n\tfor contents: {contents}")
 
-        first_name, first_gcode = all_job_sections[0]
-        all_job_sections[0] = (first_name, safety_gcode + first_gcode)
+        args['data'].update(extra_data)
+        return Postable( label=label, **args )
+
+    def _filter_for_items(self, postables):
+        """Remove/Replace items as wanted (filter list in _filter_item())
+        Returns a new list of postables
+        """
+        filter_ct = 0 # need a unique label
+        new_sections = []
+        for section_name, sublist in postables:
+            new_sublist = []
+            for item in sublist:
+                if item.data.get('noedit', False):
+                    # marked block, don't change
+                    new_sublist.append(item)
+                    continue
+
+                # None means leave alone
+                # [] means drop
+                # [str|Path.Command] means replace
+                replace  = self._filter_item(item)
+
+                if replace is None:
+                    new_sublist.append(item)
+
+                else:
+                    filter_ct += 1
+                    # We can handle a list of str's or Path.Command
+                    if replace == []:
+                        # just drop it
+                        continue
+                    else:
+                        new_sublist.append(
+                            self._smart_postable(f"Post: {section_name} {item.item_type} {item.label}{filter_ct} filtered", replace)
+                        )
+
+            new_sections.append( (section_name, new_sublist.copy()) ) # FIXME: no copy?
+
+        return new_sections
+
+    def _add_per_item_blocks(self, postables):
+        """Insert item_pre_block before, and item_post_block after it's item"""
+        pre_ct = 0 # pre-blocks need a unique label
+        post_ct = 0
+        new_sections = []
+        for section_name, sublist in postables:
+            new_sublist = []
+            for item in sublist:
+                pre = self._item_pre_block(item)
+                if pre:
+                    pre_ct += 1
+                    new_sublist.append(
+                        self._smart_postable(f"Post: {section_name} {item.item_type} {item.label} pre-block{pre_ct}", pre)
+                    )
+
+                new_sublist.append(item)
+
+                post = self._item_post_block(item)
+                if post:
+                    post_ct += 1
+                    new_sublist.append(
+                        self._smart_postable(f"Post: {section_name} {item.item_type} {item.label} post-block{post_ct}", post)
+                    )
+
+            new_sections.append( (section_name, new_sublist.copy()) )
+
+        return new_sections
+
+    def _collect_frontmatter(self) -> [Postable]:
+        """front-matter for each section
+            Each Postable might be 'str' or 'command'
+        """
+        front_matter = []
+
+        preamble_lines = self._collect_preamble_lines()
+        if preamble_lines:
+            front_matter.append(
+                self._smart_postable("Post: preamble", preamble_lines)
+            )
+
+        unit_command = self._collect_unit_command()
+        if unit_command:
+            front_matter.append(
+                self._smart_postable("Post: unit", unit_command)
+            )
+
+        pre_job_lines = self._collect_pre_job_lines()
+        if pre_job_lines:
+            front_matter.append(
+                self._smart_postable("Post: pre_job", pre_job_lines)
+            )
+
+        front_matter.append( self._smart_postable("Post: endfrontmatter", [] ) )
+        return front_matter
+
+    def _header_object_to_commands(self, gcodeheader):
+        """The header commands, or [] if option is off"""
+        header_enabled = True
+        if self._machine and hasattr(self._machine, "output"):
+            header_enabled = self._machine.output.output_header
+
+            if header_enabled:
+                return gcodeheader.Path.Commands if hasattr(gcodeheader, "Path") else []
+
+        return []
+
+    def _prefix_header_and_frontmatter(self, postables, gcodeheader, frontmatter):
+        """Insert header and frontmatter at each section"""
+        new_sections = []
+        for section_name, sublist in postables:
+            new_sublist = []
+
+            header_commands = self._header_object_to_commands(gcodeheader)
+            if header_commands:
+                new_sublist.append( 
+                    self._smart_postable(
+                        "Post: header", self._header_object_to_commands(gcodeheader), 
+                        extra_data={"noedit":True}
+                    )
+                )
+
+            new_sublist.extend( frontmatter )
+
+            new_sublist += sublist
+            new_sections.append( ( section_name, new_sublist.copy() ) )
+        return new_sections
+
+    def _append_endmatter(self, postables, endmatter):
+        """Append endmatter at each section"""
+        for section_name, sublist in postables:
+            sublist.extend( endmatter )
+
+    def _append_bcnc_postamble(self, postables ):
+        """at section[-1] only, after all other items"""
+        if not postables:
+            return
+        if commands:=self._bcnc_postamble_commands:
+            _,sublist = postables[-1]
+            bcnc_postable = self._smart_postable("Post: bcnc postamble", commands, extra_data={"noedit":True})
+            sublist.append( bcnc_postable )
+
+
+    def _add_safety_block(self, postables):
+        """at section[0] only, before other items"""
+        if not postables:
+            return
+        if safety_lines:=self._get_property_lines("safetyblock"):
+            bcnc_postable = self._smart_postable("Post: safetyblock", safety_lines, extra_data={"noedit":True})
+            _, sublist = postables[0]
+            sublist.insert(0, bcnc_postable)
+
+
+    def _filter_command(self, command : Path.Command) -> None|list[Path.Command]:
+        """Runs the built in list of filter predicates during _filter_for_command().
+            We, and each predicate, returns:
+                None : leave command in place
+                [] : drop command
+                [Path.Command] : replace command, preferably with just a comment
+            The first predicate that returns not None
+                has it's result returned.
+            Subclasses can override, typically doing their predicates before or after ours.
+        """
+        for pred in (
+            self._comment_filter,
+            self._tool_change_command_filter,
+            self._tlo_filter,
+        ):
+            rez = pred(command)
+            if rez is not None:
+                return rez
+        return None
+
+    def _tlo_filter(self, command):
+        """Remove comments if option says to
+        see _filter_command
+        """
+        if getattr(self._machine.output, "output_tool_length_offset", False):
+            return None
+        else:
+            return [] if command.Name == "G43" else None
+
+    def _comment_filter(self, command):
+        """Remove comments if option says to
+        see _filter_command
+        """
+        if getattr(getattr(self._machine.output, "comments", None), "enabled", True):
+            return None
+        else:
+            return [] if command.Name.startswith("(") else None
+
+    def _tool_change_command_filter(self, command):
+        """Remove tool-change command if option says to
+            Cf. _tool_change_filter which removes an entire Postable for the ToolChange
+            This hunts down individual tool-change commands
+        see _filter_command
+        """
+        if getattr(self._machine.processing, "tool_change", True):
+            return None
+        else:
+            return [Path.Command(f"(Tool change suppressed: {command.toGCode()})")] if command.Name in ["M6","M06"] else None
+
+    def _filter_for_commands(self, postables):
+        """Remove/Replace commands as wanted (filter list in _filter_command())
+        """
+
+        for section_name, sublist in postables:
+            for item in sublist:
+                if item.data.get('noedit', False):
+                    # marked block, don't change
+                    continue
+
+                if item.path:
+                    new_commands = []
+                    for cmd in item.Path.Commands:
+
+                        # None means leave alone
+                        # [] means drop
+                        # [Path.Command] means replace
+                        replace  = self._filter_command(cmd)
+
+                        if replace is None:
+                            new_commands.append(cmd)
+
+                        else:
+                            if replace == []:
+                                # just drop it
+                                continue
+                            else:
+                                new_commands.extend( replace )
+                    item.path = Path.Path(new_commands)
+
+
+    def _convert_job_sections(self, postables):
+        """Convert each section to output-code"""
+
+        job_sections = [] # output chunks
+        header_last_line = -1 # updated when we process Postable.label == "Post: endfrontmatter"
+        for section_name, sublist in postables:
+            #print(f"#-- Section '{section_name}'")
+
+            output_lines = []
+
+            seen_items = set()
+            for item_i, item in enumerate(sublist):
+                # DEBUG
+                #print(f"#----  Postable <{item.label}> {item.item_type}: {item}")
+                if item.path and len(item.path.Commands) < 10: # DEBUG
+                    paths = [i.toGCode() for i in item.path.Commands] if item.path and item.path.Commands else []
+                    #print(f"#--     paths {paths}")
+
+                if item.label in seen_items:
+                    Path.Log.debug( f"Internal: Postables, in a section ('{section_name}'), should have unique .label. Saw .label twice <{item.label}>. Second looks like '{item.item_type}': {item}")
+                seen_items.add( item.label )
+
+                # FIXME: skip "noedit" Postables? or let pp see them?
+
+                # NB: We are not in pure Path.Command world anymore
+                # Parameters (axis) might have been made redundant
+                # MachineState may not be able to consume Path.Command's anymore
+
+                try:
+                    self._convert_item_commands(item, output_lines)
+                except Exception as e:
+                    raise Exception(f"During section '{section_name}' item {item_i}") from e
+
+                if item.label == "Post: endfrontmatter":
+                    header_last_line = len(output_lines) - 1
+
+            # We are now in output STRING world, the output may not be gcode at all!
+
+            # ===== STAGE 4: G-CODE OPTIMIZATION =====
+
+            # Some sections/postables shouldn't be messed with: look at Postable.data['noedit']
+            # FIXME: don't optimize bcnc and other endmatter?
+            output_lines = self._optimize_gcode(header_last_line, output_lines)
+
+            output_string = "\n".join(output_lines)
+
+            if output_string:
+                job_sections.append((section_name, output_string))
+
+        return job_sections
 
     def export2(self) -> Union[None, GCodeSections]:
         """
@@ -1607,6 +1911,7 @@ class PostProcessor:
 
         Assumes Stage 0 (Configuration) is complete.
 
+        FIXME: comments are wrong now
         Stages:
         0. Pre-processing Dialog - Collect user input before processing
         1. Ordering - Build ordered list of postables
@@ -1616,6 +1921,7 @@ class PostProcessor:
         5. Output Production - Assemble final structure
         6. Remote Posting - Post-processing network operations
         """
+
         Path.Log.debug("Starting export2()")
 
         # ===== STAGE 0: PRE-PROCESSING DIALOG =====
@@ -1628,12 +1934,19 @@ class PostProcessor:
 
         # ===== STAGE 1: ORDERING =====
         all_job_sections = []
+
+        # Build ordered postables for this job
         postables = self._buildPostList()
+
+        # Allow derived postprocessors to transform postables before expansion
         self._expand_postprocessor_commands(postables)
 
         # ===== STAGE 2: COMMAND EXPANSION =====
-        gcodeheader = self._build_header(postables)
-        self._expand_translate_drill_cycles(postables)
+        # We want to collect header-info before any more changes
+        # used later to insert actual header into each section
+        gcodeheader = self._collect_header_info(postables) # a _HeaderBuilder
+
+        self._expand_translate_drill_cycles(postables) # FIXME: redundant now, but check "if"
         self._expand_canned_cycles(postables)
         self._expand_split_arcs(postables)
         self._expand_spindle_wait(postables)
@@ -1646,34 +1959,39 @@ class PostProcessor:
         Path.Log.debug(postables)
 
         # ===== STAGE 3: COMMAND CONVERSION =====
-        header_lines = self._collect_header_lines(gcodeheader)
-        preamble_lines = self._collect_preamble_lines()
-        unit_command = self._collect_unit_command()
-        pre_job_lines = self._collect_pre_job_lines()
 
-        job_sections = []
-        for section_name, sublist in postables:
-            gcode_lines = self._build_section_prefix(
-                header_lines, preamble_lines, unit_command, pre_job_lines
-            )
+        # We are no longer in pure Path world
+        # We can insert Postables of item_type="str" for literals
 
-            for item in sublist:
-                if self._emit_item_pre_block(item, gcode_lines):
-                    continue
-                self._convert_item_commands(item, gcode_lines)
-                self._emit_item_post_block(item, gcode_lines)
+        postables = self._filter_for_items(postables)
+        postables = self._add_per_item_blocks(postables)
 
-            # ===== STAGE 4: G-CODE OPTIMIZATION =====
-            gcode_string = self._optimize_gcode(header_lines, gcode_lines)
-            if gcode_string:
-                gcode_string = self._append_trailing_lines(gcode_string)
-                job_sections.append((section_name, gcode_string))
+        self._filter_for_commands(postables)
 
-        self._append_bcnc_postamble(job_sections)
+        # Add some blocks, that we didn't want the above messing with
+
+        frontmatter = self._collect_frontmatter()
+        postables = self._prefix_header_and_frontmatter( postables, gcodeheader, frontmatter)
+
+        endmatter = self._collect_trailing_lines() # FIXME: test
+        self._append_endmatter( postables, endmatter )
+
+        # all appending must be done, so:
+        self._append_bcnc_postamble( postables ) # section[-1] only, after all other items
+
+        # all prefixing must be done, so:
+        self._add_safety_block(postables) # section[0] only, before other items
+
+        # Add line-numbers to all Path.Command's (if option is on)
+        self._add_line_numbers(postables)
+
+        # FIXME: post to gcode processors: pre-output
+
+        job_sections = self._convert_job_sections( postables )
+
         all_job_sections.extend(job_sections)
 
         # ===== STAGE 5: OUTPUT PRODUCTION =====
-        self._prepend_safety_block(all_job_sections)
 
         Path.Log.debug(f"Returning {len(all_job_sections)} sections")
         Path.Log.debug(f"Sections: {all_job_sections}")
@@ -1683,6 +2001,14 @@ class PostProcessor:
             self.remote_post(all_job_sections)
         except Exception as e:
             Path.Log.error(f"Remote posting failed: {e}")
+
+        # Only have to do line_ending in one place
+        line_ending = getattr(getattr(self._machine.output, "formatting", None),"end_of_line_chars", None)
+        if line_ending and line_ending != "\n":
+            all_job_sections = [ 
+                (section_name, section.replace("\n", line_ending) )
+                for section_name, section in all_job_sections 
+                ]
 
         return all_job_sections
 
@@ -1957,6 +2283,8 @@ class PostProcessor:
         Derived postprocessors can override individual hook methods to customize
         specific command handling without reimplementing the entire function.
 
+        Prefixes with line-number if N word in Path.Command, in the hooks
+
         Hook methods available for override:
           - _convert_comment() - Comment handling
           - _convert_rapid_move() - G0/G00 rapid positioning
@@ -1982,12 +2310,23 @@ class PostProcessor:
                 return super()._convert_drill_cycle(command)
         """
 
+        if not command.Name: # DEBUG
+            raise Exception("No command.Name")
+
         # Validate command is supported
-        supported = Constants.GCODE_SUPPORTED + Constants.GCODE_FIXTURES + Constants.MCODE_SUPPORTED
+        # FIXME: cache/lift out of the postables loop as this-machine's-supported
+        if s := getattr(self._machine, "properties", {}).get("supported_commands", None):
+            supported = s.split("\n")
+        else:
+            supported = (
+                Constants.GCODE_SUPPORTED
+                + Constants.MCODE_SUPPORTED
+                + Constants.GCODE_NON_CONFORMING
+            )
+
         if (
             command.Name not in supported
             and not command.Name.startswith("(")
-            and not command.Name.startswith("T")
         ):
             raise ValueError(f"Unsupported command: {command.Name}")
 
@@ -2028,20 +2367,6 @@ class PostProcessor:
 
         # Spindle control
         if command_name in Constants.MCODE_SPINDLE_ON + Constants.MCODE_SPINDLE_OFF:
-            return self._convert_spindle_command(command)
-
-        # Coolant control
-        if command_name in Constants.MCODE_COOLANT:
-            return self._convert_coolant_command(command)
-
-        # Program control
-        if (
-            command_name
-            in Constants.MCODE_STOP
-            + Constants.MCODE_OPTIONAL_STOP
-            + Constants.MCODE_END
-            + Constants.MCODE_END_RESET
-        ):
             return self._convert_program_control(command)
 
         # Fixtures
@@ -2112,33 +2437,12 @@ class PostProcessor:
         else:
             return f"{block_delete_string}{comment_symbol} {comment_text}"
 
-    def _convert_move(self, command: Path.Command) -> str:
-        """
-        Converts a rapid move command to gcode.
+    def format_parameter(self, parameter, value) -> str:
+        # Format an parameter w/precision
+        # if unknown parameter, just stringify as Pn
 
-        This method can be overridden by derived postprocessors to customize rapid move handling.
-        """
-        from Path.Post.UtilsParse import format_command_line
-
-        # Extract command components
-        command_name = command.Name
-        params = command.Parameters
-        annotations = command.Annotations
-
-        # Check for blockdelete annotation
-        block_delete_string = "/" if annotations.get("blockdelete") else ""
-
-        # Build command line
-        command_line = []
-        command_line.append(command_name)
-
-        # Format parameters with clean, stateless implementation
-        parameter_order = self.values.get(
-            "PARAMETER_ORDER", ["X", "Y", "Z", "F", "I", "J", "K", "R", "Q", "P"]
-        )
-
-        def format_axis_param(value):
-            """Format axis parameter with unit conversion and precision."""
+        def _convert_axis_param(value):
+            """axis parameter unit conversion"""
             # Apply unit conversion based on machine units setting
             is_imperial = False
             if self._machine and hasattr(self._machine, "output"):
@@ -2154,28 +2458,21 @@ class PostProcessor:
                 converted_value = value / 25.4  # Convert mm to inches
             else:
                 converted_value = value  # Keep as mm
+            return converted_value
 
+        def format_axis_param(value):
+            converted_value = _convert_axis_param(value)
             precision = self.values.get("AXIS_PRECISION") or 3
             return f"{converted_value:.{precision}f}"
 
-        def format_feed_param(value):
+        def format_feed_param(feed_value):
             """Format feed parameter with speed precision and unit conversion."""
-            # Convert from mm/sec to mm/min (multiply by 60)
-            feed_value = value * 60.0
+            feed_value = _convert_axis_param(feed_value)
 
-            # Apply unit conversion if imperial
-            is_imperial = False
-            if self._machine and hasattr(self._machine, "output"):
-                from Machine.models.machine import OutputUnits
-
-                is_imperial = self._machine.output.units == OutputUnits.IMPERIAL
-            else:
-                # Fallback to legacy UNITS value
-                units = self.values.get("UNITS", "G21")
-                is_imperial = units == "G20"
-
-            if is_imperial:
-                feed_value = feed_value / 25.4  # Convert mm/min to in/min
+            # There are actually oddball controls that use {units}/second feedrate.
+            if not ( self._machine and hasattr(self._machine, "feedrate_per_second") ):
+                # Convert from mm/sec to mm/min (multiply by 60)
+                feed_value = feed_value * 60.0
 
             precision = self.values.get("FEED_PRECISION") or 3
             return f"{feed_value:.{precision}f}"
@@ -2220,6 +2517,44 @@ class PostProcessor:
             "L": format_int_param,
             "T": format_int_param,
         }
+        if parameter in param_formatters:
+            formatted_value = param_formatters[parameter](value)
+        else:
+            # Default formatting for unhandled parameters
+            formatted_value = f"{parameter}{value}"
+        return formatted_value
+
+    def _convert_move(self, command: Path.Command) -> str:
+        # FIXME: rename to generic _convert_generic_gcode
+        """
+        Converts a rapid move command to gcode.
+
+        This method can be overridden by derived postprocessors to customize rapid move handling.
+        """
+
+        # Extract command components
+        command_name = command.Name
+        params = command.Parameters
+        annotations = command.Annotations
+
+        # Check for blockdelete annotation
+        block_delete_string = "/" if annotations.get("blockdelete") else ""
+
+        # Build command line
+        command_line = []
+
+        # line numbers
+        if params.get("N", None) is not None:
+            prefix = getattr(getattr(self._machine.output, "formatting", None), "line_number_prefix", "N")
+            command_line.append( f"{prefix}{ int(params['N']):d}" )
+
+        # GCode name
+        command_line.append(command_name)
+
+        # Format parameters with clean, stateless implementation
+        parameter_order = self.values.get(
+            "PARAMETER_ORDER", Constants.PARAMETER_ORDER
+        )
 
         for parameter in parameter_order:
             if parameter in params:
@@ -2233,22 +2568,10 @@ class PostProcessor:
                     ):
                         continue  # Skip this parameter
 
-                if parameter in param_formatters:
-                    formatted_value = param_formatters[parameter](params[parameter])
-                    command_line.append(f"{parameter}{formatted_value}")
-                    # Update modal state
-                    self._modal_state[parameter] = params[parameter]
-                else:
-                    # Default formatting for unhandled parameters
-                    command_line.append(f"{parameter}{params[parameter]}")
-                    # Update modal state for unhandled parameters too
-                    self._modal_state[parameter] = params[parameter]
-
-        # Handle tool length offset (G43) suppression
-        if command_name in ("G43",):
-            if not self.values.get("OUTPUT_TOOL_LENGTH_OFFSET", True):
-                # Tool length offset disabled - suppress G43 command
-                return None
+                formatted_value = self.format_parameter(parameter, params[parameter])
+                command_line.append(f"{parameter}{formatted_value}")
+                # Update modal state
+                self._modal_state[parameter] = params[parameter]
 
         # Format the command line
         formatted_line = format_command_line(self.values, command_line)
@@ -2390,6 +2713,7 @@ class WrapperPost(PostProcessor):
         self._tooltip = getattr(self.script_module, "TOOLTIP", "No tooltip provided")
         self._tooltipargs = getattr(self.script_module, "TOOLTIP_ARGS", [])
 
+
     def export(self):
         """Dynamically reload the module for the export to ensure up-to-date usage."""
 
@@ -2397,7 +2721,7 @@ class WrapperPost(PostProcessor):
         Path.Log.debug(f"postables count: {len(postables)}")
 
         g_code_sections = []
-        for idx, section in enumerate(postables):
+        for section in postables:
             partname, sublist = section
 
             gcode = self.script_module.export(sublist, "-", self._job.PostProcessorArgs)

--- a/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
@@ -174,7 +174,7 @@ class GenericPlasma(PostProcessor):
         Path.Log.debug("Generic Plasma post processor initialized.")
 
         # Torch commands
-        self.TorchIgniteCommand = Path.Command("M3")
+        self.TorchIgniteCommand = Path.Command("M3", {"S":1})
         self.TorchExtinguishCommand = Path.Command("M5")
 
         # State tracking for plasma-specific features

--- a/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/generic_plasma_post.py
@@ -174,7 +174,7 @@ class GenericPlasma(PostProcessor):
         Path.Log.debug("Generic Plasma post processor initialized.")
 
         # Torch commands
-        self.TorchIgniteCommand = Path.Command("M3", {"S":1})
+        self.TorchIgniteCommand = Path.Command("M3", {"S": 1})
         self.TorchExtinguishCommand = Path.Command("M5")
 
         # State tracking for plasma-specific features

--- a/src/Mod/CAM/Path/Tool/library/serializers/linuxcnc.py
+++ b/src/Mod/CAM/Path/Tool/library/serializers/linuxcnc.py
@@ -49,6 +49,10 @@ class LinuxCNCSerializer(AssetSerializer):
         if not isinstance(asset, Library):
             raise TypeError("Asset must be a Library instance")
 
+        decimals = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Units").GetInt(
+            "Decimals", 2
+        )
+
         output = io.BytesIO()
         for bit_no, bit in sorted(asset._bit_nos.items()):
             # Connor: assert isinstance(bit, ToolBit)
@@ -58,21 +62,19 @@ class LinuxCNCSerializer(AssetSerializer):
             #     )
             #     continue
             # Commenting this out. Why did we skip because it is not a rotary tool?
-            diameter = bit.get_diameter().getUserPreferred()[0]
+
             pocket = "P0"  # TODO: is there a better way?
-            # TODO: Strip units by splitting at the first space if diameter is a string
+
+            # TODO:
             # This is where we need a machine definition so we can export these out correctly
             # for a metric or imperial machine
             # Using user preferred for now
-            if hasattr(diameter, "Value"):
-                diameter_value = str(diameter.Value).replace(",", ".")
-            elif isinstance(diameter, str):
-                diameter_value = diameter.split(" ")[0].replace(",", ".")
-            else:
-                diameter_value = str(diameter).replace(",", ".")
+            units = bit.get_diameter().getUserPreferred()[2]
+            diameter_value = bit.get_diameter().getValueAs(units).Value
+
             line = (
                 f"T{bit_no} {pocket} X0 Y0 Z0 A0 B0 C0 U0 V0 W0 "
-                f"D{diameter_value} I0 J0 Q0 ;{bit.label}\n"
+                f"D{diameter_value:.{decimals}f} I0 J0 Q0 ;{bit.label}\n"
             )
             output.write(line.encode("utf-8"))
 


### PR DESCRIPTION
Use MachineState instead of ad-hoc state tracking in Post/Processor.py and post-processors (MBPP only).

See 2. in discussion #29281

This requires pr #29292.
    
DRY'd it.
    
Added tests.
    
Added tracking of retract-mode (G98/G99) for drilling, used for DrillCycleExpander. State was wrong for R-retract.
    
Added separate tracking of G1 speed, from G0 speed. G0's now include an F parameter in Path.Command, it must be kept separate from all other move F parameters. This should have caused a bug, if redundant-axis=False, I think.
    
DrillCycleExpander is more strict now.
    
Implemented a demonstration command-dedup, and axis-dedup.
    
Fixed a bug in MockToolController. Fixed a bug in toolchange.generate
    
Subclassed MachineState for Processor to track units.
    
Repaired some tests.
    
MachineState is now available in post-processors (MBPP only).
