### PR TITLE
Techdraw: incorrect dimension for straight bspline

### DIFF
--- a/src/Mod/TechDraw/App/Geometry.cpp
+++ b/src/Mod/TechDraw/App/Geometry.cpp
@@ -1659,6 +1659,7 @@ bool GeometryUtils::isLine(const TopoDS_Edge& occEdge)
     Handle(Geom_BSplineCurve) spline = adapt.BSpline();
     double firstParm = adapt.FirstParameter();
     double lastParm = adapt.LastParameter();
+    spline->Segment(firstParm, lastParm);
     auto startPoint = Base::convertTo<Base::Vector3d>(adapt.Value(firstParm));
     auto endPoint = Base::convertTo<Base::Vector3d>(adapt.Value(lastParm));
     auto edgeLong = edgeLength(occEdge);


### PR DESCRIPTION
Fixes issue #29392

BSpline Line checker was not taking into account the case when the spline was trimmed. So the length comparison to check if BSpline can be treated as a straight line was false. It was checking wrt original untrimmed end points.

before:

<img width="357" height="259" alt="before" src="https://github.com/user-attachments/assets/98c0fc9b-bcc8-4470-8f47-09cf04de8b6a" />

after:

<img width="371" height="316" alt="after" src="https://github.com/user-attachments/assets/06b4034a-6779-4331-a712-871f624900ec" />
