### PR TITLE
Sketcher: Better Angle Placement

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -213,7 +213,7 @@ namespace SketcherGui::AngularDatumLabelPlacement
 
     if (constraint->Second == Sketcher::GeoEnum::GeoUndef) {
         const Part::Geometry* arc = freecad_cast<const Part::GeomArcOfCircle*>(sketch->getGeometry(constraint->First));
-        
+
         if (!arc) {
             return false;
         }

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -212,7 +212,11 @@ namespace SketcherGui::AngularDatumLabelPlacement
     };
 
     if (constraint->Second == Sketcher::GeoEnum::GeoUndef) {
-        const Part::Geometry* geometry = sketch->getGeometry(constraint->First);
+        const Part::Geometry* arc = freecad_cast<const Part::GeomArcOfCircle*>(sketch->getGeometry(constraint->First));
+        
+        if (!arc) {
+            return false;
+        }
         if (!geometry || !isArcOfCircle(*geometry)) {
             return false;
         }

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -24,6 +24,7 @@
 
 #include <limits>
 #include <cmath>
+#include <optional>
 
 #include <Precision.hxx>
 #include <Bnd_Box.hxx>
@@ -181,12 +182,11 @@ namespace SketcherGui::LinearDatumLabelPlacement
 
 namespace SketcherGui::AngularDatumLabelPlacement
 {
-[[nodiscard]] std::optional<Base::Vector2d> computeLabelPosition(const Sketcher::SketchObject* sketch,const Sketcher::Constraint* constraint)
-                                        const Sketcher::Constraint* constraint,
-                                        Base::Vector2d& position)
+[[nodiscard]] std::optional<Base::Vector2d> computeLabelPosition(const Sketcher::SketchObject* sketch,
+                                                                   const Sketcher::Constraint* constraint)
 {
     if (constraint->Type != Sketcher::Angle) {
-        return false;
+        return std::nullopt;
     }
 
     const bool firstIsAxis = constraint->First == Sketcher::GeoEnum::HAxis
@@ -212,16 +212,13 @@ namespace SketcherGui::AngularDatumLabelPlacement
     };
 
     if (constraint->Second == Sketcher::GeoEnum::GeoUndef) {
-        const Part::Geometry* arc = freecad_cast<const Part::GeomArcOfCircle*>(sketch->getGeometry(constraint->First));
+        const auto* arc = freecad_cast<const Part::GeomArcOfCircle*>(
+            sketch->getGeometry(constraint->First));
 
         if (!arc) {
-            return false;
-        }
-        if (!geometry || !isArcOfCircle(*geometry)) {
-            return false;
+            return std::nullopt;
         }
 
-        const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geometry);
         double startAngle = 0.0;
         double endAngle = 0.0;
         arc->getRange(startAngle, endAngle, true);
@@ -229,19 +226,17 @@ namespace SketcherGui::AngularDatumLabelPlacement
         const Base::Vector2d center(arc->getCenter().x, arc->getCenter().y);
         const double radius = arc->getRadius();
         const double middleAngle = 0.5 * (startAngle + endAngle);
-        position = center + Base::Vector2d(std::cos(middleAngle), std::sin(middleAngle))
+        return center + Base::Vector2d(std::cos(middleAngle), std::sin(middleAngle))
                 * (radius + constraint->LabelDistance);
-        return true;
     }
     else if (firstIsAxis != secondIsAxis) {
         const int axisGeoId = firstIsAxis ? constraint->First : constraint->Second;
-        const Part::Geometry* geometry =
-            sketch->getGeometry(firstIsAxis ? constraint->Second : constraint->First);
-        if (!geometry || !isLineSegment(*geometry)) {
-            return false;
+        const auto* lineSegment = freecad_cast<const Part::GeomLineSegment*>(
+            sketch->getGeometry(firstIsAxis ? constraint->Second : constraint->First));
+        if (!lineSegment) {
+            return std::nullopt;
         }
 
-        const auto* lineSegment = static_cast<const Part::GeomLineSegment*>(geometry);
         const Base::Vector2d startPoint(lineSegment->getStartPoint().x, lineSegment->getStartPoint().y);
         const Base::Vector2d endPoint(lineSegment->getEndPoint().x, lineSegment->getEndPoint().y);
         const Base::Vector2d lineSpan = endPoint - startPoint;
@@ -251,22 +246,18 @@ namespace SketcherGui::AngularDatumLabelPlacement
                                              ? Base::Vector2d(1.0, 0.0)
                                              : Base::Vector2d(0.0, 1.0)),
                             vertex)) {
-            return false;
+            return std::nullopt;
         }
 
         if (vertexOnSegment(startPoint, lineSpan, vertex)) {
-            return false;
+            return std::nullopt;
         }
 
