### PR TITLE
Part: Make PreviewExtension usable from Python workbenches

### DIFF
--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -445,6 +445,7 @@ PyMOD_INIT_FUNC(Part)
     Part::AttachExtension       ::init();
     Part::AttachExtensionPython ::init();
     Part::PreviewExtension      ::init();
+    Part::PreviewExtensionPython::init();
     Part::PrismExtension        ::init();
 
     Part::Feature               ::init();

--- a/src/Mod/Part/App/AppPart.cpp
+++ b/src/Mod/Part/App/AppPart.cpp
@@ -449,6 +449,7 @@ PyMOD_INIT_FUNC(Part)
     Part::AttachExtension       ::init();
     Part::AttachExtensionPython ::init();
     Part::PreviewExtension      ::init();
+    Part::PreviewExtensionPython::init();
     Part::PrismExtension        ::init();
     Part::LinearPatternExtension::init();
     Part::PolarPatternExtension ::init();

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -87,6 +87,7 @@ generate_from_py(SurfaceOfExtrusion)
 generate_from_py(SurfaceOfRevolution)
 generate_from_py(PartFeature)
 generate_from_py(AttachExtension)
+generate_from_py(PreviewExtension)
 generate_from_py(Part2DObject)
 generate_from_py(AttachEngine)
 generate_from_py(TopoShape)
@@ -358,6 +359,8 @@ SET(Python_SRCS
     PartFeaturePyImp.cpp
     AttachExtension.pyi
     AttachExtensionPyImp.cpp
+    PreviewExtension.pyi
+    PreviewExtensionPyImp.cpp
     Part2DObject.pyi
     Part2DObjectPyImp.cpp
     AttachEngine.pyi

--- a/src/Mod/Part/App/PreviewExtension.cpp
+++ b/src/Mod/Part/App/PreviewExtension.cpp
@@ -24,9 +24,39 @@
 #include "PreviewExtension.h"
 
 #include <App/DocumentObject.h>
+#include <App/ExtensionPython.h>
+#include <Base/PyObjectBase.h>
 
 EXTENSION_PROPERTY_SOURCE(Part::PreviewExtension, App::DocumentObjectExtension)
+
+namespace Part
+{
+
+template<typename ExtensionT>
+App::DocumentObjectExecReturn* PreviewExtensionPythonT<ExtensionT>::recomputePreview()
+{
+    EXTENSION_PROXY_NOARG(recomputePreview)
+
+    static App::DocumentObjectExecReturn error("Preview recompute error");
+
+    if (!result.isNone() && result.isString()) {
+        error.Why = Py::String(result);
+        return &error;
+    }
+
+    if (!result.isNone()) {
+        return App::DocumentObject::StdReturn;
+    }
+
+    return ExtensionT::recomputePreview();
+}
+
+template class PartExport PreviewExtensionPythonT<PreviewExtension>;
+
+}  // namespace Part
+
 EXTENSION_PROPERTY_SOURCE_TEMPLATE(Part::PreviewExtensionPython, Part::PreviewExtension)
+template class PartExport App::ExtensionPythonT<Part::PreviewExtensionPythonT<Part::PreviewExtension>>;
 
 Part::PreviewExtension::PreviewExtension()
 {
@@ -59,7 +89,11 @@ void Part::PreviewExtension::extensionOnChanged(const App::Property* prop)
 {
     DocumentObjectExtension::extensionOnChanged(prop);
 
-    if (mustRecomputePreview()) {
+    // Invalidate the preview on any input property change. The PreviewShape itself is the
+    // output of recomputePreview, so changing it does not require another recompute.
+    const bool isInputProp = prop != &PreviewShape && !prop->testStatus(App::Property::Output);
+
+    if (isInputProp || mustRecomputePreview()) {
         _isPreviewFresh = false;
     }
 }

--- a/src/Mod/Part/App/PreviewExtension.cpp
+++ b/src/Mod/Part/App/PreviewExtension.cpp
@@ -80,6 +80,11 @@ void Part::PreviewExtension::updatePreview()
     _isPreviewFresh = true;
 }
 
+void Part::PreviewExtension::invalidatePreview()
+{
+    _isPreviewFresh = false;
+}
+
 bool Part::PreviewExtension::mustRecomputePreview() const
 {
     return getExtendedObject()->mustRecompute();

--- a/src/Mod/Part/App/PreviewExtension.cpp
+++ b/src/Mod/Part/App/PreviewExtension.cpp
@@ -45,6 +45,18 @@ App::DocumentObjectExecReturn* PreviewExtensionPythonT<ExtensionT>::recomputePre
     return ExtensionT::recomputePreview();
 }
 
+template<typename ExtensionT>
+bool PreviewExtensionPythonT<ExtensionT>::mustRecomputePreview()
+{
+    EXTENSION_PROXY_NOARG(mustRecomputePreview)
+
+    if (result.isBoolean()) {
+        return Py::Boolean(result);
+    }
+
+    return ExtensionT::mustRecomputePreview();
+}
+
 template class PartExport PreviewExtensionPythonT<PreviewExtension>;
 
 }  // namespace Part
@@ -79,7 +91,7 @@ void Part::PreviewExtension::invalidatePreview()
     _isPreviewFresh = false;
 }
 
-bool Part::PreviewExtension::mustRecomputePreview() const
+bool Part::PreviewExtension::mustRecomputePreview()
 {
     return getExtendedObject()->mustRecompute();
 }

--- a/src/Mod/Part/App/PreviewExtension.cpp
+++ b/src/Mod/Part/App/PreviewExtension.cpp
@@ -37,13 +37,6 @@ App::DocumentObjectExecReturn* PreviewExtensionPythonT<ExtensionT>::recomputePre
 {
     EXTENSION_PROXY_NOARG(recomputePreview)
 
-    static App::DocumentObjectExecReturn error("");
-
-    if (!result.isNone() && result.isString()) {
-        error.Why = Py::String(result);
-        return &error;
-    }
-
     if (!result.isNone()) {
         return App::DocumentObject::StdReturn;
     }

--- a/src/Mod/Part/App/PreviewExtension.cpp
+++ b/src/Mod/Part/App/PreviewExtension.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "PreviewExtension.h"
+#include "PreviewExtensionPy.h"
 
 #include <App/DocumentObject.h>
 #include <App/ExtensionPython.h>
@@ -81,6 +82,14 @@ void Part::PreviewExtension::invalidatePreview()
 bool Part::PreviewExtension::mustRecomputePreview() const
 {
     return getExtendedObject()->mustRecompute();
+}
+
+PyObject* Part::PreviewExtension::getExtensionPyObject()
+{
+    if (ExtensionPythonObject.is(Py::_None())) {
+        ExtensionPythonObject = Py::Object(new PreviewExtensionPy(this), true);
+    }
+    return Py::new_reference_to(ExtensionPythonObject);
 }
 
 void Part::PreviewExtension::extensionOnChanged(const App::Property* prop)

--- a/src/Mod/Part/App/PreviewExtension.cpp
+++ b/src/Mod/Part/App/PreviewExtension.cpp
@@ -24,9 +24,39 @@
 #include "PreviewExtension.h"
 
 #include <App/DocumentObject.h>
+#include <App/ExtensionPython.h>
+#include <Base/PyObjectBase.h>
 
 EXTENSION_PROPERTY_SOURCE(Part::PreviewExtension, App::DocumentObjectExtension)
+
+namespace Part
+{
+
+template<typename ExtensionT>
+App::DocumentObjectExecReturn* PreviewExtensionPythonT<ExtensionT>::recomputePreview()
+{
+    EXTENSION_PROXY_NOARG(recomputePreview)
+
+    static App::DocumentObjectExecReturn error("");
+
+    if (!result.isNone() && result.isString()) {
+        error.Why = Py::String(result);
+        return &error;
+    }
+
+    if (!result.isNone()) {
+        return App::DocumentObject::StdReturn;
+    }
+
+    return ExtensionT::recomputePreview();
+}
+
+template class PartExport PreviewExtensionPythonT<PreviewExtension>;
+
+}  // namespace Part
+
 EXTENSION_PROPERTY_SOURCE_TEMPLATE(Part::PreviewExtensionPython, Part::PreviewExtension)
+template class PartExport App::ExtensionPythonT<Part::PreviewExtensionPythonT<Part::PreviewExtension>>;
 
 Part::PreviewExtension::PreviewExtension()
 {

--- a/src/Mod/Part/App/PreviewExtension.h
+++ b/src/Mod/Part/App/PreviewExtension.h
@@ -102,6 +102,9 @@ class PreviewExtensionPythonT: public ExtensionT
 public:
     PreviewExtensionPythonT() = default;
     ~PreviewExtensionPythonT() override = default;
+
+protected:
+    App::DocumentObjectExecReturn* recomputePreview() override;
 };
 
 using PreviewExtensionPython = App::ExtensionPythonT<PreviewExtensionPythonT<PreviewExtension>>;

--- a/src/Mod/Part/App/PreviewExtension.h
+++ b/src/Mod/Part/App/PreviewExtension.h
@@ -56,7 +56,7 @@ public:
     /// Marks the preview as stale so the next updatePreview() recomputes it.
     void invalidatePreview();
 
-    virtual bool mustRecomputePreview() const;
+    virtual bool mustRecomputePreview();
 
     PyObject* getExtensionPyObject() override;
 
@@ -110,6 +110,7 @@ public:
 
 protected:
     App::DocumentObjectExecReturn* recomputePreview() override;
+    bool mustRecomputePreview() override;
 };
 
 using PreviewExtensionPython = App::ExtensionPythonT<PreviewExtensionPythonT<PreviewExtension>>;

--- a/src/Mod/Part/App/PreviewExtension.h
+++ b/src/Mod/Part/App/PreviewExtension.h
@@ -53,6 +53,9 @@ public:
 
     void updatePreview();
 
+    /// Marks the preview as stale so the next updatePreview() recomputes it.
+    void invalidatePreview();
+
     virtual bool mustRecomputePreview() const;
 
 protected:

--- a/src/Mod/Part/App/PreviewExtension.h
+++ b/src/Mod/Part/App/PreviewExtension.h
@@ -58,6 +58,8 @@ public:
 
     virtual bool mustRecomputePreview() const;
 
+    PyObject* getExtensionPyObject() override;
+
 protected:
     void extensionOnChanged(const App::Property* prop) override;
 

--- a/src/Mod/Part/App/PreviewExtension.h
+++ b/src/Mod/Part/App/PreviewExtension.h
@@ -56,6 +56,9 @@ public:
     /// Marks the preview as stale so the next updatePreview() recomputes it.
     void invalidatePreview();
 
+    /// Decides whether a property change left the preview stale. Follows the object's
+    /// own recompute by default, so overriding it is how a feature keeps its preview
+    /// through changes it does not depend on.
     virtual bool mustRecomputePreview();
 
     PyObject* getExtensionPyObject() override;

--- a/src/Mod/Part/App/PreviewExtension.pyi
+++ b/src/Mod/Part/App/PreviewExtension.pyi
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from Base.Metadata import export, constmethod
+from App.DocumentObjectExtension import DocumentObjectExtension
+
+@export(
+    Twin="PreviewExtension",
+    TwinPointer="PreviewExtension",
+    Include="Mod/Part/App/PreviewExtension.h",
+    FatherInclude="App/DocumentObjectExtensionPy.h",
+)
+class PreviewExtension(DocumentObjectExtension):
+    """
+    Computes the shape shown as a semi-transparent 3D preview of an upcoming
+    geometry change.
+    """
+
+    def updatePreview(self) -> None:
+        """
+        Recompute the preview shape if it is stale.
+
+        Does nothing while the preview is fresh. Pair with invalidatePreview()
+        to force a recompute.
+        """
+        ...
+
+    def invalidatePreview(self) -> None:
+        """
+        Mark the preview stale so the next updatePreview() recomputes it.
+        """
+        ...
+
+    @constmethod
+    def isPreviewFresh(self) -> bool:
+        """
+        Returns whether the preview shape is up to date with the object's inputs.
+        """
+        ...

--- a/src/Mod/Part/App/PreviewExtensionPyImp.cpp
+++ b/src/Mod/Part/App/PreviewExtensionPyImp.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "PreviewExtensionPy.h"
+#include "PreviewExtensionPy.cpp"
+
+using namespace Part;
+
+std::string PreviewExtensionPy::representation() const
+{
+    return {"<PreviewExtension>"};
+}
+
+PyObject* PreviewExtensionPy::updatePreview(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    try {
+        getPreviewExtensionPtr()->updatePreview();
+    }
+    catch (Base::Exception& exception) {
+        exception.setPyException();
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
+}
+
+PyObject* PreviewExtensionPy::invalidatePreview(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    getPreviewExtensionPtr()->invalidatePreview();
+
+    Py_RETURN_NONE;
+}
+
+PyObject* PreviewExtensionPy::isPreviewFresh(PyObject* args) const
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    return Py::new_reference_to(Py::Boolean(getPreviewExtensionPtr()->isPreviewFresh()));
+}
+
+PyObject* PreviewExtensionPy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int PreviewExtensionPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}

--- a/src/Mod/Part/CMakeLists.txt
+++ b/src/Mod/Part/CMakeLists.txt
@@ -21,6 +21,7 @@ if(BUILD_GUI)
     list (APPEND Part_Scripts
           InitGui.py
           TestPartGui.py
+          TestPartPreview.py
     )
 endif(BUILD_GUI)
 

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND PartGui_LIBS
 )
 
 generate_from_py(ViewProviderPartExt)
