### PR TITLE
Assembly: Fix issues in Simulation tool

### DIFF
--- a/src/Mod/Assembly/CommandCreateSimulation.py
+++ b/src/Mod/Assembly/CommandCreateSimulation.py
@@ -855,7 +855,6 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         self.form.GlobalErrorToleranceSpinBox.setProperty(
             "rawValue", self.simFeaturePy.fGlobalErrorTolerance
         )
-        self.setFrameValue(0)
         self.form.FramesPerSecondSpinBox.setValue(self.simFeaturePy.jFramesPerSecond)
 
     def setSpinboxPrecision(self, spinbox, precision, unit=App.Units.TimeSpan):


### PR DESCRIPTION
Related to https://github.com/FreeCAD/FreeCAD/issues/22543 But it does not fix it.

What this PR does : 
`TaskAssemblyCreateSimulation` has a UI initialisation called `setUiInitialValues`

This function was doing `self.setFrameValue(0)` which caused the following bug : 

https://github.com/user-attachments/assets/c5fdf852-ff63-44cf-bced-09173ce82a7f

See ? If you move something in the assembly, then double click the simulation tool, it will move back the assembly! Even though we have not clicked 'generate' yet. The tool should do nothing until generate is clicked.

What heppens is that `setFrameValue `triggers `onFrameChanged` which triggers `assembly.updateForFrame` which causes some undefined behavior since the runkinematic for the simulation has not run yet.

Besides this `self.setFrameValue(0)` serves absolutely no purpose because the frame slider is hidden until the user clicks generate. And when the user clicks generates, then the widget is visible, but we call `self.setFrameValue(nFrms - 1)`. So the early set to 0 is totally useless.