### PR TITLE
CAM: improve stock color and visualization

### DIFF
--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -450,6 +450,7 @@ class StockEdit(object):
             obj.Document.removeObject(obj.Stock.Name)
         Path.Log.track(stock.Name)
         obj.Stock = stock
+        PathStock.ApplyStockViewDefaults(stock)
         if stock.ViewObject and stock.ViewObject.Proxy:
             stock.ViewObject.Proxy.onEdit(_OpenCloseResourceEditor)
 
@@ -835,6 +836,7 @@ class TaskPanel:
                 material_manager = Materials.MaterialManager()
                 material = material_manager.getMaterial(dialog.uuid)
                 self.obj.Stock.ShapeMaterial = material
+                PathStock.ApplyStockViewDefaults(self.obj.Stock)
 
     def preCleanup(self):
         Path.Log.track()

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -87,7 +87,11 @@ def createResourceClone(obj, orig, name, icon):
 
         Path.Base.Gui.IconViewProvider.Attach(clone.ViewObject, icon)
         clone.ViewObject.Visibility = False
-        clone.ViewObject.Transparency = 80
+        clone.ViewObject.DisplayMode = "Flat Lines"
+        clone.ViewObject.ShapeColor = (0.447, 0.475, 0.502)
+        clone.ViewObject.Transparency = 0
+        clone.ViewObject.LineColor = (0.310, 0.333, 0.357)
+        clone.ViewObject.ShapeMaterial.Shininess = 0.85
     obj.Document.recompute()  # necessary to create the clone shape
     return clone
 
@@ -391,8 +395,9 @@ class ObjectJob:
                 obj.Stock = PathStock.CreateFromTemplate(obj, json.loads(stockTemplate))
             if not obj.Stock:
                 obj.Stock = PathStock.CreateFromBase(obj)
-        if obj.Stock.ViewObject:
-            obj.Stock.ViewObject.Visibility = False
+        PathStock.ApplyStockViewDefaults(obj.Stock)
+        if obj.Stock and obj.Stock.ViewObject:
+            obj.Stock.ViewObject.Visibility = True
 
     def removeBase(self, obj, base, removeFromModel):
         if isResourceClone(obj, base, None):

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -607,4 +607,18 @@ def CreateFromTemplate(job, template):
         return None
 
 
+def ApplyStockViewDefaults(stock):
+    """Apply default appearance settings to a stock object's ViewObject."""
+    if stock and stock.ViewObject:
+        stock.ViewObject.ShapeColor = (0.792, 0.718, 0.537)
+        stock.ViewObject.Transparency = 85
+        stock.ViewObject.LineColor = (0.553, 0.502, 0.376)
+        stock.ViewObject.PointColor = (0.553, 0.502, 0.376)
+        stock.ViewObject.DrawStyle = "Dotted"
+        stock.ViewObject.DisplayMode = "Flat Lines"
+        stock.ViewObject.PointSize = 1
+        stock.ViewObject.LineWidth = 1
+        stock.ViewObject.Selectable = False
+
+
 FreeCAD.Console.PrintLog("Loading PathStock... done\n")


### PR DESCRIPTION
Change the default view properties of the stock and model objects in the CAM job.
This provides maximum visibility and contrast across the three main themes.
<img width="959" height="701" alt="stockbefore" src="https://github.com/user-attachments/assets/611cde69-c560-4cd5-8164-fac3b6c5d7bc" />
<img width="988" height="744" alt="stockbefore1" src="https://github.com/user-attachments/assets/79c23786-5763-4281-a956-365bec6cf0c6" />
<img width="978" height="718" alt="stockbefore2" src="https://github.com/user-attachments/assets/7aa0704c-a571-4e2b-ac29-2046d2fc1dd1" />

<img width="989" height="748" alt="stockafter" src="https://github.com/user-attachments/assets/c859e493-9f02-4cf4-86d8-00f0be76ae04" />
<img width="1043" height="758" alt="stockafter1" src="https://github.com/user-attachments/assets/470626ed-5900-487e-86a1-d1002e55b53e" />
<img width="1071" height="808" alt="stockafter2" src="https://github.com/user-attachments/assets/055c3346-d5cc-44aa-ae07-6ccc5c439d1d" />

