### PR TITLE
Gui: marshal worker-driven updates to the main thread

### DIFF
--- a/.github/scripts/run-thread-affinity-debug.ps1
+++ b/.github/scripts/run-thread-affinity-debug.ps1
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$BuildDir,
+
+    [Parameter(Mandatory = $true)]
+    [string]$TestRegex,
+
+    [Parameter(Mandatory = $true)]
+    [string]$TestProcessName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputDir,
+
+    [int]$TimeoutSeconds = 90
+)
+
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Write-DiagnosticLine {
+    param([string]$Message)
+
+    $timestamp = [DateTimeOffset]::UtcNow.ToString("O")
+    Write-Host "[thread-affinity-runner][$timestamp] $Message"
+}
+
+function Write-ProcessSnapshot {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [string]$Path
+    )
+
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("Captured: $([DateTimeOffset]::UtcNow.ToString('O'))")
+    $lines.Add("PID: $($Process.Id)")
+
+    try {
+        $Process.Refresh()
+        $lines.Add("Name: $($Process.ProcessName)")
+        $lines.Add("Responding: $($Process.Responding)")
+        $lines.Add("StartTime: $($Process.StartTime.ToUniversalTime().ToString('O'))")
+        $lines.Add("TotalProcessorTime: $($Process.TotalProcessorTime)")
+        $lines.Add("WorkingSet64: $($Process.WorkingSet64)")
+        $lines.Add("PrivateMemorySize64: $($Process.PrivateMemorySize64)")
+        $lines.Add("HandleCount: $($Process.HandleCount)")
+        $lines.Add("ThreadCount: $($Process.Threads.Count)")
+    }
+    catch {
+        $lines.Add("Get-Process details failed: $($_.Exception)")
+    }
+
+    $lines.Add("")
+    $lines.Add("Win32_Process:")
+    try {
+        $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId = $($Process.Id)"
+        $lines.Add(($processInfo |
+            Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CommandLine |
+            Format-List |
+            Out-String))
+    }
+    catch {
+        $lines.Add("Win32_Process query failed: $($_.Exception)")
+    }
+
+    $lines.Add("")
+    $lines.Add("Win32_Thread:")
+    try {
+        $threadInfo = Get-CimInstance Win32_Thread |
+            Where-Object { $_.ProcessHandle -eq [string]$Process.Id } |
+            Select-Object Handle, ThreadState, ThreadWaitReason, Priority,
+                PriorityBase, KernelModeTime, UserModeTime, StartAddress
+        $lines.Add(($threadInfo | Format-Table -AutoSize | Out-String))
+    }
+    catch {
+        $lines.Add("Win32_Thread query failed: $($_.Exception)")
+    }
+
+    $lines | Set-Content -Path $Path -Encoding UTF8
+}
+
+function Write-MiniDump {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [string]$Path
+    )
+
+    if (-not ("ThreadAffinityDiagnostics.MiniDump" -as [type])) {
+        Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace ThreadAffinityDiagnostics
+{
+    public static class MiniDump
+    {
+        [Flags]
+        public enum DumpType : uint
+        {
+            Normal = 0x00000000,
+            WithHandleData = 0x00000004,
+            WithUnloadedModules = 0x00000020,
+            WithIndirectlyReferencedMemory = 0x00000040,
+            WithProcessThreadData = 0x00000100,
+            WithFullMemoryInfo = 0x00000800,
+            WithThreadInfo = 0x00001000
+        }
+
+        [DllImport("Dbghelp.dll", SetLastError = true)]
+        public static extern bool MiniDumpWriteDump(
+            IntPtr processHandle,
+            uint processId,
+            IntPtr fileHandle,
+            DumpType dumpType,
+            IntPtr exceptionParam,
+            IntPtr userStreamParam,
+            IntPtr callbackParam
+        );
+    }
+}
+"@
+    }
+
+    $dumpType =
+        [ThreadAffinityDiagnostics.MiniDump+DumpType]::WithHandleData -bor
+        [ThreadAffinityDiagnostics.MiniDump+DumpType]::WithUnloadedModules -bor
+        [ThreadAffinityDiagnostics.MiniDump+DumpType]::WithIndirectlyReferencedMemory -bor
+        [ThreadAffinityDiagnostics.MiniDump+DumpType]::WithProcessThreadData -bor
+        [ThreadAffinityDiagnostics.MiniDump+DumpType]::WithFullMemoryInfo -bor
+        [ThreadAffinityDiagnostics.MiniDump+DumpType]::WithThreadInfo
+
+    $stream = [System.IO.File]::Open(
+        $Path,
+        [System.IO.FileMode]::Create,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::None
+    )
+
+    try {
+        $Process.Refresh()
+        $success = [ThreadAffinityDiagnostics.MiniDump]::MiniDumpWriteDump(
+            $Process.Handle,
+            [uint32]$Process.Id,
+            $stream.SafeFileHandle.DangerousGetHandle(),
+            $dumpType,
+            [IntPtr]::Zero,
+            [IntPtr]::Zero,
+            [IntPtr]::Zero
+        )
+
+        if (-not $success) {
+            $errorCode = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+            throw "MiniDumpWriteDump failed with Win32 error $errorCode"
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Publish-TestOutput {
+    param(
+        [string]$Label,
+        [string]$Path
+    )
+
+    Write-DiagnosticLine "===== ${Label}: $Path ====="
+    if (Test-Path $Path) {
+        Get-Content -Path $Path | ForEach-Object { Write-Host $_ }
+    }
+    else {
+        Write-DiagnosticLine "$Label file was not created"
+    }
+}
+
+function Find-DescendantProcess {
+    param(
+        [int]$RootProcessId,
+        [string]$ProcessName
+    )
+
+    $processes = @(Get-CimInstance Win32_Process |
+        Select-Object ProcessId, ParentProcessId, Name, CreationDate)
+
+    $pending = [System.Collections.Generic.Queue[uint32]]::new()
+    $descendantIds = [System.Collections.Generic.HashSet[uint32]]::new()
+    $pending.Enqueue([uint32]$RootProcessId)
+    $descendantIds.Add([uint32]$RootProcessId) | Out-Null
+
+    while ($pending.Count -gt 0) {
+        $parentId = $pending.Dequeue()
+        foreach ($child in $processes | Where-Object { $_.ParentProcessId -eq $parentId }) {
+            if ($descendantIds.Add([uint32]$child.ProcessId)) {
+                $pending.Enqueue([uint32]$child.ProcessId)
+            }
+        }
+    }
+
+    $match = $processes |
+        Where-Object {
+            $_.ProcessId -ne $RootProcessId -and
+            $descendantIds.Contains([uint32]$_.ProcessId) -and
+            $_.Name -ieq $ProcessName
+        } |
+        Sort-Object CreationDate -Descending |
+        Select-Object -First 1
+
+    if (-not $match) {
+        return $null
+    }
+
+    return Get-Process -Id $match.ProcessId -ErrorAction SilentlyContinue
+}
+
+function Write-ProcessTree {
+    param(
+        [int]$RootProcessId,
+        [string]$Path
+    )
+
+    try {
+        $processes = @(Get-CimInstance Win32_Process |
+            Select-Object ProcessId, ParentProcessId, Name, ExecutablePath,
+                CommandLine, CreationDate)
+        $descendantIds = [System.Collections.Generic.HashSet[uint32]]::new()
+        $pending = [System.Collections.Generic.Queue[uint32]]::new()
+        $pending.Enqueue([uint32]$RootProcessId)
+        $descendantIds.Add([uint32]$RootProcessId) | Out-Null
+
+        while ($pending.Count -gt 0) {
+            $parentId = $pending.Dequeue()
+            foreach ($child in $processes | Where-Object { $_.ParentProcessId -eq $parentId }) {
+                if ($descendantIds.Add([uint32]$child.ProcessId)) {
+                    $pending.Enqueue([uint32]$child.ProcessId)
+                }
+            }
+        }
+
+        $tree = $processes |
+            Where-Object { $descendantIds.Contains([uint32]$_.ProcessId) } |
+            Sort-Object CreationDate
+
+        @(
+            "Captured: $([DateTimeOffset]::UtcNow.ToString('O'))"
+            "Root PID: $RootProcessId"
+            ""
+            ($tree | Format-Table -Wrap -AutoSize | Out-String)
+        ) | Set-Content -Path $Path -Encoding UTF8
+    }
+    catch {
+        "Process-tree capture failed: $($_.Exception)" |
+            Set-Content -Path $Path -Encoding UTF8
+    }
+}
+
+function Stop-ProcessTree {
+    param([int]$RootProcessId)
+
+    & taskkill.exe /PID $RootProcessId /T /F 2>&1 |
+        ForEach-Object { Write-DiagnosticLine "taskkill: $_" }
+}
+
+$resolvedBuildDir = (Resolve-Path $BuildDir).Path
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+$resolvedOutputDir = (Resolve-Path $OutputDir).Path
+
+$ctestCommand = Get-Command ctest.exe -ErrorAction Stop
+$env:QT_FORCE_STDERR_LOGGING = "1"
+$env:FREECAD_MAIN_THREAD_TRACE = "1"
+
+$stdoutPath = Join-Path $resolvedOutputDir "ThreadAffinity.ctest.stdout.log"
+$stderrPath = Join-Path $resolvedOutputDir "ThreadAffinity.ctest.stderr.log"
+$snapshotPath = Join-Path $resolvedOutputDir "ThreadAffinity.process.txt"
+$treePath = Join-Path $resolvedOutputDir "ThreadAffinity.process-tree.txt"
+$dumpPath = Join-Path $resolvedOutputDir "ThreadAffinity.hang.dmp"
+$runnerPath = Join-Path $resolvedOutputDir "ThreadAffinity.runner.txt"
+
+$ctestArguments = @(
+    "--test-dir"
+    $resolvedBuildDir
+    "-R"
+    $TestRegex
+    "-V"
+    "--output-on-failure"
+)
+
+@(
+    "Started: $([DateTimeOffset]::UtcNow.ToString('O'))"
+    "CTest: $($ctestCommand.Source)"
+    "Arguments: $($ctestArguments -join ' ')"
+    "BuildDir: $resolvedBuildDir"
+    "TestRegex: $TestRegex"
+    "TestProcessName: $TestProcessName"
+    "OutputDir: $resolvedOutputDir"
+    "TimeoutSeconds: $TimeoutSeconds"
+    "FREECAD_MAIN_THREAD_TRACE: $env:FREECAD_MAIN_THREAD_TRACE"
+) | Set-Content -Path $runnerPath -Encoding UTF8
+
+Write-DiagnosticLine "Starting CTest for $TestRegex"
+$ctestProcess = Start-Process `
+    -FilePath $ctestCommand.Source `
+    -ArgumentList $ctestArguments `
+    -PassThru `
+    -NoNewWindow `
+    -RedirectStandardOutput $stdoutPath `
+    -RedirectStandardError $stderrPath
+
+Write-DiagnosticLine "CTest PID=$($ctestProcess.Id), watchdog=${TimeoutSeconds}s"
+$deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+$nextHeartbeat = [DateTimeOffset]::UtcNow
+$nextChildLookup = [DateTimeOffset]::UtcNow
+$testProcess = $null
+$timedOut = $false
+
+while (-not $ctestProcess.HasExited) {
+    $now = [DateTimeOffset]::UtcNow
+    if ($now -ge $deadline) {
+        $timedOut = $true
+        break
+    }
+
+    if (
+        $now -ge $nextChildLookup -and
+        (-not $testProcess -or $testProcess.HasExited)
+    ) {
+        $testProcess = Find-DescendantProcess `
+            -RootProcessId $ctestProcess.Id `
+            -ProcessName $TestProcessName
+
+        if ($testProcess) {
+            Write-DiagnosticLine (
+                "Located test process PID=$($testProcess.Id) name=$($testProcess.ProcessName)"
+            )
+        }
+        $nextChildLookup = $now.AddSeconds(1)
+    }
+
+    if ($now -ge $nextHeartbeat) {
+        try {
+            $ctestProcess.Refresh()
+            $testStatus = "not-found"
+            if ($testProcess -and -not $testProcess.HasExited) {
+                $testProcess.Refresh()
+                $testStatus = (
+                    "pid=$($testProcess.Id) cpu=$($testProcess.TotalProcessorTime) " +
+                    "threads=$($testProcess.Threads.Count) workingSet=$($testProcess.WorkingSet64)"
+                )
+            }
+
+            Write-DiagnosticLine (
+                "alive ctestPid=$($ctestProcess.Id) ctestCpu=$($ctestProcess.TotalProcessorTime) " +
+                "test=[$testStatus]"
+            )
+        }
+        catch {
+            Write-DiagnosticLine "heartbeat refresh failed: $($_.Exception.Message)"
+        }
+        $nextHeartbeat = $now.AddSeconds(10)
+    }
+
+    Start-Sleep -Milliseconds 250
+}
+
+if ($timedOut) {
+    Write-Host "::error::$TestRegex exceeded the ${TimeoutSeconds}s diagnostic watchdog"
+
+    if (-not $testProcess -or $testProcess.HasExited) {
+        $testProcess = Find-DescendantProcess `
+            -RootProcessId $ctestProcess.Id `
+            -ProcessName $TestProcessName
+    }
+
+    Write-ProcessTree -RootProcessId $ctestProcess.Id -Path $treePath
+
+    $dumpProcess = $testProcess
+    if (-not $dumpProcess -or $dumpProcess.HasExited) {
+        Write-DiagnosticLine (
+            "Test process was not available; capturing the CTest process instead"
+        )
+        $dumpProcess = $ctestProcess
+    }
+
+    Write-ProcessSnapshot -Process $dumpProcess -Path $snapshotPath
+    try {
+        Write-MiniDump -Process $dumpProcess -Path $dumpPath
+        Write-DiagnosticLine (
+            "Wrote minidump for PID=$($dumpProcess.Id): $dumpPath"
+        )
+    }
+    catch {
+        Write-DiagnosticLine "Minidump capture failed: $($_.Exception)"
+        $_ | Out-String | Add-Content -Path $snapshotPath
+    }
+
+    Stop-ProcessTree -RootProcessId $ctestProcess.Id
+    Wait-Process -Id $ctestProcess.Id -Timeout 10 -ErrorAction SilentlyContinue
+
+    Publish-TestOutput -Label "CTEST STDOUT" -Path $stdoutPath
+    Publish-TestOutput -Label "CTEST STDERR" -Path $stderrPath
+    Publish-TestOutput -Label "PROCESS SNAPSHOT" -Path $snapshotPath
+    Publish-TestOutput -Label "PROCESS TREE" -Path $treePath
+    exit 124
+}
+
+$ctestProcess.WaitForExit()
+Publish-TestOutput -Label "CTEST STDOUT" -Path $stdoutPath
+Publish-TestOutput -Label "CTEST STDERR" -Path $stderrPath
+
+Write-DiagnosticLine "CTest exited with code $($ctestProcess.ExitCode)"
+exit $ctestProcess.ExitCode

--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -228,6 +228,13 @@ jobs:
         reportFile: ${{ env.reportdir }}${{ env.reportfilename }}
         shellCmd: ${{ env.shellCmd }}
 
+    - name: Thread-affinity regression test on Windows
+      if: runner.os == 'Windows' && !inputs.skipBuild
+      timeout-minutes: 5
+      run: >-
+        pixi run ctest --test-dir "${{ env.builddir }}" -R
+        "^ThreadAffinity_Tests_run$" --output-on-failure --timeout 120
+
     - name: CMake Install
       if: "!inputs.skipBuild"
       run: |

--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -223,6 +223,28 @@ jobs:
         builddir: ${{ env.builddir }}
         reportFile: ${{ env.reportdir }}${{ env.reportfilename }}
 
+    - name: Thread-affinity regression test on Windows
+      if: runner.os == 'Windows' && !inputs.skipBuild
+      timeout-minutes: 3
+      shell: pwsh
+      run: |
+        pixi run pwsh -NoProfile -File `
+          ".github/scripts/run-thread-affinity-debug.ps1" `
+          -BuildDir "${{ env.builddir }}" `
+          -TestRegex "^ThreadAffinity_Tests_run$" `
+          -TestProcessName "ThreadAffinity_Tests_run.exe" `
+          -OutputDir "${{ env.logdir }}thread-affinity" `
+          -TimeoutSeconds 90
+
+    - name: Upload thread-affinity diagnostics
+      if: runner.os == 'Windows' && !inputs.skipBuild && always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+      with:
+        name: thread-affinity-windows-${{ github.run_id }}
+        path: ${{ env.logdir }}thread-affinity
+        if-no-files-found: warn
+        retention-days: 7
+
     - name: CMake Install
       if: "!inputs.skipBuild"
       run: |

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -857,9 +857,8 @@ void Application::queueRecomputeRequest(RecomputeRequest req)
         // worker" guarantee without inventing a synthetic main thread.
         if (App::MainThreadSignalConfig::hasHooks()
             && !App::MainThreadSignalConfig::isMainThread()) {
-            App::MainThreadSignalConfig::invoke(
-                [&req, &result]() { result = processRecomputeRequest(req); },
-                /*blocking=*/true
+            result = App::MainThreadSignalConfig::callOnMainThreadSync(
+                [&req]() { return processRecomputeRequest(req); }
             );
         }
         else {

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -843,9 +843,8 @@ void Application::queueRecomputeRequest(RecomputeRequest req)
         // worker" guarantee without inventing a synthetic main thread.
         if (App::MainThreadSignalConfig::hasHooks()
             && !App::MainThreadSignalConfig::isMainThread()) {
-            App::MainThreadSignalConfig::invoke(
-                [&req, &result]() { result = processRecomputeRequest(req); },
-                /*blocking=*/true
+            result = App::MainThreadSignalConfig::callOnMainThreadSync(
+                [&req]() { return processRecomputeRequest(req); }
             );
         }
         else {

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -48,6 +48,7 @@
 
 #include <Base/Observer.h>
 #include <Base/Parameter.h>
+#include "MainThreadSignal.h"
 #include "TransactionDefs.h"
 
 // forward declarations
@@ -504,15 +505,20 @@ public:
      *
      * @{
      */
+    // These observer-facing signals are synchronous because remove and rename
+    // payloads borrow storage whose lifetime ends when the mutator returns.
+    // In GUI mode they are delivered on the configured main thread; without
+    // GUI hooks they retain same-thread behavior.
 
-    /// Signal on adding a dynamic property.
-    fastsignals::signal<void (const App::Property&)> signalAppendDynamicProperty;
-    /// Signal on renaming a dynamic property.
-    fastsignals::signal<void (const App::Property&, const char*)> signalRenameDynamicProperty;
+    /// Main-thread observer signal on adding a dynamic property.
+    App::MainThreadSignal<void (const App::Property&)> signalAppendDynamicProperty;
+    /// Main-thread observer signal on renaming a dynamic property.
+    App::MainThreadSignal<void (const App::Property&, const char*)>
+        signalRenameDynamicProperty;
     /// signal on moving a dynamic property
     fastsignals::signal<void (const App::Property&, const App::DocumentObject&)> signalMoveDynamicProperty;
-    /// Signal before removing a dynamic property.
-    fastsignals::signal<void (const App::Property&)> signalRemoveDynamicProperty;
+    /// Main-thread observer signal before removing a dynamic property.
+    App::MainThreadSignal<void (const App::Property&)> signalRemoveDynamicProperty;
     /// Signal before changing the editor mode of a property.
     fastsignals::signal<void (const App::Document&, const App::Property&)> signalChangePropertyEditor;
     /// @}

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -48,6 +48,7 @@
 
 #include <Base/Observer.h>
 #include <Base/Parameter.h>
+#include "MainThreadSignal.h"
 #include "TransactionDefs.h"
 
 // forward declarations
@@ -505,12 +506,18 @@ public:
      * @{
      */
 
-    /// Signal on adding a dynamic property.
-    fastsignals::signal<void (const App::Property&)> signalAppendDynamicProperty;
-    /// Signal on renaming a dynamic property.
-    fastsignals::signal<void (const App::Property&, const char*)> signalRenameDynamicProperty;
-    /// Signal before removing a dynamic property.
-    fastsignals::signal<void (const App::Property&)> signalRemoveDynamicProperty;
+    // These observer-facing signals are synchronous because remove and rename
+    // payloads borrow storage whose lifetime ends when the mutator returns.
+    // In GUI mode they are delivered on the configured main thread; without
+    // GUI hooks they retain same-thread behavior.
+
+    /// Main-thread observer signal on adding a dynamic property.
+    App::MainThreadSignal<void (const App::Property&)> signalAppendDynamicProperty;
+    /// Main-thread observer signal on renaming a dynamic property.
+    App::MainThreadSignal<void (const App::Property&, const char*)>
+        signalRenameDynamicProperty;
+    /// Main-thread observer signal before removing a dynamic property.
+    App::MainThreadSignal<void (const App::Property&)> signalRemoveDynamicProperty;
     /// Signal before changing the editor mode of a property.
     fastsignals::signal<void (const App::Document&, const App::Property&)> signalChangePropertyEditor;
     /// @}

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -305,6 +305,7 @@ SET(FreeCADApp_CPP_SRCS
     ${Document_CPP_SRCS}
     ${Properties_CPP_SRCS}
     Application.cpp
+    MainThreadSignal.cpp
     ApplicationDirectories.cpp
     ApplicationDirectoriesPyImp.cpp
     ApplicationPy.cpp

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -299,6 +299,7 @@ SET(FreeCADApp_CPP_SRCS
     ${Document_CPP_SRCS}
     ${Properties_CPP_SRCS}
     Application.cpp
+    MainThreadSignal.cpp
     ApplicationDirectories.cpp
     ApplicationDirectoriesPyImp.cpp
     ApplicationPy.cpp

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -40,6 +40,7 @@
 #include "DynamicProperty.h"
 #include "Application.h"
 #include "Property.h"
+#include "PropertyExpressionEngine.h"
 #include "PropertyContainer.h"
 
 
@@ -498,6 +499,7 @@ bool DynamicProperty::renameDynamicProperty(Property* prop,
         d.property->myName = d.name.c_str();
     });
 
+    PropertyExpressionContainer::handleDynamicPropertyRename(*prop, oldName.c_str());
     GetApplication().signalRenameDynamicProperty(*prop, oldName.c_str());
 
     return true;

--- a/src/App/MainThreadSignal.cpp
+++ b/src/App/MainThreadSignal.cpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "MainThreadSignal.h"
+
+#include <atomic>
+
+namespace
+{
+struct MainThreadHooks
+{
+    App::MainThreadSignalConfig::IsMainThreadFn isMainThread;
+    App::MainThreadSignalConfig::InvokeSyncFn invokeSync;
+};
+
+MainThreadHooks installedHooks {};
+std::atomic<const MainThreadHooks*> activeHooks {nullptr};
+}
+
+namespace App
+{
+
+void MainThreadSignalConfig::installHooks(
+    IsMainThreadFn isMainThread,
+    InvokeSyncFn invokeSync
+)
+{
+    if (!isMainThread || !invokeSync) {
+        throw std::invalid_argument(
+            "Main-thread hooks must provide both an affinity predicate and a synchronous invoker"
+        );
+    }
+
+    // Concurrent replacement is prohibited by the lifecycle contract. Publish
+    // the complete hook pair with one release-store so readers never observe a
+    // partially installed configuration.
+    installedHooks = {isMainThread, invokeSync};
+    activeHooks.store(&installedHooks, std::memory_order_release);
+}
+
+void MainThreadSignalConfig::clearHooks()
+{
+    // Emitters must already be stopped. Remove the complete hook snapshot with
+    // one store and restore App-only inline behaviour.
+    activeHooks.store(nullptr, std::memory_order_release);
+}
+
+bool MainThreadSignalConfig::isMainThread()
+{
+    if (const auto* hooks = activeHooks.load(std::memory_order_acquire)) {
+        return hooks->isMainThread();
+    }
+    return true;  // no GUI hooks: preserve same-thread behavior
+}
+
+bool MainThreadSignalConfig::hasHooks()
+{
+    return activeHooks.load(std::memory_order_acquire) != nullptr;
+}
+
+bool MainThreadSignalConfig::invokeSync(TaskFn task, void* context)
+{
+    if (const auto* hooks = activeHooks.load(std::memory_order_acquire)) {
+        return hooks->invokeSync(task, context);
+    }
+
+    task(context);
+    return true;
+}
+
+}  // namespace App

--- a/src/App/MainThreadSignal.cpp
+++ b/src/App/MainThreadSignal.cpp
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "MainThreadSignal.h"
+
+#include <atomic>
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace
+{
+using TraceClock = std::chrono::steady_clock;
+
+const auto traceStart = TraceClock::now();
+std::atomic<std::uint64_t> traceSequence {0};
+std::mutex traceMutex;
+
+bool traceEnabled()
+{
+    static const bool enabled = [] {
+        const char* value = std::getenv("FREECAD_MAIN_THREAD_TRACE");
+        return value && value[0] != '\0' && value[0] != '0';
+    }();
+    return enabled;
+}
+
+std::uint64_t nativeThreadId()
+{
+#ifdef _WIN32
+    return static_cast<std::uint64_t>(GetCurrentThreadId());
+#else
+    return static_cast<std::uint64_t>(
+        std::hash<std::thread::id> {}(std::this_thread::get_id())
+    );
+#endif
+}
+
+void traceEvent(const char* event, const void* context = nullptr, int value = -1)
+{
+    if (!traceEnabled()) {
+        return;
+    }
+
+    const auto sequence = traceSequence.fetch_add(1, std::memory_order_relaxed) + 1;
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        TraceClock::now() - traceStart
+    ).count();
+
+    std::scoped_lock lock(traceMutex);
+    std::fprintf(
+        stderr,
+        "[MTS][seq=%" PRIu64 "][ms=%lld][tid=%" PRIu64
+        "][event=%s][context=%p][value=%d]\n",
+        sequence,
+        static_cast<long long>(elapsed),
+        nativeThreadId(),
+        event,
+        context,
+        value
+    );
+    std::fflush(stderr);
+}
+
+struct MainThreadHooks
+{
+    App::MainThreadSignalConfig::IsMainThreadFn isMainThread;
+    App::MainThreadSignalConfig::InvokeSyncFn invokeSync;
+};
+
+MainThreadHooks installedHooks {};
+std::atomic<const MainThreadHooks*> activeHooks {nullptr};
+}
+
+namespace App
+{
+
+void MainThreadSignalConfig::installHooks(
+    IsMainThreadFn isMainThread,
+    InvokeSyncFn invokeSync
+)
+{
+    traceEvent("hooks.install.begin");
+    if (!isMainThread || !invokeSync) {
+        traceEvent("hooks.install.invalid");
+        throw std::invalid_argument(
+            "Main-thread hooks must provide both an affinity predicate and a synchronous invoker"
+        );
+    }
+
+    // Concurrent replacement is prohibited by the lifecycle contract. Publish
+    // the complete hook pair with one release-store so readers never observe a
+    // partially installed configuration.
+    installedHooks = {isMainThread, invokeSync};
+    activeHooks.store(&installedHooks, std::memory_order_release);
+    traceEvent("hooks.install.end");
+}
+
+void MainThreadSignalConfig::clearHooks()
+{
+    traceEvent("hooks.clear.begin");
+    // Emitters must already be stopped. Remove the complete hook snapshot with
+    // one store and restore App-only inline behaviour.
+    activeHooks.store(nullptr, std::memory_order_release);
+    traceEvent("hooks.clear.end");
+}
+
+bool MainThreadSignalConfig::isMainThread()
+{
+    if (const auto* hooks = activeHooks.load(std::memory_order_acquire)) {
+        const bool result = hooks->isMainThread();
+        if (!result) {
+            traceEvent("is-main.false", nullptr, 0);
+        }
+        return result;
+    }
+    traceEvent("is-main.no-hooks", nullptr, 1);
+    return true;  // no GUI hooks: preserve same-thread behavior
+}
+
+bool MainThreadSignalConfig::hasHooks()
+{
+    const bool result = activeHooks.load(std::memory_order_acquire) != nullptr;
+    traceEvent("has-hooks", nullptr, result ? 1 : 0);
+    return result;
+}
+
+bool MainThreadSignalConfig::invokeSync(TaskFn task, void* context)
+{
+    traceEvent("invoke.enter", context);
+    if (const auto* hooks = activeHooks.load(std::memory_order_acquire)) {
+        traceEvent("invoke.hook.begin", context);
+        const bool result = hooks->invokeSync(task, context);
+        traceEvent("invoke.hook.end", context, result ? 1 : 0);
+        return result;
+    }
+
+    traceEvent("invoke.inline.begin", context);
+    task(context);
+    traceEvent("invoke.inline.end", context, 1);
+    return true;
+}
+
+}  // namespace App

--- a/src/App/MainThreadSignal.h
+++ b/src/App/MainThreadSignal.h
@@ -23,70 +23,189 @@
 #define APP_MAINTHREADSIGNAL_H
 
 #include <Base/Interpreter.h>
+#include <FCGlobal.h>
 #include <fastsignals/signal.h>
+#include <exception>
 #include <functional>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <tuple>
 #include <type_traits>
 #include <utility>
-#include <variant>
 
 namespace App
 {
 
-// App owns these signal types because App::Document declares them. Gui installs
-// the actual main-thread hooks when a GUI application is available.
+// App owns this Qt-free dispatch abstraction because App emits synchronous
+// observer notifications that GUI code may consume. Gui installs the concrete
+// main-thread hooks when a GUI application is available.
 //
-// These signals are intended for document-scoped notifications that GUI code
-// may observe while recompute can run on a worker thread. Raw
-// App::DocumentObject signals intentionally remain plain fastsignals with
-// same-thread semantics.
-class MainThreadSignalConfig
+// MainThreadSignal is intended for App-owned observer notifications whose
+// subscribers require main-thread delivery while the mutation may originate
+// on a worker. Without installed hooks, emission remains synchronous on the
+// calling thread. Raw App::DocumentObject signals intentionally remain plain
+// fastsignals with same-thread semantics.
+class AppExport MainThreadSignalConfig
 {
 public:
     using IsMainThreadFn = bool (*)();  // true iff currently on GUI/main thread
-    using InvokeFn = void (*)(std::function<void()>&& fn, bool blocking);
+    using TaskFn = void (*)(void* context);
+    using InvokeSyncFn = bool (*)(TaskFn task, void* context);
 
-    static void setHooks(IsMainThreadFn isMainThread, InvokeFn invoke)
-    {
-        isMainThreadSlot() = isMainThread;
-        invokeSlot() = invoke;
-    }
+    // task/context are non-owning and remain valid only until InvokeSyncFn
+    // returns. A successful synchronous invocation executes task(context)
+    // exactly once and does not return until all task side effects are visible
+    // to the caller. False means that the task was not executed.
+    //
+    // Hooks are installed during GUI initialization and must remain unchanged
+    // while worker threads can emit a MainThreadSignal. Replacing or clearing
+    // them is only safe after all such emitters have stopped.
+    static void installHooks(IsMainThreadFn isMainThread, InvokeSyncFn invokeSync);
+    static void clearHooks();
+    static bool isMainThread();
+    static bool hasHooks();
 
-    static inline bool isMainThread()
+    // Blocking delivery is intentional: signal payloads can contain references
+    // whose lifetime is guaranteed only until the emitter returns.
+    template<typename Fn>
+    static std::invoke_result_t<Fn&> callOnMainThreadSync(Fn&& fn)
     {
-        auto* f = isMainThreadSlot();
-        return f ? f() : true;  // no hooks, treat current thread as "main"
-    }
+        using Callable = std::remove_reference_t<Fn>;
+        using Result = std::invoke_result_t<Fn&>;
 
-    static inline bool hasHooks()
-    {
-        return isMainThreadSlot() && invokeSlot();
-    }
+        static_assert(
+            !std::is_rvalue_reference_v<Result>,
+            "callOnMainThreadSync cannot safely return an rvalue reference"
+        );
 
-    static inline void invoke(std::function<void()>&& fn, bool blocking)
-    {
-        auto* f = invokeSlot();
-        if (f) {
-            f(std::move(fn), blocking);
+        if (isMainThread()) {
+            return std::invoke(fn);
+        }
+
+        // Invocation is synchronous, so both lvalue and temporary callables
+        // remain alive for the entire dispatch. Keep the callable and all
+        // result state on this stack frame.
+        auto invokeSyncWithGILReleased = [](TaskFn task, void* context) {
+            std::optional<Base::PyGILStateRelease> release;
+            if (Py_IsInitialized() && PyGILState_Check()) {
+                release.emplace();
+            }
+
+            return MainThreadSignalConfig::invokeSync(task, context);
+        };
+
+        auto validateInvocation = [](
+                                      bool invoked,
+                                      bool completed,
+                                      const std::exception_ptr& exception
+                                  ) {
+            if (!invoked) {
+                throw std::runtime_error("Failed to invoke callable on the main thread");
+            }
+            if (exception) {
+                std::rethrow_exception(exception);
+            }
+            if (!completed) {
+                throw std::logic_error(
+                    "Main-thread hook returned before the callable completed"
+                );
+            }
+        };
+
+        if constexpr (std::is_void_v<Result>) {
+            struct State
+            {
+                Callable* callable;
+                std::exception_ptr exception;
+                bool completed = false;
+            } state {std::addressof(fn), {}, false};
+
+            const bool invoked = invokeSyncWithGILReleased(
+                [](void* context) {
+                    auto& state = *static_cast<State*>(context);
+                    try {
+                        std::invoke(*state.callable);
+                    }
+                    catch (...) {
+                        state.exception = std::current_exception();
+                    }
+                    state.completed = true;
+                },
+                &state
+            );
+
+            validateInvocation(invoked, state.completed, state.exception);
+        }
+        else if constexpr (std::is_lvalue_reference_v<Result>) {
+            using Referent = std::remove_reference_t<Result>;
+
+            struct State
+            {
+                Callable* callable;
+                std::optional<std::reference_wrapper<Referent>> result;
+                std::exception_ptr exception;
+                bool completed = false;
+            } state {std::addressof(fn), {}, {}, false};
+
+            const bool invoked = invokeSyncWithGILReleased(
+                [](void* context) {
+                    auto& state = *static_cast<State*>(context);
+                    try {
+                        state.result = std::ref(std::invoke(*state.callable));
+                    }
+                    catch (...) {
+                        state.exception = std::current_exception();
+                    }
+                    state.completed = true;
+                },
+                &state
+            );
+
+            validateInvocation(invoked, state.completed, state.exception);
+            if (!state.result) {
+                throw std::logic_error("Main-thread callable completed without a result");
+            }
+
+            return state.result->get();
         }
         else {
-            fn();  // no hooks, run inline
+            using StoredResult = std::remove_cv_t<Result>;
+
+            struct State
+            {
+                Callable* callable;
+                std::optional<StoredResult> result;
+                std::exception_ptr exception;
+                bool completed = false;
+            } state {std::addressof(fn), {}, {}, false};
+
+            const bool invoked = invokeSyncWithGILReleased(
+                [](void* context) {
+                    auto& state = *static_cast<State*>(context);
+                    try {
+                        state.result.emplace(std::invoke(*state.callable));
+                    }
+                    catch (...) {
+                        state.exception = std::current_exception();
+                    }
+                    state.completed = true;
+                },
+                &state
+            );
+
+            validateInvocation(invoked, state.completed, state.exception);
+            if (!state.result) {
+                throw std::logic_error("Main-thread callable completed without a result");
+            }
+
+            // Supports both move-only and copy-only result types.
+            return std::move_if_noexcept(*state.result);
         }
     }
 
 private:
-    static IsMainThreadFn& isMainThreadSlot()
-    {
-        static IsMainThreadFn fn = nullptr;
-        return fn;
-    }
-    static InvokeFn& invokeSlot()
-    {
-        static InvokeFn fn = nullptr;
-        return fn;
-    }
+    static bool invokeSync(TaskFn task, void* context);
 };
 
 namespace detail
@@ -132,11 +251,10 @@ auto captureSignalArg(PDecl&& x)
     }
 }
 
-template<class T>
-using non_void_t = std::conditional_t<std::is_void_v<T>, std::monostate, T>;
 }  // namespace detail
 
-// Wrapper that mirrors fastsignals::signal but executes slots on GUI thread.
+// Wrapper that mirrors fastsignals::signal and executes slots on the GUI thread
+// when hooks are installed; otherwise slots run on the calling thread.
 template<class Signature, template<class T> class Combiner = ::fastsignals::optional_last_value>
 class MainThreadSignal;
 
@@ -234,32 +352,20 @@ private:
             return self->sig_(std::forward<typename ::fastsignals::signal_arg_t<Arguments>>(args)...);
         }
 
-        Base::PyGILStateRelease release;
-
         auto caps = std::make_tuple(
             detail::captureSignalArg<typename ::fastsignals::signal_arg_t<Arguments>>(args)...
         );
 
-        if constexpr (std::is_void_v<result_type>) {
-            MainThreadSignalConfig::invoke(
-                [self, caps = std::move(caps)]() mutable {
-                    std::apply([self](auto&... c) { self->sig_(c.get()...); }, caps);
-                },
-                /*blocking=*/true
-            );
-        }
-        else {
-            std::optional<detail::non_void_t<result_type>> result;
-            MainThreadSignalConfig::invoke(
-                [self, caps = std::move(caps), &result]() mutable {
-                    result.emplace(
-                        std::apply([self](auto&... c) { return self->sig_(c.get()...); }, caps)
-                    );
-                },
-                /*blocking=*/true
-            );
-            return std::move(*result);
-        }
+        return MainThreadSignalConfig::callOnMainThreadSync(
+            [self, caps = std::move(caps)]() mutable -> result_type {
+                return std::apply(
+                    [self](auto&... captured) -> result_type {
+                        return self->sig_(captured.get()...);
+                    },
+                    caps
+                );
+            }
+        );
     }
 
     mutable base_sig sig_;

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -58,8 +58,6 @@ PropertyExpressionContainer::PropertyExpressionContainer()
         inited = true;
         GetApplication().signalRelabelDocument.connect(
             PropertyExpressionContainer::slotRelabelDocument);
-        GetApplication().signalRenameDynamicProperty.connect(
-            PropertyExpressionContainer::slotRenameDynamicProperty);
         GetApplication().signalMoveDynamicProperty.connect(
             PropertyExpressionContainer::slotMoveDynamicProperty);
     }
@@ -84,7 +82,7 @@ void PropertyExpressionContainer::slotRelabelDocument(const App::Document& doc)
     }
 }
 
-void PropertyExpressionContainer::slotRenameDynamicProperty(const App::Property& prop, const char* oldName)
+void PropertyExpressionContainer::handleDynamicPropertyRename(const App::Property& prop, const char* oldName)
 {
     for (auto container : _ExprContainers) {
         container->onRenameDynamicProperty(prop, oldName);

--- a/src/App/PropertyExpressionEngine.cpp
+++ b/src/App/PropertyExpressionEngine.cpp
@@ -58,8 +58,6 @@ PropertyExpressionContainer::PropertyExpressionContainer()
         inited = true;
         GetApplication().signalRelabelDocument.connect(
             PropertyExpressionContainer::slotRelabelDocument);
-        GetApplication().signalRenameDynamicProperty.connect(
-            PropertyExpressionContainer::slotRenameDynamicProperty);
     }
     _ExprContainers.insert(this);
 }
@@ -82,7 +80,7 @@ void PropertyExpressionContainer::slotRelabelDocument(const App::Document& doc)
     }
 }
 
