### PR TITLE
When FREECAD_USE_EXTERNAL_E57FORMAT is turned on, use find_package to locate the external libary

### DIFF
--- a/src/Mod/Points/App/CMakeLists.txt
+++ b/src/Mod/Points/App/CMakeLists.txt
@@ -29,6 +29,8 @@ if (NOT FREECAD_USE_EXTERNAL_E57FORMAT)
         ${CMAKE_BINARY_DIR}/src/3rdParty/libE57Format
         ${CMAKE_SOURCE_DIR}/src/3rdParty/libE57Format/include
     )
+else()
+  find_package(E57Format REQUIRED)
 endif()
 
 set(Points_LIBS


### PR DESCRIPTION
When switching the Debian package to the (now packaged) libe57format, I've experienced a build failure when setting FREECAD_USE_EXTERNAL_E57FORMAT to on: Mod/Points/App does use the library, but its cmakelists.txt does not setup the library - IOW find_package() is missing.
