### PR TITLE
Gui: Navicube improvements

### DIFF
--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -557,8 +557,12 @@ void SoNaviCube::rebuildButtonFaces() const
     addButtonFace(PickId::ArrowWest, SbVec3f(0, -1, 0));
     addButtonFace(PickId::ArrowLeft, SbVec3f(0, 0, 1));
     addButtonFace(PickId::ArrowRight, SbVec3f(0, 0, -1));
-    addButtonFace(PickId::DotBackside, SbVec3f(0, 1, 0));
+    addButtonFace(PickId::Backside1, SbVec3f(0, 1, 0));
+    addButtonFace(PickId::Backside2, SbVec3f(0, 1, 0));
+    addButtonFace(PickId::Isometric);
+    addButtonFace(PickId::Home);
     addButtonFace(PickId::ViewMenu);
+    addButtonFace(PickId::ViewMenuBorder);
 }
 
 void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
@@ -588,22 +592,85 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
             break;
         }
         case PickId::ViewMenu: {
-            offx = 0.84F;
+            offx = 0.90F;
+            offy = 0.90F;
+            pointData = {0.0F, 0.0F, -13.0F, -12.0F, 13.0F, -12.0F, 0.0F, 0.0F};
+            break;
+        }
+        case PickId::ViewMenuBorder: {
+            offx = 0.90F;
+            offy = 0.87F;
+
+            float width = 19.0F;
+            float height = 13.0F;
+            float radius = 4.0F;
+
+            pointData = {
+                -width,
+                -(height - radius),
+                -(width - radius),
+                -height,
+                width - radius,
+                -height,
+                width,
+                -(height - radius),
+                width,
+                height - radius,
+                width - radius,
+                height,
+                -(width - radius),
+                height,
+                -width,
+                height - radius
+            };
+            break;
+        }
+        case PickId::Isometric: {
+            offx = 0.10F;
             offy = 0.84F;
             pointData = {0.0F, 0.0F, 15.0F,  -6.0F, 0.0F,   -12.0F, -15.0F, -6.0F,
                          0.0F, 0.0F, -15.0F, -6.0F, -15.0F, 12.0F,  0.0F,   18.0F,
                          0.0F, 0.0F, 0.0F,   18.0F, 15.0F,  12.0F,  15.0F,  -6.0F};
             break;
         }