-void PropertyExpressionContainer::slotRenameDynamicProperty(const App::Property& prop, const char* oldName)
+void PropertyExpressionContainer::handleDynamicPropertyRename(const App::Property& prop, const char* oldName)
 {
     for (auto container : _ExprContainers) {
         container->onRenameDynamicProperty(prop, oldName);

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -44,6 +44,7 @@ namespace App
 {
 
 class DocumentObject;
+class DynamicProperty;
 class DocumentObjectExecReturn;
 class ObjectIdentifier;
 class Expression;
@@ -102,10 +103,11 @@ protected:
                                        const App::DocumentObject& targetObj) = 0;
 
 private:
+    friend class DynamicProperty;
     static void slotRelabelDocument(const App::Document& doc);
-    static void slotRenameDynamicProperty(const App::Property& prop, const char* oldName);
     static void slotMoveDynamicProperty(const App::Property& prop,
                                         const App::DocumentObject& targetObj);
+    static void handleDynamicPropertyRename(const App::Property& prop, const char* oldName);
 };
 
 

--- a/src/App/PropertyExpressionEngine.h
+++ b/src/App/PropertyExpressionEngine.h
@@ -44,6 +44,7 @@ namespace App
 {
 
 class DocumentObject;
+class DynamicProperty;
 class DocumentObjectExecReturn;
 class ObjectIdentifier;
 class Expression;
@@ -100,8 +101,9 @@ protected:
     virtual void onRenameDynamicProperty(const App::Property& prop, const char* oldName) = 0;
 
 private:
+    friend class DynamicProperty;
     static void slotRelabelDocument(const App::Document& doc);
-    static void slotRenameDynamicProperty(const App::Property& prop, const char* oldName);
+    static void handleDynamicPropertyRename(const App::Property& prop, const char* oldName);
 };
 
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -431,18 +431,18 @@ bool qtIsMainThread()
     return !qApp || (QThread::currentThread() == qApp->thread());
 }
 
