### PR TITLE
Gui: Orient datum labels

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1455,6 +1455,40 @@ void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& t
     glDrawArrow(geom.pnt4, geom.dirEnd, arrowWidth, arrowLength);
 }
 
+// Returns:
+// angleRad — sketch rotation angle in radians (-pi .. pi)
+// CCW is positive, CW is negative, and the angle is measured from the camera's right vector to the
+// sketch's local X axis.
+float SoDatumLabel::getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, bool flip)
+{
+    SbMatrix m = SoModelMatrixElement::get(state);
+
+    // --- Camera basis from view volume (screen space axes) ---
+    SbVec3f camRight = viewVolume.lrf - viewVolume.llf;
+    SbVec3f camUp = viewVolume.ulf - viewVolume.llf;
+
+    camRight.normalize();
+    camUp.normalize();
+
+    SbVec3f viewDir = viewVolume.getProjectionDirection();
+
+    // --- Sketch local X axis in world space ---
+    SbVec3f x_world;
+    m.multDirMatrix(SbVec3f(1, 0, 0), x_world);
+
+    // --- Project sketch axis onto view plane ---
+    SbVec3f x_proj = x_world - viewDir * x_world.dot(viewDir);
+
+    // --- Compute angle in screen space ---
+    float cosA = x_proj.dot(camRight);
+    float sinA = x_proj.dot(camUp);
+
+    float angleRad = std::atan2(sinA, cosA);
+
+    // --- Optional flip correction (back-facing view) ---
+    return flip ? angleRad : -angleRad;
+}
+
 // NOLINTNEXTLINE
 void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, const SbVec3f& textOffset)
 {
@@ -1467,6 +1501,32 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
     SbVec3f z = vv.zVector();
 
     bool flip = norm.getValue().dot(z) > std::numeric_limits<float>::epsilon();
+
+    ///////////////////////////////////////////////
+    // Rotation of sketch in screen space (radians)
+    // This defines how the sketch X-axis is oriented relative to the camera projection
+    const float sketchAngle = getSketchRotationAngle(state, vv, flip);
+
+    // Combined angle in screen space
+    // This represents final text orientation relative to camera view
+    const float labelAngle = sketchAngle + angle;
+
+    // Hysteresis threshold to prevent flipping jitter near 90 degrees
+    // Without this, text would oscillate when angle is close to boundary
+    constexpr float threshold = 105
+        * (M_PI / 180);  // 90+15 degree hysteresis, similar to current rotate label logic.
+
+    if (flip) {
+        if (std::abs(labelAngle) > threshold) {
+            angle += M_PI;
+        }
+    }
+    else {
+        if (std::abs(labelAngle) < threshold) {
+            angle += M_PI;
+        }
+    }
+    ///////////////////////////////////////////////
 
     static bool init = false;
     static bool npot = false;

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1511,20 +1511,13 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
     bool flip = norm.getValue().dot(z) > std::numeric_limits<float>::epsilon();
 
     const float sketchAngle = getSketchRotationAngle(state, vv, flip);
-    const float labelAngle = sketchAngle + angle;
+    const float absLabelAngle = std::abs(sketchAngle + angle);
 
     // Threshold to 180 degrees rotation, 90+15 degree angle, similar to current rotate label logic.
     constexpr float threshold = Base::toRadians(105.0f);
 
-    if (flip) {
-        if (std::abs(labelAngle) > threshold) {
-            angle += std::numbers::pi;
-        }
-    }
-    else {
-        if (std::abs(labelAngle) < threshold) {
-            angle += std::numbers::pi;
-        }
+    if ((flip && absLabelAngle > threshold) || (!flip && absLabelAngle < threshold)) {
+        angle += std::numbers::pi;
     }
 
     static bool init = false;

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1458,10 +1458,20 @@ void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& t
 
 namespace
 {
-// Returns:
-// angleRad — sketch rotation angle in radians (-pi .. pi)
-// CCW is positive, CW is negative, and the angle is measured from the camera's right vector to the
-// sketch's local X axis.
+/*!
+ * \brief Compute sketch rotation angle in screen space.
+ *
+ * Calculates the rotation of the sketch relative to the camera view.
+ * The angle is measured from the camera right vector to the sketch's local X axis.
+ *
+ * \param state Current Coin3D traversal state used to retrieve view and model matrices.
+ * \param viewVolume Active view volume describing the camera projection and orientation.
+ * \param flip If true, the resulting angle is inverted to account for back-facing view direction.
+ *
+ * \return Rotation angle in radians in the range [-pi, pi].
+ *         Positive values correspond to counter-clockwise (CCW) rotation,
+ *         negative values correspond to clockwise (CW) rotation.
+ */
 float getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, bool flip)
 {
     // --- Camera basis from view volume (screen space axes) ---
@@ -1500,7 +1510,6 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
 
     bool flip = norm.getValue().dot(z) > std::numeric_limits<float>::epsilon();
 
-    ///////////////////////////////////////////////
     const float sketchAngle = getSketchRotationAngle(state, vv, flip);
     const float labelAngle = sketchAngle + angle;
 
@@ -1517,7 +1526,6 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
             angle += std::numbers::pi;
         }
     }
-    ///////////////////////////////////////////////
 
     static bool init = false;
     static bool npot = false;

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1513,8 +1513,8 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
     const float sketchAngle = getSketchRotationAngle(state, vv, flip);
     const float absLabelAngle = std::abs(sketchAngle + angle);
 
-    constexpr float quarter = 90.0F;    // vertical line
-    constexpr float hysteresis = 15.0F; // extra to avoid flipping back and forth when close to vertical
+    constexpr float quarter = 90.0F;  // vertical line
+    constexpr float hysteresis = 15.0F;  // extra to avoid flipping back and forth when close to vertical
     constexpr float threshold = Base::toRadians(quarter + hysteresis);
 
     if ((flip && absLabelAngle > threshold) || (!flip && absLabelAngle < threshold)) {

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1474,25 +1474,25 @@ namespace
  */
 float getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, bool flip)
 {
-    // --- Camera basis from view volume (screen space axes) ---
+    // Camera basis from view volume (screen space axes
     SbVec3f camRight = viewVolume.lrf - viewVolume.llf;
     SbVec3f camUp = viewVolume.ulf - viewVolume.llf;
 
     camRight.normalize();
     camUp.normalize();
 
-    // --- Sketch local X axis in world space ---
+    // Sketch local X axis in world space
     const SbMatrix& m = SoModelMatrixElement::get(state);
     SbVec3f xWorld;
     m.multDirMatrix(SbVec3f(1, 0, 0), xWorld);
 
-    // --- Compute angle in screen space ---
+    // Compute angle in screen space
     float cosA = xWorld.dot(camRight);
     float sinA = xWorld.dot(camUp);
 
     float angleRad = std::atan2(sinA, cosA);
 
-    // --- Optional flip correction (back-facing view) ---
+    // Optional flip correction (back-facing view)
     return flip ? angleRad : -angleRad;
 }
 }  // unnamed namespace

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1513,8 +1513,9 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
     const float sketchAngle = getSketchRotationAngle(state, vv, flip);
     const float absLabelAngle = std::abs(sketchAngle + angle);
 
