### PR TITLE
TechDraw: stable Draft/Arch view anchoring on LockPosition (#27812)

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.cpp
@@ -139,7 +139,81 @@ void QGIViewSymbol::symbolToSvg(QByteArray qba)
         Base::Console().error("Error - Could not load Symbol into SVG renderer for %s\n",
                               getViewName());
     }
-    m_svgItem->centerAt(0., 0.);
+
+    // Placement rules for Draft/Arch views (other symbol views use the
+    // legacy centerAt(0,0) below):
+    //
+    //   * LockPosition = true            -> anchor the SVG on a point captured
+    //                                       when lock was enabled (current
+    //                                       bbox centre at that moment), so
+    //                                       adding new objects later grows the
+    //                                       bounding box around the anchor
+    //                                       without shifting already-visible
+    //                                       content (issue #27812).
+    //
+    //   * LockPosition = false (after a
+    //     preceding locked session)      -> KEEP the captured anchor for this
+    //                                       single redraw so the unlock
+    //                                       transition itself is seamless.
+    //                                       The anchor is then cleared; the
+    //                                       NEXT unlocked redraw (e.g. from a
+    //                                       content change) goes back to
+    //                                       centerAt(0,0) = legacy auto-recentre.
+    //
+    //   * LockPosition = false (no prior
+    //     lock in this session)          -> legacy centerAt(0,0).
+    auto* dv = getViewObject();
+    const bool isDraftArch = dv &&
+        (dynamic_cast<TechDraw::DrawViewDraft*>(dv) ||
+         dynamic_cast<TechDraw::DrawViewArch*>(dv));
+    const bool locked = dv && dv->LockPosition.getValue();
+    const bool unlockTransition = isDraftArch && !locked && m_wasLocked;
+    m_wasLocked = locked;
+
+    QRectF vb = isDraftArch ? m_svgItem->renderer()->viewBox() : QRectF();
+    QRectF br = isDraftArch ? m_svgItem->boundingRect() : QRectF();
+    const bool geometryValid = isDraftArch && vb.isValid()
+            && br.width() > 0 && br.height() > 0
+            && vb.width() > 0 && vb.height() > 0;
+
+    const bool useAnchor = isDraftArch && geometryValid && (locked || unlockTransition);
+
+    if (useAnchor) {
+        // On lock->draw: capture the current bbox centre as the anchor the
+        // first time (equivalent to centerAt at that moment, so no jump).
+        if (locked && !m_lockedSvgAnchor) {
+            m_lockedSvgAnchor = QPointF(vb.x() + vb.width()  / 2.0,
+                                        vb.y() + vb.height() / 2.0);
+        }
+
+        if (m_lockedSvgAnchor) {
+            // Map the captured SVG-space anchor to view-group (0,0).
+            // Renderer maps viewBox -> boundingRect, so SVG (ax, ay) is at
+            // item-local (br.x + (ax - vb.x) * br.w/vb.w,
+            //              br.y + (ay - vb.y) * br.h/vb.h).
+            // With setScale(s): parent = setPos + itemLocal * s, so
+            //   setPos = -itemLocal * s keeps the anchor at parent (0,0).
+            const double sx = br.width()  / vb.width();
+            const double sy = br.height() / vb.height();
+            const double s  = m_svgItem->scale();
+            const QPointF anchorSvg = *m_lockedSvgAnchor;
+            const double localX = br.x() + (anchorSvg.x() - vb.x()) * sx;
+            const double localY = br.y() + (anchorSvg.y() - vb.y()) * sy;
+            m_svgItem->setPos(-localX * s, -localY * s);
+        } else {
+            m_svgItem->centerAt(0., 0.);
+        }
+
+        // Having consumed the anchor during the unlock transition, drop it
+        // so the next unlocked redraw falls back to legacy centerAt.
+        if (unlockTransition) {
+            m_lockedSvgAnchor.reset();
+        }
+    } else {
+        // Unlocked and no pending transition, or non-Draft/Arch: legacy.
+        m_lockedSvgAnchor.reset();
+        m_svgItem->centerAt(0., 0.);
+    }
 
     if (Preferences::lightOnDark()) {
         QColor color = PreferencesGui::getAccessibleQColor(QColor(Qt::black));

--- a/src/Mod/TechDraw/Gui/QGIViewSymbol.h
+++ b/src/Mod/TechDraw/Gui/QGIViewSymbol.h
@@ -26,6 +26,8 @@
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
 #include <QByteArray>
+#include <QPointF>
+#include <optional>
 
 #include "QGIView.h"
 #include "QGIUserTypes.h"
@@ -64,6 +66,16 @@ protected:
 
     QGDisplayArea* m_displayArea;
     QGCustomSvg *m_svgItem;
+
+    // Anchor point in SVG viewBox coordinates.  Captured when a Draft/Arch
+    // view transitions into LockPosition = true (or on first draw if already
+    // locked) and used to keep already-visible content at a stable page
+    // position as new objects grow the bounding box.  Preserved across a
+    // lock->unlock transition so that unlocking itself never causes a visible
+    // jump; cleared on the next unlocked redraw so that subsequent content
+    // changes re-centre the view (legacy behaviour).
+    std::optional<QPointF> m_lockedSvgAnchor;
+    bool m_wasLocked = false;
 };
 
 } // namespace


### PR DESCRIPTION
Fixes #27812.

Draft/Arch views on a TechDraw page were visibly shifting whenever new geometry was added that grew their bounding box, even with `LockPosition = Yes`.

The cause is that `QGIViewSymbol::symbolToSvg()` always calls `centerAt(0, 0)` on the SVG item, so the view re-centers on the current bbox centre every redraw. Adding content (e.g. a `Draft_Dimension` to the left of a wall, or another wall into the parent `Section`/`Level`) shifts that centre in world space, so the whole view jumps on the page.

The fix captures a stable SVG-space anchor when the view is locked and reuses it on subsequent draws. Unlocked views keep the existing auto-recentering, so this only changes things when the user has actually asked the position to be locked.

Behaviour:
- Unlocked: same as before, auto-recenters.
- Locking: anchor is captured at the current bbox centre, so flipping the lock on doesn't cause a jump.
- Locked, new content added: existing content stays put and the bbox grows around the anchor.
- Unlocking right after locking: the anchor is reused once more so the unlock itself is also seamless.

One edge case I couldn't avoid cleanly: lock -> add content -> unlock -> add more content. The second unlocked addition will recenter, because by that point the captured anchor and the new bbox centre sit at different world positions, and ``don't jump on unlock`` + ``auto-recenter when unlocked`` can't both hold forever. The compromise is that the unlock transition itself is always seamless, and the old behaviour resumes on the next unlocked change.

Open to suggestions if anyone sees a cleaner way around the trade-off, for example an ``anchor on next drag`` mode, or persisting the anchor as an App-side property so it survives save/reopen.

Non-Draft/Arch symbol views are not touched.

## Test plan
- Open the reproducer [FC-moving-view.FCStd.txt](https://github.com/user-attachments/files/25478311/FC-moving-view.FCStd.txt) from the issue.
- With `LockPosition = Yes`, add a `Draft_Dimension` to the left of the existing wall and `Arch_Add` it to the `Section`. Nothing should shift on the page.
- Move a wall into the `Level` container. Nothing should shift.
- Toggle `LockPosition` on and off, no jump either way.
- With `LockPosition = No` from the start, the old auto-recentering should still work when objects are added.
- Plain `DrawViewSymbol` (non-Draft/Arch) should behave exactly as before.