### PR TITLE
clarify step compound merge tooltip text

### DIFF
--- a/src/Mod/Import/Resources/ui/preferences-import.ui
+++ b/src/Mod/Import/Resources/ui/preferences-import.ui
@@ -83,7 +83,7 @@
    <item>
     <widget class="Gui::PrefCheckBox" name="checkBox">
      <property name="toolTip">
-      <string>If this is checked, Compound merge will be done during file reading (slower but higher details).</string>
+      <string>If checked, all shapes in the STEP file are merged into a single compound during import. Part instances are resolved and transforms applied, which increases import time. Geometry accuracy and rendering quality are not affected.</string>
      </property>
      <property name="text">
       <string>Enable STEP Compound merge</string>

--- a/src/Mod/Part/Gui/DlgImportStep.ui
+++ b/src/Mod/Part/Gui/DlgImportStep.ui
@@ -26,7 +26,7 @@
       <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxMergeCompound">
         <property name="toolTip">
-         <string>Merges compounds during file reading (slower but higher details)</string>
+         <string>Merges all shapes into a single compound during import, resolving part instances and applying transforms. Increases import time but does not affect geometry accuracy or rendering quality.</string>
         </property>
         <property name="text">
          <string>Enable STEP compound merge</string>

--- a/src/Mod/Part/Gui/Resources/translations/Part.ts
+++ b/src/Mod/Part/Gui/Resources/translations/Part.ts
@@ -3168,7 +3168,7 @@ Check one or more edge entities first.</source>
     </message>
     <message>
         <location filename="../../DlgImportStep.ui" line="29"/>
-        <source>Merges compounds during file reading (slower but higher details)</source>
+        <source>Merges all shapes into a single compound during import, resolving part instances and applying transforms. Increases import time but does not affect geometry accuracy or rendering quality.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
hey, saw #26297 and took a look

the "slower but higher details" tooltip for the STEP compound merge option was pretty misleading -- "higher details" implied geometry quality but it actually just resolves part instances into a single flat compound. updated both ui files and the Part.ts source string to say what it actually does: increases import time by resolving instances, but doesnt change geometry accuracy or rendering quality.

fixes #26297

---

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
