### PR TITLE
Feature/jtreader jt10 improvements

### DIFF
--- a/src/Mod/JtReader/App/AppJtReaderPy.cpp
+++ b/src/Mod/JtReader/App/AppJtReaderPy.cpp
@@ -105,7 +105,26 @@ private:
 
 #ifdef JTREADER_HAVE_TKJT
             JtReaderNS::TKJtReader jtReader;
-            jtReader.open(EncodedName);
+            try {
+                jtReader.open(EncodedName);
+            }
+            catch (const Standard_Failure& e) {
+                Base::Console().warning("JtReader: error reading '%s': %s\n",
+                                        file.fileName().c_str(), e.GetMessageString());
+                return Py::None();
+            }
+            catch (const std::exception& e) {
+                Base::Console().warning("JtReader: error reading '%s': %s\n",
+                                        file.fileName().c_str(), e.what());
+                return Py::None();
+            }
+
+            if (jtReader.shapeCount() == 0) {
+                Base::Console().warning("JtReader: no geometry could be imported from '%s'. "
+                                        "The file may use unsupported features.\n",
+                                        file.fileName().c_str());
+                return Py::None();
+            }
 
             App::Document* doc = App::GetApplication().newDocument();
             std::string objname = file.fileNamePure();
@@ -143,7 +162,26 @@ private:
 
 #ifdef JTREADER_HAVE_TKJT
             JtReaderNS::TKJtReader jtReader;
-            jtReader.open(EncodedName);
+            try {
+                jtReader.open(EncodedName);
+            }
+            catch (const Standard_Failure& e) {
+                Base::Console().warning("JtReader: error reading '%s': %s\n",
+                                        file.fileName().c_str(), e.GetMessageString());
+                return Py::None();
+            }
+            catch (const std::exception& e) {
+                Base::Console().warning("JtReader: error reading '%s': %s\n",
+                                        file.fileName().c_str(), e.what());
+                return Py::None();
+            }
+
+            if (jtReader.shapeCount() == 0) {
+                Base::Console().warning("JtReader: no geometry could be imported from '%s'. "
+                                        "The file may use unsupported features.\n",
+                                        file.fileName().c_str());
+                return Py::None();
+            }
 
             std::string objname = file.fileNamePure();
             auto iv = dynamic_cast<App::InventorObject*>(

--- a/src/Mod/JtReader/App/AppJtReaderPy.cpp
+++ b/src/Mod/JtReader/App/AppJtReaderPy.cpp
@@ -109,20 +109,28 @@ private:
                 jtReader.open(EncodedName);
             }
             catch (const Standard_Failure& e) {
-                Base::Console().warning("JtReader: error reading '%s': %s\n",
-                                        file.fileName().c_str(), e.GetMessageString());
+                Base::Console().warning(
+                    "JtReader: error reading '%s': %s\n",
+                    file.fileName().c_str(),
+                    e.GetMessageString()
+                );
                 return Py::None();
             }
             catch (const std::exception& e) {
-                Base::Console().warning("JtReader: error reading '%s': %s\n",
-                                        file.fileName().c_str(), e.what());
+                Base::Console().warning(
+                    "JtReader: error reading '%s': %s\n",
+                    file.fileName().c_str(),
+                    e.what()
+                );
                 return Py::None();
             }
 
             if (jtReader.shapeCount() == 0) {
-                Base::Console().warning("JtReader: no geometry could be imported from '%s'. "
-                                        "The file may use unsupported features.\n",
-                                        file.fileName().c_str());
+                Base::Console().warning(
+                    "JtReader: no geometry could be imported from '%s'. "
+                    "The file may use unsupported features.\n",
+                    file.fileName().c_str()
+                );
                 return Py::None();
             }
 
