### PR TITLE
FTBFS on arm64 - race condition in CMakeLists.txt for Mod/Assembly

### DIFF
--- a/src/Mod/Assembly/CMakeLists.txt
+++ b/src/Mod/Assembly/CMakeLists.txt
@@ -79,8 +79,16 @@ ADD_CUSTOM_TARGET(AssemblyTests ALL
     SOURCES ${test_files}
 )
 
+# Target AssemblyScripts handles copying AssemblyTests_SRCS and AssemblyScripts_SRCS
 fc_copy_sources(AssemblyScripts "${CMAKE_BINARY_DIR}/Mod/Assembly" ${all_files})
-fc_copy_sources(AssemblyTests "${CMAKE_BINARY_DIR}/Mod/Assembly" ${test_files})
+
+# Target AssemblyTests should only handle copying the remaining Assembly_Scripts
+# to avoid racing with AssemblyScripts over the same files.
+fc_copy_sources(AssemblyTests "${CMAKE_BINARY_DIR}/Mod/Assembly" ${Assembly_Scripts})
+
+# Ensure AssemblyScripts finishes its directory creation and copying before
+# AssemblyTests begins.
+add_dependencies(AssemblyTests AssemblyScripts)
 
 INSTALL(
     FILES


### PR DESCRIPTION
Avoid race in Assembly file copying by removing overlap and enforcing target order.  Ensure AssemblyScripts runs before AssemblyTests to guarantee directories exist. Fixes intermittent FTBFS on arm64.

This has been observed on Debian infrastructure, buld log:
https://debusine.debian.net/debian/developers/artifact/3597731/
(Complete workitem is here: https://debusine.debian.net/debian/developers/work-request/604751/)

It seems that the logic src/Mod/Assembly/CMakeLists.txt (or fc_copy_sources) is racy, leasing that the AssemblyTests  files being copied before the directory is being created:
`Error copying file "/build/reproducible-path/freecad-1.1.0+dfsg/src/Mod/Assembly/AssemblyTests/TestCommandInsertLink.py" to "/build/reproducible-path/freecad-1.1.0+dfsg/obj-aarch64-linux-gnu/Mod/Assembly/AssemblyTests/TestCommandInsertLink.py": No such file or directory`

The attached patch does two things:
- ensures that the two fc_copy_sources do not copy (some files) twice - test_files included files from all_files 
- adds a depdendency so that the steps are  not executed in parallel.

A Testbuild on debusine / upload to Debian experimental shows that this seems to fix the race.
