### PR TITLE
Fem: Remove Draft module dependence from examples

### DIFF
--- a/src/Mod/Fem/femexamples/constraint_centrif.py
+++ b/src/Mod/Fem/femexamples/constraint_centrif.py
@@ -25,7 +25,6 @@ import FreeCAD
 from FreeCAD import Vector as vec
 
 from BasicShapes import Shapes
-from Draft import clone
 from Part import makeLine
 
 import Fem
@@ -108,8 +107,9 @@ def setup(doc=None, solvertype="ccxtools"):
     doc.recompute()
 
     # standard ring
-    ring_top = clone(ring_bottom, delta=vec(0, 0, 20))
-    ring_top.Label = "RingTop"
+    ring_top = doc.addObject("Part::Mirroring", "RingTop")
+    ring_top.Source = ring_bottom
+    ring_top.Base.z = 15
 
     # compound of both rings
     geom_obj = doc.addObject("Part::Compound", "TheRingOfFire")

--- a/src/Mod/Fem/femexamples/equation_flow_elmer_2D.py
+++ b/src/Mod/Fem/femexamples/equation_flow_elmer_2D.py
@@ -21,16 +21,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-import sys
 import FreeCAD
-from FreeCAD import Placement
-from FreeCAD import Rotation
-from FreeCAD import Vector
 
-import Draft
 import ObjectsFem
+import Materials
+import Part
 
-from BOPTools import SplitFeatures
 from . import manager
 from .manager import get_meshname
 from .manager import init_doc
