### PR TITLE
CAM: Deburr - Refactor

### DIFF
--- a/src/Mod/CAM/Path/Op/Deburr.py
+++ b/src/Mod/CAM/Path/Op/Deburr.py
@@ -226,178 +226,59 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
             # return
 
         Path.Log.track(obj.Label, depth, offset)
-
-        self.basewires = []
-        self.adjusted_basewires = []
+        tol = self.job.GeometryTolerance.Value
         wires = []
-
         for base, subs in obj.Base:
             edges = []
             basewires = []
-            max_h = -99999
-            radius_top = 0
-            radius_bottom = 0
 
-            for f in subs:
-                sub = base.Shape.getElement(f)
+            for name in subs:
+                sub = base.Shape.getElement(name)
 
-                if type(sub) == Part.Edge:  # Edge
+                if isinstance(sub, Part.Edge):
                     edges.append(sub)
 
-                elif type(sub) == Part.Face and sub.normalAt(0, 0) != FreeCAD.Vector(
-                    0, 0, 1
-                ):  # Angled face
-                    # If an angled face is selected, the lower edge is projected to the height of the upper edge,
-                    # to simulate an edge
+                elif isinstance(sub, Part.Face) and sub.normalAt(0, 0) != FreeCAD.Vector(0, 0, 1):
+                    # Angled face
+                    # Find z value of upper and lower edges
+                    z = [v.Point.z for e in sub.Edges for v in e.Vertexes]
+                    max_h = max(z)
+                    min_h = min(z)
+                    v = FreeCAD.Vector(0, 0, max_h - min_h)
+                    # Search for lower edges and raise it up
+                    edges.extend(
+                        [
+                            e.translated(v)
+                            for e in sub.Edges
+                            if Path.Geom.isRoughly(e.BoundBox.ZMax, min_h)
+                        ]
+                    )
 
-                    # Find z value of upper edge
-                    for edge in sub.Edges:
-                        for p0 in edge.Vertexes:
-                            if p0.Point.z > max_h:
-                                max_h = p0.Point.z
-
-                    # Find biggest radius for top/bottom
-                    for edge in sub.Edges:
-                        if Part.Circle == type(edge.Curve):
-                            if edge.Vertexes[0].Point.z == max_h:
-                                if edge.Curve.Radius > radius_top:
-                                    radius_top = edge.Curve.Radius
-                            else:
-                                if edge.Curve.Radius > radius_bottom:
-                                    radius_bottom = edge.Curve.Radius
-
-                    # Search for lower edge and raise it to height of upper edge
-                    for edge in sub.Edges:
-                        if Part.Circle == type(edge.Curve):  # Edge is a circle
-                            if edge.Vertexes[0].Point.z < max_h:
-
-                                if edge.Closed:  # Circle
-                                    # New center
-                                    center = FreeCAD.Vector(
-                                        edge.Curve.Center.x, edge.Curve.Center.y, max_h
-                                    )
-                                    new_edge = Part.makeCircle(
-                                        edge.Curve.Radius,
-                                        center,
-                                        FreeCAD.Vector(0, 0, 1),
-                                    )
-                                    edges.append(new_edge)
-
-                                    # Modify offset for inner angled faces
-                                    if radius_bottom < radius_top:
-                                        offset -= 2 * extraOffset
-
-                                    break
-
-                                else:  # Arc
-                                    if edge.Vertexes[0].Point.z == edge.Vertexes[1].Point.z:
-                                        # Arc vertexes are on same layer
-                                        l1 = math.sqrt(
-                                            (edge.Vertexes[0].Point.x - edge.Curve.Center.x) ** 2
-                                            + (edge.Vertexes[0].Point.y - edge.Curve.Center.y) ** 2
-                                        )
-                                        l2 = math.sqrt(
-                                            (edge.Vertexes[1].Point.x - edge.Curve.Center.x) ** 2
-                                            + (edge.Vertexes[1].Point.y - edge.Curve.Center.y) ** 2
-                                        )
-
-                                        # New center
-                                        center = FreeCAD.Vector(
-                                            edge.Curve.Center.x,
-                                            edge.Curve.Center.y,
-                                            max_h,
-                                        )
-
-                                        # Calculate angles based on x-axis (0 - PI/2)
-                                        start_angle = math.acos(
-                                            (edge.Vertexes[0].Point.x - edge.Curve.Center.x) / l1
-                                        )
-                                        end_angle = math.acos(
-                                            (edge.Vertexes[1].Point.x - edge.Curve.Center.x) / l2
-                                        )
-
-                                        # Angles are based on x-axis (Mirrored on x-axis) -> negative y value means negative angle
-                                        if edge.Vertexes[0].Point.y < edge.Curve.Center.y:
-                                            start_angle *= -1
-                                        if edge.Vertexes[1].Point.y < edge.Curve.Center.y:
-                                            end_angle *= -1
-
-                                        # Create new arc
-                                        new_edge = Part.ArcOfCircle(
-                                            Part.Circle(
-                                                center,
-                                                FreeCAD.Vector(0, 0, 1),
-                                                edge.Curve.Radius,
-                                            ),
-                                            start_angle,
-                                            end_angle,
-                                        ).toShape()
-                                        edges.append(new_edge)
-
-                                        # Modify offset for inner angled faces
-                                        if radius_bottom < radius_top:
-                                            offset -= 2 * extraOffset
-
-                                        break
-
-                        else:  # Line
-                            if (
-                                edge.Vertexes[0].Point.z == edge.Vertexes[1].Point.z
-                                and edge.Vertexes[0].Point.z < max_h
-                            ):
-                                new_edge = Part.Edge(
-                                    Part.LineSegment(
-                                        FreeCAD.Vector(
-                                            edge.Vertexes[0].Point.x,
-                                            edge.Vertexes[0].Point.y,
-                                            max_h,
-                                        ),
-                                        FreeCAD.Vector(
-                                            edge.Vertexes[1].Point.x,
-                                            edge.Vertexes[1].Point.y,
-                                            max_h,
-                                        ),
-                                    )
-                                )
-                                edges.append(new_edge)
-
-                elif sub.Wires:
+                else:
+                    # Horizontal face
                     basewires.extend(sub.Wires)
 
