### PR TITLE
Material: add Python observers

### DIFF
--- a/src/Mod/Material/App/AppMaterial.cpp
+++ b/src/Mod/Material/App/AppMaterial.cpp
@@ -23,7 +23,6 @@
 
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
-#include <Base/PyObjectBase.h>
 
 #include <App/CleanupProcess.h>
 
@@ -47,8 +46,10 @@
 #include "MaterialFilterOptionsPy.h"
 #include "MaterialLibraryPy.h"
 #include "MaterialManagerPy.h"
+#include "MaterialObserverPython.h"
 #include "MaterialPropertyPy.h"
 #include "MaterialPy.h"
+#include "MaterialsModulePy.h"
 
 namespace Materials
 {
@@ -58,12 +59,10 @@ public:
     Module()
         : Py::ExtensionModule<Module>("Materials")
     {
-        initialize("This module is the Materials module.");  // register with Python
+        initialize(MaterialsModulePy::moduleDocumentation());  // register with Python
     }
 
     ~Module() override = default;
-
-private:
 };
 
 PyObject* initModule()
@@ -75,13 +74,20 @@ PyObject* initModule()
 
 PyMOD_INIT_FUNC(Materials)
 {
-#ifdef FC_DEBUG
     App::CleanupProcess::registerCleanup([]() {
+        Materials::MaterialObserverPython::cleanup();
+#ifdef FC_DEBUG
         Materials::MaterialManager::cleanup();
         Materials::ModelManager::cleanup();
-    });
 #endif
+    });
     PyObject* module = Materials::initModule();
+    if (!module) {
+        return nullptr;
+    }
+    if (Materials::MaterialsModulePy::addModuleMethods(module) < 0) {
+        return nullptr;
+    }
 
     Base::Console().log("Loading Material module… done\n");
 

--- a/src/Mod/Material/App/CMakeLists.txt
+++ b/src/Mod/Material/App/CMakeLists.txt
@@ -42,6 +42,7 @@ generate_from_py(ModelProperty)
 generate_from_py(MaterialProperty)
 generate_from_py(Model)
 generate_from_py(UUIDs)
