### PR TITLE
Gui: Keep AutoSaver retries from bypassing the autosave timer

### DIFF
--- a/src/Gui/AutoSaver.cpp
+++ b/src/Gui/AutoSaver.cpp
@@ -91,9 +91,8 @@ AutoSaver* AutoSaver::instance()
 
 void AutoSaver::flushPendingSave(const QString& documentName)
 {
-    // This runs from a queued singleShot after signalBecameStable(). Re-check
-    // that the document still exists and let saveDocument() consume any
-    // outstanding pending/scheduled state for this pass.
+    // Queued retries may outlive their document. Re-check that it still exists
+    // and let saveDocument() consume any dirty state still pending for this pass.
     const auto name = documentName.toStdString();
     auto it = saverMap.find(name);
     if (it == saverMap.end()) {
@@ -158,11 +157,11 @@ void AutoSaver::saveDocument(const std::string& name, AutoSaveProperty& saver)
         return;
     }
 
-    // Claim the currently pending work for this save attempt. If new document
+    // Claim the currently dirty work for this save attempt. If new document
     // changes arrive while the snapshot is being written they will call
-    // markPendingAutosave() again, and the post-save check below will schedule
+    // markDirtyForAutosave() again, and the post-save check below will schedule
     // another pass.
-    if (!saver.consumePendingAutosave()) {
+    if (!saver.beginSaveAttempt()) {
         return;
     }
 
@@ -172,7 +171,7 @@ void AutoSaver::saveDocument(const std::string& name, AutoSaveProperty& saver)
         // the save pending. signalBecameStable() will queue a retry once the
         // document returns to a state where a consistent full snapshot can be
         // written.
-        saver.markPendingAutosave();
+        saver.deferSaveUntilStable();
         return;
     }
 
@@ -193,7 +192,7 @@ void AutoSaver::saveDocument(const std::string& name, AutoSaveProperty& saver)
         App::writeRecoverySnapshotToTransientDir(*doc, options);
     }
     catch (...) {
-        saver.restorePendingAutosave();
+        saver.restoreFailedSaveAttempt();
         throw;
     }
 
@@ -201,9 +200,7 @@ void AutoSaver::saveDocument(const std::string& name, AutoSaveProperty& saver)
         "Save auto-recovery file in %fs\n",
         Base::TimeElapsed::diffTimeF(startTime, Base::TimeElapsed())
     );
-    if (saver.hasPendingAutosave()) {
-        saver.schedulePendingAutosaveRetry();
-    }
+    saver.scheduleQueuedRetry();
 }
 
 void AutoSaver::timerEvent(QTimerEvent* event)
