### PR TITLE
CAM: Low-risk, user visible improvements to job creation and editing.

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/DlgJobCreate.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgJobCreate.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>532</width>
-    <height>616</height>
+    <width>620</width>
+    <height>700</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -57,6 +57,48 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_bottom">
+     <item>
+      <spacer name="horizontalSpacer_bottom">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="unitSchemaGroup">
+       <property name="title">
+        <string>Document Units</string>
+       </property>
+       <property name="toolTip">
+        <string>Velocity per minute (mm/min, in/min) is required for safe G-code feed rates. Schemas marked in red express velocity per second and may produce unsafe output.</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_units">
+        <item>
+         <widget class="QComboBox" name="unitSchemaCombo">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>Unit schema for this document. Green-shaded entries express velocity per minute (recommended). Red-shaded entries express velocity per second and are unsafe for G-code feed rates.</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/Mod/CAM/Gui/Resources/panels/DlgJobTemplateExport.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/DlgJobTemplateExport.ui
@@ -15,6 +15,25 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QGroupBox" name="descriptionGroup">
+     <property name="toolTip">
+      <string>Description is shown in the tooltip when selecting a template during job creation</string>
+     </property>
+     <property name="title">
+      <string>Description</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_description">
+      <item>
+       <widget class="QPlainTextEdit" name="templateDescriptionEdit">
+        <property name="placeholderText">
+         <string>Optional. e.g. &quot;Metric defaults for 3-axis router with 600x900 work area&quot;</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="postProcessingGroup">
      <property name="toolTip">
       <string>If enabled, include all post processing settings in the template</string>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -347,12 +347,15 @@
            <item row="1" column="0" colspan="2">
             <widget class="QPushButton" name="pickTargetToggle">
              <property name="text">
-              <string>Picking: Stock</string>
+              <string>Picking: Model</string>
              </property>
              <property name="toolTip">
-              <string>Toggle whether origin/axis picks target the Stock (default) or the Model. Useful when Stock and Model overlap and the desired vertex is hidden.</string>
+              <string>Toggle whether origin/axis picks target the Model (default) or the Stock. Useful when Stock and Model overlap and the desired vertex is hidden.</string>
              </property>
              <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
               <bool>true</bool>
              </property>
             </widget>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -58,6 +58,9 @@
                  <verstretch>0</verstretch>
                 </sizepolicy>
                </property>
+               <property name="toolTip">
+                <string>Sets the stock creation method: box (explicit dimensions), cylinder, bounding box extension of the model (default), or an existing solid from the document.</string>
+               </property>
                <property name="currentIndex">
                 <number>2</number>
                </property>
@@ -88,25 +91,8 @@
                <property name="text">
                 <string>Refresh</string>
                </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnMaterial">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="MinimumExpanding">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
                <property name="toolTip">
-                <string>Assign stock material</string>
-               </property>
-               <property name="text">
-                <string/>
-               </property>
-               <property name="icon">
-                <iconset resource="../../../../Material/Gui/Resources/Material.qrc">
-                 <normaloff>:/icons/MaterialWorkbench.svg</normaloff>:/icons/MaterialWorkbench.svg</iconset>
+                <string>Recreates the stock from the current settings. Useful after changing the model bounding box or stock parameters.</string>
                </property>
               </widget>
              </item>
@@ -140,6 +126,9 @@
            <item>
             <widget class="QFrame" name="stockFromBase">
              <layout class="QGridLayout" name="gridLayout_9">
+              <property name="columnStretch">
+               <string>0,0,1,1</string>
+              </property>
               <item row="0" column="1">
                <widget class="QLabel" name="stockExtXLabel">
                 <property name="text">
@@ -148,10 +137,17 @@
                </widget>
               </item>
               <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockExtXneg"/>
+               <widget class="Gui::QuantitySpinBox" name="stockExtXneg">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
               </item>
               <item row="0" column="3">
-               <widget class="Gui::InputField" name="stockExtXpos">
+               <widget class="Gui::QuantitySpinBox" name="stockExtXpos">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                   <horstretch>0</horstretch>
@@ -168,10 +164,24 @@
                </widget>
               </item>
               <item row="1" column="2">
-               <widget class="Gui::InputField" name="stockExtYneg"/>
+               <widget class="Gui::QuantitySpinBox" name="stockExtYneg">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
               </item>
               <item row="1" column="3">
-               <widget class="Gui::InputField" name="stockExtYpos"/>
+               <widget class="Gui::QuantitySpinBox" name="stockExtYpos">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
               </item>
               <item row="2" column="1">
                <widget class="QLabel" name="stockExtZLabel">
@@ -181,10 +191,24 @@
                </widget>
               </item>
               <item row="2" column="2">
-               <widget class="Gui::InputField" name="stockExtZneg"/>
+               <widget class="Gui::QuantitySpinBox" name="stockExtZneg">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
               </item>
               <item row="2" column="3">
-               <widget class="Gui::InputField" name="stockExtZpos"/>
+               <widget class="Gui::QuantitySpinBox" name="stockExtZpos">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
               </item>
              </layout>
             </widget>
@@ -200,7 +224,7 @@
                </widget>
               </item>
               <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockCylinderRadius"/>
+               <widget class="Gui::QuantitySpinBox" name="stockCylinderRadius"/>
               </item>
               <item row="1" column="1">
                <widget class="QLabel" name="stockCylinderHeightLabel">
@@ -210,7 +234,7 @@
                </widget>
               </item>
               <item row="1" column="2">
-               <widget class="Gui::InputField" name="stockCylinderHeight"/>
+               <widget class="Gui::QuantitySpinBox" name="stockCylinderHeight"/>
               </item>
              </layout>
             </widget>
@@ -226,7 +250,7 @@
                </widget>
               </item>
               <item row="0" column="2">
-               <widget class="Gui::InputField" name="stockBoxLength"/>
+               <widget class="Gui::QuantitySpinBox" name="stockBoxLength"/>
               </item>
               <item row="1" column="1">
                <widget class="QLabel" name="stockBoxWidthLabel">
@@ -236,7 +260,7 @@
                </widget>
               </item>
               <item row="1" column="2">
-               <widget class="Gui::InputField" name="stockBoxWidth"/>
+               <widget class="Gui::QuantitySpinBox" name="stockBoxWidth"/>
               </item>
               <item row="2" column="1">
                <widget class="QLabel" name="stockBoxHeightLabel">
@@ -246,10 +270,53 @@
                </widget>
               </item>
               <item row="2" column="2">
-               <widget class="Gui::InputField" name="stockBoxHeight"/>
+               <widget class="Gui::QuantitySpinBox" name="stockBoxHeight"/>
               </item>
              </layout>
             </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="materialRowLayout">
+             <item>
+              <widget class="QPushButton" name="btnMaterial">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Assign stock material</string>
+               </property>
+               <property name="text">
+                <string>Assign Material</string>
+               </property>
+               <property name="icon">
+                <iconset resource="../../../../Material/Gui/Resources/Material.qrc">
+                 <normaloff>:/icons/MaterialWorkbench.svg</normaloff>:/icons/MaterialWorkbench.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="materialLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>1</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>Stock material currently assigned. Click the material button to change.</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="textInteractionFlags">
+                <set>Qt::TextSelectableByMouse</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
           </layout>
          </widget>
@@ -271,6 +338,22 @@
             <widget class="QPushButton" name="setOrigin">
              <property name="text">
               <string>Set Origin</string>
+             </property>
+             <property name="toolTip">
+              <string>Sets the model origin to a selected point, either a vertex or the center of the selected face. The picking button controls whether selection targets the stock or the model.</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
+            <widget class="QPushButton" name="pickTargetToggle">
+             <property name="text">
+              <string>Picking: Stock</string>
+             </property>
+             <property name="toolTip">
+              <string>Toggle whether origin/axis picks target the Stock (default) or the Model. Useful when Stock and Model overlap and the desired vertex is hidden.</string>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -294,13 +377,19 @@
         <item>
          <widget class="QGroupBox" name="modelSetGroup">
           <property name="title">