+generate_module_from_py(Materials)
 
 SET(MaterialsAPI_Files
     MaterialAPI/__init__.py
@@ -69,6 +70,8 @@ SET(Python_SRCS
     MaterialManagerPyImp.cpp
     MaterialProperty.pyi
     MaterialPropertyPyImp.cpp
+    Materials.module.pyi
+    MaterialsModulePyImp.cpp
     Material.pyi
     MaterialPyImp.cpp
     ModelManager.pyi
@@ -94,6 +97,8 @@ SET(Materials_SRCS
     MaterialFilter.h
     MaterialLibrary.cpp
     MaterialLibrary.h
+    MaterialObserverPython.cpp
+    MaterialObserverPython.h
     MaterialLoader.cpp
     MaterialLoader.h
     MaterialManager.cpp

--- a/src/Mod/Material/App/MaterialLibrary.cpp
+++ b/src/Mod/Material/App/MaterialLibrary.cpp
@@ -179,7 +179,7 @@ void MaterialLibraryLocal::renameFolder(const QString& oldPath, const QString& n
         }
     }
 
-    updatePaths(oldPath, newPath);
+    updatePaths(MaterialManager::getManager(), oldPath, newPath);
 }
 
 void MaterialLibraryLocal::deleteRecursive(const QString& path)
@@ -247,12 +247,15 @@ void MaterialLibraryLocal::deleteFile(MaterialManager& manager, const QString& p
         QString rPath = getRelativePath(path);
         try {
             auto material = getMaterialByPath(rPath);
+            Material deletedMaterial(*material);
             manager.remove(material->getUUID());
+            _materialPathMap->erase(rPath);
+            manager.notifyDeletedMaterial(deletedMaterial);
         }
         catch (const MaterialNotFound&) {
             Base::Console().log("Unable to remove file from materials list\n");
+            _materialPathMap->erase(rPath);
         }
-        _materialPathMap->erase(rPath);
     }
     else {
         QString error = QStringLiteral("DeleteError: Unable to delete ") + path;
@@ -260,23 +263,35 @@ void MaterialLibraryLocal::deleteFile(MaterialManager& manager, const QString& p
     }
 }
 
-void MaterialLibraryLocal::updatePaths(const QString& oldPath, const QString& newPath)
+void MaterialLibraryLocal::updatePaths(MaterialManager& manager,
+                                       const QString& oldPath,
+                                       const QString& newPath)
 {
     // Update the path map
     QString op = getRelativePath(oldPath);
     QString np = getRelativePath(newPath);
     std::unique_ptr<std::map<QString, std::shared_ptr<Material>>> pathMap =
         std::make_unique<std::map<QString, std::shared_ptr<Material>>>();
+    std::vector<std::shared_ptr<Material>> changedMaterials;
     for (auto& itp : *_materialPathMap) {
         QString path = itp.first;
+        bool changed = false;
         if (path.startsWith(op)) {
             path = np + path.remove(0, op.size());
+            changed = true;
         }
-        itp.second->setDirectory(path);
+        itp.second->setDirectory(getLibraryPath(path, itp.second->getFilename()));
         (*pathMap)[path] = itp.second;
+        if (changed) {
+            changedMaterials.push_back(itp.second);
+        }
     }
 
     _materialPathMap = std::move(pathMap);
+
+    for (const auto& material : changedMaterials) {
+        manager.notifyChangedMaterial(*material);
+    }
 }
 
 std::shared_ptr<Material>

--- a/src/Mod/Material/App/MaterialLibrary.h
+++ b/src/Mod/Material/App/MaterialLibrary.h
@@ -118,7 +118,7 @@ public:
 protected:
     void deleteDir(MaterialManager& manager, const QString& path);
     void deleteFile(MaterialManager& manager, const QString& path);
-    void updatePaths(const QString& oldPath, const QString& newPath);
+    void updatePaths(MaterialManager& manager, const QString& oldPath, const QString& newPath);
 
     QString getUUIDFromPath(const QString& path) const;
 

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -132,6 +132,21 @@ void MaterialManager::refresh()
     _localManager->refresh();
 }
 
+void MaterialManager::notifyCreatedMaterial(const Material& material)
+{
+    signalCreatedMaterial(material);
+}
+
+void MaterialManager::notifyChangedMaterial(const Material& material)
+{
+    signalChangedMaterial(material);
+}
+
+void MaterialManager::notifyDeletedMaterial(const Material& material)
+{
+    signalDeletedMaterial(material);
+}
+
 //=====
 //
 // Defaults

--- a/src/Mod/Material/App/MaterialManager.h
+++ b/src/Mod/Material/App/MaterialManager.h
@@ -27,6 +27,8 @@
 
 #include <filesystem>
 
+#include <fastsignals/signal.h>
+
 #include <Base/Parameter.h>
 #include <Mod/Material/MaterialGlobal.h>
 
@@ -57,6 +59,8 @@ class MaterialsExport MaterialManager: public Base::BaseClass, ParameterGrp::Obs
     TYPESYSTEM_HEADER_WITH_OVERRIDE();
 
 public:
+    using MaterialSignal = fastsignals::signal<void(const Material&)>;
+
     ~MaterialManager() override;
 
     static MaterialManager& getManager();
@@ -141,8 +145,19 @@ public:
     void dereference(std::shared_ptr<Material> material) const;
     void dereference() const;
 
+    void notifyCreatedMaterial(const Material& material);
+    void notifyChangedMaterial(const Material& material);
+    void notifyDeletedMaterial(const Material& material);
+
     /// Observer message from the ParameterGrp
     void OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason) override;
+
+    /// Signal emitted after a new material becomes available through the manager.
+    MaterialSignal signalCreatedMaterial;
+    /// Signal emitted after an existing material changes, including path moves.
+    MaterialSignal signalChangedMaterial;
+    /// Signal emitted after a material is removed from the manager.
+    MaterialSignal signalDeletedMaterial;
 
 #if defined(BUILD_MATERIAL_EXTERNAL)
     void migrateToExternal(const std::shared_ptr<Materials::MaterialLibrary>& library);

