### PR TITLE
Tests: Skip tools tests if the source isn't checked out

### DIFF
--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -208,7 +208,7 @@ jobs:
         path: /tmp/FreeCADTesting/CoinNodeSnapshots
 
     - name: src/Tools tests
-      if: always()
+      if: "!inputs.skipBuild"
       run: python3 -m unittest discover -s src/Tools/tests -p "test_*.py"
 
     - name: C++ tests


### PR DESCRIPTION
The Tools tests have to be skipped if the checkout is skipped (as in, we've already run the CI on this SHA). 