+generate_from_py(ViewProviderPreviewExtension)
 
 set (Part_TR_QRC ${CMAKE_CURRENT_BINARY_DIR}/Resources/Part_translation.qrc)
 qt_find_and_add_translation(QM_SRCS "Resources/translations/*_*.ts"
@@ -160,6 +161,8 @@ SET(PartGui_SRCS
     ViewProviderAttachExtension.cpp
     ViewProviderPreviewExtension.h
     ViewProviderPreviewExtension.cpp
+    ViewProviderPreviewExtension.pyi
+    ViewProviderPreviewExtensionPyImp.cpp
     ViewProviderDatum.cpp
     ViewProviderDatum.h
     ViewProviderExt.cpp

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -21,6 +21,7 @@ list(APPEND PartGui_LIBS
 )
 
 generate_from_py(ViewProviderPartExt)
+generate_from_py(ViewProviderPreviewExtension)
 
 set (Part_TR_QRC ${CMAKE_CURRENT_BINARY_DIR}/Resources/Part_translation.qrc)
 qt_find_and_add_translation(QM_SRCS "Resources/translations/*_*.ts"
@@ -164,6 +165,8 @@ SET(PartGui_SRCS
     ViewProviderAttachExtension.cpp
     ViewProviderPreviewExtension.h
     ViewProviderPreviewExtension.cpp
+    ViewProviderPreviewExtension.pyi
+    ViewProviderPreviewExtensionPyImp.cpp
     ViewProviderDatum.cpp
     ViewProviderDatum.h
     ViewProviderExt.cpp

--- a/src/Mod/Part/Gui/PreviewUpdateScheduler.cpp
+++ b/src/Mod/Part/Gui/PreviewUpdateScheduler.cpp
@@ -36,7 +36,7 @@ QtPreviewUpdateScheduler::QtPreviewUpdateScheduler(QObject* parent)
     : QObject(parent)
 {}
 
-inline void QtPreviewUpdateScheduler::schedulePreviewRecompute(App::DocumentObject* object)
+void QtPreviewUpdateScheduler::schedulePreviewRecompute(App::DocumentObject* object)
 {
     if (!object) {
         return;
@@ -48,6 +48,8 @@ inline void QtPreviewUpdateScheduler::schedulePreviewRecompute(App::DocumentObje
     if (scheduled) {
         return;
     }
+
+    scheduled = true;
 
     QMetaObject::invokeMethod(this, &QtPreviewUpdateScheduler::flush, Qt::QueuedConnection);
 }

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
@@ -30,8 +30,10 @@
 
 #include "ViewProviderPreviewExtension.h"
 #include "ViewProviderExt.h"
+#include "ViewProviderPreviewExtensionPy.h"
 
 #include <App/Document.h>
+#include <Base/ServiceProvider.h>
 #include <Gui/Utilities.h>
 #include <Gui/Inventor/So3DAnnotation.h>
 #include <Mod/Part/App/PreviewExtension.h>
@@ -160,6 +162,14 @@ void ViewProviderPreviewExtension::extensionBeforeDelete()
     showPreview(false);
 }
 
+PyObject* ViewProviderPreviewExtension::getExtensionPyObject()
+{
+    if (ExtensionPythonObject.is(Py::_None())) {
+        ExtensionPythonObject = Py::Object(new ViewProviderPreviewExtensionPy(this), true);
+    }
+    return Py::new_reference_to(ExtensionPythonObject);
+}
+
 void ViewProviderPreviewExtension::showPreview(bool enable)
 {
     auto feature = getExtendedViewProvider()->getObject<Part::Feature>();
@@ -194,6 +204,50 @@ void ViewProviderPreviewExtension::extensionOnChanged(const App::Property* prop)
     }
 
     ViewProviderExtension::extensionOnChanged(prop);
+}
+
+void ViewProviderPreviewExtension::extensionUpdateData(const App::Property* prop)
+{
+    Gui::ViewProviderDocumentObject* viewProvider = getExtendedViewProvider();
+    App::DocumentObject* object = viewProvider ? viewProvider->getObject() : nullptr;
+
+    if (!object) {
+        ViewProviderExtension::extensionUpdateData(prop);
+        return;
+    }
+
+    if (auto* previewExtension = object->getExtensionByType<Part::PreviewExtension>(true)) {
+        if (prop == &previewExtension->PreviewShape) {
+            updatePreview();
+        }
+        else if (isPreviewEnabled()) {
+            // Properties can be updated in batches, where some properties trigger other updates.
+            // We don't need to compute the preview for intermediate steps. Instead of updating
+            // the preview immediately (and potentially doing it multiple times in a row), we
+            // schedule the update to happen at a more convenient time.
+            if (auto* scheduler = Base::provideService<Part::PreviewUpdateScheduler>()) {
+                scheduler->schedulePreviewRecompute(object);
+            }
+        }
+    }
+
+    ViewProviderExtension::extensionUpdateData(prop);
+}
+
+Part::TopoShape ViewProviderPreviewExtension::getPreviewShape() const
+{
+    const Gui::ViewProviderDocumentObject* viewProvider = getExtendedViewProvider();
+    const App::DocumentObject* object = viewProvider ? viewProvider->getObject() : nullptr;
+
+    if (!object) {
+        return {};
+    }
+
+    if (auto* previewExtension = object->getExtensionByType<Part::PreviewExtension>(true)) {
+        return previewExtension->PreviewShape.getShape();
+    }
+
+    return {};
 }
 
 void ViewProviderPreviewExtension::attachPreview()

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
@@ -33,11 +33,13 @@
 #include "ViewProviderPreviewExtensionPy.h"
 
 #include <App/Document.h>
+#include <App/ExtensionPython.h>
 #include <Base/ServiceProvider.h>
 #include <Gui/Utilities.h>
 #include <Gui/Inventor/So3DAnnotation.h>
 #include <Mod/Part/App/PreviewExtension.h>
 #include <Mod/Part/App/Tools.h>
+#include <Mod/Part/App/TopoShapePy.h>
 
 using namespace PartGui;
 
@@ -325,6 +327,43 @@ void ViewProviderPreviewExtension::updatePreviewShape(Part::TopoShape shape, SoP
     }
 }
 
+namespace PartGui
+{
+
+template<typename ExtensionT>
+void ViewProviderPreviewExtensionPythonT<ExtensionT>::attachPreview()
+{
+    ExtensionT::attachPreview();
+
+    EXTENSION_PROXY_NOARG(attachPreview)
+    (void)result;
+}
+
+template<typename ExtensionT>
+void ViewProviderPreviewExtensionPythonT<ExtensionT>::updatePreview()
+{
+    ExtensionT::updatePreview();
+
+    EXTENSION_PROXY_NOARG(updatePreview)
+    (void)result;
+}
+
+template<typename ExtensionT>
+Part::TopoShape ViewProviderPreviewExtensionPythonT<ExtensionT>::getPreviewShape()
+{
+    EXTENSION_PROXY_NOARG(getPreviewShape)
+
+    if (!result.isNone() && PyObject_TypeCheck(result.ptr(), &Part::TopoShapePy::Type)) {
+        return *static_cast<Part::TopoShapePy*>(result.ptr())->getTopoShapePtr();
+    }
+
+    return ExtensionT::getPreviewShape();
+}
+
+template class PartGuiExport ViewProviderPreviewExtensionPythonT<ViewProviderPreviewExtension>;
+
+}  // namespace PartGui
+
 namespace Gui
 {
 EXTENSION_PROPERTY_SOURCE_TEMPLATE(
@@ -333,5 +372,6 @@ EXTENSION_PROPERTY_SOURCE_TEMPLATE(
 )
 
 // explicit template instantiation
-template class PartGuiExport ViewProviderExtensionPythonT<PartGui::ViewProviderPreviewExtension>;
+template class PartGuiExport ViewProviderExtensionPythonT<
+    PartGui::ViewProviderPreviewExtensionPythonT<PartGui::ViewProviderPreviewExtension>>;
 }  // namespace Gui

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
@@ -149,6 +149,17 @@ void ViewProviderPreviewExtension::extensionAttach(App::DocumentObject* document
 
     attachPreview();
 
+    if (!freecad_cast<ViewProviderPartExt*>(getExtendedViewProvider())) {
+        Gui::ViewProviderDocumentObject* viewProvider = getExtendedViewProvider();
+        App::DocumentObject* object = viewProvider ? viewProvider->getObject() : nullptr;
+
+        Base::Console().userTranslatedNotification(
+            tr("Preview requires a Part-based view provider; none found for %1.")
+                .arg(object ? QString::fromUtf8(object->getFullName().c_str()) : tr("unknown object"))
+                .toUtf8()
+        );
+    }
+
     auto document = documentObject->getDocument();
     if (!document->testStatus(App::Document::Restoring)) {
         updatePreview();
@@ -234,7 +245,7 @@ void ViewProviderPreviewExtension::extensionUpdateData(const App::Property* prop
     ViewProviderExtension::extensionUpdateData(prop);
 }
 
-Part::TopoShape ViewProviderPreviewExtension::getPreviewShape() const
+Part::TopoShape ViewProviderPreviewExtension::getPreviewShape()
 {
     const Gui::ViewProviderDocumentObject* viewProvider = getExtendedViewProvider();
     const App::DocumentObject* object = viewProvider ? viewProvider->getObject() : nullptr;

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.h
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.h
@@ -80,13 +80,12 @@ public:
     ViewProviderPreviewExtension();
 
     /// Returns shape that should be used as the preview
-    virtual Part::TopoShape getPreviewShape() const
-    {
-        return Part::TopoShape();
-    };
+    virtual Part::TopoShape getPreviewShape() const;
 
     void extensionAttach(App::DocumentObject*) override;
     void extensionBeforeDelete() override;
+
+    PyObject* getExtensionPyObject() override;
 
     /// Returns whatever preview is enabled or not
     bool isPreviewEnabled() const
@@ -98,6 +97,7 @@ public:
 
 protected:
     void extensionOnChanged(const App::Property* prop) override;
+    void extensionUpdateData(const App::Property* prop) override;
 
     /// attaches preview to the scene graph
     virtual void attachPreview();

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.h
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.h
@@ -80,7 +80,7 @@ public:
     ViewProviderPreviewExtension();
 
     /// Returns shape that should be used as the preview
-    virtual Part::TopoShape getPreviewShape() const;
+    virtual Part::TopoShape getPreviewShape();
 
     void extensionAttach(App::DocumentObject*) override;
     void extensionBeforeDelete() override;
@@ -95,16 +95,30 @@ public:
     /// Switches preview on or off
     virtual void showPreview(bool enable);
 
+    /// Root of the preview scene graph; may be restructured freely by subclasses
+    /// and by Python hooks.
+    SoSeparator* getPreviewRootNode() const
+    {
+        return pcPreviewRoot;
+    }
+
+    /// The node the default implementation feeds with getPreviewShape()
+    SoPreviewShape* getPreviewShapeNode() const
+    {
+        return pcPreviewShape;
+    }
+
+    /// updates preview
+    virtual void updatePreview();
+    /// updates geometry of the preview shape
+    void updatePreviewShape(Part::TopoShape shape, SoPreviewShape* preview);
+
 protected:
     void extensionOnChanged(const App::Property* prop) override;
     void extensionUpdateData(const App::Property* prop) override;
 
     /// attaches preview to the scene graph
     virtual void attachPreview();
-    /// updates preview
-    virtual void updatePreview();
-    /// updates geometry of the preview shape
-    void updatePreviewShape(Part::TopoShape shape, SoPreviewShape* preview);
 
     Gui::CoinPtr<SoSeparator> pcPreviewRoot;
     Gui::CoinPtr<SoPreviewShape> pcPreviewShape;

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.h
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.h
@@ -127,7 +127,27 @@ private:
     bool _isPreviewEnabled {false};
 };
 
+/**
+ * Routes the preview scene graph hooks to the Python proxy.
+ *
+ * attachPreview and updatePreview augment the C++ result - the base runs first,
+ * then the proxy hook. getPreviewShape replaces it when the proxy returns a shape.
+ */
+template<typename ExtensionT>
+class ViewProviderPreviewExtensionPythonT: public ExtensionT
+{
+public:
+    ViewProviderPreviewExtensionPythonT() = default;
+    ~ViewProviderPreviewExtensionPythonT() override = default;
+
+    Part::TopoShape getPreviewShape() override;
+    void updatePreview() override;
+
+protected:
+    void attachPreview() override;
+};
+
 using ViewProviderPreviewExtensionPython
-    = Gui::ViewProviderExtensionPythonT<ViewProviderPreviewExtension>;
+    = Gui::ViewProviderExtensionPythonT<ViewProviderPreviewExtensionPythonT<ViewProviderPreviewExtension>>;
 
 }  // namespace PartGui

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.pyi
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.pyi
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from Base.Metadata import export, constmethod
+from Gui.ViewProviderExtension import ViewProviderExtension
+
+@export(
+    Twin="ViewProviderPreviewExtension",
+    TwinPointer="ViewProviderPreviewExtension",
+    Include="Mod/Part/Gui/ViewProviderPreviewExtension.h",
+    FatherInclude="Gui/ViewProviderExtensionPy.h",
+    Namespace="PartGui",
+    FatherNamespace="Gui",
+)
+class ViewProviderPreviewExtension(ViewProviderExtension):
+    """
+    Provides a 3D preview of an upcoming geometry change.
+    """
+
+    def showPreview(self, enable: bool, /) -> None:
+        """
+        Show or hide the preview in the 3D view.
+        """
+        ...
+
+    @constmethod
+    def isPreviewEnabled(self) -> bool:
+        """
+        Returns if the preview is currently shown.
+        """
+        ...

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.pyi
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.pyi
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from Base.Metadata import export, constmethod
 from Gui.ViewProviderExtension import ViewProviderExtension
+from typing import Any, Final
 
 @export(
     Twin="ViewProviderPreviewExtension",
@@ -18,6 +19,19 @@ class ViewProviderPreviewExtension(ViewProviderExtension):
     Provides a 3D preview of an upcoming geometry change.
     """
 
+    PreviewRootNode: Final[Any] = ...
+    """
+    Root of the preview scene graph, as a pivy SoSeparator.
+
+    Children may be added, removed, or replaced wholesale from an
+    attachPreview or updatePreview hook.
+    """
+
+    PreviewShapeNode: Final[Any] = ...
+    """
+    The SoPreviewShape the default implementation feeds with the preview shape.
+    """
+
     def showPreview(self, enable: bool, /) -> None:
         """
         Show or hide the preview in the 3D view.
@@ -28,5 +42,26 @@ class ViewProviderPreviewExtension(ViewProviderExtension):
     def isPreviewEnabled(self) -> bool:
         """
         Returns if the preview is currently shown.
+        """
+        ...
+
+    def updatePreview(self) -> None:
+        """
+        Rebuild the preview scene graph.
+
+        Use when the preview arrangement depends on data other than PreviewShape,
+        which is the only property that triggers a rebuild automatically.
+
+        Never call this from inside an updatePreview hook - it dispatches back
+        into that hook and recurses.
+        """
+        ...
+
+    def updatePreviewShape(self, shape: Any, node: Any, /) -> None:
+        """
+        Tessellate a Part.Shape into an SoPreviewShape node, honouring the view
+        provider's Deviation and AngularDeflection.
+
+        Raises TypeError if node is not an SoPreviewShape.
         """
         ...

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.pyi
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.pyi
@@ -17,6 +17,20 @@ from typing import Any, Final
 class ViewProviderPreviewExtension(ViewProviderExtension):
     """
     Provides a 3D preview of an upcoming geometry change.
+
+    The view provider's Proxy may define three optional hooks:
+
+    - attachPreview(self, vext) and updatePreview(self, vext) run AFTER the
+      C++ default and augment its result (add nodes, rewire the scene graph).
+    - getPreviewShape(self, vext) -> Part.Shape | None REPLACES the default
+      shape when it returns one; returning None keeps the default.
+
+    A Coin node held in a Python attribute across calls - e.g. shared between
+    updatePreview() invocations - is not kept alive by that reference alone;
+    unlike Gui::CoinPtr on the C++ side, a SWIG pointer does not ref() the
+    underlying SoBase. Call node.ref() while retaining such a node, or it may be
+    freed the moment its last scene graph parent is removed, crashing on next
+    use, and pair that with node.unref() once it is no longer retained.
     """
 
     PreviewRootNode: Final[Any] = ...

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtensionPyImp.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtensionPyImp.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/****************************************************************************
+ *                                                                          *
+ *   Copyright (c) 2025 Kacper Donat <kacper@kadet.net>                     *
+ *                                                                          *
+ *   This file is part of FreeCAD.                                          *
+ *                                                                          *
+ *   FreeCAD is free software: you can redistribute it and/or modify it     *
+ *   under the terms of the GNU Lesser General Public License as            *
+ *   published by the Free Software Foundation, either version 2.1 of the   *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ *   FreeCAD is distributed in the hope that it will be useful, but         *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of             *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU       *
+ *   Lesser General Public License for more details.                        *
+ *                                                                          *
+ *   You should have received a copy of the GNU Lesser General Public       *
+ *   License along with FreeCAD. If not, see                                *
+ *   <https://www.gnu.org/licenses/>.                                       *
+ *                                                                          *
+ ***************************************************************************/
+
+#include "ViewProviderPreviewExtensionPy.h"
+#include "ViewProviderPreviewExtensionPy.cpp"
+
+using namespace PartGui;
+
+std::string ViewProviderPreviewExtensionPy::representation() const
+{
+    return {"<ViewProviderPreviewExtension>"};
+}
+
+PyObject* ViewProviderPreviewExtensionPy::showPreview(PyObject* args)
+{
+    int enable {};
+    if (!PyArg_ParseTuple(args, "p", &enable)) {
+        return nullptr;
+    }
+
+    try {
+        getViewProviderPreviewExtensionPtr()->showPreview(enable != 0);
+    }
+    catch (Base::Exception& exception) {
+        exception.setPyException();
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
+}
+
+PyObject* ViewProviderPreviewExtensionPy::isPreviewEnabled(PyObject* args) const
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    return Py::new_reference_to(Py::Boolean(getViewProviderPreviewExtensionPtr()->isPreviewEnabled()));
+}
+
+PyObject* ViewProviderPreviewExtensionPy::getCustomAttributes(const char* /*attr*/) const
+{
+    return nullptr;
+}
+
+int ViewProviderPreviewExtensionPy::setCustomAttributes(const char* /*attr*/, PyObject* /*obj*/)
+{
+    return 0;
+}

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtensionPyImp.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtensionPyImp.cpp
@@ -24,6 +24,9 @@
 #include "ViewProviderPreviewExtensionPy.h"
 #include "ViewProviderPreviewExtensionPy.cpp"
 
+#include <Base/Interpreter.h>
+#include <Mod/Part/App/TopoShapePy.h>
+
 using namespace PartGui;
 
 std::string ViewProviderPreviewExtensionPy::representation() const
@@ -55,6 +58,108 @@ PyObject* ViewProviderPreviewExtensionPy::isPreviewEnabled(PyObject* args) const
         return nullptr;
     }
     return Py::new_reference_to(Py::Boolean(getViewProviderPreviewExtensionPtr()->isPreviewEnabled()));
+}
+
+Py::Object ViewProviderPreviewExtensionPy::getPreviewRootNode() const
+{
+    try {
+        SoSeparator* node = getViewProviderPreviewExtensionPtr()->getPreviewRootNode();
+
+        // Null until extensionAttach() runs; addExtension() alone does not
+        // trigger that, so a preview node can legitimately not exist yet.
+        if (!node) {
+            throw Py::RuntimeError("Preview extension is not attached");
+        }
+
+        PyObject* pointer
+            = Base::Interpreter().createSWIGPointerObj("pivy.coin", "_p_SoSeparator", node, 1);
+        node->ref();
+
+        return Py::Object(pointer, true);
+    }
+    catch (const Base::Exception& exception) {
+        throw Py::RuntimeError(exception.what());
+    }
+}
+
+Py::Object ViewProviderPreviewExtensionPy::getPreviewShapeNode() const
+{
+    try {
+        SoPreviewShape* node = getViewProviderPreviewExtensionPtr()->getPreviewShapeNode();
+
+        if (!node) {
+            throw Py::RuntimeError("Preview extension is not attached");
+        }
+
+        // pivy has no wrapper for the concrete SoPreviewShape type, so it is
+        // handed out as its SoSeparator base.
+        PyObject* pointer
+            = Base::Interpreter().createSWIGPointerObj("pivy.coin", "_p_SoSeparator", node, 1);
+        node->ref();
+
+        return Py::Object(pointer, true);
+    }
+    catch (const Base::Exception& exception) {
+        throw Py::RuntimeError(exception.what());
+    }
+}
+
+PyObject* ViewProviderPreviewExtensionPy::updatePreview(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+
+    try {
+        getViewProviderPreviewExtensionPtr()->updatePreview();
+    }
+    catch (Base::Exception& exception) {
+        exception.setPyException();
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
+}
+
+PyObject* ViewProviderPreviewExtensionPy::updatePreviewShape(PyObject* args)
+{
+    PyObject* shapeObject {nullptr};
+    PyObject* nodeObject {nullptr};
+
+    if (!PyArg_ParseTuple(args, "O!O", &Part::TopoShapePy::Type, &shapeObject, &nodeObject)) {
+        return nullptr;
+    }
+
+    void* pointer {nullptr};
+    try {
+        Base::Interpreter().convertSWIGPointerObj("pivy.coin", "_p_SoNode", nodeObject, &pointer, 0);
+    }
+    catch (const Base::Exception&) {
+        PyErr_SetString(PyExc_TypeError, "second argument must be an SoPreviewShape");
+        return nullptr;
+    }
+
+    auto* node = static_cast<SoNode*>(pointer);
+
+    if (!node || !node->isOfType(SoPreviewShape::getClassTypeId())) {
+        PyErr_SetString(PyExc_TypeError, "second argument must be an SoPreviewShape");
+        return nullptr;
+    }
+
+    const Part::TopoShape shape = *static_cast<Part::TopoShapePy*>(shapeObject)->getTopoShapePtr();
+
+    try {
+        getViewProviderPreviewExtensionPtr()->updatePreviewShape(
+            shape,
+            static_cast<SoPreviewShape*>(node)
+        );
+    }
+    catch (Base::Exception& exception) {
+        exception.setPyException();
+        return nullptr;
+    }
+
+    Py_RETURN_NONE;
 }
 
 PyObject* ViewProviderPreviewExtensionPy::getCustomAttributes(const char* /*attr*/) const

--- a/src/Mod/Part/InitGui.py
+++ b/src/Mod/Part/InitGui.py
@@ -75,3 +75,4 @@ class PartWorkbench(Gui.Workbench):
 Gui.addWorkbench(PartWorkbench())
 
 App.__unit_test__ += ["TestPartGui"]
+App.__unit_test__ += ["TestPartPreview"]

--- a/src/Mod/Part/TestPartPreview.py
+++ b/src/Mod/Part/TestPartPreview.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+import FreeCAD
+import Part
+
+
+class PreviewFeature:
+    """Minimal Python feature carrying the preview extension."""
+
+    def __init__(self, obj):
+        obj.Proxy = self
+        obj.addProperty("App::PropertyLength", "Size", "Test", "Drives the preview")
+        obj.Size = 10.0
+        if not obj.hasExtension("Part::PreviewExtensionPython"):
+            obj.addExtension("Part::PreviewExtensionPython")
+        self.recomputePreviewCalls = 0
+
+    def recomputePreview(self, ext):
+        self.recomputePreviewCalls += 1
+        obj = ext.ExtendedObject
+        obj.PreviewShape = Part.makeBox(obj.Size, obj.Size, obj.Size)
+
+    def execute(self, obj):
+        obj.Shape = Part.makeBox(obj.Size, obj.Size, obj.Size)
+
+
+class TestPreviewExtensionPython(unittest.TestCase):
+    def setUp(self):
+        self.document = FreeCAD.newDocument("PreviewExtensionTest")
+        self.object = self.document.addObject("Part::FeaturePython", "Feature")
+        self.feature = PreviewFeature(self.object)
+        self.document.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.document.Name)
+
+    def testRecomputePreviewProxyIsCalled(self):
+        self.object.invalidatePreview()
+        self.object.updatePreview()
+
+        self.assertGreaterEqual(self.feature.recomputePreviewCalls, 1)
+        self.assertFalse(self.object.PreviewShape.isNull())
+
+    def testUpdatePreviewIsNoOpWhileFresh(self):
+        self.object.invalidatePreview()
+        self.object.updatePreview()
+        callsAfterFirst = self.feature.recomputePreviewCalls
+
+        self.object.updatePreview()
+
+        self.assertEqual(self.feature.recomputePreviewCalls, callsAfterFirst)
+
+    def testInvalidatePreviewForcesRecompute(self):
+        self.object.updatePreview()
+        callsBefore = self.feature.recomputePreviewCalls
+
+        self.object.invalidatePreview()
+        self.object.updatePreview()
+
+        self.assertEqual(self.feature.recomputePreviewCalls, callsBefore + 1)
+
+    def testIsPreviewFreshTracksInvalidation(self):
+        self.object.updatePreview()
+        self.assertTrue(self.object.isPreviewFresh())
+
+        self.object.Size = 20.0
+
+        self.assertFalse(self.object.isPreviewFresh())

--- a/src/Mod/Part/TestPartPreview.py
+++ b/src/Mod/Part/TestPartPreview.py
@@ -220,3 +220,181 @@ class TestPreviewNodeAccessBeforeAttach(unittest.TestCase):
         # node raises at all rather than segfaulting.
         with self.assertRaises(AttributeError):
             self.object.ViewObject.PreviewRootNode
+
+
+class TwoNodeViewProvider(PreviewViewProvider):
+    """Reproduces the PartDesign FeatureAddSub arrangement: a primary preview
+    node plus a second, more transparent 'tool' node sharing its colour."""
+
+    def attachPreview(self, vext):
+        from pivy import coin
+
+        self.toolNode = coin.SoType.fromName("SoPreviewShape").createInstance()
+        self.toolNode.color.connectFrom(vext.PreviewShapeNode.color)
+        self.toolNode.transparency.setValue(0.95)
+        vext.PreviewRootNode.addChild(self.toolNode)
+
+    def updatePreview(self, vext):
+        self.updatePreviewCalls = getattr(self, "updatePreviewCalls", 0) + 1
+        vext.updatePreviewShape(Part.makeBox(3, 3, 3), self.toolNode)
+
+
+class InstancingViewProvider(PreviewViewProvider):
+    """Reproduces the PartDesign ViewProviderTransformed arrangement: the default
+    node is discarded and one shared shape node is instanced under N transforms."""
+
+    instanceCount = 3
+
+    def attachPreview(self, vext):
+        from pivy import coin
+
+        self.sharedNode = coin.SoType.fromName("SoPreviewShape").createInstance()
+        # removeAllChildren() below drops every scene graph parent, so without an
+        # explicit ref Coin frees the node between updatePreview() calls.
+        self.sharedNode.ref()
+
+    def updatePreview(self, vext):
+        from pivy import coin
+
+        vext.updatePreviewShape(Part.makeBox(2, 2, 2), self.sharedNode)
+
+        vext.PreviewRootNode.removeAllChildren()
+        for index in range(self.instanceCount):
+            transform = coin.SoTransform()
+            transform.translation.setValue(index * 10.0, 0.0, 0.0)
+
+            separator = coin.SoSeparator()
+            separator.addChild(transform)
+            separator.addChild(self.sharedNode)
+
+            vext.PreviewRootNode.addChild(separator)
+
+
+class ReplacingShapeViewProvider(PreviewViewProvider):
+    """Overrides the shape the preview is built from."""
+
+    def getPreviewShape(self, vext):
+        return Part.makeSphere(4)
+
+
+def _makePreviewObject(document, viewProviderClass):
+    obj = document.addObject("Part::FeaturePython", "Feature")
+    feature = PreviewFeature(obj)
+    viewProviderClass(obj.ViewObject)
+    document.recompute()
+    return obj, feature
+
+
+class TestPreviewProxyHooks(unittest.TestCase):
+    def setUp(self):
+        self.document = FreeCAD.newDocument("PreviewHookTest")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.document.Name)
+
+    def testAttachPreviewHookCanAddNodes(self):
+        obj, _ = _makePreviewObject(self.document, TwoNodeViewProvider)
+
+        # default node plus the tool node the hook added
+        self.assertEqual(obj.ViewObject.PreviewRootNode.getNumChildren(), 2)
+
+    def testTwoNodesCarryIndependentTransparency(self):
+        obj, _ = _makePreviewObject(self.document, TwoNodeViewProvider)
+
+        toolNode = obj.ViewObject.PreviewRootNode.getChild(1)
+
+        self.assertAlmostEqual(toolNode.transparency.getValue(), 0.95, places=5)
+        self.assertNotAlmostEqual(
+            obj.ViewObject.PreviewShapeNode.transparency.getValue(), 0.95, places=5
+        )
+
+    def testTwoNodesShareColourThroughConnectFrom(self):
+        obj, _ = _makePreviewObject(self.document, TwoNodeViewProvider)
+
+        toolNode = obj.ViewObject.PreviewRootNode.getChild(1)
+        obj.ViewObject.PreviewShapeNode.color.setValue(0.25, 0.5, 0.75)
+
+        self.assertEqual(toolNode.color.getValue().getValue(), (0.25, 0.5, 0.75))
+
+    def testUpdatePreviewHookIsCalledWhenPreviewShapeChanges(self):
+        obj, _ = _makePreviewObject(self.document, TwoNodeViewProvider)
+        callsBefore = getattr(obj.ViewObject.Proxy, "updatePreviewCalls", 0)
+
+        obj.PreviewShape = Part.makeBox(7, 7, 7)
+
+        self.assertGreater(obj.ViewObject.Proxy.updatePreviewCalls, callsBefore)
+
+    def testInstancingArrangementReplacesDefaultNode(self):
+        obj, _ = _makePreviewObject(self.document, InstancingViewProvider)
+
+        obj.ViewObject.updatePreview()
+        root = obj.ViewObject.PreviewRootNode
+
+        self.assertEqual(root.getNumChildren(), InstancingViewProvider.instanceCount)
+        # the shape node is genuinely shared, not copied
+        self.assertEqual(root.getChild(0).getChild(1), root.getChild(1).getChild(1))
+
+    def testInstanceTransformsAreDistinct(self):
+        obj, _ = _makePreviewObject(self.document, InstancingViewProvider)
+
+        obj.ViewObject.updatePreview()
+        root = obj.ViewObject.PreviewRootNode
+
+        translations = [
+            root.getChild(index).getChild(0).translation.getValue().getValue()
+            for index in range(InstancingViewProvider.instanceCount)
+        ]
+
+        self.assertEqual(translations[0], (0.0, 0.0, 0.0))
+        self.assertEqual(translations[1], (10.0, 0.0, 0.0))
+        self.assertEqual(translations[2], (20.0, 0.0, 0.0))
+
+    def testRepeatedUpdatePreviewDoesNotAccumulateChildren(self):
+        obj, _ = _makePreviewObject(self.document, InstancingViewProvider)
+
+        obj.ViewObject.updatePreview()
+        obj.ViewObject.updatePreview()
+        obj.ViewObject.updatePreview()
+
+        self.assertEqual(
+            obj.ViewObject.PreviewRootNode.getNumChildren(), InstancingViewProvider.instanceCount
+        )
+
+    def testGetPreviewShapeHookReplacesPreviewShapeProperty(self):
+        obj, _ = _makePreviewObject(self.document, ReplacingShapeViewProvider)
+
+        obj.PreviewShape = Part.makeBox(1, 1, 1)
+        obj.ViewObject.updatePreview()
+
+        # a unit box tessellates to 32 points, a sphere of radius 4 to thousands
+        self.assertGreater(_coordinateCount(obj.ViewObject.PreviewShapeNode), 100)
+
+    def testSchedulerCoalescesBatchedUpdatesIntoOneRecompute(self):
+        import FreeCADGui
+
+        obj, feature = _makePreviewObject(self.document, TwoNodeViewProvider)
+        obj.ViewObject.showPreview(True)
+
+        callsBefore = feature.recomputePreviewCalls
+        for size in (11.0, 12.0, 13.0, 14.0):
+            obj.Size = size
+
+        FreeCADGui.updateGui()  # drains the scheduler
+
+        recomputes = feature.recomputePreviewCalls - callsBefore
+        self.assertEqual(recomputes, 1)
+
+
+class TestExtensionRegisteredNameUnchanged(unittest.TestCase):
+    """Workbenches look the extension up by this exact literal string, so the
+    registered type name must survive changes to the class hierarchy."""
+
+    def testHasExtensionByLiteralName(self):
+        document = FreeCAD.newDocument("ExtensionNameCheckTest")
+        obj = document.addObject("Part::FeaturePython", "Feature")
+        PreviewViewProvider(obj.ViewObject)
+        document.recompute()
+
+        self.assertTrue(obj.ViewObject.hasExtension("PartGui::ViewProviderPreviewExtensionPython"))
+
+        FreeCAD.closeDocument(document.Name)

--- a/src/Mod/Part/TestPartPreview.py
+++ b/src/Mod/Part/TestPartPreview.py
@@ -68,3 +68,31 @@ class TestPreviewExtensionPython(unittest.TestCase):
         self.object.Size = 20.0
 
         self.assertFalse(self.object.isPreviewFresh())
+
+
+class FreshPreviewFeature(PreviewFeature):
+    """Feature that declares its preview never needs recomputing."""
+
+    def mustRecomputePreview(self, ext):
+        return False
+
+
+class TestMustRecomputePreviewRouting(unittest.TestCase):
+    def setUp(self):
+        self.document = FreeCAD.newDocument("MustRecomputePreviewTest")
+        self.object = self.document.addObject("Part::FeaturePython", "Feature")
+        self.feature = FreshPreviewFeature(self.object)
+        self.document.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.document.Name)
+
+    def testReturningFalseKeepsPreviewFresh(self):
+        """Counterpart of testIsPreviewFreshTracksInvalidation, which makes the same
+        change without the override and does go stale."""
+        self.object.updatePreview()
+        self.assertTrue(self.object.isPreviewFresh())
+
+        self.object.Size = 20.0
+
+        self.assertTrue(self.object.isPreviewFresh())

--- a/src/Mod/Part/TestPartPreview.py
+++ b/src/Mod/Part/TestPartPreview.py
@@ -96,3 +96,127 @@ class TestMustRecomputePreviewRouting(unittest.TestCase):
         self.object.Size = 20.0
 
         self.assertTrue(self.object.isPreviewFresh())
+
+
+def _coordinateCount(node):
+    """Number of points in the node's SoCoordinate3.
+
+    coords is a plain child rather than a registered field, so it is reached by
+    searching the scene graph. A freshly-constructed SoCoordinate3 already
+    reports 1, so an untessellated node counts 1 rather than 0.
+    """
+    from pivy import coin
+
+    search = coin.SoSearchAction()
+    search.setType(coin.SoCoordinate3.getClassTypeId())
+    search.apply(node)
+    return search.getPath().getTail().point.getNum()
+
+
+class PreviewViewProvider:
+    """Minimal Python view provider carrying the preview view extension."""
+
+    def __init__(self, vobj):
+        vobj.Proxy = self
+
+    def attach(self, vobj):
+        self.ViewObject = vobj
+        if not vobj.hasExtension("PartGui::ViewProviderPreviewExtensionPython"):
+            vobj.addExtension("PartGui::ViewProviderPreviewExtensionPython")
+
+
+class TestPreviewNodeAccess(unittest.TestCase):
+    def setUp(self):
+        self.document = FreeCAD.newDocument("PreviewNodeTest")
+        self.object = self.document.addObject("Part::FeaturePython", "Feature")
+        self.feature = PreviewFeature(self.object)
+        PreviewViewProvider(self.object.ViewObject)
+        self.document.recompute()
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.document.Name)
+
+    def testPreviewRootNodeIsASeparator(self):
+        from pivy import coin
+
+        root = self.object.ViewObject.PreviewRootNode
+
+        self.assertIsNotNone(root)
+        self.assertTrue(root.isOfType(coin.SoSeparator.getClassTypeId()))
+
+    def testPreviewShapeNodeIsAPreviewShape(self):
+        from pivy import coin
+
+        node = self.object.ViewObject.PreviewShapeNode
+
+        self.assertIsNotNone(node)
+        self.assertTrue(node.isOfType(coin.SoType.fromName("SoPreviewShape")))
+
+    def testDefaultShapeNodeIsChildOfRoot(self):
+        root = self.object.ViewObject.PreviewRootNode
+
+        self.assertEqual(root.getNumChildren(), 1)
+        self.assertEqual(root.getChild(0), self.object.ViewObject.PreviewShapeNode)
+
+    def testUpdatePreviewShapePopulatesGeometry(self):
+        from pivy import coin
+
+        node = coin.SoType.fromName("SoPreviewShape").createInstance()
+
+        self.object.ViewObject.updatePreviewShape(Part.makeBox(5, 5, 5), node)
+
+        self.assertGreaterEqual(_coordinateCount(node), 8)
+
+    def testUpdatePreviewShapeRejectsWrongNodeType(self):
+        from pivy import coin
+
+        with self.assertRaises(TypeError):
+            self.object.ViewObject.updatePreviewShape(Part.makeBox(5, 5, 5), coin.SoSeparator())
+
+    def testUpdatePreviewShapeRejectsNonCoinArgument(self):
+        with self.assertRaises(TypeError):
+            self.object.ViewObject.updatePreviewShape(Part.makeBox(5, 5, 5), object())
+
+    def testShowPreviewAttachesAndDetachesRoot(self):
+        annotation = self.object.ViewObject.Annotation
+        root = self.object.ViewObject.PreviewRootNode
+
+        self.object.ViewObject.showPreview(True)
+        self.assertGreaterEqual(annotation.findChild(root), 0)
+
+        self.object.ViewObject.showPreview(False)
+        self.assertLess(annotation.findChild(root), 0)
+
+
+class BarePreviewViewProvider:
+    """View provider that attaches without adding the preview extension."""
+
+    def __init__(self, vobj):
+        vobj.Proxy = self
+
+    def attach(self, vobj):
+        self.ViewObject = vobj
+
+
+class TestPreviewNodeAccessBeforeAttach(unittest.TestCase):
+    """Covers addExtension() called after the view provider has already attached,
+    which leaves extensionAttach() unrun and the preview nodes legitimately null.
+    """
+
+    def setUp(self):
+        self.document = FreeCAD.newDocument("PreviewNodeBeforeAttachTest")
+        self.object = self.document.addObject("Part::FeaturePython", "Feature")
+        self.feature = PreviewFeature(self.object)
+        BarePreviewViewProvider(self.object.ViewObject)
+        self.document.recompute()
+        self.object.ViewObject.addExtension("PartGui::ViewProviderPreviewExtensionPython")
+
+    def tearDown(self):
+        FreeCAD.closeDocument(self.document.Name)
+
+    def testPreviewRootNodeRaisesInsteadOfCrashing(self):
+        # ExtensionContainerPy::getCustomAttributes() replaces the getter's
+        # RuntimeError with AttributeError; what matters is that accessing the
+        # node raises at all rather than segfaulting.
+        with self.assertRaises(AttributeError):
+            self.object.ViewObject.PreviewRootNode

--- a/src/Mod/Part/part.dox
+++ b/src/Mod/Part/part.dox
@@ -2,6 +2,9 @@
  *  \ingroup CWORKBENCHES
  *  \brief Main anchor point with OpenCasCade functionality, base geometry tools
 
+Part also hosts the @ref PreviewFramework "Preview framework", used by any
+workbench to show an upcoming geometry change in the 3D view.
+
 See \ref src/Mod/Draft/draft.dox as an example of how to populate this page
 
 */

--- a/src/Mod/Part/previews.dox
+++ b/src/Mod/Part/previews.dox
@@ -1,0 +1,315 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-FileCopyrightText: 2026 Kacper Donat */
+/* SPDX-FileNotice: Part of the FreeCAD project. */
+
+/**
+ * @defgroup PreviewFramework Preview framework
+ * @ingroup PART
+ * @brief System to show an upcoming geometry change in the 3D view.
+ *
+ * @section preview_intro Introduction
+ *
+ * A preview is a semi-transparent shape drawn over the model while a feature is
+ * being edited, showing the change before it is committed.  The framework
+ * provides:
+ * 1. a working preview for any feature, from a single shape it publishes,
+ * 2. the ability to show geometry that is not the feature's result, such as the
+ *    volume a cut removes rather than what remains,
+ * 3. the ability to show any number of shapes at once, each with its own
+ *    appearance, and
+ * 4. the ability to draw one shape many times, as a pattern does for its
+ *    instances.
+ *
+ * The first point is what a feature gets for free.  The rest is what a feature
+ * can reach for when the default is not expressive enough.
+ *
+ * The framework is available to C++ and to Python workbenches on equal terms.
+ * Everything described here can be done from either.
+ *
+ * @section preview_default What a feature gets by default
+ *
+ * A preview has two halves.  @ref Part::PreviewExtension "PreviewExtension" on
+ * the feature owns the geometry, and @ref
+ * PartGui::ViewProviderPreviewExtension "ViewProviderPreviewExtension" on the
+ * view provider owns the appearance.
+ *
+ * A feature that adds both extensions and publishes a shape gets a complete
+ * preview: the shape is rendered semi-transparently over the model, with hidden
+ * edges dashed so the change reads against the geometry behind it.  Nothing is
+ * drawn until the view provider is asked to show it, normally when an edit
+ * session begins.
+ *
+ * The split matters for testing as much as for structure.  The geometry half
+ * never touches the scene graph, so what a feature previews can be verified
+ * without a GUI.
+ *
+ * @section preview_adding Adding a preview to a feature
+ *
+ * In C++ both halves are inherited.  The feature publishes its shape from
+ * `recomputePreview()`:
+ *
+ * @code{.cpp}
+ * class MyFeature: public Part::Feature, public Part::PreviewExtension
+ * {
+ *     PROPERTY_HEADER_WITH_OVERRIDE(MyModule::MyFeature);
+ *
+ * public:
+ *     MyFeature()
+ *     {
+ *         Part::PreviewExtension::initExtension(this);
+ *     }
+ *
+ * protected:
+ *     App::DocumentObjectExecReturn* recomputePreview() override
+ *     {
+ *         PreviewShape.setValue(computeSomethingCheap());
+ *         return App::DocumentObject::StdReturn;
+ *     }
+ * };
+ * @endcode
+ *
+ * The view provider inherits @ref PartGui::ViewProviderPreviewExtension
+ * "ViewProviderPreviewExtension" and turns the preview on for the duration of an
+ * edit:
+ *
+ * @code{.cpp}
+ * bool MyViewProvider::setEdit(int mode)
+ * {
+ *     showPreview(true);
+ *     return inherited::setEdit(mode);
+ * }
+ *
+ * void MyViewProvider::unsetEdit(int mode)
+ * {
+ *     showPreview(false);
+ *     inherited::unsetEdit(mode);
+ * }
+ * @endcode
+ *
+ * In Python both halves are added as extensions, and the hooks live on the
+ * `Proxy`:
+ *
+ * @code{.py}
+ * class MyFeature:
+ *     def __init__(self, obj):
+ *         obj.Proxy = self
+ *         if not obj.hasExtension("Part::PreviewExtensionPython"):
+ *             obj.addExtension("Part::PreviewExtensionPython")
+ *
+ *     def recomputePreview(self, ext):
+ *         obj = ext.ExtendedObject
+ *         obj.PreviewShape = self.computeSomethingCheap(obj)
+ *
+ * class MyViewProvider:
+ *     def attach(self, vobj):
+ *         self.ViewObject = vobj
+ *         if not vobj.hasExtension("PartGui::ViewProviderPreviewExtensionPython"):
+ *             vobj.addExtension("PartGui::ViewProviderPreviewExtensionPython")
+ * @endcode
+ *
+ * The view extension has to be added from `attach()`.  Its scene graph is built
+ * when the extension attaches, and adding it to a view provider that is already
+ * attached leaves the preview with nothing to draw into.
+ *
+ * @section preview_what_to_show Choosing what to show
+ *
+ * The most useful previews rarely show the feature's own result.  A preview
+ * exists to communicate a change, and the change is often better described by
+ * something the model will never contain.
+ *
+ * A subtractive feature is the clearest case.  Showing the shape that remains
+ * says very little, because the interesting part is what disappears.  Instead it
+ * can intersect its tool with the base shape and show exactly the volume that
+ * will be removed — geometry that exists only for the preview:
+ *
+ * @code{.cpp}
+ * App::DocumentObjectExecReturn* MyCut::recomputePreview()
+ * {
+ *     TopoShape removed;
+ *     removed.makeElementBoolean(Part::OpCodes::Common, {getBaseTopoShape(), AddSubShape.getShape()});
+ *     PreviewShape.setValue(removed);
+ *
+ *     return App::DocumentObject::StdReturn;
+ * }
+ * @endcode
+ *
+ * PartDesign goes further and shows two shapes at once: the removed volume, and,
+ * fainter behind it, the whole tool, so the user can see how much of the tool
+ * actually bites.  A dress-up feature has a similar choice, and shows only the
+ * faces it generates rather than the entire solid.
+ *
+ * Anything the feature can compute is fair game.  The preview is not obliged to
+ * be a shape the document could hold.
+ *
+ * @section preview_multiple Showing several shapes
+ *
+ * A preview is a small scene, not a single shape.  A feature can add as many
+ * shapes as the change needs, each with its own colour, transparency and line
+ * width, so that different parts of the change read differently — added material
+ * against removed material, or a tool against its effect.
+ *
+ * Additional shapes are introduced when the scene is built and fed when it is
+ * refreshed:
+ *
+ * @code{.cpp}
+ * void MyViewProvider::attachPreview()
+ * {
+ *     inherited::attachPreview();
+ *
+ *     pcToolPreview = new PartGui::SoPreviewShape;
+ *     pcToolPreview->color.connectFrom(&pcPreviewShape->color);
+ *     pcToolPreview->transparency = 0.95F;
+ *
+ *     pcPreviewRoot->addChild(pcToolPreview);
+ * }
+ *
+ * void MyViewProvider::updatePreview()
+ * {
+ *     inherited::updatePreview();
+ *
+ *     updatePreviewShape(getToolShape(), pcToolPreview);
+ * }
+ * @endcode
+ *
+ * The same in Python:
+ *
+ * @code{.py}
+ * def attachPreview(self, vext):
+ *     from pivy import coin
+ *
+ *     self.toolNode = coin.SoType.fromName("SoPreviewShape").createInstance()
+ *     self.toolNode.color.connectFrom(vext.PreviewShapeNode.color)
+ *     self.toolNode.transparency.setValue(0.95)
+ *
+ *     vext.PreviewRootNode.addChild(self.toolNode)
+ *
+ * def updatePreview(self, vext):
+ *     vext.updatePreviewShape(self.getToolShape(), self.toolNode)
+ * @endcode
+ *
+ * @section preview_instances Showing one shape many times
+ *
+ * A feature can also draw one shape repeatedly.  A pattern previews every
+ * instance it will create by placing the same geometry at each transformation.
+ * The shape is tessellated once and drawn at each location, so previewing fifty
+ * instances costs little more than previewing one.  This is what lets a
+ * transformation show its full result while the user is still choosing the
+ * count.
+ *
+ * Such a feature builds the scene itself rather than adding to the default one:
+ *
+ * @code{.py}
+ * def attachPreview(self, vext):
+ *     from pivy import coin
+ *
+ *     self.sharedNode = coin.SoType.fromName("SoPreviewShape").createInstance()
+ *     # Held only by this attribute between refreshes, so it needs an explicit
+ *     # reference to survive being detached from the scene graph.
+ *     self.sharedNode.ref()
+ *
+ * def updatePreview(self, vext):
+ *     from pivy import coin
+ *
+ *     vext.updatePreviewShape(self.getShape(), self.sharedNode)
+ *     vext.PreviewRootNode.removeAllChildren()
+ *
+ *     for placement in self.getPlacements():
+ *         transform = coin.SoTransform()
+ *         transform.translation.setValue(*placement)
+ *
+ *         separator = coin.SoSeparator()
+ *         separator.addChild(transform)
+ *         separator.addChild(self.sharedNode)
+ *
+ *         vext.PreviewRootNode.addChild(separator)
+ * @endcode
+ *
+ * @section preview_cost Keeping previews cheap
+ *
+ * A preview is recomputed while the user drags a spinbox, so its cost is felt
+ * directly.  Two things keep it affordable.
+ *
+ * The first is scheduling.  Previews are recomputed lazily, only once something
+ * they depend on has changed, and a burst of property changes is coalesced by
+ * @ref Part::PreviewUpdateScheduler "PreviewUpdateScheduler" into a single
+ * recompute rather than one per change.  A feature whose preview does not depend
+ * on all of its properties can say so through `mustRecomputePreview()` and skip
+ * the work entirely.
+ *
+ * The second is choosing simpler geometry.  Recomputing the object to obtain the
+ * preview is a legitimate approach, and for some features it is the only one —
+ * if the shape is genuinely what the user needs to see, compute it.  But where a
+ * cheaper shape communicates the same change, prefer it.  In particular a
+ * preview usually does not need to be joined to the base shape: showing the tool
+ * or the affected volume on its own reads just as well and avoids a boolean
+ * operation on every keystroke.  The preview's job is to be understood, not to
+ * be correct in the way a final shape must be.
+ *
+ * @section preview_appearance Appearance and theming
+ *
+ * Preview colours carry meaning.  PartDesign draws additive features green and
+ * subtractive ones red, and makes a tool fainter than the volume it affects, so
+ * the nature of a change is legible before reading any dialog.
+ *
+ * These colours come from style parameters rather than being fixed, so previews
+ * follow the active theme.  `PreviewColor` sets the colour of the primary shape;
+ * additional shapes should link to it, as in the examples above, rather than
+ * hardcoding a value, so the whole preview stays consistent when the theme
+ * changes.
+ *
+ * @note Style parameters are currently reachable only from C++.  Python access
+ * is coming; until then a Python workbench that needs specific colours has to
+ * restate them, and linking additional shapes to the primary one keeps that to a
+ * single value to revisit later.
+ *
+ * @section preview_extension_points Extension points
+ *
+ * A feature customises its preview by overriding parts of the two extensions.
+ * In C++ these are virtual functions; in Python they are methods on the object's
+ * or the view provider's `Proxy`, and the two sets correspond exactly.
+ *
+ * On the geometry half:
+ * - `recomputePreview` decides what the preview shows.  This is where a
+ *   subtractive feature computes its removed volume.
+ * - `mustRecomputePreview` decides when that work is worth doing.  It follows
+ *   the object's own recompute by default, so overriding it is how a feature
+ *   both skips changes its preview does not depend on and reports staleness the
+ *   property system cannot see, such as a dependency on a linked object.
+ *
+ * On the appearance half:
+ * - `attachPreview` builds the scene, and is where additional shapes are
+ *   introduced.
+ * - `updatePreview` refreshes it, and is where instanced arrangements are laid
+ *   out.
+ * - `getPreviewShape` chooses which shape feeds the default rendering.
+ *
+ * The two appearance hooks add to what the framework has already built rather
+ * than replacing it, so a feature that only wants one extra shape does not have
+ * to reproduce the default.  A feature that wants full control can rebuild the
+ * scene from scratch instead, as the instancing example does.
+ *
+ * @section preview_pitfalls Things worth knowing
+ *
+ * The preview is refreshed automatically when the published shape changes.  An
+ * arrangement that depends on anything else — a count, a set of transformations
+ * — has to ask for a refresh when that changes.
+ *
+ * A failure inside a Python hook is reported rather than propagated, which
+ * leaves the previous preview on screen.  A hook that cannot compute its
+ * geometry should publish an empty shape, so the preview disappears instead of
+ * silently going stale.
+ *
+ * Coin nodes a Python workbench keeps between refreshes need an explicit
+ * `ref()`; a Python variable alone does not keep them alive.  Release it with a
+ * matching `unref()` once the node is no longer retained.
+ *
+ * @section preview_seealso See also
+ *
+ * - @ref Part::PreviewExtension "PreviewExtension" — the geometry half
+ * - @ref PartGui::ViewProviderPreviewExtension "ViewProviderPreviewExtension" —
+ *   the appearance half
+ * - @ref Part::PreviewUpdateScheduler "PreviewUpdateScheduler" — coalescing of
+ *   recompute requests
+ * - @ref PartGui::SoPreviewShape "SoPreviewShape" — the node a preview shape is
+ *   drawn with
+ */

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -210,25 +210,6 @@ void ViewProvider::unsetEdit(int ModNum)
     }
 }
 
