### PR TITLE
CAM: MachineState tracks G0's F separate from all other movement F, and drill ReturnMode

### DIFF
--- a/src/Mod/CAM/CAMTests/TestPathHelpers.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelpers.py
@@ -96,7 +96,7 @@ class TestPathHelpers(PathTestBase):
         # G0F separate from F
         # The commandlist does G0...G1, so G1 is after G0:
         # (Does not prove (yet) that G0 does-not affect F, see below)
-        self.assertEqual(machine.F, 111) # G1's
+        self.assertEqual(machine.F, 111)  # G1's
         self.assertEqual(machine.G0F, 1001)
 
         machine.addCommand(Path.Command("M3 S200"))
@@ -124,25 +124,29 @@ class TestPathHelpers(PathTestBase):
         self.assertTrue(result, "Changed state")
 
         # Test that Drilling moves are handled correctly
-        machine.addCommands([
-            Path.Command("G98"),
-            Path.Command("G81 X50 Y50 Z0"),
-        ])
+        machine.addCommands(
+            [
+                Path.Command("G98"),
+                Path.Command("G81 X50 Y50 Z0"),
+            ]
+        )
         self.assertEqual(machine.X, 50)
         self.assertEqual(machine.Y, 50)
         self.assertEqual(machine.Z, 5)
         self.assertEqual(machine.ReturnMode, "Z")
 
-        machine.addCommands([
-            Path.Command("G99"),
-            Path.Command("G81 X50 Y50 Z0 R10"),
-        ])
+        machine.addCommands(
+            [
+                Path.Command("G99"),
+                Path.Command("G81 X50 Y50 Z0 R10"),
+            ]
+        )
         self.assertEqual(machine.Z, 10)
         self.assertEqual(machine.ReturnMode, "R")
 
         # Prove G0 F does not interfere with G1 F
         # Would only interfere if a G0 was after a G1, so, final G0:
-        machine.addCommand( Path.Command("G0 X510 Y500 Z0 F99"))
+        machine.addCommand(Path.Command("G0 X510 Y500 Z0 F99"))
         self.assertEqual(machine.F, 111)
         self.assertEqual(machine.G0F, 99)
 
@@ -156,14 +160,14 @@ class TestPathHelpers(PathTestBase):
 
         # Test Tracked and .setState
         # we are relying on MachineState to not validate the tracked parameters
-        expected = { k:"x"+k for k in PathMachineState.MachineState.Tracked }
-        self.assertNotEqual( expected, {}, "Tracked has some keys in it" ) # sanity
-        machine.setState( expected )
-        self.assertEqual( machine.getState(), expected, "Set all w/Tracked" )
+        expected = {k: "x" + k for k in PathMachineState.MachineState.Tracked}
+        self.assertNotEqual(expected, {}, "Tracked has some keys in it")  # sanity
+        machine.setState(expected)
+        self.assertEqual(machine.getState(), expected, "Set all w/Tracked")
 
-        machine.setState( None )
-        expected = { k:None for k in PathMachineState.MachineState.Tracked }
-        self.assertEqual( machine.getState(), expected, "All None" )
+        machine.setState(None)
+        expected = {k: None for k in PathMachineState.MachineState.Tracked}
+        self.assertEqual(machine.getState(), expected, "All None")
 
     def test02(self):
         """Test PathUtils filterarcs"""

--- a/src/Mod/CAM/CAMTests/TestPathHelpers.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelpers.py
@@ -48,10 +48,10 @@ class TestPathHelpers(PathTestBase):
     def setUp(self):
         self.doc = FreeCAD.newDocument("TestPathUtils")
 
-        c1 = Path.Command("G0 Z10")
-        c2 = Path.Command("G0 X20 Y10")
-        c3 = Path.Command("G1 X20 Y10 Z5")
-        c4 = Path.Command("G1 X20 Y20")
+        c1 = Path.Command("G0 Z10 F1000")
+        c2 = Path.Command("G0 X20 Y10 F1001")
+        c3 = Path.Command("G1 X20 Y10 Z5 F110")
+        c4 = Path.Command("G1 X20 Y20 F111")
 
         self.commandlist = [c1, c2, c3, c4]
 
@@ -76,22 +76,28 @@ class TestPathHelpers(PathTestBase):
         self.assertTrue(resultlist[3].Parameters["F"] == 20)
 
     def test01(self):
