### PR TITLE
Gui: do not restore Selection view panel when toggling bottom panels

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -4272,7 +4272,7 @@ void StdCmdToggleBottomPanels::activated(int iMsg)
         // No visible bottom panels: restore the previously hidden ones. The default covers a fresh
         // install with no saved state.
         const auto savedNames = QString::fromStdString(
-            hGrp->GetASCII("HiddenBottomWidgets", "Python console;;Report view;;Selection view")
+            hGrp->GetASCII("HiddenBottomWidgets", "Python console;;Report view")
         );
         QStringList panelNamesToRestore = savedNames.split(QStringLiteral(";;"));
 


### PR DESCRIPTION
Do not restore the Selection view panel as a bottom panel, since by default it is a side panel. Restoration of the Selection panel was carried over from the original BIM code, but it appears it would have been an issue there too.

I'm setting this as draft for now: the fix seems obvious at a glance, but I've not looked at side effects in detail yet, and the local branch build has not yet finished. 

## Issues

Fixes: #29468