### PR TITLE
Add .3mf extension if none is entered  (AppMeshPy.cpp)

### DIFF
--- a/src/Mod/Mesh/App/AppMeshPy.cpp
+++ b/src/Mod/Mesh/App/AppMeshPy.cpp
@@ -246,7 +246,7 @@ private:
         if (lastDot == std::string::npos || lastDot == outputFileName.length() - 1) {
             outputFileName += ".3mf";
         }
-        
+
         // Construct list of objects to export before making the Exporter, so
         // we don't get empty exports if the list can't be constructed.
         Py::Sequence list(objects);

--- a/src/Mod/Mesh/App/AppMeshPy.cpp
+++ b/src/Mod/Mesh/App/AppMeshPy.cpp
@@ -241,6 +241,12 @@ private:
         std::string outputFileName(fileNamePy);
         PyMem_Free(fileNamePy);
 
+        // --- Add .3mf as default if the user doesn't enter a format ---
+        size_t lastDot = outputFileName.find_last_of('.');
+        if (lastDot == std::string::npos || lastDot == outputFileName.length() - 1) {
+            outputFileName += ".3mf";
+        }
+        
         // Construct list of objects to export before making the Exporter, so
         // we don't get empty exports if the list can't be constructed.
         Py::Sequence list(objects);


### PR DESCRIPTION
If the user does not provide an extension, assume .3mf



## Issues
fixes the error message "Cannot determine the mesh format from the filename" (also mentioned in #24361)
