### PR TITLE
BIM: restore missing view providers after headless saves

### DIFF
--- a/src/Mod/BIM/ArchAxis.py
+++ b/src/Mod/BIM/ArchAxis.py
@@ -132,14 +132,14 @@ def get_axis_bubble_data(obj, vobj):
 
     pos = ["Start"]
     both_mode = False
-    if hasattr(vobj, "BubblePosition"):
-        if vobj.BubblePosition in ["Both", "Arrow left", "Arrow right", "Bar left", "Bar right"]:
-            pos = ["Start", "End"]
-            both_mode = True
-        elif vobj.BubblePosition == "None":
-            pos = []
-        else:
-            pos = [vobj.BubblePosition]
+    bubble_position = getattr(vobj, "BubblePosition", "Start")
+    if bubble_position in ["Both", "Arrow left", "Arrow right", "Bar left", "Bar right"]:
+        pos = ["Start", "End"]
+        both_mode = True
+    elif bubble_position == "None":
+        pos = []
+    else:
+        pos = [bubble_position]
 
     n = len(obj.Shape.Edges)
     if getattr(obj, "Limit", 0):
@@ -165,16 +165,16 @@ def get_axis_bubble_data(obj, vobj):
             if p == "Start":
                 p1 = verts[0]
                 p2 = verts[1]
-                if vobj.BubblePosition.endswith("left"):
+                if bubble_position.endswith("left"):
                     arrow = True
-                elif vobj.BubblePosition.endswith("right"):
+                elif bubble_position.endswith("right"):
                     arrow = False
             else:
                 p1 = verts[1]
                 p2 = verts[0]
-                if vobj.BubblePosition.endswith("left"):
+                if bubble_position.endswith("left"):
                     arrow = False
-                elif vobj.BubblePosition.endswith("right"):
+                elif bubble_position.endswith("right"):
                     arrow = True
 
             dv = p2.sub(p1)
@@ -309,6 +309,9 @@ class _Axis:
     def onDocumentRestored(self, obj):
 
         self.setProperties(obj)
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
 
     def execute(self, obj):
 
@@ -542,6 +545,7 @@ class _ViewProviderAxis:
         sep.addChild(self.lineset)
         sep.addChild(self.bubbleset)
         sep.addChild(self.labelset)
+        self.setProperties(vobj)
         vobj.addDisplayMode(sep, "Default")
         self.onChanged(vobj, "BubbleSize")
         self.onChanged(vobj, "ShowLabel")

--- a/src/Mod/BIM/ArchAxisSystem.py
+++ b/src/Mod/BIM/ArchAxisSystem.py
@@ -86,6 +86,9 @@ class _AxisSystem:
     def onDocumentRestored(self, obj):
 
         self.setProperties(obj)
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
 
     def execute(self, obj):
 

--- a/src/Mod/BIM/ArchBuildingPart.py
+++ b/src/Mod/BIM/ArchBuildingPart.py
@@ -320,14 +320,17 @@ class BuildingPart(ArchIFC.IfcProduct):
 
     def onDocumentRestored(self, obj):
 
-        self.setProperties(obj)
+        super().onDocumentRestored(obj)
 
         vobj = getattr(obj, "ViewObject", None)
         if vobj is None:
             return
-        if hasattr(vobj, "ChildrenShapeColor"):
+        import ArchRestore
+
+        proxy = ArchRestore.get_view_provider_proxy(vobj)
+        if hasattr(vobj, "ChildrenShapeColor") and proxy is not None:
             # add the ChildrenShapeAppearance property:
-            vobj.Proxy.setProperties(vobj)
+            proxy.setProperties(vobj)
             if vobj.getTypeIdOfProperty("ChildrenShapeColor") == "App::PropertyColor":
                 # <= v0.21
                 material = FreeCAD.Material()
@@ -937,7 +940,7 @@ class ViewProviderBuildingPart:
         # print(vobj.Object.Label," - ",prop)
 
         if prop == "ShapeAppearance":
-            if hasattr(vobj, "ShapeAppearance"):
+            if hasattr(vobj, "ShapeAppearance") and hasattr(self, "mat"):
                 color = vobj.ShapeAppearance[0].DiffuseColor[:-1]  # remove alpha value
                 self.mat.diffuseColor.setValue(*color)
         elif prop == "LineWidth":