-        const Base::Vector3d vertex3d(vertex.x, vertex.y, lineSegment->getStartPoint().z);
-        rayPoint2 = Base::DistanceP2(vertex3d, lineSegment->getStartPoint())
-                <= Base::DistanceP2(vertex3d, lineSegment->getEndPoint())
-            ? startPoint
-            : endPoint;
+        rayPoint2 = (startPoint - vertex).Sqr() <= (endPoint - vertex).Sqr() ? startPoint : endPoint;
 
         radius = (rayPoint2 - vertex).Length();
         if (radius <= Precision::Confusion()) {
-            return false;
+            return std::nullopt;
         }
 
         rayPoint1 = axisGeoId == Sketcher::GeoEnum::HAxis
@@ -274,15 +265,14 @@ namespace SketcherGui::AngularDatumLabelPlacement
             : vertex + Base::Vector2d(0.0, (rayPoint2 - vertex).y >= 0.0 ? radius : -radius);
     }
     else {
-        const Part::Geometry* firstGeometry = sketch->getGeometry(constraint->First);
-        const Part::Geometry* secondGeometry = sketch->getGeometry(constraint->Second);
-        if (!firstGeometry || !secondGeometry || !isLineSegment(*firstGeometry)
-            || !isLineSegment(*secondGeometry)) {
-            return false;
+        const auto* firstLine =
+            freecad_cast<const Part::GeomLineSegment*>(sketch->getGeometry(constraint->First));
+        const auto* secondLine =
+            freecad_cast<const Part::GeomLineSegment*>(sketch->getGeometry(constraint->Second));
+        if (!firstLine || !secondLine) {
+            return std::nullopt;
         }
 
-        const auto* firstLine = static_cast<const Part::GeomLineSegment*>(firstGeometry);
-        const auto* secondLine = static_cast<const Part::GeomLineSegment*>(secondGeometry);
         const Base::Vector2d firstStart(firstLine->getStartPoint().x, firstLine->getStartPoint().y);
         const Base::Vector2d firstEnd(firstLine->getEndPoint().x, firstLine->getEndPoint().y);
         const Base::Vector2d secondStart(secondLine->getStartPoint().x, secondLine->getStartPoint().y);
@@ -290,27 +280,19 @@ namespace SketcherGui::AngularDatumLabelPlacement
         const Base::Vector2d firstSpan = firstEnd - firstStart;
         const Base::Vector2d secondSpan = secondEnd - secondStart;
         if (!Base::Line2d(firstStart, firstEnd).Intersect(Base::Line2d(secondStart, secondEnd), vertex)) {
-            return false;
+            return std::nullopt;
         }
 
         if (vertexOnSegment(firstStart, firstSpan, vertex)
             && vertexOnSegment(secondStart, secondSpan, vertex)) {
-            return false;
+            return std::nullopt;
         }
 
-        const Base::Vector3d firstVertex3d(vertex.x, vertex.y, firstLine->getStartPoint().z);
-        const Base::Vector3d secondVertex3d(vertex.x, vertex.y, secondLine->getStartPoint().z);
-        rayPoint1 = Base::DistanceP2(firstVertex3d, firstLine->getStartPoint())
-                <= Base::DistanceP2(firstVertex3d, firstLine->getEndPoint())
-            ? firstStart
-            : firstEnd;
-        rayPoint2 = Base::DistanceP2(secondVertex3d, secondLine->getStartPoint())
-                <= Base::DistanceP2(secondVertex3d, secondLine->getEndPoint())
-            ? secondStart
-            : secondEnd;
+        rayPoint1 = (firstStart - vertex).Sqr() <= (firstEnd - vertex).Sqr() ? firstStart : firstEnd;
+        rayPoint2 = (secondStart - vertex).Sqr() <= (secondEnd - vertex).Sqr() ? secondStart : secondEnd;
         radius = std::min((rayPoint1 - vertex).Length(), (rayPoint2 - vertex).Length());
         if (radius <= Precision::Confusion()) {
-            return false;
+            return std::nullopt;
         }
     }
 
@@ -318,12 +300,12 @@ namespace SketcherGui::AngularDatumLabelPlacement
     Base::Vector2d secondDirection = rayPoint2 - vertex;
     if (firstDirection.Length() <= Precision::Confusion()
         || secondDirection.Length() <= Precision::Confusion()) {
-        return false;
+        return std::nullopt;
     }
 
     firstDirection.Normalize();
     secondDirection.Normalize();
-    position = firstDirection + secondDirection;
+    Base::Vector2d position = firstDirection + secondDirection;
     if (position.Length() <= Precision::Confusion()) {
         position = firstDirection.Perpendicular(false);
     }
@@ -331,8 +313,7 @@ namespace SketcherGui::AngularDatumLabelPlacement
         position.Normalize();
     }
 
