### PR TITLE
TechDraw: correct dimension placement in tree on undo operation after deletion

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -126,7 +126,6 @@ DrawViewDimension::DrawViewDimension()
                       (App::Prop_None),
                       "3D Geometry References");
     References3D.setScope(App::LinkScope::Global);
-
     ADD_PROPERTY_TYPE(FormatSpec,
                       (getDefaultFormatSpec()),
                       "Format",
@@ -300,6 +299,18 @@ void DrawViewDimension::resetArea()
     m_areaPoint.actualArea = 0.0;
 }
 
+void DrawViewDimension::onBeforeChange(const App::Property* prop)
+{
+    // re-parenting of tree on 2D reference changes
+    if (prop == &References2D && !isRestoring()) {
+        auto* dvp = getViewPart();
+        if (dvp) {
+            dvp->touch();
+        }
+    }
+    DrawView::onBeforeChange(prop);
+}
+
 void DrawViewDimension::onChanged(const App::Property* prop)
 {
     if (prop == &References3D) {
@@ -317,6 +328,10 @@ void DrawViewDimension::onChanged(const App::Property* prop)
 
     if (prop == &References2D) {
         updateSavedGeometry();
+        auto* dvp = getViewPart();
+        if (dvp) {
+            dvp->touch();
+        }
     }
     else if (prop == &References3D) {
         // remove the old measurement object

--- a/src/Mod/TechDraw/App/DrawViewDimension.h
+++ b/src/Mod/TechDraw/App/DrawViewDimension.h
@@ -232,6 +232,7 @@ public:
 protected:
     void handleChangedPropertyType(Base::XMLReader& reader, const char* typeName, App::Property* propss) override;
     void Restore(Base::XMLReader& reader) override;
+    void onBeforeChange(const App::Property* prop) override;
     void onChanged(const App::Property* prop) override;
     void onDocumentRestored() override;
     std::string getPrefixForDimType() const;


### PR DESCRIPTION
Fixes #24110 
Currently if you delete a dimension & then undo it, the dimension nesting order in the tree is wrong. To fix it, I added touch to the view before change and on change of 2D references, so it refreshes tree to correct nesting.

<img width="1216" height="526" alt="1" src="https://github.com/user-attachments/assets/20a9ad99-a0f8-46af-b089-d5586f58cdb8" />
