### PR TITLE
Part: make MultiFuse "not enough shapes" error actionable

### DIFF
--- a/src/Mod/Part/App/FeaturePartFuse.cpp
+++ b/src/Mod/Part/App/FeaturePartFuse.cpp
@@ -227,7 +227,24 @@ App::DocumentObjectExecReturn* MultiFuse::execute()
         }
     }
     else {
-        throw Base::CADKernelError("Not enough shape objects linked");
+        if (obj.empty()) {
+            throw Base::CADKernelError(
+                "MultiFuse has no linked shapes. Add at least two solids "
+                "to the Shapes list."
+            );
+        }
+        if (!argumentsAreInCompound) {
+            const std::string label = obj[0]->Label.getValue();
+            throw Base::CADKernelError((std::string("MultiFuse has only one linked shape ('") + label
+                                        + "'). Add at least one more solid to the Shapes list, "
+                                          "or supply a compound containing two or more solids.")
+                                           .c_str());
+        }
+        // Single compound input that didn't expand to >= 2 children.
+        throw Base::CADKernelError((std::string("MultiFuse received a compound with ")
+                                    + std::to_string(shapes.size())
+                                    + " child shape(s); at least 2 are required.")
+                                       .c_str());
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the static `"Not enough shape objects linked"` throw in `MultiFuse::execute()` with three branches that report the actual failure: empty `Shapes`, single non-compound input (naming the object's label), or single compound with fewer than two children (reporting the child count).
- Matches the actionable-message style already used elsewhere in Part for boolean-input diagnostics.

## Motivation

When a `MultiFuse`/Union loses inputs — e.g. because an upstream feature was deleted, or a Shapes entry was never populated — the previous message said nothing about which object was involved or what was missing. Identifying the failing node in a large assembly required opening the property editor and guessing. The new messages tell the user which `MultiFuse` is complaining and what to add.

## Before / after

Before:
```
Generalized-Window: Not enough shape objects linked
```

After (the common case — a single non-compound input):
```
Generalized-Window: MultiFuse has only one linked shape ('Cut'). Add at
least one more solid to the Shapes list, or supply a compound containing
two or more solids.
```

## Test plan

- [x] A `MultiFuse` with an empty `Shapes` list reports the empty-list message on recompute.
- [x] A `MultiFuse` with one `Part::Box` reports the single-input message and names the box's label.
- [x] A `MultiFuse` pointed at a single `Part::Compound` containing fewer than two solids reports the child-count message.
- [x] Normal operation with two or more solids is unchanged.