### PR TITLE
gui: statusbar: show preselection text in a tooltip when elided

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -304,7 +304,7 @@ private:
 struct MainWindowP
 {
     DimensionWidget* sizeLabel;
-    QLabel* actionLabel;
+    StatusBarLabel* actionLabel;
     InputHintWidget* hintLabel;
     QLabel* rightSideLabel;
     QTimer* actionTimer;
@@ -420,6 +420,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     d->status = new StatusBarObserver();
     d->actionLabel = new StatusBarLabel(statusBar());
     d->actionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+    d->actionLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    d->actionLabel->setMinimumWidth(0);
     d->sizeLabel = new DimensionWidget(statusBar());
 
     statusBar()->addWidget(d->actionLabel, 1);
@@ -484,7 +486,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     // clears the action label
     d->actionTimer = new QTimer(this);
     d->actionTimer->setObjectName(QStringLiteral("actionTimer"));
-    connect(d->actionTimer, &QTimer::timeout, d->actionLabel, &QLabel::clear);
+    connect(d->actionTimer, &QTimer::timeout, d->actionLabel, &StatusBarLabel::clearText);
 
     // clear status type
     d->statusTimer = new QTimer(this);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -468,7 +468,10 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     d->actionLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
     // Preselection text yields under width pressure: it elides with an ellipsis
     // rather than crowding out higher-priority widgets like Input Hints.
-    d->actionLabel->setElideMode(Qt::ElideRight);
+    // preselection puts the element ID and coordinates at the end of the string,
+    // so elide the middle: the leading document and object labels are the least
+    // informative part and the tail is what the user is reading
+    d->actionLabel->setElideMode(Qt::ElideMiddle);
     d->actionLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     addStatusBarItem(
         d->actionLabel,

--- a/src/Gui/StatusBarLabel.cpp
+++ b/src/Gui/StatusBarLabel.cpp
@@ -28,6 +28,7 @@
 #include <QAction>
 #include <QContextMenuEvent>
 #include <QHideEvent>
+#include <QResizeEvent>
 
 #include "StatusBarLabel.h"
 #include <App/Application.h>
@@ -86,6 +87,37 @@ void StatusBarLabel::contextMenuEvent(QContextMenuEvent* event)
 
     menu.exec(event->globalPos());
 }
+
+void StatusBarLabel::setText(const QString& text)
+{
+    m_fullText = text;
+    setToolTip(text);
+    updateElidedText();
+}
+
+void StatusBarLabel::clearText()
+{
+    m_fullText.clear();
+    setToolTip(QString());
+    QLabel::clear();
+}
+
+void StatusBarLabel::resizeEvent(QResizeEvent* event)
+{
+    QLabel::resizeEvent(event);
+    updateElidedText();
+}
+
+void StatusBarLabel::updateElidedText()
+{
+    if (m_fullText.isEmpty()) {
+        QLabel::setText(QString());
+        return;
+    }
+    const QString elided = fontMetrics().elidedText(m_fullText, Qt::ElideMiddle, width());
+    QLabel::setText(elided);
+}
+
 
 void StatusBarLabel::setVisible(bool visible)
 {

--- a/src/Gui/StatusBarLabel.cpp
+++ b/src/Gui/StatusBarLabel.cpp
@@ -63,11 +63,23 @@ QSize StatusBarLabel::minimumSizeHint() const
 void StatusBarLabel::paintEvent(QPaintEvent* event)
 {
     if (m_elideMode == Qt::ElideNone) {
+        if (!toolTip().isEmpty()) {
+            setToolTip(QString());
+        }
         QLabel::paintEvent(event);
         return;
     }
+
     QPainter painter(this);
     const QString elided = fontMetrics().elidedText(text(), m_elideMode, contentsRect().width());
+
+    // when the text doesn't fit, show full string on hover. cleared when it fits
+    // so a fully visible label doesn't get a tooltip repeating itself
+    const QString tip = (elided != text()) ? text() : QString();
+    if (toolTip() != tip) {
+        setToolTip(tip);
+    }
+
     painter.drawText(contentsRect(), static_cast<int>(alignment()), elided);
 }
 

--- a/src/Gui/StatusBarLabel.h
+++ b/src/Gui/StatusBarLabel.h
@@ -37,6 +37,8 @@
 
 #include <Base/Parameter.h>
 
+class QResizeEvent;
+
 namespace Gui
 {
 /**
@@ -51,13 +53,27 @@ class GuiExport StatusBarLabel: public QLabel
 public:
     explicit StatusBarLabel(QWidget* parent, const std::string& parameterName = {});
 
+    /// set displayed text. stores the full string and renders an elided
+    /// version that fis the current width. the full text label is shown as a tooltip.
+    /// shadows qlabel::settext, callers must use a statusbarlabel* not qlabel*
+    void setText(const QString& text);
+
+public Q_SLOTS:
+    /// clear both displayed and stored text. use this instead of qlabel::clear()
+    /// so that the next resize doesn't restore stale text.
+    void clearText();
+
 protected:
     void contextMenuEvent(QContextMenuEvent* event) override;
     void setVisible(bool visible) override;
+    void resizeEvent(QResizeEvent* event) override;
 
 private:
+    void updateElidedText();
+
     ParameterGrp::handle hGrp;
     std::string parameterName;
+    QString m_fullText;
 };
 
 }  // Namespace Gui


### PR DESCRIPTION
**updated september 2 2026**

this pr addresses #26435, ie. by making sure the items on the **right side** of the status bar do not get clipped / omitted / "elided". it also adds a tooltip for the preselect text when it becomes to large to fit in the status bar. also allows on the fly resizing of the preselection text when resizing the main gui window.

example

```
Preselected: <doc>.<object>.Edge74 (-159.46 mm, -535.85 mm, 906.31 mm)
```

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/26435

## Before and After Images

#### before

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/0cb29248-7366-4e54-97a5-b193a5ff962a" />

---

notice there is no tooltip with the current build before this PR

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/5bd0225a-ee75-492d-bb70-21749bcc9111" />

#### after

notice the text on the far right is still visible.

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/d6f7544f-6b1f-4395-b268-8d91e7530a47" />

<br />
<br />

<hr />

full names are shown in the tooltip

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/b678b58f-4f68-4547-856b-f3a5c6b79d84" />