-void ViewProvider::updateData(const App::Property* prop)
-{
-    if (strcmp(prop->getName(), "PreviewShape") == 0) {
-        updatePreview();
-    }
-    else if (auto* previewExtension = getObject()->getExtensionByType<Part::PreviewExtension>(true)) {
-        if (isPreviewEnabled() && !previewExtension->isPreviewFresh() && isEditing()) {
-            // Properties can be updated in batches, where some properties trigger other updates.
-            // We don't need to compute the preview for intermediate steps. Instead of updating
-            // the preview immediately (and potentially doing it multiple times in a row), we
-            // schedule the update to happen at a more convenient time.
-            if (auto* scheduler = Base::provideService<Part::PreviewUpdateScheduler>()) {
-                scheduler->schedulePreviewRecompute(getObject());
-            }
-        }
-    }
-    inherited::updateData(prop);
-}
-
 void ViewProvider::attachPreview()
 {
     ViewProviderPreviewExtension::attachPreview();
@@ -375,17 +356,6 @@ bool ViewProvider::onDelete(const std::vector<std::string>&)
     makeChildrenVisible();
 
     return true;
-}
-
-Part::TopoShape ViewProvider::getPreviewShape() const
-{
-    if (auto feature = getObject()->getExtensionByType<Part::PreviewExtension>(true)) {
-        // Feature is responsible for generating proper shape and this ViewProvider
-        // is using it instead of more normal `Shape` property.
-        return feature->PreviewShape.getShape();
-    }
-
-    return {};
 }
 
 void ViewProvider::showPreviousFeature(bool enable)

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -82,8 +82,6 @@ public:
     // Returns the ViewProvider of the body the feature belongs to, or NULL, if not in a body
     ViewProviderBody* getBodyViewProvider();
 
