### PR TITLE
Gui: let selection filters choose nearby allowed picks

### DIFF
--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -824,6 +824,69 @@ void SelectionSingleton::slotSelectionChanged(const SelectionChanges& msg)
     }
 }
 
+bool SelectionSingleton::testSelection(
+    App::Document* pDoc,
+    App::DocumentObject* pObject,
+    const char* pSubName
+) const
+{
+    if (!pObject) {
+        return false;
+    }
+
+    if (!pDoc) {
+        pDoc = pObject->getDocument();
+    }
+    if (!pDoc) {
+        return false;
+    }
+
+    auto foundContext = docSelectionContext.find(pDoc);
+    if (foundContext == docSelectionContext.end() || !foundContext->second.gate) {
+        return true;
+    }
+    const auto& info = foundContext->second;
+
+    const char* objectName = pObject->getNameInDocument();
+    if (!objectName) {
+        return false;
+    }
+
+    SelectionDescription temp;
+    int ret = checkSelection(
+        pDoc->getName(),
+        objectName,
+        pSubName,
+        ResolveMode::NoResolve,
+        temp,
+        &info.selList
+    );
+    if (ret < 0) {
+        return false;
+    }
+
+    const char* subelement = nullptr;
+    auto gateObject
+        = getObjectOfType(temp, App::DocumentObject::getClassTypeId(), info.resolveMode, &subelement);
+
+    auto* gate = info.gate;
+    std::string notAllowedReason = gate->notAllowedReason;
+    bool allowed
+        = gate->allow(gateObject ? gateObject->getDocument() : temp.pDoc, gateObject, subelement);
+    gate->notAllowedReason = notAllowedReason;
+    return allowed;
+}
+
+bool SelectionSingleton::hasSelectionGate(App::Document* pDoc) const
+{
+    if (!pDoc) {
+        return false;
+    }
+
+    auto foundContext = docSelectionContext.find(pDoc);
+    return foundContext != docSelectionContext.end() && foundContext->second.gate;
+}
+
 int SelectionSingleton::setPreselect(
     const char* pDocName,
     const char* pObjectName,
@@ -1122,9 +1185,11 @@ void SelectionSingleton::rmvSelectionGate(App::Document* doc)
         foundContext->second.gate = nullptr;
 
         // if a document is about to be closed it has no MDI view any more
-        if (Gui::Document* guiDoc = Gui::Application::Instance->getDocument(doc)) {
-            if (Gui::MDIView* mdi = guiDoc->getActiveView()) {
-                mdi->restoreOverrideCursor();
+        if (Gui::Application::Instance && Gui::getMainWindow()) {
+            if (Gui::Document* guiDoc = Gui::Application::Instance->getDocument(doc)) {
+                if (Gui::MDIView* mdi = guiDoc->getActiveView()) {
+                    mdi->restoreOverrideCursor();
+                }
             }
         }
     }

--- a/src/Gui/Selection/Selection.h
+++ b/src/Gui/Selection/Selection.h
@@ -401,6 +401,14 @@ public:
         ResolveMode resolve = ResolveMode::OldStyleElement
     ) const;
 
+    /// Check if an object or sub-element passes the active selection gate without changing selection.
+    bool testSelection(
+        App::Document* pDoc,
+        App::DocumentObject* pObject,
+        const char* pSubName = nullptr
+    ) const;
+    bool hasSelectionGate(App::Document* pDoc) const;
+
     std::string getSelectedElement(App::DocumentObject*, const char* pSubName) const;
 
     /// set the preselected object (mostly by the 3D view)

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -111,6 +111,46 @@ void printPreselectionInfo(
 
 SoFullPath* Gui::SoFCUnifiedSelection::currentHighlightPath = nullptr;
 
+namespace Gui::SelectionPickPolicy
+{
+
+std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
+{
+    if (picked.empty()) {
+        return 0;
+    }
+
+    std::size_t preferred = 0;
+    int pickedPriority = picked.front().priority;
+    const void* firstOwner = picked.front().owner;
+    bool preferredIsAnnotation = picked.front().isAnnotation;
+
+    for (std::size_t i = 1; i < picked.size(); ++i) {
+        const auto& info = picked[i];
+        if (info.owner != firstOwner) {
+            break;
+        }
+
+        if (!info.closeToFirst) {
+            continue;
+        }
+
+        if (info.priority > pickedPriority) {
+            preferred = i;
+            pickedPriority = info.priority;
+            preferredIsAnnotation = info.isAnnotation;
+        }
+        else if (info.priority == pickedPriority && info.isAnnotation && !preferredIsAnnotation) {
+            preferred = i;
+            preferredIsAnnotation = true;
+        }
+    }
+
+    return preferred;
+}
+
+}  // namespace Gui::SelectionPickPolicy
+
 // *************************************************************************
 
 SO_NODE_SOURCE(SoFCUnifiedSelection)
@@ -267,6 +307,39 @@ int SoFCUnifiedSelection::getPriority(const SoPickedPoint* p)
     return 0;
 }
 
+SelectionPickPolicy::Candidate SoFCUnifiedSelection::getPickCandidate(
+    const PickedInfo& info,
+    const Document* doc,
+    const PickedInfo* firstPicked
+)
+{
+    SelectionPickPolicy::Candidate candidate;
+    candidate.owner = info.vpd;
+    candidate.priority = getPriority(info.pp);
+    candidate.isAnnotation = doc && info.pp && isAnnotationPick(info.pp, doc);
+
+    if (firstPicked && info.pp && firstPicked->pp) {
+        candidate.closeToFirst = info.pp->getPoint().equals(firstPicked->pp->getPoint(), 0.2F);
+    }
+
+    return candidate;
+}
+
+std::vector<SelectionPickPolicy::Candidate> SoFCUnifiedSelection::getPickCandidates(
+    const std::vector<PickedInfo>& picked,
+    const Document* doc
+)
+{
+    std::vector<SelectionPickPolicy::Candidate> candidates;
+    candidates.reserve(picked.size());
+    const PickedInfo* firstPicked = picked.empty() ? nullptr : &picked.front();
+    for (const auto& info : picked) {
+        candidates.push_back(getPickCandidate(info, doc, firstPicked));
+    }
+
+    return candidates;
+}
+
 std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedList(
     SoHandleEventAction* action,
     bool singlePick
@@ -327,38 +400,8 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedLis
     // points where the first is of a face and the second of a line with
     // almost similar coordinates we use the second point, instead.
 
-    int picked_prio = getPriority(ret[0].pp);
-    auto last_vpd = ret[0].vpd;
-    const SbVec3f& picked_pt = ret.front().pp->getPoint();
-    auto itPicked = ret.begin();
-    for (auto it = ret.begin() + 1; it != ret.end(); ++it) {
-        auto& info = *it;
-        if (last_vpd != info.vpd) {
-            break;
-        }
-
-        int cur_prio = getPriority(info.pp);
-        const SbVec3f& cur_pt = info.pp->getPoint();
-
-        if (!picked_pt.equals(cur_pt, 0.2F)) {
-            continue;
-        }
-
-        if (cur_prio > picked_prio) {
-            itPicked = it;
-            picked_prio = cur_prio;
-        }
-        // When priorities are equal, prefer annotation picks (overlays)
-        // over regular shape picks, so that e.g. sketch internal faces
-        // on a solid surface are picked before the solid face.
-        else if (cur_prio == picked_prio && this->pcDocument) {
-            bool curIsAnnotation = isAnnotationPick(info.pp, this->pcDocument);
-            bool pickedIsAnnotation = isAnnotationPick(itPicked->pp, this->pcDocument);
-            if (curIsAnnotation && !pickedIsAnnotation) {
-                itPicked = it;
-            }
-        }
-    }
+    auto pickedIndex = SelectionPickPolicy::choosePreferredPick(getPickCandidates(ret, this->pcDocument));
+    auto itPicked = ret.begin() + pickedIndex;
 
     if (singlePick) {
         std::vector<PickedInfo> sret(itPicked, itPicked + 1);

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -114,6 +114,24 @@ SoFullPath* Gui::SoFCUnifiedSelection::currentHighlightPath = nullptr;
 namespace Gui::SelectionPickPolicy
 {
 
+bool canFinalizeSinglePick(const std::vector<Candidate>& picked)
+{
+    bool foundSelectionGate = false;
+    for (const auto& info : picked) {
+        if (!info.hasGate) {
+            continue;
+        }
+
+        foundSelectionGate = true;
+        if (info.passesGate) {
+            return true;
+        }
+    }
+
+    // Preserve the existing first-object behavior unless an active gate rejected every pick so far.
+    return !foundSelectionGate;
+}
+
 std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
 {
     if (picked.empty()) {
@@ -143,6 +161,15 @@ std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
         else if (info.priority == pickedPriority && info.isAnnotation && !preferredIsAnnotation) {
             preferred = i;
             preferredIsAnnotation = true;
+        }
+    }
+
+    if (!picked[preferred].passesGate) {
+        for (std::size_t i = 0; i < picked.size(); ++i) {
+            if (picked[i].passesGate) {
+                preferred = i;
+                break;
+            }
         }
     }
 
@@ -307,6 +334,34 @@ int SoFCUnifiedSelection::getPriority(const SoPickedPoint* p)
     return 0;
 }
 
+bool SoFCUnifiedSelection::passesSelectionGate(const PickedInfo& info)
+{
+    if (!info.vpd) {
+        return false;
+    }
+
+    App::DocumentObject* obj = info.vpd->getObject();
+    if (!obj) {
+        return false;
+    }
+
+    return Selection().testSelection(obj->getDocument(), obj, info.element.c_str());
+}
+
+bool SoFCUnifiedSelection::hasSelectionGate(const PickedInfo& info)
+{
+    if (!info.vpd) {
+        return false;
+    }
+
+    App::DocumentObject* obj = info.vpd->getObject();
+    if (!obj) {
+        return false;
+    }
+
+    return Selection().hasSelectionGate(obj->getDocument());
+}
+
 SelectionPickPolicy::Candidate SoFCUnifiedSelection::getPickCandidate(
     const PickedInfo& info,
     const Document* doc,
@@ -317,6 +372,8 @@ SelectionPickPolicy::Candidate SoFCUnifiedSelection::getPickCandidate(
     candidate.owner = info.vpd;
     candidate.priority = getPriority(info.pp);
     candidate.isAnnotation = doc && info.pp && isAnnotationPick(info.pp, doc);
+    candidate.hasGate = hasSelectionGate(info);
+    candidate.passesGate = passesSelectionGate(info);
 
     if (firstPicked && info.pp && firstPicked->pp) {
         candidate.closeToFirst = info.pp->getPoint().equals(firstPicked->pp->getPoint(), 0.2F);
@@ -340,6 +397,11 @@ std::vector<SelectionPickPolicy::Candidate> SoFCUnifiedSelection::getPickCandida
     return candidates;
 }
 
+bool SoFCUnifiedSelection::canFinalizeSinglePick(const std::vector<PickedInfo>& picked)
+{
+    return SelectionPickPolicy::canFinalizeSinglePick(getPickCandidates(picked, nullptr));
+}
+
 std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedList(
     SoHandleEventAction* action,
     bool singlePick
@@ -356,8 +418,8 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedLis
         auto path = Gui::toFullPath(info.pp->getPath());
         if (this->pcDocument && path && path->containsPath(action->getCurPath())) {
             vp = this->pcDocument->getViewProviderByPathFromHead(path);
-            if (singlePick && last_vp && last_vp != vp) {
-                return ret;
+            if (singlePick && last_vp && last_vp != vp && canFinalizeSinglePick(ret)) {
+                break;
             }
         }
         if (!vp || !vp->isDerivedFrom(ViewProviderDocumentObject::getClassTypeId())) {
@@ -395,12 +457,12 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedLis
         return ret;
     }
 
-    // To identify the picking of lines in a concave area we have to
-    // get all intersection points. If we have two or more intersection
-    // points where the first is of a face and the second of a line with
-    // almost similar coordinates we use the second point, instead.
-
-    auto pickedIndex = SelectionPickPolicy::choosePreferredPick(getPickCandidates(ret, this->pcDocument));
+    // To identify the picking of lines in a concave area we have to get all intersection points.
+    // If the preferred point is rejected by the active selection gate, choose the first allowed
+    // candidate still inside the viewer pick radius.
+    auto pickedIndex = SelectionPickPolicy::choosePreferredPick(
+        getPickCandidates(ret, this->pcDocument)
+    );
     auto itPicked = ret.begin() + pickedIndex;
 
     if (singlePick) {

--- a/src/Gui/Selection/SoFCUnifiedSelection.h
+++ b/src/Gui/Selection/SoFCUnifiedSelection.h
@@ -23,9 +23,11 @@
 
 #pragma once
 
+#include <cstddef>
 #include <list>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include <Inventor/elements/SoLazyElement.h>
 #include <Inventor/fields/SoSFBool.h>
@@ -44,6 +46,21 @@ class SoDetail;
 
 namespace Gui
 {
+
+namespace SelectionPickPolicy
+{
+
+struct Candidate
+{
+    const void* owner {nullptr};
+    int priority {0};
+    bool closeToFirst {false};
+    bool isAnnotation {false};
+};
+
+GuiExport std::size_t choosePreferredPick(const std::vector<Candidate>& picked);
+
+}  // namespace SelectionPickPolicy
 
 class Document;
 class ViewProviderDocumentObject;
@@ -105,6 +122,16 @@ private:
         ViewProviderDocumentObject* vpd {nullptr};
         std::string element;
     };
+
+    static SelectionPickPolicy::Candidate getPickCandidate(
+        const PickedInfo&,
+        const Document*,
+        const PickedInfo* firstPicked = nullptr
+    );
+    static std::vector<SelectionPickPolicy::Candidate> getPickCandidates(
+        const std::vector<PickedInfo>&,
+        const Document*
+    );
 
     bool setPreselect(const PickedInfo&);
     bool setPreselect(

--- a/src/Gui/Selection/SoFCUnifiedSelection.h
+++ b/src/Gui/Selection/SoFCUnifiedSelection.h
@@ -56,8 +56,11 @@ struct Candidate
     int priority {0};
     bool closeToFirst {false};
     bool isAnnotation {false};
+    bool hasGate {false};
+    bool passesGate {false};
 };
 
+GuiExport bool canFinalizeSinglePick(const std::vector<Candidate>& picked);
 GuiExport std::size_t choosePreferredPick(const std::vector<Candidate>& picked);
 
 }  // namespace SelectionPickPolicy
@@ -123,6 +126,8 @@ private:
         std::string element;
     };
 
+    static bool passesSelectionGate(const PickedInfo&);
+    static bool hasSelectionGate(const PickedInfo&);
     static SelectionPickPolicy::Candidate getPickCandidate(
         const PickedInfo&,
         const Document*,
@@ -132,6 +137,7 @@ private:
         const std::vector<PickedInfo>&,
         const Document*
     );
+    static bool canFinalizeSinglePick(const std::vector<PickedInfo>&);
 
     bool setPreselect(const PickedInfo&);
     bool setPreselect(

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(Gui_tests_run
         StyleParameters/ParameterManagerTest.cpp
         StyleParameters/YamlParameterSourceTest.cpp
         InputHintTest.cpp
+        SelectionTest.cpp
 )
 
 # Qt tests

--- a/tests/src/Gui/SelectionTest.cpp
+++ b/tests/src/Gui/SelectionTest.cpp
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include <src/App/InitApplication.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <Gui/Selection/Selection.h>
+#include <Gui/Selection/SoFCUnifiedSelection.h>
+
+namespace
+{
+
+class ObjectNameGate: public Gui::SelectionGate
+{
+public:
+    explicit ObjectNameGate(const char* allowedName)
+        : _allowedName(allowedName)
+    {}
+
+    bool allow(App::Document*, App::DocumentObject* obj, const char*) override
+    {
+        if (!obj || _allowedName != obj->getNameInDocument()) {
+            notAllowedReason = "rejected by test gate";
+            return false;
+        }
+        return true;
+    }
+
+private:
+    std::string _allowedName;
+};
+
+class SelectionTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        // Keep this fixture headless even if another Gui gtest already created
+        // Gui::Application in the shared binary.
+        App::DocumentInitFlags createFlags;
+        createFlags.createView = false;
+        _docName = App::GetApplication().getUniqueDocumentName("selection_test");
+        _doc = App::GetApplication().newDocument(_docName.c_str(), "testUser", createFlags);
+        _allowedObject = _doc->addObject("App::FeatureTest", "Allowed");
+        _rejectedObject = _doc->addObject("App::FeatureTest", "Rejected");
+    }
+
+    void TearDown() override
+    {
+        Gui::Selection().rmvSelectionGate(_docName.c_str());
+        Gui::Selection().clearSelection(_docName.c_str());
+        if (App::GetApplication().getDocument(_docName.c_str())) {
+            App::GetApplication().closeDocument(_docName.c_str());
+        }
+    }
+
+    std::string _docName;
+    App::Document* _doc {};
+    App::DocumentObject* _allowedObject {};
+    App::DocumentObject* _rejectedObject {};
+};
+
+Gui::SelectionPickPolicy::Candidate pickCandidate(
+    const void* owner,
+    int priority,
+    bool closeToFirst,
+    bool hasGate,
+    bool passesGate
+)
+{
+    Gui::SelectionPickPolicy::Candidate candidate;
+    candidate.owner = owner;
+    candidate.priority = priority;
+    candidate.closeToFirst = closeToFirst;
+    candidate.hasGate = hasGate;
+    candidate.passesGate = passesGate;
+    return candidate;
+}
+
+}  // namespace
+
+TEST_F(SelectionTest, testSelectionAllowsObjectsWhenNoGateIsInstalled)
+{
+    EXPECT_TRUE(Gui::Selection().testSelection(_doc, _allowedObject));
+}
+
+TEST_F(SelectionTest, testSelectionUsesActiveGateWithoutKeepingRejectionReason)
+{
+    auto* gate = new ObjectNameGate(_allowedObject->getNameInDocument());
+    gate->notAllowedReason = "existing reason";
+    Gui::Selection().addSelectionGate(gate, Gui::ResolveMode::NoResolve, _docName.c_str());
+
+    EXPECT_TRUE(Gui::Selection().testSelection(_doc, _allowedObject));
+    EXPECT_EQ(gate->notAllowedReason, "existing reason");
+
+    EXPECT_FALSE(Gui::Selection().testSelection(_doc, _rejectedObject));
+    EXPECT_EQ(gate->notAllowedReason, "existing reason");
+    EXPECT_FALSE(Gui::Selection().hasPreselection());
+    EXPECT_FALSE(Gui::Selection().hasSelection(_docName.c_str(), Gui::ResolveMode::NoResolve));
+}
+
+TEST(SelectionPickPolicyTest, canFinalizeSinglePickWhenNoGateIsInstalled)
+{
+    int owner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&owner, 0, true, false, true),
+    };
+
+    EXPECT_TRUE(Gui::SelectionPickPolicy::canFinalizeSinglePick(candidates));
+}
+
+TEST(SelectionPickPolicyTest, continuesSinglePickWhenGateRejectedAllCurrentCandidates)
+{
+    int owner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&owner, 0, true, true, false),
+    };
+
+    EXPECT_FALSE(Gui::SelectionPickPolicy::canFinalizeSinglePick(candidates));
+}
+
+TEST(SelectionPickPolicyTest, choosesAllowedCandidateWhenPreferredPickIsRejected)
+{
+    int firstOwner {};
+    int secondOwner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&firstOwner, 1, true, true, false),
+        pickCandidate(&secondOwner, 0, true, true, true),
+    };
+
+    EXPECT_EQ(Gui::SelectionPickPolicy::choosePreferredPick(candidates), 1U);
+}
+
+TEST(SelectionPickPolicyTest, preservesPriorityChoiceWithinFirstOwner)
+{
+    int firstOwner {};
+    int secondOwner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&firstOwner, 1, true, false, true),
+        pickCandidate(&firstOwner, 2, true, false, true),
+        pickCandidate(&secondOwner, 3, true, false, true),
+    };
+
+    EXPECT_EQ(Gui::SelectionPickPolicy::choosePreferredPick(candidates), 1U);
+}
+
+TEST(SelectionPickPolicyTest, keepsPreferredPickWhenNoCandidatePassesGate)
+{
+    int firstOwner {};
+    int secondOwner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&firstOwner, 1, true, true, false),
+        pickCandidate(&secondOwner, 0, true, true, false),
+    };
+
+    EXPECT_EQ(Gui::SelectionPickPolicy::choosePreferredPick(candidates), 0U);
+}