--- a/src/Mod/Material/App/MaterialManagerLocal.cpp
+++ b/src/Mod/Material/App/MaterialManagerLocal.cpp
@@ -35,6 +35,7 @@
 #include "MaterialFilter.h"
 #include "MaterialLibrary.h"
 #include "MaterialLoader.h"
+#include "MaterialManager.h"
 #include "MaterialManagerLocal.h"
 #include "ModelManager.h"
 #include "ModelUuids.h"
@@ -428,9 +429,18 @@ void MaterialManagerLocal::saveMaterial(const std::shared_ptr<MaterialLibraryLoc
                                         bool saveInherited) const
 {
     if (library->isLocal()) {
+        bool fileExisted = library->fileExists(path);
         auto newMaterial =
             library->saveMaterial(material, path, overwrite, saveAsCopy, saveInherited);
         (*_materialMap)[newMaterial->getUUID()] = newMaterial;
+
+        auto& manager = MaterialManager::getManager();
+        if (fileExisted) {
+            manager.notifyChangedMaterial(*newMaterial);
+        }
+        else {
+            manager.notifyCreatedMaterial(*newMaterial);
+        }
     }
 }
 

--- a/src/Mod/Material/App/MaterialObserverPython.cpp
+++ b/src/Mod/Material/App/MaterialObserverPython.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <functional>
+#include <algorithm>
+
+#include <Base/Interpreter.h>
+
+#include "MaterialManager.h"
+#include "MaterialObserverPython.h"
+#include "MaterialPy.h"
+
+using namespace Materials;
+namespace sp = std::placeholders;
+
+std::vector<std::unique_ptr<MaterialObserverPython>> MaterialObserverPython::_instances;
+
+void MaterialObserverPython::addObserver(const Py::Object& obj)
+{
+    _instances.push_back(std::make_unique<MaterialObserverPython>(obj));
+}
+
+void MaterialObserverPython::removeObserver(const Py::Object& obj)
+{
+    auto it = std::find_if(_instances.begin(),
+                           _instances.end(),
+                           [&obj](const auto& observer) { return observer->inst == obj; });
+    if (it != _instances.end()) {
+        _instances.erase(it);
+    }
+}
+
+void MaterialObserverPython::cleanup()
+{
+    Base::PyGILStateLocker lock;
+    _instances.clear();
+}
+
+MaterialObserverPython::MaterialObserverPython(const Py::Object& obj)
+    : inst(obj)
+{
+#define FC_PY_ELEMENT_ARG1(_name1, _signal)                                                       \
+    do {                                                                                           \
+        FC_PY_GetCallable(obj.ptr(), "slot" #_name1, py##_name1.py);                               \
+        if (!py##_name1.py.isNone())                                                               \
+            py##_name1.slot = MaterialManager::getManager().signal##_signal.connect(               \
+                std::bind(&MaterialObserverPython::slot##_name1, this, sp::_1));                   \
+    } while (0)
+
+    FC_PY_ELEMENT_ARG1(CreatedMaterial, CreatedMaterial);
+    FC_PY_ELEMENT_ARG1(ChangedMaterial, ChangedMaterial);
+    FC_PY_ELEMENT_ARG1(DeletedMaterial, DeletedMaterial);
+
+#undef FC_PY_ELEMENT_ARG1
+}
+
+MaterialObserverPython::~MaterialObserverPython() = default;
+
+void MaterialObserverPython::slotCreatedMaterial(const Material& material)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        Py::Tuple args(1);
+        args.setItem(0, Py::Object(new MaterialPy(new Material(material)), true));
+        Base::pyCall(pyCreatedMaterial.ptr(), args.ptr());
+    }
+    catch (Py::Exception&) {
+        Base::PyException e;
+        e.reportException();
+    }
+}
+
+void MaterialObserverPython::slotChangedMaterial(const Material& material)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        Py::Tuple args(1);
+        args.setItem(0, Py::Object(new MaterialPy(new Material(material)), true));
+        Base::pyCall(pyChangedMaterial.ptr(), args.ptr());
+    }
+    catch (Py::Exception&) {
+        Base::PyException e;
+        e.reportException();
+    }
+}
+
+void MaterialObserverPython::slotDeletedMaterial(const Material& material)
+{
+    Base::PyGILStateLocker lock;
+    try {
+        Py::Tuple args(1);
+        args.setItem(0, Py::Object(new MaterialPy(new Material(material)), true));
+        Base::pyCall(pyDeletedMaterial.ptr(), args.ptr());
+    }
+    catch (Py::Exception&) {
+        Base::PyException e;
+        e.reportException();
+    }
+}

