### PR TITLE
"sketcher: fixes 28639, restore preselect highlight for faces when using external projection tool"

### DIFF
--- a/src/Mod/Sketcher/CMakeLists.txt
+++ b/src/Mod/Sketcher/CMakeLists.txt
@@ -33,6 +33,7 @@ if(BUILD_GUI)
           SketcherTests/GuiTestCase.py
           SketcherTests/TestPlacementUpdate.py
           SketcherTests/TestOnViewParameterGui.py
+          SketcherTests/TestExternalFacePreselection.py
     )
 endif(BUILD_GUI)
 

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -3110,20 +3110,16 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
     editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.constrGrpSelect);
     setConstraintSelectability();  // Ensure default value;
 
-    // disable depth testing for constraint icons so they render ON TOP of geometry lines
-    // check issues #25840 and #11603
-    SoDepthBuffer* constrDepthOff = new SoDepthBuffer();
-    constrDepthOff->test.setValue(false);
-    editModeScenegraphNodes.EditRoot->addChild(constrDepthOff);
+    // Render constraint icons ON TOP of geometry lines without
+    // affecting depth state for other nodes (#28639).
+    // See also issues #25840 and #11603.
+    SoAnnotation* constrAnnotation = new SoAnnotation();
 
     editModeScenegraphNodes.constrGroup = new SmSwitchboard();
     editModeScenegraphNodes.constrGroup->setName("ConstraintGroup");
-    editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.constrGroup);
+    constrAnnotation->addChild(editModeScenegraphNodes.constrGroup);
 
-    // re-enable depth testing for the rest of the nodes
-    SoDepthBuffer* constrDepthOn = new SoDepthBuffer();
-    constrDepthOn->test.setValue(true);
-    editModeScenegraphNodes.EditRoot->addChild(constrDepthOn);
+    editModeScenegraphNodes.EditRoot->addChild(constrAnnotation);
 
     SoPickStyle* ps = new SoPickStyle();  // used to following nodes aren't impacted
     ps->style.setValue(SoPickStyle::SHAPE);

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.cpp
@@ -27,9 +27,10 @@
 #include <QPainter>
 #include <QRegularExpression>
 #include <Bnd_Box.hxx>
+#include <algorithm>
 #include <limits>
-#include <memory>
 #include <map>
+#include <ranges>
 #include <stack>
 #include <cmath>
 
@@ -37,7 +38,6 @@
 #include <Inventor/SbVec3f.h>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/nodes/SoAnnotation.h>
-#include <Inventor/nodes/SoDepthBuffer.h>
 #include <Inventor/nodes/SoDrawStyle.h>
 #include <Inventor/nodes/SoGroup.h>
 #include <Inventor/nodes/SoImage.h>
@@ -73,7 +73,6 @@
 #include "ViewProviderSketch.h"
 #include "ViewProviderSketchCoinAttorney.h"
 
-
 using namespace Gui;
 using namespace SketcherGui;
 using namespace Sketcher;
