### PR TITLE
Gui: pre-select near filter entity within pick radius on hover

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3446,33 +3446,25 @@ SoPickedPoint* View3DInventorViewer::pickPoint(const SbVec2s& pos) const
     SoRayPickAction rp(getSoRenderManager()->getViewportRegion());
     rp.setPoint(pos);
     rp.apply(getSoRenderManager()->getSceneGraph());
-
-    // returns a copy of the point
     SoPickedPoint* pick = rp.getPickedPoint();
-    // return (pick ? pick->copy() : 0); // needs the same instance of CRT under MS Windows
     return (pick ? new SoPickedPoint(*pick) : nullptr);
 }
-
-const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) const
-{
+const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) const{
     if (selectionRoot) {
         auto ret = selectionRoot->getPickedList(n->getAction(), true);
         auto passesFilter = [&](const SoPickedPoint* pp) -> bool {
-            if (!pp) {
-                return false;
-            }
-            App::DocumentObject* obj = nullptr;
-            std::string subname;
-            if (!Gui::ViewProvider::getElementPicked(pp, obj, subname)) {
-                return false;
-            }
-            if (!obj) {
-                return false;
-            }
-            App::Document* doc = obj->getDocument();
-            return Gui::Selection().testSelection(doc, obj, subname.c_str());
-        };
 
+            if (!pp)
+                return false;
+            std::string subname;
+            Gui::ViewProvider* vp = Gui::ViewProvider::getElementPicked(pp, subname);
+            if (!vp)
+                return false;
+            App::DocumentObject* obj = vp->getObject();
+            if (!obj)
+                return false;
+            return Gui::Selection().isSelectable(obj, subname.c_str());
+        };
         if (!ret.empty()) {
             const SoPickedPoint* top = ret[0].pp;
             if (passesFilter(top)) {
@@ -3483,19 +3475,20 @@ const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) co
                     return ret[i].pp;
                 }
             }
+            if (!n->getEvent())
+                return nullptr;
+            
             const SbVec2s cursorPos = n->getEvent()->getPosition();
             constexpr float pickRadius = 10.0f;
-
             SoRayPickAction rp(getSoRenderManager()->getViewportRegion());
             rp.setPoint(cursorPos);
             rp.setRadius(pickRadius);
             rp.setPickAll(true);
             rp.apply(getSoRenderManager()->getSceneGraph());
-
             const SoPickedPointList& nearby = rp.getPickedPointList();
             for (int i = 0; i < nearby.getLength(); ++i) {
                 if (passesFilter(nearby[i])) {
-                    return nearby[i];
+                    return new SoPickedPoint(*nearby[i]);
                 }
             }
             return nullptr;
@@ -3503,6 +3496,7 @@ const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) co
     }
     return n->getPickedPoint();
 }
