### PR TITLE
Build: Make pixi default build rel-with-deb-info, across all machine types

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -44,6 +44,21 @@
         }
       },
       {
+        "name": "rel-with-deb-info",
+        "displayName": "RelWithDebInfo",
+        "description": "Default RelWithDebInfo profile",
+        "binaryDir": "${sourceDir}/build/relWithDebInfo",
+        "inherits": [
+          "common"
+        ],
+        "cacheVariables": {
+          "CMAKE_BUILD_TYPE": {
+            "type": "STRING",
+            "value": "RelWithDebInfo"
+          }
+        }
+      },
+      {
         "name": "release",
         "displayName": "Release",
         "description": "Default release profile",
@@ -229,6 +244,16 @@
         ]
       },
       {
+        "name": "conda-rel-with-deb-info",
+        "hidden": true,
+        "displayName": "Conda RelWithDebInfo",
+        "description": "Conda RelWithDebInfo profile",
+        "inherits": [
+          "rel-with-deb-info",
+          "conda"
+        ]
+      },
+      {
         "name": "conda-release",
         "hidden": true,
         "displayName": "Conda Release",
@@ -244,6 +269,15 @@
         "description": "Conda debug profile",
         "inherits": [
           "conda-debug",
+          "conda-linux"
+        ]
+      },
+      {
+        "name": "conda-linux-rel-with-deb-info",
+        "displayName": "Conda RelWithDebInfo",
+        "description": "Conda RelWithDebInfo profile",
+        "inherits": [
+          "conda-rel-with-deb-info",
           "conda-linux"
         ]
       },
@@ -266,6 +300,15 @@
         ]
       },
       {
+        "name": "conda-macos-rel-with-deb-info",
+        "displayName": "Conda RelWithDebInfo",
+        "description": "Conda RelWithDebInfo profile",
+        "inherits": [
+          "conda-rel-with-deb-info",
+          "conda-macos"
+        ]
+      },
+      {
         "name": "conda-macos-release",
         "displayName": "Conda Release",
         "description": "Conda release profile",
@@ -281,13 +324,16 @@
         "inherits": [
           "conda-debug",
           "conda-windows"
-        ],
-        "cacheVariables": {
-          "CMAKE_BUILD_TYPE": {
-            "type": "STRING",
-            "value": "RelWithDebInfo"
-          }
-        }
+        ]
+      },
+      {
+        "name": "conda-windows-rel-with-deb-info",
+        "displayName": "Conda RelWithDebInfo",
+        "description": "Conda RelWithDebInfo profile",
+        "inherits": [
+          "conda-rel-with-deb-info",
+          "conda-windows"
+        ]
       },
       {
         "name": "conda-windows-release",

--- a/pixi.toml
+++ b/pixi.toml
@@ -158,22 +158,27 @@ freecad-stubs = "*"
 
 ## Qt 6 Configuration Presets
 [target.linux-64.tasks]
+configure-rel-with-deb-info = { cmd = [ "cmake", "--preset", "conda-linux-rel-with-deb-info", "{{ extra_args }}" ], args = [{ "arg" ="extra_args", "default" = "" }], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-debug = { cmd = [ "cmake", "--preset", "conda-linux-debug", "{{ extra_args }}" ], args = [{ "arg" ="extra_args", "default" = "" }], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-release = { cmd = [ "cmake", "--preset", "conda-linux-release" ], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 
 [target.linux-aarch64.tasks]
+configure-rel-with-deb-info = { cmd = [ "cmake", "--preset", "conda-linux-rel-with-deb-info", "{{ extra_args }}" ], args = [{ "arg" = "extra_args", "default" = "" }], depends-on= ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-debug = { cmd = [ "cmake", "--preset", "conda-linux-debug", "{{ extra_args }}" ], args = [{ "arg" = "extra_args", "default" = "" }], depends-on= ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-release = { cmd = [ "cmake", "--preset", "conda-linux-release" ], depends-on= ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 
 [target.osx-64.tasks]
+configure-rel-with-deb-info = { cmd = [ "cmake", "--preset", "conda-macos-rel-with-deb-info", "{{ extra_args }}" ], args = [{ "arg" = "extra_args", "default" = "" }], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-debug = { cmd = [ "cmake", "--preset", "conda-macos-debug", "{{ extra_args }}" ], args = [{ "arg" = "extra_args", "default" = "" }], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-release = { cmd = [ "cmake", "--preset", "conda-macos-release" ], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 
 [target.osx-arm64.tasks]
+configure-rel-with-deb-info = { cmd = [ "cmake", "--preset", "conda-macos-rel-with-deb-info", "{{ extra_args }}" ], args = [{ "arg" = "extra_args", "default" = "" }], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-debug = { cmd = [ "cmake", "--preset", "conda-macos-debug", "{{ extra_args }}" ], args = [{ "arg" = "extra_args", "default" = "" }], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-release = { cmd = [ "cmake", "--preset", "conda-macos-release" ], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 
 [target.win-64.tasks]
+configure-rel-with-deb-info = { cmd = [ "cmake", "--preset", "conda-windows-rel-with-deb-info", "-DCMAKE_GENERATOR_PLATFORM=", "-DCMAKE_GENERATOR_TOOLSET=", "{{ extra_args }}" ], args = [{ "arg" = "extra_args", "default" = "" }], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-debug = { cmd = [ "cmake", "--preset", "conda-windows-debug", "-DCMAKE_GENERATOR_PLATFORM=", "-DCMAKE_GENERATOR_TOOLSET=", "{{ extra_args }}" ], args = [{ "arg" = "extra_args", "default" = "" }], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 configure-release = { cmd = [ "cmake", "--preset", "conda-windows-release", "-DCMAKE_GENERATOR_PLATFORM=", "-DCMAKE_GENERATOR_TOOLSET=" ], depends-on = ["initialize"], env={ CFLAGS="", CXXFLAGS="", DEBUG_CFLAGS="", DEBUG_CXXFLAGS="" }}
 freecad-debug = { cmd = [ ".pixi/envs/default/Library/bin/FreeCAD.exe" ], depends-on = ["install-debug"]}
@@ -182,7 +187,7 @@ freecad-release = { cmd = [ ".pixi/envs/default/Library/bin/FreeCAD.exe" ], depe
 [tasks]
 initialize = { cmd = ["git", "submodule", "update", "--init", "--recursive"]}
 # redirect to debug by default
-configure = [{ task = "configure-debug" }]
+configure = [{ task = "configure-rel-with-deb-info" }]
 build = [{ task = "build-debug" }]
 install = [{ task = "install-debug" }]
 test = [{ task = "test-debug" }]


### PR DESCRIPTION
Fixes #29471 

tbh I'm not entirely sure how to test this because I'm not experienced with pixi and only have a linux system to play with, but consider this at least a draft/proposal/suggested fix for #29471 