--- a/src/Mod/Material/App/MaterialObserverPython.h
+++ b/src/Mod/Material/App/MaterialObserverPython.h
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#pragma once
+
+#include <fastsignals/signal.h>
+#include <CXX/Objects.hxx>
+
+#include <memory>
+#include <vector>
+
+namespace Materials
+{
+
+class Material;
+
+class MaterialObserverPython
+{
+public:
+    explicit MaterialObserverPython(const Py::Object& obj);
+    virtual ~MaterialObserverPython();
+
+    static void addObserver(const Py::Object& obj);
+    static void removeObserver(const Py::Object& obj);
+    static void cleanup();
+
+private:
+    void slotCreatedMaterial(const Material& material);
+    void slotChangedMaterial(const Material& material);
+    void slotDeletedMaterial(const Material& material);
+
+private:
+    // Keep a strong reference to the Python observer while it is registered.
+    Py::Object inst;
+    static std::vector<std::unique_ptr<MaterialObserverPython>> _instances;
+
+    using Connection = struct PythonObject
+    {
+        fastsignals::scoped_connection slot;
+        Py::Object py;
+        PyObject* ptr()
+        {
+            return py.ptr();
+        }
+    };
+
+    Connection pyCreatedMaterial;
+    Connection pyChangedMaterial;
+    Connection pyDeletedMaterial;
+};
+
+}  // namespace Materials

--- a/src/Mod/Material/App/Materials.module.pyi
+++ b/src/Mod/Material/App/Materials.module.pyi
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Joao Matos
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+from __future__ import annotations
+
+"""
+This module is the Materials module.
+"""
+
+
+def addMaterialObserver(observer: object) -> None:
+    """
+    Register an observer object for material lifecycle callbacks.
+
+    Observers may implement any of:
+    slotCreatedMaterial(material), slotChangedMaterial(material),
+    slotDeletedMaterial(material).
+    """
+    ...
+
+
+def removeMaterialObserver(observer: object) -> None:
+    """
+    Remove an observer previously registered with addMaterialObserver().
+    """
+    ...

--- a/src/Mod/Material/App/MaterialsModulePyImp.cpp
+++ b/src/Mod/Material/App/MaterialsModulePyImp.cpp
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <array>
+
+#include <Base/PyWrapParseTupleAndKeywords.h>
+
+#include "MaterialObserverPython.h"
+#include "MaterialsModulePy.h"
+
+#include "MaterialsModulePy.cpp"
+
+using namespace Materials;
+
+namespace
+{
+
+PyObject* parseObserverArgument(PyObject* args, PyObject* kwd)
+{
+    static constexpr std::array<const char*, 2> keywords {"observer", nullptr};
+
+    PyObject* obj {};
+    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwd, "O", keywords, &obj)) {
+        return nullptr;
+    }
+
+    if (obj == Py_None) {
+        PyErr_SetString(PyExc_TypeError, "observer cannot be None");
+        return nullptr;
+    }
+
+    return obj;
+}
+
+}  // namespace
+
+PyObject* MaterialsModulePy::addMaterialObserver(PyObject* args, PyObject* kwd)
+{
+    PyObject* obj = parseObserverArgument(args, kwd);
+    if (!obj) {
+        return nullptr;
+    }
+
+    MaterialObserverPython::addObserver(Py::Object(obj));
+    return Py::new_reference_to(Py::None());
+}
+
+PyObject* MaterialsModulePy::removeMaterialObserver(PyObject* args, PyObject* kwd)
+{
+    PyObject* obj = parseObserverArgument(args, kwd);
+    if (!obj) {
+        return nullptr;
+    }
+
+    MaterialObserverPython::removeObserver(Py::Object(obj));
+    return Py::new_reference_to(Py::None());
+}

