### PR TITLE
Gui: sync focalDistance to fix label scaling during SpaceMouse moves

### DIFF
--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -1932,6 +1932,15 @@ SbBool NavigationStyle::processMotionEvent(const SoMotion3Event* const ev)
     camera->enableNotify(false);
     camera->orientation.setValue(newRotation);
     camera->position = finalPosition;
+
+    // Recompute focalDistance for the new camera position so that
+    // perspective-dependent screen-space elements (e.g. Sketcher labels)
+    // scale correctly during SpaceMouse motion.
+    float newFocalDist = (center - finalPosition).dot(newDirection);
+    if (newFocalDist > 0.0f) {
+        camera->focalDistance = newFocalDist;
+    }
+
     camera->enableNotify(true);
     camera->touch();
 


### PR DESCRIPTION
processMotionEvent() updates camera position and orientation but not focalDistance.  This causes perspective-dependent screen-space elements — most visibly Sketcher dimension and constraint labels — to scale incorrectly when the camera is moved with a SpaceMouse.

Recompute focalDistance as the projection of the camera-to-center vector onto the viewing direction, consistent with the existing doZoom() implementation.

Fixes label scaling in Perspective and Isometric camera modes; Orthographic mode is unaffected (scale is focal-distance-independent).

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
**Initial state:**
<img width="1758" height="1080" alt="before_zoom" src="https://github.com/user-attachments/assets/495cd1f2-dbc9-49a7-b3e6-b26d0ac47640" />
**Bug: Zooming with SpaceMouse** (labels scale incorrectly along with the 3D geometry):
<img width="1758" height="1080" alt="SpaceMouse_zoom_before_fix" src="https://github.com/user-attachments/assets/b7ae02ea-8021-46c7-b506-9afb854de9da" />
**Fixed: Zooming with SpaceMouse** (labels maintain correct screen-space size, perfectly matching standard mouse scroll behavior):
<img width="1940" height="1080" alt="SpaceMouse_zoom_after_fix" src="https://github.com/user-attachments/assets/87b1e0da-c8d6-4ffa-b56f-f0ffd320299f" />



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
