### PR TITLE
CI: prevent cron actions from running in forks

### DIFF
--- a/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
+++ b/.github/workflows/auto-close_stale_issues_and_pull-requests.yml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'FreeCAD'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   upload_src:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'FreeCAD'
     outputs:
       build_tag: ${{ steps.get_tag.outputs.build_tag }}
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    if: github.repository_owner == 'FreeCAD'
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/codeql_cpp.yml
+++ b/.github/workflows/codeql_cpp.yml
@@ -35,6 +35,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    if: github.repository_owner == 'FreeCAD'
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/fetch_crowdin_translations.yml
+++ b/.github/workflows/fetch_crowdin_translations.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update-crowdin:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'FreeCAD'
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/push_crowdin_translations.yml
+++ b/.github/workflows/push_crowdin_translations.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   update-crowdin:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'FreeCAD'
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -21,6 +21,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'FreeCAD'
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
I noticed that GitHub actions triggered automatically by cron were running in all forks of the repository, wasting countless resources.

For instance: https://github.com/chennes/FreeCAD/actions/workflows/scorecards.yml

This PR should prevent these actions from running in 'forked' repositories. I pushed this commit on my own `main` branch, you can see a scheduled job skipped today (05/05/26): https://github.com/Lgt2x/FreeCAD/actions/workflows/scorecards.yml

I also found a discussion on the topic: https://github.com/orgs/community/discussions/26684