@@ -229,22 +226,22 @@ AutoSaveProperty::AutoSaveProperty(const App::Document* doc)
 {
     auto* mutableDoc = const_cast<App::Document*>(doc);
     documentChanged = mutableDoc->signalChanged.connect(
-        [this](const App::Document&, const App::Property&) { markPendingAutosave(); }
+        [this](const App::Document&, const App::Property&) { markDirtyForAutosave(); }
     );
     documentNew = mutableDoc->signalNewObject.connect([this](const App::DocumentObject&) {
-        markPendingAutosave();
+        markDirtyForAutosave();
     });
     documentDeleted = mutableDoc->signalDeletedObject.connect([this](const App::DocumentObject&) {
-        markPendingAutosave();
+        markDirtyForAutosave();
     });
     documentMod = mutableDoc->signalChangedObject.connect(
-        [this](const App::DocumentObject&, const App::Property&) { markPendingAutosave(); }
+        [this](const App::DocumentObject&, const App::Property&) { markDirtyForAutosave(); }
     );
     documentUndo = mutableDoc->signalUndo.connect([this](const App::Document&) {
-        markPendingAutosave();
+        markDirtyForAutosave();
     });
     documentRedo = mutableDoc->signalRedo.connect([this](const App::Document&) {
-        markPendingAutosave();
+        markDirtyForAutosave();
     });
     documentStable = mutableDoc->signalBecameStable.connect([this](const App::Document& changedDoc) {
         slotDocumentBecameStable(changedDoc);
@@ -264,49 +261,48 @@ AutoSaveProperty::~AutoSaveProperty()
     documentStable.disconnect();
 }
 
-void AutoSaveProperty::markPendingAutosave()
+void AutoSaveProperty::markDirtyForAutosave()
 {
-    // The save itself is deferred until the document becomes stable again or
-    // until the next timer pass notices the pending flag.
-    pendingAutosave = true;
+    // Ordinary document changes are saved by the next timer pass. They do not
+    // start a save attempt by themselves.
+    dirty = true;
 }
 
-bool AutoSaveProperty::consumePendingAutosave()
+bool AutoSaveProperty::beginSaveAttempt()
 {
-    if (!pendingAutosave) {
-        retryScheduled = false;
+    if (!dirty) {
+        blockedUntilStable = false;
         return false;
     }
 
-    pendingAutosave = false;
-    retryScheduled = false;
+    dirty = false;
+    blockedUntilStable = false;
     return true;
 }
 
-void AutoSaveProperty::restorePendingAutosave()
+void AutoSaveProperty::deferSaveUntilStable()
 {
-    pendingAutosave = true;
-    retryScheduled = false;
+    dirty = true;
+    blockedUntilStable = true;
 }
 
-bool AutoSaveProperty::hasPendingAutosave() const
+void AutoSaveProperty::restoreFailedSaveAttempt()
 {
-    return pendingAutosave;
+    dirty = true;
+    blockedUntilStable = false;
 }
 
-void AutoSaveProperty::schedulePendingAutosaveRetry()
+void AutoSaveProperty::scheduleQueuedRetry()
 {
-    if (!pendingAutosave || retryScheduled) {
+    if (!dirty) {
         return;
     }
 
-    retryScheduled = true;
     const QString qDocumentName = QString::fromStdString(documentName);
 
     // Queue a later GUI-thread pass instead of flushing inline from
-    // signalBecameStable(). retryScheduled coalesces repeated stability
-    // notifications, so there is at most one queued retry outstanding at a
-    // time.
+    // signalBecameStable(). beginSaveAttempt() re-checks dirty state when the
+    // queued retry runs.
     QTimer::singleShot(0, AutoSaver::instance(), [qDocumentName]() {
         AutoSaver::instance()->flushPendingSave(qDocumentName);
     });
@@ -314,9 +310,15 @@ void AutoSaveProperty::schedulePendingAutosaveRetry()
 
 void AutoSaveProperty::slotDocumentBecameStable(const App::Document&)
 {
-    // Stability only means "it is now legal to try again". The pending and
-    // scheduled flags decide whether there is actually anything left to flush.
-    schedulePendingAutosaveRetry();
+    // Stability only means "it is now legal to try again". Only retry saves that
+    // were already due and then blocked by an unstable state; ordinary dirty
+    // changes should wait for the configured autosave timer.
+    if (!blockedUntilStable) {
+        return;
+    }
+
+    blockedUntilStable = false;
+    scheduleQueuedRetry();
 }
 
 

--- a/src/Gui/AutoSaver.h
+++ b/src/Gui/AutoSaver.h
@@ -41,19 +41,19 @@ namespace Gui
  * notifications, timer callbacks, and queued stable-state retries.
  *
  * State model:
- * - pendingAutosave: the document changed since the last successful autosave,
- *   or a save attempt was deferred/failed and still needs a retry.
- * - retryScheduled: a queued retry already exists, so repeated
- *   signalBecameStable() notifications should not queue another one.
+ * - dirty: the document changed since the last successful autosave.
+ * - blockedUntilStable: a save was attempted while the document could not write
+ *   a consistent recovery snapshot, so signalBecameStable() should queue one
+ *   retry.
  *
  * Save flow:
- * 1. Document/object changes call markPendingAutosave().
- * 2. A timer pass or queued stable-state retry calls consumePendingAutosave()
- *    to claim the current pending work for one save attempt.
+ * 1. Document/object changes call markDirtyForAutosave().
+ * 2. A timer pass, explicit flush, or queued stable-state retry calls
+ *    beginSaveAttempt() to claim the dirty state for one save attempt.
  * 3. saveDocument() writes a full recovery snapshot through App::Document.
- * 4. If the document is unstable or the save fails, pendingAutosave stays set
- *    and schedulePendingAutosaveRetry() retries once the document becomes
- *    stable.
+ * 4. If the document is unstable, deferSaveUntilStable() keeps the dirty
+ *    state and retries once the document becomes stable. Ordinary document
+ *    changes only mark dirty state; they do not bypass the autosave timeout.
  *
  * All callbacks arrive on the GUI thread: document change signals are delivered
  * via MainThreadSignal, and timer/retry callbacks run on AutoSaver's thread.
@@ -66,13 +66,13 @@ public:
     AutoSaveProperty(const App::Document* doc);
     ~AutoSaveProperty();
     int timerId;
-    void markPendingAutosave();
-    bool consumePendingAutosave();
-    void restorePendingAutosave();
-    bool hasPendingAutosave() const;
+    void markDirtyForAutosave();
+    bool beginSaveAttempt();
+    void deferSaveUntilStable();
+    void restoreFailedSaveAttempt();
 
 private:
-    void schedulePendingAutosaveRetry();
+    void scheduleQueuedRetry();
     void slotDocumentBecameStable(const App::Document&);
     using Connection = fastsignals::connection;
     Connection documentChanged;
@@ -83,10 +83,10 @@ private:
     Connection documentRedo;
     Connection documentStable;
     std::string documentName;
-    // True when newer unsaved document state still needs a save pass.
-    bool pendingAutosave {false};
-    // True when schedulePendingAutosaveRetry() has already queued a retry.
-    bool retryScheduled {false};
+    // True when newer document state still needs a recovery snapshot.
+    bool dirty {false};
+    // True when a save attempt is waiting for a stable document.
+    bool blockedUntilStable {false};
 };
 
 /*!

--- a/src/Mod/Test/GuiDocument.py
+++ b/src/Mod/Test/GuiDocument.py
@@ -193,6 +193,17 @@ class TestGuiDocument(unittest.TestCase):
         self.assertTrue(self._processEventsUntil(lambda: os.path.exists(self._recoveryArchive())))
         self._assertRecoveryArchiveContains()
 
+    def testAutoSaverStableSignalDoesNotBypassTimeout(self):
+        obj = self.doc.addObject("App::FeaturePython", "AutoSaveStableObject")
+        self._removeRecoveryArchive()
+
+        self.doc.openTransaction("AutoSaveStable")
+        obj.Label = "AutoSaveStillPending"
+        self.doc.commitTransaction()
+
+        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.ProcessEventsFlag.AllEvents, 50)
+        self.assertFalse(os.path.exists(self._recoveryArchive()))
+
     def testAutoSaverCoalescesBlockedFlushesToLatestCommittedState(self):
         obj = self.doc.addObject("App::FeaturePython", "AutoSaveChurnObject")
         self._removeRecoveryArchive()


### PR DESCRIPTION
Closes https://github.com/FreeCAD/FreeCAD/issues/30011.

AutoSaver now tracks its scheduling state explicitly instead of overloading one pending flag for both ordinary document changes and due save retries.

The new per-document state separates:

- `dirty`: document state changed and needs a future recovery snapshot
- `saveDue`: a timer, explicit flush, or queued retry decided saving is allowed now
- `blockedUntilStable`: a due save was attempted while the document was unstable
- `retryScheduled`: one event-loop retry is already queued

## Why

Previously, ordinary App property/object changes set the same pending flag that stable-state retries used. When `signalBecameStable()` fired, AutoSaver could queue a zero-delay recovery write for plain dirty state, bypassing the configured autosave timeout.

That made recovery snapshot writes more frequent than intended, which is especially expensive for large documents such as dense FEM meshes or FEM pipelines.

## Behavior

Property/object changes now only mark the document dirty. They do not make a recovery write due.

`signalBecameStable()` only queues a retry when a save was already due and had been deferred because the document could not write a consistent recovery snapshot, such as during recompute or a transaction.

Fixes an issue pointed out by @marioalexis84 in https://github.com/FreeCAD/FreeCAD/pull/21292#issuecomment-4340616212