@@ -40,8 +36,8 @@ from .meshes import generate_mesh
 def get_information():
     return {
         "name": "Flow - Elmer 2D",
-        "meshtype": "solid",
-        "meshelement": "Tet10",
+        "meshtype": "face",
+        "meshelement": "Tria3",
         "constraints": [
             "initial pressure",
             "initial temperature",
@@ -82,52 +78,26 @@ def setup(doc=None, solvertype="elmer"):
     # geometric objects
 
     # the wire defining the pipe volume in 2D
-    p1 = Vector(400, -50.000, 0)
-    p2 = Vector(400, -150.000, 0)
-    p3 = Vector(1200, -150.000, 0)
-    p4 = Vector(1200, 50.000, 0)
-    p5 = Vector(0, 50.000, 0)
-    p6 = Vector(0, -50.000, 0)
-    wire = Draft.make_wire([p1, p2, p3, p4, p5, p6], closed=True)
-    wire.MakeFace = True
-    wire.Label = "Wire"
+    p1 = FreeCAD.Vector(400, -50.000, 0)
+    p2 = FreeCAD.Vector(400, -150.000, 0)
+    p3 = FreeCAD.Vector(1200, -150.000, 0)
+    p4 = FreeCAD.Vector(1200, 50.000, 0)
+    p5 = FreeCAD.Vector(0, 50.000, 0)
+    p6 = FreeCAD.Vector(0, -50.000, 0)
+    wire = Part.makePolygon([p1, p2, p3, p4, p5, p6, p1])
+    circ_center = FreeCAD.Vector(160, 0, 0)
+    circle = Part.makeCircle(10, circ_center)
 
-    # the circle defining the heating rod
-    pCirc = Vector(160, 0, 0)
-    axisCirc = Vector(1, 0, 0)
-    placementCircle = Placement(pCirc, Rotation(axisCirc, 0))
-    circle = Draft.make_circle(10, placement=placementCircle)
-    circle.MakeFace = True
-    circle.Label = "HeatingRod"
-    circle.ViewObject.Visibility = False
+    f1 = Part.makeFace([circle])
+    f2 = Part.makeFace([wire, circle])
 
-    # a link of the circle
-    circleLink = doc.addObject("App::Link", "Link-HeatingRod")
-    circleLink.LinkTransform = True
-    circleLink.LinkedObject = circle
+    shape = Part.makeShell([f1, f2])
 
-    # cut rod from wire to get volume of fluid
-    cut = doc.addObject("Part::Cut", "Cut")
-    cut.Base = wire
-    cut.Tool = circleLink
-    cut.ViewObject.Visibility = False
-
-    # BooleanFregments object to combine cut with rod
-    BooleanFragments = SplitFeatures.makeBooleanFragments(name="BooleanFragments")
-    BooleanFragments.Objects = [cut, circle]
-
-    # set view
-    doc.recompute()
-    if FreeCAD.GuiUp:
-        BooleanFragments.ViewObject.Transparency = 50
-        BooleanFragments.ViewObject.Document.activeView().fitAll()
+    shell = doc.addObject("Part::Feature", "Shell")
+    shell.Shape = shape
 
     # analysis
     analysis = ObjectsFem.makeAnalysis(doc, "Analysis")
-    if FreeCAD.GuiUp:
-        import FemGui
-
-        FemGui.setActiveAnalysis(analysis)
 
     # solver
     if solvertype == "elmer":
@@ -156,43 +126,30 @@ def setup(doc=None, solvertype="elmer"):
     equation_heat.Stabilize = True
 
     # material
+    mat_manager = Materials.MaterialManager()
 
-    # fluid
-    material_obj = ObjectsFem.makeMaterialFluid(doc, "Material_Fluid")
-    mat = material_obj.Material
-    mat["Name"] = "Air"
-    mat["Density"] = "1.204 kg/m^3"
-    mat["DynamicViscosity"] = "1.80e-5 kg/m/s"
-    mat["KinematicViscosity"] = "1.511e-5 m^2/s"
-    mat["ThermalConductivity"] = "0.02587 W/m/K"
-    mat["ThermalExpansionCoefficient"] = "3.43e-3 1/K"
-    mat["SpecificHeat"] = "1.01 kJ/kg/K"
-    mat["ElectricalConductivity"] = "1e-12 S/m"
-    mat["RelativePermeability"] = "1.0"
-    mat["RelativePermittivity"] = "1.00059"
-    material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face2")]
-    analysis.addObject(material_obj)
+    # fluid - air
+    air = mat_manager.getMaterial("94370b96-c97e-4a3f-83b2-11d7461f7da7")
+    air_obj = ObjectsFem.makeMaterialFluid(doc, "Material_Fluid")
+    air_obj.UUID = air.UUID
+    air_obj.Material = air.Properties
+    air_obj.References = [(shell, "Face2")]
+    analysis.addObject(air_obj)
 
-    # tube wall
-    material_obj = ObjectsFem.makeMaterialSolid(doc, "Material_Wall")
-    mat = material_obj.Material
-    mat["Name"] = "Aluminum Generic"
-    mat["Density"] = "2700 kg/m^3"
-    mat["PoissonRatio"] = "0.35"
-    mat["ShearModulus"] = "25.0 GPa"
-    mat["UltimateTensileStrength"] = "310 MPa"
-    mat["YoungsModulus"] = "70000 MPa"
-    mat["ThermalConductivity"] = "237.0 W/m/K"
-    mat["ThermalExpansionCoefficient"] = "23.1 µm/m/K"
-    mat["SpecificHeat"] = "897.0 J/kg/K"
-    material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face1")]
-    analysis.addObject(material_obj)
+    # tube wall - aluminium generic
+    alum = mat_manager.getMaterial("9bf060e9-1663-44a2-88e2-2ff6ee858efe")
+    alum_obj = ObjectsFem.makeMaterialSolid(doc, "Material_Wall")
+    alum_obj.UUID = alum.UUID
+    alum_obj.Material = alum.Properties
+    alum_obj.References = [(shell, "Face1")]
+    analysis.addObject(alum_obj)
+
+    inlet_refs = (shell, "Edge6")
+    walls_refs = (shell, ("Edge2", "Edge3", "Edge5", "Edge7"))
 
     # constraint inlet velocity
     FlowVelocity_Inlet = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Inlet")
-    FlowVelocity_Inlet.References = [(BooleanFragments, "Edge5")]
+    FlowVelocity_Inlet.References = [inlet_refs]
     FlowVelocity_Inlet.VelocityXFormula = (
         'Variable Coordinate 2; Real MATC "10*(tx+50e-3)*(50e-3-tx)"'
     )
@@ -203,57 +160,43 @@ def setup(doc=None, solvertype="elmer"):
 
     # constraint wall velocity
     FlowVelocity_Wall = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Wall")
-    FlowVelocity_Wall.References = [
-        (BooleanFragments, "Edge2"),
-        (BooleanFragments, "Edge3"),
-        (BooleanFragments, "Edge4"),
-        (BooleanFragments, "Edge7"),
-    ]
+    FlowVelocity_Wall.References = [walls_refs]
     FlowVelocity_Wall.VelocityXUnspecified = False
     FlowVelocity_Wall.VelocityYUnspecified = False
     analysis.addObject(FlowVelocity_Wall)
 
     # constraint initial temperature
     Temperature_Initial = ObjectsFem.makeConstraintInitialTemperature(doc, "Temperature_Initial")
-    Temperature_Initial.InitialTemperature = 300.0
+    Temperature_Initial.InitialTemperature = "300.0 K"
     analysis.addObject(Temperature_Initial)
 
     # constraint wall temperature
     Temperature_Wall = ObjectsFem.makeConstraintTemperature(doc, "Temperature_Wall")
-    Temperature_Wall.Temperature = 300.0
-    Temperature_Wall.NormalDirection = Vector(0, 0, -1)
-    Temperature_Wall.References = [
-        (BooleanFragments, "Edge2"),
-        (BooleanFragments, "Edge3"),
-        (BooleanFragments, "Edge4"),
-        (BooleanFragments, "Edge7"),
-    ]
+    Temperature_Wall.Temperature = "300.0 K"
+    Temperature_Wall.References = [walls_refs]
     analysis.addObject(Temperature_Wall)
 
     # constraint inlet temperature
     Temperature_Inlet = ObjectsFem.makeConstraintTemperature(doc, "Temperature_Inlet")
-    Temperature_Inlet.Temperature = 300.0
-    Temperature_Inlet.NormalDirection = Vector(-1, 0, 0)
-    Temperature_Inlet.References = [(BooleanFragments, "Edge5")]
+    Temperature_Inlet.Temperature = "300.0 K"
+    Temperature_Inlet.References = [inlet_refs]
     analysis.addObject(Temperature_Inlet)
 
     # constraint heating rod temperature
     Temperature_HeatingRod = ObjectsFem.makeConstraintTemperature(doc, "Temperature_HeatingRod")
-    Temperature_HeatingRod.Temperature = 373.0
-    Temperature_HeatingRod.NormalDirection = Vector(0, -1, 0)
-    Temperature_HeatingRod.References = [(BooleanFragments, "Edge1")]
+    Temperature_HeatingRod.Temperature = "373.0 K"
+    Temperature_HeatingRod.References = [(shell, "Edge1")]
     analysis.addObject(Temperature_HeatingRod)
 
     # constraint initial pressure
     Pressure_Initial = ObjectsFem.makeConstraintInitialPressure(doc, "Pressure_Initial")
     Pressure_Initial.Pressure = "100.0 kPa"
-    Pressure_Initial.NormalDirection = Vector(0, -1, 0)
-    Pressure_Initial.References = [(BooleanFragments, "Face2")]
+    Pressure_Initial.References = [(shell, "Face2")]
     analysis.addObject(Pressure_Initial)
 
     # mesh
     femmesh_obj = analysis.addObject(ObjectsFem.makeMeshGmsh(doc, get_meshname()))[0]
-    femmesh_obj.Shape = BooleanFragments
+    femmesh_obj.Shape = shell
     femmesh_obj.ElementOrder = "1st"
     femmesh_obj.CharacteristicLengthMax = "4 mm"
     femmesh_obj.ViewObject.Visibility = False
@@ -262,12 +205,17 @@ def setup(doc=None, solvertype="elmer"):
     mesh_region = ObjectsFem.makeMeshRegion(doc, femmesh_obj, name="MeshRegion")
     mesh_region.CharacteristicLength = "2 mm"
     mesh_region.References = [
-        (BooleanFragments, "Edge1"),
-        (BooleanFragments, "Vertex2"),
-        (BooleanFragments, "Vertex4"),
-        (BooleanFragments, "Vertex6"),
+        (shell, ("Edge1", "Vertex2", "Vertex6", "Vertex7")),
     ]
     mesh_region.ViewObject.Visibility = False
+
+    # set view
+    doc.recompute()
+    if FreeCAD.GuiUp:
+        import FemGui
+        shell.ViewObject.Transparency = 50
+        shell.ViewObject.Document.activeView().fitAll()
+        FemGui.setActiveAnalysis(analysis)
 
     # generate the mesh
     generate_mesh.mesh_from_mesher(femmesh_obj, "gmsh")

--- a/src/Mod/Fem/femexamples/equation_flow_initial_elmer_2D.py
+++ b/src/Mod/Fem/femexamples/equation_flow_initial_elmer_2D.py
@@ -21,16 +21,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-import sys
 import FreeCAD
-from FreeCAD import Placement
-from FreeCAD import Rotation
-from FreeCAD import Vector
 
-import Draft
 import ObjectsFem
+import Materials
+import Part
 
-from BOPTools import SplitFeatures
 from . import manager
 from .manager import get_meshname
 from .manager import init_doc
@@ -40,8 +36,8 @@ from .meshes import generate_mesh
 def get_information():
     return {
         "name": "Initial Flow - Elmer 2D",
-        "meshtype": "solid",
-        "meshelement": "Tet10",
+        "meshtype": "face",
+        "meshelement": "Tria3",
         "constraints": [
             "initial pressure",
             "initial temperature",
@@ -83,52 +79,26 @@ def setup(doc=None, solvertype="elmer"):
     # geometric objects
 
     # the wire defining the pipe volume in 2D
-    p1 = Vector(400, -50.000, 0)
-    p2 = Vector(400, -150.000, 0)
-    p3 = Vector(1200, -150.000, 0)
-    p4 = Vector(1200, 50.000, 0)
-    p5 = Vector(0, 50.000, 0)
-    p6 = Vector(0, -50.000, 0)
-    wire = Draft.make_wire([p1, p2, p3, p4, p5, p6], closed=True)
-    wire.MakeFace = True
-    wire.Label = "Wire"
+    p1 = FreeCAD.Vector(400, -50.000, 0)
+    p2 = FreeCAD.Vector(400, -150.000, 0)
+    p3 = FreeCAD.Vector(1200, -150.000, 0)
+    p4 = FreeCAD.Vector(1200, 50.000, 0)
+    p5 = FreeCAD.Vector(0, 50.000, 0)
+    p6 = FreeCAD.Vector(0, -50.000, 0)
+    wire = Part.makePolygon([p1, p2, p3, p4, p5, p6, p1])
+    circ_center = FreeCAD.Vector(160, 0, 0)
+    circle = Part.makeCircle(10, circ_center)
 
-    # the circle defining the heating rod
-    pCirc = Vector(160, 0, 0)
-    axisCirc = Vector(1, 0, 0)
-    placementCircle = Placement(pCirc, Rotation(axisCirc, 0))
-    circle = Draft.make_circle(10, placement=placementCircle)
-    circle.MakeFace = True
-    circle.Label = "HeatingRod"
-    circle.ViewObject.Visibility = False
+    f1 = Part.makeFace([circle])
+    f2 = Part.makeFace([wire, circle])
 
-    # a link of the circle
-    circleLink = doc.addObject("App::Link", "Link-HeatingRod")
-    circleLink.LinkTransform = True
-    circleLink.LinkedObject = circle
+    shape = Part.makeShell([f1, f2])
 
-    # cut rod from wire to get volume of fluid
-    cut = doc.addObject("Part::Cut", "Cut")
-    cut.Base = wire
-    cut.Tool = circleLink
-    cut.ViewObject.Visibility = False
-
-    # BooleanFregments object to combine cut with rod
-    BooleanFragments = SplitFeatures.makeBooleanFragments(name="BooleanFragments")
-    BooleanFragments.Objects = [cut, circle]
-
-    # set view
-    doc.recompute()
-    if FreeCAD.GuiUp:
-        BooleanFragments.ViewObject.Transparency = 50
-        BooleanFragments.ViewObject.Document.activeView().fitAll()
+    shell = doc.addObject("Part::Feature", "Shell")
+    shell.Shape = shape
 
     # analysis
     analysis = ObjectsFem.makeAnalysis(doc, "Analysis")
-    if FreeCAD.GuiUp:
-        import FemGui
-
-        FemGui.setActiveAnalysis(analysis)
 
     # solver
     if solvertype == "elmer":
@@ -163,58 +133,44 @@ def setup(doc=None, solvertype="elmer"):
     equation_heat.Stabilize = True
 
     # material
+    mat_manager = Materials.MaterialManager()
 
-    # fluid
-    material_obj = ObjectsFem.makeMaterialFluid(doc, "Material_Fluid")
-    mat = material_obj.Material
-    mat["Name"] = "Carbon dioxide"
-    mat["Density"] = "1.8393 kg/m^3"
-    mat["DynamicViscosity"] = "14.7e-6 kg/m/s"
-    mat["ThermalConductivity"] = "0.016242 W/m/K"
-    mat["ThermalExpansionCoefficient"] = "0.00343 m/m/K"
-    mat["SpecificHeat"] = "0.846 kJ/kg/K"
-    material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face2")]
-    analysis.addObject(material_obj)
+    # fluid - carbon dioxide
+    co2 = mat_manager.getMaterial("ef0e4040-a498-48c3-a87b-e996bfd89195")
+    co2_obj = ObjectsFem.makeMaterialFluid(doc, "Material_Fluid")
+    co2_obj.UUID = co2.UUID
+    co2_obj.Material = co2.Properties
+    co2_obj.References = [(shell, "Face2")]
+    analysis.addObject(co2_obj)
 
-    # tube wall
-    material_obj = ObjectsFem.makeMaterialSolid(doc, "Material_Wall")
-    mat = material_obj.Material
-    mat["Name"] = "Aluminum Generic"
-    mat["Density"] = "2700 kg/m^3"
-    mat["PoissonRatio"] = "0.35"
-    mat["ShearModulus"] = "25.0 GPa"
-    mat["UltimateTensileStrength"] = "310 MPa"
-    mat["YoungsModulus"] = "70000 MPa"
-    mat["ThermalConductivity"] = "237.0 W/m/K"
-    mat["ThermalExpansionCoefficient"] = "23.1 µm/m/K"
-    mat["SpecificHeat"] = "897.0 J/kg/K"
-    material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face1")]
-    analysis.addObject(material_obj)
+    # tube wall - aluminium generic
+    alum = mat_manager.getMaterial("9bf060e9-1663-44a2-88e2-2ff6ee858efe")
+    alum_obj = ObjectsFem.makeMaterialSolid(doc, "Material_Wall")
+    alum_obj.UUID = alum.UUID
+    alum_obj.Material = alum.Properties
+    alum_obj.References = [(shell, "Face1")]
+    analysis.addObject(alum_obj)
+
+    inlet_refs = (shell, "Edge6")
+    walls_refs = (shell, ("Edge2", "Edge3", "Edge5", "Edge7"))
 
     # constraint inlet velocity
     FlowVelocity_Inlet = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Inlet")
-    FlowVelocity_Inlet.References = [(BooleanFragments, "Edge5")]
+    FlowVelocity_Inlet.References = [inlet_refs]
     FlowVelocity_Inlet.VelocityX = "20.0 mm/s"
     FlowVelocity_Inlet.VelocityXUnspecified = False
     analysis.addObject(FlowVelocity_Inlet)
 
     # constraint wall velocity
     FlowVelocity_Wall = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Wall")
-    FlowVelocity_Wall.References = [
-        (BooleanFragments, "Edge2"),
-        (BooleanFragments, "Edge3"),
-        (BooleanFragments, "Edge4"),
-        (BooleanFragments, "Edge7"),
-    ]
+    FlowVelocity_Wall.References = [walls_refs]
     FlowVelocity_Wall.VelocityXUnspecified = False
     FlowVelocity_Wall.VelocityYUnspecified = False
     analysis.addObject(FlowVelocity_Wall)
 
     # constraint initial velocity
     FlowVelocity_Initial = ObjectsFem.makeConstraintInitialFlowVelocity(doc, "FlowVelocity_Initial")
-    FlowVelocity_Initial.References = [(BooleanFragments, "Face2")]
+    FlowVelocity_Initial.References = [(shell, "Face2")]
     FlowVelocity_Initial.VelocityX = "20.0 mm/s"
     FlowVelocity_Initial.VelocityY = "-20.0 mm/s"
     FlowVelocity_Initial.VelocityXUnspecified = False
@@ -223,45 +179,36 @@ def setup(doc=None, solvertype="elmer"):
 
     # constraint initial temperature
     Temperature_Initial = ObjectsFem.makeConstraintInitialTemperature(doc, "Temperature_Initial")
-    Temperature_Initial.InitialTemperature = 300.0
+    Temperature_Initial.InitialTemperature = "300.0 K"
     analysis.addObject(Temperature_Initial)
 
     # constraint wall temperature
     Temperature_Wall = ObjectsFem.makeConstraintTemperature(doc, "Temperature_Wall")
-    Temperature_Wall.Temperature = 300.0
-    Temperature_Wall.NormalDirection = Vector(0, 0, -1)
-    Temperature_Wall.References = [
-        (BooleanFragments, "Edge2"),
-        (BooleanFragments, "Edge3"),
-        (BooleanFragments, "Edge4"),
-        (BooleanFragments, "Edge7"),
-    ]
+    Temperature_Wall.Temperature = "300.0 K"
+    Temperature_Wall.References = [walls_refs]
     analysis.addObject(Temperature_Wall)
 
     # constraint inlet temperature
     Temperature_Inlet = ObjectsFem.makeConstraintTemperature(doc, "Temperature_Inlet")
-    Temperature_Inlet.Temperature = 300.0
-    Temperature_Inlet.NormalDirection = Vector(-1, 0, 0)
-    Temperature_Inlet.References = [(BooleanFragments, "Edge5")]
+    Temperature_Inlet.Temperature = "300.0 K"
+    Temperature_Inlet.References = [inlet_refs]
     analysis.addObject(Temperature_Inlet)
 
     # constraint heating rod temperature
     Temperature_HeatingRod = ObjectsFem.makeConstraintTemperature(doc, "Temperature_HeatingRod")
-    Temperature_HeatingRod.Temperature = 373.0
-    Temperature_HeatingRod.NormalDirection = Vector(0, -1, 0)
-    Temperature_HeatingRod.References = [(BooleanFragments, "Edge1")]
+    Temperature_HeatingRod.Temperature = "373.0 K"
+    Temperature_HeatingRod.References = [(shell, "Edge1")]
     analysis.addObject(Temperature_HeatingRod)
 
     # constraint initial pressure
     Pressure_Initial = ObjectsFem.makeConstraintInitialPressure(doc, "Pressure_Initial")
     Pressure_Initial.Pressure = "100.0 kPa"
-    Pressure_Initial.NormalDirection = Vector(0, -1, 0)
-    Pressure_Initial.References = [(BooleanFragments, "Face2")]
+    Pressure_Initial.References = [(shell, "Face2")]
     analysis.addObject(Pressure_Initial)
 
     # mesh
     femmesh_obj = analysis.addObject(ObjectsFem.makeMeshGmsh(doc, get_meshname()))[0]
-    femmesh_obj.Shape = BooleanFragments
+    femmesh_obj.Shape = shell
     femmesh_obj.ElementOrder = "1st"
     femmesh_obj.CharacteristicLengthMax = "4 mm"
     femmesh_obj.ViewObject.Visibility = False
@@ -270,12 +217,17 @@ def setup(doc=None, solvertype="elmer"):
     mesh_region = ObjectsFem.makeMeshRegion(doc, femmesh_obj, name="MeshRegion")
     mesh_region.CharacteristicLength = "2 mm"
     mesh_region.References = [
-        (BooleanFragments, "Edge1"),
-        (BooleanFragments, "Vertex2"),
-        (BooleanFragments, "Vertex4"),
-        (BooleanFragments, "Vertex6"),
+        (shell, ("Edge1", "Vertex2", "Vertex6", "Vertex7")),
     ]
     mesh_region.ViewObject.Visibility = False
+
+    # set view
+    doc.recompute()
+    if FreeCAD.GuiUp:
+        import FemGui
+        shell.ViewObject.Transparency = 50
+        shell.ViewObject.Document.activeView().fitAll()
+        FemGui.setActiveAnalysis(analysis)
 
     # generate the mesh
     generate_mesh.mesh_from_mesher(femmesh_obj, "gmsh")

--- a/src/Mod/Fem/femexamples/equation_flow_turbulent_elmer_2D.py
+++ b/src/Mod/Fem/femexamples/equation_flow_turbulent_elmer_2D.py
@@ -21,16 +21,12 @@
 # *                                                                         *
 # ***************************************************************************
 
-import sys
 import FreeCAD
-from FreeCAD import Placement
-from FreeCAD import Rotation
-from FreeCAD import Vector
 
-import Draft
 import ObjectsFem
+import Materials
+import Part
 
-from BOPTools import SplitFeatures
 from . import manager
 from .manager import get_meshname
 from .manager import init_doc
@@ -40,8 +36,8 @@ from .meshes import generate_mesh
 def get_information():
     return {
         "name": "Turbulent Flow - Elmer 2D",
-        "meshtype": "solid",
-        "meshelement": "Tet10",
+        "meshtype": "face",
+        "meshelement": "Tria3",
         "constraints": [
             "initial pressure",
             "initial temperature",
@@ -82,52 +78,26 @@ def setup(doc=None, solvertype="elmer"):
     # geometric objects
 
     # the wire defining the pipe volume in 2D
-    p1 = Vector(400, -50.000, 0)
-    p2 = Vector(400, -150.000, 0)
-    p3 = Vector(1200, -150.000, 0)
-    p4 = Vector(1200, 50.000, 0)
-    p5 = Vector(0, 50.000, 0)
-    p6 = Vector(0, -50.000, 0)
-    wire = Draft.make_wire([p1, p2, p3, p4, p5, p6], closed=True)
-    wire.MakeFace = True
-    wire.Label = "Wire"
+    p1 = FreeCAD.Vector(400, -50.000, 0)
+    p2 = FreeCAD.Vector(400, -150.000, 0)
+    p3 = FreeCAD.Vector(1200, -150.000, 0)
+    p4 = FreeCAD.Vector(1200, 50.000, 0)
+    p5 = FreeCAD.Vector(0, 50.000, 0)
+    p6 = FreeCAD.Vector(0, -50.000, 0)
+    wire = Part.makePolygon([p1, p2, p3, p4, p5, p6, p1])
+    circ_center = FreeCAD.Vector(160, 0, 0)
+    circle = Part.makeCircle(10, circ_center)
 
-    # the circle defining the heating rod
-    pCirc = Vector(160, 0, 0)
-    axisCirc = Vector(1, 0, 0)
-    placementCircle = Placement(pCirc, Rotation(axisCirc, 0))
-    circle = Draft.make_circle(10, placement=placementCircle)
-    circle.MakeFace = True
-    circle.Label = "HeatingRod"
-    circle.ViewObject.Visibility = False
+    f1 = Part.makeFace([circle])
+    f2 = Part.makeFace([wire, circle])
 
-    # a link of the circle
-    circleLink = doc.addObject("App::Link", "Link-HeatingRod")
-    circleLink.LinkTransform = True
-    circleLink.LinkedObject = circle
+    shape = Part.makeShell([f1, f2])
 
-    # cut rod from wire to get volume of fluid
-    cut = doc.addObject("Part::Cut", "Cut")
-    cut.Base = wire
-    cut.Tool = circleLink
-    cut.ViewObject.Visibility = False
-
-    # BooleanFregments object to combine cut with rod
-    BooleanFragments = SplitFeatures.makeBooleanFragments(name="BooleanFragments")
-    BooleanFragments.Objects = [cut, circle]
-
-    # set view
-    doc.recompute()
-    if FreeCAD.GuiUp:
-        BooleanFragments.ViewObject.Transparency = 50
-        BooleanFragments.ViewObject.Document.activeView().fitAll()
+    shell = doc.addObject("Part::Feature", "Shell")
+    shell.Shape = shape
 
     # analysis
     analysis = ObjectsFem.makeAnalysis(doc, "Analysis")
-    if FreeCAD.GuiUp:
-        import FemGui
-
-        FemGui.setActiveAnalysis(analysis)
 
     # solver
     if solvertype == "elmer":
@@ -166,39 +136,30 @@ def setup(doc=None, solvertype="elmer"):
     equation_heat.Stabilize = True
 
     # material
+    mat_manager = Materials.MaterialManager()
 
-    # fluid
-    material_obj = ObjectsFem.makeMaterialFluid(doc, "Material_Fluid")
-    mat = material_obj.Material
-    mat["Name"] = "Water"
-    mat["Density"] = "998 kg/m^3"
-    mat["DynamicViscosity"] = "1.003e-3 kg/m/s"
-    mat["ThermalConductivity"] = "0.591 W/m/K"
-    mat["ThermalExpansionCoefficient"] = "2.07e-4 m/m/K"
-    mat["SpecificHeat"] = "4182 J/kg/K"
-    material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face2")]
-    analysis.addObject(material_obj)
+    # fluid - water
+    water = mat_manager.getMaterial("7e5559d5-be15-4571-a72f-20c39edd41cf")
+    water_obj = ObjectsFem.makeMaterialFluid(doc, "Material_Fluid")
+    water_obj.UUID = water.UUID
+    water_obj.Material = water.Properties
+    water_obj.References = [(shell, "Face2")]
+    analysis.addObject(water_obj)
 
-    # tube wall
-    material_obj = ObjectsFem.makeMaterialSolid(doc, "Material_Wall")
-    mat = material_obj.Material
-    mat["Name"] = "Aluminum Generic"
-    mat["Density"] = "2700 kg/m^3"
-    mat["PoissonRatio"] = "0.35"
-    mat["ShearModulus"] = "25.0 GPa"
-    mat["UltimateTensileStrength"] = "310 MPa"
-    mat["YoungsModulus"] = "70000 MPa"
-    mat["ThermalConductivity"] = "237.0 W/m/K"
-    mat["ThermalExpansionCoefficient"] = "23.1 µm/m/K"
-    mat["SpecificHeat"] = "897.0 J/kg/K"
-    material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face1")]
-    analysis.addObject(material_obj)
+    # tube wall - aluminium generic
+    alum = mat_manager.getMaterial("9bf060e9-1663-44a2-88e2-2ff6ee858efe")
+    alum_obj = ObjectsFem.makeMaterialSolid(doc, "Material_Wall")
+    alum_obj.UUID = alum.UUID
+    alum_obj.Material = alum.Properties
+    alum_obj.References = [(shell, "Face1")]
+    analysis.addObject(alum_obj)
+
+    inlet_refs = (shell, "Edge6")
+    walls_refs = (shell, ("Edge2", "Edge3", "Edge5", "Edge7"))
 
     # constraint inlet velocity
     FlowVelocity_Inlet = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Inlet")
-    FlowVelocity_Inlet.References = [(BooleanFragments, "Edge5")]
+    FlowVelocity_Inlet.References = [inlet_refs]
     FlowVelocity_Inlet.VelocityXFormula = (
         'Variable Coordinate 2; Real MATC "10*(tx+50e-3)*(50e-3-tx)"'
     )
@@ -209,57 +170,43 @@ def setup(doc=None, solvertype="elmer"):
 
     # constraint wall velocity
     FlowVelocity_Wall = ObjectsFem.makeConstraintFlowVelocity(doc, "FlowVelocity_Wall")
-    FlowVelocity_Wall.References = [
-        (BooleanFragments, "Edge2"),
-        (BooleanFragments, "Edge3"),
-        (BooleanFragments, "Edge4"),
-        (BooleanFragments, "Edge7"),
-    ]
+    FlowVelocity_Wall.References = [walls_refs]
     FlowVelocity_Wall.VelocityXUnspecified = False
     FlowVelocity_Wall.VelocityYUnspecified = False
     analysis.addObject(FlowVelocity_Wall)
 
     # constraint initial temperature
     Temperature_Initial = ObjectsFem.makeConstraintInitialTemperature(doc, "Temperature_Initial")
-    Temperature_Initial.InitialTemperature = 300.0
+    Temperature_Initial.InitialTemperature = "300.0 K"
     analysis.addObject(Temperature_Initial)
 
     # constraint wall temperature
     Temperature_Wall = ObjectsFem.makeConstraintTemperature(doc, "Temperature_Wall")
-    Temperature_Wall.Temperature = 300.0
-    Temperature_Wall.NormalDirection = Vector(0, 0, -1)
-    Temperature_Wall.References = [
-        (BooleanFragments, "Edge2"),
-        (BooleanFragments, "Edge3"),
-        (BooleanFragments, "Edge4"),
-        (BooleanFragments, "Edge7"),
-    ]
+    Temperature_Wall.Temperature = "300.0 K"
+    Temperature_Wall.References = [walls_refs]
     analysis.addObject(Temperature_Wall)
 
     # constraint inlet temperature
     Temperature_Inlet = ObjectsFem.makeConstraintTemperature(doc, "Temperature_Inlet")
-    Temperature_Inlet.Temperature = 350.0
-    Temperature_Inlet.NormalDirection = Vector(-1, 0, 0)
-    Temperature_Inlet.References = [(BooleanFragments, "Edge5")]
+    Temperature_Inlet.Temperature = "350.0 K"
+    Temperature_Inlet.References = [inlet_refs]
     analysis.addObject(Temperature_Inlet)
 
     # constraint heating rod temperature
     Temperature_HeatingRod = ObjectsFem.makeConstraintTemperature(doc, "Temperature_HeatingRod")
-    Temperature_HeatingRod.Temperature = 373.0
-    Temperature_HeatingRod.NormalDirection = Vector(0, -1, 0)
-    Temperature_HeatingRod.References = [(BooleanFragments, "Edge1")]
+    Temperature_HeatingRod.Temperature = "373.0 K"
+    Temperature_HeatingRod.References = [(shell, "Edge1")]
     analysis.addObject(Temperature_HeatingRod)
 
     # constraint initial pressure
     Pressure_Initial = ObjectsFem.makeConstraintInitialPressure(doc, "Pressure_Initial")
     Pressure_Initial.Pressure = "100.0 kPa"
-    Pressure_Initial.NormalDirection = Vector(0, -1, 0)
-    Pressure_Initial.References = [(BooleanFragments, "Face2")]
+    Pressure_Initial.References = [(shell, "Face2")]
     analysis.addObject(Pressure_Initial)
 
     # mesh
     femmesh_obj = analysis.addObject(ObjectsFem.makeMeshGmsh(doc, get_meshname()))[0]
-    femmesh_obj.Shape = BooleanFragments
+    femmesh_obj.Shape = shell
     femmesh_obj.ElementOrder = "1st"
     femmesh_obj.CharacteristicLengthMax = "4 mm"
     femmesh_obj.ViewObject.Visibility = False
@@ -268,12 +215,17 @@ def setup(doc=None, solvertype="elmer"):
     mesh_region = ObjectsFem.makeMeshRegion(doc, femmesh_obj, name="MeshRegion")
     mesh_region.CharacteristicLength = "2 mm"
     mesh_region.References = [
-        (BooleanFragments, "Edge1"),
-        (BooleanFragments, "Vertex2"),
-        (BooleanFragments, "Vertex4"),
-        (BooleanFragments, "Vertex6"),
+        (shell, ("Edge1", "Vertex2", "Vertex6", "Vertex7")),
     ]
     mesh_region.ViewObject.Visibility = False
+
+    # set view
+    doc.recompute()
+    if FreeCAD.GuiUp:
+        import FemGui
+        shell.ViewObject.Transparency = 50
+        shell.ViewObject.Document.activeView().fitAll()
+        FemGui.setActiveAnalysis(analysis)
 
     # generate the mesh
     generate_mesh.mesh_from_mesher(femmesh_obj, "gmsh")

--- a/src/Mod/Fem/femexamples/equation_magnetodynamics_2D_elmer.py
+++ b/src/Mod/Fem/femexamples/equation_magnetodynamics_2D_elmer.py
@@ -21,15 +21,13 @@
 # *                                                                         *
 # ***************************************************************************
 
-import sys
 import FreeCAD
 from FreeCAD import Vector
 
-import Draft
 import ObjectsFem
+import Materials
 import Part
 
-from BOPTools import SplitFeatures
 from . import manager
 from .manager import get_meshname
 from .manager import init_doc
@@ -39,8 +37,8 @@ from .meshes import generate_mesh
 def get_information():
     return {
         "name": "Inductive heating - Elmer 2D",
-        "meshtype": "solid",
-        "meshelement": "Tet10",
+        "meshtype": "face",
+        "meshelement": "Tria3",
         "constraints": ["current density"],
         "solvers": ["elmer"],
         "material": "solid",
@@ -84,20 +82,14 @@ def setup(doc=None, solvertype="elmer"):
     p6 = Vector(25.0, 100.0, 0.0)
     p7 = Vector(25.0, 20.0, 0.0)
     p8 = Vector(0.0, 20.0, 0.0)
-    Insulation = Draft.make_wire([p1, p2, p3, p4, p5, p6, p7, p8], closed=True)
-    Insulation.MakeFace = True
-    Insulation.Label = "Insulation"
-    Insulation.ViewObject.Visibility = False
+    insulation = Part.makePolygon([p1, p2, p3, p4, p5, p6, p7, p8, p1])
 
     # wire defining the coil volume
     p1 = Vector(50.0, -10.0, 0.0)
     p2 = Vector(55.0, -10.0, 0.0)
     p3 = Vector(55.0, 110.0, 0.0)
     p4 = Vector(50.0, 110.0, 0.0)
-    Coil = Draft.make_wire([p1, p2, p3, p4], closed=True)
-    Coil.MakeFace = True
-    Coil.Label = "Coil"
-    Coil.ViewObject.Visibility = False
+    coil = Part.makePolygon([p1, p2, p3, p4, p1])
 
     # wire defining the crucible area
     p1 = Vector(0.0, 20.0, 0.0)
@@ -108,78 +100,25 @@ def setup(doc=None, solvertype="elmer"):
     p6 = Vector(20.0, 90.0, 0.0)
     p7 = Vector(20.0, 30.0, 0.0)
     p8 = Vector(0.0, 30.0, 0.0)
-    Crucible = Draft.make_wire([p1, p2, p3, p4, p5, p6, p7, p8], closed=True)
-    Crucible.MakeFace = True
-    Crucible.Label = "Crucible"
-    Crucible.ViewObject.Visibility = False
+    crucible = Part.makePolygon([p1, p2, p3, p4, p5, p6, p7, p8, p1])
 
     # wire defining the powder volume
     p1 = Vector(0.0, 30.0, 0.0)
     p2 = Vector(20.0, 30.0, 0.0)
     p3 = Vector(20.0, 40.0, 0.0)
     p4 = Vector(0.0, 40.0, 0.0)
-    Powder = Draft.make_wire([p1, p2, p3, p4], closed=True)
-    Powder.MakeFace = True
-    Powder.Label = "Powder"
-    Powder.ViewObject.Visibility = False
+    powder = Part.makePolygon([p1, p2, p3, p4, p1])
 
     # a half circle defining later the air volume
-    Air_Circle = Part.makeCircle(140.0, Vector(0.0, 60.0, 0.0), Vector(0.0, 0.0, 1.0), -90.0, 90.0)
-    Air_Line = Part.makeLine((0.0, -80.0, 0.0), (0.0, 200.0, 0.0))
-    Air_Area = doc.addObject("Part::Feature", "Air_Area")
-    Air_Area.Shape = Part.Face([Part.Wire([Air_Circle, Air_Line])])
+    air_circle = Part.makeCircle(140.0, Vector(0.0, 60.0, 0.0), Vector(0.0, 0.0, 1.0), -90.0, 90.0)
+    air_line = Part.makeLine((0.0, -80.0, 0.0), (0.0, 200.0, 0.0))
+    air_area = Part.makeFace(Part.Wire((air_circle, air_line)))
+    cut_area = Part.makeFace((coil, insulation, powder, crucible))
+    air_area = air_area.cut(cut_area)
 
-    # a link of the Insulation
-    InsulationLink = doc.addObject("App::Link", "Link_Insulation")
-    InsulationLink.LinkTransform = True
-    InsulationLink.LinkedObject = Insulation
-    InsulationLink.ViewObject.Visibility = False
-
-    # a link of the Coil
-    CoilLink = doc.addObject("App::Link", "Link_Coil")
-    CoilLink.LinkTransform = True
-    CoilLink.LinkedObject = Coil
-    CoilLink.ViewObject.Visibility = False
-
-    # a link of the Crucible
-    CrucibleLink = doc.addObject("App::Link", "Link_Crucible")
-    CrucibleLink.LinkTransform = True
-    CrucibleLink.LinkedObject = Crucible
-    CrucibleLink.ViewObject.Visibility = False
-
-    # a link of the Powder
-    PowderLink = doc.addObject("App::Link", "Link_Powder")
-    PowderLink.LinkTransform = True
-    PowderLink.LinkedObject = Powder
-    PowderLink.ViewObject.Visibility = False
-
-    # fusion of all links
-    Fusion = doc.addObject("Part::MultiFuse", "Fusion")
-    Fusion.Shapes = [InsulationLink, CoilLink, CrucibleLink, PowderLink]
-    Fusion.ViewObject.Visibility = False
-
-    # cut all objects from Air wire to get volume of fluid
-    Cut = doc.addObject("Part::Cut", "Cut_Air")
-    Cut.Base = Air_Area
-    Cut.Tool = Fusion
-    Cut.ViewObject.Visibility = False
-
-    # BooleanFregments object to combine cut with rod
-    BooleanFragments = SplitFeatures.makeBooleanFragments(name="BooleanFragments")
-    BooleanFragments.Objects = [Insulation, Coil, Crucible, Powder, Cut]
-
-    # set view
-    doc.recompute()
-    if FreeCAD.GuiUp:
-        BooleanFragments.ViewObject.Document.activeView().viewTop()
-        BooleanFragments.ViewObject.Document.activeView().fitAll()
-
-    # analysis
-    analysis = ObjectsFem.makeAnalysis(doc, "Analysis")
-    if FreeCAD.GuiUp:
-        import FemGui
-
-        FemGui.setActiveAnalysis(analysis)
+    shape = Part.makeShell(air_area.Faces + cut_area.Faces)
+    shell = doc.addObject("Part::Feature", "Shell")
+    shell.Shape = shape
 
     # solver
     if solvertype == "elmer":
@@ -197,38 +136,29 @@ def setup(doc=None, solvertype="elmer"):
             "No solver object was created.\n".format(solvertype)
         )
         return doc
+
+    # analysis
+    analysis = ObjectsFem.makeAnalysis(doc, "Analysis")
     analysis.addObject(solver_obj)
 
     # materials
+    mat_manager = Materials.MaterialManager()
 
     # air around the objects and inside the coil
-    material_obj = ObjectsFem.makeMaterialFluid(doc, "Air")
-    mat = material_obj.Material
-    mat["Name"] = "Air"
-    mat["Density"] = "1.204 kg/m^3"
-    mat["ThermalConductivity"] = "0.02587 W/m/K"
-    mat["ThermalExpansionCoefficient"] = "3.43e-3 1/K"
-    mat["SpecificHeat"] = "1.01 kJ/kg/K"
-    mat["ElectricalConductivity"] = "1e-12 S/m"
-    mat["RelativePermeability"] = "1.0"
-    mat["RelativePermittivity"] = "1.00059"
-    material_obj.Material = mat
-    material_obj.References = [
-        (BooleanFragments, "Face2"),
-        (BooleanFragments, "Face5"),
-        (BooleanFragments, "Face6"),
-    ]
-    analysis.addObject(material_obj)
+    air = mat_manager.getMaterial("94370b96-c97e-4a3f-83b2-11d7461f7da7")
+    air_obj = ObjectsFem.makeMaterialFluid(doc, "Air")
+    air_obj.UUID = air.UUID
+    air_obj.Material = air.Properties
+    air_obj.References = [(shell, ("Face1", "Face3", "Face5"))]
+    analysis.addObject(air_obj)
 
     # graphite of the crucible
-    material_obj = ObjectsFem.makeMaterialSolid(doc, "Material-Crucible")
-    mat = material_obj.Material
-    mat["Name"] = "Graphite"
-    mat["ElectricalConductivity"] = "2e4 S/m"
-    mat["RelativePermeability"] = "1.0"
-    material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face3")]
-    analysis.addObject(material_obj)
+    graphite = mat_manager.getMaterial("5c67b675-69a2-4782-902a-bb90c3952f07")
+    graphite_obj = ObjectsFem.makeMaterialSolid(doc, "Material-Crucible")
+    graphite_obj.UUID = graphite.UUID
+    graphite_obj.Material = graphite.Properties
+    graphite_obj.References = [(shell, "Face4")]
+    analysis.addObject(graphite_obj)
 
     # insulation of the crucible
     material_obj = ObjectsFem.makeMaterialSolid(doc, "Material-Insulation")
@@ -237,7 +167,7 @@ def setup(doc=None, solvertype="elmer"):
     mat["ElectricalConductivity"] = "2.0e3 S/m"
     mat["RelativePermeability"] = "1.0"
     material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face1")]
+    material_obj.References = [(shell, "Face2")]
     analysis.addObject(material_obj)
 
     # material of powder
@@ -247,19 +177,19 @@ def setup(doc=None, solvertype="elmer"):
     mat["ElectricalConductivity"] = "1e4 S/m"
     mat["RelativePermeability"] = "1.0"
     material_obj.Material = mat
-    material_obj.References = [(BooleanFragments, "Face4")]
+    material_obj.References = [(shell, "Face6")]
     analysis.addObject(material_obj)
 
     # constraint current density
     CurrentDensity = ObjectsFem.makeConstraintCurrentDensity(doc, "CurrentDensity")
-    CurrentDensity.References = [(BooleanFragments, "Face2")]
+    CurrentDensity.References = [(shell, "Face3")]
     CurrentDensity.NormalCurrentDensity_re = "250000.000 A/m^2"
     CurrentDensity.Mode = "Normal"
     analysis.addObject(CurrentDensity)
 
     # mesh
     femmesh_obj = analysis.addObject(ObjectsFem.makeMeshGmsh(doc, get_meshname()))[0]
-    femmesh_obj.Shape = BooleanFragments
+    femmesh_obj.Shape = shell
     femmesh_obj.CharacteristicLengthMax = "3 mm"
     femmesh_obj.ViewObject.Visibility = False
 
@@ -267,12 +197,17 @@ def setup(doc=None, solvertype="elmer"):
     mesh_region = ObjectsFem.makeMeshRegion(doc, femmesh_obj, name="MeshRegion")
     mesh_region.CharacteristicLength = "1 mm"
     mesh_region.References = [
-        (BooleanFragments, "Face1"),
-        (BooleanFragments, "Face2"),
-        (BooleanFragments, "Face3"),
-        (BooleanFragments, "Face4"),
+        (shell, ("Face2", "Face3", "Face4", "Face6")),
     ]
     mesh_region.ViewObject.Visibility = False
+
+    # set view
+    doc.recompute()
+    if FreeCAD.GuiUp:
+        import FemGui
+        shell.ViewObject.Transparency = 50
+        shell.ViewObject.Document.activeView().fitAll()
+        FemGui.setActiveAnalysis(analysis)
 
     # generate the mesh
     generate_mesh.mesh_from_mesher(femmesh_obj, "gmsh")

--- a/src/Mod/Fem/femexamples/magnetic_shielding_2D.py
+++ b/src/Mod/Fem/femexamples/magnetic_shielding_2D.py
@@ -117,12 +117,12 @@ def setup(doc=None, solvertype="elmer"):
     mat_manager = Materials.MaterialManager()
     air = mat_manager.getMaterial("94370b96-c97e-4a3f-83b2-11d7461f7da7")
     air_obj = ObjectsFem.makeMaterialFluid(doc, "Air")
-    air_obj.UUID = "94370b96-c97e-4a3f-83b2-11d7461f7da7"
+    air_obj.UUID = air.UUID
     air_obj.Material = air.Properties
 
     iron = mat_manager.getMaterial("1826c364-d26a-43fb-8f61-288281236836")
     iron_obj = ObjectsFem.makeMaterialFluid(doc, "Iron")
-    iron_obj.UUID = "1826c364-d26a-43fb-8f61-288281236836"
+    iron_obj.UUID = iron.UUID
     iron_obj.Material = iron.Properties
 
     air_obj.References = [(shell, ("Face1","Face3"))]


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Fem workbench shouldn't depend on Draft module, so Draft functions are replaced by Part module functions.
Updated examples:
constraint centrif (CalculiX)
flow, flow initial, flow turbulent (Elmer)
Inductive heating (Elmer)

@FEA-eng since Gmsh groups are broken, you must use Netgen if you want to run Elmer examples.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