-           <string>Set</string>
+           <string>Origin &amp;&amp; Orientation</string>
+          </property>
+          <property name="toolTip">
+           <string>Position the Model so a picked edge defines an axis and a picked vertex zeroes the model on that axis. The G54-G59 Fixture is set on the Output tab.</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_5">
            <item row="0" column="0">
             <widget class="QPushButton" name="modelSetXAxis">
              <property name="text">
               <string>X-Axis</string>
+             </property>
+             <property name="toolTip">
+              <string>Rotate the Model so a picked edge becomes the X axis.</string>
              </property>
             </widget>
            </item>
@@ -309,12 +398,18 @@
              <property name="text">
               <string>Y-Axis</string>
              </property>
+             <property name="toolTip">
+              <string>Rotate the Model so a picked edge becomes the Y axis.</string>
+             </property>
             </widget>
            </item>
            <item row="0" column="2">
             <widget class="QPushButton" name="modelSetZAxis">
              <property name="text">
               <string>Z-Axis</string>
+             </property>
+             <property name="toolTip">
+              <string>Rotate the Model so a picked edge becomes the Z axis.</string>
              </property>
             </widget>
            </item>
@@ -323,12 +418,18 @@
              <property name="text">
               <string>X=0</string>
              </property>
+             <property name="toolTip">
+              <string>Translate the Model so the picked vertex has X = 0.</string>
+             </property>
             </widget>
            </item>
            <item row="1" column="1">
             <widget class="QPushButton" name="modelSetY0">
              <property name="text">
               <string>Y=0</string>
+             </property>
+             <property name="toolTip">
+              <string>Translate the Model so the picked vertex has Y = 0.</string>
              </property>
             </widget>
            </item>
@@ -337,12 +438,18 @@
              <property name="text">
               <string>Z=0</string>
              </property>
+             <property name="toolTip">
+              <string>Translate the Model so the picked vertex has Z = 0.</string>
+             </property>
             </widget>
            </item>
            <item row="2" column="0">
             <widget class="QCheckBox" name="linkStockAndModel">
              <property name="text">
               <string>Link stock and model</string>
+             </property>
+             <property name="toolTip">
+              <string>When checked, Stock follows Model translations and rotations performed in this dialog. Disable to position Stock independently of the Model.</string>
              </property>
             </widget>
            </item>
@@ -510,7 +617,10 @@
         <item>
          <widget class="QGroupBox" name="modelRotateGroup">
           <property name="title">
-           <string>Rotate - XY</string>
+           <string>Rotate around Z</string>
+          </property>
+          <property name="toolTip">
+           <string>Rotate the Model about the Z axis. Use the Compound checkbox to apply rotations cumulatively.</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="0">
@@ -567,6 +677,9 @@
               <widget class="QCheckBox" name="modelRotateCompound">
                <property name="text">
                 <string>Compound</string>
+               </property>
+               <property name="toolTip">
+                <string>When checked, rotations stack: each press rotates by the value above relative to the current orientation. When unchecked, each press resets and rotates from the original orientation.</string>
                </property>
                <property name="checked">
                 <bool>true</bool>
@@ -890,21 +1003,39 @@ Default: &quot;5mm&quot;</string>
           </layout>
          </widget>
         </item>
+        <item>
+         <widget class="QGroupBox" name="machineGroup">
+          <property name="title">
+           <string>Machine</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_machine">
+           <item>
+            <widget class="QComboBox" name="jobMachine">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>Machine for this Job. Pick from machines available in the asset path. Use the New Machine button to create one if your machine isn't listed.</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="jobMachineNew">
+             <property name="text">
+              <string>New Machine</string>
+             </property>
+             <property name="toolTip">
+              <string>Opens the Machine Editor to create a new machine. The new machine will be available for selection once saved.</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
        </layout>
-      </widget>
-      <widget class="QWidget" name="templateExport">
-       <property name="geometry">
-        <rect>
-         <x>0</x>
-         <y>0</y>
-         <width>100</width>
-         <height>30</height>
-        </rect>
-       </property>
-       <attribute name="label">
-        <string>Template export</string>
-       </attribute>
-       <layout class="QVBoxLayout" name="verticalLayout_13"/>
       </widget>
      </widget>
     </item>
@@ -1549,23 +1680,32 @@ If &lt;span style=&quot; font-style:italic;&quot;&gt;order by&lt;/span&gt; is se
     </item>
    </layout>
   </widget>
-  <widget class="QWidget" name="tabOpDefaults">
+  <widget class="QWidget" name="tabAdvanced">
    <attribute name="title">
-    <string>Op Defaults</string>
+    <string>Advanced</string>
    </attribute>
-   <layout class="QVBoxLayout" name="verticalLayout_11">
+   <layout class="QVBoxLayout" name="verticalLayout_advanced">
     <item>
-     <widget class="QComboBox" name="opDefaultOp"/>
+     <widget class="QTabWidget" name="advancedSubTabs">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="tabOpDefaults">
+       <attribute name="title">
+        <string>Operation Defaults</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_11">
+        <item>
+         <widget class="QComboBox" name="opDefaultOp"/>
+        </item>
+       </layout>
+      </widget>
+     </widget>
     </item>
    </layout>
   </widget>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>Gui::InputField</class>
-   <extends>QLineEdit</extends>
-   <header>Gui/InputField.h</header>
-  </customwidget>
   <customwidget>
    <class>Gui::QuantitySpinBox</class>
    <extends>QWidget</extends>

--- a/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PathEdit.ui
@@ -383,7 +383,7 @@
            <string>Origin &amp;&amp; Orientation</string>
           </property>
           <property name="toolTip">
-           <string>Position the Model so a picked edge defines an axis and a picked vertex zeroes the model on that axis. The G54-G59 Fixture is set on the Output tab.</string>
+           <string>Positions the model so a picked edge defines an axis and a picked vertex zeros the model on that axis. The G54-G59 fixture is set on the output tab.</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_5">
            <item row="0" column="0">
@@ -392,7 +392,7 @@
               <string>X-Axis</string>
              </property>
              <property name="toolTip">
-              <string>Rotate the Model so a picked edge becomes the X axis.</string>
+              <string>Rotates the model so a picked edge becomes the X-axis</string>
              </property>
             </widget>
            </item>
@@ -402,7 +402,7 @@
               <string>Y-Axis</string>
              </property>
              <property name="toolTip">
-              <string>Rotate the Model so a picked edge becomes the Y axis.</string>
+              <string>Rotates the model so a picked edge becomes the Y-axis</string>
              </property>
             </widget>
            </item>
@@ -412,7 +412,7 @@
               <string>Z-Axis</string>
              </property>
              <property name="toolTip">
-              <string>Rotate the Model so a picked edge becomes the Z axis.</string>
+              <string>Rotates the model so a picked edge becomes the Z-axis</string>
              </property>
             </widget>
            </item>
@@ -422,7 +422,7 @@
               <string>X=0</string>
              </property>
              <property name="toolTip">
-              <string>Translate the Model so the picked vertex has X = 0.</string>
+              <string>Translates the model so the picked vertex has X = 0</string>
              </property>
             </widget>
            </item>
@@ -432,7 +432,7 @@
               <string>Y=0</string>
              </property>
              <property name="toolTip">
-              <string>Translate the Model so the picked vertex has Y = 0.</string>
+              <string>Translates the model so the picked vertex has Y = 0</string>
              </property>
             </widget>
            </item>
@@ -442,7 +442,7 @@
               <string>Z=0</string>
              </property>
              <property name="toolTip">
-              <string>Translate the Model so the picked vertex has Z = 0.</string>
+              <string>Translates the model so the picked vertex has Z = 0</string>
              </property>
             </widget>
            </item>
@@ -452,7 +452,7 @@
               <string>Link stock and model</string>
              </property>
              <property name="toolTip">
