### PR TITLE
Gui: remove error when cancelling a non-Win32 native file dialog

### DIFF
--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -419,10 +419,17 @@ QStringList FileDialogInternal::nativeFileDialog(
         );
     }
     selectedFilterIndex = qtFilterList.indexOf(selectedQtFilter);
+    if (selectedFilterIndex < 0 && selected.isEmpty()) {
+        // No files selected means the user cancelled, and a missing/incorrect filter can be
+        // returned by Qt's implementations. Default to index 0 as caller code still might
+        // use this value even though it should not.
+        selectedFilterIndex = 0;
+    }
     if (selectedFilterIndex < 0) {
         Base::Console().error(
             "Qt-backed nativeFileDialog returned a selected filter that wasn't in the original "
-            "list, defaulting to index 0"
+            "list, defaulting to index 0\nProblem cause filter: \"%s\"\n",
+            selectedQtFilter.toStdString()
         );
         selectedFilterIndex = 0;
     }
@@ -588,8 +595,11 @@ QString FileDialog::getSaveFileName(
         actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
         if (actuallySelectedFilterIndex < 0) {
             // Log an error since this happening means the code is incorrect
-            Base::Console()
-                .error("FileDialog returned a selected filter that wasn't in the original list, defaulting to index 0");
+            Base::Console().error(
+                "Non-native FileDialog returned a selected filter that wasn't in the original "
+                "list, defaulting to index 0\nProblem cause filter: \"%s\"\n",
+                dlg.selectedNameFilter().toStdString()
+            );
             actuallySelectedFilterIndex = 0;
         }
     }
@@ -716,8 +726,11 @@ QString FileDialog::getOpenFileName(
         actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
         if (actuallySelectedFilterIndex < 0) {
             // Log an error since this happening means the code is incorrect
-            Base::Console()
-                .error("FileDialog returned a selected filter that wasn't in the original list, defaulting to index 0");
+            Base::Console().error(
+                "Non-native FileDialog returned a selected filter that wasn't in the original "
+                "list, defaulting to index 0\nProblem cause filter: \"%s\"\n",
+                dlg.selectedNameFilter().toStdString()
+            );
             actuallySelectedFilterIndex = 0;
         }
     }
@@ -808,8 +821,11 @@ QStringList FileDialog::getOpenFileNames(
         actuallySelectedFilterIndex = qtFilterList.indexOf(dlg.selectedNameFilter());
         if (actuallySelectedFilterIndex < 0) {
             // Log an error since this happening means the code is incorrect
-            Base::Console()
-                .error("FileDialog returned a selected filter that wasn't in the original list, defaulting to index 0");
+            Base::Console().error(
+                "Non-native FileDialog returned a selected filter that wasn't in the original "
+                "list, defaulting to index 0\nProblem cause filter: \"%s\"\n",
+                dlg.selectedNameFilter().toStdString()
+            );
             actuallySelectedFilterIndex = 0;
         }
     }


### PR DESCRIPTION
* Fixes #29761

Qt-backed calls to native file dialogs can return empty/invalid filters when the user cancels one such dialog. This incorrectly triggered the filter-not-found failsafe and its `Base::Console().error()` call, although the error is entirely nonfatal.

Check for the cancel case and bypass the failsafe by directly setting the returned selected filter index to 0, which is a safe fallback value even if caller code indexes into an array based on it irrespective of cancellation.

TLDR: silence, console spam