@@ -166,20 +174,28 @@ private:
                 jtReader.open(EncodedName);
             }
             catch (const Standard_Failure& e) {
-                Base::Console().warning("JtReader: error reading '%s': %s\n",
-                                        file.fileName().c_str(), e.GetMessageString());
+                Base::Console().warning(
+                    "JtReader: error reading '%s': %s\n",
+                    file.fileName().c_str(),
+                    e.GetMessageString()
+                );
                 return Py::None();
             }
             catch (const std::exception& e) {
-                Base::Console().warning("JtReader: error reading '%s': %s\n",
-                                        file.fileName().c_str(), e.what());
+                Base::Console().warning(
+                    "JtReader: error reading '%s': %s\n",
+                    file.fileName().c_str(),
+                    e.what()
+                );
                 return Py::None();
             }
 
             if (jtReader.shapeCount() == 0) {
-                Base::Console().warning("JtReader: no geometry could be imported from '%s'. "
-                                        "The file may use unsupported features.\n",
-                                        file.fileName().c_str());
+                Base::Console().warning(
+                    "JtReader: no geometry could be imported from '%s'. "
+                    "The file may use unsupported features.\n",
+                    file.fileName().c_str()
+                );
                 return Py::None();
             }
 

--- a/src/Mod/JtReader/App/TKJtReader.cpp
+++ b/src/Mod/JtReader/App/TKJtReader.cpp
@@ -55,13 +55,14 @@ void TKJtReader::clear()
 {
     result.str(std::string());
     result.clear();
+    myShapeCount = 0;
+    myFileName.clear();
 }
 
 void TKJtReader::open(const std::string& filename)
 {
     clear();
-
-    fprintf(stderr, "TKJtReader::open(%s)\n", filename.c_str());
+    myFileName = filename;
 
     Base::FileInfo file(filename);
     jtDir = TCollection_ExtendedString(TCollection_AsciiString((file.dirPath() + '/').c_str()));
@@ -73,8 +74,6 @@ void TKJtReader::open(const std::string& filename)
         Handle(JtNode_Partition) aNode = aModel->Init();
         if (!aNode.IsNull()) {
             rootNode = aNode;
-
-            fprintf(stderr, "TKJtReader: model init OK, traversing graph\n");
             builder.addHeader();
             builder.beginSeparator();
             Base::ShapeHintsItem shapeHints;
@@ -84,20 +83,23 @@ void TKJtReader::open(const std::string& filename)
             traverseGraph(aNode);
             builder.endSeparator();
             rootNode.Nullify();
-            fprintf(stderr, "TKJtReader: done, output size=%zu bytes\n", result.str().size());
         }
-        else {
-            fprintf(stderr, "TKJtReader: aModel->Init() returned null\n");
-        }
-    }
-    else {
-        fprintf(stderr, "TKJtReader: JtData_Model is null (file not found or unreadable)\n");
     }
 }
 
 std::string TKJtReader::getOutput() const
 {
     return result.str();
+}
+
+int TKJtReader::shapeCount() const
+{
+    return myShapeCount;
+}
+
+std::string TKJtReader::fileName() const
+{
+    return myFileName;
 }
 
 void TKJtReader::readMaterialAttribute(const Handle(JtAttribute_Material) & aMaterial)