-              <string>When checked, Stock follows Model translations and rotations performed in this dialog. Disable to position Stock independently of the Model.</string>
+              <string>When checked, stock follows model translations and rotations performed in this dialog. When unchecked, stock can be positioned independently of the model.</string>
              </property>
             </widget>
            </item>
@@ -623,7 +623,7 @@
            <string>Rotate around Z</string>
           </property>
           <property name="toolTip">
-           <string>Rotate the Model about the Z axis. Use the Compound checkbox to apply rotations cumulatively.</string>
+           <string>Rotates the model about the Z-axis. When the compound checkbox is enabled, rotations stack cumulatively.</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_6">
            <item row="0" column="0">
@@ -1021,7 +1021,7 @@ Default: &quot;5mm&quot;</string>
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>Machine for this Job. Pick from machines available in the asset path. Use the New Machine button to create one if your machine isn't listed.</string>
+              <string>Machine configuration for this job, drawn from machines available in the asset path. New machines can be added with the New Machine button.</string>
              </property>
             </widget>
            </item>

--- a/src/Mod/CAM/Gui/Resources/preferences/Advanced.ui
+++ b/src/Mod/CAM/Gui/Resources/preferences/Advanced.ui
@@ -59,25 +59,6 @@
        </widget>
       </item>
       <item>
-       <widget class="Gui::PrefCheckBox" name="WarningSuppressVelocity">
-        <property name="toolTip">
-         <string>Suppress warning whenever a path selection mode is activated</string>
-        </property>
-        <property name="text">
-         <string>Suppress feed rate warning</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>WarningSuppressVelocity</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/CAM</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="Gui::PrefCheckBox" name="WarningSuppressSelectionMode">
         <property name="toolTip">
          <string>Suppress warning whenever a path selection mode is activated</string>

--- a/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
+++ b/src/Mod/CAM/Path/Base/Gui/PreferencesAdvanced.py
@@ -47,7 +47,6 @@ class AdvancedPreferencesPage:
             self.form.WarningSuppressRapidSpeeds.isChecked(),
             self.form.WarningSuppressSelectionMode.isChecked(),
             self.form.WarningSuppressOpenCamLib.isChecked(),
-            self.form.WarningSuppressVelocity.isChecked(),
         )
 
     def loadSettings(self):
@@ -63,7 +62,6 @@ class AdvancedPreferencesPage:
             Path.Preferences.advancedOCLFeaturesEnabled()
         )
         self.form.WarningSuppressOpenCamLib.setChecked(Path.Preferences.suppressOpenCamLibWarning())
-        self.form.WarningSuppressVelocity.setChecked(Path.Preferences.suppressVelocity())
         self.updateSelection()
 
     def updateSelection(self, state=None):

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -254,7 +254,7 @@ class ViewProvider:
         self.deleteOnReject = False
 
     def resetTaskPanel(self):
-        self.showOriginAxis(False)
+        self.showOriginAxis(self.vobj.Visibility)
         self.taskPanel = None
 
     def unsetEdit(self, arg1, arg2):
@@ -911,6 +911,13 @@ class TaskPanel:
     def preCleanup(self):
         Path.Log.track()
         FreeCADGui.Selection.removeObserver(self)
+        # Restore natural selectability: model selectable, stock non-selectable
+        stock = self.obj.Stock
+        if stock and stock.ViewObject:
+            stock.ViewObject.Selectable = False
+        for base in self.obj.Model.Group:
+            if base and base.ViewObject:
+                base.ViewObject.Selectable = True
         self.vproxy.resetEditVisibility(self.obj)
         self.vproxy.resetTaskPanel()
 