+
 
 bool View3DInventorViewer::pubSeekToPoint(const SbVec2s& pos)
 {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3457,10 +3457,43 @@ const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) co
 {
     if (selectionRoot) {
         auto ret = selectionRoot->getPickedList(n->getAction(), true);
+        auto passesFilter = [&](const SoPickedPoint* pp) -> bool {
+            if (!pp)
+                return false;
+            App::DocumentObject* obj = nullptr;
+            std::string subname;
+            if (!Gui::ViewProvider::getElementPicked(pp, obj, subname))
+                return false;
+            if (!obj)
+                return false;
+            App::Document* doc = obj->getDocument();
+            return Gui::Selection().testSelection(doc, obj, subname.c_str());
+        };
+
         if (!ret.empty()) {
-            return ret[0].pp;
+            const SoPickedPoint* top = ret[0].pp;
+            if (passesFilter(top))
+                return top;
+            for (size_t i = 1; i < ret.size(); ++i) {
+                if (passesFilter(ret[i].pp))
+                    return ret[i].pp;
+            }
+            const SbVec2s cursorPos = n->getEvent()->getPosition();
+            constexpr float pickRadius = 10.0f;
+
+            SoRayPickAction rp(getSoRenderManager()->getViewportRegion());
+            rp.setPoint(cursorPos);
+            rp.setRadius(pickRadius);
+            rp.setPickAll(true);
+            rp.apply(getSoRenderManager()->getSceneGraph());
+
+            const SoPickedPointList& nearby = rp.getPickedPointList();
+            for (int i = 0; i < nearby.getLength(); ++i) {
+                if (passesFilter(nearby[i]))
+                    return nearby[i];
+            }
+            return nullptr;
         }
-        return nullptr;
     }
     return n->getPickedPoint();
 }

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3458,25 +3458,30 @@ const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) co
     if (selectionRoot) {
         auto ret = selectionRoot->getPickedList(n->getAction(), true);
         auto passesFilter = [&](const SoPickedPoint* pp) -> bool {
-            if (!pp)
+            if (!pp) {
                 return false;
+            }
             App::DocumentObject* obj = nullptr;
             std::string subname;
-            if (!Gui::ViewProvider::getElementPicked(pp, obj, subname))
+            if (!Gui::ViewProvider::getElementPicked(pp, obj, subname)) {
                 return false;
-            if (!obj)
+            }
+            if (!obj) {
                 return false;
+            }
             App::Document* doc = obj->getDocument();
             return Gui::Selection().testSelection(doc, obj, subname.c_str());
         };
 
         if (!ret.empty()) {
             const SoPickedPoint* top = ret[0].pp;
-            if (passesFilter(top))
+            if (passesFilter(top)) {
                 return top;
+            }
             for (size_t i = 1; i < ret.size(); ++i) {
-                if (passesFilter(ret[i].pp))
+                if (passesFilter(ret[i].pp)) {
                     return ret[i].pp;
+                }
             }
             const SbVec2s cursorPos = n->getEvent()->getPosition();
             constexpr float pickRadius = 10.0f;
@@ -3489,8 +3494,9 @@ const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) co
 
             const SoPickedPointList& nearby = rp.getPickedPointList();
             for (int i = 0; i < nearby.getLength(); ++i) {
-                if (passesFilter(nearby[i]))
+                if (passesFilter(nearby[i])) {
                     return nearby[i];
+                }
             }
             return nullptr;
         }

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -3449,20 +3449,23 @@ SoPickedPoint* View3DInventorViewer::pickPoint(const SbVec2s& pos) const
     SoPickedPoint* pick = rp.getPickedPoint();
     return (pick ? new SoPickedPoint(*pick) : nullptr);
 }
-const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) const{
+const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) const
+{
     if (selectionRoot) {
         auto ret = selectionRoot->getPickedList(n->getAction(), true);
         auto passesFilter = [&](const SoPickedPoint* pp) -> bool {
-
-            if (!pp)
+            if (!pp) {
                 return false;
+            }
             std::string subname;
             Gui::ViewProvider* vp = Gui::ViewProvider::getElementPicked(pp, subname);
-            if (!vp)
+            if (!vp) {
                 return false;
+            }
             App::DocumentObject* obj = vp->getObject();
-            if (!obj)
+            if (!obj) {
                 return false;
+            }
             return Gui::Selection().isSelectable(obj, subname.c_str());
         };
         if (!ret.empty()) {
@@ -3475,9 +3478,10 @@ const SoPickedPoint* View3DInventorViewer::getPickedPoint(SoEventCallback* n) co
                     return ret[i].pp;
                 }
             }
-            if (!n->getEvent())
+            if (!n->getEvent()) {
                 return nullptr;
-            
+            }
+
             const SbVec2s cursorPos = n->getEvent()->getPosition();
             constexpr float pickRadius = 10.0f;
             SoRayPickAction rp(getSoRenderManager()->getViewportRegion());


### PR DESCRIPTION
this will contain the pre-selected filter near to hover radius and the cpp part fall back to pick radius depending upon entity selection.

As per the description in #28979 the passfilter now get to wider set of points and in first pass candidates come from selectionRoot->getPickedList() (i.e the cursor point) and second for radius that is from SoRayPickAction with setRadius(10.0f).
