### PR TITLE
FEM: Collection of small fixes for Gmsh advanced refinement tools

### DIFF
--- a/src/Mod/Fem/Gui/Resources/ui/MeshAdvanced.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshAdvanced.ui
@@ -207,7 +207,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Mesh size when distance &lt; DistanceMinimum</string>
+               <string>Mesh size when distance = DistanceMaximum</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -334,7 +334,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Mesh size when distance = DistanceMaximum</string>
+               <string>Mesh size when distance &lt; DistanceMinimum</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -396,7 +396,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Mesh size when distance &lt; DistanceMinimum</string>
+               <string>Mesh size when distance = DistanceMaximum</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -427,7 +427,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Mesh size when distance = DistanceMaximum</string>
+               <string>Mesh size when distance &lt; DistanceMinimum</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>

--- a/src/Mod/Fem/Gui/Resources/ui/MeshDistance.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshDistance.ui
@@ -38,7 +38,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Define mesh element size based on distance to chosen reference geometries.</string>
+      <string>Define mesh element size based on the distance to the chosen reference geometries.</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -65,7 +65,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Mesh size when distance &lt; DistanceMinimum</string>
+        <string>Mesh size when distance = DistanceMaximum</string>
        </property>
        <property name="keyboardTracking">
         <bool>false</bool>
@@ -175,7 +175,7 @@
         </size>
        </property>
        <property name="toolTip">
-        <string>Mesh size when distance = DistanceMaximum</string>
+        <string>Mesh size when distance &lt; DistanceMinimum</string>
        </property>
        <property name="keyboardTracking">
         <bool>false</bool>
@@ -301,7 +301,7 @@
          </sizepolicy>
         </property>
         <property name="toolTip">
-         <string>Number of sampling points used to discretize curves and surfaces. For surface it is the sampling size per direction.</string>
+         <string>Number of sampling points used to discretize curves and surfaces. For surfaces, it is the sampling size per direction.</string>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>

--- a/src/Mod/Fem/Gui/Resources/ui/MeshManipulate.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshManipulate.ui
@@ -53,7 +53,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Drag the refinement, that should be altered, into the Manipulate object in the document tree</string>
+        <string>Drag the refinement that should be altered into the Manipulate object in the document tree</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -233,7 +233,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Mesh size when distance &lt; DistanceMinimum</string>
+               <string>Mesh size when distance = DistanceMaximum</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -343,7 +343,7 @@
                </size>
               </property>
               <property name="toolTip">
-               <string>Mesh size when distance = DistanceMaximum</string>
+               <string>Mesh size when distance &lt; DistanceMinimum</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -524,7 +524,7 @@ F = (G(x + delta, y, z) + G(x - delta, y, z) + G(x, y + delta, z) + G(x, y - del
                </size>
               </property>
               <property name="toolTip">
-               <string>Distance at which the mesh size will be SizeMaximum</string>
+               <string>Delta in the aforementioned equation</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -633,7 +633,7 @@ F = (G(Kind + Delta/2) - G(Kind - Delta/2)) / Delta
                </size>
               </property>
               <property name="toolTip">
-               <string>Distance at which the mesh size will be SizeMaximum</string>
+               <string>Delta in the aforementioned equation</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -705,7 +705,7 @@ F = div(norm(grad(G)))
                </size>
               </property>
               <property name="toolTip">
-               <string>Distance at which the mesh size will be SizeMaximum</string>
+               <string>Delta in the aforementioned equation</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>
@@ -777,7 +777,7 @@ F = G(x+d,y,z) + G(x-d,y,z) + G(x,y+d,z) + G(x,y-d,z) + G(x,y,z+d) + G(x,y,z-d) 
                </size>
               </property>
               <property name="toolTip">
-               <string>Distance at which the mesh size will be SizeMaximum</string>
+               <string>Delta in the aforementioned equation</string>
               </property>
               <property name="keyboardTracking">
                <bool>false</bool>

--- a/src/Mod/Fem/Gui/Resources/ui/MeshTransfiniteCurve.ui
+++ b/src/Mod/Fem/Gui/Resources/ui/MeshTransfiniteCurve.ui
@@ -86,7 +86,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Mesh size when distance = DistanceMaximum</string>
+          <string>Number of nodes on the edge</string>
          </property>
          <property name="keyboardTracking">
           <bool>false</bool>
@@ -214,7 +214,7 @@
           </size>
          </property>
          <property name="toolTip">
-          <string>Mesh size when distance = DistanceMaximum</string>
+          <string>Coefficient for bump/progression growth rate</string>
          </property>
          <property name="keyboardTracking">
           <bool>false</bool>

--- a/src/Mod/Fem/femtaskpanels/task_mesh_tfcurve.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_tfcurve.py
@@ -56,7 +56,7 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
         # geometry selection widget
         # only allow valid distance objects!
         self.selection_widget = selection_widgets.GeometryElementsSelection(
-            obj.References, ["Face", "Edge", "Vertex"], True, False
+            obj.References, ["Edge"], True, False
         )
         self.selection_widget.setWindowTitle("Reference Geometries")
         self.selection_widget.setWindowIcon(FreeCADGui.getIcon(":icons/FEM_MeshDistance.svg"))
@@ -68,8 +68,8 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
         ui = self.parameter_widget
 
-        # There is no known way to access the colors set by stylesheets. It is hence not posssible to make a universal
-        # correct desicion on which image to use. Workaround is to check stylesheet name if one ist set for "dark" and "ligth"
+        # There is no known way to access the colors set by stylesheets. It is hence not possible to make a universal
+        # correct decision on which image to use. Workaround is to check stylesheet name if one is set for "dark" and "light"
         stylesheet = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/MainWindow").GetString(
             "StyleSheet"
         )

--- a/src/Mod/Fem/femtaskpanels/task_mesh_tfsurface.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_tfsurface.py
@@ -53,8 +53,6 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
         self.parameter_widget.setWindowIcon(FreeCADGui.getIcon(":icons/FEM_MeshDistance.svg"))
         self._init_parameter_widget()
 
-        self._init_parameter_widget()
-
         # geometry selection widget
         # only allow valid distance objects!
         self.selection_widget = selection_widgets.GeometryElementsSelection(

--- a/src/Mod/Fem/femtaskpanels/task_mesh_tfvolume.py
+++ b/src/Mod/Fem/femtaskpanels/task_mesh_tfvolume.py
@@ -53,8 +53,6 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
         self.parameter_widget.setWindowIcon(FreeCADGui.getIcon(":icons/FEM_MeshDistance.svg"))
         self._init_parameter_widget()
 
-        self._init_parameter_widget()
-
         # geometry selection widget
         # only allow valid distance objects!
         self.selection_widget = selection_widgets.GeometryElementsSelection(
@@ -70,8 +68,8 @@ class _TaskPanel(base_femtaskpanel._BaseTaskPanel):
 
         ui = self.parameter_widget
 
-        # There is no known way to access the colors set by stylesheets. It is hence not posssible to make a universal
-        # correct desicion on which image to use. Workaround is to check stylesheet name if one ist set for "dark" and "ligth"
+        # There is no known way to access the colors set by stylesheets. It is hence not possible to make a universal
+        # correct decision on which image to use. Workaround is to check stylesheet name if one is set for "dark" and "light"
         stylesheet = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/MainWindow").GetString(
             "StyleSheet"
         )


### PR DESCRIPTION
Fixes a few small issues in the Gmsh advanced refinement tools: swapped or incorrect tooltips, duplicated drop-down list entries, redundant geometry entity types in the selector, and some typos

@ickby Please just take a look if I got everything right following our discussion