### PR TITLE
CAM: Path.Op.Util.approximation - Fix trim

### DIFF
--- a/src/Mod/CAM/Path/Geom.py
+++ b/src/Mod/CAM/Path/Geom.py
@@ -307,7 +307,9 @@ def cmdsForEdge(edge, flip=False, approximation=False, hSpeed=0, vSpeed=0, tol=0
 
         if isinstance(edge.Curve, Part.BSplineCurve):
             # convert B-Spline to arcs and lines
-            curves = edge.Curve.toBiArcs(tol)
+            curve = edge.Curve
+            trimmed_curve = curve.trim(*edge.ParameterRange)
+            curves = trimmed_curve.toBiArcs(tol)
             for curve in curves:
                 edge = curve.toShape()
                 if isinstance(edge.Curve, Part.Circle) and not isVertical(edge.Curve.Axis):

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -210,7 +210,9 @@ def approximateWire(wire, tolerance=0.01):
 
             if isinstance(edge.Curve, Part.BSplineCurve):
                 # Convert BSpline to arcs
-                curves = edge.Curve.toBiArcs(tolerance)
+                curve = edge.Curve
+                trimmed_curve = curve.trim(*edge.ParameterRange)
+                curves = trimmed_curve.toBiArcs(tolerance)
                 for curve in curves:
                     processed_edges.append(curve.toShape())
             else:

--- a/src/Mod/Draft/importSVG.py
+++ b/src/Mod/Draft/importSVG.py
@@ -490,7 +490,9 @@ def approximateWire(wire, tolerance=0.01):
 
             if isinstance(edge.Curve, Part.BSplineCurve):
                 # Convert BSpline to arcs
-                curves = edge.Curve.toBiArcs(tolerance)
+                curve = edge.Curve
+                trimmed_curve = curve.trim(*edge.ParameterRange)
+                curves = trimmed_curve.toBiArcs(tolerance)
                 for curve in curves:
                     processed_edges.append(curve.toShape())
             else:


### PR DESCRIPTION
There is a cases then new method `Path.Op.Util.approximation()` can give incorrect result
Description in [forum](https://forum.freecad.org/viewtopic.php?t=104840)

<img width="561" height="391" alt="Screenshot_20260420_131702_lossy" src="https://github.com/user-attachments/assets/d855303e-e2e4-4411-acd7-1f9db042e07b" />