@@ -1460,15 +1467,17 @@ class TaskPanel:
 
     def togglePickTarget(self, checked):
         """Toggle whether origin/axis picks target the Stock or the Model.
-        When checked, Stock is non-selectable so picks fall through to the Model."""
+        When checked (Picking: Model): model selectable, stock non-selectable.
+        When unchecked (Picking: Stock): stock selectable, model non-selectable."""
         stock = self.obj.Stock
-        if not stock or not stock.ViewObject:
-            return
+        if stock and stock.ViewObject:
+            stock.ViewObject.Selectable = not checked
+        for base in self.obj.Model.Group:
+            if base and base.ViewObject:
+                base.ViewObject.Selectable = checked
         if checked:
-            stock.ViewObject.Selectable = False
             self.form.pickTargetToggle.setText(translate("CAM_Job", "Picking: Model"))
         else:
-            stock.ViewObject.Selectable = True
             self.form.pickTargetToggle.setText(translate("CAM_Job", "Picking: Stock"))
 
     def alignSetOrigin(self):
@@ -1484,6 +1493,7 @@ class TaskPanel:
         placement = FreeCADGui.ActiveDocument.ActiveView.viewPosition()
         placement.Base = placement.Base + by
         FreeCADGui.ActiveDocument.ActiveView.viewPosition(placement, 0)
+        FreeCADGui.Selection.clearSelection()
 
     def alignMoveToOrigin(self):
         selObject = None
@@ -1703,6 +1713,7 @@ class TaskPanel:
             Path.Log.error(str(ee))
         self.updateStockEditor(-1, False)
         self.setFields()
+        FreeCADGui.Selection.clearSelection()
 
         # Info
         self.form.jobLabel.editingFinished.connect(self.getFields)

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -39,6 +39,8 @@ import Path.Main.Stock as PathStock
 import Path.Tool.Gui.Controller as PathToolControllerGui
 import PathScripts.PathUtils as PathUtils
 from Path.Tool.toolbit.ui.selector import ToolBitSelector
+from Machine.models import MachineFactory
+from Machine.ui.editor import MachineEditorDialog
 import math
 import traceback
 from PySide import QtWidgets
@@ -367,10 +369,11 @@ class ViewProvider:
 
 
 class MaterialDialog(QtWidgets.QDialog):
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, current_uuid=None):
         super(MaterialDialog, self).__init__(parent)
 
-        self.setWindowTitle("Assign Material")
+        self.setWindowTitle(translate("CAM_Job", "Assign Stock Material"))
+        self.uuid = current_uuid
 
         self.materialTree = FreeCADGui.UiLoader().createWidget("MatGui::MaterialTreeWidget")
         self.materialTreeWidget = MatGui.MaterialTreeWidget(self.materialTree)
@@ -380,6 +383,12 @@ class MaterialDialog(QtWidgets.QDialog):
         material_filter.RequiredModels = [Materials.UUIDs().Machinability]
         self.materialTreeWidget.setFilter(material_filter)
         self.materialTreeWidget.selectFilter("Machining Materials")
+
+        if current_uuid:
+            try:
+                self.materialTreeWidget.UUID = current_uuid
+            except Exception as e:
+                Path.Log.debug("Could not pre-select material %s: %s" % (current_uuid, e))
 
         # Create OK and Cancel buttons
         self.okButton = QtWidgets.QPushButton("OK")
@@ -454,7 +463,9 @@ class StockEdit(object):
             stock.ViewObject.Proxy.onEdit(_OpenCloseResourceEditor)
 
     def setLengthField(self, widget, prop):
-        widget.setText(FreeCAD.Units.Quantity(prop.Value, FreeCAD.Units.Length).UserString)
+        quantity = FreeCAD.Units.Quantity(prop.Value, FreeCAD.Units.Length)
+        widget.setProperty("unit", quantity.getUserPreferred()[2])
+        widget.setProperty("rawValue", prop.Value)
 
     # the following members must be overwritten by subclasses
     def editorFrame(self):
@@ -487,17 +498,29 @@ class StockFromBaseBoundBoxEdit(StockEdit):
             fields = ["xneg", "xpos", "yneg", "ypos", "zneg", "zpos"]
         try:
             if "xneg" in fields:
-                stock.ExtXneg = FreeCAD.Units.Quantity(self.form.stockExtXneg.text())
+                stock.ExtXneg = FreeCAD.Units.Quantity(
+                    self.form.stockExtXneg.property("rawValue"), FreeCAD.Units.Length
+                )
             if "xpos" in fields:
-                stock.ExtXpos = FreeCAD.Units.Quantity(self.form.stockExtXpos.text())
+                stock.ExtXpos = FreeCAD.Units.Quantity(
+                    self.form.stockExtXpos.property("rawValue"), FreeCAD.Units.Length
+                )
             if "yneg" in fields:
-                stock.ExtYneg = FreeCAD.Units.Quantity(self.form.stockExtYneg.text())
+                stock.ExtYneg = FreeCAD.Units.Quantity(
+                    self.form.stockExtYneg.property("rawValue"), FreeCAD.Units.Length
+                )
             if "ypos" in fields:
-                stock.ExtYpos = FreeCAD.Units.Quantity(self.form.stockExtYpos.text())
+                stock.ExtYpos = FreeCAD.Units.Quantity(
+                    self.form.stockExtYpos.property("rawValue"), FreeCAD.Units.Length
+                )
             if "zneg" in fields:
-                stock.ExtZneg = FreeCAD.Units.Quantity(self.form.stockExtZneg.text())
+                stock.ExtZneg = FreeCAD.Units.Quantity(
+                    self.form.stockExtZneg.property("rawValue"), FreeCAD.Units.Length
+                )
             if "zpos" in fields:
-                stock.ExtZpos = FreeCAD.Units.Quantity(self.form.stockExtZpos.text())
+                stock.ExtZpos = FreeCAD.Units.Quantity(
+                    self.form.stockExtZpos.property("rawValue"), FreeCAD.Units.Length
+                )
         except Exception:
             pass
 
@@ -542,35 +565,47 @@ class StockFromBaseBoundBoxEdit(StockEdit):
             self.form.linkStockAndModel.setChecked(False)
 
     def checkXpos(self):
-        self.trackXpos = self.form.stockExtXneg.text() == self.form.stockExtXpos.text()
+        self.trackXpos = self.form.stockExtXneg.property(
+            "rawValue"
+        ) == self.form.stockExtXpos.property("rawValue")
         self.getFields(self.obj, ["xpos"])
 
     def checkYpos(self):
-        self.trackYpos = self.form.stockExtYneg.text() == self.form.stockExtYpos.text()
+        self.trackYpos = self.form.stockExtYneg.property(
+            "rawValue"
+        ) == self.form.stockExtYpos.property("rawValue")
         self.getFields(self.obj, ["ypos"])
 
     def checkZpos(self):
-        self.trackZpos = self.form.stockExtZneg.text() == self.form.stockExtZpos.text()
+        self.trackZpos = self.form.stockExtZneg.property(
+            "rawValue"
+        ) == self.form.stockExtZpos.property("rawValue")
         self.getFields(self.obj, ["zpos"])
 
     def updateXpos(self):
         fields = ["xneg"]
         if self.trackXpos:
-            self.form.stockExtXpos.setText(self.form.stockExtXneg.text())
+            self.form.stockExtXpos.setProperty(
+                "rawValue", self.form.stockExtXneg.property("rawValue")
+            )
             fields.append("xpos")
         self.getFields(self.obj, fields)
 
     def updateYpos(self):
         fields = ["yneg"]
         if self.trackYpos:
-            self.form.stockExtYpos.setText(self.form.stockExtYneg.text())
+            self.form.stockExtYpos.setProperty(
+                "rawValue", self.form.stockExtYneg.property("rawValue")
+            )
             fields.append("ypos")
         self.getFields(self.obj, fields)
 
     def updateZpos(self):
         fields = ["zneg"]
         if self.trackZpos:
-            self.form.stockExtZpos.setText(self.form.stockExtZneg.text())
+            self.form.stockExtZpos.setProperty(
+                "rawValue", self.form.stockExtZneg.property("rawValue")
+            )
             fields.append("zpos")
         self.getFields(self.obj, fields)
 
@@ -588,11 +623,17 @@ class StockCreateBoxEdit(StockEdit):
         try:
             if self.IsStock(obj):
                 if "length" in fields:
-                    obj.Stock.Length = FreeCAD.Units.Quantity(self.form.stockBoxLength.text())
+                    obj.Stock.Length = FreeCAD.Units.Quantity(
+                        self.form.stockBoxLength.property("rawValue"), FreeCAD.Units.Length
+                    )
                 if "width" in fields:
-                    obj.Stock.Width = FreeCAD.Units.Quantity(self.form.stockBoxWidth.text())
+                    obj.Stock.Width = FreeCAD.Units.Quantity(
+                        self.form.stockBoxWidth.property("rawValue"), FreeCAD.Units.Length
+                    )
                 if "height" in fields:
-                    obj.Stock.Height = FreeCAD.Units.Quantity(self.form.stockBoxHeight.text())
+                    obj.Stock.Height = FreeCAD.Units.Quantity(
+                        self.form.stockBoxHeight.property("rawValue"), FreeCAD.Units.Length
+                    )
             else:
                 Path.Log.error("Stock not a box!")
         except Exception:
@@ -626,9 +667,13 @@ class StockCreateCylinderEdit(StockEdit):
         try:
             if self.IsStock(obj):
                 if "radius" in fields:
-                    obj.Stock.Radius = FreeCAD.Units.Quantity(self.form.stockCylinderRadius.text())
+                    obj.Stock.Radius = FreeCAD.Units.Quantity(
+                        self.form.stockCylinderRadius.property("rawValue"), FreeCAD.Units.Length
+                    )
                 if "height" in fields:
-                    obj.Stock.Height = FreeCAD.Units.Quantity(self.form.stockCylinderHeight.text())
+                    obj.Stock.Height = FreeCAD.Units.Quantity(
+                        self.form.stockCylinderHeight.property("rawValue"), FreeCAD.Units.Length
+                    )
             else:
                 Path.Log.error(translate("CAM_Job", "Stock not a cylinder!"))
         except Exception:
@@ -751,7 +796,6 @@ class TaskPanel:
         self.obj = vobj.Object
         self.deleteOnReject = deleteOnReject
         self.form = FreeCADGui.PySideUic.loadUi(":/panels/PathEdit.ui")
-        self.template = PathJobDlg.JobTemplateExport(self.obj, self.form.jobBox.widget(1))
         self.name = self.obj.Name
 
         vUnit = FreeCAD.Units.Quantity(1, FreeCAD.Units.Velocity).getUserPreferred()[2]
@@ -823,18 +867,44 @@ class TaskPanel:
             for text, data in enumTups[prop]:  #  load enumerations
                 box.addItem(text, data)
 
+    def _currentStockMaterial(self):
+        """Return the (uuid, name) of the stock's currently assigned material,
+        or (None, None) if nothing is assigned."""
+        stock = getattr(self.obj, "Stock", None)
+        if stock is None:
+            return (None, None)
+        mat = getattr(stock, "ShapeMaterial", None)
+        if mat is None:
+            return (None, None)
+        name = getattr(mat, "Name", "") or ""
+        if name in ("", "Default"):
+            return (None, None)
+        return (getattr(mat, "UUID", None), name)
+
+    def updateMaterialLabel(self):
+        """Refresh the material label next to btnMaterial to reflect the
+        currently assigned stock material."""
+        label = getattr(self.form, "materialLabel", None)
+        if label is None:
+            return
+        _, name = self._currentStockMaterial()
+        if name:
+            label.setText(name)
+            label.setStyleSheet("")
+        else:
+            label.setText(translate("CAM_Job", "(none assigned)"))
+            label.setStyleSheet("color: gray; font-style: italic;")
+
     def assignMaterial(self):
-        dialog = MaterialDialog()
+        current_uuid, _ = self._currentStockMaterial()
+        dialog = MaterialDialog(current_uuid=current_uuid)
         result = dialog.exec_()
 
-        if result == QtWidgets.QDialog.Accepted:
-            FreeCAD.Console.PrintMessage("Material assigned\n")
-            # Add code to handle the material assignment
-
-            if dialog.uuid is not None:
-                material_manager = Materials.MaterialManager()
-                material = material_manager.getMaterial(dialog.uuid)
-                self.obj.Stock.ShapeMaterial = material
+        if result == QtWidgets.QDialog.Accepted and dialog.uuid is not None:
+            material_manager = Materials.MaterialManager()
+            material = material_manager.getMaterial(dialog.uuid)
+            self.obj.Stock.ShapeMaterial = material
+            self.updateMaterialLabel()
 
     def preCleanup(self):
         Path.Log.track()
@@ -1060,6 +1130,7 @@ class TaskPanel:
         self.stockEdit.setFields(self.obj)
         self.setupGlobal.setFields()
         self.setupOps.setFields()
+        self.populateMachineCombo()
 
     def setPostProcessorOutputFile(self):
         filename = QtGui.QFileDialog.getSaveFileName(
@@ -1221,8 +1292,6 @@ class TaskPanel:
                 pass
             item.setText("%g" % getattr(tc, prop).Value)
 
-        self.template.updateUI()
-
     def modelSetAxis(self, axis):
         Path.Log.track(axis)
 
@@ -1347,6 +1416,59 @@ class TaskPanel:
                 for sel in selection:
                     Draft.rotate(sel.Object, angle, sel.Object.Shape.BoundBox.Center, axis)
 
+    def populateMachineCombo(self):
+        """Populate jobMachine combo from MachineFactory and select current Job.Machine."""
+        combo = self.form.jobMachine
+        combo.blockSignals(True)
+        combo.clear()
+        try:
+            entries = MachineFactory.list_configuration_files()
+        except Exception as e:
+            Path.Log.warning("Failed to list machines: %s" % e)
+            entries = [("<none>", None)]
+        for display, filename in entries:
+            combo.addItem(display, filename or "")
+        current = getattr(self.obj, "Machine", "") or ""
+        idx = combo.findData(current)
+        if idx < 0:
+            idx = 0
+        combo.setCurrentIndex(idx)
+        combo.blockSignals(False)
+
+    def machineChanged(self):
+        """Write the selected machine filename back to Job.Machine."""
+        if not hasattr(self.obj, "Machine"):
+            return
+        data = self.form.jobMachine.currentData()
+        self.obj.Machine = data if data else ""
+
+    def newMachine(self):
+        """Open the Machine Editor to create a new machine, then refresh the combo."""
+        try:
+            editor = MachineEditorDialog()
+            if editor.exec_() == QtWidgets.QDialog.Accepted:
+                new_filename = getattr(editor, "filename", None)
+                self.populateMachineCombo()
+                if new_filename:
+                    idx = self.form.jobMachine.findData(new_filename)
+                    if idx >= 0:
+                        self.form.jobMachine.setCurrentIndex(idx)
+        except Exception as e:
+            Path.Log.error("Failed to open Machine Editor: %s" % e)
+
+    def togglePickTarget(self, checked):
+        """Toggle whether origin/axis picks target the Stock or the Model.
+        When checked, Stock is non-selectable so picks fall through to the Model."""
+        stock = self.obj.Stock
+        if not stock or not stock.ViewObject:
+            return
+        if checked:
+            stock.ViewObject.Selectable = False
+            self.form.pickTargetToggle.setText(translate("CAM_Job", "Picking: Model"))
+        else:
+            stock.ViewObject.Selectable = True
+            self.form.pickTargetToggle.setText(translate("CAM_Job", "Picking: Stock"))
+
     def alignSetOrigin(self):
         obj, by = self.alignMoveToOrigin()
 
@@ -1443,9 +1565,6 @@ class TaskPanel:
                     % (self.form.stock.currentText(), index)
                 )
         self.stockEdit.activate(self.obj, index == -1)
-
-        if -1 != index:
-            self.template.updateUI()
 
     def refreshStock(self):
         self.updateStockEditor(self.form.stock.currentIndex(), True)
@@ -1569,12 +1688,10 @@ class TaskPanel:
 
     def tabPageChanged(self, index):
         if index == 0:
-            # update the template with potential changes
             self.getFields()
             self.setupGlobal.accept()
             self.setupOps.accept()
             self.obj.Document.recompute()
-            self.template.updateUI()
 
     def setupUi(self, activate):
         self.setupGlobal.setupUi()
@@ -1588,6 +1705,10 @@ class TaskPanel:
         # Info
         self.form.jobLabel.editingFinished.connect(self.getFields)
         self.form.jobModelEdit.clicked.connect(self.jobModelEdit)
+
+        # Machine
+        self.form.jobMachine.currentIndexChanged.connect(self.machineChanged)
+        self.form.jobMachineNew.clicked.connect(self.newMachine)
 
         # Post Processor
         self.form.postProcessor.currentIndexChanged.connect(self.getFields)
@@ -1617,6 +1738,7 @@ class TaskPanel:
 
         # Stock, Orientation and Alignment
         self.form.btnMaterial.clicked.connect(self.assignMaterial)
+        self.updateMaterialLabel()
         self.form.centerInStock.clicked.connect(self.alignCenterInStock)
         self.form.centerInStockXY.clicked.connect(self.alignCenterInStockXY)
 
@@ -1632,6 +1754,7 @@ class TaskPanel:
 
         self.form.setOrigin.clicked.connect(self.alignSetOrigin)
         self.form.moveToOrigin.clicked.connect(self.alignMoveToOrigin)
+        self.form.pickTargetToggle.toggled.connect(self.togglePickTarget)
 
         self.form.modelMoveLeftUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 1, 0)))
         self.form.modelMoveLeft.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 0, 0)))
@@ -1668,11 +1791,6 @@ class TaskPanel:
             self.form.setCurrentIndex(4)
 
         self.form.currentChanged.connect(self.tabPageChanged)
-        self.template.exportButton().clicked.connect(self.templateExport)
-
-    def templateExport(self):
-        self.getFields()
-        PathJobCmd.CommandJobTemplateExport.SaveDialog(self.obj, self.template)
 
     def open(self):
         FreeCADGui.Selection.addObserver(self)

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -459,6 +459,7 @@ class StockEdit(object):
             obj.Document.removeObject(obj.Stock.Name)
         Path.Log.track(stock.Name)
         obj.Stock = stock
+        PathStock.ApplyStockViewDefaults(stock)
         if stock.ViewObject and stock.ViewObject.Proxy:
             stock.ViewObject.Proxy.onEdit(_OpenCloseResourceEditor)
 
@@ -904,6 +905,7 @@ class TaskPanel:
             material_manager = Materials.MaterialManager()
             material = material_manager.getMaterial(dialog.uuid)
             self.obj.Stock.ShapeMaterial = material
+            PathStock.ApplyStockViewDefaults(self.obj.Stock)
             self.updateMaterialLabel()
 
     def preCleanup(self):

--- a/src/Mod/CAM/Path/Main/Gui/Job.py
+++ b/src/Mod/CAM/Path/Main/Gui/Job.py
@@ -1757,6 +1757,7 @@ class TaskPanel:
         self.form.setOrigin.clicked.connect(self.alignSetOrigin)
         self.form.moveToOrigin.clicked.connect(self.alignMoveToOrigin)
         self.form.pickTargetToggle.toggled.connect(self.togglePickTarget)
+        self.togglePickTarget(self.form.pickTargetToggle.isChecked())
 
         self.form.modelMoveLeftUp.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 1, 0)))
         self.form.modelMoveLeft.clicked.connect(lambda: self.modelMove(FreeCAD.Vector(-1, 0, 0)))

--- a/src/Mod/CAM/Path/Main/Gui/JobCmd.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobCmd.py
@@ -148,6 +148,14 @@ class CommandJobTemplateExport:
     def Execute(cls, job, path, dialog=None):
         attrs = job.Proxy.templateAttrs(job)
 
+        # description: override (or remove) using the dialog's edited value
+        if dialog:
+            desc = dialog.description()
+            if desc:
+                attrs[PathJob.JobTemplate.Description] = desc
+            else:
+                attrs.pop(PathJob.JobTemplate.Description, None)
+
         # post processor settings
         if dialog and not dialog.includePostProcessing():
             attrs.pop(PathJob.JobTemplate.PostProcessor, None)

--- a/src/Mod/CAM/Path/Main/Gui/JobDlg.py
+++ b/src/Mod/CAM/Path/Main/Gui/JobDlg.py
@@ -30,6 +30,7 @@ import Path.Base.Util as PathUtil
 import Path.Main.Job as PathJob
 import Path.Main.Stock as PathStock
 import glob
+import json
 import os
 
 translate = FreeCAD.Qt.translate
@@ -57,8 +58,6 @@ class JobCreate:
     DataObject = QtCore.Qt.ItemDataRole.UserRole
 
     def __init__(self, parent=None, sel=None):
-        self._warnUserIfNotUsingMinutes()
-
         self.dialog = FreeCADGui.PySideUic.loadUi(":/panels/DlgJobCreate.ui")
         self.itemsSolid = QtGui.QStandardItem(translate("CAM_Job", "Solids"))
         self.items2D = QtGui.QStandardItem(translate("CAM_Job", "2D"))
@@ -72,188 +71,122 @@ class JobCreate:
         self.index = None
         self.model = None
 
-    def _getMinuteBasedSchemas(self):
-        """Dynamically discover which unit schemas support velocity in minutes."""
-        internal_names = FreeCAD.Units.listSchemas()
-        minute_based_schemes = []
+        self._setupUnitSchema()
 
-        # Create a test velocity quantity
-        q = FreeCAD.Units.Quantity(1, FreeCAD.Units.Velocity)
-
-        for i, key in enumerate(internal_names):
-            try:
-                label = FreeCAD.Units.listSchemas(i)
-                r = FreeCAD.Units.schemaTranslate(q, i)
-                if "/min" in r[2]:
-                    minute_based_schemes.append({"id": i, "label": label})
-            except (IndexError, TypeError):
-                # Skip invalid schema indices
-                continue
-
-        return minute_based_schemes
-
-    def _currentSchemaUsesMinutes(self):
-        """Test if the current unit schema uses minutes for velocity."""
+    def _schemaUsesMinutes(self, schema_id):
+        """Return True if the given unit schema expresses velocity in /min."""
         try:
-            # Create a test velocity quantity
             q = FreeCAD.Units.Quantity(1, FreeCAD.Units.Velocity)
-
-            # Get current schema's representation of velocity
-            current_representation = q.getUserPreferred()[2]
-
-            # Check if the current representation contains '/min'
-            return "/min" in current_representation
-        except Exception:
-            # If we can't determine, assume it doesn't use minutes
+            r = FreeCAD.Units.schemaTranslate(q, schema_id)
+            return "/min" in r[2]
+        except (IndexError, TypeError):
             return False
 
-    def _warnUserIfNotUsingMinutes(self):
-        # Warn user if current schema doesn't use minute for time in velocity
-        if Path.Preferences.suppressVelocity():
-            return
+    # Colors for the unit-schema combobox: green = minute-based (safe);
+    # red = per-second (unsafe).
+    _SCHEMA_SAFE_BG = QtGui.QColor(76, 175, 80)
+    _SCHEMA_SAFE_FG = QtGui.QColor(0, 0, 0)
+    _SCHEMA_UNSAFE_BG = QtGui.QColor(192, 57, 43)
+    _SCHEMA_UNSAFE_FG = QtGui.QColor(255, 255, 255)
 
-        # Test if current schema uses minutes for velocity
-        if self._currentSchemaUsesMinutes():
-            return
+    class _ColoredComboDelegate(QtGui.QStyledItemDelegate):
+        """Combobox item delegate that explicitly fills each row from the
+        model's BackgroundRole brush. The native popup style ignores
+        BackgroundRole; this delegate paints it before the text."""
 
-        # Get all minute-based schemas for the dialog
-        minute_based_schemes = self._getMinuteBasedSchemas()
+        def paint(self, painter, option, index):
+            bg = index.data(QtCore.Qt.BackgroundRole)
+            if bg is not None:
+                if not isinstance(bg, QtGui.QBrush):
+                    bg = QtGui.QBrush(bg)
+                painter.save()
+                painter.fillRect(option.rect, bg)
+                painter.restore()
+            super().paint(painter, option, index)
 
-        # Create custom dialog with unit schema selection
-        dialog = QtGui.QDialog()
-        dialog.setWindowTitle(translate("CAM_Job", "Warning: Incompatible Unit Schema"))
-        dialog.setModal(True)
-        dialog.resize(500, 400)
+    def _setupUnitSchema(self):
+        """Populate the unit-schema combobox in the create dialog.
 
