### PR TITLE
Fix/helix multiple solids error message

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -417,9 +417,10 @@ App::DocumentObjectExecReturn* Helix::execute()
             }
 
             if (!isSingleSolidRuleSatisfied(result)) {
-                return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
-                );
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                    "Exception",
+                    "Result has multiple solids: enable 'Allow Compound' in the active body."
+                ));
             }
 
             // store shape before refinement
@@ -438,9 +439,10 @@ App::DocumentObjectExecReturn* Helix::execute()
             }
 
             if (!isSingleSolidRuleSatisfied(mkFuse.Shape())) {
-                return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
-                );
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                    "Exception",
+                    "Result has multiple solids: enable 'Allow Compound' in the active body."
+                ));
             }
 
             // we have to get the solids (fuse sometimes creates compounds)
@@ -483,9 +485,10 @@ App::DocumentObjectExecReturn* Helix::execute()
             }
 
             if (!isSingleSolidRuleSatisfied(rawBoolOp)) {
-                return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
-                );
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                    "Exception",
+                    "Result has multiple solids: enable 'Allow Compound' in the active body."
+                ));
             }
 
             boolOp = this->getSolid(rawBoolOp);

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -418,7 +418,7 @@ App::DocumentObjectExecReturn* Helix::execute()
 
             if (!isSingleSolidRuleSatisfied(result)) {
                 return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Error: Result has multiple solids")
+                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
                 );
             }
 
@@ -448,7 +448,7 @@ App::DocumentObjectExecReturn* Helix::execute()
 
             if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
                 return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Error: Result has multiple solids")
+                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
                 );
             }
 
@@ -489,7 +489,7 @@ App::DocumentObjectExecReturn* Helix::execute()
 
             if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
                 return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Error: Result has multiple solids")
+                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
                 );
             }
 

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -417,9 +417,10 @@ App::DocumentObjectExecReturn* Helix::execute()
             }
 
             if (!isSingleSolidRuleSatisfied(result)) {
-                return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
-                );
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                    "Exception",
+                    "Result has multiple solids: enable 'Allow Compound' in the active body."
+                ));
             }
 
             // store shape before refinement
@@ -447,9 +448,10 @@ App::DocumentObjectExecReturn* Helix::execute()
             }
 
             if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
-                return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
-                );
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                    "Exception",
+                    "Result has multiple solids: enable 'Allow Compound' in the active body."
+                ));
             }
 
             // store shape before refinement
@@ -488,9 +490,10 @@ App::DocumentObjectExecReturn* Helix::execute()
             }
 
             if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
-                return new App::DocumentObjectExecReturn(
-                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
-                );
+                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
+                    "Exception",
+                    "Result has multiple solids: enable 'Allow Compound' in the active body."
+                ));
             }
 
             // store shape before refinement

--- a/src/Mod/PartDesign/App/FeatureHelix.cpp
+++ b/src/Mod/PartDesign/App/FeatureHelix.cpp
@@ -417,10 +417,9 @@ App::DocumentObjectExecReturn* Helix::execute()
             }
 
             if (!isSingleSolidRuleSatisfied(result)) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
-                    "Exception",
-                    "Result has multiple solids: enable 'Allow Compound' in the active body."
-                ));
+                return new App::DocumentObjectExecReturn(
+                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
+                );
             }
 
             // store shape before refinement
@@ -437,6 +436,13 @@ App::DocumentObjectExecReturn* Helix::execute()
                     QT_TRANSLATE_NOOP("Exception", "Error: Adding the helix failed")
                 );
             }
+
+            if (!isSingleSolidRuleSatisfied(mkFuse.Shape())) {
+                return new App::DocumentObjectExecReturn(
+                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
+                );
+            }
+
             // we have to get the solids (fuse sometimes creates compounds)
             TopoShape boolOp = this->getSolid(mkFuse.Shape());
 
