### PR TITLE
CAM: sort wires when approximating edges

### DIFF
--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -223,7 +223,7 @@ def approximateWire(wire, tolerance=0.01):
 
     # Reassemble the wire if any edges were replaced
     if modified:
-        return Part.Wire(processed_edges)
+        return Part.Wire(Part.__sortEdges__(processed_edges))
     return wire
 
 


### PR DESCRIPTION
Follow-up on #28645

See [my comment](#28645) on the issue, and @tarman3's test case before it