### PR TITLE
core: Improve performance of fps label

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2021,7 +2021,6 @@ void View3DInventorViewer::setEnabledFPSCounter(bool on)
             fpsCounter = new QLabel(this);
             fpsCounter->setAttribute(Qt::WA_TransparentForMouseEvents);
         }
-        // fpsCounter->show();
         if (!fpsUpdateTimer) {
             fpsUpdateTimer = new QTimer(this);
             fpsUpdateTimer->setInterval(250);  // 4 Hz

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2046,12 +2046,11 @@ void View3DInventorViewer::updateFPSLabel()
         return;
     }
 
-    std::stringstream stream;
-    stream.precision(1);
-    stream.setf(std::ios::fixed | std::ios::showpoint);
-    stream << framesPerSecond[0] << " ms / " << framesPerSecond[1] << " fps";
-
-    fpsCounter->setText(QString::fromStdString(stream.str()));
+    fpsCounter->setText(
+        QString::fromStdString(
+            fmt::format("{:.1f} ms / {:.1f} fps", framesPerSecond[0], framesPerSecond[1])
+        )
+    );
 
     // update color from user preference (only when it changes)
     ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2021,11 +2021,66 @@ void View3DInventorViewer::setEnabledFPSCounter(bool on)
             fpsCounter = new QLabel(this);
             fpsCounter->setAttribute(Qt::WA_TransparentForMouseEvents);
         }
+        // fpsCounter->show();
+        if (!fpsUpdateTimer) {
+            fpsUpdateTimer = new QTimer(this);
+            fpsUpdateTimer->setInterval(250);  // 4 Hz
+            connect(fpsUpdateTimer, &QTimer::timeout, this, &View3DInventorViewer::updateFPSLabel);
+        }
         fpsCounter->show();
+        fpsUpdateTimer->start();
     }
-    else if (fpsCounter) {
-        fpsCounter->hide();
+    else {
+        if (fpsUpdateTimer) {
+            fpsUpdateTimer->stop();
+        }
+        if (fpsCounter) {
+            fpsCounter->hide();
+        }
     }
+}
+
+void View3DInventorViewer::updateFPSLabel()
+{
+    if (!fpsEnabled || !fpsCounter) {
+        return;
+    }
+
+    std::stringstream stream;
+    stream.precision(1);
+    stream.setf(std::ios::fixed | std::ios::showpoint);
+    stream << framesPerSecond[0] << " ms / " << framesPerSecond[1] << " fps";
+
+    fpsCounter->setText(QString::fromStdString(stream.str()));
+
+    // update color from user preference (only when it changes)
+    ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View"
+    );
+
+    unsigned long axisLetterColor = hGrpView->GetUnsigned("AxisLetterColor", 4294902015);  // default
+                                                                                           // yellow
+
+    if (axisLetterColor != previousAxisLetterColor) {
+        previousAxisLetterColor = axisLetterColor;
+        Base::Color c(static_cast<uint32_t>(axisLetterColor));
+        fpsCounter->setStyleSheet(
+            QString::fromLatin1("color: rgb(%1,%2,%3); background: transparent;")
+                .arg(int(c.r * 255))
+                .arg(int(c.g * 255))
+                .arg(int(c.b * 255))
+        );
+    }
+
+    // size must be current before we use width()/height() for positioning
+    fpsCounter->adjustSize();
+
+    // position, bottom left, accounting for left-side overlay widgets
+    ParameterGrp::handle hGrpOverlayL = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
+    );
+    int xOffset = hGrpOverlayL->GetASCII("Widgets", "").empty() ? 10 : fpsCounter->width() + 20;
+    fpsCounter->move(xOffset, height() - fpsCounter->height() - 5);
 }
 
 
@@ -3345,37 +3400,6 @@ void View3DInventorViewer::renderScene()
                 it->paintGL();
             }
         }