@@ -96,8 +95,7 @@ EditModeConstraintCoinManager::EditModeConstraintCoinManager(
     , coinMapping(coinMap)
 {}
 
-EditModeConstraintCoinManager::~EditModeConstraintCoinManager()
-{}
+EditModeConstraintCoinManager::~EditModeConstraintCoinManager() = default;
 
 void EditModeConstraintCoinManager::updateVirtualSpace()
 {
@@ -124,6 +122,7 @@ void EditModeConstraintCoinManager::updateVirtualSpace()
 
 void EditModeConstraintCoinManager::processConstraints(const GeoListFacade& geolistfacade)
 {
+    using Part::GeomCircle;
     using std::numbers::pi;
 
     const auto& constrlist = ViewProviderSketchCoinAttorney::getConstraints(viewProvider);
@@ -164,26 +163,23 @@ Restart:
                 Base::Vector3d linedir = line->getEndPoint() - line->getStartPoint();
                 return Base::Vector3d(-linedir.y, linedir.x, 0);
             }
-            else {
-                Base::Vector3d normal;
-                try {
-                    if (!(curve && curve->normalAt(pointoncurve, normal))) {
-                        normal = Base::Vector3d(1, 0, 0);
-                    }
-                }
-                catch (const Base::CADKernelError&) {
+
+            Base::Vector3d normal;
+            try {
+                if (!(curve && curve->normalAt(pointoncurve, normal))) {
                     normal = Base::Vector3d(1, 0, 0);
                 }
-
-                return normal;
             }
+            catch (const Base::CADKernelError&) {
+                normal = Base::Vector3d(1, 0, 0);
+            }
+
+            return normal;
         };
 
     // go through the constraints and update the position
     int i = 0;
-    for (std::vector<Sketcher::Constraint*>::const_iterator it = constrlist.begin();
-         it != constrlist.end();
-         ++it, i++) {
+    for (auto it = constrlist.begin(); it != constrlist.end(); ++it, i++) {
         // check if the type has changed
         if ((*it)->Type != vConstrType[i]) {
             // clearing the type vector will force a rebuild of the visual nodes
@@ -194,9 +190,7 @@ Restart:
         }
         try {  // because calculateNormalAtPoint, used in there, can throw
             // root separator for this constraint
-            SoSeparator* sep = static_cast<SoSeparator*>(
-                editModeScenegraphNodes.constrGroup->getChild(i)
-            );
+            auto* sep = static_cast<SoSeparator*>(editModeScenegraphNodes.constrGroup->getChild(i));
             const Constraint* Constr = *it;
 
             if (Constr->First < -extGeoCount || Constr->First >= intGeoCount
@@ -229,8 +223,7 @@ Restart:
                         Base::Vector3d norm;
 
                         if (geo->is<Part::GeomLineSegment>()) {
-                            const Part::GeomLineSegment* lineSeg
-                                = static_cast<const Part::GeomLineSegment*>(geo);
+                            const auto* lineSeg = static_cast<const Part::GeomLineSegment*>(geo);
 
                             // calculate the half distance between the start and endpoint
                             midpos = ((lineSeg->getEndPoint() + lineSeg->getStartPoint()) / 2);
@@ -241,8 +234,7 @@ Restart:
                             norm = Base::Vector3d(-dir.y, dir.x, 0);
                         }
                         else if (geo->is<Part::GeomBSplineCurve>()) {
-                            const Part::GeomBSplineCurve* bsp
-                                = static_cast<const Part::GeomBSplineCurve*>(geo);
+                            const auto* bsp = static_cast<const Part::GeomBSplineCurve*>(geo);
                             midpos = Base::Vector3d(0, 0, 0);
 
                             std::vector<Base::Vector3d> poles = bsp->getPoles();
@@ -252,10 +244,8 @@ Restart:
                             double ws = 1.0 / poles.size();
                             double w = 1.0;
 
-                            for (std::vector<Base::Vector3d>::iterator it = poles.begin();
-                                 it != poles.end();
-                                 ++it) {
-                                midpos += w * (*it);
+                            for (auto& pole : poles) {
+                                midpos += w * pole;
                                 w -= ws;
                             }
 
@@ -270,15 +260,13 @@ Restart:
                                 angleplus = 0.;  // arc angle (t parameter for ellipses)
 
                             if (geo->is<Part::GeomCircle>()) {
-                                const Part::GeomCircle* circle
-                                    = static_cast<const Part::GeomCircle*>(geo);
+                                const auto* circle = static_cast<const Part::GeomCircle*>(geo);
                                 ra = circle->getRadius();
                                 angle = pi / 4;
                                 midpos = circle->getCenter();
                             }
                             else if (geo->is<Part::GeomArcOfCircle>()) {
-                                const Part::GeomArcOfCircle* arc
-                                    = static_cast<const Part::GeomArcOfCircle*>(geo);
+                                const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
                                 ra = arc->getRadius();
                                 double startangle, endangle;
                                 arc->getRange(startangle, endangle, /*emulateCCW=*/true);
@@ -286,8 +274,7 @@ Restart:
                                 midpos = arc->getCenter();
                             }
                             else if (geo->is<Part::GeomEllipse>()) {
-                                const Part::GeomEllipse* ellipse
-                                    = static_cast<const Part::GeomEllipse*>(geo);
+                                const auto* ellipse = static_cast<const Part::GeomEllipse*>(geo);
                                 ra = ellipse->getMajorRadius();
                                 rb = ellipse->getMinorRadius();
                                 Base::Vector3d majdir = ellipse->getMajorAxisDir();
@@ -296,8 +283,7 @@ Restart:
                                 midpos = ellipse->getCenter();
                             }
                             else if (geo->is<Part::GeomArcOfEllipse>()) {
-                                const Part::GeomArcOfEllipse* aoe
-                                    = static_cast<const Part::GeomArcOfEllipse*>(geo);
+                                const auto* aoe = static_cast<const Part::GeomArcOfEllipse*>(geo);
                                 ra = aoe->getMajorRadius();
                                 rb = aoe->getMinorRadius();
                                 double startangle, endangle;
@@ -308,8 +294,7 @@ Restart:
                                 midpos = aoe->getCenter();
                             }
                             else if (geo->is<Part::GeomArcOfHyperbola>()) {
-                                const Part::GeomArcOfHyperbola* aoh
-                                    = static_cast<const Part::GeomArcOfHyperbola*>(geo);
+                                const auto* aoh = static_cast<const Part::GeomArcOfHyperbola*>(geo);
                                 ra = aoh->getMajorRadius();
                                 rb = aoh->getMinorRadius();
                                 double startangle, endangle;
@@ -320,8 +305,7 @@ Restart:
                                 midpos = aoh->getCenter();
                             }
                             else if (geo->is<Part::GeomArcOfParabola>()) {
-                                const Part::GeomArcOfParabola* aop
-                                    = static_cast<const Part::GeomArcOfParabola*>(geo);
+                                const auto* aop = static_cast<const Part::GeomArcOfParabola*>(geo);
                                 ra = aop->getFocal();
                                 double startangle, endangle;
                                 aop->getRange(startangle, endangle, /*emulateCCW=*/true);
@@ -469,24 +453,22 @@ Restart:
                     else if (Constr->FirstPos == Sketcher::PointPos::none) {
 
                         if (geo1->is<Part::GeomLineSegment>()) {
-                            const Part::GeomLineSegment* lineSeg1
-                                = static_cast<const Part::GeomLineSegment*>(geo1);
+                            const auto* lineSeg1 = static_cast<const Part::GeomLineSegment*>(geo1);
                             midpos1 = ((lineSeg1->getEndPoint() + lineSeg1->getStartPoint()) / 2);
                             dir1 = (lineSeg1->getEndPoint() - lineSeg1->getStartPoint()).Normalize();
                             norm1 = Base::Vector3d(-dir1.y, dir1.x, 0.);
                         }
                         else if (geo1->is<Part::GeomArcOfCircle>()) {
-                            const Part::GeomArcOfCircle* arc
-                                = static_cast<const Part::GeomArcOfCircle*>(geo1);
+                            const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo1);
                             double startangle, endangle, midangle;
-                            arc->getRange(startangle, endangle, /*emulateCCW=*/true);
+                            arc->getRange(startangle, endangle, /*emulateCCWXY=*/true);
                             midangle = (startangle + endangle) / 2;
                             norm1 = Base::Vector3d(cos(midangle), sin(midangle), 0);
                             dir1 = Base::Vector3d(-norm1.y, norm1.x, 0);
                             midpos1 = arc->getCenter() + arc->getRadius() * norm1;
                         }
                         else if (geo1->is<Part::GeomCircle>()) {
-                            const Part::GeomCircle* circle = static_cast<const Part::GeomCircle*>(geo1);
+                            const auto* circle = static_cast<const Part::GeomCircle*>(geo1);
                             norm1 = Base::Vector3d(cos(pi / 4), sin(pi / 4), 0);
                             dir1 = Base::Vector3d(-norm1.y, norm1.x, 0);
                             midpos1 = circle->getCenter() + circle->getRadius() * norm1;
@@ -496,15 +478,13 @@ Restart:
                         }
 
                         if (geo2->is<Part::GeomLineSegment>()) {
-                            const Part::GeomLineSegment* lineSeg2
-                                = static_cast<const Part::GeomLineSegment*>(geo2);
+                            const auto* lineSeg2 = static_cast<const Part::GeomLineSegment*>(geo2);
                             midpos2 = ((lineSeg2->getEndPoint() + lineSeg2->getStartPoint()) / 2);
                             dir2 = (lineSeg2->getEndPoint() - lineSeg2->getStartPoint()).Normalize();
                             norm2 = Base::Vector3d(-dir2.y, dir2.x, 0.);
                         }
                         else if (geo2->is<Part::GeomArcOfCircle>()) {
-                            const Part::GeomArcOfCircle* arc
-                                = static_cast<const Part::GeomArcOfCircle*>(geo2);
+                            const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo2);
                             double startangle, endangle, midangle;
                             arc->getRange(startangle, endangle, /*emulateCCW=*/true);
                             midangle = (startangle + endangle) / 2;
@@ -513,7 +493,7 @@ Restart:
                             midpos2 = arc->getCenter() + arc->getRadius() * norm2;
                         }
                         else if (geo2->is<Part::GeomCircle>()) {
-                            const Part::GeomCircle* circle = static_cast<const Part::GeomCircle*>(geo2);
+                            const auto* circle = static_cast<const Part::GeomCircle*>(geo2);
                             norm2 = Base::Vector3d(cos(pi / 4), sin(pi / 4), 0);
                             dir2 = Base::Vector3d(-norm2.y, norm2.x, 0);
                             midpos2 = circle->getCenter() + circle->getRadius() * norm2;
@@ -563,15 +543,13 @@ Restart:
                                                              // whole; angle1plus = arc angle (t
                                                              // parameter for ellipses).
                             if (geo1->is<Part::GeomCircle>()) {
-                                const Part::GeomCircle* circle
-                                    = static_cast<const Part::GeomCircle*>(geo1);
+                                const auto* circle = static_cast<const Part::GeomCircle*>(geo1);
                                 r1a = circle->getRadius();
                                 angle1 = pi / 4;
                                 midpos1 = circle->getCenter();
                             }
                             else if (geo1->is<Part::GeomArcOfCircle>()) {
-                                const Part::GeomArcOfCircle* arc
-                                    = static_cast<const Part::GeomArcOfCircle*>(geo1);
+                                const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo1);
                                 r1a = arc->getRadius();
                                 double startangle, endangle;
                                 arc->getRange(startangle, endangle, /*emulateCCW=*/true);
@@ -579,8 +557,7 @@ Restart:
                                 midpos1 = arc->getCenter();
                             }
                             else if (geo1->is<Part::GeomEllipse>()) {
-                                const Part::GeomEllipse* ellipse
-                                    = static_cast<const Part::GeomEllipse*>(geo1);
+                                const auto* ellipse = static_cast<const Part::GeomEllipse*>(geo1);
                                 r1a = ellipse->getMajorRadius();
                                 r1b = ellipse->getMinorRadius();
                                 Base::Vector3d majdir = ellipse->getMajorAxisDir();
@@ -589,8 +566,7 @@ Restart:
                                 midpos1 = ellipse->getCenter();
                             }
                             else if (geo1->is<Part::GeomArcOfEllipse>()) {
-                                const Part::GeomArcOfEllipse* aoe
-                                    = static_cast<const Part::GeomArcOfEllipse*>(geo1);
+                                const auto* aoe = static_cast<const Part::GeomArcOfEllipse*>(geo1);
                                 r1a = aoe->getMajorRadius();
                                 r1b = aoe->getMinorRadius();
                                 double startangle, endangle;
@@ -601,8 +577,7 @@ Restart:
                                 midpos1 = aoe->getCenter();
                             }
                             else if (geo1->is<Part::GeomArcOfHyperbola>()) {
-                                const Part::GeomArcOfHyperbola* aoh
-                                    = static_cast<const Part::GeomArcOfHyperbola*>(geo1);
+                                const auto* aoh = static_cast<const Part::GeomArcOfHyperbola*>(geo1);
                                 r1a = aoh->getMajorRadius();
                                 r1b = aoh->getMinorRadius();
                                 double startangle, endangle;
@@ -613,8 +588,7 @@ Restart:
                                 midpos1 = aoh->getCenter();
                             }
                             else if (geo1->is<Part::GeomArcOfParabola>()) {
-                                const Part::GeomArcOfParabola* aop
-                                    = static_cast<const Part::GeomArcOfParabola*>(geo1);
+                                const auto* aop = static_cast<const Part::GeomArcOfParabola*>(geo1);
                                 r1a = aop->getFocal();
                                 double startangle, endangle;
                                 aop->getRange(startangle, endangle, /*emulateCCW=*/true);
@@ -628,15 +602,13 @@ Restart:
                             }
 
                             if (geo2->is<Part::GeomCircle>()) {
-                                const Part::GeomCircle* circle
-                                    = static_cast<const Part::GeomCircle*>(geo2);
+                                const auto* circle = static_cast<const Part::GeomCircle*>(geo2);
                                 r2a = circle->getRadius();
                                 angle2 = pi / 4;
                                 midpos2 = circle->getCenter();
                             }
                             else if (geo2->is<Part::GeomArcOfCircle>()) {
-                                const Part::GeomArcOfCircle* arc
-                                    = static_cast<const Part::GeomArcOfCircle*>(geo2);
+                                const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo2);
                                 r2a = arc->getRadius();
                                 double startangle, endangle;
                                 arc->getRange(startangle, endangle, /*emulateCCW=*/true);
@@ -644,8 +616,7 @@ Restart:
                                 midpos2 = arc->getCenter();
                             }
                             else if (geo2->is<Part::GeomEllipse>()) {
-                                const Part::GeomEllipse* ellipse
-                                    = static_cast<const Part::GeomEllipse*>(geo2);
+                                const auto* ellipse = static_cast<const Part::GeomEllipse*>(geo2);
                                 r2a = ellipse->getMajorRadius();
                                 r2b = ellipse->getMinorRadius();
                                 Base::Vector3d majdir = ellipse->getMajorAxisDir();
@@ -654,8 +625,7 @@ Restart:
                                 midpos2 = ellipse->getCenter();
                             }
                             else if (geo2->is<Part::GeomArcOfEllipse>()) {
-                                const Part::GeomArcOfEllipse* aoe
-                                    = static_cast<const Part::GeomArcOfEllipse*>(geo2);
+                                const auto* aoe = static_cast<const Part::GeomArcOfEllipse*>(geo2);
                                 r2a = aoe->getMajorRadius();
                                 r2b = aoe->getMinorRadius();
                                 double startangle, endangle;
@@ -666,8 +636,7 @@ Restart:
                                 midpos2 = aoe->getCenter();
                             }
                             else if (geo2->is<Part::GeomArcOfHyperbola>()) {
-                                const Part::GeomArcOfHyperbola* aoh
-                                    = static_cast<const Part::GeomArcOfHyperbola*>(geo2);
+                                const auto* aoh = static_cast<const Part::GeomArcOfHyperbola*>(geo2);
                                 r2a = aoh->getMajorRadius();
                                 r2b = aoh->getMinorRadius();
                                 double startangle, endangle;
@@ -678,8 +647,7 @@ Restart:
                                 midpos2 = aoh->getCenter();
                             }
                             else if (geo2->is<Part::GeomArcOfParabola>()) {
-                                const Part::GeomArcOfParabola* aop
-                                    = static_cast<const Part::GeomArcOfParabola*>(geo2);
+                                const auto* aop = static_cast<const Part::GeomArcOfParabola*>(geo2);
                                 r2a = aop->getFocal();
                                 double startangle, endangle;
                                 aop->getRange(startangle, endangle, /*emulateCCW=*/true);
@@ -756,10 +724,8 @@ Restart:
                         }
                     }
                     else {
-                        const Part::GeomLineSegment* lineSeg1
-                            = static_cast<const Part::GeomLineSegment*>(geo1);
-                        const Part::GeomLineSegment* lineSeg2
-                            = static_cast<const Part::GeomLineSegment*>(geo2);
+                        const auto* lineSeg1 = static_cast<const Part::GeomLineSegment*>(geo1);
+                        const auto* lineSeg2 = static_cast<const Part::GeomLineSegment*>(geo2);
 
                         // calculate the half distance between the start and endpoint
                         midpos1 = ((lineSeg1->getEndPoint() + lineSeg1->getStartPoint()) / 2);
@@ -824,7 +790,7 @@ Restart:
 
                     if (!totalBBox.HasFinitePart() || totalBBox.IsVoid()) {
                         // If no valid box, hide the geometry by setting all points to the origin.
-                        SoCoordinate3* coords = static_cast<SoCoordinate3*>(sep->getChild(2));
+                        auto* coords = static_cast<SoCoordinate3*>(sep->getChild(2));
 
                         // Use startEditing() to get a writable pointer to the internal array.
                         SbVec3f* points = coords->point.startEditing();
@@ -866,7 +832,7 @@ Restart:
 
                     // 3. Get the SoCoordinate3 node we created in rebuildConstraintNodes
                     //    Index 0: SoMaterial, Index 1: SoDrawStyle, Index 2: SoCoordinate3
-                    SoCoordinate3* coords = static_cast<SoCoordinate3*>(sep->getChild(2));
+                    auto* coords = static_cast<SoCoordinate3*>(sep->getChild(2));
 
                     // 4. Update the points in the node to draw the rectangle
                     SbVec3f* points = coords->point.startEditing();
@@ -1048,7 +1014,7 @@ Restart:
 
                             double angle = toVector2d(pnt2 - center2).Angle();  // between -pi and pi
                             double startAngle, endAngle;  // between 0 and 2*pi
-                            arc->getRange(startAngle, endAngle, /*emulateCCW=*/true);
+                            arc->getRange(startAngle, endAngle, /*emulateCCWXY=*/true);
 
                             findHelperAngles(helperStartAngle2, helperRange2, angle, startAngle, endAngle);
 
@@ -1170,10 +1136,8 @@ Restart:
                         const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(Constr->Second);
 
                         if (geo1->is<Part::GeomLineSegment>() && geo2->is<Part::GeomLineSegment>()) {
-                            const Part::GeomLineSegment* lineSeg1
-                                = static_cast<const Part::GeomLineSegment*>(geo1);
-                            const Part::GeomLineSegment* lineSeg2
-                                = static_cast<const Part::GeomLineSegment*>(geo2);
+                            const auto* lineSeg1 = static_cast<const Part::GeomLineSegment*>(geo1);
+                            const auto* lineSeg2 = static_cast<const Part::GeomLineSegment*>(geo2);
                             // tangency between two lines
                             Base::Vector3d midpos1
                                 = ((lineSeg1->getEndPoint() + lineSeg1->getStartPoint()) / 2);
@@ -1213,19 +1177,17 @@ Restart:
 
                             break;
                         }
-                        else if (geo2->is<Part::GeomLineSegment>()) {
+                        if (geo2->is<Part::GeomLineSegment>()) {
                             std::swap(geo1, geo2);
                         }
 
                         if (geo1->is<Part::GeomLineSegment>()) {
-                            const Part::GeomLineSegment* lineSeg
-                                = static_cast<const Part::GeomLineSegment*>(geo1);
+                            const auto* lineSeg = static_cast<const Part::GeomLineSegment*>(geo1);
                             Base::Vector3d dir
                                 = (lineSeg->getEndPoint() - lineSeg->getStartPoint()).Normalize();
                             Base::Vector3d norm(-dir.y, dir.x, 0);
                             if (geo2->is<Part::GeomCircle>()) {
-                                const Part::GeomCircle* circle
-                                    = static_cast<const Part::GeomCircle*>(geo2);
+                                const auto* circle = static_cast<const Part::GeomCircle*>(geo2);
                                 // tangency between a line and a circle
                                 float length = (circle->getCenter() - lineSeg->getStartPoint()) * dir;
 
@@ -1238,13 +1200,11 @@ Restart:
 
                                 Base::Vector3d center;
                                 if (geo2->is<Part::GeomEllipse>()) {
-                                    const Part::GeomEllipse* ellipse
-                                        = static_cast<const Part::GeomEllipse*>(geo2);
+                                    const auto* ellipse = static_cast<const Part::GeomEllipse*>(geo2);
                                     center = ellipse->getCenter();
                                 }
                                 else {
-                                    const Part::GeomArcOfEllipse* aoc
-                                        = static_cast<const Part::GeomArcOfEllipse*>(geo2);
+                                    const auto* aoc = static_cast<const Part::GeomArcOfEllipse*>(geo2);
                                     center = aoc->getCenter();
                                 }
 
@@ -1255,8 +1215,7 @@ Restart:
                                 relPos = norm * 1;
                             }
                             else if (geo2->is<Part::GeomArcOfCircle>()) {
-                                const Part::GeomArcOfCircle* arc
-                                    = static_cast<const Part::GeomArcOfCircle*>(geo2);
+                                const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo2);
                                 // tangency between a line and an arc
                                 float length = (arc->getCenter() - lineSeg->getStartPoint()) * dir;
 
@@ -1266,12 +1225,8 @@ Restart:
                         }
 
                         if (geo1->is<Part::GeomCircle>() && geo2->is<Part::GeomCircle>()) {
-                            const Part::GeomCircle* circle1 = static_cast<const Part::GeomCircle*>(
-                                geo1
-                            );
-                            const Part::GeomCircle* circle2 = static_cast<const Part::GeomCircle*>(
-                                geo2
-                            );
+                            const auto* circle1 = static_cast<const Part::GeomCircle*>(geo1);
+                            const auto* circle2 = static_cast<const Part::GeomCircle*>(geo2);
                             // tangency between two circles
                             Base::Vector3d dir
                                 = (circle2->getCenter() - circle1->getCenter()).Normalize();
@@ -1283,9 +1238,8 @@ Restart:
                         }
 
                         if (geo1->is<Part::GeomCircle>() && geo2->is<Part::GeomArcOfCircle>()) {
-                            const Part::GeomCircle* circle = static_cast<const Part::GeomCircle*>(geo1);
-                            const Part::GeomArcOfCircle* arc
-                                = static_cast<const Part::GeomArcOfCircle*>(geo2);
+                            const auto* circle = static_cast<const Part::GeomCircle*>(geo1);
+                            const auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo2);
                             // tangency between a circle and an arc
                             Base::Vector3d dir = (arc->getCenter() - circle->getCenter()).Normalize();
                             pos = circle->getCenter() + dir * circle->getRadius();
@@ -1294,10 +1248,8 @@ Restart:
                         else if (
                             geo1->is<Part::GeomArcOfCircle>() && geo2->is<Part::GeomArcOfCircle>()
                         ) {
-                            const Part::GeomArcOfCircle* arc1
-                                = static_cast<const Part::GeomArcOfCircle*>(geo1);
-                            const Part::GeomArcOfCircle* arc2
-                                = static_cast<const Part::GeomArcOfCircle*>(geo2);
+                            const auto* arc1 = static_cast<const Part::GeomArcOfCircle*>(geo1);
+                            const auto* arc2 = static_cast<const Part::GeomArcOfCircle*>(geo2);
                             // tangency between two arcs
                             Base::Vector3d dir = (arc2->getCenter() - arc1->getCenter()).Normalize();
                             pos = arc1->getCenter() + dir * arc1->getRadius();
@@ -1324,7 +1276,7 @@ Restart:
                     dir.normalize();
                     SbVec3f norm(-dir[1], dir[0], 0);
 
-                    SoDatumLabel* asciiText = static_cast<SoDatumLabel*>(
+                    auto* asciiText = static_cast<SoDatumLabel*>(
                         sep->getChild(static_cast<int>(ConstraintNodePosition::DatumLabelIndex))
                     );
                     asciiText->datumtype = SoDatumLabel::SYMMETRIC;
@@ -1451,8 +1403,8 @@ Restart:
 
                             startangle = atan2(dir1.y, dir1.x);
                             range = atan2(
-                                dir1.x * dir2.y - dir1.y * dir2.x,
-                                dir1.x * dir2.x + dir1.y * dir2.y
+                                (dir1.x * dir2.y) - (dir1.y * dir2.x),
+                                (dir1.x * dir2.x) + (dir1.y * dir2.y)
                             );
                         }
                     }
@@ -1463,8 +1415,8 @@ Restart:
                             p0 = Base::convertTo<SbVec3f>(
                                 (lineSeg->getEndPoint() + lineSeg->getStartPoint()) / 2
                             );
-                            double l1 = 2 * distance
-                                - (lineSeg->getEndPoint() - lineSeg->getStartPoint()).Length() / 2;
+                            double l1 = (2 * distance)
+                                - ((lineSeg->getEndPoint() - lineSeg->getStartPoint()).Length() / 2);
                             endLineLength1 = 2 * distance;
                             endLineLength2 = l1 > 0. ? l1 : 0.;
 
@@ -1476,10 +1428,10 @@ Restart:
                             auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
                             p0 = Base::convertTo<SbVec3f>(arc->getCenter());
 
-                            endLineLength1 = 2 * distance - arc->getRadius();
+                            endLineLength1 = (2 * distance) - arc->getRadius();
                             endLineLength2 = endLineLength1;
 
-                            double endangle;
+                            double endangle = NAN;
                             arc->getRange(startangle, endangle, /*emulateCCWXY=*/true);
                             range = endangle - startangle;
                         }
@@ -1491,7 +1443,7 @@ Restart:
                         break;
                     }
 
-                    SoDatumLabel* asciiText = static_cast<SoDatumLabel*>(
+                    auto* asciiText = static_cast<SoDatumLabel*>(
                         sep->getChild(static_cast<int>(ConstraintNodePosition::DatumLabelIndex))
                     );
                     asciiText->string = SbString(getPresentationString(Constr).toUtf8().constData());
@@ -1529,9 +1481,9 @@ Restart:
                     if (geo->is<Part::GeomArcOfCircle>()) {
                         auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
                         double radius = arc->getRadius();
-                        double angle = (double)Constr->LabelPosition;  // between -pi and pi
-                        double startAngle, endAngle;                   // between 0 and 2*pi
-                        arc->getRange(startAngle, endAngle, /*emulateCCW=*/true);
+                        auto angle = (double)Constr->LabelPosition;  // between -pi and pi
+                        double startAngle = NAN, endAngle = NAN;     // between 0 and 2*pi
+                        arc->getRange(startAngle, endAngle, /*emulateCCWXY=*/true);
 
                         if (angle == 10) {
                             angle = (startAngle + endAngle) / 2;
@@ -1548,7 +1500,7 @@ Restart:
                     else if (geo->is<Part::GeomCircle>()) {
                         auto* circle = static_cast<const Part::GeomCircle*>(geo);
                         double radius = circle->getRadius();
-                        double angle = (double)Constr->LabelPosition;
+                        auto angle = (double)Constr->LabelPosition;
                         if (angle == 10) {
                             angle = 0;
                         }
@@ -1563,7 +1515,7 @@ Restart:
                     SbVec3f p1(pnt1.x, pnt1.y, zConstrH);
                     SbVec3f p2(pnt2.x, pnt2.y, zConstrH);
 
-                    SoDatumLabel* asciiText = static_cast<SoDatumLabel*>(
+                    auto* asciiText = static_cast<SoDatumLabel*>(
                         sep->getChild(static_cast<int>(ConstraintNodePosition::DatumLabelIndex))
                     );
 
@@ -1605,9 +1557,9 @@ Restart:
                     if (geo->is<Part::GeomArcOfCircle>()) {
                         auto* arc = static_cast<const Part::GeomArcOfCircle*>(geo);
                         double radius = arc->getRadius();
-                        double angle = (double)Constr->LabelPosition;  // between -pi and pi
-                        double startAngle, endAngle;                   // between 0 and 2*pi
-                        arc->getRange(startAngle, endAngle, /*emulateCCW=*/true);
+                        auto angle = (double)Constr->LabelPosition;  // between -pi and pi
+                        double startAngle = NAN, endAngle = NAN;     // between 0 and 2*pi
+                        arc->getRange(startAngle, endAngle, /*emulateCCWXY=*/true);
 
                         if (angle == 10) {
                             angle = (startAngle + endAngle) / 2;
@@ -1622,11 +1574,11 @@ Restart:
                         auto* circle = static_cast<const Part::GeomCircle*>(geo);
                         auto gf = GeometryFacade::getFacade(geo);
 
-                        double radius;
+                        double radius = NAN;
 
                         radius = circle->getRadius();
 
-                        double angle = (double)Constr->LabelPosition;
+                        auto angle = (double)Constr->LabelPosition;
                         if (angle == 10) {
                             angle = 0;
                         }
@@ -1640,7 +1592,7 @@ Restart:
                     SbVec3f p1(pnt1.x, pnt1.y, zConstrH);
                     SbVec3f p2(pnt2.x, pnt2.y, zConstrH);
 
-                    SoDatumLabel* asciiText = static_cast<SoDatumLabel*>(
+                    auto* asciiText = static_cast<SoDatumLabel*>(
                         sep->getChild(static_cast<int>(ConstraintNodePosition::DatumLabelIndex))
                     );
 
@@ -1713,7 +1665,7 @@ void EditModeConstraintCoinManager::findHelperAngles(
     if (endAngle > 2 * pi && angle < endAngle - 2 * pi) {
         angle = angle + 2 * pi;
     }
-    if (!(angle > startAngle && angle < endAngle)) {
+    if (angle <= startAngle || angle >= endAngle) {
         if ((angle < startAngle && startAngle - angle < angle + 2 * pi - endAngle)
             || (angle > endAngle && startAngle + 2 * pi - angle < angle - endAngle)) {
             if (angle > startAngle) {
@@ -1737,7 +1689,7 @@ Base::Vector3d EditModeConstraintCoinManager::seekConstraintPosition(
     float step
 )
 {
-    return norm * 0.5f * step;
+    return norm * 0.5F * step;
 }
 
 void EditModeConstraintCoinManager::updateConstraintColor(
@@ -1772,7 +1724,7 @@ void EditModeConstraintCoinManager::updateConstraintColor(
 
     // colors of the constraints
     for (int i = 0; i < maxNumberOfConstraints; i++) {
-        SoSeparator* s = static_cast<SoSeparator*>(editModeScenegraphNodes.constrGroup->getChild(i));
+        auto* s = static_cast<SoSeparator*>(editModeScenegraphNodes.constrGroup->getChild(i));
 
         // Check Constraint Type
         Sketcher::Constraint* constraint = constraints[i];
@@ -1810,7 +1762,7 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                     int index = multifieldIndex.fieldIndex;
                     int layer = multifieldIndex.layerId;
                     if (layer < static_cast<int>(PtNum.size()) && index >= 0 && index < PtNum[layer]) {
-                        pcolor[layer][index] = drawingParameters.SelectColor;
+                        pcolor[layer][index] = SketcherGui::DrawingParameters::SelectColor;
                     }
                 }
             }
@@ -1827,7 +1779,7 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                     if (layer < static_cast<int>(CurvNum.size())
                         && sublayer < static_cast<int>(CurvNum[layer].size()) && index >= 0
                         && index < CurvNum[layer][sublayer]) {
-                        color[layer][sublayer][index] = drawingParameters.SelectColor;
+                        color[layer][sublayer][index] = SketcherGui::DrawingParameters::SelectColor;
                     }
                 }
             }
@@ -1836,13 +1788,13 @@ void EditModeConstraintCoinManager::updateConstraintColor(
 
         if (ViewProviderSketchCoinAttorney::isConstraintSelected(viewProvider, i)) {
             if (hasDatumLabel) {
-                SoDatumLabel* l = static_cast<SoDatumLabel*>(
+                auto* l = static_cast<SoDatumLabel*>(
                     s->getChild(static_cast<int>(ConstraintNodePosition::DatumLabelIndex))
                 );
-                l->textColor = drawingParameters.SelectColor;
+                l->textColor = SketcherGui::DrawingParameters::SelectColor;
             }
             else if (hasMaterial) {
-                m->diffuseColor = drawingParameters.SelectColor;
+                m->diffuseColor = SketcherGui::DrawingParameters::SelectColor;
             }
             else if (type == Sketcher::Coincident) {
                 selectpoint(constraint->First, constraint->FirstPos);
@@ -1872,13 +1824,13 @@ void EditModeConstraintCoinManager::updateConstraintColor(
         }
         else if (ViewProviderSketchCoinAttorney::isConstraintPreselected(viewProvider, i)) {
             if (hasDatumLabel) {
-                SoDatumLabel* l = static_cast<SoDatumLabel*>(
+                auto* l = static_cast<SoDatumLabel*>(
                     s->getChild(static_cast<int>(ConstraintNodePosition::DatumLabelIndex))
                 );
-                l->textColor = drawingParameters.PreselectColor;
+                l->textColor = SketcherGui::DrawingParameters::PreselectColor;
             }
             else if (hasMaterial) {
-                m->diffuseColor = drawingParameters.PreselectColor;
+                m->diffuseColor = SketcherGui::DrawingParameters::PreselectColor;
             }
         }
         else {
@@ -1887,22 +1839,24 @@ void EditModeConstraintCoinManager::updateConstraintColor(
                 constraint
             );
             if (hasDatumLabel) {
-                SoDatumLabel* l = static_cast<SoDatumLabel*>(
+                auto* l = static_cast<SoDatumLabel*>(
                     s->getChild(static_cast<int>(ConstraintNodePosition::DatumLabelIndex))
                 );
 
                 l->textColor = isActive
                     ? ViewProviderSketchCoinAttorney::constraintHasExpression(viewProvider, i)
                         ? drawingParameters.ExprBasedConstrDimColor
-                        : (constraint->isDriving ? drawingParameters.ConstrDimColor
-                                                 : drawingParameters.NonDrivingConstrDimColor)
-                    : drawingParameters.DeactivatedConstrDimColor;
+                        : (constraint->isDriving
+                               ? SketcherGui::DrawingParameters::ConstrDimColor
+                               : SketcherGui::DrawingParameters::NonDrivingConstrDimColor)
+                    : SketcherGui::DrawingParameters::DeactivatedConstrDimColor;
             }
             else if (hasMaterial) {
                 m->diffuseColor = isActive
-                    ? (constraint->isDriving ? drawingParameters.ConstrDimColor
-                                             : drawingParameters.NonDrivingConstrDimColor)
-                    : drawingParameters.DeactivatedConstrDimColor;
+                    ? (constraint->isDriving
+                           ? SketcherGui::DrawingParameters::ConstrDimColor
+                           : SketcherGui::DrawingParameters::NonDrivingConstrDimColor)
+                    : SketcherGui::DrawingParameters::DeactivatedConstrDimColor;
             }
         }
     }
@@ -1963,27 +1917,25 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
 )
 {
 
-    for (std::vector<Sketcher::Constraint*>::const_iterator it = constrlist.begin();
-         it != constrlist.end();
-         ++it) {
+    for (auto it : constrlist) {
         // root separator for one constraint
-        SoSeparator* sep = new SoSeparator();
+        auto* sep = new SoSeparator();
         sep->ref();
         // no caching for frequently-changing data structures
         sep->renderCaching = SoSeparator::OFF;
 
         // every constrained visual node gets its own material for preselection and selection
-        SoMaterial* mat = new SoMaterial;
+        auto* mat = new SoMaterial;
         mat->ref();
-        bool isActive = ViewProviderSketchCoinAttorney::isConstraintActiveInSketch(viewProvider, *it);
+        bool isActive = ViewProviderSketchCoinAttorney::isConstraintActiveInSketch(viewProvider, it);
         mat->diffuseColor = isActive
-            ? ((*it)->isDriving ? drawingParameters.ConstrDimColor
-                                : drawingParameters.NonDrivingConstrDimColor)
-            : drawingParameters.DeactivatedConstrDimColor;
+            ? (it->isDriving ? SketcherGui::DrawingParameters::ConstrDimColor
+                             : SketcherGui::DrawingParameters::NonDrivingConstrDimColor)
+            : SketcherGui::DrawingParameters::DeactivatedConstrDimColor;
 
 
         // distinguish different constraint types to build up
-        switch ((*it)->Type) {
+        switch (it->Type) {
             case Distance:
             case DistanceX:
             case DistanceY:
@@ -1991,13 +1943,13 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
             case Diameter:
             case Weight:
             case Angle: {
-                SoDatumLabel* text = new SoDatumLabel();
+                auto* text = new SoDatumLabel();
                 text->norm.setValue(norm);
                 text->string = "";
                 text->textColor = isActive
-                    ? ((*it)->isDriving ? drawingParameters.ConstrDimColor
-                                        : drawingParameters.NonDrivingConstrDimColor)
-                    : drawingParameters.DeactivatedConstrDimColor;
+                    ? (it->isDriving ? SketcherGui::DrawingParameters::ConstrDimColor
+                                     : SketcherGui::DrawingParameters::NonDrivingConstrDimColor)
+                    : SketcherGui::DrawingParameters::DeactivatedConstrDimColor;
                 if (!drawingParameters.labelFontName.isEmpty()) {
                     text->name.setValue(drawingParameters.labelFontName.toStdString().c_str());
                 }
@@ -2006,7 +1958,7 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 text->useAntialiasing = false;
                 sep->addChild(text);
                 editModeScenegraphNodes.constrGroup->addChild(sep);
-                vConstrType.push_back((*it)->Type);
+                vConstrType.push_back(it->Type);
                 // nodes not needed
                 sep->unref();
                 mat->unref();
@@ -2031,7 +1983,7 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 sep->addChild(new SoInfo());
 
                 // remember the type of this constraint node
-                vConstrType.push_back((*it)->Type);
+                vConstrType.push_back(it->Type);
             } break;
             case Group:
             case Text: {
@@ -2042,21 +1994,21 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 sep->addChild(mat);
 
                 // 2. DrawStyle (to make the line dashed)
-                SoDrawStyle* drawStyle = new SoDrawStyle();
+                auto* drawStyle = new SoDrawStyle();
                 drawStyle->linePattern = 0x0F0F;  // A standard 50% dashed pattern
                 sep->addChild(drawStyle);
 
                 // 3. Coordinates (for the 4 corners + 1 to close the loop)
-                SoCoordinate3* coords = new SoCoordinate3();
+                auto* coords = new SoCoordinate3();
                 coords->point.setNum(5);  // Pre-allocate 5 points for a closed rectangle
                 sep->addChild(coords);
 
                 // 4. LineSet (to connect the coordinates)
-                SoLineSet* lineSet = new SoLineSet();
+                auto* lineSet = new SoLineSet();
                 lineSet->numVertices.set1Value(0, 5);  // A single polyline of 5 vertices
                 sep->addChild(lineSet);
 
-                vConstrType.push_back((*it)->Type);
+                vConstrType.push_back(it->Type);
             } break;
             case Coincident:  // no visual for coincident so far
                 vConstrType.push_back(Coincident);
@@ -2080,7 +2032,7 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 sep->addChild(new SoInfo());
 
                 // remember the type of this constraint node
-                vConstrType.push_back((*it)->Type);
+                vConstrType.push_back(it->Type);
             } break;
             case PointOnObject:
             case Tangent:
@@ -2094,9 +2046,9 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
                 sep->addChild(new SoInfo());
 
-                if ((*it)->Type == Tangent) {
-                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId((*it)->First);
-                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId((*it)->Second);
+                if (it->Type == Tangent) {
+                    const Part::Geometry* geo1 = geolistfacade.getGeometryFromGeoId(it->First);
+                    const Part::Geometry* geo2 = geolistfacade.getGeometryFromGeoId(it->Second);
                     if (!geo1 || !geo2) {
                         Base::Console().developerWarning(
                             "EditModeConstraintCoinManager",
@@ -2113,13 +2065,13 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                     }
                 }
 
-                vConstrType.push_back((*it)->Type);
+                vConstrType.push_back(it->Type);
             } break;
             case Symmetric: {
-                SoDatumLabel* arrows = new SoDatumLabel();
+                auto* arrows = new SoDatumLabel();
                 arrows->norm.setValue(norm);
                 arrows->string = "";
-                arrows->textColor = drawingParameters.ConstrDimColor;
+                arrows->textColor = SketcherGui::DrawingParameters::ConstrDimColor;
                 arrows->lineWidth = 2 * drawingParameters.pixelScalingFactor;
 
                 // #define CONSTRAINT_SEPARATOR_INDEX_MATERIAL_OR_DATUMLABEL 0
@@ -2131,13 +2083,13 @@ void EditModeConstraintCoinManager::rebuildConstraintNodes(
                 // #define CONSTRAINT_SEPARATOR_INDEX_FIRST_CONSTRAINTID 3
                 sep->addChild(new SoInfo());
 
-                vConstrType.push_back((*it)->Type);
+                vConstrType.push_back(it->Type);
             } break;
             case InternalAlignment: {
-                vConstrType.push_back((*it)->Type);
+                vConstrType.push_back(it->Type);
             } break;
             default:
-                vConstrType.push_back((*it)->Type);
+                vConstrType.push_back(it->Type);
         }
 
         editModeScenegraphNodes.constrGroup->addChild(sep);
@@ -2214,7 +2166,7 @@ QString EditModeConstraintCoinManager::getPresentationString(
 
     int constraintIndex = -1;
     const auto& constrlist = ViewProviderSketchCoinAttorney::getConstraints(viewProvider);
-    auto it = std::find(constrlist.begin(), constrlist.end(), constraint);
+    auto it = std::ranges::find(constrlist, constraint);
     if (it != constrlist.end()) {
         constraintIndex = std::distance(constrlist.begin(), it);
         if (ViewProviderSketchCoinAttorney::constraintHasExpression(viewProvider, constraintIndex)) {
@@ -2244,7 +2196,7 @@ std::set<int> EditModeConstraintCoinManager::detectPreselectionConstr(
     }
 
     SoNode* tail = path->getTail();  // This is the SoImage or SoDatumLabel node that was picked.
-    SoSeparator* sep = static_cast<SoSeparator*>(path->getNode(path->getLength() - 2));
+    auto* sep = static_cast<SoSeparator*>(path->getNode(path->getLength() - 2));
 
     for (int childIdx = 0; childIdx < sep->getNumChildren(); ++childIdx) {
         if (tail == sep->getChild(childIdx) && dynamic_cast<SoImage*>(tail)) {
@@ -2514,15 +2466,13 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
         }
 
         // Find the Constraint Icon SoImage Node
-        SoSeparator* sep = static_cast<SoSeparator*>(
-            editModeScenegraphNodes.constrGroup->getChild(constrId)
-        );
+        auto* sep = static_cast<SoSeparator*>(editModeScenegraphNodes.constrGroup->getChild(constrId));
         int numChildren = sep->getNumChildren();
 
         SbVec3f absPos;
         // Somewhat hacky - we use SoZoomTranslations for most types of icon,
         // but symmetry icons use SoTranslations...
-        SoTranslation* translationPtr = static_cast<SoTranslation*>(
+        auto* translationPtr = static_cast<SoTranslation*>(
             sep->getChild(static_cast<int>(ConstraintNodePosition::FirstTranslationIndex))
         );
 
@@ -2533,10 +2483,10 @@ void EditModeConstraintCoinManager::drawConstraintIcons(const GeoListFacade& geo
             absPos = translationPtr->translation.getValue();
         }
 
-        SoImage* coinIconPtr = dynamic_cast<SoImage*>(
+        auto* coinIconPtr = dynamic_cast<SoImage*>(
             sep->getChild(static_cast<int>(ConstraintNodePosition::FirstIconIndex))
         );
-        SoInfo* infoPtr = static_cast<SoInfo*>(
+        auto* infoPtr = static_cast<SoInfo*>(
             sep->getChild(static_cast<int>(ConstraintNodePosition::FirstConstraintIdIndex))
         );
 
@@ -2624,7 +2574,7 @@ void EditModeConstraintCoinManager::combineConstraintIcons(IconQueue iconQueue)
 
     // Grid size needs to be slightly larger than the max merge distance to ensure
     // we catch neighbors.
-    float gridSize = std::max(1.0f, std::abs(scale) * 1.1f);
+    float gridSize = std::max(1.0F, 1.1F * std::abs(scale));
 
     // 2. FILTERING & PREPARATION
     // We create a list of valid indices.
@@ -2660,8 +2610,7 @@ void EditModeConstraintCoinManager::combineConstraintIcons(IconQueue iconQueue)
     // 4. CLUSTERING (Reversed Iteration)
     std::vector<bool> processed(iconQueue.size(), false);
 
-    for (auto it = validIndices.rbegin(); it != validIndices.rend(); ++it) {
-        int startIdx = *it;
+    for (int startIdx : std::views::reverse(validIndices)) {
         if (processed[startIdx]) {
             continue;
         }
@@ -2725,8 +2674,8 @@ void EditModeConstraintCoinManager::combineConstraintIcons(IconQueue iconQueue)
 
 void EditModeConstraintCoinManager::drawMergedConstraintIcons(IconQueue iconQueue)
 {
-    for (IconQueue::iterator i = iconQueue.begin(); i != iconQueue.end(); ++i) {
-        clearCoinImage(i->destination);
+    for (auto& i : iconQueue) {
+        clearCoinImage(i.destination);
     }
 
     QImage compositeIcon;
@@ -2742,12 +2691,12 @@ void EditModeConstraintCoinManager::drawMergedConstraintIcons(IconQueue iconQueu
     QString thisType;
     QColor iconColor;
     QList<QColor> labelColors;
-    int maxColorPriority;
-    double iconRotation;
+    int maxColorPriority = 0;
+    double iconRotation = NAN;
 
     ConstrIconBBVec boundingBoxes;
     while (!iconQueue.empty()) {
-        IconQueue::iterator i = iconQueue.begin();
+        auto i = iconQueue.begin();
 
         labels.clear();
         labels.append(i->label);
@@ -2806,7 +2755,7 @@ void EditModeConstraintCoinManager::drawMergedConstraintIcons(IconQueue iconQueu
             );
         }
         else {
-            int thisVPad;
+            int thisVPad = 0;
             QImage partialIcon = renderConstrIcon(
                 thisType,
                 iconColor,
@@ -2841,17 +2790,16 @@ void EditModeConstraintCoinManager::drawMergedConstraintIcons(IconQueue iconQueu
         }
 
         // Add bounding boxes for the icon we just rendered to boundingBoxes
-        std::vector<int>::iterator id = ids.begin();
+        auto id = ids.begin();
         std::set<int> nextIds;
-        for (std::vector<QRect>::iterator bb = boundingBoxesVec.begin(); bb != boundingBoxesVec.end();
-             ++bb) {
+        for (auto bb = boundingBoxesVec.begin(); bb != boundingBoxesVec.end(); ++bb) {
             nextIds.clear();
 
             if (bb == boundingBoxesVec.begin()) {
                 // The first bounding box is for the icon at left, so assign
                 // all IDs for that type of constraint to the icon.
-                for (std::vector<int>::iterator j = ids.begin(); j != ids.end(); ++j) {
-                    nextIds.insert(*j);
+                for (int& id : ids) {
+                    nextIds.insert(id);
                 }
             }
             else {
@@ -2901,7 +2849,7 @@ QImage EditModeConstraintCoinManager::renderConstrIcon(
     }
     QImage icon = pxMap.toImage();
     // The pixmap was already scaled so we don't need to scale the image
-    icon.setDevicePixelRatio(1.0f);
+    icon.setDevicePixelRatio(1.0F);
 
     QFont font = ViewProviderSketchCoinAttorney::getApplicationFont(viewProvider);
     font.setPixelSize(static_cast<int>(1.0 * drawingParameters.constraintIconSize));
@@ -2924,7 +2872,7 @@ QImage EditModeConstraintCoinManager::renderConstrIcon(
 
     // Make a bounding box for the icon
     if (boundingBoxes) {
-        boundingBoxes->push_back(QRect(0, 0, roticon.width(), roticon.height()));
+        boundingBoxes->emplace_back(0, 0, roticon.width(), roticon.height());
     }
 
     // Render the Icons
@@ -3017,7 +2965,7 @@ QString EditModeConstraintCoinManager::iconTypeFromConstraint(Constraint* constr
         case Block:
             return QStringLiteral("Constraint_Block");
         default:
-            return QString();
+            return {};
     }
 }
 
@@ -3045,7 +2993,7 @@ void EditModeConstraintCoinManager::clearCoinImage(SoImage* soImagePtr)
 QColor EditModeConstraintCoinManager::constrColor(int constraintId)
 {
     auto toQColor = [](auto sbcolor) -> QColor {
-        return QColor((int)(sbcolor[0] * 255.0f), (int)(sbcolor[1] * 255.0f), (int)(sbcolor[2] * 255.0f));
+        return {(int)(sbcolor[0] * 255.0F), (int)(sbcolor[1] * 255.0F), (int)(sbcolor[2] * 255.0F)};
     };
 
     const auto constraints = ViewProviderSketchCoinAttorney::getConstraints(viewProvider);
@@ -3055,20 +3003,19 @@ QColor EditModeConstraintCoinManager::constrColor(int constraintId)
     );
 
     if (ViewProviderSketchCoinAttorney::isConstraintPreselected(viewProvider, constraintId)) {
-        return toQColor(drawingParameters.PreselectColor);
+        return toQColor(SketcherGui::DrawingParameters::PreselectColor);
     }
-    else if (ViewProviderSketchCoinAttorney::isConstraintSelected(viewProvider, constraintId)) {
-        return toQColor(drawingParameters.SelectColor);
+    if (ViewProviderSketchCoinAttorney::isConstraintSelected(viewProvider, constraintId)) {
+        return toQColor(SketcherGui::DrawingParameters::SelectColor);
     }
-    else if (!isActive) {
-        return toQColor(drawingParameters.DeactivatedConstrDimColor);
+    if (!isActive) {
+        return toQColor(SketcherGui::DrawingParameters::DeactivatedConstrDimColor);
     }
-    else if (!constraints[constraintId]->isDriving) {
-        return toQColor(drawingParameters.NonDrivingConstrDimColor);
+    if (!constraints[constraintId]->isDriving) {
+        return toQColor(SketcherGui::DrawingParameters::NonDrivingConstrDimColor);
     }
-    else {
-        return toQColor(drawingParameters.ConstrIcoColor);
-    }
+
+    return toQColor(SketcherGui::DrawingParameters::ConstrIcoColor);
 }
 
 int EditModeConstraintCoinManager::constrColorPriority(int constraintId)
@@ -3076,15 +3023,14 @@ int EditModeConstraintCoinManager::constrColorPriority(int constraintId)
     if (ViewProviderSketchCoinAttorney::isConstraintPreselected(viewProvider, constraintId)) {
         return 3;
     }
-    else if (ViewProviderSketchCoinAttorney::isConstraintSelected(viewProvider, constraintId)) {
+    if (ViewProviderSketchCoinAttorney::isConstraintSelected(viewProvider, constraintId)) {
         return 2;
     }
-    else {
-        return 1;
-    }
+
+    return 1;
 }
 
-SoSeparator* EditModeConstraintCoinManager::getConstraintIdSeparator(int i)
+SoSeparator* EditModeConstraintCoinManager::getConstraintIdSeparator(int i) const
 {
     return dynamic_cast<SoSeparator*>(editModeScenegraphNodes.constrGroup->getChild(i));
 }
@@ -3092,7 +3038,7 @@ SoSeparator* EditModeConstraintCoinManager::getConstraintIdSeparator(int i)
 void EditModeConstraintCoinManager::createEditModeInventorNodes()
 {
     // group node for the Constraint visual +++++++++++++++++++++++++++++++++++
-    SoMaterialBinding* MtlBind = new SoMaterialBinding;
+    auto* MtlBind = new SoMaterialBinding;
     MtlBind->setName("ConstraintMaterialBinding");
     MtlBind->value = SoMaterialBinding::OVERALL;
     editModeScenegraphNodes.EditRoot->addChild(MtlBind);
@@ -3100,7 +3046,9 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
     // use small line width for the Constraints
     editModeScenegraphNodes.ConstraintDrawStyle = new SoDrawStyle;
     editModeScenegraphNodes.ConstraintDrawStyle->setName("ConstraintDrawStyle");
-    editModeScenegraphNodes.ConstraintDrawStyle->lineWidth = 1 * drawingParameters.pixelScalingFactor;
+    editModeScenegraphNodes.ConstraintDrawStyle->lineWidth = static_cast<float>(
+        drawingParameters.pixelScalingFactor
+    );
     editModeScenegraphNodes.EditRoot->addChild(editModeScenegraphNodes.ConstraintDrawStyle);
 
     // add the group where all the constraints has its SoSeparator
@@ -3113,7 +3061,7 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
     // Render constraint icons ON TOP of geometry lines without
     // affecting depth state for other nodes (#28639).
     // See also issues #25840 and #11603.
-    SoAnnotation* constrAnnotation = new SoAnnotation();
+    auto* constrAnnotation = new SoAnnotation();
 
     editModeScenegraphNodes.constrGroup = new SmSwitchboard();
     editModeScenegraphNodes.constrGroup->setName("ConstraintGroup");
@@ -3121,7 +3069,7 @@ void EditModeConstraintCoinManager::createEditModeInventorNodes()
 
     editModeScenegraphNodes.EditRoot->addChild(constrAnnotation);
 
-    SoPickStyle* ps = new SoPickStyle();  // used to following nodes aren't impacted
+    auto* ps = new SoPickStyle();  // used to following nodes aren't impacted
     ps->style.setValue(SoPickStyle::SHAPE);
     editModeScenegraphNodes.EditRoot->addChild(ps);
 }

--- a/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeConstraintCoinManager.h
@@ -24,7 +24,6 @@
 
 #pragma once
 
-#include <functional>
 #include <vector>
 
 #include <QColor>
@@ -141,7 +140,7 @@ public:
         Base::Vector3d* pickedPoint = nullptr
     );
 
-    SoSeparator* getConstraintIdSeparator(int i);
+    SoSeparator* getConstraintIdSeparator(int i) const;
 
     void createEditModeInventorNodes();
 

--- a/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
+++ b/src/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# --------------------------------------------------------------------------
+#                                                                          *
+#    Copyright (c) 2026 Chris Jones github.com/ipatch                      *
+#                                                                          *
+#    This file is part of FreeCAD.                                         *
+#                                                                          *
+#    FreeCAD is free software: you can redistribute it and/or modify it    *
+#    under the terms of the GNU Lesser General Public License as           *
+#    published by the Free Software Foundation, either version 2.1 of the  *
+#    License, or (at your option) any later version.                       *
+#                                                                          *
+#    FreeCAD is distributed in the hope that it will be useful, but        *
+#    WITHOUT ANY WARRANTY; without even the implied warranty of            *
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+#    Lesser General Public License for more details.                       *
+#                                                                          *
+#    You should have received a copy of the GNU Lesser General Public      *
+#    License along with FreeCAD. If not, see                               *
+#    <https://www.gnu.org/licenses/>.                                      *
+#                                                                          *
+# --------------------------------------------------------------------------
+
+"""Regression test for issue #28639: face preselection under External Geometry tool.
+
+Commit b1fdf659d8 added SoDepthBuffer nodes as direct children of
+Sketch_EditRoot to render constraint icons on top of geometry. This
+leaked depth-buffer state into the highlight render pass and prevented
+face highlights on external geometry from rendering.
+
+The fix replaces SoDepthBuffer with SoAnnotation, which renders its
+children on top without affecting depth state for other nodes.
+"""
+
+import unittest
+
+import FreeCAD
+import Part
+import Sketcher
+
+try:
+    import FreeCADGui
+
+    GUI_AVAILABLE = FreeCADGui.getMainWindow() is not None
+except (ImportError, AttributeError):
+    GUI_AVAILABLE = False
+
+if GUI_AVAILABLE:
+    from PySide import QtCore, QtGui
+
+
+class TestExternalFacePreselection(unittest.TestCase):
+
+    def setUp(self):
+        if not GUI_AVAILABLE:
+            self.skipTest("GUI not available")
+
+        FreeCADGui.activateWorkbench("PartDesignWorkbench")
+        self.doc = FreeCAD.newDocument("TestExtFacePresel")
+
+        body = self.doc.addObject("PartDesign::Body", "Body")
+
+        sketch = body.newObject("Sketcher::SketchObject", "BaseSketch")
+        sketch.AttachmentSupport = [(body.Origin.OriginFeatures[3], "")]
+        sketch.MapMode = "FlatFace"
+
+        # 40x40 rectangle
+        sketch.addGeometry(
+            Part.LineSegment(FreeCAD.Vector(-20, -20, 0), FreeCAD.Vector(20, -20, 0))
+        )
+        sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(20, -20, 0), FreeCAD.Vector(20, 20, 0)))
+        sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(20, 20, 0), FreeCAD.Vector(-20, 20, 0)))
+        sketch.addGeometry(
+            Part.LineSegment(FreeCAD.Vector(-20, 20, 0), FreeCAD.Vector(-20, -20, 0))
+        )
+        sketch.addConstraint(Sketcher.Constraint("Coincident", 0, 2, 1, 1))
+        sketch.addConstraint(Sketcher.Constraint("Coincident", 1, 2, 2, 1))
+        sketch.addConstraint(Sketcher.Constraint("Coincident", 2, 2, 3, 1))
+        sketch.addConstraint(Sketcher.Constraint("Coincident", 3, 2, 0, 1))
+        self.doc.recompute()
+
+        pad = body.newObject("PartDesign::Pad", "Pad")
+        pad.Profile = sketch
+        pad.Length = 20.0
+        self.doc.recompute()
+
+        # Second sketch on top face for external geometry
+        self.testSketch = body.newObject("Sketcher::SketchObject", "TestSketch")
+        self.testSketch.AttachmentSupport = [(pad, "Face6")]
+        self.testSketch.MapMode = "FlatFace"
+        self.doc.recompute()
+
+        self.body = body
+        self.pad = pad
+
+    def tearDown(self):
+        if not GUI_AVAILABLE:
+            return
+        gui_doc = FreeCADGui.ActiveDocument
+        if gui_doc is not None:
+            gui_doc.resetEdit()
+        if self.doc.Name in FreeCAD.listDocuments():
+            FreeCAD.closeDocument(self.doc.Name)
+
+    def pump(self, timeout_ms=50):
+        loop = QtCore.QEventLoop()
+        QtCore.QTimer.singleShot(timeout_ms, loop.quit)
+        loop.exec_()
+
+    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def testNoDepthBufferInEditRoot(self):
+        """SoDepthBuffer nodes must not be direct children of
+        Sketch_EditRoot. Bare SoDepthBuffer nodes leak depth state
+        to sibling nodes during the highlight render pass, which
+        breaks face preselection for external geometry (#28639)."""
+
+        from pivy import coin
+
+        FreeCADGui.ActiveDocument.setEdit(self.testSketch.Name)
+        self.pump(300)
+
+        view = FreeCADGui.ActiveDocument.ActiveView
+        viewer = view.getViewer()
+        scene_root = viewer.getSoRenderManager().getSceneGraph()
+
+        # Find all SoDepthBuffer nodes in the scene graph
+        sa = coin.SoSearchAction()
+        sa.setType(coin.SoDepthBuffer.getClassTypeId())
+        sa.setInterest(coin.SoSearchAction.ALL)
+        sa.setSearchingAll(True)
+        sa.apply(scene_root)
+        paths = sa.getPaths()
+        num_paths = paths.getLength()
+
+        bad_nodes = []
+        for i in range(num_paths):
+            p = paths[i]
+            parent = p.getNodeFromTail(1)
+            parent_name = parent.getName().getString() if parent.getName() else ""
+            if parent_name == "Sketch_EditRoot":
+                bad_nodes.append(i)
+
+        self.assertEqual(
+            len(bad_nodes),
+            0,
+            f"Found {len(bad_nodes)} SoDepthBuffer node(s) as direct "
+            f"children of Sketch_EditRoot. Use SoAnnotation instead "
+            f"to render constraint icons on top without leaking depth "
+            f"state (#28639).",
+        )
+
+    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def testConstraintGroupInsideAnnotation(self):
+        """The ConstraintGroup node must be inside an SoAnnotation so
+        constraint icons render on top of geometry without affecting
+        depth state for other scene graph nodes (#28639)."""
+
+        from pivy import coin
+
+        FreeCADGui.ActiveDocument.setEdit(self.testSketch.Name)
+        self.pump(300)
+
+        view = FreeCADGui.ActiveDocument.ActiveView
+        viewer = view.getViewer()
+        scene_root = viewer.getSoRenderManager().getSceneGraph()
+
+        # Find the ConstraintGroup node by name
+        sa = coin.SoSearchAction()
+        sa.setName("ConstraintGroup")
+        sa.setSearchingAll(True)
+        sa.apply(scene_root)
+        path = sa.getPath()
+
+        self.assertIsNotNone(path, "Could not find 'ConstraintGroup' node in scene graph")
+
+        # Walk up the path looking for an SoAnnotation ancestor
+        found_annotation = False
+        for i in range(path.getLength()):
+            node = path.getNode(i)
+            if node.isOfType(coin.SoAnnotation.getClassTypeId()):
+                found_annotation = True
+                break
+
+        self.assertTrue(
+            found_annotation,
+            "ConstraintGroup is not inside an SoAnnotation. Without "
+            "SoAnnotation, constraint icon rendering can interfere "
+            "with face highlight rendering for external geometry "
+            "preselection (#28639).",
+        )
+
+    @unittest.skipIf(not GUI_AVAILABLE, "GUI not available")
+    def testFacePickableUnderExternalTool(self):
+        """A face on the Pad must be preselectable via mouse hover
+        while the External Geometry tool is active (#28639)."""
+
+        FreeCADGui.ActiveDocument.setEdit(self.testSketch.Name)
+        self.pump(300)
+
+        # Add geometry + constraints so constraint icons are rendered.
+        self.testSketch.addGeometry(
+            Part.LineSegment(FreeCAD.Vector(-10, -10, 0), FreeCAD.Vector(10, -10, 0))
+        )
+        self.testSketch.addGeometry(
+            Part.LineSegment(FreeCAD.Vector(10, -10, 0), FreeCAD.Vector(10, 10, 0))
+        )
+        self.testSketch.addConstraint(Sketcher.Constraint("DistanceX", 0, 1, 0, 2, 20.0))
+        self.testSketch.addConstraint(Sketcher.Constraint("DistanceY", 1, 1, 1, 2, 20.0))
+        self.doc.recompute()
+        self.pump(300)
+
+        view = FreeCADGui.ActiveDocument.ActiveView
+        view.viewFront()
+        view.fitAll()
+        self.pump(300)
+
+        # Activate External Geometry tool
+        FreeCADGui.runCommand("Sketcher_Projection", 0)
+        self.pump(300)
+
+        # Simulate mouse hover over the front face center
+        viewport = view.graphicsView().viewport()
+        face_center_3d = FreeCAD.Vector(0, -20, 10)
+        screen_pt = view.getPointOnScreen(face_center_3d)
+        hover_pos = QtCore.QPoint(int(screen_pt[0]), int(screen_pt[1]))
+
+        # Send mouse move events
+        for offset in [(0, 0), (1, 0), (0, 1)]:
+            pos = QtCore.QPoint(hover_pos.x() + offset[0], hover_pos.y() + offset[1])
+            event = QtGui.QMouseEvent(
+                QtCore.QEvent.MouseMove,
+                pos,
+                viewport.mapToGlobal(pos),
+                QtCore.Qt.NoButton,
+                QtCore.Qt.NoButton,
+                QtCore.Qt.NoModifier,
+            )
+            QtGui.QApplication.sendEvent(viewport, event)
+            self.pump(100)
+
+        presel = FreeCADGui.Selection.getPreselection()
+        self.assertNotEqual(
+            presel.ObjectName,
+            "",
+            "No object was preselected — mouse hover did not produce a "
+            "pick. This may indicate the #28639 regression.",
+        )
+        sub_names = presel.SubElementNames
+        self.assertTrue(
+            any("Face" in s for s in sub_names),
+            f"Expected a Face preselection but got " f"SubElementNames={sub_names}.",
+        )

--- a/src/Mod/Sketcher/TestSketcherGui.py
+++ b/src/Mod/Sketcher/TestSketcherGui.py
@@ -3,6 +3,7 @@ from SketcherTests.TestConstraintPreselectionGui import SketcherGuiTestCases
 from SketcherTests.TestOnViewParameterGui import TestOnViewParameterGui
 from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
 from SketcherTests.TestExternalFacePreselection import TestExternalFacePreselection
+
 # Use the module so that code checkers don't complain (flake8)
 (
     True

--- a/src/Mod/Sketcher/TestSketcherGui.py
+++ b/src/Mod/Sketcher/TestSketcherGui.py
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
-
 from SketcherTests.TestConstraintPreselectionGui import SketcherGuiTestCases
 from SketcherTests.TestOnViewParameterGui import TestOnViewParameterGui
 from SketcherTests.TestPlacementUpdate import TestSketchPlacementUpdate
-
+from SketcherTests.TestExternalFacePreselection import TestExternalFacePreselection
 # Use the module so that code checkers don't complain (flake8)
-True if SketcherGuiTestCases and TestSketchPlacementUpdate and TestOnViewParameterGui else False
+(
+    True
+    if SketcherGuiTestCases
+    and TestSketchPlacementUpdate
+    and TestOnViewParameterGui
+    and TestExternalFacePreselection
+    else False
+)


### PR DESCRIPTION
this pr includes several commits.

1. the first being an inclusion of a unit test in hopes of preventing a similar regression in the future, and the actual fix to the `EditModeConstraintCoinManager.cpp`
~~3. run pre-commit on edited files~~
2. run clang-tidy code actions on `EditModeConstraintCoinManager.cpp`
~~5. run pre-commit a second time.~~

with this PR merged preselection of faces should be restored when using the external projection tool in the sketcher workbench.

without fix, failing unit tests.

```
FreeCAD 1.2.0, Libs: 1.2.0devR46696 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

testConstraintGroupInsideAnnotation (SketcherTests.TestExternalFacePreselection.TestExternalFacePreselection.testConstraintGroupInsideAnnotation)
The ConstraintGroup node must be inside an SoAnnotation so ... FAIL
testFacePickableUnderExternalTool (SketcherTests.TestExternalFacePreselection.TestExternalFacePreselection.testFacePickableUnderExternalTool)
A face on the Pad must be preselectable via mouse hover ... ok
testNoDepthBufferInEditRoot (SketcherTests.TestExternalFacePreselection.TestExternalFacePreselection.testNoDepthBufferInEditRoot)
SoDepthBuffer nodes must not be direct children of ... FAIL
test_rectangle_ovp_enter_finishes_without_crash (SketcherTests.TestOnViewParameterGui.TestOnViewParameterGui.test_rectangle_ovp_enter_finishes_without_crash)
Reproduce the rectangle OVP acceptance flow from PR #29201 review: ... ok
test_attachment_offset_updates_in_edit_mode (SketcherTests.TestPlacementUpdate.TestSketchPlacementUpdate.test_attachment_offset_updates_in_edit_mode)
test that changing AttachmentOffset while editing updates the transform. ... ok
test_multiple_attachment_offset_updates (SketcherTests.TestPlacementUpdate.TestSketchPlacementUpdate.test_multiple_attachment_offset_updates)
test that multiple AttachmentOffset changes in edit mode all update correctly. ... ok
test_no_update_when_not_editing (SketcherTests.TestPlacementUpdate.TestSketchPlacementUpdate.test_no_update_when_not_editing)
verify that attachment offset changes don't cause issues when sketch is not in edit mode. ... ok
test_unattached_sketch_placement_updates (SketcherTests.TestPlacementUpdate.TestSketchPlacementUpdate.test_unattached_sketch_placement_updates)
test that unattached sketches also work correctly. ... ok

======================================================================
FAIL: testConstraintGroupInsideAnnotation (SketcherTests.TestExternalFacePreselection.TestExternalFacePreselection.testConstraintGroupInsideAnnotation)
The ConstraintGroup node must be inside an SoAnnotation so
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py", line 168, in testConstraintGroupInsideAnnotation
    self.assertTrue(
    ~~~~~~~~~~~~~~~^
        found_annotation,
        ^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        "preselection (#28639).",
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: False is not true : ConstraintGroup is not inside an SoAnnotation. Without SoAnnotation, constraint icon rendering can interfere with face highlight rendering for external geometry preselection (#28639).

======================================================================
FAIL: testNoDepthBufferInEditRoot (SketcherTests.TestExternalFacePreselection.TestExternalFacePreselection.testNoDepthBufferInEditRoot)
SoDepthBuffer nodes must not be direct children of
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/code/git/github/forks/freecad-git/installs/issue.tshooting.qt6.py313/Mod/Sketcher/SketcherTests/TestExternalFacePreselection.py", line 125, in testNoDepthBufferInEditRoot
    self.assertEqual(
    ~~~~~~~~~~~~~~~~^
        len(bad_nodes),
        ^^^^^^^^^^^^^^^
    ...<4 lines>...
        f"state (#28639).",
        ^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: 2 != 0 : Found 2 SoDepthBuffer node(s) as direct children of Sketch_EditRoot. Use SoAnnotation instead to render constraint icons on top without leaking depth state (#28639).

----------------------------------------------------------------------
Ran 8 tests in 10.667s

FAILED (failures=2)
System exit
```

with the fix, passing unit tests (note these tests require the gui to run)

```
╰─λ /opt/code/fcgit/installs/issue.tshooting.qt6.py313/bin/FreeCAD -t TestSketcherGui
FreeCAD 1.2.0, Libs: 1.2.0devR46696 (Git)
(C) 2001-2026 FreeCAD contributors
FreeCAD is free and open-source software licensed under the terms of LGPL2+ license.

testConstraintGroupInsideAnnotation (SketcherTests.TestExternalFacePreselection.TestExternalFacePreselection.testConstraintGroupInsideAnnotation)
The ConstraintGroup node must be inside an SoAnnotation so ... ok
testFacePickableUnderExternalTool (SketcherTests.TestExternalFacePreselection.TestExternalFacePreselection.testFacePickableUnderExternalTool)
A face on the Pad must be preselectable via mouse hover ... ok
testNoDepthBufferInEditRoot (SketcherTests.TestExternalFacePreselection.TestExternalFacePreselection.testNoDepthBufferInEditRoot)
SoDepthBuffer nodes must not be direct children of ... ok
test_rectangle_ovp_enter_finishes_without_crash (SketcherTests.TestOnViewParameterGui.TestOnViewParameterGui.test_rectangle_ovp_enter_finishes_without_crash)
Reproduce the rectangle OVP acceptance flow from PR #29201 review: ... ok
test_attachment_offset_updates_in_edit_mode (SketcherTests.TestPlacementUpdate.TestSketchPlacementUpdate.test_attachment_offset_updates_in_edit_mode)
test that changing AttachmentOffset while editing updates the transform. ... ok
test_multiple_attachment_offset_updates (SketcherTests.TestPlacementUpdate.TestSketchPlacementUpdate.test_multiple_attachment_offset_updates)
test that multiple AttachmentOffset changes in edit mode all update correctly. ... ok
test_no_update_when_not_editing (SketcherTests.TestPlacementUpdate.TestSketchPlacementUpdate.test_no_update_when_not_editing)
verify that attachment offset changes don't cause issues when sketch is not in edit mode. ... ok
test_unattached_sketch_placement_updates (SketcherTests.TestPlacementUpdate.TestSketchPlacementUpdate.test_unattached_sketch_placement_updates)
test that unattached sketches also work correctly. ... ok

----------------------------------------------------------------------
Ran 8 tests in 9.970s

OK
System exit
```

note as for the code action changes here are the before after results with my editor ie. neovim


before

```lua
:lua local d = vim.diagnostic.get(); local c = {E=0,W=0,I=0,H=0}; for _,v in ipairs(d) do local s = v.severity; if s==1 then c.E=c.E+1 elseif s==2 then c.W=c.W+1 elseif s==3 then c.I=c.I+1 else c.H=c.H+1 end end; print(string.format("E:%d W:%d I:%d H:%d", c.E, c.W, c.I, c.H))
```

```
487
```

after

```
E:16 W:428 I:19 H:0
```

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/28639

## Before and After Images

