### PR TITLE
Draft: add hints for annotation tools

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -345,6 +345,7 @@ class Dimension(gui_base_original.Creator):
                     self.ui.switchUi(True)
                     if hasattr(Gui, "Snapper"):
                         Gui.Snapper.setSelectMode(True)
+                        self.update_hints()
                 snapped = self.view.getObjectInfo((arg["Position"][0], arg["Position"][1]))
                 if snapped:
                     ob = self.doc.getObject(snapped["Object"])
@@ -385,6 +386,7 @@ class Dimension(gui_base_original.Creator):
                     self.ui.switchUi(False)
                     if hasattr(Gui, "Snapper"):
                         Gui.Snapper.setSelectMode(False)
+                        self.update_hints()
                 if self.node and self.dir and len(self.node) < 2:
                     _p = DraftVecUtils.project(self.point.sub(self.node[0]), self.dir)
                     self.point = self.node[0].add(_p)
@@ -538,6 +540,7 @@ class Dimension(gui_base_original.Creator):
                         self.node.append(self.point)
                         self.createObject()
                         self.finish()
+                    self.update_hints()
 
     def numericInput(self, numx, numy, numz):
         """Validate the entry fields in the user interface.
@@ -554,6 +557,7 @@ class Dimension(gui_base_original.Creator):
             self.createObject()
             if not self.chain:
                 self.finish()
+        self.update_hints()
 
     def set_constraint_node(self):
         """Set constrained nodes for vertical or horizontal dimension
@@ -581,6 +585,63 @@ class Dimension(gui_base_original.Creator):
             elif self.force == 2:
                 self.node[0] = self.proj_point1
                 self.node[1] = self.proj_point1 + self.wp.u * proj_u
+
+    def get_hints(self):
+
+        position_txt = translate("draft", "%1 pick dimension postion")
+
+        if hasattr(Gui, "Snapper") and Gui.Snapper.selectMode:
+            # Edge selection mode: update hints for clarity.
+            hints = [
+                Gui.InputHint(translate("draft", "%1 select edge"), Gui.UserInput.MouseLeft)
+            ]
+        elif self.center is not None:
+            # 2 straight edges that intersect have been selected: angular dimension.
+            hints = [
+                Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)
+            ]
+        elif self.arcmode:
+            # 1 circular edge has been selected.
+            hints = [
+                Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)
+            ]
+            hints += gui_tool_utils._get_hint_mod_constrain_dimension_radial()
+        elif self.edges:
+            # 1 straight edge has been selected: linear or angular dimension.
+            hints = [
+                Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)
+            ]
+            hints += gui_tool_utils._get_hint_mod_constrain_dimension_linear()
+            hints += gui_tool_utils._get_hint_select_edge()
+        elif self.chain is not None:
+            # 1st linear dimension is defined, chain points can be picked.
+            hints = [
+                Gui.InputHint(translate("draft", "%1 pick next dimension point"), Gui.UserInput.MouseLeft),
+                Gui.InputHint(translate("draft", "%1 finish"), Gui.UserInput.KeyEscape),
+            ]
+        elif len(self.node) == 0:
+            # 0 points picked.
+            hints = [
+                Gui.InputHint(translate("draft", "%1 pick first dimension point"), Gui.UserInput.MouseLeft)
+            ]
+            hints += gui_tool_utils._get_hint_mod_snap()
+            hints += gui_tool_utils._get_hint_select_edge()
+        elif len(self.node) == 1:
+            # 1 point picked.
+            hints = [
+                Gui.InputHint(translate("draft", "%1 pick second dimension point"), Gui.UserInput.MouseLeft)
+            ]
+            hints += gui_tool_utils._get_hint_xyz_constrain()
+            hints += gui_tool_utils._get_hint_mod_constrain()
+            hints += gui_tool_utils._get_hint_mod_snap()
+        else:
+            # 2 points picked.
+            hints = [
+                Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)
+            ]
+            hints += gui_tool_utils._get_hint_mod_constrain_dimension_linear()
+
+        return hints
 
 
 Gui.addCommand("Draft_Dimension", Dimension())

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -588,7 +588,7 @@ class Dimension(gui_base_original.Creator):
 
     def get_hints(self):
 