-    }
-
-    if (fpsEnabled && fpsCounter) {
-        std::stringstream stream;
-        stream.precision(1);
-        stream.setf(std::ios::fixed | std::ios::showpoint);
-        stream << framesPerSecond[0] << " ms / " << framesPerSecond[1] << " fps";
-
-        ParameterGrp::handle hGrpView = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/Preferences/View"
-        );
-        unsigned long axisLetterColor = hGrpView->GetUnsigned("AxisLetterColor", 4294902015);
-        if (axisLetterColor != previousAxisLetterColor) {
-            previousAxisLetterColor = axisLetterColor;
-            Base::Color c(static_cast<uint32_t>(axisLetterColor));
-            fpsCounter->setStyleSheet(
-                QString::fromLatin1("color: rgb(%1,%2,%3); background: transparent;")
-                    .arg(int(c.r * 255))
-                    .arg(int(c.g * 255))
-                    .arg(int(c.b * 255))
-            );
-        }
-
-        fpsCounter->setText(QString::fromStdString(stream.str()));
-        fpsCounter->adjustSize();
-
-        ParameterGrp::handle hGrpOverlayL = App::GetApplication().GetParameterGroupByPath(
-            "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
-        );
-        int xOffset = hGrpOverlayL->GetASCII("Widgets", "").empty() ? 10 : fpsCounter->width() + 20;
-        fpsCounter->move(xOffset, height() - fpsCounter->height() - 5);
     }
 
     // Workaround for inconsistent QT behavior related to handling custom OpenGL widgets that

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -64,6 +64,7 @@
 class QOpenGLFramebufferObject;
 class QOpenGLWidget;
 class QSurfaceFormat;
+class QTimer;
 
 class SoTranslation;
 class SoTransform;
@@ -697,9 +698,12 @@ private:
     // stuff needed to draw the fps counter
     bool fpsEnabled;
     QLabel* fpsCounter = nullptr;
+    QTimer* fpsUpdateTimer = nullptr;
     unsigned long previousAxisLetterColor = 0;
     bool vboEnabled;
     bool naviCubeEnabled;
+
+
     // Screen-only viewer decorations such as the navicube are rendered only
     // when the active render intent allows them.
     mutable std::vector<RenderIntent> renderIntentOverrideStack;
@@ -727,6 +731,10 @@ private:
     static unsigned char XPM_pixel_data[YPM_WIDTH * YPM_HEIGHT * YPM_BYTES_PER_PIXEL + 1];
     static unsigned char YPM_pixel_data[YPM_WIDTH * YPM_HEIGHT * YPM_BYTES_PER_PIXEL + 1];
     static unsigned char ZPM_pixel_data[ZPM_WIDTH * ZPM_HEIGHT * ZPM_BYTES_PER_PIXEL + 1];
+
+private Q_SLOTS:
+    void updateFPSLabel();
+
 
     // friends
     friend class NavigationStyle;

--- a/src/Gui/View3DInventorViewer.h
+++ b/src/Gui/View3DInventorViewer.h
@@ -703,7 +703,6 @@ private:
     bool vboEnabled;
     bool naviCubeEnabled;
 
-
     // Screen-only viewer decorations such as the navicube are rendered only
     // when the active render intent allows them.
     mutable std::vector<RenderIntent> renderIntentOverrideStack;
@@ -734,7 +733,6 @@ private:
 
 private Q_SLOTS:
     void updateFPSLabel();
-
 
     // friends
     friend class NavigationStyle;


### PR DESCRIPTION
improve the performance of the fps label, ie. addresses #29427

before this PR on my 4th gen i7 running arch linux i was getting ~ 180fps using the turntable at maximum speed "orbiting" part sphere as original mentioned the below issue.

when the fps label is enabled via the preferences without this PR i was getting ~ 40-50fps

after this PR with the fps label enabled i am getting ~ 130 fps

the big hold up / "bottleneck" on this one is going to be using the "QLabel" as that is renderened a different pipeline non GL than original `draw2DString` was using before @Bojan9597  submitted his PR for hidpi scaling.

@7sDream @Syres916 @kevenwyld 
y'all mind testing and providing some feedback when you get some time.

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/29427

## Before and After Images

those running freecad on linux can test the fps performance using the below command. obviously update path to local build install of freecad.

```
vblank_mode=0 GALLIUM_HUD=fps,frametime,cpu \
/opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD
```

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/274ee69f-341d-4719-818c-2688562d1005" />