### PR TITLE
measure: measurement: address issue #24514

### DIFF
--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -292,7 +292,8 @@ bool MeasureAngle::computeOriginFaceFace(TopoDS_Shape& s1, TopoDS_Shape& s2)
         }
     }
 
-    return false;
+    outOrigin = gp_Pnt((location1().XYZ() + location2().XYZ()) / 2.0);
+    return true;
 }
 
 bool MeasureAngle::computeOriginEdgeEdge(TopoDS_Shape& s1, TopoDS_Shape& s2)


### PR DESCRIPTION
this pr aims at fixing the issue presented in #24514

@leoheck you mind testing this PR when get a chance? are these the results you are / were expecting?

### steps to reproduce.

1. create new document
2. create a cube/box with the part workbench.
3. run the below commands in the python console of the gui application.

```py
doc = FreeCAD.ActiveDocument
print(doc.Objects)
box = doc.getObject("Box")
m = doc.addObject("Measure::MeasureAngle", "AngleTest")
m.Element1 = (box, ["Face5"])
m.Element2 = (box, ["Face6"])
doc.recompute()
print("Angle:", m.Angle)
print("ImgOrigin:", m.isImgOrigin() if hasattr(m, 'isImgOrigin') else "n/a")
```

## Issues

- https://github.com/freecad/freecad/issues/24514

## Before and After Images

- [x] will upload before / after images in a second using github web ui.

#### before

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/1cbc1a32-28ac-4b6c-aa09-0f3fc9234100" />

---

#### after

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/71347380-bb9a-4b42-81ce-cfcac704f14e" />



