### PR TITLE
Sketcher: Add OVP for arc of ellipse, hyperbola, and parabola

### DIFF
--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -1175,6 +1175,27 @@ protected:
         return static_cast<Part::GeomArcOfCircle*>(ShapeGeometry.emplace_back(std::move(arc)).get());
     }
 
+    /** @brief Function to add an arc of hyperbola to the ShapeGeometry vector.*/
+    auto addArcOfHyperbolaToShapeGeometry(
+        Base::Vector3d centerPoint,
+        Base::Vector3d majorAxisDirection,
+        double majorRadius,
+        double minorRadius,
+        double start,
+        double end,
+        bool constructionMode
+    )
+    {
+        auto arc = std::make_unique<Part::GeomArcOfHyperbola>();
+        arc->setCenter(centerPoint);
+        arc->setMajorAxisDir(majorAxisDirection);
+        arc->setMajorRadius(majorRadius);
+        arc->setMinorRadius(minorRadius);
+        arc->setRange(start, end, true);
+        Sketcher::GeometryFacade::setConstruction(arc.get(), constructionMode);
+        return static_cast<Part::GeomArcOfHyperbola*>(ShapeGeometry.emplace_back(std::move(arc)).get());
+    }
+
     /** @brief Function to add a point to the ShapeGeometry vector.*/
     auto addPointToShapeGeometry(Base::Vector3d p1, bool constructionMode)
     {

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -1175,6 +1175,27 @@ protected:
         return static_cast<Part::GeomArcOfCircle*>(ShapeGeometry.emplace_back(std::move(arc)).get());
     }
 
+    /** @brief Function to add an arc of ellipse to the ShapeGeometry vector.*/
+    auto addArcOfEllipseToShapeGeometry(
+        Base::Vector3d centerPoint,
+        Base::Vector3d majorAxisDirection,
+        double majorRadius,
+        double minorRadius,
+        double start,
+        double end,
+        bool constructionMode
+    )
+    {
+        auto arc = std::make_unique<Part::GeomArcOfEllipse>();
+        arc->setCenter(centerPoint);
+        arc->setMajorAxisDir(majorAxisDirection);
+        arc->setMajorRadius(majorRadius);
+        arc->setMinorRadius(minorRadius);
+        arc->setRange(start, end, true);
+        Sketcher::GeometryFacade::setConstruction(arc.get(), constructionMode);
+        return static_cast<Part::GeomArcOfEllipse*>(ShapeGeometry.emplace_back(std::move(arc)).get());
+    }
+    
     /** @brief Function to add an arc of hyperbola to the ShapeGeometry vector.*/
     auto addArcOfHyperbolaToShapeGeometry(
         Base::Vector3d centerPoint,

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -1217,6 +1217,25 @@ protected:
         return static_cast<Part::GeomArcOfHyperbola*>(ShapeGeometry.emplace_back(std::move(arc)).get());
     }
 
+    /** @brief Function to add an arc of parabola to the ShapeGeometry vector.*/
+    auto addArcOfParabolaToShapeGeometry(
+        Base::Vector3d axisDirection,
+        Base::Vector3d centerPoint,
+        double focal,
+        double start,
+        double end,
+        bool constructionMode
+    )
+    {
+        auto arc = std::make_unique<Part::GeomArcOfParabola>();
+        arc->setXAxisDir(axisDirection);
+        arc->setCenter(centerPoint);
+        arc->setFocal(focal);
+        arc->setRange(start, end, true);
+        Sketcher::GeometryFacade::setConstruction(arc.get(), constructionMode);
+        return static_cast<Part::GeomArcOfParabola*>(ShapeGeometry.emplace_back(std::move(arc)).get());
+    }
+
     /** @brief Function to add a point to the ShapeGeometry vector.*/
     auto addPointToShapeGeometry(Base::Vector3d p1, bool constructionMode)
     {

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -1195,7 +1195,7 @@ protected:
         Sketcher::GeometryFacade::setConstruction(arc.get(), constructionMode);
         return static_cast<Part::GeomArcOfEllipse*>(ShapeGeometry.emplace_back(std::move(arc)).get());
     }
