### PR TITLE
Fix Part Loft and sweep when filename contains unicode characters.

### DIFF
--- a/src/Mod/Part/Gui/TaskLoft.cpp
+++ b/src/Mod/Part/Gui/TaskLoft.cpp
@@ -216,14 +216,14 @@ bool LoftWidget::accept()
                   "App.getDocument('%5').ActiveObject.Ruled=%3\n"
                   "App.getDocument('%5').ActiveObject.Closed=%4\n"
         )
-                  .arg(list, solid, ruled, closed, QString::fromLatin1(d->document.c_str()));
+                  .arg(list, solid, ruled, closed, d->document.c_str());
 
         Gui::Document* doc = Gui::Application::Instance->getDocument(d->document.c_str());
         if (!doc) {
             throw Base::RuntimeError("Document doesn't exist anymore");
         }
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Loft"));
-        Gui::Command::runCommand(Gui::Command::App, cmd.toLatin1());
+        Gui::Command::runCommand(Gui::Command::App, cmd.toUtf8());
         doc->getDocument()->recompute();
         App::DocumentObject* obj = doc->getDocument()->getActiveObject();
         if (obj && !obj->isValid()) {

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -410,10 +410,10 @@ bool SweepWidget::accept()
         )
                   .arg(
                       list,
-                      QLatin1String(selection.c_str()),
+                      selection.c_str(),
                       solid,
                       frenet,
-                      QString::fromLatin1(d->document.c_str())
+                      d->document.c_str()
                   );
 
         Gui::Document* doc = Gui::Application::Instance->getDocument(d->document.c_str());
@@ -421,7 +421,7 @@ bool SweepWidget::accept()
             throw Base::RuntimeError("Document doesn't exist anymore");
         }
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Sweep"));
-        Gui::Command::runCommand(Gui::Command::App, cmd.toLatin1());
+        Gui::Command::runCommand(Gui::Command::App, cmd.toUtf8());
         doc->getDocument()->recompute();
         App::DocumentObject* obj = doc->getDocument()->getActiveObject();
         if (obj && !obj->isValid()) {

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -408,13 +408,7 @@ bool SweepWidget::accept()
                   "App.getDocument('%5').ActiveObject.Solid=%3\n"
                   "App.getDocument('%5').ActiveObject.Frenet=%4\n"
         )
-                  .arg(
-                      list,
-                      selection.c_str(),
-                      solid,
-                      frenet,
-                      d->document.c_str()
-                  );
+                  .arg(list, selection.c_str(), solid, frenet, d->document.c_str());
 
         Gui::Document* doc = Gui::Application::Instance->getDocument(d->document.c_str());
         if (!doc) {


### PR DESCRIPTION
This is a very exploratory fix for a problem in Part Loft when the filename contains unicode characters. 

In the code at issue there is an invocation of `QString::fromLatin1(…)` that does not seem to be needed in a similar pattern elsewhere in the code.

Removing that invocation and replacing the `.toLatin1()` with `.toUtf8()` later in the code in a way that mirrors the fix in #26514 seems to correct this problem, allowing the Loft to proceed.

I have also added a fix for Part Sweep which has a similar issue.

No AI here — just old-fashioned poking about.

## Issues
Aimed at fixing #29724