-                else:  # Flat face
-                    basewires.append(Part.Wire(sub.Edges))
-
-            self.edges = edges
-            for edgelist in Part.sortEdges(edges):
-                basewires.append(Part.Wire(edgelist))
-
-            self.basewires.extend(basewires)
+            basewires.extend(Part.Wire(se) for se in Part.sortEdges(edges))
 
             # Set default side
             side = ["Outside"]
 
             for w in basewires:
-                self.adjusted_basewires.append(w)
-                wire = PathOpUtil.offsetWire(
-                    w, base.Shape, offset, True, side, self.job.GeometryTolerance.Value
-                )
-                if wire:
-                    wires.append(wire)
+                offsetWire = PathOpUtil.offsetWire(w, base.Shape, offset, True, side, tol)
+                if offsetWire:
+                    wires.append(offsetWire)
 
         # Set direction of op
         forward = obj.Direction == "CW"
 
         # Set value of side
         obj.Side = side[0]
-        # Check side extra for angled faces
-        if radius_top > radius_bottom:
-            obj.Side = "Inside"
 
         zValues = []
         z = 0
         if obj.StepDown.Value != 0:
             while z + obj.StepDown.Value < depth:
-                z = z + obj.StepDown.Value
+                z += obj.StepDown.Value
                 zValues.append(z)
 
         zValues.append(depth)
@@ -406,7 +287,6 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
         if obj.EntryPoint < 0:
             obj.EntryPoint = 0
 
-        self.wires = wires
         self.buildpathocc(obj, wires, zValues, True, forward, obj.EntryPoint)
 
     def opRejectAddBase(self, obj, base, sub):

--- a/src/Mod/CAM/Path/Op/Util.py
+++ b/src/Mod/CAM/Path/Op/Util.py
@@ -177,6 +177,13 @@ def orientWire(w, forward=True):
     return wire
 
 
