### PR TITLE
Sketcher: Remove incorrect optimization due to isSame not checking solver result

### DIFF
--- a/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectConstraints.cpp
@@ -172,10 +172,7 @@ int SketchObject::solve(bool updateGeoAfterSolving /*=true*/)
             std::vector<Part::Geometry*> geomlist = solvedSketch.extractGeometry();
             Part::PropertyGeometryList tmp;
             tmp.setValues(std::move(geomlist));
-            // Only set values if there is actual changes
-            if (Constraints.isTouched() || !Geometry.isSame(tmp)) {
-                Geometry.moveValues(std::move(tmp));
-            }
+            Geometry.moveValues(std::move(tmp));
         }
     }
 


### PR DESCRIPTION
Fixes #15939

The symptoms described in the issue is no longer seen. But this changes removes the root cause which could be misleading. See https://github.com/FreeCAD/FreeCAD/issues/15939#issuecomment-4365903420 .