### PR TITLE
Ubuntu CI build: use external PyCXX

### DIFF
--- a/.github/workflows/sub_buildUbuntu.yml
+++ b/.github/workflows/sub_buildUbuntu.yml
@@ -145,7 +145,7 @@ jobs:
       - name: CMake Configure
         uses: ./.github/workflows/actions/linux/configure
         with:
-          extraParameters: -G Ninja --preset ${{ env.config }}
+          extraParameters: -G Ninja --preset ${{ env.config }} -DFREECAD_USE_EXTERNAL_PYCXX=ON
           builddir: ${{ env.builddir }}
           logFile: ${{ env.logdir }}Cmake.log
           errorFile: ${{ env.logdir }}CmakeErrors.log

--- a/package/ubuntu/install-apt-packages.sh
+++ b/package/ubuntu/install-apt-packages.sh
@@ -55,6 +55,7 @@ packages=(
   ninja-build
   occt-draw
   pyside6-tools
+  python3-cxx-dev
   python3-dev
   python3-defusedxml
   python3-git


### PR DESCRIPTION
Follow-up to #29659 @marioalexis84 