### PR TITLE
TechDraw: stable Draft/Arch view anchoring on LockPosition (#27812)

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -139,7 +139,81 @@ void QGIViewSymbol::symbolToSvg(QByteArray qba)
         Base::Console().error("Error - Could not load Symbol into SVG renderer for %s\n",
                               getViewName());
     }
-    m_svgItem->centerAt(0., 0.);
+
+    // Placement rules for Draft/Arch views (other symbol views use the
+    // legacy centerAt(0,0) below):
+    //
+    //   * LockPosition = true            -> anchor the SVG on a point captured
+    //                                       when lock was enabled (current
+    //                                       bbox centre at that moment), so
+    //                                       adding new objects later grows the
+    //                                       bounding box around the anchor
+    //                                       without shifting already-visible
+    //                                       content (issue #27812).
+    //
+    //   * LockPosition = false (after a
+    //     preceding locked session)      -> KEEP the captured anchor for this
+    //                                       single redraw so the unlock
+    //                                       transition itself is seamless.
+    //                                       The anchor is then cleared; the
+    //                                       NEXT unlocked redraw (e.g. from a
+    //                                       content change) goes back to
+    //                                       centerAt(0,0) = legacy auto-recentre.
+    //
+    //   * LockPosition = false (no prior
+    //     lock in this session)          -> legacy centerAt(0,0).
+    auto* dv = getViewObject();
+    const bool isDraftArch = dv &&
+        (dynamic_cast<TechDraw::DrawViewDraft*>(dv) ||
+         dynamic_cast<TechDraw::DrawViewArch*>(dv));
+    const bool locked = dv && dv->LockPosition.getValue();
+    const bool unlockTransition = isDraftArch && !locked && m_wasLocked;
+    m_wasLocked = locked;
+
+    QRectF vb = isDraftArch ? m_svgItem->renderer()->viewBox() : QRectF();
+    QRectF br = isDraftArch ? m_svgItem->boundingRect() : QRectF();
+    const bool geometryValid = isDraftArch && vb.isValid()
+            && br.width() > 0 && br.height() > 0
+            && vb.width() > 0 && vb.height() > 0;
+
+    const bool useAnchor = isDraftArch && geometryValid && (locked || unlockTransition);
+
+    if (useAnchor) {
+        // On lock->draw: capture the current bbox centre as the anchor the
+        // first time (equivalent to centerAt at that moment, so no jump).
+        if (locked && !m_lockedSvgAnchor) {
+            m_lockedSvgAnchor = QPointF(vb.x() + vb.width()  / 2.0,
+                                        vb.y() + vb.height() / 2.0);
+        }
+
+        if (m_lockedSvgAnchor) {
+            // Map the captured SVG-space anchor to view-group (0,0).
+            // Renderer maps viewBox -> boundingRect, so SVG (ax, ay) is at
+            // item-local (br.x + (ax - vb.x) * br.w/vb.w,
+            //              br.y + (ay - vb.y) * br.h/vb.h).
+            // With setScale(s): parent = setPos + itemLocal * s, so
+            //   setPos = -itemLocal * s keeps the anchor at parent (0,0).
+            const double sx = br.width()  / vb.width();
+            const double sy = br.height() / vb.height();
+            const double s  = m_svgItem->scale();
+            const QPointF anchorSvg = *m_lockedSvgAnchor;
+            const double localX = br.x() + (anchorSvg.x() - vb.x()) * sx;
+            const double localY = br.y() + (anchorSvg.y() - vb.y()) * sy;
+            m_svgItem->setPos(-localX * s, -localY * s);
+        } else {
+            m_svgItem->centerAt(0., 0.);
+        }
+
+        // Having consumed the anchor during the unlock transition, drop it
+        // so the next unlocked redraw falls back to legacy centerAt.
+        if (unlockTransition) {
+            m_lockedSvgAnchor.reset();
+        }
+    } else {
+        // Unlocked and no pending transition, or non-Draft/Arch: legacy.
+        m_lockedSvgAnchor.reset();
+        m_svgItem->centerAt(0., 0.);
+    }
 
     if (Preferences::lightOnDark()) {
         QColor color = PreferencesGui::getAccessibleQColor(QColor(Qt::black));

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.h
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.h
@@ -26,6 +26,8 @@
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
 #include <QByteArray>
+#include <QPointF>
+#include <optional>
 
 #include "QGIView.h"
 #include "QGIUserTypes.h"
@@ -64,6 +66,16 @@ protected:
 
     QGDisplayArea* m_displayArea;
     QGCustomSvg *m_svgItem;
+
+    // Anchor point in SVG viewBox coordinates.  Captured when a Draft/Arch
+    // view transitions into LockPosition = true (or on first draw if already
+    // locked) and used to keep already-visible content at a stable page
+    // position as new objects grow the bounding box.  Preserved across a
+    // lock->unlock transition so that unlocking itself never causes a visible
+    // jump; cleared on the next unlocked redraw so that subsequent content
+    // changes re-centre the view (legacy behaviour).
+    std::optional<QPointF> m_lockedSvgAnchor;
+    bool m_wasLocked = false;
 };
 
 } // namespace


