### PR TITLE
Core: Avoid duplicate disabled addon notices

### DIFF
--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -1291,6 +1291,9 @@ class DirModScanner:
             Wrn(warning)
 
         if flat:
+            resolved = base.resolve()
+            if any(mod.path.resolve() == resolved for mod in self.mods.values()):
+                return
             self.mods[str(base)] = DirMod(base)
             return
 

--- a/src/App/FreeCADInit.py
+++ b/src/App/FreeCADInit.py
@@ -725,6 +725,10 @@ class Transient:
 
 transient = Transient()
 
+@transient
+@functools.cache
+def resolve_path(path: Path) -> Path:
+    return path.resolve()
 
 @transient
 def call_in_place(fn):
@@ -1277,7 +1281,7 @@ class DirModScanner:
         """
         Scan in base with higher priority.
         """
-        if (key := str(base.resolve())) in self.visited:
+        if (key := str(resolve_path(base))) in self.visited:
             return
 
         self.visited.add(key)
@@ -1291,8 +1295,8 @@ class DirModScanner:
             Wrn(warning)
 
         if flat:
-            resolved = base.resolve()
-            if any(mod.path.resolve() == resolved for mod in self.mods.values()):
+            resolved = resolve_path(base)
+            if any(resolve_path(mod.path) == resolved for mod in self.mods.values()):
                 return
             self.mods[str(base)] = DirMod(base)
             return


### PR DESCRIPTION
Prevents duplicate `ADDON_DISABLED` notices when the same disabled addon is discovered both through the normal user `Mod` directory scan and again through an additional flat module path.

When scanning a flat module path, the path is now resolved and compared against already discovered directory-based modules. If the same addon path has already been registered, the duplicate entry is skipped.

## Issues

Fixes #27465

## Before and After Images

Before:

<img width="1468" height="247" alt="before" src="https://github.com/user-attachments/assets/692d472c-b0ea-4680-842c-19b2c803267d" />


After:

<img width="1757" height="125" alt="after" src="https://github.com/user-attachments/assets/0d299d77-1078-459d-b660-f53c500ef181" />

