### PR TITLE
CAM: Set StartPoint from Task panel

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpPocketFullEdit.ui
@@ -166,14 +166,14 @@ The latter can be used to face of the entire stock area to ensure uniform height
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel" name="zigZagAngle_label">
+       <widget class="QLabel" name="angle_label">
         <property name="text">
          <string>Angle</string>
         </property>
        </widget>
       </item>
       <item row="2" column="1">
-       <widget class="Gui::InputField" name="zigZagAngle">
+       <widget class="Gui::InputField" name="angle">
         <property name="toolTip">
          <string>Angle in which the pattern is applied</string>
         </property>
@@ -226,16 +226,6 @@ The latter can be used to face of the entire stock area to ensure uniform height
     <widget class="QWidget" name="pocketWidget">
      <layout class="QGridLayout" name="gridLayout">
       <item row="1" column="0">
-       <widget class="QCheckBox" name="useStartPoint">
-        <property name="toolTip">
-         <string>Specify if this operation uses a starting point</string>
-        </property>
-        <property name="text">
-         <string>Use start point</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
        <widget class="QCheckBox" name="useOutline">
         <property name="toolTip">
          <string>If selected the operation uses the outline of the selected base geometry and ignores all holes</string>
@@ -269,10 +259,35 @@ The latter can be used to face of the entire stock area to ensure uniform height
         </property>
        </widget>
       </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="useStartPoint">
+        <property name="toolTip">
+         <string>Specify if this operation uses a starting point</string>
+        </property>
+        <property name="text">
+         <string>Use start point</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QToolButton" name="setStartPoint">
+        <property name="toolTip">
+         <string>Set picked point as start point</string>
+        </property>
+        <property name="text">
+         <string notr="true">…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg
+         </iconset>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <spacer name="verticalSpacer_2">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageOpProfileFullEdit.ui
@@ -165,16 +165,6 @@
    <item row="2" column="0">
     <widget class="QWidget" name="widget_2">
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="useStartPoint">
-        <property name="toolTip">
-         <string>Check if this operation should use a starting point</string>
-        </property>
-        <property name="text">
-         <string>Use Start Point</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1">
        <widget class="QCheckBox" name="processHoles">
         <property name="toolTip">
@@ -215,10 +205,35 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="useStartPoint">
+        <property name="toolTip">
+         <string>Check if this operation should use a starting point</string>
+        </property>
+        <property name="text">
+         <string>Use start point</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QToolButton" name="setStartPoint">
+        <property name="toolTip">
+         <string>Set picked point as start point</string>
+        </property>
+        <property name="text">
+         <string notr="true">…</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/icons/button_left.svg</normaloff>:/icons/button_left.svg
+         </iconset>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/CAM/Path/Op/Gui/PocketBase.py
+++ b/src/Mod/CAM/Path/Op/Gui/PocketBase.py
@@ -193,3 +193,17 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
             signals.append(self.form.clearEdges.clicked)
 
         return signals
+
+    def registerSignalHandlers(self, obj):
+        self.form.setStartPoint.clicked.connect(self.setStartPoint)
+
+    def setStartPoint(self):
+        selEx = FreeCADGui.Selection.getSelectionEx()
+        if selEx and selEx[0].PickedPoints:
+            point = selEx[0].PickedPoints[0]
+            self.obj.StartPoint = point
+            self.setDirty()
+            Path.Log.info(
+                translate("CAM_Pocket", "Set start point: %s, %s")
+                % (round(point.x, 3), round(point.y, 3))
+            )

--- a/src/Mod/CAM/Path/Op/Gui/Profile.py
+++ b/src/Mod/CAM/Path/Op/Gui/Profile.py
@@ -26,7 +26,7 @@ import FreeCADGui
 import Path.Base.Gui.Util as PathGuiUtil
 import Path.Op.Gui.Base as PathOpGui
 import Path.Op.Profile as PathProfile
-import PathGui
+import Path
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 __title__ = "CAM Profile Operation UI"
@@ -34,6 +34,7 @@ __author__ = "sliptonic (Brad Collette)"
 __url__ = "https://www.freecad.org"
 __doc__ = "Profile operation page controller and command implementation."
 
+translate = FreeCAD.Qt.translate
 
 FeatureSide = 0x01
 FeatureProcessing = 0x02
@@ -171,6 +172,19 @@ class TaskPanelOpPage(PathOpGui.TaskPanelPage):
         else:  # Qt version < 6.7.0
             self.form.useCompensation.stateChanged.connect(self.updateVisibility)
         self.form.numPasses.editingFinished.connect(self.updateVisibility)
+
+        self.form.setStartPoint.clicked.connect(self.setStartPoint)
+
+    def setStartPoint(self):
+        selEx = FreeCADGui.Selection.getSelectionEx()
+        if selEx and selEx[0].PickedPoints:
+            point = selEx[0].PickedPoints[0]
+            self.obj.StartPoint = point
+            self.setDirty()
+            Path.Log.info(
+                translate("CAM_Profile", "Set start point: %s, %s")
+                % (round(point.x, 3), round(point.y, 3))
+            )
 
 
 # Eclass

--- a/src/Mod/CAM/Path/Op/Gui/Selection.py
+++ b/src/Mod/CAM/Path/Op/Gui/Selection.py
@@ -173,26 +173,19 @@ class FACEGate(PathBaseGate):
 
 class PROFILEGate(PathBaseGate):
     def allow(self, doc, obj, sub):
-        if sub and sub[0:4] == "Edge":
-            return True
-
         try:
             obj = obj.Shape
         except Exception:
             return False
 
-        if obj.ShapeType == "Compound":
-            if sub and sub[0:4] == "Face":
-                return True
-
-        elif obj.ShapeType == "Face":
+        if not sub:
             return True
-
-        elif obj.ShapeType == "Solid":
-            if sub and sub[0:4] == "Face":
-                return True
-
-        elif obj.ShapeType == "Wire":
+        if sub.startswith("Edge"):
+            return True
+        if sub.startswith("Face"):
+            return True
+        if sub.startswith("Vertex"):
+            # required for setStartPoint
             return True
 
         return False
@@ -200,28 +193,22 @@ class PROFILEGate(PathBaseGate):
 
 class POCKETGate(PathBaseGate):
     def allow(self, doc, obj, sub):
-
-        pocketable = False
         try:
             obj = obj.Shape
         except Exception:
             return False
 
-        if obj.ShapeType == "Edge":
-            pocketable = False
+        if not sub:
+            return False
+        if sub.startswith("Edge"):
+            return True
+        if sub.startswith("Face"):
+            return True
+        if sub.startswith("Vertex"):
+            # required for setStartPoint
+            return True
 
-        elif obj.ShapeType == "Face":
-            pocketable = True
-
-        elif obj.ShapeType == "Solid":
-            if sub and sub[0:4] in ("Face", "Edge"):
-                pocketable = True
-
-        elif obj.ShapeType == "Compound":
-            if sub and sub[0:4] in ("Face", "Edge"):
-                pocketable = True
-
-        return pocketable
+        return False
 
 
 class ADAPTIVEGate(PathBaseGate):


### PR DESCRIPTION
> [!CAUTION]
> Should be reviewed after
> - #26842

---

Fixes #24463
- #24463

---
 
Allows to set `Start Point` from **Task panel** for **Profile** and **Pocket** operations

<img width="794" height="571" alt="Screenshot_20260419_174657_hor_lossy" src="https://github.com/user-attachments/assets/995f5ee6-a844-4e7f-87c7-8b7c5e2696e2" />

https://github.com/user-attachments/assets/135a034f-4585-4a77-bb94-fdfd439fdf10

