### PR TITLE
Core: Update d->programVersion after successful save

### DIFF
--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1948,7 +1948,13 @@ bool Document::save()
             LastModifiedBy.setValue(Author.c_str());
         }
 
-        return saveToFile(FileName.getValue());
+        bool result = saveToFile(FileName.getValue());
+        if (result) {
+            d->programVersion = Application::Config()["BuildVersionMajor"] + "."
+                + Application::Config()["BuildVersionMinor"] + "R"
+                + Application::Config()["BuildRevision"];
+        }
+        return result;
     }
 
     return false;


### PR DESCRIPTION
This fixes a bug where the document's internal version string was not updated to the current FreeCAD version after a successful save. This prevents repeated version warnings on subsequent saves.

This is related to PR #28389 