### PR TITLE
CAM: Fix HiDPI support and font scaling in CAM tool widgets

### DIFF
--- a/src/Mod/CAM/Path/Tool/shape/ui/shapewidget.py
+++ b/src/Mod/CAM/Path/Tool/shape/ui/shapewidget.py
@@ -57,12 +57,14 @@ class ShapeWidget(QtGui.QWidget):
         icon = self.shape.get_icon()
         if icon:
             pixmap = icon.get_qpixmap(size)
+            pixmap.setDevicePixelRatio(ratio)
             self.icon_widget.setPixmap(pixmap)
             return
 
         thumbnail = self.shape.get_thumbnail()
         if thumbnail:
             pixmap = _png2qpixmap(thumbnail, size)
+            pixmap.setDevicePixelRatio(ratio)
             self.icon_widget.setPixmap(pixmap)
             return
 

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/tablecell.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/tablecell.py
@@ -112,7 +112,7 @@ class TwoLineTableCell(QtGui.QWidget):
         self.label_right.setText(text)
 
         text = self._highlight(self.upper_text)
-        self.label_upper.setText(f"<big><b>{text}</b></big>")
+        self.label_upper.setText(f"<b>{text}</b>")
 
         text = self._highlight(self.lower_text)
         self.label_lower.setText(text)
@@ -146,6 +146,7 @@ class TwoLineTableCell(QtGui.QWidget):
             return
         pixmap = icon.get_qpixmap(self.icon_size)
         if pixmap:
+            pixmap.setDevicePixelRatio(self.devicePixelRatioF())
             self.set_icon(pixmap)
 
     def contains_text(self, text):
@@ -173,8 +174,10 @@ class CompactTwoLineTableCell(TwoLineTableCell):
         ratio = self.devicePixelRatioF()
         self.icon_size = QtCore.QSize(32 * ratio, 32 * ratio)
 
-        # Reduce margins
-        self.label_upper.setStyleSheet("margin: 2px 0px 0px 0px; font-size: .8em;")
-        self.label_lower.setStyleSheet("margin: 0px 0px 2px 0px; font-size: .8em;")
+        # Reduce margins and scale font size based on system default
+        base_pt = QtGui.QApplication.font().pointSizeF()
+        upper_pt = base_pt * 1.2
+        self.label_upper.setStyleSheet(f"margin: 2px 0px 0px -2px; font-size: {upper_pt}pt;")
+        self.label_lower.setStyleSheet("margin: 0px 0px 2px 0px;")
         self.vbox.setSpacing(0)
         self.hbox.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
This PR addresses HiDPI rendering issues and font scaling in CAM tool widgets, specifically in the shape and toolbit UI components.

The changes include:
- Set device pixel ratio for QPixmaps in shape and toolbit widgets to improve HiDPI rendering.
- Adjust font size in CompactTwoLineTableCell based on system default for better scaling.
- Refine label margins and remove deprecated <big> tag for upper label.
- Minor code cleanup and import organization.

src/Mod/CAM/Path/Tool/shape/ui/shapewidget.py:
- Set device pixel ratio for icon and thumbnail pixmaps.

src/Mod/CAM/Path/Tool/toolbit/ui/tablecell.py:
- Set device pixel ratio for icon pixmap.
- Scale font size for upper label based on system font.
- Refine label margins and remove <big> tag.
- Add platform import.
