### PR TITLE
CAM:  Fix Default Curve accuracy bug

### DIFF
--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -188,6 +188,9 @@ void InputField::updateText(const Base::Quantity& quant)
     std::string unitStr;
     std::string txt = quant.getUserString(dFactor, unitStr);
     actUnitValue = quant.getValue() / dFactor;
+    // Block signals to prevent newInput from re-parsing the display text
+    // and overwriting actQuantity with a precision-truncated value.
+    QSignalBlocker blocker(this);
     setText(QString::fromStdString(txt));
 }
 
@@ -468,7 +471,9 @@ void InputField::setValue(const Base::Quantity& quant)
 
     actUnit = quant.getUnit();
 
-    updateText(quant);
+    updateText(actQuantity);
+    Q_EMIT valueChanged(actQuantity);
+    Q_EMIT valueChanged(actQuantity.getValue());
 }
 
 void InputField::setValue(const double& value)
@@ -522,7 +527,7 @@ void InputField::setRawText(const QString& text)
 {
     Base::Quantity quant = Base::Quantity::parse(text.toStdString());
     // Input and then format the quantity
-    newInput(QString::fromStdString(quant.getUserString()));
+    newInput(QString::fromStdString(quant.getSafeUserString()));
     updateText(actQuantity);
 }
 
@@ -551,6 +556,8 @@ void InputField::setMaximum(double m)
     if (actQuantity.getValue() > Maximum) {
         actQuantity.setValue(Maximum);
         updateText(actQuantity);
+        Q_EMIT valueChanged(actQuantity);
+        Q_EMIT valueChanged(actQuantity.getValue());
     }
 }
 
@@ -567,6 +574,8 @@ void InputField::setMinimum(double m)
     if (actQuantity.getValue() < Minimum) {
         actQuantity.setValue(Minimum);
         updateText(actQuantity);
+        Q_EMIT valueChanged(actQuantity);
+        Q_EMIT valueChanged(actQuantity.getValue());
     }
 }
 

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -194,6 +194,13 @@ void InputField::updateText(const Base::Quantity& quant)
     setText(QString::fromStdString(txt));
 }
 
+void InputField::notifyValueChanged()
+{
+    updateText(actQuantity);
+    Q_EMIT valueChanged(actQuantity);
+    Q_EMIT valueChanged(actQuantity.getValue());
+}
+
 void InputField::resizeEvent(QResizeEvent* /*event*/)
 {
     QSize iconSize = iconLabel->sizeHint();
@@ -471,9 +478,7 @@ void InputField::setValue(const Base::Quantity& quant)
 
     actUnit = quant.getUnit();
 
-    updateText(actQuantity);
-    Q_EMIT valueChanged(actQuantity);
-    Q_EMIT valueChanged(actQuantity.getValue());
+    notifyValueChanged();
 }
 
 void InputField::setValue(const double& value)
@@ -555,9 +560,7 @@ void InputField::setMaximum(double m)
     Maximum = m;
     if (actQuantity.getValue() > Maximum) {
         actQuantity.setValue(Maximum);
-        updateText(actQuantity);
-        Q_EMIT valueChanged(actQuantity);
-        Q_EMIT valueChanged(actQuantity.getValue());
+        notifyValueChanged();
     }
 }
 
@@ -573,9 +576,7 @@ void InputField::setMinimum(double m)
     Minimum = m;
     if (actQuantity.getValue() < Minimum) {
         actQuantity.setValue(Minimum);
-        updateText(actQuantity);
-        Q_EMIT valueChanged(actQuantity);
-        Q_EMIT valueChanged(actQuantity.getValue());
+        notifyValueChanged();
     }
 }
 

--- a/src/Gui/InputField.h
+++ b/src/Gui/InputField.h
@@ -221,6 +221,7 @@ protected:
 private:
     QPixmap getValidationIcon(const char* name, const QSize& size) const;
     void updateText(const Base::Quantity&);
