### PR TITLE
CAM: DressupTag - Clear all tags

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/HoldingTagsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/HoldingTagsEdit.ui
@@ -15,127 +15,184 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QWidget" name="parameterGroup">
-     <layout class="QFormLayout">
-      <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-      </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Width</string>
+    <layout class="QGridLayout" name="gridLayout_10">
+     <item row="0" column="0">
+      <widget class="QWidget" name="parameterGroup_1">
+       <layout class="QFormLayout">
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Height</string>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Width</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::InputField" name="ifWidth">
+          <property name="toolTip">
+           <string>Width of the resulting holding tag</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Angle</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QDoubleSpinBox" name="dsbAngle">
+          <property name="toolTip">
+           <string>Plunge angle for ascent and descent of holding tag</string>
+          </property>
+          <property name="suffix">
+           <string> °</string>
+          </property>
+          <property name="minimum">
+           <double>5.000000000000000</double>
+          </property>
+          <property name="maximum">
+           <double>90.000000000000000</double>
+          </property>
+          <property name="singleStep">
+           <double>15.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>45.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QWidget" name="parameterGroup_2">
+       <layout class="QFormLayout">
+        <property name="fieldGrowthPolicy">
+         <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
         </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Angle</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="Gui::InputField" name="ifWidth">
-        <property name="toolTip">
-         <string>Width of the resulting holding tag</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="Gui::InputField" name="ifHeight">
-        <property name="toolTip">
-         <string>Height of holding tag. Note that resulting tag might be smaller if the tag's width and angle result in a triangular shape.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QDoubleSpinBox" name="dsbAngle">
-        <property name="toolTip">
-         <string>Plunge angle for ascent and descent of holding tag</string>
-        </property>
-        <property name="minimum">
-         <double>5.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>90.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>15.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>45.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Radius</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="Gui::InputField" name="ifRadius">
-        <property name="toolTip">
-         <string>Radius of the fillet at the top. If the radius is too big for the tag shape it gets reduced to the maximum possible radius - resulting in a spherical shape.</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Height</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::InputField" name="ifHeight">
+          <property name="toolTip">
+           <string>Height of holding tag. Note that resulting tag might be smaller if the tag's width and angle result in a triangular shape.</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Radius</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="Gui::InputField" name="ifRadius">
+          <property name="toolTip">
+           <string>Radius of the fillet at the top. If the radius is too big for the tag shape it gets reduced to the maximum possible radius - resulting in a spherical shape.</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item row="1" column="0">
-    <widget class="QListWidget" name="lwTags">
-     <property name="toolTip">
-      <string>List of current tags. Edit coordinates by double click or Edit button. Tags are automatically disabled if they overlap with the previous tag, or don't lie on the base wire.</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QWidget" name="removeEditAddGroup">
-     <layout class="QGridLayout" name="gridLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="pbDelete">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Delete</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="pbEdit">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Edit</string>
-        </property>
-       </widget>
-      </item>
-     <item row="1" column="2">
-       <widget class="QPushButton" name="pbAdd">
-        <property name="text">
-         <string>Add</string>
-        </property>
-       </widget>
-      </item>
+    <layout class="QFormLayout">
+     <item row="0" column="0">
+      <widget class="QListWidget" name="lwTags">
+       <property name="maximumSize">
+        <size>
+         <width>200</width>
+         <height>300</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>List of current tags. Edit coordinates by double click or Edit button. Tags are automatically disabled if they overlap with the previous tag, or don't lie on the base wire.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QPushButton" name="pbClear">
+         <property name="toolTip">
+          <string>Remove all tags from list</string>
+         </property>
+         <property name="text">
+          <string>Clear</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QPushButton" name="pbRemove">
+         <property name="toolTip">
+          <string>Remove selected tag from list</string>
+         </property>
+         <property name="text">
+          <string>Remove</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QPushButton" name="pbEdit">
+         <property name="toolTip">
+          <string>Edit position of selected tag</string>
+         </property>
+         <property name="text">
+          <string>Edit</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QPushButton" name="pbAdd">
+         <property name="toolTip">
+          <string>Add new tags</string>
+         </property>
+         <property name="text">
+          <string>Add</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QPushButton" name="pbSwitch">
+         <property name="toolTip">
+          <string>Enable/disable all tags</string>
+         </property>
+         <property name="text">
+          <string>Enable All</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QPushButton" name="pbCopy">
+         <property name="toolTip">
+          <string>Replace all tags by tags from another DressupTag</string>
+         </property>
+         <property name="text">
+          <string>Copy</string>
+         </property>
+        </widget>
+       </item>
       </layout>
