### PR TITLE
Fix SubShapeBinder drag cursor showing wrong icon

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2316,7 +2316,13 @@ void TreeWidget::dragMoveEvent(QDragMoveEvent* event)
     auto items = selectedItems();
 
     auto da = getDropAction(items.size(), targetItem->type());
-    event->setDropAction(da);
+    auto visualDa = da;
+    if (targetItem->type() == TreeWidget::ObjectType) {
+        if (auto* vp = static_cast<DocumentObjectItem*>(targetItem)->object()) {
+            visualDa = vp->getDropActionForTarget(da);
+        }
+    }
+    event->setDropAction(visualDa);
 
     if (targetItem->type() == TreeWidget::DocumentType) {
         leaveEvent(nullptr);

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -476,6 +476,12 @@ public:
         return {};
     }
 
+    /// Override to remap the drop cursor icon shown when dragging over this view provider.
+    virtual Qt::DropAction getDropActionForTarget(Qt::DropAction action) const
+    {
+        return action;
+    }
+
     /** Add an object with full qualified name to the view provider by drag and drop
      *
      * @param obj: the object being dropped

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.h
@@ -71,6 +71,18 @@ public:
     {
         return false;
     }
+    Qt::DropAction getDropActionForTarget(Qt::DropAction action) const override
+    {
+        // SubShapeBinder's drop convention is the reverse of the Qt default:
+        // no modifier = add geometry ([+]), Ctrl = replace geometry ([>]).
+        if (action == Qt::CopyAction) {
+            return Qt::MoveAction;
+        }
+        if (action == Qt::MoveAction) {
+            return Qt::CopyAction;
+        }
+        return action;
+    }
     bool canDropObjectEx(
         App::DocumentObject* obj,
         App::DocumentObject* owner,


### PR DESCRIPTION
Closes #21199

The drag cursor for SubShapeBinder was logically backwards:
- Without Ctrl (add geometry): showed `[>]` instead of `[+]`
- With Ctrl (replace geometry): showed `[+]` instead of `[>]`

### Solution

Added a virtual `getDropActionForTarget()` hook to `ViewProvider` (default: pass-through). `ViewProviderSubShapeBinder` overrides it to swap `CopyAction` and `MoveAction` so the cursor icon matches the operation that will actually be performed.

The actual drop logic is unchanged - only the visual cursor is affected.

### Before / After

https://github.com/user-attachments/assets/e83adcec-6c7e-47f0-8539-f1ba2de67633





https://github.com/user-attachments/assets/e7657c0d-b917-478e-964c-385f184724ca

