### PR TITLE
Assembly: Fix crash on right click assembly link

### DIFF
--- a/src/Mod/Assembly/Gui/ViewProviderAssemblyLink.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssemblyLink.cpp
@@ -178,7 +178,7 @@ void ViewProviderAssemblyLink::setupContextMenu(QMenu* menu, QObject* receiver, 
 
     Gui::CommandManager& mgr = Gui::Application::Instance->commandManager();
     Gui::Command* cmd = mgr.getCommandByName("Assembly_LinkSelectLinked");
-    if (cmd) {
+    if (cmd && cmd->getAction()) {
         QAction* action = cmd->getAction()->action();
         if (action) {
             menu->addAction(action);


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/29702

Note before `cmd->getAction()` never returned null. I think before cmd was null if there was no action.

So what happens is that if you have not loaded assembly workbench, then the command Assembly_LinkSelectLinked is not loaded yet.

Before I guess that in this case cmd was nullptr. But now it is apparantly not null anymore. But now getAction still returns null because the command is not loaded yet.