--- a/src/Mod/Material/CMakeLists.txt
+++ b/src/Mod/Material/CMakeLists.txt
@@ -322,6 +322,7 @@ set(MaterialTest_Files
     materialtests/TestMaterialCreation.py
     materialtests/TestMaterialDocument.py
     materialtests/TestMaterialFilter.py
+    materialtests/TestMaterialObserver.py
 )
 
 ADD_CUSTOM_TARGET(MaterialTest ALL

--- a/src/Mod/Material/TestMaterialsApp.py
+++ b/src/Mod/Material/TestMaterialsApp.py
@@ -32,3 +32,13 @@ from materialtests.TestModels import ModelTestCases
 from materialtests.TestMaterials import MaterialTestCases
 from materialtests.TestMaterialCreation import MaterialCreationTestCases
 from materialtests.TestMaterialFilter import MaterialFilterTestCases
+from materialtests.TestMaterialObserver import MaterialObserverTestCases
+
+# Keep explicit references so unittest discovery can collect these imported test cases.
+TEST_CASES = (
+    ModelTestCases,
+    MaterialTestCases,
+    MaterialCreationTestCases,
+    MaterialFilterTestCases,
+    MaterialObserverTestCases,
+)

--- a/src/Mod/Material/materialtests/TestMaterialObserver.py
+++ b/src/Mod/Material/materialtests/TestMaterialObserver.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 Joao Matos
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Test module for FreeCAD material observers
+"""
+
+import gc
+import shutil
+import tempfile
+import unittest
+import weakref
+
+import FreeCAD
+import Materials
+
+
+class _RecordingObserver:
+    def __init__(self):
+        self.created = []
+        self.changed = []
+        self.deleted = []
+
+    def slotCreatedMaterial(self, material):
+        self.created.append(material)
+
+    def slotChangedMaterial(self, material):
+        self.changed.append(material)
+
+    def slotDeletedMaterial(self, material):
+        self.deleted.append(material)
+
+
+class MaterialObserverTestCases(unittest.TestCase):
+    """
+    Test class for FreeCAD material observer registration and callbacks
+    """
+
+    def setUp(self):
+        self.MaterialManager = Materials.MaterialManager()
+        self.observer = _RecordingObserver()
+        self._observer_registrations = 0
+        self._resource_param = FreeCAD.ParamGet(
+            "User parameter:BaseApp/Preferences/Mod/Material/Resources"
+        )
+        self._external_param = FreeCAD.ParamGet(
+            "User parameter:BaseApp/Preferences/Mod/Material/ExternalInterface"
+        )
+        self._saved_resource_prefs = {
+            "CustomMaterialsDir": self._resource_param.GetString("CustomMaterialsDir", ""),
+            "UseBuiltInMaterials": self._resource_param.GetBool("UseBuiltInMaterials", True),
+            "UseMaterialsFromWorkbenches": self._resource_param.GetBool(
+                "UseMaterialsFromWorkbenches", True
+            ),
+            "UseMaterialsFromConfigDir": self._resource_param.GetBool(
+                "UseMaterialsFromConfigDir", True
+            ),
+            "UseMaterialsFromCustomDir": self._resource_param.GetBool(
+                "UseMaterialsFromCustomDir", False
+            ),
+        }
+        self._saved_external_prefs = {
+            "UseExternal": self._external_param.GetBool("UseExternal", False),
+        }
+        self._custom_dir = tempfile.mkdtemp(prefix="freecad-material-observer-")
+        self._resource_param.SetString("CustomMaterialsDir", self._custom_dir)
+        self._resource_param.SetBool("UseBuiltInMaterials", False)
+        self._resource_param.SetBool("UseMaterialsFromWorkbenches", False)
+        self._resource_param.SetBool("UseMaterialsFromConfigDir", False)
+        self._resource_param.SetBool("UseMaterialsFromCustomDir", True)
+        self._external_param.SetBool("UseExternal", False)
+        self.MaterialManager.refresh()
+        self._library_name = "Custom"
+
+    def tearDown(self):
+        while self._observer_registrations > 0:
+            Materials.removeMaterialObserver(self.observer)
+            self._observer_registrations -= 1
+
+        shutil.rmtree(self._custom_dir, ignore_errors=True)
+        self._restore_preferences()
+
+    def _register_observer(self):
+        Materials.addMaterialObserver(observer=self.observer)
+        self._observer_registrations += 1
+
+    def _remove_observer(self):
+        if self._observer_registrations > 0:
+            Materials.removeMaterialObserver(observer=self.observer)
+            self._observer_registrations -= 1
+
+    def _restore_preferences(self):
+        for key, value in self._saved_resource_prefs.items():
+            if key == "CustomMaterialsDir":
+                self._resource_param.SetString(key, value)
+            else:
+                self._resource_param.SetBool(key, value)
+        for key, value in self._saved_external_prefs.items():
+            self._external_param.SetBool(key, value)
+        self.MaterialManager.refresh()
+
+    def testObserverReceivesCreateAndChange(self):
+        material = Materials.Material()
+        material.Description = "created"
+        created_uuid = material.UUID
+
+        self._register_observer()
+
+        self.MaterialManager.save(
+            self._library_name,
+            material,
+            "Example/ObserverCard.FCMat",
+            overwrite=True,
+        )
+        self.assertEqual(len(self.observer.created), 1)
+        self.assertEqual(self.observer.created[0].UUID, created_uuid)
+        self.assertEqual(self.observer.created[0].Name, "ObserverCard")
+        self.assertEqual(len(self.observer.changed), 0)
+        self.assertEqual(len(self.observer.deleted), 0)
+
+        material.Description = "changed"
+        self.MaterialManager.save(
+            self._library_name,
+            material,
+            "Example/ObserverCard.FCMat",
+            overwrite=True,
+        )
+        self.assertEqual(len(self.observer.changed), 1)
+        self.assertEqual(self.observer.changed[0].UUID, created_uuid)
+        self.assertEqual(self.observer.changed[0].Name, "ObserverCard")
+
+        self._remove_observer()
+
+        material.Description = "changed again"
+        self.MaterialManager.save(
+            self._library_name,
+            material,
+            "Example/ObserverCard.FCMat",
+            overwrite=True,
+        )
+        self.assertEqual(len(self.observer.changed), 1)
+
+    def testDuplicateRegistrationAndUnknownRemoval(self):
+        material = Materials.Material()
+        material.Description = "created"
+        created_uuid = material.UUID
+
+        stranger = _RecordingObserver()
+        Materials.removeMaterialObserver(stranger)
+
+        self._register_observer()
+        self._register_observer()
+
+        self.MaterialManager.save(
+            self._library_name,
+            material,
+            "Example/DuplicateObserverCard.FCMat",
+            overwrite=True,
+        )
+        self.assertEqual(len(self.observer.created), 2)
+        self.assertTrue(all(event.UUID == created_uuid for event in self.observer.created))
+
+        self._remove_observer()
+        material.Description = "changed"
+        self.MaterialManager.save(
+            self._library_name,
+            material,
+            "Example/DuplicateObserverCard.FCMat",
+            overwrite=True,
+        )
+        self.assertEqual(len(self.observer.changed), 1)
+        self.assertEqual(self.observer.changed[0].UUID, created_uuid)
+
+        self._remove_observer()
+
+        material.Description = "changed again"
+        self.MaterialManager.save(
+            self._library_name,
+            material,
+            "Example/DuplicateObserverCard.FCMat",
+            overwrite=True,
+        )
+        self.assertEqual(len(self.observer.changed), 1)
+
+    def testObserverKeepsPythonObjectAliveWhileRegistered(self):
+        observer = _RecordingObserver()
+        observer_ref = weakref.ref(observer)
+
+        Materials.addMaterialObserver(observer=observer)
+        try:
+            del observer
+            gc.collect()
+
+            registered_observer = observer_ref()
+            self.assertIsNotNone(registered_observer)
+
+            material = Materials.Material()
+            material.Description = "created"
+            self.MaterialManager.save(
+                self._library_name,
+                material,
+                "Example/ObserverCard.FCMat",
+                overwrite=True,
+            )
+            self.assertEqual(len(registered_observer.created), 1)
+        finally:
+            registered_observer = observer_ref()
+            if registered_observer is not None:
+                Materials.removeMaterialObserver(observer=registered_observer)
+                del registered_observer
+
+        gc.collect()
+        self.assertIsNone(observer_ref())

--- a/tests/src/Mod/Material/App/CMakeLists.txt
+++ b/tests/src/Mod/Material/App/CMakeLists.txt
@@ -3,6 +3,7 @@
 add_executable(Material_tests_run
         TestMaterialCards.cpp
         TestMaterialFilter.cpp
+        TestMaterialObserver.cpp
         TestMaterialProperties.cpp
         TestMaterials.cpp
         TestMaterialValue.cpp

--- a/tests/src/Mod/Material/App/TestMaterialObserver.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialObserver.cpp
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#include <QString>
+
+#include <vector>
+
+#include <App/Application.h>
+#include <Base/Interpreter.h>
+#include <src/App/InitApplication.h>
+#include <src/TempDirectory.h>
+
+#include <Mod/Material/App/MaterialLibrary.h>
+#include <Mod/Material/App/MaterialManager.h>
+#include <Mod/Material/App/ModelManager.h>
+
+class TestMaterialObserver: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        if (App::Application::GetARGC() == 0) {
+            tests::initApplication();
+        }
+    }
+
+    void SetUp() override
+    {
+        Base::Interpreter().runString("import Part");
+
+        QString libPath = QString::fromStdString(_tempDir.string());
+        _library = std::make_shared<Materials::MaterialLibraryLocal>(
+            QStringLiteral("Testing"),
+            libPath,
+            QStringLiteral(":/icons/preferences-general.svg"),
+            false
+        );
+        _modelManager = &(Materials::ModelManager::getManager());
+        _materialManager = &(Materials::MaterialManager::getManager());
+
+        createdConn = _materialManager->signalCreatedMaterial.connect(
+            [this](const Materials::Material& material) { createdEvents.push_back(material); }
+        );
+        changedConn = _materialManager->signalChangedMaterial.connect(
+            [this](const Materials::Material& material) { changedEvents.push_back(material); }
+        );
+        deletedConn = _materialManager->signalDeletedMaterial.connect(
+            [this](const Materials::Material& material) { deletedEvents.push_back(material); }
+        );
+    }
+
+    void TearDown() override
+    {
+        ASSERT_NE(_materialManager, nullptr);
+        ASSERT_TRUE(_library);
+
+        for (const auto& path :
+             {QStringLiteral("/SignalCard.FCMat"),
+              QStringLiteral("/Folder"),
+              QStringLiteral("/Renamed")}) {
+            try {
+                _materialManager->deleteRecursive(_library, path);
+            }
+            catch (...) {
+            }
+        }
+
+        createdConn.disconnect();
+        changedConn.disconnect();
+        deletedConn.disconnect();
+
+        _modelManager->refresh();
+        _materialManager->refresh();
+    }
+
+    tests::TempDirectory _tempDir {"TestMaterialObserver"};
+    Materials::ModelManager* _modelManager {};
+    Materials::MaterialManager* _materialManager {};
+    std::shared_ptr<Materials::MaterialLibraryLocal> _library;
+    std::vector<Materials::Material> createdEvents;
+    std::vector<Materials::Material> changedEvents;
+    std::vector<Materials::Material> deletedEvents;
+    fastsignals::scoped_connection createdConn;
+    fastsignals::scoped_connection changedConn;
+    fastsignals::scoped_connection deletedConn;
+};
+
+TEST_F(TestMaterialObserver, TestMaterialLifecycleSignals)
+{
+    ASSERT_NE(_materialManager, nullptr);
+    ASSERT_TRUE(_library);
+
+    auto material = std::make_shared<Materials::Material>();
+    material->setDescription(QStringLiteral("created"));
+    QString uuid = material->getUUID();
+
+    _materialManager
+        ->saveMaterial(_library, material, QStringLiteral("/SignalCard.FCMat"), true, false, false);
+
+    ASSERT_EQ(createdEvents.size(), 1);
+    EXPECT_EQ(createdEvents.front().getUUID(), uuid);
+    EXPECT_EQ(createdEvents.front().getName(), QStringLiteral("SignalCard"));
+    EXPECT_TRUE(changedEvents.empty());
+    EXPECT_TRUE(deletedEvents.empty());
+
+    material->setDescription(QStringLiteral("changed"));
+    _materialManager
+        ->saveMaterial(_library, material, QStringLiteral("/SignalCard.FCMat"), true, false, false);
+
+    ASSERT_EQ(changedEvents.size(), 1);
+    EXPECT_EQ(changedEvents.front().getUUID(), uuid);
+    EXPECT_EQ(changedEvents.front().getName(), QStringLiteral("SignalCard"));
+
+    _materialManager->deleteRecursive(_library, QStringLiteral("/SignalCard.FCMat"));
+
+    ASSERT_EQ(deletedEvents.size(), 1);
+    EXPECT_EQ(deletedEvents.front().getUUID(), uuid);
+    EXPECT_EQ(deletedEvents.front().getName(), QStringLiteral("SignalCard"));
+}
+
+TEST_F(TestMaterialObserver, TestRenameFolderSignalsChangedMaterial)
+{
+    ASSERT_NE(_materialManager, nullptr);
+    ASSERT_TRUE(_library);
+
+    auto material = std::make_shared<Materials::Material>();
+    _materialManager->saveMaterial(
+        _library,
+        material,
+        QStringLiteral("/Folder/RenamedCard.FCMat"),
+        true,
+        false,
+        false
+    );
+    createdEvents.clear();
+    changedEvents.clear();
+    deletedEvents.clear();
+    bool renamedPathVisibleDuringCallback = false;
+    auto verifyConn = _materialManager->signalChangedMaterial.connect(
+        [this, &renamedPathVisibleDuringCallback](const Materials::Material& changed) {
+            try {
+                auto renamed = _library->getMaterialByPath(QStringLiteral("Renamed/RenamedCard.FCMat"));
+                renamedPathVisibleDuringCallback = renamed->getUUID() == changed.getUUID();
+            }
+            catch (...) {
+            }
+        }
+    );
+
+    _materialManager->renameFolder(_library, QStringLiteral("/Folder"), QStringLiteral("/Renamed"));
+
+    ASSERT_EQ(changedEvents.size(), 1);
+    EXPECT_EQ(changedEvents.front().getUUID(), material->getUUID());
+    EXPECT_EQ(changedEvents.front().getDirectory(), QStringLiteral("Renamed"));
+    EXPECT_TRUE(renamedPathVisibleDuringCallback);
+
+    auto renamed = _library->getMaterialByPath(QStringLiteral("Renamed/RenamedCard.FCMat"));
+    EXPECT_EQ(renamed->getDirectory(), QStringLiteral("Renamed"));
+
+    verifyConn.disconnect();
+}


### PR DESCRIPTION
This PR adds a Python observer API for the Materials subsystem and the binding-generator support needed to expose that API at module scope.

The stack is split into three reviewable pieces:

- add `.module.pyi` support to the Python bindings generator
- add material lifecycle signals in `MaterialManager` for create/change/delete
- expose `Materials.addMaterialObserver()` and `Materials.removeMaterialObserver()` on top of those signals

It also adds C++ and Python coverage for the observer lifecycle, including duplicate registration and observer removal semantics.

Fixes #29829