-        layout = QtGui.QVBoxLayout(dialog)
-
-        # Warning message
-        warning_label = QtGui.QLabel()
-        warning_label.setText(
-            translate(
-                "CAM_Job",
-                "<b>This document uses an improper unit schema which can result in "
-                "dangerous situations and machine crashes!</b>",
-            )
-        )
-        warning_label.setWordWrap(True)
-        warning_label.setStyleSheet("color: red; font-weight: bold; margin-bottom: 10px;")
-        layout.addWidget(warning_label)
-
-        # Current schema info
-        current_info = QtGui.QLabel()
-        current_info.setText(
-            translate(
-                "CAM_Job",
-                "Current unit schema '{}' expresses velocity in values <i>per second</i>.",
-            ).format(FreeCAD.ActiveDocument.UnitSystem)
-        )
-        current_info.setWordWrap(True)
-        layout.addWidget(current_info)
-
-        # Recommendation
-        recommendation = QtGui.QLabel()
-        recommendation.setText(
-            translate(
-                "CAM_Job",
-                "Please select a unit schema that expresses feed rates <i>per minute</i> instead:",
-            )
-        )
-        recommendation.setWordWrap(True)
-        layout.addWidget(recommendation)
-
-        # Unit schema selection
-        schema_group = QtGui.QGroupBox(translate("CAM_Job", "Recommended Unit Schemas"))
-        schema_layout = QtGui.QVBoxLayout(schema_group)
-
-        self.schema_buttons = []
-        for i, schema in enumerate(minute_based_schemes):
-            radio = QtGui.QRadioButton(schema["label"])
-            radio.setProperty("schema_id", schema["id"])  # Store the schema ID
-            if i == 0:  # Select first (most preferred) by default
-                radio.setChecked(True)
-            self.schema_buttons.append(radio)
-            schema_layout.addWidget(radio)
-
-        layout.addWidget(schema_group)
-
-        # Additional info
-        info_label = QtGui.QLabel()
-        info_label.setText(
-            translate(
-                "CAM_Job",
-                "Keeping the current unit schema can result in dangerous G-code errors. "
-                "For details please refer to the "
-                "<a href='https://wiki.freecad.org/CAM_Workbench#Units'>Units section</a> "
-                "of the CAM Workbench's wiki page.",
-            )
-        )
-        info_label.setWordWrap(True)
-        info_label.setOpenExternalLinks(True)
-        layout.addWidget(info_label)
-
-        # Buttons
-        button_layout = QtGui.QHBoxLayout()
-
-        change_button = QtGui.QPushButton(translate("CAM_Job", "Change Unit Schema"))
-        change_button.setDefault(True)
-        change_button.clicked.connect(lambda: self._applyUnitSchema(dialog))
-
-        keep_button = QtGui.QPushButton(translate("CAM_Job", "Keep Current Schema"))
-        keep_button.clicked.connect(dialog.reject)
-
-        dont_show_button = QtGui.QPushButton(translate("CAM_Job", "Don't Show Again"))
-        dont_show_button.clicked.connect(lambda: self._suppressWarning(dialog))
-
-        button_layout.addWidget(change_button)
-        button_layout.addWidget(keep_button)
-        button_layout.addWidget(dont_show_button)
-
-        layout.addLayout(button_layout)
-
-        dialog.exec_()
-
-    def _applyUnitSchema(self, dialog):
-        """Apply the selected unit schema to the document."""
-        selected_schema_id = None
-        selected_schema_label = None
-        for button in self.schema_buttons:
-            if button.isChecked():
-                selected_schema_id = button.property("schema_id")
-                selected_schema_label = button.text()
-                break
-
-        if selected_schema_id is not None:
+        Lists every schema returned by FreeCAD.Units.listSchemas(). Minute-based
+        schemas are shown black-on-green (safe); per-second schemas are shown
+        white-on-red (unsafe). The closed combobox restyles itself on selection
+        change so the displayed item matches its dropdown coloring. The selected
+        schema is applied only if the user clicks OK (see exec_)."""
+        keys = FreeCAD.Units.listSchemas()
+        labels = []
+        for i in range(len(keys)):
             try:
-                FreeCAD.ActiveDocument.UnitSystem = selected_schema_id
-                FreeCAD.ActiveDocument.recompute()
+                labels.append(FreeCAD.Units.listSchemas(i))
+            except (IndexError, TypeError):
+                labels.append(keys[i])
 
-                # Show success message
-                QtGui.QMessageBox.information(
-                    dialog,
-                    translate("CAM_Job", "Unit Schema Changed"),
-                    translate("CAM_Job", "Unit schema successfully changed to '{}'.").format(
-                        selected_schema_label
-                    ),
+        current_label = FreeCAD.ActiveDocument.UnitSystem if FreeCAD.ActiveDocument else labels[0]
+
+        combo = self.dialog.unitSchemaCombo
+        # Force a custom delegate that explicitly paints BackgroundRole on every
+        # dropdown row (the native style ignores model background brushes).
+        combo.setItemDelegate(self._ColoredComboDelegate(combo))
+        combo.clear()
+        for i, label in enumerate(labels):
+            uses_minutes = self._schemaUsesMinutes(i)
+            combo.addItem(label, label)
+            if uses_minutes:
+                bg, fg = self._SCHEMA_SAFE_BG, self._SCHEMA_SAFE_FG
+                tip = translate("CAM_Job", "Velocity expressed per minute (recommended for G-code)")
+            else:
+                bg, fg = self._SCHEMA_UNSAFE_BG, self._SCHEMA_UNSAFE_FG
+                tip = translate(
+                    "CAM_Job",
+                    "Velocity expressed per second. Unsafe for G-code feed rates.",
                 )
-                dialog.accept()
-            except Exception as e:
-                QtGui.QMessageBox.critical(
-                    dialog,
-                    translate("CAM_Job", "Error"),
-                    translate("CAM_Job", "Failed to change unit schema: {}").format(str(e)),
-                )
+            row = combo.count() - 1
+            combo.setItemData(row, QtGui.QBrush(bg), QtCore.Qt.BackgroundRole)
+            combo.setItemData(row, QtGui.QBrush(fg), QtCore.Qt.ForegroundRole)
+            combo.setItemData(row, tip, QtCore.Qt.ToolTipRole)
+
+        # Default selection: the document's current schema, by label match.
+        idx = combo.findData(current_label)
+        if idx < 0:
+            for i in range(len(labels)):
+                if self._schemaUsesMinutes(i):
+                    idx = i
+                    break
+        if idx < 0:
+            idx = 0
+        combo.setCurrentIndex(idx)
+
+        combo.currentIndexChanged.connect(self._updateUnitSchemaStatus)
+        self._updateUnitSchemaStatus()
+
+    def _updateUnitSchemaStatus(self):
+        """Restyle the closed combobox to match the selected item's colors."""
+        combo = self.dialog.unitSchemaCombo
+        idx = combo.currentIndex()
+        if idx < 0:
+            combo.setStyleSheet("")
+            return
+        if self._schemaUsesMinutes(idx):
+            bg, fg = self._SCHEMA_SAFE_BG, self._SCHEMA_SAFE_FG
         else:
-            QtGui.QMessageBox.warning(
-                dialog,
-                translate("CAM_Job", "No Selection"),
-                translate("CAM_Job", "Please select a unit schema."),
-            )
+            bg, fg = self._SCHEMA_UNSAFE_BG, self._SCHEMA_UNSAFE_FG
+        combo.setStyleSheet(
+            "QComboBox { background-color: %s; color: %s; }" % (bg.name(), fg.name())
+        )
 
-    def _suppressWarning(self, dialog):
-        """Suppress future warnings and close dialog."""
-        Path.Preferences.preferences().SetBool(Path.Preferences.WarningSuppressVelocity, True)
-        dialog.reject()
+    def _applySelectedSchema(self):
+        """Apply the selected unit schema to the active document. Called on OK."""
+        if not FreeCAD.ActiveDocument:
+            return
+        label = self.dialog.unitSchemaCombo.currentData()
+        if not label:
+            return
+        if FreeCAD.ActiveDocument.UnitSystem == label:
+            return
+        try:
+            FreeCAD.ActiveDocument.UnitSystem = label
+            FreeCAD.ActiveDocument.recompute()
+        except Exception as e:
+            Path.Log.warning("Failed to set unit schema: %s" % e)
 
     def setupTitle(self, title):
         self.dialog.setWindowTitle(title)