-    </widget>
+     </item>
+    </layout>
    </item>
    <item row="3" column="0">
     <widget class="QGroupBox" name="cbTagGeneration">
@@ -143,49 +200,66 @@
       <string>Auto Generate</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <widget class="QSpinBox" name="sbCount">
-        <property name="minimum">
-         <number>2</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="pbGenerate">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Replace All</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-  <item row="4" column="0">
-    <widget class="QGroupBox" name="gbCopy">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="title">
-      <string>Copy From</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_4">
       <item row="0" column="0">
-       <widget class="QComboBox" name="cbSource"/>
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Min</string>
+        </property>
+       </widget>
       </item>
       <item row="0" column="1">
-       <widget class="QPushButton" name="pbCopy">
+       <widget class="QSpinBox" name="sbMinCount">
+        <property name="toolTip">
+         <string>Minimum number of tags per short wire</string>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>45</width>
+          <height>45</height>
+         </size>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Replace All</string>
+         <string>Max</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QSpinBox" name="sbMaxCount">
+        <property name="toolTip">
+         <string>Maximum number of tags per long wire</string>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>45</width>
+          <height>45</height>
+         </size>
+        </property>
+        <property name="minimum">
+         <number>1</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QPushButton" name="pbGenerate">
+        <property name="toolTip">
+         <string>Create the specified number of tags for each bottom wire</string>
+        </property>
+        <property name="text">
+         <string>Replace Existing Tags</string>
         </property>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
-   </layout>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/Mod/CAM/Path/Dressup/Gui/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Gui/Tags.py
@@ -54,7 +54,7 @@ class PathDressupTagTaskPanel:
         self.obj.Proxy.obj = obj
         self.viewProvider = viewProvider
         self.form = FreeCADGui.PySideUic.loadUi(":/panels/HoldingTagsEdit.ui")
-        self.getPoint = PathGetPoint.TaskPanel(self.form.removeEditAddGroup, True)
+        self.getPoint = PathGetPoint.TaskPanel(self.form.cbTagGeneration, True)
         self.jvo = PathUtils.findParentJob(obj).ViewObject
         if jvoVisibility is None:
             FreeCAD.ActiveDocument.openTransaction("Edit HoldingTags Dress-up")
@@ -130,6 +130,8 @@ class PathDressupTagTaskPanel:
         height = FreeCAD.Units.Quantity(self.form.ifHeight.text()).Value
         angle = self.form.dsbAngle.value()
         radius = FreeCAD.Units.Quantity(self.form.ifRadius.text()).Value
+        minCount = self.form.sbMinCount.value()
+        maxCount = self.form.sbMaxCount.value()
 
         tags = self.getTags(True)
         positions = []
@@ -157,6 +159,12 @@ class PathDressupTagTaskPanel:
         if disabled != self.obj.Disabled:
             self.obj.Disabled = disabled
             self.isDirty = True
+        if minCount != self.obj.Proxy.minCount:
+            self.obj.Proxy.minCount = minCount
+            self.isDirty = True
+        if maxCount != self.obj.Proxy.maxCount:
+            self.obj.Proxy.maxCount = maxCount
+            self.isDirty = True
 
     def updateTagsView(self):
         Path.Log.track()
@@ -181,36 +189,43 @@ class PathDressupTagTaskPanel:
         self.form.lwTags.blockSignals(False)
         self.whenTagSelectionChanged()
         self.viewProvider.updatePositions(self.Positions, self.Disabled)
+        self.updateButtonEnable()
+
+    def updateButtonEnable(self):
+        if self.Disabled:
+            self.form.pbSwitch.setText("Enable All")
+        else:
+            self.form.pbSwitch.setText("Disable All")
 
     def generateNewTags(self):
-        count = self.form.sbCount.value()
-        Path.Log.track(count)
-        if not self.obj.Proxy.generateTags(self.obj, count):
+        self.getFields()
+        if not self.obj.Proxy.generateTags(self.obj):
             self.obj.Proxy.execute(self.obj)
         self.Positions = self.obj.Positions
         self.Disabled = self.obj.Disabled
         self.updateTagsView()
 
     def copyNewTags(self):