@@ -202,6 +204,7 @@ void TKJtReader::getTriangleStripSet(const Handle(JtElement_ShapeLOD_TriStripSet
     // NOLINTEND
     builder.addNode(Base::Coordinate3Item {points});
     builder.addNode(Base::FaceSetItem {faces});
+    ++myShapeCount;
 }
 
 void TKJtReader::getPolygonSet(const Handle(JtElement_ShapeLOD_PolygonSet) & aLOD)
@@ -227,6 +230,7 @@ void TKJtReader::getPolygonSet(const Handle(JtElement_ShapeLOD_PolygonSet) & aLO
     // NOLINTEND
     builder.addNode(Base::Coordinate3Item {points});
     builder.addNode(Base::FaceSetItem {faces});
+    ++myShapeCount;
 }
 
 void TKJtReader::getPolylineSet(const Handle(JtElement_ShapeLOD_PolylineSet) & aLOD)
@@ -245,6 +249,7 @@ void TKJtReader::getPolylineSet(const Handle(JtElement_ShapeLOD_PolylineSet) & a
     if (!points.empty()) {
         builder.addNode(Base::Coordinate3Item {points});
         builder.addNode(Base::LineSetItem {});
+        ++myShapeCount;
     }
 }
 

--- a/src/Mod/JtReader/App/TKJtReader.cpp
+++ b/src/Mod/JtReader/App/TKJtReader.cpp
@@ -42,6 +42,9 @@ const Handle(Standard_Type) Type_JtNode_Shape_Base              = STANDARD_TYPE(
 const Handle(Standard_Type) Type_JtNode_Shape_Vertex            = STANDARD_TYPE(JtNode_Shape_Vertex);
 const Handle(Standard_Type) Type_JtNode_Shape_TriStripSet       = STANDARD_TYPE(JtNode_Shape_TriStripSet);
 // clang-format on
+
+const Handle(Standard_Type) Type_JtElement_ShapeLOD_PolygonSet  = STANDARD_TYPE(JtElement_ShapeLOD_PolygonSet);
+const Handle(Standard_Type) Type_JtElement_ShapeLOD_PolylineSet = STANDARD_TYPE(JtElement_ShapeLOD_PolylineSet);
 }  // namespace
 
 TKJtReader::TKJtReader()
@@ -58,6 +61,8 @@ void TKJtReader::open(const std::string& filename)
 {
     clear();
 
+    fprintf(stderr, "TKJtReader::open(%s)\n", filename.c_str());
+
     Base::FileInfo file(filename);
     jtDir = TCollection_ExtendedString(TCollection_AsciiString((file.dirPath() + '/').c_str()));
 
@@ -69,6 +74,7 @@ void TKJtReader::open(const std::string& filename)
         if (!aNode.IsNull()) {
             rootNode = aNode;
 
+            fprintf(stderr, "TKJtReader: model init OK, traversing graph\n");
             builder.addHeader();
             builder.beginSeparator();
             Base::ShapeHintsItem shapeHints;
@@ -78,7 +84,14 @@ void TKJtReader::open(const std::string& filename)
             traverseGraph(aNode);
             builder.endSeparator();
             rootNode.Nullify();
+            fprintf(stderr, "TKJtReader: done, output size=%zu bytes\n", result.str().size());
         }
+        else {
+            fprintf(stderr, "TKJtReader: aModel->Init() returned null\n");
+        }
+    }
+    else {
+        fprintf(stderr, "TKJtReader: JtData_Model is null (file not found or unreadable)\n");
     }
 }
 
@@ -151,6 +164,18 @@ void TKJtReader::readShapeVertex(const Handle(JtNode_Shape_Vertex) & aShape)
                 aLOD = Handle(JtElement_ShapeLOD_TriStripSet)::DownCast(anObject);
             if (!aLOD.IsNull()) {
                 getTriangleStripSet(aLOD);
+                continue;
+            }
+            if (anObject->IsKind(Type_JtElement_ShapeLOD_PolygonSet)) {
+                Handle(JtElement_ShapeLOD_PolygonSet)
+                    aPolyLOD = Handle(JtElement_ShapeLOD_PolygonSet)::DownCast(anObject);
+                getPolygonSet(aPolyLOD);
+                continue;
+            }
+            if (anObject->IsKind(Type_JtElement_ShapeLOD_PolylineSet)) {
+                Handle(JtElement_ShapeLOD_PolylineSet)
+                    aLineLOD = Handle(JtElement_ShapeLOD_PolylineSet)::DownCast(anObject);
+                getPolylineSet(aLineLOD);
             }
         }
     }