-    /// Provides preview shape
-    Part::TopoShape getPreviewShape() const override;
     /// Toggles visibility of the preview
     void showPreviousFeature(bool);
 
@@ -101,7 +99,6 @@ protected:
     void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;
     bool setEdit(int ModNum) override;
     void unsetEdit(int ModNum) override;
-    void updateData(const App::Property* prop) override;
 
     void attachPreview() override;
     void updatePreview() override;

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -84,8 +84,6 @@ public:
 
     void toggleVisibility() override;
 
-    /// Provides preview shape
-    Part::TopoShape getPreviewShape() const override;
     /// Toggles visibility of the preview
     void showPreviousFeature(bool);
 
@@ -103,7 +101,6 @@ protected:
     void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;
     bool setEdit(int ModNum) override;
     void unsetEdit(int ModNum) override;
-    void updateData(const App::Property* prop) override;
 
     void attachPreview() override;
     void updatePreview() override;

--- a/tests/src/Mod/Part/App/CMakeLists.txt
+++ b/tests/src/Mod/Part/App/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(Part_tests_run
         PartFeature.cpp
         PartFeatures.cpp
         PartTestHelpers.cpp
+        PreviewExtension.cpp
         PropertyTopoShape.cpp
         TopoDS_Shape.cpp
         TopoShape.cpp

--- a/tests/src/Mod/Part/App/PreviewExtension.cpp
+++ b/tests/src/Mod/Part/App/PreviewExtension.cpp
@@ -56,8 +56,23 @@ protected:
 
 PROPERTY_SOURCE(Part::PreviewTestFeature, Part::Feature)
 
+/// Feature whose preview does not depend on its properties.
+class PreviewIndependentFeature: public PreviewTestFeature
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::PreviewIndependentFeature);
+
+public:
+    bool mustRecomputePreview() override
+    {
+        return false;
+    }
+};
+
+PROPERTY_SOURCE(Part::PreviewIndependentFeature, Part::PreviewTestFeature)
+
 }  // namespace Part
 
