### PR TITLE
Gui: Add Input Hints to Text Editor

### DIFF
--- a/src/Gui/EditorView.cpp
+++ b/src/Gui/EditorView.cpp
@@ -43,6 +43,7 @@
 #include "EditorView.h"
 #include "Application.h"
 #include "FileDialog.h"
+#include "InputHint.h"
 #include "Macro.h"
 #include "MainWindow.h"
 #include "PythonEditor.h"
@@ -129,6 +130,13 @@ EditorView::EditorView(TextEdit* editor, QWidget* parent)
     setCurrentFileName(QString());
     d->textEdit->setFocus();
 
+    connect(d->textEdit, &QPlainTextEdit::cursorPositionChanged, this, &EditorView::updateInputHints);
+    connect(d->textEdit, &QPlainTextEdit::selectionChanged, this, &EditorView::updateInputHints);
+    connect(qApp, &QApplication::focusChanged, this, [this](QWidget*, QWidget*) {
+        updateInputHints();
+    });
+    connect(d->searchBar, &SearchBar::textChanged, this, &EditorView::updateInputHints);
+
     setWindowIcon(d->textEdit->windowIcon());
 
     ParameterGrp::handle hPrefGrp = getWindowParameter();
@@ -154,6 +162,8 @@ EditorView::EditorView(TextEdit* editor, QWidget* parent)
 /** Destroys the object and frees any allocated resources */
 EditorView::~EditorView()
 {
+    Gui::getMainWindow()->hideHints();
+
     d->activityTimer->stop();
     // to avoid the assert introduced a debug version of Qt >6.3. See QTBUG-105473
     for (auto conn : connectionList) {  // NOLINT(performance-for-range-copy)
@@ -173,11 +183,16 @@ void EditorView::showEvent(QShowEvent* event)
 {
     Gui::MainWindow* mw = Gui::getMainWindow();
     mw->updateEditorActions();
+
+    updateInputHints();
+
     MDIView::showEvent(event);
 }
 
 void EditorView::hideEvent(QHideEvent* event)
 {
+    Gui::getMainWindow()->hideHints();
+
     MDIView::hideEvent(event);
 }
 
@@ -635,12 +650,85 @@ QStringList EditorView::undoActions() const
 QStringList EditorView::redoActions() const
 {
     return d->redos;
-    ;
 }
 
 void EditorView::focusInEvent(QFocusEvent*)
 {
     d->textEdit->setFocus();
+}
+
+/**
+ * Somewhat contextual Input Hints in Status Bar.
+ */
+void EditorView::updateInputHints()
+{
+    auto* mw = Gui::getMainWindow();
+    if (!mw) {
+        return;
+    }
+
+    if (mw->activeWindow() != this) {
+        mw->hideHints();
+        return;
+    }
+
+    using enum Gui::InputHint::UserInput;
+
+    std::list<Gui::InputHint> hints;
+
+    QWidget* fw = QApplication::focusWidget();
+
+    bool editorFocus = fw && (fw == d->textEdit || d->textEdit->isAncestorOf(fw));
+    bool searchFocus = fw && (fw == d->searchBar || d->searchBar->isAncestorOf(fw));
+
+    QTextCursor cursor = d->textEdit->textCursor();
+    bool hasSelection = cursor.hasSelection();
+
+    if (editorFocus) {
+
+        hints.push_back({.message = tr("%1 search"), .sequences = {{ModifierCtrl, KeyF}}});
+
+        hints.push_back({.message = tr("%1 toggle breakpoint"), .sequences = {{KeyF9}}});
+
+        hints.push_back(
+            {.message = tr("(%1) %2 (un)indent"), .sequences = {{ModifierShift}, {KeyTab}}}
+        );
+
+        if (hasSelection) {
+            hints.push_back(
+                {.message = tr("%1 / %2 (un)comment"), .sequences = {{ModifierAlt, KeyC}, {KeyU}}}
+            );
+
+            hints.push_back(
+                {.message = tr("%1 execute selection"),
+                 .sequences = {{ModifierAlt, ModifierShift, KeyP}}}
+            );
+        }
+
+        if (d->textEdit->hasCompletion()) {
+            hints.push_back(
+                {.message = tr("%1 auto-complete"), .sequences = {{ModifierCtrl, KeySpace}}}
+            );
+        }
+    }
+
+    else if (searchFocus) {
+
+        bool hasText = !d->searchBar->getSearchText().isEmpty();
+
+        if (hasText) {
+            hints.push_back({.message = tr("%1 next result"), .sequences = {{KeyReturn}}});
+        }
+
+        hints.push_back({.message = tr("%1 close search"), .sequences = {{KeyEscape}}});
+    }
+
+    else {
+        mw->hideHints();
+        return;
+    }
+
+    mw->showHints(hints);
 }
 
 // ---------------------------------------------------------
@@ -760,10 +848,12 @@ SearchBar::SearchBar(QWidget* parent)
 
     searchText = new QLineEdit(this);
     searchText->setClearButtonEnabled(true);
+    searchText->setPlaceholderText(tr("Find in document..."));
     horizontalLayout->addWidget(searchText);
     connect(searchText, &QLineEdit::returnPressed, this, &SearchBar::findNext);
     connect(searchText, &QLineEdit::textChanged, this, &SearchBar::findCurrent);
     connect(searchText, &QLineEdit::textChanged, this, &SearchBar::updateButtons);
+    connect(searchText, &QLineEdit::textChanged, this, &SearchBar::textChanged);
 
     prevButton = new QToolButton(this);
     prevButton->setIcon(style()->standardIcon(QStyle::SP_ArrowBack));
@@ -936,6 +1026,11 @@ void SearchBar::changeEvent(QEvent* event)
     }
 
     QWidget::changeEvent(event);
+}
+
+QString SearchBar::getSearchText() const
+{
+    return searchText->text();
 }
 
 #include "moc_EditorView.cpp"