### PR DESCRIPTION
## Summary

Implements the feature requested in issue [#27812](https://github.com/FreeCAD/FreeCAD/issues/27812): stop Draft/Arch views from visibly shifting on the TechDraw page when objects are added that enlarge the view's bounding box.

Previously, `QGIViewSymbol::symbolToSvg()` always placed the SVG item with `centerAt(0, 0)`, anchoring on the current bounding-box centre. Because the bbox centre shifts in world-space whenever new geometry is added (e.g. a `Draft_Dimension` to the left of an existing wall, or a wall added to the parent `Section`/`Level`), the whole view appeared to jump on the page — even with `LockPosition = Yes`.

The fix anchors Draft/Arch views on a captured SVG-space point that is stable across content changes, and is tied to the `LockPosition` property so that unlocked views retain their legacy auto-recentering behaviour.

### Behaviour matrix (Draft/Arch views)

| Scenario | Before | After |
|---|---|---|
| Unlocked, never locked, add content | auto-recenter | auto-recenter (unchanged) |
| Toggle `LockPosition` on | n/a — view still drifted later | captures anchor at current bbox centre; no visual jump |
| Locked, add content near border | view drifted on the page | existing content stays put, bbox grows around the anchor |
| Toggle `LockPosition` off (right after) | would snap to new bbox centre | seamless — anchor reused one more draw |
| Unlocked, add more content afterwards | auto-recenter | auto-recenter (legacy) |

Non-Draft/Arch symbol views are unchanged (legacy `centerAt(0, 0)`).

### Known trade-off

There is one unavoidable edge case: if the user **locks → adds content → unlocks → adds more content**, the *second* content addition while unlocked will cause a visible recentering. This is because the \"locked anchor\" and the \"new bbox centre\" are at different world positions by that point, and the two user-visible requirements — *\"unlocking must not cause a jump\"* and *\"unlocked views must auto-recenter like before\"* — cannot both hold indefinitely. The chosen compromise is: the unlock transition itself is always seamless, and legacy auto-recentering resumes on the next unlocked content change.

**If anyone has a cleaner solution for this trade-off, please let me know** — open to ideas (e.g. a dedicated \"anchor on next drag\" mode, or persisting the anchor as an App-side property so it survives save/reopen and behaves more predictably across sessions).

### Files touched

- [src/Mod/TechDraw/Gui/QGIViewSymbol.h](https://github.com/FreeCAD/FreeCAD/blob/main/src/Mod/TechDraw/Gui/QGIViewSymbol.h) — adds `m_lockedSvgAnchor` and `m_wasLocked` members.
- [src/Mod/TechDraw/Gui/QGIViewSymbol.cpp](https://github.com/FreeCAD/FreeCAD/blob/main/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp) — new placement logic in `symbolToSvg()`; other symbol views untouched.

#27812.

## Test plan

- [ ] Open the reproducer file [FC-moving-view.FCStd.txt](https://github.com/user-attachments/files/25478311/FC-moving-view.FCStd.txt) from the issue.
- [ ] With `LockPosition = Yes`, add a `Draft_Dimension` to the left of the existing wall and `Arch_Add` it to the `Section`. Existing content should not move on the page.
- [ ] Move a wall into the `Level` container. Existing content should not move on the page.
- [ ] Toggle `LockPosition` on and off. The view should not jump in either direction.
- [ ] With `LockPosition = No` from the start, verify legacy auto-recentering still works when objects are added.
- [ ] Sanity-check other symbol views (plain SVG `DrawViewSymbol`): behaviour unchanged.