### PR TITLE
TechDraw: Fix crash in automatic dimension snapping

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
+++ b/src/Mod/TechDraw/Gui/QGIDatumLabel.cpp
@@ -113,7 +113,11 @@ QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant& va
     else if (change == ItemPositionHasChanged && scene()) {
         if (!(QApplication::keyboardModifiers() & Qt::AltModifier)) {
             QPointF newPos = value.toPointF();    //position within parent!
-            snapPosition(newPos);
+            if (!m_inhibitSnapOnPosChange) {
+                // we don't want to snap if snap caused this position change
+                snapPosition(newPos);
+            }
+            m_inhibitSnapOnPosChange = false;
         }
 
         m_dragState = DragState::Dragging;
@@ -125,6 +129,10 @@ QVariant QGIDatumLabel::itemChange(GraphicsItemChange change, const QVariant& va
 
 void QGIDatumLabel::snapPosition(QPointF& pos)
 {
+    if (!Preferences::SnapViews()) {
+        return;
+    }
+
     qreal snapPercent = 0.4;
     double dimSpacing = Rez::guiX(activeDimAttributes.getCascadeSpacing());
 
@@ -145,6 +153,10 @@ void QGIDatumLabel::snapPosition(QPointF& pos)
 
     // 1 - We try to snap the label to its center position.
     pointPair pp = dim->getLinearPoints();
+    if (pp.first().IsEqual(pp.second(), EWTOLERANCE)) {
+        // probably a broken dim
+        return;
+    }
     Base::Vector3d p1_3d = Rez::guiX(pp.first());
     Base::Vector3d p2_3d = Rez::guiX(pp.second());
     Base::Vector2d p1 = Base::Vector2d(p1_3d.x, p1_3d.y);
@@ -238,8 +250,9 @@ void QGIDatumLabel::snapPosition(QPointF& pos)
         }
     }
 
-
-    setPos(pos); // no infinite loop because if pos doesn't change then itemChanged is not triggered.
+    // block itemChange from calling snapPosition again
+    m_inhibitSnapOnPosChange = true;
+    setPos(pos);
 }
 
 void QGIDatumLabel::mousePressEvent(QGraphicsSceneMouseEvent* event)

--- a/src/Mod/TechDraw/Gui/QGIDatumLabel.h
+++ b/src/Mod/TechDraw/Gui/QGIDatumLabel.h
@@ -124,6 +124,7 @@ private:
     bool m_ctrl;
 
     DragState m_dragState;
+    bool m_inhibitSnapOnPosChange{false};
 
 private:
 };


### PR DESCRIPTION
This PR implements a fix for issue #27909.

The fault occurs in the automatic snapping logic in QGIDatumLabel::snapPosition. The code attempts to align the datum label (dimension text) to other dimensions by an incremental position change for each dimension.  

Each position change triggers itemChange, which in turn calls snapPosition.  If the incremental changes do not converge rapidly to a stable position, this will cause an infinite loop (or at least one that consumes excessive resources), and eventually a stack overflow or access violation.

The number of dimensions involved in the alignment process affects the likelihood of a crash.  The algorithm works for view with a small number of dimensions that are close to the proper alignment.

Two other changes are included.  The first is a check that snapping is enabled before beginning the incremental 
process.  The second skips broken distance dimensions.

This change prevents the crash with the sample file referenced in the issue. 

It may be that the better long term solution is to remove the auto-snap logic completely and replace it with a solution
where all the dimensions to be aligned are selected and then aligned as a group.  As an example, this is the approach taken in Inkscape's Align and Distribute menu.  This may not be the traditional CAD solution, however.