@@ -407,6 +340,31 @@ class JobCreate:
         self.index = index
         editor.valueChanged.connect(self.item1ValueChanged)
 
+    def _loadTemplateDescription(self, filepath, name):
+        """Return a tooltip-ready description for a job template.
+
+        Reads the canonical PathJob.JobTemplate.Description key ('Desc') from
+        the JSON. If absent or empty, falls back to a synthesized description
+        of the form '<name> (YYYY-MM-DD)' using the file's modification time."""
+        if not filepath:
+            return ""
+        try:
+            with open(filepath, "r") as fp:
+                data = json.load(fp)
+            desc = data.get(PathJob.JobTemplate.Description, "") or ""
+        except Exception:
+            desc = ""
+        if desc:
+            return desc
+        try:
+            import datetime
+
+            mtime = os.path.getmtime(filepath)
+            stamp = datetime.date.fromtimestamp(mtime).isoformat()
+            return "%s (%s)" % (name, stamp)
+        except Exception:
+            return name
+
     def setupTemplate(self):
         templateFiles = []
         for path in Path.Preferences.searchPaths():
@@ -433,11 +391,17 @@ class JobCreate:
             template[name] = tFile
 
         index = 0
-        self.dialog.jobTemplate.addItem(translate("CAM_Job", "<none>"), "")
+        none_label = translate("CAM_Job", "(none)")
+        self.dialog.jobTemplate.addItem(none_label, "")
+        self.dialog.jobTemplate.setItemData(0, "", QtCore.Qt.ToolTipRole)
         for name in sorted(template):
             if template[name] == selectTemplate:
                 index = self.dialog.jobTemplate.count()
             self.dialog.jobTemplate.addItem(name, template[name])
+            tooltip = self._loadTemplateDescription(template[name], name)
+            self.dialog.jobTemplate.setItemData(
+                self.dialog.jobTemplate.count() - 1, tooltip, QtCore.Qt.ToolTipRole
+            )
         self.dialog.jobTemplate.setCurrentIndex(index)
         self.dialog.templateGroup.show()
 
@@ -478,6 +442,8 @@ class JobCreate:
         self.model.dataChanged.connect(self.updateData)
         rc = self.dialog.exec_()
         self.model.dataChanged.disconnect()
+        if rc == 1:
+            self._applySelectedSchema()
         return rc
 
 
@@ -501,6 +467,11 @@ class JobTemplateExport:
 
     def updateUI(self):
         job = self.job
+        # Description: pre-fill from the Job's own Description field. Editing
+        # this field overrides only what gets written to the template; the
+        # running Job's Description is untouched until the user edits it on
+        # the General tab.
+        self.dialog.templateDescriptionEdit.setPlainText(getattr(job, "Description", "") or "")
         if job.PostProcessor:
             ppHint = "%s %s %s" % (
                 job.PostProcessor,
@@ -584,6 +555,10 @@ class JobTemplateExport:
         )
         for i in range(self.dialog.toolsList.count()):
             self.dialog.toolsList.item(i).setCheckState(state)
