### PR TITLE
(cp) Gui: Re-add ViewProviderOrigin

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2464,6 +2464,7 @@ void Application::initTypes()
     Gui::ViewProviderOriginGroup                ::init();
     Gui::ViewProviderPart                       ::init();
     Gui::ViewProviderCoordinateSystem           ::init();
+    Gui::ViewProviderOrigin                     ::init();
     Gui::ViewProviderMaterialObject             ::init();
     Gui::ViewProviderMaterialObjectPython       ::init();
     Gui::ViewProviderTextDocument               ::init();

--- a/src/Gui/ViewProviderCoordinateSystem.cpp
+++ b/src/Gui/ViewProviderCoordinateSystem.cpp
@@ -46,6 +46,7 @@ using namespace Gui;
 
 
 PROPERTY_SOURCE(Gui::ViewProviderCoordinateSystem, Gui::ViewProviderGeoFeatureGroup)
+PROPERTY_SOURCE(Gui::ViewProviderOrigin, Gui::ViewProviderCoordinateSystem)
 
 /**
  * Creates the view provider for an object group.

--- a/src/Gui/ViewProviderCoordinateSystem.h
+++ b/src/Gui/ViewProviderCoordinateSystem.h
@@ -121,6 +121,18 @@ private:
     std::map<Gui::ViewProvider*, bool> tempVisMap;
 };
 
+// Keep for backward compatibility
+class GuiExport ViewProviderOrigin: public ViewProviderCoordinateSystem
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderOrigin);
+
+public:
+    /// constructor.
+    ViewProviderOrigin() = default;
+    /// destructor.
+    ~ViewProviderOrigin() override = default;
+};
+
 }  // namespace Gui
 
 ENABLE_BITMASK_OPERATORS(Gui::DatumElement)


### PR DESCRIPTION
Cherry-pick from @wwmayer https://codeberg.org/wwmayer/FreeCAD11/src/branch/fix_origin

With https://github.com/FreeCAD/FreeCAD/pull/18126 the class ViewProviderOrigin was renamed to ViewProviderCoordinateSystem.

However, this change breaks backward compatibility of old project files where the type Gui::ViewProviderOrigin is explicitly set as ViewType in Document.xml.

To fix this the class ViewProviderOrigin is readded as subclass of ViewProviderCoordinateSystem.

An example file can be found here: https://forum.freecad.org/viewtopic.php?p=228225#p228225
