### PR TITLE
CAM: Fix some brittleness in some PP tests that use line-indexes, but shouldn't.

### DIFF
--- a/src/Mod/CAM/CAMTests/TestLinuxCNCPost.py
+++ b/src/Mod/CAM/CAMTests/TestLinuxCNCPost.py
@@ -111,8 +111,8 @@ class TestLinuxCNCPost(PathTestUtils.PathTestBase):
         gcode = self.post.export2()[0][1]
         lines = gcode.splitlines()
         # Preamble stuff, up to next piece, which should be unit-command (`_collect_unit_command`)
-        idx = lines.index("G21") # throws IndexError if unexpectedly missing
-        preamble = "\n".join( lines[ :idx ] )
+        idx = lines.index("G21")  # throws IndexError if unexpectedly missing
+        preamble = "\n".join(lines[:idx])
         return gcode, preamble
 
     def test_blend_mode_exact_path(self):

--- a/src/Mod/CAM/CAMTests/TestLinuxCNCPost.py
+++ b/src/Mod/CAM/CAMTests/TestLinuxCNCPost.py
@@ -106,6 +106,15 @@ class TestLinuxCNCPost(PathTestUtils.PathTestBase):
         """
         pass
 
+    def _gcode_and_preamble(self):
+        """convenience to get the preamble stuff"""
+        gcode = self.post.export2()[0][1]
+        lines = gcode.splitlines()
+        # Preamble stuff, up to next piece, which should be unit-command (`_collect_unit_command`)
+        idx = lines.index("G21") # throws IndexError if unexpectedly missing
+        preamble = "\n".join( lines[ :idx ] )
+        return gcode, preamble
+
     def test_blend_mode_exact_path(self):
         """Test EXACT_PATH blend mode outputs G61."""
         self.profile_op.Path = Path.Path([])
@@ -185,19 +194,10 @@ class TestLinuxCNCPost(PathTestUtils.PathTestBase):
         self.post._machine.postprocessor_properties["blend_tolerance"] = 0.1
         self.post._machine.output.comments.enabled = False
         self.post._machine.output.output_header = False
-        gcode = self.post.export2()[0][1]
-        lines = gcode.splitlines()
 
-        # Find G64 P line
-        g64_line_idx = None
-        for i, line in enumerate(lines):
-            if "G64 P" in line:
-                g64_line_idx = i
-                break
+        gcode, preamble = self._gcode_and_preamble()
 
-        self.assertIsNotNone(g64_line_idx, "G64 P command not found")
-        # Should be early in output (within first few lines of preamble)
-        self.assertLess(g64_line_idx, 5, "G64 command should be in preamble")
+        self.assertIn("G64 P", preamble, "G64 P command not found preamble: full gcode\n{gcode}")
 
     def test_blend_tolerance_zero_equals_no_tolerance(self):
         """Test that blend tolerance of 0 outputs G64 without P parameter."""
@@ -221,18 +221,10 @@ class TestLinuxCNCPost(PathTestUtils.PathTestBase):
         self.post._machine.postprocessor_properties["blend_mode"] = "BLEND"
         self.post._machine.output.comments.enabled = False
         self.post._machine.output.output_header = False
-        gcode = self.post.export2()[0][1]
-        lines = gcode.splitlines()
-        # G64 should appear early in the output
-        self.assertIn("G64", gcode)
-        # Find G64 line
-        g64_idx = None
-        for i, line in enumerate(lines):
-            if "G64" in line:
-                g64_idx = i
-                break
-        self.assertIsNotNone(g64_idx)
-        self.assertLess(g64_idx, 5, "G64 should be in preamble")
+
+        gcode, preamble = self._gcode_and_preamble()
+
+        self.assertIn("G64", preamble, "G64 command not found preamble: full gcode\n{gcode}")
 
     def test_rigid_tapping_g84_basic(self):
         """

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -1615,7 +1615,9 @@ class TestExport2Integration(unittest.TestCase):
                 f"Should have only 1 G1 command when duplicates suppressed, found {g1_count}",
             )
             self.assertEqual(
-                suppressed_count, 3, f"Should have 3 suppressed G1 moves, found {suppressed_count}, in\n{gcode}"
+                suppressed_count,
+                3,
+                f"Should have 3 suppressed G1 moves, found {suppressed_count}, in\n{gcode}",
             )
 
     def test128b_bare_command_suppressed_when_all_params_duplicate(self):

--- a/src/Mod/CAM/CAMTests/TestPostOutput.py
+++ b/src/Mod/CAM/CAMTests/TestPostOutput.py
@@ -1597,7 +1597,7 @@ class TestExport2Integration(unittest.TestCase):
                 Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 5.0}),
             ]
         ):
-            machine = self._create_machine(commands=False, parameters=True)
+            machine = self._create_machine(commands=False, parameters=True, duplicates=False)
             results = self._run_export2(machine)
             gcode = self._get_all_gcode(results)
             lines = [
@@ -1615,7 +1615,7 @@ class TestExport2Integration(unittest.TestCase):
                 f"Should have only 1 G1 command when duplicates suppressed, found {g1_count}",
             )
             self.assertEqual(
-                suppressed_count, 3, f"Should have 3 suppressed G1 moves, found {suppressed_count}"
+                suppressed_count, 3, f"Should have 3 suppressed G1 moves, found {suppressed_count}, in\n{gcode}"
             )
 
     def test128b_bare_command_suppressed_when_all_params_duplicate(self):
@@ -1696,7 +1696,7 @@ class TestExport2Integration(unittest.TestCase):
             # Find the second M3 line (after second M6)
             m3_lines = [l for l in lines if l.startswith("M3")]
             self.assertGreaterEqual(
-                len(m3_lines), 2, f"Should have at least 2 M3 lines, got: {m3_lines}"
+                len(m3_lines), 2, f"Should have at least 2 M3 lines, got: {m3_lines}, in\n{gcode}"
             )
             self.assertIn(
                 "S", m3_lines[1], f"Second M3 must include S parameter, got: '{m3_lines[1]}'"

--- a/src/Mod/CAM/Path/Post/Processor.py
+++ b/src/Mod/CAM/Path/Post/Processor.py
@@ -1470,7 +1470,7 @@ class PostProcessor:
                     gcode_lines.append(gcode)
 
             except (ValueError, AttributeError) as e:
-                Path.Log.debug(f"Skipping command {cmd.Name}: {e}")
+                Path.Log.error(f"Failed to deal with a command {cmd.Name}: {e}")
 
         if in_rotary_group:
             gcode_lines.extend(self._get_property_lines("post_rotary_move"))


### PR DESCRIPTION
Things like `assertEqual( lines.index("something"), 4 )`

Only a few found on this pass. I inserted extra lines in the gcode output to see if things would fail, to find these cases.

This is to make less changed-lines as I cause gcode output to change for #29282.

## Issues

One of the tasks in #29282,
>     Find all the brittle tests that use line-numbers, change to a block search
