### PR TITLE
Sketcher: change 'Change Value' to 'Edit Value' in task panel

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -651,7 +651,7 @@ void ConstraintView::contextMenuEvent(QContextMenuEvent* event)
 
     // This does the same as a double-click and thus it should be the first action and with bold
     // text
-    QAction* change = menu.addAction(tr("Change Value"), this, &ConstraintView::modifyCurrentItem);
+    QAction* change = menu.addAction(tr("Edit Value"), this, &ConstraintView::modifyCurrentItem);
     change->setEnabled(isQuantity);
     menu.setDefaultAction(change);
 


### PR DESCRIPTION
For compatibility with the 3D View context menu of dimensions:
<img width="461" height="200" alt="afbeelding" src="https://github.com/user-attachments/assets/2db54b3a-4e6a-4ab5-9437-316bf430e2a4" />