@@ -445,13 +451,6 @@ App::DocumentObjectExecReturn* Helix::execute()
                 return new App::DocumentObjectExecReturn(
                     QT_TRANSLATE_NOOP("Exception", "Error: Result is not a solid")
                 );
-            }
-
-            if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
-                    "Exception",
-                    "Result has multiple solids: enable 'Allow Compound' in the active body."
-                ));
             }
 
             // store shape before refinement
@@ -463,6 +462,7 @@ App::DocumentObjectExecReturn* Helix::execute()
 
             TopoShape boolOp;
 
+            TopoDS_Shape rawBoolOp;
             if (Outside.getValue()) {  // are we subtracting the inside or the outside of the profile.
                 FCBRepAlgoAPI_Common mkCom(result, base.getShape());
                 if (!mkCom.IsDone()) {
@@ -470,7 +470,7 @@ App::DocumentObjectExecReturn* Helix::execute()
                         QT_TRANSLATE_NOOP("Exception", "Error: Intersecting the helix failed")
                     );
                 }
-                boolOp = this->getSolid(mkCom.Shape());
+                rawBoolOp = mkCom.Shape();
             }
             else {
                 FCBRepAlgoAPI_Cut mkCut(base.getShape(), result);
@@ -479,21 +479,22 @@ App::DocumentObjectExecReturn* Helix::execute()
                         QT_TRANSLATE_NOOP("Exception", "Error: Subtracting the helix failed")
                     );
                 }
-                boolOp = this->getSolid(mkCut.Shape());
+                rawBoolOp = mkCut.Shape();
             }
+
+            if (!isSingleSolidRuleSatisfied(rawBoolOp)) {
+                return new App::DocumentObjectExecReturn(
+                    QT_TRANSLATE_NOOP("Exception", "Result has multiple solids: enable 'Allow Compound' in the active body.")
+                );
+            }
+
+            boolOp = this->getSolid(rawBoolOp);
 
             // lets check if the result is a solid
             if (boolOp.isNull()) {
                 return new App::DocumentObjectExecReturn(
                     QT_TRANSLATE_NOOP("Exception", "Error: Result is not a solid")
                 );
-            }
-
-            if (!isSingleSolidRuleSatisfied(boolOp.getShape())) {
-                return new App::DocumentObjectExecReturn(QT_TRANSLATE_NOOP(
-                    "Exception",
-                    "Result has multiple solids: enable 'Allow Compound' in the active body."
-                ));
             }
 
             // store shape before refinement

--- a/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskHelixParameters.cpp
@@ -299,6 +299,9 @@ void TaskHelixParameters::updateStatus()
     else if (status.compare("NCollection_IndexedDataMap::FindFromKey") == 0) {
         translatedStatus = tr("Error: helix touches itself");
     }
+    else {
+        translatedStatus = QString::fromStdString(status);
+    }
     ui->labelMessage->setText(translatedStatus);
 }
 


### PR DESCRIPTION
PartDesign: fix Helix multiple solids error message and task panel status

## Issues
Closes #23634

`FeatureHelix` was using a short `"Error: Result has multiple solids"` message
(without guidance) on all three code paths where the multiple-solids check fires,
while all other PartDesign features (Extrude, Chamfer, Draft, Boolean) already
used the full informative message:
`"Result has multiple solids: enable 'Allow Compound' in the active body."`

Additionally, `TaskHelixParameters::updateStatus()` left the task panel status
label blank for any error state not explicitly handled. A fallback `else` branch
now shows the raw status string in the label.

Note: the cryptic "Error" popup dialog reported in the issue was already fixed
upstream in commit 5b50f228c7, which replaced `QMessageBox::warning` with
`Base::Console().error()` for all PartDesign features. This PR addresses the
remaining Helix-specific inconsistencies.

**Changes:**
1. `FeatureHelix.cpp`: align all three multiple-solids error paths with the rest of the codebase
2. `TaskHelixParameters.cpp`: add fallback `else` branch in `updateStatus()` so unhandled error states are shown in the task panel label rather than left blank