+using Part::PreviewIndependentFeature;
 using Part::PreviewTestFeature;
 
 class PreviewExtensionTest: public ::testing::Test
@@ -69,6 +84,7 @@ protected:
         // registers Part::Feature, the parent type init() below resolves
         Base::Interpreter().runString("import Part");
         PreviewTestFeature::init();
+        PreviewIndependentFeature::init();
     }
 
     void SetUp() override
@@ -86,6 +102,11 @@ protected:
     PreviewTestFeature* getFeature() const
     {
         return _feature;
+    }
+
+    App::Document* getDocument() const
+    {
+        return _doc;
     }
 
 private:
@@ -192,4 +213,17 @@ TEST_F(PreviewExtensionTest, mustRecomputePreviewFollowsMustRecompute)
 
     ASSERT_TRUE(feature->mustRecompute());
     EXPECT_EQ(feature->mustRecomputePreview(), feature->mustRecompute());
+}
+
+/// Counterpart of changingInputPropertyInvalidates: the same change on a feature
+/// that declines the recompute must leave the preview alone.
+TEST_F(PreviewExtensionTest, decliningRecomputeKeepsPreviewFreshOnInputChange)
+{
+    auto* feature = getDocument()->addObject<PreviewIndependentFeature>("Independent");
+    feature->updatePreview();
+    ASSERT_TRUE(feature->isPreviewFresh());
+
+    feature->Trigger.setValue(42);
+
+    EXPECT_TRUE(feature->isPreviewFresh());
 }

