### PR TITLE
Gui: ignore Graphviz unflatten result if empty

### DIFF
--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -104,7 +104,10 @@ public:
             unflattenProc.closeWriteChannel();
             // no error handling: unflatten is optional
             unflattenProc.waitForFinished();
-            preprocessed = unflattenProc.readAll();
+            QByteArray unflatPreproc = unflattenProc.readAll();
+            if (!unflatPreproc.isEmpty()) {
+                preprocessed = unflatPreproc;
+            }
         }
         else {
             unflattenProc.closeWriteChannel();
@@ -373,7 +376,7 @@ void GraphvizView::updateSvgItem(const App::Document& doc)
 void GraphvizView::svgFileRead(const QByteArray& data)
 {
     // Update renderer with new SVG file, and give message if something went wrong
-    if (renderer->load(data)) {
+    if (! data.isEmpty() && renderer->load(data)) {
         svgItem->setSharedRenderer(renderer);
     }
     else {

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -376,7 +376,7 @@ void GraphvizView::updateSvgItem(const App::Document& doc)
 void GraphvizView::svgFileRead(const QByteArray& data)
 {
     // Update renderer with new SVG file, and give message if something went wrong
-    if (! data.isEmpty() && renderer->load(data)) {
+    if (!data.isEmpty() && renderer->load(data)) {
         svgItem->setSharedRenderer(renderer);
     }
     else {


### PR DESCRIPTION
The unflatten utility of Graphviz sometime fails to produce a result. As this result is, by default, used as the input for the main dependency graph creation process it ends with the **Graphviz failed to create an image file** error.

This PR introduce a check on the unflatten result and silently ignore it if it's empty.

https://forum.freecad.org/viewtopic.php?p=884859 [fr]

EDIT : in fact the _unflatten_ executable existence is not checked and if this tool is not installed (e.g. on debian trixie _dot_ and _unflatten_ are in two different packages) the process silently fails.