### PR TITLE
Fem: Handling multiple ElementGeometry1D objects with Z88 solver

### DIFF
--- a/src/Mod/Fem/femmesh/meshtools.py
+++ b/src/Mod/Fem/femmesh/meshtools.py
@@ -279,6 +279,23 @@ def get_element_faces_elements_from_binary_search(bit_pattern_dict):
     return faces
 
 
+def get_element_edges_elements_from_binary_search(bit_pattern_dict):
+    """get edge element by coincident nodes"""
+    mask_seg2 = {0b11: 1}
+    mask_seg3 = {0b111: 1}
+    vol_dict = {
+        2: mask_seg2,
+        3: mask_seg3,
+    }
+    edges = []
+    for ele in bit_pattern_dict:
+        mask_dict = vol_dict[bit_pattern_dict[ele][0]]
+        for key in mask_dict:
+            if (key & bit_pattern_dict[ele][1]) == key:
+                edges.append(ele)
+    return edges
+
+
 def get_element_edges_from_binary_search(
     bit_pattern_dict, mask_tria3={}, mask_tria6={}, mask_quad4={}, mask_quad8={}
 ):
@@ -1576,6 +1593,8 @@ def get_elements_by_references(sets_getter, femobj_ref):
             elem = get_element_volumes_elements_from_binary_search(bit_pattern_dict)
         elif sh.ShapeType == "Face":
             elem = get_element_faces_elements_from_binary_search(bit_pattern_dict)
+        elif sh.ShapeType == "Edge":
+            elem = get_element_edges_elements_from_binary_search(bit_pattern_dict)
 
         result = (sub, elem)
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Currently, only one cross section object is supported. Now is possible to assign different cross sections to truss elements (and beams when enabled).
The logic is the same as for materials and 2D thickness: the unreferenced cross section object is used as the default for elements without assignments.

@FEA-eng 
<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
