### PR TITLE
TechDraw: Fix view frame visibility not persisting on view selection

### DIFF
--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -1089,7 +1089,7 @@ bool QGIView::shouldShowFrame() const
         return false;
     }
 
-    if (isViewSelected()) {
+    if (isSelected()) {
         return true;
     }
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -199,7 +199,7 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
     // wf: why scene()? because if our selected state has changed because we have been removed from
     //     the scene, we don't do anything except wait to be deleted.
     if (change == ItemSelectedHasChanged && scene()) {
-        if (isSelected() || hasSelectedChildren(this)) {
+        if (isViewSelected()) {
             m_colCurrent = getSelectColor();
             m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
         } else {
@@ -526,7 +526,7 @@ void QGIView::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 
     m_isHovered = true;
 
-    if (isSelected()) {
+    if (isViewSelected()) {
         m_colCurrent = getSelectColor();
     } else {
         m_colCurrent = getPreColor();
@@ -546,7 +546,7 @@ void QGIView::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
     m_isHovered = false;
 
-    if (isSelected()) {
+    if (isViewSelected()) {
         m_colCurrent = getSelectColor();
         m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
     } else {
@@ -1040,20 +1040,6 @@ void QGIView::makeMark(double xPos, double yPos, QColor color)
     vItem->setZValue(ZVALUE::VERTEX);
 }
 
-//! true if parent has any children which are selected
-bool QGIView::hasSelectedChildren(QGIView* parent)
-{
-    QList<QGraphicsItem*> children = parent->childItems();
-
-    auto itMatch = std::find_if(children.begin(), children.end(),
-             [&](QGraphicsItem* child) {
-                return child->isSelected();
-             });
-
-    return itMatch != children.end();
-}
-
-
 void QGIView::makeMark(Base::Vector3d pos, QColor color)
 {
     makeMark(pos.x, pos.y, color);
@@ -1081,13 +1067,29 @@ void QGIView::updateFrameVisibility()
     }
 }
 
+// true if the whole view (not just a sub-element) is selected in the App selection
+bool QGIView::isViewSelected() const
+{
+    if (!viewObj || !viewObj->getDocument()) {
+        return false;
+    }
+    const auto selection =
+        Gui::Selection().getSelectionEx(viewObj->getDocument()->getName());
+    for (const auto& selObj : selection) {
+        if (selObj.getObject() == viewObj && selObj.getSubNames().empty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool QGIView::shouldShowFrame() const
 {
     if (isExporting()) {
         return false;
     }
 
-    if (isSelected()) {
+    if (isViewSelected()) {
         return true;
     }
 
@@ -1099,11 +1101,9 @@ bool QGIView::shouldShowFrame() const
             return true;
         case ViewFrameMode::AlwaysOff:
             return false;
-            break;
         default:
             return m_isHovered;
-    };
-
+    }
 }
 
 bool QGIView::shouldShowFromViewProvider() const

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -1087,6 +1087,10 @@ bool QGIView::shouldShowFrame() const
         return false;
     }
 
+    if (isSelected()) {
+        return true;
+    }
+
     ViewFrameMode frameMode = PreferencesGui::getViewFrameMode();
     switch(frameMode) {
         case ViewFrameMode::Manual:

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -1115,7 +1115,7 @@ bool QGIView::shouldShowFrame() const
         return false;
     }
 
-    if (isViewSelected()) {
+    if (isSelected()) {
         return true;
     }
 

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -199,7 +199,7 @@ QVariant QGIView::itemChange(GraphicsItemChange change, const QVariant &value)
     // wf: why scene()? because if our selected state has changed because we have been removed from
     //     the scene, we don't do anything except wait to be deleted.
     if (change == ItemSelectedHasChanged && scene()) {
-        if (isSelected() || hasSelectedChildren(this)) {
+        if (isViewSelected()) {
             m_colCurrent = getSelectColor();
             m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
         } else {
@@ -552,7 +552,7 @@ void QGIView::hoverEnterEvent(QGraphicsSceneHoverEvent *event)
 
     m_isHovered = true;
 
-    if (isSelected()) {
+    if (isViewSelected()) {
         m_colCurrent = getSelectColor();
     } else {
         m_colCurrent = getPreColor();
@@ -572,7 +572,7 @@ void QGIView::hoverLeaveEvent(QGraphicsSceneHoverEvent *event)
 
     m_isHovered = false;
 
-    if (isSelected()) {
+    if (isViewSelected()) {
         m_colCurrent = getSelectColor();
         m_lock->setVisible(getViewObject()->isLocked() && getViewObject()->showLock());
     } else {
@@ -1066,20 +1066,6 @@ void QGIView::makeMark(double xPos, double yPos, QColor color)
     vItem->setZValue(ZVALUE::VERTEX);
 }
 
-//! true if parent has any children which are selected
-bool QGIView::hasSelectedChildren(QGIView* parent)
-{
-    QList<QGraphicsItem*> children = parent->childItems();
-
-    auto itMatch = std::find_if(children.begin(), children.end(),
-             [&](QGraphicsItem* child) {
-                return child->isSelected();
-             });
-
-    return itMatch != children.end();
-}
-
-
 void QGIView::makeMark(Base::Vector3d pos, QColor color)
 {
     makeMark(pos.x, pos.y, color);
@@ -1107,13 +1093,29 @@ void QGIView::updateFrameVisibility()
     }
 }
 
+// true if the whole view (not just a sub-element) is selected in the App selection
+bool QGIView::isViewSelected() const
+{
+    if (!viewObj || !viewObj->getDocument()) {
+        return false;
+    }
+    const auto selection =
+        Gui::Selection().getSelectionEx(viewObj->getDocument()->getName());
+    for (const auto& selObj : selection) {
+        if (selObj.getObject() == viewObj && selObj.getSubNames().empty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool QGIView::shouldShowFrame() const
 {
     if (isExporting()) {
         return false;
     }
 
-    if (isSelected()) {
+    if (isViewSelected()) {
         return true;
     }
 
@@ -1125,11 +1127,9 @@ bool QGIView::shouldShowFrame() const
             return true;
         case ViewFrameMode::AlwaysOff:
             return false;
-            break;
         default:
             return m_isHovered;
-    };
-
+    }
 }
 
 bool QGIView::shouldShowFromViewProvider() const

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -1113,6 +1113,10 @@ bool QGIView::shouldShowFrame() const
         return false;
     }
 
+    if (isSelected()) {
+        return true;
+    }
+
     ViewFrameMode frameMode = PreferencesGui::getViewFrameMode();
     switch(frameMode) {
         case ViewFrameMode::Manual:

--- a/src/Mod/TechDraw/Gui/QGIView.cpp
+++ b/src/Mod/TechDraw/Gui/QGIView.cpp
@@ -1102,7 +1102,7 @@ bool QGIView::isViewSelected() const
     const auto selection =
         Gui::Selection().getSelectionEx(viewObj->getDocument()->getName());
     for (const auto& selObj : selection) {
-        if (selObj.getObject() == viewObj && selObj.getSubNames().empty()) {
+        if (selObj.getObject() == viewObj) {
             return true;
         }
     }
@@ -1115,7 +1115,7 @@ bool QGIView::shouldShowFrame() const
         return false;
     }
 
-    if (isSelected()) {
+    if (isViewSelected()) {
         return true;
     }
 

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -182,8 +182,6 @@ public:
 
     bool pseudoEventFilter(QGraphicsItem *watched, QEvent *event) { return sceneEventFilter(watched, event); }
 
-    static bool hasSelectedChildren(QGIView* parent);
-
     bool isExporting() const;
 
     virtual void setMovableFlag();
@@ -205,6 +203,7 @@ protected:
     virtual void updateFrameVisibility();
     bool shouldShowFromViewProvider() const;
     bool shouldShowFrame() const;
+    bool isViewSelected() const;
 
     Base::Reference<ParameterGrp> getParmGroupCol();
 

--- a/src/Mod/TechDraw/Gui/QGIView.h
+++ b/src/Mod/TechDraw/Gui/QGIView.h
@@ -183,8 +183,6 @@ public:
 
     bool pseudoEventFilter(QGraphicsItem *watched, QEvent *event) { return sceneEventFilter(watched, event); }
 
-    static bool hasSelectedChildren(QGIView* parent);
-
     bool isExporting() const;
 
     virtual void setMovableFlag();
@@ -206,6 +204,7 @@ protected:
     virtual void updateFrameVisibility();
     bool shouldShowFromViewProvider() const;
     bool shouldShowFrame() const;
+    bool isViewSelected() const;
 
     Base::Reference<ParameterGrp> getParmGroupCol();
 


### PR DESCRIPTION
This PR fixes the issue where view frames do not stay visible on selection.

## Issues
Fixes #29601

## Before 
<img width="1026" height="714" alt="20260424_19h58m40s_grim" src="https://github.com/user-attachments/assets/78c2cf6a-0c7b-473c-b239-736540acb6b8" />
 

## After
<img width="1122" height="716" alt="20260424_19h57m35s_grim" src="https://github.com/user-attachments/assets/ea44f8c1-8787-4ef8-bfc8-2f55bfdf7bcb" />