### PR TITLE
CI: fix rattler-build freecad version.

### DIFF
--- a/package/rattler-build/pixi.lock
+++ b/package/rattler-build/pixi.lock
@@ -4285,7 +4285,7 @@ packages:
   timestamp: 1765632825351
 - conda: .
   name: freecad
-  version: 1.1.0dev
+  version: 1.2.0dev
   build: h3c70cbc_0
   subdir: win-64
   variants:
@@ -4347,7 +4347,7 @@ packages:
   - tbb >=2022.3.0
 - conda: .
   name: freecad
-  version: 1.1.0dev
+  version: 1.2.0dev
   build: h6d4d2f9_0
   subdir: linux-aarch64
   variants:
@@ -4410,7 +4410,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
 - conda: .
   name: freecad
-  version: 1.1.0dev
+  version: 1.2.0dev
   build: h81b34b9_0
   subdir: linux-64
   variants:
@@ -4474,7 +4474,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
 - conda: .
   name: freecad
-  version: 1.1.0dev
+  version: 1.2.0dev
   build: hc347f7b_0
   subdir: osx-64
   variants:
@@ -4535,7 +4535,7 @@ packages:
   - libzlib >=1.3.1,<2.0a0
 - conda: .
   name: freecad
-  version: 1.1.0dev
+  version: 1.2.0dev
   build: he8ea13f_0
   subdir: osx-arm64
   variants:


### PR DESCRIPTION
Fixes the `pixi.lock` to also have the updated FreeCAD version, fixing the weekly builds.

## Issues

* None yet.

## Before and After Images

* N/A
