### PR TITLE
Draft: Fix crossed segment pairing when binding offset wall wires

### DIFF
--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -95,6 +95,85 @@ class TestArchWall(TestArchBase.TestArchBase):
                     "Arch Wall with MultiMaterial and 3 alignments failed",
                 )
 
+    def test_wall_from_issue_29701_left_align(self):
+        """Regression test for a sketch-based left-aligned wall that previously truncated."""
+        operation = "Checking Arch Wall left-align regression from issue 29701..."
+        self.printTestMessage(operation)
+
+        point_data = [
+            (0.0, 0.0),
+            (9842.5, 0.0),
+            (9842.5, -393.7),
+            (9740.9, -393.7),
+            (9740.9, -3657.6),
+            (13004.8, -3657.6),
+            (13004.8, -393.7),
+            (12903.2, -393.7),
+            (12903.2, 0.0),
+            (17278.35, 0.0),
+            (17278.35, 3873.5),
+            (17179.925, 3873.5),
+            (17179.925, 4267.2),
+            (17278.35, 4267.2),
+            (17278.35, 7737.475),
+            (10369.55, 7737.475),
+            (10369.55, 6924.675),
+            (10077.45, 6924.675),
+            (10077.45, 7318.375),
+            (10175.875, 7318.375),
+            (10175.875, 11191.875),
+            (5908.675, 11191.875),
+            (5908.675, 11801.475),
+            (4079.875, 11801.475),
+            (4079.875, 10556.875),
+            (3787.775, 10556.875),
+            (3787.775, 10950.575),
+            (3886.2, 10950.575),
+            (3886.2, 14030.637),
+            (3095.937, 14820.9),
+            (787.4, 14820.9),
+            (0.0, 14033.5),
+            (0.0, 10972.8),
+            (98.425, 10972.8),
+            (98.425, 10579.1),
+            (0.0, 10579.1),
+            (0.0, 8515.35),
+            (98.425, 8515.35),
+            (98.425, 8121.65),
+            (0.0, 8121.65),
+            (0.0, 5683.25),
+            (98.425, 5683.25),
+            (98.425, 5289.55),
+            (0.0, 5289.55),
+        ]
+        points = [App.Vector(x, y, 0) for x, y in point_data]
+        sketch = self.document.addObject("Sketcher::SketchObject", "Issue29701Sketch")
+        sketch.addGeometry(
+            [Part.LineSegment(start, end) for start, end in zip(points, points[1:] + points[:1])]
+        )
+        self.document.recompute()
+
+        wall = Arch.makeWall(sketch, width=193.675, height=2641.6, align="Left")
+        self.document.recompute()
+
+        self.assertTrue(wall.Shape.isValid(), "The wall shape should be valid.")
+        self.assertEqual(len(wall.Shape.Solids), 1, "The wall should produce one solid.")
+        self.assertGreater(
+            wall.Shape.BoundBox.XLength,
+            17000.0,
+            "The left-aligned wall should span the full sketch width.",
+        )
+        self.assertGreater(
+            wall.Shape.BoundBox.YLength,
+            18000.0,
+            "The left-aligned wall should span the full sketch height.",
+        )
+        self.assertGreater(
+            wall.Shape.Volume,
+            3.8e10,
+            "The left-aligned wall volume should not collapse after binding the segments.",
+        )
+
     def test_makeWall(self):
         """Test the makeWall function."""
         operation = "Testing makeWall function"

--- a/src/Mod/Draft/draftgeoutils/faces.py
+++ b/src/Mod/Draft/draftgeoutils/faces.py
@@ -32,10 +32,9 @@
 import lazy_loader.lazy_loader as lz
 
 import DraftVecUtils
-import FreeCAD as App
 from FreeCAD import Base
 from draftgeoutils.geometry import are_coplanar
-from draftutils.messages import _wrn
+from draftutils.messages import _err, _wrn
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
@@ -117,6 +116,52 @@ def is_coplanar(faces, tol=-1):
 isCoplanar = is_coplanar
 
 