+def discretizeWire(wire, tolerance):
+    vertices = wire.discretize(Deflection=tolerance)
+    line_edges = [Part.makeLine(vertices[i], vertices[i + 1]) for i in range(len(vertices) - 1)]
+
+    return Part.Wire(line_edges)
+
+
 def approximateWire(wire, tolerance=0.01):
     """approximateWire approximates any non-line/arc edges with lines or arcs.
     Edges that are lines or circular arcs are kept as-is.
@@ -210,7 +217,9 @@ def approximateWire(wire, tolerance=0.01):
 
             if isinstance(edge.Curve, Part.BSplineCurve):
                 # Convert BSpline to arcs
-                curves = edge.Curve.toBiArcs(tolerance)
+                curve = edge.Curve
+                trimmed_curve = curve.trim(*edge.ParameterRange)
+                curves = trimmed_curve.toBiArcs(tolerance)
                 for curve in curves:
                     processed_edges.append(curve.toShape())
             else:
@@ -236,7 +245,15 @@ def offsetWire(wire, base, offset, forward, Side=None, tolerance=0.01):
     Path.Log.track("offsetWire")
 
     # Pre-process the wire: approximate any non-line/arc edges with arcs and lines
-    wire = approximateWire(wire, tolerance)
+    awire = approximateWire(wire, tolerance)
+    cwire = orientWire(awire)
+    es = cwire.Edges
+    for i in range(len(es) - 1):
+        if not Path.Geom.pointsCoincide(es[i].lastVertex().Point, es[i + 1].firstVertex().Point):
+            awire = discretizeWire(wire, tolerance)
+            break
+
+    wire = awire
 
     if len(wire.Edges) == 1:
         edge = wire.Edges[0]
@@ -382,15 +399,12 @@ def offsetWire(wire, base, offset, forward, Side=None, tolerance=0.01):
 
     # find edges that are not inside the shape
     common = base.common(owire)
-    insideEndpoints = [e.lastVertex().Point for e in common.Edges]
-    insideEndpoints.append(common.Edges[0].firstVertex().Point)
+    insideEndpoints = [v.Point for v in common.Vertexes]
 
     def isInside(edge):
-        p0 = edge.firstVertex().Point
-        p1 = edge.lastVertex().Point
-        for p in insideEndpoints:
-            if Path.Geom.pointsCoincide(p, p0, 0.01) or Path.Geom.pointsCoincide(p, p1, 0.01):
-                return True
+        candidates = (edge.firstVertex().Point, edge.lastVertex().Point)
+        if any(Path.Geom.pointsCoincide(p, c, 0.01) for p in insideEndpoints for c in candidates):
+            return True
         return False
 
     outside = [e for e in owire.Edges if not isInside(e)]


### PR DESCRIPTION
There are two problems in one project while creates **Deburr** operation

[PS pump bracket - third try - CAM.zip](https://github.com/user-attachments/files/26969167/PS.pump.bracket.-.third.try.-.CAM.zip)

<img width="1074" height="407" alt="Screenshot_20260422_152108_hor_lossy" src="https://github.com/user-attachments/assets/cab3e8c3-558e-44a4-9221-4e90e1b47995" />

---

### Edges not properly connected

https://forum.freecad.org/viewtopic.php?t=104885
`orientWire()` and `_orientEdges()` works incorrect if edges not properly connected

> Vector (-3.1789899866187232, 88.67640709462987, 9.57)
> Vector (38.899**871**145794854, 88.67640709462987, 9.57)

> Vector (38.899**874**551397595, 88.67640709457677, 9.57)
> Vector (48.14990605322293, 79.42640709463042, 9.57) 

Difference greater than `1e-6`, so all checks `Path.Geom.isRougly()` and `Path.Geom.pointsCoincide()` will give incorrect result

<img width="654" height="352" alt="Screenshot_20260422_110457_lossy" src="https://github.com/user-attachments/assets/d581a784-d110-4759-b4e1-a5a6a9cecb66" />

[wire_issue.zip](https://github.com/user-attachments/files/26968800/wire_issue.zip)

**Solution:** discretize wire

---

### Face with BSplineCurve

**Deburr** operation can process only Face with simple edges `Part.LineSegment` and `Part.Circle`
All complex curves ignores

**Solution:** simplify method processing face