-        position_txt = translate("draft", "%1 pick dimension postion")
+        position_txt = translate("draft", "%1 pick dimension position")
 
         if hasattr(Gui, "Snapper") and Gui.Snapper.selectMode:
             # Edge selection mode: update hints for clarity.

--- a/src/Mod/Draft/draftguitools/gui_dimensions.py
+++ b/src/Mod/Draft/draftguitools/gui_dimensions.py
@@ -592,53 +592,49 @@ class Dimension(gui_base_original.Creator):
 
         if hasattr(Gui, "Snapper") and Gui.Snapper.selectMode:
             # Edge selection mode: update hints for clarity.
-            hints = [
-                Gui.InputHint(translate("draft", "%1 select edge"), Gui.UserInput.MouseLeft)
-            ]
+            hints = [Gui.InputHint(translate("draft", "%1 select edge"), Gui.UserInput.MouseLeft)]
         elif self.center is not None:
             # 2 straight edges that intersect have been selected: angular dimension.
-            hints = [
-                Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)
-            ]
+            hints = [Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)]
         elif self.arcmode:
             # 1 circular edge has been selected.
-            hints = [
-                Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)
-            ]
+            hints = [Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)]
             hints += gui_tool_utils._get_hint_mod_constrain_dimension_radial()
         elif self.edges:
             # 1 straight edge has been selected: linear or angular dimension.
-            hints = [
-                Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)
-            ]
+            hints = [Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)]
             hints += gui_tool_utils._get_hint_mod_constrain_dimension_linear()
             hints += gui_tool_utils._get_hint_select_edge()
         elif self.chain is not None:
             # 1st linear dimension is defined, chain points can be picked.
             hints = [
-                Gui.InputHint(translate("draft", "%1 pick next dimension point"), Gui.UserInput.MouseLeft),
+                Gui.InputHint(
+                    translate("draft", "%1 pick next dimension point"), Gui.UserInput.MouseLeft
+                ),
                 Gui.InputHint(translate("draft", "%1 finish"), Gui.UserInput.KeyEscape),
             ]
         elif len(self.node) == 0:
             # 0 points picked.
             hints = [
-                Gui.InputHint(translate("draft", "%1 pick first dimension point"), Gui.UserInput.MouseLeft)
+                Gui.InputHint(
+                    translate("draft", "%1 pick first dimension point"), Gui.UserInput.MouseLeft
+                )
             ]
             hints += gui_tool_utils._get_hint_mod_snap()
             hints += gui_tool_utils._get_hint_select_edge()
         elif len(self.node) == 1:
             # 1 point picked.
             hints = [
-                Gui.InputHint(translate("draft", "%1 pick second dimension point"), Gui.UserInput.MouseLeft)
+                Gui.InputHint(
+                    translate("draft", "%1 pick second dimension point"), Gui.UserInput.MouseLeft
+                )
             ]
             hints += gui_tool_utils._get_hint_xyz_constrain()
             hints += gui_tool_utils._get_hint_mod_constrain()
             hints += gui_tool_utils._get_hint_mod_snap()
         else:
             # 2 points picked.
-            hints = [
-                Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)
-            ]
+            hints = [Gui.InputHint(position_txt, Gui.UserInput.MouseLeft)]
             hints += gui_tool_utils._get_hint_mod_constrain_dimension_linear()
 
         return hints

--- a/src/Mod/Draft/draftguitools/gui_labels.py
+++ b/src/Mod/Draft/draftguitools/gui_labels.py
@@ -239,11 +239,17 @@ class Label(gui_base_original.Creator):
 
     def get_hints(self):
         if len(self.node) == 0:
-            hints = [Gui.InputHint(translate("draft", "%1 pick arrow point"), Gui.UserInput.MouseLeft)]
+            hints = [
+                Gui.InputHint(translate("draft", "%1 pick arrow point"), Gui.UserInput.MouseLeft)
+            ]
         elif len(self.node) == 1:
-            hints = [Gui.InputHint(translate("draft", "%1 pick corner point"), Gui.UserInput.MouseLeft)]
+            hints = [
+                Gui.InputHint(translate("draft", "%1 pick corner point"), Gui.UserInput.MouseLeft)
+            ]
         else:
-            hints = [Gui.InputHint(translate("draft", "%1 pick text point"), Gui.UserInput.MouseLeft)]
+            hints = [
+                Gui.InputHint(translate("draft", "%1 pick text point"), Gui.UserInput.MouseLeft)
+            ]
         return hints + gui_tool_utils._get_hint_mod_snap()
 
 

--- a/src/Mod/Draft/draftguitools/gui_labels.py
+++ b/src/Mod/Draft/draftguitools/gui_labels.py
@@ -207,6 +207,7 @@ class Label(gui_base_original.Creator):
                         # third click
                         self.node.append(self.point)
                         self.create()
+                    self.update_hints()
 
     def numericInput(self, numx, numy, numz):
         """Validate the entry fields in the user interface.
@@ -234,6 +235,16 @@ class Label(gui_base_original.Creator):
             # third click
             self.node.append(self.point)
             self.create()
+        self.update_hints()
+
+    def get_hints(self):
+        if len(self.node) == 0:
+            hints = [Gui.InputHint(translate("draft", "%1 pick arrow point"), Gui.UserInput.MouseLeft)]
+        elif len(self.node) == 1:
+            hints = [Gui.InputHint(translate("draft", "%1 pick corner point"), Gui.UserInput.MouseLeft)]
+        else:
+            hints = [Gui.InputHint(translate("draft", "%1 pick text point"), Gui.UserInput.MouseLeft)]
+        return hints + gui_tool_utils._get_hint_mod_snap()
 
 
 Draft_Label = Label

--- a/src/Mod/Draft/draftguitools/gui_texts.py
+++ b/src/Mod/Draft/draftguitools/gui_texts.py
@@ -159,6 +159,7 @@ class Text(gui_base_original.Creator):
                     self.node.append(self.point)
                     self.ui.textUi()
                     self.ui.textValue.setFocus()
+                    self.update_hints()
 
     def numericInput(self, numx, numy, numz):
         """Validate the entry fields in the user interface.
@@ -170,6 +171,14 @@ class Text(gui_base_original.Creator):
         self.node.append(self.point)
         self.ui.textUi()
         self.ui.textValue.setFocus()
+        self.update_hints()
+
+    def get_hints(self):
+        if self.node:
+            return []
+        return [
+            Gui.InputHint(translate("draft", "%1 pick point"), Gui.UserInput.MouseLeft)
+        ] + gui_tool_utils._get_hint_mod_snap()
 
 
 Gui.addCommand("Draft_Text", Text())

--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -145,7 +145,9 @@ def _get_hint_select_edge():
     shortcut = params.get_param("inCommandShortcutSelectEdge").upper()
     if pattern.fullmatch(shortcut):
         shortcut_key = getattr(Gui.UserInput, "Key" + shortcut)
-        return [Gui.InputHint(translate("draft", "%1 / hold %2 select edge"), shortcut_key, mod_key)]
+        return [
+            Gui.InputHint(translate("draft", "%1 / hold %2 select edge"), shortcut_key, mod_key)
+        ]
     return [Gui.InputHint(translate("draft", "Hold %1 select edge"), mod_key)]
 
 

--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -76,6 +76,16 @@ def _get_hint_mod_constrain():
     return [Gui.InputHint(translate("draft", "%1 constrain"), key)]
 
 
+def _get_hint_mod_constrain_dimension_linear():
+    key = _HINT_MOD_KEYS[params.get_param("modconstrain")]
+    return [Gui.InputHint(translate("draft", "%1 horizontal/vertical dimension"), key)]
+
+
+def _get_hint_mod_constrain_dimension_radial():
+    key = _HINT_MOD_KEYS[params.get_param("modconstrain")]
+    return [Gui.InputHint(translate("draft", "%1 radial dimension"), key)]
+
+
 def _get_hint_mod_snap():
     if params.get_param("alwaysSnap"):
         return []
@@ -126,6 +136,15 @@ def _get_hint_continue():
     if pattern.fullmatch(shortcut):
         key = getattr(Gui.UserInput, "Key" + shortcut)
         return [Gui.InputHint(translate("draft", "%1 toggle continue"), key)]