-        sel = self.form.cbSource.currentText()
-        tags = [o for o in FreeCAD.ActiveDocument.Objects if sel == o.Label]
-        if 1 == len(tags):
-            if not self.obj.Proxy.copyTags(self.obj, tags[0]):
+        objs = FreeCAD.ActiveDocument.Objects
+        tags = [o for o in objs if "DressupTag" in o.Name and self.obj.Name != o.Name]
+        tagsLabels = [t.Label for t in tags]
+        form = FreeCADGui.PySideUic.loadUi(":/panels/DlgTCChooser.ui")
+        form.setWindowTitle("Dressup Tag")
+        form.label.setText("Copy tags from")
+        form.uiToolController.addItems(tagsLabels)
+        r = form.exec()
+        if r:
+            index = form.uiToolController.currentIndex()
+            if not self.obj.Proxy.copyTags(self.obj, tags[index]):
                 self.obj.Proxy.execute(self.obj)
             self.Positions = self.obj.Positions
             self.Disabled = self.obj.Disabled
             self.updateTagsView()
-        else:
-            Path.Log.error("Cannot copy tags - internal error")
 
     def updateModel(self):
         self.getFields()
         self.updateTagsView()
         self.isDirty = True
-
-    def whenCountChanged(self):
-        count = self.form.sbCount.value()
-        self.form.pbGenerate.setEnabled(count)
 
     def selectTagWithId(self, index):
         Path.Log.track(index)
@@ -218,8 +233,7 @@ class PathDressupTagTaskPanel:
 
     def whenTagSelectionChanged(self):
         index = self.form.lwTags.currentRow()
-        count = self.form.lwTags.count()
-        self.form.pbDelete.setEnabled(index != -1 and count > 2)
+        self.form.pbRemove.setEnabled(index != -1)
         self.form.pbEdit.setEnabled(index != -1)
         self.viewProvider.selectTag(index)
 
@@ -229,11 +243,22 @@ class PathDressupTagTaskPanel:
     def updateTagsViewWith(self, tags):
         self.tags = tags
         self.Positions = [FreeCAD.Vector(t[0], t[1], 0) for t in tags]
-        self.Disabled = [i for (i, t) in enumerate(self.tags) if not t[2]]
+        self.Disabled = [i for i, t in enumerate(tags) if not t[2]]
         self.updateTagsView()
 
-    def deleteSelectedTag(self):
+    def removeSelectedTag(self):
         self.updateTagsViewWith(self.getTags(False))
+
+    def clearTagsList(self):
+        self.updateTagsViewWith([])  # remove all tags
+
+    def switchTags(self):
+        if self.Disabled:  # enable all tags
+            self.Disabled = []
+        else:  # disable all tags
+            tags = self.getTags(True)
+            self.Disabled = list(range(len(tags)))
+        self.updateTagsView()
 
     def addNewTagAt(self, point, obj):
         if point and obj and self.obj.Proxy.pointIsOnPath(self.obj, point):
@@ -272,7 +297,6 @@ class PathDressupTagTaskPanel:
 
     def setFields(self):
         self.updateTagsView()
-        self.form.sbCount.setValue(int(len(self.Positions) / self.obj.Proxy.amountClosedWires))
         self.form.ifHeight.setText(
             FreeCAD.Units.Quantity(self.obj.Height, FreeCAD.Units.Length).UserString
         )
@@ -283,38 +307,34 @@ class PathDressupTagTaskPanel:
         self.form.ifRadius.setText(
             FreeCAD.Units.Quantity(self.obj.Radius, FreeCAD.Units.Length).UserString
         )
+        self.form.sbMinCount.setValue(self.obj.Proxy.minCount)
+        self.form.sbMaxCount.setValue(self.obj.Proxy.maxCount)
 
     def setupUi(self):
         self.Positions = self.obj.Positions
         self.Disabled = self.obj.Disabled
 
         self.setFields()
-        self.whenCountChanged()
+        self.updateButtonEnable()
 
         if self.obj.Proxy.supportsTagGeneration(self.obj):
-            self.form.sbCount.valueChanged.connect(self.whenCountChanged)
             self.form.pbGenerate.clicked.connect(self.generateNewTags)
-        else:
-            self.form.cbTagGeneration.setEnabled(False)
 
