### PR TITLE
Draft: Refresh Link array view after Base change

### DIFF
--- a/src/Mod/Draft/draftviewproviders/view_draftlink.py
+++ b/src/Mod/Draft/draftviewproviders/view_draftlink.py
@@ -56,6 +56,10 @@ class ViewProviderDraftLink(ViewProviderDraft):
         elif tp == "PointArray":
             return ":/icons/Draft_PointLinkArray.svg"
 
+    def updateData(self, obj, prop):
+        if prop == "Base":
+            obj.ViewObject.update()
+
     def claimChildren(self):
         obj = self.Object
         if hasattr(obj, "ExpandArray"):


### PR DESCRIPTION
Refreshes the Draft Link array view when the array `Base` property is changed in the property editor. The array shape already recomputed correctly, but the Link view could keep rendering the previous base until the document was reopened.

## Issues
Fixes #29393

## Before and After Images
Before video:


https://github.com/user-attachments/assets/51cc0309-4964-4bf2-acb9-db4147bc99f2









After video:


https://github.com/user-attachments/assets/1bda4969-e6ab-4faf-9d23-0c2eb2b4236a









