### PR TITLE
Add Document Window context menu to TechDraw and Spreadsheet (#29276)

### DIFF
--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -203,6 +203,12 @@ SheetTableView::SheetTableView(QWidget* parent)
     actionPaste = createAction(":/icons/edit-paste.svg", tr("Paste"), &SheetTableView::pasteClipboard);
     actionDel = createAction(":/icons/edit-delete.svg", tr("Delete"), &SheetTableView::deleteSelection);
 
+    auto& commandManager = Gui::Application::Instance->commandManager();
+    if (commandManager.getCommandByName("Std_ViewDockUndockFullscreen")) {
+        contextMenu.addSeparator();
+        commandManager.addTo("Std_ViewDockUndockFullscreen", &contextMenu);
+    }
+
     addAction(actionProperties);
 
     horizontalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
@@ -225,12 +225,7 @@ void ZoomableView::contextMenuEvent(QContextMenuEvent* event)
             return false;
         }
 
-        QContextMenuEvent forwarded(
-            QContextMenuEvent::Mouse,
-            targetPos,
-            globalPos,
-            event->modifiers()
-        );
+        QContextMenuEvent forwarded(QContextMenuEvent::Mouse, targetPos, globalPos, event->modifiers());
         QCoreApplication::sendEvent(target, &forwarded);
         return true;
     };

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
@@ -22,6 +22,8 @@
  ***************************************************************************/
 
 #include <QInputDialog>
+#include <QContextMenuEvent>
+#include <QCoreApplication>
 #include <QGraphicsProxyWidget>
 
 #include "ZoomableView.h"
@@ -200,6 +202,47 @@ void ZoomableView::updateView(void)
     setSceneRect(new_geometry_f);
     scale(scale_factor, scale_factor);
     centerOn(new_geometry_f.center());
+}
+
+void ZoomableView::contextMenuEvent(QContextMenuEvent* event)
+{
+    if (!event || !stv || event->reason() != QContextMenuEvent::Mouse) {
+        QGraphicsView::contextMenuEvent(event);
+        return;
+    }
+
+    // In floating/fullscreen MDI modes on Windows, context menu events can stop at the
+    // QGraphicsView. Forward them explicitly to the embedded table widgets.
+    const QPoint globalPos = event->globalPos();
+
+    auto forwardContextMenu = [&](QWidget* target) {
+        if (!target) {
+            return false;
+        }
+
+        const QPoint targetPos = target->mapFromGlobal(globalPos);
+        if (!target->rect().contains(targetPos)) {
+            return false;
+        }
+
+        QContextMenuEvent forwarded(
+            QContextMenuEvent::Mouse,
+            targetPos,
+            globalPos,
+            event->modifiers()
+        );
+        QCoreApplication::sendEvent(target, &forwarded);
+        return true;
+    };
+
+    if (forwardContextMenu(stv->horizontalHeader()->viewport())
+        || forwardContextMenu(stv->verticalHeader()->viewport())
+        || forwardContextMenu(stv->viewport())) {
+        event->accept();
+        return;
+    }
+
+    QGraphicsView::contextMenuEvent(event);
 }
 
 void ZoomableView::focusOutEvent(QFocusEvent* event)

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.h
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.h
@@ -71,6 +71,7 @@ private:
     int m_zoomLevel {0};
 
 protected:
+    void contextMenuEvent(QContextMenuEvent* event) override;
     void focusOutEvent(QFocusEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -456,6 +456,11 @@ void MDIViewPage::contextMenuEvent(QContextMenuEvent* event)
         menu.addAction(m_exportDXFAction);
         menu.addAction(m_exportPDFAction);
         menu.addAction(m_printAllAction);
+        auto& commandManager = Gui::Application::Instance->commandManager();
+        if (commandManager.getCommandByName("Std_ViewDockUndockFullscreen")) {
+            menu.addSeparator();
+            commandManager.addTo("Std_ViewDockUndockFullscreen", &menu);
+        }
         if (PreferencesGui::getViewFrameMode() == ViewFrameMode::Manual) {
             m_toggleFrameAction->setEnabled(true);
         } else {


### PR DESCRIPTION
This PR adds the Document Window submenu to the right-click context menus of Spreadsheet and TechDraw views, matching the behavior users already have in 3D views.

- Spreadsheet: adds Document Window to the cell-view context menu.
- TechDraw: adds Document Window to the page-view context menu.
- Reuses the existing standard command and actions (Docked, Undocked, Fullscreen).
- Prevents duplication in Spreadsheet by adding the entry once when the persistent menu is built.

Changed files:
- SheetTableView.cpp
- MDIViewPage.cpp

## Issues
Closes #29276

## Before and After Images

### Before
No Document Window option was available in Spreadsheet and TechDraw RMB menus when those views were undocked (as reported in #29276).

### After
- Spreadsheet RMB now includes Document Window with Docked, Undocked, Fullscreen.
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/8392a2c7-6c5d-4737-ae71-298b78509dde" />
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/cd56d2a9-5bf9-4c0e-8f48-8698a3777471" />



- TechDraw page RMB now includes Document Window with Docked, Undocked, Fullscreen.
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/0b779aca-168b-4df1-b5bb-d038a652ed4a" />
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/6560bfb4-ffdc-40ea-a95e-51a25e760748" />


## Validation
- Rebased on updated main before branching.
- Compiled successfully.
- Manual UI validation completed:
  - Spreadsheet undocked view: Document Window appears.
  - Spreadsheet repeated RMB open/close: no duplicate Document Window entries.
  - TechDraw undocked page view: Document Window appears.
  - Docked action repeatedly returns window to the main panel in both workbenches.

## Notes
- UI-only change.
- No file format impact.
- No new translatable strings introduced (existing standard command text is reused).