### PR TITLE
Draft: reject Trimex on sketch objects

### DIFF
--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -105,26 +105,22 @@ class Trimex(gui_base_original.Modifier):
             self.finish()
             return
         self.obj = sel[0]
+        sel = Gui.Selection.getSelectionEx("", 0)[0]
 
         import DraftGeomUtils
         import Part
 
-        if not hasattr(self.obj, "Shape"):
+        reason = utils.get_trimex_unsupported_reason(self.obj, sel.SubObjects)
+        if reason:
             self.obj = None
             self.finish()
-            _err(translate("draft", "This object is not supported"))
-            return
-        if self.obj.isDerivedFrom("Sketcher::SketchObject"):
-            self.obj = None
-            self.finish()
-            _err(translate("draft", "Trimex does not support this object type"))
+            _err(reason)
             return
         self.ui.trimUi(title=translate("draft", self.featureName))
         self.linetrack = trackers.lineTracker()
         if hasattr(self.obj, "Placement"):
             self.placement = self.obj.Placement
         if self.obj.Shape.Faces:
-            sel = Gui.Selection.getSelectionEx("", 0)[0]
             self.obj = sel.Object
             if len(self.obj.Shape.Faces) == 1:
                 # simple extrude mode, the object itself is extruded

--- a/src/Mod/Draft/draftguitools/gui_trimex.py
+++ b/src/Mod/Draft/draftguitools/gui_trimex.py
@@ -105,8 +105,6 @@ class Trimex(gui_base_original.Modifier):
             self.finish()
             return
         self.obj = sel[0]
-        self.ui.trimUi(title=translate("draft", self.featureName))
-        self.linetrack = trackers.lineTracker()
 
         import DraftGeomUtils
         import Part
@@ -116,6 +114,13 @@ class Trimex(gui_base_original.Modifier):
             self.finish()
             _err(translate("draft", "This object is not supported"))
             return
+        if self.obj.isDerivedFrom("Sketcher::SketchObject"):
+            self.obj = None
+            self.finish()
+            _err(translate("draft", "Trimex does not support this object type"))
+            return
+        self.ui.trimUi(title=translate("draft", self.featureName))
+        self.linetrack = trackers.lineTracker()
         if hasattr(self.obj, "Placement"):
             self.placement = self.obj.Placement
         if self.obj.Shape.Faces:

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -366,7 +366,14 @@ def get_trimex_unsupported_reason(obj, subobjects=None):
         `None` if the object is supported by Trimex, otherwise
         a translated error message explaining why it is rejected.
     """
-    import DraftGeomUtils
+    import Part
+
+    def edge_geom_type(edge):
+        if isinstance(edge.Curve, (Part.LineSegment, Part.Line)):
+            return "Line"
+        if isinstance(edge.Curve, Part.Circle):
+            return "Circle"
+        return "Unknown"
 
     if not hasattr(obj, "Shape"):
         return translate("draft", "This object is not supported")
@@ -397,7 +404,7 @@ def get_trimex_unsupported_reason(obj, subobjects=None):
         edges = shape.Edges
 
     for edge in edges:
-        if DraftGeomUtils.geomType(edge) not in {"Line", "Circle"}:
+        if edge_geom_type(edge) not in {"Line", "Circle"}:
             return translate("draft", "Trimex does not support this object type")
 
     obj_type = get_type(obj)

--- a/src/Mod/Draft/draftutils/utils.py
+++ b/src/Mod/Draft/draftutils/utils.py
@@ -350,6 +350,71 @@ def get_type(obj):
 getType = get_type
 
 
+def get_trimex_unsupported_reason(obj, subobjects=None):
+    """Return a translated Trimex error message for unsupported objects.
+
+    Parameters
+    ----------
+    obj : App::DocumentObject
+        Object that Trimex should operate on.
+    subobjects : list, optional
+        Selected subobjects associated with `obj`.
+
+    Returns
+    -------
+    str or None
+        `None` if the object is supported by Trimex, otherwise
+        a translated error message explaining why it is rejected.
+    """
+    import DraftGeomUtils
+
+    if not hasattr(obj, "Shape"):
+        return translate("draft", "This object is not supported")
+
+    shape = obj.Shape
+    if shape.Faces:
+        if len(shape.Faces) == 1:
+            return None
+        if (
+            subobjects
+            and len(subobjects) == 1
+            and getattr(subobjects[0], "ShapeType", None) == "Face"
+        ):
+            return None
+        return translate("draft", "Only a single face can be extruded")
+
+    if obj.isDerivedFrom("Sketcher::SketchObject"):
+        return translate("draft", "Trimex does not support this object type")
+
+    if len(shape.Wires) > 1:
+        return translate("draft", "Trimex does not support this object type")
+
+    if shape.Wires:
+        edges = shape.Wires[0].Edges
+    else:
+        if len(shape.Edges) != 1:
+            return translate("draft", "Trimex does not support this object type")
+        edges = shape.Edges
+
+    for edge in edges:
+        if DraftGeomUtils.geomType(edge) not in {"Line", "Circle"}:
+            return translate("draft", "Trimex does not support this object type")
+
+    obj_type = get_type(obj)
+    if obj_type in {"Wire", "Part::Line", "Circle"}:
+        return None
+
+    if obj.TypeId in {"Part::Feature", "Part::Part2DObject"}:
+        return None
+
+    if obj.TypeId in {"Part::FeaturePython", "Part::Part2DObjectPython"}:
+        proxy = getattr(obj, "Proxy", None)
+        if proxy is None or not hasattr(proxy, "execute"):
+            return None
+
+    return translate("draft", "Trimex does not support this object type")
+
+
 def get_objects_of_type(objects, typ):
     """Return only the objects that match the type in the list of objects.
 


### PR DESCRIPTION
Trimex currently accepts `Sketcher::SketchObject` selections and opens the task panel, but it cannot write the trim/extend result back to the sketch. The command therefore appears to run and then ends in a confusing no-op.

This change rejects sketch selections before opening the Trimex UI and reports that the object type is unsupported.

## Issues
Fixes #23681

## Before and After Images
Before video:

https://github.com/user-attachments/assets/134c967e-6f50-4349-9c07-9d8f125efb51



After video:

https://github.com/user-attachments/assets/7923b8ea-49ea-4ac4-b749-668baa5fc80e



## Validation
- Reproduced the issue with the attached `FC_draft_trimex_sketch.FCStd` sample
- Verified that after the fix, selecting `Sketch` and launching `Trimex` no longer enters the misleading Trimex workflow