-        """Test that Machine State initializes and stores position correctly"""
+        """Test that Machine State initializes and updates position correctly"""
 
         machine = PathMachineState.MachineState()
-        state = machine.getState()
-        self.assertTrue(state["X"] == 0)
-        self.assertTrue(state["Y"] == 0)
-        self.assertTrue(state["Z"] == 0)
+        self.assertTrue(machine.X == 0)
+        self.assertTrue(machine.Y == 0)
+        self.assertTrue(machine.Z == 0)
+        self.assertTrue(machine.F == 0)
+        self.assertTrue(machine.G0F == 0)
+        self.assertTrue(machine.ReturnMode == "Z")
         self.assertTrue(machine.WCS == "G54")
 
         for c in self.commandlist:
             result = machine.addCommand(c)
 
-        state = machine.getState()
-        self.assertTrue(state["X"] == 20)
-        self.assertTrue(state["Y"] == 20)
-        self.assertTrue(state["Z"] == 5)
+        self.assertTrue(machine.X == 20)
+        self.assertTrue(machine.Y == 20)
+        self.assertTrue(machine.Z == 5)
+        # G0F separate from F
+        # The commandlist does G0...G1, so G1 is after G0:
+        # (Does not prove (yet) that G0 does-not affect F, see below)
+        self.assertTrue(machine.F == 111) # G1's
+        self.assertTrue(machine.G0F == 1001)
 
         machine.addCommand(Path.Command("M3 S200"))
         self.assertTrue(machine.S == 200)
@@ -118,20 +124,46 @@ class TestPathHelpers(PathTestBase):
         self.assertTrue(result)
 
         # Test that Drilling moves are handled correctly
-        result = machine.addCommand(Path.Command("G81 X50 Y50 Z0"))
-        state = machine.getState()
-        self.assertTrue(state["X"] == 50)
-        self.assertTrue(state["Y"] == 50)
-        self.assertTrue(state["Z"] == 5)
+        result = machine.addCommands([
+            Path.Command("G98"),
+            Path.Command("G81 X50 Y50 Z0"),
+        ])
+        self.assertTrue(machine.X == 50)
+        self.assertTrue(machine.Y == 50)
+        self.assertTrue(machine.Z == 5)
+        self.assertTrue(machine.ReturnMode == "Z")
+
+        result = machine.addCommands([
+            Path.Command("G99"),
+            Path.Command("G81 X50 Y50 Z0 R10"),
+        ])
+        self.assertTrue(machine.Z == 10)
+        self.assertTrue(machine.ReturnMode == "R")
+
+        # Prove G0 F does not interfere with G1 F
+        # Would only interfere if a G0 was after a G1, so, final G0:
+        machine.addCommand( Path.Command("G0 X510 Y500 Z0 F99"))
+        self.assertTrue(machine.F == 111)
+        self.assertEqual(machine.G0F, 99)
 
         # Test process list of commands
         machine = PathMachineState.MachineState()
         machine.addCommands(self.commandlist[0])
         machine.addCommands(self.commandlist[1:])
-        state = machine.getState()
-        self.assertEqual(state["X"], 20)
-        self.assertEqual(state["Y"], 20)
-        self.assertEqual(state["Z"], 5)
+        self.assertEqual(machine.X, 20)
+        self.assertEqual(machine.Y, 20)
+        self.assertEqual(machine.Z, 5)
+
+        # Test Tracked and .setState
+        # we are relying on MachineState to not validate the tracked parameters
+        expected = { k:"x"+k for k in PathMachineState.MachineState.Tracked }
+        self.assertNotEqual( expected, {}, "Tracked has some keys in it" ) # sanity
+        machine.setState( expected )
+        self.assertEqual( machine.getState(), expected, "Set all w/Tracked" )
+
+        machine.setState( None )
+        expected = { k:None for k in PathMachineState.MachineState.Tracked }
+        self.assertEqual( machine.getState(), expected, "All None" )
 
     def test02(self):
         """Test PathUtils filterarcs"""

--- a/src/Mod/CAM/CAMTests/TestPathHelpers.py
+++ b/src/Mod/CAM/CAMTests/TestPathHelpers.py
@@ -28,12 +28,12 @@ import Path.Base.FeedRate as PathFeedRate
 import Path.Base.MachineState as PathMachineState
 from Path.Tool.toolbit import ToolBit
 import Path.Tool.Controller as PathToolController
