### PR TITLE
BIM: fix faulty Presets paths

### DIFF
--- a/src/Mod/BIM/ArchComponent.py
+++ b/src/Mod/BIM/ArchComponent.py
@@ -2473,7 +2473,7 @@ class ComponentTaskPanel:
         ]
         self.psetdefs = {}
         psetspath = os.path.join(
-            FreeCAD.getResourceDir(), "Mod", "Arch", "Presets", "pset_definitions.csv"
+            FreeCAD.getResourceDir(), "Mod", "BIM", "Presets", "pset_definitions.csv"
         )
         if os.path.exists(psetspath):
             with open(psetspath, "r") as csvfile:

--- a/src/Mod/BIM/bimcommands/BimPreflight.py
+++ b/src/Mod/BIM/bimcommands/BimPreflight.py
@@ -716,7 +716,7 @@ class BIM_Preflight_TaskPanel:
             psetspath = os.path.join(
                 FreeCAD.getResourceDir(),
                 "Mod",
-                "Arch",
+                "BIM",
                 "Presets",
                 "pset_definitions.csv",
             )
@@ -788,7 +788,7 @@ class BIM_Preflight_TaskPanel:
             psetspath = os.path.join(
                 FreeCAD.getResourceDir(),
                 "Mod",
-                "Arch",
+                "BIM",
                 "Presets",
                 "pset_definitions.csv",
             )


### PR DESCRIPTION
Some Presets paths still used "Arch" instead of "BIM".