### PR TITLE
Gui: preserve full property names in editor

### DIFF
--- a/src/Gui/propertyeditor/PropertyModel.cpp
+++ b/src/Gui/propertyeditor/PropertyModel.cpp
@@ -238,15 +238,66 @@ QModelIndex PropertyModel::propertyIndexFromPath(const QStringList& path) const
     return index;
 }
 
-static void setPropertyItemName(PropertyItem* item, const char* propName, QString groupName)
+static QString propertyGroupName(const App::Property* prop)
+{
+    const char* group = prop->getGroup();
+    bool isEmpty = Base::Tools::isNullOrEmpty(group);
+    return QString::fromUtf8(isEmpty ? QT_TRANSLATE_NOOP("App::Property", "Base") : group);
+}
+
+static QString shortenedPropertyName(const QString& name, const QString& groupName)
+{
+    if (name.size() > groupName.size() + 1 && name.startsWith(groupName + QLatin1Char('_'))) {
+        return name.right(name.size() - groupName.size() - 1);
+    }
+
+    return name;
+}
+
+static void setPropertyItemName(PropertyItem* item,
+                                const char* propName,
+                                const QString& groupName,
+                                bool keepFullName)
 {
     QString name = QString::fromUtf8(propName);
     QString realName = name;
-    if (name.size() > groupName.size() + 1 && name.startsWith(groupName + QLatin1Char('_'))) {
-        name = name.right(name.size() - groupName.size() - 1);
+    if (!keepFullName) {
+        name = shortenedPropertyName(name, groupName);
     }
 
     item->setPropertyName(name, realName);
+}
+
+static bool groupHasPropertyName(const PropertyModel::PropertyList& props,
+                                 const QString& groupName,
+                                 const QString& propName)
+{
+    for (const auto& propInfo : props) {
+        App::Property* prop = propInfo.second.front();
+        if (propertyGroupName(prop) != groupName) {
+            continue;
+        }
+        if (QString::fromUtf8(prop->getName()) == propName) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static bool groupHasPropertyName(PropertyItem* groupItem,
+                                 const QString& propName,
+                                 const App::Property* ignoredProp = nullptr)
+{
+    for (int row = 0; row < groupItem->childCount(); ++row) {
+        auto child = groupItem->child(row);
+        auto prop = child->getFirstProperty();
+        if (prop && prop != ignoredProp && QString::fromUtf8(prop->getName()) == propName) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 static PropertyItem* createPropertyItem(App::Property* prop)
@@ -269,9 +320,7 @@ static PropertyItem* createPropertyItem(App::Property* prop)
 
 PropertyModel::GroupInfo& PropertyModel::getGroupInfo(App::Property* prop)
 {
-    const char* group = prop->getGroup();
-    bool isEmpty = Base::Tools::isNullOrEmpty(group);
-    QString groupName = QString::fromUtf8(isEmpty ? QT_TRANSLATE_NOOP("App::Property", "Base") : group);
+    QString groupName = propertyGroupName(prop);
 
     auto res = groupItems.insert(std::make_pair(groupName, GroupInfo()));
     if (res.second) {
@@ -374,7 +423,13 @@ void PropertyModel::findOrCreateChildren(const PropertyModel::PropertyList& prop
         groupInfo.children.push_back(item);
 
         item->setLinked(boost::ends_with(jt.first, "*"));
-        setPropertyItemName(item, prop->getName(), groupInfo.groupItem->propertyName());
+        QString groupName = propertyGroupName(prop);
+        QString realName = QString::fromUtf8(prop->getName());
+        QString shortName = shortenedPropertyName(realName, groupName);
+        setPropertyItemName(item,
+                            prop->getName(),
+                            groupName,
+                            shortName != realName && groupHasPropertyName(props, groupName, shortName));
 
         if (jt.second != item->getPropertyData()) {
             for (auto prop : item->getPropertyData()) {
@@ -540,9 +595,30 @@ void PropertyModel::appendProperty(const App::Property& _prop)
     QModelIndex midx = this->index(groupInfo.groupItem->_row, 0, QModelIndex());
     beginInsertRows(midx, row, row);
     groupInfo.groupItem->insertChild(row, item);
-    setPropertyItemName(item, prop->getName(), groupInfo.groupItem->propertyName());
     item->setPropertyData({prop});
     endInsertRows();
+
+    QString groupName = propertyGroupName(prop);
+    for (int changedRow = 0; changedRow < groupInfo.groupItem->childCount(); ++changedRow) {
+        auto child = groupInfo.groupItem->child(changedRow);
+        auto childProp = child->getFirstProperty();
+        if (!childProp) {
+            continue;
+        }
+
+        QString oldName = child->propertyName();
+        QString realName = QString::fromUtf8(childProp->getName());
+        QString shortName = shortenedPropertyName(realName, groupName);
+        setPropertyItemName(child,
+                            childProp->getName(),
+                            groupName,
+                            shortName != realName
+                                && groupHasPropertyName(groupInfo.groupItem, shortName, childProp));
+        if (child->propertyName() != oldName) {
+            QModelIndex changed = this->index(changedRow, 0, midx);
+            Q_EMIT dataChanged(changed, changed);
+        }
+    }
 }
 
 void PropertyModel::removeProperty(const App::Property& _prop)

--- a/src/Gui/propertyeditor/PropertyModel.cpp
+++ b/src/Gui/propertyeditor/PropertyModel.cpp
@@ -254,10 +254,12 @@ static QString shortenedPropertyName(const QString& name, const QString& groupNa
     return name;
 }
 
-static void setPropertyItemName(PropertyItem* item,
-                                const char* propName,
-                                const QString& groupName,
-                                bool keepFullName)
+static void setPropertyItemName(
+    PropertyItem* item,
+    const char* propName,
+    const QString& groupName,
+    bool keepFullName
+)
 {
     QString name = QString::fromUtf8(propName);
     QString realName = name;
@@ -268,9 +270,11 @@ static void setPropertyItemName(PropertyItem* item,
     item->setPropertyName(name, realName);
 }
 
-static bool groupHasPropertyName(const PropertyModel::PropertyList& props,
-                                 const QString& groupName,
-                                 const QString& propName)
+static bool groupHasPropertyName(
+    const PropertyModel::PropertyList& props,
+    const QString& groupName,
+    const QString& propName
+)
 {
     for (const auto& propInfo : props) {
         App::Property* prop = propInfo.second.front();
@@ -285,9 +289,11 @@ static bool groupHasPropertyName(const PropertyModel::PropertyList& props,
     return false;
 }
 
-static bool groupHasPropertyName(PropertyItem* groupItem,
-                                 const QString& propName,
-                                 const App::Property* ignoredProp = nullptr)
+static bool groupHasPropertyName(
+    PropertyItem* groupItem,
+    const QString& propName,
+    const App::Property* ignoredProp = nullptr
+)
 {
     for (int row = 0; row < groupItem->childCount(); ++row) {
         auto child = groupItem->child(row);
@@ -426,10 +432,12 @@ void PropertyModel::findOrCreateChildren(const PropertyModel::PropertyList& prop
         QString groupName = propertyGroupName(prop);
         QString realName = QString::fromUtf8(prop->getName());
         QString shortName = shortenedPropertyName(realName, groupName);
-        setPropertyItemName(item,
-                            prop->getName(),
-                            groupName,
-                            shortName != realName && groupHasPropertyName(props, groupName, shortName));
+        setPropertyItemName(
+            item,
+            prop->getName(),
+            groupName,
+            shortName != realName && groupHasPropertyName(props, groupName, shortName)
+        );
 
         if (jt.second != item->getPropertyData()) {
             for (auto prop : item->getPropertyData()) {
@@ -609,11 +617,12 @@ void PropertyModel::appendProperty(const App::Property& _prop)
         QString oldName = child->propertyName();
         QString realName = QString::fromUtf8(childProp->getName());
         QString shortName = shortenedPropertyName(realName, groupName);
-        setPropertyItemName(child,
-                            childProp->getName(),
-                            groupName,
-                            shortName != realName
-                                && groupHasPropertyName(groupInfo.groupItem, shortName, childProp));
+        setPropertyItemName(
+            child,
+            childProp->getName(),
+            groupName,
+            shortName != realName && groupHasPropertyName(groupInfo.groupItem, shortName, childProp)
+        );
         if (child->propertyName() != oldName) {
             QModelIndex changed = this->index(changedRow, 0, midx);
             Q_EMIT dataChanged(changed, changed);


### PR DESCRIPTION
Keeps VarSet property names distinguishable in the Property Editor when the existing `<group>_` prefix stripping would make two properties appear with the same label.

The editor still keeps the shorter display name when it is unambiguous. For example, `Cam_Width` in group `Cam` continues to display as `Width`, while `Cam_Length` stays visible as `Cam_Length` when another property named `Length` exists in the same group.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
Fixes #29496.

## Before and After Images
After:


https://github.com/user-attachments/assets/2bd8bb9d-1f11-4be0-8c95-507ac5d4dc63







<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
