### PR TITLE
Gui: Improve Text Editor search feedback

### DIFF
--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -24,6 +24,7 @@
 #include <QCheckBox>
 #include <QClipboard>
 #include <QDateTime>
+#include <QLabel>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include <QLineEdit>
@@ -55,6 +56,11 @@
 
 #include <Gui/PreferencePages/DlgSettingsPDF.h>
 
+
+namespace
+{
+constexpr int SearchSelectionProperty = QTextFormat::UserProperty + 1;
+}
 
 using namespace Gui;
 namespace Gui
@@ -762,8 +768,17 @@ SearchBar::SearchBar(QWidget* parent)
     searchText->setClearButtonEnabled(true);
     horizontalLayout->addWidget(searchText);
     connect(searchText, &QLineEdit::returnPressed, this, &SearchBar::findNext);
-    connect(searchText, &QLineEdit::textChanged, this, &SearchBar::findCurrent);
+    connect(searchText, &QLineEdit::textChanged, this, [this]() {
+        if (!skipSearch) {
+            findCurrent();
+        }
+    });
     connect(searchText, &QLineEdit::textChanged, this, &SearchBar::updateButtons);
+
+    resultLabel = new QLabel(this);
+    resultLabel->setMinimumWidth(60);
+    resultLabel->setAlignment(Qt::AlignCenter);
+    horizontalLayout->addWidget(resultLabel);
 
     prevButton = new QToolButton(this);
     prevButton->setIcon(style()->standardIcon(QStyle::SP_ArrowBack));
@@ -794,6 +809,7 @@ SearchBar::SearchBar(QWidget* parent)
 
     setMinimumWidth(minimumSizeHint().width());
     updateButtons();
+    resultLabel->setText("");
     hide();
 }
 
@@ -828,13 +844,18 @@ void SearchBar::activate(const QString& prefill)
     show();
 
     if (!prefill.isEmpty()) {
-        QSignalBlocker blocker(searchText);  // block auto-search jump to next match after prefill
+        skipSearch = true;  // prevent cursor jump to next search match after prefill
         searchText->setText(prefill);
+        skipSearch = false;
     }
 
     searchText->selectAll();
     searchText->setFocus(Qt::ShortcutFocusReason);
     updateButtons();
+
+    if (!searchText->text().isEmpty()) {
+        updateSearchResults(searchText->text());
+    }
 }
 
 void SearchBar::deactivate()
@@ -843,6 +864,141 @@ void SearchBar::deactivate()
         textEditor->setFocus();
     }
     hide();
+}
+
+/**
+ * Get all search result matches in document.
+ */
+SearchBar::SearchResults SearchBar::findAllMatches(const QString& str)
+{
+    SearchResults matches;
+
+    if (!textEditor || str.isEmpty()) {
+        return matches;
+    }
+
+    QTextDocument* doc = textEditor->document();
+    if (!doc) {
+        return matches;
+    }
+
+    QTextDocument::FindFlags options = {};
+    if (matchCase->isChecked()) {
+        options |= QTextDocument::FindCaseSensitively;
+    }
+    if (matchWord->isChecked()) {
+        options |= QTextDocument::FindWholeWords;
+    }
+
+    QTextCursor cursor(doc);
+    QTextCursor currentCursor = textEditor->textCursor();
+
+    while (true) {
+        cursor = doc->find(str, cursor, options);
+        if (cursor.isNull()) {
+            break;
+        }
+
+        const int start = cursor.selectionStart();
+        const int end = cursor.selectionEnd();
+
+        matches.matchRanges.push_back({start, end});
+
+        if (currentCursor.position() >= start && currentCursor.position() <= end) {
+            matches.currentIndex = matches.matchRanges.size();
+        }
+    }
+
+    return matches;
+}
+
+/**
+ * Show current search result position and total matches count.
+ */
+void SearchBar::updateSearchResults(const QString& str)
+{
+    if (!textEditor || str.isEmpty()) {
+        resultLabel->clear();
+        return;
+    }
+
+    SearchResults matches = findAllMatches(str);
+
+    if (matches.matchRanges.isEmpty()) {
+        resultLabel->setText(tr("No results"));
+        highlightSearchResults(matches);
+        return;
+    }
+
+    int total = matches.matchRanges.size();
+    int currentIndex = matches.currentIndex;
+
+    if (currentIndex == -1) {
+        resultLabel->setText(QString("0 / %1").arg(total));
+    }
+    else {
+        resultLabel->setText(QString("%1 / %2").arg(currentIndex).arg(total));
+    }
+
+    highlightSearchResults(matches);
+}
+
+/**
+ * Highlight visually all search result matches.
+ * Note: highlight stays after closing search bar, but disappears after any subsequent click.
+ */
+void SearchBar::highlightSearchResults(const SearchResults& matches)
+{
+    if (!textEditor || !textEditor->document()) {
+        return;
+    }
+
+    const auto& selections = textEditor->extraSelections();
+
+    QVector<QTextEdit::ExtraSelection> cleaned;
+    cleaned.reserve(selections.size());
+
+    for (const auto& sel : selections) {
+        if (!sel.format.property(SearchSelectionProperty).toBool()) {
+            cleaned.push_back(sel);
+        }
+    }
+
+    QVector<QTextEdit::ExtraSelection> searchSelections;
+    searchSelections.reserve(matches.matchRanges.size());
+
+    QTextCursor currentCursor = textEditor->textCursor();
+
+    const QPalette pal = textEditor->palette();
+    const QColor highlightColor = pal.color(QPalette::Highlight);
+
+    QColor matchColor = highlightColor;
+    matchColor.setAlphaF(0.75);
+
+    QTextDocument* doc = textEditor->document();
+
+    for (const auto& range : matches.matchRanges) {
+        QTextCursor cursor(doc);
+        cursor.setPosition(range.first);
+        cursor.setPosition(range.second, QTextCursor::KeepAnchor);
+
+        QTextEdit::ExtraSelection sel;
+        sel.cursor = cursor;
+
+        const int pos = currentCursor.position();
+        const bool isCurrent = (pos >= range.first && pos <= range.second);
+
+        QTextCharFormat format;
+        format.setBackground(isCurrent ? highlightColor : matchColor);
+        format.setProperty(QTextFormat::FullWidthSelection, true);
+        format.setProperty(SearchSelectionProperty, true);
+
+        sel.format = format;
+        searchSelections.push_back(sel);
+    }
+
+    cleaned += searchSelections;
+    textEditor->setExtraSelections(cleaned);
 }
 
 void SearchBar::findPrevious()
