### PR TITLE
Sketcher: Polyline rework.

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -151,7 +151,7 @@ public:
 
         setCheckable(false);
 
-        addCommand("Sketcher_CreatePolyline");
+        addCommand("Sketcher_CreatePolyline2");
         addCommand("Sketcher_CreateLine");
     }
 
@@ -249,6 +249,36 @@ void CmdSketcherCreatePolyline::activated(int iMsg)
 }
 
 bool CmdSketcherCreatePolyline::isActive()
+{
+    return isCommandActive(getActiveGuiDocument());
+}
+// Polyline2 ================================================================
+
+DEF_STD_CMD_AU(CmdSketcherCreatePolyline2)
+
+CmdSketcherCreatePolyline2::CmdSketcherCreatePolyline2()
+    : Command("Sketcher_CreatePolyline2")
+{
+    sAppModule = "Sketcher";
+    sGroup = "Sketcher";
+    sMenuText = QT_TR_NOOP("Create polyline");
+    sToolTipText = QT_TR_NOOP("Create a polyline in the sketch. 'M' Key cycles behaviour");
+    sWhatsThis = "Sketcher_CreatePolyline";
+    sStatusTip = sToolTipText;
+    sPixmap = "Sketcher_CreatePolyline";
+    sAccel = "L";
+    eType = ForEdit;
+}
+
+CONSTRUCTION_UPDATE_ACTION(CmdSketcherCreatePolyline2, "Sketcher_CreatePolyline2")
+
+void CmdSketcherCreatePolyline2::activated(int iMsg)
+{
+    Q_UNUSED(iMsg);
+    ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerPolyLine>());
+}
+
+bool CmdSketcherCreatePolyline2::isActive()
 {
     return isCommandActive(getActiveGuiDocument());
 }
@@ -1962,6 +1992,7 @@ void CreateSketcherCommandsCreateGeo()
     rcCmdMgr.addCommand(new CmdSketcherCreatePeriodicBSplineByInterpolation());
     rcCmdMgr.addCommand(new CmdSketcherCreateLine());
     rcCmdMgr.addCommand(new CmdSketcherCreatePolyline());
+    rcCmdMgr.addCommand(new CmdSketcherCreatePolyline2());
     rcCmdMgr.addCommand(new CmdSketcherCreateRectangle());
     rcCmdMgr.addCommand(new CmdSketcherCreateRectangleCenter());
     rcCmdMgr.addCommand(new CmdSketcherCreateOblong());

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -261,7 +261,7 @@ CmdSketcherCreatePolyline::CmdSketcherCreatePolyline()
 {
     sAppModule = "Sketcher";
     sGroup = "Sketcher";
-    sMenuText = QT_TR_NOOP("Create polyline");
+    sMenuText = QT_TR_NOOP("Polyline");
     sToolTipText = QT_TR_NOOP("Create a polyline in the sketch. 'M' Key cycles behaviour");
     sWhatsThis = "Sketcher_CreatePolyline";
     sStatusTip = sToolTipText;

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -151,7 +151,7 @@ public:
 
         setCheckable(false);
 
-        addCommand("Sketcher_CreatePolyline2");
+        addCommand("Sketcher_CreatePolyline");
         addCommand("Sketcher_CreateLine");
     }
 
@@ -220,12 +220,12 @@ bool CmdSketcherCreateLine::isActive()
     return isCommandActive(getActiveGuiDocument());
 }
 
-// Polyline ================================================================
+// Polyline old tool ======================================================
 
-DEF_STD_CMD_AU(CmdSketcherCreatePolyline)
+DEF_STD_CMD_AU(CmdSketcherCreatePolylineLegacy)
 
-CmdSketcherCreatePolyline::CmdSketcherCreatePolyline()
-    : Command("Sketcher_CreatePolyline")
+CmdSketcherCreatePolylineLegacy::CmdSketcherCreatePolylineLegacy()
+    : Command("Sketcher_CreatePolylineLegacy")
 {
     sAppModule = "Sketcher";
     sGroup = "Sketcher";
@@ -233,31 +233,31 @@ CmdSketcherCreatePolyline::CmdSketcherCreatePolyline()
     sToolTipText = QT_TR_NOOP(
         "Creates a continuous polyline. Press the 'M' key to switch segment modes"
     );
-    sWhatsThis = "Sketcher_CreatePolyline";
+    sWhatsThis = "Sketcher_CreatePolylineLegacy";
     sStatusTip = sToolTipText;
     sPixmap = "Sketcher_CreatePolyline";
     sAccel = "G, M";
     eType = ForEdit;
 }
 
-CONSTRUCTION_UPDATE_ACTION(CmdSketcherCreatePolyline, "Sketcher_CreatePolyline")
+CONSTRUCTION_UPDATE_ACTION(CmdSketcherCreatePolylineLegacy, "Sketcher_CreatePolylineLegacy")
 
-void CmdSketcherCreatePolyline::activated(int iMsg)
+void CmdSketcherCreatePolylineLegacy::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerLineSet>());
 }
 
-bool CmdSketcherCreatePolyline::isActive()
+bool CmdSketcherCreatePolylineLegacy::isActive()
 {
     return isCommandActive(getActiveGuiDocument());
 }
-// Polyline2 ================================================================
+// Polyline ================================================================
 
-DEF_STD_CMD_AU(CmdSketcherCreatePolyline2)
+DEF_STD_CMD_AU(CmdSketcherCreatePolyline)
 
-CmdSketcherCreatePolyline2::CmdSketcherCreatePolyline2()
-    : Command("Sketcher_CreatePolyline2")
+CmdSketcherCreatePolyline::CmdSketcherCreatePolyline()
+    : Command("Sketcher_CreatePolyline")
 {
     sAppModule = "Sketcher";
     sGroup = "Sketcher";
@@ -270,15 +270,15 @@ CmdSketcherCreatePolyline2::CmdSketcherCreatePolyline2()
     eType = ForEdit;
 }
 
-CONSTRUCTION_UPDATE_ACTION(CmdSketcherCreatePolyline2, "Sketcher_CreatePolyline2")
+CONSTRUCTION_UPDATE_ACTION(CmdSketcherCreatePolyline, "Sketcher_CreatePolyline")
 
-void CmdSketcherCreatePolyline2::activated(int iMsg)
+void CmdSketcherCreatePolyline::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     ActivateHandler(getActiveGuiDocument(), std::make_unique<DrawSketchHandlerPolyLine>());
 }
 
-bool CmdSketcherCreatePolyline2::isActive()
+bool CmdSketcherCreatePolyline::isActive()
 {
     return isCommandActive(getActiveGuiDocument());
 }
@@ -1992,7 +1992,7 @@ void CreateSketcherCommandsCreateGeo()
     rcCmdMgr.addCommand(new CmdSketcherCreatePeriodicBSplineByInterpolation());
     rcCmdMgr.addCommand(new CmdSketcherCreateLine());
     rcCmdMgr.addCommand(new CmdSketcherCreatePolyline());
-    rcCmdMgr.addCommand(new CmdSketcherCreatePolyline2());
+    rcCmdMgr.addCommand(new CmdSketcherCreatePolylineLegacy());
     rcCmdMgr.addCommand(new CmdSketcherCreateRectangle());
     rcCmdMgr.addCommand(new CmdSketcherCreateRectangleCenter());
     rcCmdMgr.addCommand(new CmdSketcherCreateOblong());

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -262,7 +262,7 @@ CmdSketcherCreatePolyline::CmdSketcherCreatePolyline()
     sAppModule = "Sketcher";
     sGroup = "Sketcher";
     sMenuText = QT_TR_NOOP("Polyline");
-    sToolTipText = QT_TR_NOOP("Create a polyline in the sketch. 'M' Key cycles behaviour");
+    sToolTipText = QT_TR_NOOP("Creates a polyline in the sketch. M key cycles through segment modes.");
     sWhatsThis = "Sketcher_CreatePolyline";
     sStatusTip = sToolTipText;
     sPixmap = "Sketcher_CreatePolyline";

--- a/src/Mod/Sketcher/Gui/DrawSketchControllableHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchControllableHandler.h
@@ -125,6 +125,11 @@ protected:
     }
     //@}
 
+    void addStepControlConstraints()
+    {
+        toolWidgetManager.addStepConstraints();
+    }
+
 private:
     /** @name functions requiring specialisation */
     //@{

--- a/src/Mod/Sketcher/Gui/DrawSketchController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchController.h
@@ -485,6 +485,10 @@ public:
     virtual void addConstraints()
     {}
 
+    /// function to create constraints based on control information for infinite DSH (polyline).
+    virtual void addStepConstraints()
+    {}
+
     /// Configures on-view parameters
     void configureOnViewParameters()
     {}
@@ -767,14 +771,29 @@ protected:
                 bool visible = isOnViewParameterVisible(i);
 
                 if (visible) {
-                    onViewParameters[i]->activate();
-
-                    // points/value will be overridden by the mouseMove triggered by the mode
-                    // change.
-                    onViewParameters[i]->setPoints(Base::Vector3d(), Base::Vector3d());
-                    onViewParameters[i]->startEdit(0.0, keymanager.get());
+                    activateOnViewParameter(i);
                 }
             }
+        }
+    }
+
+    void activateOnViewParameter(size_t i)
+    {
+        if (i < onViewParameters.size()) {
+            onViewParameters[i]->activate();
+
+            // points/value will be overridden by the mouseMove triggered by the mode
+            // change.
+            onViewParameters[i]->setPoints(Base::Vector3d(), Base::Vector3d());
+            onViewParameters[i]->startEdit(0.0, keymanager.get());
+        }
+    }
+
+    void deactivateOnViewParameter(size_t i)
+    {
+        if (i < onViewParameters.size()) {
+            onViewParameters[i]->stopEdit();
+            onViewParameters[i]->deactivate();
         }
     }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -782,60 +782,70 @@ protected:
                 c->First = (geoId2 != Sketcher::GeoEnum::GeoUndef ? geoId2 : geoId1);
                 AutoConstraints.push_back(std::move(c));
             } break;
