### PR TITLE
Gui: Std_ToggleBottomPanels observes bottom panel visibility

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -530,6 +530,15 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
 
     setupDockWindows();
 
+    for (auto* panel : findChildren<QDockWidget*>()) {
+        connect(panel, &QDockWidget::visibilityChanged, this, [this](bool) {
+            syncBottomPanelsButtonState(this);
+        });
+        connect(panel, &QDockWidget::dockLocationChanged, this, [this](Qt::DockWidgetArea) {
+            syncBottomPanelsButtonState(this);
+        });
+    }
+
     // accept drops on the window, get handled in dropEvent, dragEnterEvent
     setAcceptDrops(true);
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -50,6 +50,7 @@
 #include <QThread>
 #include <QTimer>
 #include <QToolBar>
+#include <QToolButton>
 #include <QUrlQuery>
 #include <QWhatsThis>
 #include <QWindow>
@@ -335,6 +336,23 @@ struct MainWindowP
 
 /* TRANSLATOR Gui::MainWindow */
 
+// Sets the toggle bottom panels button checked state to reflect actual panel visibility.
+static void syncBottomPanelsButtonState(QMainWindow* mainWindow)
+{
+    auto* button = mainWindow->findChild<QToolButton*>(QStringLiteral("toggleBottomPanelsButton"));
+    if (!button) {
+        return;
+    }
+    bool anyVisible = false;
+    for (auto* panel : mainWindow->findChildren<QDockWidget*>()) {
+        if (mainWindow->dockWidgetArea(panel) == Qt::BottomDockWidgetArea && panel->isVisible()) {
+            anyVisible = true;
+            break;
+        }
+    }
+    button->setChecked(anyVisible);
+}
+
 MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     : QMainWindow(parent, f /*WDestructiveClose*/)
 {
@@ -438,10 +456,6 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     toggleBottomPanelsButton->setIconSize(QSize(iconSize, iconSize));
     toggleBottomPanelsButton->setIcon(BitmapFactory().pixmap("Std_ToggleBottomPanels"));
     toggleBottomPanelsButton->setCheckable(true);
-    // Starts checked because FreeCAD shows bottom panels by default on first launch. On subsequent
-    // launches the command restores the persisted state, but that happens after this point, so
-    // the button state is always an approximation until the first toggle.
-    toggleBottomPanelsButton->setChecked(true);
     //: Tooltip for the status bar button that toggles bottom dock panels
     toggleBottomPanelsButton->setToolTip(tr("Toggles the bottom dock panels"));
     toggleBottomPanelsButton->setAutoRaise(true);
@@ -2106,6 +2120,7 @@ void MainWindow::loadWindowSettings()
     std::clog << "Toolbars restored" << std::endl;
 
     OverlayManager::instance()->restore();
+    syncBottomPanelsButtonState(this);
 }
 
 bool MainWindow::isRestoringWindowState() const


### PR DESCRIPTION
The status bar <kbd>Toggle Bottom Panels</kbd> button always started checked on launch regardless of whether any bottom panels were actually visible. Closing a panel via its title bar X button left the button out of sync.

With this PR, <kbd>Toggle Bottom Panels</kbd> now reads the actual panel state on startup and updates itself whenever a panel is shown, hidden, or dragged away to another area.

It's in Draft, as I'm not yet confident on the implementation.

## Issues

Fixes: https://github.com/FreeCAD/FreeCAD/issues/29740