-        enableCopy = False
-        for tags in sorted(
-            [o.Label for o in FreeCAD.ActiveDocument.Objects if "DressupTag" in o.Name]
-        ):
-            if tags != self.obj.Label:
-                enableCopy = True
-                self.form.cbSource.addItem(tags)
-        if enableCopy:
-            self.form.gbCopy.setEnabled(True)
+        objs = FreeCAD.ActiveDocument.Objects
+        if any(o for o in objs if "DressupTag" in o.Name and self.obj.Name != o.Name):
             self.form.pbCopy.clicked.connect(self.copyNewTags)
+        else:
+            self.form.pbCopy.hide()
 
         self.form.lwTags.itemChanged.connect(self.whenTagsViewChanged)
         self.form.lwTags.itemSelectionChanged.connect(self.whenTagSelectionChanged)
         self.form.lwTags.itemActivated.connect(self.editTag)
 
-        self.form.pbDelete.clicked.connect(self.deleteSelectedTag)
+        self.form.pbClear.clicked.connect(self.clearTagsList)
+        self.form.pbRemove.clicked.connect(self.removeSelectedTag)
         self.form.pbEdit.clicked.connect(self.editSelectedTag)
         self.form.pbAdd.clicked.connect(self.addNewTag)
+        self.form.pbSwitch.clicked.connect(self.switchTags)
 
         self.viewProvider.turnMarkerDisplayOn(True)
 

--- a/src/Mod/CAM/Path/Dressup/Tags.py
+++ b/src/Mod/CAM/Path/Dressup/Tags.py
@@ -694,10 +694,9 @@ class PathData:
             self.edges = self.wire.Edges
         else:
             self.edges = []
-        self.baseWires = self.findBottomWire(self.edges)
-        self.obj.Proxy.amountClosedWires = max(1, len(self.baseWires))
+        self.baseWires = self.findBottomWires(self.edges)
 
-    def findBottomWire(self, edges):
+    def findBottomWires(self, edges):
         minZ, maxZ = self.findZLimits(edges)
         self.minZ = minZ
         self.maxZ = maxZ
@@ -736,10 +735,14 @@ class PathData:
         edges = sorted(wire.Edges, key=lambda e: e.Length)
         return (edges[0], edges[-1])
 
-    def generateTags(self, obj, count, width=None, height=None, angle=None, radius=None):
+    def generateTags(
+        self, obj, minCount=2, maxCount=4, width=None, height=None, angle=None, radius=None
+    ):
         tags = []
+        maxLength = max(w.Length for w in self.baseWires)
         for wire in self.baseWires:
-            logger.track(count, width, height, angle)
+            optimalCount = math.ceil(round(wire.Length / maxLength * maxCount, 6))
+            numberTags = max(minCount, optimalCount)
 
             # copy edge list into python array for (much) faster random access
             Edges = list(wire.Edges)
@@ -747,7 +750,7 @@ class PathData:
             # for e in Edges:
             #    debugMarker(e.Vertexes[0].Point, 'base', (0.0, 1.0, 1.0), 0.2)
 
-            tagDistance = wire.Length / (count if count else 4)
+            tagDistance = wire.Length / numberTags
 
             W = width if width else self.defaultTagWidth()
             H = height if height else self.defaultTagHeight()
@@ -990,16 +993,25 @@ class ObjectTagDressup:
         self.pathData = None
         self.toolRadius = None
         self.mappers = []
-        self.amountClosedWires = 1
+        self.minCount = 2
+        self.maxCount = 4
 
         obj.Proxy = self
         obj.Base = base
 
     def dumps(self):
-        return None
+        state = {}
+        state["minCount"] = self.minCount
+        state["maxCount"] = self.maxCount
+        return state
 
     def loads(self, state):
-        self.obj = state
+        if isinstance(state, dict):
+            self.minCount = state.get("minCount", 2)
+            self.maxCount = state.get("maxCount", 4)
+        else:
+            self.minCount = 2
+            self.maxCount = 4
         self.solids = []
         self.tags = []
         self.pathData = None
@@ -1030,12 +1042,13 @@ class ObjectTagDressup:
             self.setup(obj)
         return self.pathData.supportsTagGeneration()
 
