### PR TITLE
Start: fix thumbnail generation causing QPixmap::resize errors

### DIFF
--- a/src/Base/Stream.cpp
+++ b/src/Base/Stream.cpp
@@ -425,6 +425,79 @@ std::streambuf::pos_type StringIStreambuf::seekpos(
 
 // ----------------------------------------------------------------------
 
+std::streambuf* BufferStreambuf::setbuf(char* s, std::streamsize n)
+{
+    // [spanbuf.virtuals] 8
+    span({s, size_t(n)});
+    return this;
+}
+
+std::streambuf::pos_type BufferStreambuf::seekoff(
+    off_type off,
+    std::ios::seekdir way,
+    std::ios::openmode which
+)
+{
+    // NOLINTBEGIN(modernize-return-braced-init-list,cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    which &= std::ios::in | std::ios::out;
+
+    // [spanbuf.virtuals] 3
+    if (which == (std::ios::in | std::ios::out) && way == std::ios::cur) {
+        // [spanbuf.virtuals] 6
+        return pos_type(off_type(-1));
+    }
+
+    // [spanbuf.virtuals] 4
+    off_type baseOffset = 0;
+    if (way == std::ios::beg) {
+        // [spanbuf.virtuals] 4.1
+        baseOffset = 0;
+    }
+    else {
+        if (which == std::ios::out) {
+            // [spanbuf.virtuals] 4.2 & 4.3.1
+            baseOffset = pptr() - pbase();
+        }
+        else if (way == std::ios::cur) {
+            // [spanbuf.virtuals] 4.2
+            baseOffset = gptr() - eback();
+        }
+        else if (way == std::ios::end) {
+            // [spanbuf.virtuals] 4.3.2
+            baseOffset = off_type(buffer.size());
+        }
+    }
+
+    // [spanbuf.virtuals] 5
+    const off_type newOffset = off + baseOffset;
+    if (newOffset < 0 || size_t(newOffset) > buffer.size()) {
+        // [spanbuf.virtuals] 6
+        return pos_type(off_type(-1));
+    }
+
+    // [spanbuf.virtuals] 2
+    if (which & std::ios::in) {
+        // [spanbuf.virtuals] 2.1
+        setg(eback(), eback() + newOffset, egptr());
+    }
+    if (which & std::ios::out) {
+        // [spanbuf.virtuals] 2.2
+        setp(pbase(), epptr());
+        pbump(int(newOffset));
+    }
+
+    return pos_type(newOffset);
+    // NOLINTEND(modernize-return-braced-init-list,cppcoreguidelines-pro-bounds-pointer-arithmetic)
+}
+
+std::streambuf::pos_type BufferStreambuf::seekpos(pos_type pos, std::ios_base::openmode which)
+{
+    // [spanbuf.virtuals] 7
+    return seekoff(off_type(pos), std::ios_base::beg, which);
+}
+
+// ----------------------------------------------------------------------
+
 // ---------------------------------------------------------
 
 #define PYSTREAM_BUFFERED

--- a/src/Base/Stream.h
+++ b/src/Base/Stream.h
@@ -30,10 +30,12 @@
 #endif
 
 #include <fstream>
+#include <span>
 #include <sstream>
+#include <streambuf>
 #include <string>
 #include <vector>
-#include <streambuf>
+
 #include "FileInfo.h"
 
 
@@ -421,6 +423,100 @@ public:
 private:
     const std::string& _buffer;
     int _beg, _end, _cur;
+};
+
+/**
+ * Streambuf for reading/writing to a fixed memory buffer.
+ * Equivalent in functionality to C++23 std::spanbuf.
+ */
+class BaseExport
+#ifdef __cpp_lib_spanstream
+    [[deprecated("Use std::spanbuf wrapped in a \"#ifdef __cpp_lib_spanstream\" condition instead")]]
+#endif
+    BufferStreambuf: public std::streambuf
+{
+public:
+    BufferStreambuf()
+        : BufferStreambuf(std::ios::in | std::ios::out)
+    {}
+
+    explicit BufferStreambuf(std::ios::openmode mode)
+        : mode(mode)
+    {}
+
+    explicit BufferStreambuf(
+        std::span<char> buffer,
+        std::ios::openmode mode = std::ios::in | std::ios::out
+    )
+        : mode(mode)
+    {
+        span(buffer);
+    }
+
+    BufferStreambuf(BufferStreambuf&& rhs) noexcept
+        : std::streambuf(rhs)
+        , mode(rhs.mode)
+    {
+        span(rhs.buffer);
+    }
+    BufferStreambuf& operator=(BufferStreambuf&& rhs) noexcept
+    {
+        mode = rhs.mode;
+        buffer = rhs.buffer;
+        // No need for std::move() here, std::streambuf lacks a move assignment operator
+        std::streambuf::operator=(rhs);
+        return *this;
+    }
+
+    BufferStreambuf(const BufferStreambuf&) = delete;
+    BufferStreambuf& operator=(const BufferStreambuf&) = delete;
+
+    ~BufferStreambuf() override = default;
+
+    void swap(BufferStreambuf& rhs) noexcept
+    {
+        std::streambuf::swap(rhs);
+        std::swap(mode, rhs.mode);
+        std::swap(buffer, rhs.buffer);
+    }
+
+    std::span<char> span() const noexcept
+    {
+        if (mode & std::ios::out) {
+            return {pbase(), pptr()};
+        }
+        return buffer;
+    }
+
+    void span(std::span<char> s) noexcept
+    {
+        buffer = s;
+        if (mode & std::ios::in) {
+            setg(s.data(), s.data(), s.data() + s.size());
+        }
+        if (mode & std::ios::out) {
+            setp(s.data(), s.data() + s.size());
+            if (mode & std::ios::ate) {
+                pbump(int(s.size()));
+            }
+        }
+    }
+
+protected:
+    std::streambuf* setbuf(char* s, std::streamsize n) override;
+    pos_type seekoff(
+        off_type off,
+        std::ios::seekdir way,
+        std::ios::openmode which = std::ios::in | std::ios::out
+    ) override;
+    pos_type seekpos(
+        pos_type pos,
+        std::ios_base::openmode which = std::ios_base::in | std::ios_base::out
+    ) override;
+
+private:
+    std::ios_base::openmode mode;
+    std::span<char> buffer;
 };
 
 class BaseExport PyStreambuf: public std::streambuf

