### PR TITLE
FEM: Remove ViewObject.update() calls after DiffuseColor set

### DIFF
--- a/src/Mod/Fem/femguiutils/disambiguate_solid_selection.py
+++ b/src/Mod/Fem/femguiutils/disambiguate_solid_selection.py
@@ -71,7 +71,6 @@ class HighlightContext:
 
     def _set_color(self, color: highlight_color_t) -> None:
         self._parent_part.ViewObject.DiffuseColor = color
-        self._parent_part.ViewObject.update()
 
     def __enter__(self) -> None:
         self._set_color(self._unhighlighted_color)
@@ -157,7 +156,6 @@ def disambiguate_solid_selection(
             solid_name = None
 
         parent_part.ViewObject.DiffuseColor = highlight_colors_for_solid[solid_name]
-        parent_part.ViewObject.update()
 
     def display_hover(action: QtGui.QAction) -> None:
         if last_action and last_action[0].text() == action.text():


### PR DESCRIPTION
Fixes #28903 -- FEM was inadvertently "overwriting" its own face highlighting by calling `ViewObject.update()` after setting the diffuse color. Setting that color *already* creates all of the appropriate Coin nodes, etc. Before our recent optimization work, calling `update()` here was harmless, it was just redundant, doing the same thing that setting the DiffuseColor was already doing a second time. But now we have an early-return that is shortcutting that code, resulting in this call to update basically undoing the highlighting.

This can replace #29045 pending user testing.