### PR TITLE
PartDesign: Give ViewProvider deletion higher priority over forceDeletion

### DIFF
--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -1619,7 +1619,7 @@ void StdCmdDelete::activated(int iMsg)
                         manageDocCommand(obj->getDocument());
                         // ask the ViewProvider if it wants to do some clean up
                         // skip if user explicitly confirmed deletion of objects with dependencies
-                        if (forceDeletion || vp->onDelete(sel.getSubNames())) {
+                        if (vp->onDelete(sel.getSubNames()) || forceDeletion) {
                             docs.insert(obj->getDocument());
                             FCMD_OBJ_DOC_CMD(obj, "removeObject('" << obj->getNameInDocument() << "')");
                         }


### PR DESCRIPTION
Fixes #29658 

The issue was caused by the reversed order of the operands in the logical OR operator. I've fixed the order so that the ViewProvider deletion is given a higher priority over forced deletion.

As it turns out, when the left operand is evaluated to true in a logical OR operation in C++, the right operand isn't checked for truth at all.

Following this behavior, when confirmed force deletion of objects with dependencies took place, the old code always skipped vp->onDelete() entirely always. Thereby never letting the ViewProvider to perform its cleanup tasks. This ultimately causes the model to break after deleting a chain linked feature.