@@ -179,6 +204,50 @@ void TKJtReader::getTriangleStripSet(const Handle(JtElement_ShapeLOD_TriStripSet
     builder.addNode(Base::FaceSetItem {faces});
 }
 
+void TKJtReader::getPolygonSet(const Handle(JtElement_ShapeLOD_PolygonSet) & aLOD)
+{
+    // Polygon set: vertices are already flat triangles via the same Indices/Vertices layout
+    // as TriStripSet — treat identically (indices are already triangle-indexed after decode).
+    const int pointsPerFace = 3;
+    std::vector<Base::Vector3f> points;
+    std::vector<int> faces;
+    const JtElement_ShapeLOD_Vertex::VertexData& vertices = aLOD->Vertices();
+    const JtElement_ShapeLOD_Vertex::IndicesVec& indices = aLOD->Indices();
+    float* data = vertices.Data();
+    // NOLINTBEGIN
+    for (int index = 0; index < indices.Count(); index += 3) {
+        int coordIndex = indices[index] * 3;
+        points.emplace_back(data[coordIndex], data[coordIndex + 1], data[coordIndex + 2]);
+        coordIndex = indices[index + 1] * 3;
+        points.emplace_back(data[coordIndex], data[coordIndex + 1], data[coordIndex + 2]);
+        coordIndex = indices[index + 2] * 3;
+        points.emplace_back(data[coordIndex], data[coordIndex + 1], data[coordIndex + 2]);
+        faces.push_back(pointsPerFace);
+    }
+    // NOLINTEND
+    builder.addNode(Base::Coordinate3Item {points});
+    builder.addNode(Base::FaceSetItem {faces});
+}
+
+void TKJtReader::getPolylineSet(const Handle(JtElement_ShapeLOD_PolylineSet) & aLOD)
+{
+    // Polyline set: emit each indexed vertex as a point in a line set.
+    std::vector<Base::Vector3f> points;
+    const JtElement_ShapeLOD_Vertex::VertexData& vertices = aLOD->Vertices();
+    const JtElement_ShapeLOD_Vertex::IndicesVec& indices = aLOD->Indices();
+    float* data = vertices.Data();
+    // NOLINTBEGIN
+    for (int index = 0; index < indices.Count(); ++index) {
+        int coordIndex = indices[index] * 3;
+        points.emplace_back(data[coordIndex], data[coordIndex + 1], data[coordIndex + 2]);
+    }
+    // NOLINTEND
+    if (!points.empty()) {
+        builder.addNode(Base::Coordinate3Item {points});
+        builder.addNode(Base::LineSetItem {});
+    }
+}
+
 void TKJtReader::readPartition(const Handle(JtNode_Partition) & aPart)
 {
     if (rootNode != aPart) {
@@ -196,7 +265,7 @@ void TKJtReader::readPartition(const Handle(JtNode_Partition) & aPart)
 void TKJtReader::readGroup(const Handle(JtNode_Group) & aGroup)
 {
     if (!transformations.empty()) {
-        builder.addNode(Base::TransformItem {transformations.back()});
+        builder.addNode(Base::TransformItem(transformations.back()));
         transformations.pop_back();
     }
     const auto& aChildren = aGroup->Children();

--- a/src/Mod/JtReader/App/TKJtReader.cpp
+++ b/src/Mod/JtReader/App/TKJtReader.cpp
@@ -43,8 +43,12 @@ const Handle(Standard_Type) Type_JtNode_Shape_Vertex            = STANDARD_TYPE(
 const Handle(Standard_Type) Type_JtNode_Shape_TriStripSet       = STANDARD_TYPE(JtNode_Shape_TriStripSet);
 // clang-format on
 
-const Handle(Standard_Type) Type_JtElement_ShapeLOD_PolygonSet  = STANDARD_TYPE(JtElement_ShapeLOD_PolygonSet);
-const Handle(Standard_Type) Type_JtElement_ShapeLOD_PolylineSet = STANDARD_TYPE(JtElement_ShapeLOD_PolylineSet);
+const Handle(Standard_Type) Type_JtElement_ShapeLOD_PolygonSet = STANDARD_TYPE(
+    JtElement_ShapeLOD_PolygonSet
+);
+const Handle(Standard_Type) Type_JtElement_ShapeLOD_PolylineSet = STANDARD_TYPE(
+    JtElement_ShapeLOD_PolylineSet
+);
 }  // namespace
 
 TKJtReader::TKJtReader()

--- a/src/Mod/JtReader/App/TKJtReader.h
+++ b/src/Mod/JtReader/App/TKJtReader.h
@@ -27,6 +27,8 @@
 # include <JtAttribute_GeometricTransform.hxx>
 # include <JtAttribute_Material.hxx>
 # include <JtData_Model.hxx>
+# include <JtElement_ShapeLOD_PolygonSet.hxx>
+# include <JtElement_ShapeLOD_PolylineSet.hxx>
 # include <JtElement_ShapeLOD_TriStripSet.hxx>
 # include <JtNode_Instance.hxx>
 # include <JtNode_Partition.hxx>
@@ -35,7 +37,9 @@
 # include <JtNode_Shape_Vertex.hxx>
 # include <TCollection_AsciiString.hxx>
 # include <TCollection_ExtendedString.hxx>
+# include <list>
 # include <Base/Builder3D.h>
+# include <Base/Matrix.h>
 
 namespace JtReaderNS
 {
@@ -59,6 +63,8 @@ private:
     void readInstance(const Handle(JtNode_Instance) & anInstance);
     void readAttributes(const JtData_Object::VectorOfObjects& attr);
     void getTriangleStripSet(const Handle(JtElement_ShapeLOD_TriStripSet) & aLOD);
+    void getPolygonSet(const Handle(JtElement_ShapeLOD_PolygonSet) & aLOD);
+    void getPolylineSet(const Handle(JtElement_ShapeLOD_PolylineSet) & aLOD);
 
 private:
     TCollection_ExtendedString jtDir;

--- a/src/Mod/JtReader/App/TKJtReader.h
+++ b/src/Mod/JtReader/App/TKJtReader.h
@@ -28,6 +28,7 @@
 # include <JtAttribute_Material.hxx>
 # include <JtData_Model.hxx>
 # include <JtElement_ShapeLOD_PolygonSet.hxx>
+# include <Standard_Failure.hxx>
 # include <JtElement_ShapeLOD_PolylineSet.hxx>
 # include <JtElement_ShapeLOD_TriStripSet.hxx>
 # include <JtNode_Instance.hxx>
@@ -51,6 +52,8 @@ public:
     void open(const std::string& filename);
     void clear();
     std::string getOutput() const;
+    int shapeCount() const;
+    std::string fileName() const;
 
 private:
     void traverseGraph(const Handle(JtNode_Base) & aNode);
@@ -72,6 +75,8 @@ private:
     std::stringstream result;
     Base::InventorBuilder builder;
     std::list<Base::Matrix4D> transformations;
+    std::string myFileName;
+    int myShapeCount {0};
 };
 
 };  // namespace JtReaderNS


### PR DESCRIPTION
## Summary

Two improvements to the JT importer (`src/Mod/JtReader`), complementing
the JT 10.x read support added in [wwmayer/TKJT#<N>](https://github.com/wwmayer/TKJT/pull/<N>).

## Changes

### PolygonSet and PolylineSet LOD geometry
`TKJtReader` now handles two previously-ignored LOD element types:
- `JtElement_ShapeLOD_PolygonSet` — triangle-indexed polygon geometry,
  rendered the same way as `TriStripSet`
- `JtElement_ShapeLOD_PolylineSet` — indexed polyline geometry, emitted
  as a `LineSet`

Both are dispatched from `readShapeVertex` alongside the existing
`TriStripSet` path.

### User-visible import error reporting
Previously, if a JT file failed to decode (unsupported codec, incomplete
file, OCCT exception, etc.) the importer would silently create an empty
object in the document with no feedback.

Now:
- If TKJT/OCCT raises `Standard_Failure` or a `std::exception` during
  `open()`, a warning is printed to the FreeCAD Report View:
  `JtReader: error reading 'file.jt': <message>`
- If `open()` completes but no geometry was decoded, a warning is printed:
  `JtReader: no geometry could be imported from 'file.jt'. The file may
  use unsupported features.`
- In both cases, no empty document object is created.

Applied to both the `open()` and `insert()` (importer) code paths.

## Dependency
The PolygonSet/PolylineSet types require the corresponding TKJT classes
from [wwmayer/TKJT#1](https://github.com/wwmayer/TKJT/pull/1).
The error reporting changes have no library dependency.