### PR TITLE
Gui: use status bar icon size for Toggle Bottom Panels icon

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -435,9 +435,13 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     toggleBottomPanelsButton->setObjectName(QStringLiteral("toggleBottomPanelsButton"));
     //: A context menu action used to show or hide the Toggle Bottom Panels button in the status bar
     toggleBottomPanelsButton->setWindowTitle(tr("Bottom Panel Toggle"));
-    int iconSize = App::GetApplication()
-                       .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                       ->GetInt("ToolbarIconSize", 24);
+    auto hGeneral = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/General"
+    );
+    int iconSize = hGeneral->GetInt("StatusBarIconSize", 0);
+    if (iconSize <= 0) {
+        iconSize = static_cast<int>(hGeneral->GetInt("ToolbarIconSize", 24) * 0.6);
+    }
     toggleBottomPanelsButton->setIconSize(QSize(iconSize, iconSize));
     toggleBottomPanelsButton->setIcon(BitmapFactory().pixmap("Std_ToggleBottomPanels"));
     toggleBottomPanelsButton->setCheckable(true);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -435,14 +435,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
     toggleBottomPanelsButton->setObjectName(QStringLiteral("toggleBottomPanelsButton"));
     //: A context menu action used to show or hide the Toggle Bottom Panels button in the status bar
     toggleBottomPanelsButton->setWindowTitle(tr("Bottom Panel Toggle"));
-    auto hGeneral = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/General"
-    );
-    int iconSize = hGeneral->GetInt("StatusBarIconSize", 0);
-    if (iconSize <= 0) {
-        iconSize = static_cast<int>(hGeneral->GetInt("ToolbarIconSize", 24) * 0.6);
-    }
-    toggleBottomPanelsButton->setIconSize(QSize(iconSize, iconSize));
+    toggleBottomPanelsButton->setIconSize(QSize(16, 16));
     toggleBottomPanelsButton->setIcon(BitmapFactory().pixmap("Std_ToggleBottomPanels"));
     toggleBottomPanelsButton->setCheckable(true);
     // Starts checked because FreeCAD shows bottom panels by default on first launch. On subsequent


### PR DESCRIPTION
The toggle bottom panels button was using `ToolbarIconSize` for its icon, making it visibly larger than the other status bar widgets. ~~It now reads `StatusBarIconSize` instead, falling back to `ToolbarIconSize * 0.6` when unset. This is the same logic `ToolBarManager::toolBarIconSize()` applies to toolbar actions in the status bar area.~~ It is now being set to 16 px, without being configurable.

Note: this also brings back the status bar height to its original size, which had been increased by the bigger icon.

| State | Before | After |
| --- | --- | --- |
|Unchecked| <img width="351" height="39" alt="Captura de pantalla de 2026-05-01 07-15-14-wide" src="https://github.com/user-attachments/assets/baada714-0513-41d1-b46a-e9bca1d463f3" />| <img width="351" height="39" alt="Captura de pantalla de 2026-05-01 15-07-19" src="https://github.com/user-attachments/assets/d2b9bdb7-2746-4987-9deb-0f92503e11b1" /> |
|Checked|<img width="351" height="39" alt="Captura de pantalla de 2026-05-01 07-15-14" src="https://github.com/user-attachments/assets/903cb1f8-e62f-4f4a-a8d5-198312db9e59" />| <img width="351" height="39" alt="Captura de pantalla de 2026-05-01 15-07-25" src="https://github.com/user-attachments/assets/28bac47a-a082-49dd-9d32-e11d3fb2dfd7" /> |

Please squash.