### PR TITLE
CAM: PocketShape - Open wire

### DIFF
--- a/src/Mod/CAM/Path/Op/PocketShape.py
+++ b/src/Mod/CAM/Path/Op/PocketShape.py
@@ -36,6 +36,7 @@ math = LazyLoader("math", globals(), "math")
 PathUtils = LazyLoader("PathScripts.PathUtils", globals(), "PathScripts.PathUtils")
 FeatureExtensions = LazyLoader("Path.Op.FeatureExtension", globals(), "Path.Op.FeatureExtension")
 
+translate = FreeCAD.Qt.translate
 
 __title__ = "CAM Pocket Shape Operation"
 __author__ = "sliptonic (Brad Collette)"
@@ -60,101 +61,14 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             | PathOp.FeatureBaseEdges
         )
 
-    def removeHoles(self, solid, face):
-        """removeHoles(solid, face) ... Remove hole wires from a face, keeping outer wire and boss wires.
-
-        Uses a cross-section algorithm: sections the solid slightly above the face level.
-        Wires that appear in the section are bosses (material above).
-        Wires that don't appear are holes (voids).
-
-        Args:
-            solid: The parent solid object
-            face: The face to process
-
-        Returns:
-            New face with outer wire and boss wires only
-        """
+    def removeHoles(self, solids, face):
+        """Create face from outer wire and remove collisions with solids"""
         outer_wire = face.OuterWire
-        candidate_wires = [w for w in face.Wires if not w.isSame(outer_wire)]
-
-        # Adaptive tolerance based on face size
-        adaptive_tolerance = max(1e-6, min(1e-2, face.BoundBox.DiagonalLength * 1e-5))
-        Path.Log.debug(
-            f"removeHoles: Using adaptive tolerance {adaptive_tolerance} (face diagonal: {face.BoundBox.DiagonalLength})"
-        )
-
-        for i, w in enumerate(candidate_wires):
-            Path.Log.debug(f"  Candidate {i}: Length={w.Length}")
-
-        if not candidate_wires:
-            return face
-
-        boss_wires = []
-
-        try:
-            # Create cutting plane from outer wire, offset above face by adaptive_tolerance
-            cutting_plane = Part.Face(outer_wire)
-            cutting_plane.translate(FreeCAD.Vector(0, 0, adaptive_tolerance))
-
-            # Section the solid
-            section = solid.Shape.section(cutting_plane)
-
-            if hasattr(section, "Edges") and section.Edges:
-                # Translate section edges back to face level
-                translated_edges = []
-                for edge in section.Edges:
-                    translated_edge = edge.copy()
-                    translated_edge.translate(FreeCAD.Vector(0, 0, -adaptive_tolerance))
-                    translated_edges.append(translated_edge)
-
-                # Build closed wires from edges
-                edge_groups = Part.sortEdges(translated_edges)
-                all_section_wires = []
-
-                for edge_list in edge_groups:
-                    try:
-                        wire = Part.Wire(edge_list)
-                        if wire.isClosed():
-                            all_section_wires.append(wire)
-                    except Exception:
-                        # ignore any wires that can't be built
-                        pass
-
-                Path.Log.debug(f"removeHoles: Section found {len(all_section_wires)} wires")
-                for i, w in enumerate(all_section_wires):
-                    Path.Log.debug(f"  Section wire {i}: Length={w.Length}")
-
-                # Filter out outer wire, keep remaining as boss wires
-                for wire in all_section_wires:
-                    if not wire.isSame(outer_wire):
-                        length_diff = abs(wire.Length - outer_wire.Length)
-                        if length_diff > adaptive_tolerance:
-                            boss_wires.append(wire)
-                            Path.Log.debug(
-                                f"  Preserving boss wire: Length={wire.Length}, diff={length_diff}"
-                            )
-                        else:
-                            Path.Log.debug(
-                                f"  Discarding wire (too similar to outer): Length={wire.Length}, diff={length_diff}"
-                            )
-
-        except Exception as e:
-            Path.Log.error("removeHoles: Section algorithm failed: {}".format(e))
-            boss_wires = candidate_wires
-            Path.Log.debug("removeHoles: Section failed, preserving all candidate wires as bosses")
-
-        Path.Log.debug(f"removeHoles: Preserving {len(boss_wires)} boss wires")
-        for i, w in enumerate(boss_wires):
-            Path.Log.debug(f"  Preserved boss {i}: Length={w.Length}")
-
-        removed_wires = [w for w in candidate_wires if not any(w.isSame(bw) for bw in boss_wires)]
-        Path.Log.debug(f"removeHoles: Removing {len(removed_wires)} hole wires")
-        for i, w in enumerate(removed_wires):
-            Path.Log.debug(f"  Removed hole {i}: Length={w.Length}")
-
-        # Construct new face with outer wire and boss wires
-        wire_compound = Part.makeCompound([outer_wire] + boss_wires)
-        new_face = Part.makeFace(wire_compound, "Part::FaceMakerBullseye")
+        outer_face = Part.Face(outer_wire)
+        translate_dist = face.BoundBox.ZLength + self.tol
+        outer_face.translate(FreeCAD.Vector(0, 0, translate_dist))
+        new_face = outer_face.cut(solids)
+        new_face.translate(FreeCAD.Vector(0, 0, -translate_dist))
 
         return new_face
 