-// Hook: invoke a functor on the GUI thread, either blocking or queued.
-void qtInvokeOnMain(std::function<void()>&& fn, bool blocking)
+// Hook: synchronously invoke a non-owning task on the GUI thread.
+bool qtInvokeOnMain(App::MainThreadSignalConfig::TaskFn task, void* context)
 {
     if (!qApp) {
-        fn();
-        return;
+        task(context);
+        return true;
     }
 
-    QMetaObject::invokeMethod(
+    return QMetaObject::invokeMethod(
         MainThreadInvoker::instance(),
-        [f = std::move(fn)]() mutable { f(); },
-        blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection
+        [task, context] { task(context); },
+        Qt::BlockingQueuedConnection
     );
 }
 
@@ -532,7 +532,7 @@ Application::Application(bool GUIenabled)
 {
     // App::GetApplication().Attach(this);
     if (GUIenabled) {
-        App::MainThreadSignalConfig::setHooks(&qtIsMainThread, &qtInvokeOnMain);
+        App::MainThreadSignalConfig::installHooks(&qtIsMainThread, &qtInvokeOnMain);
 
         // NOLINTBEGIN
         App::GetApplication().signalNewDocument.connect(

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -412,18 +412,18 @@ bool qtIsMainThread()
     return !qApp || (QThread::currentThread() == qApp->thread());
 }
 
-// Hook: invoke a functor on the GUI thread, either blocking or queued.
-void qtInvokeOnMain(std::function<void()>&& fn, bool blocking)
+// Hook: synchronously invoke a non-owning task on the GUI thread.
+bool qtInvokeOnMain(App::MainThreadSignalConfig::TaskFn task, void* context)
 {
     if (!qApp) {
-        fn();
-        return;
+        task(context);
+        return true;
     }
 
-    QMetaObject::invokeMethod(
+    return QMetaObject::invokeMethod(
         MainThreadInvoker::instance(),
-        [f = std::move(fn)]() mutable { f(); },
-        blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection
+        [task, context] { task(context); },
+        Qt::BlockingQueuedConnection
     );
 }
 
@@ -513,7 +513,7 @@ Application::Application(bool GUIenabled)
 {
     // App::GetApplication().Attach(this);
     if (GUIenabled) {
-        App::MainThreadSignalConfig::setHooks(&qtIsMainThread, &qtInvokeOnMain);
+        App::MainThreadSignalConfig::installHooks(&qtIsMainThread, &qtInvokeOnMain);
 
         // NOLINTBEGIN
         App::GetApplication().signalNewDocument.connect(

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -350,7 +350,7 @@ private:
     struct ApplicationP* d;
     /// workbench python dictionary
     PyObject* _pcWorkbenchDictionary;
-    NavlibInterface* pNavlibInterface;
+    NavlibInterface* pNavlibInterface {nullptr};
     void shutdown();
     static void init3DMouse(MainWindow* mainWindow, QApplication* qtApp);
 

--- a/src/Gui/PropertyView.cpp
+++ b/src/Gui/PropertyView.cpp
@@ -153,6 +153,7 @@ PropertyView::~PropertyView()
     this->connectPropView.disconnect();
     this->connectPropAppend.disconnect();
     this->connectPropRemove.disconnect();
+    this->connectPropRename.disconnect();
     this->connectPropChange.disconnect();
     this->connectUndoDocument.disconnect();
     this->connectRedoDocument.disconnect();

--- a/src/Gui/PropertyView.h
+++ b/src/Gui/PropertyView.h
@@ -31,6 +31,7 @@ class QTabWidget;
 
 namespace App
 {
+class Document;
 class Property;
 class PropertyContainer;
 class DocumentObject;

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -34,6 +34,7 @@
 #include <App/DocumentObjectPy.h>
 #include <App/GeoFeature.h>
 #include <App/Link.h>
+#include <App/MainThreadSignal.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Tools.h>
@@ -60,6 +61,15 @@ FC_LOG_LEVEL_INIT("Selection", false, true, true)
 using namespace Gui;
 using namespace std;
 namespace sp = std::placeholders;
+
+namespace
+{
+template<typename Fn>
+decltype(auto) invokeOnMainThread(Fn&& fn)
+{
+    return App::MainThreadSignalConfig::callOnMainThreadSync(std::forward<Fn>(fn));
+}
+}  // namespace
 
 SelectionGateFilterExternal::SelectionGateFilterExternal(const char* docName, const char* objName)
 {
@@ -569,6 +579,10 @@ SelectionSingleton::SelectionAllowance SelectionSingleton::isSelectionAllowed(co
 
 void SelectionSingleton::enablePickedList(bool enable)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { enablePickedList(enable); });
+    }
+
     if (enable != _needPickedList) {
         _needPickedList = enable;
         _PickedList.clear();
@@ -914,6 +928,12 @@ int SelectionSingleton::setPreselect(
     SelectionChanges::PickedPoint pickedPoint
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() {
+            return setPreselect(pDocName, pObjectName, pSubName, x, y, z, signal, pickedPoint);
+        });
+    }
+
     if (!pDocName || !pObjectName) {
         rmvPreselect();  // Invalid request
         return 0;
@@ -1104,6 +1124,10 @@ void printPreselectionInfo(
 
 void SelectionSingleton::setPreselectCoord(float x, float y, float z)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { setPreselectCoord(x, y, z); });
+    }
+
     // if nothing is in preselect ignore
     if (CurrentPreselection.Object.getObjectName().empty()) {
         return;
@@ -1126,6 +1150,10 @@ void SelectionSingleton::setPreselectCoord(float x, float y, float z)
 
 void SelectionSingleton::rmvPreselect(bool signal)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { rmvPreselect(signal); });
+    }
+
     if (DocName.empty()) {
         return;
     }
@@ -1285,6 +1313,12 @@ bool SelectionSingleton::addSelection(
     SelectionChanges::PickedPoint pickedPoint
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() {
+            return addSelection(pDocName, pObjectName, pSubName, x, y, z, pickedList, clearPreselect, pickedPoint);
+        });
+    }
+
     if (pickedList) {
         _PickedList.clear();
         for (const auto& sel : *pickedList) {
@@ -1376,6 +1410,10 @@ bool SelectionSingleton::addSelection(
 
 void SelectionSingleton::selStackPush(bool clearForward, bool overwrite)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { selStackPush(clearForward, overwrite); });
+    }
+
     static int stackSize;
     if (!stackSize) {
         stackSize = App::GetApplication()
@@ -1406,6 +1444,10 @@ void SelectionSingleton::selStackPush(bool clearForward, bool overwrite)
 
 void SelectionSingleton::selStackGoBack(int count)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { selStackGoBack(count); });
+    }
+
     if ((int)_SelStackBack.size() < count) {
         count = _SelStackBack.size();
     }
@@ -1449,6 +1491,10 @@ void SelectionSingleton::selStackGoBack(int count)
 
 void SelectionSingleton::selStackGoForward(int count)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { selStackGoForward(count); });
+    }
+
     if ((int)_SelStackForward.size() < count) {
         count = _SelStackForward.size();
     }
@@ -1533,6 +1579,12 @@ bool SelectionSingleton::addSelections(
     const std::vector<std::string>& pSubNames
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([&, this]() {
+            return addSelections(pDocName, pObjectName, pSubNames);
+        });
+    }
+
     if (!_PickedList.empty()) {
         _PickedList.clear();
         notify(SelectionChanges(SelectionChanges::PickedListChanged));
@@ -1607,6 +1659,12 @@ bool SelectionSingleton::updateSelection(
     const char* pSubName
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() {
+            return updateSelection(show, pDocName, pObjectName, pSubName);
+        });
+    }
+
     if (!pDocName || !pObjectName) {
         return false;
     }
@@ -1653,6 +1711,12 @@ bool SelectionSingleton::updateSelection(
 
 bool SelectionSingleton::addSelection(const SelectionObject& obj, bool clearPreselect)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([&obj, clearPreselect, this]() {
+            return addSelection(obj, clearPreselect);
+        });
+    }
+
     const std::vector<std::string>& subNames = obj.getSubNames();
     const std::vector<Base::Vector3d> points = obj.getPickedPoints();
     if (!subNames.empty() && subNames.size() == points.size()) {
@@ -1693,6 +1757,12 @@ void SelectionSingleton::rmvSelection(
     const std::vector<SelObj>* pickedList
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() {
+            rmvSelection(pDocName, pObjectName, pSubName, pickedList);
+        });
+    }
+
     if (pickedList) {
         _PickedList.clear();
         for (const auto& sel : *pickedList) {
@@ -1781,6 +1851,10 @@ struct SelInfo
 
 void SelectionSingleton::setVisible(VisibleState vis)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { setVisible(vis); });
+    }
+
     std::set<std::pair<App::DocumentObject*, App::DocumentObject*>> filter;
     int visible;
     switch (vis) {
@@ -1909,6 +1983,10 @@ void SelectionSingleton::setVisible(VisibleState vis)
 
 void SelectionSingleton::setSelection(const char* pDocName, const std::vector<App::DocumentObject*>& sel)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([&, this]() { setSelection(pDocName, sel); });
+    }
+
     if (!_PickedList.empty()) {
         _PickedList.clear();
         notify(SelectionChanges(SelectionChanges::PickedListChanged));
@@ -1938,6 +2016,10 @@ void SelectionSingleton::setSelection(const char* pDocName, const std::vector<Ap
 
 void SelectionSingleton::clearSelection(const char* pDocName, bool clearPreSelect)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { clearSelection(pDocName, clearPreSelect); });
+    }
+
     // Because the introduction of external editing, it is best to make
     // clearSelection(0) behave as clearCompleteSelection(), which is the same
     // behavior of python Selection.clearSelection(None)
@@ -1987,6 +2069,10 @@ void SelectionSingleton::clearSelection(const char* pDocName, bool clearPreSelec
 
 void SelectionSingleton::clearCompleteSelection(bool clearPreSelect)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { clearCompleteSelection(clearPreSelect); });
+    }
+
     if (!_PickedList.empty()) {
         _PickedList.clear();
         notify(SelectionChanges(SelectionChanges::PickedListChanged));

--- a/src/Gui/Selection/Selection.cpp
+++ b/src/Gui/Selection/Selection.cpp
@@ -34,6 +34,7 @@
 #include <App/DocumentObjectPy.h>
 #include <App/GeoFeature.h>
 #include <App/Link.h>
+#include <App/MainThreadSignal.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Tools.h>
@@ -60,6 +61,15 @@ FC_LOG_LEVEL_INIT("Selection", false, true, true)
 using namespace Gui;
 using namespace std;
 namespace sp = std::placeholders;
+
+namespace
+{
+template<typename Fn>
+decltype(auto) invokeOnMainThread(Fn&& fn)
+{
+    return App::MainThreadSignalConfig::callOnMainThreadSync(std::forward<Fn>(fn));
+}
+}  // namespace
 
 SelectionGateFilterExternal::SelectionGateFilterExternal(const char* docName, const char* objName)
 {
@@ -569,6 +579,10 @@ SelectionSingleton::SelectionAllowance SelectionSingleton::isSelectionAllowed(co
 
 void SelectionSingleton::enablePickedList(bool enable)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { enablePickedList(enable); });
+    }
+
     if (enable != _needPickedList) {
         _needPickedList = enable;
         _PickedList.clear();
@@ -914,6 +928,12 @@ int SelectionSingleton::setPreselect(
     SelectionChanges::PickedPoint pickedPoint
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() {
+            return setPreselect(pDocName, pObjectName, pSubName, x, y, z, signal, pickedPoint);
+        });
+    }
+
     if (!pDocName || !pObjectName) {
         rmvPreselect();  // Invalid request
         return 0;
@@ -1104,6 +1124,10 @@ void printPreselectionInfo(
 
 void SelectionSingleton::setPreselectCoord(float x, float y, float z)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { setPreselectCoord(x, y, z); });
+    }
+
     // if nothing is in preselect ignore
     if (CurrentPreselection.Object.getObjectName().empty()) {
         return;
@@ -1126,6 +1150,10 @@ void SelectionSingleton::setPreselectCoord(float x, float y, float z)
 
 void SelectionSingleton::rmvPreselect(bool signal)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { rmvPreselect(signal); });
+    }
+
     if (DocName.empty()) {
         return;
     }
@@ -1285,6 +1313,12 @@ bool SelectionSingleton::addSelection(
     SelectionChanges::PickedPoint pickedPoint
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() {
+            return addSelection(pDocName, pObjectName, pSubName, x, y, z, pickedList, clearPreselect, pickedPoint);
+        });
+    }
+
     if (pickedList) {
         _PickedList.clear();
         for (const auto& sel : *pickedList) {
@@ -1376,6 +1410,10 @@ bool SelectionSingleton::addSelection(
 
 void SelectionSingleton::selStackPush(bool clearForward, bool overwrite)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { selStackPush(clearForward, overwrite); });
+    }
+
     static int stackSize;
     if (!stackSize) {
         stackSize = App::GetApplication()
@@ -1406,6 +1444,10 @@ void SelectionSingleton::selStackPush(bool clearForward, bool overwrite)
 
 void SelectionSingleton::selStackGoBack(int count)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { selStackGoBack(count); });
+    }
+
     if ((int)_SelStackBack.size() < count) {
         count = _SelStackBack.size();
     }
@@ -1448,6 +1490,10 @@ void SelectionSingleton::selStackGoBack(int count)
 
 void SelectionSingleton::selStackGoForward(int count)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { selStackGoForward(count); });
+    }
+
     if ((int)_SelStackForward.size() < count) {
         count = _SelStackForward.size();
     }