-        case PickId::DotBackside: {
-            int steps = 16;
-            pointData.reserve(steps * 2);
-            for (int i = 0; i < steps; i++) {
-                float angle = 2.0F * std::numbers::pi_v<float>
-                    * (static_cast<float>(i) + 0.5F) / static_cast<float>(steps);
-                pointData.emplace_back(10.0F * std::cos(angle) + 87.0F);
-                pointData.emplace_back(10.0F * std::sin(angle) - 87.0F);
-            }
+        case PickId::Home: {
+            offx = 0.09F;
+            offy = 0.09F;
+            pointData = {
+                // Roof (triangle with overhang)
+                0.0F,   -18.0F,  // Top of the roof
+                18.0F,  -6.0F,   // Bottom-right corner of the roof (overhang)
+
+                12.0F,  -6.0F,  // Top-right corner of the base
+                12.0F,  8.0F,   // Bottom-right corner of the base
+                4.0F,   8.0F,   // Bottom-right of the door
+                4.0F,   0.0F,   // Top-right of the door
+                -4.0F,  0.0F,   // Top-left of the door
+                -4.0F,  8.0F,   // Bottom-left of the door
+                -12.0F, 8.0F,   // Bottom-left corner of the base
+                -12.0F, -6.0F,  // Top-left corner of the base
+
+                -18.0F, -6.0F,  // Bottom-left corner of the roof (overhang)
+                0.0F,   -18.0F  // Back to the top of the roof
+            };
+            break;
+        }
+        case PickId::Backside1: {
+            offx = 0.80F;
+            offy = 0.0F;
+            pointData = {24., 21.5, 17.,  29.1, 16.7, 25.6, 12.0, 25.3, 8.2, 24.0, 4.,  22.,
+                         1.2, 19.,  0.,   15.,  0.,   10.,  1.5,  8.1,  4.4, 6.1,  8.0, 5.5,
+                         14., 4.,   14.6, 9.2,  10.1, 10.2, 6.,   12.,  3.5, 14.,  3.4, 14.5,
+                         6.0, 15.8, 10.,  17.,  16.3, 18.,  16.3, 13.6, 24., 21.5};
+            break;
+        }
+        case PickId::Backside2: {
+            offx = 0.80F;
+            offy = 0.0F;
+            pointData = {18.,  6.,   22.6, 0.,   22.5, 3.0,  27.,  3.3,  31.4, 4.3,  35.0,
+                         5.6,  37.5, 7.1,  40.,  9.7,  40.,  12.8, 38.5, 16.5, 36.2, 20.,
+                         33.,  21.9, 28.3, 22.9, 28.7, 16.,  32.8, 15.,  36.4, 12.9, 33.8,
+                         10.8, 30.,  9.3,  26.1, 8.5,  22.5, 8.1,  22.4, 10.8, 18.,  6.};
             break;
         }
     }

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -609,12 +609,14 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
     auto transform = [&](float px, float py) {
         float x = px * scale + offx;
         float y = py * scale + offy;
-        if (pickId == PickId::ArrowNorth || pickId == PickId::ArrowWest || pickId == PickId::ArrowLeft) {
+        if (pickId == PickId::ArrowNorth || pickId == PickId::ArrowWest
+            || pickId == PickId::ArrowLeft) {
             x = 1.0F - x;
         }
         if (pickId == PickId::ArrowSouth || pickId == PickId::ArrowNorth) {
             return SbVec3f(y, x, 0.0F);
-        } else {
+        }
+        else {
             return SbVec3f(x, y, 0.0F);
         }
     };
@@ -753,7 +755,7 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
             break;
         }
     }
-    
+
     if (!pointData.empty()) {
         int count = static_cast<int>(pointData.size()) / 2;
         face.vertexArray.reserve(count);

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -287,7 +287,7 @@ void SoNaviCube::renderGL(bool pickMode) const
 
     const auto& baseFaces = faces();
     for (const auto& [pickId, face] : baseFaces) {
-        if (face.vertexArray.empty()) {
+        if (face.vertexArray.empty() && face.trianglesArray.empty()) {
             continue;
         }
         if (pickMode) {
@@ -298,8 +298,14 @@ void SoNaviCube::renderGL(bool pickMode) const
             const float* rgb = color.rgb.getValue();
             glColor4f(rgb[0], rgb[1], rgb[2], color.alpha * currentOpacity);
         }
-        glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
-        glDrawArrays(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(face.vertexArray.size()));
+        if (!face.trianglesArray.empty()) {
+            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.trianglesArray.data()));
+            glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(face.trianglesArray.size()));
+        }
+        else if (!face.vertexArray.empty()) {
+            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
+            glDrawArrays(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(face.vertexArray.size()));
+        }
     }
 
     if (!pickMode) {
@@ -351,9 +357,11 @@ void SoNaviCube::renderGL(bool pickMode) const
     glLoadIdentity();
 
     for (const auto& [pickId, face] : buttons) {
-        if (face.vertexArray.empty()) {
+        // 1. Allow faces that use explicit triangles to pass through
+        if (face.vertexArray.empty() && face.trianglesArray.empty()) {
             continue;
         }
+
         if (pickMode) {
             glColor3ub(static_cast<GLubyte>(pickId), 0, 0);
         }
@@ -362,12 +370,34 @@ void SoNaviCube::renderGL(bool pickMode) const
             const float* rgb = color.rgb.getValue();
             glColor4f(rgb[0], rgb[1], rgb[2], color.alpha * currentOpacity);
         }
-        glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
-        glDrawArrays(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(face.vertexArray.size()));
+
+        // 2. Draw the filled shape using triangles if available, else fallback to fans
+        if (!face.trianglesArray.empty()) {
+            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.trianglesArray.data()));
+            glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(face.trianglesArray.size()));
+        }
+        else if (!face.vertexArray.empty()) {
+            glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
+            glDrawArrays(GL_TRIANGLE_FAN, 0, static_cast<GLsizei>(face.vertexArray.size()));
+        }
+
+        // 3. Draw the outlines
         if (!pickMode) {
             const float* rgb = emph.rgb.getValue();
             glColor4f(rgb[0], rgb[1], rgb[2], emph.alpha * currentOpacity);
-            glDrawArrays(GL_LINE_LOOP, 0, static_cast<GLsizei>(face.vertexArray.size()));
+            if (!face.lineLoops.empty()) {
+                for (const auto& loop : face.lineLoops) {
+                    if (loop.empty()) {
+                        continue;
+                    }
+                    glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(loop.data()));
+                    glDrawArrays(GL_LINE_LOOP, 0, static_cast<GLsizei>(loop.size()));
+                }
+            }
+            else if (!face.vertexArray.empty()) {
+                glVertexPointer(3, GL_FLOAT, 0, reinterpret_cast<const float*>(face.vertexArray.data()));
+                glDrawArrays(GL_LINE_LOOP, 0, static_cast<GLsizei>(face.vertexArray.size()));
+            }
         }
     }
 
