### PR TITLE
Gui: Sketcher: solve the focus war between OVP and 3Dview

### DIFF
--- a/src/Gui/EditableDatumLabel.cpp
+++ b/src/Gui/EditableDatumLabel.cpp
@@ -233,13 +233,13 @@ bool EditableDatumLabel::eventFilter(QObject* watched, QEvent* event)
 {
     if (event->type() == QEvent::KeyPress) {
         auto* keyEvent = static_cast<QKeyEvent*>(event);
-        if (keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter
-            || keyEvent->key() == Qt::Key_Tab) {
+        int key = keyEvent->key();
 
+        if (key == Qt::Key_Return || key == Qt::Key_Enter || key == Qt::Key_Tab) {
             if (auto* spinBox = qobject_cast<QAbstractSpinBox*>(watched)) {
                 // if tab has been pressed and user did not type anything previously,
                 // then just cycle but don't lock anything, otherwise we lock the label
-                if (keyEvent->key() == Qt::Key_Tab && !this->isSet) {
+                if (key == Qt::Key_Tab && !this->isSet) {
                     if (!this->spinBox->hasValidInput()) {
                         Q_EMIT this->spinBox->valueChanged(this->value);
                         return true;
@@ -259,6 +259,18 @@ bool EditableDatumLabel::eventFilter(QObject* watched, QEvent* event)
                     return true;
                 }
             }
+        }
+        else if (
+            key == Qt::Key_Left || key == Qt::Key_Right || key == Qt::Key_Up || key == Qt::Key_Down
+            || key == Qt::Key_Home || key == Qt::Key_End
+        ) {
+            // cursor movement fights between viewer and ovp
+            // send the event to the viewer directly for camera movement
+            if (!viewer) {
+                return false;
+            }
+            QCoreApplication::sendEvent(viewer, event);
+            return true;
         }
         else if (this->hasFinishedEditing && keyEvent->key() != Qt::Key_Tab) {
             this->setLockedAppearance(false);


### PR DESCRIPTION

Issue: the arrow keys and home key, have inconsistent behaviour during OVP show

Steps to reproduce 1.0+:
* edit a sketch
* select a tool to draw, rectangle for example
* click to draw
* use the arrow keys
Result: the 3Dview will move (panning)
* type in a number in the OVP like 1234
* wait 2 or 3 seconds
* use the arrow keys
Result: the 3Dview will move (panning)
* press tab and change to the other ovp
* type in a number like 1234
* immediately press the arrows left or right repeatedly until the 3dview moves
Result: the cursor inside the OVP entry will move a few times but after a few seconds the 3Dview will move instead

Conclusion, the 3Dview camera will take over control of the arrows and home key after about 2 seconds, using numbers or backspace will give you a moment of arrow usage before going back to the 3Dview


Technical notes
after a second or 2 the event will not even pass trough the ovp eventFilter 

Proposed solution:
pass those first keystrokes directly to the 3Dview, this gives us consistent behaviour (arrows always move the camera)
the user can still use backspace or delete keys or Ctrl+A and Ctrl+V, etc to edit.