### PR TITLE
[GUI] Fix Escape Button when Bottom Overlay is hidden

### DIFF
--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -1503,7 +1503,7 @@ void OverlayTabWidget::updateSplitterHandles()
 
 bool OverlayTabWidget::onEscape()
 {
-    if (getState() == OverlayTabWidget::State::Hint || getState() == OverlayTabWidget::State::Hidden) {
+    if (getState() == OverlayTabWidget::State::Hint) {
         setState(OverlayTabWidget::State::HintHidden);
         return true;
     }


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->
This handling that the sketch couldn't be exited with escape when the bottom overlay is hidden is there since the initial implementation of the overlays (#7888).

The Problem here is that the state gets changed to State hintHidden when the escape Button is pressed and the State of the overlay is currently Hint or hidden. 
I don't see a reason why the state should be changed to `HintHidden`, when the overlay is already hidden. So removing this also fixes the mentioned issue in #23559. 

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes #23559

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->
n/a


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
