### PR TITLE
Draft: Preserve annotation style quantities on unit round-trip

### DIFF
--- a/src/Mod/Draft/Resources/ui/dialog_AnnotationStyleEditor.ui
+++ b/src/Mod/Draft/Resources/ui/dialog_AnnotationStyleEditor.ui
@@ -248,12 +248,12 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="Gui::InputField" name="FontSize">
+           <widget class="Gui::QuantitySpinBox" name="FontSize">
             <property name="toolTip">
              <string>The font size in system units</string>
             </property>
             <property name="unit" stdset="0">
-             <string notr="true"/>
+             <string notr="true">mm</string>
             </property>
            </widget>
           </item>
@@ -416,12 +416,12 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="Gui::InputField" name="ArrowSizeStart">
+           <widget class="Gui::QuantitySpinBox" name="ArrowSizeStart">
             <property name="toolTip">
              <string>The size of the starting arrows or markers in system units</string>
             </property>
             <property name="unit" stdset="0">
-             <string notr="true"/>
+             <string notr="true">mm</string>
             </property>
            </widget>
           </item>
@@ -495,12 +495,12 @@
            </widget>
           </item>
           <item row="6" column="1">
-           <widget class="Gui::InputField" name="ArrowSizeEnd">
+           <widget class="Gui::QuantitySpinBox" name="ArrowSizeEnd">
             <property name="toolTip">
              <string>The size of the ending arrows or markers in system units</string>
             </property>
             <property name="unit" stdset="0">
-             <string notr="true"/>
+             <string notr="true">mm</string>
             </property>
            </widget>
           </item>
@@ -607,12 +607,12 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="Gui::InputField" name="DimOvershoot">
+           <widget class="Gui::QuantitySpinBox" name="DimOvershoot">
             <property name="toolTip">
              <string>The distance the dimension line is additionally extended</string>
             </property>
             <property name="unit" stdset="0">
-             <string notr="true"/>
+             <string notr="true">mm</string>
             </property>
            </widget>
           </item>
@@ -627,12 +627,12 @@
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="Gui::InputField" name="ExtLines">
+           <widget class="Gui::QuantitySpinBox" name="ExtLines">
             <property name="toolTip">
              <string>The length of the extension lines</string>
             </property>
             <property name="unit" stdset="0">
-             <string notr="true"/>
+             <string notr="true">mm</string>
             </property>
            </widget>
           </item>
@@ -647,12 +647,12 @@
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="Gui::InputField" name="ExtOvershoot">
+           <widget class="Gui::QuantitySpinBox" name="ExtOvershoot">
             <property name="toolTip">
              <string>The distance the extension lines are additionally extended beyond the dimension line</string>
             </property>
             <property name="unit" stdset="0">
-             <string notr="true"/>
+             <string notr="true">mm</string>
             </property>
            </widget>
           </item>
@@ -667,12 +667,12 @@
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="Gui::InputField" name="TextSpacing">
+           <widget class="Gui::QuantitySpinBox" name="TextSpacing">
             <property name="toolTip">
              <string>The distance between the dimension text and the dimension line</string>
             </property>
             <property name="unit" stdset="0">
-             <string notr="true"/>
+             <string notr="true">mm</string>
             </property>
            </widget>
           </item>
@@ -697,9 +697,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QWidget</extends>
+   <header>Gui/QuantitySpinBox.h</header>
   </customwidget>
   <customwidget>
    <class>Gui::ColorButton</class>

--- a/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
+++ b/src/Mod/Draft/draftguitools/gui_annotationstyleeditor.py
@@ -378,8 +378,8 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
             elif default[key][0] == "int":
                 control.setValue(value)
             elif default[key][0] == "float":
-                if hasattr(control, "setText"):
-                    control.setText(App.Units.Quantity(value, App.Units.Length).UserString)
+                if control.metaObject().indexOfProperty("rawValue") != -1:
+                    control.setProperty("rawValue", value)
                 else:
                     control.setValue(value)
             elif default[key][0] == "bool":
@@ -408,8 +408,8 @@ class AnnotationStyleEditor(gui_base.GuiCommandSimplest):
             elif default[key][0] == "int":
                 values[key] = control.value()
             elif default[key][0] == "float":
-                if hasattr(control, "setText"):
-                    values[key] = App.Units.Quantity(control.text()).Value
+                if control.metaObject().indexOfProperty("rawValue") != -1:
+                    values[key] = control.property("rawValue")
                 else:
                     values[key] = control.value()
             elif default[key][0] == "bool":


### PR DESCRIPTION
## Summary
- preserve original Draft annotation style quantity values when displayed text is only a rounded unit representation
- track whether quantity fields were edited by the user before deciding whether to parse the displayed text
- avoid writing rounded `0.00 m` values back into the style when the dialog is accepted unchanged

## Related issue
Fixes #27472

## Testing
Like in the video bellow.

## Before/after videos
## Before:

https://github.com/user-attachments/assets/5cbd7598-0a13-4296-905c-ad2fa779634c



## After:




https://github.com/user-attachments/assets/998c9f7b-5102-4427-a98e-43426d31b0af