+def _make_segment_face(edge1, edge2):
+    """Create a face between two matching edges.
+
+    Corresponding edges in offset wires can be oriented such that connecting
+    their start points and end points with the same pairing fails. In that
+    case, retry with the alternate endpoint pairing and keep the first valid
+    face.
+    """
+
+    pairings = (
+        (
+            edge1.Vertexes[0].Point,
+            edge2.Vertexes[0].Point,
+            edge1.Vertexes[-1].Point,
+            edge2.Vertexes[-1].Point,
+        ),
+        (
+            edge1.Vertexes[0].Point,
+            edge2.Vertexes[-1].Point,
+            edge1.Vertexes[-1].Point,
+            edge2.Vertexes[0].Point,
+        ),
+    )
+    for start1, start2, end1, end2 in pairings:
+        face = None
+        try:
+            connector_start = Part.LineSegment(start1, start2).toShape()
+            connector_end = Part.LineSegment(end1, end2).toShape()
+            face = Part.Face(
+                Part.Wire(edge1.Edges + [connector_start] + edge2.Edges + [connector_end])
+            )
+        except Part.OCCError:
+            continue
+
+        if face is None:
+            continue
+
+        if not face.isValid():
+            continue
+
+        return face
+
+    _err("DraftGeomUtils: unable to bind wires")
+    return None
+
+
 def bind(w1, w2, per_segment=False):
     """Bind 2 wires by their endpoints and returns a face / compound of faces.
 
@@ -127,23 +172,8 @@ def bind(w1, w2, per_segment=False):
     a loop that ends in a T-connection (f.e. a wire shaped like a number 6).
     """
 
-    def create_face(w1, w2):
-
-        try:
-            w3 = Part.LineSegment(w1.Vertexes[0].Point, w2.Vertexes[0].Point).toShape()
-            w4 = Part.LineSegment(w1.Vertexes[-1].Point, w2.Vertexes[-1].Point).toShape()
-        except Part.OCCError:
-            App.Console.PrintError("DraftGeomUtils: unable to bind wires\n")
-            return None
-        if w3.section(w4).Vertexes:
-            App.Console.PrintWarning(
-                "DraftGeomUtils: Problem, a segment is self-intersecting, please check!\n"
-            )
-        f = Part.Face(Part.Wire(w1.Edges + [w3] + w2.Edges + [w4]))
-        return f
-
     if not w1 or not w2:
-        App.Console.PrintError("DraftGeomUtils: unable to bind wires\n")
+        _err("DraftGeomUtils: unable to bind wires")
         return None
 
     if per_segment and len(w1.Edges) > 1 and len(w1.Edges) == len(w2.Edges):
@@ -170,7 +200,7 @@ def bind(w1, w2, per_segment=False):
                 faces = []  # Reset original faces variable
                 continue  # Skip the touching edge pair
             else:
-                face = create_face(edge1, edge2)
+                face = _make_segment_face(edge1, edge2)
                 if face is None:
                     return None
                 faces.append(face)
@@ -206,12 +236,12 @@ def bind(w1, w2, per_segment=False):
                 l = len(faces)
                 m = max(countDir.values())  # max(countDir, key=countDir.get)
                 if m != l:
-                    App.Console.PrintWarning(
+                    _wrn(
                         "DraftGeomUtils: Problem, the direction of "
                         + str(l - m)
                         + " out of "
                         + str(l)
-                        + " segment is reversed, please check!\n"
+                        + " segment is reversed, please check!"
                     )
                 if len(faces) > 1:
                     # Below not good if a face is self-intersecting or reversed
@@ -236,12 +266,12 @@ def bind(w1, w2, per_segment=False):
             l = len(faces)
             m = max(countDir.values())  # max(countDir, key=countDir.get)
             if m != l:
-                App.Console.PrintWarning(
+                _wrn(
                     "DraftGeomUtils: Problem, the direction of "
                     + str(l - m)
                     + " out of "
                     + str(l)
-                    + " segment is reversed, please check!\n"
+                    + " segment is reversed, please check!"
                 )
             # Below not good if a face is self-intersecting or reversed
             # return faces[0].fuse(faces[1:]).removeSplitter().Faces[0]
@@ -263,10 +293,10 @@ def bind(w1, w2, per_segment=False):
             face.fix(1e-7, 0, 1)
             return face
         except Part.OCCError:
-            App.Console.PrintError("DraftGeomUtils: unable to bind wires\n")
+            _err("DraftGeomUtils: unable to bind wires")
             return None
     else:
-        return create_face(w1, w2)
+        return _make_segment_face(w1, w2)
 
 
 def cleanFaces(shape):

--- a/src/Mod/Draft/draftgeoutils/faces.py
+++ b/src/Mod/Draft/draftgeoutils/faces.py
@@ -32,8 +32,10 @@
 import lazy_loader.lazy_loader as lz
 
 import DraftVecUtils
+import FreeCAD as App
 from FreeCAD import Base
 from draftgeoutils.geometry import are_coplanar
+from draftutils.messages import _wrn
 
 # Delay import of module until first use because it is heavy
 Part = lz.LazyLoader("Part", globals(), "Part")
@@ -51,7 +53,7 @@ def concatenate(shape):
         wires = [Part.Wire(edges) for edges in sorted_edges]
         face = Part.makeFace(wires, "Part::FaceMakerBullseye")
     except Base.FreeCADError:
-        print(
+        _wrn(
             "DraftGeomUtils: Fails to join faces into one. "
             + "The precision of the faces would be insufficient"
         )
@@ -131,15 +133,17 @@ def bind(w1, w2, per_segment=False):
             w3 = Part.LineSegment(w1.Vertexes[0].Point, w2.Vertexes[0].Point).toShape()
             w4 = Part.LineSegment(w1.Vertexes[-1].Point, w2.Vertexes[-1].Point).toShape()
         except Part.OCCError:
-            print("DraftGeomUtils: unable to bind wires")
+            App.Console.PrintError("DraftGeomUtils: unable to bind wires\n")
             return None
         if w3.section(w4).Vertexes:
-            print("DraftGeomUtils: Problem, a segment is self-intersecting, please check!")
+            App.Console.PrintWarning(
+                "DraftGeomUtils: Problem, a segment is self-intersecting, please check!\n"
+            )
         f = Part.Face(Part.Wire(w1.Edges + [w3] + w2.Edges + [w4]))
         return f
 
     if not w1 or not w2:
-        print("DraftGeomUtils: unable to bind wires")
+        App.Console.PrintError("DraftGeomUtils: unable to bind wires\n")
         return None
 
     if per_segment and len(w1.Edges) > 1 and len(w1.Edges) == len(w2.Edges):
@@ -202,12 +206,12 @@ def bind(w1, w2, per_segment=False):
                 l = len(faces)
                 m = max(countDir.values())  # max(countDir, key=countDir.get)
                 if m != l:
-                    print(
+                    App.Console.PrintWarning(
                         "DraftGeomUtils: Problem, the direction of "
                         + str(l - m)
                         + " out of "
                         + str(l)
-                        + " segment is reversed, please check!"
+                        + " segment is reversed, please check!\n"
                     )
                 if len(faces) > 1:
                     # Below not good if a face is self-intersecting or reversed
@@ -232,12 +236,12 @@ def bind(w1, w2, per_segment=False):
             l = len(faces)
             m = max(countDir.values())  # max(countDir, key=countDir.get)
             if m != l:
-                print(
+                App.Console.PrintWarning(
                     "DraftGeomUtils: Problem, the direction of "
                     + str(l - m)
                     + " out of "
                     + str(l)
-                    + " segment is reversed, please check!"
+                    + " segment is reversed, please check!\n"
                 )
             # Below not good if a face is self-intersecting or reversed
             # return faces[0].fuse(faces[1:]).removeSplitter().Faces[0]
@@ -259,7 +263,7 @@ def bind(w1, w2, per_segment=False):
             face.fix(1e-7, 0, 1)
             return face
         except Part.OCCError:
-            print("DraftGeomUtils: unable to bind wires")
+            App.Console.PrintError("DraftGeomUtils: unable to bind wires\n")
             return None
     else:
         return create_face(w1, w2)

--- a/src/Mod/Draft/drafttests/test_draftgeomutils.py
+++ b/src/Mod/Draft/drafttests/test_draftgeomutils.py
@@ -251,6 +251,35 @@ class TestDraftGeomUtils(test_base.DraftTestCaseNoDoc):
         wire.Orientation = "Reversed"
         self.check_wire(wire)
 
+    def test_make_segment_face_repairs_crossed_connectors(self):
+        """The segment face builder should retry with the alternate endpoint pairing."""
+        operation = "DraftGeomUtils._make_segment_face crossed connectors"
+        _msg("  Test '{}'".format(operation))
+
+        edge1 = Part.makeLine(Vector(10369.55, 6924.675, 0), Vector(10077.45, 6924.675, 0))
+        edge2 = Part.makeLine(Vector(10175.875, 7118.35, 0), Vector(10271.125, 7118.35, 0))
+
+        default_start = Part.LineSegment(edge1.Vertexes[0].Point, edge2.Vertexes[0].Point).toShape()
+        default_end = Part.LineSegment(edge1.Vertexes[-1].Point, edge2.Vertexes[-1].Point).toShape()
+        default_face = Part.Face(
+            Part.Wire(edge1.Edges + [default_start] + edge2.Edges + [default_end])
+        )
+        self.assertTrue(
+            default_start.section(default_end).Vertexes,
+            "The default connector pairing should reproduce the crossed-strip case.",
+        )
+        self.assertFalse(default_face.isValid(), "The default face should be invalid.")
+
+        fixed_face = DraftGeomUtils.bind(edge1, edge2)
+        self.assertIsNotNone(fixed_face, "The repaired segment face should be created.")
+        self.assertTrue(fixed_face.isValid(), "The repaired segment face should be valid.")
+        self.assertAlmostEqual(
+            fixed_face.Area,
+            37510.005625,
+            places=2,
+            msg="The repaired segment face area is incorrect.",
+        )
+
 
 # suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestDraftGeomUtils)
 # unittest.TextTestRunner().run(suite)

--- a/src/Mod/Draft/draftutils/messages.py
+++ b/src/Mod/Draft/draftutils/messages.py
@@ -37,7 +37,6 @@ added manually.
 ## \addtogroup draftutils
 # @{
 import FreeCAD as App
-from draftutils import params
 
 
 def _msg(text, end="\n"):
@@ -63,6 +62,8 @@ def _log(text, end="\n"):
 def _toolmsg(text, end="\n"):
     """Write messages to the console including the line ending,
     only if ToolMessages pref setting is True"""
+    from draftutils import params
+
     if params.get_param("ToolMessages"):
         App.Console.PrintMessage(text + end)
 


### PR DESCRIPTION
This fixes a regression in sketch-based walls where some left-aligned wall traces could lose large parts of their shape during base face generation.

The issue was not in `ArchWall` itself, but in the Draft face binding code used to stitch the two offset wall wires together. In some cases, two corresponding offset segments were connected by matching start-to-start and end-to-end, which produced a crossed quad. That strip face became invalid, and the later fuse step dropped geometry from the final wall.

This change teaches the per-segment binding path to retry with the alternate endpoint pairing and keep the first valid, non-crossing face. That preserves the current `per_segment=True` approach for difficult wall traces while fixing the bad wall shape from `#29701`.

This regression was originally introduced in https://github.com/FreeCAD/FreeCAD/pull/20395.

## Changes

- detect crossed connector pairing when building a strip face between two corresponding edges
- retry segment face construction with the alternate endpoint pairing
- add a focused Draft regression test for the crossed-strip case
- add a BIM wall regression test based on the sketch from `#29701`

## Validation

- `TestDraftGeomUtils.test_make_segment_face_repairs_crossed_connectors`
- `TestArchWall.test_wall_from_issue_29701_left_align`

Closes #29701.