### PR TITLE
Gui: keep input hints visible in status bar

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -456,7 +456,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     //: A context menu action used to show or hide the input hints in the status bar
     d->hintLabel->setWindowTitle(tr("Input Hints"));
 
-    statusBar()->addWidget(d->hintLabel);
+    // Use a permanent status bar widget so temporary command/status messages do not hide the input hints.
+    statusBar()->addPermanentWidget(d->hintLabel);
 
     // right side label
     d->rightSideLabel = new StatusBarLabel(statusBar(), "QuickMeasureEnabled");

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -456,7 +456,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     //: A context menu action used to show or hide the input hints in the status bar
     d->hintLabel->setWindowTitle(tr("Input Hints"));
 
-    // Use a permanent status bar widget so temporary command/status messages do not hide the input hints.
+    // Use a permanent status bar widget so temporary command/status messages do not hide the input
+    // hints.
     statusBar()->addPermanentWidget(d->hintLabel);
 
     // right side label

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1202,6 +1202,8 @@ bool MainWindow::event(QEvent* e)
         if (std::abs(d->currentStatusType) <= MainWindow::Wrn) {
             return true;
         }
+        showMessage(static_cast<QStatusTipEvent*>(e)->tip());
+        return true;
     }
     return QMainWindow::event(e);
 }


### PR DESCRIPTION
Keep the input hints widget visible while FreeCAD shows temporary status-bar messages from actions and status tips.

Fixes #23478.

## Root Cause

`MainWindow` added `hintLabel` with `QStatusBar::addWidget()`. Qt allows temporary status messages to obscure normal status-bar widgets, which caused command/action status text to replace the input hints.

## Change

Use `QStatusBar::addPermanentWidget()` for `hintLabel` in `MainWindow.cpp` so the input hints remain visible while temporary messages are shown.