### PR TITLE
BIM: fix Arch_CutPlane deselection issue

### DIFF
--- a/src/Mod/BIM/bimcommands/BimCutPlane.py
+++ b/src/Mod/BIM/bimcommands/BimCutPlane.py
@@ -86,6 +86,7 @@ class CutPlaneTaskPanel:
         _, self.base, self.cutter = ArchCutPlane._getShapes(
             FreeCADGui.Selection.getSelectionEx("", 0)
         )
+        FreeCADGui.doCommand("sels = FreeCADGui.Selection.getSelectionEx('', 0)")
 
         self.previewObj = FreeCAD.ActiveDocument.addObject("Part::Feature", "PreviewCutVolume")
         self.previewObj.ViewObject.ShapeColor = (1.00, 0.00, 0.00)
@@ -116,7 +117,6 @@ class CutPlaneTaskPanel:
         side = self.combobox.currentIndex()
         FreeCAD.ActiveDocument.openTransaction(translate("Arch", "Cutting"))
         FreeCADGui.addModule("ArchCutPlane")
-        FreeCADGui.doCommand("sels = FreeCADGui.Selection.getSelectionEx('', 0)")
         FreeCADGui.doCommand("ArchCutPlane.cutComponentwithPlane(sels, side=" + str(side) + ")")
         FreeCAD.ActiveDocument.commitTransaction()
         FreeCAD.ActiveDocument.recompute()


### PR DESCRIPTION
Fixes #26631.

The adopted solution is perhaps a bit simple:
`FreeCADGui.doCommand("sels = FreeCADGui.Selection.getSelectionEx('', 0)")`
was moved from the `accept` function to the `__init__` function of the `CutPlaneTaskPanel` class.