### PR TITLE
Spreadsheet: add support for vertical configuration tables

### DIFF
--- a/src/App/Expression.cpp
+++ b/src/App/Expression.cpp
@@ -1718,6 +1718,7 @@ FunctionExpression::FunctionExpression(const DocumentObject *_owner, Function _f
         if (args.size() != 2)
             ARGUMENT_THROW("exactly two required.");
         break;
+    case ADDRESS:
     case CATH:
     case HYPOT:
     case ROTATION:
@@ -2283,6 +2284,38 @@ Py::Object FunctionExpression::evaluate(const Expression *expr, int f, const std
         initialiseObject(&vector, args);
         return vector;
     }
+    case ADDRESS: {
+        Py::Object row = args[0]->getPyValue();
+        Py::Object col = args[1]->getPyValue();
+        bool absRow = true;
+        bool absCol = true;
+
+        if (!PyLong_Check(row.ptr()))
+            _EXPR_THROW("Function requires the first argument to be an integer.", expr);
+        if (!PyLong_Check(col.ptr()))
+            _EXPR_THROW("Function requires the second argument to be an integer.", expr);
+
+        if (args.size() > 2) {
+            Py::Object refType = args[2]->getPyValue();
+            if (!PyLong_Check(refType.ptr()))
+                _EXPR_THROW("Function requires the third argument to be an integer.", expr);
+
+            auto value = PyLong_AsLong(refType.ptr());
+            if (value < 1 || value > 4)
+                _EXPR_THROW("Invalid reference type: must be 1, 2, 3, or 4.", expr);
+
+            // 1 is Absolute, 2 is Absolute Row / Relative Column,
+            // 3 is Relative Row / Absolute Column, 4 is Relative
+            absRow = value == 1 || value == 2;
+            absCol = value == 1 || value == 3;
+        }
+
+        auto cell = CellAddress(PyLong_AsLong(row.ptr()) - 1, PyLong_AsLong(col.ptr()) - 1, absRow, absCol);
+        if (!cell.isValid())
+            _EXPR_THROW("Cell address out of bounds.", expr);
+
+        return Py::String(cell.toString());
+    }
     case HIDDENREF:
     case HREF:
         return args[0]->getPyValue();
@@ -2735,6 +2768,8 @@ void FunctionExpression::_toString(std::ostream &ss, bool persistent,int) const
         ss << "tuple("; break;;
     case VECTOR:
         ss << "vector("; break;;
+    case ADDRESS:
+        ss << "address("; break;;
     case HIDDENREF:
         ss << "hiddenref("; break;;
     case HREF:
@@ -3625,6 +3660,7 @@ static void initParser(const App::DocumentObject *owner)
         registered_functions["tuple"] = FunctionExpression::TUPLE;
         registered_functions["vector"] = FunctionExpression::VECTOR;
 
+        registered_functions["address"] = FunctionExpression::ADDRESS;
         registered_functions["hiddenref"] = FunctionExpression::HIDDENREF;
         registered_functions["href"] = FunctionExpression::HREF;
 

--- a/src/App/ExpressionParser.h
+++ b/src/App/ExpressionParser.h
@@ -369,6 +369,8 @@ public:
         TUPLE,         // Create Python tuple.
         VECTOR,        // Create vector object.
 
+        ADDRESS,    // Format a cell address string from row and column
+
         HIDDENREF,  // hidden reference that has no dependency check
         HREF,       // deprecated alias of HIDDENREF
 

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -46,14 +46,9 @@ DlgSheetConf::DlgSheetConf(Sheet* sheet, Range range, QWidget* parent)
 {
     ui->setupUi(this);
 
-    if (range.colCount() == 1) {
-        auto to = range.to();
-        to.setCol(CellAddress::MAX_COLUMNS - 1);
-        range = Range(range.from(), to);
-    }
-
     ui->lineEditStart->setText(QString::fromLatin1(range.from().toString().c_str()));
     ui->lineEditEnd->setText(QString::fromLatin1(range.to().toString().c_str()));
+    ui->verticalCheckBox->setChecked(range.from().col() == range.to().col());
 
     ui->lineEditProp->setDocumentObject(sheet, false);
 
@@ -90,22 +85,35 @@ App::Property* DlgSheetConf::prepare(
     from = sheet->getCellAddress(ui->lineEditStart->text().trimmed().toLatin1().constData());
     to = sheet->getCellAddress(ui->lineEditEnd->text().trimmed().toLatin1().constData());
 
-    if (from.col() >= to.col()) {
-        FC_THROWM(Base::RuntimeError, "Invalid cell range");
+    // rangeConf is supposed to hold the range of string cells, each holding
+    // the name of a configuration. The '-' / '|' below indicates a growing but
+    // continuous row / column (respectively), so that we can auto include new
+    // configurations. We'll bind the string list to a PropertyEnumeration for
+    // dynamical switching of the configuration.
+
+    if (ui->verticalCheckBox->isChecked()) {
+        if (from.row() >= to.row()) {
+            FC_THROWM(Base::RuntimeError, "Invalid cell range");
+        }
+
+        // Setup column as parameters, and row as configurations
+        to.setCol(from.col());
+
+        CellAddress confFrom(from.row(), from.col() + 1);
+        rangeConf = confFrom.toString();
+        rangeConf += ":-";
+    } else {
+        if (from.col() >= to.col()) {
+            FC_THROWM(Base::RuntimeError, "Invalid cell range");
+        }
+
+        // Setup row as parameters, and column as configurations
+        to.setRow(from.row());
+
+        CellAddress confFrom(from.row() + 1, from.col());
+        rangeConf = confFrom.toString();
+        rangeConf += ":|";
     }
-
-    // Setup row as parameters, and column as configurations
-    to.setRow(from.row());
-
-    CellAddress confFrom(from.row() + 1, from.col());
-    rangeConf = confFrom.toString();
-    // rangeConf is supposed to hold the range of string cells, each
-    // holding the name of a configuration. The '|' below indicates a
-    // growing but continuous column, so that we can auto include new
-    // configurations. We'll bind the string list to a
-    // PropertyEnumeration for dynamical switching of the
-    // configuration.
-    rangeConf += ":|";
 
     if (!init) {
         std::string exprTxt(ui->lineEditProp->text().trimmed().toUtf8().constData());
@@ -263,24 +271,43 @@ void DlgSheetConf::accept()
             prop->getFullName()
         );
 
-        // Adjust the range to skip the first cell
-        range = Range(from.row(), from.col() + 1, to.row(), to.col());
+        if (ui->verticalCheckBox->isChecked()) {
+            // Adjust the range to skip the first cell
+            range = Range(from.row() + 1, from.col(), to.row(), to.col());
 
-        // Formulate expression to calculate the row binding using
-        // PropertyEnumeration
-        Gui::cmdAppObjectArgs(
-            sheet,
-            "setExpression('.cells.Bind.%s.%s', "
-            "'tuple(.cells, <<%s>> + str(hiddenref(%s)+%d), <<%s>> + str(hiddenref(%s)+%d))')",
-            range.from().toString(CellAddress::Cell::ShowRowColumn),
-            range.to().toString(CellAddress::Cell::ShowRowColumn),
-            range.from().toString(CellAddress::Cell::ShowColumn),
-            prop->getFullName(),
-            from.row() + 2,
-            range.to().toString(CellAddress::Cell::ShowColumn),
-            prop->getFullName(),
-            from.row() + 2
-        );
+            // Formulate expression to calculate the column binding using
+            // PropertyEnumeration
+            Gui::cmdAppObjectArgs(
+                sheet,
+                "setExpression('.cells.Bind.%1$s.%2$s', "
+                "'tuple(.cells; "
+                "((%3$d+hiddenref(%4$s)) < 26 ? <<>> : <<%%c>> %% (65+sum(0;floor((%3$d+hiddenref(%4$s))/26)-1))) + <<%%c>> %% (65+(%3$d+hiddenref(%4$s))%%26) + str(%5$d); "
+                "((%3$d+hiddenref(%4$s)) < 26 ? <<>> : <<%%c>> %% (65+sum(0;floor((%3$d+hiddenref(%4$s))/26)-1))) + <<%%c>> %% (65+(%3$d+hiddenref(%4$s))%%26) + str(%6$d))')",
+                range.from().toString(CellAddress::Cell::ShowRowColumn),
+                range.to().toString(CellAddress::Cell::ShowRowColumn),
+                from.col() + 1,
+                prop->getFullName(),
+                range.from().row() + 1,
+                range.to().row() + 1
+            );
+        } else {
+            // Adjust the range to skip the first cell
+            range = Range(from.row(), from.col() + 1, to.row(), to.col());
+
+            // Formulate expression to calculate the row binding using
+            // PropertyEnumeration
+            Gui::cmdAppObjectArgs(
+                sheet,
+                "setExpression('.cells.Bind.%1$s.%2$s', "
+                "'tuple(.cells; <<%5$s>> + str(%3$d+hiddenref(%4$s)); <<%6$s>> + str(%3$d+hiddenref(%4$s)))')",
+                range.from().toString(CellAddress::Cell::ShowRowColumn),
+                range.to().toString(CellAddress::Cell::ShowRowColumn),
+                from.row() + 2,
+                prop->getFullName(),
+                range.from().toString(CellAddress::Cell::ShowColumn),
+                range.to().toString(CellAddress::Cell::ShowColumn)
+            );
+        }
 
         Gui::Command::doCommand(Gui::Command::Doc, "App.ActiveDocument.recompute()");
         sheet->getDocument()->commitTransaction();

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -48,7 +48,8 @@ DlgSheetConf::DlgSheetConf(Sheet* sheet, Range range, QWidget* parent)
 
     ui->lineEditStart->setText(QString::fromLatin1(range.from().toString().c_str()));
     ui->lineEditEnd->setText(QString::fromLatin1(range.to().toString().c_str()));
-    ui->verticalCheckBox->setChecked(range.from().col() == range.to().col());
+    ui->radioButtonOrientationHorizontal->setChecked(range.from().col() != range.to().col());
+    ui->radioButtonOrientationVertical->setChecked(range.from().col() == range.to().col());
 
     ui->lineEditProp->setDocumentObject(sheet, false);
 
@@ -91,7 +92,7 @@ App::Property* DlgSheetConf::prepare(
     // configurations. We'll bind the string list to a PropertyEnumeration for
     // dynamical switching of the configuration.
 
-    if (ui->verticalCheckBox->isChecked()) {
+    if (ui->radioButtonOrientationVertical->isChecked()) {
         if (from.row() >= to.row()) {
             FC_THROWM(Base::RuntimeError, "Invalid cell range");
         }
@@ -272,7 +273,7 @@ void DlgSheetConf::accept()
             prop->getFullName()
         );
 
-        if (ui->verticalCheckBox->isChecked()) {
+        if (ui->radioButtonOrientationVertical->isChecked()) {
             // Adjust the range to skip the first cell (containing variant string)
             range = Range(from.row() + 1, from.col(), to.row(), to.col());
 

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -286,57 +286,21 @@ void DlgSheetConf::accept()
             //
             // The bind target cell range is:
             //      <dynamic column><from row>:<dynamic column><to row>
-            // where <from row> and <to row> are the fixed strings str(%5$d)
-            // and str(%6$d), populated with range.from().row() + 1 and
-            // range.to().row() + 1, respectively (the + 1 constant is because
-            // row() is 0-based).
+            // where <from row> is fixed to range.from().row() + 1, <to row> is
+            // fixed to range.to().row() + 1, and <dynamic column> is the
+            // configuration table column offset plus the property enumeration
+            // variant index.
             //
-            // <dynamic column> is an alpha string ranging from A to ZZ.
-            // However, we can only use spreadsheet expressions to compute it.
-            // In the approach below, we form the two alpha letters of the
-            // column by converting the dynamic column index into ASCII
-            // characters with Python format strings.
-            // The upper letter is formed with the expression:
-            //      (column < 26) ? "" : "%c" % (65 + floor(column / 26) - 1)
-            // and the lower letter with the expression:
-            //      "%c" % (65 + column % 26)
-            // where column is the 0-based column index into the selected
-            // configuration column.
-            //
-            // In terms of spreadsheet expressions, the column index is:
-            //      %3$d+hiddenref(%4$s)
-            // which is the configuration table column offset plus the property
-            // enumeration variant index. The configuration table column offset
-            // is populated with from.col() + 1 (the + 1 constant is to start
-            // at the first parameter column, while keeping the overall
-            // expression 0-based).
-            //
-            // The final expression (omitting format escapes) for the column is:
-            //      ((%3$d+hiddenref(%4$s)) < 26 ?
-            //          <<>> :
-            //          <<%c>> % (65 +
-            //              sum(0;floor((%3$d+hiddenref(%4$s)) / 26) - 1)))
-            //      + <<%c>> % (65 + (%3$d+hiddenref(%4$s)) % 26)
-            // The sum(0;...) expression is needed to coerce the Base.Quantity
-            // type returned by floor() back into an integer type suitable for
-            // the format string.
-            //
-            // In the future, a new expression function to compute a cell
-            // address from integral row and column indices (e.g.
-            // `celladdress(2,3)` -> D3) could be used to vastly simplify this.
+            // The + 1 constants are needed because the expression function
+            // address() is 1-based, while row() and col() are 0-based.
             Gui::cmdAppObjectArgs(
                 sheet,
-                "setExpression('.cells.Bind.%1$s.%2$s', "
-                "'tuple(.cells; "
-                "((%3$d+hiddenref(%4$s)) < 26 ? <<>> : <<%%c>> %% "
-                "(65+sum(0;floor((%3$d+hiddenref(%4$s))/26)-1))) + <<%%c>> %% "
-                "(65+(%3$d+hiddenref(%4$s))%%26) + str(%5$d); "
-                "((%3$d+hiddenref(%4$s)) < 26 ? <<>> : <<%%c>> %% "
-                "(65+sum(0;floor((%3$d+hiddenref(%4$s))/26)-1))) + <<%%c>> %% "
-                "(65+(%3$d+hiddenref(%4$s))%%26) + str(%6$d))')",
+                "setExpression('.cells.Bind.%1$s.%2$s', 'tuple(.cells; "
+                "address(%5$d; %3$d+hiddenref(%4$s); 4); "
+                "address(%6$d; %3$d+hiddenref(%4$s); 4))')",
                 range.from().toString(CellAddress::Cell::ShowRowColumn),
                 range.to().toString(CellAddress::Cell::ShowRowColumn),
-                from.col() + 1,
+                from.col() + 2,
                 prop->getFullName(),
                 range.from().row() + 1,
                 range.to().row() + 1
@@ -355,27 +319,24 @@ void DlgSheetConf::accept()
             //
             // The bind target cell range is:
             //      <from column><dynamic row>:<to column><dynamic row>
-            // where <from column> and <to column> are the fixed strings
-            // <<%5$s>> and <<%6$s>>, populated with range.from() and
-            // range.to() columns, respectively.
+            // where <from column> is fixed to range.from().col() + 1, <to
+            // column> is fixed to range.to().col() + 1, and <dynamic row> is
+            // the configuration table row offset plus the property enumeration
+            // variant index.
             //
-            // <dynamic row> is computed dynamically with the cell expression:
-            //      str(%3$d+hiddenref(%4$s))
-            // which is the configuration table row offset plus the property
-            // enumeration variant index. The configuration table row offset is
-            // populated with from.row() + 2 (the + 2 constant is because row()
-            // is 0-based and to start at the first parameter row).
+            // The + 1 constants are needed because the expression function
+            // address() is 1-based, while row() and col() are 0-based.
             Gui::cmdAppObjectArgs(
                 sheet,
-                "setExpression('.cells.Bind.%1$s.%2$s', "
-                "'tuple(.cells; <<%5$s>> + str(%3$d+hiddenref(%4$s)); <<%6$s>> + "
-                "str(%3$d+hiddenref(%4$s)))')",
+                "setExpression('.cells.Bind.%1$s.%2$s', 'tuple(.cells; "
+                "address(%3$d+hiddenref(%4$s); %5$d; 4); "
+                "address(%3$d+hiddenref(%4$s); %6$d; 4))')",
                 range.from().toString(CellAddress::Cell::ShowRowColumn),
                 range.to().toString(CellAddress::Cell::ShowRowColumn),
                 from.row() + 2,
                 prop->getFullName(),
-                range.from().toString(CellAddress::Cell::ShowColumn),
-                range.to().toString(CellAddress::Cell::ShowColumn)
+                range.from().col() + 1,
+                range.to().col() + 1
             );
         }
 

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -273,11 +273,56 @@ void DlgSheetConf::accept()
         );
 
         if (ui->verticalCheckBox->isChecked()) {
-            // Adjust the range to skip the first cell
+            // Adjust the range to skip the first cell (containing variant string)
             range = Range(from.row() + 1, from.col(), to.row(), to.col());
 
-            // Formulate expression to calculate the column binding using
-            // PropertyEnumeration
+            // Dynamically bind the active configuration column to the
+            // configuration column selected by the property enumeration
+            // variant. For example, if the active configuration column is
+            // B2:B4, we would bind to C2:C4 for variant 0, D2:D4 for variant
+            // 1, and so on. The column varies with the selected property
+            // enumeration variant, but the rows are fixed.
+            //
+            // The bind target cell range is:
+            //      <dynamic column><from row>:<dynamic column><to row>
+            // where <from row> and <to row> are the fixed strings str(%5$d)
+            // and str(%6$d), populated with range.from().row() + 1 and
+            // range.to().row() + 1, respectively (the + 1 constant is because
+            // row() is 0-based).
+            //
+            // <dynamic column> is an alpha string ranging from A to ZZ.
+            // However, we can only use spreadsheet expressions to compute it.
+            // In the approach below, we form the two alpha letters of the
+            // column by converting the dynamic column index into ASCII
+            // characters with Python format strings.
+            // The upper letter is formed with the expression:
+            //      (column < 26) ? "" : "%c" % (65 + floor(column / 26) - 1)
+            // and the lower letter with the expression:
+            //      "%c" % (65 + column % 26)
+            // where column is the 0-based column index into the selected
+            // configuration column.
+            //
+            // In terms of spreadsheet expressions, the column index is:
+            //      %3$d+hiddenref(%4$s)
+            // which is the configuration table column offset plus the property
+            // enumeration variant index. The configuration table column offset
+            // is populated with from.col() + 1 (the + 1 constant is to start
+            // at the first parameter column, while keeping the overall
+            // expression 0-based).
+            //
+            // The final expression (omitting format escapes) for the column is:
+            //      ((%3$d+hiddenref(%4$s)) < 26 ?
+            //          <<>> :
+            //          <<%c>> % (65 +
+            //              sum(0;floor((%3$d+hiddenref(%4$s)) / 26) - 1)))
+            //      + <<%c>> % (65 + (%3$d+hiddenref(%4$s)) % 26)
+            // The sum(0;...) expression is needed to coerce the Base.Quantity
+            // type returned by floor() back into an integer type suitable for
+            // the format string.
+            //
+            // In the future, a new expression function to compute a cell
+            // address from integral row and column indices (e.g.
+            // `celladdress(2,3)` -> D3) could be used to vastly simplify this.
             Gui::cmdAppObjectArgs(
                 sheet,
                 "setExpression('.cells.Bind.%1$s.%2$s', "
@@ -297,11 +342,28 @@ void DlgSheetConf::accept()
             );
         }
         else {
-            // Adjust the range to skip the first cell
+            // Adjust the range to skip the first cell (containing variant string)
             range = Range(from.row(), from.col() + 1, to.row(), to.col());
 
-            // Formulate expression to calculate the row binding using
-            // PropertyEnumeration
+            // Dynamically bind the active configuration row to the
+            // configuration row selected by the property enumeration variant.
+            // For example, if the active configuration row is located at
+            // B2:D2, we would bind to B3:D3 for variant 0, B4:D4 for variant
+            // 1, and so on. The row varies with the selected property
+            // enumeration variant, but the columns are fixed.
+            //
+            // The bind target cell range is:
+            //      <from column><dynamic row>:<to column><dynamic row>
+            // where <from column> and <to column> are the fixed strings
+            // <<%5$s>> and <<%6$s>>, populated with range.from() and
+            // range.to() columns, respectively.
+            //
+            // <dynamic row> is computed dynamically with the cell expression:
+            //      str(%3$d+hiddenref(%4$s))
+            // which is the configuration table row offset plus the property
+            // enumeration variant index. The configuration table row offset is
+            // populated with from.row() + 2 (the + 2 constant is because row()
+            // is 0-based and to start at the first parameter row).
             Gui::cmdAppObjectArgs(
                 sheet,
                 "setExpression('.cells.Bind.%1$s.%2$s', "

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -43,6 +43,7 @@ DlgSheetConf::DlgSheetConf(Sheet* sheet, Range range, QWidget* parent)
     : QDialog(parent)
     , sheet(sheet)
     , ui(new Ui::DlgSheetConf)
+    , originalRange(range)
 {
     ui->setupUi(this);
 
@@ -50,6 +51,19 @@ DlgSheetConf::DlgSheetConf(Sheet* sheet, Range range, QWidget* parent)
     ui->lineEditEnd->setText(QString::fromLatin1(range.to().toString().c_str()));
     ui->radioButtonOrientationHorizontal->setChecked(range.from().col() != range.to().col());
     ui->radioButtonOrientationVertical->setChecked(range.from().col() == range.to().col());
+
+    connect(
+        ui->radioButtonOrientationHorizontal,
+        &QRadioButton::clicked,
+        this,
+        &DlgSheetConf::onOrientationChanged
+    );
+    connect(
+        ui->radioButtonOrientationVertical,
+        &QRadioButton::clicked,
+        this,
+        &DlgSheetConf::onOrientationChanged
+    );
 
     ui->lineEditProp->setDocumentObject(sheet, false);
 
@@ -83,8 +97,8 @@ App::Property* DlgSheetConf::prepare(
     bool init
 )
 {
-    from = sheet->getCellAddress(ui->lineEditStart->text().trimmed().toLatin1().constData());
-    to = sheet->getCellAddress(ui->lineEditEnd->text().trimmed().toLatin1().constData());
+    from = originalRange.from();
+    to = originalRange.to();
 
     // rangeConf is supposed to hold the range of string cells, each holding
     // the name of a configuration. The '-' / '|' below indicates a growing but
@@ -351,6 +365,16 @@ void DlgSheetConf::accept()
             sheet->getDocument()->abortTransaction();
         }
     }
+}
+
+void DlgSheetConf::onOrientationChanged()
+{
+    CellAddress from, to;
+    std::string rangeConf;
+    ObjectIdentifier path;
+    prepare(from, to, rangeConf, path, true);
+    ui->lineEditStart->setText(QString::fromLatin1(from.toString().c_str()));
+    ui->lineEditEnd->setText(QString::fromLatin1(to.toString().c_str()));
 }
 
 void DlgSheetConf::onDiscard()

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.cpp
@@ -102,7 +102,8 @@ App::Property* DlgSheetConf::prepare(
         CellAddress confFrom(from.row(), from.col() + 1);
         rangeConf = confFrom.toString();
         rangeConf += ":-";
-    } else {
+    }
+    else {
         if (from.col() >= to.col()) {
             FC_THROWM(Base::RuntimeError, "Invalid cell range");
         }
@@ -281,8 +282,12 @@ void DlgSheetConf::accept()
                 sheet,
                 "setExpression('.cells.Bind.%1$s.%2$s', "
                 "'tuple(.cells; "
-                "((%3$d+hiddenref(%4$s)) < 26 ? <<>> : <<%%c>> %% (65+sum(0;floor((%3$d+hiddenref(%4$s))/26)-1))) + <<%%c>> %% (65+(%3$d+hiddenref(%4$s))%%26) + str(%5$d); "
-                "((%3$d+hiddenref(%4$s)) < 26 ? <<>> : <<%%c>> %% (65+sum(0;floor((%3$d+hiddenref(%4$s))/26)-1))) + <<%%c>> %% (65+(%3$d+hiddenref(%4$s))%%26) + str(%6$d))')",
+                "((%3$d+hiddenref(%4$s)) < 26 ? <<>> : <<%%c>> %% "
+                "(65+sum(0;floor((%3$d+hiddenref(%4$s))/26)-1))) + <<%%c>> %% "
+                "(65+(%3$d+hiddenref(%4$s))%%26) + str(%5$d); "
+                "((%3$d+hiddenref(%4$s)) < 26 ? <<>> : <<%%c>> %% "
+                "(65+sum(0;floor((%3$d+hiddenref(%4$s))/26)-1))) + <<%%c>> %% "
+                "(65+(%3$d+hiddenref(%4$s))%%26) + str(%6$d))')",
                 range.from().toString(CellAddress::Cell::ShowRowColumn),
                 range.to().toString(CellAddress::Cell::ShowRowColumn),
                 from.col() + 1,
@@ -290,7 +295,8 @@ void DlgSheetConf::accept()
                 range.from().row() + 1,
                 range.to().row() + 1
             );
-        } else {
+        }
+        else {
             // Adjust the range to skip the first cell
             range = Range(from.row(), from.col() + 1, to.row(), to.col());
 
@@ -299,7 +305,8 @@ void DlgSheetConf::accept()
             Gui::cmdAppObjectArgs(
                 sheet,
                 "setExpression('.cells.Bind.%1$s.%2$s', "
-                "'tuple(.cells; <<%5$s>> + str(%3$d+hiddenref(%4$s)); <<%6$s>> + str(%3$d+hiddenref(%4$s)))')",
+                "'tuple(.cells; <<%5$s>> + str(%3$d+hiddenref(%4$s)); <<%6$s>> + "
+                "str(%3$d+hiddenref(%4$s)))')",
                 range.from().toString(CellAddress::Cell::ShowRowColumn),
                 range.to().toString(CellAddress::Cell::ShowRowColumn),
                 from.row() + 2,

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.h
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.h
@@ -54,11 +54,13 @@ public:
     );
 
 public Q_SLOTS:
+    void onOrientationChanged();
     void onDiscard();
 
 private:
     Spreadsheet::Sheet* sheet;
     Ui::DlgSheetConf* ui;
+    App::Range originalRange;
 };
 
 }  // namespace SpreadsheetGui

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.ui
@@ -81,6 +81,13 @@ switch the design configuration. The property will be created if not exist.</str
     </widget>
    </item>
    <item row="3" column="1" colspan="2">
+    <widget class="QCheckBox" name="verticalCheckBox">
+     <property name="text">
+      <string>Vertical configuration table</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QPushButton" name="btnDiscard">

--- a/src/Mod/Spreadsheet/Gui/DlgSheetConf.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgSheetConf.ui
@@ -80,10 +80,30 @@ switch the design configuration. The property will be created if not exist.</str
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QCheckBox" name="verticalCheckBox">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>Vertical configuration table</string>
+      <string>Orientation</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QRadioButton" name="radioButtonOrientationHorizontal">
+     <property name="text">
+      <string>Horizontal</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="QRadioButton" name="radioButtonOrientationVertical">
+     <property name="text">
+      <string>Vertical</string>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
      </property>
     </widget>
    </item>

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -245,11 +245,10 @@ void SheetTableView::onBind()
 void SheetTableView::onConfSetup()
 {
     auto ranges = selectedRanges();
-    if (ranges.empty()) {
-        return;
+    if (ranges.size() == 1 && ranges.back().size() > 1) {
+        DlgSheetConf dlg {sheet, ranges.back()};
+        dlg.exec();
     }
-    DlgSheetConf dlg {sheet, ranges.back()};
-    dlg.exec();
 }
 
 void SheetTableView::cellProperties()
@@ -1052,6 +1051,7 @@ void SheetTableView::contextMenuEvent(QContextMenuEvent*)
 
     auto ranges = selectedRanges();
     actionBind->setEnabled(!ranges.empty() && ranges.size() <= 2);
+    actionConf->setEnabled(ranges.size() == 1 && ranges.back().size() > 1);
 
     contextMenu.exec(QCursor::pos());
 }

--- a/src/Mod/Spreadsheet/TestSpreadsheet.py
+++ b/src/Mod/Spreadsheet/TestSpreadsheet.py
@@ -311,6 +311,46 @@ class SpreadsheetAggregates(unittest.TestCase):
         self.assertEqual(self.sheet.C6, 0)
         self.assertEqual(self.sheet.C7, 1)
 
+    def test_address(self):
+        # Valid cases
+        self.sheet.set("A1", "=address(1;2)")
+        self.sheet.set("A2", "=address(1;2;1)")
+        self.sheet.set("A3", "=address(1;2;2)")
+        self.sheet.set("A4", "=address(1;2;3)")
+        self.sheet.set("A5", "=address(1;2;4)")
+        self.sheet.set("A6", "=address(1;1)")
+        self.sheet.set("A7", "=address(16384;702)")
+
+        # Invalid reference type
+        self.sheet.set("A8", "=address(1;2;0)")
+        self.sheet.set("A9", "=address(1;2;5)")
+
+        # Out of bounds
+        self.sheet.set("A10", "=address(0;0)")
+        self.sheet.set("A11", "=address(0;1)")
+        self.sheet.set("A12", "=address(1;0)")
+        self.sheet.set("A13", "=address(16384+1;1)")
+        self.sheet.set("A14", "=address(1;702+1)")
+
+        self.doc.recompute()
+
+        self.assertEqual(self.sheet.A1, "$B$1")
+        self.assertEqual(self.sheet.A2, "$B$1")
+        self.assertEqual(self.sheet.A3, "B$1")
+        self.assertEqual(self.sheet.A4, "$B1")
+        self.assertEqual(self.sheet.A5, "B1")
+        self.assertEqual(self.sheet.A6, "$A$1")
+        self.assertEqual(self.sheet.A7, "$ZZ$16384")
+
+        self.assertTrue(self.sheet.A8.startswith("ERR: Invalid reference type:"))
+        self.assertTrue(self.sheet.A9.startswith("ERR: Invalid reference type:"))
+
+        self.assertTrue(self.sheet.A10.startswith("ERR: Cell address out of bounds."))
+        self.assertTrue(self.sheet.A11.startswith("ERR: Cell address out of bounds."))
+        self.assertTrue(self.sheet.A12.startswith("ERR: Cell address out of bounds."))
+        self.assertTrue(self.sheet.A13.startswith("ERR: Cell address out of bounds."))
+        self.assertTrue(self.sheet.A14.startswith("ERR: Cell address out of bounds."))
+
 
 #############################################################################################
 class SpreadsheetFunction(unittest.TestCase):


### PR DESCRIPTION
Horizontal configuration tables can become unwieldy for many parameters, as columns (parameters) are wider than rows (variants) are tall. This commit adds support for vertical configuration tables, which are laid out vertically, with rows for parameters and columns for variants, and function identically to horizontal configuration tables.

Since configuration tables are essentially spreadsheet bindings, vertical configuration tables created in newer versions of FreeCAD can be used by older versions of FreeCAD, but not easily reconfigured. Horizontal and vertical configuration tables can also co-exist in the same spreadsheet.

For more predictable behavior between configuring horizontal or vertical configuration tables, this commit removes the implicit max width table expansion when only a single column is selected in the configuration
table setup.

In the future, the addition of an expression function to form a cell address from integral row and column indices could be used to simplify the cell column calculation in the bind expression for vertical configuration tables.

## Before

<img width="736" height="396" alt="screenshot-before" src="https://github.com/user-attachments/assets/12532966-9264-415d-8872-0fc2faa52869" />

## After

Setup vertical configuration table:

<img width="842" height="401" alt="screenshot1" src="https://github.com/user-attachments/assets/9a26907d-7672-4c1b-9f64-7dd161699013" /><br/>

Vertical configuration table:

<img width="843" height="398" alt="screenshot2" src="https://github.com/user-attachments/assets/84fb4c51-4bac-420b-9bec-18153a99740e" /><br/>

Vertical and horizontal configuration tables co-existing:

<img width="843" height="417" alt="screenshot3" src="https://github.com/user-attachments/assets/9d37de73-625e-47f0-94d3-359a9aea2f03" />