-    def generateTags(self, obj, count):
+    def generateTags(self, obj):
         if self.supportsTagGeneration(obj):
             if self.pathData:
                 self.tags = self.pathData.generateTags(
                     obj,
-                    count,
+                    self.minCount,
+                    self.maxCount,
                     obj.Width.Value,
                     obj.Height.Value,
                     obj.Angle,
@@ -1045,7 +1058,7 @@ class ObjectTagDressup:
                 obj.Disabled = []
                 return False
             else:
-                self.setup(obj, count)
+                self.setup(obj)
                 self.execute(obj)
                 return True
         else:
@@ -1082,7 +1095,6 @@ class ObjectTagDressup:
         logger.track()
         commands = []
         lastEdge = 0
-        lastTag = 0
         t = 0
         edge = None
 
@@ -1098,7 +1110,7 @@ class ObjectTagDressup:
         vertRapid = tc.VertRapid.Value
 
         while edge or lastEdge < len(pathData.edges):
-            logger.debug("------- lastEdge = {}/{}.{}/{}", lastEdge, lastTag, t, len(tags))
+            logger.debug("------- lastEdge = {}.{}/{}", lastEdge, t, len(tags))
             if not edge:
                 edge = pathData.edges[lastEdge]
                 debugEdge(edge, "=======  new edge: {}/{}", lastEdge, len(pathData.edges))
@@ -1117,7 +1129,7 @@ class ObjectTagDressup:
                     edge = None
 
             if edge:
-                tIndex = (t + lastTag) % len(tags)
+                tIndex = t % len(tags)
                 t += 1
                 i = tagsSorted[tIndex].intersects(edge, edge.FirstParameter)
                 if i and self.isValidTagStartIntersection(edge, i):
@@ -1134,7 +1146,7 @@ class ObjectTagDressup:
                     edge = mapper.tail
 
             if not mapper and t >= len(tags):
-                # gone through all tags, consume edge and move on
+                # gone through all sorted tags, consume edge and move on
                 if edge:
                     debugEdge(edge, "++++++++")
                     if pathData.rapid.isRapid(edge):
@@ -1313,8 +1325,8 @@ class ObjectTagDressup:
             obj.Width = self.pathData.defaultTagWidth()
             obj.Angle = self.pathData.defaultTagAngle()
             obj.Radius = self.pathData.defaultTagRadius()
-            count = HoldingTagPreferences.defaultCount()
-            self.generateTags(obj, count)
+            self.minCount = self.maxCount = HoldingTagPreferences.defaultCount()
+            self.generateTags(obj)
         return self.pathData
 
     def setXyEnabled(self, triples):


### PR DESCRIPTION
### Changes in Task panel:

- Added button `Clear` to clear tags list
- Added button `Enable All` / `Disable All` to disable and enable all tags
- Renamed button `Delete` to `Remove` to align with others Task panels
- Widget `Copy From` replaced by button `Copy`
  It is hidden if there is no others DressupTag in document
  While press `Copy` button get pop dialog to select source of tags position
- Makes task panel more compact
- Added suffix `°` to field `Angle`
- Added tool tips to all widgets
- Allows to delete last two tags
- Decreased minimal number of auto generation tags from 2 to 1
- Added `Min` and `Max` fields to optimize number of tags dependent from wire length
   `Min`: minimum number of tags
   `Max`: maximum number of tags per longest contour
   Example:
   Min = 2; Max = 5; Longest contour 500 mm; Short contour 100
   100 / 500 * 5 = 1, so optimal number of tags for short contour is 1,
   but will be 2 from lower limit 
   <img width="1115" height="400" alt="Screenshot_20260522_173417_lossy" src="https://github.com/user-attachments/assets/5af69d96-13f7-440f-94f4-dc2dd31adbe3" />


---

### Copy feature disabled
<img width="722" height="562" alt="Screenshot_20260521_140642_hor_lossy" src="https://github.com/user-attachments/assets/a8320df5-ebc3-447b-afec-173f3423ca4f" />

### Copy feature enabled
<img width="722" height="562" alt="Screenshot_20260521_140658_hor_lossy" src="https://github.com/user-attachments/assets/b5f38cc4-141b-48bd-9f3a-2be08915567e" />

### Edit tag position
<img width="722" height="667" alt="Screenshot_20260521_140705_hor_lossy" src="https://github.com/user-attachments/assets/c43a0f62-2610-4a90-818f-2d15d0024e4a" />
