### PR TITLE
Part: Add input hints for attachment dialog

### DIFF
--- a/src/Mod/Part/Gui/TaskAttacher.cpp
+++ b/src/Mod/Part/Gui/TaskAttacher.cpp
@@ -47,6 +47,7 @@
 #include <Gui/CommandT.h>
 #include <Gui/Control.h>
 #include <Gui/Document.h>
+#include <Gui/InputHint.h>
 #include <Gui/MainWindow.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
@@ -1493,10 +1494,27 @@ TaskDlgAttacher::TaskDlgAttacher(
             );
         }
     }
+
+    // Status-bar input hints
+    using enum Gui::InputHint::UserInput;
+    std::list<Gui::InputHint> hints {
+        {
+            .message = tr("%1 select reference"),
+            .sequences = {MouseLeft},
+        },
+    };
+    if (onAccept) {
+        hints.push_back({
+            .message = tr("2x%1 select and confirm"),
+            .sequences = {MouseLeft},
+        });
+    }
+    Gui::getMainWindow()->showHints(hints);
 }
 
 TaskDlgAttacher::~TaskDlgAttacher()
 {
+    Gui::getMainWindow()->hideHints();
     if (dblClickViewer) {
         // Re-enable selection in case it was disabled for a double-click that never completed
         dblClickViewer->setSelectionEnabled(true);


### PR DESCRIPTION
Follow up on https://github.com/FreeCAD/FreeCAD/pull/29168 to show input hints for the new double click behavior to select and confirm the attachment dialog.

<img width="636" height="136" alt="grafik" src="https://github.com/user-attachments/assets/731a7eb8-36a6-40a9-8823-542ec55c70a8" />