-    // Threshold to 180 degrees rotation, 90+15 degree angle, similar to current rotate label logic.
-    constexpr float threshold = Base::toRadians(105.0f);
+    constexpr float quarter = 90.0F;  // <-- feel free to rename this
+    constexpr float hysteresis = 15.0F;
+    constexpr float threshold = Base::toRadians(quarter + hysteresis);
 
     if ((flip && absLabelAngle > threshold) || (!flip && absLabelAngle < threshold)) {
         angle += std::numbers::pi;

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1459,7 +1459,7 @@ void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& t
 // angleRad — sketch rotation angle in radians (-pi .. pi)
 // CCW is positive, CW is negative, and the angle is measured from the camera's right vector to the
 // sketch's local X axis.
-float SoDatumLabel::getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, bool flip)
+float getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, bool flip)
 {
     SbMatrix m = SoModelMatrixElement::get(state);
 

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1513,8 +1513,8 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
     const float sketchAngle = getSketchRotationAngle(state, vv, flip);
     const float absLabelAngle = std::abs(sketchAngle + angle);
 
-    constexpr float quarter = 90.0F;  // <-- feel free to rename this
-    constexpr float hysteresis = 15.0F;
+    constexpr float quarter = 90.0F;    // vertical line
+    constexpr float hysteresis = 15.0F; // extra to avoid flipping back and forth when close to vertical
     constexpr float threshold = Base::toRadians(quarter + hysteresis);
 
     if ((flip && absLabelAngle > threshold) || (!flip && absLabelAngle < threshold)) {

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -44,6 +44,7 @@
 #include <Inventor/SoPrimitiveVertex.h>
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/elements/SoFocalDistanceElement.h>
+#include <Inventor/elements/SoModelMatrixElement.h>
 #include <Inventor/elements/SoViewportRegionElement.h>
 #include <Inventor/elements/SoViewVolumeElement.h>
 #include <Inventor/misc/SoState.h>
@@ -1455,14 +1456,14 @@ void SoDatumLabel::drawArcLength(const SbVec3f* points, float& angle, SbVec3f& t
     glDrawArrow(geom.pnt4, geom.dirEnd, arrowWidth, arrowLength);
 }
 
+namespace
+{
 // Returns:
 // angleRad — sketch rotation angle in radians (-pi .. pi)
 // CCW is positive, CW is negative, and the angle is measured from the camera's right vector to the
 // sketch's local X axis.
 float getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, bool flip)
 {
-    SbMatrix m = SoModelMatrixElement::get(state);
-
     // --- Camera basis from view volume (screen space axes) ---
     SbVec3f camRight = viewVolume.lrf - viewVolume.llf;
     SbVec3f camUp = viewVolume.ulf - viewVolume.llf;
@@ -1470,24 +1471,21 @@ float getSketchRotationAngle(SoState* state, const SbViewVolume& viewVolume, boo
     camRight.normalize();
     camUp.normalize();
 
-    SbVec3f viewDir = viewVolume.getProjectionDirection();
-
     // --- Sketch local X axis in world space ---
-    SbVec3f x_world;
-    m.multDirMatrix(SbVec3f(1, 0, 0), x_world);
-
-    // --- Project sketch axis onto view plane ---
-    SbVec3f x_proj = x_world - viewDir * x_world.dot(viewDir);
+    const SbMatrix& m = SoModelMatrixElement::get(state);
+    SbVec3f xWorld;
+    m.multDirMatrix(SbVec3f(1, 0, 0), xWorld);
 
     // --- Compute angle in screen space ---
-    float cosA = x_proj.dot(camRight);
-    float sinA = x_proj.dot(camUp);
+    float cosA = xWorld.dot(camRight);
+    float sinA = xWorld.dot(camUp);
 
     float angleRad = std::atan2(sinA, cosA);
 
     // --- Optional flip correction (back-facing view) ---
     return flip ? angleRad : -angleRad;
 }
+}  // unnamed namespace
 
 // NOLINTNEXTLINE
 void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, const SbVec3f& textOffset)
@@ -1503,27 +1501,20 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
     bool flip = norm.getValue().dot(z) > std::numeric_limits<float>::epsilon();
 
     ///////////////////////////////////////////////
-    // Rotation of sketch in screen space (radians)
-    // This defines how the sketch X-axis is oriented relative to the camera projection
     const float sketchAngle = getSketchRotationAngle(state, vv, flip);
-
-    // Combined angle in screen space
-    // This represents final text orientation relative to camera view
     const float labelAngle = sketchAngle + angle;
 
-    // Hysteresis threshold to prevent flipping jitter near 90 degrees
-    // Without this, text would oscillate when angle is close to boundary
-    constexpr float threshold = 105
-        * (M_PI / 180);  // 90+15 degree hysteresis, similar to current rotate label logic.
+    // Threshold to 180 degrees rotation, 90+15 degree angle, similar to current rotate label logic.
+    constexpr float threshold = Base::toRadians(105.0f);
 
     if (flip) {
         if (std::abs(labelAngle) > threshold) {
-            angle += M_PI;
+            angle += std::numbers::pi;
         }
     }
     else {
         if (std::abs(labelAngle) < threshold) {
-            angle += M_PI;
+            angle += std::numbers::pi;
         }
     }
     ///////////////////////////////////////////////

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -232,7 +232,6 @@ private:
 
 private:
     void drawImage();
-    static float getSketchRotationAngle(SoState* state, const SbViewVolume& vv, bool flip);
     float imgWidth;
     float imgHeight;
     bool glimagevalid;

--- a/src/Gui/SoDatumLabel.h
+++ b/src/Gui/SoDatumLabel.h
@@ -232,6 +232,7 @@ private:
 
 private:
     void drawImage();
+    static float getSketchRotationAngle(SoState* state, const SbViewVolume& vv, bool flip);
     float imgWidth;
     float imgHeight;
     bool glimagevalid;


### PR DESCRIPTION
Fixes #13315 **Sketcher: dimension labels adapting to view rotation**


This PR calculates actual sketch rotation and corrects datum label angle to show text upside up. 


Current version:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/db96c8bc-f2ba-47d9-a9d9-7a5e703bb682" />

PR:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/7aa29f0d-fb14-46b4-acf6-0d77619000d3" />

Orientation switch is performed at 105 degrees, like current labels when they are rotated inside the sketch: 


Current version:
<img width="360" alt="image" src="https://github.com/user-attachments/assets/b6c7a024-32e7-4f3c-90e6-7476ded945ea" />

<img width="360" alt="image" src="https://github.com/user-attachments/assets/f02a6f0b-3fbd-4bae-ae3b-a2c4efd9d891" />

