### PR TITLE
sketcher: fix issue #29738 fix toolbar icons disappearing

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -1261,6 +1261,33 @@ ToolBarItem::DefaultVisibility ToolBarManager::getToolbarPolicy(const QToolBar* 
 
 void ToolBarManager::setState(const QList<QString>& names, State state)
 {
+#ifdef FC_DEBUG
+    QString stateStr;
+    switch (state) {
+        case State::SaveState:
+            stateStr = "SaveState";
+            break;
+        case State::RestoreDefault:
+            stateStr = "RestoreDefault";
+            break;
+        case State::ForceAvailable:
+            stateStr = "ForceAvailable";
+            break;
+        case State::ForceHidden:
+            stateStr = "ForceHidden";
+            break;
+        default:
+            stateStr = "Unknown";
+            break;
+    }
+    Base::Console().message(
+        "ToolBarManager::setState [%s] for %d toolbars: %s\n",
+        stateStr.toUtf8().constData(),
+        (int)names.size(),
+        names.join(QStringLiteral(", ")).toUtf8().constData()
+    );
+#endif
+
     for (auto& name : names) {
         setState(name, state);
     }
@@ -1269,7 +1296,16 @@ void ToolBarManager::setState(const QList<QString>& names, State state)
 void ToolBarManager::setState(const QString& name, State state)
 {
     auto visibility = [this, name](bool defaultvalue) {
-        return hPref->GetBool(name.toStdString().c_str(), defaultvalue);
+        bool result = hPref->GetBool(name.toStdString().c_str(), defaultvalue);
+#ifdef FC_DEBUG
+        Base::Console().message(
+            "  visibility(%s, default=%d) = %d\n",
+            name.toUtf8().constData(),
+            defaultvalue,
+            result
+        );
+#endif
+        return result;
     };
 
     auto saveVisibility = [this, visibility, name](bool value, ToolBarItem::DefaultVisibility policy) {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3601,7 +3601,8 @@ void ViewProviderSketch::setupContextMenu(QMenu* menu, QObject* receiver, const 
 bool ViewProviderSketch::setEdit(int ModNum)
 {
 #ifdef FC_DEBUG
-    Base::Console().message("ViewProviderSketch::setEdit ENTRY (ModNum=%d) doc=%s\n",
+     Base::Console().message("ViewProviderSketch::setEdit ENTRY this=%p (ModNum=%d) doc=%s\n",
+            (void*)this,
             ModNum,
             getObject()->getDocument()->getName());
 #endif
@@ -3802,12 +3803,26 @@ bool ViewProviderSketch::setEdit(int ModNum)
 }
 void ViewProviderSketch::setupActiveAndInEdit()
 {
+#ifdef FC_DEBUG
+    Base::Console().message("ViewProviderSketch::setupActiveAndInEdit ENTRY this=%p doc=%s listener-before=%s\n",
+                            (void*)this,
+                            getObject()->getDocument()->getName(),
+                            listener ? "non-null" : "null");
+#endif
+
     if (!listener) {
         // intercept del key press from main app
         listener = std::make_unique<ShortcutListener>(this);
 
         Gui::getMainWindow()->installEventFilter(listener.get());
     }
+
+#ifdef FC_DEBUG
+    Base::Console().message("ViewProviderSketch::setupActiveAndInEdit MIDPOINT this=%p listener-after=%s\n",
+                            (void*)this,
+                            listener ? "non-null" : "null");
+#endif
+
     attachSelection();
 
     Workbench::enterEditMode();
@@ -3818,6 +3833,13 @@ void ViewProviderSketch::setupActiveAndInEdit()
 }
 void ViewProviderSketch::unsetupActiveAndInEdit()
 {
+#ifdef FC_DEBUG
+     Base::Console().message("ViewProviderSketch::unsetupActiveAndInEdit ENTRY this=%p doc=%s listener=%s\n",
+                            (void*)this,
+                            getObject()->getDocument()->getName(),
+                            listener ? "non-null" : "null");
+#endif
+
     if (!listener) {
         return; // already torn down see: github issue #29738 so avoid duplicate teardowns
     }
@@ -3830,8 +3852,9 @@ void ViewProviderSketch::unsetupActiveAndInEdit()
 void ViewProviderSketch::setActive(bool active)
 {
 #ifdef FC_DEBUG
-    Base::Console().message("ViewProviderSketch::setActive(%s) doc=%s inEdit=%s\n",
+     Base::Console().message("ViewProviderSketch::setActive(%s) this=%p doc=%s inEdit=%s\n",
                             active ? "true" : "false",
+                            (void*)this,
                             getObject()->getDocument()->getName(),
                             isInEditMode() ? "true" : "false");
 #endif
@@ -3977,9 +4000,11 @@ void ViewProviderSketch::UpdateSolverInformation()
 void ViewProviderSketch::unsetEdit(int ModNum)
 {
 #ifdef FC_DEBUG
-    Base::Console().message("ViewProviderSketch::unsetEdit ENTRY (ModNum=%d) doc=%s\n",
+      Base::Console().message("ViewProviderSketch::unsetEdit ENTRY this=%p (ModNum=%d) doc=%s listener=%s\n",
+                            (void*)this,
                             ModNum,
-                            getObject()->getDocument()->getName());
+                            getObject()->getDocument()->getName(),
+                            listener ? "non-null" : "null");
 #endif
 
     if (ModNum != ViewProviderSketch::Default) {
@@ -3989,11 +4014,6 @@ void ViewProviderSketch::unsetEdit(int ModNum)
     setGridEnabled(nullptr);
     auto gridnode = getGridNode();
     pcRoot->removeChild(gridnode);
-
-    if (listener) {
-        Gui::getMainWindow()->removeEventFilter(listener.get());
-        listener.reset();
-    }
 
     if (isInEditMode()) {
         if (sketchHandler) {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3600,6 +3600,11 @@ void ViewProviderSketch::setupContextMenu(QMenu* menu, QObject* receiver, const 
 
 bool ViewProviderSketch::setEdit(int ModNum)
 {
+#ifdef FC_DEBUG
+    Base::Console().message("ViewProviderSketch::setEdit ENTRY (ModNum=%d) doc=%s\n",
+            ModNum,
+            getObject()->getDocument()->getName());
+#endif
     if (ModNum != ViewProviderSketch::Default) {
         return PartGui::ViewProvider2DObject::setEdit(ModNum);
     }
@@ -3781,6 +3786,15 @@ bool ViewProviderSketch::setEdit(int ModNum)
     // intercept del key press from main app
     listener = std::make_unique<ShortcutListener>(this);
 
+#ifdef FC_DEBUG
+    Base::Console().message(
+        "setEdit: editDoc=%p editDoc->isActive()=%s -> %s\n",
+        (void*)editDoc,
+        editDoc ? (editDoc->isActive() ? "true" : "false") : "n/a",
+        (editDoc && editDoc->isActive()) ? "ENTERING setupActiveAndInEdit" : "SKIPPING setupActiveAndInEdit");
+#endif
+
+
     Gui::getMainWindow()->installEventFilter(listener.get());
     setupActiveAndInEdit();
 
@@ -3804,16 +3818,23 @@ void ViewProviderSketch::setupActiveAndInEdit()
 }
 void ViewProviderSketch::unsetupActiveAndInEdit()
 {
-    if (listener) {
-        Gui::getMainWindow()->removeEventFilter(listener.get());
-        listener.reset();
+    if (!listener) {
+        return; // already torn down see: github issue #29738 so avoid duplicate teardowns
     }
-    detachSelection();
+    Gui::getMainWindow()->removeEventFilter(listener.get());
+    listener.reset();
 
+    detachSelection();
     Workbench::leaveEditMode();
 }
 void ViewProviderSketch::setActive(bool active)
 {
+#ifdef FC_DEBUG
+    Base::Console().message("ViewProviderSketch::setActive(%s) doc=%s inEdit=%s\n",
+                            active ? "true" : "false",
+                            getObject()->getDocument()->getName(),
+                            isInEditMode() ? "true" : "false");
+#endif
     bool inEdit = isInEditMode();
     if (active && inEdit) {
         setupActiveAndInEdit();
@@ -3955,6 +3976,12 @@ void ViewProviderSketch::UpdateSolverInformation()
 
 void ViewProviderSketch::unsetEdit(int ModNum)
 {
+#ifdef FC_DEBUG
+    Base::Console().message("ViewProviderSketch::unsetEdit ENTRY (ModNum=%d) doc=%s\n",
+                            ModNum,
+                            getObject()->getDocument()->getName());
+#endif
+
     if (ModNum != ViewProviderSketch::Default) {
         return PartGui::ViewProvider2DObject::unsetEdit(ModNum);
     }
@@ -4034,7 +4061,7 @@ void ViewProviderSketch::unsetEdit(int ModNum)
 
 void ViewProviderSketch::setEditViewer(Gui::View3DInventorViewer* viewer, int ModNum)
 {
-    if (ModNum != ViewProviderSketch::Default) {
+        if (ModNum != ViewProviderSketch::Default) {
         return PartGui::ViewProvider2DObject::setEditViewer(viewer, ModNum);
     }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3782,9 +3782,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
     listener = std::make_unique<ShortcutListener>(this);
 
     Gui::getMainWindow()->installEventFilter(listener.get());
-    if (editDoc && editDoc->isActive()) {
-        setupActiveAndInEdit();
-    }
+    setupActiveAndInEdit();
 
     return true;
 }

--- a/src/Mod/Sketcher/Gui/Workbench.cpp
+++ b/src/Mod/Sketcher/Gui/Workbench.cpp
@@ -176,6 +176,9 @@ inline const QStringList nonEditModeToolbarNames()
 
 void Workbench::activated()
 {
+#ifdef FC_DEBUG
+    Base::Console().message("Workbench::activated ENTRY\n");
+#endif
     /* When the workbench is activated, it may happen that we are in edit mode or not.
      * If we are not in edit mode, the function enterEditMode (called by the ViewProvider) takes
      * care to save the state of toolbars outside of edit mode. We cannot do it here, as we are
@@ -202,10 +205,16 @@ void Workbench::activated()
             Gui::ToolBarManager::State::ForceHidden
         );
     }
+#ifdef FC_DEBUG
+    Base::Console().message("Workbench::activated EXIT\n");
+#endif
 }
 
 void Workbench::enterEditMode()
 {
+#ifdef FC_DEBUG
+    Base::Console().message("Workbench::enterEditMode ENTRY\n");
+#endif
     /* Ensure the state left by the non-edit mode toolbars is saved (in case of changing to edit
      * mode) without changing workbench
      */
@@ -222,10 +231,20 @@ void Workbench::enterEditMode()
         nonEditModeToolbarNames(),
         Gui::ToolBarManager::State::ForceHidden
     );
+
+    // inEditMode = true;
+
+#ifdef FC_DEBUG
+    Base::Console().message("Workbench::enterEditMode EXIT\n");
+#endif
 }
 
 void Workbench::leaveEditMode()
 {
+#ifdef FC_DEBUG
+    Base::Console().message("Workbench::leaveEditMode ENTRY\n");
+#endif
+
     /* Ensure the state left by the edit mode toolbars is saved (in case of changing to edit mode)
      * without changing workbench.
      *
@@ -250,6 +269,10 @@ void Workbench::leaveEditMode()
         nonEditModeToolbarNames(),
         Gui::ToolBarManager::State::RestoreDefault
     );
+
+#ifdef FC_DEBUG
+    Base::Console().message("Workbench::leaveEditMode EXIT bottom\n");
+#endif
 }
 
 namespace SketcherGui


### PR DESCRIPTION
**update may 13th**

i can't really go much further with this PR until some people weigh in on how multi doc editing is supposed to operate.

1. Should File -> New, end an in-progress sketch edit, or suspend it? (is this documented somewhere) ?
2. Should clicking another doc's tab end the current edit, or suspend it?
3. if suspend, where should the task dialog go? hidden? globally? or per doc?


**update may 11th**

i came across 2x scenarios with multi doc multi sketch editing and one scenario in a single doc. two of them are demo'd in the below youtube video. and the third is demo'd by @FEA-eng this PR should address / fix all three scenarios. obviously i do not know of every scenario when it comes to multi doc editing and with multiple sketches in a doc. there's quite a large "net to cast" to cover every possible scenario, and some of them i'm just unaware of. if you're reading this **please build freecad with PR and test to see if you can find another issue.**

i couldn't come up with a good way to unit test all of this. i spent a couple of hours trying without much luck so i guarded all of my debug statements as seen below, and i'd suggest keeping these statements in the code for a while until the multi doc editing matures or possibly somebody writes some unit tests that covers the scenarios presented in this PR. obviously these statements / code paths won't be present in a release build of freecad, and one has to manually add the below arg to their CXX flags in order for them to be present in their build. ie. `-DCMAKE_CXX_FLAGS="-DFC_DEBUG ..."`

```cpp
#ifdef FC_DEBUG

Base::Console.warning("why do you hate me multi doc editing");

#endif
```



---

the fix, ie. fixes 29738 the below mentioned issue appeared ie. started happen after  the recent merge of the multi file editing from PR https://github.com/FreeCAD/FreeCAD/pull/21978 there really should be some unit tests written for the multi document editing but unfortunately i was not getting reliable results when i started writing a unit test for this issue. my incomplete work can found below.

https://github.com/ipatch/FreeCAD/tree/ipatch.tshoot.29738-unit-test

@theo-vt

do you remember why you "gated" the below `setupActiveAndInEdit()` call?

looking at the git blame for the below lines, i see the following message from the following commit, f4665aa7

```
Core: support multiple active transactions
```

```diff
-    if (editDoc && editDoc->isActive()) {
-        setupActiveAndInEdit();
-    }
+    setupActiveAndInEdit();
```

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/29738

## Before and After Images

below is a little video i recorded demonstrating two separate issues i ran into while troubleshooting this issue. there are really two separate issues. and this PR contains two distinct commits each commit addresses a different "sub issue" if you will.

https://youtu.be/FyOXeKhMn0U 📺️

see above mentioned issue for steps to reproduce. with this simple change the sketcher toolbar icons will restore when entering a second / subsequent sketch in a document.
