### PR TITLE
Measure: fix crash and issues caused by #27135

### DIFF
--- a/src/Mod/Measure/Gui/TaskMeasure.cpp
+++ b/src/Mod/Measure/Gui/TaskMeasure.cpp
@@ -610,12 +610,13 @@ bool TaskMeasure::apply(bool reset)
 bool TaskMeasure::reject()
 {
     removeObject();
-    closeDialog();
 
-    // Abort transaction
+    // Commit after removing the preview measurement so only intended changes (sector flip)
+    // remain in the document transaction.
     if (mTargetDoc) {
-        mTargetDoc->abortCommand();
+        mTargetDoc->commitCommand();
     }
+    closeDialog();
     return false;
 }
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureAngle.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureAngle.cpp
@@ -668,8 +668,9 @@ void ViewProviderMeasureAngle::positionAnno(const Measure::MeasureBase* measureO
 
 void ViewProviderMeasureAngle::onLabelMoved()
 {
-    if (!Gui::Control().activeDialog()
-        || !dynamic_cast<MeasureGui::TaskMeasure*>(Gui::Control().activeDialog())) {
+    auto* activeDialog = Gui::Control().activeDialog();
+    const bool isTaskMeasure = activeDialog && dynamic_cast<MeasureGui::TaskMeasure*>(activeDialog);
+    if (!isTaskMeasure) {
         return;
     }
     SbVec3f trans = pLabelTranslation->translation.getValue();
@@ -702,10 +703,7 @@ void ViewProviderMeasureAngle::onLabelMoved()
 
 void ViewProviderMeasureAngle::onLabelMoveFinish()
 {
-    if (!Gui::Control().activeDialog()
-        || !dynamic_cast<MeasureGui::TaskMeasure*>(Gui::Control().activeDialog())) {
-        return;
-    }
+    ViewProviderMeasureBase::onLabelMoveFinish();
     IsFlipped.setValue(isArcFlipped.getValue());
 }
 

--- a/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
+++ b/src/Mod/Measure/Gui/ViewProviderMeasureBase.cpp
@@ -278,7 +278,7 @@ void ViewProviderMeasureBase::finishRestoring()
 {
     // Restore dragger position from saved property
     Base::Vector3d pos = LabelPosition.getValue();
-    pDragger->translation.setValue(SbVec3f(pos.x, pos.y, pos.z));
+    setLabelTranslation(toSbVec3f(pos));
 
     if (Visibility.getValue() && isSubjectVisible()) {
         show();
@@ -358,8 +358,9 @@ void ViewProviderMeasureBase::onLabelMoveStart()
 void ViewProviderMeasureBase::onLabelMoveFinish()
 {
     SbVec3f currentLabelPos = pLabelTranslation->translation.getValue();
-    pDragger->translation.setValue(SbVec3f(0.0f, 0.0f, 0.0f));
     pDraggerFrame->translation.setValue(currentLabelPos);
+    pDragger->translation.setValue(SbVec3f(0.0f, 0.0f, 0.0f));
+    LabelPosition.setValue(Base::Vector3d(currentLabelPos[0], currentLabelPos[1], currentLabelPos[2]));
 }
 
 void ViewProviderMeasureBase::setLabelValue(const Base::Quantity& value)


### PR DESCRIPTION
fix the crash caused when we move a label while in transaction , then abort the transaction.
and also fix the issues cause in #27135  (messed some thing in rebase)  really sorry.