### PR TITLE
Part: respect child delete workflow in compounds

### DIFF
--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -67,7 +67,7 @@ bool ViewProviderCompound::onDelete(const std::vector<std::string>& subNames)
         // so delete everything recursively
         bool inGroupDeletion = !subNames.empty() && subNames[0] == "group_recursive_deletion";
 
-        if (inGroupDeletion) {
+        auto deleteAllLinks = [&]() -> bool {
             for (auto pLink : pLinks) {
                 if (!pLink || !pLink->isAttachedToDocument() || pLink->isRemoving()) {
                     continue;
@@ -83,6 +83,11 @@ bool ViewProviderCompound::onDelete(const std::vector<std::string>& subNames)
                 }
             }
             return true;
+        };
+
+        // Mirrors ViewProviderGroupExtension::extensionOnDelete()
+        if (inGroupDeletion) {
+            return deleteAllLinks();
         }
         QMessageBox::StandardButton choice = QMessageBox::question(
             Gui::getMainWindow(),
@@ -99,21 +104,7 @@ bool ViewProviderCompound::onDelete(const std::vector<std::string>& subNames)
         }
 
         if (choice == QMessageBox::Yes) {
-            for (auto pLink : pLinks) {
-                if (!pLink || !pLink->isAttachedToDocument() || pLink->isRemoving()) {
-                    continue;
-                }
-                if (auto guiDoc = Gui::Application::Instance->getDocument(pLink->getDocument())) {
-                    if (auto vp = guiDoc->getViewProvider(pLink);
-                        vp && !vp->onDelete(groupDeletionMarker)) {
-                        return false;
-                    }
-                }
-                if (pLink->isAttachedToDocument() && !pLink->isRemoving()) {
-                    pLink->getDocument()->removeObject(pLink->getNameInDocument());
-                }
-            }
-            return true;
+            return deleteAllLinks();
         }
 
         for (auto pLink : pLinks) {

--- a/src/Mod/Part/Gui/ViewProviderCompound.cpp
+++ b/src/Mod/Part/Gui/ViewProviderCompound.cpp
@@ -30,7 +30,9 @@
 
 #include <App/Document.h>
 #include <Gui/Application.h>
+#include <Gui/Document.h>
 #include <Gui/MainWindow.h>
+#include <Gui/ViewProvider.h>
 #include <Mod/Part/App/FeatureCompound.h>
 
 #include "ViewProviderCompound.h"
@@ -59,13 +61,24 @@ bool ViewProviderCompound::onDelete(const std::vector<std::string>& subNames)
     std::vector<App::DocumentObject*> pLinks = pComp->Links.getValues();
 
     if (!pLinks.empty()) {
+        const std::vector<std::string> groupDeletionMarker = {"group_recursive_deletion"};
+
         // check group deletion marker -> it means group called this VP to delete it's content
         // so delete everything recursively
         bool inGroupDeletion = !subNames.empty() && subNames[0] == "group_recursive_deletion";
 
         if (inGroupDeletion) {
             for (auto pLink : pLinks) {
-                if (pLink && pLink->isAttachedToDocument() && !pLink->isRemoving()) {
+                if (!pLink || !pLink->isAttachedToDocument() || pLink->isRemoving()) {
+                    continue;
+                }
+                if (auto guiDoc = Gui::Application::Instance->getDocument(pLink->getDocument())) {
+                    if (auto vp = guiDoc->getViewProvider(pLink);
+                        vp && !vp->onDelete(groupDeletionMarker)) {
+                        return false;
+                    }
+                }
+                if (pLink->isAttachedToDocument() && !pLink->isRemoving()) {
                     pLink->getDocument()->removeObject(pLink->getNameInDocument());
                 }
             }
@@ -87,7 +100,16 @@ bool ViewProviderCompound::onDelete(const std::vector<std::string>& subNames)
 
         if (choice == QMessageBox::Yes) {
             for (auto pLink : pLinks) {
-                if (pLink && pLink->isAttachedToDocument() && !pLink->isRemoving()) {
+                if (!pLink || !pLink->isAttachedToDocument() || pLink->isRemoving()) {
+                    continue;
+                }
+                if (auto guiDoc = Gui::Application::Instance->getDocument(pLink->getDocument())) {
+                    if (auto vp = guiDoc->getViewProvider(pLink);
+                        vp && !vp->onDelete(groupDeletionMarker)) {
+                        return false;
+                    }
+                }
+                if (pLink->isAttachedToDocument() && !pLink->isRemoving()) {
                     pLink->getDocument()->removeObject(pLink->getNameInDocument());
                 }
             }


### PR DESCRIPTION
## Summary
Compound deletion currently removes linked child objects directly from the document.
For PartDesign bodies that bypasses the child view provider delete workflow and can leave child objects such as Sketch behind.

This change makes compound deletion respect the child view provider delete path before removing the object from the document.

## Root cause
`Part::Compound` called `removeObject()` directly on its linked children.
`PartDesign::Body` needs its own delete workflow to remove its internal children cleanly.

## Reproduction
1. Create a `Body`
2. Add the `Body` to a `Compound`
3. Delete the `Compound`
4. Click `Yes` when prompted to delete compound content

Before:
A child object such as `Sketch` can remain in the document.

After:
The `Compound`, `Body`, and its child objects are all removed.

## Validation
- Reproduced the issue locally on the original build
- Verified the fix locally on the patched build using the same sample document

## Before / After Videos
Before video:

https://github.com/user-attachments/assets/020a33ba-e092-4777-9209-4e1b801659b4



After video:

https://github.com/user-attachments/assets/cc1264ca-3190-4d33-8d01-562644687ca3



## Issue
Fixes #27680