--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -370,6 +370,10 @@ class Component(ArchIFC.IfcProduct):
         """
         Component.setProperties(self, obj)
 
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
+
     def execute(self, obj):
         """Method run when the object is recomputed.
 

--- a/src/Mod/BIM/ArchFloor.py
+++ b/src/Mod/BIM/ArchFloor.py
@@ -258,6 +258,9 @@ class _Floor(ArchIFC.IfcProduct):
         """Method run when the document is restored. Re-adds the properties."""
 
         _Floor.setProperties(self, obj)
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
 
     def dumps(self):
 

--- a/src/Mod/BIM/ArchGrid.py
+++ b/src/Mod/BIM/ArchGrid.py
@@ -175,6 +175,9 @@ class ArchGrid:
     def onDocumentRestored(self, obj):
 
         self.setProperties(obj)
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
 
     def getSizes(self, obj):
         "returns rowsizes,columnsizes,spangroups"

--- a/src/Mod/BIM/ArchIFC.py
+++ b/src/Mod/BIM/ArchIFC.py
@@ -100,6 +100,15 @@ class IfcRoot:
 
         self.migrateDeprecatedAttributes(obj)
 
+    def onDocumentRestored(self, obj):
+        """Restore IFC properties and any missing Python view provider."""
+
+        self.setProperties(obj)
+
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
+
     def onChanged(self, obj, prop):
         """Method called when the object has a property changed.
 

--- a/src/Mod/BIM/ArchMaterial.py
+++ b/src/Mod/BIM/ArchMaterial.py
@@ -189,6 +189,9 @@ class _ArchMaterial:
     def onDocumentRestored(self, obj):
 
         self.setProperties(obj)
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
 
     def setProperties(self, obj):
 

--- a/src/Mod/BIM/ArchPanel.py
+++ b/src/Mod/BIM/ArchPanel.py
@@ -39,6 +39,7 @@ import math
 import FreeCAD
 import ArchCommands
 import ArchComponent
+import ArchRestore
 import Draft
 import DraftVecUtils
 import Part
@@ -756,6 +757,7 @@ class PanelCut(Draft.DraftObject):
     def onDocumentRestored(self, obj):
 
         self.setProperties(obj)
+        ArchRestore.restore_view_object(obj)
 
     def execute(self, obj):
 
@@ -1149,6 +1151,7 @@ class PanelSheet(Draft.DraftObject):
     def onDocumentRestored(self, obj):
 
         self.setProperties(obj)
+        ArchRestore.restore_view_object(obj)
 
     def execute(self, obj):
 

--- a/src/Mod/BIM/ArchProfile.py
+++ b/src/Mod/BIM/ArchProfile.py
@@ -113,6 +113,12 @@ class _Profile(Draft._DraftObject):
     def onDocumentRestored(self, obj):
         """Rename property OutDiameter to OutsideDiameter and rename property group Draft to Profile"""
 
+        super().onDocumentRestored(obj)
+
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
+
         if hasattr(obj, "OutDiameter"):
             # 1v1 to 1v2 changes.
             obj.setPropertyStatus("OutDiameter", "-LockDynamic")

--- a/src/Mod/BIM/ArchProject.py
+++ b/src/Mod/BIM/ArchProject.py
@@ -86,7 +86,8 @@ class _Project(ArchIFC.IfcContext):
 
     def onDocumentRestored(self, obj):
         """Method run when the document is restored. Re-add the properties."""
-        self.setProperties(obj)
+
+        super().onDocumentRestored(obj)
 
     def dumps(self):
 

--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -101,11 +101,15 @@ class ArchReference:
 
     def onDocumentRestored(self, obj):
 
+        import ArchRestore
+
         ArchReference.setProperties(self, obj)
+        ArchRestore.restore_view_object(obj)
+        proxy = ArchRestore.get_view_provider_proxy(getattr(obj, "ViewObject", None))
         if obj.ReferenceMode == "Lightweight":
             self.reload = False
-            if obj.ViewObject and obj.ViewObject.Proxy:
-                obj.ViewObject.Proxy.loadInventor(obj)
+            if proxy is not None:
+                proxy.loadInventor(obj)
         else:
             self.reload = True
             self.execute(obj)  # sets self.reload to False again
@@ -120,18 +124,21 @@ class ArchReference:
 
     def onChanged(self, obj, prop):
 
+        import ArchRestore
+
         if prop in ["File", "Part"]:
             self.reload = True
         elif prop == "ReferenceMode":
+            proxy = ArchRestore.get_view_provider_proxy(getattr(obj, "ViewObject", None))
             if obj.ReferenceMode == "Normal":
-                if obj.ViewObject and obj.ViewObject.Proxy:
-                    obj.ViewObject.Proxy.unloadInventor(obj)
+                if proxy is not None:
+                    proxy.unloadInventor(obj)
                 if (not obj.Shape) or obj.Shape.isNull():
                     self.reload = True
                     obj.touch()
             elif obj.ReferenceMode == "Transient":
-                if obj.ViewObject and obj.ViewObject.Proxy:
-                    obj.ViewObject.Proxy.unloadInventor(obj)
+                if proxy is not None:
+                    proxy.unloadInventor(obj)
                 self.reload = False
             elif obj.ReferenceMode == "Lightweight":
                 self.reload = False
@@ -140,8 +147,8 @@ class ArchReference:
                 pl = obj.Placement
                 obj.Shape = Part.Shape()
                 obj.Placement = pl
-                if obj.ViewObject and obj.ViewObject.Proxy:
-                    obj.ViewObject.Proxy.loadInventor(obj)
+                if proxy is not None:
+                    proxy.loadInventor(obj)
 
     def execute(self, obj):
 

--- a/src/Mod/BIM/ArchReport.py
+++ b/src/Mod/BIM/ArchReport.py
@@ -2,9 +2,10 @@
 #
 # Copyright (c) 2025 The FreeCAD Project
 
-import FreeCAD
 import os
 import json
+
+import FreeCAD
 
 if FreeCAD.GuiUp:
     from PySide import QtCore, QtWidgets, QtGui
@@ -446,9 +447,12 @@ class _ArchReport:
     def onDocumentRestored(self, obj):
         """Called after the object properties are restored from a file."""
         # Rebuild the live list of objects from the newly loaded persistent data
+        import ArchRestore
+
         self.obj = obj
         self.hydrate_live_statements(obj)
         self.setProperties(obj)  # This will ensure observer is re-attached
+        ArchRestore.restore_view_object(obj)
 
     def hydrate_live_statements(self, obj):
         """(Re)builds the live list of objects from the stored list of dicts."""

--- a/src/Mod/BIM/ArchRestore.py
+++ b/src/Mod/BIM/ArchRestore.py
@@ -26,7 +26,8 @@ def _get_view_provider_modules(module_name):
     try:
         yield importlib.import_module(module_name + "Gui")
     except ImportError:
-        pass
+        # Some BIM modules define the view provider next to the data proxy.
+        return
 
 
 def _get_view_provider_constructor(obj):

--- a/src/Mod/BIM/ArchRestore.py
+++ b/src/Mod/BIM/ArchRestore.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Arch/BIM view-provider resolution for headless-save restore.
+
+The generic "missing view-provider proxy" restore contract is owned by
+``draftutils.gui_utils.restore_view_object``. This module only contains the
+Arch/BIM-specific convention for finding the matching view-provider
+constructor from an object's data-proxy class.
+"""
+
+import importlib
+
+import FreeCAD
+
+from draftutils import gui_utils
+
+
+def _get_view_provider_modules(module_name):
+    """Yield the data-proxy module and optional ``*Gui`` companion module."""
+
+    try:
+        yield importlib.import_module(module_name)
+    except ImportError:
+        return
+
+    try:
+        yield importlib.import_module(module_name + "Gui")
+    except ImportError:
+        pass
+
+
+def _get_view_provider_constructor(obj):
+    """Return the constructor for a BIM object's view provider."""
+
+    proxy = getattr(obj, "Proxy", None)
+    if proxy is None:
+        return None
+
+    for cls in type(proxy).mro():
+        if cls is object:
+            continue
+
+        module_name = getattr(cls, "__module__", None)
+        class_name = getattr(cls, "__name__", None)
+        if not module_name or not class_name:
+            continue
+
+        candidates = []
+        if class_name.startswith("_"):
+            stem = class_name[1:]
+            candidates.extend((f"_ViewProvider{stem}", f"ViewProvider{stem}"))
+        else:
+            candidates.extend((f"ViewProvider{class_name}", f"_ViewProvider{class_name}"))
+
+        if module_name.endswith("ArchReport") and class_name == "_ArchReport":
+            candidates.append("ViewProviderReport")
+
+        for module in _get_view_provider_modules(module_name):
+            for candidate in candidates:
+                constructor = getattr(module, candidate, None)
+                if constructor is not None:
+                    return constructor
+
+    return None
+
+
+def get_view_provider_proxy(vobj):
+    """Return a real Python view-provider proxy, or ``None`` if it is missing."""
+
+    return gui_utils.get_view_provider_proxy(vobj)
+
+
+def restore_view_object(obj):
+    """Restore a missing Arch/BIM Python view provider after a headless save."""
+
+    if not FreeCAD.GuiUp:
+        return
+
+    constructor = _get_view_provider_constructor(obj)
+    if constructor is None:
+        return
+
+    try:
+        restored = gui_utils.restore_view_object(obj, format=False, vp_constructor=constructor)
+        if restored and hasattr(obj.ViewObject, "Visibility"):
+            # A headless-saved file has no GuiDocument.xml visibility state.
+            obj.ViewObject.Visibility = True
+    except Exception as exc:
+        name = getattr(obj, "Name", "<unnamed>")
+        FreeCAD.Console.PrintWarning(f"Arch: failed to restore the view object for {name}: {exc}\n")

