### PR TITLE
Measurement: Allow measuring of internal sketch faces

### DIFF
--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -100,7 +100,7 @@ TopoDS_Shape getLocatedShape(const App::SubObjectT& subject, Base::Matrix4D* mat
         subject.getElementName(),
         mat
     );
-    
+
     if (shape.IsNull()) {
         Base::Console().log(
             "Part::MeasureClient::getLocatedShape: Did not retrieve shape for %s, %s\n",
@@ -109,7 +109,7 @@ TopoDS_Shape getLocatedShape(const App::SubObjectT& subject, Base::Matrix4D* mat
         );
         return {};
     }
-    
+
     return shape;
 }
 

--- a/src/Mod/Part/App/MeasureClient.cpp
+++ b/src/Mod/Part/App/MeasureClient.cpp
@@ -93,14 +93,15 @@ TopoDS_Shape getLocatedShape(const App::SubObjectT& subject, Base::Matrix4D* mat
         return {};
     }
 
-    Part::TopoShape shape = Part::Feature::getTopoShape(
+    TopoDS_Shape shape = Part::Feature::getShape(
         obj,
-        Part::ShapeOption::ResolveLink | Part::ShapeOption::Transform,
+        Part::ShapeOption::NeedSubElement | Part::ShapeOption::ResolveLink
+            | Part::ShapeOption::Transform,
         subject.getElementName(),
         mat
     );
-
-    if (shape.isNull()) {
+    
+    if (shape.IsNull()) {
         Base::Console().log(
             "Part::MeasureClient::getLocatedShape: Did not retrieve shape for %s, %s\n",
             obj->getNameInDocument(),
@@ -108,20 +109,8 @@ TopoDS_Shape getLocatedShape(const App::SubObjectT& subject, Base::Matrix4D* mat
         );
         return {};
     }
-
-    auto placement
-        = App::GeoFeature::getGlobalPlacement(obj, subject.getObject(), subject.getSubName());
-    shape.setPlacement(placement);
-
-    // Don't get the subShape from datum elements
-    if (obj->isDerivedFrom<Part::Datum>()) {
-        return shape.getShape();
-    }
-
-    if (!subject.getElementName()) {
-        return shape.getShape();
-    }
-    return shape.getSubShape(subject.getElementName(), true);
+    
+    return shape;
 }
 
 


### PR DESCRIPTION
Allows for the measuring of internal sketch faces in the Std_Measure tool. 

Now `getLocatedShape` uses the same logic as `PartMeasureTypeCb` to find the shape.

## Isssue
Closes: #28817 

## Images
Before:
<img width="1080" height="629" alt="before" src="https://github.com/user-attachments/assets/d2bf7ec4-8935-4934-9827-fa531834b275" />
After:
<img width="1357" height="757" alt="after" src="https://github.com/user-attachments/assets/53c54c57-f9c0-4aed-8be1-1192bb246fb6" />