@@ -169,6 +83,16 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             )
 
         FeatureExtensions.initialize_properties(obj)
+        if not hasattr(obj, "CloseOpenPaths"):
+            obj.addProperty(
+                "App::PropertyBool",
+                "CloseOpenPaths",
+                "Pocket",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Close open area formed by edges or vertical faces by straight line.",
+                ),
+            )
 
     def areaOpOnDocumentRestored(self, obj):
         """opOnDocumentRestored(obj) ... adds the UseOutline property if it doesn't exist."""
@@ -189,11 +113,11 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
     def areaOpShapes(self, obj):
         """areaOpShapes(obj) ... return shapes representing the solids to be removed."""
         Path.Log.track()
-        self.removalshapes = []
-
         # self.isDebug = True if Path.Log.getLevel(Path.Log.thisModule()) == 4 else False
         self.removalshapes = []
         avoidFeatures = list()
+        self.tol = self.job.GeometryTolerance.Value or 0.01
+        solids = [base.Shape for base in self.model if base.Shape.Faces]
 
         # Get extensions and identify faces to avoid
         extensions = FeatureExtensions.getExtensions(obj)
@@ -219,48 +143,32 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                         continue
                     Path.Log.error("Pocket does not support shape {}.{}".format(base.Label, sub))
 
+            if self.vert:
+                self.processVerticalFaces(obj, self.vert)
+
             # Create horizonatal faces from closed wires
             for sortEdges in Part.sortEdges(self.edges):
                 wire = Part.Wire(sortEdges)
-                if wire.isClosed():
-                    face = Part.Face(wire)
-                    self.horiz.append((face, base))
+                if not wire.isClosed():
+                    if obj.CloseOpenPaths:  # add straight line to close wire
+                        vertexes = wire.OrderedVertexes[0].Point, wire.OrderedVertexes[-1].Point
+                        e = Part.makeLine(*vertexes)
+                        wire = Part.Wire(sortEdges + [e])
+                    else:
+                        Path.Log.error(
+                            translate(
+                                "Pocket_Shape",
+                                "Pocke_Shape can not process open wire.\nYou can enable feature Close Open Path",
+                            )
+                        )
+                        continue
+                self.horiz.append(Part.Face(wire))
 
             # Convert horizontal faces to use outline only if requested
             Path.Log.debug("UseOutline: {}".format(obj.UseOutline))
             Path.Log.debug("self.horiz: {}".format(self.horiz))
             if obj.UseOutline and self.horiz:
-                horiz = [self.removeHoles(base, face) for (face, base) in self.horiz]
-                self.horiz = horiz
-            else:
-                # Extract just the faces from the tuples for further processing
-                self.horiz = [face for (face, base) in self.horiz]
-
-            # Check if selected vertical faces form a loop
-            if len(self.vert) > 0:
-                self.vertical = Path.Geom.combineConnectedShapes(self.vert)
-                self.vWires = []
-                for shape in self.vertical:
-                    try:
-                        self.vWires.append(
-                            TechDraw.findShapeOutline(shape, 1, FreeCAD.Vector(0, 0, 1))
-                        )
-                    except ValueError as e:
-                        # findShapeOutline raises when the shape's edges cannot be
-                        # projected onto Z (e.g. a face whose plane contains the Z
-                        # axis). Skip — caller will produce an empty toolpath.
-                        Path.Log.warning(
-                            "Pocket {}: cannot project vertical face onto Z, "
-                            "skipping ({})".format(obj.Label, e)
-                        )
-                for wire in self.vWires:
-                    w = Path.Geom.removeDuplicateEdges(wire)
-                    face = Part.Face(w)
-                    # face.tessellate(0.1)
-                    if Path.Geom.isRoughly(face.Area, 0):
-                        Path.Log.error("Vertical faces do not form a loop - ignoring")
-                    else:
-                        self.horiz.append(face)
+                self.horiz = [self.removeHoles(solids, face) for face in self.horiz]
 
             # Add faces for extensions
             # Note: Extension faces don't have a parent base object, so we append them directly
@@ -342,7 +250,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             if Path.Geom.isVertical(face.Surface.Axis):
                 Path.Log.debug("  -isVertical()")
                 # it's a flat horizontal face
-                self.horiz.append((face, bs))
+                self.horiz.append(face)
                 return True
 
             elif Path.Geom.isHorizontal(face.Surface.Axis):
@@ -356,7 +264,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             Path.Log.debug("face Part.BSplineSurface")
             if Path.Geom.isRoughly(face.BoundBox.ZLength, 0):
                 Path.Log.debug("  flat horizontal or almost flat horizontal")
-                self.horiz.append((face, bs))
+                self.horiz.append(face)
                 return True
 
         elif isinstance(face.Surface, Part.Cylinder) and Path.Geom.isVertical(face.Surface.Axis):
@@ -368,7 +276,7 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
                 circle = Part.makeCircle(face.Surface.Radius, face.Surface.Center)
                 disk = Part.Face(Part.Wire(circle))
                 disk.translate(FreeCAD.Vector(0, 0, face.BoundBox.ZMin - disk.BoundBox.ZMin))
-                self.horiz.append((disk, bs))
+                self.horiz.append(disk)
                 return True
 
             else:
@@ -392,6 +300,66 @@ class ObjectPocket(PathPocketBase.ObjectPocket):
             Path.Log.debug("  -type(face.Surface): {}".format(type(face.Surface)))
             return False
 
