### PR TITLE
CAM: restore missing legacy posts

### DIFF
--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -321,22 +321,27 @@ SET(PathPythonPostGui_SRCS
 SET(PathPythonPostScripts_SRCS
     Path/Post/scripts/__init__.py
     Path/Post/scripts/centroid_legacy_post.py
+    Path/Post/scripts/centroid_post.py
     Path/Post/scripts/dxf_post.py
     Path/Post/scripts/dynapath_legacy_post.py
     Path/Post/scripts/dynapath_4060_legacy_post.py
     Path/Post/scripts/estlcam_legacy_post.py
+    Path/Post/scripts/fablin_legacy_post.py
     Path/Post/scripts/fanuc_legacy_post.py
     Path/Post/scripts/fangling_legacy_post.py
     Path/Post/scripts/gcode_pre.py
     Path/Post/scripts/generic_post.py
     Path/Post/scripts/generic_plasma_post.py
     Path/Post/scripts/grbl_post.py
+    Path/Post/scripts/grbl_legacy_post.py
     Path/Post/scripts/heidenhain_legacy_post.py
     Path/Post/scripts/KineticNCBeamicon2_legacy_post.py
     Path/Post/scripts/linuxcnc_post.py
     Path/Post/scripts/linuxcnc_legacy_post.py
     Path/Post/scripts/jtech_legacy_post.py
     Path/Post/scripts/mach3_mach4_legacy_post.py
+    Path/Post/scripts/mach3_mach4_post.py
+    Path/Post/scripts/masso_g3_post.py
     Path/Post/scripts/marlin_legacy_post.py
     Path/Post/scripts/nccad_legacy_post.py
     Path/Post/scripts/opensbp_legacy_post.py
@@ -350,6 +355,7 @@ SET(PathPythonPostScripts_SRCS
     Path/Post/scripts/smoothie_post.py
     Path/Post/scripts/snapmaker_legacy_post.py
     Path/Post/scripts/svg_post.py
+    Path/Post/scripts/uccnc_legacy_post.py
     Path/Post/scripts/wedm_legacy_post.py
 )
 
@@ -518,14 +524,17 @@ SET(Tests_SRCS
     CAMTests/test_holes00.fcstd
     CAMTests/TestCAMSanity.py
     CAMTests/TestCentroidLegacyPost.py
+    CAMTests/TestCentroidPost.py
     CAMTests/TestDxfPost.py
     CAMTests/TestFanucPost.py
     CAMTests/TestGenericPost.py
     CAMTests/TestGenericPlasma.py
+    CAMTests/TestGrblPost.py
     CAMTests/TestLinuxCNCPost.py
     CAMTests/TestLinkingGenerator.py
     CAMTests/TestMachine.py
     CAMTests/TestMach3Mach4LegacyPost.py
+    CAMTests/TestMach3Mach4Post.py
     CAMTests/TestMassoG3Post.py
     CAMTests/TestPathAdaptive.py
     CAMTests/TestPathCommandAnnotations.py

--- a/src/Mod/CAM/Path/Post/scripts/masso_g3_post.py
+++ b/src/Mod/CAM/Path/Post/scripts/masso_g3_post.py
@@ -51,8 +51,6 @@ else:
 #
 Values = Dict[str, Any]
 
-POST_TYPE = "machine"
-
 
 class Masso_G3(PostProcessor):
     """The Masso G3 post processor class."""

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -117,10 +117,10 @@ from CAMTests.TestLinuxCNCPost import TestLinuxCNCPost
 from CAMTests.TestDxfPost import TestDxfPost
 from CAMTests.TestFanucPost import TestFanucPost
 
-# from CAMTests.TestGrblPost import TestGrblPost
-# from CAMTests.TestMassoG3Post import TestMassoG3Post
-# from CAMTests.TestCentroidPost import TestCentroidPost
-# from CAMTests.TestMach3Mach4Post import TestMach3Mach4Post
+from CAMTests.TestGrblPost import TestGrblPost
+from CAMTests.TestMassoG3Post import TestMassoG3Post
+from CAMTests.TestCentroidPost import TestCentroidPost
+from CAMTests.TestMach3Mach4Post import TestMach3Mach4Post
 from CAMTests.TestTestPost import TestTestPost
 from CAMTests.TestPostGCodes import TestPostGCodes
 from CAMTests.TestPostMCodes import TestPostMCodes


### PR DESCRIPTION
Some legacy posts and tests were dropped from the cmake copy.
Restored.  Restore testing.