### PR TITLE
CAM: Job - SkipRecomputes

### DIFF
--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -227,6 +227,12 @@ class ObjectJob:
             ),
         )
         obj.PostProcessorPropertyOverrides = "{}"
+        obj.addProperty(
+            "App::PropertyBool",
+            "SkipRecomputes",
+            "Base",
+            QT_TRANSLATE_NOOP("App::Property", "Do not recomputes operations"),
+        )
 
         obj.Fixtures = ["G54"]
 
@@ -592,6 +598,14 @@ class ObjectJob:
                 ),
             )
             obj.PostProcessorPropertyOverrides = "{}"
+
+        if not hasattr(obj, "SkipRecomputes"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "SkipRecomputes",
+                "Base",
+                QT_TRANSLATE_NOOP("App::Property", "Do not recomputes operations"),
+            )
 
         for n in self.propertyEnumerations():
             setattr(obj, n[0], n[1])

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -771,6 +771,10 @@ class ObjectOp(object):
         """
         Path.Log.track()
 
+        job = getattr(self, "job", None) or PathUtils.findParentJob(obj)
+        if getattr(job, "SkipRecomputes", False):
+            return
+
         if not obj.Active:
             path = Path.Path("(inactive operation)")
             obj.Path = path


### PR DESCRIPTION
To skip recomputes operations we have two solution:
- Enable `Skip recomputes` for whole document
- Set `Active` to `False` for all operations in **Job**

Both these ways not convenient if:
- **Job** contains a lot of operations with long time recomputes
- Twice not convenient if some operations uses `Rest Machining` feature, because need to change state of operations in right order
Deactivate from bottom to top
Activate from top to bottom
- Need make a lot changes in document models, which uses in **Job** 

Suggest to add option, which will allows to skip recomputes for all operations in **Job**

<img width="595" height="185" alt="Screenshot_20260419_201011_lossy" src="https://github.com/user-attachments/assets/39c61bed-3fd8-4177-acd0-82dd7f3427a3" />