### PR TITLE
TechDraw: prevent crash on document load

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -172,7 +172,6 @@ App::DocumentObjectExecReturn* DrawViewDetail::execute()
     }
 
     detailExec(shape3d, dvp, dvs);
-    addPoints();
 
     dvp->requestPaint();//to refresh detail highlight in base view
     return DrawView::execute();

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -442,7 +442,6 @@ App::DocumentObjectExecReturn* DrawViewSection::execute()
     }
 
     sectionExec(baseShape);
-    addPoints();
 
     return DrawView::execute();     //NOLINT
 }


### PR DESCRIPTION
This PR implements a fix for issue #29644.  It removes the problematic calls to addPoints mentioned in the issue.

- call to addPoints was being made before creation of GeometryObject.
- addPoints is already called by DrawViewPart::postHlrTasks and should not be called in DrawViewSection::execute or DrawViewDetail::execute.
