### PR TITLE
Fix #28599: Trim Edge shortcut hijacked by new Text tool

### DIFF
--- a/src/Gui/PreferencePackTemplates/Shortcuts.cfg
+++ b/src/Gui/PreferencePackTemplates/Shortcuts.cfg
@@ -545,6 +545,7 @@
           <FCText Name="Sketcher_CreateRegularPolygon">G, P, R</FCText>
           <FCText Name="Sketcher_CreateSlot">G, S</FCText>
           <FCText Name="Sketcher_CreateSquare">G, P, 4</FCText>
+          <FCText Name="Sketcher_CreateText"></FCText>
           <FCText Name="Sketcher_CreateTriangle">G, P, 3</FCText>
           <FCText Name="Sketcher_DeleteAllConstraints"></FCText>
           <FCText Name="Sketcher_DeleteAllGeometry"></FCText>

--- a/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
+++ b/src/Mod/Sketcher/Gui/CommandCreateGeo.cpp
@@ -1377,7 +1377,7 @@ CmdSketcherCreateText::CmdSketcherCreateText()
     sWhatsThis = "Sketcher_CreateText";
     sStatusTip = sToolTipText;
     sPixmap = "Sketcher_CreateText";
-    sAccel = "G, T";
+    sAccel = "";
     eType = ForEdit;
 }
 


### PR DESCRIPTION
The new Text tool's shortcut was the same as the Trim Edge's shortcut (G + T), therefore when trying to use the Trim Edge shortcut, the Text tool was activated instead.

~~Fixed by making the Text tool's shortcut "X + T", as suggested by a comment on the issue page.~~
~~Fixed by making the Trim tool's shortcut "X + T", as suggested by the DWG~~
Fixed by restoring the Trim tool's shortcut "G + T", and leaving Text without shortcut as suggested by the DWG

Motivation for the lack text chosen shortcut. Only G,U and G,D are currently free under the G prefix. Using one of these two is not a lasting solution as they are neither easy to remember and it just delays the problem to some future new sketcher tool that will lack available shortcut. The best option seems be to move the geometry modifier tools to its own prefix. E.g X. And reserve the G prefix for the tools in the Geometry toolbar. 

This fix was originally authored by @crissapinasantos  in PR [28961](https://github.com/FreeCAD/FreeCAD/pull/28961) . That PR was closed due to AI policy.
Here I have simply removed the AI written tests. The remaining code can be easily reviewed.

I have tested the patch and it does work for me.

## Issues

closes https://github.com/FreeCAD/FreeCAD/issues/28599




