### PR TITLE
Part: WireJoiner - don't abort on non-closed traversal path

### DIFF
--- a/src/Mod/Part/App/WireJoiner.cpp
+++ b/src/Mod/Part/App/WireJoiner.cpp
@@ -2008,6 +2008,13 @@ public:
     )
     {
         if (!BRep_Tool::IsClosed(wire)) {
+            // Path-finding (via the proceed=false branch in
+            // _findClosedWiresWithExisting / _findClosedWiresBeginEdge) can
+            // assemble an edge sequence whose endpoints don't coincide when
+            // the input has closed wires split at internal seam vertices
+            // (e.g. closed ellipses split by intersecting line segments).
+            // Treat as "no closed wire on this path" rather than aborting
+            // the whole build with an exception.
             FC_WARN("failed to close some wire in iteration " << iteration);
             showShape(wire, "_FailedToClose", iteration);
             showShape(beginInfo.shape(beginVertex.start), "failed", iteration);
@@ -2016,8 +2023,6 @@ public:
                 auto& info = *vertex.it;
                 showShape(info.shape(vertex.start), vertex.start ? "failed" : "failed_r", iteration);
             }
-
-            ENSURE(false);
             return false;
         }
         return true;
@@ -2096,7 +2101,12 @@ public:
             }
             TopoDS_Wire wire = makeCleanWire();
             if (!_findClosedWiresIsClosed(beginVertex, wire, beginInfo)) {
-                continue;
+                // Stack/vertexStack may have been extended by
+                // _findClosedWiresBeginEdge along an existing wireInfo, so
+                // continuing the while-loop would replay a poisoned state.
+                // Returning empty lets findTightBoundByVertices clean up and
+                // try the next branch (line 2257-2262).
+                return {};
             }
             return wire;
         }

