### PR TITLE
CI: fix Pixi src/Tools test step

### DIFF
--- a/.github/workflows/sub_buildPixi.yml
+++ b/.github/workflows/sub_buildPixi.yml
@@ -208,8 +208,8 @@ jobs:
         path: /tmp/FreeCADTesting/CoinNodeSnapshots
 
     - name: src/Tools tests
-      if: always()
-      run: python3 -m unittest discover -s src/Tools/tests -p "test_*.py"
+      if: always() && !inputs.skipBuild
+      run: pixi run python -m unittest discover -s src/Tools/tests -p "test_*.py"
 
     - name: C++ tests
       timeout-minutes: 10


### PR DESCRIPTION
Fix the `src/Tools tests` step in the Pixi workflow.

This change:
- skips the step when `skipBuild` is true
- runs the tests with `pixi run python` instead of host `python3`

## Root cause

In the Pixi workflow, most build-related steps were correctly gated on `!inputs.skipBuild`, but `src/Tools tests` still used `if: always()` and ran even when checkout/setup/build had been skipped.

The test command also used the host `python3` instead of the Pixi environment, which made the step sensitive to runner Python differences.

You can see an example of a failing CI build that this fixes: https://github.com/FreeCAD/FreeCAD/actions/runs/25486901180/job/74784799100?pr=29857