### PR TITLE
Gui: Pause Coin realTime sensor when MainWindow loses focus

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -82,6 +82,7 @@
 #include <Base/Stream.h>
 #include <Base/Tools.h>
 #include <Base/UnitsApi.h>
+#include <Inventor/SoDB.h>
 #include <DAGView/DAGView.h>
 #include <TaskView/TaskView.h>
 
@@ -2538,9 +2539,16 @@ void MainWindow::changeEvent(QEvent* e)
         App::GetApplication().retranslateExportTypes();
     }
     else if (e->type() == QEvent::ActivationChange) {
+        static SbTime savedRealTimeInterval = SoDB::getRealTimeInterval();
         if (isActiveWindow()) {
             QMdiSubWindow* mdi = d->mdiArea->currentSubWindow();
             setActiveSubWindow(mdi);
+            SoDB::enableRealTimeSensor(true);
+            SoDB::setRealTimeInterval(savedRealTimeInterval);
+        }
+        else {
+            savedRealTimeInterval = SoDB::getRealTimeInterval();
+            SoDB::enableRealTimeSensor(false);
         }
     }
     else {


### PR DESCRIPTION
Coin's realTime SoTimerSensor fires every 40 ms regardless of focus
state, causing unnecessary wakeups when FreeCAD is idle in the
background. Hook QEvent::ActivationChange in MainWindow::changeEvent
to disable the sensor via SoDB::enableRealTimeSensor on focus loss
and restore it on focus regain. The original interval is saved via
SoDB::getRealTimeInterval to avoid hardcoding any value.

Closes #21997