--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -88,6 +88,9 @@ class _ArchSchedule:
     def onDocumentRestored(self, obj):
 
         self.setProperties(obj)
+        import ArchRestore
+
+        ArchRestore.restore_view_object(obj)
         if hasattr(obj, "Result"):
             self.update_properties_0v21(obj)
         if hasattr(obj, "Description"):

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -39,6 +39,7 @@ import uuid
 import FreeCAD
 import ArchCommands
 import ArchComponent
+import ArchRestore
 import Draft
 import DraftVecUtils
 
@@ -1031,6 +1032,7 @@ class _SectionPlane:
     def onDocumentRestored(self, obj):
 
         self.setProperties(obj)
+        ArchRestore.restore_view_object(obj)
 
     def execute(self, obj):
         import math

--- a/src/Mod/BIM/ArchSite.py
+++ b/src/Mod/BIM/ArchSite.py
@@ -46,6 +46,7 @@ import FreeCAD
 import ArchCommands
 import ArchComponent
 import ArchIFC
+import ArchRestore
 import Draft
 
 from draftutils import params
@@ -798,7 +799,7 @@ class _Site(ArchIFC.IfcProduct):
         """
 
         # 1. Restore properties on the data object.
-        self.setProperties(obj)
+        super().onDocumentRestored(obj)
 
         # 2. Trigger the restoration sequence for the associated view provider.
         # This block only runs in GUI mode.
@@ -816,7 +817,7 @@ class _Site(ArchIFC.IfcProduct):
             # correctly initialized, especially for backward compatibility when a newer version of
             # FreeCAD adds new properties.
             try:
-                proxy = getattr(obj.ViewObject, "Proxy", None)
+                proxy = ArchRestore.get_view_provider_proxy(obj.ViewObject)
                 if proxy is not None and hasattr(proxy, "setProperties"):
                     proxy.setProperties(obj.ViewObject)
             except Exception as e:
@@ -840,9 +841,9 @@ class _Site(ArchIFC.IfcProduct):
             # one event loop cycle *before* we apply the constraints in a subsequent cycle.
             from PySide import QtCore
 
-            QtCore.QTimer.singleShot(
-                0, lambda: obj.ViewObject.Proxy.restoreConstraints(obj.ViewObject)
-            )
+            proxy = ArchRestore.get_view_provider_proxy(obj.ViewObject)
+            if proxy is not None and hasattr(proxy, "restoreConstraints"):
+                QtCore.QTimer.singleShot(0, lambda: proxy.restoreConstraints(obj.ViewObject))
 
     def execute(self, obj):
         """Method run when the object is recomputed.