@@ -569,10 +599,25 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
 {
     auto& face = m_ButtonFaces[pickId];
     face.vertexArray.clear();
+    face.trianglesArray.clear();
+    face.lineLoops.clear();
     float scale = 0.005F;
     float offx = 0.5F;
     float offy = 0.5F;
     std::vector<float> pointData;
+
+    auto transform = [&](float px, float py) {
+        float x = px * scale + offx;
+        float y = py * scale + offy;
+        if (pickId == PickId::ArrowNorth || pickId == PickId::ArrowWest || pickId == PickId::ArrowLeft) {
+            x = 1.0F - x;
+        }
+        if (pickId == PickId::ArrowSouth || pickId == PickId::ArrowNorth) {
+            return SbVec3f(y, x, 0.0F);
+        } else {
+            return SbVec3f(x, y, 0.0F);
+        }
+    };
 
     switch (pickId) {
         default:
@@ -636,59 +681,84 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
         case PickId::Home: {
             offx = 0.09F;
             offy = 0.09F;
-            pointData = {
-                // Roof (triangle with overhang)
-                0.0F,   -18.0F,  // Top of the roof
-                18.0F,  -6.0F,   // Bottom-right corner of the roof (overhang)
-
-                12.0F,  -6.0F,  // Top-right corner of the base
-                12.0F,  8.0F,   // Bottom-right corner of the base
-                4.0F,   8.0F,   // Bottom-right of the door
-                4.0F,   0.0F,   // Top-right of the door
-                -4.0F,  0.0F,   // Top-left of the door
-                -4.0F,  8.0F,   // Bottom-left of the door
-                -12.0F, 8.0F,   // Bottom-left corner of the base
-                -12.0F, -6.0F,  // Top-left corner of the base
-
-                -18.0F, -6.0F,  // Bottom-left corner of the roof (overhang)
-                0.0F,   -18.0F  // Back to the top of the roof
-            };
+            std::vector<float> pts = {0.0F,   -18.0F, 18.0F,  -6.0F, 12.0F,  -6.0F, 12.0F, 8.0F,
+                                      4.0F,   8.0F,   4.0F,   0.0F,  -4.0F,  0.0F,  -4.0F, 8.0F,
+                                      -12.0F, 8.0F,   -12.0F, -6.0F, -18.0F, -6.0F};
+            std::vector<SbVec3f> loop;
+            for (size_t i = 0; i < pts.size(); i += 2) {
+                loop.push_back(transform(pts[i], pts[i + 1]));
+            }
+            face.lineLoops.push_back(loop);
+            face.trianglesArray.push_back(transform(-18, -6));
+            face.trianglesArray.push_back(transform(18, -6));
+            face.trianglesArray.push_back(transform(0, -18));
+            face.trianglesArray.push_back(transform(-12, -6));
+            face.trianglesArray.push_back(transform(12, -6));
+            face.trianglesArray.push_back(transform(12, 0));
+            face.trianglesArray.push_back(transform(-12, -6));
+            face.trianglesArray.push_back(transform(12, 0));
+            face.trianglesArray.push_back(transform(-12, 0));
+            face.trianglesArray.push_back(transform(-12, 0));
+            face.trianglesArray.push_back(transform(-4, 0));
+            face.trianglesArray.push_back(transform(-4, 8));
+            face.trianglesArray.push_back(transform(-12, 0));
+            face.trianglesArray.push_back(transform(-4, 8));
+            face.trianglesArray.push_back(transform(-12, 8));
+            face.trianglesArray.push_back(transform(4, 0));
+            face.trianglesArray.push_back(transform(12, 0));
+            face.trianglesArray.push_back(transform(12, 8));
+            face.trianglesArray.push_back(transform(4, 0));
+            face.trianglesArray.push_back(transform(12, 8));
+            face.trianglesArray.push_back(transform(4, 8));
             break;
         }
-        case PickId::Backside1: {
+        case PickId::Backside: {
             offx = 0.80F;
             offy = 0.0F;
-            pointData = {24., 21.5, 17.,  29.1, 16.7, 25.6, 12.0, 25.3, 8.2, 24.0, 4.,  22.,
-                         1.2, 19.,  0.,   15.,  0.,   10.,  1.5,  8.1,  4.4, 6.1,  8.0, 5.5,
-                         14., 4.,   14.6, 9.2,  10.1, 10.2, 6.,   12.,  3.5, 14.,  3.4, 14.5,
-                         6.0, 15.8, 10.,  17.,  16.3, 18.,  16.3, 13.6, 24., 21.5};
-            break;
-        }
-        case PickId::Backside2: {
-            offx = 0.80F;
-            offy = 0.0F;
-            pointData = {18.,  6.,   22.6, 0.,   22.5, 3.0,  27.,  3.3,  31.4, 4.3,  35.0,
-                         5.6,  37.5, 7.1,  40.,  9.7,  40.,  12.8, 38.5, 16.5, 36.2, 20.,
-                         33.,  21.9, 28.3, 22.9, 28.7, 16.,  32.8, 15.,  36.4, 12.9, 33.8,
-                         10.8, 30.,  9.3,  26.1, 8.5,  22.5, 8.1,  22.4, 10.8, 18.,  6.};
+            std::vector<float> pts1 = {24.,  21.5, 17.,  29.1, 16.7, 25.6, 12.0, 25.3, 8.2,
+                                       24.0, 4.,   22.,  1.2,  19.,  0.,   15.,  0.,   10.,
+                                       1.5,  8.1,  4.4,  6.1,  8.0,  5.5,  14.,  4.,   14.6,
+                                       9.2,  10.1, 10.2, 6.,   12.,  3.5,  14.,  3.4,  14.5,
+                                       6.0,  15.8, 10.,  17.,  16.3, 18.,  16.3, 13.6};
+            std::vector<SbVec3f> loop1;
+            for (size_t i = 0; i < pts1.size(); i += 2) {
+                loop1.push_back(transform(pts1[i], pts1[i + 1]));
+            }
+            face.lineLoops.push_back(loop1);
+            std::vector<int> idx1 = {0,  1,  2, 0,  2,  20, 0,  20, 21, 2,  20, 3,  20, 19, 3,
+                                     3,  19, 4, 19, 18, 4,  4,  18, 5,  18, 17, 5,  5,  17, 6,
+                                     17, 16, 6, 6,  16, 7,  16, 15, 7,  7,  15, 8,  15, 14, 8,
+                                     8,  14, 9, 14, 13, 9,  9,  13, 10, 10, 13, 11, 11, 13, 12};
+            for (int i : idx1) {
+                face.trianglesArray.push_back(loop1[i]);
+            }
+
+            std::vector<float> pts2 = {18.,  6.,   22.6, 0.,   22.5, 3.0,  27.,  3.3,  31.4,
+                                       4.3,  35.0, 5.6,  37.5, 7.1,  40.,  9.7,  40.,  12.8,
+                                       38.5, 16.5, 36.2, 20.,  33.,  21.9, 28.3, 22.9, 28.7,
+                                       16.,  32.8, 15.,  36.4, 12.9, 33.8, 10.8, 30.,  9.3,
+                                       26.1, 8.5,  22.5, 8.1,  22.4, 10.8};
+            std::vector<SbVec3f> loop2;
+            for (size_t i = 0; i < pts2.size(); i += 2) {
+                loop2.push_back(transform(pts2[i], pts2[i + 1]));
+            }
+            face.lineLoops.push_back(loop2);
+            std::vector<int> idx2 = {0,  1,  2, 0,  2,  19, 0,  19, 20, 2,  19, 3, 19, 18, 3,
+                                     3,  18, 4, 18, 17, 4,  4,  17, 5,  17, 16, 5, 5,  16, 6,
+                                     16, 15, 6, 6,  15, 7,  15, 14, 7,  7,  14, 8, 14, 13, 8,
+                                     8,  13, 9, 9,  13, 10, 10, 13, 11, 11, 13, 12};
+            for (int i : idx2) {
+                face.trianglesArray.push_back(loop2[i]);
+            }
             break;
         }
     }
-
-    int count = static_cast<int>(pointData.size()) / 2;
-    face.vertexArray.reserve(count);
-    for (int i = 0; i < count; i++) {
-        float x = pointData[i * 2] * scale + offx;
-        float y = pointData[i * 2 + 1] * scale + offy;
-        if (pickId == PickId::ArrowNorth || pickId == PickId::ArrowWest
-            || pickId == PickId::ArrowLeft) {
-            x = 1.0F - x;
-        }
-        if (pickId == PickId::ArrowSouth || pickId == PickId::ArrowNorth) {
-            face.vertexArray.emplace_back(SbVec3f(y, x, 0.0F));
-        }
-        else {
-            face.vertexArray.emplace_back(SbVec3f(x, y, 0.0F));
+    
+    if (!pointData.empty()) {
+        int count = static_cast<int>(pointData.size()) / 2;
+        face.vertexArray.reserve(count);
+        for (int i = 0; i < count; i++) {
+            face.vertexArray.push_back(transform(pointData[i * 2], pointData[i * 2 + 1]));
         }
     }
     face.type = FaceType::Button;

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -587,8 +587,7 @@ void SoNaviCube::rebuildButtonFaces() const
     addButtonFace(PickId::ArrowWest, SbVec3f(0, -1, 0));
     addButtonFace(PickId::ArrowLeft, SbVec3f(0, 0, 1));
     addButtonFace(PickId::ArrowRight, SbVec3f(0, 0, -1));
-    addButtonFace(PickId::Backside1, SbVec3f(0, 1, 0));
-    addButtonFace(PickId::Backside2, SbVec3f(0, 1, 0));
+    addButtonFace(PickId::Backside, SbVec3f(0, 1, 0));
     addButtonFace(PickId::Home);
     addButtonFace(PickId::ViewMenu);
 }

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -589,10 +589,8 @@ void SoNaviCube::rebuildButtonFaces() const
     addButtonFace(PickId::ArrowRight, SbVec3f(0, 0, -1));
     addButtonFace(PickId::Backside1, SbVec3f(0, 1, 0));
     addButtonFace(PickId::Backside2, SbVec3f(0, 1, 0));
-    addButtonFace(PickId::Isometric);
     addButtonFace(PickId::Home);
     addButtonFace(PickId::ViewMenu);
-    addButtonFace(PickId::ViewMenuBorder);
 }
 
 void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
@@ -640,36 +638,34 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
         }
         case PickId::ViewMenu: {
             offx = 0.90F;
-            offy = 0.90F;
-            pointData = {0.0F, 0.0F, -13.0F, -12.0F, 13.0F, -12.0F, 0.0F, 0.0F};
-            break;
-        }
-        case PickId::ViewMenuBorder: {
-            offx = 0.90F;
-            offy = 0.87F;
+            offy = 0.95F;
 
-            float width = 19.0F;
-            float height = 13.0F;
-            float radius = 4.0F;
+            // 1. The small bar on top
+            std::vector<float> ptsBar = {-13.0F, -20.0F, 13.0F, -20.0F, 13.0F, -16.0F, -13.0F, -16.0F};
+            std::vector<SbVec3f> loopBar;
+            for (size_t i = 0; i < ptsBar.size(); i += 2) {
+                loopBar.push_back(transform(ptsBar[i], ptsBar[i + 1]));
+            }
+            face.lineLoops.push_back(loopBar);
 
-            pointData = {
-                -width,
-                -(height - radius),
-                -(width - radius),
-                -height,
-                width - radius,
-                -height,
-                width,
-                -(height - radius),
-                width,
-                height - radius,
-                width - radius,
-                height,
-                -(width - radius),
-                height,
-                -width,
-                height - radius
-            };
+            face.trianglesArray.push_back(loopBar[0]);
+            face.trianglesArray.push_back(loopBar[1]);
+            face.trianglesArray.push_back(loopBar[2]);
+            face.trianglesArray.push_back(loopBar[0]);
+            face.trianglesArray.push_back(loopBar[2]);
+            face.trianglesArray.push_back(loopBar[3]);
+
+            // 2. The triangle pointing down
+            std::vector<float> ptsTri = {-13.0F, -12.0F, 13.0F, -12.0F, 0.0F, 0.0F};
+            std::vector<SbVec3f> loopTri;
+            for (size_t i = 0; i < ptsTri.size(); i += 2) {
+                loopTri.push_back(transform(ptsTri[i], ptsTri[i + 1]));
+            }
+            face.lineLoops.push_back(loopTri);
+
+            face.trianglesArray.push_back(loopTri[0]);
+            face.trianglesArray.push_back(loopTri[1]);
+            face.trianglesArray.push_back(loopTri[2]);
             break;
         }
         case PickId::Isometric: {

--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -667,14 +667,6 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
             face.trianglesArray.push_back(loopTri[2]);
             break;
         }
-        case PickId::Isometric: {
-            offx = 0.10F;
-            offy = 0.84F;
-            pointData = {0.0F, 0.0F, 15.0F,  -6.0F, 0.0F,   -12.0F, -15.0F, -6.0F,
-                         0.0F, 0.0F, -15.0F, -6.0F, -15.0F, 12.0F,  0.0F,   18.0F,
-                         0.0F, 0.0F, 0.0F,   18.0F, 15.0F,  12.0F,  15.0F,  -6.0F};
-            break;
-        }
         case PickId::Home: {
             offx = 0.09F;
             offy = 0.09F;

--- a/src/Gui/Inventor/SoNaviCube.h
+++ b/src/Gui/Inventor/SoNaviCube.h
@@ -92,8 +92,12 @@ public:
         ArrowWest,
         ArrowRight,
         ArrowLeft,
-        DotBackside,
-        ViewMenu
+        Backside1,
+        Backside2,
+        Home,
+        Isometric,
+        ViewMenu,
+        ViewMenuBorder
     };
 
     enum class FaceType

--- a/src/Gui/Inventor/SoNaviCube.h
+++ b/src/Gui/Inventor/SoNaviCube.h
@@ -94,7 +94,6 @@ public:
         ArrowLeft,
         Backside,
         Home,
-        Isometric,
         ViewMenu
     };
 