-    
+
     /** @brief Function to add an arc of hyperbola to the ShapeGeometry vector.*/
     auto addArcOfHyperbolaToShapeGeometry(
         Base::Vector3d centerPoint,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -320,6 +320,8 @@ private:
 
     void createShape(bool onlyeditoutline) override
     {
+        Q_UNUSED(onlyeditoutline);
+
         ShapeGeometry.clear();
 
         if (!valid) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
- *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *   
+ *   Copyright (c) 2026 Loke S. Haugsnes <Lokesh@live.no>                  *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -38,405 +39,56 @@
 #include "SnapManager.h"
 
 
+#include <Base/Tools.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/MainWindow.h>
+#include <Mod/Part/App/Geometry2d.h>
+
+
+#include "DrawSketchDefaultWidgetController.h"
+#include "DrawSketchControllableHandler.h"
+
+#include <vector>
+#include <algorithm>
+
+// Ellipse governing equation:
+// point(t) = origin + a * cos(angle) * aDir.x + b * sin(angle) * bDir.x;
+
 namespace SketcherGui
 {
 
 extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
-class DrawSketchHandlerArcOfEllipse: public DrawSketchHandler
+class DrawSketchHandlerArcOfEllipse;
+
+using DSHArcOfEllipseController = DrawSketchController<
+    DrawSketchHandlerArcOfEllipse,
+    StateMachines::FourSeekEnd,
+    /*PAutoConstraintSize =*/4,
+    /*OnViewParametersT =*/OnViewParameters<7>>;
+
+using DrawSketchHandlerArcOfEllipseBase = DrawSketchControllableHandler<DSHArcOfEllipseController>;
+
+class DrawSketchHandlerArcOfEllipse: public DrawSketchHandlerArcOfEllipseBase
 {
     Q_DECLARE_TR_FUNCTIONS(SketcherGui::DrawSketchHandlerArcOfEllipse)
 
+    friend DSHArcOfEllipseController;
+
 public:
-    DrawSketchHandlerArcOfEllipse()
-        : Mode(SelectMode::First)
-        , EditCurve(34)
+    explicit DrawSketchHandlerArcOfEllipse()
+        : DrawSketchHandlerArcOfEllipseBase()
+        , centerPoint({0.0, 0.0})
+        , axisPoint({0.0, 0.0})
+        , secondRadius(0)
         , startAngle(0)
-        , endAngle(0)
         , arcAngle(0)
+        , valid(true)
+        , secondSet(false)
+        , ellipseGeoId(Sketcher::GeoEnum::GeoUndef)
     {}
 
     ~DrawSketchHandlerArcOfEllipse() override = default;
-
-    /// mode table
-    enum class SelectMode
-    {
-        First,
-        Second,
-        Third,
-        Fourth,
-        End
-    };
-
-    void mouseMove(SnapManager::SnapHandle snapHandle) override
-    {
-        using std::numbers::pi;
-        Base::Vector2d onSketchPos = snapHandle.compute();
-
-        if (Mode == SelectMode::First) {
-            setPositionText(onSketchPos);
-            seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));  // TODO:
-                                                                                             // ellipse
-                                                                                             // prio 1
-        }
-        else if (Mode == SelectMode::Second) {
-            double rx0 = onSketchPos.x - EditCurve[0].x;
-            double ry0 = onSketchPos.y - EditCurve[0].y;
-            for (int i = 0; i < 16; i++) {
-                double angle = i * pi / 16.0;
-                double rx1 = rx0 * cos(angle) + ry0 * sin(angle);
-                double ry1 = -rx0 * sin(angle) + ry0 * cos(angle);
-                EditCurve[1 + i] = Base::Vector2d(EditCurve[0].x + rx1, EditCurve[0].y + ry1);
-                EditCurve[17 + i] = Base::Vector2d(EditCurve[0].x - rx1, EditCurve[0].y - ry1);
-            }
-            EditCurve[33] = EditCurve[1];
-
-            // Display radius for user
-            float radius = (onSketchPos - EditCurve[0]).Length();
-
-            if (showCursorCoords()) {
-                SbString text;
-                std::string radiusString = lengthToDisplayFormat(radius, 1);
-                text.sprintf(" (R%s, R%s)", radiusString.c_str(), radiusString.c_str());
-                setPositionText(onSketchPos, text);
-            }
-
-            drawEdit(EditCurve);
-            seekAndRenderAutoConstraint(
-                sugConstr2,
-                onSketchPos,
-                onSketchPos - centerPoint,
-                AutoConstraint::CURVE
-            );
-        }
-        else if (Mode == SelectMode::Third) {
-            Base::Vector2d delta12 = axisPoint - centerPoint;
-
-            double a = delta12.Length();
-
-            Base::Vector2d aDir = delta12.Normalize();
-            Base::Vector2d bDir(-aDir.y, aDir.x);
-
-            Base::Vector2d delta13 = onSketchPos - centerPoint;
-            Base::Vector2d delta13Prime(
-                delta13.x * aDir.x + delta13.y * aDir.y,
-                delta13.x * bDir.x + delta13.y * bDir.y
-            );
-
-            double cosT = max(-1.0, min(1.0, delta13Prime.x / a));
-            double sinT = sqrt(max(0.0, 1 - cosT * cosT));
-
-            double b = abs(delta13Prime.y) / sinT;
-            if (sinT == 0.0) {
-                b = 0.0;
-                a = 0.0;
-            }
-
-            for (int i = 1; i < 16; i++) {
-                double angle = i * pi / 16.0;
-                double rx1 = a * cos(angle) * aDir.x + b * sin(angle) * bDir.x;
-                double ry1 = a * cos(angle) * aDir.y + b * sin(angle) * bDir.y;
-                EditCurve[1 + i] = Base::Vector2d(EditCurve[0].x + rx1, EditCurve[0].y + ry1);
-                EditCurve[17 + i] = Base::Vector2d(EditCurve[0].x - rx1, EditCurve[0].y - ry1);
-            }
-            EditCurve[33] = EditCurve[1];
-            EditCurve[17] = EditCurve[16];
-
-            // Display radius for user
-            if (showCursorCoords()) {
-                SbString text;
-                std::string aString = lengthToDisplayFormat(a, 1);
-                std::string bString = lengthToDisplayFormat(b, 1);
-                text.sprintf(" (R%s, R%s)", aString.c_str(), bString.c_str());
-                setPositionText(onSketchPos, text);
-            }
-
-            drawEdit(EditCurve);
-            seekAndRenderAutoConstraint(sugConstr3, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-        else if (Mode == SelectMode::Fourth) {  // here we differ from ellipse creation
-            Base::Vector2d delta12 = axisPoint - centerPoint;
-
-            double a = delta12.Length();
-
-            Base::Vector2d aDir = delta12.Normalize();
-            Base::Vector2d bDir(-aDir.y, aDir.x);
-
-            Base::Vector2d delta13 = startingPoint - centerPoint;
-            Base::Vector2d delta13Prime(
-                delta13.x * aDir.x + delta13.y * aDir.y,
-                delta13.x * bDir.x + delta13.y * bDir.y
-            );
-
-            double cosT = max(-1.0, min(1.0, delta13Prime.x / a));
-            double sinT = sqrt(max(0.0, 1 - cosT * cosT));
-
-            double b = abs(delta13Prime.y) / sinT;
-
-            startAngle = atan2(delta13Prime.y / b, delta13Prime.x / a);
-
-            Base::Vector2d delta14 = onSketchPos - centerPoint;
-            Base::Vector2d delta14Prime(
-                delta14.x * aDir.x + delta14.y * aDir.y,
-                delta14.x * bDir.x + delta14.y * bDir.y
-            );
-            double angle1 = atan2(delta14Prime.y / b, delta14Prime.x / a) - startAngle;
-            double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * pi;
-
-            arcAngle = abs(angle1 - arcAngle) < abs(angle2 - arcAngle) ? angle1 : angle2;
-
-            for (int i = 0; i < 34; i++) {
-                double angle = startAngle + i * arcAngle / 33.0;
-                double rx1 = a * cos(angle) * aDir.x + b * sin(angle) * bDir.x;
-                double ry1 = a * cos(angle) * aDir.y + b * sin(angle) * bDir.y;
-                EditCurve[i] = Base::Vector2d(centerPoint.x + rx1, centerPoint.y + ry1);
-            }
-
-            // Display radii and angle for user
-            if (showCursorCoords()) {
-                SbString text;
-                std::string aString = lengthToDisplayFormat(a, 1);
-                std::string bString = lengthToDisplayFormat(b, 1);
-                std::string angleString = angleToDisplayFormat(arcAngle * 180.0 / pi, 1);
-                text.sprintf(" (R%s, R%s, %s)", aString.c_str(), bString.c_str(), angleString.c_str());
-                setPositionText(onSketchPos, text);
-            }
-
-            if (onSketchPos != centerPoint) {
-                drawEdit(EditCurve);
-            }
-            else {
-                drawEdit(std::vector<Base::Vector2d>());
-            }
-            seekAndRenderAutoConstraint(sugConstr4, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-    }
-
-    bool pressButton(Base::Vector2d onSketchPos) override
-    {
-        using std::numbers::pi;
-
-        if (Mode == SelectMode::First) {
-            EditCurve[0] = onSketchPos;
-            centerPoint = onSketchPos;
-            setAngleSnapping(true, centerPoint);
-            Mode = SelectMode::Second;
-        }
-        else if (
-            Mode == SelectMode::Second
-            && (centerPoint - onSketchPos).Length() >= Precision::Confusion()
-        ) {
-            EditCurve[1] = onSketchPos;
-            axisPoint = onSketchPos;
-            Mode = SelectMode::Third;
-        }
-        else if (Mode == SelectMode::Third && validThirdPoint(onSketchPos)) {
-            startingPoint = onSketchPos;
-            arcAngle = 0.;
-            Mode = SelectMode::Fourth;
-        }
-        else if (
-            Mode == SelectMode::Fourth && centerPoint != onSketchPos && arcAngle != 0
-            && abs(arcAngle) != 2 * pi
-        ) {
-            endPoint = onSketchPos;
-
-            setAngleSnapping(false);
-            Mode = SelectMode::End;
-        }
-
-        updateHint();
-        return true;
-    }
-
-    bool releaseButton(Base::Vector2d onSketchPos) override
-    {
-        Q_UNUSED(onSketchPos);
-
-        using std::numbers::pi;
-
-        if (Mode == SelectMode::End) {
-            unsetCursor();
-            resetPositionText();
-
-            Base::Vector2d delta12 = axisPoint - centerPoint;
-
-            double a = delta12.Length();
-
-            Base::Vector2d aDir = delta12.Normalize();
-            Base::Vector2d bDir(-aDir.y, aDir.x);
-
-            Base::Vector2d delta13 = startingPoint - centerPoint;
-            Base::Vector2d delta13Prime(
-                delta13.x * aDir.x + delta13.y * aDir.y,
-                delta13.x * bDir.x + delta13.y * bDir.y
-            );
-
-            double cosT = max(-1.0, min(1.0, delta13Prime.x / a));
-            double sinT = sqrt(max(0.0, 1 - cosT * cosT));
-
-            double b = abs(delta13Prime.y) / sinT;
-
-            Base::Vector2d delta14 = endPoint - centerPoint;
-            Base::Vector2d delta14Prime(
-                delta14.x * aDir.x + delta14.y * aDir.y,
-                delta14.x * bDir.x + delta14.y * bDir.y
-            );
-            double angle1 = atan2(delta14Prime.y / b, delta14Prime.x / a) - startAngle;
-            double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * pi;
-
-            arcAngle = abs(angle1 - arcAngle) < abs(angle2 - arcAngle) ? angle1 : angle2;
-
-            bool isOriginalArcCCW = true;
-
-            if (arcAngle > 0) {
-                endAngle = startAngle + arcAngle;
-            }
-            else {
-                endAngle = startAngle;
-                startAngle += arcAngle;
-                isOriginalArcCCW = false;
-            }
-
-            Base::Vector2d majAxisDir, minAxisDir, minAxisPoint, majAxisPoint;
-            // We always create a CCW ellipse, because we want our XY reference system to be in the
-            // +X +Y direction Our normal will then always be in the +Z axis (local +Z axis of the
-            // sketcher)
-
-            if (a > b) {
-                // force second semidiameter to be perpendicular to first semidiamater
-                majAxisDir = axisPoint - centerPoint;
-                Base::Vector2d perp(-majAxisDir.y, majAxisDir.x);
-                perp.Normalize();
-                perp.Scale(abs(b));
-                minAxisPoint = centerPoint + perp;
-                majAxisPoint = centerPoint + majAxisDir;
-            }
-            else {
-                // force second semidiameter to be perpendicular to first semidiamater
-                minAxisDir = axisPoint - centerPoint;
-                Base::Vector2d perp(minAxisDir.y, -minAxisDir.x);
-                perp.Normalize();
-                perp.Scale(abs(b));
-                majAxisPoint = centerPoint + perp;
-                minAxisPoint = centerPoint + minAxisDir;
-                endAngle += pi / 2;
-                startAngle += pi / 2;
-            }
-
-            int currentgeoid = getHighestCurveIndex();
-
-            try {
-                openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch arc of ellipse"));
-
-                Gui::cmdAppObjectArgs(
-                    sketchgui->getObject(),
-                    "addGeometry(Part.ArcOfEllipse"
-                    "(Part.Ellipse(App.Vector(%f,%f,0),App.Vector(%f,%f,0),App."
-                    "Vector(%f,%f,0)),%f,%f),%s)",
-                    majAxisPoint.x,
-                    majAxisPoint.y,
-                    minAxisPoint.x,
-                    minAxisPoint.y,
-                    centerPoint.x,
-                    centerPoint.y,
-                    startAngle,
-                    endAngle,
-                    constructionModeAsBooleanText()
-                );
-
-                currentgeoid++;
-
-                Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
-            }
-            catch (const Base::Exception&) {
-                Gui::NotifyError(
-                    sketchgui,
-                    QT_TRANSLATE_NOOP("Notifications", "Error"),
-                    QT_TRANSLATE_NOOP("Notifications", "Failed to add arc of ellipse")
-                );
-                abortCommand();
-
-                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
-
-                return false;
-            }
-
-            commitCommand();
-
-            // add auto constraints for the center point
-            if (!sugConstr1.empty()) {
-                createAutoConstraints(sugConstr1, currentgeoid, Sketcher::PointPos::mid);
-                sugConstr1.clear();
-            }
-
-            // add suggested constraints for arc
-            if (!sugConstr2.empty()) {
-                createAutoConstraints(sugConstr2, currentgeoid, Sketcher::PointPos::none);
-                sugConstr2.clear();
-            }
-
-            // add suggested constraints for start of arc
-            if (!sugConstr3.empty()) {
-                createAutoConstraints(
-                    sugConstr3,
-                    currentgeoid,
-                    isOriginalArcCCW ? Sketcher::PointPos::start : Sketcher::PointPos::end
-                );
-                sugConstr3.clear();
-            }
-
-            // add suggested constraints for start of arc
-            if (!sugConstr4.empty()) {
-                createAutoConstraints(
-                    sugConstr4,
-                    currentgeoid,
-                    isOriginalArcCCW ? Sketcher::PointPos::end : Sketcher::PointPos::start
-                );
-                sugConstr4.clear();
-            }
-
-            tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
-
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-                "User parameter:BaseApp/Preferences/Mod/Sketcher"
-            );
-            bool continuousMode = hGrp->GetBool("ContinuousCreationMode", true);
-            if (continuousMode) {
-                // This code enables the continuous creation mode.
-                Mode = SelectMode::First;
-                EditCurve.clear();
-                drawEdit(EditCurve);
-                EditCurve.resize(34);
-                applyCursor();
-                /* this is ok not to call to purgeHandler
-                 * in continuous creation mode because the
-                 * handler is destroyed by the quit() method on pressing the
-                 * right button of the mouse */
-            }
-            else {
-                sketchgui->purgeHandler();  // no code after this line, Handler get deleted in
-                                            // ViewProvider
-            }
-        }
-
-        updateHint();
-
-        return true;
-    }
-
-private:
-    QString getCrosshairCursorSVGName() const override
-    {
-        return QStringLiteral("Sketcher_Pointer_Create_ArcOfEllipse");
-    }
-
-protected:
-    SelectMode Mode;
-    std::vector<Base::Vector2d> EditCurve;
-    Base::Vector2d centerPoint, axisPoint, startingPoint, endPoint;
-    double startAngle, endAngle, arcAngle;
-    std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
 
 private:
     std::list<Gui::InputHint> getToolHints() const override
@@ -444,24 +96,24 @@ private:
         using enum Gui::InputHint::UserInput;
 
         return Gui::lookupHints<SelectMode>(
-            Mode,
+            state(),
             {
-                {.state = SelectMode::First,
+                {.state = SelectMode::SeekFirst,
                  .hints =
                      {
-                         {tr("%1 pick ellipse center"), {MouseLeft}},
+                         {tr("%1 pick ellipse center point"), {MouseLeft}},
                      }},
-                {.state = SelectMode::Second,
+                {.state = SelectMode::SeekSecond,
                  .hints =
                      {
                          {tr("%1 pick axis point"), {MouseLeft}},
                      }},
-                {.state = SelectMode::Third,
+                {.state = SelectMode::SeekThird,
                  .hints =
                      {
                          {tr("%1 pick arc start point"), {MouseLeft}},
                      }},
-                {.state = SelectMode::Fourth,
+                {.state = SelectMode::SeekFourth,
                  .hints =
                      {
                          {tr("%1 pick arc end point"), {MouseLeft}},
@@ -469,24 +121,734 @@ private:
             });
     }
 
-    bool validThirdPoint(Base::Vector2d onSketchPos)
+    void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        Base::Vector2d delta12 = axisPoint - centerPoint;
+        using std::numbers::pi;
+        valid = true;
+        switch (state()) {
+            case SelectMode::SeekFirst: {
+                centerPoint = onSketchPos;
+                toolWidgetManager.drawDirectionAtCursor(onSketchPos, centerPoint);
+                seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            case SelectMode::SeekSecond: {
+                axisPoint = onSketchPos;
+                if ((axisPoint - centerPoint).Length() < Precision::Confusion()) {
+                    valid = false;
+                    break;
+                }
 
-        double a = delta12.Length();
+                toolWidgetManager.drawDirectionAtCursor(onSketchPos, axisPoint);
+                seekAndRenderAutoConstraint(
+                    sugConstraints[1],
+                    onSketchPos,
+                    onSketchPos - centerPoint,
+                    AutoConstraint::CURVE
+                );
+            } break;
+            case SelectMode::SeekThird: {
+                double a = firstRadius();
+                Base::Vector2d aDir = firstAxis();
+                Base::Vector2d bDir = secondAxis();
 
-        Base::Vector2d aDir = delta12.Normalize();
-        Base::Vector2d bDir(-aDir.y, aDir.x);
+                Base::Vector2d delta13 = onSketchPos - centerPoint;
+                Base::Vector2d delta13Prime(
+                    delta13.x * aDir.x + delta13.y * aDir.y,
+                    delta13.x * bDir.x + delta13.y * bDir.y
+                );
 
-        Base::Vector2d delta13 = onSketchPos - centerPoint;
-        Base::Vector2d delta13Prime(
-            delta13.x * aDir.x + delta13.y * aDir.y,
-            delta13.x * bDir.x + delta13.y * bDir.y
-        );
+                if (!secondSet) {
+                    double cosT = std::max(-1.0, std::min(1.0, delta13Prime.x / a));
+                    double sinT = std::sqrt(std::max(0.0, 1 - cosT * cosT));
 
-        double cosT = max(-1.0, min(1.0, delta13Prime.x / a));
-        return cosT != -1.0 && cosT != 1.0 && delta13Prime.y != 0;
+                    if (sinT < Precision::Confusion()) {
+                        valid = false;
+                        break;
+                    }
+
+                    secondRadius = std::abs(delta13Prime.y) / sinT;
+                    if (std::abs(delta13Prime.y) < Precision::Confusion()) {
+                        valid = false;
+                        break;
+                    }
+                }
+
+                startAngle = std::atan2(delta13Prime.y / secondRadius, delta13Prime.x / a);
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                seekAndRenderAutoConstraint(sugConstraints[2], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            case SelectMode::SeekFourth: {
+                Base::Vector2d aDir = firstAxis();
+                Base::Vector2d bDir = secondAxis();
+                Base::Vector2d delta14 = onSketchPos - centerPoint;
+                Base::Vector2d delta14Prime(
+                    delta14.x * aDir.x + delta14.y * aDir.y,
+                    delta14.x * bDir.x + delta14.y * bDir.y
+                );
+
+                double angle1
+                    = std::atan2(delta14Prime.y / secondRadius, delta14Prime.x / firstRadius())
+                    - startAngle;
+                double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * pi;
+
+                arcAngle = std::abs(angle1 - arcAngle) < std::abs(angle2 - arcAngle) ? angle1
+                                                                                     : angle2;
+                if (abs(arcAngle) < Precision::Confusion()) {
+                    valid = false;
+                    break;
+                }
+
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                seekAndRenderAutoConstraint(sugConstraints[3], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            default:
+                return;
+        }
+
+        CreateAndDrawShapeGeometry();
+    }
+
+    void executeCommands() override
+    {
+        try {
+            openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch arc of hyperbola"));
+
+            ellipseGeoId = getHighestCurveIndex() + 1;
+
+            createShape(true);
+
+            commandAddShapeGeometryAndConstraints();
+
+            Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", ellipseGeoId);
+
+            commitCommand();
+        }
+        catch (const Base::Exception&) {
+            Gui::NotifyError(
+                sketchgui,
+                QT_TRANSLATE_NOOP("Notifications", "Error"),
+                QT_TRANSLATE_NOOP("Notifications", "Failed to add arc of hyperbola")
+            );
+
+            abortCommand();
+            THROWM(
+                Base::RuntimeError,
+                QT_TRANSLATE_NOOP(
+                    "Notifications",
+                    "Tool execution aborted"
+                ) "\n"
+            )  // This prevents constraints from being
+               // applied on non existing geometry
+        }
+    }
+
+    void generateAutoConstraints() override
+    {
+        auto& ac1 = sugConstraints[0];
+        auto& ac2 = sugConstraints[1];
+        auto& ac3 = sugConstraints[2];
+        auto& ac4 = sugConstraints[3];
+
+        if (!ac1.empty()) {
+            generateAutoConstraintsOnElement(ac1, ellipseGeoId, Sketcher::PointPos::mid);
+        }
+
+        if (!ac2.empty()) {
+            generateAutoConstraintsOnElement(ac2, ellipseGeoId, Sketcher::PointPos::none);
+        }
+
+        if (!ac3.empty()) {
+            generateAutoConstraintsOnElement(
+                ac3,
+                ellipseGeoId,
+                (arcAngle > 0) ? Sketcher::PointPos::start : Sketcher::PointPos::end
+            );
+        }
+
+        if (!ac4.empty()) {
+            generateAutoConstraintsOnElement(
+                ac4,
+                ellipseGeoId,
+                (arcAngle > 0) ? Sketcher::PointPos::end : Sketcher::PointPos::start
+            );
+        }
+
+        // Ensure temporary autoconstraints do not generate a redundancy and that the geometry
+        // parameters are accurate This is particularly important for adding widget mandated
+        // constraints.
+        removeRedundantAutoConstraints();
+    }
+
+    void createAutoConstraints() override
+    {
+        // execute python command to create autoconstraints
+        createGeneratedAutoConstraints(true);
+
+        sugConstraints[0].clear();
+        sugConstraints[1].clear();
+        sugConstraints[2].clear();
+        sugConstraints[3].clear();
+    }
+
+    std::string getToolName() const override
+    {
+        return "DSH_ArcOfEllipse";
+    }
+
+    QString getCrosshairCursorSVGName() const override
+    {
+        return QStringLiteral("Sketcher_Pointer_Create_ArcOfEllipse");
+    }
+
+    QPixmap getToolIcon() const override
+    {
+        return Gui::BitmapFactory().pixmap("Sketcher_CreateElliptical_Arc");
+    }
+
+    bool canGoToNextMode() override
+    {
+        if (!valid) {
+            return false;
+        }
+        return true;
+    }
+
+    void angleSnappingControl() override
+    {
+        setAngleSnapping(false);
+    }
+
+    void createShape(bool onlyeditoutline) override
+    {
+        ShapeGeometry.clear();
+
+        if (!valid) {
+            return;
+        }
+
+        if (state() == SelectMode::SeekSecond) {
+            addEllipseToShapeGeometry(
+                toVector3d(centerPoint),
+                toVector3d(firstAxis()),
+                firstRadius(),
+                firstRadius() / 2,
+                isConstructionMode()
+            );
+        }
+
+        Ellipse ellipse = getEllipse();
+
+        if (state() == SelectMode::SeekThird) {
+            addEllipseToShapeGeometry(
+                toVector3d(centerPoint),
+                toVector3d(ellipse.majorAxis),
+                ellipse.majorRadius,
+                ellipse.minorRadius,
+                isConstructionMode()
+            );
+        }
+
+        if (state() == SelectMode::SeekFourth || state() == SelectMode::End) {
+            addArcOfEllipseToShapeGeometry(
+                toVector3d(centerPoint),
+                toVector3d(ellipse.majorAxis),
+                ellipse.majorRadius,
+                ellipse.minorRadius,
+                ellipse.startAngle,
+                ellipse.endAngle,
+                isConstructionMode()
+            );
+        }
+    }
+
+private:
+    Base::Vector2d centerPoint, axisPoint;
+    double secondRadius, startAngle, arcAngle;
+    bool valid, secondSet;
+    int ellipseGeoId;
+
+    double firstRadius()
+    {
+        return (centerPoint - axisPoint).Length();
+    }
+
+    Base::Vector2d firstAxis()
+    {
+        return (axisPoint - centerPoint).Normalize();
+    }
+
+    Base::Vector2d secondAxis()
+    {
+        return firstAxis().Rotate(std::numbers::pi / 2);
+    }
+
+    struct Ellipse
+    {
+        double majorRadius;
+        double minorRadius;
+        Base::Vector2d majorAxis;
+        Base::Vector2d minorAxis;
+        double startAngle;
+        double endAngle;
+    };
+
+    Ellipse getEllipse()
+    {
+        double ellipseStartAngle = (firstRadius() >= secondRadius)
+            ? startAngle
+            : startAngle - std::numbers::pi / 2;
+        return Ellipse {
+            .majorRadius = std::max(firstRadius(), secondRadius),
+            .minorRadius = std::min(firstRadius(), secondRadius),
+            .majorAxis = (firstRadius() >= secondRadius) ? firstAxis() : secondAxis(),
+            .minorAxis = (firstRadius() >= secondRadius) ? secondAxis() : firstAxis(),
+            .startAngle = (arcAngle > 0) ? ellipseStartAngle : arcAngle + ellipseStartAngle,
+            .endAngle = (arcAngle > 0) ? arcAngle + ellipseStartAngle : ellipseStartAngle,
+        };
     }
 };
+
+template<>
+auto DSHArcOfEllipseController::getState(int labelindex) const
+{
+    switch (labelindex) {
+        case OnViewParameter::First:
+        case OnViewParameter::Second:
+            return SelectMode::SeekFirst;
+            break;
+        case OnViewParameter::Third:
+        case OnViewParameter::Fourth:
+            return SelectMode::SeekSecond;
+            break;
+        case OnViewParameter::Fifth:
+        case OnViewParameter::Sixth:
+            return SelectMode::SeekThird;
+            break;
+        case OnViewParameter::Seventh:
+            return SelectMode::SeekFourth;
+            break;
+        default:
+            THROWM(Base::ValueError, "OnViewParameter index without an associated machine state")
+    }
+}
+
+template<>
+void DSHArcOfEllipseController::configureOnViewParameters()
+{
+    onViewParameters[OnViewParameter::First]->setLabelType(Gui::SoDatumLabel::DISTANCEX);
+    onViewParameters[OnViewParameter::Second]->setLabelType(Gui::SoDatumLabel::DISTANCEY);
+
+    onViewParameters[OnViewParameter::Third]->setLabelType(
+        Gui::SoDatumLabel::RADIUS,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+    onViewParameters[OnViewParameter::Fourth]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+
+    onViewParameters[OnViewParameter::Fifth]->setLabelType(
+        Gui::SoDatumLabel::RADIUS,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+    onViewParameters[OnViewParameter::Sixth]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+
+    onViewParameters[OnViewParameter::Seventh]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+}
+
+template<>
+void DSHArcOfEllipseController::doEnforceControlParameters(Base::Vector2d& onSketchPos)
+{
+    handler->updateDataAndDrawToPosition(
+        onSketchPos
+    );  // ensure that the member variables are updated to date values before enforcing parameters
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (firstParam->isSet) {
+                onSketchPos.x = firstParam->getValue();
+            }
+
+            if (secondParam->isSet) {
+                onSketchPos.y = secondParam->getValue();
+            }
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& firstRadiusParam = onViewParameters[OnViewParameter::Third];
+            auto& angleParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (!firstRadiusParam->isSet && !angleParam->isSet) {
+                return;
+            }
+
+            double firstRadius = handler->firstRadius();
+            auto firstAxis = handler->firstAxis();
+
+            if (firstRadiusParam->isSet) {
+                firstRadius = firstRadiusParam->getValue();
+                if (firstRadius < Precision::Confusion() && firstRadiusParam->hasFinishedEditing) {
+                    unsetOnViewParameter(firstRadiusParam.get());
+                    return;
+                }
+            }
+
+            if (angleParam->isSet) {
+                double angle = Base::toRadians(angleParam->getValue());
+                firstAxis = {cos(angle), sin(angle)};
+            }
+
+            onSketchPos = handler->centerPoint + firstRadius * firstAxis;
+        } break;
+        case SelectMode::SeekThird: {
+            auto& secondRadiusParam = onViewParameters[OnViewParameter::Fifth];
+            auto& startAngleParam = onViewParameters[OnViewParameter::Sixth];
+
+            if (!secondRadiusParam->isSet && !startAngleParam->isSet) {
+                return;
+            }
+
+            double secondRadius = handler->secondRadius;
+            auto startAngle = handler->startAngle;
+
+            if (secondRadiusParam->isSet) {
+                secondRadius = secondRadiusParam->getValue();
+                handler->secondSet = true;
+                if (secondRadius < Precision::Confusion() && secondRadiusParam->hasFinishedEditing) {
+                    handler->secondSet = false;
+                    unsetOnViewParameter(secondRadiusParam.get());
+                    return;
+                }
+            }
+
+            if (startAngleParam->isSet) {
+                startAngle = Base::toRadians(startAngleParam->getValue());
+            }
+
+            onSketchPos = handler->centerPoint
+                + handler->firstRadius() * std::cos(startAngle) * handler->firstAxis()
+                + secondRadius * std::sin(startAngle) * handler->secondAxis();
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& arcAngleParam = onViewParameters[OnViewParameter::Seventh];
+
+            if (!arcAngleParam->isSet) {
+                return;
+            }
+
+            double arcAngle = Base::toRadians(arcAngleParam->getValue());
+            if (std::fmod(std::abs(arcAngle), 2 * std::numbers::pi) < Precision::Confusion()
+                && arcAngleParam->hasFinishedEditing) {
+                unsetOnViewParameter(arcAngleParam.get());
+                return;
+            }
+
+            double endAngle = handler->startAngle + arcAngle;
+
+            double xPrime = handler->firstRadius() * std::cos(endAngle);
+            double yPrime = handler->secondRadius * std::sin(endAngle);
+
+            Base::Vector2d delta = handler->firstAxis() * xPrime + handler->secondAxis() * yPrime;
+
+            onSketchPos = handler->centerPoint + delta;
+
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfEllipseController::adaptParameters(Base::Vector2d onSketchPos)
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (!firstParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
+            }
+
+            if (!secondParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
+            }
+
+            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+            firstParam->setLabelAutoDistanceReverse(!sameSign);
+            secondParam->setLabelAutoDistanceReverse(sameSign);
+            firstParam->setPoints(Base::Vector3d(), toVector3d(onSketchPos));
+            secondParam->setPoints(Base::Vector3d(), toVector3d(onSketchPos));
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& firstRadiusParam = onViewParameters[OnViewParameter::Third];
+            auto& angleParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (!firstRadiusParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::Third, handler->firstRadius());
+            }
+
+            if (!angleParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Fourth,
+                    Base::toDegrees(handler->firstAxis().Angle()),
+                    Base::Unit::Angle
+                );
+            }
+
+            Base::Vector3d start = toVector3d(handler->centerPoint);
+            Base::Vector3d end = toVector3d(onSketchPos);
+
+            firstRadiusParam->setPoints(start, end);
+            angleParam->setPoints(start, Base::Vector3d());
+            angleParam->setLabelRange(handler->firstAxis().Angle());
+        } break;
+        case SelectMode::SeekThird: {
+            auto& secondRadiusParam = onViewParameters[OnViewParameter::Fifth];
+            auto& startAngleParam = onViewParameters[OnViewParameter::Sixth];
+
+            if (!secondRadiusParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Fifth,
+                    handler->valid ? handler->secondRadius : 0
+                );
+            }
+
+            if (!startAngleParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Sixth,
+                    Base::toDegrees(handler->startAngle),
+                    Base::Unit::Angle
+                );
+            }
+
+            Base::Vector3d start = toVector3d(handler->centerPoint);
+            startAngleParam->setPoints(start, Base::Vector3d());
+            startAngleParam->setLabelStartAngle(handler->firstAxis().Angle());
+            startAngleParam->setLabelRange(handler->startAngle);
+
+            Base::Vector3d end = toVector3d(
+                handler->centerPoint + handler->secondAxis() * handler->secondRadius
+            );
+            secondRadiusParam->setPoints(start, end);
+            if (!handler->valid) {
+                secondRadiusParam->setPoints(start, start);
+            }
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& arcAngleParam = onViewParameters[OnViewParameter::Seventh];
+
+            if (!arcAngleParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Seventh,
+                    Base::toDegrees(handler->arcAngle),
+                    Base::Unit::Angle
+                );
+            }
+
+            Base::Vector3d start = toVector3d(handler->centerPoint);
+
+            arcAngleParam->setPoints(start, Base::Vector3d());
+            arcAngleParam->setLabelStartAngle(handler->firstAxis().Angle() + handler->startAngle);
+            arcAngleParam->setLabelRange(handler->arcAngle);
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfEllipseController::computeNextDrawSketchHandlerMode()
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (firstParam->hasFinishedEditing && secondParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekSecond);
+            }
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& thirdParam = onViewParameters[OnViewParameter::Third];
+            auto& fourthParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekThird);
+            }
+        } break;
+        case SelectMode::SeekThird: {
+            auto& fifthParam = onViewParameters[OnViewParameter::Fifth];
+            auto& sixthParam = onViewParameters[OnViewParameter::Sixth];
+
+            if (fifthParam->hasFinishedEditing && sixthParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekFourth);
+            }
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& seventh = onViewParameters[OnViewParameter::Seventh];
+
+            if (seventh->hasFinishedEditing) {
+                handler->setNextState(SelectMode::End);
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfEllipseController::addConstraints()
+{
+    App::DocumentObject* obj = handler->sketchgui->getObject();
+
+    int firstCurve = handler->ellipseGeoId;
+    int majorLine = firstCurve + 1;
+    int minorLine = firstCurve + 2;
+
+    double majorRadius = std::max(handler->firstRadius(), handler->secondRadius);
+    double minorRadius = std::min(handler->firstRadius(), handler->secondRadius);
+
+    using namespace Sketcher;
+
+    bool x0set = onViewParameters[OnViewParameter::First]->isSet;
+    bool y0set = onViewParameters[OnViewParameter::Second]->isSet;
+    bool majorRadiusSet = onViewParameters[OnViewParameter::Third]->isSet;
+    bool firstAxisSet = onViewParameters[OnViewParameter::Fourth]->isSet;
+    bool minorRadiusSet = onViewParameters[OnViewParameter::Fifth]->isSet;
+
+    auto constraintx0 = [&]() {
+        ConstraintToAttachment(
+            GeoElementId(firstCurve, PointPos::mid),
+            GeoElementId::VAxis,
+            handler->centerPoint.x,
+            obj
+        );
+    };
+
+    auto constrainty0 = [&]() {
+        ConstraintToAttachment(
+            GeoElementId(firstCurve, PointPos::mid),
+            GeoElementId::HAxis,
+            handler->centerPoint.y,
+            obj
+        );
+    };
+
+    auto constraintMajorRadius = [&]() {
+        Gui::cmdAppObjectArgs(
+            obj,
+            "addConstraint(Sketcher.Constraint('Distance',%d,%d,%d,%d,%f)) ",
+            majorLine,
+            1,
+            firstCurve,
+            3,
+            majorRadius
+        );
+    };
+
+    // we are constraining the first line not the major line as this is what the user inputs
+    auto constraintFirstAngle = [&]() {
+        Gui::cmdAppObjectArgs(
+            obj,
+            "addConstraint(Sketcher.Constraint('Angle',%d,%f)) ",
+            (majorRadius == handler->firstRadius()) ? majorLine : minorLine,
+            handler->firstAxis().Angle()
+        );
+    };
+
+    auto constraintMinorRadius = [&]() {
+        Gui::cmdAppObjectArgs(
+            obj,
+            "addConstraint(Sketcher.Constraint('Distance',%d,%d,%d,%d,%f)) ",
+            minorLine,
+            1,
+            firstCurve,
+            3,
+            minorRadius
+        );
+    };
+
+    if (handler->AutoConstraints.empty()) {  // No valid diagnosis. Every constraint can be added.
+        if (x0set && y0set && handler->centerPoint.IsNull(Precision::Confusion())) {
+            ConstraintToAttachment(GeoElementId(firstCurve, PointPos::mid), GeoElementId::RtPnt, 0., obj);
+        }
+        else {
+            if (x0set) {
+                constraintx0();
+            }
+
+            if (y0set) {
+                constrainty0();
+            }
+        }
+
+        if (majorRadiusSet) {
+            constraintMajorRadius();
+        }
+        if (firstAxisSet) {
+            constraintFirstAngle();
+        }
+
+        if (minorRadiusSet) {
+            constraintMinorRadius();
+        }
+    }
+    else {  // Valid diagnosis. Must check which constraints may be added.
+        auto centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+
+        if (x0set && centerPointInfo.isXDoF()) {
+            constraintx0();
+
+            handler->diagnoseWithAutoConstraints();  // ensure we have recalculated parameters after
+                                                     // each constraint addition
+            // get updated point position
+            centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+        }
+
+        if (y0set && centerPointInfo.isYDoF()) {
+            constrainty0();
+
+            handler->diagnoseWithAutoConstraints();  // ensure we have recalculated parameters after
+                                                     // each constraint addition
+            // get updated point position
+            centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+        }
+
+        centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+
+        int majorDoFs = handler->getLineDoFs(majorLine);
+
+        if (majorRadiusSet && majorDoFs > 0) {
+            constraintMajorRadius();
+            handler->diagnoseWithAutoConstraints();
+            majorDoFs = handler->getLineDoFs(majorLine);
+        }
+
+        if (firstAxisSet && majorDoFs > 0 && majorRadius == handler->firstRadius()) {
+            constraintFirstAngle();
+            handler->diagnoseWithAutoConstraints();
+        }
+
+        int minorDoFs = handler->getLineDoFs(minorLine);
+
+        if (minorRadiusSet && minorDoFs > 0) {
+            constraintMinorRadius();
+            handler->diagnoseWithAutoConstraints();
+            minorDoFs = handler->getLineDoFs(minorLine);
+        }
+
+        if (firstAxisSet && minorDoFs > 0 && majorRadius != handler->firstRadius()) {
+            constraintFirstAngle();
+        }
+    }
+}
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -52,7 +52,7 @@
 #include <algorithm>
 
 // Ellipse governing equation:
-// point(t) = origin + a * cos(angle) * aDir.x + b * sin(angle) * bDir.x;
+// point(t) = origin + majorRad * cos(t) * majorDir + minorRad * sin(t) * minorDir
 
 namespace SketcherGui
 {
@@ -84,7 +84,7 @@ public:
         , startAngle(0)
         , arcAngle(0)
         , valid(true)
-        , secondSet(false)
+        , secondRadiusSet(false)
         , ellipseGeoId(Sketcher::GeoEnum::GeoUndef)
     {}
 
@@ -157,7 +157,7 @@ private:
                     delta13.x * bDir.x + delta13.y * bDir.y
                 );
 
-                if (!secondSet) {
+                if (!secondRadiusSet) {
                     double cosT = std::max(-1.0, std::min(1.0, delta13Prime.x / a));
                     double sinT = std::sqrt(std::max(0.0, 1 - cosT * cosT));
 
@@ -211,7 +211,7 @@ private:
     void executeCommands() override
     {
         try {
-            openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch arc of hyperbola"));
+            openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch arc of ellipse"));
 
             ellipseGeoId = getHighestCurveIndex() + 1;
 
@@ -227,7 +227,7 @@ private:
             Gui::NotifyError(
                 sketchgui,
                 QT_TRANSLATE_NOOP("Notifications", "Error"),
-                QT_TRANSLATE_NOOP("Notifications", "Failed to add arc of hyperbola")
+                QT_TRANSLATE_NOOP("Notifications", "Failed to add arc of ellipse")
             );
 
             abortCommand();
@@ -364,20 +364,20 @@ private:
 private:
     Base::Vector2d centerPoint, axisPoint;
     double secondRadius, startAngle, arcAngle;
-    bool valid, secondSet;
+    bool valid, secondRadiusSet;
     int ellipseGeoId;
 
-    double firstRadius()
+    double firstRadius() const
     {
         return (centerPoint - axisPoint).Length();
     }
 
-    Base::Vector2d firstAxis()
+    Base::Vector2d firstAxis() const
     {
         return (axisPoint - centerPoint).Normalize();
     }
 
-    Base::Vector2d secondAxis()
+    Base::Vector2d secondAxis() const
     {
         return firstAxis().Rotate(std::numbers::pi / 2);
     }
@@ -392,7 +392,7 @@ private:
         double endAngle;
     };
 
-    Ellipse getEllipse()
+    Ellipse getEllipse() const
     {
         double ellipseStartAngle = (firstRadius() >= secondRadius)
             ? startAngle
@@ -520,9 +520,9 @@ void DSHArcOfEllipseController::doEnforceControlParameters(Base::Vector2d& onSke
 
             if (secondRadiusParam->isSet) {
                 secondRadius = secondRadiusParam->getValue();
-                handler->secondSet = true;
+                handler->secondRadiusSet = true;
                 if (secondRadius < Precision::Confusion() && secondRadiusParam->hasFinishedEditing) {
-                    handler->secondSet = false;
+                    handler->secondRadiusSet = false;
                     unsetOnViewParameter(secondRadiusParam.get());
                     return;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -128,7 +128,7 @@ private:
         switch (state()) {
             case SelectMode::SeekFirst: {
                 centerPoint = onSketchPos;
-                toolWidgetManager.drawDirectionAtCursor(onSketchPos, centerPoint);
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
                 seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
             } break;
             case SelectMode::SeekSecond: {
@@ -138,7 +138,7 @@ private:
                     break;
                 }
 
-                toolWidgetManager.drawDirectionAtCursor(onSketchPos, axisPoint);
+                toolWidgetManager.drawDirectionAtCursor(onSketchPos, centerPoint);
                 seekAndRenderAutoConstraint(
                     sugConstraints[1],
                     onSketchPos,
@@ -174,7 +174,7 @@ private:
                 }
 
                 startAngle = std::atan2(delta13Prime.y / secondRadius, delta13Prime.x / a);
-                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                toolWidgetManager.drawWidthHeightAtCursor(onSketchPos, firstRadius(), secondRadius);
                 seekAndRenderAutoConstraint(sugConstraints[2], onSketchPos, Base::Vector2d(0.f, 0.f));
             } break;
             case SelectMode::SeekFourth: {
@@ -198,7 +198,7 @@ private:
                     break;
                 }
 
-                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                toolWidgetManager.drawDoubleAtCursor(onSketchPos, arcAngle, Base::Unit::Angle);
                 seekAndRenderAutoConstraint(sugConstraints[3], onSketchPos, Base::Vector2d(0.f, 0.f));
             } break;
             default:
@@ -723,6 +723,7 @@ void DSHArcOfEllipseController::addConstraints()
     bool majorRadiusSet = onViewParameters[OnViewParameter::Third]->isSet;
     bool firstAxisSet = onViewParameters[OnViewParameter::Fourth]->isSet;
     bool minorRadiusSet = onViewParameters[OnViewParameter::Fifth]->isSet;
+    // cant constrain the angles
 
     auto constraintx0 = [&]() {
         ConstraintToAttachment(

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfEllipse.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
- *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *   
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
  *   Copyright (c) 2026 Loke S. Haugsnes <Lokesh@live.no>                  *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -132,7 +132,7 @@ private:
         switch (state()) {
             case SelectMode::SeekFirst: {
                 centerPoint = onSketchPos;
-                toolWidgetManager.drawDirectionAtCursor(onSketchPos, centerPoint);
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
                 seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
             } break;
             case SelectMode::SeekSecond: {
@@ -142,7 +142,7 @@ private:
                     break;
                 }
 
-                toolWidgetManager.drawDirectionAtCursor(onSketchPos, axisPoint);
+                toolWidgetManager.drawDirectionAtCursor(onSketchPos, centerPoint);
                 seekAndRenderAutoConstraint(
                     sugConstraints[1],
                     onSketchPos,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
- *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *   Copyright (c) 2026 Loke S. Haugsnes <Lokesh@live.no>                   *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -38,384 +38,84 @@
 #include "SnapManager.h"
 
 
+#include <Base/Tools.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/MainWindow.h>
+#include <Mod/Part/App/Geometry2d.h>
+
+
+#include "DrawSketchDefaultWidgetController.h"
+#include "DrawSketchControllableHandler.h"
+
+#include <vector>
+#include <algorithm>
+
+// Hyperbola governing equation:
+// point(t) = origin + majRad*cosh(t)*majorDir + minRad*sinh(t)*minorDir
+// Note that major radius can be less than minor radius, they are just the coefficients of the
+// parametric equation. But the major direction is always the direction with respect to which way
+// the hyperbola opens. This is different to how the more commonly known ellipse is defined.
+// Angles are hyperbolic angles not the same as circular angles, look it up for more info
+
 namespace SketcherGui
 {
 
 extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
-class DrawSketchHandlerArcOfHyperbola: public DrawSketchHandler
+class DrawSketchHandlerArcOfHyperbola;
+
+using DSHArcOfHyperbolaController = DrawSketchController<
+    DrawSketchHandlerArcOfHyperbola,
+    StateMachines::FourSeekEnd,
+    /*PAutoConstraintSize =*/4,
+    /*OnViewParametersT =*/OnViewParameters<7>>;
+
+using DrawSketchHandlerArcOfHyperbolaBase = DrawSketchControllableHandler<DSHArcOfHyperbolaController>;
+
+class DrawSketchHandlerArcOfHyperbola: public DrawSketchHandlerArcOfHyperbolaBase
 {
     Q_DECLARE_TR_FUNCTIONS(SketcherGui::DrawSketchHandlerArcOfHyperbola)
 
+    friend DSHArcOfHyperbolaController;
+
 public:
-    DrawSketchHandlerArcOfHyperbola()
-        : Mode(SelectMode::First)
-        , EditCurve(34)
-        , arcAngle(0)
+    explicit DrawSketchHandlerArcOfHyperbola()
+        : DrawSketchHandlerArcOfHyperbolaBase()
+        , centerPoint({0.0, 0.0})
+        , axisPoint({0.0, 0.0})
+        , minorRadius(0)
+        , startAngle(0)
+        , endAngle(0)
+        , valid(true)
+        , hyperbolaGeoId(Sketcher::GeoEnum::GeoUndef)
     {}
 
     ~DrawSketchHandlerArcOfHyperbola() override = default;
-    /// mode table
-    enum class SelectMode
-    {
-        First,
-        Second,
-        Third,
-        Fourth,
-        End
-    };
-
-    void mouseMove(SnapManager::SnapHandle snapHandle) override
-    {
-        Base::Vector2d onSketchPos = snapHandle.compute();
-        if (Mode == SelectMode::First) {
-            setPositionText(onSketchPos);
-            seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-        else if (Mode == SelectMode::Second) {
-            EditCurve[1] = onSketchPos;
-
-            // Display radius for user
-            float radius = (onSketchPos - centerPoint).Length();
-            if (showCursorCoords()) {
-                SbString text;
-                std::string radiusString = lengthToDisplayFormat(radius, 1);
-                text.sprintf(" (R%s, R%s)", radiusString.c_str(), radiusString.c_str());
-                setPositionText(onSketchPos, text);
-            }
-
-            drawEdit(EditCurve);
-            seekAndRenderAutoConstraint(
-                sugConstr2,
-                onSketchPos,
-                Base::Vector2d(0.f, 0.f),
-                AutoConstraint::CURVE
-            );
-        }
-        else if (Mode == SelectMode::Third) {
-            // angle between the major axis of the hyperbola and the X axis
-            Base::Vector2d delta12 = axisPoint - centerPoint;
-
-            double a = delta12.Length();
-            assert(
-                a > Precision::Confusion()
-                && "DrawSketchHandlerArcOfHyperbola: First and second point are at the same place"
-            );
-
-            Base::Vector2d aDir = delta12.Normalize();
-            Base::Vector2d bDir(-aDir.y, aDir.x);
-
-            Base::Vector2d delta13 = onSketchPos - centerPoint;
-            Base::Vector2d delta13Prime(
-                delta13.x * aDir.x + delta13.y * aDir.y,
-                delta13.x * bDir.x + delta13.y * bDir.y
-            );
-
-            // 0 if less than Precision::Confusion()
-            double b = getMinorRadius(onSketchPos);
-
-            double angleatpoint = 0;
-            if (b != 0) {
-                angleatpoint = atanh((delta13Prime.y * a) / (delta13Prime.x * b));
-            }
-
-            for (int i = 16; i >= -16; i--) {
-                // P(U) = O + MajRad*Cosh(U)*XDir + MinRad*Sinh(U)*YDir
-                double angle = i * angleatpoint / 16.0;
-                double rx = a * cosh(angle) * aDir.x + b * sinh(angle) * bDir.x;
-                double ry = a * cosh(angle) * aDir.y + b * sinh(angle) * bDir.y;
-                EditCurve[16 + i] = Base::Vector2d(centerPoint.x + rx, centerPoint.y + ry);
-            }
-
-            // Display radius for user
-            if (showCursorCoords()) {
-                SbString text;
-                std::string aString = lengthToDisplayFormat(a, 1);
-                std::string bString = lengthToDisplayFormat(b, 1);
-                text.sprintf(" (R%s, R%s)", aString.c_str(), bString.c_str());
-                setPositionText(onSketchPos, text);
-            }
-
-            if (b != 0) {
-                drawEdit(EditCurve);
-            }
-            else {
-                drawEdit(std::vector<Base::Vector2d>());
-            }
-
-            seekAndRenderAutoConstraint(sugConstr3, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-        else if (Mode == SelectMode::Fourth) {
-            // angle between the major axis of the hyperbola and the X axis
-            Base::Vector2d delta12 = axisPoint - centerPoint;
-
-            double a = delta12.Length();
-            assert(
-                a > Precision::Confusion()
-                && "DrawSketchHandlerArcOfHyperbola: First and second point are at the same place"
-            );
-
-            Base::Vector2d aDir = delta12.Normalize();
-            Base::Vector2d bDir(-aDir.y, aDir.x);
-
-            Base::Vector2d delta13 = startingPoint - centerPoint;
-            Base::Vector2d delta13Prime(
-                delta13.x * aDir.x + delta13.y * aDir.y,
-                delta13.x * bDir.x + delta13.y * bDir.y
-            );
-
-            double b = getMinorRadius(startingPoint);
-            assert(
-                b > Precision::Confusion() && "DrawSketchHandlerArcOfHyperbola: Minor radius was unexpectedly set to invalid value"
-            );
-
-            double startAngle = atanh((delta13Prime.y * a) / (delta13Prime.x * b));
-
-            Base::Vector2d delta14 = onSketchPos - centerPoint;
-            Base::Vector2d delta14Prime(
-                delta14.x * aDir.x + delta14.y * aDir.y,
-                delta14.x * bDir.x + delta14.y * bDir.y
-            );
-
-            double angleatpoint = atanh((delta14Prime.y * a) / (delta14Prime.x * b));
-
-            arcAngle = angleatpoint - startAngle;
-
-            if (std::abs((delta14Prime.y * a) / (delta14Prime.x * b)) > 1) {
-                arcAngle = 0;
-            }
-
-            for (int i = 0; i < 33; i++) {
-                // P(U) = O + MajRad*Cosh(U)*XDir + MinRad*Sinh(U)*YDir
-                double angle = startAngle + i * arcAngle / 32.0;
-                double rx = a * cosh(angle) * aDir.x + b * sinh(angle) * bDir.x;
-                double ry = a * cosh(angle) * aDir.y + b * sinh(angle) * bDir.y;
-                EditCurve[i] = Base::Vector2d(centerPoint.x + rx, centerPoint.y + ry);
-            }
-
-            // Display radius for user
-            if (showCursorCoords()) {
-                SbString text;
-                std::string aString = lengthToDisplayFormat(a, 1);
-                std::string bString = lengthToDisplayFormat(b, 1);
-                std::string arcAngleString = angleToDisplayFormat(Base::toDegrees(arcAngle), 1);
-                text.sprintf(" (R%s, R%s, %s)", aString.c_str(), bString.c_str(), arcAngleString.c_str());
-                setPositionText(onSketchPos, text);
-            }
-
-            drawEdit(EditCurve);
-            seekAndRenderAutoConstraint(sugConstr4, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-    }
-
-    bool pressButton(Base::Vector2d onSketchPos) override
-    {
-        if (Mode == SelectMode::First) {
-            EditCurve[0] = onSketchPos;
-            centerPoint = onSketchPos;
-            EditCurve.resize(2);
-            Mode = SelectMode::Second;
-        }
-        else if (
-            Mode == SelectMode::Second && (centerPoint - onSketchPos).Length() > Precision::Confusion()
-        ) {
-            EditCurve[1] = onSketchPos;
-            axisPoint = onSketchPos;
-            EditCurve.resize(33);
-            Mode = SelectMode::Third;
-        }
-        else if (Mode == SelectMode::Third && getMinorRadius(onSketchPos) > Precision::Confusion()) {
-            startingPoint = onSketchPos;
-            arcAngle = 0.;
-            Mode = SelectMode::Fourth;
-        }
-        else if (Mode == SelectMode::Fourth && arcAngle != 0) {
-            endPoint = onSketchPos;
-
-            Mode = SelectMode::End;
-        }
-
-        updateHint();
-        return true;
-    }
-
-    bool releaseButton(Base::Vector2d /*onSketchPos*/) override
-    {
-        if (Mode == SelectMode::End) {
-            unsetCursor();
-            resetPositionText();
-
-            Base::Vector2d delta12 = axisPoint - centerPoint;
-
-            double a = delta12.Length();
-
-            Base::Vector2d aDir = delta12.Normalize();
-            Base::Vector2d bDir(-aDir.y, aDir.x);
-
-            Base::Vector2d delta13 = startingPoint - centerPoint;
-            Base::Vector2d delta13Prime(
-                delta13.x * aDir.x + delta13.y * aDir.y,
-                delta13.x * bDir.x + delta13.y * bDir.y
-            );
-
-            double b = getMinorRadius(startingPoint);
-
-            double startAngle = atanh((delta13Prime.y * a) / (delta13Prime.x * b));
-
-            Base::Vector2d delta14 = endPoint - centerPoint;
-            Base::Vector2d delta14Prime(
-                delta14.x * aDir.x + delta14.y * aDir.y,
-                delta14.x * bDir.x + delta14.y * bDir.y
-            );
-            double endAngle = atanh((delta14Prime.y * a) / (delta14Prime.x * b));
-
-            bool isOriginalArcCCW = true;
-
-            if (endAngle < startAngle) {
-                std::swap(startAngle, endAngle);
-                isOriginalArcCCW = false;
-            }
-
-            Base::Vector2d minAxisPoint, majAxisPoint;
-            // We always create a CCW hyperbola, because we want our XY reference system to be in
-            // the +X +Y direction Our normal will then always be in the +Z axis (local +Z axis of
-            // the sketcher)
-            majAxisPoint = centerPoint + (aDir * a);
-            minAxisPoint = centerPoint + (bDir * b);
-
-            int currentgeoid = getHighestCurveIndex();
-
-            try {
-
-                openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch arc of hyperbola"));
-
-                // Add arc of hyperbola, point and constrain point as focus2. We add focus2 for it
-                // to balance the intrinsic focus1, in order to balance out the intrinsic invisible
-                // focus1 when AOE is dragged by its center
-                Gui::cmdAppObjectArgs(
-                    sketchgui->getObject(),
-                    "addGeometry(Part.ArcOfHyperbola"
-                    "(Part.Hyperbola(App.Vector(%f,%f,0),App.Vector(%f,%f,0),App."
-                    "Vector(%f,%f,0)),%f,%f),%s)",
-                    majAxisPoint.x,
-                    majAxisPoint.y,
-                    minAxisPoint.x,
-                    minAxisPoint.y,
-                    centerPoint.x,
-                    centerPoint.y,
-                    startAngle,
-                    endAngle,
-                    constructionModeAsBooleanText()
-                );
-
-                currentgeoid++;
-
-                Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
-            }
-            catch (const Base::Exception&) {
-                Gui::NotifyError(
-                    sketchgui,
-                    QT_TRANSLATE_NOOP("Notifications", "Error"),
-                    QT_TRANSLATE_NOOP("Notifications", "Cannot create arc of hyperbola")
-                );
-                abortCommand();
-
-                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
-
-                return false;
-            }
-
-            commitCommand();
-
-            // add auto constraints for the center point
-            if (!sugConstr1.empty()) {
-                createAutoConstraints(sugConstr1, currentgeoid, Sketcher::PointPos::mid);
-                sugConstr1.clear();
-            }
-
-            // add suggested constraints for arc
-            if (!sugConstr2.empty()) {
-                createAutoConstraints(sugConstr2, currentgeoid, Sketcher::PointPos::none);
-                sugConstr2.clear();
-            }
-
-            // add suggested constraints for start of arc
-            if (!sugConstr3.empty()) {
-                createAutoConstraints(
-                    sugConstr3,
-                    currentgeoid,
-                    isOriginalArcCCW ? Sketcher::PointPos::start : Sketcher::PointPos::end
-                );
-                sugConstr3.clear();
-            }
-
-            // add suggested constraints for start of arc
-            if (!sugConstr4.empty()) {
-                createAutoConstraints(
-                    sugConstr4,
-                    currentgeoid,
-                    isOriginalArcCCW ? Sketcher::PointPos::end : Sketcher::PointPos::start
-                );
-                sugConstr4.clear();
-            }
-
-            tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
-
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-                "User parameter:BaseApp/Preferences/Mod/Sketcher"
-            );
-            bool continuousMode = hGrp->GetBool("ContinuousCreationMode", true);
-
-            if (continuousMode) {
-                // This code enables the continuous creation mode.
-                Mode = SelectMode::First;
-                EditCurve.clear();
-                drawEdit(EditCurve);
-                EditCurve.resize(34);
-                applyCursor();
-                /* It is ok not to call to purgeHandler
-                 * in continuous creation mode because the
-                 * handler is destroyed by the quit() method on pressing the
-                 * right button of the mouse */
-            }
-            else {
-                sketchgui->purgeHandler();  // no code after this line, Handler get deleted in
-                                            // ViewProvider
-            }
-        }
-        updateHint();
-        return true;
-    }
 
 private:
-    QString getCrosshairCursorSVGName() const override
-    {
-        return QStringLiteral("Sketcher_Pointer_Create_ArcOfHyperbola");
-    }
-
     std::list<Gui::InputHint> getToolHints() const override
     {
         using enum Gui::InputHint::UserInput;
 
         return Gui::lookupHints<SelectMode>(
-            Mode,
+            state(),
             {
-                {.state = SelectMode::First,
+                {.state = SelectMode::SeekFirst,
                  .hints =
                      {
                          {tr("%1 pick center point"), {MouseLeft}},
                      }},
-                {.state = SelectMode::Second,
+                {.state = SelectMode::SeekSecond,
                  .hints =
                      {
                          {tr("%1 pick axis point"), {MouseLeft}},
                      }},
-                {.state = SelectMode::Third,
+                {.state = SelectMode::SeekThird,
                  .hints =
                      {
                          {tr("%1 pick arc start point"), {MouseLeft}},
                      }},
-                {.state = SelectMode::Fourth,
+                {.state = SelectMode::SeekFourth,
                  .hints =
                      {
                          {tr("%1 pick arc end point"), {MouseLeft}},
@@ -423,34 +123,703 @@ private:
             });
     }
 
-    double getMinorRadius(const Base::Vector2d& onSketchPos)
+    void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
     {
-        Base::Vector2d delta12 = axisPoint - centerPoint;
+        using std::numbers::pi;
+        valid = true;
+        switch (state()) {
+            case SelectMode::SeekFirst: {
+                centerPoint = onSketchPos;
+                toolWidgetManager.drawDirectionAtCursor(onSketchPos, centerPoint);
+                seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            case SelectMode::SeekSecond: {
+                axisPoint = onSketchPos;
+                if ((axisPoint - centerPoint).Length() < Precision::Confusion()) {
+                    valid = false;
+                    break;
+                }
 
-        double a = delta12.Length();
+                toolWidgetManager.drawDirectionAtCursor(onSketchPos, axisPoint);
+                seekAndRenderAutoConstraint(
+                    sugConstraints[1],
+                    onSketchPos,
+                    Base::Vector2d(0.f, 0.f),
+                    AutoConstraint::CURVE
+                );
+            } break;
+            case SelectMode::SeekThird: {
+                double a = majorRadius();
 
-        Base::Vector2d aDir = delta12.Normalize();
-        Base::Vector2d bDir(-aDir.y, aDir.x);
+                Base::Vector2d aDir = majorAxis();
+                Base::Vector2d bDir = minorAxis();
 
-        Base::Vector2d delta13 = onSketchPos - centerPoint;
-        Base::Vector2d delta13Prime(
-            delta13.x * aDir.x + delta13.y * aDir.y,
-            delta13.x * bDir.x + delta13.y * bDir.y
-        );
+                Base::Vector2d delta13 = onSketchPos - centerPoint;
+                Base::Vector2d delta13Prime(
+                    delta13.x * aDir.x + delta13.y * aDir.y,
+                    delta13.x * bDir.x + delta13.y * bDir.y
+                );
+                if (abs(delta13Prime.y) < Precision::Confusion()) {
+                    valid = false;
+                    break;
+                }
 
-        double denom = (delta13Prime.x * delta13Prime.x) / (a * a) - 1.0;
-        if (denom <= Precision::Confusion()) {
-            return 0;
+                double denom = (delta13Prime.x * delta13Prime.x) / (a * a) - 1.0;
+                if (denom < Precision::Confusion()) {
+                    valid = false;
+                    break;
+                }
+                minorRadius = std::sqrt((delta13Prime.y * delta13Prime.y) / denom);
+                startAngle = atanh((delta13Prime.y * a) / (delta13Prime.x * minorRadius));
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                seekAndRenderAutoConstraint(sugConstraints[2], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            case SelectMode::SeekFourth: {
+                Base::Vector2d aDir = majorAxis();
+                Base::Vector2d bDir = minorAxis();
+                Base::Vector2d delta14 = onSketchPos - centerPoint;
+                Base::Vector2d delta14Prime(
+                    delta14.x * aDir.x + delta14.y * aDir.y,
+                    delta14.x * bDir.x + delta14.y * bDir.y
+                );
+
+                if (std::abs((delta14Prime.y * majorRadius()) / (delta14Prime.x * minorRadius)) > 1) {
+                    valid = false;
+                    break;
+                }
+                endAngle = atanh((delta14Prime.y * majorRadius()) / (delta14Prime.x * minorRadius));
+                if (abs(getArcAngle()) < Precision::Confusion()) {
+                    valid = false;
+                    break;
+                }
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                seekAndRenderAutoConstraint(sugConstraints[3], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            default:
+                return;
         }
-        return std::sqrt((delta13Prime.y * delta13Prime.y) / denom);
+
+        CreateAndDrawShapeGeometry();
     }
 
-protected:
-    SelectMode Mode;
-    std::vector<Base::Vector2d> EditCurve;
-    Base::Vector2d centerPoint, axisPoint, startingPoint, endPoint;
-    double arcAngle;
-    std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
+    void executeCommands() override
+    {
+        try {
+            openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch arc of hyperbola"));
+
+            hyperbolaGeoId = getHighestCurveIndex() + 1;
+
+            createShape(true);
+
+            commandAddShapeGeometryAndConstraints();
+
+            Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", hyperbolaGeoId);
+
+            commitCommand();
+        }
+        catch (const Base::Exception&) {
+            Gui::NotifyError(
+                sketchgui,
+                QT_TRANSLATE_NOOP("Notifications", "Error"),
+                QT_TRANSLATE_NOOP("Notifications", "Failed to add arc of hyperbola")
+            );
+
+            abortCommand();
+            THROWM(
+                Base::RuntimeError,
+                QT_TRANSLATE_NOOP(
+                    "Notifications",
+                    "Tool execution aborted"
+                ) "\n"
+            )  // This prevents constraints from being
+               // applied on non existing geometry
+        }
+    }
+
+    void generateAutoConstraints() override
+    {
+        auto& ac1 = sugConstraints[0];
+        auto& ac2 = sugConstraints[1];
+        auto& ac3 = sugConstraints[2];
+        auto& ac4 = sugConstraints[3];
+
+        if (!ac1.empty()) {
+            generateAutoConstraintsOnElement(ac1, hyperbolaGeoId, Sketcher::PointPos::mid);
+        }
+
+        if (!ac2.empty()) {
+            generateAutoConstraintsOnElement(ac2, hyperbolaGeoId, Sketcher::PointPos::none);
+        }
+
+        if (!ac3.empty()) {
+            generateAutoConstraintsOnElement(
+                ac3,
+                hyperbolaGeoId,
+                (getArcAngle() > 0) ? Sketcher::PointPos::start : Sketcher::PointPos::end
+            );
+        }
+
+        if (!ac4.empty()) {
+            generateAutoConstraintsOnElement(
+                ac4,
+                hyperbolaGeoId,
+                (getArcAngle() > 0) ? Sketcher::PointPos::end : Sketcher::PointPos::start
+            );
+        }
+
+        // Ensure temporary autoconstraints do not generate a redundancy and that the geometry
+        // parameters are accurate This is particularly important for adding widget mandated
+        // constraints.
+        removeRedundantAutoConstraints();
+    }
+
+    void createAutoConstraints() override
+    {
+        // execute python command to create autoconstraints
+        createGeneratedAutoConstraints(true);
+
+        sugConstraints[0].clear();
+        sugConstraints[1].clear();
+        sugConstraints[2].clear();
+        sugConstraints[3].clear();
+    }
+
+    std::string getToolName() const override
+    {
+        return "DSH_ArcOfHyperbola";
+    }
+
+    QString getCrosshairCursorSVGName() const override
+    {
+        return QStringLiteral("Sketcher_Pointer_Create_ArcOfHyperbola");
+    }
+
+    QPixmap getToolIcon() const override
+    {
+        return Gui::BitmapFactory().pixmap("Sketcher_CreateHyperbolic_Arc");
+    }
+
+    bool canGoToNextMode() override
+    {
+        if (!valid) {
+            return false;
+        }
+        return true;
+    }
+
+    void angleSnappingControl() override
+    {
+        setAngleSnapping(false);
+    }
+
+    void createShape(bool onlyeditoutline) override
+    {
+        ShapeGeometry.clear();
+
+        if (!valid) {
+            return;
+        }
+
+        if (state() == SelectMode::SeekSecond) {
+            addLineToShapeGeometry(toVector3d(centerPoint), toVector3d(axisPoint), isConstructionMode());
+        }
+
+        // Idea to help user see the boundary of the hyperbola
+        // if (state() == SelectMode::SeekThird || state() == SelectMode::SeekFourth) {
+        //    addLineToShapeGeometry(
+        //        toVector3d(centerPoint),
+        //        toVector3d(axisPoint + minorAxis() * minorRadius),
+        //        true
+        //    );
+        //
+        //    addLineToShapeGeometry(
+        //        toVector3d(centerPoint),
+        //        toVector3d(axisPoint - minorAxis() * minorRadius),
+        //        true
+        //    );
+        //}
+
+        if (state() == SelectMode::SeekThird) {
+            addArcOfHyperbolaToShapeGeometry(
+                toVector3d(centerPoint),
+                toVector3d(majorAxis()),
+                majorRadius(),
+                minorRadius,
+                startAngle,
+                -startAngle,
+                isConstructionMode()
+            );
+        }
+
+        if (state() == SelectMode::SeekFourth || state() == SelectMode::End) {
+            addArcOfHyperbolaToShapeGeometry(
+                toVector3d(centerPoint),
+                toVector3d(majorAxis()),
+                majorRadius(),
+                minorRadius,
+                (startAngle < endAngle) ? startAngle : endAngle,
+                (startAngle < endAngle) ? endAngle : startAngle,
+                isConstructionMode()
+            );
+        }
+    }
+
+private:
+    Base::Vector2d centerPoint, axisPoint;
+    double minorRadius, startAngle, endAngle;
+    bool valid;
+    int hyperbolaGeoId;
+
+    double majorRadius()
+    {
+        return (centerPoint - axisPoint).Length();
+    }
+
+    Base::Vector2d majorAxis()
+    {
+        return (axisPoint - centerPoint).Normalize();
+    }
+
+    Base::Vector2d minorAxis()
+    {
+        return majorAxis().Rotate(std::numbers::pi / 2);
+    }
+
+    double getArcAngle()
+    {
+        return endAngle - startAngle;
+    }
 };
+
+template<>
+auto DSHArcOfHyperbolaController::getState(int labelindex) const
+{
+    switch (labelindex) {
+        case OnViewParameter::First:
+        case OnViewParameter::Second:
+            return SelectMode::SeekFirst;
+            break;
+        case OnViewParameter::Third:
+        case OnViewParameter::Fourth:
+            return SelectMode::SeekSecond;
+            break;
+        case OnViewParameter::Fifth:
+        case OnViewParameter::Sixth:
+            return SelectMode::SeekThird;
+            break;
+        case OnViewParameter::Seventh:
+            return SelectMode::SeekFourth;
+            break;
+        default:
+            THROWM(Base::ValueError, "OnViewParameter index without an associated machine state")
+    }
+}
+
+template<>
+void DSHArcOfHyperbolaController::configureOnViewParameters()
+{
+    onViewParameters[OnViewParameter::First]->setLabelType(Gui::SoDatumLabel::DISTANCEX);
+    onViewParameters[OnViewParameter::Second]->setLabelType(Gui::SoDatumLabel::DISTANCEY);
+
+    onViewParameters[OnViewParameter::Third]->setLabelType(
+        Gui::SoDatumLabel::RADIUS,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+    onViewParameters[OnViewParameter::Fourth]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+
+    onViewParameters[OnViewParameter::Fifth]->setLabelType(
+        Gui::SoDatumLabel::DISTANCE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+
+    // not real angle but hyperbolic angle
+    onViewParameters[OnViewParameter::Sixth]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+
+    onViewParameters[OnViewParameter::Seventh]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+}
+
+template<>
+void DSHArcOfHyperbolaController::doEnforceControlParameters(Base::Vector2d& onSketchPos)
+{
+    handler->updateDataAndDrawToPosition(
+        onSketchPos
+    );  // ensure that the member variables are updated to date values before enforcing parameters
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (firstParam->isSet) {
+                onSketchPos.x = firstParam->getValue();
+            }
+
+            if (secondParam->isSet) {
+                onSketchPos.y = secondParam->getValue();
+            }
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& firstRadiusParam = onViewParameters[OnViewParameter::Third];
+            auto& angleParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (!firstRadiusParam->isSet && !angleParam->isSet) {
+                return;
+            }
+
+            double majorRadius = handler->majorRadius();
+            auto majorAxis = handler->majorAxis();
+
+            if (firstRadiusParam->isSet) {
+                majorRadius = firstRadiusParam->getValue();
+                if (majorRadius < Precision::Confusion() && firstRadiusParam->hasFinishedEditing) {
+                    unsetOnViewParameter(firstRadiusParam.get());
+                    return;
+                }
+            }
+
+            if (angleParam->isSet) {
+                double angle = Base::toRadians(angleParam->getValue());
+                majorAxis = {cos(angle), sin(angle)};
+            }
+
+            onSketchPos = handler->centerPoint + majorRadius * majorAxis;
+        } break;
+        case SelectMode::SeekThird: {
+            auto& secondRadiusParam = onViewParameters[OnViewParameter::Fifth];
+            auto& startAngleParam = onViewParameters[OnViewParameter::Sixth];
+
+            if (!secondRadiusParam->isSet && !startAngleParam->isSet) {
+                return;
+            }
+
+            double minorRadius = handler->minorRadius;
+            auto startAngle = handler->startAngle;
+
+            if (secondRadiusParam->isSet) {
+                minorRadius = secondRadiusParam->getValue();
+                if (minorRadius < Precision::Confusion() && secondRadiusParam->hasFinishedEditing) {
+                    unsetOnViewParameter(secondRadiusParam.get());
+                    return;
+                }
+            }
+
+            if (startAngleParam->isSet) {
+                startAngle = startAngleParam->getValue();
+            }
+
+            onSketchPos = handler->centerPoint
+                + handler->majorRadius() * std::cosh(startAngle) * handler->majorAxis()
+                + minorRadius * std::sinh(startAngle) * handler->minorAxis();
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& arcAngleParam = onViewParameters[OnViewParameter::Seventh];
+
+            if (!arcAngleParam->isSet) {
+                return;
+            }
+
+            double arcAngle = -arcAngleParam->getValue();
+
+            double endAngle = handler->startAngle - arcAngle;
+
+            double xPrime = handler->majorRadius() * std::cosh(endAngle);
+            double yPrime = handler->minorRadius * std::sinh(endAngle);
+
+            Base::Vector2d delta = handler->majorAxis() * xPrime + handler->minorAxis() * yPrime;
+
+            onSketchPos = handler->centerPoint + delta;
+
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfHyperbolaController::adaptParameters(Base::Vector2d onSketchPos)
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (!firstParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
+            }
+
+            if (!secondParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
+            }
+
+            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+            firstParam->setLabelAutoDistanceReverse(!sameSign);
+            secondParam->setLabelAutoDistanceReverse(sameSign);
+            firstParam->setPoints(Base::Vector3d(), toVector3d(onSketchPos));
+            secondParam->setPoints(Base::Vector3d(), toVector3d(onSketchPos));
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& firstRadiusParam = onViewParameters[OnViewParameter::Third];
+            auto& angleParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (!firstRadiusParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::Third, handler->majorRadius());
+            }
+
+            if (!angleParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Fourth,
+                    Base::toDegrees(handler->majorAxis().Angle()),
+                    Base::Unit::Angle
+                );
+            }
+
+            Base::Vector3d start = toVector3d(handler->centerPoint);
+            Base::Vector3d end = toVector3d(onSketchPos);
+
+            firstRadiusParam->setPoints(start, end);
+            angleParam->setPoints(start, Base::Vector3d());
+            angleParam->setLabelRange(handler->majorAxis().Angle());
+        } break;
+        case SelectMode::SeekThird: {
+            auto& secondRadiusParam = onViewParameters[OnViewParameter::Fifth];
+            auto& startAngleParam = onViewParameters[OnViewParameter::Sixth];
+
+            if (!secondRadiusParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Fifth,
+                    handler->valid ? handler->minorRadius : 0
+                );
+            }
+
+            if (!startAngleParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Sixth,
+                    handler->valid ? handler->startAngle : 0,
+                    Base::Unit::One
+                );
+            }
+
+            Base::Vector3d start = toVector3d(handler->axisPoint);
+
+            startAngleParam->setPoints(start, Base::Vector3d());
+            startAngleParam->setLabelStartAngle(handler->majorAxis().Angle());
+            startAngleParam->setLabelRange(0);
+            secondRadiusParam->setPoints(
+                start,
+                start
+                    + toVector3d(
+                        handler->minorAxis()
+                        * (handler->minorRadius * (handler->startAngle > 0) - (handler->startAngle < 0))
+                    )
+            );
+            if (!handler->valid) {
+                secondRadiusParam->setPoints(start, start);
+            }
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& arcAngleParam = onViewParameters[OnViewParameter::Seventh];
+
+            if (!arcAngleParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::Seventh, handler->getArcAngle(), Base::Unit::One);
+            }
+
+            Base::Vector3d start = toVector3d(handler->axisPoint);
+
+            arcAngleParam->setPoints(start, Base::Vector3d());
+            arcAngleParam->setLabelStartAngle(handler->majorAxis().Angle());
+            arcAngleParam->setLabelRange(0);
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfHyperbolaController::computeNextDrawSketchHandlerMode()
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (firstParam->hasFinishedEditing && secondParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekSecond);
+            }
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& thirdParam = onViewParameters[OnViewParameter::Third];
+            auto& fourthParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekThird);
+            }
+        } break;
+        case SelectMode::SeekThird: {
+            auto& fifthParam = onViewParameters[OnViewParameter::Fifth];
+            auto& sixthParam = onViewParameters[OnViewParameter::Sixth];
+
+            if (fifthParam->hasFinishedEditing && sixthParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekFourth);
+            }
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& seventh = onViewParameters[OnViewParameter::Seventh];
+
+            if (seventh->hasFinishedEditing) {
+                handler->setNextState(SelectMode::End);
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfHyperbolaController::addConstraints()
+{
+    App::DocumentObject* obj = handler->sketchgui->getObject();
+
+    int firstCurve = handler->hyperbolaGeoId;
+    int majorLine = firstCurve + 1;
+    int minorLine = firstCurve + 2;
+    int point = firstCurve + 3;
+
+    using namespace Sketcher;
+
+    auto x0set = onViewParameters[OnViewParameter::First]->isSet;
+    auto y0set = onViewParameters[OnViewParameter::Second]->isSet;
+    auto majorRadiusSet = onViewParameters[OnViewParameter::Third]->isSet;
+    auto majorAxisSet = onViewParameters[OnViewParameter::Fourth]->isSet;
+    auto minorRadiusSet = onViewParameters[OnViewParameter::Fifth]->isSet;
+    // can't constrain the hyperbolic angle.
+
+    auto constraintx0 = [&]() {
+        ConstraintToAttachment(
+            GeoElementId(firstCurve, PointPos::mid),
+            GeoElementId::VAxis,
+            handler->centerPoint.x,
+            obj
+        );
+    };
+
+    auto constrainty0 = [&]() {
+        ConstraintToAttachment(
+            GeoElementId(firstCurve, PointPos::mid),
+            GeoElementId::HAxis,
+            handler->centerPoint.y,
+            obj
+        );
+    };
+
+    auto constraintMajorRadius = [&]() {
+        Gui::cmdAppObjectArgs(
+            obj,
+            "addConstraint(Sketcher.Constraint('Distance',%d,%d,%d,%d,%f)) ",
+            firstCurve,
+            3,
+            majorLine,
+            1,
+            handler->majorRadius()
+        );
+    };
+
+    auto constraintMajorAngle = [&]() {
+        Gui::cmdAppObjectArgs(
+            obj,
+            "addConstraint(Sketcher.Constraint('Angle',%d,%f)) ",
+            majorLine,
+            handler->majorAxis().Angle() - std::numbers::pi  // the major line is reversed compared
+                                                             // to how the input looks like
+        );
+    };
+
+    auto constraintMinorRadius = [&]() {
+        Gui::cmdAppObjectArgs(
+            obj,
+            "addConstraint(Sketcher.Constraint('Distance',%d,%d,%d,%d,%f)) ",
+            majorLine,
+            1,
+            minorLine,
+            1,
+            handler->minorRadius
+        );
+    };
+
+    if (handler->AutoConstraints.empty()) {  // No valid diagnosis. Every constraint can be added.
+        if (x0set && y0set && handler->centerPoint.IsNull(Precision::Confusion())) {
+            ConstraintToAttachment(GeoElementId(firstCurve, PointPos::mid), GeoElementId::RtPnt, 0., obj);
+        }
+        else {
+            if (x0set) {
+                constraintx0();
+            }
+
+            if (y0set) {
+                constrainty0();
+            }
+        }
+
+        if (majorRadiusSet) {
+            constraintMajorRadius();
+        }
+        if (majorAxisSet) {
+            constraintMajorAngle();
+        }
+
+        if (minorRadiusSet) {
+            constraintMinorRadius();
+        }
+    }
+    else {  // Valid diagnosis. Must check which constraints may be added.
+        auto centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+
+        if (x0set && centerPointInfo.isXDoF()) {
+            constraintx0();
+
+            handler->diagnoseWithAutoConstraints();  // ensure we have recalculated parameters after
+                                                     // each constraint addition
+            // get updated point position
+            centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+        }
+
+        if (y0set && centerPointInfo.isYDoF()) {
+            constrainty0();
+
+            handler->diagnoseWithAutoConstraints();  // ensure we have recalculated parameters after
+                                                     // each constraint addition
+            // get updated point position
+            centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+        }
+
+        centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+
+        int majorDoFs = handler->getLineDoFs(majorLine);
+
+        if (majorRadiusSet && majorDoFs > 0) {
+            constraintMajorRadius();
+            handler->diagnoseWithAutoConstraints();
+            majorDoFs = handler->getLineDoFs(majorDoFs);
+        }
+
+        if (majorAxisSet && majorDoFs > 0) {
+            constraintMajorAngle();
+            handler->diagnoseWithAutoConstraints();
+        }
+
+        int minorDoFs = handler->getLineDoFs(minorLine);
+
+        if (minorRadiusSet && minorDoFs > 0) {
+            constraintMinorRadius();
+        }
+    }
+}
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 /***************************************************************************
- *   Copyright (c) 2026 Loke S. Haugsnes <Lokesh@live.no>                   *
+ *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *   Copyright (c) 2026 Loke S. Haugsnes <Lokesh@live.no>                  *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -806,7 +807,7 @@ void DSHArcOfHyperbolaController::addConstraints()
         if (majorRadiusSet && majorDoFs > 0) {
             constraintMajorRadius();
             handler->diagnoseWithAutoConstraints();
-            majorDoFs = handler->getLineDoFs(majorDoFs);
+            majorDoFs = handler->getLineDoFs(majorLine);
         }
 
         if (majorAxisSet && majorDoFs > 0) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -624,7 +624,8 @@ void DSHArcOfHyperbolaController::adaptParameters(Base::Vector2d onSketchPos)
                 start
                     + toVector3d(
                         handler->minorAxis()
-                        * (handler->minorRadius * ((handler->startAngle > 0) - (handler->startAngle < 0)))
+                        * (handler->minorRadius
+                           * ((handler->startAngle > 0) - (handler->startAngle < 0)))
                     )
             );
             if (!handler->valid) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -319,6 +319,8 @@ private:
 
     void createShape(bool onlyeditoutline) override
     {
+        Q_UNUSED(onlyeditoutline);
+
         ShapeGeometry.clear();
 
         if (!valid) {
@@ -698,7 +700,7 @@ void DSHArcOfHyperbolaController::addConstraints()
     int firstCurve = handler->hyperbolaGeoId;
     int majorLine = firstCurve + 1;
     int minorLine = firstCurve + 2;
-    int point = firstCurve + 3;
+    // int point = firstCurve + 3;
 
     using namespace Sketcher;
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfHyperbola.h
@@ -88,6 +88,7 @@ public:
         , startAngle(0)
         , endAngle(0)
         , valid(true)
+        , minorRadiusSet(false)
         , hyperbolaGeoId(Sketcher::GeoEnum::GeoUndef)
     {}
 
@@ -160,17 +161,20 @@ private:
                     delta13.x * aDir.x + delta13.y * aDir.y,
                     delta13.x * bDir.x + delta13.y * bDir.y
                 );
-                if (abs(delta13Prime.y) < Precision::Confusion()) {
-                    valid = false;
-                    break;
-                }
 
-                double denom = (delta13Prime.x * delta13Prime.x) / (a * a) - 1.0;
-                if (denom < Precision::Confusion()) {
-                    valid = false;
-                    break;
+                if (!minorRadiusSet) {
+                    if (abs(delta13Prime.y) < Precision::Confusion()) {
+                        valid = false;
+                        break;
+                    }
+
+                    double denom = (delta13Prime.x * delta13Prime.x) / (a * a) - 1.0;
+                    if (denom < Precision::Confusion()) {
+                        valid = false;
+                        break;
+                    }
+                    minorRadius = std::sqrt((delta13Prime.y * delta13Prime.y) / denom);
                 }
-                minorRadius = std::sqrt((delta13Prime.y * delta13Prime.y) / denom);
                 startAngle = atanh((delta13Prime.y * a) / (delta13Prime.x * minorRadius));
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
                 seekAndRenderAutoConstraint(sugConstraints[2], onSketchPos, Base::Vector2d(0.f, 0.f));
@@ -340,7 +344,7 @@ private:
         //    );
         //}
 
-        if (state() == SelectMode::SeekThird) {
+        if (state() == SelectMode::SeekThird && std::abs(startAngle) > Precision::Confusion()) {
             addArcOfHyperbolaToShapeGeometry(
                 toVector3d(centerPoint),
                 toVector3d(majorAxis()),
@@ -368,25 +372,25 @@ private:
 private:
     Base::Vector2d centerPoint, axisPoint;
     double minorRadius, startAngle, endAngle;
-    bool valid;
+    bool valid, minorRadiusSet;
     int hyperbolaGeoId;
 
-    double majorRadius()
+    double majorRadius() const
     {
         return (centerPoint - axisPoint).Length();
     }
 
-    Base::Vector2d majorAxis()
+    Base::Vector2d majorAxis() const
     {
         return (axisPoint - centerPoint).Normalize();
     }
 
-    Base::Vector2d minorAxis()
+    Base::Vector2d minorAxis() const
     {
         return majorAxis().Rotate(std::numbers::pi / 2);
     }
 
-    double getArcAngle()
+    double getArcAngle() const noexcept
     {
         return endAngle - startAngle;
     }
@@ -506,7 +510,9 @@ void DSHArcOfHyperbolaController::doEnforceControlParameters(Base::Vector2d& onS
 
             if (secondRadiusParam->isSet) {
                 minorRadius = secondRadiusParam->getValue();
+                handler->minorRadiusSet = true;
                 if (minorRadius < Precision::Confusion() && secondRadiusParam->hasFinishedEditing) {
+                    handler->minorRadiusSet = false;
                     unsetOnViewParameter(secondRadiusParam.get());
                     return;
                 }
@@ -618,7 +624,7 @@ void DSHArcOfHyperbolaController::adaptParameters(Base::Vector2d onSketchPos)
                 start
                     + toVector3d(
                         handler->minorAxis()
-                        * (handler->minorRadius * (handler->startAngle > 0) - (handler->startAngle < 0))
+                        * (handler->minorRadius * ((handler->startAngle > 0) - (handler->startAngle < 0)))
                     )
             );
             if (!handler->valid) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -2,6 +2,7 @@
 
 /***************************************************************************
  *   Copyright (c) 2022 Abdullah Tahiri <abdullah.tahiri.yo@gmail.com>     *
+ *   Copyright (c) 2026 Loke S. Haugsnes <Lokesh@live.no>                  *
  *                                                                         *
  *   This file is part of the FreeCAD CAx development system.              *
  *                                                                         *
@@ -24,10 +25,7 @@
 
 #pragma once
 
-#include <boost/math/special_functions/fpclassify.hpp>
-
 #include <Gui/Notifications.h>
-
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
 #include <Gui/InputHint.h>
@@ -40,310 +38,55 @@
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
 
+
+#include <Base/Tools.h>
+#include <Gui/BitmapFactory.h>
+#include <Gui/MainWindow.h>
+#include <Mod/Part/App/Geometry2d.h>
+
+
+#include "DrawSketchDefaultWidgetController.h"
+#include "DrawSketchControllableHandler.h"
+
+#include <vector>
+#include <algorithm>
+
+// Parabola governing equation:
+// point(t) = origin + t*t/(4*focal)*XDir + t*YDir
+
 namespace SketcherGui
 {
 
 extern GeometryCreationMode geometryCreationMode;  // defined in CommandCreateGeo.cpp
 
-class DrawSketchHandlerArcOfParabola: public DrawSketchHandler
+class DrawSketchHandlerArcOfParabola;
+
+using DSHArcOfParabolaController = DrawSketchController<
+    DrawSketchHandlerArcOfParabola,
+    StateMachines::FourSeekEnd,
+    /*PAutoConstraintSize =*/4,
+    /*OnViewParametersT =*/OnViewParameters<6>>;
+
+using DrawSketchHandlerArcOfParabolaBase = DrawSketchControllableHandler<DSHArcOfParabolaController>;
+
+class DrawSketchHandlerArcOfParabola: public DrawSketchHandlerArcOfParabolaBase
 {
     Q_DECLARE_TR_FUNCTIONS(SketcherGui::DrawSketchHandlerArcOfParabola)
 
+    friend DSHArcOfParabolaController;
+
 public:
-    DrawSketchHandlerArcOfParabola()
-        : Mode(STATUS_SEEK_First)
-        , EditCurve(34)
-        , startAngle(0)
-        , endAngle(0)
-        , arcAngle(0)
-        , arcAngle_t(0)
+    explicit DrawSketchHandlerArcOfParabola()
+        : DrawSketchHandlerArcOfParabolaBase()
+        , centerPoint({0.0, 0.0})
+        , focusPoint({0.0, 0.0})
+        , startPoint(0)
+        , endPoint(0)
+        , valid(true)
+        , parabolaGeoId(Sketcher::GeoEnum::GeoUndef)
     {}
 
     ~DrawSketchHandlerArcOfParabola() override = default;
-
-    /// mode table
-    enum SelectMode
-    {
-        STATUS_SEEK_First,
-        STATUS_SEEK_Second,
-        STATUS_SEEK_Third,
-        STATUS_SEEK_Fourth,
-        STATUS_Close
-    };
-
-    void mouseMove(SnapManager::SnapHandle snapHandle) override
-    {
-        Base::Vector2d onSketchPos = snapHandle.compute();
-        if (Mode == STATUS_SEEK_First) {
-            setPositionText(onSketchPos);
-            seekAndRenderAutoConstraint(sugConstr1, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-        else if (Mode == STATUS_SEEK_Second) {
-            EditCurve[1] = onSketchPos;
-
-            // Display radius for user
-            float radius = (onSketchPos - focusPoint).Length();
-            if (showCursorCoords()) {
-                SbString text;
-                std::string radiusString = lengthToDisplayFormat(radius, 1);
-                text.sprintf(" (F%s)", radiusString.c_str());
-                setPositionText(onSketchPos, text);
-            }
-
-            drawEdit(EditCurve);
-            seekAndRenderAutoConstraint(sugConstr2, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-        else if (Mode == STATUS_SEEK_Third) {
-            double focal = (axisPoint - focusPoint).Length();
-            double phi = atan2(focusPoint.y - axisPoint.y, focusPoint.x - axisPoint.x);
-
-            // P(U) = O + U*U/(4.*F)*XDir + U*YDir
-            //
-            // pnt = Base::Vector3d(pnt0.x + angle * angle / 4 / focal * cos(phi) - angle *
-            // sin(phi),
-            //                      pnt0.y + angle * angle / 4 / focal * sin(phi) + angle *
-            //                      cos(phi), 0.f);
-
-            // This is the angle at cursor point
-            double u
-                = (cos(phi) * (onSketchPos.y - axisPoint.y)
-                   - (onSketchPos.x - axisPoint.x) * sin(phi));
-
-            for (int i = 15; i >= -15; i--) {
-                double angle = i * u / 15;
-                double rx = angle * angle / 4 / focal * cos(phi) - angle * sin(phi);
-                double ry = angle * angle / 4 / focal * sin(phi) + angle * cos(phi);
-                EditCurve[15 + i] = Base::Vector2d(axisPoint.x + rx, axisPoint.y + ry);
-            }
-
-            // Display radius for user
-            if (showCursorCoords()) {
-                SbString text;
-                std::string focalString = lengthToDisplayFormat(focal, 1);
-                text.sprintf(" (F%s)", focalString.c_str());
-                setPositionText(onSketchPos, text);
-            }
-
-            drawEdit(EditCurve);
-
-            seekAndRenderAutoConstraint(sugConstr3, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-        else if (Mode == STATUS_SEEK_Fourth) {
-            double focal = (axisPoint - focusPoint).Length();
-            double phi = atan2(focusPoint.y - axisPoint.y, focusPoint.x - axisPoint.x);
-
-            // P(U) = O + U*U/(4.*F)*XDir + U*YDir
-            //
-            // pnt = Base::Vector3d(pnt0.x + angle * angle / 4 / focal * cos(phi) - angle *
-            // sin(phi),
-            //                      pnt0.y + angle * angle / 4 / focal * sin(phi) + angle *
-            //                      cos(phi), 0.f);
-
-            // This is the angle at starting point
-            double ustartpoint
-                = (cos(phi) * (startingPoint.y - axisPoint.y)
-                   - (startingPoint.x - axisPoint.x) * sin(phi));
-
-            double startValue = ustartpoint;
-
-            double u
-                = (cos(phi) * (onSketchPos.y - axisPoint.y)
-                   - (onSketchPos.x - axisPoint.x) * sin(phi));
-
-
-            arcAngle = u - startValue;
-
-            if (!boost::math::isnan(arcAngle)) {
-                EditCurve.resize(33);
-                for (std::size_t i = 0; i < 33; i++) {
-                    double angle = startValue + i * arcAngle / 32.0;
-                    double rx = angle * angle / 4 / focal * cos(phi) - angle * sin(phi);
-                    double ry = angle * angle / 4 / focal * sin(phi) + angle * cos(phi);
-                    EditCurve[i] = Base::Vector2d(axisPoint.x + rx, axisPoint.y + ry);
-                }
-
-                if (showCursorCoords()) {
-                    SbString text;
-                    std::string focalString = lengthToDisplayFormat(focal, 1);
-                    text.sprintf(" (F%s)", focalString.c_str());
-                    setPositionText(onSketchPos, text);
-                }
-            }
-            else {
-                arcAngle = 0.;
-            }
-
-            drawEdit(EditCurve);
-            seekAndRenderAutoConstraint(sugConstr4, onSketchPos, Base::Vector2d(0.f, 0.f));
-        }
-    }
-
-    bool pressButton(Base::Vector2d onSketchPos) override
-    {
-        if (Mode == STATUS_SEEK_First) {
-            EditCurve[0] = onSketchPos;
-            focusPoint = onSketchPos;
-            EditCurve.resize(2);
-            Mode = STATUS_SEEK_Second;
-        }
-        else if (Mode == STATUS_SEEK_Second) {
-            EditCurve[1] = onSketchPos;
-            axisPoint = onSketchPos;
-            EditCurve.resize(31);
-            Mode = STATUS_SEEK_Third;
-        }
-        else if (Mode == STATUS_SEEK_Third) {
-            startingPoint = onSketchPos;
-            arcAngle = 0.;
-            arcAngle_t = 0.;
-            Mode = STATUS_SEEK_Fourth;
-        }
-        else {  // Fourth
-            endPoint = onSketchPos;
-            Mode = STATUS_Close;
-        }
-
-        updateHint();
-        return true;
-    }
-
-    bool releaseButton(Base::Vector2d /*onSketchPos*/) override
-    {
-        if (Mode == STATUS_Close) {
-            unsetCursor();
-            resetPositionText();
-
-            double phi = atan2(focusPoint.y - axisPoint.y, focusPoint.x - axisPoint.x);
-
-            double ustartpoint
-                = (cos(phi) * (startingPoint.y - axisPoint.y)
-                   - (startingPoint.x - axisPoint.x) * sin(phi));
-
-            double startAngle = ustartpoint;
-
-            double endAngle;
-
-            bool isOriginalArcCCW = true;
-
-            if (arcAngle > 0) {
-                endAngle = startAngle + arcAngle;
-            }
-            else {
-                endAngle = startAngle;
-                startAngle += arcAngle;
-                isOriginalArcCCW = false;
-            }
-
-            int currentgeoid = getHighestCurveIndex();
-
-            try {
-                openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch arc of Parabola"));
-
-                // Add arc of parabola
-                Gui::cmdAppObjectArgs(
-                    sketchgui->getObject(),
-                    "addGeometry(Part.ArcOfParabola"
-                    "(Part.Parabola(App.Vector(%f,%f,0),App.Vector(%f,%f,0),App."
-                    "Vector(0,0,1)),%f,%f),%s)",
-                    focusPoint.x,
-                    focusPoint.y,
-                    axisPoint.x,
-                    axisPoint.y,
-                    startAngle,
-                    endAngle,
-                    constructionModeAsBooleanText()
-                );
-
-                currentgeoid++;
-
-                Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", currentgeoid);
-            }
-            catch (const Base::Exception&) {
-                Gui::NotifyError(
-                    sketchgui,
-                    QT_TRANSLATE_NOOP("Notifications", "Error"),
-                    QT_TRANSLATE_NOOP("Notifications", "Cannot create arc of parabola")
-                );
-                abortCommand();
-
-                tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
-
-                return false;
-            }
-
-            commitCommand();
-
-            // add auto constraints for the focus point
-            if (!sugConstr1.empty()) {
-                createAutoConstraints(sugConstr1, currentgeoid + 1, Sketcher::PointPos::start);
-                sugConstr1.clear();
-            }
-
-            // add suggested constraints for vertex point
-            if (!sugConstr2.empty()) {
-                createAutoConstraints(sugConstr2, currentgeoid, Sketcher::PointPos::mid);
-                sugConstr2.clear();
-            }
-
-            // add suggested constraints for start of arc
-            if (!sugConstr3.empty()) {
-                createAutoConstraints(
-                    sugConstr3,
-                    currentgeoid,
-                    isOriginalArcCCW ? Sketcher::PointPos::start : Sketcher::PointPos::end
-                );
-                sugConstr3.clear();
-            }
-
-            // add suggested constraints for start of arc
-            if (!sugConstr4.empty()) {
-                createAutoConstraints(
-                    sugConstr4,
-                    currentgeoid,
-                    isOriginalArcCCW ? Sketcher::PointPos::end : Sketcher::PointPos::start
-                );
-                sugConstr4.clear();
-            }
-
-            tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
-
-            ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-                "User parameter:BaseApp/Preferences/Mod/Sketcher"
-            );
-            bool continuousMode = hGrp->GetBool("ContinuousCreationMode", true);
-            if (continuousMode) {
-                // This code enables the continuous creation mode.
-                Mode = STATUS_SEEK_First;
-                EditCurve.clear();
-                drawEdit(EditCurve);
-                EditCurve.resize(34);
-                applyCursor();
-                /* It is ok not to call to purgeHandler
-                 * in continuous creation mode because the
-                 * handler is destroyed by the quit() method on pressing the
-                 * right button of the mouse */
-            }
-            else {
-                sketchgui->purgeHandler();  // no code after this line, Handler get deleted in
-                                            // ViewProvider
-            }
-        }
-        updateHint();
-        return true;
-    }
-
-private:
-    QString getCrosshairCursorSVGName() const override
-    {
-        return QStringLiteral("Sketcher_Pointer_Create_ArcOfParabola");
-    }
-
-protected:
-    SelectMode Mode;
-    std::vector<Base::Vector2d> EditCurve;
-    Base::Vector2d focusPoint, axisPoint, startingPoint, endPoint;
-    double startAngle, endAngle, arcAngle, arcAngle_t;
-    std::vector<AutoConstraint> sugConstr1, sugConstr2, sugConstr3, sugConstr4;
 
 private:
     std::list<Gui::InputHint> getToolHints() const override
@@ -351,30 +94,598 @@ private:
         using enum Gui::InputHint::UserInput;
 
         return Gui::lookupHints<SelectMode>(
-            Mode,
+            state(),
             {
-                {.state = STATUS_SEEK_First,
+                {.state = SelectMode::SeekFirst,
                  .hints =
                      {
                          {tr("%1 pick focus point"), {MouseLeft}},
                      }},
-                {.state = STATUS_SEEK_Second,
+                {.state = SelectMode::SeekSecond,
                  .hints =
                      {
                          {tr("%1 pick axis point"), {MouseLeft}},
                      }},
-                {.state = STATUS_SEEK_Third,
+                {.state = SelectMode::SeekThird,
                  .hints =
                      {
                          {tr("%1 pick starting point"), {MouseLeft}},
                      }},
-                {.state = STATUS_SEEK_Fourth,
+                {.state = SelectMode::SeekFourth,
                  .hints =
                      {
                          {tr("%1 pick end point"), {MouseLeft}},
                      }},
             });
     }
+
+    void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
+    {
+        using std::numbers::pi;
+        valid = true;
+        switch (state()) {
+            case SelectMode::SeekFirst: {
+                focusPoint = onSketchPos;
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            case SelectMode::SeekSecond: {
+                centerPoint = onSketchPos;
+                if ((centerPoint - focusPoint).Length() < Precision::Confusion()) {
+                    valid = false;
+                    break;
+                }
+
+                toolWidgetManager.drawDirectionAtCursor(onSketchPos, focusPoint);
+                seekAndRenderAutoConstraint(sugConstraints[1], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            case SelectMode::SeekThird: {
+                Base::Vector2d delta23 = onSketchPos - centerPoint;
+                startPoint = delta23.x * axis().Rotate(std::numbers::pi / 2).x
+                    + delta23.y * axis().Rotate(std::numbers::pi / 2).y;
+
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                seekAndRenderAutoConstraint(sugConstraints[2], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            case SelectMode::SeekFourth: {
+                Base::Vector2d delta24 = onSketchPos - centerPoint;
+                endPoint = delta24.x * axis().Rotate(std::numbers::pi / 2).x
+                    + delta24.y * axis().Rotate(std::numbers::pi / 2).y;
+
+                if (abs(endPoint - startPoint) < Precision::Confusion()) {
+                    valid = false;
+                    break;
+                }
+
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+                seekAndRenderAutoConstraint(sugConstraints[3], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            default:
+                return;
+        }
+
+        CreateAndDrawShapeGeometry();
+    }
+
+    void executeCommands() override
+    {
+        try {
+            openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch arc of parabola"));
+
+            parabolaGeoId = getHighestCurveIndex() + 1;
+
+            createShape(true);
+
+            commandAddShapeGeometryAndConstraints();
+
+            Gui::cmdAppObjectArgs(sketchgui->getObject(), "exposeInternalGeometry(%d)", parabolaGeoId);
+
+            commitCommand();
+        }
+        catch (const Base::Exception&) {
+            Gui::NotifyError(
+                sketchgui,
+                QT_TRANSLATE_NOOP("Notifications", "Error"),
+                QT_TRANSLATE_NOOP("Notifications", "Failed to add arc of parabola")
+            );
+
+            abortCommand();
+            THROWM(
+                Base::RuntimeError,
+                QT_TRANSLATE_NOOP(
+                    "Notifications",
+                    "Tool execution aborted"
+                ) "\n"
+            )  // This prevents constraints from being
+               // applied on non existing geometry
+        }
+    }
+
+    void generateAutoConstraints() override
+    {
+        auto& ac1 = sugConstraints[0];
+        auto& ac2 = sugConstraints[1];
+        auto& ac3 = sugConstraints[2];
+        auto& ac4 = sugConstraints[3];
+
+        if (!ac1.empty()) {
+            generateAutoConstraintsOnElement(ac1, parabolaGeoId + 1, Sketcher::PointPos::start);
+        }
+
+        if (!ac2.empty()) {
+            generateAutoConstraintsOnElement(ac2, parabolaGeoId, Sketcher::PointPos::mid);
+        }
+
+        if (!ac3.empty()) {
+            generateAutoConstraintsOnElement(
+                ac3,
+                parabolaGeoId,
+                (startPoint < endPoint) ? Sketcher::PointPos::start : Sketcher::PointPos::end
+            );
+        }
+
+        if (!ac4.empty()) {
+            generateAutoConstraintsOnElement(
+                ac4,
+                parabolaGeoId,
+                (startPoint < endPoint) ? Sketcher::PointPos::end : Sketcher::PointPos::start
+            );
+        }
+
+        // Ensure temporary autoconstraints do not generate a redundancy and that the geometry
+        // parameters are accurate This is particularly important for adding widget mandated
+        // constraints.
+        removeRedundantAutoConstraints();
+    }
+
+    void createAutoConstraints() override
+    {
+        // execute python command to create autoconstraints
+        createGeneratedAutoConstraints(true);
+
+        sugConstraints[0].clear();
+        sugConstraints[1].clear();
+        sugConstraints[2].clear();
+        sugConstraints[3].clear();
+    }
+
+    std::string getToolName() const override
+    {
+        return "DSH_ArcOfParabola";
+    }
+
+    QString getCrosshairCursorSVGName() const override
+    {
+        return QStringLiteral("Sketcher_Pointer_Create_ArcOfParabola");
+    }
+
+    QPixmap getToolIcon() const override
+    {
+        return Gui::BitmapFactory().pixmap("Sketcher_CreateParabolic_Arc");
+    }
+
+    bool canGoToNextMode() override
+    {
+        if (!valid) {
+            return false;
+        }
+        return true;
+    }
+
+    void angleSnappingControl() override
+    {
+        setAngleSnapping(false);
+    }
+
+    void createShape(bool onlyeditoutline) override
+    {
+        ShapeGeometry.clear();
+
+        if (!valid) {
+            return;
+        }
+
+        if (state() == SelectMode::SeekSecond) {
+            addLineToShapeGeometry(toVector3d(focusPoint), toVector3d(centerPoint), isConstructionMode());
+        }
+
+        // starting point can be 0 but then the curve cant be displayed
+        if (state() == SelectMode::SeekThird && abs(startPoint) > Precision::Confusion()) {
+            addArcOfParabolaToShapeGeometry(
+                toVector3d(axis()),
+                toVector3d(centerPoint),
+                focal(),
+                startPoint,
+                -startPoint,
+                isConstructionMode()
+            );
+        }
+
+        if (state() == SelectMode::SeekFourth || state() == SelectMode::End) {
+            addArcOfParabolaToShapeGeometry(
+                toVector3d(axis()),
+                toVector3d(centerPoint),
+                focal(),
+                (startPoint < endPoint) ? startPoint : endPoint,
+                (startPoint < endPoint) ? endPoint : startPoint,
+                isConstructionMode()
+            );
+        }
+    }
+
+private:
+    Base::Vector2d centerPoint, focusPoint;
+    double startPoint, endPoint;
+    bool valid;
+    int parabolaGeoId;
+
+    Base::Vector2d axis() const
+    {
+        return (focusPoint - centerPoint).Normalize();
+    }
+
+    double focal() const
+    {
+        return (focusPoint - centerPoint).Length();
+    }
 };
+
+template<>
+auto DSHArcOfParabolaController::getState(int labelindex) const
+{
+    switch (labelindex) {
+        case OnViewParameter::First:
+        case OnViewParameter::Second:
+            return SelectMode::SeekFirst;
+            break;
+        case OnViewParameter::Third:
+        case OnViewParameter::Fourth:
+            return SelectMode::SeekSecond;
+            break;
+        case OnViewParameter::Fifth:
+            return SelectMode::SeekThird;
+            break;
+        case OnViewParameter::Sixth:
+            return SelectMode::SeekFourth;
+            break;
+        default:
+            THROWM(Base::ValueError, "OnViewParameter index without an associated machine state")
+    }
+}
+
+template<>
+void DSHArcOfParabolaController::configureOnViewParameters()
+{
+    onViewParameters[OnViewParameter::First]->setLabelType(Gui::SoDatumLabel::DISTANCEX);
+    onViewParameters[OnViewParameter::Second]->setLabelType(Gui::SoDatumLabel::DISTANCEY);
+
+    onViewParameters[OnViewParameter::Third]->setLabelType(
+        Gui::SoDatumLabel::RADIUS,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+    onViewParameters[OnViewParameter::Fourth]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+
+    onViewParameters[OnViewParameter::Fifth]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+    onViewParameters[OnViewParameter::Sixth]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+}
+
+template<>
+void DSHArcOfParabolaController::doEnforceControlParameters(Base::Vector2d& onSketchPos)
+{
+    handler->updateDataAndDrawToPosition(
+        onSketchPos
+    );  // ensure that the member variables are updated to date values before enforcing parameters
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (firstParam->isSet) {
+                onSketchPos.x = firstParam->getValue();
+            }
+
+            if (secondParam->isSet) {
+                onSketchPos.y = secondParam->getValue();
+            }
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& focalParam = onViewParameters[OnViewParameter::Third];
+            auto& angleParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (!focalParam->isSet && !angleParam->isSet) {
+                return;
+            }
+
+            double focal = handler->focal();
+            auto axis = handler->axis();
+
+            if (focalParam->isSet) {
+                focal = focalParam->getValue();
+                if (focal < Precision::Confusion() && focalParam->hasFinishedEditing) {
+                    unsetOnViewParameter(focalParam.get());
+                    return;
+                }
+            }
+
+            if (angleParam->isSet) {
+                double angle = Base::toRadians(angleParam->getValue());
+                axis = {cos(angle), sin(angle)};
+            }
+
+            onSketchPos = handler->focusPoint + focal * -axis;
+        } break;
+        case SelectMode::SeekThird: {
+            auto& startParam = onViewParameters[OnViewParameter::Fifth];
+
+            if (!startParam->isSet) {
+                return;
+            }
+
+            auto start = startParam->getValue();
+
+            onSketchPos = handler->centerPoint + start * handler->axis().Rotate(std::numbers::pi / 2);
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& arcParam = onViewParameters[OnViewParameter::Sixth];
+
+            if (!arcParam->isSet) {
+                return;
+            }
+
+            double arc = -arcParam->getValue();
+
+            if (std::abs(arc) < Precision::Confusion() && arcParam->hasFinishedEditing) {
+                unsetOnViewParameter(arcParam.get());
+                return;
+            }
+
+            double end = handler->endPoint;
+
+            onSketchPos = handler->centerPoint + end * handler->axis().Rotate(std::numbers::pi / 2);
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfParabolaController::adaptParameters(Base::Vector2d onSketchPos)
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (!firstParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
+            }
+
+            if (!secondParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
+            }
+
+            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+            firstParam->setLabelAutoDistanceReverse(!sameSign);
+            secondParam->setLabelAutoDistanceReverse(sameSign);
+            firstParam->setPoints(Base::Vector3d(), toVector3d(onSketchPos));
+            secondParam->setPoints(Base::Vector3d(), toVector3d(onSketchPos));
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& focalParam = onViewParameters[OnViewParameter::Third];
+            auto& angleParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (!focalParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::Third, handler->focal());
+            }
+
+            if (!angleParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Fourth,
+                    Base::toDegrees(handler->axis().Angle()),
+                    Base::Unit::Angle
+                );
+            }
+
+            Base::Vector3d start = toVector3d(handler->focusPoint);
+            Base::Vector3d end = toVector3d(onSketchPos);
+
+            focalParam->setPoints(start, end);
+            angleParam->setPoints(start, Base::Vector3d());
+            angleParam->setLabelRange(handler->axis().Angle());
+        } break;
+        case SelectMode::SeekThird: {
+            auto& startAngleParam = onViewParameters[OnViewParameter::Fifth];
+
+            if (!startAngleParam->isSet) {
+                setOnViewParameterValue(OnViewParameter::Fifth, handler->startPoint, Base::Unit::One);
+            }
+
+            Base::Vector3d start = toVector3d(handler->centerPoint);
+
+            startAngleParam->setPoints(start, Base::Vector3d());
+            startAngleParam->setLabelStartAngle(handler->axis().Angle());
+            startAngleParam->setLabelRange(0);
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& arcAngleParam = onViewParameters[OnViewParameter::Sixth];
+
+            if (!arcAngleParam->isSet) {
+                setOnViewParameterValue(
+                    OnViewParameter::Sixth,
+                    handler->endPoint - handler->startPoint,
+                    Base::Unit::One
+                );
+            }
+
+            Base::Vector3d start = toVector3d(handler->centerPoint);
+
+            arcAngleParam->setPoints(start, Base::Vector3d());
+            arcAngleParam->setLabelStartAngle(handler->axis().Angle());
+            arcAngleParam->setLabelRange(0);
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfParabolaController::computeNextDrawSketchHandlerMode()
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (firstParam->hasFinishedEditing && secondParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekSecond);
+            }
+        } break;
+        case SelectMode::SeekSecond: {
+            auto& thirdParam = onViewParameters[OnViewParameter::Third];
+            auto& fourthParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekThird);
+            }
+        } break;
+        case SelectMode::SeekThird: {
+            auto& fifthParam = onViewParameters[OnViewParameter::Fifth];
+
+            if (fifthParam->hasFinishedEditing) {
+                handler->setNextState(SelectMode::SeekFourth);
+            }
+        } break;
+        case SelectMode::SeekFourth: {
+            auto& sixth = onViewParameters[OnViewParameter::Sixth];
+
+            if (sixth->hasFinishedEditing) {
+                handler->setNextState(SelectMode::End);
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHArcOfParabolaController::addConstraints()
+{
+    App::DocumentObject* obj = handler->sketchgui->getObject();
+
+    int firstCurve = handler->parabolaGeoId;
+    int focusPoint = firstCurve + 1;
+    int line = firstCurve + 2;
+
+    using namespace Sketcher;
+
+    bool x0set = onViewParameters[OnViewParameter::First]->isSet;
+    bool y0set = onViewParameters[OnViewParameter::Second]->isSet;
+    bool focalSet = onViewParameters[OnViewParameter::Third]->isSet;
+    bool axisSet = onViewParameters[OnViewParameter::Fourth]->isSet;
+    // can't constrain the parameters.
+
+    auto constraintx0 = [&]() {
+        ConstraintToAttachment(
+            GeoElementId(focusPoint, PointPos::mid),
+            GeoElementId::VAxis,
+            handler->focusPoint.x,
+            obj
+        );
+    };
+
+    auto constrainty0 = [&]() {
+        ConstraintToAttachment(
+            GeoElementId(focusPoint, PointPos::mid),
+            GeoElementId::HAxis,
+            handler->focusPoint.y,
+            obj
+        );
+    };
+
+    auto constraintFocal = [&]() {
+        Gui::cmdAppObjectArgs(
+            obj,
+            "addConstraint(Sketcher.Constraint('Distance',%d,%d,%d,%d,%f)) ",
+            line,
+            1,
+            line,
+            2,
+            handler->focal()
+        );
+    };
+
+    auto constraintAngle = [&]() {
+        Gui::cmdAppObjectArgs(
+            obj,
+            "addConstraint(Sketcher.Constraint('Angle',%d,%f)) ",
+            line,
+            handler->axis().Angle()
+        );
+    };
+
+    if (handler->AutoConstraints.empty()) {  // No valid diagnosis. Every constraint can be added.
+        if (x0set && y0set && handler->focusPoint.IsNull(Precision::Confusion())) {
+            ConstraintToAttachment(GeoElementId(focusPoint, PointPos::mid), GeoElementId::RtPnt, 0., obj);
+        }
+        else {
+            if (x0set) {
+                constraintx0();
+            }
+
+            if (y0set) {
+                constrainty0();
+            }
+        }
+
+        if (focalSet) {
+            constraintFocal();
+        }
+        if (axisSet) {
+            constraintAngle();
+        }
+    }
+    else {  // Valid diagnosis. Must check which constraints may be added.
+        auto centerPointInfo = handler->getPointInfo(GeoElementId(focusPoint, PointPos::mid));
+
+        if (x0set && centerPointInfo.isXDoF()) {
+            constraintx0();
+
+            handler->diagnoseWithAutoConstraints();  // ensure we have recalculated parameters after
+                                                     // each constraint addition
+            // get updated point position
+            centerPointInfo = handler->getPointInfo(GeoElementId(focusPoint, PointPos::mid));
+        }
+
+        if (y0set && centerPointInfo.isYDoF()) {
+            constrainty0();
+
+            handler->diagnoseWithAutoConstraints();  // ensure we have recalculated parameters after
+                                                     // each constraint addition
+            // get updated point position
+            centerPointInfo = handler->getPointInfo(GeoElementId(firstCurve, PointPos::mid));
+        }
+
+        int lineDoFs = handler->getLineDoFs(line);
+
+        if (focalSet && lineDoFs > 0) {
+            constraintFocal();
+            handler->diagnoseWithAutoConstraints();
+            lineDoFs = handler->getLineDoFs(line);
+        }
+
+        if (axisSet && lineDoFs > 0) {
+            constraintAngle();
+        }
+    }
+}
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerArcOfParabola.h
@@ -279,6 +279,8 @@ private:
 
     void createShape(bool onlyeditoutline) override
     {
+        Q_UNUSED(onlyeditoutline);
+
         ShapeGeometry.clear();
 
         if (!valid) {


### PR DESCRIPTION
This PR introduces on-view parameters (OVP) for the arc tools of ellipses, hyperbolas, and parabolas in the Sketcher.

Points requiring attention:
* Ellipse angle input
For highly eccentric ellipses, the widget arrow used for angle input looks visually distorted or unintuitive.
* Ellipse orientation instability
When an explicit orientation is provided and the first radius becomes the major radius, the solver is exhibit unstable behavior, leading to the arc looking somewhat off from the input and occasionally reporting an error. But all constraints are respected.
* Hyperbola and parabola parameter widgets
Ideally there should be a just a box with no arrows, but in the current implementation of the OVP it must have these arrows in some form, from what i found. 
* Widget placement
Also the box is put in the center of the hyperbola and parabola but it may be better to have it on the edge point of the arc.

## Issue
Adds: #12463

## Video

https://github.com/user-attachments/assets/a6476c70-2908-4e9a-92c4-087f8ddecc54

