### PR TITLE
FEM: Mesh groups are correctly set up by gmsh if vtk file datatransfer is used. fixes #29368

### DIFF
--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1678,8 +1678,7 @@ void FemMesh::read(const char* FileName)
     }
 }
 
-void FemMesh::readVTKWithGroups(const char* FileName,
-                                const char* vtk_group_cell_array)
+void FemMesh::readVTKWithGroups(const char* FileName, const char* vtk_group_cell_array)
 {
 #ifdef FC_USE_VTK
     Base::FileInfo File(FileName);
@@ -1705,17 +1704,15 @@ void FemMesh::writeVTK(const std::string& fileName, bool highest) const
 #endif
 }
 
-void FemMesh::writeVTKWithGroups(const std::string& FileName,
-                                 const std::string& vtk_group_cell_array,
-                                 std::map<std::string, int> name_to_id,
-                                 bool highest)
+void FemMesh::writeVTKWithGroups(
+    const std::string& FileName,
+    const std::string& vtk_group_cell_array,
+    std::map<std::string, int> name_to_id,
+    bool highest
+)
 {
 #ifdef FC_USE_VTK
-    FemVTKTools::writeVTKMeshWithGroups(FileName,
-                                        this,
-                                        vtk_group_cell_array,
-                                        name_to_id,
-                                        highest);
+    FemVTKTools::writeVTKMeshWithGroups(FileName, this, vtk_group_cell_array, name_to_id, highest);
 #endif
 }
 

--- a/src/Mod/Fem/App/FemMesh.cpp
+++ b/src/Mod/Fem/App/FemMesh.cpp
@@ -1666,7 +1666,7 @@ void FemMesh::read(const char* FileName)
 #ifdef FC_USE_VTK
     else if (File.hasExtension({"vtk", "vtu", "pvtu"})) {
         // read *.vtk legacy format or *.vtu XML unstructure Mesh
-        FemVTKTools::readVTKMesh(File.filePath().c_str(), this);
+        FemVTKTools::readVTKMesh(File.filePath().c_str(), this, nullptr);
     }
 #endif
     else if (File.hasExtension("z88")) {
@@ -1678,10 +1678,44 @@ void FemMesh::read(const char* FileName)
     }
 }
 
+void FemMesh::readVTKWithGroups(const char* FileName,
+                                const char* vtk_group_cell_array)
+{
+#ifdef FC_USE_VTK
+    Base::FileInfo File(FileName);
+    if (File.hasExtension({"vtk", "vtu", "pvtu"})) {
+        // checking on the file
+        if (!File.isReadable()) {
+            throw Base::FileException("File to load not existing or not readable", File);
+        }
+
+        // read *.vtk legacy format or *.vtu XML unstructure Mesh
+        FemVTKTools::readVTKMesh(File.filePath().c_str(), this, vtk_group_cell_array);
+        return;
+    }
+#endif
+
+    return read(FileName);
+}
+
 void FemMesh::writeVTK(const std::string& fileName, bool highest) const
 {
 #ifdef FC_USE_VTK
     FemVTKTools::writeVTKMesh(fileName.c_str(), this, highest);
+#endif
+}
+
+void FemMesh::writeVTKWithGroups(const std::string& FileName,
+                                 const std::string& vtk_group_cell_array,
+                                 std::map<std::string, int> name_to_id,
+                                 bool highest)
+{
+#ifdef FC_USE_VTK
+    FemVTKTools::writeVTKMeshWithGroups(FileName,
+                                        this,
+                                        vtk_group_cell_array,
+                                        name_to_id,
+                                        highest);
 #endif
 }
 

--- a/src/Mod/Fem/App/FemMesh.h
+++ b/src/Mod/Fem/App/FemMesh.h
@@ -211,8 +211,7 @@ public:
     // the cell data array, the name is the entry. Int and String array are
     // supported. String array creates groups names according to the string,
     // int array leads to groups with the string version of the integer as name.
