### PR TITLE
BIM: fix fill of shaft-like objects in Draft_Shape2DView

### DIFF
--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -113,7 +113,7 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
                 App.Vector(2000, 1000, 0),
                 App.Vector(2000, 0, 0),
             ],
-            closed=True
+            closed=True,
         )
         wire.MakeFace = False
         wall = Arch.makeWall(wire, height=3000, width=200)

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -44,7 +44,7 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
             section_plane.Label, "TestSectionPlane", "Section plane label is incorrect."
         )
 
-    def testViewGeneration(self):
+    def testTechDrawViewGeneration(self):
         """Tests the whole TD view generation workflow"""
 
         # Create a few objects
@@ -100,3 +100,33 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         view.Y = "15cm"
         App.ActiveDocument.recompute()
         assert True
+
+    def testShape2DViewGeneration(self):
+        """Tests Draft_Shape2DView face with hole creation"""
+
+        # Create a wall based on a clock-wise wire starting at the lower left corner.
+        # Such a wire would previously result in an invalid face in the Shape2DView.
+        wire = Draft.make_wire(
+            [
+                App.Vector(0, 0, 0),
+                App.Vector(0, 1000, 0),
+                App.Vector(2000, 1000, 0),
+                App.Vector(2000, 0, 0),
+            ],
+            closed=True
+        )
+        wire.MakeFace = False
+        wall = Arch.makeWall(wire, height=3000, width=200)
+        App.ActiveDocument.recompute()
+
+        section = Arch.makeSectionPlane(wall)
+        shp_view = Draft.make_shape2dview(section)
+        shp_view.InPlace = False
+        shp_view.ProjectionMode = "Cutfaces"
+        App.ActiveDocument.recompute()
+
+        face = shp_view.Shape.Faces[0]
+        self.assertTrue(face.isValid())
+
+        area_expected = 1200 * 2200 - 800 * 1800
+        self.assertAlmostEqual(face.Area, area_expected)

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -349,35 +349,11 @@ class Shape2DView(DraftObject):
                                 if hasattr(obj, "InPlace"):
                                     if obj.InPlace:
                                         faces = facesOrg
-                                    # Alternative approach in https://forum.freecad.org/viewtopic.php?p=807314#p807314, not adopted
                                     else:
                                         for faceOrg in facesOrg:
-                                            if len(faceOrg.Wires) == 1:
-                                                wireProj = self.getProjected(obj, faceOrg, proj)
-                                                # return Compound
-                                                wireProjWire = Part.Wire(wireProj.Edges)
-                                                faceProj = Part.Face(wireProjWire)
-                                            elif len(faceOrg.Wires) == 2:
-                                                wireClosedOuter = faceOrg.OuterWire
-                                                for w in faceOrg.Wires:
-                                                    if not w.isEqual(wireClosedOuter):
-                                                        wireClosedInner = w
-                                                        break
-                                                wireProjOuter = self.getProjected(
-                                                    obj, wireClosedOuter, proj
-                                                )
-                                                # return Compound
-                                                wireProjOuterWire = Part.Wire(wireProjOuter.Edges)
-                                                faceProj = Part.Face(wireProjOuterWire)
-                                                wireProjInner = self.getProjected(
-                                                    obj, wireClosedInner, proj
-                                                )
-                                                # return Compound
-                                                wireProjInnerWire = Part.Wire(wireProjInner.Edges)
-                                                faceProj.cutHoles(
-                                                    [wireProjInnerWire]
-                                                )  # (list of wires)
-                                            faces.append(faceProj)
+                                            edge_compounds = [self.getProjected(obj, w, proj) for w in faceOrg.Wires]
+                                            wires = [Part.Wire(comp.Edges) for comp in edge_compounds]
+                                            faces.extend(Part.makeFace(wires, "Part::FaceMakerBullseye").Faces)
                             else:
                                 c = sh.section(cutp)
                                 if hasattr(obj, "InPlace"):

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -351,9 +351,18 @@ class Shape2DView(DraftObject):
                                         faces = facesOrg
                                     else:
                                         for faceOrg in facesOrg:
-                                            edge_compounds = [self.getProjected(obj, w, proj) for w in faceOrg.Wires]
-                                            wires = [Part.Wire(comp.Edges) for comp in edge_compounds]
-                                            faces.extend(Part.makeFace(wires, "Part::FaceMakerBullseye").Faces)
+                                            edge_compounds = [
+                                                self.getProjected(obj, w, proj)
+                                                for w in faceOrg.Wires
+                                            ]
+                                            wires = [
+                                                Part.Wire(comp.Edges) for comp in edge_compounds
+                                            ]
+                                            faces.extend(
+                                                Part.makeFace(
+                                                    wires, "Part::FaceMakerBullseye"
+                                                ).Faces
+                                            )
                             else:
                                 c = sh.section(cutp)
                                 if hasattr(obj, "InPlace"):


### PR DESCRIPTION
Reported on the forum:
https://forum.freecad.org/viewtopic.php?t=104639

The old code could fail to detect voids in sectioned objects. In the example file attached to the forum topic a wall based on a clock-wise rectangular Draft_Wire starting at the lower left corner, caused such a failure. Fixed by using `Part::FaceMakerBullseye`. Test code for this particular case has been added.

Related:
#29537: PR to fix the same issue in TechDraw_ArchViews.
#19306: Previous PR to fix the issue in Draft_Shape2DViews. The new code has been tested with the example from the related issue.