### PR TITLE
Core: Add double-click to clear expression and retain value in spinboxes

### DIFF
--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -43,6 +43,51 @@ using namespace Gui;
 using namespace App;
 using namespace Base;
 
+namespace SpinBoxPrivate
+{
+class ExpressionResetDoubleClickFilter: public QObject
+{
+public:
+    explicit ExpressionResetDoubleClickFilter(ExpressionSpinBox& binding, QObject* parent)
+        : QObject(parent)
+        , m_binding(binding)
+    {}
+
+    bool eventFilter(QObject*, QEvent* event) override
+    {
+        if (event->type() == QEvent::MouseButtonDblClick && m_binding.hasExpression()
+            && !m_binding.isTentativeDiscard()) {
+            m_binding.discardExpression();
+            return true;
+        }
+        return false;
+    }
+
+private:
+    ExpressionSpinBox& m_binding;
+};
+
+class ExpressionFocusOutFilter: public QObject
+{
+public:
+    explicit ExpressionFocusOutFilter(ExpressionSpinBox& binding, QObject* parent)
+        : QObject(parent)
+        , m_binding(binding)
+    {}
+
+    bool eventFilter(QObject*, QEvent* event) override
+    {
+        if (event->type() == QEvent::FocusOut) {
+            m_binding.handleFocusOut();
+        }
+        return false;
+    }
+
+private:
+    ExpressionSpinBox& m_binding;
+};
+}  // namespace SpinBoxPrivate
+
 ExpressionSpinBox::ExpressionSpinBox(QAbstractSpinBox* sb)
     : spinbox(sb)
 {
@@ -56,9 +101,43 @@ ExpressionSpinBox::ExpressionSpinBox(QAbstractSpinBox* sb)
 
     makeLabel(lineedit);
     QObject::connect(iconLabel, &ExpressionLabel::clicked, [this]() { this->openFormulaDialog(); });
+
+    lineedit->installEventFilter(new SpinBoxPrivate::ExpressionResetDoubleClickFilter(*this, spinbox));
+    // FocusOut filter goes on the spinbox, not lineedit
+    // QAbstractSpinBox handles focus at the spinbox level.
+    spinbox->installEventFilter(new SpinBoxPrivate::ExpressionFocusOutFilter(*this, spinbox));
 }
 
 ExpressionSpinBox::~ExpressionSpinBox() = default;
