### PR TITLE
Reduce risk of crash in old versions of Graphviz

### DIFF
--- a/src/App/Graphviz.cpp
+++ b/src/App/Graphviz.cpp
@@ -447,24 +447,16 @@ void Document::exportGraphviz(std::ostream& out) const
             GlobalVertexList[getId(docObj)] = vertex_no++;
 
             // If node is in main graph, style it with rounded corners. If not, make it invisible.
+            auto& props = get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]];
             if (!GraphList[docObj]) {
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["style"] = "filled";
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["shape"] = "Mrecord";
-                // Set node label
-                if (name == label) {
-                    get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["label"] = name;
-                }
-                else {
-                    get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["label"] =
-                        name + "&#92;n(" + label + ")";
-                }
+                props["style"] = "rounded,filled";
+                props["shape"] = "box";
+                props["label"] = name == label ? name : name + "&#92;n(" + label + ")";
             }
             else {
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["style"] = "invis";
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["fixedsize"] =
-                    "true";
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["width"] = "0";
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["height"] = "0";
+                props["style"] = "invis";
+                props["shape"] = "point";
+                props["margin"] = "0";
             }
 
             // Add expressions and its dependencies

--- a/src/App/Graphviz.cpp
+++ b/src/App/Graphviz.cpp
@@ -325,24 +325,16 @@ void Document::exportGraphviz(std::ostream& out) const
             GlobalVertexList[getId(docObj)] = vertex_no++;
 
             // If node is in main graph, style it with rounded corners. If not, make it invisible.
+            auto& props = get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]];
             if (!GraphList[docObj]) {
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["style"] = "filled";
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["shape"] = "Mrecord";
-                // Set node label
-                if (name == label) {
-                    get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["label"] = name;
-                }
-                else {
-                    get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["label"] =
-                        name + "&#92;n(" + label + ")";
-                }
+                props["style"] = "rounded,filled";
+                props["shape"] = "box";
+                props["label"] = name == label ? name : name + "&#92;n(" + label + ")";
             }
             else {
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["style"] = "invis";
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["fixedsize"] =
-                    "true";
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["width"] = "0";
-                get(vertex_attribute, *sgraph)[LocalVertexList[getId(docObj)]]["height"] = "0";
+                props["style"] = "invis";
+                props["shape"] = "point";
+                props["margin"] = "0";
             }
 
             // Add expressions and its dependencies


### PR DESCRIPTION
Fixes #17835

The problem seems to be that older versions of graphviz crashes in some situations. Perhaps when the constraint problem is hard to solve. As mentioned in the issue, I made a small script to simplify the original graph causing the crash in a randomized manner. Running it ~20 times seem to show that two sets of vertex attributes provoke the problem:
- "style=filled, shape=Mrecord" The "Mrecord" shape is used even though the node is not used as a record, i.e. the label just contain the name and if different also the label. The code comment says "style it with rounded corners", and the documentation for Mrecord says "The Mrecord shape is identical to a record shape, except that the outermost box has rounded corners" ([ref](https://graphviz.org/doc/info/shapes.html)). So it appears that the node is made into a record just to give it rounded corners. using "style="rounded,filled", shape=box" have the same effect, seem more straight forward and fixes the crash.
- "style=invis, fixedsize=true, width=0, height=0" This causes "Warning: node 'xx', graph '' size too small for label" warnings that a not pretty, but harmless. But removing this rule also removes the crash. That rule is trying to do to the node is (quoting the comment in the code) to "make it invisible" and that might perhaps be done in a more straight forward manner with "style=invis, shape=point, margin=0" and this removes the crash.

I tried all 8 combinations of the code with and without the two fixes using graphviz 2.38 and 14.1.4 and the fixes seem only to make minor changes to the graph (except of course to case that crashes) within the same version of graphviz, i.e some lines attaches to slightly different places on boxes. Changes across graphviz versions are probably due to algorithm changes in graphviz.