-    position = vertex + position * (radius + constraint->LabelDistance);
-    return true;
+    return vertex + position * (radius + constraint->LabelDistance);
 }
 }  // namespace SketcherGui::AngularDatumLabelPlacement
 
@@ -418,12 +399,10 @@ void finishDatumConstraint(Gui::Command* cmd,
                 }
             }
             else if (lastConstraintType == Angle) {
-                Base::Vector2d labelPosition;
-
-                if (AngularDatumLabelPlacement::computeLabelPosition(
-                        sketch, ConStr[i], labelPosition)) {
+                if (auto labelPosition = AngularDatumLabelPlacement::computeLabelPosition(
+                        sketch, ConStr[i])) {
                     ViewProviderSketchCommandConstraintsAttorney::moveConstraint(
-                        *vp, i, labelPosition);
+                        *vp, i, *labelPosition);
                 }
             }
             else {

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -181,7 +181,7 @@ namespace SketcherGui::LinearDatumLabelPlacement
 
 namespace SketcherGui::AngularDatumLabelPlacement
 {
-[[nodiscard]] bool computeLabelPosition(const Sketcher::SketchObject* sketch,
+[[nodiscard]] std::optional<Base::Vector2d> computeLabelPosition(const Sketcher::SketchObject* sketch,const Sketcher::Constraint* constraint)
                                         const Sketcher::Constraint* constraint,
                                         Base::Vector2d& position)
 {

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -202,13 +202,20 @@ namespace SketcherGui::AngularDatumLabelPlacement
     const auto vertexOnSegment = [](const Base::Vector2d& segmentStart,
                                     const Base::Vector2d& segmentSpan,
                                     const Base::Vector2d& point) {
+        const double tolerance = Precision::Confusion();
         const Base::Vector2d segmentToPoint = point - segmentStart;
-        return std::abs(segmentSpan.x * segmentToPoint.y - segmentSpan.y * segmentToPoint.x)
-                <= Precision::Confusion()
-            && (segmentToPoint.x * segmentSpan.x + segmentToPoint.y * segmentSpan.y)
-                >= -Precision::Confusion()
-            && (segmentToPoint.x * segmentSpan.x + segmentToPoint.y * segmentSpan.y)
-                <= segmentSpan.Sqr() + Precision::Confusion();
+
+        const double crossProduct = segmentSpan.x * segmentToPoint.y
+            - segmentSpan.y * segmentToPoint.x;
+        const double dotProduct = segmentToPoint.x * segmentSpan.x
+            + segmentToPoint.y * segmentSpan.y;
+        const double segmentLengthSquared = segmentSpan.Sqr();
+
+        const bool pointIsOnLine = std::abs(crossProduct) <= tolerance;
+        const bool pointIsAfterSegmentStart = dotProduct >= -tolerance;
+        const bool pointIsBeforeSegmentEnd = dotProduct <= segmentLengthSquared + tolerance;
+
+        return pointIsOnLine && pointIsAfterSegmentStart && pointIsBeforeSegmentEnd;
     };
 
     if (constraint->Second == Sketcher::GeoEnum::GeoUndef) {

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -179,6 +179,159 @@ namespace SketcherGui::LinearDatumLabelPlacement
 }
 }  // namespace SketcherGui::LinearDatumLabelPlacement
 
+namespace SketcherGui::AngularDatumLabelPlacement
+{
+[[nodiscard]] bool computeLabelPosition(const Sketcher::SketchObject* sketch,
+                                        const Sketcher::Constraint* constraint,
+                                        Base::Vector2d& position)
+{
+    if (constraint->Type != Sketcher::Angle) {
+        return false;
+    }
+
+    const bool firstIsAxis = constraint->First == Sketcher::GeoEnum::HAxis
+        || constraint->First == Sketcher::GeoEnum::VAxis;
+    const bool secondIsAxis = constraint->Second == Sketcher::GeoEnum::HAxis
+        || constraint->Second == Sketcher::GeoEnum::VAxis;
+
+    Base::Vector2d vertex;
+    Base::Vector2d rayPoint1;
+    Base::Vector2d rayPoint2;
+    double radius = 0.0;
+
+    const auto vertexOnSegment = [](const Base::Vector2d& segmentStart,
+                                    const Base::Vector2d& segmentSpan,
+                                    const Base::Vector2d& point) {
+        const Base::Vector2d segmentToPoint = point - segmentStart;
+        return std::abs(segmentSpan.x * segmentToPoint.y - segmentSpan.y * segmentToPoint.x)
+                <= Precision::Confusion()
+            && (segmentToPoint.x * segmentSpan.x + segmentToPoint.y * segmentSpan.y)
+                >= -Precision::Confusion()
+            && (segmentToPoint.x * segmentSpan.x + segmentToPoint.y * segmentSpan.y)
+                <= segmentSpan.Sqr() + Precision::Confusion();
+    };
+
+    if (constraint->Second == Sketcher::GeoEnum::GeoUndef) {
+        const Part::Geometry* geometry = sketch->getGeometry(constraint->First);
+        if (!geometry || !isArcOfCircle(*geometry)) {
+            return false;
+        }
+
+        const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geometry);
+        double startAngle = 0.0;
+        double endAngle = 0.0;
+        arc->getRange(startAngle, endAngle, true);
+
+        const Base::Vector2d center(arc->getCenter().x, arc->getCenter().y);
+        const double radius = arc->getRadius();
+        const double middleAngle = 0.5 * (startAngle + endAngle);
+        position = center + Base::Vector2d(std::cos(middleAngle), std::sin(middleAngle))
+                * (radius + constraint->LabelDistance);
+        return true;
+    }
+    else if (firstIsAxis != secondIsAxis) {
+        const int axisGeoId = firstIsAxis ? constraint->First : constraint->Second;
+        const Part::Geometry* geometry =
+            sketch->getGeometry(firstIsAxis ? constraint->Second : constraint->First);
+        if (!geometry || !isLineSegment(*geometry)) {
+            return false;
+        }
+
+        const auto* lineSegment = static_cast<const Part::GeomLineSegment*>(geometry);
+        const Base::Vector2d startPoint(lineSegment->getStartPoint().x, lineSegment->getStartPoint().y);
+        const Base::Vector2d endPoint(lineSegment->getEndPoint().x, lineSegment->getEndPoint().y);
+        const Base::Vector2d lineSpan = endPoint - startPoint;
+        if (!Base::Line2d(startPoint, endPoint)
+                 .Intersect(Base::Line2d(Base::Vector2d(0.0, 0.0),
+                                         axisGeoId == Sketcher::GeoEnum::HAxis
+                                             ? Base::Vector2d(1.0, 0.0)
+                                             : Base::Vector2d(0.0, 1.0)),
+                            vertex)) {
+            return false;
+        }
+
+        if (vertexOnSegment(startPoint, lineSpan, vertex)) {
+            return false;
+        }
+
+        const Base::Vector3d vertex3d(vertex.x, vertex.y, lineSegment->getStartPoint().z);
+        rayPoint2 = Base::DistanceP2(vertex3d, lineSegment->getStartPoint())
+                <= Base::DistanceP2(vertex3d, lineSegment->getEndPoint())
+            ? startPoint
+            : endPoint;
+
+        radius = (rayPoint2 - vertex).Length();
+        if (radius <= Precision::Confusion()) {
+            return false;
+        }
+
+        rayPoint1 = axisGeoId == Sketcher::GeoEnum::HAxis
+            ? vertex + Base::Vector2d((rayPoint2 - vertex).x >= 0.0 ? radius : -radius, 0.0)
+            : vertex + Base::Vector2d(0.0, (rayPoint2 - vertex).y >= 0.0 ? radius : -radius);
+    }
+    else {
+        const Part::Geometry* firstGeometry = sketch->getGeometry(constraint->First);
+        const Part::Geometry* secondGeometry = sketch->getGeometry(constraint->Second);
+        if (!firstGeometry || !secondGeometry || !isLineSegment(*firstGeometry)
+            || !isLineSegment(*secondGeometry)) {
+            return false;
+        }
+
+        const auto* firstLine = static_cast<const Part::GeomLineSegment*>(firstGeometry);
+        const auto* secondLine = static_cast<const Part::GeomLineSegment*>(secondGeometry);
+        const Base::Vector2d firstStart(firstLine->getStartPoint().x, firstLine->getStartPoint().y);
+        const Base::Vector2d firstEnd(firstLine->getEndPoint().x, firstLine->getEndPoint().y);
+        const Base::Vector2d secondStart(secondLine->getStartPoint().x, secondLine->getStartPoint().y);
+        const Base::Vector2d secondEnd(secondLine->getEndPoint().x, secondLine->getEndPoint().y);
+        const Base::Vector2d firstSpan = firstEnd - firstStart;
+        const Base::Vector2d secondSpan = secondEnd - secondStart;
+        if (!Base::Line2d(firstStart, firstEnd).Intersect(Base::Line2d(secondStart, secondEnd), vertex)) {
+            return false;
+        }
+
+        if (vertexOnSegment(firstStart, firstSpan, vertex)
+            && vertexOnSegment(secondStart, secondSpan, vertex)) {
+            return false;
+        }
+
+        const Base::Vector3d firstVertex3d(vertex.x, vertex.y, firstLine->getStartPoint().z);
+        const Base::Vector3d secondVertex3d(vertex.x, vertex.y, secondLine->getStartPoint().z);
+        rayPoint1 = Base::DistanceP2(firstVertex3d, firstLine->getStartPoint())
+                <= Base::DistanceP2(firstVertex3d, firstLine->getEndPoint())
+            ? firstStart
+            : firstEnd;
+        rayPoint2 = Base::DistanceP2(secondVertex3d, secondLine->getStartPoint())
+                <= Base::DistanceP2(secondVertex3d, secondLine->getEndPoint())
+            ? secondStart
+            : secondEnd;
+        radius = std::min((rayPoint1 - vertex).Length(), (rayPoint2 - vertex).Length());
+        if (radius <= Precision::Confusion()) {
+            return false;
+        }
+    }
+
+    Base::Vector2d firstDirection = rayPoint1 - vertex;
+    Base::Vector2d secondDirection = rayPoint2 - vertex;
+    if (firstDirection.Length() <= Precision::Confusion()
+        || secondDirection.Length() <= Precision::Confusion()) {
+        return false;
+    }
+
+    firstDirection.Normalize();
+    secondDirection.Normalize();
+    position = firstDirection + secondDirection;
+    if (position.Length() <= Precision::Confusion()) {
+        position = Base::Vector2d(-firstDirection.y, firstDirection.x);
+    }
+    else {
+        position.Normalize();
+    }
+
+    position = vertex + position * (radius + constraint->LabelDistance);
+    return true;
+}
+}  // namespace SketcherGui::AngularDatumLabelPlacement
+
 namespace SketcherGui
 {
 class ViewProviderSketchCommandConstraintsAttorney
@@ -258,6 +411,15 @@ void finishDatumConstraint(Gui::Command* cmd,
 
                 if (geo && isCircle(*geo)) {
                     ConStr[i]->LabelPosition = labelPosition;
+                }
+            }
+            else if (lastConstraintType == Angle) {
+                Base::Vector2d labelPosition;
+
+                if (AngularDatumLabelPlacement::computeLabelPosition(
+                        sketch, ConStr[i], labelPosition)) {
+                    ViewProviderSketchCommandConstraintsAttorney::moveConstraint(
+                        *vp, i, labelPosition);
                 }
             }
             else {

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -325,7 +325,7 @@ namespace SketcherGui::AngularDatumLabelPlacement
     secondDirection.Normalize();
     position = firstDirection + secondDirection;
     if (position.Length() <= Precision::Confusion()) {
-        position = Base::Vector2d(-firstDirection.y, firstDirection.x);
+        position = firstDirection.Perpendicular(false);
     }
     else {
         position.Normalize();


### PR DESCRIPTION
For non-intersecting lines, the angle was created outside the screen, while for arcs, the angle was created inside the arc; however, their placement is adjusted to look better.

After #29538, while working on #29594, I noticed that the arc angles were placed very awkwardly. I made a change to correct this, which was relatively simple. For angles on lines, the normal behavior is to take the intersection point as the angle vertex. This works in most cases, but if the lines don't intersect on the screen, the angle often goes off-screen. Here, for these specific cases, I move the angle to the nearest point. Since it's still very logical for the angle to form at the intersection point, the main problem here is defining the exceptional cases. I do this by checking if the intersection point is on the two lines. 

To be honest, I was so focused on this that I forgot about the previous version; this is a really big improvement.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->

Before:
<img width="1283" height="879" alt="resim" src="https://github.com/user-attachments/assets/07271cf5-e760-4b9b-9c6b-9ac19ed367cb" />


After:
<img width="1270" height="880" alt="resim" src="https://github.com/user-attachments/assets/87500155-75c2-4ba0-8f96-d4e2527f90d8" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
