### PR TITLE
Gui: fix accidental range selection when clicking tree expand indicator

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -2037,7 +2037,33 @@ void TreeWidget::mousePressEvent(QMouseEvent* event)
         }
     }
 
+    expandIndicatorPressed = false;
+    if (event->button() == Qt::LeftButton) {
+        QTreeWidgetItem* pressedItem = itemAt(event->pos());
+        if (pressedItem && pressedItem->childCount() > 0) {
+            auto itemRect = visualItemRect(pressedItem);
+            int x = event->pos().x();
+            if (x >= itemRect.left() - indentation() && x < itemRect.left()) {
+                expandIndicatorPressed = true;
+            }
+        }
+    }
+
     QTreeWidget::mousePressEvent(event);
+}
+
+void TreeWidget::mouseMoveEvent(QMouseEvent* event)
+{
+    if (expandIndicatorPressed) {
+        return;
+    }
+    QTreeWidget::mouseMoveEvent(event);
+}
+
+void TreeWidget::mouseReleaseEvent(QMouseEvent* event)
+{
+    expandIndicatorPressed = false;
+    QTreeWidget::mouseReleaseEvent(event);
 }
 
 void TreeWidget::mouseDoubleClickEvent(QMouseEvent* event)

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -190,6 +190,8 @@ protected:
     bool event(QEvent* e) override;
     void keyPressEvent(QKeyEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
 
     void showEvent(QShowEvent* ev) override;
@@ -295,6 +297,8 @@ private:
 
     // this timer is used to prevent double click event on visibility icon
     QTimer visibilityIconDoubleClickTimer;
+
+    bool expandIndicatorPressed = false;
 
     static std::unique_ptr<QPixmap> documentPixmap;
     static std::unique_ptr<QPixmap> documentPartialPixmap;


### PR DESCRIPTION
Clicking the expand/collapse indicator in the tree view while slightly dragging the mouse would trigger a range selection between the previously selected item and the clicked item, as if Shift+click was used. This happened because Qt's extended selection mode interprets any mouse move after a press as a drag-select gesture.

The fix overrides `mouseMoveEvent` and `mouseReleaseEvent` in `TreeWidget` to suppress selection drag when the initial press landed on the expand/collapse indicator zone. Expand/collapse behavior is unaffected since Qt handles that on mouse release.

Fixes #28412.