### PR TITLE
Measurement: Added Support for spheres and toruses

### DIFF
--- a/src/App/MeasureManager.h
+++ b/src/App/MeasureManager.h
@@ -55,6 +55,8 @@ enum class MeasureElementType
     CYLINDER,
     VOLUME,
     SURFACE,
+    TORUS,
+    SPHERE,
 };
 
 

--- a/src/Mod/Measure/App/MeasureArea.cpp
+++ b/src/Mod/Measure/App/MeasureArea.cpp
@@ -58,7 +58,9 @@ bool MeasureArea::isSupported(App::MeasureElementType type)
            (type == App::MeasureElementType::CYLINDER) ||
            (type == App::MeasureElementType::SURFACE) ||
            (type == App::MeasureElementType::VOLUME) ||
-           (type == App::MeasureElementType::DISC);
+           (type == App::MeasureElementType::DISC)  ||
+           (type == App::MeasureElementType::TORUS)  ||
+           (type == App::MeasureElementType::SPHERE);
     // clang-format on
 }
 

--- a/src/Mod/Measure/App/MeasureDiameter.cpp
+++ b/src/Mod/Measure/App/MeasureDiameter.cpp
@@ -70,7 +70,8 @@ bool MeasureDiameter::isValidSelection(const App::MeasureSelection& selection)
     }
 
     if (type != App::MeasureElementType::CIRCLE && type != App::MeasureElementType::ARC
-        && type != App::MeasureElementType::CYLINDER && type != App::MeasureElementType::DISC) {
+        && type != App::MeasureElementType::CYLINDER && type != App::MeasureElementType::DISC
+        && type != App::MeasureElementType::TORUS && type != App::MeasureElementType::SPHERE) {
         return false;
     }
 
@@ -87,7 +88,8 @@ bool MeasureDiameter::isPrioritizedSelection(const App::MeasureSelection& select
     auto type = App::MeasureManager::getMeasureElementType(element);
 
     if (type == App::MeasureElementType::CIRCLE || type == App::MeasureElementType::ARC
-        || type == App::MeasureElementType::CYLINDER || type == App::MeasureElementType::DISC) {
+        || type == App::MeasureElementType::CYLINDER || type == App::MeasureElementType::DISC
+        || type == App::MeasureElementType::TORUS || type == App::MeasureElementType::SPHERE) {
         return true;
     }
 

--- a/src/Mod/Measure/App/MeasureDistance.cpp
+++ b/src/Mod/Measure/App/MeasureDistance.cpp
@@ -129,7 +129,8 @@ bool MeasureDistance::isValidSelection(const App::MeasureSelection& selection)
         if (type != App::MeasureElementType::POINT && type != App::MeasureElementType::LINE
             && type != App::MeasureElementType::LINESEGMENT && type != App::MeasureElementType::CIRCLE
             && type != App::MeasureElementType::ARC && type != App::MeasureElementType::CURVE
-            && type != App::MeasureElementType::PLANE && type != App::MeasureElementType::CYLINDER) {
+            && type != App::MeasureElementType::PLANE && type != App::MeasureElementType::CYLINDER
+            && type != App::MeasureElementType::SPHERE && type != App::MeasureElementType::TORUS) {
             return false;
         }
     }

--- a/src/Mod/Measure/App/MeasureRadius.cpp
+++ b/src/Mod/Measure/App/MeasureRadius.cpp
@@ -79,7 +79,8 @@ bool MeasureRadius::isValidSelection(const App::MeasureSelection& selection)
     }
 
     if (type != App::MeasureElementType::CIRCLE && type != App::MeasureElementType::ARC
-        && type != App::MeasureElementType::CYLINDER && type != App::MeasureElementType::DISC) {
+        && type != App::MeasureElementType::CYLINDER && type != App::MeasureElementType::DISC
+        && type != App::MeasureElementType::TORUS && type != App::MeasureElementType::SPHERE) {
         return false;
     }
 
@@ -98,7 +99,8 @@ bool MeasureRadius::isPrioritizedSelection(const App::MeasureSelection& selectio
     auto type = App::MeasureManager::getMeasureElementType(element);
 
     if (type == App::MeasureElementType::CIRCLE || type == App::MeasureElementType::ARC
-        || type == App::MeasureElementType::CYLINDER || type == App::MeasureElementType::DISC) {
+        || type == App::MeasureElementType::CYLINDER || type == App::MeasureElementType::DISC
+        || type == App::MeasureElementType::TORUS || type == App::MeasureElementType::SPHERE) {
         return true;
     }
 

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -219,6 +219,12 @@ App::MeasureElementType PartMeasureTypeCb(App::DocumentObject* ob, const char* s
                 case GeomAbs_Cylinder: {
                     return App::MeasureElementType::CYLINDER;
                 }
+                case GeomAbs_Torus: {
+                    return App::MeasureElementType::TORUS;
+                }
+                case GeomAbs_Sphere: {
+                    return App::MeasureElementType::SPHERE;
+                }
                 case GeomAbs_Plane: {
                     TopExp_Explorer edges(face, TopAbs_EDGE);
                     if (!edges.More()) {
@@ -408,8 +414,22 @@ MeasureRadiusInfoPtr MeasureRadiusHandler(const App::SubObjectT& subject)
             center = surf.Cylinder().Location();
             radius = surf.Cylinder().Radius();
         }
+        else if (surf.GetType() == GeomAbs_Torus) {
+            center = surf.Torus().Location();
+            radius = surf.Torus().MinorRadius();
 
-        if (surf.GetType() == GeomAbs_Plane) {
+            // Places the label point inside the torus
+            // Which is better than placing it in the middle of the torus hole
+            gp_Vec direction(surf.Torus().Position().XDirection());
+            double majorRadius = surf.Torus().MajorRadius();
+            direction = direction * majorRadius;
+            center = center.Translated(direction);
+        }
+        else if (surf.GetType() == GeomAbs_Sphere) {
+            center = surf.Sphere().Location();
+            radius = surf.Sphere().Radius();
+        }
+        else if (surf.GetType() == GeomAbs_Plane) {
             TopExp_Explorer edges(face, TopAbs_EDGE);
             if (!edges.More()) {
                 return invalidRes;


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Measurement can now measure a sphere or a torus. 
Works the same way as measuring cylindrical faces. 

It already works in quickmeasure so no change there

For toruses the label is in the shape.
<img width="346" height="200" alt="image" src="https://github.com/user-attachments/assets/a2bb4268-e303-4f80-9d26-1e3e6d1c644f" />
It also works for fillets on a cylinder
<img width="340" height="240" alt="image" src="https://github.com/user-attachments/assets/551b9d46-8695-48e9-8b34-29a5f5ec64de" />

For spheres the label just points to the middle
<img width="237" height="126" alt="image" src="https://github.com/user-attachments/assets/5e4d0033-bb80-4439-99ef-0f98af8eed1a" />