+            case Sketcher::Perpendicular: {
+                auto c = std::make_unique<Sketcher::Constraint>();
+                c->Type = Sketcher::Perpendicular;
+                c->First = geoId1;
+                c->Second = geoId2;
+                AutoConstraints.push_back(std::move(c));
+            } break;
+            case Sketcher::Parallel: {
+                auto c = std::make_unique<Sketcher::Constraint>();
+                c->Type = Sketcher::Parallel;
+                c->First = geoId1;
+                c->Second = geoId2;
+                AutoConstraints.push_back(std::move(c));
+            } break;
             case Sketcher::Tangent: {
                 Sketcher::SketchObject* Obj = sketchgui->getObject<Sketcher::SketchObject>();
 
                 const Part::Geometry* geom1 = Obj->getGeometry(geoId1);
                 const Part::Geometry* geom2 = Obj->getGeometry(geoId2);
-
-                // ellipse tangency support using construction elements (lines)
-                if (geom1 && geom2
-                    && (geom1->is<Part::GeomEllipse>() || geom2->is<Part::GeomEllipse>())) {
-                    if (!geom1->is<Part::GeomEllipse>()) {
-                        std::swap(geoId1, geoId2);
-                    }
-
-                    // geoId1 is the ellipse
-                    geom1 = Obj->getGeometry(geoId1);
-                    geom2 = Obj->getGeometry(geoId2);
-
-                    if (geom2->is<Part::GeomEllipse>() || geom2->is<Part::GeomArcOfEllipse>()
-                        || geom2->is<Part::GeomCircle>() || geom2->is<Part::GeomArcOfCircle>()) {
-                        // in all these cases an intermediate element is needed
-                        // makeTangentToEllipseviaNewPoint(
-                        //     Obj,
-                        //     static_cast<const Part::GeomEllipse*>(geom1),
-                        //     geom2,
-                        //     geoId1,
-                        //     geoId2);
-                        // NOTE: Temporarily deactivated
-                        return false;
-                    }
+                if (!geom1 || !geom2) {
+                    return false;
                 }
 
-                // arc of ellipse tangency support using external elements
-                if (geom1 && geom2
-                    && (geom1->is<Part::GeomArcOfEllipse>() || geom2->is<Part::GeomArcOfEllipse>())) {
-                    if (!geom1->is<Part::GeomArcOfEllipse>()) {
-                        std::swap(geoId1, geoId2);
-                    }
-
-                    // geoId1 is the arc of ellipse
-                    geom1 = Obj->getGeometry(geoId1);
-                    geom2 = Obj->getGeometry(geoId2);
-
-                    if (geom2->is<Part::GeomArcOfEllipse>() || geom2->is<Part::GeomCircle>()
-                        || geom2->is<Part::GeomArcOfCircle>()) {
-                        // in all these cases an intermediate element is needed
-                        // makeTangentToArcOfEllipseviaNewPoint(
-                        //     Obj,
-                        //     static_cast<const Part::GeomArcOfEllipse*>(geom1),
-                        //     geom2,
-                        //     geoId1,
-                        //     geoId2);
-                        // NOTE: Temporarily deactivated
-                        return false;
-                    }
+                // 2026.01.16: Do not use swap as it did before or it breaks resultCoincident.
+                // NOTE: Temporarily deactivated : ellipse tangency support using construction elements
+                if (geom1->is<Part::GeomEllipse>()
+                    && (geom2->is<Part::GeomConic>() || geom2->is<Part::GeomArcOfConic>())) {
+                    // makeTangentToEllipseviaNewPoint(
+                    //     Obj,
+                    //     static_cast<const Part::GeomEllipse*>(geom1),
+                    //     geom2,
+                    //     geoId1,
+                    //     geoId2);
+                    return false;
+                }
+                else if (geom2->is<Part::GeomEllipse>()
+                         && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())) {
+                    // makeTangentToEllipseviaNewPoint(
+                    //     Obj,
+                    //     static_cast<const Part::GeomEllipse*>(geom2),
+                    //     geom1,
+                    //     geoId2,
+                    //     geoId1);
+                    return false;
+                }
+                else if (geom1->is<Part::GeomArcOfEllipse>()
+                         && (geom2->is<Part::GeomConic>() || geom2->is<Part::GeomArcOfConic>())) {
+                    // makeTangentToArcOfEllipseviaNewPoint(
+                    //     Obj,
+                    //     static_cast<const Part::GeomArcOfEllipse*>(geom1),
+                    //     geom2,
+                    //     geoId1,
+                    //     geoId2);
+                    return false;
+                }
+                else if (geom2->is<Part::GeomArcOfEllipse>()
+                         && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())) {
+                    // makeTangentToArcOfEllipseviaNewPoint(
+                    //     Obj,
+                    //     static_cast<const Part::GeomArcOfEllipse*>(geom2),
+                    //     geom1,
+                    //     geoId2,
+                    //     geoId1);
+                    return false;
                 }
 
                 auto resultCoincident = std::ranges::find_if(AutoConstraints, [&](const auto& ace) {
@@ -979,7 +989,7 @@ protected:
         sketchobject->diagnoseAdditionalConstraints(autoConstraints);
 
         if (sketchobject->getLastHasRedundancies()) {
-            Base::Console().warning(
+            Base::Console().message(
                 sketchobject->getFullLabel(),
                 QT_TRANSLATE_NOOP("Notifications", "Autoconstraints cause redundancy. Removing them") "\n"
             );

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultHandler.h
@@ -817,8 +817,10 @@ protected:
                     //     geoId2);
                     return false;
                 }
-                else if (geom2->is<Part::GeomEllipse>()
-                         && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())) {
+                else if (
+                    geom2->is<Part::GeomEllipse>()
+                    && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())
+                ) {
                     // makeTangentToEllipseviaNewPoint(
                     //     Obj,
                     //     static_cast<const Part::GeomEllipse*>(geom2),
@@ -827,8 +829,10 @@ protected:
                     //     geoId1);
                     return false;
                 }
-                else if (geom1->is<Part::GeomArcOfEllipse>()
-                         && (geom2->is<Part::GeomConic>() || geom2->is<Part::GeomArcOfConic>())) {
+                else if (
+                    geom1->is<Part::GeomArcOfEllipse>()
+                    && (geom2->is<Part::GeomConic>() || geom2->is<Part::GeomArcOfConic>())
+                ) {
                     // makeTangentToArcOfEllipseviaNewPoint(
                     //     Obj,
                     //     static_cast<const Part::GeomArcOfEllipse*>(geom1),
@@ -837,8 +841,10 @@ protected:
                     //     geoId2);
                     return false;
                 }
-                else if (geom2->is<Part::GeomArcOfEllipse>()
-                         && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())) {
+                else if (
+                    geom2->is<Part::GeomArcOfEllipse>()
+                    && (geom1->is<Part::GeomConic>() || geom1->is<Part::GeomArcOfConic>())
+                ) {
                     // makeTangentToArcOfEllipseviaNewPoint(
                     //     Obj,
                     //     static_cast<const Part::GeomArcOfEllipse*>(geom2),

--- a/src/Mod/Sketcher/Gui/DrawSketchDefaultWidgetController.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchDefaultWidgetController.h
@@ -251,6 +251,10 @@ public:
     void addConstraints() override
     {}
 
+    /// function to create constraints based on control information for infinite DSH (polyline).
+    virtual void addStepConstraints()
+    {}
+
     /// function to configure the default widget.
     void configureToolWidget()
     {}

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -417,6 +417,12 @@ std::vector<QPixmap> DrawSketchHandler::suggestedConstraintsPixmaps(
             case Tangent:
                 iconType = QStringLiteral("Constraint_Tangent");
                 break;
+            case Perpendicular:
+                iconType = QStringLiteral("Constraint_Perpendicular");
+                break;
+            case Parallel:
+                iconType = QStringLiteral("Constraint_Parallel");
+                break;
             default:
                 break;
         }
@@ -432,7 +438,7 @@ std::vector<QPixmap> DrawSketchHandler::suggestedConstraintsPixmaps(
     return pixmaps;
 }
 
-DrawSketchHandler::PreselectionData DrawSketchHandler::getPreselectionData()
+DrawSketchHandler::PreselectionData DrawSketchHandler::getPreselectionData() const
 {
     SketchObject* obj = sketchgui->getSketchObject();
 
@@ -545,8 +551,9 @@ void DrawSketchHandler::seekPreselectionAutoConstraint(
     }
 }
 
-void DrawSketchHandler::seekAlignmentAutoConstraint(
+bool DrawSketchHandler::seekAlignmentAutoConstraint(
     std::vector<AutoConstraint>& suggestedConstraints,
+    const Base::Vector2d& Pos,
     const Base::Vector2d& Dir
 )
 {
@@ -566,21 +573,107 @@ void DrawSketchHandler::seekAlignmentAutoConstraint(
         // Suggest vertical constraint
         constr.Type = Sketcher::Vertical;
     }
+    else {
+        // Check for parallels and perpendiculars
+        // For this we need to find the closest match. So we need to find the closest matching line
+        // to Pos
+        double bestDistance = std::numeric_limits<double>::max();
+        int bestIndex = -1;
+        Sketcher::ConstraintType bestConstraint = Sketcher::None;
+
+        SketchObject* obj = sketchgui->getSketchObject();
+        const std::vector<Part::Geometry*> geomlist = obj->getCompleteGeometry();
+        for (size_t i = 0; i < geomlist.size(); ++i) {
+            auto* geo = geomlist[i];
+
+            if (geo->isDerivedFrom<Part::GeomLineSegment>()) {
+                auto* line = static_cast<const Part::GeomLineSegment*>(geo);
+                Base::Vector3d start = line->getStartPoint();
+                Base::Vector3d end = line->getEndPoint();
+                Base::Vector3d lineDir = end - start;
+
+                // ignore vertical and horizontal lines.
+                if (fabs(lineDir.x) < Precision::Confusion()
+                    || fabs(lineDir.y) < Precision::Confusion()) {
+                    continue;
+                }
+
+                lineDir.Normalize();
+                double lineAngle = atan2(lineDir.y, lineDir.x);
+                angle = atan2(Dir.y, Dir.x);
+
+                Sketcher::ConstraintType candidateConstraint = Sketcher::None;
+                if (std::abs(lineAngle - angle) < angleDevRad
+                    || std::abs(lineAngle - angle + M_PI) < angleDevRad
+                    || std::abs(lineAngle - angle - M_PI) < angleDevRad) {
+                    candidateConstraint = Sketcher::Parallel;
+                }
+                else if (std::abs(lineAngle - angle - M_PI_2) < angleDevRad
+                         || std::abs(lineAngle - angle + M_PI_2) < angleDevRad) {
+                    candidateConstraint = Sketcher::Perpendicular;
+                }
+
+                if (candidateConstraint != Sketcher::None) {
+                    // Compute the distance from Pos to the finite line segment
+                    Base::Vector2d start2d(start.x, start.y);
+                    Base::Vector2d end2d(end.x, end.y);
+                    Base::Vector2d segVec = end2d - start2d;
+                    Base::Vector2d posVec = Pos - start2d;
+
+                    // Project posVec onto segVec to find the projection parameter t
+                    double t = (posVec * segVec) / (segVec * segVec);
+
+                    double distance;
+                    if (t < 0) {
+                        // Closest to start point
+                        distance = (Pos - start2d).Length();
+                    }
+                    else if (t > 1) {
+                        // Closest to end point
+                        distance = (Pos - end2d).Length();
+                    }
+                    else {
+                        // Closest to the projection on the segment
+                        Base::Vector2d projPoint = start2d + t * segVec;
+                        distance = (Pos - projPoint).Length();
+                    }
+
+                    if (distance < bestDistance) {
+                        bestDistance = distance;
+                        bestIndex = static_cast<int>(i);
+                        bestConstraint = candidateConstraint;
+                    }
+                }
+            }
+        }
+
+        if (bestConstraint != Sketcher::None) {
+            AutoConstraint constr;
+            constr.Type = bestConstraint;
+            constr.GeoId = bestIndex;
+            constr.PosId = PointPos::none;  // or set appropriately
+            suggestedConstraints.push_back(constr);
+        }
+    }
 
     if (constr.Type != Sketcher::None) {
         suggestedConstraints.push_back(constr);
+        return true;
     }
+    return false;
 }
 
-void DrawSketchHandler::seekTangentAutoConstraint(
+bool DrawSketchHandler::seekTangentAutoConstraint(
     std::vector<AutoConstraint>& suggestedConstraints,
     const Base::Vector2d& Pos,
     const Base::Vector2d& Dir
 )
 {
     using std::numbers::pi;
+    // This function does not handle endpoint tangencies.
     SketchObject* obj = sketchgui->getSketchObject();
     int tangId = GeoEnum::GeoUndef;
+    PointPos tanPos = PointPos::none;
 
     // Do not consider if distance is more than that.
     // Decrease this value when a candidate is found.
@@ -593,15 +686,24 @@ void DrawSketchHandler::seekTangentAutoConstraint(
     Base::Vector3d tmpDir(Dir.x, Dir.y, 0.f);                    // Direction of line
     Base::Vector3d tmpStart(Pos.x - Dir.x, Pos.y - Dir.y, 0.f);  // Start point
 
+    auto removeCoincidentConstraint = [&](int geoId, PointPos pos) {
+        auto newEnd = std::remove_if(
+            suggestedConstraints.begin(),
+            suggestedConstraints.end(),
+            [geoId, pos](const AutoConstraint& c) {
+                return (c.Type == Coincident && c.GeoId == geoId && c.PosId == pos);
+            }
+        );
+        suggestedConstraints.erase(newEnd, suggestedConstraints.end());
+    };
+
     int i = -1;
     for (auto* geo : geomlist) {
         i++;
 
-        if (geo->is<Part::GeomCircle>()) {
+        if (geo->isDerivedFrom<Part::GeomCircle>()) {
             auto* circle = static_cast<const Part::GeomCircle*>(geo);
-
             Base::Vector3d center = circle->getCenter();
-
             double radius = circle->getRadius();
 
             // ignore if no touch (use dot product)
@@ -619,9 +721,8 @@ void DrawSketchHandler::seekTangentAutoConstraint(
                 tangDeviation = projDist;
             }
         }
-        else if (geo->is<Part::GeomEllipse>()) {
+        else if (geo->isDerivedFrom<Part::GeomEllipse>()) {
             auto* ellipse = static_cast<const Part::GeomEllipse*>(geo);
-
             Base::Vector3d center = ellipse->getCenter();
 
             double a = ellipse->getMajorRadius();
@@ -647,9 +748,8 @@ void DrawSketchHandler::seekTangentAutoConstraint(
                 tangDeviation = error;
             }
         }
-        else if (geo->is<Part::GeomArcOfCircle>()) {
+        else if (geo->isDerivedFrom<Part::GeomArcOfCircle>()) {
             auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
-
             Base::Vector3d center = arc->getCenter();
             double radius = arc->getRadius();
 
@@ -663,24 +763,58 @@ void DrawSketchHandler::seekTangentAutoConstraint(
             double projDist = std::abs(projPnt.Length() - radius);
 
             if (projDist < tangDeviation) {
-                double startAngle, endAngle;
-                arc->getRange(startAngle, endAngle, /*emulateCCW=*/true);
+                Base::Vector3d start = arc->getStartPoint();
+                Base::Vector3d end = arc->getEndPoint();
 
-                double angle = atan2(projPnt.y, projPnt.x);
-                while (angle < startAngle) {
-                    angle += 2 * pi;  // Bring it to range of arc
-                }
-
-                // if the point is on correct side of arc
-                if (angle <= endAngle) {  // Now need to check only one side
+                if ((start - tmpPos).Length() < Precision::Confusion()) {
+                    tanPos = PointPos::start;
                     tangId = i;
                     tangDeviation = projDist;
+
+                    // There must be a coincident autoconstraint added before. So we remove it
+                    removeCoincidentConstraint(tangId, tanPos);
+                }
+                else if ((start - tmpStart).Length() < Precision::Confusion()) {
+                    tanPos = PointPos::start;
+                    tangId = i;
+                    tangDeviation = projDist;
+                    // Coincident is added somewhere else so it has to be handled after the geo
+                    // creation.
+                }
+                else if ((end - tmpPos).Length() < Precision::Confusion()) {
+                    tanPos = PointPos::end;
+                    tangId = i;
+                    tangDeviation = projDist;
+
+                    // There must be a coincident autoconstraint added before. So we remove it
+                    removeCoincidentConstraint(tangId, tanPos);
+                }
+                else if ((end - tmpStart).Length() < Precision::Confusion()) {
+                    tanPos = PointPos::end;
+                    tangId = i;
+                    tangDeviation = projDist;
+                    // Coincident is added somewhere else so it has to be handled after the geo
+                    // creation.
+                }
+                else {
+                    double startAngle, endAngle;
+                    arc->getRange(startAngle, endAngle, /*emulateCCW=*/true);
+
+                    double angle = atan2(projPnt.y, projPnt.x);
+                    while (angle < startAngle) {
+                        angle += 2 * pi;  // Bring it to range of arc
+                    }
+
+                    // if the point is on correct side of arc
+                    if (angle <= endAngle) {  // Now need to check only one side
+                        tangId = i;
+                        tangDeviation = projDist;
+                    }
                 }
             }
         }
-        else if (geo->is<Part::GeomArcOfEllipse>()) {
+        else if (geo->isDerivedFrom<Part::GeomArcOfEllipse>()) {
             auto* aoe = static_cast<const Part::GeomArcOfEllipse*>(geo);
-
             Base::Vector3d center = aoe->getCenter();
 
             double a = aoe->getMajorRadius();
@@ -702,25 +836,32 @@ void DrawSketchHandler::seekTangentAutoConstraint(
             double error = fabs((focus1PMirrored - focus2P).Length() - 2 * a);
 
             if (error < tangDeviation) {
-                double startAngle, endAngle;
-                aoe->getRange(startAngle, endAngle, /*emulateCCW=*/true);
+                Base::Vector3d start = aoe->getStartPoint();
+                Base::Vector3d end = aoe->getEndPoint();
 
-                double angle = Base::fmod(
-                    atan2(
-                        -aoe->getMajorRadius()
-                            * ((tmpPos.x - center.x) * majdir.y - (tmpPos.y - center.y) * majdir.x),
-                        aoe->getMinorRadius()
-                            * ((tmpPos.x - center.x) * majdir.x + (tmpPos.y - center.y) * majdir.y)
-                    ) - startAngle,
-                    2.f * pi
-                );
-
-                while (angle < startAngle) {
-                    angle += 2 * pi;  // Bring it to range of arc
+                if ((start - tmpPos).Length() < Precision::Confusion()) {
+                    tanPos = PointPos::start;
+                    tangId = i;
+                    tangDeviation = error;
+                    removeCoincidentConstraint(tangId, tanPos);
                 }
-
-                // if the point is on correct side of arc
-                if (angle <= endAngle) {  // Now need to check only one side
+                else if ((start - tmpStart).Length() < Precision::Confusion()) {
+                    tanPos = PointPos::start;
+                    tangId = i;
+                    tangDeviation = error;
+                }
+                else if ((end - tmpPos).Length() < Precision::Confusion()) {
+                    tanPos = PointPos::end;
+                    tangId = i;
+                    tangDeviation = error;
+                    removeCoincidentConstraint(tangId, tanPos);
+                }
+                else if ((end - tmpStart).Length() < Precision::Confusion()) {
+                    tanPos = PointPos::end;
+                    tangId = i;
+                    tangDeviation = error;
+                }
+                else {
                     tangId = i;
                     tangDeviation = error;
                 }
@@ -735,9 +876,11 @@ void DrawSketchHandler::seekTangentAutoConstraint(
         AutoConstraint constr;
         constr.Type = Tangent;
         constr.GeoId = tangId;
-        constr.PosId = PointPos::none;
+        constr.PosId = tanPos;
         suggestedConstraints.push_back(constr);
+        return true;
     }
+    return false;
 }
 
 void DrawSketchHandler::openCommand(const std::string& name)
@@ -769,10 +912,14 @@ int DrawSketchHandler::seekAutoConstraint(
     seekPreselectionAutoConstraint(suggestedConstraints, Pos, Dir, type);
 
     if (Dir.Length() > 1e-8 && type != AutoConstraint::CURVE) {
-        seekAlignmentAutoConstraint(suggestedConstraints, Dir);
-
+        bool tangentCreated = false;
         if (type != AutoConstraint::VERTEX_NO_TANGENCY) {
-            seekTangentAutoConstraint(suggestedConstraints, Pos, Dir);
+            tangentCreated = seekTangentAutoConstraint(suggestedConstraints, Pos, Dir);
+        }
+
+        if (!tangentCreated) {
+            // We don't check for alignment if there is already a tangency.
+            seekAlignmentAutoConstraint(suggestedConstraints, Pos, Dir);
         }
     }
 
@@ -862,6 +1009,22 @@ void DrawSketchHandler::createAutoConstraints(
                     sketchgui->getObject(),
                     "addConstraint(Sketcher.Constraint('Vertical',%d)) ",
                     geoId2 != GeoEnum::GeoUndef ? geoId2 : geoId1
+                );
+            } break;
+            case Sketcher::Perpendicular: {
+                Gui::cmdAppObjectArgs(
+                    sketchgui->getObject(),
+                    "addConstraint(Sketcher.Constraint('Perpendicular',%d, %d)) ",
+                    geoId1,
+                    geoId2
+                );
+            } break;
+            case Sketcher::Parallel: {
+                Gui::cmdAppObjectArgs(
+                    sketchgui->getObject(),
+                    "addConstraint(Sketcher.Constraint('Parallel',%d, %d)) ",
+                    geoId1,
+                    geoId2
                 );
             } break;
             case Sketcher::Tangent: {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -604,13 +604,13 @@ bool DrawSketchHandler::seekAlignmentAutoConstraint(
 
                 Sketcher::ConstraintType candidateConstraint = Sketcher::None;
                 if (std::abs(lineAngle - angle) < angleDevRad
-                    || std::abs(lineAngle - angle + M_PI) < angleDevRad
-                    || std::abs(lineAngle - angle - M_PI) < angleDevRad) {
+                    || std::abs(lineAngle - angle + pi) < angleDevRad
+                    || std::abs(lineAngle - angle - pi) < angleDevRad) {
                     candidateConstraint = Sketcher::Parallel;
                 }
                 else if (
-                    std::abs(lineAngle - angle - M_PI_2) < angleDevRad
-                    || std::abs(lineAngle - angle + M_PI_2) < angleDevRad
+                    std::abs(lineAngle - angle - 2.0 * pi) < angleDevRad
+                    || std::abs(lineAngle - angle + 2.0 * pi) < angleDevRad
                 ) {
                     candidateConstraint = Sketcher::Perpendicular;
                 }
@@ -689,14 +689,9 @@ bool DrawSketchHandler::seekTangentAutoConstraint(
     Base::Vector3d tmpStart(Pos.x - Dir.x, Pos.y - Dir.y, 0.f);  // Start point
 
     auto removeCoincidentConstraint = [&](int geoId, PointPos pos) {
-        auto newEnd = std::remove_if(
-            suggestedConstraints.begin(),
-            suggestedConstraints.end(),
-            [geoId, pos](const AutoConstraint& c) {
-                return (c.Type == Coincident && c.GeoId == geoId && c.PosId == pos);
-            }
-        );
-        suggestedConstraints.erase(newEnd, suggestedConstraints.end());
+        std::erase_if(suggestedConstraints, [geoId, pos](const AutoConstraint& c) {
+            return c.Type == Coincident && c.GeoId == geoId && c.PosId == pos;
+        });
     };
 
     int i = -1;
@@ -768,7 +763,7 @@ bool DrawSketchHandler::seekTangentAutoConstraint(
                 Base::Vector3d start = arc->getStartPoint();
                 Base::Vector3d end = arc->getEndPoint();
 
-                if ((start - tmpPos).Length() < Precision::Confusion()) {
+                if ((start - tmpPos).Sqr() < Precision::SquareConfusion()) {
                     tanPos = PointPos::start;
                     tangId = i;
                     tangDeviation = projDist;
@@ -776,14 +771,14 @@ bool DrawSketchHandler::seekTangentAutoConstraint(
                     // There must be a coincident autoconstraint added before. So we remove it
                     removeCoincidentConstraint(tangId, tanPos);
                 }
-                else if ((start - tmpStart).Length() < Precision::Confusion()) {
+                else if ((start - tmpStart).Sqr() < Precision::SquareConfusion()) {
                     tanPos = PointPos::start;
                     tangId = i;
                     tangDeviation = projDist;
                     // Coincident is added somewhere else so it has to be handled after the geo
                     // creation.
                 }
-                else if ((end - tmpPos).Length() < Precision::Confusion()) {
+                else if ((end - tmpPos).Sqr() < Precision::SquareConfusion()) {
                     tanPos = PointPos::end;
                     tangId = i;
                     tangDeviation = projDist;
@@ -791,7 +786,7 @@ bool DrawSketchHandler::seekTangentAutoConstraint(
                     // There must be a coincident autoconstraint added before. So we remove it
                     removeCoincidentConstraint(tangId, tanPos);
                 }
-                else if ((end - tmpStart).Length() < Precision::Confusion()) {
+                else if ((end - tmpStart).Sqr() < Precision::SquareConfusion()) {
                     tanPos = PointPos::end;
                     tangId = i;
                     tangDeviation = projDist;
@@ -841,24 +836,24 @@ bool DrawSketchHandler::seekTangentAutoConstraint(
                 Base::Vector3d start = aoe->getStartPoint();
                 Base::Vector3d end = aoe->getEndPoint();
 
-                if ((start - tmpPos).Length() < Precision::Confusion()) {
+                if ((start - tmpPos).Sqr() < Precision::SquareConfusion()) {
                     tanPos = PointPos::start;
                     tangId = i;
                     tangDeviation = error;
                     removeCoincidentConstraint(tangId, tanPos);
                 }
-                else if ((start - tmpStart).Length() < Precision::Confusion()) {
+                else if ((start - tmpStart).Sqr() < Precision::SquareConfusion()) {
                     tanPos = PointPos::start;
                     tangId = i;
                     tangDeviation = error;
                 }
-                else if ((end - tmpPos).Length() < Precision::Confusion()) {
+                else if ((end - tmpPos).Sqr() < Precision::SquareConfusion()) {
                     tanPos = PointPos::end;
                     tangId = i;
                     tangDeviation = error;
                     removeCoincidentConstraint(tangId, tanPos);
                 }
-                else if ((end - tmpStart).Length() < Precision::Confusion()) {
+                else if ((end - tmpStart).Sqr() < Precision::SquareConfusion()) {
                     tanPos = PointPos::end;
                     tangId = i;
                     tangDeviation = error;

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -608,8 +608,10 @@ bool DrawSketchHandler::seekAlignmentAutoConstraint(
                     || std::abs(lineAngle - angle - M_PI) < angleDevRad) {
                     candidateConstraint = Sketcher::Parallel;
                 }
-                else if (std::abs(lineAngle - angle - M_PI_2) < angleDevRad
-                         || std::abs(lineAngle - angle + M_PI_2) < angleDevRad) {
+                else if (
+                    std::abs(lineAngle - angle - M_PI_2) < angleDevRad
+                    || std::abs(lineAngle - angle + M_PI_2) < angleDevRad
+                ) {
                     candidateConstraint = Sketcher::Perpendicular;
                 }
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -315,7 +315,7 @@ protected:
         Base::Vector3d hitShapeDir = Base::Vector3d(0, 0, 0);
         bool isLine = false;
     };
-    PreselectionData getPreselectionData();
+    PreselectionData getPreselectionData() const;
 
     void seekPreselectionAutoConstraint(
         std::vector<AutoConstraint>& constraints,
@@ -326,9 +326,13 @@ protected:
 
     bool isLineCenterAutoConstraint(int GeoId, const Base::Vector2d& Pos) const;
 
-    void seekAlignmentAutoConstraint(std::vector<AutoConstraint>& constraints, const Base::Vector2d& Dir);
+    bool seekAlignmentAutoConstraint(
+        std::vector<AutoConstraint>& constraints,
+        const Base::Vector2d& Pos,
+        const Base::Vector2d& Dir
+    );
 
-    void seekTangentAutoConstraint(
+    bool seekTangentAutoConstraint(
         std::vector<AutoConstraint>& constraints,
         const Base::Vector2d& Pos,
         const Base::Vector2d& Dir

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerBSpline.h
@@ -919,14 +919,14 @@ void DSHBSplineController::secondKeyShortcut()
 template<>
 void DSHBSplineController::thirdKeyShortcut()
 {
-    auto firstchecked = toolWidget->getCheckboxChecked(WCheckbox::FirstBox);
-    toolWidget->setCheckboxChecked(WCheckbox::FirstBox, !firstchecked);
+    handler->undoLastPoint();
 }
 
 template<>
 void DSHBSplineController::fourthKeyShortcut()
 {
-    handler->undoLastPoint();
+    auto firstchecked = toolWidget->getCheckboxChecked(WCheckbox::FirstBox);
+    toolWidget->setCheckboxChecked(WCheckbox::FirstBox, !firstchecked);
 }
 
 template<>
@@ -935,7 +935,7 @@ void DSHBSplineController::configureToolWidget()
     if (!init) {  // Code to be executed only upon initialisation
         toolWidget->setNoticeVisible(true);
         toolWidget->setNoticeText(
-            QApplication::translate("TaskSketcherTool_c1_bspline", "Press F to undo last point.")
+            QApplication::translate("TaskSketcherTool_c1_bspline", "Press R to undo last point.")
         );
 
         QStringList names = {
@@ -946,7 +946,7 @@ void DSHBSplineController::configureToolWidget()
 
         toolWidget->setCheckboxLabel(
             WCheckbox::FirstBox,
-            QApplication::translate("TaskSketcherTool_c1_bspline", "Periodic (R)")
+            QApplication::translate("TaskSketcherTool_c1_bspline", "Periodic (F)")
         );
         toolWidget->setCheckboxToolTip(
             WCheckbox::FirstBox,

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -29,6 +29,7 @@
 #include <Inventor/events/SoKeyboardEvent.h>
 #include <boost/math/special_functions/fpclassify.hpp>
 
+#include <Gui/BitmapFactory.h>
 #include <Gui/Notifications.h>
 #include <Gui/Command.h>
 #include <Gui/CommandT.h>
@@ -36,12 +37,16 @@
 
 #include <Mod/Sketcher/App/SketchObject.h>
 
+#include "DrawSketchDefaultWidgetController.h"
+#include "DrawSketchControllableHandler.h"
+
 #include "DrawSketchHandler.h"
 #include "GeometryCreationMode.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "SnapManager.h"
 
+using namespace Sketcher;
 
 namespace SketcherGui
 {
@@ -877,5 +882,1227 @@ protected:
         dirVec.Normalize();
     }
 };
+
+// ==================== New version of the polyline ==============================
+
+class DrawSketchHandlerPolyLine;
+
+namespace ConstructionMethods
+{
+enum class PolyLineConstructionMethod
+{
+    Line,
+    Arc,
+    End  // Must be the last one
+};
+}  // namespace ConstructionMethods
+
+using DSHPolyLineController = DrawSketchDefaultWidgetController<
+    DrawSketchHandlerPolyLine,
+    /*SelectModeT*/ StateMachines::TwoSeekEnd,
+    /*PAutoConstraintSize =*/2,
+    /*OnViewParametersT =*/OnViewParameters<5, 5>,  // NOLINT
+    /*WidgetParametersT =*/WidgetParameters<0, 0>,  // NOLINT
+    /*WidgetCheckboxesT =*/WidgetCheckboxes<1, 1>,  // NOLINT
+    /*WidgetComboboxesT =*/WidgetComboboxes<1, 1>,  // NOLINT
+    /*WidgetLineEditsT =*/WidgetLineEdits<0, 0>,    // NOLINT
+    ConstructionMethods::PolyLineConstructionMethod,
+    /*bool PFirstComboboxIsConstructionMethod =*/true>;
+
+using DSHPolyLineControllerBase = DSHPolyLineController::ControllerBase;
+
+using DrawSketchHandlerPolyLineBase = DrawSketchControllableHandler<DSHPolyLineController>;
+
+
+class DrawSketchHandlerPolyLine: public DrawSketchHandlerPolyLineBase
+{
+    friend DSHPolyLineController;
+    friend DSHPolyLineControllerBase;
+
+public:
+    explicit DrawSketchHandlerPolyLine(ConstructionMethod constrMethod = ConstructionMethod::Line)
+        : DrawSketchHandlerPolyLineBase(constrMethod)
+        , prevCursorPos(Base::Vector2d())
+        , resetSeekSecond(false)
+        , resetEdge(true)
+        , fillet(false)
+        , previousDirectionAngle(0.0)
+        , startAngle(0.0)
+        , range(0.0)
+        , dirChangeAngle(0.0)
+        , angleToPrevious(0.0)
+        , pos(PointPos::end) {};
+    ~DrawSketchHandlerPolyLine() override = default;
+
+    void activated() override
+    {
+        DrawSketchHandlerPolyLineBase::activated();
+        openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch polyline"));
+    }
+
+private:
+    void updateDataAndDrawToPosition(Base::Vector2d onSketchPos) override
+    {
+        prevCursorPos = onSketchPos;
+
+        switch (state()) {
+            case SelectMode::SeekFirst: {
+                toolWidgetManager.drawPositionAtCursor(onSketchPos);
+
+                seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
+            } break;
+            case SelectMode::SeekSecond: {
+                toolWidgetManager.drawDirectionAtCursor(onSketchPos, getLastPoint());
+
+                double angle1 = (onSketchPos - getLastPoint()).Angle() - previousDirectionAngle;
+                double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+                dirChangeAngle = abs(angle1 - dirChangeAngle) < abs(angle2 - dirChangeAngle)
+                    ? angle1
+                    : angle2;
+
+                try {
+                    CreateAndDrawShapeGeometry();
+                }
+                catch (const Base::ValueError&) {
+                }  // equal points while hovering raise an objection that can be safely ignored
+
+                Base::Vector2d vec;
+                if (constructionMethod() == ConstructionMethod::Line) {
+                    vec = onSketchPos - getLastPoint();
+                }
+
+                seekAndRenderAutoConstraint(sugConstraints[1], onSketchPos, vec);
+            } break;
+            default:
+                break;
+        }
+    }
+
+    void executeCommands() override
+    {
+        commitCommand();
+    }
+
+    void generateAutoConstraints() override
+    {
+        // The auto constraints are already generated in canGoToNextMode
+        removeRedundantAutoConstraints();
+    }
+
+    void createAutoConstraints() override
+    {
+        // The auto constraints are already generated in canGoToNextMode
+    }
+
+    std::string getToolName() const override
+    {
+        return "DSH_PolyLine";
+    }
+
+    QString getCrosshairCursorSVGName() const override
+    {
+        return QStringLiteral("Sketcher_Pointer_Create_Lineset");
+    }
+
+    std::unique_ptr<QWidget> createWidget() const override
+    {
+        return std::make_unique<SketcherToolDefaultWidget>();
+    }
+
+    bool isWidgetVisible() const override
+    {
+        return true;
+    };
+
+    QPixmap getToolIcon() const override
+    {
+        return Gui::BitmapFactory().pixmap("Sketcher_CreatePolyline");
+    }
+
+    QString getToolWidgetText() const override
+    {
+        return QString(QObject::tr("PolyLine parameters"));
+    }
+
+    bool canGoToNextMode() override
+    {
+        if (state() == SelectMode::SeekFirst) {
+            points.push_back(prevCursorPos);
+        }
+        if (state() == SelectMode::SeekSecond) {
+            // We create the geometry first.
+            createShape(false);
+
+            commandAddShapeGeometryAndConstraints();
+
+            int geoId = getHighestCurveIndex();
+            geoEltIds.push_back(GeoElementId(geoId, pos));
+
+            // Add the OVP constraints.
+            addStepControlConstraints();
+
+            // Gui::Command::commitCommand();
+
+            // We stay in SeekSecond unless the user closed the PolyLine.
+            bool isClosed = false;
+            PointPos ac1Pos = pos;
+
+            if (geoEltIds.size() == 1) {  // first line
+                auto& ac0 = sugConstraints[0];
+                generateAutoConstraintsOnElement(ac0, geoId, PointPos::start);
+            }
+            else {
+                // check if coincident with first point
+                for (auto& ac : sugConstraints[1]) {
+                    if (ac.Type == Sketcher::Coincident || ac.Type == Sketcher::Tangent) {
+                        if (ac.GeoId == geoEltIds[0].GeoId && ac.PosId == Sketcher::PointPos::start) {
+                            isClosed = true;
+                        }
+                        else {
+                            // The coincidence with first point may be indirect
+                            const auto coincidents = sketchgui->getSketchObject()
+                                                         ->getAllCoincidentPoints(ac.GeoId, ac.PosId);
+
+                            auto it = coincidents.find(geoEltIds[0].GeoId);
+                            if (it != coincidents.end() && it->second == Sketcher::PointPos::start) {
+                                isClosed = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            auto& ac1 = sugConstraints[1];
+            generateAutoConstraintsOnElement(ac1, geoId, ac1Pos);
+            ac1.clear();
+
+            removeRedundantAutoConstraints();
+
+            createGeneratedAutoConstraints(false);
+            sugConstraints[0].clear();
+            sugConstraints[1].clear();
+            AutoConstraints.clear();
+
+            auto obj = sketchgui->getSketchObject();
+            obj->solve();
+
+            if (fillet && geoEltIds.size() > 1) {
+                int geoId1 = geoEltIds.back().GeoId;
+                int geoId2 = geoEltIds[geoEltIds.size() - 2].GeoId;
+
+                const Part::Geometry* newGeo = obj->getGeometry(geoId1);
+                const Part::Geometry* prevGeo = obj->getGeometry(geoId2);
+
+                PointPos newGeoPos = geoEltIds.back().Pos == PointPos::start ? PointPos::end
+                                                                             : PointPos::start;
+                PointPos prevGeoPos = geoEltIds[geoEltIds.size() - 2].Pos;
+
+                double radius;
+                Base::Vector3d refPnt1, refPnt2;
+                getFilletData(refPnt1, refPnt2, radius, newGeo, prevGeo, newGeoPos, prevGeoPos);
+
+                obj->fillet(geoId1, geoId2, refPnt1, refPnt2, radius, true, true);
+
+                if (isConstructionMode()) {
+                    int filletGeoId = geoId + 1;
+                    Gui::cmdAppObjectArgs(obj, "toggleConstruction(%d) ", filletGeoId);
+                }
+            }
+
+            Base::Vector3d p3d = obj->getPoint(geoEltIds.back().GeoId, geoEltIds.back().Pos);
+            points.push_back(toVector2d(p3d));
+            calculatePreviousDirectionAngle();
+
+            if (!isClosed) {
+                setAngleSnapping(true, getLastPoint());
+                resetSeekSecond = true;
+                resetEdge = true;
+                // redraw the OVPs
+                auto snapHandle = std::make_unique<SnapManager::SnapHandle>(nullptr, prevCursorPos);
+                mouseMove(*snapHandle);
+            }
+            return isClosed;
+        }
+        return true;
+    }
+
+    void calculatePreviousDirectionAngle()
+    {
+        previousDirectionAngle = getPreviousDirection().Angle();
+    }
+
+    Base::Vector2d getPreviousDirection()
+    {
+        if (points.size() > 1) {
+            int geoId = geoEltIds.back().GeoId;
+
+            auto* geom = sketchgui->getSketchObject()->getGeometry(geoId);
+            if (geom && isArcOfCircle(*geom)) {
+                auto* obj = sketchgui->getSketchObject();
+                Base::Vector2d start = toVector2d(obj->getPoint(geoId, PointPos::start));
+                Base::Vector2d end = toVector2d(obj->getPoint(geoId, PointPos::end));
+                Base::Vector2d center = toVector2d(obj->getPoint(geoId, PointPos::mid));
+
+                Base::Vector2d dir;
+                if (geoEltIds.back().Pos == PointPos::end) {
+                    dir = end - center;
+                    dir = Base::Vector2d(dir.y, -dir.x);
+                }
+                else {
+                    dir = start - center;
+                    dir = Base::Vector2d(-dir.y, dir.x);
+                }
+                return dir.Normalize();
+            }
+            else {
+                return (points[points.size() - 2] - points[points.size() - 1]).Normalize();
+            }
+        }
+
+        return Base::Vector2d(1., 0.);
+    }
+
+    Base::Vector2d getCurrentInitialDirection()
+    {
+        Base::Vector2d dir;
+        if (constructionMethod() == ConstructionMethod::Line) {
+            return prevCursorPos - getLastPoint();
+        }
+        else {
+            dir = getPreviousDirection();
+            dir.Rotate(angleToPrevious);
+        }
+
+        return dir;
+    }
+
+    bool isPreviousArc()
+    {
+        if (!geoEltIds.empty()) {
+            auto* geo = sketchgui->getSketchObject()->getGeometry(geoEltIds.back().GeoId);
+            return geo->is<Part::GeomArcOfCircle>();
+        }
+        return false;
+    }
+
+    void angleSnappingControl() override
+    {
+        if (state() == SelectMode::SeekSecond) {
+            setAngleSnapping(true, getLastPoint());
+        }
+        else {
+            setAngleSnapping(false);
+        }
+    }
+
+    void quit() override
+    {
+        if (state() == SelectMode::SeekSecond) {
+            if (geoEltIds.size() > 0) {
+                setState(SelectMode::End);
+                finish();
+            }
+            else {
+                // We don't want to finish() as that'll create auto-constraints
+                handleContinuousMode();
+            }
+        }
+        else {
+            DrawSketchHandler::quit();
+        }
+    }
+
+    void rightButtonOrEsc() override
+    {
+        quit();
+    }
+
+    void onReset() override
+    {
+        abortCommand();
+        tryAutoRecomputeIfNotSolve(sketchgui->getSketchObject());
+        openCommand(QT_TRANSLATE_NOOP("Command", "Add sketch polyline"));
+
+        geoEltIds.clear();
+        points.clear();
+
+        previousDirectionAngle = 0.0;
+        dirChangeAngle = 0.0;
+        angleToPrevious = 0.0;
+        pos = PointPos::end;
+
+        toolWidgetManager.resetControls();
+
+        setConstructionMethod(ConstructionMethod::Line);
+        ensureFocus();
+    }
+
+    void undoLastPoint()
+    {
+        // can only delete last pole/knot if it exists
+        if (state() != SelectMode::SeekSecond) {
+            return;
+        }
+
+        if (geoEltIds.empty()) {
+            // this also exits b-spline creation if continuous mode is off
+            quit();
+            return;
+        }
+
+        // reverse the steps of press/release button
+        try {
+            auto* obj = sketchgui->getSketchObject();
+            int delGeoId = geoEltIds.back().GeoId;
+            int lastGeoId = getHighestCurveIndex();
+            // 3 cases :
+            // - no fillet, then delGeoId == lastGeoId
+            // - fillet between 2 lines, then delGeoId + 2 == lastGeoId
+            // - fillet other, then delGeoId + 1 == lastGeoId (no points are created)
+            bool filletWasCreated = delGeoId < lastGeoId;
+            bool pointWasCreated = delGeoId + 2 == lastGeoId;
+
+            geoEltIds.pop_back();
+            points.pop_back();
+
+            // Start by removing last edge and fillet arc if any
+            if (filletWasCreated) {
+                obj->delGeometries({delGeoId, delGeoId + 1});
+            }
+            else {
+                obj->delGeometry(delGeoId);
+            }
+
+            if (!geoEltIds.empty()) {
+                // Move back the previous edge point
+                int prevGeoId = geoEltIds.back().GeoId;
+                PointPos prevPos = geoEltIds.back().Pos;
+                obj->moveGeometry(prevGeoId, prevPos, toVector3d(points.back()));
+
+                // Then transfert back the constraints
+                if (pointWasCreated) {
+                    int pointGeoId = getHighestCurveIndex();
+                    // We must first remove the point on object constraint.
+                    const auto& constraints = sketchgui->getSketchObject()->Constraints.getValues();
+                    for (int i = constraints.size() - 1; i >= 0; --i) {
+                        if (constraints[i]->Type == PointOnObject
+                            && ((constraints[i]->First == pointGeoId
+                                 && constraints[i]->Second == prevGeoId)
+                                || (constraints[i]->First == prevGeoId
+                                    && constraints[i]->Second == pointGeoId))) {
+                            obj->delConstraint(i);
+                            break;
+                        }
+                    }
+
+                    obj->transferConstraints(pointGeoId, PointPos::start, prevGeoId, prevPos);
+
+                    // Delete the point
+                    obj->delGeometry(delGeoId);
+                }
+            }
+
+            obj->solve();
+
+            calculatePreviousDirectionAngle();
+
+            setAngleSnapping(true, getLastPoint());
+
+            auto snapHandle = std::make_unique<SnapManager::SnapHandle>(nullptr, prevCursorPos);
+            mouseMove(*snapHandle);
+        }
+        catch (const Base::Exception&) {
+            Gui::NotifyError(
+                sketchgui,
+                QT_TRANSLATE_NOOP("Notifications", "Error"),
+                QT_TRANSLATE_NOOP("Notifications", "Error deleting last pole/knot")
+            );
+            // some commands might have already deleted some constraints/geometries but not
+            // others
+            abortCommand();
+
+            sketchgui->getSketchObject()->solve();
+
+            return;
+        }
+    }
+
+private:
+    Base::Vector2d prevCursorPos, center;
+
+    std::vector<Base::Vector2d> points;
+    std::vector<GeoElementId> geoEltIds;
+    bool resetSeekSecond;
+    bool resetEdge;
+    bool fillet;
+    double previousDirectionAngle, dirChangeAngle, startAngle, range, angleToPrevious;
+    PointPos pos;
+
+
+    void changeConstructionMethode()
+    {
+        if (constructionMethod() == ConstructionMethod::Arc) {
+            if (geoEltIds.empty()) {
+                setConstructionMethod(ConstructionMethod::Line);
+            }
+        }
+    }
+
+    Base::Vector2d getLastPoint()
+    {
+        return points.empty() ? Base::Vector2d() : points.back();
+    }
+
+    double getArcCenter(Base::Vector2d& center, Base::Vector2d pos)
+    {
+        Base::Vector2d lastPoint = getLastPoint();
+        Base::Vector2d Tangent = getCurrentInitialDirection();
+        double theta = Tangent.GetAngle(pos - lastPoint);
+        double radius = (pos - lastPoint).Length() / (2.0 * sin(theta));
+
+        double x1 = lastPoint.x;
+        double y1 = lastPoint.y;
+        double x2 = x1 + Tangent.x;
+        double y2 = y1 + Tangent.y;
+        double x3 = pos.x;
+        double y3 = pos.y;
+        if ((x2 * y3 - x3 * y2) - (x1 * y3 - x3 * y1) + (x1 * y2 - x2 * y1) > 0) {
+            radius *= -1;
+        }
+        if (boost::math::isnan(radius) || boost::math::isinf(radius)) {
+            radius = 0.0;
+        }
+
+        center = lastPoint + Base::Vector2d(radius * Tangent.y, -radius * Tangent.x);
+        return radius;
+    }
+
+    void getFilletData(
+        Base::Vector3d& refPnt1,
+        Base::Vector3d& refPnt2,
+        double& radius,
+        const Part::Geometry* newGeo,
+        const Part::Geometry* prevGeo,
+        PointPos newGeoPos,
+        PointPos prevGeoPos
+    )
+    {
+        Base::Vector2d lastPoint = getLastPoint();
+
+        Base::Vector2d lastButOnePoint = points[points.size() - 2];  // if geoEltIds not empty we
+                                                                     // have at least 2 points
+
+        radius = min(
+            (prevCursorPos - lastPoint).Length() * 0.3,
+            (lastButOnePoint - lastPoint).Length() * 0.3
+        );
+
+        refPnt1 = toVector3d(lastPoint + (prevCursorPos - lastPoint).Normalize() * radius);
+        refPnt2 = toVector3d(lastPoint + (lastButOnePoint - lastPoint).Normalize() * radius);
+
+        if (isLineSegment(*newGeo) && isLineSegment(*prevGeo)) {
+            // guess fillet radius
+            auto* line1 = static_cast<const Part::GeomLineSegment*>(newGeo);
+            auto* line2 = static_cast<const Part::GeomLineSegment*>(prevGeo);
+
+            radius = Part::suggestFilletRadius(line1, line2, refPnt1, refPnt2);
+        }
+        double start, end, newAngle;
+        double devAngle = 0.3;  // about 15deg
+        if (isArcOfCircle(*newGeo)) {
+            auto* arc = static_cast<const Part::GeomArcOfCircle*>(newGeo);
+            // Get arc properties
+            Base::Vector3d center = arc->getCenter();
+            double radius = arc->getRadius();
+            arc->getRange(start, end, true);
+
+            double arcAngle = end - start;
+            if (newGeoPos == PointPos::end) {
+                newAngle = end - std::min(arcAngle, devAngle);
+            }
+            else {
+                newAngle = start + std::min(arcAngle, devAngle);
+            }
+
+            refPnt1 = Base::Vector3d(
+                center.x + radius * cos(newAngle),
+                center.y + radius * sin(newAngle)
+            );
+            if (isLineSegment(*prevGeo)) {
+                refPnt2 = toVector3d(lastPoint)
+                    + (refPnt2 - toVector3d(lastPoint)).Normalize()
+                        * (toVector3d(lastPoint) - refPnt1).Length();
+            }
+        }
+        if (isArcOfCircle(*prevGeo)) {
+            auto* arc = static_cast<const Part::GeomArcOfCircle*>(prevGeo);
+            // Get arc properties
+            Base::Vector3d center = arc->getCenter();
+            double radius = arc->getRadius();
+            arc->getRange(start, end, true);
+
+            double arcAngle = end - start;
+            if (prevGeoPos == PointPos::end) {
+                newAngle = end - std::min(arcAngle, devAngle);
+            }
+            else {
+                newAngle = start + std::min(arcAngle, devAngle);
+            }
+
+            refPnt2 = Base::Vector3d(
+                center.x + radius * cos(newAngle),
+                center.y + radius * sin(newAngle)
+            );
+            if (isLineSegment(*newGeo)) {
+                refPnt1 = toVector3d(lastPoint)
+                    + (refPnt1 - toVector3d(lastPoint)).Normalize()
+                        * (toVector3d(lastPoint) - refPnt2).Length();
+            }
+        }
+    }
+
+    void createShape(bool onlyeditoutline) override
+    {
+        ShapeGeometry.clear();
+        ShapeConstraints.clear();
+
+        if (points.size() < 1) {
+            return;
+        }
+        Base::Vector2d lastPoint = getLastPoint();
+        Base::Vector2d currentDir = prevCursorPos - lastPoint;
+        if (currentDir.Length() < Precision::Confusion()) {
+            resetEdge = true;
+            return;
+        }
+
+        pos = PointPos::end;
+        PointPos posId = PointPos::start;
+        Base::Vector2d prevDir = getPreviousDirection();
+
+        Part::Geometry* newGeo = nullptr;
+        if (constructionMethod() == ConstructionMethod::Line) {
+            newGeo = addLineToShapeGeometry(
+                toVector3d(points[points.size() - 1]),
+                toVector3d(prevCursorPos),
+                isConstructionMode()
+            );
+        }
+        else {
+            if (resetEdge) {
+                resetEdge = false;
+
+                // We check the direction of the first mouse move to determine tangent or
+                // perpendicular
+                int sign = (prevDir.x * (prevCursorPos.y - lastPoint.y)
+                            - prevDir.y * (prevCursorPos.x - lastPoint.x))
+                        > 0
+                    ? 1
+                    : -1;
+
+                angleToPrevious = sign * (currentDir.GetAngle(prevDir) - M_PI);
+                angleToPrevious = std::round(angleToPrevious / (M_PI * 0.5)) * (M_PI * 0.5);
+            }
+
+            Base::Vector2d Tangent = getCurrentInitialDirection();
+            double theta = Tangent.GetAngle(currentDir);
+            double radius = getArcCenter(center, prevCursorPos);
+
+            if (radius == 0.0) {
+                // fall back to a line
+                addLineToShapeGeometry(
+                    toVector3d(points[points.size() - 1]),
+                    toVector3d(prevCursorPos),
+                    isConstructionMode()
+                );
+            }
+
+            double rx = lastPoint.x - center.x;
+            double ry = lastPoint.y - center.y;
+
+            startAngle = atan2(ry, rx);
+
+            double rxe = prevCursorPos.x - center.x;
+            double rye = prevCursorPos.y - center.y;
+            range = atan2(-rxe * ry + rye * rx, rxe * rx + rye * ry);
+            if (boost::math::isnan(range) || boost::math::isinf(range)) {
+                range = 0.f;
+            }
+            if (radius >= 0 && range > 0) {
+                range -= 2 * M_PI;
+            }
+            if (radius < 0 && range < 0) {
+                range += 2 * M_PI;
+            }
+
+            double endAngle = startAngle + range;
+            double startAngleToUseHere = startAngle;
+            if (radius < 0) {
+                std::swap(startAngleToUseHere, endAngle);
+                posId = PointPos::end;
+                pos = PointPos::start;
+            }
+
+            newGeo = addArcToShapeGeometry(
+                toVector3d(center),
+                startAngleToUseHere,
+                endAngle,
+                fabs(radius),
+                isConstructionMode()
+            );
+
+            // range is weirdly handled before. We fix the range for the OVP
+            if (radius < 0) {
+                range = -2 * M_PI + range;
+            }
+            else {
+                range = 2 * M_PI + range;
+            }
+        }
+
+        if (onlyeditoutline && !geoEltIds.empty() && fillet) {
+            auto* obj = sketchgui->getSketchObject();
+            const Part::Geometry* prevGeo = obj->getGeometry(geoEltIds.back().GeoId);
+
+            double radius;
+            Base::Vector3d refPnt1, refPnt2;
+            getFilletData(refPnt1, refPnt2, radius, newGeo, prevGeo, posId, geoEltIds.back().Pos);
+
+            int pos1 = 0;
+            int pos2 = 0;
+            bool reverse = false;
+            std::unique_ptr<Part::GeomArcOfCircle> arc(
+                Part::createFilletGeometry(newGeo, prevGeo, refPnt1, refPnt2, radius, pos1, pos2, reverse)
+            );
+            if (arc) {
+                if (isLineSegment(*newGeo)) {
+                    Base::Vector3d newStart = reverse ? arc->getStartPoint() : arc->getEndPoint();
+                    auto* line = static_cast<Part::GeomLineSegment*>(newGeo);
+                    line->setPoints(newStart, line->getEndPoint());
+                }
+
+                ShapeGeometry.emplace_back(std::move(arc));
+            }
+        }
+
+        if (!onlyeditoutline && !geoEltIds.empty()) {
+            // Add constraints.
+            int geoId = geoEltIds.back().GeoId;
+            int geoId2 = getHighestCurveIndex() + 1;
+
+            if (constructionMethod() == ConstructionMethod::Line) {
+                auto& ac1 = sugConstraints[1];
+                auto newEnd = std::remove_if(ac1.begin(), ac1.end(), [&](const AutoConstraint& c) {
+                    return (c.Type == Tangent && c.GeoId == geoId && c.PosId == geoEltIds.back().Pos);
+                });
+                bool erased = (newEnd != ac1.end());  // Check if anything was removed
+                ac1.erase(newEnd, ac1.end());
+
+                if (erased) {
+                    addToShapeConstraints(Sketcher::Tangent, geoId, geoEltIds.back().Pos, geoId2, posId);
+                }
+                else {
+                    addToShapeConstraints(Sketcher::Coincident, geoId, geoEltIds.back().Pos, geoId2, posId);
+                }
+            }
+            else {
+                double roundedByPi = std::round(angleToPrevious / (M_PI)) * M_PI;
+                double roundedByHalfPi = std::round(angleToPrevious / (M_PI * 0.5)) * (M_PI * 0.5);
+
+                if (fabs(angleToPrevious - roundedByPi) < Precision::Confusion()) {
+                    addToShapeConstraints(Sketcher::Tangent, geoId, geoEltIds.back().Pos, geoId2, posId);
+                }
+                else if (fabs(angleToPrevious - roundedByHalfPi) < Precision::Confusion()) {
+                    addToShapeConstraints(
+                        Sketcher::Perpendicular,
+                        geoId,
+                        geoEltIds.back().Pos,
+                        geoId2,
+                        posId
+                    );
+                }
+            }
+        }
+    }
+};
+
+template<>
+auto DSHPolyLineControllerBase::getState(int labelindex) const
+{
+    switch (labelindex) {
+        case OnViewParameter::First:
+        case OnViewParameter::Second:
+            return SelectMode::SeekFirst;
+            break;
+        case OnViewParameter::Third:
+        case OnViewParameter::Fourth:
+        case OnViewParameter::Fifth:
+            return SelectMode::SeekSecond;
+            break;
+        default:
+            THROWM(Base::ValueError, "Label index without an associated machine state")
+    }
+}
+
+template<>
+void DSHPolyLineController::thirdKeyShortcut()
+{
+    handler->undoLastPoint();
+}
+
+template<>
+void DSHPolyLineController::fourthKeyShortcut()
+{
+    auto firstchecked = toolWidget->getCheckboxChecked(WCheckbox::FirstBox);
+    toolWidget->setCheckboxChecked(WCheckbox::FirstBox, !firstchecked);
+}
+
+template<>
+void DSHPolyLineController::configureToolWidget()
+{
+    if (!init) {  // Code to be executed only upon initialisation
+        toolWidget->setNoticeVisible(true);
+        toolWidget->setNoticeText(
+            QApplication::translate("TaskSketcherTool_c1_PolyLine", "Press R to undo last point.")
+        );
+
+        QStringList names = {
+            QApplication::translate("Sketcher_CreatePolyline", "Line"),
+            QApplication::translate("Sketcher_CreatePolyline", "Arc")
+        };
+        toolWidget->setComboboxElements(WCombobox::FirstCombo, names);
+
+        toolWidget->setCheckboxLabel(
+            WCheckbox::FirstBox,
+            QApplication::translate("TaskSketcherTool_c1_PolyLine", "Fillet (F)")
+        );
+        toolWidget->setCheckboxToolTip(
+            WCheckbox::FirstBox,
+            QApplication::translate(
+                "TaskSketcherTool_c1_PolyLine",
+                "Add a fillet between the current and previous line."
+            )
+        );
+        syncCheckboxToHandler(WCheckbox::FirstBox, handler->fillet);
+
+        if (isConstructionMode()) {
+            toolWidget->setComboboxItemIcon(
+                WCombobox::FirstCombo,
+                0,
+                Gui::BitmapFactory().iconFromTheme("Sketcher_CreateLine_Constr")
+            );
+            toolWidget->setComboboxItemIcon(
+                WCombobox::FirstCombo,
+                1,
+                Gui::BitmapFactory().iconFromTheme("Sketcher_CreateArc_Constr")
+            );
+            toolWidget->setCheckboxIcon(
+                WCheckbox::FirstBox,
+                Gui::BitmapFactory().iconFromTheme("Sketcher_CreateFillet_Constr")
+            );
+        }
+        else {
+            toolWidget->setComboboxItemIcon(
+                WCombobox::FirstCombo,
+                0,
+                Gui::BitmapFactory().iconFromTheme("Sketcher_CreateLine")
+            );
+            toolWidget->setComboboxItemIcon(
+                WCombobox::FirstCombo,
+                1,
+                Gui::BitmapFactory().iconFromTheme("Sketcher_CreateArc")
+            );
+            toolWidget->setCheckboxIcon(
+                WCheckbox::FirstBox,
+                Gui::BitmapFactory().iconFromTheme("Sketcher_CreateFillet")
+            );
+        }
+    }
+
+    onViewParameters[OnViewParameter::First]->setLabelType(Gui::SoDatumLabel::DISTANCEX);
+    onViewParameters[OnViewParameter::Second]->setLabelType(Gui::SoDatumLabel::DISTANCEY);
+
+    Gui::SoDatumLabel::Type thirdType = handler->constructionMethod() == ConstructionMethod::Line
+        ? Gui::SoDatumLabel::DISTANCE
+        : Gui::SoDatumLabel::RADIUS;
+
+    onViewParameters[OnViewParameter::Third]->setLabelType(
+        thirdType,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+    onViewParameters[OnViewParameter::Fourth]->setLabelType(
+        Gui::SoDatumLabel::ANGLE,
+        Gui::EditableDatumLabel::Function::Dimensioning
+    );
+
+    if (handler->constructionMethod() == ConstructionMethod::Line) {
+        deactivateOnViewParameter(OnViewParameter::Fifth);
+    }
+    else {
+        onViewParameters[OnViewParameter::Fifth]->setLabelType(
+            Gui::SoDatumLabel::ANGLE,
+            Gui::EditableDatumLabel::Function::Dimensioning
+        );
+
+        activateOnViewParameter(OnViewParameter::Fifth);
+    }
+
+    toolWidget->setCheckboxChecked(WCheckbox::FirstBox, handler->fillet);
+}
+
+template<>
+void DSHPolyLineController::adaptDrawingToCheckboxChange(int checkboxindex, bool value)
+{
+    switch (checkboxindex) {
+        case WCheckbox::FirstBox:
+            handler->fillet = value;
+            break;
+    }
+
+    handler->updateCursor();
+}
+
+template<>
+void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSketchPos)
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            if (onViewParameters[OnViewParameter::First]->isSet) {
+                onSketchPos.x = onViewParameters[OnViewParameter::First]->getValue();
+            }
+
+            if (onViewParameters[OnViewParameter::Second]->isSet) {
+                onSketchPos.y = onViewParameters[OnViewParameter::Second]->getValue();
+            }
+        } break;
+        case SelectMode::SeekSecond: {
+            if (handler->resetSeekSecond) {
+                handler->resetSeekSecond = false;
+                unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
+                unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
+                unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
+                setFocusToOnViewParameter(OnViewParameter::Third);
+                return;
+            }
+
+            Base::Vector2d prevPoint = handler->getLastPoint();
+
+            if (handler->constructionMethod() == ConstructionMethod::Line) {
+                if (onViewParameters[OnViewParameter::Third]->isSet) {
+                    Base::Vector2d dir = onSketchPos - prevPoint;
+                    if (dir.Length() < Precision::Confusion()) {
+                        dir.x = 1.0;  // if direction null, default to (1,0)
+                    }
+                    double length = onViewParameters[OnViewParameter::Third]->getValue();
+                    if (length < Precision::Confusion()) {
+                        unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
+                        return;
+                    }
+
+                    onSketchPos = prevPoint + length * dir.Normalize();
+                }
+
+                if (onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    double arcAngle = Base::toRadians(
+                        onViewParameters[OnViewParameter::Fourth]->getValue()
+                    );
+                    double angle = handler->previousDirectionAngle + arcAngle;
+
+                    // Project onSketchPos on the line starting from prevPoint with angle of angle
+                    Base::Vector2d ovpDir(cos(angle), sin(angle));
+                    onSketchPos.ProjectToLine(onSketchPos - prevPoint, ovpDir);
+                    onSketchPos += prevPoint;
+                }
+
+                if (onViewParameters[OnViewParameter::Third]->isSet
+                    && onViewParameters[OnViewParameter::Fourth]->isSet
+                    && (onSketchPos - prevPoint).Length() < Precision::Confusion()) {
+                    unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
+                    unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
+                }
+            }
+            else {
+                if (onViewParameters[OnViewParameter::Third]->isSet) {
+                    double radius = onViewParameters[OnViewParameter::Third]->getValue();
+                    if (radius < Precision::Confusion()) {
+                        unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
+                        return;
+                    }
+
+                    Base::Vector2d dir = handler->getPreviousDirection();
+                    dir.Rotate(handler->angleToPrevious);
+
+                    int sign = (dir.x * (onSketchPos.y - prevPoint.y)
+                                - dir.y * (onSketchPos.x - prevPoint.x))
+                            > 0
+                        ? 1
+                        : -1;
+
+                    Base::Vector2d normal = sign * Base::Vector2d(-dir.y, dir.x);
+                    Base::Vector2d center = prevPoint + radius * normal.Normalize();
+
+                    dir = onSketchPos - center;
+                    onSketchPos = center + radius * dir.Normalize();
+                }
+                if (onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    Base::Vector2d center;
+                    ;
+                    double radius = handler->getArcCenter(center, onSketchPos);
+                    int sign = radius < 0 ? -1 : 1;
+                    radius = fabs(radius);
+                    double range = Base::toRadians(
+                        onViewParameters[OnViewParameter::Fourth]->getValue()
+                    );
+                    double angle = handler->startAngle + sign * range;
+                    Base::Vector2d dir(1.0, 0.0);
+                    dir.Rotate(angle);
+                    onSketchPos = center + dir * radius;
+                }
+                if (onViewParameters[OnViewParameter::Fifth]->isSet) {
+                    double angle = Base::toRadians(
+                        onViewParameters[OnViewParameter::Fifth]->getValue()
+                    );
+
+                    if (handler->angleToPrevious != angle) {
+                        handler->angleToPrevious = angle;
+                    }
+                }
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            if (!onViewParameters[OnViewParameter::First]->isSet) {
+                setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
+            }
+
+            if (!onViewParameters[OnViewParameter::Second]->isSet) {
+                setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
+            }
+
+            bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
+            onViewParameters[OnViewParameter::First]->setLabelAutoDistanceReverse(!sameSign);
+            onViewParameters[OnViewParameter::Second]->setLabelAutoDistanceReverse(sameSign);
+            onViewParameters[OnViewParameter::First]->setPoints(
+                Base::Vector3d(),
+                toVector3d(onSketchPos)
+            );
+            onViewParameters[OnViewParameter::Second]->setPoints(
+                Base::Vector3d(),
+                toVector3d(onSketchPos)
+            );
+        } break;
+        case SelectMode::SeekSecond: {
+            Base::Vector2d prevPoint;
+            if (!handler->points.empty()) {
+                prevPoint = handler->getLastPoint();
+            }
+            if (handler->constructionMethod() == ConstructionMethod::Line) {
+                Base::Vector3d start = toVector3d(prevPoint);
+                Base::Vector3d end = toVector3d(onSketchPos);
+                Base::Vector3d vec = end - start;
+
+                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Third, vec.Length());
+                }
+
+                double range = Base::toDegrees(handler->dirChangeAngle);
+                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
+                }
+                else if (vec.Length() > Precision::Confusion()) {
+                    double ovpRange = onViewParameters[OnViewParameter::Fourth]->getValue();
+
+                    if (fabs(range - ovpRange) > Precision::Confusion()) {
+                        setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
+                    }
+                }
+
+                onViewParameters[OnViewParameter::Third]->setPoints(start, end);
+                onViewParameters[OnViewParameter::Fourth]->setPoints(start, Base::Vector3d());
+                onViewParameters[OnViewParameter::Fourth]->setLabelStartAngle(
+                    handler->previousDirectionAngle
+                );
+                onViewParameters[OnViewParameter::Fourth]->setLabelRange(handler->dirChangeAngle);
+            }
+            else {
+                Base::Vector3d start = toVector3d(handler->center);
+                Base::Vector3d end = toVector3d(onSketchPos);
+                Base::Vector3d vec = end - start;
+
+                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Third, vec.Length());
+                }
+
+                double range = Base::toDegrees(handler->range);
+                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
+                }
+
+                double angle = Base::toDegrees(handler->angleToPrevious);
+                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
+                    setOnViewParameterValue(OnViewParameter::Fifth, angle, Base::Unit::Angle);
+                }
+
+                onViewParameters[OnViewParameter::Third]->setPoints(start, end);
+                onViewParameters[OnViewParameter::Fourth]->setPoints(start, Base::Vector3d());
+                onViewParameters[OnViewParameter::Fourth]->setLabelStartAngle(handler->startAngle);
+                onViewParameters[OnViewParameter::Fourth]->setLabelRange(handler->range);
+
+                onViewParameters[OnViewParameter::Fifth]->setPoints(
+                    toVector3d(prevPoint),
+                    Base::Vector3d()
+                );
+                onViewParameters[OnViewParameter::Fifth]->setLabelStartAngle(
+                    handler->previousDirectionAngle
+                );
+                onViewParameters[OnViewParameter::Fifth]->setLabelRange(handler->angleToPrevious);
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHPolyLineController::computeNextDrawSketchHandlerMode()
+{
+    switch (handler->state()) {
+        case SelectMode::SeekFirst: {
+            if (onViewParameters[OnViewParameter::First]->isSet
+                && onViewParameters[OnViewParameter::Second]->isSet) {
+                double x = onViewParameters[OnViewParameter::First]->getValue();
+                double y = onViewParameters[OnViewParameter::Second]->getValue();
+                handler->onButtonPressed(Base::Vector2d(x, y));
+            }
+        } break;
+        case SelectMode::SeekSecond: {
+            if (onViewParameters[OnViewParameter::Third]->isSet
+                && onViewParameters[OnViewParameter::Fourth]->isSet) {
+                handler->canGoToNextMode();  // its not going to next mode
+
+                unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
+                unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
+                unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
+            }
+        } break;
+        default:
+            break;
+    }
+}
+
+template<>
+void DSHPolyLineController::doConstructionMethodChanged()
+{
+    handler->changeConstructionMethode();
+
+    configureToolWidget();
+
+    syncConstructionMethodComboboxToHandler();
+}
+
+template<>
+bool DSHPolyLineControllerBase::resetOnConstructionMethodeChanged()
+{
+    return false;
+}
+
+template<>
+void DSHPolyLineController::addStepConstraints()
+{
+    App::DocumentObject* obj = handler->sketchgui->getObject();
+
+    int lastCurve = handler->getHighestCurveIndex();
+
+    if (handler->geoEltIds.size() == 1) {
+        auto x0 = onViewParameters[OnViewParameter::First]->getValue();
+        auto y0 = onViewParameters[OnViewParameter::Second]->getValue();
+
+        auto x0set = onViewParameters[OnViewParameter::First]->isSet;
+        auto y0set = onViewParameters[OnViewParameter::Second]->isSet;
+
+        auto constraintToOrigin = [&]() {
+            ConstraintToAttachment(GeoElementId(lastCurve, PointPos::start), GeoElementId::RtPnt, x0, obj);
+        };
+
+        auto constraintx0 = [&]() {
+            ConstraintToAttachment(GeoElementId(lastCurve, PointPos::start), GeoElementId::VAxis, x0, obj);
+        };
+
+        auto constrainty0 = [&]() {
+            ConstraintToAttachment(GeoElementId(lastCurve, PointPos::start), GeoElementId::HAxis, y0, obj);
+        };
+
+        if (x0set && y0set && x0 == 0. && y0 == 0.) {
+            constraintToOrigin();
+        }
+        else {
+            if (x0set) {
+                constraintx0();
+            }
+
+            if (y0set) {
+                constrainty0();
+            }
+        }
+    }
+
+    auto p3 = onViewParameters[OnViewParameter::Third]->getValue();
+    auto p4 = onViewParameters[OnViewParameter::Fourth]->getValue();
+    auto p5 = onViewParameters[OnViewParameter::Fifth]->getValue();
+
+    auto p3set = onViewParameters[OnViewParameter::Third]->isSet;
+    auto p4set = onViewParameters[OnViewParameter::Fourth]->isSet;
+    auto p5set = onViewParameters[OnViewParameter::Fifth]->isSet;
+
+    if (handler->constructionMethod() == ConstructionMethod::Line) {
+        if (p3set) {
+            Gui::cmdAppObjectArgs(
+                obj,
+                "addConstraint(Sketcher.Constraint('Distance',%d,%f)) ",
+                lastCurve,
+                fabs(p3)
+            );
+        }
+
+        if (p4set) {
+            if (handler->geoEltIds.size() > 1) {
+                if (!handler->isPreviousArc()) {
+                    int geoId2 = handler->geoEltIds[handler->geoEltIds.size() - 2].GeoId;
+                    Constraint2LinesByAngle(lastCurve, geoId2, Base::toRadians(p4), obj);
+                }
+            }
+            else {
+                ConstraintLineByAngle(lastCurve, Base::toRadians(p4), obj);
+            }
+        }
+    }
+    else {
+        if (p3set) {
+            Gui::cmdAppObjectArgs(
+                obj,
+                "addConstraint(Sketcher.Constraint('Radius',%d,%f)) ",
+                lastCurve,
+                fabs(p3)
+            );
+        }
+
+        if (p4set) {
+            Gui::cmdAppObjectArgs(
+                obj,
+                "addConstraint(Sketcher.Constraint('Angle',%d,%f)) ",
+                lastCurve,
+                fabs(Base::toRadians(p4))
+            );
+        }
+    }
+}
 
 }  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -950,13 +950,13 @@ private:
             case SelectMode::SeekFirst: {
                 toolWidgetManager.drawPositionAtCursor(onSketchPos);
 
-                seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.f, 0.f));
+                seekAndRenderAutoConstraint(sugConstraints[0], onSketchPos, Base::Vector2d(0.F, 0.F));
             } break;
             case SelectMode::SeekSecond: {
                 toolWidgetManager.drawDirectionAtCursor(onSketchPos, getLastPoint());
 
                 double angle1 = (onSketchPos - getLastPoint()).Angle() - previousDirectionAngle;
-                double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * M_PI;
+                double angle2 = angle1 + (angle1 < 0. ? 2 : -2) * std::numbers::pi;
                 dirChangeAngle = abs(angle1 - dirChangeAngle) < abs(angle2 - dirChangeAngle)
                     ? angle1
                     : angle2;
@@ -1055,20 +1055,22 @@ private:
             else {
                 // check if coincident with first point
                 for (auto& ac : sugConstraints[1]) {
-                    if (ac.Type == Sketcher::Coincident || ac.Type == Sketcher::Tangent) {
-                        if (ac.GeoId == geoEltIds[0].GeoId && ac.PosId == Sketcher::PointPos::start) {
-                            isClosed = true;
-                        }
-                        else {
-                            // The coincidence with first point may be indirect
-                            const auto coincidents = sketchgui->getSketchObject()
-                                                         ->getAllCoincidentPoints(ac.GeoId, ac.PosId);
+                    if (ac.Type != Sketcher::Coincident && ac.Type != Sketcher::Tangent) {
+                        continue;
+                    }
 
-                            auto it = coincidents.find(geoEltIds[0].GeoId);
-                            if (it != coincidents.end() && it->second == Sketcher::PointPos::start) {
-                                isClosed = true;
-                            }
-                        }
+                    if (ac.GeoId == geoEltIds[0].GeoId && ac.PosId == Sketcher::PointPos::start) {
+                        isClosed = true;
+                        continue;
+                    }
+
+                    // The coincidence with first point may be indirect
+                    const auto coincidents = sketchgui->getSketchObject()
+                                                    ->getAllCoincidentPoints(ac.GeoId, ac.PosId);
+
+                    auto it = coincidents.find(geoEltIds[0].GeoId);
+                    if (it != coincidents.end() && it->second == Sketcher::PointPos::start) {
+                        isClosed = true;
                     }
                 }
             }
@@ -1134,33 +1136,33 @@ private:
 
     Base::Vector2d getPreviousDirection()
     {
-        if (points.size() > 1) {
-            int geoId = geoEltIds.back().GeoId;
-
-            auto* geom = sketchgui->getSketchObject()->getGeometry(geoId);
-            if (geom && isArcOfCircle(*geom)) {
-                auto* obj = sketchgui->getSketchObject();
-                Base::Vector2d start = toVector2d(obj->getPoint(geoId, PointPos::start));
-                Base::Vector2d end = toVector2d(obj->getPoint(geoId, PointPos::end));
-                Base::Vector2d center = toVector2d(obj->getPoint(geoId, PointPos::mid));
-
-                Base::Vector2d dir;
-                if (geoEltIds.back().Pos == PointPos::end) {
-                    dir = end - center;
-                    dir = Base::Vector2d(dir.y, -dir.x);
-                }
-                else {
-                    dir = start - center;
-                    dir = Base::Vector2d(-dir.y, dir.x);
-                }
-                return dir.Normalize();
-            }
-            else {
-                return (points[points.size() - 2] - points[points.size() - 1]).Normalize();
-            }
+        if (points.size() <= 1) {
+            return Base::Vector2d(1., 0.);
         }
 
-        return Base::Vector2d(1., 0.);
+        int geoId = geoEltIds.back().GeoId;
+
+        auto* geom = sketchgui->getSketchObject()->getGeometry(geoId);
+        if (!geom || !isArcOfCircle(*geom)) {
+            return (points[points.size() - 2] - points[points.size() - 1]).Normalize();
+        }
+
+        auto* obj = sketchgui->getSketchObject();
+        Base::Vector2d start = toVector2d(obj->getPoint(geoId, PointPos::start));
+        Base::Vector2d end = toVector2d(obj->getPoint(geoId, PointPos::end));
+        Base::Vector2d center = toVector2d(obj->getPoint(geoId, PointPos::mid));
+
+        Base::Vector2d dir;
+        if (geoEltIds.back().Pos == PointPos::end) {
+            dir = end - center;
+            dir = Base::Vector2d(dir.y, -dir.x);
+        }
+        else {
+            dir = start - center;
+            dir = Base::Vector2d(-dir.y, dir.x);
+        }
+
+        return dir.Normalize();
     }
 
     Base::Vector2d getCurrentInitialDirection()
@@ -1169,10 +1171,10 @@ private:
         if (constructionMethod() == ConstructionMethod::Line) {
             return prevCursorPos - getLastPoint();
         }
-        else {
-            dir = getPreviousDirection();
-            dir.Rotate(angleToPrevious);
-        }
+
+        dir = getPreviousDirection();
+        dir.Rotate(angleToPrevious);
+
 
         return dir;
     }
@@ -1198,19 +1200,19 @@ private:
 
     void quit() override
     {
-        if (state() == SelectMode::SeekSecond) {
-            if (geoEltIds.size() > 0) {
-                setState(SelectMode::End);
-                finish();
-            }
-            else {
-                // We don't want to finish() as that'll create auto-constraints
-                handleContinuousMode();
-            }
-        }
-        else {
+        if (state() != SelectMode::SeekSecond) {
             DrawSketchHandler::quit();
+            return;
         }
+
+        if (geoEltIds.size() <= 0) {
+            // We don't want to finish() as that'll create auto-constraints
+            handleContinuousMode();
+            return;
+        }
+
+        setState(SelectMode::End);
+        finish();
     }
 
     void rightButtonOrEsc() override
@@ -1288,11 +1290,14 @@ private:
                     // We must first remove the point on object constraint.
                     const auto& constraints = sketchgui->getSketchObject()->Constraints.getValues();
                     for (int i = constraints.size() - 1; i >= 0; --i) {
-                        if (constraints[i]->Type == PointOnObject
-                            && ((constraints[i]->First == pointGeoId
-                                 && constraints[i]->Second == prevGeoId)
-                                || (constraints[i]->First == prevGeoId
-                                    && constraints[i]->Second == pointGeoId))) {
+                        if (constraints[i]->Type != PointOnObject) {
+                            continue;
+                        }
+                        int first = constraints[i]->getGeoId(0);
+                        int second = constraints[i]->getGeoId(1);
+                        bool case1 = first == pointGeoId && second == prevGeoId;
+                        bool case2 = first == prevGeoId && second == pointGeoId;
+                        if (case1 || case2) {
                             obj->delConstraint(i);
                             break;
                         }
@@ -1365,7 +1370,7 @@ private:
         if ((x2 * y3 - x3 * y2) - (x1 * y3 - x3 * y1) + (x1 * y2 - x2 * y1) > 0) {
             radius *= -1;
         }
-        if (boost::math::isnan(radius) || boost::math::isinf(radius)) {
+        if (std::isnan(radius) || std::isinf(radius)) {
             radius = 0.0;
         }
 
@@ -1459,6 +1464,7 @@ private:
 
     void createShape(bool onlyeditoutline) override
     {
+        using std::numbers::pi;
         ShapeGeometry.clear();
         ShapeConstraints.clear();
 
@@ -1496,8 +1502,8 @@ private:
                     ? 1
                     : -1;
 
-                angleToPrevious = sign * (currentDir.GetAngle(prevDir) - M_PI);
-                angleToPrevious = std::round(angleToPrevious / (M_PI * 0.5)) * (M_PI * 0.5);
+                angleToPrevious = sign * (currentDir.GetAngle(prevDir) - pi);
+                angleToPrevious = std::round(angleToPrevious / (pi * 0.5)) * (pi * 0.5);
             }
 
             Base::Vector2d Tangent = getCurrentInitialDirection();
@@ -1525,10 +1531,10 @@ private:
                 range = 0.f;
             }
             if (radius >= 0 && range > 0) {
-                range -= 2 * M_PI;
+                range -= 2 * pi;
             }
             if (radius < 0 && range < 0) {
-                range += 2 * M_PI;
+                range += 2 * pi;
             }
 
             double endAngle = startAngle + range;
@@ -1549,10 +1555,10 @@ private:
 
             // range is weirdly handled before. We fix the range for the OVP
             if (radius < 0) {
-                range = -2 * M_PI + range;
+                range = -2 * pi + range;
             }
             else {
-                range = 2 * M_PI + range;
+                range = 2 * pi + range;
             }
         }
 
@@ -1602,8 +1608,8 @@ private:
                 }
             }
             else {
-                double roundedByPi = std::round(angleToPrevious / (M_PI)) * M_PI;
-                double roundedByHalfPi = std::round(angleToPrevious / (M_PI * 0.5)) * (M_PI * 0.5);
+                double roundedByPi = std::round(angleToPrevious / (pi)) * pi;
+                double roundedByHalfPi = std::round(angleToPrevious / (pi * 0.5)) * (pi * 0.5);
 
                 if (fabs(angleToPrevious - roundedByPi) < Precision::Confusion()) {
                     addToShapeConstraints(Sketcher::Tangent, geoId, geoEltIds.back().Pos, geoId2, posId);
@@ -2063,6 +2069,9 @@ void DSHPolyLineController::addStepConstraints()
                 constrainty0();
             }
         }
+
+        deactivateOnViewParameter(OnViewParameter::First);
+        deactivateOnViewParameter(OnViewParameter::Second);
     }
 
     auto p3 = onViewParameters[OnViewParameter::Third]->getValue();

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1065,8 +1065,8 @@ private:
                     }
 
                     // The coincidence with first point may be indirect
-                    const auto coincidents = sketchgui->getSketchObject()
-                                                    ->getAllCoincidentPoints(ac.GeoId, ac.PosId);
+                    const auto coincidents
+                        = sketchgui->getSketchObject()->getAllCoincidentPoints(ac.GeoId, ac.PosId);
 
                     auto it = coincidents.find(geoEltIds[0].GeoId);
                     if (it != coincidents.end() && it->second == Sketcher::PointPos::start) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1821,9 +1821,7 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     onSketchPos = prevPoint + length * handler->capturedDirection;
                 }
                 else if (fourthParam->isSet) {
-                    double arcAngle = Base::toRadians(
-                        fourthParam->getValue()
-                    );                    
+                    double arcAngle = Base::toRadians(fourthParam->getValue());
                     onSketchPos.ProjectToLine(onSketchPos - prevPoint, handler->capturedDirection);
                     onSketchPos += prevPoint;
                 }
@@ -1864,9 +1862,7 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     double radius = handler->getArcCenter(center, onSketchPos);
                     int sign = radius < 0 ? -1 : 1;
                     radius = fabs(radius);
-                    double range = Base::toRadians(
-                        fourthParam->getValue()
-                    );
+                    double range = Base::toRadians(fourthParam->getValue());
                     double angle = handler->startAngle + sign * range;
                     Base::Vector2d dir(1.0, 0.0);
                     dir.Rotate(angle);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -901,7 +901,7 @@ using DSHPolyLineController = DrawSketchDefaultWidgetController<
     DrawSketchHandlerPolyLine,
     /*SelectModeT*/ StateMachines::TwoSeekEnd,
     /*PAutoConstraintSize =*/2,
-    /*OnViewParametersT =*/OnViewParameters<5, 5>,  // NOLINT
+    /*OnViewParametersT =*/OnViewParameters<4, 5>,  // NOLINT
     /*WidgetParametersT =*/WidgetParameters<0, 0>,  // NOLINT
     /*WidgetCheckboxesT =*/WidgetCheckboxes<1, 1>,  // NOLINT
     /*WidgetComboboxesT =*/WidgetComboboxes<1, 1>,  // NOLINT
@@ -1344,15 +1344,6 @@ private:
     // Direction tracking to check once OVP is locked
     Base::Vector2d capturedDirection;
 
-    void changeConstructionMethode()
-    {
-        if (constructionMethod() == ConstructionMethod::Arc) {
-            if (geoEltIds.empty()) {
-                setConstructionMethod(ConstructionMethod::Line);
-            }
-        }
-    }
-
     Base::Vector2d getLastPoint()
     {
         return points.empty() ? Base::Vector2d() : points.back();
@@ -1740,16 +1731,11 @@ void DSHPolyLineController::configureToolWidget()
         Gui::EditableDatumLabel::Function::Dimensioning
     );
 
-    if (handler->constructionMethod() == ConstructionMethod::Line) {
-        deactivateOnViewParameter(OnViewParameter::Fifth);
-    }
-    else {
+    if (handler->constructionMethod() == ConstructionMethod::Arc) {
         onViewParameters[OnViewParameter::Fifth]->setLabelType(
             Gui::SoDatumLabel::ANGLE,
             Gui::EditableDatumLabel::Function::Dimensioning
         );
-
-        activateOnViewParameter(OnViewParameter::Fifth);
     }
 
     toolWidget->setCheckboxChecked(WCheckbox::FirstBox, handler->fillet);
@@ -1788,7 +1774,9 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                 handler->resetSeekSecond = false;
                 unsetOnViewParameter(thirdParam.get());
                 unsetOnViewParameter(fourthParam.get());
-                unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
+                if (handler->constructionMethod() == ConstructionMethod::Arc) {
+                    unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
+                }
                 setFocusToOnViewParameter(OnViewParameter::Third);
                 return;
             }
@@ -1821,7 +1809,9 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     onSketchPos = prevPoint + length * handler->capturedDirection;
                 }
                 else if (fourthParam->isSet) {
-                    double arcAngle = Base::toRadians(fourthParam->getValue());
+                    double arcAngle = Base::toRadians(
+                        fourthParam->getValue()
+                    );                    
                     onSketchPos.ProjectToLine(onSketchPos - prevPoint, handler->capturedDirection);
                     onSketchPos += prevPoint;
                 }
@@ -1862,7 +1852,9 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     double radius = handler->getArcCenter(center, onSketchPos);
                     int sign = radius < 0 ? -1 : 1;
                     radius = fabs(radius);
-                    double range = Base::toRadians(fourthParam->getValue());
+                    double range = Base::toRadians(
+                        fourthParam->getValue()
+                    );
                     double angle = handler->startAngle + sign * range;
                     Base::Vector2d dir(1.0, 0.0);
                     dir.Rotate(angle);
@@ -1937,7 +1929,9 @@ void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
 
                 thirdParam->setPoints(start, end);
                 fourthParam->setPoints(start, Base::Vector3d());
-                fourthParam->setLabelStartAngle(handler->previousDirectionAngle);
+                fourthParam->setLabelStartAngle(
+                    handler->previousDirectionAngle
+                );
                 fourthParam->setLabelRange(handler->dirChangeAngle);
             }
             else {
@@ -1999,7 +1993,9 @@ void DSHPolyLineController::computeNextDrawSketchHandlerMode()
 
                 unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
                 unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
-                unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
+                if (handler->constructionMethod() == ConstructionMethod::Arc) {
+                    unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
+                }
             }
         } break;
         default:
@@ -2010,9 +2006,21 @@ void DSHPolyLineController::computeNextDrawSketchHandlerMode()
 template<>
 void DSHPolyLineController::doConstructionMethodChanged()
 {
-    handler->changeConstructionMethode();
+    // First segment cannot be an arc (yet?). So if user changed the mode, we roll that back.
+    if (handler->constructionMethod() == ConstructionMethod::Arc) {
+        if (handler->geoEltIds.empty()) {
+            handler->setConstructionMethod(ConstructionMethod::Line);
+            return;
+        }
+    }
+
+    // Since line has 4 OVP but arc has 5, and because we are not reseting the whole tool,
+    // we need to reset the OVP to have the correct number.
+    resetOnViewParameters();
 
     configureToolWidget();
+
+    setModeOnViewParameters();
 
     syncConstructionMethodComboboxToHandler();
 }
@@ -2065,11 +2073,9 @@ void DSHPolyLineController::addStepConstraints()
 
     auto p3 = onViewParameters[OnViewParameter::Third]->getValue();
     auto p4 = onViewParameters[OnViewParameter::Fourth]->getValue();
-    auto p5 = onViewParameters[OnViewParameter::Fifth]->getValue();
 
     auto p3set = onViewParameters[OnViewParameter::Third]->isSet;
     auto p4set = onViewParameters[OnViewParameter::Fourth]->isSet;
-    auto p5set = onViewParameters[OnViewParameter::Fifth]->isSet;
 
     if (handler->constructionMethod() == ConstructionMethod::Line) {
         if (p3set) {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1022,7 +1022,7 @@ private:
 
     QString getToolWidgetText() const override
     {
-        return QString(QObject::tr("PolyLine parameters"));
+        return QString(QObject::tr("Polyline parameters"));
     }
 
     bool canGoToNextMode() override

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1937,9 +1937,7 @@ void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
 
                 thirdParam->setPoints(start, end);
                 fourthParam->setPoints(start, Base::Vector3d());
-                fourthParam->setLabelStartAngle(
-                    handler->previousDirectionAngle
-                );
+                fourthParam->setLabelStartAngle(handler->previousDirectionAngle);
                 fourthParam->setLabelRange(handler->dirChangeAngle);
             }
             else {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1665,7 +1665,7 @@ void DSHPolyLineController::configureToolWidget()
     if (!init) {  // Code to be executed only upon initialisation
         toolWidget->setNoticeVisible(true);
         toolWidget->setNoticeText(
-            QApplication::translate("TaskSketcherTool_c1_PolyLine", "Press R to undo last point.")
+            QApplication::translate("TaskSketcherTool_c1_PolyLine", "R undoes the last point")
         );
 
         QStringList names = {

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1682,7 +1682,7 @@ void DSHPolyLineController::configureToolWidget()
             WCheckbox::FirstBox,
             QApplication::translate(
                 "TaskSketcherTool_c1_PolyLine",
-                "Add a fillet between the current and previous line."
+                "Adds a fillet between the current and previous line"
             )
         );
         syncCheckboxToHandler(WCheckbox::FirstBox, handler->fillet);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1976,16 +1976,20 @@ void DSHPolyLineController::computeNextDrawSketchHandlerMode()
 {
     switch (handler->state()) {
         case SelectMode::SeekFirst: {
-            if (onViewParameters[OnViewParameter::First]->isSet
-                && onViewParameters[OnViewParameter::Second]->isSet) {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (firstParam->hasFinishedEditing && secondParam->hasFinishedEditing) {
                 double x = onViewParameters[OnViewParameter::First]->getValue();
                 double y = onViewParameters[OnViewParameter::Second]->getValue();
                 handler->onButtonPressed(Base::Vector2d(x, y));
             }
         } break;
         case SelectMode::SeekSecond: {
-            if (onViewParameters[OnViewParameter::Third]->isSet
-                && onViewParameters[OnViewParameter::Fourth]->isSet) {
+            auto& thirdParam = onViewParameters[OnViewParameter::Third];
+            auto& fourthParam = onViewParameters[OnViewParameter::Fourth];
+
+            if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing) {
                 handler->canGoToNextMode();  // its not going to next mode
 
                 unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1889,27 +1889,27 @@ void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
 {
     switch (handler->state()) {
         case SelectMode::SeekFirst: {
-            if (!onViewParameters[OnViewParameter::First]->isSet) {
+            auto& firstParam = onViewParameters[OnViewParameter::First];
+            auto& secondParam = onViewParameters[OnViewParameter::Second];
+
+            if (!firstParam->isSet) {
                 setOnViewParameterValue(OnViewParameter::First, onSketchPos.x);
             }
 
-            if (!onViewParameters[OnViewParameter::Second]->isSet) {
+            if (!secondParam->isSet) {
                 setOnViewParameterValue(OnViewParameter::Second, onSketchPos.y);
             }
 
             bool sameSign = onSketchPos.x * onSketchPos.y > 0.;
-            onViewParameters[OnViewParameter::First]->setLabelAutoDistanceReverse(!sameSign);
-            onViewParameters[OnViewParameter::Second]->setLabelAutoDistanceReverse(sameSign);
-            onViewParameters[OnViewParameter::First]->setPoints(
-                Base::Vector3d(),
-                toVector3d(onSketchPos)
-            );
-            onViewParameters[OnViewParameter::Second]->setPoints(
-                Base::Vector3d(),
-                toVector3d(onSketchPos)
-            );
+            firstParam->setLabelAutoDistanceReverse(!sameSign);
+            secondParam->setLabelAutoDistanceReverse(sameSign);
+            firstParam->setPoints(Base::Vector3d(), toVector3d(onSketchPos));
+            secondParam->setPoints(Base::Vector3d(), toVector3d(onSketchPos));
         } break;
         case SelectMode::SeekSecond: {
+            auto& thirdParam = onViewParameters[OnViewParameter::Third];
+            auto& fourthParam = onViewParameters[OnViewParameter::Fourth];
+
             Base::Vector2d prevPoint;
             if (!handler->points.empty()) {
                 prevPoint = handler->getLastPoint();
@@ -1919,61 +1919,58 @@ void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
                 Base::Vector3d end = toVector3d(onSketchPos);
                 Base::Vector3d vec = end - start;
 
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                if (!thirdParam->isSet) {
                     setOnViewParameterValue(OnViewParameter::Third, vec.Length());
                 }
 
                 double range = Base::toDegrees(handler->dirChangeAngle);
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                if (!fourthParam->isSet) {
                     setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
                 }
                 else if (vec.Length() > Precision::Confusion()) {
-                    double ovpRange = onViewParameters[OnViewParameter::Fourth]->getValue();
+                    double ovpRange = fourthParam->getValue();
 
                     if (fabs(range - ovpRange) > Precision::Confusion()) {
                         setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
                     }
                 }
 
-                onViewParameters[OnViewParameter::Third]->setPoints(start, end);
-                onViewParameters[OnViewParameter::Fourth]->setPoints(start, Base::Vector3d());
-                onViewParameters[OnViewParameter::Fourth]->setLabelStartAngle(
+                thirdParam->setPoints(start, end);
+                fourthParam->setPoints(start, Base::Vector3d());
+                fourthParam->setLabelStartAngle(
                     handler->previousDirectionAngle
                 );
-                onViewParameters[OnViewParameter::Fourth]->setLabelRange(handler->dirChangeAngle);
+                fourthParam->setLabelRange(handler->dirChangeAngle);
             }
             else {
+                auto& fifthParam = onViewParameters[OnViewParameter::Fifth];
+
                 Base::Vector3d start = toVector3d(handler->center);
                 Base::Vector3d end = toVector3d(onSketchPos);
                 Base::Vector3d vec = end - start;
 
-                if (!onViewParameters[OnViewParameter::Third]->isSet) {
+                if (!thirdParam->isSet) {
                     setOnViewParameterValue(OnViewParameter::Third, vec.Length());
                 }
 
                 double range = Base::toDegrees(handler->range);
-                if (!onViewParameters[OnViewParameter::Fourth]->isSet) {
+                if (!fourthParam->isSet) {
                     setOnViewParameterValue(OnViewParameter::Fourth, range, Base::Unit::Angle);
                 }
 
-                double angle = Base::toDegrees(handler->angleToPrevious);
-                if (!onViewParameters[OnViewParameter::Fifth]->isSet) {
+                if (!fifthParam->isSet) {
+                    double angle = Base::toDegrees(handler->angleToPrevious);
                     setOnViewParameterValue(OnViewParameter::Fifth, angle, Base::Unit::Angle);
                 }
 
-                onViewParameters[OnViewParameter::Third]->setPoints(start, end);
-                onViewParameters[OnViewParameter::Fourth]->setPoints(start, Base::Vector3d());
-                onViewParameters[OnViewParameter::Fourth]->setLabelStartAngle(handler->startAngle);
-                onViewParameters[OnViewParameter::Fourth]->setLabelRange(handler->range);
+                thirdParam->setPoints(start, end);
+                fourthParam->setPoints(start, Base::Vector3d());
+                fourthParam->setLabelStartAngle(handler->startAngle);
+                fourthParam->setLabelRange(handler->range);
 
-                onViewParameters[OnViewParameter::Fifth]->setPoints(
-                    toVector3d(prevPoint),
-                    Base::Vector3d()
-                );
-                onViewParameters[OnViewParameter::Fifth]->setLabelStartAngle(
-                    handler->previousDirectionAngle
-                );
-                onViewParameters[OnViewParameter::Fifth]->setLabelRange(handler->angleToPrevious);
+                fifthParam->setPoints(toVector3d(prevPoint), Base::Vector3d());
+                fifthParam->setLabelStartAngle(handler->previousDirectionAngle);
+                fifthParam->setLabelRange(handler->angleToPrevious);
             }
         } break;
         default:

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -931,7 +931,8 @@ public:
         , range(0.0)
         , dirChangeAngle(0.0)
         , angleToPrevious(0.0)
-        , pos(PointPos::end) {};
+        , pos(PointPos::end)
+        , capturedDirection(0.0, 0.0) {};
     ~DrawSketchHandlerPolyLine() override = default;
 
     void activated() override
@@ -1231,6 +1232,8 @@ private:
         angleToPrevious = 0.0;
         pos = PointPos::end;
 
+        capturedDirection = Base::Vector2d(0.0, 0.0);
+
         toolWidgetManager.resetControls();
 
         setConstructionMethod(ConstructionMethod::Line);
@@ -1338,6 +1341,8 @@ private:
     double previousDirectionAngle, dirChangeAngle, startAngle, range, angleToPrevious;
     PointPos pos;
 
+    // Direction tracking to check once OVP is locked
+    Base::Vector2d capturedDirection;
 
     void changeConstructionMethode()
     {
@@ -1776,10 +1781,13 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
             }
         } break;
         case SelectMode::SeekSecond: {
+            auto& thirdParam = onViewParameters[OnViewParameter::Third];
+            auto& fourthParam = onViewParameters[OnViewParameter::Fourth];
+
             if (handler->resetSeekSecond) {
                 handler->resetSeekSecond = false;
-                unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
-                unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
+                unsetOnViewParameter(thirdParam.get());
+                unsetOnViewParameter(fourthParam.get());
                 unsetOnViewParameter(onViewParameters[OnViewParameter::Fifth].get());
                 setFocusToOnViewParameter(OnViewParameter::Third);
                 return;
@@ -1788,44 +1796,50 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
             Base::Vector2d prevPoint = handler->getLastPoint();
 
             if (handler->constructionMethod() == ConstructionMethod::Line) {
-                if (onViewParameters[OnViewParameter::Third]->isSet) {
-                    Base::Vector2d dir = onSketchPos - prevPoint;
+                Base::Vector2d dir = onSketchPos - prevPoint;
+
+                if (fourthParam->isSet) {
+                    const double angle = Base::toRadians(fourthParam->getValue());
+                    const Base::Vector2d ovpDir(cos(angle), sin(angle));
+                    handler->capturedDirection = ovpDir;
+                }
+                else {
+                    handler->capturedDirection = dir.Normalize();
+                }
+
+                if (thirdParam->isSet) {
                     if (dir.Length() < Precision::Confusion()) {
                         dir.x = 1.0;  // if direction null, default to (1,0)
                     }
-                    double length = onViewParameters[OnViewParameter::Third]->getValue();
-                    if (length < Precision::Confusion()) {
-                        unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
+                    double length = thirdParam->getValue();
+                    if (length < Precision::Confusion() && thirdParam->hasFinishedEditing) {
+                        unsetOnViewParameter(thirdParam.get());
+                        handler->capturedDirection = Base::Vector2d(0.0, 0.0);
                         return;
                     }
 
-                    onSketchPos = prevPoint + length * dir.Normalize();
+                    onSketchPos = prevPoint + length * handler->capturedDirection;
                 }
-
-                if (onViewParameters[OnViewParameter::Fourth]->isSet) {
+                else if (fourthParam->isSet) {
                     double arcAngle = Base::toRadians(
-                        onViewParameters[OnViewParameter::Fourth]->getValue()
-                    );
-                    double angle = handler->previousDirectionAngle + arcAngle;
-
-                    // Project onSketchPos on the line starting from prevPoint with angle of angle
-                    Base::Vector2d ovpDir(cos(angle), sin(angle));
-                    onSketchPos.ProjectToLine(onSketchPos - prevPoint, ovpDir);
+                        fourthParam->getValue()
+                    );                    
+                    onSketchPos.ProjectToLine(onSketchPos - prevPoint, handler->capturedDirection);
                     onSketchPos += prevPoint;
                 }
 
-                if (onViewParameters[OnViewParameter::Third]->isSet
-                    && onViewParameters[OnViewParameter::Fourth]->isSet
+                if (thirdParam->hasFinishedEditing && fourthParam->hasFinishedEditing
                     && (onSketchPos - prevPoint).Length() < Precision::Confusion()) {
-                    unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
-                    unsetOnViewParameter(onViewParameters[OnViewParameter::Fourth].get());
+                    unsetOnViewParameter(thirdParam.get());
+                    unsetOnViewParameter(fourthParam.get());
+                    handler->capturedDirection = Base::Vector2d();
                 }
             }
             else {
-                if (onViewParameters[OnViewParameter::Third]->isSet) {
-                    double radius = onViewParameters[OnViewParameter::Third]->getValue();
+                if (thirdParam->isSet) {
+                    double radius = thirdParam->getValue();
                     if (radius < Precision::Confusion()) {
-                        unsetOnViewParameter(onViewParameters[OnViewParameter::Third].get());
+                        unsetOnViewParameter(thirdParam.get());
                         return;
                     }
 
@@ -1844,14 +1858,14 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     dir = onSketchPos - center;
                     onSketchPos = center + radius * dir.Normalize();
                 }
-                if (onViewParameters[OnViewParameter::Fourth]->isSet) {
+                if (fourthParam->isSet) {
                     Base::Vector2d center;
                     ;
                     double radius = handler->getArcCenter(center, onSketchPos);
                     int sign = radius < 0 ? -1 : 1;
                     radius = fabs(radius);
                     double range = Base::toRadians(
-                        onViewParameters[OnViewParameter::Fourth]->getValue()
+                        fourthParam->getValue()
                     );
                     double angle = handler->startAngle + sign * range;
                     Base::Vector2d dir(1.0, 0.0);

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1793,7 +1793,8 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                 Base::Vector2d dir = onSketchPos - prevPoint;
 
                 if (fourthParam->isSet) {
-                    const double angle = Base::toRadians(fourthParam->getValue());
+                    const double angle = handler->previousDirectionAngle
+                        + Base::toRadians(fourthParam->getValue());
                     const Base::Vector2d ovpDir(cos(angle), sin(angle));
                     handler->capturedDirection = ovpDir;
                 }
@@ -1815,7 +1816,6 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     onSketchPos = prevPoint + length * handler->capturedDirection;
                 }
                 else if (fourthParam->isSet) {
-                    double arcAngle = Base::toRadians(fourthParam->getValue());
                     onSketchPos.ProjectToLine(onSketchPos - prevPoint, handler->capturedDirection);
                     onSketchPos += prevPoint;
                 }

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerLineSet.h
@@ -1809,9 +1809,7 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     onSketchPos = prevPoint + length * handler->capturedDirection;
                 }
                 else if (fourthParam->isSet) {
-                    double arcAngle = Base::toRadians(
-                        fourthParam->getValue()
-                    );                    
+                    double arcAngle = Base::toRadians(fourthParam->getValue());
                     onSketchPos.ProjectToLine(onSketchPos - prevPoint, handler->capturedDirection);
                     onSketchPos += prevPoint;
                 }
@@ -1852,9 +1850,7 @@ void DSHPolyLineControllerBase::doEnforceControlParameters(Base::Vector2d& onSke
                     double radius = handler->getArcCenter(center, onSketchPos);
                     int sign = radius < 0 ? -1 : 1;
                     radius = fabs(radius);
-                    double range = Base::toRadians(
-                        fourthParam->getValue()
-                    );
+                    double range = Base::toRadians(fourthParam->getValue());
                     double angle = handler->startAngle + sign * range;
                     Base::Vector2d dir(1.0, 0.0);
                     dir.Rotate(angle);
@@ -1929,9 +1925,7 @@ void DSHPolyLineController::adaptParameters(Base::Vector2d onSketchPos)
 
                 thirdParam->setPoints(start, end);
                 fourthParam->setPoints(start, Base::Vector3d());
-                fourthParam->setLabelStartAngle(
-                    handler->previousDirectionAngle
-                );
+                fourthParam->setLabelStartAngle(handler->previousDirectionAngle);
                 fourthParam->setLabelRange(handler->dirChangeAngle);
             }
             else {


### PR DESCRIPTION
This PR adds a new command Sketcher_CreatePolyline2
Why? Because I am sure many people will yell murder if their polyline tool is removed and I don't want to deal with it.

So this PR is not touching the existing tool and adds another tool. In the toolbar, we are replacing the command in the line command group. The individual command remain untouched.

This PR also adds autoconstraints such as tangent, parallel and perpendicular.

Fix https://github.com/FreeCAD/FreeCAD/issues/12462