+    return []
+
+
+def _get_hint_select_edge():
+    pattern = re.compile("[A-Z]")
+    shortcut = params.get_param("inCommandShortcutSelectEdge").upper()
+    if pattern.fullmatch(shortcut):
+        key = getattr(Gui.UserInput, "Key" + shortcut)
+        return [Gui.InputHint(translate("draft", "%1 select edge"), key)]
     return []
 
 

--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -107,7 +107,7 @@ def _get_hint_xyz_constrain():
         key_y = getattr(Gui.UserInput, "Key" + shortcut_y)
         key_z = getattr(Gui.UserInput, "Key" + shortcut_z)
         return [
-            Gui.InputHint(translate("draft", "%1/%2/%3 switch constraint"), key_x, key_y, key_z)
+            Gui.InputHint(translate("draft", "%1 / %2 / %3 switch constraint"), key_x, key_y, key_z)
         ]
     return []
 
@@ -140,12 +140,13 @@ def _get_hint_continue():
 
 
 def _get_hint_select_edge():
+    mod_key = _HINT_MOD_KEYS[params.get_param("modalt")]
     pattern = re.compile("[A-Z]")
     shortcut = params.get_param("inCommandShortcutSelectEdge").upper()
     if pattern.fullmatch(shortcut):
-        key = getattr(Gui.UserInput, "Key" + shortcut)
-        return [Gui.InputHint(translate("draft", "%1 select edge"), key)]
-    return []
+        shortcut_key = getattr(Gui.UserInput, "Key" + shortcut)
+        return [Gui.InputHint(translate("draft", "%1 / hold %2 select edge"), shortcut_key, mod_key)]
+    return [Gui.InputHint(translate("draft", "Hold %1 select edge"), mod_key)]
 
 
 def format_unit(exp, unit="mm"):

--- a/src/Mod/Draft/draftguitools/gui_tool_utils.py
+++ b/src/Mod/Draft/draftguitools/gui_tool_utils.py
@@ -73,24 +73,24 @@ _HINT_MOD_KEYS = [Gui.UserInput.KeyShift, Gui.UserInput.KeyControl, Gui.UserInpu
 
 def _get_hint_mod_constrain():
     key = _HINT_MOD_KEYS[params.get_param("modconstrain")]
-    return [Gui.InputHint(translate("draft", "%1 constrain"), key)]
+    return [Gui.InputHint(translate("draft", "Hold %1 constrain"), key)]
 
 
 def _get_hint_mod_constrain_dimension_linear():
     key = _HINT_MOD_KEYS[params.get_param("modconstrain")]
-    return [Gui.InputHint(translate("draft", "%1 horizontal/vertical dimension"), key)]
+    return [Gui.InputHint(translate("draft", "Hold %1 horizontal/vertical dimension"), key)]
 
 
 def _get_hint_mod_constrain_dimension_radial():
     key = _HINT_MOD_KEYS[params.get_param("modconstrain")]
-    return [Gui.InputHint(translate("draft", "%1 radial dimension"), key)]
+    return [Gui.InputHint(translate("draft", "Hold %1 radial dimension"), key)]
 
 
 def _get_hint_mod_snap():
     if params.get_param("alwaysSnap"):
         return []
     key = _HINT_MOD_KEYS[params.get_param("modsnap")]
-    return [Gui.InputHint(translate("draft", "%1 snap"), key)]
+    return [Gui.InputHint(translate("draft", "Hold %1 snap"), key)]
 
 
 def _get_hint_xyz_constrain():

--- a/src/Mod/Draft/drafttaskpanels/task_shapestring.py
+++ b/src/Mod/Draft/drafttaskpanels/task_shapestring.py
@@ -210,9 +210,10 @@ class ShapeStringTaskPanel:
         if self.pointPicked:
             Gui.HintManager.hide()
         else:
-            Gui.HintManager.show(
+            hints = [
                 Gui.InputHint(translate("draft", "%1 pick point"), Gui.UserInput.MouseLeft)
-            )
+            ] + gui_tool_utils._get_hint_mod_snap()
+            Gui.HintManager.show(*hints)
 
 
 class ShapeStringTaskPanelCmd(ShapeStringTaskPanel):


### PR DESCRIPTION
Related: #22298.

This PR adds hints for the Draft annotation tools.

The hint for ShapeStrings did not mention the snap modifier key (which is not required by default, but can be specified in the preferences).