### PR TITLE
Gui/Draft/Part: fix decimal entry blocked by trailing zeros in spinboxes

### DIFF
--- a/src/Gui/SpinBox.cpp
+++ b/src/Gui/SpinBox.cpp
@@ -649,6 +649,47 @@ void DoubleSpinBox::resizeEvent(QResizeEvent* event)
     resizeWidget();
 }
 
+QValidator::State DoubleSpinBox::validate(QString& input, int& pos) const
+{
+    QString decPt = locale().decimalPoint();
+    if (input.contains(decPt)) {
+        int decIdx = input.indexOf(decPt);
+        int decimalPlaces = input.length() - decIdx - decPt.length();
+        if (decimalPlaces > decimals()) {
+            int trailingZeros = 0;
+            for (int i = input.length() - 1; i >= 0 && input[i] == QLatin1Char('0'); --i) {
+                ++trailingZeros;
+            }
+            int toStrip = qMin(trailingZeros, decimalPlaces - decimals());
+            if (toStrip > 0) {
+                QString stripped = input.left(input.length() - toStrip);
+                int newPos = qMin(pos, stripped.length());
+                if (QDoubleSpinBox::validate(stripped, newPos) == QValidator::Acceptable) {
+                    input = stripped;
+                    pos = newPos;
+                    return QValidator::Acceptable;
+                }
+            }
+        }
+    }
+    return QDoubleSpinBox::validate(input, pos);
+}
+
+double DoubleSpinBox::valueFromText(const QString& text) const
+{
+    QString copy = text;
+    QString decPt = locale().decimalPoint();
+    if (copy.contains(decPt)) {
+        while (copy.endsWith(QLatin1Char('0'))) {
+            copy.chop(1);
+        }
+        if (copy.endsWith(decPt)) {
+            copy.chop(decPt.size());
+        }
+    }
+    return QDoubleSpinBox::valueFromText(copy);
+}
+
 void DoubleSpinBox::keyPressEvent(QKeyEvent* event)
 {
     if (!handleKeyEvent(event->text())) {

--- a/src/Gui/SpinBox.h
+++ b/src/Gui/SpinBox.h
@@ -215,6 +215,9 @@ public:
     using ExpressionSpinBox::apply;
     void setNumberExpression(App::NumberExpression*) override;
 
+    QValidator::State validate(QString& input, int& pos) const override;
+    double valueFromText(const QString& text) const override;
+
     void keyPressEvent(QKeyEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void paintEvent(QPaintEvent* event) override;

--- a/src/Mod/Draft/drafttaskpanels/task_scale.py
+++ b/src/Mod/Draft/drafttaskpanels/task_scale.py
@@ -43,6 +43,34 @@ from draftutils import utils
 from draftutils.translate import translate
 
 
+class _DecimalSpinBox(QtWidgets.QDoubleSpinBox):
+    """QDoubleSpinBox that allows inserting digits among trailing zeros."""
+
+    def validate(self, text, pos):
+        dec = self.locale().decimalPoint()
+        if dec in text:
+            dec_idx = text.index(dec)
+            decimal_places = len(text) - dec_idx - len(dec)
+            if decimal_places > self.decimals():
+                n_trailing = len(text) - len(text.rstrip("0"))
+                to_strip = min(n_trailing, decimal_places - self.decimals())
+                if to_strip > 0:
+                    stripped = text[:-to_strip]
+                    new_pos = min(pos, len(stripped))
+                    result = super().validate(stripped, new_pos)
+                    if result[0] == QtGui.QValidator.Acceptable:
+                        return QtGui.QValidator.Acceptable, stripped, new_pos
+        return super().validate(text, pos)
+
+    def valueFromText(self, text):
+        dec = self.locale().decimalPoint()
+        if dec in text:
+            text = text.rstrip("0")
+            if text.endswith(dec):
+                text = text[: -len(dec)]
+        return super().valueFromText(text)
+
+
 class ScaleTaskPanel:
     """The task panel for the Draft Scale tool."""
 
@@ -56,7 +84,7 @@ class ScaleTaskPanel:
         self.xLabel = QtWidgets.QLabel()
         self.xLabel.setText(translate("Draft", "X-factor"))
         layout.addWidget(self.xLabel, 0, 0, 1, 1)
-        self.xValue = QtWidgets.QDoubleSpinBox()
+        self.xValue = _DecimalSpinBox()
         self.xValue.setRange(-1000000.0, 1000000.0)
         self.xValue.setDecimals(decimals)
         self.xValue.setValue(1)
@@ -64,7 +92,7 @@ class ScaleTaskPanel:
         self.yLabel = QtWidgets.QLabel()
         self.yLabel.setText(translate("Draft", "Y-factor"))
         layout.addWidget(self.yLabel, 1, 0, 1, 1)
-        self.yValue = QtWidgets.QDoubleSpinBox()
+        self.yValue = _DecimalSpinBox()
         self.yValue.setRange(-1000000.0, 1000000.0)
         self.yValue.setDecimals(decimals)
         self.yValue.setValue(1)
@@ -72,7 +100,7 @@ class ScaleTaskPanel:
         self.zLabel = QtWidgets.QLabel()
         self.zLabel.setText(translate("Draft", "Z-factor"))
         layout.addWidget(self.zLabel, 2, 0, 1, 1)
-        self.zValue = QtWidgets.QDoubleSpinBox()
+        self.zValue = _DecimalSpinBox()
         self.zValue.setRange(-1000000.0, 1000000.0)
         self.zValue.setDecimals(decimals)
         self.zValue.setValue(1)

--- a/src/Mod/Part/Gui/DlgScale.ui
+++ b/src/Mod/Part/Gui/DlgScale.ui
@@ -31,7 +31,7 @@
       </widget>
      </item>
      <item row="4" column="1">
-      <widget class="QDoubleSpinBox" name="dsbYScale">
+      <widget class="Gui::DoubleSpinBox" name="dsbYScale">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -79,7 +79,7 @@
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="dsbXScale">
+      <widget class="Gui::DoubleSpinBox" name="dsbXScale">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -124,7 +124,7 @@
       </widget>
      </item>
      <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="dsbUniformScale">
+      <widget class="Gui::DoubleSpinBox" name="dsbUniformScale">
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
@@ -143,7 +143,7 @@
       </widget>
      </item>
      <item row="5" column="1">
-      <widget class="QDoubleSpinBox" name="dsbZScale">
+      <widget class="Gui::DoubleSpinBox" name="dsbZScale">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -235,6 +235,13 @@
   <tabstop>dsbZScale</tabstop>
   <tabstop>treeWidget</tabstop>
  </tabstops>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::DoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>Gui/SpinBox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Fixes #23937

QDoubleSpinBox rejects input when inserting a digit among trailing zeros causes the decimal count to temporarily exceed the configured limit. For example, with decimals=4, typing "5" after "1." in "1.0000" creates "1.50000" which is rejected.

Fix: override validate() in Gui::DoubleSpinBox to strip trailing zeros before checking precision, so "1.50000" is treated as "1.5" and accepted. The same logic is applied in the Draft Scale Python task panel. The Part Scale dialog is updated to use Gui::DoubleSpinBox.