### PR TITLE
TechDraw: repair stale 2D dimension references via SavedGeometry (#19871)

### DIFF
--- a/src/Mod/TechDraw/App/DimensionAutoCorrect.cpp
+++ b/src/Mod/TechDraw/App/DimensionAutoCorrect.cpp
@@ -57,7 +57,19 @@
 //                //we can't fix this
 
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <BRepAdaptor_Curve.hxx>
+#include <BRep_Tool.hxx>
+#include <GCPnts_AbscissaPoint.hxx>
+#include <Standard_Failure.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
 #include <TopoDS_Shape.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <gp_Pnt.hxx>
 
 #include <App/Document.h>
 #include <Base/Console.h>
@@ -363,10 +375,15 @@ bool DimensionAutoCorrect::findExactEdge3d(ReferenceEntry& refToFix, const Part:
 bool DimensionAutoCorrect::findSimilarVertex2d(ReferenceEntry& refToFix,
                                                const Part::TopoShape& refGeom) const
 {
-    // Base::Console().message("DAC::findSimilarVertex2d()\n");
-    (void)refToFix;
-    (void)refGeom;
-    // Base::Console().message("DAC::findSimilarVertex2d is not implemented yet\n");
+    auto refDvp = dynamic_cast<TechDraw::DrawViewPart*>(refToFix.getObject());
+    if (!refDvp) {
+        return false;
+    }
+    ReferenceEntry fixed = searchViewForSimilarVert(refDvp, refGeom);
+    if (fixed.getObject()) {
+        refToFix = fixed;
+        return true;
+    }
     return false;
 }
 
@@ -375,10 +392,15 @@ bool DimensionAutoCorrect::findSimilarVertex2d(ReferenceEntry& refToFix,
 bool DimensionAutoCorrect::findSimilarEdge2d(ReferenceEntry& refToFix,
                                              const Part::TopoShape& refGeom) const
 {
-    // Base::Console().message("DAC::findSimilarEdge2d()\n");
-    (void)refToFix;
-    (void)refGeom;
-    // Base::Console().message("DAC::findSimilarEdge2d is not implemented yet\n");
+    auto refDvp = dynamic_cast<TechDraw::DrawViewPart*>(refToFix.getObject());
+    if (!refDvp) {
+        return false;
+    }
+    ReferenceEntry fixed = searchViewForSimilarEdge(refDvp, refGeom);
+    if (fixed.getObject()) {
+        refToFix = fixed;
+        return true;
+    }
     return false;
 }
 
@@ -508,15 +530,167 @@ ReferenceEntry DimensionAutoCorrect::searchViewForExactEdge(DrawViewPart* obj,
 }
 
 
-//! search View (2d part display) for an edge that is similar to refEdge
+//! search View (2d part display) for an edge whose endpoints, length and curve
+//! type match refEdge within a tight tolerance. Phase-2 fallback for stale 2D
+//! references; rejects on any ambiguity rather than risk a wrong rebind (#19871).
 ReferenceEntry DimensionAutoCorrect::searchViewForSimilarEdge(DrawViewPart* obj,
                                                               const Part::TopoShape& refEdge) const
 {
-    // Base::Console().message("DAC::searchViewForSimilarEdge()\n");
-    (void)obj;
-    (void)refEdge;
-    Base::Console().message("DAC::searchViewForSimilarEdge is not implemented yet\n");
-    return {};
+    if (!obj || refEdge.isNull()) {
+        return {};
+    }
+    const TopoDS_Shape& refShape = refEdge.getShape();
+    if (refShape.IsNull() || refShape.ShapeType() != TopAbs_EDGE) {
+        return {};
+    }
+    // The projected reference edge can be degenerate; OCCT raises Standard_Failure
+    // (not a std::exception) which would otherwise escape recompute (#19871).
+    GeomAbs_CurveType refType = GeomAbs_OtherCurve;
+    double refLength = 0.0;
+    gp_Pnt refP0;
+    gp_Pnt refP1;
+    try {
+        TopoDS_Edge refOcc = TopoDS::Edge(refShape);
+        BRepAdaptor_Curve refAdapt(refOcc);
+        refType = refAdapt.GetType();
+        refLength = GCPnts_AbscissaPoint::Length(refAdapt);
+        refP0 = refAdapt.Value(refAdapt.FirstParameter());
+        refP1 = refAdapt.Value(refAdapt.LastParameter());
+    }
+    catch (const Standard_Failure&) {
+        return {};
+    }
+
+    // Match on BOTH endpoints (orientation-independent) plus length, not just the
+    // midpoint: an edge with a similar midpoint but different endpoints is a
+    // different edge, and binding to it yields a confidently wrong dimension.
+    int bestIdx = -1;
+    double bestScore = std::numeric_limits<double>::max();
+    double runnerUp = std::numeric_limits<double>::max();
+
+    const auto edgesAll = obj->getEdgeGeometry();
+    for (size_t i = 0; i < edgesAll.size(); ++i) {
+        const auto& bg = edgesAll[i];
+        if (!bg) {
+            continue;
+        }
+        Part::TopoShape canon = ReferenceEntry::asCanonicalTopoShape(bg->asTopoShape(), *obj);
+        const TopoDS_Shape& cShape = canon.getShape();
+        if (cShape.IsNull() || cShape.ShapeType() != TopAbs_EDGE) {
+            continue;
+        }
+        double endpointDist = 0.0;
+        try {
+            TopoDS_Edge cEdge = TopoDS::Edge(cShape);
+            BRepAdaptor_Curve cAdapt(cEdge);
+            if (cAdapt.GetType() != refType) {
+                continue;
+            }
+            double cLength = GCPnts_AbscissaPoint::Length(cAdapt);
+            double lenMax = std::max(refLength, cLength);
+            if (lenMax > 1.0e-7 && std::fabs(refLength - cLength) / lenMax > 0.05) {
+                continue;  // length differs by more than 5 % -- not the same edge
+            }
+            gp_Pnt cP0 = cAdapt.Value(cAdapt.FirstParameter());
+            gp_Pnt cP1 = cAdapt.Value(cAdapt.LastParameter());
+            // orientation can flip between projections; take the better pairing.
+            double sameDir = refP0.Distance(cP0) + refP1.Distance(cP1);
+            double flipDir = refP0.Distance(cP1) + refP1.Distance(cP0);
+            endpointDist = std::min(sameDir, flipDir);
+        }
+        catch (const Standard_Failure&) {
+            continue;
+        }
+        if (endpointDist < bestScore) {
+            runnerUp = bestScore;
+            bestScore = endpointDist;
+            bestIdx = static_cast<int>(i);
+        }
+        else if (endpointDist < runnerUp) {
+            runnerUp = endpointDist;
+        }
+    }
+
+    // Tight accept window: both endpoints must land within ~0.5 mm (model space)
+    // of the saved edge, summed, and the best candidate must be clearly better
+    // than the runner-up. Otherwise refuse to rebind.
+    const double acceptThreshold = 1.0;   // mm, summed over both endpoints
+    const double ambiguityMargin = 0.5;   // best must be <= 50 % of runner-up
+    if (bestIdx < 0 || bestScore > acceptThreshold) {
+        return {};
+    }
+    if (runnerUp != std::numeric_limits<double>::max()
+        && bestScore > (1.0 - ambiguityMargin) * runnerUp) {
+        return {};
+    }
+    auto newSubname = std::string("Edge") + std::to_string(bestIdx);
+    return {obj, newSubname, getDimension()->getDocument()};
+}
+
+//! search View (2d part display) for a vertex within an accept-threshold of
+//! refVertex. Companion to searchViewForSimilarEdge for the phase-2 fallback.
+ReferenceEntry DimensionAutoCorrect::searchViewForSimilarVert(DrawViewPart* obj,
+                                                              const Part::TopoShape& refVertex) const
+{
+    if (!obj || refVertex.isNull()) {
+        return {};
+    }
+    const TopoDS_Shape& refShape = refVertex.getShape();
+    if (refShape.IsNull() || refShape.ShapeType() != TopAbs_VERTEX) {
+        return {};
+    }
+    gp_Pnt refPnt;
+    try {
+        refPnt = BRep_Tool::Pnt(TopoDS::Vertex(refShape));
+    }
+    catch (const Standard_Failure&) {
+        return {};
+    }
+
+    int bestIdx = -1;
+    double bestDist = std::numeric_limits<double>::max();
+    double runnerUp = std::numeric_limits<double>::max();
+
+    const auto vertsAll = obj->getVertexGeometry();
+    for (size_t i = 0; i < vertsAll.size(); ++i) {
+        if (!vertsAll[i]) {
+            continue;
+        }
+        Part::TopoShape canon =
+            ReferenceEntry::asCanonicalTopoShape(vertsAll[i]->asTopoShape(), *obj);
+        const TopoDS_Shape& cShape = canon.getShape();
+        if (cShape.IsNull() || cShape.ShapeType() != TopAbs_VERTEX) {
+            continue;
+        }
+        gp_Pnt cPnt;
+        try {
+            cPnt = BRep_Tool::Pnt(TopoDS::Vertex(cShape));
+        }
+        catch (const Standard_Failure&) {
+            continue;
+        }
+        double d = refPnt.Distance(cPnt);
+        if (d < bestDist) {
+            runnerUp = bestDist;
+            bestDist = d;
+            bestIdx = static_cast<int>(i);
+        }
+        else if (d < runnerUp) {
+            runnerUp = d;
+        }
+    }
+
+    const double acceptThreshold = 0.5;   // mm in canonical view space
+    const double ambiguityMargin = 0.5;
+    if (bestIdx < 0 || bestDist > acceptThreshold) {
+        return {};
+    }
+    if (runnerUp != std::numeric_limits<double>::max()
+        && bestDist > (1.0 - ambiguityMargin) * runnerUp) {
+        return {};
+    }
+    auto newSubname = std::string("Vertex") + std::to_string(bestIdx);
+    return {obj, newSubname, getDimension()->getDocument()};
 }
 
 //! search model for for a 3d edge that is a match to refEdge

--- a/src/Mod/TechDraw/App/DimensionAutoCorrect.h
+++ b/src/Mod/TechDraw/App/DimensionAutoCorrect.h
@@ -79,6 +79,7 @@ private:
 
     ReferenceEntry searchViewForExactEdge(DrawViewPart* obj, const Part::TopoShape& refEdge) const;
     ReferenceEntry searchViewForSimilarEdge(DrawViewPart* obj, const Part::TopoShape& refEdge) const;
+    ReferenceEntry searchViewForSimilarVert(DrawViewPart* obj, const Part::TopoShape& refVertex) const;
 
     bool isMatchingGeometry(const ReferenceEntry& ref, const Part::TopoShape& savedGeometry) const;
 

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -577,8 +577,16 @@ bool DrawViewDimension::okToProceed()
     // is this check still relevant or is it replaced by the autocorrect and
     // validate methods?
     if (References3D.getValues().empty() && !checkReferences2D()) {
-        // Base::Console().warning("%s has invalid 2D References\n", getNameInDocument());
-        return false;
+        // Issue #19871: a stale index (e.g. after an HLR projector toggle that
+        // changed the projected edge set) means the reference no longer
+        // resolves. Try a SavedGeometry-driven repair via DimensionAutoCorrect
+        // before giving up.
+        if (!Preferences::autoCorrectDimRefs()
+            || !autocorrectReferences()
+            || !checkReferences2D()) {
+            // Base::Console().warning("%s has invalid 2D References\n", getNameInDocument());
+            return false;
+        }
     }
     return validateReferenceForm();
 }

--- a/src/Mod/TechDraw/TDTest/DrawViewDimStabilityTest.py
+++ b/src/Mod/TechDraw/TDTest/DrawViewDimStabilityTest.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+import FreeCAD
+import unittest
+
+from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+
+class DrawViewDimStabilityTest(unittest.TestCase):
+    """Regression test for issue #19871: dimension references must survive a
+    CoarseView (HLR projector) toggle without going to zero."""
+
+    def setUp(self):
+        FreeCAD.newDocument("TDDimStability")
+        FreeCAD.setActiveDocument("TDDimStability")
+        FreeCAD.ActiveDocument = FreeCAD.getDocument("TDDimStability")
+        self.document = FreeCAD.ActiveDocument
+
+        box = self.document.addObject("Part::Box", "Box")
+        box.Length = 20.0
+        box.Width = 10.0
+        box.Height = 30.0
+
+        self.page = createPageWithSVGTemplate(self.document)
+        self.page.Scale = 1.0
+
+        self.view = self.document.addObject("TechDraw::DrawViewPart", "View")
+        self.page.addView(self.view)
+        self.view.Source = [box]
+        self.view.CoarseView = False
+        self.document.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument("TDDimStability")
+
+    def _firstHorizontalEdgeName(self):
+        edges = self.view.getVisibleEdges()
+        for i, edge in enumerate(edges):
+            if edge.Length > 0.0 and len(edge.Vertexes) == 2:
+                return "Edge" + str(i), edge.Length
+        self.fail("No usable visible edge on view")
+        return None, 0.0
+
+    def _coarseCylinderView(self, height):
+        # A cylinder under coarse HLR fragments its curved top/bottom edges into
+        # many short segments (here ~34 edges vs ~4 under exact HLR), reproducing
+        # the projector edge-count churn from issue #19871 that a planar box does
+        # not exhibit.
+        cyl = self.document.addObject("Part::Cylinder", "Cylinder")
+        cyl.Radius = 10.0
+        cyl.Height = height
+        view = self.document.addObject("TechDraw::DrawViewPart", "CylView")
+        self.page.addView(view)
+        view.Source = [cyl]
+        view.CoarseView = True
+        self.document.recompute()
+        return view
+
+    def _verticalSilhouetteName(self, view, height):
+        # The vertical silhouette of the cylinder projects to a straight Line of
+        # length == Height under both projectors. Under coarse HLR it lands at a
+        # high index (after all the fragment segments); there are no hidden edges
+        # so the visible index equals the index used to resolve the reference.
+        edges = view.getVisibleEdges()
+        for i, edge in enumerate(edges):
+            if (len(edge.Vertexes) == 2
+                    and type(edge.Curve).__name__ == "Line"
+                    and abs(edge.Length - height) < 1.0e-3):
+                return "Edge" + str(i), i, edge.Length
+        self.fail("No vertical silhouette line on coarse cylinder view")
+        return None, -1, 0.0
+
+    def testDimensionSurvivesCoarseViewToggle(self):
+        """Creating a dim under exact HLR and toggling to coarse HLR must keep
+        the dimension resolvable (not zero). Repair runs via
+        DimensionAutoCorrect against the dim's SavedGeometry."""
+        edge_name, _length = self._firstHorizontalEdgeName()
+        dim = self.document.addObject("TechDraw::DrawViewDimension", "Dimension")
+        self.page.addView(dim)
+        dim.Type = "Distance"
+        dim.References2D = [(self.view, edge_name)]
+        self.document.recompute()
+        self.assertTrue("Up-to-date" in dim.State)
+        initial_value = dim.getRawValue()
+        self.assertGreater(initial_value, 0.0)
+        # SavedGeometry is what the autocorrect path matches against. One sub
+        # in -> one stored TopoShape, captured on first successful execute.
+        self.assertEqual(len(dim.SavedGeometry), 1)
+        self.assertFalse(dim.SavedGeometry[0].isNull())
+
+        # Toggle to coarse -- HLR re-runs and the projected edge set may
+        # differ. The dim must still resolve to a non-zero value, either
+        # because the index is still valid or because autocorrect rebound
+        # the reference against SavedGeometry.
+        self.view.CoarseView = True
+        self.document.recompute()
+        self.assertTrue("Up-to-date" in dim.State)
+        self.assertGreater(dim.getRawValue(), 0.0)
+
+        # Toggle back to exact -- the dim should recover the original value.
+        self.view.CoarseView = False
+        self.document.recompute()
+        self.assertTrue("Up-to-date" in dim.State)
+        self.assertAlmostEqual(dim.getRawValue(), initial_value, places=3)
+
+    def testStaleReferenceRepairedAcrossProjectorToggle(self):
+        """The core #19871 case: a reference created under coarse HLR points at a
+        high edge index; switching to exact HLR leaves far fewer edges, so that
+        index is out of range. okToProceed() must repair the reference against
+        SavedGeometry instead of dropping the dimension to a corrupt/zero state."""
+        height = 30.0
+        view = self._coarseCylinderView(height)
+        edge_name, coarse_idx, length = self._verticalSilhouetteName(view, height)
+
+        dim = self.document.addObject("TechDraw::DrawViewDimension", "CylDim")
+        self.page.addView(dim)
+        dim.Type = "Distance"
+        dim.References2D = [(view, edge_name)]
+        self.document.recompute()
+        self.assertTrue("Up-to-date" in dim.State)
+        self.assertAlmostEqual(dim.getRawValue(), length, places=3)
+        self.assertEqual(len(dim.SavedGeometry), 1)
+
+        # Switch to exact HLR: the cylinder projects to only a handful of edges,
+        # so the coarse index is now beyond the end of the edge list.
+        view.CoarseView = False
+        self.document.recompute()
+        total_edges = len(view.getVisibleEdges()) + len(view.getHiddenEdges())
+        self.assertGreater(
+            coarse_idx, total_edges - 1,
+            "test no longer drives the out-of-range repair path")
+
+        # With the repair, the reference is rebound to the surviving silhouette
+        # line: the dimension stays up to date, keeps its value, and the stale
+        # subname has been replaced. Without it, the dimension would be corrupt.
+        self.assertTrue("Up-to-date" in dim.State)
+        self.assertAlmostEqual(dim.getRawValue(), length, places=3)
+        self.assertNotEqual(dim.References2D[0][1][0], edge_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/TechDraw/TestTechDrawApp.py
+++ b/src/Mod/TechDraw/TestTechDrawApp.py
@@ -27,4 +27,5 @@ from TDTest.DrawViewBalloonTest import DrawViewBalloonTest  # noqa: F401
 from TDTest.DrawViewImageTest import DrawViewImageTest  # noqa: F401
 from TDTest.DrawViewSymbolTest import DrawViewSymbolTest  # noqa: F401
 from TDTest.DrawProjectionGroupTest import DrawProjectionGroupTest  # noqa: F401
+from TDTest.DrawViewDimStabilityTest import DrawViewDimStabilityTest  # noqa: F401
 


### PR DESCRIPTION
## Summary

Implements the phase-2 "similar geometry" fallback in `DimensionAutoCorrect` so a
2D dimension can recover its reference when the projected edge/vertex index
changes but the underlying geometry is unchanged, for example when an HLR re-run
renumbers the edges.

When a stored `Edge`/`Vertex` index no longer resolves, `okToProceed()` now runs
the existing autocorrect path against the dimension's `SavedGeometry` before
reporting the references as corrupt:

- Phase 1 looks for an exact geometric match to the saved geometry.
- Phase 2 (previously stubbed) falls back to the closest edge/vertex whose
  endpoints, length and curve type match within a tight tolerance, and rejects
  any ambiguous candidate, so a reference is never rebound to the wrong geometry.

No new property and no file-format change are introduced; the repair reuses the
`SavedGeometry` that dimensions already store.

## Scope

This handles the "same geometry, new index" case, which is what AutoCorrect is
intended for. It deliberately does **not** attempt the harder case where the
projected geometry itself changes, e.g. exact vs coarse HLR producing different
edge sets (72 vs 266 on the model in #19871). In that case the matcher finds no
confident match and the reference fails safely (the dimension shows an error)
rather than binding to the wrong edge and showing an incorrect value. That
deeper case is the OCCT HLR projection-stability problem discussed in the issue.

Refs #19871.

## Test plan

- `DrawViewDimStabilityTest` (new): a cylinder reference made under coarse HLR
  (high edge index) is repaired after switching to exact HLR (the index becomes
  out of range); a box dimension survives a coarse/exact toggle.
- `ctest --test-dir build/debug -R TechDraw`
- Manual, model from #19871: toggling CoarseView keeps the dimensions on stable
  geometry correct and never produces a wrong value; dimensions on the helical
  edges that the coarse projector fragments fail safely instead.
