### PR TITLE
Build: Correct the version string used in conda

### DIFF
--- a/package/rattler-build/pixi.toml
+++ b/package/rattler-build/pixi.toml
@@ -8,7 +8,7 @@ preview = ["pixi-build"]
 
 [package]
 name = "freecad"
-version = "1.2.0-dev"
+version = "1.2.0dev"
 homepage = "https://freecad.org"
 repository = "https://github.com/FreeCAD/FreeCAD"
 description = "FreeCAD"

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.2.0-dev"
+  version: "1.2.0dev"
 
 package:
   name: freecad

--- a/src/Tools/sync_version.py
+++ b/src/Tools/sync_version.py
@@ -70,6 +70,11 @@ class VersionInfo:
         return f"{self.simple}~{self.suffix}" if self.suffix else self.simple
 
     @property
+    def conda(self) -> str:
+        """Version with suffix appended directly per conda convention, e.g. "1.2.0dev"."""
+        return f"{self.simple}{self.suffix}" if self.suffix else self.simple
+
+    @property
     def lowercase_name(self) -> str:
         """Lowercased project name, e.g. "freecad"."""
         return self.name.lower()
@@ -120,7 +125,7 @@ def sync_rattler_build_pixi_toml(filepath: Path, version: VersionInfo) -> tuple[
     """
     content = filepath.read_text(encoding="utf-8")
     updated = content
-    updated = replace_in_toml_section(updated, "[package]", "version", version.complete)
+    updated = replace_in_toml_section(updated, "[package]", "version", version.conda)
     updated = replace_in_toml_section(updated, "[package]", "name", version.lowercase_name)
     updated = replace_in_toml_section(updated, "[package]", "description", version.name)
     return updated, updated != content
@@ -139,7 +144,7 @@ def sync_recipe_yaml(filepath: Path, version: VersionInfo) -> tuple[str, bool]:
     # context:\n  version: "1.2.0dev"
     updated = re.sub(
         r'(context:\s*\n\s*version:\s*)"[^"]*"',
-        rf'\g<1>"{version.complete}"',
+        rf'\g<1>"{version.conda}"',
         updated,
     )
 

--- a/src/Tools/tests/test_sync_version.py
+++ b/src/Tools/tests/test_sync_version.py
@@ -61,6 +61,18 @@ class TestVersionInfo(unittest.TestCase):
         version = make_version(suffix="RC1")
         self.assertEqual(version.rpm, "1.2.0~RC1")
 
+    def test_conda_version_with_suffix(self):
+        version = make_version(suffix="dev")
+        self.assertEqual(version.conda, "1.2.0dev")
+
+    def test_conda_version_without_suffix(self):
+        version = make_version(suffix="")
+        self.assertEqual(version.conda, "1.2.0")
+
+    def test_conda_version_rc(self):
+        version = make_version(suffix="RC1")
+        self.assertEqual(version.conda, "1.2.0RC1")
+
     def test_lowercase_name(self):
         version = make_version(name="FreeCAD")
         self.assertEqual(version.lowercase_name, "freecad")
@@ -210,7 +222,7 @@ class TestSyncRattlerBuildPixiToml(unittest.TestCase):
             version = make_version()
             result, changed = sync_rattler_build_pixi_toml(filepath, version)
             self.assertTrue(changed)
-            self.assertIn('version = "1.2.0-dev"', result)
+            self.assertIn('version = "1.2.0dev"', result)
             self.assertIn('name = "freecad"', result)
             self.assertIn('description = "FreeCAD"', result)
 
@@ -246,7 +258,7 @@ class TestSyncRecipeYaml(unittest.TestCase):
             version = make_version()
             result, changed = sync_recipe_yaml(filepath, version)
             self.assertTrue(changed)
-            self.assertIn('version: "1.2.0-dev"', result)
+            self.assertIn('version: "1.2.0dev"', result)
             self.assertIn("name: freecad", result)
 
     def test_preserves_version_template_reference(self):


### PR DESCRIPTION
PR #28414 broke the conda builds when it shifted to using proper Semantic Versioning. It turns out that *Conda* does *not* use SemVer after all, no dash is permitted. But it's not quite RPM either! So another set of functions and tests...
