### PR TITLE
Document alternate rotation & dragging shortcuts in CAD navigation style in app

### DIFF
--- a/src/Gui/Navigation/CADNavigationStyle.cpp
+++ b/src/Gui/Navigation/CADNavigationStyle.cpp
@@ -48,9 +48,9 @@ const char* CADNavigationStyle::mouseButtons(ViewerMode mode)
         case NavigationStyle::SELECTION:
             return QT_TR_NOOP("Press left mouse button");
         case NavigationStyle::PANNING:
-            return QT_TR_NOOP("Press middle mouse button");
+            return QT_TR_NOOP("Press middle or ctrl+right mouse button");
         case NavigationStyle::DRAGGING:
-            return QT_TR_NOOP("Press middle+left or middle+right mouse button");
+            return QT_TR_NOOP("Press middle+left, middle+right or shift+right mouse button");
         case NavigationStyle::ZOOMING:
             return QT_TR_NOOP(
                 "Scroll mouse wheel or keep middle button depressed\n"


### PR DESCRIPTION
Document alternate rotation & dragging shortcuts in CAD navigation style

The ctrl+right mouse button panning and shift+right mouse button rotation shortcuts are documented at https://wiki.freecad.org/Mouse_navigation/en#CAD_navigation but were not listed in the in-app settings help.

If using a device with no "normal" middle button, such as a ThinkPad with a TrackPoint which defaults to using middle button to scroll on Linux (see https://wiki.archlinux.org/title/TrackPoint#Middle_button_scroll), current in app help strings did not show any control scheme which would allow control without use of a middle button despite the default scheme having relevant alternate controls.

Validated the change in app:
<img width="1003" height="513" alt="image" src="https://github.com/user-attachments/assets/427f09d7-1461-4a41-a2fc-f9368d6497bb" />

Since this is changing a translated string, all translations will need updates. Looking at the localization docs it seems that loc file updates are driven by maintainers so I've left out any changes here. Please do let me know if there should be some.