### PR TITLE
add macos trackpad pinch-to-zoom via native gesture events

### DIFF
--- a/src/Gui/SoTouchEvents.cpp
+++ b/src/Gui/SoTouchEvents.cpp
@@ -25,6 +25,7 @@
 
 #include <QApplication>
 #include <QGestureEvent>
+#include <QNativeGestureEvent>
 #include <QWidget>
 
 #include <Base/Exception.h>
@@ -205,8 +206,66 @@ const SoEvent* GesturesDevice::translateEvent(QEvent* event)
         auto sg = static_cast<QSwipeGesture*>(gevent->gesture(Qt::SwipeGesture));
         if (sg) {
             gevent->setAccepted(Qt::SwipeGesture, true);
-            return new SoGesturePanEvent(pg, this->widget);
+            return new SoGestureSwipeEvent(sg, this->widget);
         }
     }
+
+    // handle macOS native trackpad gestures (pinch-to-zoom)
+    // Qt::BeginNativeGesture and Qt::EndNativeGesture are macOS-specific,
+    // so nativeGestureActive stays false on other platforms and zoom updates
+    // are safely ignored there.
+    if (event->type() == QEvent::NativeGesture) {
+        auto* nge = static_cast<QNativeGestureEvent*>(event);
+        const Qt::NativeGestureType gestureType = nge->gestureType();
+
+        int h = widget->height();
+        SbVec2f center(nge->pos().x(), h - nge->pos().y());
+
+        auto* pinch = new SoGesturePinchEvent();
+        pinch->deltaAngle = 0;
+        pinch->totalAngle = 0;
+        pinch->deltaCenter = SbVec2f(0, 0);
+
+        if (gestureType == Qt::BeginNativeGesture) {
+            nativeGestureAccumZoom = 1.0;
+            nativeGestureCenter = center;
+            nativeGestureActive = true;
+            pinch->state = SoGestureEvent::SbGSStart;
+            pinch->deltaZoom = 1.0;
+            pinch->totalZoom = 1.0;
+            pinch->startCenter = center;
+            pinch->curCenter = center;
+        }
+        else if (gestureType == Qt::ZoomNativeGesture && nativeGestureActive) {
+            double delta = nge->value();
+            nativeGestureAccumZoom *= (1.0 + delta);
+            pinch->state = SoGestureEvent::SbGSUpdate;
+            pinch->deltaZoom = 1.0 + delta;
+            pinch->totalZoom = nativeGestureAccumZoom;
+            pinch->startCenter = nativeGestureCenter;
+            pinch->curCenter = center;
+        }
+        else if (gestureType == Qt::EndNativeGesture && nativeGestureActive) {
+            nativeGestureActive = false;
+            pinch->state = SoGestureEvent::SbGSEnd;
+            pinch->deltaZoom = 1.0;
+            pinch->totalZoom = nativeGestureAccumZoom;
+            pinch->startCenter = nativeGestureCenter;
+            pinch->curCenter = center;
+        }
+        else {
+            delete pinch;
+            return nullptr;
+        }
+
+        pinch->setPosition(SbVec2s(static_cast<short>(center[0]), static_cast<short>(center[1])));
+        Qt::KeyboardModifiers mods = QApplication::keyboardModifiers();
+        pinch->setAltDown(mods.testFlag(Qt::AltModifier));
+        pinch->setCtrlDown(mods.testFlag(Qt::ControlModifier));
+        pinch->setShiftDown(mods.testFlag(Qt::ShiftModifier));
+        pinch->setTime(SbTime::getTimeOfDay());
+        return pinch;
+    }
+
     return nullptr;
 }

--- a/src/Gui/SoTouchEvents.h
+++ b/src/Gui/SoTouchEvents.h
@@ -139,4 +139,10 @@ public:
 
 protected:
     QWidget* widget;
+
+private:
+    // state for native gesture sequences (e.g. macOS trackpad pinch)
+    double nativeGestureAccumZoom {1.0};
+    SbVec2f nativeGestureCenter;
+    bool nativeGestureActive {false};
 };


### PR DESCRIPTION
hey, saw #5938 and took a look

added handling for `QNativeGestureEvent` in `GesturesDevice::translateEvent()` so macOS trackpad pinch gestures (BeginNativeGesture → ZoomNativeGesture → EndNativeGesture) get translated into the existing `SoGesturePinchEvent` pipeline instead of falling through unhandled. also fixed a pre-existing bug in the swipe gesture branch that was passing a null `pg` pointer and using the wrong event type -- it was creating a `SoGesturePanEvent(pg, ...)` when it should have been `SoGestureSwipeEvent(sg, ...)`. the `nativeGestureActive` flag means zoom updates without a preceding begin event are ignored, so non-mac platforms wont be affected.

fixes #5938

---

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
