### PR TITLE
Exploratory fixes for unicode filename issues in Part Loft and Sweep

### DIFF
--- a/src/Mod/Part/Gui/TaskLoft.cpp
+++ b/src/Mod/Part/Gui/TaskLoft.cpp
@@ -216,14 +216,14 @@ bool LoftWidget::accept()
                   "App.getDocument('%5').ActiveObject.Ruled=%3\n"
                   "App.getDocument('%5').ActiveObject.Closed=%4\n"
         )
-                  .arg(list, solid, ruled, closed, QString::fromLatin1(d->document.c_str()));
+                  .arg(list, solid, ruled, closed, d->document.c_str());
 
         Gui::Document* doc = Gui::Application::Instance->getDocument(d->document.c_str());
         if (!doc) {
             throw Base::RuntimeError("Document doesn't exist anymore");
         }
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Loft"));
-        Gui::Command::runCommand(Gui::Command::App, cmd.toLatin1());
+        Gui::Command::runCommand(Gui::Command::App, cmd.toUtf8());
         doc->getDocument()->recompute();
         App::DocumentObject* obj = doc->getDocument()->getActiveObject();
         if (obj && !obj->isValid()) {

--- a/src/Mod/Part/Gui/TaskSweep.cpp
+++ b/src/Mod/Part/Gui/TaskSweep.cpp
@@ -408,20 +408,14 @@ bool SweepWidget::accept()
                   "App.getDocument('%5').ActiveObject.Solid=%3\n"
                   "App.getDocument('%5').ActiveObject.Frenet=%4\n"
         )
-                  .arg(
-                      list,
-                      QLatin1String(selection.c_str()),
-                      solid,
-                      frenet,
-                      QString::fromLatin1(d->document.c_str())
-                  );
+                  .arg(list, selection.c_str(), solid, frenet, d->document.c_str());
 
         Gui::Document* doc = Gui::Application::Instance->getDocument(d->document.c_str());
         if (!doc) {
             throw Base::RuntimeError("Document doesn't exist anymore");
         }
         doc->openCommand(QT_TRANSLATE_NOOP("Command", "Sweep"));
-        Gui::Command::runCommand(Gui::Command::App, cmd.toLatin1());
+        Gui::Command::runCommand(Gui::Command::App, cmd.toUtf8());
         doc->getDocument()->recompute();
         App::DocumentObject* obj = doc->getDocument()->getActiveObject();
         if (obj && !obj->isValid()) {


### PR DESCRIPTION
This is a very exploratory fix for problems in Part Loft and Sweep when the filename contains unicode characters. (I am absolutely a novice FreeCAD developer)

In the code at issue there are invocations of `QString::fromLatin1(…)` that do not seem to be needed in similar patterns elsewhere in existing code (including in the Loft task itself).

The fix removes those invocations and replaces `.toLatin1()` with `.toUtf8()` in the runCommand calls in a way that mirrors a similar fix for this problem in #26514 

No AI here — just old-fashioned poking about.

## Issues
Aimed at fixing #29724
