### PR TITLE
OpenSCAD: fix n-ary intersection() import failing with AttributeError

### DIFF
--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -498,6 +498,32 @@ bool PropertyLinkBase::_updateElementReference(DocumentObject* feature,
                            << oldName << " -> " << newName);
                 }
             }
+            else if (missing && reverse) {
+                // Geometry-based search failed during an element-map version
+                // migration (reverse=true).  As a last resort, fall back to
+                // resolving by the indexed element name.  This is safe here
+                // because reverse is only true when the element-map version
+                // changed, which preserves BRep topology while only renaming
+                // the internal element tags.
+                std::string newsub(subname, strlen(subname) - strlen(element));
+                newsub += oldElement;
+                ShadowSub fallbackName;
+                if (GeoFeature::resolveElement(obj,
+                                               newsub.c_str(),
+                                               fallbackName,
+                                               true,
+                                               GeoFeature::ElementNameType::Export,
+                                               feature)
+                    && !GeoFeature::hasMissingElement(fallbackName.oldName.c_str())
+                    && !fallbackName.newName.empty()) {
+                    missing = false;
+                    elementName = std::move(fallbackName);
+                    const auto& oldName = shadow.newName.size() ? shadow.newName : shadow.oldName;
+                    FC_LOG(propertyName(this)
+                           << " auto change element reference (indexed) " << ret->getFullName()
+                           << " " << oldName << " -> " << elementName.newName);
+                }
+            }
         }
     }
 

--- a/src/Mod/OpenSCAD/OpenSCADTest/app/test_importCSG.py
+++ b/src/Mod/OpenSCAD/OpenSCADTest/app/test_importCSG.py
@@ -191,6 +191,26 @@ polyhedron(
         self.assertAlmostEqual (object.Shape.Volume, 3108.8677, 3)
         FreeCAD.closeDocument(doc.Name)
 
+    def test_import_intersection_nary(self):
+        # 3-ary intersection() should import without AttributeError (issue #29309)
+        csg = (
+            "intersection() {\n"
+            "    cube(size = [15, 15, 15], center = true);\n"
+            "    sphere($fn = 0, $fa = 12, $fs = 2, r = 10);\n"
+            "    cube(size = [8, 8, 20], center = true);\n"
+            "}\n"
+        )
+        filename = self.temp_dir.name + os.path.sep + "intersection_nary.csg"
+        with open(filename, "w") as f:
+            f.write(csg)
+        doc = importCSG.open(filename)
+        obj = doc.getObject("intersection")
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.TypeId, "Part::MultiCommon")
+        self.assertFalse(obj.Shape.isNull())
+        self.assertAlmostEqual(obj.Shape.Volume, 960.0)
+        FreeCAD.closeDocument(doc.Name)
+
     def test_import_union(self):
         doc = self.utility_create_scad("union() { cube(15, center=true); sphere(10); }", "union")
         object = doc.ActiveObject

--- a/src/Mod/OpenSCAD/importCSG.py
+++ b/src/Mod/OpenSCAD/importCSG.py
@@ -661,6 +661,7 @@ def p_intersection_action(p):
         mycommon.Tool = p[5][1]
         checkObjShape(mycommon.Base)
         checkObjShape(mycommon.Tool)
+        mycommon.Shape = mycommon.Base.Shape.common(mycommon.Tool.Shape)
         if gui:
             mycommon.Base.ViewObject.hide()
             mycommon.Tool.ViewObject.hide()
@@ -668,7 +669,6 @@ def p_intersection_action(p):
         mycommon = p[5][0]
     else : # 1 child
         mycommon = placeholder('group',[],'{}')
-    mycommon.Shape = mycommon.Base.Shape.common(mycommon.Tool.Shape)
     p[0] = [mycommon]
     if printverbose: print("End Intersection")
 

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -508,9 +508,12 @@ void PropertyPartShape::Restore(Base::XMLReader& reader)
                     }
                     owner->getDocument()->addRecomputeObject(owner);
 
-                    // sometimes objects will not update _Ver properly,
-                    // so lets do it here to avoid unnecessary remigration
-                    _Ver = ver;
+                    // Keep _Ver as the old version so that GeoFeature::onDocumentRestored()
+                    // initialises _ElementMapVersion to the old version string.  When the
+                    // recompute rebuilds the shape with the new element-map version the
+                    // mismatch is detected, reset=true is set, and reverse=true is propagated
+                    // into _updateElementReference — enabling the indexed-name fallback that
+                    // recovers missing edge references after version migration.
                 }
             }
         }


### PR DESCRIPTION
Fix `intersection()` with 3+ children in the OpenSCAD CSG importer — `mycommon.Shape` was assigned outside the 2-child branch where `.Base`/`.Tool` exist, causing an `AttributeError` on any n-ary intersection.

Also fix v1.0 files with Fillet features failing to recompute in v1.1. The element-map version migration was losing edge references because `PropertyPartShape::Restore()` pre-updated `_Ver` to the new version, making `reverse=false` during the migration recompute and skipping the recovery path.

Fixes #29309
Fixes #29304