### PR TITLE
3rdParty: Fix macOS Navlib regression in 862dae0

### DIFF
--- a/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
+++ b/src/Gui/3Dconnexion/navlib/NavlibNavigation.cpp
@@ -51,7 +51,10 @@
 #include <Base/Console.h>
 
 #if defined(Q_OS_MAC)
-#include <CoreFoundation/CFBundle.h>
+#include <QCoreApplication>
+#include <libproc.h>
+#include <objc/message.h>
+#include <objc/runtime.h>
 #endif
 
 NavlibInterface::NavlibInterface()
@@ -187,15 +190,83 @@ void NavlibInterface::onViewChanged(const Gui::MDIView* view)
     }
 }
 
+#if defined(Q_OS_MAC)
+// Navlib appears to require two things to recognize an application:
+//
+// 1. The process's executable path (as resolved by the kernel) must be
+//    inside an .app bundle.
+//
+// 2. The process must have been launched through LaunchServices (e.g.
+//    via `open FreeCAD.app`), which registers the bundle identity with
+//    the window server.  Running the binary directly skips this.
+
+static bool NavlibCanRecognizeApp()
+{
+    bool ok = true;
+
+    // Is the executable inside an .app bundle?
+    bool inBundle = false;
+    QString path;
+    char pathbuf[PROC_PIDPATHINFO_MAXSIZE];
+    if (proc_pidpath(QCoreApplication::applicationPid(), pathbuf, sizeof(pathbuf)) > 0) {
+        path = QString::fromUtf8(pathbuf);
+        if (path.contains(QLatin1String(".app/"))) {
+            inBundle = true;
+        }
+    }
+    if (!inBundle) {
+        Base::Console().log("3Dconnexion: executable path is %s\n", path.toUtf8().constData());
+        Base::Console().log("3Dconnexion Navigation Framework requires the executable path to be inside an .app bundle.\n");
+        Base::Console().error("3Dconnexion Navigation Framework cannot recognize this build of FreeCAD.\n");
+        ok = false;
+    }
+
+    // Was the application launched through LaunchServices?
+    //
+    // Use the Objective-C runtime to call:
+    //   [[NSRunningApplication currentApplication] bundleIdentifier]
+    // This returns the bundle ID registered by LaunchServices (by PID),
+    // which is only set when the app is launched via `open` or equivalent.
+    bool hasLaunchServicesId = false;
+    Class raClass = objc_getClass("NSRunningApplication");
+    if (raClass) {
+        using MsgSendId = id (*)(id, SEL);
+        using MsgSendStr = const char* (*)(id, SEL);
+        auto msgSend = reinterpret_cast<MsgSendId>(objc_msgSend);
+        id currentApp = msgSend(reinterpret_cast<id>(raClass),
+                                sel_registerName("currentApplication"));
+        if (currentApp) {
+            id bundleId = msgSend(currentApp, sel_registerName("bundleIdentifier"));
+            if (bundleId) {
+                auto msgSendUTF8 = reinterpret_cast<MsgSendStr>(objc_msgSend);
+                const char* idStr = msgSendUTF8(bundleId,
+                                                sel_registerName("UTF8String"));
+                if (idStr && idStr[0]) {
+                    hasLaunchServicesId = true;
+                    // Base::Console().log("3Dconnexion: LaunchServices bundle ID is %s\n", idStr);
+                }
+            }
+        }
+    }
+    if (!hasLaunchServicesId) {
+        Base::Console().log("3Dconnexion: no LaunchServices bundle identity.\n");
+        Base::Console().error("3Dconnexion Navigation Framework requires FreeCAD to be launched by opening the .app.\n");
+        ok = false;
+    }
+
+    return ok;
+}
+#endif
+
 void NavlibInterface::enableNavigation()
 {
 #if defined(Q_OS_MAC)
-    if (!CFBundleGetIdentifier(CFBundleGetMainBundle())) {
-        // As of 3DxWare version 10.8.11, EnableNavigation will silently fail if there's
-        // no bundle identifier. This happens when executing the binary directly rather
+    if (!NavlibCanRecognizeApp()) {
+        // As of 3DxWare version 10.8.11, EnableNavigation will silently fail if these
+        // tests fail. This primarily happens when executing the binary directly rather
         // than opening the .app. If future versions of the driver report the error,
         // this special case can be removed.
-        Base::Console().error("3Dconnexion Navigation Framework does not support running apart from an .app!\n");
+        Base::Console().error("3Dconnexion Navigation Framework disabled.\n");
         return;
     }
 #endif


### PR DESCRIPTION
Release builds unexpectedly failed the bundle check due to their launcher stub, disabling the SpaceMouse drivers.

The parallel PR #29411, which harmonizes the local and release build process, assisted in diagnosing and testing this fix.

## Issues
Fixes #29003.