### PR TITLE
BIM: fix fill of shaft-like objects in TechDraw_ArchView

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -169,13 +169,8 @@ def getCutShapes(
                     if sub.Volume < 0:
                         sub = sub.reversed()  # Use reversed as sub is immutable.
                     c = sub.cut(cutvolume)
-                    s = sub.section(cutface)
-                    try:
-                        wires = DraftGeomUtils.findWires(s.Edges)
-                        tmpSshapes.extend(Part.makeFace(wires, "Part::FaceMakerBullseye").Faces)
-                    except Part.OCCError:
-                        # print "ArchView: unable to get a face"
-                        tmpSshapes.append(s)
+                    s = sub.common(cutface)
+                    tmpSshapes.extend(s.Faces)
                     shapes.extend(c.SubShapes if c.ShapeType == "Compound" else [c])
                     if showHidden:
                         c = sub.cut(invcutvolume)

--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -172,9 +172,7 @@ def getCutShapes(
                     s = sub.section(cutface)
                     try:
                         wires = DraftGeomUtils.findWires(s.Edges)
-                        for w in wires:
-                            f = Part.Face(w)
-                            tmpSshapes.append(f)
+                        tmpSshapes.extend(Part.makeFace(wires, "Part::FaceMakerBullseye").Faces)
                     except Part.OCCError:
                         # print "ArchView: unable to get a face"
                         tmpSshapes.append(s)


### PR DESCRIPTION
Fixes #27813.

Sectioned objects with enclosed voids, such as shafts, were not handled properly. For every wire a separate face was created, resulting in a filled void in the TD view. Fixed by using `Part::FaceMakerBullseye`.