### PR TITLE
Gui: billboard Sketcher dimension labels toward camera

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1560,6 +1560,40 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
     // Apply a rotation and translation matrix
     glTranslatef(textOffset[0], textOffset[1], textOffset[2]);
     glRotatef(Base::toDegrees<GLfloat>(angle), 0, 0, 1);
+
+    // Cylindrical billboard: tilt the text around the dimension line axis
+    // (local X) so that it faces the camera regardless of view angle.
+    {
+        GLfloat mv[16];
+        glGetFloatv(GL_MODELVIEW_MATRIX, mv);
+
+        SbVec3f axisX(mv[0], mv[1], mv[2]);   // dimension line in eye space
+        SbVec3f curZ(mv[8], mv[9], mv[10]);    // current text normal
+        axisX.normalize();
+        curZ.normalize();
+
+        // Project current and desired normals onto the plane perpendicular
+        // to the dimension line to obtain the tilt angle around it.
+        SbVec3f target(0.0f, 0.0f, 1.0f);     // toward camera in eye space
+        SbVec3f curProj = curZ - axisX * curZ.dot(axisX);
+        SbVec3f tgtProj = target - axisX * target.dot(axisX);
+
+        if (curProj.length() > 1e-6f && tgtProj.length() > 1e-6f) {
+            curProj.normalize();
+            tgtProj.normalize();
+
+            float cosA = curProj.dot(tgtProj);
+            float sinA = curProj.cross(tgtProj).dot(axisX);
+            float tilt = atan2f(sinA, cosA);
+            glRotatef(Base::toDegrees<GLfloat>(tilt), 1.0f, 0.0f, 0.0f);
+
+            // Crossing the sketch plane (tilt > 90°) desynchronizes the
+            // UV flip computed earlier from the camera-vs-normal test.
+            if (cosA < 0.0f) {
+                flip = !flip;
+            }
+        }
+    }
     glBegin(GL_QUADS);
 
     glColor3f(1.F, 1.F, 1.F);

--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -1567,14 +1567,14 @@ void SoDatumLabel::drawText(SoState* state, int srcw, int srch, float angle, con
         GLfloat mv[16];
         glGetFloatv(GL_MODELVIEW_MATRIX, mv);
 
-        SbVec3f axisX(mv[0], mv[1], mv[2]);   // dimension line in eye space
-        SbVec3f curZ(mv[8], mv[9], mv[10]);    // current text normal
+        SbVec3f axisX(mv[0], mv[1], mv[2]);  // dimension line in eye space
+        SbVec3f curZ(mv[8], mv[9], mv[10]);  // current text normal
         axisX.normalize();
         curZ.normalize();
 
         // Project current and desired normals onto the plane perpendicular
         // to the dimension line to obtain the tilt angle around it.
-        SbVec3f target(0.0f, 0.0f, 1.0f);     // toward camera in eye space
+        SbVec3f target(0.0f, 0.0f, 1.0f);  // toward camera in eye space
         SbVec3f curProj = curZ - axisX * curZ.dot(axisX);
         SbVec3f tgtProj = target - axisX * target.dot(axisX);
 


### PR DESCRIPTION
Dimension labels (SoDatumLabel) are rendered as textured quads fixed in the sketch plane.  When the view is tilted — common with a SpaceMouse in perspective mode — labels become foreshortened and hard to read, unlike constraint icons (SoImage) which always face the camera.

Add a cylindrical billboard in drawText(): after positioning the text quad on the dimension line, compute the tilt angle that aligns the text normal with the camera direction, projected perpendicular to the dimension line axis.  This keeps labels anchored to their dimension lines while rotating them toward the viewer.

When the tilt exceeds 90° (viewing from behind the sketch plane), toggle the UV flip to maintain text readability across the crossing.

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
**Previous behavior: Sketch viewed at an angle in Perspective mode** (dimension labels lie flat on the sketch plane, causing severe foreshortening and making the text illegible):
<img width="684" height="640" alt="before_billboard" src="https://github.com/user-attachments/assets/42011c22-3aa0-4ca6-a42e-e6827eff7aa2" />
**New behavior: Sketch viewed at the same angle** (labels use a cylindrical billboard to dynamically tilt toward the camera around the dimension line axis, ensuring perfect readability):
<img width="684" height="640" alt="after_billboard" src="https://github.com/user-attachments/assets/4100cfd9-0871-49cc-83eb-3266ede5ad77" />


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