--- a/src/Gui/Inventor/SoNaviCube.h
+++ b/src/Gui/Inventor/SoNaviCube.h
@@ -92,8 +92,7 @@ public:
         ArrowWest,
         ArrowRight,
         ArrowLeft,
-        Backside1,
-        Backside2,
+        Backside,
         Home,
         Isometric,
         ViewMenu,
@@ -113,6 +112,8 @@ public:
     {
         FaceType type {FaceType::None};
         std::vector<SbVec3f> vertexArray;
+        std::vector<SbVec3f> trianglesArray;
+        std::vector<std::vector<SbVec3f>> lineLoops;
         SbRotation rotation;
     };
 

--- a/src/Gui/Inventor/SoNaviCube.h
+++ b/src/Gui/Inventor/SoNaviCube.h
@@ -95,8 +95,7 @@ public:
         Backside,
         Home,
         Isometric,
-        ViewMenu,
-        ViewMenuBorder
+        ViewMenu
     };
 
     enum class FaceType

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -63,6 +63,7 @@
 #include <Base/Tools.h>
 #include "NaviCube.h"
 #include "Application.h"
+#include "Camera.h"
 #include "Command.h"
 #include "Action.h"
 #include "MainWindow.h"
@@ -1016,18 +1017,33 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             }
         }
         else if (faceType == FaceType::Button) {
-
+            Base::Console().warning("button \n");  
             // Handle the menu
-            if (pickId == PickId::ViewMenu) {
+            if (pickId == PickId::ViewMenu || pickId == PickId::ViewMenuBorder) {
+                Base::Console().warning("ViewMenu \n");  
                 resetClickState();
                 handleMenu();
+                return true;
+            }
+            else if (pickId == PickId::Home) {
+                Base::Console().warning("home \n");  
+                CommandManager& rcCmdMgr = Application::Instance->commandManager();
+                rcCmdMgr.runCommandByName("Std_ViewHome");
+
+                return true;
+            }
+            else if (pickId == PickId::Isometric) {
+                Base::Console().warning("isometric \n");  
+                SbRotation rotation;
+                m_View3DInventorViewer->setCameraOrientation(Camera::rotation(Camera::Isometric));
                 return true;
             }
 
             // Handle the flat buttons
             resetClickState();
             SbRotation rotation = getFaceRotation(pickId);
-            if (pickId == PickId::DotBackside) {
+            if (pickId == PickId::Backside1 || pickId == PickId::Backside2) {
+                Base::Console().warning("bbackside \n");  
                 rotation.scaleAngle(pi);
             }
             else {
@@ -1209,11 +1225,20 @@ QMenu* NaviCubeImplementation::createNaviCubeMenu()
     if (commands.empty()) {
         commands.emplace_back("Std_OrthographicCamera");
         commands.emplace_back("Std_PerspectiveCamera");
-        commands.emplace_back("Std_ViewIsometric");
         commands.emplace_back("Separator");
         commands.emplace_back("Std_ViewFitAll");
         commands.emplace_back("Std_ViewFitSelection");
         commands.emplace_back("Std_AlignToSelection");
+        commands.emplace_back("Separator");
+        commands.emplace_back("Std_ViewFront");
+        commands.emplace_back("Std_ViewTop");
+        commands.emplace_back("Std_ViewRight");
+        commands.emplace_back("Std_ViewRear");
+        commands.emplace_back("Std_ViewBottom");
+        commands.emplace_back("Std_ViewLeft");
+        commands.emplace_back("Separator");
+        commands.emplace_back("Std_DrawStyle");
+        commands.emplace_back("Std_ViewDockUndockFullscreen");
         commands.emplace_back("Separator");
         commands.emplace_back("NaviCubeDraggableCmd");
     }

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1220,20 +1220,11 @@ QMenu* NaviCubeImplementation::createNaviCubeMenu()
     if (commands.empty()) {
         commands.emplace_back("Std_OrthographicCamera");
         commands.emplace_back("Std_PerspectiveCamera");
+        commands.emplace_back("Std_ViewIsometric");
         commands.emplace_back("Separator");
         commands.emplace_back("Std_ViewFitAll");
         commands.emplace_back("Std_ViewFitSelection");
         commands.emplace_back("Std_AlignToSelection");
-        commands.emplace_back("Separator");
-        commands.emplace_back("Std_ViewFront");
-        commands.emplace_back("Std_ViewTop");
-        commands.emplace_back("Std_ViewRight");
-        commands.emplace_back("Std_ViewRear");
-        commands.emplace_back("Std_ViewBottom");
-        commands.emplace_back("Std_ViewLeft");
-        commands.emplace_back("Separator");
-        commands.emplace_back("Std_DrawStyle");
-        commands.emplace_back("Std_ViewDockUndockFullscreen");
         commands.emplace_back("Separator");
         commands.emplace_back("NaviCubeDraggableCmd");
     }

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1017,23 +1017,19 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             }
         }
         else if (faceType == FaceType::Button) {
-            Base::Console().warning("button \n");
             // Handle the menu
             if (pickId == PickId::ViewMenu || pickId == PickId::ViewMenuBorder) {
-                Base::Console().warning("ViewMenu \n");
                 resetClickState();
                 handleMenu();
                 return true;
             }
             else if (pickId == PickId::Home) {
-                Base::Console().warning("home \n");
                 CommandManager& rcCmdMgr = Application::Instance->commandManager();
                 rcCmdMgr.runCommandByName("Std_ViewHome");
 
                 return true;
             }
             else if (pickId == PickId::Isometric) {
-                Base::Console().warning("isometric \n");
                 SbRotation rotation;
                 m_View3DInventorViewer->setCameraOrientation(Camera::rotation(Camera::Isometric));
                 return true;
@@ -1043,7 +1039,6 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             resetClickState();
             SbRotation rotation = getFaceRotation(pickId);
             if (pickId == PickId::Backside1 || pickId == PickId::Backside2) {
-                Base::Console().warning("bbackside \n");
                 rotation.scaleAngle(pi);
             }
             else {

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1018,7 +1018,7 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
         }
         else if (faceType == FaceType::Button) {
             // Handle the menu
-            if (pickId == PickId::ViewMenu || pickId == PickId::ViewMenuBorder) {
+            if (pickId == PickId::ViewMenu) {
                 resetClickState();
                 handleMenu();
                 return true;

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1029,11 +1029,6 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
 
                 return true;
             }
-            else if (pickId == PickId::Isometric) {
-                SbRotation rotation;
-                m_View3DInventorViewer->setCameraOrientation(Camera::rotation(Camera::Isometric));
-                return true;
-            }
 
             // Handle the flat buttons
             resetClickState();

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1038,7 +1038,7 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             // Handle the flat buttons
             resetClickState();
             SbRotation rotation = getFaceRotation(pickId);
-            if (pickId == PickId::Backside1 || pickId == PickId::Backside2) {
+            if (pickId == PickId::Backside) {
                 rotation.scaleAngle(pi);
             }
             else {

--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -1017,23 +1017,23 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             }
         }
         else if (faceType == FaceType::Button) {
-            Base::Console().warning("button \n");  
+            Base::Console().warning("button \n");
             // Handle the menu
             if (pickId == PickId::ViewMenu || pickId == PickId::ViewMenuBorder) {
-                Base::Console().warning("ViewMenu \n");  
+                Base::Console().warning("ViewMenu \n");
                 resetClickState();
                 handleMenu();
                 return true;
             }
             else if (pickId == PickId::Home) {
-                Base::Console().warning("home \n");  
+                Base::Console().warning("home \n");
                 CommandManager& rcCmdMgr = Application::Instance->commandManager();
                 rcCmdMgr.runCommandByName("Std_ViewHome");
 
                 return true;
             }
             else if (pickId == PickId::Isometric) {
-                Base::Console().warning("isometric \n");  
+                Base::Console().warning("isometric \n");
                 SbRotation rotation;
                 m_View3DInventorViewer->setCameraOrientation(Camera::rotation(Camera::Isometric));
                 return true;
@@ -1043,7 +1043,7 @@ bool NaviCubeImplementation::mouseReleased(short x, short y)
             resetClickState();
             SbRotation rotation = getFaceRotation(pickId);
             if (pickId == PickId::Backside1 || pickId == PickId::Backside2) {
-                Base::Console().warning("bbackside \n");  
+                Base::Console().warning("bbackside \n");
                 rotation.scaleAngle(pi);
             }
             else {


### PR DESCRIPTION
Please squash

Navicube improvements
Before:
<img width="235" height="219" alt="image" src="https://github.com/user-attachments/assets/8d5797ad-702c-40c5-a10f-57ad0446841c" />


After:
<img width="315" height="211" alt="image" src="https://github.com/user-attachments/assets/45682a81-3344-461f-8feb-3dc0738024ad" />


- The menu is now a shape that looks like a menu.
- Add  a home button.
- make 2 kind of arrows for the 'rotate back to forth' button instead of a point.
- This PR does not change the menu content.