--- a/tests/src/Mod/Part/App/PreviewExtension.cpp
+++ b/tests/src/Mod/Part/App/PreviewExtension.cpp
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <src/App/InitApplication.h>
+#include <App/Document.h>
+#include <App/PropertyStandard.h>
+#include <Base/Interpreter.h>
+#include <Mod/Part/App/PartFeature.h>
+#include <Mod/Part/App/PreviewExtension.h>
+
+/// Feature carrying the preview extension, counting recompute calls so the
+/// invalidation rules can be observed.
+///
+/// PROPERTY_HEADER_WITH_OVERRIDE requires the namespace to match the source
+/// directory, so this reopens Part rather than using an anonymous or test-local one.
+namespace Part
+{
+
+class PreviewTestFeature: public Part::Feature, public Part::PreviewExtension
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(Part::PreviewTestFeature);
+
+public:
+    PreviewTestFeature()
+    {
+        ADD_PROPERTY_TYPE(Trigger, (0), "Test", App::Prop_None, "Plain input property");
+        ADD_PROPERTY_TYPE(Result, (0), "Test", App::Prop_None, "Output declared by status bit");
+        Result.setStatus(App::Property::Output, true);
+        ADD_PROPERTY_TYPE(
+            TypeOnlyOutput,
+            (0),
+            "Test",
+            App::Prop_Output,
+            "Output declared by property type only, as PartDesign::Feature::_Body is"
+        );
+
+        // Required for a statically-inherited extension: without it property changes never
+        // reach extensionOnChanged() and getExtendedObject() does not resolve.
+        Part::PreviewExtension::initExtension(this);
+    }
+
+    App::PropertyInteger Trigger;
+    App::PropertyInteger Result;
+    App::PropertyInteger TypeOnlyOutput;
+
+    int recomputePreviewCalls {0};
+
+protected:
+    App::DocumentObjectExecReturn* recomputePreview() override
+    {
+        ++recomputePreviewCalls;
+        return App::DocumentObject::StdReturn;
+    }
+};
+
+PROPERTY_SOURCE(Part::PreviewTestFeature, Part::Feature)
+
+}  // namespace Part
+
+using Part::PreviewTestFeature;
+
+class PreviewExtensionTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+        // registers Part::Feature, the parent type init() below resolves
+        Base::Interpreter().runString("import Part");
+        PreviewTestFeature::init();
+    }
+
+    void SetUp() override
+    {
+        _docName = App::GetApplication().getUniqueDocumentName("previewtest");
+        _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser");
+        _feature = _doc->addObject<PreviewTestFeature>("Feature");
+    }
+
+    void TearDown() override
+    {
+        App::GetApplication().closeDocument(_docName.c_str());
+    }
+
+    PreviewTestFeature* getFeature() const
+    {
+        return _feature;
+    }
+
+private:
+    std::string _docName;
+    App::Document* _doc = nullptr;
+    PreviewTestFeature* _feature = nullptr;
+};
+
+TEST_F(PreviewExtensionTest, previewShapeIsOutputTransientAndHidden)
+{
+    const auto& previewShape = getFeature()->PreviewShape;
+
+    EXPECT_TRUE(previewShape.testStatus(App::Property::Output));
+    EXPECT_TRUE(previewShape.testStatus(App::Property::Transient));
+    EXPECT_TRUE(previewShape.testStatus(App::Property::Hidden));
+}
+
+TEST_F(PreviewExtensionTest, updatePreviewRecomputesOnceThenMarksFresh)
+{
+    auto* feature = getFeature();
+    feature->invalidatePreview();
+
+    feature->updatePreview();
+
+    EXPECT_EQ(feature->recomputePreviewCalls, 1);
+    EXPECT_TRUE(feature->isPreviewFresh());
+}
+
+TEST_F(PreviewExtensionTest, updatePreviewIsNoOpWhileFresh)
+{
+    auto* feature = getFeature();
+    feature->invalidatePreview();
+    feature->updatePreview();
+
+    feature->updatePreview();
+
+    EXPECT_EQ(feature->recomputePreviewCalls, 1);
+}
+
+TEST_F(PreviewExtensionTest, changingInputPropertyInvalidates)
+{
+    auto* feature = getFeature();
+    feature->updatePreview();
+    ASSERT_TRUE(feature->isPreviewFresh());
+
+    feature->Trigger.setValue(42);
+
+    EXPECT_FALSE(feature->isPreviewFresh());
+}
+
+TEST_F(PreviewExtensionTest, changingPreviewShapeDoesNotInvalidate)
+{
+    auto* feature = getFeature();
+    feature->updatePreview();
+    ASSERT_TRUE(feature->isPreviewFresh());
+
+    feature->PreviewShape.setValue(Part::TopoShape());
+
+    EXPECT_TRUE(feature->isPreviewFresh());
+}
+
+TEST_F(PreviewExtensionTest, changingOutputPropertyDoesNotInvalidate)
+{
+    auto* feature = getFeature();
+    feature->updatePreview();
+    ASSERT_TRUE(feature->isPreviewFresh());
+
+    ASSERT_TRUE(feature->Result.testStatus(App::Property::Output));
+    feature->Result.setValue(7);
+
+    EXPECT_TRUE(feature->isPreviewFresh());
+}
+
+TEST_F(PreviewExtensionTest, changingTypeOnlyOutputPropertyDoesNotInvalidate)
+{
+    auto* feature = getFeature();
+    feature->updatePreview();
+    ASSERT_TRUE(feature->isPreviewFresh());
+
+    ASSERT_FALSE(feature->TypeOnlyOutput.testStatus(App::Property::Output));
+    feature->TypeOnlyOutput.setValue(7);
+
+    EXPECT_TRUE(feature->isPreviewFresh());
+}
+
+TEST_F(PreviewExtensionTest, invalidatePreviewForcesRecompute)
+{
+    auto* feature = getFeature();
+    feature->updatePreview();
+    const int callsBefore = feature->recomputePreviewCalls;
+
+    feature->invalidatePreview();
+    feature->updatePreview();
+
+    EXPECT_EQ(feature->recomputePreviewCalls, callsBefore + 1);
+}
+
+TEST_F(PreviewExtensionTest, mustRecomputePreviewFollowsMustRecompute)
+{
+    auto* feature = getFeature();
+    ASSERT_EQ(feature->mustRecomputePreview(), feature->mustRecompute());
+
+    feature->Trigger.setValue(42);
+
+    ASSERT_TRUE(feature->mustRecompute());
+    EXPECT_EQ(feature->mustRecomputePreview(), feature->mustRecompute());
+}


### PR DESCRIPTION
This will allow Python features to use the preview feature without the need of subclassing in C++.

It exposes all of the features in C++ to Python classes via proxies and extensions in a full feature-parity way. Python workbenches now can utilize previews - both simple ones and more complex ones with multiple different shapes.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
- As part of https://github.com/FreeCAD/FPA-grant-proposals/issues/22
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