### PR DESCRIPTION
When a selection gate rejects the frontmost picked entity, keep considering other picked entities within the viewer pick radius instead of immediately showing the blocked-selection state.

This lets selection filters fall through to a nearby allowed object or sub-element while preserving the existing pick-priority behavior when no active gate rejects the current candidate.

Fixes #28979.

## Details

- Extracts the picked-point choice policy so the gate-aware behavior can be tested directly.
- Adds a quiet `SelectionSingleton::testSelection()` probe for checking whether a picked object/sub-element passes the active selection gate without mutating selection or preselection.
- Uses that probe from `SoFCUnifiedSelection` when building and choosing the picked list.
- Keeps using the existing `SoHandleEventAction` picked-point list

## Tests

- Added GUI C++ tests for the quiet selection-gate probe.
- Added policy tests for gate-rejected candidates, allowed fallthrough candidates, and existing priority behavior.

## Difference from #29498

This PR fixes the same issue as #29498, but in the shared selection path instead of adding a second ray-pick fallback in the 3D viewer.

In practice, that means the gate-aware fallback applies to the normal unified selection flow, including both preselection and actual selection. It also keeps using the picked-point list FreeCAD already computed for the current event, so there is no extra hardcoded pick radius and no picked-point ownership issue from returning a point created by a temporary ray-pick action.

The main behavior change is simple: if the first picked candidate is rejected by the active selection filter, FreeCAD now keeps looking through the nearby picked candidates and uses the first one that the filter allows.
