### PR TITLE
Draw sketch on objects top in edit mode

### DIFF
--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -884,7 +884,7 @@ void EditModeCoinManager::updateGeometryLayersConfiguration()
 void EditModeCoinManager::createEditModeInventorNodes()
 {
     // 1 - Create the edit root node
-    editModeScenegraphNodes.EditRoot = new SoSeparator;
+    editModeScenegraphNodes.EditRoot = new Gui::So3DAnnotation;
     editModeScenegraphNodes.EditRoot->ref();  // Node is unref in the destructor of EditModeCoinManager
     editModeScenegraphNodes.EditRoot->setName("Sketch_EditRoot");
     ViewProviderSketchCoinAttorney::addNodeToRoot(viewProvider, editModeScenegraphNodes.EditRoot);

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.h
@@ -44,6 +44,7 @@
 #include <Base/Color.h>
 #include <Gui/ViewParams.h>
 #include <Gui/Inventor/SmSwitchboard.h>
+#include <Gui/Inventor/So3DAnnotation.h>
 #include <Mod/Sketcher/App/GeoList.h>
 
 #include "ViewProviderSketchGeometryExtension.h"
@@ -399,7 +400,7 @@ struct EditModeScenegraphNodes
 {
     /** @name Point nodes*/
     //@{
-    SoSeparator* EditRoot;
+    Gui::So3DAnnotation* EditRoot;
     SmSwitchboard* PointsGroup;
     std::vector<SoMaterial*> PointsMaterials;
     std::vector<SoCoordinate3*> PointsCoordinate;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3664,7 +3664,11 @@ bool ViewProviderSketch::setEdit(int ModNum)
     auto gridnode = getGridNode();
     Base::Placement plm = getEditingPlacement();
     setGridOrientation(plm.getPosition(), plm.getRotation());
-    addNodeToRoot(gridnode);
+
+    pcGridAnnotation = new Gui::So3DAnnotation;
+    pcGridAnnotation->setName("Sketch_GridAnnotation");
+    pcGridAnnotation->addChild(gridnode);
+    addNodeToRoot(pcGridAnnotation);
 
     // create the container for the additional edit data
     assert(!isInEditMode());
@@ -3964,6 +3968,11 @@ void ViewProviderSketch::unsetEdit(int ModNum)
     setGridEnabled(nullptr);
     auto gridnode = getGridNode();
     pcRoot->removeChild(gridnode);
+
+    if (pcGridAnnotation) {
+        pcRoot->removeChild(pcGridAnnotation);
+        pcGridAnnotation = nullptr;
+    }
 
     if (listener) {
         Gui::getMainWindow()->removeEventFilter(listener.get());

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -49,6 +49,7 @@
 #include "ShortcutListener.h"
 #include "Utils.h"
 
+#include <Gui/Inventor/So3DAnnotation.h>
 #include <Gui/Inventor/SoToggleSwitch.h>
 #include <Mod/Part/Gui/ViewProviderPreviewExtension.h>
 
@@ -1007,6 +1008,7 @@ private:
     std::string editObjName;
     std::string editSubName;
 
+    Gui::So3DAnnotation* pcGridAnnotation = nullptr;
     Gui::CoinPtr<SoSketchFaces> pcSketchFaces;
     Gui::CoinPtr<SoToggleSwitch> pcSketchFacesToggle;
 


### PR DESCRIPTION
Followup to  [Sketch could be hidden by or inside the body](https://github.com/FreeCAD/FreeCAD/issues/29132) #29132

Despite that original feature request was rejected I still decided to propose this PR. I think it's reasonable to always see edited sketch from any direction, otherwise how can we edit it?

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5be18f8e-b716-48e0-9c01-d70c3129c7a9" />
.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/bfcc009c-178a-425c-8c5a-54c6a2ed1434" />

It replaces  SoSeparator with Gui::So3DAnnotation.