@@ -2102,7 +2103,11 @@ class _ViewProviderSite:
 
     def updateSunPosition(self, vobj):
         """Calculates sun position and updates the sphere, path arc, and ray object."""
-        if not hasattr(vobj, "ShowSunPosition"):
+        try:
+            if not hasattr(vobj, "ShowSunPosition"):
+                return
+            obj = vobj.Object
+        except ReferenceError:
             return
 
         import math
@@ -2110,7 +2115,6 @@ class _ViewProviderSite:
         import datetime
         from pivy import coin
 
-        obj = vobj.Object
         declination_rot = FreeCAD.Rotation(
             FreeCAD.Vector(0, 0, 1),
             obj.Declination.Value if hasattr(obj, "Declination") else 0.0,

--- a/src/Mod/BIM/CMakeLists.txt
+++ b/src/Mod/BIM/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(Arch_SRCS
     Init.py
     InitGui.py
     ArchComponent.py
+    ArchRestore.py
     ArchIFC.py
     ArchIFCView.py
     ArchIFCSchema.py
@@ -264,6 +265,7 @@ SET(bimtests_SRCS
     bimtests/TestArchStairsGui.py
     bimtests/TestArchReport.py
     bimtests/TestArchReportGui.py
+    bimtests/TestArchReferenceGui.py
 )
 
 set(bimtests_FIXTURES

--- a/src/Mod/BIM/TestArchGui.py
+++ b/src/Mod/BIM/TestArchGui.py
@@ -29,7 +29,7 @@ from bimtests.TestArchAxisGui import TestArchAxisGui
 from bimtests.TestArchBuildingPartGui import TestArchBuildingPartGui
 from bimtests.TestArchStairsGui import TestArchStairsGui
 from bimtests.TestArchReportGui import TestArchReportGui
-from bimtests.TestArchReferenceGui import TestArchReferenceGui
+from bimtests.TestArchReferenceGui import TestArchReferenceGui  # noqa: F401
 from bimtests.TestArchSiteGui import TestArchSiteGui
 from bimtests.TestArchWallGui import TestArchWallGui
 from bimtests.TestWebGLExportGui import TestWebGLExportGui

--- a/src/Mod/BIM/TestArchGui.py
+++ b/src/Mod/BIM/TestArchGui.py
@@ -29,6 +29,7 @@ from bimtests.TestArchAxisGui import TestArchAxisGui
 from bimtests.TestArchBuildingPartGui import TestArchBuildingPartGui
 from bimtests.TestArchStairsGui import TestArchStairsGui
 from bimtests.TestArchReportGui import TestArchReportGui
+from bimtests.TestArchReferenceGui import TestArchReferenceGui
 from bimtests.TestArchSiteGui import TestArchSiteGui
 from bimtests.TestArchWallGui import TestArchWallGui
 from bimtests.TestWebGLExportGui import TestWebGLExportGui

--- a/src/Mod/BIM/bimtests/TestArchBaseGui.py
+++ b/src/Mod/BIM/bimtests/TestArchBaseGui.py
@@ -22,7 +22,10 @@
 # *                                                                         *
 # ***************************************************************************
 
+import os
+import tempfile
 import unittest
+import zipfile
 import FreeCAD
 import FreeCADGui
 from bimtests.TestArchBase import TestArchBase
@@ -86,3 +89,48 @@ class TestArchBaseGui(TestArchBase):
         except Exception:
             # Best-effort: if Qt isn't present or event pumping fails, continue.
             pass
+
+    def save_without_gui_document(self, doc=None):
+        """Save a document and remove GuiDocument.xml from the FCStd archive."""
+
+        document = doc or FreeCAD.ActiveDocument
+        archive = tempfile.NamedTemporaryFile(delete=False, suffix=".FCStd")
+        archive.close()
+
+        rewritten = tempfile.NamedTemporaryFile(delete=False, suffix=".FCStd")
+        rewritten.close()
+
+        try:
+            document.saveAs(archive.name)
+            with zipfile.ZipFile(archive.name, "r") as src, zipfile.ZipFile(
+                rewritten.name, "w"
+            ) as dst:
+                for info in src.infolist():
+                    if info.filename == "GuiDocument.xml":
+                        continue
+                    dst.writestr(info, src.read(info.filename))
+
+            os.replace(rewritten.name, archive.name)
+            return archive.name
+        finally:
+            if os.path.exists(rewritten.name):
+                os.unlink(rewritten.name)
+
+    def reopen_without_gui_document(self, obj=None, doc=None, timeout_ms=500):
+        """Reopen a stripped FCStd after closing the source document."""
+
+        document = doc or self.document or FreeCAD.ActiveDocument
+        archive = self.save_without_gui_document(document)
+        target_name = getattr(obj, "Name", None)
+
+        if getattr(self, "document", None) is document:
+            self.document = None
+
+        FreeCAD.closeDocument(document.Name)
+
+        reopened = FreeCAD.openDocument(archive)
+        self.document = reopened
+        self.pump_gui_events(timeout_ms)
+
+        restored = reopened.getObject(target_name) if target_name else None
+        return archive, reopened, restored

--- a/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
@@ -1,6 +1,9 @@
+import os
+
 import FreeCAD as App
 import FreeCADGui
 import Arch
+import ArchRestore
 import Draft
 import Part
 import Sketcher
@@ -77,3 +80,27 @@ class TestArchBuildingPartGui(TestArchBaseGui):
         FreeCADGui.runCommand("Std_ToggleVisibility", 0)
         App.ActiveDocument.recompute()
         assert wall.Visibility
+
+    def test_building_part_restores_view_provider_when_guidocument_is_missing(self):
+        building_part = Arch.makeBuildingPart(name="HeadlessRestoreLevel")
+        App.ActiveDocument.recompute()
+
+        archive = None
+        try:
+            archive, _, restored = self.reopen_without_gui_document(building_part)
+            self.assertIsNotNone(restored)
+            self.assertIsNotNone(restored.ViewObject)
+            self.assertIsNotNone(restored.ViewObject.Proxy)
+            self.assertEqual(type(restored.ViewObject.Proxy).__name__, "ViewProviderBuildingPart")
+            self.assertTrue(restored.ViewObject.Visibility)
+            self.assertIn("ShowLevel", restored.ViewObject.PropertiesList)
+            self.assertIn("ShowLabel", restored.ViewObject.PropertiesList)
+
+            # Regression for the follow-up hardening: a truthy integer proxy
+            # placeholder must still be treated as missing and restored.
+            restored.ViewObject.Proxy = 1
+            ArchRestore.restore_view_object(restored)
+            self.assertEqual(type(restored.ViewObject.Proxy).__name__, "ViewProviderBuildingPart")
+        finally:
+            if archive is not None:
+                os.unlink(archive)

--- a/src/Mod/BIM/bimtests/TestArchReferenceGui.py
+++ b/src/Mod/BIM/bimtests/TestArchReferenceGui.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import os
+
+import Arch
+from bimtests.TestArchBaseGui import TestArchBaseGui
+
+
+class TestArchReferenceGui(TestArchBaseGui):
+
+    def test_lightweight_reference_restores_view_provider_when_guidocument_is_missing(self):
+        reference = Arch.makeReference(name="HeadlessRestoreReference")
+        reference.ReferenceMode = "Lightweight"
+        self.document.recompute()
+
+        archive = None
+        try:
+            archive, _, restored = self.reopen_without_gui_document(reference)
+
+            self.assertIsNotNone(restored)
+            self.assertIsNotNone(restored.ViewObject)
+            self.assertIsNotNone(restored.ViewObject.Proxy)
+            self.assertEqual(type(restored.ViewObject.Proxy).__name__, "ViewProviderArchReference")
+            self.assertTrue(restored.ViewObject.Visibility)
+            self.assertIn("TimeStamp", restored.ViewObject.PropertiesList)
+            self.assertIn("UpdateColors", restored.ViewObject.PropertiesList)
+            self.assertEqual(restored.ReferenceMode, "Lightweight")
+            self.assertFalse(restored.Proxy.reload)
+        finally:
+            if archive is not None:
+                os.unlink(archive)

--- a/src/Mod/BIM/bimtests/TestArchReportGui.py
+++ b/src/Mod/BIM/bimtests/TestArchReportGui.py
@@ -4,6 +4,8 @@ These tests inherit from the GUI test base `TestArchBaseGui` which skips
 the whole class when `FreeCAD.GuiUp` is False.
 """
 
+import os
+
 import FreeCAD
 import Arch
 import FreeCADGui
@@ -191,3 +193,43 @@ class TestArchReportGui(TestArchBaseGui):
 
         clause_tooltip = editor._get_tooltip_for_word("SELECT")
         self.assertIn("SQL Clause", clause_tooltip)
+
+    def test_report_restores_view_provider_when_guidocument_is_missing(self):
+        report_obj = Arch.makeReport(name="HeadlessRestoreReport")
+        self.doc.recompute()
+
+        # Force the report's spreadsheet child into existence so claimChildren()
+        # has a real persisted target to rediscover after reopen.
+        spreadsheet = report_obj.Proxy.getSpreadSheet(report_obj, force=True)
+        self.assertIsNotNone(spreadsheet)
+        self.doc.recompute()
+
+        archive = None
+        try:
+            archive, _, restored = self.reopen_without_gui_document(report_obj)
+            self.assertIsNotNone(restored)
+            self.assertIsNotNone(restored.ViewObject)
+            self.assertIsNotNone(restored.ViewObject.Proxy)
+            self.assertEqual(type(restored.ViewObject.Proxy).__name__, "ViewProviderReport")
+            self.assertTrue(restored.ViewObject.Visibility)
+
+            claimed_children = restored.ViewObject.Proxy.claimChildren()
+            self.assertEqual(len(claimed_children), 1)
+            self.assertEqual(claimed_children[0].TypeId, "Spreadsheet::Sheet")
+            self.assertEqual(claimed_children[0].ReportName, restored.Name)
+
+            # Clear any unrelated active task panel before checking that the
+            # restored report can open its own editor.
+            FreeCADGui.Control.closeDialog()
+            self.pump_gui_events()
+            self.panel = None
+            self.assertTrue(restored.ViewObject.Proxy.setEdit(restored.ViewObject, 0))
+            self.pump_gui_events()
+            self.assertTrue(FreeCADGui.Control.activeDialog())
+            self.panel = True
+        finally:
+            if self.panel:
+                FreeCADGui.Control.closeDialog()
+                self.panel = None
+            if archive is not None:
+                os.unlink(archive)

--- a/src/Mod/BIM/bimtests/TestArchSiteGui.py
+++ b/src/Mod/BIM/bimtests/TestArchSiteGui.py
@@ -118,6 +118,25 @@ class TestArchSiteGui(TestArchBaseGui.TestArchBaseGui):
             except Exception:
                 pass
 
+    def test_site_restores_view_provider_when_guidocument_is_missing(self):
+        site = Arch.makeSite(name="HeadlessRestoreSite")
+        FreeCAD.ActiveDocument.recompute()
+
+        archive = None
+        try:
+            archive, _, restored = self.reopen_without_gui_document(site)
+            self.assertIsNotNone(restored)
+            self.assertIsNotNone(restored.ViewObject)
+            self.assertIsNotNone(restored.ViewObject.Proxy)
+            self.assertEqual(type(restored.ViewObject.Proxy).__name__, "_ViewProviderSite")
+            self.assertTrue(restored.ViewObject.Visibility)
+            self.assertIn("ShowSunPosition", restored.ViewObject.PropertiesList)
+            self.assertIn("SunDateMonth", restored.ViewObject.PropertiesList)
+            self.assertIn("SolarDiagramScale", restored.ViewObject.PropertiesList)
+        finally:
+            if archive is not None:
+                os.unlink(archive)
+
     def test_legacy_site_migration(self):
         """Legacy migration test (<=1.0.0 -> newer)
 

--- a/src/Mod/BIM/bimtests/TestArchWallGui.py
+++ b/src/Mod/BIM/bimtests/TestArchWallGui.py
@@ -24,6 +24,8 @@
 
 """GUI tests for the ArchWall module."""
 
+import os
+
 import FreeCAD
 import FreeCADGui
 import Draft
@@ -205,6 +207,23 @@ class TestArchWallGui(TestArchBaseGui.TestArchBaseGui):
         self.assertEqual(Draft.get_type(wall), "Wall")
         self.assertEqual(base.TypeId, "Sketcher::SketchObject")
         self.assertEqual(wall.Base, base, "The wall's Base should be the newly created sketch.")
+
+    def test_wall_restores_view_provider_when_guidocument_is_missing(self):
+        wall = Arch.makeWall(length=2000, width=200, height=2500)
+        self.document.recompute()
+
+        archive = None
+        try:
+            archive, _, restored = self.reopen_without_gui_document(wall)
+            self.assertIsNotNone(restored)
+            self.assertIsNotNone(restored.ViewObject)
+            self.assertIsNotNone(restored.ViewObject.Proxy)
+            self.assertEqual(type(restored.ViewObject.Proxy).__name__, "_ViewProviderWall")
+            self.assertTrue(restored.ViewObject.Visibility)
+            self.assertIn("UseMaterialColor", restored.ViewObject.PropertiesList)
+        finally:
+            if archive is not None:
+                os.unlink(archive)
 
     def test_stretch_rotated_baseless_wall(self):
         """Tests that the Draft_Stretch tool correctly handles a rotated baseless wall."""

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -488,7 +488,22 @@ def apply_current_style(objs):
                     setattr(vobj, prop, style[prop][1])
 
 
-def restore_view_object(obj, vp_module, vp_class, format=True, format_ref=None):
+def get_view_provider_proxy(vobj):
+    """Return a real Python view-provider proxy, or ``None`` if it is missing."""
+
+    if vobj is None:
+        return None
+
+    proxy = getattr(vobj, "Proxy", None)
+    if proxy is None or isinstance(proxy, int):
+        return None
+
+    return proxy
+
+
+def restore_view_object(
+    obj, vp_module=None, vp_class=None, format=True, format_ref=None, *, vp_constructor=None
+):
     """Restore the ViewObject if the object was saved without the GUI.
 
     Parameters
@@ -496,11 +511,18 @@ def restore_view_object(obj, vp_module, vp_class, format=True, format_ref=None):
     obj: App::DocumentObject
         Object whose ViewObject needs to be restored.
 
-    vp_module: string
-        View provider module. Must be in the draftviewproviders directory.
+    vp_module: string, optional
+        View provider module. Must be in the draftviewproviders directory
+        unless ``vp_constructor`` is provided.
 
-    vp_class: string
+    vp_class: string, optional
         View provider class.
+
+    vp_constructor: callable, optional
+        View provider constructor. If provided, ``vp_module`` and
+        ``vp_class`` are ignored. This lets other workbenches reuse the
+        Draft restore contract while owning their workbench-specific view
+        provider resolution.
 
     format: bool, optional
         Defaults to `True`.
@@ -512,13 +534,19 @@ def restore_view_object(obj, vp_module, vp_class, format=True, format_ref=None):
         Reference object to copy ViewObject properties from.
     """
     if not getattr(obj, "ViewObject", None):
-        return
+        return False
     vobj = obj.ViewObject
-    if not getattr(vobj, "Proxy", None):
-        vp_module = importlib.import_module("draftviewproviders." + vp_module)
-        getattr(vp_module, vp_class)(vobj)
+    if get_view_provider_proxy(vobj) is None:
+        if vp_constructor is None:
+            if vp_module is None or vp_class is None:
+                return False
+            vp_module = importlib.import_module("draftviewproviders." + vp_module)
+            vp_constructor = getattr(vp_module, vp_class)
+        vp_constructor(vobj)
         if format:
             format_object(obj, format_ref)
+        return True
+    return False
 
 
 def format_object(target, origin=None, ignore_construction=False):


### PR DESCRIPTION
When reopening a BIM document saved without `GuiDocument.xml`, several BIM objects can keep a missing or placeholder `ViewObject.Proxy`. That leaves Python view providers, view properties, and restore-time GUI behavior unavailable.

This reuses Draft's missing-view-provider restore helper, adds a BIM-specific resolver in `ArchRestore`, and restores BIM view providers from common restore hooks where possible. Restored BIM view objects are made visible because stripped/headless files do not contain GUI visibility state.

## Issues
Closes #23376

## Before and After Images
Report object reopened from an affected test file.

Before

<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/3f2f2161-0d2e-43fb-bcff-de1ccac1f83a" />

After

<img width="1600" height="1000" alt="image" src="https://github.com/user-attachments/assets/d2098342-d317-46a2-a02c-6fbfd3fdb416" />