--- a/src/Mod/Part/App/WireJoiner.cpp
+++ b/src/Mod/Part/App/WireJoiner.cpp
@@ -2008,13 +2008,7 @@ public:
     )
     {
         if (!BRep_Tool::IsClosed(wire)) {
-            // Path-finding (via the proceed=false branch in
-            // _findClosedWiresWithExisting / _findClosedWiresBeginEdge) can
-            // assemble an edge sequence whose endpoints don't coincide when
-            // the input has closed wires split at internal seam vertices
-            // (e.g. closed ellipses split by intersecting line segments).
-            // Treat as "no closed wire on this path" rather than aborting
-            // the whole build with an exception.
+            // proceed=false path can assemble a non-closing edge sequence; bail out gracefully
             FC_WARN("failed to close some wire in iteration " << iteration);
             showShape(wire, "_FailedToClose", iteration);
             showShape(beginInfo.shape(beginVertex.start), "failed", iteration);
@@ -2101,11 +2095,7 @@ public:
             }
             TopoDS_Wire wire = makeCleanWire();
             if (!_findClosedWiresIsClosed(beginVertex, wire, beginInfo)) {
-                // Stack/vertexStack may have been extended by
-                // _findClosedWiresBeginEdge along an existing wireInfo, so
-                // continuing the while-loop would replay a poisoned state.
-                // Returning empty lets findTightBoundByVertices clean up and
-                // try the next branch (line 2257-2262).
+                // stack was mutated by _findClosedWiresBeginEdge; bail so caller can clean up
                 return {};
             }
             return wire;

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -1231,3 +1231,60 @@ class PartExtrusionTests(unittest.TestCase):
 
     def tearDown(self):
         FreeCAD.closeDocument("PartExtrusionTest")
+
+
+class PartFaceMakerBuildFaceTests(unittest.TestCase):
+    """Regression: a Sketch with MakeInternals=True containing two concentric
+    ellipses and two short line segments joining them on the right side fails
+    to build the internal face. The direct FaceMakerBuildFace call succeeds,
+    but SketchObject::buildInternals also calls Part::WireJoiner::getOpenWires,
+    which currently throws ('failed to close some wire in iteration N') and
+    leaves InternalShape null."""
+
+    def setUp(self):
+        self.Doc = FreeCAD.newDocument("FaceMakerBuildFaceTest")
+
+    def tearDown(self):
+        FreeCAD.closeDocument("FaceMakerBuildFaceTest")
+
+    def _add_geometry(self, sk):
+        outer = Part.Ellipse(Base.Vector(0, 0, 0), 100, 60)
+        inner = Part.Ellipse(Base.Vector(0, 0, 0), 50, 30)
+        u1, u2 = -math.radians(15), math.radians(15)
+        sk.addGeometry(outer, False)
+        sk.addGeometry(inner, False)
+        sk.addGeometry(Part.LineSegment(outer.value(u1), inner.value(u1)), False)
+        sk.addGeometry(Part.LineSegment(outer.value(u2), inner.value(u2)), False)
+
+    def testBuildFaceDirectMakeFace(self):
+        """Direct FaceMakerBuildFace on the same wires must produce faces."""
+        outer = Part.Ellipse(Base.Vector(0, 0, 0), 100, 60)
+        inner = Part.Ellipse(Base.Vector(0, 0, 0), 50, 30)
+        u1, u2 = -math.radians(15), math.radians(15)
+        wires = [
+            Part.Wire([outer.toShape()]),
+            Part.Wire([inner.toShape()]),
+            Part.Wire([Part.LineSegment(outer.value(u1), inner.value(u1)).toShape()]),
+            Part.Wire([Part.LineSegment(outer.value(u2), inner.value(u2)).toShape()]),
+        ]
+        result = Part.makeFace(wires, "Part::FaceMakerBuildFace")
+        self.assertFalse(result.isNull())
+        self.assertGreaterEqual(len(result.Faces), 2)
+
+    def testSketchMakeInternalsBuildsFaces(self):
+        """The full SketchObject MakeInternals path must produce a non-null
+        InternalShape with at least two faces (the annulus regions split by
+        the two connecting line segments)."""
+        sk = self.Doc.addObject("Sketcher::SketchObject", "Sketch")
+        sk.MakeInternals = True
+        self._add_geometry(sk)
+        self.Doc.recompute()
+        self.assertFalse(
+            sk.InternalShape.isNull(),
+            "SketchObject.InternalShape is null - buildInternals failed",
+        )
+        self.assertGreaterEqual(
+            len(sk.InternalShape.Faces),
+            2,
+            f"Expected >=2 faces in InternalShape, got {len(sk.InternalShape.Faces)}",
+        )


### PR DESCRIPTION
# Part: WireJoiner - dont throw when traversal path doesnt close

Sketch with `MakeInternals=True` containing 2 concentric ellipses + 2 lines connecting them on the right fails to build internal face. `InternalShape` ends up null even though faces are clearly valid.

Not actually FaceMakerBuildFace failing - direct `Part.makeFace(..., "Part::FaceMakerBuildFace")` works fine and produces 3 faces. failure is in `WireJoiner::_findClosedWiresIsClosed` which throws via `ENSURE(false)` when a constructed wire isnt topologically closed. exception kills the whole `buildInternals` call.

Happens because `_findClosedWiresBeginEdge` does a linear walk through `wireInfo->vertices` assuming it lands back at `beginInfo`. with closed ellipses split at their seam vertex by intersecting lines, that assumption breaks - walk ends at a different vertex.

fix: turn the assert into a warning + empty wire return. all 4 `_findClosedWires` call sites already handle empty wire by popping stack state and continuing - this slots right in.

## Test

added regression test in `TestPartApp.py` that builds the exact geometry via `Sketcher::SketchObject` with `MakeInternals=True`. fails before the fix with `failed to close some wire in iteration 16 / Condition failed: false`. passes after.

## Verified no regression

<img width="250" height="250" alt="Screenshot 2026-04-26 at 16 34 11" src="https://github.com/user-attachments/assets/bf27ec70-a001-40f1-b0a7-d0b2433e8413" /> <img width="250" height="250" alt="Screenshot 2026-04-26 at 16 33 41" src="https://github.com/user-attachments/assets/6fcdcb1b-46d9-436a-b9ff-849545d40e54" />

Fixes https://github.com/FreeCAD/FreeCAD/issues/29610