+    void notifyValueChanged();
 
 private:
     QByteArray m_sPrefGrp;

--- a/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/PathJob.ui
@@ -74,12 +74,15 @@ If left empty no template will be preselected.</string>
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="Gui::InputField" name="geometryTolerance">
+             <widget class="Gui::QuantitySpinBox" name="geometryTolerance">
               <property name="toolTip">
                <string>Default value for new jobs, used for computing Paths. Smaller increases accuracy, but slows down computation</string>
               </property>
               <property name="minimum">
-               <number>0</number>
+               <double>0.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.001000000000000</double>
               </property>
              </widget>
             </item>
@@ -91,12 +94,15 @@ If left empty no template will be preselected.</string>
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="Gui::InputField" name="curveAccuracy">
+             <widget class="Gui::QuantitySpinBox" name="curveAccuracy">
               <property name="toolTip">
                <string>Uses while calculates arcs. Smaller increases accuracy, but slows down computation</string>
               </property>
               <property name="minimum">
-               <number>0</number>
+               <double>0.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.001000000000000</double>
               </property>
              </widget>
             </item>

--- a/src/Mod/CAM/Path/Main/Gui/PreferencesJob.py
+++ b/src/Mod/CAM/Path/Main/Gui/PreferencesJob.py
@@ -46,16 +46,14 @@ class JobPreferencesPage:
 
     def saveSettings(self):
         jobTemplate = self.form.leDefaultJobTemplate.text()
-        geometryTolerance = Units.Quantity(self.form.geometryTolerance.text())
-        curveAccuracy = Units.Quantity(self.form.curveAccuracy.text())
+        geometryTolerance = self.form.geometryTolerance.property("rawValue")
+        curveAccuracy = self.form.curveAccuracy.property("rawValue")
 
         if not geometryTolerance:
-            geomTol = Units.Quantity(Path.Preferences.defaultGeometryTolerance(), Units.Length)
-            self.form.geometryTolerance.setText(geomTol.UserString)
+            geometryTolerance = Path.Preferences.defaultGeometryTolerance()
 
         if not curveAccuracy:
-            curveAcc = Units.Quantity(Path.Preferences.defaultLibAreaCurveAccuracy(), Units.Length)
-            self.form.curveAccuracy.setText(curveAcc.UserString)
+            curveAccuracy = Path.Preferences.defaultLibAreaCurveAccuracy()
 
         Path.Preferences.setJobDefaults(jobTemplate, geometryTolerance, curveAccuracy)
 
@@ -173,10 +171,16 @@ class JobPreferencesPage:
 
         self.form.defaultPostProcessorArgs.setText(Path.Preferences.defaultPostProcessorArgs())
 
-        geomTol = Units.Quantity(Path.Preferences.defaultGeometryTolerance(), Units.Length)
-        self.form.geometryTolerance.setText(geomTol.UserString)
-        curveAcc = Units.Quantity(Path.Preferences.defaultLibAreaCurveAccuracy(), Units.Length)
-        self.form.curveAccuracy.setText(curveAcc.UserString)
+        self.form.geometryTolerance.setProperty("unit", "mm")
+        self.form.curveAccuracy.setProperty("unit", "mm")
+        self.form.geometryTolerance.setProperty("decimals", 8)
+        self.form.curveAccuracy.setProperty("decimals", 8)
+        self.form.geometryTolerance.setProperty(
+            "rawValue", Path.Preferences.defaultGeometryTolerance()
+        )
+        self.form.curveAccuracy.setProperty(
+            "rawValue", Path.Preferences.defaultLibAreaCurveAccuracy()
+        )
 
         self.form.leOutputFile.setText(Path.Preferences.defaultOutputFile())
         self.selectComboEntry(self.form.cboOutputPolicy, Path.Preferences.defaultOutputPolicy())


### PR DESCRIPTION
The number of digits to display causes the inputwidget to truncate the value.  This can result in 
an undesired curve accuracy getting stored.

https://forum.freecad.org/viewtopic.php?t=104895