-import PathScripts.PathUtils as PathUtils
+from PathScripts import PathUtils
 
 from CAMTests.PathTestUtils import PathTestBase
 
 
-def createTool(name="t1", diameter=1.75):
+def create_tool(name="t1", diameter=1.75):
     attrs = {
         "name": name or "t1",
         "shape": "endmill.fcstd",
@@ -60,7 +60,7 @@ class TestPathHelpers(PathTestBase):
 
     def test00(self):
         """Test that FeedRate Helper populates horiz and vert feed rate based on TC"""
-        t = createTool("test", 5.0)
+        t = create_tool("test", 5.0)
         tc = PathToolController.Create("TC0", t)
         tc.VertRapid = 5
         tc.HorizRapid = 10
@@ -70,80 +70,80 @@ class TestPathHelpers(PathTestBase):
         resultlist = PathFeedRate.setFeedRate(self.commandlist, tc)
         print(resultlist)
 
-        self.assertTrue(resultlist[0].Parameters["F"] == 5)
-        self.assertTrue(resultlist[1].Parameters["F"] == 10)
-        self.assertTrue(resultlist[2].Parameters["F"] == 15)
-        self.assertTrue(resultlist[3].Parameters["F"] == 20)
+        self.assertEqual(resultlist[0].Parameters["F"], 5)
+        self.assertEqual(resultlist[1].Parameters["F"], 10)
+        self.assertEqual(resultlist[2].Parameters["F"], 15)
+        self.assertEqual(resultlist[3].Parameters["F"], 20)
 
     def test01(self):
         """Test that Machine State initializes and updates position correctly"""
 
         machine = PathMachineState.MachineState()
-        self.assertTrue(machine.X == 0)
-        self.assertTrue(machine.Y == 0)
-        self.assertTrue(machine.Z == 0)
-        self.assertTrue(machine.F == 0)
-        self.assertTrue(machine.G0F == 0)
-        self.assertTrue(machine.ReturnMode == "Z")
-        self.assertTrue(machine.WCS == "G54")
+        self.assertEqual(machine.X, 0)
+        self.assertEqual(machine.Y, 0)
+        self.assertEqual(machine.Z, 0)
+        self.assertEqual(machine.F, 0)
+        self.assertEqual(machine.G0F, 0)
+        self.assertEqual(machine.ReturnMode, "Z")
+        self.assertEqual(machine.WCS, "G54")
 
         for c in self.commandlist:
-            result = machine.addCommand(c)
+            machine.addCommand(c)
 
-        self.assertTrue(machine.X == 20)
-        self.assertTrue(machine.Y == 20)
-        self.assertTrue(machine.Z == 5)
+        self.assertEqual(machine.X, 20)
+        self.assertEqual(machine.Y, 20)
+        self.assertEqual(machine.Z, 5)
         # G0F separate from F
         # The commandlist does G0...G1, so G1 is after G0:
         # (Does not prove (yet) that G0 does-not affect F, see below)
-        self.assertTrue(machine.F == 111) # G1's
-        self.assertTrue(machine.G0F == 1001)
+        self.assertEqual(machine.F, 111) # G1's
+        self.assertEqual(machine.G0F, 1001)
 
         machine.addCommand(Path.Command("M3 S200"))
-        self.assertTrue(machine.S == 200)
-        self.assertTrue(machine.Spindle == "CW")
+        self.assertEqual(machine.S, 200)
+        self.assertEqual(machine.Spindle, "CW")
 
         machine.addCommand(Path.Command("M4 S200"))
-        self.assertTrue(machine.Spindle == "CCW")
+        self.assertEqual(machine.Spindle, "CCW")
 
         machine.addCommand(Path.Command("M2"))
-        self.assertTrue(machine.Spindle == "off")
-        self.assertTrue(machine.S == 0)
+        self.assertEqual(machine.Spindle, "off")
+        self.assertEqual(machine.S, 0)
 
         machine.addCommand(Path.Command("G57"))
-        self.assertTrue(machine.WCS == "G57")
+        self.assertEqual(machine.WCS, "G57")
 
         machine.addCommand(Path.Command("M6 T5"))
-        self.assertTrue(machine.T == 5)
+        self.assertEqual(machine.T, 5)
 
         # Test that non-change commands return false
         result = machine.addCommand(Path.Command("G0 X20"))
-        self.assertFalse(result)
+        self.assertFalse(result, "No changed state")
 
         result = machine.addCommand(Path.Command("G0 X30"))
-        self.assertTrue(result)
+        self.assertTrue(result, "Changed state")
 
         # Test that Drilling moves are handled correctly
-        result = machine.addCommands([
+        machine.addCommands([
             Path.Command("G98"),
             Path.Command("G81 X50 Y50 Z0"),
         ])
-        self.assertTrue(machine.X == 50)
-        self.assertTrue(machine.Y == 50)
-        self.assertTrue(machine.Z == 5)
-        self.assertTrue(machine.ReturnMode == "Z")
+        self.assertEqual(machine.X, 50)
+        self.assertEqual(machine.Y, 50)
+        self.assertEqual(machine.Z, 5)
+        self.assertEqual(machine.ReturnMode, "Z")
 
-        result = machine.addCommands([
+        machine.addCommands([
             Path.Command("G99"),
             Path.Command("G81 X50 Y50 Z0 R10"),
         ])
-        self.assertTrue(machine.Z == 10)
-        self.assertTrue(machine.ReturnMode == "R")
+        self.assertEqual(machine.Z, 10)
+        self.assertEqual(machine.ReturnMode, "R")
 
         # Prove G0 F does not interfere with G1 F
         # Would only interfere if a G0 was after a G1, so, final G0:
         machine.addCommand( Path.Command("G0 X510 Y500 Z0 F99"))
-        self.assertTrue(machine.F == 111)
+        self.assertEqual(machine.F, 111)
         self.assertEqual(machine.G0F, 99)
 
         # Test process list of commands
@@ -174,19 +174,19 @@ class TestPathHelpers(PathTestBase):
         edge = c.toShape()
 
         results = PathUtils.filterArcs(edge)
-        self.assertTrue(len(results) == 2)
+        self.assertEqual(len(results), 2)
         e1 = results[0]
-        self.assertTrue(isinstance(e1.Curve, Part.Circle))
+        self.assertIsInstance(e1.Curve, Part.Circle)
         self.assertTrue(Path.Geom.pointsCoincide(edge.Curve.Location, e1.Curve.Location))
-        self.assertTrue(edge.Curve.Radius == e1.Curve.Radius)
+        self.assertEqual(edge.Curve.Radius, e1.Curve.Radius)
 
         # filter a 180 degree arc
         results = PathUtils.filterArcs(e1)
-        self.assertTrue(len(results) == 1)
+        self.assertEqual(len(results), 1)
 
         # Handle a straight segment
         v1 = FreeCAD.Vector(0, 0, 0)
         v2 = FreeCAD.Vector(10, 0, 0)
         l = Part.makeLine(v1, v2)
         results = PathUtils.filterArcs(l)
-        self.assertTrue(len(results) == 0)
+        self.assertEqual(len(results), 0)

--- a/src/Mod/CAM/Path/Base/MachineState.py
+++ b/src/Mod/CAM/Path/Base/MachineState.py
@@ -38,15 +38,23 @@ else:
 
 class MachineState:
     Tracked = [
-        "X", "Y", "Z", "A", "B", "C", "F", "S", "T",
-        "Coolant", # true/false for on/off
-        "WCS", # work-coordinate system Gcode
-        "Spindle", # rpms
-        "ReturnMode", # Z(G98) or R(G99) for drills
-        "G0F", # F for G0's, distinct from all other move F. all G0's should have an F now.
+        "X",
+        "Y",
+        "Z",
+        "A",
+        "B",
+        "C",
+        "F",
+        "S",
+        "T",
+        "Coolant",  # true/false for on/off
+        "WCS",  # work-coordinate system Gcode
+        "Spindle",  # rpms
+        "ReturnMode",  # Z(G98) or R(G99) for drills
+        "G0F",  # F for G0's, distinct from all other move F. all G0's should have an F now.
     ]
 
-    def __init__(self, initial : None|dict = None):
+    def __init__(self, initial: None | dict = None):
         """an initial state is optional, and doesn't have to set all Tracked properties"""
         self.WCSLIST = [
             "G53",
@@ -78,10 +86,10 @@ class MachineState:
         self.WCS = "G54"  #: str = field(default="G54")
         self.Spindle = "off"  #: str = field(default="off")
         self.ReturnMode = "Z"  #: str = Z|R for G98/G99, for drill cycles
-        self.G0F = 0.0 #: float = field(default=None)
+        self.G0F = 0.0  #: float = field(default=None)
         self.S = 0  #: int = field(default=0)
         self.T = None  #: int = field(default=None)
-        if missing:=[ k for k in self.Tracked if k not in dir(self) ]:
+        if missing := [k for k in self.Tracked if k not in dir(self)]:
             raise Exception(f"Internal: didn't initialize a Tracked Parameter {missing}")
 
         if initial:
@@ -101,7 +109,7 @@ class MachineState:
             return not oldstate == self.getState()
 
         if command.Name in ["G98", "G99"]:
-            self.ReturnMode = "R" if command.Name=="G99" else "Z"
+            self.ReturnMode = "R" if command.Name == "G99" else "Z"
             return not oldstate == self.getState()
 
         if command.Name in ["M2", "M5"]:
@@ -126,7 +134,7 @@ class MachineState:
 
             if self.ReturnMode == "R":
                 self.Z = command.Parameters["R"]
-            else: # Z/G98 mode
+            else:  # Z/G98 mode
                 oldZ = self.Z
                 r = command.Parameters.get("R", None)
                 if oldZ is None or r is None:
@@ -135,7 +143,7 @@ class MachineState:
                     # Which shouldn't happen unless testing
                     self.Z = oldZ
                 else:
-                    self.Z = max( oldZ, r )
+                    self.Z = max(oldZ, r)
 
             return not oldstate == self.getState()
 
@@ -145,7 +153,7 @@ class MachineState:
                 continue
 
             # G0's F is distinct
-            if command.Name in ["G0","G00"] and p == "F":
+            if command.Name in ["G0", "G00"] and p == "F":
                 self.G0F = command.Parameters[p]
             else:
                 self.__setattr__(p, command.Parameters[p])
@@ -163,11 +171,11 @@ class MachineState:
         return False
 
     def copy(self):
-        return MachineState( self.getState() )
+        return MachineState(self.getState())
 
-    def setState(self, state : dict|None):
+    def setState(self, state: dict | None):
         """Set the state from a dict
-            Convenience mode: None causes all parameters=None
+        Convenience mode: None causes all parameters=None
         """
         for s in self.Tracked:
             if state is None:
@@ -179,7 +187,7 @@ class MachineState:
         """
         Returns a dictionary of the current machine state
         """
-        return { k: getattr(self,k) for k in self.Tracked }
+        return {k: getattr(self, k) for k in self.Tracked}
 
     def getPosition(self):
         """

--- a/src/Mod/CAM/Path/Base/MachineState.py
+++ b/src/Mod/CAM/Path/Base/MachineState.py
@@ -37,7 +37,17 @@ else:
 
 
 class MachineState:
-    def __init__(self):
+    Tracked = [
+        "X", "Y", "Z", "A", "B", "C", "F", "S", "T",
+        "Coolant", # true/false for on/off
+        "WCS", # work-coordinate system Gcode
+        "Spindle", # rpms
+        "ReturnMode", # Z(G98) or R(G99) for drills
+        "G0F", # F for G0's, distinct from all other move F. all G0's should have an F now.
+    ]
+
+    def __init__(self, initial : None|dict = None):
+        """an initial state is optional, and doesn't have to set all Tracked properties"""
         self.WCSLIST = [
             "G53",
             "G54",
@@ -67,8 +77,15 @@ class MachineState:
         self.Coolant = False  #: bool = field(default=False)
         self.WCS = "G54"  #: str = field(default="G54")
         self.Spindle = "off"  #: str = field(default="off")
+        self.ReturnMode = "Z"  #: str = Z|R for G98/G99, for drill cycles
+        self.G0F = 0.0 #: float = field(default=None)
         self.S = 0  #: int = field(default=0)
         self.T = None  #: int = field(default=None)
+        if missing:=[ k for k in self.Tracked if k not in dir(self) ]:
+            raise Exception(f"Internal: didn't initialize a Tracked Parameter {missing}")
+
+        if initial:
+            self.setState(initial)
 
     def addCommand(self, command):
         """Processes a command and updates the internal state of the machine.
@@ -83,6 +100,10 @@ class MachineState:
             self.Spindle = "CW" if command.Name == "M3" else "CCW"
             return not oldstate == self.getState()
 
+        if command.Name in ["G98", "G99"]:
+            self.ReturnMode = "R" if command.Name=="G99" else "Z"
+            return not oldstate == self.getState()
+
         if command.Name in ["M2", "M5"]:
             self.S = 0
             self.Spindle = "off"
@@ -93,14 +114,41 @@ class MachineState:
             return not oldstate == self.getState()
 
         if command.Name in Path.Geom.CmdMoveDrill:
-            oldZ = self.Z
+            # Special logic for drill: old-Z or R
             for p in command.Parameters:
-                self.__setattr__(p, command.Parameters[p])
-            self.__setattr__("Z", oldZ)
+
+                # Z depends on ReturnMode
+                if p == "Z":
+                    continue
+
+                if p in self.Tracked:
+                    self.__setattr__(p, command.Parameters[p])
+
+            if self.ReturnMode == "R":
+                self.Z = command.Parameters["R"]
+            else: # Z/G98 mode
+                oldZ = self.Z
+                r = command.Parameters.get("R", None)
+                if oldZ is None or r is None:
+                    # can't test R vs old Z
+                    # You need to establish an old Z, and specify an R
+                    # Which shouldn't happen unless testing
+                    self.Z = oldZ
+                else:
+                    self.Z = max( oldZ, r )
+
             return not oldstate == self.getState()
 
-        for p in command.Parameters:
-            self.__setattr__(p, command.Parameters[p])
+        # just the usual GCode Parameters (except G0's F)
+        for p in self.Tracked:
+            if p not in command.Parameters:
+                continue
+
+            # G0's F is distinct
+            if command.Name in ["G0","G00"] and p == "F":
+                self.G0F = command.Parameters[p]
+            else:
+                self.__setattr__(p, command.Parameters[p])
 
         return not oldstate == self.getState()
 
@@ -114,25 +162,24 @@ class MachineState:
 
         return False
 
+    def copy(self):
+        return MachineState( self.getState() )
+
+    def setState(self, state : dict|None):
+        """Set the state from a dict
+            Convenience mode: None causes all parameters=None
+        """
+        for s in self.Tracked:
+            if state is None:
+                setattr(self, s, None)
+            elif s in state:
+                setattr(self, s, state[s])
+
     def getState(self):
         """
         Returns a dictionary of the current machine state
         """
-        state = {}
-        state["X"] = self.X
-        state["Y"] = self.Y
-        state["Z"] = self.Z
-        state["A"] = self.A
-        state["B"] = self.B
-        state["C"] = self.C
-        state["F"] = self.F
-        state["Coolant"] = self.Coolant
-        state["WCS"] = self.WCS
-        state["Spindle"] = self.Spindle
-        state["S"] = self.S
-        state["T"] = self.T
-
-        return state
+        return { k: getattr(self,k) for k in self.Tracked }
 
     def getPosition(self):
         """
@@ -142,3 +189,6 @@ class MachineState:
         # This is technical debt.  The actual position may include a rotation
         # component as well.  We should probably be returning a placement
         return FreeCAD.Vector(self.X, self.Y, self.Z)
+
+    def __str__(self):
+        return f"MachineState({self.getState()})"


### PR DESCRIPTION
Adds MachineState.G0F, and .ReturnMode for drill commands.

Around v1.1, Path generation started including "F" parameters for G0 (rapid move), but MachineState only tracked a single "F": G0's would cause the wrong "F" state for preceding movements. PP's are probably most sensitive to this, as they process command-by-command, and can "optimize" eliding parameters, etc. It would affect machine motion (speed). No tests detected this conflation. 

During work on DrillCycleExpander, it was realized that the MachineState for the Z position wasn't tracking drill-cycle commands correctly when there was an "R" and the mode was G99 (final retract to R, not start-Z). This affected machine motion. No tests detected this case.

DrillCycleExpander, and Processor.py (and PP's) need to be updated to use MachineState instead of ad-hoc/duplicate state tracking. That will be another PR.

Tests added.

Refactoring removed duplication. It also enabled some additional functionality, which I happen to know will be required for MBPP.


## Issues
Addresses one task in #29282
> Update MachineState class to support G0's F distinct from all other F.