@@ -1532,6 +1578,12 @@ bool SelectionSingleton::addSelections(
     const std::vector<std::string>& pSubNames
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([&, this]() {
+            return addSelections(pDocName, pObjectName, pSubNames);
+        });
+    }
+
     if (!_PickedList.empty()) {
         _PickedList.clear();
         notify(SelectionChanges(SelectionChanges::PickedListChanged));
@@ -1606,6 +1658,12 @@ bool SelectionSingleton::updateSelection(
     const char* pSubName
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() {
+            return updateSelection(show, pDocName, pObjectName, pSubName);
+        });
+    }
+
     if (!pDocName || !pObjectName) {
         return false;
     }
@@ -1652,6 +1710,12 @@ bool SelectionSingleton::updateSelection(
 
 bool SelectionSingleton::addSelection(const SelectionObject& obj, bool clearPreselect)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([&obj, clearPreselect, this]() {
+            return addSelection(obj, clearPreselect);
+        });
+    }
+
     const std::vector<std::string>& subNames = obj.getSubNames();
     const std::vector<Base::Vector3d> points = obj.getPickedPoints();
     if (!subNames.empty() && subNames.size() == points.size()) {
@@ -1692,6 +1756,12 @@ void SelectionSingleton::rmvSelection(
     const std::vector<SelObj>* pickedList
 )
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() {
+            rmvSelection(pDocName, pObjectName, pSubName, pickedList);
+        });
+    }
+
     if (pickedList) {
         _PickedList.clear();
         for (const auto& sel : *pickedList) {
@@ -1780,6 +1850,10 @@ struct SelInfo
 
 void SelectionSingleton::setVisible(VisibleState vis)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { setVisible(vis); });
+    }
+
     std::set<std::pair<App::DocumentObject*, App::DocumentObject*>> filter;
     int visible;
     switch (vis) {
@@ -1908,6 +1982,10 @@ void SelectionSingleton::setVisible(VisibleState vis)
 
 void SelectionSingleton::setSelection(const char* pDocName, const std::vector<App::DocumentObject*>& sel)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([&, this]() { setSelection(pDocName, sel); });
+    }
+
     if (!_PickedList.empty()) {
         _PickedList.clear();
         notify(SelectionChanges(SelectionChanges::PickedListChanged));
@@ -1937,6 +2015,10 @@ void SelectionSingleton::setSelection(const char* pDocName, const std::vector<Ap
 
 void SelectionSingleton::clearSelection(const char* pDocName, bool clearPreSelect)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { clearSelection(pDocName, clearPreSelect); });
+    }
+
     // Because the introduction of external editing, it is best to make
     // clearSelection(0) behave as clearCompleteSelection(), which is the same
     // behavior of python Selection.clearSelection(None)
