### PR TITLE
Whitelist disc for angle measurement.

### DIFF
--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -95,7 +95,8 @@ bool MeasureAngle::isValidSelection(const App::MeasureSelection& selection)
         }
 
         if (!(type == App::MeasureElementType::LINE || type == App::MeasureElementType::PLANE
-              || type == App::MeasureElementType::LINESEGMENT || type == App::MeasureElementType::DISC)) {
+              || type == App::MeasureElementType::LINESEGMENT
+              || type == App::MeasureElementType::DISC)) {
             return false;
         }
     }

--- a/src/Mod/Measure/App/MeasureAngle.cpp
+++ b/src/Mod/Measure/App/MeasureAngle.cpp
@@ -95,7 +95,7 @@ bool MeasureAngle::isValidSelection(const App::MeasureSelection& selection)
         }
 
         if (!(type == App::MeasureElementType::LINE || type == App::MeasureElementType::PLANE
-              || type == App::MeasureElementType::LINESEGMENT)) {
+              || type == App::MeasureElementType::LINESEGMENT || type == App::MeasureElementType::DISC)) {
             return false;
         }
     }


### PR DESCRIPTION
A disc has a normal so it can be be measured using the angle tool just like any other plane.