+    def processVerticalFaces(self, obj, faces):
+        """processVerticalFaces(self, faces) ... create horizonatal face from wall"""
+        z = obj.FinalDepth.Value
+        depthparams = PathUtils.depth_params(0, z, z, 0, 0, z)
+        for vertCon in Path.Geom.combineConnectedShapes(faces):
+            try:
+                if shapeEnv := PathUtils.getEnvelope(vertCon, depthparams=depthparams):
+                    self.horiz.append(shapeEnv)
+            except Exception:
+                # getEnvelope failed, probably this is open wall
+
+                # try to add edge which will close area
+                if obj.CloseOpenPaths:
+                    # Find faces which placed on ends of the wall
+                    endFaces = []
+                    candidates = vertCon.Faces[:]
+                    for face in candidates:
+                        c = 0
+                        for candidate in candidates:
+                            if face == candidate:
+                                continue
+                            if face.BoundBox.intersect(candidate.BoundBox) and Path.Geom.isRoughly(
+                                face.distToShape(candidate)[0], 0
+                            ):
+                                c += 1
+                            if c > 1:  # face should touch only one another face
+                                break
+                        else:
+                            endFaces.append(face)
+
+                    # Add helper edge and try getEnvelope again
+                    if len(endFaces) == 2:  # should be only two end faces
+                        points = []  # farest points which should be connected
+                        for face in endFaces:
+                            candidates.remove(face)
+                            comp = Part.Compound(candidates)
+                            tPoint = face.distToShape(comp)[1][0][0]  # face touched compound here
+                            ps = [(v.Point.distanceToPoint(tPoint), v.Point) for v in face.Vertexes]
+                            p = sorted(ps, key=lambda tup: tup[0])[-1][1]  # farest point
+                            points.append(p)
+
+                        edge = Part.makeLine(*points)
+                        newComp = Part.Compound([vertCon, edge])
+                        try:
+                            if shapeEnv := PathUtils.getEnvelope(newComp, depthparams=depthparams):
+                                self.horiz.append(shapeEnv)
+                                continue
+                        except Exception:
+                            Path.Log.error(
+                                translate("Pocket_Shape", "Processing vertical faces was failed")
+                            )
+                            continue
+
+                Path.Log.error(
+                    translate(
+                        "Pocket_Shape",
+                        "Processing vertical faces was failed.\nYou can enable feature Close Open Path",
+                    )
+                )
+
 
 # Eclass
 
@@ -402,6 +370,7 @@ def SetupProperties():
 
     # Add properties initialized here in PocketShape
     setup.append("UseOutline")
+    setup.append("CloseOpenPaths")
     return setup
 
 

--- a/src/Mod/CAM/PathScripts/PathUtils.py
+++ b/src/Mod/CAM/PathScripts/PathUtils.py
@@ -337,11 +337,11 @@ def makeWorkplane(shape):
 def getEnvelope(partshape, subshape=None, depthparams=None):
     """
     getEnvelope(partshape, stockheight=None)
-    returns a shape corresponding to the partshape silhouette extruded to height.
-    if stockheight is given, the returned shape is extruded to that height otherwise the returned shape
+    Returns a shape corresponding to the partshape silhouette extruded to height.
+    If depthparams is given, the returned shape is extruded to that height otherwise the returned shape
     is the height of the original shape boundbox
     partshape = solid object
-    stockheight = float - Absolute Z height of the top of material before cutting.
+    To get flat face at height z use getEnvelope(shape, depthparams=depth_params(0, z, z, 0, 0, z)
     """
     Path.Log.track(partshape, subshape, depthparams)
 


### PR DESCRIPTION
### Changes:
- Simplified method `removeHoles()`

- Allowed to use `UseOutline` not only with horizontal faces, but also with edges and vertical faces

- Added property `CloseOpenPaths`, which allows to process open wire and open wall (vertical faces)
   Connects end points of the open shape by straight line to get closed area

Test 1 - **Ignore holes**: [bosstest.zip](https://github.com/user-attachments/files/30192580/bosstest.zip) from [CAM: Avoid bosses when pocketing #24723](https://github.com/FreeCAD/FreeCAD/pull/24723) (refactor)

Test 2 - **Open area**: [test_open_pocket.zip](https://github.com/user-attachments/files/29934399/test_open_pocket.zip)

<img width="1253" height="269" alt="610311834-cf08b1bc-87a2-4851-9aca-1aceddf6f1f0_hor" src="https://github.com/user-attachments/assets/bba184ee-2265-488e-a9f7-f5a49f4b141b" />

<img width="1605" height="362" alt="Screenshot_20260731_225455_hor" src="https://github.com/user-attachments/assets/383421a2-b8f4-4564-abc4-b560332bfc78" />