@@ -879,7 +1035,7 @@ void SearchBar::findText(bool skip, bool next, const QString& str)
     bool found = true;
     QTextCursor newCursor = cursor;
     if (!str.isEmpty()) {
-        QTextDocument::FindFlags options;
+        QTextDocument::FindFlags options = {};
         if (!next) {
             options |= QTextDocument::FindBackward;
         }
@@ -920,6 +1076,7 @@ void SearchBar::findText(bool skip, bool next, const QString& str)
     }
 
     searchText->setStyleSheet(styleSheet);
+    updateSearchResults(str);
 }
 
 void SearchBar::updateButtons()

--- a/src/Gui/EditorView.h
+++ b/src/Gui/EditorView.h
@@ -34,6 +34,7 @@ class QHBoxLayout;
 class QToolButton;
 class QCheckBox;
 class QSpacerItem;
+class QLabel;
 QT_END_NAMESPACE
 
 namespace Gui
@@ -174,6 +175,14 @@ private:
     void retranslateUi();
     void findText(bool skip, bool next, const QString& str);
     void updateButtons();
+    struct SearchResults
+    {
+        QVector<QPair<int, int>> matchRanges;
+        int currentIndex = -1;
+    };
+    SearchResults findAllMatches(const QString& str);
+    void updateSearchResults(const QString& str);
+    void highlightSearchResults(const SearchResults& matches);
 
 private:
     QPlainTextEdit* textEditor;
@@ -181,10 +190,12 @@ private:
     QSpacerItem* horizontalSpacer;
     QToolButton* closeButton;
     QLineEdit* searchText;
+    QLabel* resultLabel;
     QToolButton* prevButton;
     QToolButton* nextButton;
     QCheckBox* matchCase;
     QCheckBox* matchWord;
+    bool skipSearch = false;
 };
 
 }  // namespace Gui


### PR DESCRIPTION
For the Text Editor (i.e. integrated Python macro IDE), the search now:

- Displays the current search result position and total matches count in search bar (between search field and prev/next buttons.
- Highlights visually all search result matches in code plainTextEditor (background and foreground tweaks to stand out a bit).
- Additionally fix minor issues with previous Text Editor search PR [#27674](https://github.com/FreeCAD/FreeCAD/pull/27674): better way to prevent unexpected auto-jump to next match when calling search from selection (i.e. do not use `QSignalBlocker`); fix disappearance of clear search input button when calling search from selection.

## Before and After Images

https://github.com/user-attachments/assets/ac94ee78-33ee-493a-94f2-0c4a5a4f0e85

Not included in this PR (future nice-to-have, note for myself or others if interested):

- Expose the search feature in menus and status bar input hints, and tooltips.
- Support multi-line search (search field already becomes red with unsupported multi-line), find and replace (single instance or all), regex and in current selection search.
- Refactor and general cleanup of `src/Gui/EditorView.cpp/.h`, `src/Gui/TextDocumentEditorView.cpp/.h`, and `src/Gui/TextEdit.cpp/.h`.