### PR TITLE
App: avoid parent touch on child visibility changes

### DIFF
--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -408,9 +408,10 @@ void GroupExtension::extensionOnChanged(const Property* p)
 
 void GroupExtension::slotChildChanged(const DocumentObject& obj, const Property& prop)
 {
-    if (&prop == &obj.Visibility) {
-        _GroupTouched.touch();
-    }
+    // Child visibility is a view-state sync, not a model dependency change.
+    // Touching the parent here makes simple eye toggles look like recompute work.
+    (void)obj;
+    (void)prop;
 }
 
 bool GroupExtension::extensionGetSubObject(DocumentObject*& ret,

--- a/src/Mod/Part/TestPartGui.py
+++ b/src/Mod/Part/TestPartGui.py
@@ -80,6 +80,31 @@ class PartGuiViewProviderTestCases(unittest.TestCase):
         with self.assertRaises(TypeError):
             box.ViewObject.dropObject(box, 0)
 
+    def testNestedPartVisibilityDoesNotTouchParent(self):
+        parent = self.Doc.addObject("App::Part", "Parent")
+        child = self.Doc.addObject("App::Part", "Child")
+        parent.addObject(child)
+        self.Doc.recompute()
+
+        self.assertNotIn("Touched", parent.State)
+        self.assertFalse(parent.MustExecute)
+
+        FreeCADGui.Selection.clearSelection()
+        FreeCADGui.Selection.addSelection(self.Doc.Name, child.Name)
+        FreeCADGui.runCommand("Std_ToggleVisibility", 0)
+        QtWidgets.QApplication.processEvents()
+
+        self.assertFalse(child.Visibility)
+        self.assertNotIn("Touched", parent.State)
+        self.assertFalse(parent.MustExecute)
+
+        FreeCADGui.runCommand("Std_ToggleVisibility", 0)
+        QtWidgets.QApplication.processEvents()
+
+        self.assertTrue(child.Visibility)
+        self.assertNotIn("Touched", parent.State)
+        self.assertFalse(parent.MustExecute)
+
     def tearDown(self):
         # closing doc
         FreeCAD.closeDocument("PartGuiTest")


### PR DESCRIPTION
This fixes the false recompute markers when toggling visibility on non-empty BIM container hierarchies and adds a focused nested `App::Part` GUI regression for the shared owner-layer path.

Validation: `TestPartGui.PartGuiViewProviderTestCases.testNestedPartVisibilityDoesNotTouchParent`

## Issues
Fixes #21674

## Before and After Images

N/A. The visible change is the recompute/touched state in the tree after a visibility toggle; the fix is covered by the added GUI regression.