--- a/src/Mod/Start/App/DisplayedFilesModel.cpp
+++ b/src/Mod/Start/App/DisplayedFilesModel.cpp
@@ -165,6 +165,7 @@ void DisplayedFilesModel::addFile(const QString& filePath)
             &DisplayedFilesModel::processNewFcstdInfo
         );
         QThreadPool::globalInstance()->start(runner);
+        return;
     }
     const QStringList ignoredExtensions {
         QLatin1String("fcmacro"),

--- a/src/Mod/Start/App/FcstdInfoSource.cpp
+++ b/src/Mod/Start/App/FcstdInfoSource.cpp
@@ -23,7 +23,11 @@
 
 #include "FcstdInfoSource.h"
 
-#include <sstream>
+#if __cplusplus >= 202302L
+# include <spanstream>
+#else
+# include <ostream>
+#endif
 
 #include <Base/Console.h>
 #include <Base/Stream.h>
@@ -53,10 +57,21 @@ static QByteArray loadFCStdThumbnail(const App::ProjectFile& proj, const QString
                 createThumbnailsDir();
 
                 // Read the thumbnail into a buffer
-                QByteArray data(proj.sizeOfFile(pathToThumbnail), Qt::Uninitialized);
-                std::ostringstream dataStream;
-                dataStream.rdbuf()->pubsetbuf(data.data(), data.size());
+                const auto dataSize = proj.sizeOfFile(pathToThumbnail);
+#if __cplusplus >= 202302L
+                QByteArray data(dataSize, Qt::Uninitialized);
+                std::spanstream dataStream({data.data(), size_t(data.size())});
+#else
+                std::string dataString;
+                dataString.reserve(dataSize);
+                Base::StringOStreambuf dataStreambuf(dataString);
+                std::ostream dataStream(&dataStreambuf);
+#endif
                 proj.readInputFileDirect(pathToThumbnail, dataStream);
+#if __cplusplus < 202302L
+                // Incurs a copy
+                QByteArray data(dataString.data(), qsizetype(dataString.size()));
+#endif
 
                 // Save that buffer to the thumbnail cache
                 const Base::FileInfo thumbnailFileInfo(pathToCachedThumbnail.toStdString());

--- a/src/Mod/Start/App/FcstdInfoSource.cpp
+++ b/src/Mod/Start/App/FcstdInfoSource.cpp
@@ -23,7 +23,7 @@
 
 #include "FcstdInfoSource.h"
 
-#if __cplusplus >= 202302L
+#ifdef __cpp_lib_spanstream
 # include <spanstream>
 #else
 # include <ostream>
@@ -58,20 +58,14 @@ static QByteArray loadFCStdThumbnail(const App::ProjectFile& proj, const QString
 
                 // Read the thumbnail into a buffer
                 const auto dataSize = proj.sizeOfFile(pathToThumbnail);
-#if __cplusplus >= 202302L
                 QByteArray data(dataSize, Qt::Uninitialized);
+#ifdef __cpp_lib_spanstream
                 std::spanstream dataStream({data.data(), size_t(data.size())});
 #else
-                std::string dataString;
-                dataString.reserve(dataSize);
-                Base::StringOStreambuf dataStreambuf(dataString);
+                Base::BufferStreambuf dataStreambuf({data.data(), size_t(data.size())});
                 std::ostream dataStream(&dataStreambuf);
 #endif
                 proj.readInputFileDirect(pathToThumbnail, dataStream);
-#if __cplusplus < 202302L
-                // Incurs a copy
-                QByteArray data(dataString.data(), qsizetype(dataString.size()));
-#endif
 
                 // Save that buffer to the thumbnail cache
                 const Base::FileInfo thumbnailFileInfo(pathToCachedThumbnail.toStdString());

--- a/src/Mod/Start/Gui/FileCardDelegate.cpp
+++ b/src/Mod/Start/Gui/FileCardDelegate.cpp
@@ -104,7 +104,8 @@ void FileCardDelegate::paint(
     if (!image.isEmpty()) {
         pixmap.loadFromData(image);
     }
-    else {
+    // Check for null in case no data is available yet or the above loadFromData() failed
+    if (pixmap.isNull()) {
         pixmap = generateThumbnail(path);
     }
 

--- a/tests/src/Base/Stream.cpp
+++ b/tests/src/Base/Stream.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <array>
+
 #include <gtest/gtest.h>
 
 #ifdef _MSC_VER
@@ -167,4 +169,196 @@ TEST_F(StringStreambufTest, RoundTripBinaryData)
     in.clear();
     in.seekg(3);
     EXPECT_EQ(0, in.get());
+}
+
+
+// Change this type alias to std::streambuf should still have the tests below pass.
+using BufferStreambuf = Base::BufferStreambuf;
+
+TEST(BufferStreambuf, emptyBufferIn)
+{
+    std::array<char, 0> array;
+    BufferStreambuf streambuf(array, std::ios::in);
+    std::istream stream(&streambuf);
+
+    // Read a byte with get()
+    EXPECT_TRUE(stream.good());
+    EXPECT_EQ(stream.get(), std::istream::traits_type::eof());
+    EXPECT_TRUE(stream.eof());
+    EXPECT_TRUE(stream.fail());
+
+    // Peek a byte
+    stream.seekg(0, std::ios::beg);
+    stream.clear();
+    EXPECT_TRUE(stream.good());
+    EXPECT_EQ(stream.peek(), std::istream::traits_type::eof());
+    EXPECT_TRUE(stream.eof());
+    EXPECT_FALSE(stream.fail());
+
+    // Read a char with formatted input
+    stream.seekg(0, std::ios::beg);
+    stream.clear();
+    EXPECT_TRUE(stream.good());
+    char c = 123;
+    stream >> c;
+    EXPECT_EQ(c, 123);
+    EXPECT_TRUE(stream.eof());
+    EXPECT_TRUE(stream.fail());
+}
+
+TEST(BufferStreambuf, emptyBufferOut)
+{
+    std::array<char, 0> array;
+    BufferStreambuf streambuf(array, std::ios::out);
+    std::ostream stream(&streambuf);
+
+    // put() a char
+    EXPECT_TRUE(stream.good());
+    stream.put('a');
+    EXPECT_TRUE(stream.fail());
+
+    // write() a string
+    stream.seekp(0, std::ios::beg);
+    stream.clear();
+    EXPECT_TRUE(stream.good());
+    stream.write("ab", 2);
+    EXPECT_TRUE(stream.fail());
+
+    // Insert a string with formatted output
+    stream.seekp(0, std::ios::beg);
+    stream.clear();
+    EXPECT_TRUE(stream.good());
+    stream << "test";
+    EXPECT_TRUE(stream.fail());
+}
+
+TEST(BufferStreambuf, bufferIn)  // codespell:ignore bufferin
+{
+    auto array = std::to_array("h\0ello\nline2\r\nline3|9");
+    BufferStreambuf streambuf(array, std::ios::in);
+    std::istream stream(&streambuf);
+
+    // Check stream size matches the buffer size
+    EXPECT_TRUE(stream.good());
+    stream.seekg(0, std::ios::end);
+    EXPECT_EQ(stream.tellg(), array.size());
+    stream.seekg(0, std::ios::beg);
+
+    // Read bytes with get()
+    EXPECT_TRUE(stream.good());
+    EXPECT_EQ(stream.get(), 'h');
+    EXPECT_TRUE(stream.good());
+    EXPECT_EQ(stream.get(), '\0');
+    EXPECT_TRUE(stream.good());
+
+    // Extract strings with formatted input
+    stream.seekg(5, std::ios::beg);
+    std::string line;
+    stream >> line;
+    EXPECT_EQ(line, "o");
+    stream >> line;
+    EXPECT_EQ(line, "line2");
+
+    // Extract strings with getline()
+    std::array<char, 8> aline;
+    stream.getline(aline.data(), aline.size(), '|');
+    EXPECT_EQ(aline[0], '\r');
+    EXPECT_EQ(aline[1], '\n');
+    EXPECT_EQ(aline[6], '3');
+    EXPECT_EQ(aline[7], '\0');
+    EXPECT_FALSE(stream.eof());
+
+    // Extract numbers with formatted input
+    unsigned int number = -1;
+    stream >> number;
+    EXPECT_EQ(number, 9);
+    EXPECT_FALSE(stream.fail());
+    EXPECT_EQ(stream.get(), '\0');  // Consume string literal null terminator
+    EXPECT_FALSE(stream.fail());
+    EXPECT_FALSE(stream.eof());
+    stream >> number;
+    // [istream.formatted.reqmts] precludes the formatted input from working at all when
+    // at eof because the "sentry" object will signal failure before conversion is attempted.
+    // `number` is therefore left untouched, and the fail & eof bits set as usual.
+    EXPECT_EQ(number, 9);
+    EXPECT_TRUE(stream.fail());
+    EXPECT_TRUE(stream.eof());
+
+    // Seek to and then go before begin
+    stream.clear();
+    stream.seekg(0, std::ios::beg);
+    stream.seekg(-8, std::ios::cur);
+    EXPECT_EQ(stream.tellg(), -1);
+    EXPECT_TRUE(stream.fail());
+    // Seek to and then go past end
+    stream.clear();
+    stream.seekg(array.size(), std::ios::beg);
+    EXPECT_EQ(stream.tellg(), array.size());
+    stream.seekg(1, std::ios::cur);
+    EXPECT_EQ(stream.tellg(), -1);
+    EXPECT_TRUE(stream.fail());
+}
+
+TEST(BufferStreambuf, bufferOut)
+{
+    std::array<char, 12> array;
+    BufferStreambuf streambuf(array, std::ios::out | std::ios::ate);
+    std::ostream stream(&streambuf);
+
+    // Expect to start at end of array
+    EXPECT_TRUE(stream.good());
+    EXPECT_EQ(stream.tellp(), array.size());
+    // Seek past the end at once
+    stream.seekp(array.size() + 4, std::ios::cur);
+    EXPECT_EQ(stream.tellp(), -1);
+    EXPECT_TRUE(stream.fail());
+    // Seek to std::ios::end, which is by definition *not* the buffer end in out-only mode
+    // but the current cursor position ([spanbuf.virtuals] 4.3.1)
+    stream.clear();
+    stream.seekp(3, std::ios::beg);
+    stream.seekp(0, std::ios::end);
+    EXPECT_EQ(stream.tellp(), 3);
+    // Seek to and then go before begin
+    stream.clear();
+    stream.seekp(0, std::ios::beg);
+    stream.seekp(-8, std::ios::cur);
+    EXPECT_EQ(stream.tellp(), -1);
+    EXPECT_TRUE(stream.fail());
+    // Seek to and then go past end
+    stream.clear();
+    stream.seekp(array.size(), std::ios::beg);
+    EXPECT_EQ(stream.tellp(), array.size());
+    stream.seekp(1, std::ios::cur);
+    EXPECT_EQ(stream.tellp(), -1);
+    EXPECT_TRUE(stream.fail());
+
+    // Insert a byte with put()
+    stream.clear();
+    stream.seekp(0, std::ios::beg);
+    stream.put('a');
+    EXPECT_EQ(array[0], 'a');
+
+    // Insert strings with formatted output
+    stream << "123\n456";
+    EXPECT_EQ(array[1], '1');
+    EXPECT_EQ(array[4], '\n');
+    EXPECT_EQ(array[5], '4');
+    stream << "z";
+    EXPECT_EQ(array[8], 'z');
+
+    // Insert numbers with formatted output
+    stream << 89;
+    EXPECT_EQ(array[9], '8');
+    EXPECT_EQ(array[10], '9');
+
+    // Insert a string and then overflow the buffer
+    stream.write("eof", 3);
+    stream.put('X');
+    EXPECT_TRUE(stream.fail());
+
+    // Insert a string to overflow the buffer at once
+    stream.clear();
+    stream.seekp(array.size() - 2, std::ios::beg);
+    stream.write("EOF", 3);
+    EXPECT_TRUE(stream.fail());
 }


### PR DESCRIPTION
* Fixes #29397

1. `DisplayedFilesModel::addFile()` had a logic error where 3D thumbnail generation would still try to run for FCStd files, although it would immediately fail.
2. Windows does what Windoes best and its `std::ostringstream` mangles `'\n'` bytes if not preceded by `'\r'` within `operator>>` which `App::ProjectFile` & zipios++ use. This caused QPixmap loading to fail as the PNG files were corrupted. Switch to `Base::StringOStreambuf` or `std::spanstream` if available to avoid that.
3. Always fall back to a placeholder/QImageReader/system thumbnail if the main thumbnail loading process failed.