+
+    def description(self):
+        """Return the (possibly edited) description to write to the template."""
+        return self.dialog.templateDescriptionEdit.toPlainText().strip()
 
     def includePostProcessing(self):
         return self.dialog.postProcessingGroup.isChecked()

--- a/src/Mod/CAM/Path/Main/Job.py
+++ b/src/Mod/CAM/Path/Main/Job.py
@@ -87,7 +87,11 @@ def createResourceClone(obj, orig, name, icon):
 
         Path.Base.Gui.IconViewProvider.Attach(clone.ViewObject, icon)
         clone.ViewObject.Visibility = False
-        clone.ViewObject.Transparency = 80
+        clone.ViewObject.DisplayMode = "Flat Lines"
+        clone.ViewObject.ShapeColor = (0.447, 0.475, 0.502)
+        clone.ViewObject.Transparency = 0
+        clone.ViewObject.LineColor = (0.310, 0.333, 0.357)
+        clone.ViewObject.ShapeMaterial.Shininess = 0.85
     obj.Document.recompute()  # necessary to create the clone shape
     return clone
 
@@ -391,8 +395,9 @@ class ObjectJob:
                 obj.Stock = PathStock.CreateFromTemplate(obj, json.loads(stockTemplate))
             if not obj.Stock:
                 obj.Stock = PathStock.CreateFromBase(obj)
-        if obj.Stock.ViewObject:
-            obj.Stock.ViewObject.Visibility = False
+        PathStock.ApplyStockViewDefaults(obj.Stock)
+        if obj.Stock and obj.Stock.ViewObject:
+            obj.Stock.ViewObject.Visibility = True
 
     def removeBase(self, obj, base, removeFromModel):
         if isResourceClone(obj, base, None):

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -607,4 +607,18 @@ def CreateFromTemplate(job, template):
         return None
 
 
+def ApplyStockViewDefaults(stock):
+    """Apply default appearance settings to a stock object's ViewObject."""
+    if stock and stock.ViewObject:
+        stock.ViewObject.ShapeColor = (0.792, 0.718, 0.537)
+        stock.ViewObject.Transparency = 85
+        stock.ViewObject.LineColor = (0.553, 0.502, 0.376)
+        stock.ViewObject.PointColor = (0.553, 0.502, 0.376)
+        stock.ViewObject.DrawStyle = "Dotted"
+        stock.ViewObject.DisplayMode = "Flat Lines"
+        stock.ViewObject.PointSize = 1
+        stock.ViewObject.LineWidth = 1
+        stock.ViewObject.Selectable = False
+
+
 FreeCAD.Console.PrintLog("Loading PathStock... done\n")

--- a/src/Mod/CAM/Path/Preferences.py
+++ b/src/Mod/CAM/Path/Preferences.py
@@ -66,7 +66,6 @@ WarningSuppressRapidSpeeds = "WarningSuppressRapidSpeeds"
 WarningSuppressAllSpeeds = "WarningSuppressAllSpeeds"
 WarningSuppressSelectionMode = "WarningSuppressSelectionMode"
 WarningSuppressOpenCamLib = "WarningSuppressOpenCamLib"
-WarningSuppressVelocity = "WarningSuppressVelocity"
 EnableExperimentalFeatures = "EnableExperimentalFeatures"
 EnableAdvancedOCLFeatures = "EnableAdvancedOCLFeatures"
 
@@ -561,14 +560,9 @@ def suppressOpenCamLibWarning():
     return preferences().GetBool(WarningSuppressOpenCamLib, True)
 
 
-def suppressVelocity():
-    return preferences().GetBool(WarningSuppressVelocity, False)
-
-
-def setPreferencesAdvanced(ocl, warnSpeeds, warnRapids, warnModes, warnOCL, warnVelocity):
+def setPreferencesAdvanced(ocl, warnSpeeds, warnRapids, warnModes, warnOCL):
     preferences().SetBool(EnableAdvancedOCLFeatures, ocl)
     preferences().SetBool(WarningSuppressAllSpeeds, warnSpeeds)
     preferences().SetBool(WarningSuppressRapidSpeeds, warnRapids)
     preferences().SetBool(WarningSuppressSelectionMode, warnModes)
     preferences().SetBool(WarningSuppressOpenCamLib, warnOCL)
-    preferences().SetBool(WarningSuppressVelocity, warnVelocity)


### PR DESCRIPTION
Changes

Unit schema selector folded into the New Job dialog — replaces the old separate modal "Warning: Incompatible Unit Schema" with an inline Document Units group bottom-right of the create
  dialog. All schemas listed; minute-based (safe) shown black-on-green, per-second (unsafe) shown white-on-red, in both the closed combobox and the dropdown. Selection applies to the
  document only on OK. The WarningSuppressVelocity preference and its Advanced-prefs checkbox are removed.
  
  
<img width="1027" height="587" alt="image" src="https://github.com/user-attachments/assets/c467cbd9-853e-488c-adf5-1cdf76df4a66" />

  

 Template description.
 Added a template description to the json.  Added an input so the user can give templates a description. 
 
<img width="973" height="1005" alt="image" src="https://github.com/user-attachments/assets/a52184c1-1539-4c09-8ae1-986eb24b5baa" />

 Display the template description in the tooltip when selecting. Backwards compatible.  Missing description is derived from template name and creation date.
 
 Machine selector on the General tab — combobox sourced from MachineFactory.list_configuration_files() reads/writes the existing Job.Machine string property. 
 
 Also adds a button to allow creating a New Machine directly without visiting preference->Cam Assets
 Launches MachineEditorDialog inline; on accept the combo refreshes and pre-selects the new machine. No friction trip to preferences to create a machine first.
 
 
<img width="726" height="974" alt="image" src="https://github.com/user-attachments/assets/6a43257d-aeb8-4f09-82b1-39d51c451f8d" />

 
 Stock numeric inputs (1) are now unit-aware (Gui::InputField → Gui::QuantitySpinBox for all 11 stock fields: Ext.X/Y/Z neg/pos, box L/W/H, cylinder R/H). Unitless input now respects the document unit schema. Closes #24419.
 
 "Set" group renamed to "Origin & Orientation" (2) with a tooltip explaining the group's actual scope (Model placement; Fixture remains on the Output tab). Closes #26373.
 
 "Rotate - XY" renamed to "Rotate around Z"  (3) to match actual behavior. Closes #26374. (Real X/Y rotation, #26337, deferred to the kinematics track.)
 
 Pick-target toggle button (4) in the Alignment group — single push-button labeled "Picking: Stock" / "Picking: Model" toggles Stock.ViewObject.Selectable so the user can pick vertices on the underlying Model when Stock and Model overlap. Closes #20620 and #24420.  This will be more useful when the improved stock visualization PR (#29841) merges. 
 

"Op Defaults" tab renamed to "Advanced", (5)  with the original Op Defaults editor reorganized as a sub-tab inside it. Sets up future expansion (additional advanced concerns become sibling sub-tabs) without enlarging the top-level tab bar.

<img width="721" height="1185" alt="image" src="https://github.com/user-attachments/assets/9b4994b7-b5f3-4e3b-ae58-0ff744e77a53" />

  
Inline JobTemplateExport widget removed from the General tab. Template export remains accessible via the tree context menu and the main menu (CommandJobTemplateExport). The General tab  is now substantially less crowded.


Targeted tooltips on previously opaque widgets: stock-mode combo, Refresh, Link stock and model, Set Origin, X/Y/Z-Axis buttons, X=0/Y=0/Z=0 buttons, Compound checkbox.

Closes
#26373 · #26374 · #24419 · #24420 · #20620

#21835 (partial — tool-management consolidation; full fix tracked in #28419) · 

contributes to #29402