### PR TITLE
BIM: only add sibling walls to window hosts if there is a reasonable Z overlap

### DIFF
--- a/src/Mod/BIM/bimcommands/BimWindow.py
+++ b/src/Mod/BIM/bimcommands/BimWindow.py
@@ -111,17 +111,17 @@ class Arch_Window:
                     FreeCADGui.doCommand(
                         "win = Arch.makeWindow(FreeCAD.ActiveDocument." + obj.Name + ")"
                     )
-                    if host and self.Include:
+                    if self.Include and host is not None and Draft.getType(host) in ALLOWEDHOSTS:
                         FreeCADGui.doCommand(
                             "win.Hosts = [FreeCAD.ActiveDocument." + host.Name + "]"
                         )
-                        siblings = host.Proxy.getSiblings(host)
+                        siblings = self._get_host_siblings(host)
                         sibs = [host]
                         for sibling in siblings:
                             if not sibling in sibs:
                                 sibs.append(sibling)
                                 FreeCADGui.doCommand(
-                                    "win.Hosts = win.Hosts+[FreeCAD.ActiveDocument."
+                                    "win.Hosts = win.Hosts + [FreeCAD.ActiveDocument."
                                     + sibling.Name
                                     + "]"
                                 )
@@ -324,16 +324,15 @@ class Arch_Window:
                 )
                 SketchArch = False
 
-        if self.Include:
-            if Draft.getType(host) in ALLOWEDHOSTS:
-                FreeCADGui.doCommand("win.Hosts = [FreeCAD.ActiveDocument." + host.Name + "]")
-                siblings = host.Proxy.getSiblings(host)
-                for sibling in siblings:
-                    FreeCADGui.doCommand(
-                        "win.Hosts = win.Hosts + [FreeCAD.ActiveDocument." + sibling.Name + "]"
-                    )
-                if SketchArch:
-                    ArchSketchObject.attachToHost(w, target=host, pl=wPl)
+        if self.Include and host is not None and Draft.getType(host) in ALLOWEDHOSTS:
+            FreeCADGui.doCommand("win.Hosts = [FreeCAD.ActiveDocument." + host.Name + "]")
+            siblings = self._get_host_siblings(host)
+            for sibling in siblings:
+                FreeCADGui.doCommand(
+                    "win.Hosts = win.Hosts + [FreeCAD.ActiveDocument." + sibling.Name + "]"
+                )
+            if SketchArch:
+                ArchSketchObject.attachToHost(w, target=host, pl=wPl)
 
         self.doc.commitTransaction()
         self.doc.recompute()
@@ -586,6 +585,22 @@ class Arch_Window:
             self.im.hide()
             for param in self.wparams:
                 getattr(self, "val" + param).setEnabled(False)
+
+    def _get_host_siblings(self, host):
+        box_host = host.Shape.BoundBox
+        min_overlap = box_host.ZLength / 5  # Minimum Z-direction overlap: 20%.
+        siblings = []
+        for sibling in host.Proxy.getSiblings(host):
+            box_sib = sibling.Shape.BoundBox
+            if box_sib.ZLength < min_overlap:
+                pass
+            elif box_host.ZMin <= box_sib.ZMin <= box_host.ZMax - min_overlap:
+                siblings.append(sibling)
+            elif box_host.ZMin + min_overlap <= box_sib.ZMax <= box_host.ZMax:
+                siblings.append(sibling)
+            elif box_sib.ZMin < box_host.ZMin and box_sib.ZMax > box_host.ZMax:
+                siblings.append(sibling)
+        return siblings
 
 
 FreeCADGui.addCommand("Arch_Window", Arch_Window())


### PR DESCRIPTION
Fixes #28433.

This PR introduces the `_get_host_siblings` function that checks if the BoundBox of potential host siblings has a Z overlap with the BoundBox of the 'main' host that is at least 20% of the latter's height. If the overlap is less, siblings are not added as hosts of the window. This may not be the perfect solution, but should be effective in most cases.