### PR TITLE
Gui: add human-readable name for Toggle Bottom Panels menu entry

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -433,7 +433,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     auto* toggleBottomPanelsButton = new QToolButton(statusBar());
     toggleBottomPanelsButton->setObjectName(QStringLiteral("toggleBottomPanelsButton"));
     //: A context menu action used to show or hide the Toggle Bottom Panels button in the status bar
-    toggleBottomPanelsButton->setWindowTitle(tr("Toggle Bottom Panels"));
+    toggleBottomPanelsButton->setWindowTitle(tr("Bottom Panel Toggle"));
     int iconSize = App::GetApplication()
                        .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
                        ->GetInt("ToolbarIconSize", 24);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -432,6 +432,8 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     // the rightmost permanent widget.
     auto* toggleBottomPanelsButton = new QToolButton(statusBar());
     toggleBottomPanelsButton->setObjectName(QStringLiteral("toggleBottomPanelsButton"));
+    //: A context menu action used to show or hide the Toggle Bottom Panels button in the status bar
+    toggleBottomPanelsButton->setWindowTitle(tr("Toggle Bottom Panels"));
     int iconSize = App::GetApplication()
                        .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
                        ->GetInt("ToolbarIconSize", 24);


### PR DESCRIPTION
Before, the label for the status bar's "Toggle Bottom Panels" button was left as the widget's identifier. This PR makes it human-readable and translatable. Fix inspired from https://github.com/FreeCAD/FreeCAD/pull/20401

To test:

1. Place the mouse cursor over the status bar area at the bottom
1. Right-click to display the context menu
1. Check the corresponding "Toggle Bottom Panels" menu entry

## Issues

Fixes issue mentioned in https://github.com/FreeCAD/FreeCAD/issues/29468#issuecomment-4274540893

## Before

| Before | After |
| --- | --- |
| <img width="492" height="333" alt="580364826-36ce2de0-fd43-45c5-bef4-44d40ab3f1ec" src="https://github.com/user-attachments/assets/9c8b3480-20d1-415d-98af-11816737bd9a" /> | <img width="351" height="154" alt="image" src="https://github.com/user-attachments/assets/a34d680c-7a41-48b1-8712-74843a0ac076" /> |