### PR TITLE
PartDesign: fix out of scope Std_Group error

### DIFF
--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -24,6 +24,7 @@
  ***************************************************************************/
 
 #include <App/Document.h>
+#include <App/DocumentObjectGroup.h>
 #include <Base/Tools.h>
 
 #include "GeoFeatureGroupExtension.h"
@@ -494,6 +495,10 @@ bool GeoFeatureGroupExtension::isLinkValid(App::Property* prop)
     // no cross CS link for local links.
     auto result = getScopedObjectsFromLink(prop, LinkScope::Local);
     auto group = getGroupOfObject(obj);
+    if (!group && obj->isDerivedFrom(App::DocumentObjectGroup::getClassTypeId())) {
+        return true;
+    }
+
     for (auto link : result) {
         if (getGroupOfObject(link) != group) {
             return false;

--- a/src/App/GeoFeatureGroupExtension.cpp
+++ b/src/App/GeoFeatureGroupExtension.cpp
@@ -495,8 +495,8 @@ bool GeoFeatureGroupExtension::isLinkValid(App::Property* prop)
     // no cross CS link for local links.
     auto result = getScopedObjectsFromLink(prop, LinkScope::Local);
     auto group = getGroupOfObject(obj);
-    if (!group && obj->isDerivedFrom(App::DocumentObjectGroup::getClassTypeId())) {
-        return true;
+    if (!group && obj->isDerivedFrom<App::DocumentObjectGroup>()) {
+        return true; // this prop comes from Std_Group, scopes also are meaningless
     }
 
     for (auto link : result) {

--- a/tests/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/tests/src/Mod/PartDesign/App/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(PartDesign_tests_run
         DatumPlane.cpp
         ShapeBinder.cpp
         Pad.cpp
+        GeoFeatureGroupExtension.cpp
 )
 
 set(PartDesignTestData_Files

--- a/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
+++ b/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
@@ -10,16 +10,22 @@
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/Feature.h>
 
-class GeoFeatureGroupTest : public ::testing::Test {
+class GeoFeatureGroupTest: public ::testing::Test
+{
 protected:
-    static void SetUpTestSuite() { tests::initApplication(); }
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
 
-    void SetUp() override {
+    void SetUp() override
+    {
         _docName = App::GetApplication().getUniqueDocumentName("GeoTest");
         _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
     }
 
-    void TearDown() override {
+    void TearDown() override
+    {
         App::GetApplication().closeDocument(_docName.c_str());
     }
 
@@ -27,7 +33,8 @@ protected:
     std::string _docName;
 };
 
-TEST_F(GeoFeatureGroupTest, testIsLinkValidForDocumentObjectGroup) {
+TEST_F(GeoFeatureGroupTest, testIsLinkValidForDocumentObjectGroup)
+{
     auto group = _doc->addObject<App::DocumentObjectGroup>("Group");
 
     auto body1 = _doc->addObject<PartDesign::Body>("Body1");
@@ -42,7 +49,8 @@ TEST_F(GeoFeatureGroupTest, testIsLinkValidForDocumentObjectGroup) {
     EXPECT_TRUE(App::GeoFeatureGroupExtension::isLinkValid(prop));
 }
 
-TEST_F(GeoFeatureGroupTest, testIsLinkValidCrossFailure) {
+TEST_F(GeoFeatureGroupTest, testIsLinkValidCrossFailure)
+{
     auto body1 = _doc->addObject<PartDesign::Body>("Body1");
     auto body2 = _doc->addObject<PartDesign::Body>("Body2");
 

--- a/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
+++ b/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
@@ -43,32 +43,26 @@ protected:
 void createRectangle(Sketcher::SketchObject* sketch, double width, double height)
 {
     auto line1 = std::make_unique<Part::GeomLineSegment>();
-    line1->setPoints(Base::Vector3d(0, 0, 0),
-                     Base::Vector3d(width, 0, 0));
+    line1->setPoints(Base::Vector3d(0, 0, 0), Base::Vector3d(width, 0, 0));
     sketch->addGeometry(line1.release(), false);
 
     auto line2 = std::make_unique<Part::GeomLineSegment>();
-    line2->setPoints(Base::Vector3d(width, 0, 0),
-                     Base::Vector3d(width, height, 0));
+    line2->setPoints(Base::Vector3d(width, 0, 0), Base::Vector3d(width, height, 0));
     sketch->addGeometry(line2.release(), false);
 
     auto line3 = std::make_unique<Part::GeomLineSegment>();
-    line3->setPoints(Base::Vector3d(width, height, 0),
-                     Base::Vector3d(0, height, 0));
+    line3->setPoints(Base::Vector3d(width, height, 0), Base::Vector3d(0, height, 0));
     sketch->addGeometry(line3.release(), false);
 
     auto line4 = std::make_unique<Part::GeomLineSegment>();
-    line4->setPoints(Base::Vector3d(0, height, 0),
-                     Base::Vector3d(0, 0, 0));
+    line4->setPoints(Base::Vector3d(0, height, 0), Base::Vector3d(0, 0, 0));
     sketch->addGeometry(line4.release(), false);
 
-    auto createConstraint =
-        [](Sketcher::ConstraintType type,
-           int geo1,
-           Sketcher::PointPos pos1,
-           int geo2,
-           Sketcher::PointPos pos2)
-    {
+    auto createConstraint = [](Sketcher::ConstraintType type,
+                               int geo1,
+                               Sketcher::PointPos pos1,
+                               int geo2,
+                               Sketcher::PointPos pos2) {
         auto c = std::make_unique<Sketcher::Constraint>();
 
         c->Type = type;
@@ -81,45 +75,54 @@ void createRectangle(Sketcher::SketchObject* sketch, double width, double height
         return c;
     };
 
-    sketch->addConstraint(
-        createConstraint(
-            Sketcher::ConstraintType::Coincident,
-            0, Sketcher::PointPos::end,
-            1, Sketcher::PointPos::start
-        ).release());
+    sketch->addConstraint(createConstraint(
+                              Sketcher::ConstraintType::Coincident,
+                              0,
+                              Sketcher::PointPos::end,
+                              1,
+                              Sketcher::PointPos::start
+    )
+                              .release());
 
-    sketch->addConstraint(
-        createConstraint(
-            Sketcher::ConstraintType::Coincident,
-            1, Sketcher::PointPos::end,
-            2, Sketcher::PointPos::start
-        ).release());
+    sketch->addConstraint(createConstraint(
+                              Sketcher::ConstraintType::Coincident,
+                              1,
+                              Sketcher::PointPos::end,
+                              2,
+                              Sketcher::PointPos::start
+    )
+                              .release());
 
-    sketch->addConstraint(
-        createConstraint(
-            Sketcher::ConstraintType::Coincident,
-            2, Sketcher::PointPos::end,
-            3, Sketcher::PointPos::start
-        ).release());
+    sketch->addConstraint(createConstraint(
+                              Sketcher::ConstraintType::Coincident,
+                              2,
+                              Sketcher::PointPos::end,
+                              3,
+                              Sketcher::PointPos::start
+    )
+                              .release());
 
-    sketch->addConstraint(
-        createConstraint(
-            Sketcher::ConstraintType::Coincident,
-            3, Sketcher::PointPos::end,
-            0, Sketcher::PointPos::start
-        ).release());
+    sketch->addConstraint(createConstraint(
+                              Sketcher::ConstraintType::Coincident,
+                              3,
+                              Sketcher::PointPos::end,
+                              0,
+                              Sketcher::PointPos::start
+    )
+                              .release());
 }
 
-TEST_F(GeoFeatureGroupTest, testDocumentObjectGroupAcceptsBoolean) {
+TEST_F(GeoFeatureGroupTest, testDocumentObjectGroupAcceptsBoolean)
+{
     auto group = _doc->addObject<App::DocumentObjectGroup>("Group");
 
     auto body1 = _doc->addObject<PartDesign::Body>("Body10x10");
     group->addObject(body1);
-    
+
     auto sketch1 = _doc->addObject<Sketcher::SketchObject>("Sketch1");
     body1->addObject(sketch1);
     createRectangle(sketch1, 10.0, 10.0);
-    
+
     auto pad1 = _doc->addObject<PartDesign::Pad>("Pad10");
     body1->addObject(pad1);
     pad1->Profile.setValue(sketch1);
@@ -128,23 +131,23 @@ TEST_F(GeoFeatureGroupTest, testDocumentObjectGroupAcceptsBoolean) {
 
     auto body2 = _doc->addObject<PartDesign::Body>("Body10x20");
     group->addObject(body2);
-    
+
     auto sketch2 = _doc->addObject<Sketcher::SketchObject>("Sketch2");
     body2->addObject(sketch2);
     createRectangle(sketch2, 10.0, 20.0);
-    
+
     auto pad2 = _doc->addObject<PartDesign::Pad>("Pad20");
     body2->addObject(pad2);
     pad2->Profile.setValue(sketch2);
-    pad2->Length.setValue(20.0); // Altura do Pad = 20
+    pad2->Length.setValue(20.0);  // Altura do Pad = 20
     body2->Group.setValue({sketch2, pad2});
 
     auto boolOp = _doc->addObject<PartDesign::Boolean>("BooleanOp");
     body1->addObject(boolOp);
-    
-    boolOp->Type.setValue("Fuse"); 
 
-    boolOp->Group.setValue({body2}); 
+    boolOp->Type.setValue("Fuse");
+
+    boolOp->Group.setValue({body2});
     _doc->recompute();
 
     std::vector<App::Property*> list;

--- a/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
+++ b/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
@@ -140,7 +140,7 @@ TEST_F(GeoFeatureGroupTest, testDocumentObjectGroupAcceptsBoolean)
     auto pad2 = _doc->addObject<PartDesign::Pad>("Pad20");
     body2->addObject(pad2);
     pad2->Profile.setValue(sketch2);
-    pad2->Length.setValue(20.0); //20 in height difference
+    pad2->Length.setValue(20.0);  // 20 in height difference
     body2->Group.setValue({sketch2, pad2});
 
     auto boolOp = _doc->addObject<PartDesign::Boolean>("BooleanOp");

--- a/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
+++ b/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+#include "src/App/InitApplication.h"
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObjectGroup.h>
+#include <App/GeoFeatureGroupExtension.h>
+#include <Mod/PartDesign/App/Body.h>
+#include <Mod/PartDesign/App/Feature.h>
+
+class GeoFeatureGroupTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() { tests::initApplication(); }
+
+    void SetUp() override {
+        _docName = App::GetApplication().getUniqueDocumentName("GeoTest");
+        _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
+    }
+
+    void TearDown() override {
+        App::GetApplication().closeDocument(_docName.c_str());
+    }
+
+    App::Document* _doc = nullptr;
+    std::string _docName;
+};
+
+TEST_F(GeoFeatureGroupTest, testIsLinkValidForDocumentObjectGroup) {
+    auto group = _doc->addObject<App::DocumentObjectGroup>("Group");
+
+    auto body1 = _doc->addObject<PartDesign::Body>("Body1");
+    auto body2 = _doc->addObject<PartDesign::Body>("Body2");
+
+    group->addObject(body1);
+    group->addObject(body2);
+
+    auto prop = group->getPropertyByName("Group");
+    ASSERT_TRUE(prop != nullptr);
+
+    EXPECT_TRUE(App::GeoFeatureGroupExtension::isLinkValid(prop));
+}
+
+TEST_F(GeoFeatureGroupTest, testIsLinkValidCrossFailure) {
+    auto body1 = _doc->addObject<PartDesign::Body>("Body1");
+    auto body2 = _doc->addObject<PartDesign::Body>("Body2");
+
+    auto feature = _doc->addObject<PartDesign::Feature>("Feature");
+    body2->addObject(feature);
+
+    auto linkProp = new App::PropertyLink();
+    linkProp->setContainer(body1);
+    linkProp->setValue(feature);
+
+    bool valid = App::GeoFeatureGroupExtension::isLinkValid(linkProp);
+    EXPECT_FALSE(valid);
+}

--- a/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
+++ b/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
@@ -13,9 +13,10 @@
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/Feature.h>
 #include <Mod/PartDesign/App/FeatureBoolean.h>
-#include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/FeaturePad.h>
 #include <Mod/Sketcher/App/SketchObject.h>
+
+// NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
 
 class GeoFeatureGroupTest: public ::testing::Test
 {
@@ -139,7 +140,7 @@ TEST_F(GeoFeatureGroupTest, testDocumentObjectGroupAcceptsBoolean)
     auto pad2 = _doc->addObject<PartDesign::Pad>("Pad20");
     body2->addObject(pad2);
     pad2->Profile.setValue(sketch2);
-    pad2->Length.setValue(20.0);  // Altura do Pad = 20
+    pad2->Length.setValue(20.0); //20 in height difference
     body2->Group.setValue({sketch2, pad2});
 
     auto boolOp = _doc->addObject<PartDesign::Boolean>("BooleanOp");
@@ -172,3 +173,5 @@ TEST_F(GeoFeatureGroupTest, testIsLinkValidCrossFailure)
     bool valid = App::GeoFeatureGroupExtension::isLinkValid(&linkProp);
     EXPECT_FALSE(valid);
 }
+
+// NOLINTEND(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)

--- a/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
+++ b/tests/src/Mod/PartDesign/App/GeoFeatureGroupExtension.cpp
@@ -1,14 +1,21 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <gtest/gtest.h>
+#include <memory>
+
 #include "src/App/InitApplication.h"
 
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObjectGroup.h>
 #include <App/GeoFeatureGroupExtension.h>
+
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/Feature.h>
+#include <Mod/PartDesign/App/FeatureBoolean.h>
+#include <Mod/PartDesign/App/Body.h>
+#include <Mod/PartDesign/App/FeaturePad.h>
+#include <Mod/Sketcher/App/SketchObject.h>
 
 class GeoFeatureGroupTest : public ::testing::Test {
 protected:
@@ -27,19 +34,118 @@ protected:
     std::string _docName;
 };
 
-TEST_F(GeoFeatureGroupTest, testIsLinkValidForDocumentObjectGroup) {
+void createRectangle(Sketcher::SketchObject* sketch, double width, double height)
+{
+    auto line1 = std::make_unique<Part::GeomLineSegment>();
+    line1->setPoints(Base::Vector3d(0, 0, 0),
+                     Base::Vector3d(width, 0, 0));
+    sketch->addGeometry(line1.release(), false);
+
+    auto line2 = std::make_unique<Part::GeomLineSegment>();
+    line2->setPoints(Base::Vector3d(width, 0, 0),
+                     Base::Vector3d(width, height, 0));
+    sketch->addGeometry(line2.release(), false);
+
+    auto line3 = std::make_unique<Part::GeomLineSegment>();
+    line3->setPoints(Base::Vector3d(width, height, 0),
+                     Base::Vector3d(0, height, 0));
+    sketch->addGeometry(line3.release(), false);
+
+    auto line4 = std::make_unique<Part::GeomLineSegment>();
+    line4->setPoints(Base::Vector3d(0, height, 0),
+                     Base::Vector3d(0, 0, 0));
+    sketch->addGeometry(line4.release(), false);
+
+    auto createConstraint =
+        [](Sketcher::ConstraintType type,
+           int geo1,
+           Sketcher::PointPos pos1,
+           int geo2,
+           Sketcher::PointPos pos2)
+    {
+        auto c = std::make_unique<Sketcher::Constraint>();
+
+        c->Type = type;
+
+        c->setGeoId(0, geo1);
+        c->setPosId(0, pos1);
+        c->setGeoId(1, geo2);
+        c->setPosId(1, pos2);
+
+        return c;
+    };
+
+    sketch->addConstraint(
+        createConstraint(
+            Sketcher::ConstraintType::Coincident,
+            0, Sketcher::PointPos::end,
+            1, Sketcher::PointPos::start
+        ).release());
+
+    sketch->addConstraint(
+        createConstraint(
+            Sketcher::ConstraintType::Coincident,
+            1, Sketcher::PointPos::end,
+            2, Sketcher::PointPos::start
+        ).release());
+
+    sketch->addConstraint(
+        createConstraint(
+            Sketcher::ConstraintType::Coincident,
+            2, Sketcher::PointPos::end,
+            3, Sketcher::PointPos::start
+        ).release());
+
+    sketch->addConstraint(
+        createConstraint(
+            Sketcher::ConstraintType::Coincident,
+            3, Sketcher::PointPos::end,
+            0, Sketcher::PointPos::start
+        ).release());
+}
+
+TEST_F(GeoFeatureGroupTest, testDocumentObjectGroupAcceptsBoolean) {
     auto group = _doc->addObject<App::DocumentObjectGroup>("Group");
 
-    auto body1 = _doc->addObject<PartDesign::Body>("Body1");
-    auto body2 = _doc->addObject<PartDesign::Body>("Body2");
-
+    auto body1 = _doc->addObject<PartDesign::Body>("Body10x10");
     group->addObject(body1);
+    
+    auto sketch1 = _doc->addObject<Sketcher::SketchObject>("Sketch1");
+    body1->addObject(sketch1);
+    createRectangle(sketch1, 10.0, 10.0);
+    
+    auto pad1 = _doc->addObject<PartDesign::Pad>("Pad10");
+    body1->addObject(pad1);
+    pad1->Profile.setValue(sketch1);
+    pad1->Length.setValue(10.0);
+    body1->Group.setValue({sketch1, pad1});
+
+    auto body2 = _doc->addObject<PartDesign::Body>("Body10x20");
     group->addObject(body2);
+    
+    auto sketch2 = _doc->addObject<Sketcher::SketchObject>("Sketch2");
+    body2->addObject(sketch2);
+    createRectangle(sketch2, 10.0, 20.0);
+    
+    auto pad2 = _doc->addObject<PartDesign::Pad>("Pad20");
+    body2->addObject(pad2);
+    pad2->Profile.setValue(sketch2);
+    pad2->Length.setValue(20.0); // Altura do Pad = 20
+    body2->Group.setValue({sketch2, pad2});
 
-    auto prop = group->getPropertyByName("Group");
-    ASSERT_TRUE(prop != nullptr);
+    auto boolOp = _doc->addObject<PartDesign::Boolean>("BooleanOp");
+    body1->addObject(boolOp);
+    
+    boolOp->Type.setValue("Fuse"); 
 
-    EXPECT_TRUE(App::GeoFeatureGroupExtension::isLinkValid(prop));
+    boolOp->Group.setValue({body2}); 
+    _doc->recompute();
+
+    std::vector<App::Property*> list;
+    group->getPropertyList(list);
+    for (App::Property* prop : list) {
+        EXPECT_TRUE(App::GeoFeatureGroupExtension::isLinkValid(prop));
+    }
 }
 
 TEST_F(GeoFeatureGroupTest, testIsLinkValidCrossFailure) {
@@ -49,10 +155,10 @@ TEST_F(GeoFeatureGroupTest, testIsLinkValidCrossFailure) {
     auto feature = _doc->addObject<PartDesign::Feature>("Feature");
     body2->addObject(feature);
 
-    auto linkProp = new App::PropertyLink();
-    linkProp->setContainer(body1);
-    linkProp->setValue(feature);
+    App::PropertyLink linkProp;
+    linkProp.setContainer(body1);
+    linkProp.setValue(feature);
 
-    bool valid = App::GeoFeatureGroupExtension::isLinkValid(linkProp);
+    bool valid = App::GeoFeatureGroupExtension::isLinkValid(&linkProp);
     EXPECT_FALSE(valid);
 }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
closes #24867.

## Brief Summary 
When `DocumentObject` recomputes, it checks if geometric links are valid (DocumentObject.cpp, line 156).
It checks geometric links by getting all `DocumentObject` properties (GeoFeatureGroupExtension.cpp, line 471),
which also return `DocumentObjectGroup` as a property in the list of properties.

Then, it checks property by property (GeoFeatureGroupExtension.cpp, line 472) if its links are valid, by getting the group of
the property and the group of the links.

The problem arises when it tries to get the group of the property `DocumentObjectGroup`, which returns null, and then compares this null with each linked object's group.

To solve this problem, whenever isLinkValid method receives a `DocumentObjectGroup`, it now returns true since it has no link scope or geometrical coordinates.


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
