### PR TITLE
Avoid invalidating iterators on unset edit document. Guard unset dragger.

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -1585,13 +1585,12 @@ void Application::unsetEditDocument(Gui::Document* pcDocument)
 }
 void Application::unsetEditDocumentIf(const std::function<bool(Gui::Document*)>& eval)
 {
-    std::erase_if(d->editDocuments, [&](Gui::Document* doc) {
-        if (eval(doc)) {
-            doc->_resetEdit();
-            return true;
-        }
-        return false;
-    });
+    std::vector<Gui::Document*> matched, unmatched;
+    ranges::partition_copy(d->editDocuments, back_inserter(matched), back_inserter(unmatched), eval);
+    std::swap(d->editDocuments, unmatched);
+    for (auto doc : matched) {
+        doc->_resetEdit();
+    }
     updateActions();
 }
 Gui::MDIView* Application::editViewOfNode(SoNode* node) const

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -130,6 +130,7 @@ ViewProviderAssembly::ViewProviderAssembly()
 ViewProviderAssembly::~ViewProviderAssembly()
 {
     m_preTransactionConn.disconnect();
+    QObject::disconnect(workbenchConnection);
 
     updateTaskPanel(false);
 };
@@ -400,10 +401,14 @@ void ViewProviderAssembly::setDragger()
 void ViewProviderAssembly::unsetDragger()
 {
     pcRoot->removeChild(asmDraggerSwitch);
-    asmDragger->unref();
-    asmDragger = nullptr;
-    asmDraggerSwitch->unref();
-    asmDraggerSwitch = nullptr;
+    if (asmDragger) {
+        asmDragger->unref();
+        asmDragger = nullptr;
+    }
+    if (asmDraggerSwitch) {
+        asmDraggerSwitch->unref();
+        asmDraggerSwitch = nullptr;
+    }
 }
 
 void ViewProviderAssembly::setEditViewer(Gui::View3DInventorViewer* viewer, int ModNum)


### PR DESCRIPTION
Fixes #28506

Looking at the stack trace of the crash, `unsetEditDocumentIf` and its use of `std::erase_if` was in the call stack with something that looked like a double delete. Adding break points in the 3 or so methods that modify editDocuments, shows that inside `std::erase_if`, the lambda calls `_resetEdit` which calls `Application::Instance->unsetEditDocument(this);` which removes the document from `editDocuments` invalidating the iterators used by `std::erase_if` causing the crash.

Git-blame point to 1665dec4 and using git bisect around that, shows that it is indeed the problem (it needs to have ad630cbb applied to compile). Its commit message says "Adress review" and checking the PR, it seems that the reviewer had noticed another iterator invalidation issue and suggested two fixes. Unfortunately the fix chosen had the present issue.

If you create more than one Assembly document before closing the first (by just switching back to the start page), you get another crash in `ViewProviderAssembly::unsetDragger` as `asmDragger` and `asmDraggerSwitch` are already null. So this fix also guards those.