--- a/src/Gui/EditorView.h
+++ b/src/Gui/EditorView.h
@@ -69,6 +69,8 @@ public:
     void setDisplayName(DisplayName);
     void OnChange(Base::Subject<const char*>& rCaller, const char* rcReason) override;
 
+    void updateInputHints();
+
     const char* getName() const override
     {
         return "EditorView";
@@ -158,6 +160,7 @@ public:
     explicit SearchBar(QWidget* parent = nullptr);
 
     void setEditor(QPlainTextEdit* textEdit);
+    QString getSearchText() const;
 
 protected:
     void keyPressEvent(QKeyEvent*) override;
@@ -169,6 +172,9 @@ public Q_SLOTS:
     void findPrevious();
     void findNext();
     void findCurrent();
+
+Q_SIGNALS:
+    void textChanged(const QString& text);
 
 private:
     void retranslateUi();

--- a/src/Gui/TextEdit.cpp
+++ b/src/Gui/TextEdit.cpp
@@ -176,6 +176,43 @@ void TextEdit::wheelEvent(QWheelEvent* e)
 }
 
 /**
+ * Check if auto-complete may return anything. Currently dumb logic for Input Hints.
+ */
+bool TextEdit::hasCompletion() const
+{
+    const QTextCursor cursor = textCursor();
+    const QTextBlock block = cursor.block();
+
+    if (!block.isValid()) {
+        return false;
+    }
+
+    const QString& text = block.text();
+    int pos = cursor.position() - block.position();
+
+    if (pos <= 0) {
+        return false;
+    }
+
+    // Support underscore for Python syntax
+    auto isWord = [](QChar c) {
+        return c.isLetterOrNumber() || c == '_';
+    };
+
+    bool isAlphaNum = false;
+    int start = pos;
+
+    while (start > 0 && isWord(text.at(start - 1))) {
+        --start;
+        if (text.at(start).isLetterOrNumber()) {
+            isAlphaNum = true;
+        }
+    }
+
+    return isAlphaNum;
+}
+
+/**
  * Completes the word.
  */
 void TextEdit::complete()

--- a/src/Gui/TextEdit.h
+++ b/src/Gui/TextEdit.h
@@ -67,6 +67,8 @@ public:
     //! Get the text of the current line being edited
     virtual QString getInputString();
 
+    bool hasCompletion() const;
+
 private Q_SLOTS:
     void complete();
 


### PR DESCRIPTION
The Text Editor (i.e. integrated Python macro IDE) behavior can be pretty obscure (not [well documented](https://wiki.freecad.org/Python_Development_Environment), few exposed shortcuts and tooltips), so adding Input Hints for it in Status Bar can help discover some of its features.

- Add search field placeholder
- Add contextual Input Hints to Text Editor:
  -  Search <kbd>Ctrl</kbd> + <kbd>F</kbd>
  - Breakpoint <kbd>F9</kbd>
  - (Un)indent (<kbd>Shift</kbd>) <kbd>Tab</kbd>
  - (Un)comment <kbd>Alt</kbd> + <kbd>C</kbd> / <kbd>U</kbd>
  - Execute selection in Python Console <kbd>Alt</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>
  - Auto-complete <kbd>Ctrl</kbd> + <kbd>Space</kbd>
  - Next result and Close search (only with focus on search bar) <kbd>Enter</kbd> and <kbd>Esc</kbd>

(Un)indent, (un)comment, auto-complete, and next result contextual logic are a bit dumb (i.e. they do not check if calling these functions will really do something meaningful), but IMHO better keep them cheap and avoid too much show/hide of hints.

Number and length of hints was kept to a minimum, so in most cases there should be no conflict with selection and quick measure info, but that can still happen (see video).

## After


https://github.com/user-attachments/assets/fda4603b-1929-449a-8a87-1913f2435548