-    void readVTKWithGroups(const char* FileName,
-                           const char* vtk_group_cell_array);
+    void readVTKWithGroups(const char* FileName, const char* vtk_group_cell_array);
 
     void write(const char* FileName) const;
     void writeABAQUS(
@@ -232,10 +231,12 @@ public:
     //        1. Only element/cell groups are supported, no node groups and no mixed groups
     //        2. Elements can only be in a single group, groups can not overlap
     //        3. Element IDs in the mesh need to be continious and start with ID 1
-    void writeVTKWithGroups(const std::string& FileName,
-                            const std::string& vtk_group_cell_array,
-                            std::map<std::string, int> name_to_id,
-                            bool highest = true);
+    void writeVTKWithGroups(
+        const std::string& FileName,
+        const std::string& vtk_group_cell_array,
+        std::map<std::string, int> name_to_id,
+        bool highest = true
+    );
     void writeZ88(const std::string& FileName) const;
 
 private:

--- a/src/Mod/Fem/App/FemMesh.h
+++ b/src/Mod/Fem/App/FemMesh.h
@@ -206,6 +206,14 @@ public:
 
     /// import from files
     void read(const char* FileName);
+    // import vtk file, and interprets the vtk_group_cell_array
+    // as group indicator. A group will be created for each unique entry in
+    // the cell data array, the name is the entry. Int and String array are
+    // supported. String array creates groups names according to the string,
+    // int array leads to groups with the string version of the integer as name.
+    void readVTKWithGroups(const char* FileName,
+                           const char* vtk_group_cell_array);
+
     void write(const char* FileName) const;
     void writeABAQUS(
         const std::string& Filename,
@@ -216,6 +224,18 @@ public:
         ABAQUS_EdgeVariant edgeVariant = ABAQUS_EdgeVariant::Beam
     ) const;
     void writeVTK(const std::string& FileName, bool highest = true) const;
+    // write vtk file, and writes the groupes into the provided cell array.
+    // If name_to_id is empty the created cell data array is a vtkStringArray,
+    // and the group name is used as entry for each element. If the map is provided
+    // a vtkIntArray is created and the mapped int is used as entry.
+    // The following limitations apply:
+    //        1. Only element/cell groups are supported, no node groups and no mixed groups
+    //        2. Elements can only be in a single group, groups can not overlap
+    //        3. Element IDs in the mesh need to be continious and start with ID 1
+    void writeVTKWithGroups(const std::string& FileName,
+                            const std::string& vtk_group_cell_array,
+                            std::map<std::string, int> name_to_id,
+                            bool highest = true);
     void writeZ88(const std::string& FileName) const;
 
 private:

--- a/src/Mod/Fem/App/FemMesh.pyi
+++ b/src/Mod/Fem/App/FemMesh.pyi
@@ -89,21 +89,38 @@ class FemMesh(ComplexGeoData):
         """Add list of volumes by list of node indices and list of nodes per volume."""
         ...
 
-    def read(self, file_name: str, /) -> None:
+    def read(self, file_name: str, vtk_cell_group_array: str) -> None:
         """
         Read in a various FEM mesh file formats.
 
-
         Supported formats: DAT, INP, MED, STL, UNV, VTK, Z88
+
+        vtk_cell_group_array: If provided uses the given cell group array to create mesh groups.
         """
         ...
 
     @constmethod
-    def write(self, file_name: str, /) -> None:
+    def write(self, file_name: str,
+                    highest: bool,
+                    vtk_cell_group_array: str,
+                    vtk_group_id_map: dict) -> None:
         """
         Write out various FEM mesh file formats.
 
         Supported formats: BDF, DAT, INP, MED, STL, UNV, VTK, Z88
+
+        highest: Export highest mesh elements only when true (default), all mesh elements if false
+
+        vtk_cell_group_array: When writing a VTK file the cell groups will be stored in a array with this name.
+                              By default it is a sring array with the group name written for each group element.
+        vtk_group_id_map:     When writing VTK with groups, the groupname can be mapped to a integer ID under
+                              which it will be stored (lessmemory usage then string). When reloading the group
+                              name is equal to the int ID as string.
+
+        Note on VTK group saving: The following limitations apply
+            1. Only element/cell groups are supported, no node groups and no mixed groups
+            2. Elements can only be in a single group, groups can not overlap
+            3. Element IDs in the mesh need to be continious and start with ID 1
         """
         ...
 

--- a/src/Mod/Fem/App/FemMesh.pyi
+++ b/src/Mod/Fem/App/FemMesh.pyi
@@ -100,10 +100,9 @@ class FemMesh(ComplexGeoData):
         ...
 
     @constmethod
-    def write(self, file_name: str,
-                    highest: bool,
-                    vtk_cell_group_array: str,
-                    vtk_group_id_map: dict) -> None:
+    def write(
+        self, file_name: str, highest: bool, vtk_cell_group_array: str, vtk_group_id_map: dict
+    ) -> None:
         """
         Write out various FEM mesh file formats.
 

--- a/src/Mod/Fem/App/FemMeshPyImp.cpp
+++ b/src/Mod/Fem/App/FemMeshPyImp.cpp
@@ -1134,8 +1134,9 @@ PyObject* FemMeshPy::read(PyObject* args, PyObject* kwds)
 
     char* Name;
     char* ArrayName = nullptr;
-    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwds, "et|et", kwlist,
-                                    "utf-8", &Name, "utf-8", &ArrayName)) {
+    if (
+        !Base::Wrapped_ParseTupleAndKeywords(args, kwds, "et|et", kwlist, "utf-8", &Name, "utf-8", &ArrayName)
+    ) {
         return nullptr;
     }
     std::string EncodedName = std::string(Name);
@@ -1148,12 +1149,11 @@ PyObject* FemMeshPy::read(PyObject* args, PyObject* kwds)
     }
 
     try {
-        if(EncodedArrayName.empty()) {
+        if (EncodedArrayName.empty()) {
             getFemMeshPtr()->read(EncodedName.c_str());
         }
         else {
-            getFemMeshPtr()->readVTKWithGroups(EncodedName.c_str(),
-                                               EncodedArrayName.c_str());
+            getFemMeshPtr()->readVTKWithGroups(EncodedName.c_str(), EncodedArrayName.c_str());
         }
     }
     catch (const std::exception& e) {
@@ -1166,16 +1166,25 @@ PyObject* FemMeshPy::read(PyObject* args, PyObject* kwds)
 PyObject* FemMeshPy::write(PyObject* args, PyObject* kwds) const
 {
 
-    static const std::array<const char*, 5> kwlist  {"file_name", "highest",
-                                                     "vtk_cell_group_array",
-                                                     "vtk_group_id_map", nullptr};
+    static const std::array<const char*, 5>
+        kwlist {"file_name", "highest", "vtk_cell_group_array", "vtk_group_id_map", nullptr};
 
     char* Name;
     PyObject* Highest = nullptr;
     char* ArrayName = nullptr;
     PyObject* PyGroupMap = nullptr;
-    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwds, "et|OetO", kwlist, "utf-8", &Name,
-                                        &Highest, "utf-8", &ArrayName, &PyGroupMap)) {
+    if (!Base::Wrapped_ParseTupleAndKeywords(
+            args,
+            kwds,
+            "et|OetO",
+            kwlist,
+            "utf-8",
+            &Name,
+            &Highest,
+            "utf-8",
+            &ArrayName,
+            &PyGroupMap
+        )) {
         return nullptr;
     }
 
@@ -1186,9 +1195,9 @@ PyObject* FemMeshPy::write(PyObject* args, PyObject* kwds) const
         EncodedArrayName = std::string(ArrayName);
         PyMem_Free(ArrayName);
 
-        if(PyGroupMap != nullptr) {
+        if (PyGroupMap != nullptr) {
             Py::Dict pymap(PyGroupMap);
-            for(auto it = pymap.begin(); it != pymap.end(); ++it) {
+            for (auto it = pymap.begin(); it != pymap.end(); ++it) {
                 auto group_name = Py::String((*it).first);
                 auto group_index = Py::Int((*it).second);
                 GroupMap[group_name.as_std_string()] = group_index.as_long();
@@ -1209,10 +1218,12 @@ PyObject* FemMeshPy::write(PyObject* args, PyObject* kwds) const
             getFemMeshPtr()->write(EncodedName.c_str());
         }
         else {
-            getFemMeshPtr()->writeVTKWithGroups(EncodedName.c_str(),
-                                                EncodedArrayName.c_str(),
-                                                GroupMap,
-                                                parsed_highest);
+            getFemMeshPtr()->writeVTKWithGroups(
+                EncodedName.c_str(),
+                EncodedArrayName.c_str(),
+                GroupMap,
+                parsed_highest
+            );
         }
     }
     catch (const std::exception& e) {

--- a/src/Mod/Fem/App/FemMeshPyImp.cpp
+++ b/src/Mod/Fem/App/FemMeshPyImp.cpp
@@ -1128,17 +1128,33 @@ PyObject* FemMeshPy::copy(PyObject* args) const
     return new FemMeshPy(new FemMesh(mesh));
 }
 
-PyObject* FemMeshPy::read(PyObject* args)
+PyObject* FemMeshPy::read(PyObject* args, PyObject* kwds)
 {
+    static const std::array<const char*, 3> kwlist {"file_name", "vtk_cell_group_array", nullptr};
+
     char* Name;
-    if (!PyArg_ParseTuple(args, "et", "utf-8", &Name)) {
+    char* ArrayName = nullptr;
+    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwds, "et|et", kwlist,
+                                    "utf-8", &Name, "utf-8", &ArrayName)) {
         return nullptr;
     }
     std::string EncodedName = std::string(Name);
     PyMem_Free(Name);
 
+    std::string EncodedArrayName;
+    if (ArrayName != nullptr) {
+        EncodedArrayName = std::string(ArrayName);
+        PyMem_Free(ArrayName);
+    }
+
     try {
-        getFemMeshPtr()->read(EncodedName.c_str());
+        if(EncodedArrayName.empty()) {
+            getFemMeshPtr()->read(EncodedName.c_str());
+        }
+        else {
+            getFemMeshPtr()->readVTKWithGroups(EncodedName.c_str(),
+                                               EncodedArrayName.c_str());
+        }
     }
     catch (const std::exception& e) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, e.what());
@@ -1147,17 +1163,57 @@ PyObject* FemMeshPy::read(PyObject* args)
     Py_Return;
 }
 
-PyObject* FemMeshPy::write(PyObject* args) const
+PyObject* FemMeshPy::write(PyObject* args, PyObject* kwds) const
 {
+
+    static const std::array<const char*, 5> kwlist  {"file_name", "highest",
+                                                     "vtk_cell_group_array",
+                                                     "vtk_group_id_map", nullptr};
+
     char* Name;
-    if (!PyArg_ParseTuple(args, "et", "utf-8", &Name)) {
+    PyObject* Highest = nullptr;
+    char* ArrayName = nullptr;
+    PyObject* PyGroupMap = nullptr;
+    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwds, "et|OetO", kwlist, "utf-8", &Name,
+                                        &Highest, "utf-8", &ArrayName, &PyGroupMap)) {
         return nullptr;
     }
+
+    // VTK with groups export handling
+    std::string EncodedArrayName;
+    std::map<std::string, int> GroupMap;
+    if (ArrayName != nullptr) {
+        EncodedArrayName = std::string(ArrayName);
+        PyMem_Free(ArrayName);
+
+        if(PyGroupMap != nullptr) {
+            Py::Dict pymap(PyGroupMap);
+            for(auto it = pymap.begin(); it != pymap.end(); ++it) {
+                auto group_name = Py::String((*it).first);
+                auto group_index = Py::Int((*it).second);
+                GroupMap[group_name.as_std_string()] = group_index.as_long();
+            }
+        }
+    }
+
+    bool parsed_highest = true;
+    if (Highest != nullptr) {
+        parsed_highest = Base::asBoolean(Highest);
+    }
+
     std::string EncodedName = std::string(Name);
     PyMem_Free(Name);
 
     try {
-        getFemMeshPtr()->write(EncodedName.c_str());
+        if (EncodedArrayName.empty()) {
+            getFemMeshPtr()->write(EncodedName.c_str());
+        }
+        else {
+            getFemMeshPtr()->writeVTKWithGroups(EncodedName.c_str(),
+                                                EncodedArrayName.c_str(),
+                                                GroupMap,
+                                                parsed_highest);
+        }
     }
     catch (const std::exception& e) {
         PyErr_SetString(Base::PyExc_FC_GeneralError, e.what());

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -76,6 +76,10 @@
 #include "FemAnalysis.h"
 #include "FemResultObject.h"
 #include "FemVTKTools.h"
+#include <SMESH_Group.hxx>
+#include <SMESHDS_GroupBase.hxx>
+#include <SMESHDS_Group.hxx>
+#include <vtkVertex.h>
 
 
 namespace Fem
@@ -174,7 +178,7 @@ void FemVTKTools::importVTKMesh(vtkSmartPointer<vtkDataSet> dataset, FemMesh* me
         switch (cell->GetCellType()) {
             // 0D vertex
             case VTK_VERTEX:
-                // we ignore it, internally we do not store separate data for a vertex
+                meshds->Add0DElementWithID(ids[0], iCell + 1);
                 break;
             // 1D edges
             case VTK_LINE:  // seg2
@@ -319,14 +323,144 @@ void FemVTKTools::importVTKMesh(vtkSmartPointer<vtkDataSet> dataset, FemMesh* me
     }
 }
 
-FemMesh* FemVTKTools::readVTKMesh(const char* filename, FemMesh* mesh)
+struct group_definition {
+    std::set<int> elements;
+    int dimension;
+};
+
+void FemVTKTools::importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* mesh, std::string arrayname)
+{
+    auto cell_data = grid->GetCellData();
+    vtkAbstractArray* cell_array = nullptr;
+
+    if (cell_data->HasArray(arrayname.c_str())) {
+        cell_array = cell_data->GetAbstractArray(arrayname.c_str());
+    }
+    else {
+        Base::Console().error("Array %s does not exist, cannot create groups\n", arrayname);
+        return;
+    }
+
+    // only support single component tuples
+    if (cell_array->GetNumberOfComponents() != 1) {
+        Base::Console().error("Only single component data can be converted into groups\n", arrayname);
+        return;
+    }
+
+    // do we have a integer cell type?
+    if (cell_array && cell_array->IsA("vtkIntArray")) {
+        std::map<vtkTypeInt64, group_definition> int_group_map;
+        auto intarray = vtkIntArray::SafeDownCast(cell_array);
+
+        // extract the groups with the respective elements
+        for (int i=0; i<intarray->GetNumberOfTuples(); i++) {
+
+            // remember: element ids in SMESH are continious from nodes to cells.
+            // in VTK nodes and cells have seperated 0 started indexes
+            vtkTypeInt64 value = intarray->GetValue(i);
+            if (value < 0) {
+                // -1 means no group
+                continue;
+            }
+            if (int_group_map.contains(value)) {
+                auto dim = grid->GetCell(i)->GetCellDimension();
+                if (int_group_map[value].dimension != dim) {
+                    Base::Console().error("Cells in group are not of same dimension\n", arrayname);
+                    return;
+                }
+                int_group_map[value].elements.insert(i+1);
+            }
+            else {
+                auto dim = grid->GetCell(i)->GetCellDimension();
+                std::set<int> elementset;
+                elementset.insert(i + 1);
+                int_group_map[value] = group_definition(elementset, dim);
+            }
+        }
+        // add it to the mesh
+        for(auto& item : int_group_map) {
+            std::string element_type;
+            switch(item.second.dimension) {
+                case 0:
+                    element_type = "0DElement";
+                    break;
+                case 1:
+                    element_type = "Edge";
+                    break;
+                case 2:
+                    element_type = "Face";
+                    break;
+                case 3:
+                    element_type = "Volume";
+                    break;
+            }
+            auto group_id = mesh->addGroup(element_type, std::to_string(item.first).c_str(), item.first);
+            mesh->addGroupElements(group_id, item.second.elements);
+        }
+    }
+
+    // seems we have a string cell type
+    std::map<std::string, group_definition> string_group_map;
+    if (cell_array && cell_array->IsA("vtkStringArray")) {
+        auto strarray = vtkStringArray::SafeDownCast(cell_array);
+
+        // extract the groups with the respective elements
+        for (int i=0; i<strarray->GetNumberOfTuples(); i++) {
+
+            auto value = strarray->GetValue(i);
+            if (value.empty()) {
+                // empty strings mean no group
+                continue;
+            }
+
+            if (string_group_map.contains(value)) {
+                auto dim = grid->GetCell(i)->GetCellDimension();
+                if (string_group_map[value].dimension != dim) {
+                    Base::Console().error("Cells in group are not of same dimension\n", arrayname);
+                    return;
+                }
+                string_group_map[value].elements.insert(i+1);
+            }
+            else {
+                auto dim = grid->GetCell(i)->GetCellDimension();
+                std::set<int> elementset;
+                elementset.insert(i + 1);
+                string_group_map[value] = group_definition(elementset, dim);
+            }
+        }
+        // add it to the mesh
+        for(auto& item : string_group_map) {
+            std::string element_type;
+            switch(item.second.dimension) {
+                case 0:
+                    element_type = "0DElement";
+                    break;
+                case 1:
+                    element_type = "Edge";
+                    break;
+                case 2:
+                    element_type = "Face";
+                    break;
+                case 3:
+                    element_type = "Volume";
+                    break;
+            }
+            std::string name(item.first);
+            auto group_id = mesh->addGroup(element_type, name);
+            mesh->addGroupElements(group_id, item.second.elements);
+        }
+    }
+}
+
+FemMesh* FemVTKTools::readVTKMesh(const char* filename, FemMesh* mesh, const char* group_array)
 {
     Base::TimeElapsed Start;
     Base::Console().log("Start: read FemMesh from VTK unstructuredGrid ======================\n");
     Base::FileInfo f(filename);
 
+    vtkSmartPointer<vtkDataSet> dataset;
     if (f.hasExtension("vtu")) {
-        vtkSmartPointer<vtkDataSet> dataset = readVTKFile<vtkXMLUnstructuredGridReader>(filename);
+        dataset = readVTKFile<vtkXMLUnstructuredGridReader>(filename);
         if (!dataset.Get()) {
             Base::Console().error("Failed to load file %s\n", filename);
             return nullptr;
@@ -334,7 +468,7 @@ FemMesh* FemVTKTools::readVTKMesh(const char* filename, FemMesh* mesh)
         importVTKMesh(dataset, mesh);
     }
     else if (f.hasExtension("pvtu")) {
-        vtkSmartPointer<vtkDataSet> dataset = readVTKFile<vtkXMLPUnstructuredGridReader>(filename);
+        dataset = readVTKFile<vtkXMLPUnstructuredGridReader>(filename);
         if (!dataset.Get()) {
             Base::Console().error("Failed to load file %s\n", filename);
             return nullptr;
@@ -342,7 +476,7 @@ FemMesh* FemVTKTools::readVTKMesh(const char* filename, FemMesh* mesh)
         importVTKMesh(dataset, mesh);
     }
     else if (f.hasExtension("vtk")) {
-        vtkSmartPointer<vtkDataSet> dataset = readVTKFile<vtkDataSetReader>(filename);
+        dataset = readVTKFile<vtkDataSetReader>(filename);
         if (!dataset.Get()) {
             Base::Console().error("Failed to load file %s\n", filename);
             return nullptr;
@@ -355,8 +489,35 @@ FemMesh* FemVTKTools::readVTKMesh(const char* filename, FemMesh* mesh)
     }
     // Mesh should link to the part feature, in order to set up FemConstraint
 
+    // load a potential array as groups
+    if (group_array != nullptr) {
+        importVTKCellGroup(dataset, mesh, group_array);
+    }
+
     Base::Console().log("    %f: Done \n", Base::TimeElapsed::diffTimeF(Start, Base::TimeElapsed()));
     return mesh;
+}
+
+
+void exportFemMeshVertices(
+    vtkSmartPointer<vtkCellArray>& elemArray,
+    std::vector<int>& types,
+    const SMDS_ElemIteratorPtr& aVertexIter
+)
+{
+    Base::Console().log("  Start: VTK mesh builder vertices.\n");
+
+    while (aVertexIter->more()) {
+        const SMDS_MeshElement* aVertex = aVertexIter->next();
+        if (aVertex->GetEntityType() == SMDSEntity_0D) {
+            fillVtkArray<vtkVertex>(elemArray, types, aVertex);
+        }
+        else {
+            throw Base::TypeError("Vertex not yet supported by FreeCAD's VTK mesh builder\n");
+        }
+    }
+
+    Base::Console().log("  End: VTK mesh builder edges.\n");
 }
 
 void exportFemMeshEdges(
@@ -516,9 +677,17 @@ void FemVTKTools::exportVTKMesh(
             SMDS_EdgeIteratorPtr aEdgeIter = meshDS->edgesIterator();
             exportFemMeshEdges(elemArray, types, aEdgeIter);
         }
+        // try vertices
+        if (elemArray->GetNumberOfCells() == 0) {
+            SMDS_ElemIteratorPtr aVertexIter = meshDS->elementsIterator(SMDSAbs_0DElement);
+            exportFemMeshVertices(elemArray, types, aVertexIter);
+        }
     }
     else {
         // export all elements
+        // vertices
+        SMDS_ElemIteratorPtr aVertexIter = meshDS->elementsIterator(SMDSAbs_0DElement);
+        exportFemMeshVertices(elemArray, types, aVertexIter);
         // edges
         SMDS_EdgeIteratorPtr aEdgeIter = meshDS->edgesIterator();
         exportFemMeshEdges(elemArray, types, aEdgeIter);
@@ -552,6 +721,119 @@ void FemVTKTools::writeVTKMesh(const char* filename, const FemMesh* mesh, bool h
     }
     else if (f.hasExtension("vtk")) {
         writeVTKFile<vtkDataSetWriter>(filename, grid);
+    }
+    else {
+        Base::Console().error("file name extension is not supported to write VTK\n");
+    }
+
+    Base::Console().log("    %f: Done \n", Base::TimeElapsed::diffTimeF(Start, Base::TimeElapsed()));
+}
+
+void FemVTKTools::writeVTKMeshWithGroups(std::string Filename,
+                                        FemMesh* mesh,
+                                        std::string group_array,
+                                        std::map<std::string, int> index_map,
+                                        bool highest)
+{
+    Base::TimeElapsed Start;
+    Base::Console().log("Start: write VTK unstructuredGrid from FemMesh including groups======================\n");
+    Base::FileInfo f(Filename);
+
+    vtkSmartPointer<vtkUnstructuredGrid> grid = vtkSmartPointer<vtkUnstructuredGrid>::New();
+    exportVTKMesh(mesh, grid, highest);
+
+    // add the groupes array!
+    vtkSmartPointer<vtkAbstractArray> cell_array;
+    if (index_map.empty()) {
+        auto cell_sarray = vtkNew<vtkStringArray>();
+        cell_sarray->SetNumberOfComponents(1);
+        cell_sarray->SetName(group_array.c_str());
+        cell_sarray->SetNumberOfTuples(grid->GetNumberOfCells());
+
+        auto smesh = mesh->getSMesh();
+        for (auto& GroupID : smesh->GetGroupIds()) {
+
+            SMESH_Group* group = smesh->GetGroup(GroupID);
+            if (!group) {
+                throw std::runtime_error("VTK group exports: No group for given id.");
+            }
+            SMESHDS_Group* groupDS = dynamic_cast<SMESHDS_Group*>(group->GetGroupDS());
+            if (!groupDS) {
+                throw std::runtime_error("VTK group export: Failed to add group elements.");
+            }
+
+            auto type = groupDS->GetType();
+            if ((type == SMDSAbs_Node) ||
+                (type == SMDSAbs_Ball) ||
+                (type == SMDSAbs_All)) {
+                // we only support VTK cell type group (0DElement, Edge,Face,Volume)
+                continue;
+            }
+
+            // Traverse the full group
+            auto name = group->GetName();
+            auto aElemIter = groupDS->GetElements();
+            while (aElemIter->more()) {
+                const SMDS_MeshElement* aElem = aElemIter->next();
+                if(aElem->GetID() > grid->GetNumberOfCells()) {
+                    throw std::runtime_error("VTK group export: Cells ids need to be continious and start with index 1.");
+                }
+                cell_sarray->SetValue(aElem->GetID()-1, name);
+            }
+        }
+        cell_array = cell_sarray;
+    }
+    else {
+        auto cell_iarray = vtkNew<vtkIntArray>();
+        cell_iarray->SetNumberOfComponents(1);
+        cell_iarray->SetName(group_array.c_str());
+        cell_iarray->SetNumberOfTuples(grid->GetNumberOfCells());
+        for(int i=0; i<grid->GetNumberOfCells(); i++) {
+            cell_iarray->SetValue(i, -1);
+        }
+
+        auto smesh = mesh->getSMesh();
+        for (auto& GroupID : smesh->GetGroupIds()) {
+
+            SMESH_Group* group = smesh->GetGroup(GroupID);
+            if (!group) {
+                throw std::runtime_error("VTK group export: No group for given id.");
+            }
+            SMESHDS_Group* groupDS = dynamic_cast<SMESHDS_Group*>(group->GetGroupDS());
+            if (!groupDS) {
+                throw std::runtime_error("VTK group export: Failed to add group elements.");
+            }
+
+            if ((groupDS->GetType() == SMDSAbs_Node) ||
+                (groupDS->GetType() == SMDSAbs_Ball) ||
+                (groupDS->GetType() == SMDSAbs_All)) {
+                // we only support VTK cell type group
+                continue;
+            }
+
+            // Traverse the full group
+            auto id = index_map[group->GetName()];
+            auto aElemIter = groupDS->GetElements();
+            while (aElemIter->more()) {
+                const SMDS_MeshElement* aElem = aElemIter->next();
+                if(aElem->GetID() > grid->GetNumberOfCells()) {
+                    throw std::runtime_error("VTK group export: Cells ids need to be continious and start with index 1.");
+                }
+                cell_iarray->SetValue(aElem->GetID()-1, id);
+            }
+        }
+        cell_array = cell_iarray;
+    }
+
+    // set the cell group data to the grid
+    grid->GetCellData()->AddArray(cell_array);
+
+    Base::Console().log("Start: writing mesh data ======================\n");
+    if (f.hasExtension("vtu")) {
+        writeVTKFile<vtkXMLUnstructuredGridWriter>(Filename.c_str(), grid);
+    }
+    else if (f.hasExtension("vtk")) {
+        writeVTKFile<vtkDataSetWriter>(Filename.c_str(), grid);
     }
     else {
         Base::Console().error("file name extension is not supported to write VTK\n");

--- a/src/Mod/Fem/App/FemVTKTools.cpp
+++ b/src/Mod/Fem/App/FemVTKTools.cpp
@@ -323,7 +323,8 @@ void FemVTKTools::importVTKMesh(vtkSmartPointer<vtkDataSet> dataset, FemMesh* me
     }
 }
 
-struct group_definition {
+struct group_definition
+{
     std::set<int> elements;
     int dimension;
 };
@@ -353,7 +354,7 @@ void FemVTKTools::importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* 
         auto intarray = vtkIntArray::SafeDownCast(cell_array);
 
         // extract the groups with the respective elements
-        for (int i=0; i<intarray->GetNumberOfTuples(); i++) {
+        for (int i = 0; i < intarray->GetNumberOfTuples(); i++) {
 
             // remember: element ids in SMESH are continious from nodes to cells.
             // in VTK nodes and cells have seperated 0 started indexes
@@ -368,7 +369,7 @@ void FemVTKTools::importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* 
                     Base::Console().error("Cells in group are not of same dimension\n", arrayname);
                     return;
                 }
-                int_group_map[value].elements.insert(i+1);
+                int_group_map[value].elements.insert(i + 1);
             }
             else {
                 auto dim = grid->GetCell(i)->GetCellDimension();
@@ -378,9 +379,9 @@ void FemVTKTools::importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* 
             }
         }
         // add it to the mesh
-        for(auto& item : int_group_map) {
+        for (auto& item : int_group_map) {
             std::string element_type;
-            switch(item.second.dimension) {
+            switch (item.second.dimension) {
                 case 0:
                     element_type = "0DElement";
                     break;
@@ -394,7 +395,8 @@ void FemVTKTools::importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* 
                     element_type = "Volume";
                     break;
             }
-            auto group_id = mesh->addGroup(element_type, std::to_string(item.first).c_str(), item.first);
+            auto group_id
+                = mesh->addGroup(element_type, std::to_string(item.first).c_str(), item.first);
             mesh->addGroupElements(group_id, item.second.elements);
         }
     }
@@ -405,7 +407,7 @@ void FemVTKTools::importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* 
         auto strarray = vtkStringArray::SafeDownCast(cell_array);
 
         // extract the groups with the respective elements
-        for (int i=0; i<strarray->GetNumberOfTuples(); i++) {
+        for (int i = 0; i < strarray->GetNumberOfTuples(); i++) {
 
             auto value = strarray->GetValue(i);
             if (value.empty()) {
@@ -419,7 +421,7 @@ void FemVTKTools::importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* 
                     Base::Console().error("Cells in group are not of same dimension\n", arrayname);
                     return;
                 }
-                string_group_map[value].elements.insert(i+1);
+                string_group_map[value].elements.insert(i + 1);
             }
             else {
                 auto dim = grid->GetCell(i)->GetCellDimension();
@@ -429,9 +431,9 @@ void FemVTKTools::importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* 
             }
         }
         // add it to the mesh
-        for(auto& item : string_group_map) {
+        for (auto& item : string_group_map) {
             std::string element_type;
-            switch(item.second.dimension) {
+            switch (item.second.dimension) {
                 case 0:
                     element_type = "0DElement";
                     break;
@@ -729,14 +731,18 @@ void FemVTKTools::writeVTKMesh(const char* filename, const FemMesh* mesh, bool h
     Base::Console().log("    %f: Done \n", Base::TimeElapsed::diffTimeF(Start, Base::TimeElapsed()));
 }
 
-void FemVTKTools::writeVTKMeshWithGroups(std::string Filename,
-                                        FemMesh* mesh,
-                                        std::string group_array,
-                                        std::map<std::string, int> index_map,
-                                        bool highest)
+void FemVTKTools::writeVTKMeshWithGroups(
+    std::string Filename,
+    FemMesh* mesh,
+    std::string group_array,
+    std::map<std::string, int> index_map,
+    bool highest
+)
 {
     Base::TimeElapsed Start;
-    Base::Console().log("Start: write VTK unstructuredGrid from FemMesh including groups======================\n");
+    Base::Console().log(
+        "Start: write VTK unstructuredGrid from FemMesh including groups======================\n"
+    );
     Base::FileInfo f(Filename);
 
     vtkSmartPointer<vtkUnstructuredGrid> grid = vtkSmartPointer<vtkUnstructuredGrid>::New();
@@ -763,9 +769,7 @@ void FemVTKTools::writeVTKMeshWithGroups(std::string Filename,
             }
 
             auto type = groupDS->GetType();
-            if ((type == SMDSAbs_Node) ||
-                (type == SMDSAbs_Ball) ||
-                (type == SMDSAbs_All)) {
+            if ((type == SMDSAbs_Node) || (type == SMDSAbs_Ball) || (type == SMDSAbs_All)) {
                 // we only support VTK cell type group (0DElement, Edge,Face,Volume)
                 continue;
             }
@@ -775,10 +779,12 @@ void FemVTKTools::writeVTKMeshWithGroups(std::string Filename,
             auto aElemIter = groupDS->GetElements();
             while (aElemIter->more()) {
                 const SMDS_MeshElement* aElem = aElemIter->next();
-                if(aElem->GetID() > grid->GetNumberOfCells()) {
-                    throw std::runtime_error("VTK group export: Cells ids need to be continious and start with index 1.");
+                if (aElem->GetID() > grid->GetNumberOfCells()) {
+                    throw std::runtime_error(
+                        "VTK group export: Cells ids need to be continious and start with index 1."
+                    );
                 }
-                cell_sarray->SetValue(aElem->GetID()-1, name);
+                cell_sarray->SetValue(aElem->GetID() - 1, name);
             }
         }
         cell_array = cell_sarray;
@@ -788,7 +794,7 @@ void FemVTKTools::writeVTKMeshWithGroups(std::string Filename,
         cell_iarray->SetNumberOfComponents(1);
         cell_iarray->SetName(group_array.c_str());
         cell_iarray->SetNumberOfTuples(grid->GetNumberOfCells());
-        for(int i=0; i<grid->GetNumberOfCells(); i++) {
+        for (int i = 0; i < grid->GetNumberOfCells(); i++) {
             cell_iarray->SetValue(i, -1);
         }
 
@@ -804,9 +810,8 @@ void FemVTKTools::writeVTKMeshWithGroups(std::string Filename,
                 throw std::runtime_error("VTK group export: Failed to add group elements.");
             }
 
-            if ((groupDS->GetType() == SMDSAbs_Node) ||
-                (groupDS->GetType() == SMDSAbs_Ball) ||
-                (groupDS->GetType() == SMDSAbs_All)) {
+            if ((groupDS->GetType() == SMDSAbs_Node) || (groupDS->GetType() == SMDSAbs_Ball)
+                || (groupDS->GetType() == SMDSAbs_All)) {
                 // we only support VTK cell type group
                 continue;
             }
@@ -816,10 +821,12 @@ void FemVTKTools::writeVTKMeshWithGroups(std::string Filename,
             auto aElemIter = groupDS->GetElements();
             while (aElemIter->more()) {
                 const SMDS_MeshElement* aElem = aElemIter->next();
-                if(aElem->GetID() > grid->GetNumberOfCells()) {
-                    throw std::runtime_error("VTK group export: Cells ids need to be continious and start with index 1.");
+                if (aElem->GetID() > grid->GetNumberOfCells()) {
+                    throw std::runtime_error(
+                        "VTK group export: Cells ids need to be continious and start with index 1."
+                    );
                 }
-                cell_iarray->SetValue(aElem->GetID()-1, id);
+                cell_iarray->SetValue(aElem->GetID() - 1, id);
             }
         }
         cell_array = cell_iarray;

--- a/src/Mod/Fem/App/FemVTKTools.h
+++ b/src/Mod/Fem/App/FemVTKTools.h
@@ -41,10 +41,10 @@ public:
     // data
     static void importVTKMesh(vtkSmartPointer<vtkDataSet> grid, FemMesh* mesh, float scale = 1.0);
 
-    // uses the content of the cell array and convert it into FemMeshGroup. Ever unique entry in the cell array
-    // becomes a group, and  this group contains all elements with the entry. If the cell array is a Integer array
-    // the value becomes the groupID, if it is a string array the value becomes the group name. Other cell types
-    // are not supportet.
+    // uses the content of the cell array and convert it into FemMeshGroup. Ever unique entry in the
+    // cell array becomes a group, and  this group contains all elements with the entry. If the cell
+    // array is a Integer array the value becomes the groupID, if it is a string array the value
+    // becomes the group name. Other cell types are not supportet.
     static void importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* mesh, std::string arrayname);
 
     // extract data from FreCAD FEM mesh and fill a vtkUnstructuredGrid instance with that data. Set
@@ -69,11 +69,13 @@ public:
 
     // FemMesh write to vtkUnstructuredGrid data file
     static void writeVTKMesh(const char* Filename, const FemMesh* mesh, bool highest = true);
-    static void writeVTKMeshWithGroups(std::string Filename,
-                                       FemMesh* mesh,
-                                       std::string group_array,
-                                       std::map<std::string, int> index_map,
-                                       bool highest = true);
+    static void writeVTKMeshWithGroups(
+        std::string Filename,
+        FemMesh* mesh,
+        std::string group_array,
+        std::map<std::string, int> index_map,
+        bool highest = true
+    );
 
     // FemResult (activeObject or created if res= NULL) read from vtkUnstructuredGrid dataset file
     static App::DocumentObject* readResult(const char* Filename, App::DocumentObject* res = nullptr);

--- a/src/Mod/Fem/App/FemVTKTools.h
+++ b/src/Mod/Fem/App/FemVTKTools.h
@@ -41,6 +41,12 @@ public:
     // data
     static void importVTKMesh(vtkSmartPointer<vtkDataSet> grid, FemMesh* mesh, float scale = 1.0);
 
+    // uses the content of the cell array and convert it into FemMeshGroup. Ever unique entry in the cell array
+    // becomes a group, and  this group contains all elements with the entry. If the cell array is a Integer array
+    // the value becomes the groupID, if it is a string array the value becomes the group name. Other cell types
+    // are not supportet.
+    static void importVTKCellGroup(vtkSmartPointer<vtkDataSet> grid, FemMesh* mesh, std::string arrayname);
+
     // extract data from FreCAD FEM mesh and fill a vtkUnstructuredGrid instance with that data. Set
     // `highest` to false to export all elements levels.
     static void exportVTKMesh(
@@ -59,10 +65,15 @@ public:
     static void exportFreeCADResult(const App::DocumentObject* result, vtkSmartPointer<vtkDataSet> grid);
 
     // FemMesh read from vtkUnstructuredGrid data file
-    static FemMesh* readVTKMesh(const char* filename, FemMesh* mesh);
+    static FemMesh* readVTKMesh(const char* filename, FemMesh* mesh, const char* group_array = nullptr);
 
     // FemMesh write to vtkUnstructuredGrid data file
     static void writeVTKMesh(const char* Filename, const FemMesh* mesh, bool highest = true);
+    static void writeVTKMeshWithGroups(std::string Filename,
+                                       FemMesh* mesh,
+                                       std::string group_array,
+                                       std::map<std::string, int> index_map,
+                                       bool highest = true);
 
     // FemResult (activeObject or created if res= NULL) read from vtkUnstructuredGrid dataset file
     static App::DocumentObject* readResult(const char* Filename, App::DocumentObject* res = nullptr);

--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -400,10 +400,12 @@ class GmshTools(ObjectTools):
     def get_group_data(self):
         # mesh group objects.
         geom = self.obj.Shape.getPropertyOfGeometry()
-        self.group_elements = {"Vertex" : len(geom.Vertexes),
-                               "Edge" : len(geom.Edges),
-                               "Face" : len(geom.Faces),
-                               "Solid" : len(geom.Solids)}
+        self.group_elements = {
+            "Vertex": len(geom.Vertexes),
+            "Edge": len(geom.Edges),
+            "Face": len(geom.Faces),
+            "Solid": len(geom.Solids),
+        }
 
     def postprocess_groups(self):
         # The created groups are for shape elements only: vertex, face, edge and solid
@@ -429,7 +431,9 @@ class GmshTools(ObjectTools):
                         for element in new_group_elements[ge]:
                             for grp_idx in fem_mesh.Groups:
                                 if fem_mesh.getGroupName(grp_idx) == element:
-                                    fem_mesh.addGroupElements(new_group, list(fem_mesh.getGroupElements(grp_idx)))
+                                    fem_mesh.addGroupElements(
+                                        new_group, list(fem_mesh.getGroupElements(grp_idx))
+                                    )
                                     break
                     else:
                         Console.PrintError("  A group with this name exists already.\n")
@@ -446,19 +450,20 @@ class GmshTools(ObjectTools):
 
             new_group_elements = meshtools.get_analysis_group_elements(self.analysis, self.part_obj)
             for ge in new_group_elements:
-                    if ge not in self.group_elements:
-                        self.group_elements[ge] = True
+                if ge not in self.group_elements:
+                    self.group_elements[ge] = True
 
-                        # build the group!
-                        new_group = fem_mesh.addGroup(ge, "All")
-                        for element in new_group_elements[ge]:
-                            for grp_idx in fem_mesh.Groups:
-                                if fem_mesh.getGroupName(grp_idx) == element:
-                                    fem_mesh.addGroupElements(new_group, list(fem_mesh.getGroupElements(grp_idx)))
-                                    break
-                    else:
-                        Console.PrintError("  A group with this name exists already.\n")
-
+                    # build the group!
+                    new_group = fem_mesh.addGroup(ge, "All")
+                    for element in new_group_elements[ge]:
+                        for grp_idx in fem_mesh.Groups:
+                            if fem_mesh.getGroupName(grp_idx) == element:
+                                fem_mesh.addGroupElements(
+                                    new_group, list(fem_mesh.getGroupElements(grp_idx))
+                                )
+                                break
+                else:
+                    Console.PrintError("  A group with this name exists already.\n")
 
     def rename_groups(self):
         # salomemesh adds a suffix to the names of element groups if there are also nodes
@@ -480,7 +485,6 @@ class GmshTools(ObjectTools):
                 if fem_mesh.getGroupName(gidx) == old_name:
                     fem_mesh.renameGroup(gidx, group)
                     break
-
 
     def version(self):
         self.get_gmsh_command()
@@ -1440,7 +1444,7 @@ class GmshTools(ObjectTools):
         # we use the element index of FreeCAD which starts with 1 (example: "Face1"),
         # same as Gmsh. For unit test we need them to have a fixed order
 
-        phy_tag = 0;
+        phy_tag = 0
         self.group_indices = {}
 
         if self.group_elements:
@@ -1461,12 +1465,14 @@ class GmshTools(ObjectTools):
                         phy_shape = "Point"
 
                 geo.write(f"For i In {{1:{element_count} }}\n")
-                geo.write(f'\tPhysical {phy_shape}(Sprintf("{group}%g", i), {phy_tag}+i) = {{i}};\n')
+                geo.write(
+                    f'\tPhysical {phy_shape}(Sprintf("{group}%g", i), {phy_tag}+i) = {{i}};\n'
+                )
                 geo.write("EndFor\n")
 
                 # store physical tags for later rename
                 for i in range(element_count):
-                    self.group_indices[group+str(i+1)] = phy_tag+1
+                    self.group_indices[group + str(i + 1)] = phy_tag + 1
                     phy_tag += 1
 
             geo.write("\n")

--- a/src/Mod/Fem/femmesh/gmshtools.py
+++ b/src/Mod/Fem/femmesh/gmshtools.py
@@ -180,11 +180,8 @@ class GmshTools(ObjectTools):
         self.ParallelProcessing = self.obj.ParallelProcessing
 
         # mesh groups
-        if self.obj.GroupsOfNodes:
-            self.group_nodes_export = True
-        else:
-            self.group_nodes_export = False
         self.group_elements = {}
+        self.group_indices = {}
 
         # mesh boundary layer
         self.bl_setting_list = []  # list of dict, each item map to MeshBoundaryLayer object
@@ -282,8 +279,16 @@ class GmshTools(ObjectTools):
         return self.process
 
     def update_properties(self):
-        self.obj.FemMesh = Fem.read(self.temp_file_mesh)
+        fem_mesh = Fem.FemMesh()
+        if self.group_elements and ".vtk" in self.temp_file_mesh:
+            fem_mesh.read(self.temp_file_mesh, vtk_cell_group_array="CellEntityIds")
+        else:
+            fem_mesh.read(self.temp_file_mesh)
+
+        self.obj.FemMesh = fem_mesh
+
         self.rename_groups()
+        self.postprocess_groups()
 
     def create_mesh(self):
         # for backward compatibility only
@@ -393,20 +398,19 @@ class GmshTools(ObjectTools):
         Console.PrintMessage("  " + self.gmsh_bin + "\n")
 
     def get_group_data(self):
-        # mesh group objects. Only one shape type is expected
+        # mesh group objects.
         geom = self.obj.Shape.getPropertyOfGeometry()
-        r_solids = range(1, len(geom.Solids) + 1)
-        r_faces = range(1, len(geom.Faces) + 1)
-        r_edges = range(1, len(geom.Edges) + 1)
-        solids = [(f"Solid{i}", [f"Solid{i}"]) for i in r_solids]
-        faces = [(f"Face{i}", [f"Face{i}"]) for i in r_faces]
-        edges = [(f"Edge{i}", [f"Edge{i}"]) for i in r_edges]
-        shapes = []
-        shapes.extend(solids)
-        shapes.extend(faces)
-        shapes.extend(edges)
+        self.group_elements = {"Vertex" : len(geom.Vertexes),
+                               "Edge" : len(geom.Edges),
+                               "Face" : len(geom.Faces),
+                               "Solid" : len(geom.Solids)}
 
-        self.group_elements = dict(shapes)
+    def postprocess_groups(self):
+        # The created groups are for shape elements only: vertex, face, edge and solid
+        # From those we need to create new groups for the analysis features
+
+        fem_mesh = self.obj.FemMesh
+
         if not self.obj.MeshGroupList:
             # print("  No mesh group objects.")
             pass
@@ -418,7 +422,15 @@ class GmshTools(ObjectTools):
                 new_group_elements = meshtools.get_mesh_group_elements(mg, self.part_obj)
                 for ge in new_group_elements:
                     if ge not in self.group_elements:
-                        self.group_elements[ge] = new_group_elements[ge]
+                        self.group_elements[ge] = -1
+
+                        # build the group!
+                        new_group = fem_mesh.addGroup(ge, "All")
+                        for element in new_group_elements[ge]:
+                            for grp_idx in fem_mesh.Groups:
+                                if fem_mesh.getGroupName(grp_idx) == element:
+                                    fem_mesh.addGroupElements(new_group, list(fem_mesh.getGroupElements(grp_idx)))
+                                    break
                     else:
                         Console.PrintError("  A group with this name exists already.\n")
 
@@ -431,29 +443,44 @@ class GmshTools(ObjectTools):
                 "  Group meshing for analysis is set to true in FEM General Preferences. "
                 "Are you really sure about this? You could run into trouble!\n"
             )
-            self.group_nodes_export = True
+
             new_group_elements = meshtools.get_analysis_group_elements(self.analysis, self.part_obj)
             for ge in new_group_elements:
-                if ge not in self.group_elements:
-                    self.group_elements[ge] = new_group_elements[ge]
-                else:
-                    Console.PrintError("  A group with this name exists already.\n")
-        # else:
-        #    Console.PrintMessage("  No Group meshing for analysis.\n")
+                    if ge not in self.group_elements:
+                        self.group_elements[ge] = True
 
-        # if self.group_elements:
-        #    Console.PrintMessage("  {}\n".format(self.group_elements))
+                        # build the group!
+                        new_group = fem_mesh.addGroup(ge, "All")
+                        for element in new_group_elements[ge]:
+                            for grp_idx in fem_mesh.Groups:
+                                if fem_mesh.getGroupName(grp_idx) == element:
+                                    fem_mesh.addGroupElements(new_group, list(fem_mesh.getGroupElements(grp_idx)))
+                                    break
+                    else:
+                        Console.PrintError("  A group with this name exists already.\n")
+
 
     def rename_groups(self):
         # salomemesh adds a suffix to the names of element groups if there are also nodes
         #  in the groups in the .unv file. This method removes the suffix
-        reg_exp = re.compile(r"(?P<item>(Edge|Face|Solid)\d+)_(?!Nodes)\w+$")
         fem_mesh = self.obj.FemMesh
+        reg_exp = re.compile(r"(?P<item>(Edge|Face|Solid)\d+)_(?!Nodes)\w+$")
         for i in fem_mesh.Groups:
             grp = fem_mesh.getGroupName(i)
             m = reg_exp.match(grp)
             if m:
                 fem_mesh.renameGroup(i, m.group("item"))
+
+        # if we load gmsh groups via vtk file the names got lost, we have only numbers.
+        # we need to rename them correctly.
+        for group in self.group_indices:
+            index = self.group_indices[group]
+            old_name = str(index)
+            for gidx in fem_mesh.Groups:
+                if fem_mesh.getGroupName(gidx) == old_name:
+                    fem_mesh.renameGroup(gidx, group)
+                    break
+
 
     def version(self):
         self.get_gmsh_command()
@@ -1412,33 +1439,35 @@ class GmshTools(ObjectTools):
         # for example: "PartObject.Solid2" -> shape: Solid, index: 2
         # we use the element index of FreeCAD which starts with 1 (example: "Face1"),
         # same as Gmsh. For unit test we need them to have a fixed order
-        reg_exp = re.compile(r"(?:.*\.)?(?P<shape>Solid|Face|Edge|Vertex)(?P<index>\d+)$")
+
+        phy_tag = 0;
+        self.group_indices = {}
 
         if self.group_elements:
             # print("  We are going to have to find elements to make mesh groups for.")
             geo.write("// group data\n")
             for group in sorted(self.group_elements):
-                gdata = self.group_elements[group]
-                ele = {"Volume": [], "Surface": [], "Line": [], "Point": []}
 
-                for i in gdata:
-                    m = reg_exp.match(i)
-                    if m:
-                        shape = m.group("shape")
-                        index = str(m.group("index"))
-                        if shape == "Solid":
-                            ele["Volume"].append(index)
-                        elif shape == "Face":
-                            ele["Surface"].append(index)
-                        elif shape == "Edge":
-                            ele["Line"].append(index)
-                        elif shape == "Vertex":
-                            ele["Point"].append(index)
+                element_count = self.group_elements[group]
 
-                for phys in ele:
-                    if ele[phys]:
-                        items = "{" + ", ".join(ele[phys]) + "}"
-                        geo.write('Physical {}("{}") = {};\n'.format(phys, group, items))
+                match group:
+                    case "Solid":
+                        phy_shape = "Volume"
+                    case "Face":
+                        phy_shape = "Surface"
+                    case "Edge":
+                        phy_shape = "Line"
+                    case "Vertex":
+                        phy_shape = "Point"
+
+                geo.write(f"For i In {{1:{element_count} }}\n")
+                geo.write(f'\tPhysical {phy_shape}(Sprintf("{group}%g", i), {phy_tag}+i) = {{i}};\n')
+                geo.write("EndFor\n")
+
+                # store physical tags for later rename
+                for i in range(element_count):
+                    self.group_indices[group+str(i+1)] = phy_tag+1
+                    phy_tag += 1
 
             geo.write("\n")
 
@@ -1739,14 +1768,6 @@ class GmshTools(ObjectTools):
 
         # save mesh
         geo.write("// save\n")
-        if self.group_elements and self.group_nodes_export:
-            geo.write("// For each group save not only the elements but the nodes too.;\n")
-            geo.write("Mesh.SaveGroupsOfNodes = 1;\n")
-            # belongs to Mesh.SaveAll but only needed if there are groups
-            geo.write(
-                "// Needed for Group meshing too, because "
-                "for one material there is no group defined;\n"
-            )
         geo.write("// Ignore Physical definitions and save all elements;\n")
         geo.write("Mesh.SaveAll = 1;\n")
         # explicit use double quotes in geo file
@@ -1810,8 +1831,16 @@ class GmshTools(ObjectTools):
 
     def read_and_set_new_mesh(self):
         if not self.error:
-            fem_mesh = Fem.read(self.temp_file_mesh)
+            fem_mesh = Fem.FemMesh()
+            if self.group_elements and ".vtk" in self.temp_file_mesh:
+                fem_mesh.read(self.temp_file_mesh, vtk_cell_group_array="CellEntityIds")
+            else:
+                fem_mesh.read(self.temp_file_mesh)
+
             self.obj.FemMesh = fem_mesh
+            self.rename_groups()
+            self.postprocess_groups()
+
             Console.PrintMessage("  New mesh was added to the mesh object.\n")
         else:
             Console.PrintError("No mesh was created.\n")
@@ -1922,7 +1951,6 @@ class GmshPreviewTools(GmshTools):
 
         # load the generated mesh
         self.obj.FemMesh = Fem.read(self.temp_file_mesh)
-        self.rename_groups()
 
         # read and extract node data
         dir = os.path.dirname(self.temp_file_geometry)

--- a/src/Mod/Fem/femobjects/mesh_gmsh.py
+++ b/src/Mod/Fem/femobjects/mesh_gmsh.py
@@ -245,15 +245,6 @@ class MeshGmsh(base_fempythonobject.BaseFemPythonObject):
         )
         prop.append(
             _PropHelper(
-                type="App::PropertyBool",
-                name="GroupsOfNodes",
-                group="Mesh Parameters",
-                doc="For each group create not only the elements but the nodes too",
-                value=True,
-            )
-        )
-        prop.append(
-            _PropHelper(
                 type="App::PropertyEnumeration",
                 name="SubdivisionAlgorithm",
                 group="Mesh Parameters",

--- a/src/Mod/Fem/femtest/app/test_mesh.py
+++ b/src/Mod/Fem/femtest/app/test_mesh.py
@@ -607,3 +607,55 @@ class TestMeshGroups(unittest.TestCase):
                 )
             ),
         )
+
+    def test_group_vtk_handling(self):
+        """
+        See if groups can be exported and imported correctly to and from vtk files
+        """
+
+        mesh = Fem.FemMesh()
+        mesh.addNode(0, 0, 0, 1)
+        mesh.addNode(1, 0, 0, 2)
+        mesh.addNode(2, 0, 0, 3)
+        mesh.addNode(3, 0, 0, 4)
+        mesh.addNode(4, 0, 0, 5)
+        mesh.addEdge(1,2)
+        mesh.addEdge(2,3)
+        mesh.addEdge(3,4)
+
+        testfile = join(testtools.get_fem_test_tmp_dir(), "group_mesh.vtu")
+
+        elements_to_be_added = [2,3]
+        group_id = mesh.addGroup("mynodegroup", "Edge")
+        mesh.addGroupElements(group_id, elements_to_be_added)
+
+        # check workbench export and read with string data
+        mesh.write(testfile, vtk_cell_group_array="groups", highest=False)
+        new_fm = Fem.FemMesh()
+        new_fm.read(testfile, vtk_cell_group_array="groups")
+
+        self.assertEqual(new_fm.GroupCount, 1, msg="Wrong number of groups detected")
+        self.assertEqual(new_fm.getGroupName(new_fm.Groups[0]), "mynodegroup",
+                         msg="Group name not retained")
+        self.assertEqual(new_fm.getGroupElementType(new_fm.Groups[0]), "Edge",
+                         msg="Group type not retained")
+
+        self.assertEqual(mesh.getGroupElements(mesh.Groups[0]),
+                         new_fm.getGroupElements(new_fm.Groups[0]),
+                         msg="Group elements not retained")
+
+        # try if this works with integer array data
+        name_id_map = {"mynodegroup": 3}
+        mesh.write(testfile, vtk_cell_group_array="groups", vtk_group_id_map=name_id_map, highest=False)
+        new_fm = Fem.FemMesh()
+        new_fm.read(testfile, vtk_cell_group_array="groups")
+        self.assertEqual(new_fm.GroupCount, 1, msg="Wrong number of groups detected")
+        self.assertEqual(new_fm.getGroupName(new_fm.Groups[0]), "3",
+                         msg="Group name not set to group id")
+        self.assertEqual(new_fm.getGroupElementType(new_fm.Groups[0]), "Edge",
+                         msg="Group type not retained")
+
+        self.assertEqual(mesh.getGroupElements(mesh.Groups[0]),
+                         new_fm.getGroupElements(new_fm.Groups[0]),
+                         msg="Group elements not retained")
+

--- a/src/Mod/Fem/femtest/app/test_mesh.py
+++ b/src/Mod/Fem/femtest/app/test_mesh.py
@@ -619,13 +619,13 @@ class TestMeshGroups(unittest.TestCase):
         mesh.addNode(2, 0, 0, 3)
         mesh.addNode(3, 0, 0, 4)
         mesh.addNode(4, 0, 0, 5)
-        mesh.addEdge(1,2)
-        mesh.addEdge(2,3)
-        mesh.addEdge(3,4)
+        mesh.addEdge(1, 2)
+        mesh.addEdge(2, 3)
+        mesh.addEdge(3, 4)
 
         testfile = join(testtools.get_fem_test_tmp_dir(), "group_mesh.vtu")
 
-        elements_to_be_added = [2,3]
+        elements_to_be_added = [2, 3]
         group_id = mesh.addGroup("mynodegroup", "Edge")
         mesh.addGroupElements(group_id, elements_to_be_added)
 
@@ -635,27 +635,36 @@ class TestMeshGroups(unittest.TestCase):
         new_fm.read(testfile, vtk_cell_group_array="groups")
 
         self.assertEqual(new_fm.GroupCount, 1, msg="Wrong number of groups detected")
-        self.assertEqual(new_fm.getGroupName(new_fm.Groups[0]), "mynodegroup",
-                         msg="Group name not retained")
-        self.assertEqual(new_fm.getGroupElementType(new_fm.Groups[0]), "Edge",
-                         msg="Group type not retained")
+        self.assertEqual(
+            new_fm.getGroupName(new_fm.Groups[0]), "mynodegroup", msg="Group name not retained"
+        )
+        self.assertEqual(
+            new_fm.getGroupElementType(new_fm.Groups[0]), "Edge", msg="Group type not retained"
+        )
 
-        self.assertEqual(mesh.getGroupElements(mesh.Groups[0]),
-                         new_fm.getGroupElements(new_fm.Groups[0]),
-                         msg="Group elements not retained")
+        self.assertEqual(
+            mesh.getGroupElements(mesh.Groups[0]),
+            new_fm.getGroupElements(new_fm.Groups[0]),
+            msg="Group elements not retained",
+        )
 
         # try if this works with integer array data
         name_id_map = {"mynodegroup": 3}
-        mesh.write(testfile, vtk_cell_group_array="groups", vtk_group_id_map=name_id_map, highest=False)
+        mesh.write(
+            testfile, vtk_cell_group_array="groups", vtk_group_id_map=name_id_map, highest=False
+        )
         new_fm = Fem.FemMesh()
         new_fm.read(testfile, vtk_cell_group_array="groups")
         self.assertEqual(new_fm.GroupCount, 1, msg="Wrong number of groups detected")
-        self.assertEqual(new_fm.getGroupName(new_fm.Groups[0]), "3",
-                         msg="Group name not set to group id")
-        self.assertEqual(new_fm.getGroupElementType(new_fm.Groups[0]), "Edge",
-                         msg="Group type not retained")
+        self.assertEqual(
+            new_fm.getGroupName(new_fm.Groups[0]), "3", msg="Group name not set to group id"
+        )
+        self.assertEqual(
+            new_fm.getGroupElementType(new_fm.Groups[0]), "Edge", msg="Group type not retained"
+        )
 
-        self.assertEqual(mesh.getGroupElements(mesh.Groups[0]),
-                         new_fm.getGroupElements(new_fm.Groups[0]),
-                         msg="Group elements not retained")
-
+        self.assertEqual(
+            mesh.getGroupElements(mesh.Groups[0]),
+            new_fm.getGroupElements(new_fm.Groups[0]),
+            msg="Group elements not retained",
+        )


### PR DESCRIPTION
A fix for the (self created) issue #29368.

Re-enables mesh groups created by GMSH for VTK data-transfer. For this it was needed:
1. To add infrastructure to read and write groups to vtk files. This is very limited in functionality. Limitations are noted in the function documentations (only element/cell groups, not overlapping, continious cell IDs)
2. I added support to read VTK vertex cells. They are stored in the FemMesh as 0DElements, and are also correctly written to vtk files. This enables "Vertex" mesh groups, which are now also created.

@FEA-eng FYI
@marioalexis84  please test the functionality if it works as expected, you do know it best.