### PR TITLE
CAM: SimulatorGL - Fix retract for G84

### DIFF
--- a/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.cpp
+++ b/src/Mod/CAM/PathSimulator/AppGL/GCodeParser.cpp
@@ -194,7 +194,7 @@ bool GCodeParser::ParseLine(const char* ptr)
                 else if (cmd == 3) {
                     newState.cmd = eRotateCCW;
                 }
-                else if (cmd == 73 || cmd == 81 || cmd == 82 || cmd == 83) {
+                else if (cmd == 73 || cmd == 81 || cmd == 82 || cmd == 83 || cmd == 84) {
                     newState.cmd = eDril;
                     newState.retract_z = lastState.z;
                 }


### PR DESCRIPTION
https://forum.freecad.org/viewtopic.php?t=105017

---

Left: before; Right: after

<img width="300" height="260" alt="untitled (1)" src="https://github.com/user-attachments/assets/56850d42-5e8a-4bde-84cc-b362ea7ca32d" />  <img width="300" height="260" alt="untitled2 (1)" src="https://github.com/user-attachments/assets/2e8e0449-dc27-4b02-91bc-50d3a388bde1" />

