### PR TITLE
Draft: Warn for unsupported subelement highlight selections

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_subelements.py
+++ b/src/Mod/Draft/draftguitools/gui_subelements.py
@@ -44,7 +44,7 @@ from draftguitools import gui_base_original
 from draftguitools import gui_tool_utils
 from draftutils import utils
 from draftutils import gui_utils
-from draftutils.messages import _msg
+from draftutils.messages import _msg, _wrn
 from draftutils.translate import translate
 
 
@@ -84,6 +84,7 @@ class SubelementHighlight(gui_base_original.Modifier):
             self.view.removeEventCallback("SoEvent", self.call)
         self.get_editable_objects_from_selection()
         if not self.editable_objects:
+            _wrn(translate("draft", "Only Draft lines, wires, and curves can be highlighted"))
             return self.finish()
         self.call = self.view.addEventCallback("SoEvent", self.action)
         self.highlight_editable_objects()
@@ -129,7 +130,7 @@ class SubelementHighlight(gui_base_original.Modifier):
                 "Wire",
             ]:
                 self.editable_objects.append(obj)
-            elif hasattr(obj, "Base") and (
+            elif getattr(obj, "Base", None) and (
                 obj.Base.isDerivedFrom("Part::Part2DObject")
                 or utils.get_type(obj.Base) in ["BezCurve", "BSpline", "Wire"]
             ):


### PR DESCRIPTION
Handles unsupported selections in `Draft_SubelementHighlight` without raising a Python exception.

When a selected object has a `Base` property set to `None`, the command now skips that base-object path instead of calling `isDerivedFrom()` on `None`. If no editable Draft line, wire, or curve is found, the command reports a warning instead of failing with a red error.

## Issues

Fixes #28034

## Before and After Images

Before:

<img width="1919" height="1079" alt="before" src="https://github.com/user-attachments/assets/07c24907-d801-45cc-984e-6aec099ead9a" />


After:

<img width="1914" height="860" alt="after" src="https://github.com/user-attachments/assets/55c1875f-62df-4e60-a67b-476cf2db8c2e" />
