### PR TITLE
App: trace resolved duplicate element mappings

### DIFF
--- a/src/App/ElementMap.cpp
+++ b/src/App/ElementMap.cpp
@@ -774,10 +774,8 @@ MappedName ElementMap::renameDuplicateElement(int index,
     ss << ELEMENT_MAP_PREFIX << 'D' << std::hex << idx;
     MappedName renamed(name);
     encodeElementName(element.getType()[0], renamed, ss, &sids, masterTag);
-    if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
-        FC_WARN("duplicate element mapping '"  // NOLINT
-                << name << " -> " << renamed << ' ' << element << '/' << element2);
-    }
+    FC_TRACE("resolved duplicate element mapping '"  // NOLINT
+             << name << " -> " << renamed << ' ' << element << '/' << element2);
     return renamed;
 }
 


### PR DESCRIPTION
## Summary

Resolved duplicate element mappings are now logged as trace diagnostics instead of user-visible warnings.

`ElementMap::setElementName()` already handles mapped-name collisions by retrying with a disambiguated duplicate postfix. That recovery path can happen during valid shape operations where multiple output subelements have equivalent operation history.

## Changes

- change successfully resolved duplicate element mapping messages from `FC_WARN` to `FC_TRACE`
- keep unresolved duplicate element mappings as `FC_ERR` when rename attempts are exhausted
- add a short code comment documenting the distinction

## Why

A duplicate mapped name is not necessarily a mapping failure. If `renameDuplicateElement()` successfully creates a unique mapped name, the element map remains usable and the operation can continue.

Only the unresolved case should remain user-visible. This keeps real failures visible while reducing warning noise from recoverable TNP name collisions.
