### PR TITLE
TechDraw: prevent edge deletion on torus and similar concentric-arc shapes

### DIFF
--- a/src/Mod/TechDraw/App/DrawProjectSplit.cpp
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.cpp
@@ -34,6 +34,7 @@
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepLProp_CurveTool.hxx>
 #include <Geom_Curve.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
 #include <GeomLib_Tool.hxx>
 #include <gp_Ax2.hxx>
 #include <gp_Pnt.hxx>
@@ -637,11 +638,55 @@ std::vector<TopoDS_Edge> DrawProjectSplit::removeOverlapEdges(const std::vector<
     return outEdges;
 }
 
+// Check whether two edges run along the same path by sampling interior points
+// on each curve and projecting them onto the other. Endpoint coincidence alone
+// is unreliable for tightly clustered arcs (e.g. torus projections) where
+// distinct concentric curves share start/end points. Both directions of
+// sampling must agree to declare coincidence.
+bool DrawProjectSplit::curvesCoincide(const TopoDS_Edge& e0,
+                                      const TopoDS_Edge& e1,
+                                      double tol)
+{
+    Standard_Real f0, l0, f1, l1;
+    Handle(Geom_Curve) c0 = BRep_Tool::Curve(e0, f0, l0);
+    Handle(Geom_Curve) c1 = BRep_Tool::Curve(e1, f1, l1);
+    if (c0.IsNull() || c1.IsNull()) {
+        return false;
+    }
+
+    constexpr int kNumSamples = 5;  // 4 interior samples (i = 1..4)
+
+    auto allSamplesOnOther = [tol](const Handle(Geom_Curve)& src, double sf, double sl,
+                                   const Handle(Geom_Curve)& dst, double df, double dl) {
+        for (int i = 1; i < kNumSamples; ++i) {
+            double t = sf + (sl - sf) * static_cast<double>(i) / kNumSamples;
+            gp_Pnt p = src->Value(t);
+            GeomAPI_ProjectPointOnCurve proj(p, dst, df, dl);
+            if (proj.NbPoints() == 0 || proj.LowerDistance() > tol) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    return allSamplesOnOther(c0, f0, l0, c1, f1, l1)
+        && allSamplesOnOther(c1, f1, l1, c0, f0, l0);
+}
+
 //determine if edge0 & edge1 are superimposed, and classify the type of overlap
 int DrawProjectSplit::isSubset(const TopoDS_Edge &edge0, const TopoDS_Edge &edge1)
 {
     if (!boxesIntersect(edge0, edge1)) {
         return NOTASUBSET;      //boxes don't intersect, so edges do not overlap
+    }
+
+    // Two edges may have intersecting bounding boxes and even share endpoints
+    // without lying on the same curve (e.g. concentric arcs on a torus
+    // projection). Verify with point sampling before trusting the
+    // tolerance-based OCCT boolean Common operation, which can over-match
+    // grazing arcs and cause legitimate edges to be deleted.
+    if (!curvesCoincide(edge0, edge1, FUZZYADJUST * EWTOLERANCE)) {
+        return NOTASUBSET;
     }
 
     //bboxes of edges intersect

--- a/src/Mod/TechDraw/App/DrawProjectSplit.h
+++ b/src/Mod/TechDraw/App/DrawProjectSplit.h
@@ -125,6 +125,9 @@ public:
                                                   const TopoDS_Edge& e2);
     static int                      isSubset(const TopoDS_Edge &e0,
                                              const TopoDS_Edge &e1);
+    static bool                     curvesCoincide(const TopoDS_Edge& e0,
+                                                   const TopoDS_Edge& e1,
+                                                   double tol);
     static std::vector<TopoDS_Edge> fuseEdges(const TopoDS_Edge& e0,
                                               const TopoDS_Edge& e1);
     static bool                     boxesIntersect(const TopoDS_Edge& e0,


### PR DESCRIPTION
Fixes #18991

## Problem

A TechDraw projected view of a torus (and similar shapes) shows missing edges. The torus loses entire arcs from its outline, making the drawing visually incorrect.

## Root cause

After HLR projection, TechDraw runs a cleanup pass called *scrubbing* that walks pairs of 2D edges and removes ones it considers duplicates. The check it uses works like this:

1. If the edges' bounding boxes don't overlap → not duplicates.
2. Otherwise, ask the geometry kernel to find the common segment between the two curves (with a small slack to absorb projection rounding).
3. If the common segment shares endpoints with one of the edges → declare that edge a duplicate and delete it.

This is fine for most shapes — straight edges of cubes, separated arcs of cylinders, etc. — because the curves are either clearly the same or clearly different.

A torus breaks it. A torus projects to a tight bundle of concentric circles and arcs that:
- run very close to each other (inner rim, outer rim, seam arcs along the same circles),
- share start/end points (everything meets at the silhouette extremes),
- and graze rather than cross.

For these arcs, the kernel's tolerant common-segment search returns a phantom result, and because the endpoints always coincide on a torus the endpoint check always agrees. The classifier concludes "duplicate" and deletes a legitimate arc. The multi-pass loop (`ScrubCount`) compounds this — each pass eats more arcs.

WandererFan confirmed in the issue that setting `ScrubCount = 0` (skipping the cleanup entirely) hides the bug, but that workaround leaves real duplicates in the output.

## The fix

Add one precondition in `isSubset()` before the kernel call: actually verify that the two curves run along the same path, not just that they touch at the ends.

The new helper `curvesCoincide()`:
- samples 4 interior points along edge A and projects each onto edge B's curve, checking that the projected distance is within tolerance,
- then does the same in reverse from B to A,
- returns true only if **both directions agree**.

If this check fails, the pair is rejected as not-a-duplicate and the kernel boolean is never invoked. True duplicates pass every sample (they sit on top of each other), so legitimate cleanup still happens. Concentric or grazing arcs that merely share endpoints fail at the very first interior sample, so they survive scrubbing.

## Why this approach

A few alternatives were considered:

- **Rewrite the multi-pass logic to be order-independent** — would help, but doesn't address the underlying misclassification; arcs would still be wrongly deleted, just deterministically.
- **Add curve-type-specific fast paths** (e.g. compare two circles by center + radius) — works for circles but doesn't generalize to splines or imported curves.
- **Tighten the slack used by the kernel** — could break legitimate duplicate detection on shapes where projection noise is real, and is hard to tune without breaking other cases.

Multi-point sampling is a single, general check that:
- handles every curve type uniformly (lines, arcs, splines, anything `BRep_Tool::Curve` returns),
- gives a definitive answer rather than relying on a tolerant kernel operation,
- is cheap (8 point projections per pair, only when bounding boxes already overlap),
- changes nothing about the cleanup loop's structure or the public API.

The existing logic stays intact below the new guard, so true duplicate removal continues to work the way it did for cubes, cylinders, and prismatic parts.

## Files changed

- `src/Mod/TechDraw/App/DrawProjectSplit.h` — add declaration for `curvesCoincide`.
- `src/Mod/TechDraw/App/DrawProjectSplit.cpp` — add definition; insert the precondition in `isSubset()`.

## Test plan

- [ ] Open the project file attached to issue #18991 and verify the torus draws with all its edges.
- [ ] Generate TechDraw views for a few prismatic and cylindrical shapes (cube, cylinder, hollow box, fillets) and verify no regressions — duplicate cleanup should still remove the expected edges.
- [ ] Generate views with `ScrubCount = 0`, `1`, and the default value and confirm the multi-pass behavior is unchanged for non-torus geometry.
- [ ] Run the TechDraw test suite: `ctest --test-dir build/debug -R TechDraw --verbose`.