@@ -1986,6 +2068,10 @@ void SelectionSingleton::clearSelection(const char* pDocName, bool clearPreSelec
 
 void SelectionSingleton::clearCompleteSelection(bool clearPreSelect)
 {
+    if (Q_UNLIKELY(!App::MainThreadSignalConfig::isMainThread())) {
+        return invokeOnMainThread([=, this]() { clearCompleteSelection(clearPreSelect); });
+    }
+
     if (!_PickedList.empty()) {
         _PickedList.clear();
         notify(SelectionChanges(SelectionChanges::PickedListChanged));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,14 +35,14 @@ function(setup_qt_test)
                 RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
             set_tests_properties(${_testname}_Tests_run PROPERTIES
                 LABELS "Qt"
-                ENVIRONMENT "QT_QPA_PLATFORM=offscreen"
+                ENVIRONMENT "${_qt_test_environment}"
                 ENVIRONMENT_MODIFICATION "${_test_env_mod}")
         else()
             set_target_properties(${_testname}_Tests_run PROPERTIES
                 RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
             set_tests_properties(${_testname}_Tests_run PROPERTIES
                 LABELS "Qt"
-                ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+                ENVIRONMENT "${_qt_test_environment}")
         endif()
     endforeach()
 endfunction()
@@ -115,6 +115,72 @@ if(WIN32)
             list(APPEND _test_env_mod "PATH=path_list_prepend:${_mod_dir}")
         endif()
     endforeach()
+endif()
+
+# Qt tests must obtain their runtime plugin path from the Qt installation used
+# by CMake. Do not rely on a caller's PATH or on a CI-specific directory layout.
+set(_qt_test_environment "QT_QPA_PLATFORM=offscreen")
+
+if(WIN32)
+    set(_qt_core_target "Qt${FREECAD_QT_MAJOR_VERSION}::Core")
+    if(NOT TARGET "${_qt_core_target}")
+        message(FATAL_ERROR
+            "Cannot configure Qt tests: imported target ${_qt_core_target} is unavailable")
+    endif()
+
+    set(_qt_core_location "")
+    foreach(_qt_config RELEASE RELWITHDEBINFO MINSIZEREL DEBUG)
+        get_target_property(
+            _qt_core_candidate
+            "${_qt_core_target}"
+            "IMPORTED_LOCATION_${_qt_config}"
+        )
+        if(_qt_core_candidate AND EXISTS "${_qt_core_candidate}")
+            set(_qt_core_location "${_qt_core_candidate}")
+            break()
+        endif()
+    endforeach()
+
+    if(NOT _qt_core_location)
+        get_target_property(_qt_core_location "${_qt_core_target}" IMPORTED_LOCATION)
+    endif()
+
+    if(NOT _qt_core_location OR NOT EXISTS "${_qt_core_location}")
+        message(FATAL_ERROR
+            "Cannot configure Qt tests: no runtime location is available for "
+            "${_qt_core_target}")
+    endif()
+
+    get_filename_component(_qt_bin_dir "${_qt_core_location}" DIRECTORY)
+    get_filename_component(_qt_install_prefix "${_qt_bin_dir}" DIRECTORY)
+    set(_qt_plugin_dir "${_qt_install_prefix}/plugins")
+    set(_qt_platform_plugin_dir "${_qt_plugin_dir}/platforms")
+
+    if(EXISTS "${_qt_platform_plugin_dir}/qoffscreen.dll"
+       OR EXISTS "${_qt_platform_plugin_dir}/qoffscreend.dll")
+        set(_qt_test_platform "offscreen")
+    elseif(EXISTS "${_qt_platform_plugin_dir}/qminimal.dll"
+           OR EXISTS "${_qt_platform_plugin_dir}/qminimald.dll")
+        set(_qt_test_platform "minimal")
+    else()
+        file(GLOB _available_qt_platform_plugins
+            RELATIVE "${_qt_platform_plugin_dir}"
+            "${_qt_platform_plugin_dir}/*.dll")
+        list(JOIN _available_qt_platform_plugins ", " _available_qt_platform_plugins_text)
+        message(FATAL_ERROR
+            "Cannot configure headless Qt tests. Neither qoffscreen nor qminimal "
+            "exists in ${_qt_platform_plugin_dir}. Available platform plugins: "
+            "${_available_qt_platform_plugins_text}")
+    endif()
+
+    set(_qt_test_environment
+        "QT_QPA_PLATFORM=${_qt_test_platform}"
+        "QT_PLUGIN_PATH=${_qt_plugin_dir}"
+        "QT_QPA_PLATFORM_PLUGIN_PATH=${_qt_platform_plugin_dir}"
+    )
+
+    message(STATUS
+        "Qt tests: platform=${_qt_test_platform}, plugins=${_qt_plugin_dir}")
 endif()
 
 add_subdirectory(src)

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -19,6 +19,10 @@ add_executable(Gui_tests_run
 
 # Qt tests
 setup_qt_test(QuantitySpinBox)
+setup_qt_test(ThreadAffinity)
+# Keep CTest as the authoritative timeout. The Windows watchdog fires first so
+# it can capture a dump before CTest terminates the process.
+set_tests_properties(ThreadAffinity_Tests_run PROPERTIES TIMEOUT 120)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -19,6 +19,9 @@ add_executable(Gui_tests_run
 
 # Qt tests
 setup_qt_test(QuantitySpinBox)
+setup_qt_test(ThreadAffinity)
+# Bound the test itself so direct CTest invocations cannot hang indefinitely.
+set_tests_properties(ThreadAffinity_Tests_run PROPERTIES TIMEOUT 120)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main

--- a/tests/src/Gui/ThreadAffinity.cpp
+++ b/tests/src/Gui/ThreadAffinity.cpp
@@ -1,0 +1,522 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <atomic>
+#include <exception>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include <QApplication>
+#include <QEvent>
+#include <QMetaObject>
+#include <QThread>
+#include <QtTest/QTest>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/MainThreadSignal.h>
+#include <App/PropertyStandard.h>
+#include <App/VarSet.h>
+#include <Gui/Application.h>
+#include <Gui/Selection/Selection.h>
+
+#include <src/App/InitApplication.h>
+
+namespace
+{
+std::atomic<int> g_mainThreadInvokeCount {0};
+
+QThread* g_mainThread = nullptr;
+std::unique_ptr<QObject> g_mainThreadInvoker;
+std::unique_ptr<Gui::Application> g_guiApplication;
+
+void drainQtEvents()
+{
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    QCoreApplication::processEvents();
+}
+
+bool isMainThread()
+{
+    return QThread::currentThread() == g_mainThread;
+}
+
+bool invokeOnMainThread(App::MainThreadSignalConfig::TaskFn task, void* context)
+{
+    g_mainThreadInvokeCount.fetch_add(1, std::memory_order_relaxed);
+
+    if (!g_mainThreadInvoker) {
+        return false;
+    }
+
+    return QMetaObject::invokeMethod(
+        g_mainThreadInvoker.get(),
+        [task, context] { task(context); },
+        Qt::BlockingQueuedConnection
+    );
+}
+
+bool rejectInvoke(App::MainThreadSignalConfig::TaskFn, void*)
+{
+    return false;
+}
+
+bool acceptWithoutInvoke(App::MainThreadSignalConfig::TaskFn, void*)
+{
+    return true;
+}
+
+QString workerError(const std::exception_ptr& exception)
+{
+    if (!exception) {
+        return {};
+    }
+    try {
+        std::rethrow_exception(exception);
+    }
+    catch (const std::exception& error) {
+        return QString::fromUtf8(error.what());
+    }
+    catch (...) {
+        return QStringLiteral("Worker threw an unknown exception");
+    }
+}
+}  // namespace
+
+class ThreadAffinity: public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        tests::initApplication();
+
+        g_mainThread = QThread::currentThread();
+        g_mainThreadInvoker = std::make_unique<QObject>();
+
+        g_guiApplication = std::make_unique<Gui::Application>(true);
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &invokeOnMainThread);
+        QVERIFY(App::MainThreadSignalConfig::hasHooks());
+    }
+
+    void cleanupTestCase()
+    {
+        drainQtEvents();
+
+        // Keep the dispatcher valid for the entire Gui::Application lifetime.
+        g_guiApplication.reset();
+
+        // Destruction can post deferred work that still needs the dispatcher.
+        drainQtEvents();
+
+        App::MainThreadSignalConfig::clearHooks();
+        g_mainThreadInvoker.reset();
+    }
+
+    void documentSignalUsesGuiHooksAcrossDllBoundary()
+    {
+        const std::string docName = App::GetApplication().getUniqueDocumentName("thread_affinity_doc");
+        App::DocumentInitFlags initFlags;
+        initFlags.createView = false;
+        App::Document* doc = App::GetApplication().newDocument(docName.c_str(), "testUser", initFlags);
+        QVERIFY(doc != nullptr);
+
+        auto* varSet = freecad_cast<App::VarSet*>(doc->addObject("App::VarSet", "VarSet"));
+        QVERIFY(varSet != nullptr);
+        auto* prop = freecad_cast<App::PropertyInteger*>(
+            varSet->addDynamicProperty("App::PropertyInteger", "Value", "Variables")
+        );
+        QVERIFY(prop != nullptr);
+
+        QThread* callbackThread = nullptr;
+        int matchingSignals = 0;
+        auto connection = doc->signalChangedObject.connect([&](const App::DocumentObject& object,
+                                                               const App::Property& changed) {
+            if (&object == varSet && &changed == prop) {
+                callbackThread = QThread::currentThread();
+                ++matchingSignals;
+            }
+        });
+
+        std::atomic<bool> done {false};
+        std::exception_ptr workerException;
+        std::thread worker([&] {
+            try {
+                prop->setValue(42);
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        worker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+
+        QCOMPARE(matchingSignals, 1);
+        QCOMPARE(callbackThread, g_mainThread);
+
+        connection.disconnect();
+
+        App::GetApplication().closeDocument(docName.c_str());
+
+        QVERIFY(App::GetApplication().getDocument(docName.c_str()) == nullptr);
+
+        // Property changes can leave queued GUI or DeferredDelete work.
+        drainQtEvents();
+    }
+
+    void dynamicPropertySignalsUseGuiHooksAcrossDllBoundary()
+    {
+        const std::string docName = App::GetApplication().getUniqueDocumentName(
+            "thread_affinity_dynamic"
+        );
+        App::DocumentInitFlags initFlags;
+        initFlags.createView = false;
+        App::Document* doc = App::GetApplication().newDocument(docName.c_str(), "testUser", initFlags);
+        QVERIFY(doc != nullptr);
+
+        auto* varSet = freecad_cast<App::VarSet*>(doc->addObject("App::VarSet", "VarSet"));
+        QVERIFY(varSet != nullptr);
+        QThread* appendThread = nullptr;
+        const App::Property* appendedProperty = nullptr;
+        auto appendConnection = App::GetApplication().signalAppendDynamicProperty.connect(
+            [&](const App::Property& appended) {
+                if (appended.getName() && std::string(appended.getName()) == "BridgeProp") {
+                    appendThread = QThread::currentThread();
+                    appendedProperty = &appended;
+                }
+            }
+        );
+
+        App::PropertyInteger* prop = nullptr;
+        std::atomic<bool> done {false};
+        std::exception_ptr workerException;
+        std::thread appendWorker([&] {
+            try {
+                prop = freecad_cast<App::PropertyInteger*>(
+                    varSet->addDynamicProperty("App::PropertyInteger", "BridgeProp", "Variables")
+                );
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        appendWorker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+        QVERIFY(prop != nullptr);
+        QVERIFY(appendedProperty == prop);
+        QCOMPARE(appendThread, g_mainThread);
+        appendConnection.disconnect();
+
+        QThread* renameThread = nullptr;
+        std::string oldName;
+        std::string newName;
+        auto renameConnection = App::GetApplication().signalRenameDynamicProperty.connect(
+            [&](const App::Property& changed, const char* previousName) {
+                if (&changed == prop) {
+                    renameThread = QThread::currentThread();
+                    oldName = previousName ? previousName : "";
+                    newName = changed.getName() ? changed.getName() : "";
+                }
+            }
+        );
+
+        done.store(false, std::memory_order_release);
+        workerException = nullptr;
+        bool renamed = false;
+        std::thread renameWorker([&] {
+            try {
+                renamed = varSet->renameDynamicProperty(prop, "BridgePropRenamed");
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        renameWorker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+
+        QVERIFY(renamed);
+        QCOMPARE(renameThread, g_mainThread);
+        QCOMPARE(QString::fromStdString(oldName), QStringLiteral("BridgeProp"));
+        QCOMPARE(QString::fromStdString(newName), QStringLiteral("BridgePropRenamed"));
+        renameConnection.disconnect();
+
+        QThread* removeThread = nullptr;
+        std::string removedName;
+        auto removeConnection = App::GetApplication().signalRemoveDynamicProperty.connect(
+            [&](const App::Property& removed) {
+                if (&removed == prop) {
+                    removeThread = QThread::currentThread();
+                    removedName = removed.getName() ? removed.getName() : "";
+                }
+            }
+        );
+
+        done.store(false, std::memory_order_release);
+        workerException = nullptr;
+        bool removed = false;
+        std::thread removeWorker([&] {
+            try {
+                removed = varSet->removeDynamicProperty("BridgePropRenamed");
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        removeWorker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+
+        QVERIFY(removed);
+        QCOMPARE(removeThread, g_mainThread);
+        QCOMPARE(QString::fromStdString(removedName), QStringLiteral("BridgePropRenamed"));
+
+        removeConnection.disconnect();
+        App::GetApplication().closeDocument(docName.c_str());
+    }
+
+    void selectionMutatorsMarshalToMainThread()
+    {
+        g_mainThreadInvokeCount.store(0, std::memory_order_relaxed);
+
+        std::atomic<bool> done {false};
+        std::thread worker([&done] {
+            Gui::Selection().rmvPreselect();
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        worker.join();
+
+        QCOMPARE(g_mainThreadInvokeCount.load(std::memory_order_relaxed), 1);
+    }
+
+    void mainThreadExceptionsReturnToWorker()
+    {
+        std::atomic<bool> done {false};
+        std::string error;
+
+        std::thread worker([&] {
+            try {
+                App::MainThreadSignalConfig::callOnMainThreadSync([] {
+                    throw std::runtime_error("main-thread failure");
+                });
+            }
+            catch (const std::runtime_error& exception) {
+                error = exception.what();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        worker.join();
+
+        QCOMPARE(QString::fromStdString(error), QStringLiteral("main-thread failure"));
+    }
+
+    void mainThreadSyncSupportsResultTypes()
+    {
+        const int constValue = 43;
+        int valueResult = 0;
+        const int* referenceResult = nullptr;
+        const int* constReferenceResult = nullptr;
+        int moveOnlyResult = 0;
+        int immovableLvalueResult = 0;
+        std::atomic<bool> done {false};
+        std::exception_ptr workerException;
+
+        struct ImmovableCallable
+        {
+            ImmovableCallable() = default;
+            ImmovableCallable(const ImmovableCallable&) = delete;
+            ImmovableCallable(ImmovableCallable&&) = delete;
+
+            int operator()() const
+            {
+                return 45;
+            }
+        };
+
+        std::thread worker([&] {
+            try {
+                valueResult = App::MainThreadSignalConfig::callOnMainThreadSync([] { return 42; });
+
+                int& reference = App::MainThreadSignalConfig::callOnMainThreadSync(
+                    [&valueResult]() -> int& { return valueResult; }
+                );
+                referenceResult = &reference;
+
+                const int& constReference = App::MainThreadSignalConfig::callOnMainThreadSync(
+                    [&constValue]() -> const int& { return constValue; }
+                );
+                constReferenceResult = &constReference;
+
+                moveOnlyResult = App::MainThreadSignalConfig::callOnMainThreadSync(
+                    [payload = std::make_unique<int>(44)] { return *payload; }
+                );
+
+                ImmovableCallable callable;
+                immovableLvalueResult = App::MainThreadSignalConfig::callOnMainThreadSync(callable);
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        worker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+
+        QCOMPARE(valueResult, 42);
+        QCOMPARE(referenceResult, &valueResult);
+        QCOMPARE(constReferenceResult, &constValue);
+        QCOMPARE(moveOnlyResult, 44);
+        QCOMPARE(immovableLvalueResult, 45);
+    }
+
+    void mainThreadSyncHandlesFallbackAndHookFailures()
+    {
+        App::MainThreadSignalConfig::clearHooks();
+
+        QThread* inlineThread = nullptr;
+        int inlineResult = 0;
+        std::atomic<bool> inlineDone {false};
+        std::exception_ptr inlineException;
+        std::thread inlineWorker([&] {
+            try {
+                inlineResult = App::MainThreadSignalConfig::callOnMainThreadSync([&] {
+                    inlineThread = QThread::currentThread();
+                    return 51;
+                });
+            }
+            catch (...) {
+                inlineException = std::current_exception();
+            }
+            inlineDone.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(inlineDone.load(std::memory_order_acquire));
+        inlineWorker.join();
+        QVERIFY2(!inlineException, qPrintable(workerError(inlineException)));
+        QVERIFY(!App::MainThreadSignalConfig::hasHooks());
+        QCOMPARE(inlineResult, 51);
+        QVERIFY(inlineThread != g_mainThread);
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &invokeOnMainThread);
+
+        bool rejectedPartialInstall = false;
+        try {
+            App::MainThreadSignalConfig::installHooks(&isMainThread, nullptr);
+        }
+        catch (const std::invalid_argument&) {
+            rejectedPartialInstall = true;
+        }
+        QVERIFY(rejectedPartialInstall);
+        QVERIFY(App::MainThreadSignalConfig::hasHooks());
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &rejectInvoke);
+        std::atomic<bool> rejectedDone {false};
+        std::string rejection;
+        std::thread rejectedWorker([&] {
+            try {
+                static_cast<void>(App::MainThreadSignalConfig::callOnMainThreadSync([] {
+                    return 52;
+                }));
+            }
+            catch (const std::runtime_error& exception) {
+                rejection = exception.what();
+            }
+            rejectedDone.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(rejectedDone.load(std::memory_order_acquire));
+        rejectedWorker.join();
+        QCOMPARE(
+            QString::fromStdString(rejection),
+            QStringLiteral("Failed to invoke callable on the main thread")
+        );
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &acceptWithoutInvoke);
+        std::atomic<bool> incompleteDone {false};
+        std::string incompleteError;
+        std::thread incompleteWorker([&] {
+            try {
+                static_cast<void>(App::MainThreadSignalConfig::callOnMainThreadSync([] {
+                    return 53;
+                }));
+            }
+            catch (const std::logic_error& exception) {
+                incompleteError = exception.what();
+            }
+            incompleteDone.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(incompleteDone.load(std::memory_order_acquire));
+        incompleteWorker.join();
+        QCOMPARE(
+            QString::fromStdString(incompleteError),
+            QStringLiteral("Main-thread hook returned before the callable completed")
+        );
+
+        std::atomic<bool> incompleteVoidDone {false};
+        std::string incompleteVoidError;
+        std::thread incompleteVoidWorker([&] {
+            try {
+                App::MainThreadSignalConfig::callOnMainThreadSync([] {});
+            }
+            catch (const std::logic_error& exception) {
+                incompleteVoidError = exception.what();
+            }
+            incompleteVoidDone.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(incompleteVoidDone.load(std::memory_order_acquire));
+        incompleteVoidWorker.join();
+        QCOMPARE(
+            QString::fromStdString(incompleteVoidError),
+            QStringLiteral("Main-thread hook returned before the callable completed")
+        );
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &invokeOnMainThread);
+        g_mainThreadInvokeCount.store(0, std::memory_order_relaxed);
+        QCOMPARE(App::MainThreadSignalConfig::callOnMainThreadSync([] { return 54; }), 54);
+        QCOMPARE(g_mainThreadInvokeCount.load(std::memory_order_relaxed), 0);
+    }
+};
+
+QTEST_MAIN(ThreadAffinity)
+
+#include "ThreadAffinity.moc"

--- a/tests/src/Gui/ThreadAffinity.cpp
+++ b/tests/src/Gui/ThreadAffinity.cpp
@@ -1,0 +1,737 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-FileCopyrightText: 2026 Joao Matos
+// SPDX-FileNotice: Part of the FreeCAD project.
+
+/******************************************************************************
+ *                                                                            *
+ *   FreeCAD is free software: you can redistribute it and/or modify          *
+ *   it under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1            *
+ *   of the License, or (at your option) any later version.                   *
+ *                                                                            *
+ *   FreeCAD is distributed in the hope that it will be useful,               *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty              *
+ *   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *
+ *   See the GNU Lesser General Public License for more details.              *
+ *                                                                            *
+ *   You should have received a copy of the GNU Lesser General Public         *
+ *   License along with FreeCAD. If not, see https://www.gnu.org/licenses     *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <atomic>
+#include <chrono>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#ifdef _WIN32
+# include <windows.h>
+#endif
+
+#include <QAbstractEventDispatcher>
+#include <QApplication>
+#include <QEvent>
+#include <QMetaObject>
+#include <QThread>
+#include <QTimer>
+#include <QtTest/QTest>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/MainThreadSignal.h>
+#include <App/PropertyStandard.h>
+#include <App/VarSet.h>
+#include <Gui/Application.h>
+#include <Gui/Selection/Selection.h>
+
+#include <src/App/InitApplication.h>
+
+namespace
+{
+using TraceClock = std::chrono::steady_clock;
+
+std::atomic<int> g_mainThreadInvokeCount {0};
+std::atomic<std::uint64_t> g_traceSequence {0};
+std::atomic<std::uint64_t> g_dispatchSequence {0};
+std::atomic<std::uint64_t> g_activeDispatch {0};
+std::atomic<const char*> g_activePhase {"idle"};
+std::atomic<void*> g_activeContext {nullptr};
+std::atomic<const char*> g_currentTest {"<startup>"};
+
+QThread* g_mainThread = nullptr;
+std::unique_ptr<QObject> g_mainThreadInvoker;
+std::unique_ptr<Gui::Application> g_guiApplication;
+std::unique_ptr<QTimer> g_heartbeatTimer;
+QtMessageHandler g_previousMessageHandler = nullptr;
+const auto g_traceStart = TraceClock::now();
+std::mutex g_traceMutex;
+
+std::uint64_t nativeThreadId()
+{
+#ifdef _WIN32
+    return static_cast<std::uint64_t>(GetCurrentThreadId());
+#else
+    return static_cast<std::uint64_t>(std::hash<std::thread::id> {}(std::this_thread::get_id()));
+#endif
+}
+
+void trace(
+    const char* event,
+    std::uint64_t dispatch = 0,
+    const void* context = nullptr,
+    const char* detail = nullptr
+)
+{
+    const auto sequence = g_traceSequence.fetch_add(1, std::memory_order_relaxed) + 1;
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             TraceClock::now() - g_traceStart
+    )
+                             .count();
+
+    std::scoped_lock lock(g_traceMutex);
+    std::fprintf(
+        stderr,
+        "[TA][seq=%" PRIu64 "][ms=%lld][tid=%" PRIu64
+        "][qthread=%p][test=%s][event=%s][dispatch=%" PRIu64 "][context=%p][detail=%s]\n",
+        sequence,
+        static_cast<long long>(elapsed),
+        nativeThreadId(),
+        static_cast<void*>(QThread::currentThread()),
+        g_currentTest.load(std::memory_order_relaxed),
+        event,
+        dispatch,
+        context,
+        detail ? detail : "-"
+    );
+    std::fflush(stderr);
+}
+
+void qtMessageHandler(QtMsgType type, const QMessageLogContext& context, const QString& message)
+{
+    const QByteArray utf8 = message.toUtf8();
+    const char* typeName = "unknown";
+    switch (type) {
+        case QtDebugMsg:
+            typeName = "debug";
+            break;
+        case QtInfoMsg:
+            typeName = "info";
+            break;
+        case QtWarningMsg:
+            typeName = "warning";
+            break;
+        case QtCriticalMsg:
+            typeName = "critical";
+            break;
+        case QtFatalMsg:
+            typeName = "fatal";
+            break;
+    }
+
+    char detail[1024];
+    std::snprintf(
+        detail,
+        sizeof(detail),
+        "%s category=%s file=%s line=%d message=%s",
+        typeName,
+        context.category ? context.category : "-",
+        context.file ? context.file : "-",
+        context.line,
+        utf8.constData()
+    );
+    trace("qt.message", 0, nullptr, detail);
+
+    if (type == QtFatalMsg) {
+        std::abort();
+    }
+}
+
+void drainQtEvents()
+{
+    trace("events.drain.begin");
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+    QCoreApplication::processEvents();
+    trace("events.drain.end");
+}
+
+bool isMainThread()
+{
+    const bool result = QThread::currentThread() == g_mainThread;
+    if (!result) {
+        trace("predicate.not-main");
+    }
+    return result;
+}
+
+bool invokeOnMainThread(App::MainThreadSignalConfig::TaskFn task, void* context)
+{
+    const auto dispatch = g_dispatchSequence.fetch_add(1, std::memory_order_relaxed) + 1;
+    g_mainThreadInvokeCount.fetch_add(1, std::memory_order_relaxed);
+    g_activeDispatch.store(dispatch, std::memory_order_release);
+    g_activeContext.store(context, std::memory_order_release);
+    g_activePhase.store("hook.enter", std::memory_order_release);
+    trace("hook.enter", dispatch, context);
+
+    if (!g_mainThreadInvoker) {
+        trace("hook.no-invoker", dispatch, context);
+        return false;
+    }
+
+    g_activePhase.store("invokeMethod.waiting", std::memory_order_release);
+    trace("invokeMethod.begin", dispatch, context);
+    const bool invoked = QMetaObject::invokeMethod(
+        g_mainThreadInvoker.get(),
+        [task, context, dispatch] {
+            g_activePhase.store("gui.lambda.enter", std::memory_order_release);
+            trace("gui.lambda.enter", dispatch, context);
+
+            g_activePhase.store("task.running", std::memory_order_release);
+            trace("task.begin", dispatch, context);
+            task(context);
+            trace("task.end", dispatch, context);
+
+            g_activePhase.store("gui.lambda.exit", std::memory_order_release);
+            trace("gui.lambda.exit", dispatch, context);
+        },
+        Qt::BlockingQueuedConnection
+    );
+
+    trace("invokeMethod.end", dispatch, context, invoked ? "true" : "false");
+    g_activePhase.store("hook.exit", std::memory_order_release);
+    trace("hook.exit", dispatch, context);
+    g_activeContext.store(nullptr, std::memory_order_release);
+    g_activeDispatch.store(0, std::memory_order_release);
+    g_activePhase.store("idle", std::memory_order_release);
+    return invoked;
+}
+
+bool rejectInvoke(App::MainThreadSignalConfig::TaskFn, void*)
+{
+    trace("hook.reject");
+    return false;
+}
+
+bool acceptWithoutInvoke(App::MainThreadSignalConfig::TaskFn, void*)
+{
+    trace("hook.accept-without-invoke");
+    return true;
+}
+
+QString workerError(const std::exception_ptr& exception)
+{
+    if (!exception) {
+        return {};
+    }
+    try {
+        std::rethrow_exception(exception);
+    }
+    catch (const std::exception& error) {
+        return QString::fromUtf8(error.what());
+    }
+    catch (...) {
+        return QStringLiteral("Worker threw an unknown exception");
+    }
+}
+}  // namespace
+
+class ThreadAffinity: public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        g_previousMessageHandler = qInstallMessageHandler(&qtMessageHandler);
+        trace("suite.init.begin");
+
+        tests::initApplication();
+        trace("suite.app.initialized");
+
+        g_mainThread = QThread::currentThread();
+        g_mainThreadInvoker = std::make_unique<QObject>();
+        trace("suite.invoker.created", 0, g_mainThreadInvoker.get());
+
+        g_guiApplication = std::make_unique<Gui::Application>(true);
+        trace("suite.gui.created", 0, g_guiApplication.get());
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &invokeOnMainThread);
+        trace("suite.hooks.installed");
+        QVERIFY(App::MainThreadSignalConfig::hasHooks());
+
+        if (auto* dispatcher = QAbstractEventDispatcher::instance(g_mainThread)) {
+            QObject::connect(dispatcher, &QAbstractEventDispatcher::aboutToBlock, [] {
+                const auto dispatch = g_activeDispatch.load(std::memory_order_acquire);
+                if (dispatch != 0) {
+                    trace(
+                        "event-loop.about-to-block",
+                        dispatch,
+                        g_activeContext.load(std::memory_order_acquire),
+                        g_activePhase.load(std::memory_order_acquire)
+                    );
+                }
+            });
+            QObject::connect(dispatcher, &QAbstractEventDispatcher::awake, [] {
+                const auto dispatch = g_activeDispatch.load(std::memory_order_acquire);
+                if (dispatch != 0) {
+                    trace(
+                        "event-loop.awake",
+                        dispatch,
+                        g_activeContext.load(std::memory_order_acquire),
+                        g_activePhase.load(std::memory_order_acquire)
+                    );
+                }
+            });
+            trace("suite.dispatcher.connected", 0, dispatcher);
+        }
+        else {
+            trace("suite.dispatcher.missing");
+        }
+
+        g_heartbeatTimer = std::make_unique<QTimer>();
+        g_heartbeatTimer->setInterval(2000);
+        QObject::connect(g_heartbeatTimer.get(), &QTimer::timeout, [] {
+            trace(
+                "heartbeat",
+                g_activeDispatch.load(std::memory_order_acquire),
+                g_activeContext.load(std::memory_order_acquire),
+                g_activePhase.load(std::memory_order_acquire)
+            );
+        });
+        g_heartbeatTimer->start();
+        trace("suite.init.end");
+    }
+
+    void cleanupTestCase()
+    {
+        g_currentTest.store("<cleanupTestCase>", std::memory_order_release);
+        trace("suite.cleanup.begin");
+
+        g_heartbeatTimer.reset();
+        trace("suite.heartbeat.stopped");
+
+        drainQtEvents();
+
+        // Keep the dispatcher valid for the entire Gui::Application lifetime.
+        trace("suite.gui.destroy.begin", 0, g_guiApplication.get());
+        g_guiApplication.reset();
+        trace("suite.gui.destroy.end");
+
+        // Destruction can post deferred work that still needs the dispatcher.
+        drainQtEvents();
+
+        trace("suite.hooks.clear.begin");
+        App::MainThreadSignalConfig::clearHooks();
+        trace("suite.hooks.clear.end");
+        g_mainThreadInvoker.reset();
+        trace("suite.invoker.destroyed");
+
+        trace("suite.cleanup.end");
+        qInstallMessageHandler(g_previousMessageHandler);
+    }
+
+    void init()
+    {
+        const char* function = QTest::currentTestFunction();
+        g_currentTest.store(function ? function : "<unknown>", std::memory_order_release);
+        trace("test.begin");
+    }
+
+    void cleanup()
+    {
+        trace("test.end");
+        g_currentTest.store("<between-tests>", std::memory_order_release);
+    }
+
+    void documentSignalUsesGuiHooksAcrossDllBoundary()
+    {
+        const std::string docName = App::GetApplication().getUniqueDocumentName("thread_affinity_doc");
+        App::DocumentInitFlags initFlags;
+        initFlags.createView = false;
+        App::Document* doc = App::GetApplication().newDocument(docName.c_str(), "testUser", initFlags);
+        QVERIFY(doc != nullptr);
+
+        auto* varSet = freecad_cast<App::VarSet*>(doc->addObject("App::VarSet", "VarSet"));
+        QVERIFY(varSet != nullptr);
+        auto* prop = freecad_cast<App::PropertyInteger*>(
+            varSet->addDynamicProperty("App::PropertyInteger", "Value", "Variables")
+        );
+        QVERIFY(prop != nullptr);
+
+        QThread* callbackThread = nullptr;
+        int matchingSignals = 0;
+        auto connection = doc->signalChangedObject.connect([&](const App::DocumentObject& object,
+                                                               const App::Property& changed) {
+            if (&object == varSet && &changed == prop) {
+                callbackThread = QThread::currentThread();
+                ++matchingSignals;
+            }
+        });
+
+        std::atomic<bool> done {false};
+        std::exception_ptr workerException;
+        std::thread worker([&] {
+            try {
+                prop->setValue(42);
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        worker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+
+        QCOMPARE(matchingSignals, 1);
+        QCOMPARE(callbackThread, g_mainThread);
+
+        connection.disconnect();
+
+        App::GetApplication().closeDocument(docName.c_str());
+
+        QVERIFY(App::GetApplication().getDocument(docName.c_str()) == nullptr);
+
+        // Property changes can leave queued GUI or DeferredDelete work.
+        drainQtEvents();
+    }
+
+    void dynamicPropertySignalsUseGuiHooksAcrossDllBoundary()
+    {
+        const std::string docName = App::GetApplication().getUniqueDocumentName(
+            "thread_affinity_dynamic"
+        );
+        App::DocumentInitFlags initFlags;
+        initFlags.createView = false;
+        App::Document* doc = App::GetApplication().newDocument(docName.c_str(), "testUser", initFlags);
+        QVERIFY(doc != nullptr);
+
+        auto* varSet = freecad_cast<App::VarSet*>(doc->addObject("App::VarSet", "VarSet"));
+        QVERIFY(varSet != nullptr);
+        QThread* appendThread = nullptr;
+        const App::Property* appendedProperty = nullptr;
+        auto appendConnection = App::GetApplication().signalAppendDynamicProperty.connect(
+            [&](const App::Property& appended) {
+                if (appended.getName() && std::string(appended.getName()) == "BridgeProp") {
+                    appendThread = QThread::currentThread();
+                    appendedProperty = &appended;
+                }
+            }
+        );
+
+        App::PropertyInteger* prop = nullptr;
+        std::atomic<bool> done {false};
+        std::exception_ptr workerException;
+        std::thread appendWorker([&] {
+            try {
+                prop = freecad_cast<App::PropertyInteger*>(
+                    varSet->addDynamicProperty("App::PropertyInteger", "BridgeProp", "Variables")
+                );
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        appendWorker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+        QVERIFY(prop != nullptr);
+        QVERIFY(appendedProperty == prop);
+        QCOMPARE(appendThread, g_mainThread);
+        appendConnection.disconnect();
+
+        QThread* renameThread = nullptr;
+        std::string oldName;
+        std::string newName;
+        auto renameConnection = App::GetApplication().signalRenameDynamicProperty.connect(
+            [&](const App::Property& changed, const char* previousName) {
+                if (&changed == prop) {
+                    renameThread = QThread::currentThread();
+                    oldName = previousName ? previousName : "";
+                    newName = changed.getName() ? changed.getName() : "";
+                }
+            }
+        );
+
+        done.store(false, std::memory_order_release);
+        workerException = nullptr;
+        bool renamed = false;
+        std::thread renameWorker([&] {
+            try {
+                renamed = varSet->renameDynamicProperty(prop, "BridgePropRenamed");
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        renameWorker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+
+        QVERIFY(renamed);
+        QCOMPARE(renameThread, g_mainThread);
+        QCOMPARE(QString::fromStdString(oldName), QStringLiteral("BridgeProp"));
+        QCOMPARE(QString::fromStdString(newName), QStringLiteral("BridgePropRenamed"));
+        renameConnection.disconnect();
+
+        QThread* removeThread = nullptr;
+        std::string removedName;
+        auto removeConnection = App::GetApplication().signalRemoveDynamicProperty.connect(
+            [&](const App::Property& removed) {
+                if (&removed == prop) {
+                    removeThread = QThread::currentThread();
+                    removedName = removed.getName() ? removed.getName() : "";
+                }
+            }
+        );
+
+        done.store(false, std::memory_order_release);
+        workerException = nullptr;
+        bool removed = false;
+        std::thread removeWorker([&] {
+            try {
+                removed = varSet->removeDynamicProperty("BridgePropRenamed");
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        removeWorker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+
+        QVERIFY(removed);
+        QCOMPARE(removeThread, g_mainThread);
+        QCOMPARE(QString::fromStdString(removedName), QStringLiteral("BridgePropRenamed"));
+
+        removeConnection.disconnect();
+        App::GetApplication().closeDocument(docName.c_str());
+    }
+
+    void selectionMutatorsMarshalToMainThread()
+    {
+        g_mainThreadInvokeCount.store(0, std::memory_order_relaxed);
+
+        std::atomic<bool> done {false};
+        std::thread worker([&done] {
+            Gui::Selection().rmvPreselect();
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        worker.join();
+
+        QCOMPARE(g_mainThreadInvokeCount.load(std::memory_order_relaxed), 1);
+    }
+
+    void mainThreadExceptionsReturnToWorker()
+    {
+        std::atomic<bool> done {false};
+        std::string error;
+
+        std::thread worker([&] {
+            try {
+                App::MainThreadSignalConfig::callOnMainThreadSync([] {
+                    throw std::runtime_error("main-thread failure");
+                });
+            }
+            catch (const std::runtime_error& exception) {
+                error = exception.what();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        worker.join();
+
+        QCOMPARE(QString::fromStdString(error), QStringLiteral("main-thread failure"));
+    }
+
+    void mainThreadSyncSupportsResultTypes()
+    {
+        const int constValue = 43;
+        int valueResult = 0;
+        const int* referenceResult = nullptr;
+        const int* constReferenceResult = nullptr;
+        int moveOnlyResult = 0;
+        int immovableLvalueResult = 0;
+        std::atomic<bool> done {false};
+        std::exception_ptr workerException;
+
+        struct ImmovableCallable
+        {
+            ImmovableCallable() = default;
+            ImmovableCallable(const ImmovableCallable&) = delete;
+            ImmovableCallable(ImmovableCallable&&) = delete;
+
+            int operator()() const
+            {
+                return 45;
+            }
+        };
+
+        std::thread worker([&] {
+            try {
+                valueResult = App::MainThreadSignalConfig::callOnMainThreadSync([] { return 42; });
+
+                int& reference = App::MainThreadSignalConfig::callOnMainThreadSync(
+                    [&valueResult]() -> int& { return valueResult; }
+                );
+                referenceResult = &reference;
+
+                const int& constReference = App::MainThreadSignalConfig::callOnMainThreadSync(
+                    [&constValue]() -> const int& { return constValue; }
+                );
+                constReferenceResult = &constReference;
+
+                moveOnlyResult = App::MainThreadSignalConfig::callOnMainThreadSync(
+                    [payload = std::make_unique<int>(44)] { return *payload; }
+                );
+
+                ImmovableCallable callable;
+                immovableLvalueResult = App::MainThreadSignalConfig::callOnMainThreadSync(callable);
+            }
+            catch (...) {
+                workerException = std::current_exception();
+            }
+            done.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(done.load(std::memory_order_acquire));
+        worker.join();
+        QVERIFY2(!workerException, qPrintable(workerError(workerException)));
+
+        QCOMPARE(valueResult, 42);
+        QCOMPARE(referenceResult, &valueResult);
+        QCOMPARE(constReferenceResult, &constValue);
+        QCOMPARE(moveOnlyResult, 44);
+        QCOMPARE(immovableLvalueResult, 45);
+    }
+
+    void mainThreadSyncHandlesFallbackAndHookFailures()
+    {
+        App::MainThreadSignalConfig::clearHooks();
+
+        QThread* inlineThread = nullptr;
+        int inlineResult = 0;
+        std::atomic<bool> inlineDone {false};
+        std::exception_ptr inlineException;
+        std::thread inlineWorker([&] {
+            try {
+                inlineResult = App::MainThreadSignalConfig::callOnMainThreadSync([&] {
+                    inlineThread = QThread::currentThread();
+                    return 51;
+                });
+            }
+            catch (...) {
+                inlineException = std::current_exception();
+            }
+            inlineDone.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(inlineDone.load(std::memory_order_acquire));
+        inlineWorker.join();
+        QVERIFY2(!inlineException, qPrintable(workerError(inlineException)));
+        QVERIFY(!App::MainThreadSignalConfig::hasHooks());
+        QCOMPARE(inlineResult, 51);
+        QVERIFY(inlineThread != g_mainThread);
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &invokeOnMainThread);
+
+        bool rejectedPartialInstall = false;
+        try {
+            App::MainThreadSignalConfig::installHooks(&isMainThread, nullptr);
+        }
+        catch (const std::invalid_argument&) {
+            rejectedPartialInstall = true;
+        }
+        QVERIFY(rejectedPartialInstall);
+        QVERIFY(App::MainThreadSignalConfig::hasHooks());
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &rejectInvoke);
+        std::atomic<bool> rejectedDone {false};
+        std::string rejection;
+        std::thread rejectedWorker([&] {
+            try {
+                static_cast<void>(App::MainThreadSignalConfig::callOnMainThreadSync([] {
+                    return 52;
+                }));
+            }
+            catch (const std::runtime_error& exception) {
+                rejection = exception.what();
+            }
+            rejectedDone.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(rejectedDone.load(std::memory_order_acquire));
+        rejectedWorker.join();
+        QCOMPARE(
+            QString::fromStdString(rejection),
+            QStringLiteral("Failed to invoke callable on the main thread")
+        );
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &acceptWithoutInvoke);
+        std::atomic<bool> incompleteDone {false};
+        std::string incompleteError;
+        std::thread incompleteWorker([&] {
+            try {
+                static_cast<void>(App::MainThreadSignalConfig::callOnMainThreadSync([] {
+                    return 53;
+                }));
+            }
+            catch (const std::logic_error& exception) {
+                incompleteError = exception.what();
+            }
+            incompleteDone.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(incompleteDone.load(std::memory_order_acquire));
+        incompleteWorker.join();
+        QCOMPARE(
+            QString::fromStdString(incompleteError),
+            QStringLiteral("Main-thread hook returned before the callable completed")
+        );
+
+        std::atomic<bool> incompleteVoidDone {false};
+        std::string incompleteVoidError;
+        std::thread incompleteVoidWorker([&] {
+            try {
+                App::MainThreadSignalConfig::callOnMainThreadSync([] {});
+            }
+            catch (const std::logic_error& exception) {
+                incompleteVoidError = exception.what();
+            }
+            incompleteVoidDone.store(true, std::memory_order_release);
+        });
+
+        QTRY_VERIFY(incompleteVoidDone.load(std::memory_order_acquire));
+        incompleteVoidWorker.join();
+        QCOMPARE(
+            QString::fromStdString(incompleteVoidError),
+            QStringLiteral("Main-thread hook returned before the callable completed")
+        );
+
+        App::MainThreadSignalConfig::installHooks(&isMainThread, &invokeOnMainThread);
+        g_mainThreadInvokeCount.store(0, std::memory_order_relaxed);
+        QCOMPARE(App::MainThreadSignalConfig::callOnMainThreadSync([] { return 54; }), 54);
+        QCOMPARE(g_mainThreadInvokeCount.load(std::memory_order_relaxed), 0);
+    }
+};
+
+QTEST_MAIN(ThreadAffinity)
+
+#include "ThreadAffinity.moc"


### PR DESCRIPTION
Fixes #29844

This fixes a set of GUI thread-affinity problems that could occur when FreeCAD objects are modified from worker threads.

The main change is to make sure notifications that are observed by GUI code are delivered on the main thread, while still keeping the underlying App code usable without a GUI. It adds a small shared dispatch mechanism between FreeCADApp and FreeCADGui, then uses it for the affected dynamic-property and selection update paths.

The PR also adds regression tests for the cases that were causing trouble, including cross-module signals, property rename/removal, selection changes, exception propagation, and GUI teardown. Since the normal C++ test suite is currently skipped on Windows CI, there is also a focused Windows CI step for the new thread-affinity test so the regression is covered on the platform where it matters most.

## Changes

- Add a shared, exported main-thread dispatcher that works across `FreeCADApp` and `FreeCADGui` DLL boundaries.
- Marshal dynamic-property observer signals synchronously to the GUI thread.
- Keep expression rename bookkeeping on the mutating thread.
- Marshal selection and preselection mutations to the GUI thread.

## CI

The new `ThreadAffinity_Tests_run` test is registered as a normal cross-platform Qt test.

Linux and macOS already run the regular C++/Qt test suite in the Pixi CI workflow. Windows currently skips the general C++ test action, so this PR adds a focused Windows invocation for the new regression test to ensure the affected platform is covered.

The broader issue of enabling the complete C++ test suite on Windows is tracked separately in #27276. Once that is resolved, the focused Windows-only CI step can be removed and this test will run through the regular suite there as well.

The targeted Windows test is bounded by a CTest timeout so a thread-affinity regression cannot hang CI indefinitely.