### PR TITLE
CAM: fix toolpath rendering for multi-revolution rotary moves   

### DIFF
--- a/src/Mod/CAM/App/PathSegmentWalker.cpp
+++ b/src/Mod/CAM/App/PathSegmentWalker.cpp
@@ -198,10 +198,9 @@ void PathSegmentWalker::walk(PathSegmentVisitor& cb, const Base::Vector3d& start
         if ((name == "G0") || (name == "G00") || (name == "G1") || (name == "G01")) {
             // straight line
             if (nrot != lrot) {
-                double amax = std::max(
-                    fmod(fabs(a - A), 360),
-                    std::max(fmod(fabs(b - B), 360), fmod(fabs(c - C), 360))
-                );
+                // Use the unwrapped angular travel so multi-revolution moves
+                // (e.g. G0 A4618 -> G0 A0) get enough segments to render smoothly.
+                double amax = std::max(fabs(a - A), std::max(fabs(b - B), fabs(c - C)));
                 double angle = Base::toRadians(amax);
                 int segments = std::max(ARC_MIN_SEGMENTS, 3.0 / (deviation / angle));
 
@@ -276,10 +275,7 @@ void PathSegmentWalker::walk(PathSegmentVisitor& cb, const Base::Vector3d& start
                 angle = std::numbers::pi * 2;
             }
 
-            double amax = std::max(
-                fmod(fabs(a - A), 360),
-                std::max(fmod(fabs(b - B), 360), fmod(fabs(c - C), 360))
-            );
+            double amax = std::max(fabs(a - A), std::max(fabs(b - B), fabs(c - C)));
 
             int segments = std::max(
                 ARC_MIN_SEGMENTS,
@@ -358,10 +354,7 @@ void PathSegmentWalker::walk(PathSegmentVisitor& cb, const Base::Vector3d& start
             p1.*pz = last.*pz;
 
             if (nrot != lrot) {
-                double amax = std::max(
-                    fmod(fabs(a - A), 360),
-                    std::max(fmod(fabs(b - B), 360), fmod(fabs(c - C), 360))
-                );
+                double amax = std::max(fabs(a - A), std::max(fabs(b - B), fabs(c - C)));
                 double angle = Base::toRadians(amax);
                 int segments = std::max(ARC_MIN_SEGMENTS, 3.0 / (deviation / angle));
 


### PR DESCRIPTION
                                                                                                                                                                                                        
  Segment count was sized from the modulo-360 rotation delta but                                                                                                                                                                   
  interpolation used the unwrapped delta, producing coarse polygons
  for moves spanning many turns (e.g. G0 A4618 -> G0 A0). Use the                                                                                                                                                                  
  unwrapped angular travel for segment count in the G0/G1, G2/G3,                                                                                                                                                                  
  and drill-cycle paths in PathSegmentWalker.       


Before
<img width="1388" height="1245" alt="before" src="https://github.com/user-attachments/assets/cf5e0607-5db7-4d34-b551-323d759fb0a5" />

After
<img width="1429" height="1274" alt="after" src="https://github.com/user-attachments/assets/7387e4d1-6c2f-4f53-92ea-36b334adda15" />

Analysis and code suggestion by claude opus 4.7.  

