### PR TITLE
[Backport releases/FreeCAD-1-1] Sketcher: preserve local overlay depth for dimensions and grid

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1189,11 +1189,9 @@ void SoDatumLabel::GLRender(SoGLRenderAction* action)
     glDisable(GL_LIGHTING);
     glDisable(GL_CULL_FACE);
 
-    // Explicitly enable depth testing for constraint lines. This is needed because the
-    // constraint group may have depth testing disabled (to allow icons to render on top),
-    // but we want constraint LINES to render BELOW geometry lines.
-    // Arrowheads are drawn at elevated Z (ZARROW_TEXT_OFFSET) so they render on top.
-    // Text rendering disables depth testing separately.
+    // Enable depth testing so constraint lines use the sketch-local Z carried by their
+    // input points. That keeps them above coplanar model geometry while still rendering
+    // below sketch elements in the normal scene.
     glEnable(GL_DEPTH_TEST);
 
     // Enable Anti-alias
@@ -1287,18 +1285,18 @@ void SoDatumLabel::drawDistance(const SbVec3f* points, float& angle, SbVec3f& te
     // Perp Lines
     glBegin(GL_LINES);
     if (this->param1.getValue() != 0.) {
-        glVertex2f(geom.p1[0], geom.p1[1]);
-        glVertex2f(geom.perp1[0], geom.perp1[1]);
+        glVertex(geom.p1);
+        glVertex(geom.perp1);
 
-        glVertex2f(geom.p2[0], geom.p2[1]);
-        glVertex2f(geom.perp2[0], geom.perp2[1]);
+        glVertex(geom.p2);
+        glVertex(geom.perp2);
     }
 
-    glVertex2f(geom.par1[0], geom.par1[1]);
-    glVertex2f(geom.par2[0], geom.par2[1]);
+    glVertex(geom.par1);
+    glVertex(geom.par2);
 
-    glVertex2f(geom.par3[0], geom.par3[1]);
-    glVertex2f(geom.par4[0], geom.par4[1]);
+    glVertex(geom.par3);
+    glVertex(geom.par4);
     glEnd();
 
     // Draw the arrowheads at elevated Z to render ON TOP of geometry lines
@@ -1347,11 +1345,11 @@ void SoDatumLabel::drawRadiusOrDiameter(const SbVec3f* points, float& angle, SbV
 
     // Draw the Lines
     glBegin(GL_LINES);
-    glVertex2f(geom.p1[0], geom.p1[1]);
-    glVertex2f(geom.pnt1[0], geom.pnt1[1]);
+    glVertex(geom.p1);
+    glVertex(geom.pnt1);
 
-    glVertex2f(geom.pnt2[0], geom.pnt2[1]);
-    glVertex2f(geom.p2[0], geom.p2[1]);
+    glVertex(geom.pnt2);
+    glVertex(geom.p2);
     glEnd();
 
     // Draw arrowhead at elevated Z to render ON TOP of geometry lines

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -443,6 +443,17 @@ Base::Vector3d GridExtensionP::getPointInSketchCoordinates(const SbVec3f& point)
 
 int GridExtensionP::getViewOrientationFactor() const
 {
+    auto* app = Gui::Application::Instance;
+    if (!app) {
+        return 1;
+    }
+
+    auto* editDoc = app->editDocument();
+    if (!editDoc) {
+        return 1;
+    }
+
+    auto* view = dynamic_cast<Gui::View3DInventor*>(editDoc->getActiveView());
     if (!view) {
         return 1;
     }

--- a/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderGridExtension.cpp
@@ -24,6 +24,7 @@
 
 #include <limits>
 
+#include <Inventor/nodes/SoCamera.h>
 #include <Inventor/nodes/SoDepthBuffer.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoLineSet.h>
@@ -63,6 +64,11 @@ App::PropertyQuantityConstraint::Constraints ViewProviderGridExtension::GridSize
 
 namespace PartGui
 {
+
+namespace
+{
+constexpr float GRID_Z_OFFSET {0.002F};
+}
 
 class GridExtensionP
 {
@@ -110,6 +116,8 @@ private:
     void createEditModeInventorNodes();
 
     Base::Vector3d getCamCenterInSketchCoordinates() const;
+    Base::Vector3d getPointInSketchCoordinates(const SbVec3f& point) const;
+    int getViewOrientationFactor() const;
 
     SbVec3f camCenterPointOnFocalPlane;
     float camMaxDimension;
@@ -309,6 +317,8 @@ void GridExtensionP::createGridPart(
     int lineWidth
 )
 {
+    float gridZ = getViewOrientationFactor() * GRID_Z_OFFSET;
+
     auto* parent = new Gui::SoSkipBoundingGroup();
     parent->mode = Gui::SoSkipBoundingGroup::EXCLUDE_BBOX;
 
@@ -378,8 +388,8 @@ void GridExtensionP::createGridPart(
         int iStep = (i + i_offset_x);
         if (((iStep % numberSubdiv == 0) && divLines)
             || ((iStep % numberSubdiv != 0) && subDivLines)) {
-            vertex_coords[2 * i].setValue(iStep * computedGridValue, minY, 0);
-            vertex_coords[2 * i + 1].setValue(iStep * computedGridValue, maxY, 0);
+            vertex_coords[2 * i].setValue(iStep * computedGridValue, minY, gridZ);
+            vertex_coords[2 * i + 1].setValue(iStep * computedGridValue, maxY, gridZ);
         }
         else {
             /*the number of vertices is defined before. To know the number of vertices ahead it would
@@ -396,8 +406,8 @@ void GridExtensionP::createGridPart(
         int iStep = (i + i_offset_y);
         if (((iStep % numberSubdiv == 0) && divLines)
             || ((iStep % numberSubdiv != 0) && subDivLines)) {
-            vertex_coords[2 * i].setValue(minX, iStep * computedGridValue, 0);
-            vertex_coords[2 * i + 1].setValue(maxX, iStep * computedGridValue, 0);
+            vertex_coords[2 * i].setValue(minX, iStep * computedGridValue, gridZ);
+            vertex_coords[2 * i + 1].setValue(maxX, iStep * computedGridValue, gridZ);
         }
         else {
             vertex_coords[2 * i].setValue(0, 0, 0);
@@ -412,19 +422,43 @@ void GridExtensionP::createGridPart(
 
 Base::Vector3d GridExtensionP::getCamCenterInSketchCoordinates() const
 {
+    return getPointInSketchCoordinates(camCenterPointOnFocalPlane);
+}
+
+Base::Vector3d GridExtensionP::getPointInSketchCoordinates(const SbVec3f& point) const
+{
     Base::Vector3d xaxis(1, 0, 0), yaxis(0, 1, 0);
 
     gridRotation.multVec(xaxis, xaxis);
     gridRotation.multVec(yaxis, yaxis);
 
     float x, y, z;
-    camCenterPointOnFocalPlane.getValue(x, y, z);
+    point.getValue(x, y, z);
 
-    Base::Vector3d center(x, y, z);
+    Base::Vector3d result(x, y, z);
+    result.TransformToCoordinateSystem(gridOrigin, xaxis, yaxis);
 
-    center.TransformToCoordinateSystem(gridOrigin, xaxis, yaxis);
+    return result;
+}
 
-    return center;
+int GridExtensionP::getViewOrientationFactor() const
+{
+    if (!view) {
+        return 1;
+    }
+
+    auto* viewer = view->getViewer();
+    if (!viewer) {
+        return 1;
+    }
+
+    auto* camera = viewer->getSoRenderManager()->getCamera();
+    if (!camera) {
+        return 1;
+    }
+
+    auto cameraPosition = getPointInSketchCoordinates(camera->position.getValue());
+    return cameraPosition.z < 0 ? -1 : 1;
 }
 
 void GridExtensionP::setEnabled(bool enable)


### PR DESCRIPTION
Backport of #29280 to `releases/FreeCAD-1-1`.

This replaces #29289.

## What changed

- preserve the local Sketcher overlay depth for dimension and helper lines
- lift the Sketcher grid slightly off the support face so it remains visible
- adapt the grid view-orientation lookup to the `releases/FreeCAD-1-1` `ViewProviderGridExtension` API

## Why

The original fix from #29280 needs a small release-branch-specific adjustment in the grid code.

On `main`, the grid patch relies on the later `ViewProviderGridExtension` refactor from #21978, where the extension stores a `Gui::View3DInventor* view` member. `releases/FreeCAD-1-1` does not have that refactor, so a straight backport leaves `ViewProviderGridExtension.cpp` referring to an undeclared `view` and fails to compile.

This branch keeps the intended overlay-depth and grid behavior from #29280, but resolves the active 3D view through the existing `releases/FreeCAD-1-1` API instead of backporting the broader refactor.

## Impact

This restores the intended Sketcher rendering fix on 1.1.x without pulling in unrelated transaction or grid-extension changes.