+
+void ExpressionSpinBox::discardExpression()
+{
+    if (!hasExpression() || m_tentativeDiscard) {
+        return;
+    }
+    m_savedExpr = getExpression();
+    m_textAtDiscard = lineedit->text();
+    m_tentativeDiscard = true;
+    setExpression(std::shared_ptr<Expression>());
+    updateExpression();
+    lineedit->selectAll();
+}
+
+void ExpressionSpinBox::handleFocusOut()
+{
+    if (!m_tentativeDiscard) {
+        return;
+    }
+    m_tentativeDiscard = false;
+    if (lineedit->text() == m_textAtDiscard) {
+        setExpression(m_savedExpr);
+        m_savedExpr.reset();
+        updateExpression();
+    }
+    else {
+        m_savedExpr.reset();
+    }
+}
 
 int ExpressionSpinBox::getMargin()
 {

--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -57,7 +57,7 @@ public:
     {
         if (event->type() == QEvent::MouseButtonDblClick && m_binding.hasExpression()
             && !m_binding.isTentativeDiscard()) {
-            m_binding.discardExpression();
+            m_binding.stashExpression();
             return true;
         }
         return false;
@@ -78,7 +78,7 @@ public:
     bool eventFilter(QObject*, QEvent* event) override
     {
         if (event->type() == QEvent::FocusOut) {
-            m_binding.handleFocusOut();
+            m_binding.restoreExpression();
         }
         return false;
     }
@@ -110,7 +110,7 @@ ExpressionSpinBox::ExpressionSpinBox(QAbstractSpinBox* sb)
 
 ExpressionSpinBox::~ExpressionSpinBox() = default;
 
-void ExpressionSpinBox::discardExpression()
+void ExpressionSpinBox::stashExpression()
 {
     if (!hasExpression() || m_tentativeDiscard) {
         return;
@@ -123,13 +123,18 @@ void ExpressionSpinBox::discardExpression()
     lineedit->selectAll();
 }
 
-void ExpressionSpinBox::handleFocusOut()
+bool ExpressionSpinBox::isValueTouched() const
+{
+    return lineedit->text() != m_textAtDiscard;
+}
+
+void ExpressionSpinBox::restoreExpression()
 {
     if (!m_tentativeDiscard) {
         return;
     }
     m_tentativeDiscard = false;
-    if (lineedit->text() == m_textAtDiscard) {
+    if (!isValueTouched()) {
         setExpression(m_savedExpr);
         m_savedExpr.reset();
         updateExpression();

--- a/src/Gui/SpinBox.h
+++ b/src/Gui/SpinBox.h
@@ -46,6 +46,12 @@ public:
     void bind(const App::ObjectIdentifier& _path) override;
     void setExpression(std::shared_ptr<App::Expression> expr) override;
     int getMargin();
+    void discardExpression();
+    void handleFocusOut();
+    bool isTentativeDiscard() const
+    {
+        return m_tentativeDiscard;
+    }
 
 protected:
     /*! Expression handling */
@@ -74,6 +80,9 @@ protected:
 
 private:
     void showExpression(Number number);
+    bool m_tentativeDiscard {false};
+    std::shared_ptr<App::Expression> m_savedExpr;
+    QString m_textAtDiscard;
 
 protected:
     QLineEdit* lineedit;

--- a/src/Gui/SpinBox.h
+++ b/src/Gui/SpinBox.h
@@ -46,8 +46,8 @@ public:
     void bind(const App::ObjectIdentifier& _path) override;
     void setExpression(std::shared_ptr<App::Expression> expr) override;
     int getMargin();
-    void discardExpression();
-    void handleFocusOut();
+    void stashExpression();
+    void restoreExpression();
     bool isTentativeDiscard() const
     {
         return m_tentativeDiscard;
@@ -80,6 +80,7 @@ protected:
 
 private:
     void showExpression(Number number);
+    bool isValueTouched() const;
     bool m_tentativeDiscard {false};
     std::shared_ptr<App::Expression> m_savedExpr;
     QString m_textAtDiscard;

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1740,7 +1740,7 @@ void ExpLineEdit::keyPressEvent(QKeyEvent* event)
     }
 }
 
-void ExpLineEdit::discardExpression()
+void ExpLineEdit::stashExpression()
 {
     if (!hasExpression() || m_tentativeDiscard) {
         return;
@@ -1756,17 +1756,22 @@ void ExpLineEdit::discardExpression()
 void ExpLineEdit::mouseDoubleClickEvent(QMouseEvent* event)
 {
     if (hasExpression() && !m_tentativeDiscard) {
-        discardExpression();
+        stashExpression();
         return;
     }
     QLineEdit::mouseDoubleClickEvent(event);
+}
+
+bool ExpLineEdit::isValueTouched() const
+{
+    return text() != m_textAtDiscard;
 }
 
 void ExpLineEdit::focusOutEvent(QFocusEvent* event)
 {
     if (m_tentativeDiscard) {
         m_tentativeDiscard = false;
-        if (text() == m_textAtDiscard) {
+        if (!isValueTouched()) {
             setExpression(m_savedExpr);
             m_savedExpr.reset();
             onChange();

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1574,6 +1574,10 @@ ExpLineEdit::ExpLineEdit(QWidget* parent, bool expressionOnly)
 
 bool ExpLineEdit::apply(const std::string& propName)
 {
+    if (m_tentativeDiscard) {
+        m_tentativeDiscard = false;
+        m_savedExpr.reset();
+    }
 
     if (!ExpressionBinding::apply(propName)) {
         if (!autoClose) {
@@ -1731,9 +1735,47 @@ void ExpLineEdit::finishFormulaDialog()
 
 void ExpLineEdit::keyPressEvent(QKeyEvent* event)
 {
-    if (!hasExpression()) {
+    if (m_tentativeDiscard || !hasExpression()) {
         QLineEdit::keyPressEvent(event);
     }
+}
+
+void ExpLineEdit::discardExpression()
+{
+    if (!hasExpression() || m_tentativeDiscard) {
+        return;
+    }
+    m_savedExpr = getExpression();
+    m_textAtDiscard = text();
+    m_tentativeDiscard = true;
+    setExpression(std::shared_ptr<App::Expression>());
+    onChange();
+    selectAll();
+}
+
+void ExpLineEdit::mouseDoubleClickEvent(QMouseEvent* event)
+{
+    if (hasExpression() && !m_tentativeDiscard) {
+        discardExpression();
+        return;
+    }
+    QLineEdit::mouseDoubleClickEvent(event);
+}
+
+void ExpLineEdit::focusOutEvent(QFocusEvent* event)
+{
+    if (m_tentativeDiscard) {
+        m_tentativeDiscard = false;
+        if (text() == m_textAtDiscard) {
+            setExpression(m_savedExpr);
+            m_savedExpr.reset();
+            onChange();
+        }
+        else {
+            m_savedExpr.reset();
+        }
+    }
+    QLineEdit::focusOutEvent(event);
 }
 
 // --------------------------------------------------------------------

--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -614,14 +614,20 @@ public:
 
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    void mouseDoubleClickEvent(QMouseEvent* event) override;
+    void focusOutEvent(QFocusEvent* event) override;
 
 private Q_SLOTS:
     void finishFormulaDialog();
     void openFormulaDialog();
     void onChange() override;
+    void discardExpression();
 
 private:
     bool autoClose;
+    bool m_tentativeDiscard {false};
+    std::shared_ptr<App::Expression> m_savedExpr;
+    QString m_textAtDiscard;
 };
 
 /*!

--- a/src/Gui/Widgets.h
+++ b/src/Gui/Widgets.h
@@ -621,9 +621,10 @@ private Q_SLOTS:
     void finishFormulaDialog();
     void openFormulaDialog();
     void onChange() override;
-    void discardExpression();
+    void stashExpression();
 
 private:
+    bool isValueTouched() const;
     bool autoClose;
     bool m_tentativeDiscard {false};
     std::shared_ptr<App::Expression> m_savedExpr;


### PR DESCRIPTION
This PR adds a user-friendly double-click-to-clear behavior for expression-bound spinboxes and ExpLineEdit.

Double-clicking an expression-bound field tentatively clears the expression while preserving the current value for direct editing. If focus is lost without any change being made, the original expression is restored.

This is especially useful in workbenches such as CAM, where expression-based spinboxes are used extensively and users often need to replace an expression with a direct value.

src/Gui/SpinBox.cpp, src/Gui/SpinBox.h:
- Add ExpressionResetDoubleClickFilter for double-click-to-clear
- Add tentative discard logic (discardExpression, handleFocusOut, m_tentativeDiscard, etc.)

src/Gui/Widgets.cpp, src/Gui/Widgets.h:
- Implement double-click-to-clear and tentative discard logic for ExpLineEdit


https://github.com/user-attachments/assets/27d14c9a-68c4-4844-94c3-5d27168efdcb

