### PR TITLE
Gui/Part: improve gated single-pick fallback and face selection

### DIFF
--- a/src/Gui/Selection/SelectionFilter.cpp
+++ b/src/Gui/Selection/SelectionFilter.cpp
@@ -82,6 +82,10 @@ std::unordered_set<std::string> SelectionFilterGate::getGatedTypes(
     const std::vector<const char*>& allTypesForGeometry
 ) const
 {
+    if (!Filter || !Filter->getAst()) {
+        return {};
+    }
+
     std::unordered_set<std::string> allowedTypes;
     std::ranges::copy_if(
         allTypesForGeometry.begin(),

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -32,6 +32,7 @@
 #include <Inventor/actions/SoGetPrimitiveCountAction.h>
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/actions/SoHandleEventAction.h>
+#include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/actions/SoWriteAction.h>
 #include <Inventor/bundles/SoMaterialBundle.h>
 #include <Inventor/details/SoFaceDetail.h>
@@ -118,20 +119,24 @@ namespace Gui::SelectionPickPolicy
 
 bool canFinalizeSinglePick(const std::vector<Candidate>& picked)
 {
+    return !shouldExpandPickRadius(picked);
+}
+
+bool shouldExpandPickRadius(const std::vector<Candidate>& picked)
+{
     bool foundSelectionGate = false;
     for (const auto& info : picked) {
+        if (info.passesGate) {
+            return false;
+        }
         if (!info.hasGate) {
             continue;
         }
 
         foundSelectionGate = true;
-        if (info.passesGate) {
-            return true;
-        }
     }
 
-    // Preserve the existing first-object behavior unless an active gate rejected every pick so far.
-    return !foundSelectionGate;
+    return foundSelectionGate;
 }
 
 std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
@@ -437,21 +442,33 @@ bool SoFCUnifiedSelection::canFinalizeSinglePick(const std::vector<PickedInfo>& 
     return SelectionPickPolicy::canFinalizeSinglePick(getPickCandidates(picked, nullptr));
 }
 
-std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedList(
-    SoHandleEventAction* action,
-    bool singlePick
+bool SoFCUnifiedSelection::shouldExpandPickRadius(const std::vector<PickedInfo>& picked)
+{
+    return SelectionPickPolicy::shouldExpandPickRadius(getPickCandidates(picked, nullptr));
+}
+
+std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::collectPickedList(
+    const SoPickedPointList& points,
+    const SoPath* actionPath,
+    bool singlePick,
+    bool copyPickedPoints
 ) const
 {
     ViewProvider* last_vp = nullptr;
     std::vector<PickedInfo> ret;
-    const SoPickedPointList& points = action->getPickedPointList();
     for (int i = 0, count = points.getLength(); i < count; ++i) {
         PickedInfo info;
-        info.pp = points[i];
+        if (copyPickedPoints) {
+            info.ownedPoint = std::shared_ptr<const SoPickedPoint>(new SoPickedPoint(*points[i]));
+            info.pp = info.ownedPoint.get();
+        }
+        else {
+            info.pp = points[i];
+        }
         info.vpd = nullptr;
         ViewProvider* vp = nullptr;
         auto path = Gui::toFullPath(info.pp->getPath());
-        if (this->pcDocument && path && path->containsPath(action->getCurPath())) {
+        if (this->pcDocument && path && actionPath && path->containsPath(actionPath)) {
             vp = this->pcDocument->getViewProviderByPathFromHead(path);
             if (singlePick && last_vp && last_vp != vp && canFinalizeSinglePick(ret)) {
                 break;
@@ -486,6 +503,63 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedLis
             last_vp = vp;
         }
         ret.push_back(info);
+    }
+
+    return ret;
+}
+
+std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getExpandedPickedList(
+    SoHandleEventAction* action
+) const
+{
+    if (!action || !action->getEvent()) {
+        return {};
+    }
+
+    const SoPath* actionPath = action->getCurPath();
+    if (!actionPath) {
+        return {};
+    }
+
+    SoNode* sceneRoot = actionPath->getHead();
+    if (!sceneRoot) {
+        return {};
+    }
+
+    constexpr float expandedPickRadiusMultiplier = 2.0F;
+
+    SoRayPickAction pickAction(action->getViewportRegion());
+    pickAction.setPoint(action->getEvent()->getPosition());
+    pickAction.setRadius(action->getPickRadius() * expandedPickRadiusMultiplier);
+    pickAction.setPickAll(true);
+    pickAction.apply(sceneRoot);
+
+    auto expanded = collectPickedList(pickAction.getPickedPointList(), actionPath, false, true);
+    if (expanded.empty()) {
+        return {};
+    }
+
+    auto candidates = getPickCandidates(expanded, this->pcDocument);
+    if (SelectionPickPolicy::shouldExpandPickRadius(candidates)) {
+        return {};
+    }
+
+    auto pickedIndex = SelectionPickPolicy::choosePreferredPick(candidates);
+    return {expanded[pickedIndex]};
+}
+
+std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedList(
+    SoHandleEventAction* action,
+    bool singlePick
+) const
+{
+    auto ret = collectPickedList(action->getPickedPointList(), action->getCurPath(), singlePick);
+
+    if (singlePick && shouldExpandPickRadius(ret)) {
+        auto expanded = getExpandedPickedList(action);
+        if (!expanded.empty()) {
+            return expanded;
+        }
     }
 
     if (ret.size() <= 1) {

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -23,6 +23,8 @@
 
 #include <FCConfig.h>
 
+#include <cmath>
+
 #include <Inventor/SoFullPath.h>
 #include <Inventor/SoPickedPoint.h>
 
@@ -114,32 +116,61 @@ void printPreselectionInfo(
 
 SoFullPath* Gui::SoFCUnifiedSelection::currentHighlightPath = nullptr;
 
+namespace
+{
+
+float getCursorDistanceSquared(const SoPickedPoint* pickedPoint, const SbVec2f& cursorPosition)
+{
+    if (!pickedPoint) {
+        return std::numeric_limits<float>::infinity();
+    }
+
+    const SoNode* imageSpaceNode = nullptr;
+    if (const auto* path = pickedPoint->getPath()) {
+        imageSpaceNode = path->getHead();
+    }
+
+    SbVec3f imagePoint = pickedPoint->getObjectPoint(imageSpaceNode);
+    pickedPoint->getObjectToImage(imageSpaceNode).multVecMatrix(imagePoint, imagePoint);
+    imagePoint[0] = 0.5F * imagePoint[0] + 0.5F;
+    imagePoint[1] = 0.5F * imagePoint[1] + 0.5F;
+
+    const auto dx = imagePoint[0] - cursorPosition[0];
+    const auto dy = imagePoint[1] - cursorPosition[1];
+    return dx * dx + dy * dy;
+}
+
+}  // namespace
+
 namespace Gui::SelectionPickPolicy
 {
 
-bool canFinalizeSinglePick(const std::vector<Candidate>& picked)
+namespace
 {
-    return !shouldExpandPickRadius(picked);
+
+constexpr float fallbackDistanceSquaredEpsilon = 1.0e-6F;
+
+bool chooseHigherPriorityPick(const Candidate& candidate, const Candidate& current)
+{
+    if (candidate.priority != current.priority) {
+        return candidate.priority > current.priority;
+    }
+    if (candidate.isAnnotation != current.isAnnotation) {
+        return candidate.isAnnotation && !current.isAnnotation;
+    }
+    return false;
 }
 
-bool shouldExpandPickRadius(const std::vector<Candidate>& picked)
+bool areFallbackDistancesEquivalent(float lhs, float rhs)
 {
-    bool foundSelectionGate = false;
-    for (const auto& info : picked) {
-        if (info.passesGate) {
-            return false;
-        }
-        if (!info.hasGate) {
-            continue;
-        }
-
-        foundSelectionGate = true;
+    if (std::isinf(lhs) || std::isinf(rhs)) {
+        return lhs == rhs;
     }
 
-    return foundSelectionGate;
+    return std::fabs(lhs - rhs) <= fallbackDistanceSquaredEpsilon;
 }
 
-std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
+std::size_t choosePrimaryPreferredPick(const std::vector<Candidate>& picked)
 {
     if (picked.empty()) {
         return 0;
@@ -171,12 +202,76 @@ std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
         }
     }
 
+    return preferred;
+}
+
+}  // namespace
+
+bool canFinalizeSinglePick(const std::vector<Candidate>& picked)
+{
+    return !shouldExpandPickRadius(picked);
+}
+
+bool shouldExpandPickRadius(const std::vector<Candidate>& picked)
+{
+    bool foundSelectionGate = false;
+    for (const auto& info : picked) {
+        if (info.passesGate) {
+            return false;
+        }
+        if (!info.hasGate) {
+            continue;
+        }
+
+        foundSelectionGate = true;
+    }
+
+    return foundSelectionGate;
+}
+
+std::optional<std::size_t> chooseAllowedFallbackPick(const std::vector<Candidate>& picked)
+{
+    std::optional<std::size_t> preferred;
+    for (std::size_t i = 0; i < picked.size(); ++i) {
+        const auto& info = picked[i];
+        if (!info.passesGate) {
+            continue;
+        }
+
+        if (!preferred.has_value()) {
+            preferred = i;
+            continue;
+        }
+
+        const auto& current = picked[*preferred];
+        if (info.cursorDistanceSquared + fallbackDistanceSquaredEpsilon
+            < current.cursorDistanceSquared) {
+            preferred = i;
+            continue;
+        }
+        if (current.cursorDistanceSquared + fallbackDistanceSquaredEpsilon
+            < info.cursorDistanceSquared) {
+            continue;
+        }
+        if (areFallbackDistancesEquivalent(info.cursorDistanceSquared, current.cursorDistanceSquared)
+            && chooseHigherPriorityPick(info, current)) {
+            preferred = i;
+        }
+    }
+
+    return preferred;
+}
+
+std::size_t choosePreferredPick(const std::vector<Candidate>& picked)
+{
+    if (picked.empty()) {
+        return 0;
+    }
+
+    auto preferred = choosePrimaryPreferredPick(picked);
     if (!picked[preferred].passesGate) {
-        for (std::size_t i = 0; i < picked.size(); ++i) {
-            if (picked[i].passesGate) {
-                preferred = i;
-                break;
-            }
+        if (auto fallback = chooseAllowedFallbackPick(picked)) {
+            preferred = *fallback;
         }
     }
 
@@ -405,7 +500,8 @@ bool SoFCUnifiedSelection::hasSelectionGate(const PickedInfo& info)
 SelectionPickPolicy::Candidate SoFCUnifiedSelection::getPickCandidate(
     const PickedInfo& info,
     const Document* doc,
-    const PickedInfo* firstPicked
+    const PickedInfo* firstPicked,
+    const SbVec2f* cursorPosition
 )
 {
     SelectionPickPolicy::Candidate candidate;
@@ -418,20 +514,24 @@ SelectionPickPolicy::Candidate SoFCUnifiedSelection::getPickCandidate(
     if (firstPicked && info.pp && firstPicked->pp) {
         candidate.closeToFirst = info.pp->getPoint().equals(firstPicked->pp->getPoint(), 0.2F);
     }
+    if (cursorPosition) {
+        candidate.cursorDistanceSquared = getCursorDistanceSquared(info.pp, *cursorPosition);
+    }
 
     return candidate;
 }
 
 std::vector<SelectionPickPolicy::Candidate> SoFCUnifiedSelection::getPickCandidates(
     const std::vector<PickedInfo>& picked,
-    const Document* doc
+    const Document* doc,
+    const SbVec2f* cursorPosition
 )
 {
     std::vector<SelectionPickPolicy::Candidate> candidates;
     candidates.reserve(picked.size());
     const PickedInfo* firstPicked = picked.empty() ? nullptr : &picked.front();
     for (const auto& info : picked) {
-        candidates.push_back(getPickCandidate(info, doc, firstPicked));
+        candidates.push_back(getPickCandidate(info, doc, firstPicked, cursorPosition));
     }
 
     return candidates;
@@ -539,7 +639,8 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getExpandedP
         return {};
     }
 
-    auto candidates = getPickCandidates(expanded, this->pcDocument);
+    const auto cursorPosition = action->getEvent()->getNormalizedPosition(action->getViewportRegion());
+    auto candidates = getPickCandidates(expanded, this->pcDocument, &cursorPosition);
     if (SelectionPickPolicy::shouldExpandPickRadius(candidates)) {
         return {};
     }
@@ -567,10 +668,18 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedLis
     }
 
     // To identify the picking of lines in a concave area we have to get all intersection points.
-    // If the preferred point is rejected by the active selection gate, choose the first allowed
+    // If the preferred point is rejected by the active selection gate, choose the nearest allowed
     // candidate still inside the viewer pick radius.
+    const SbVec2f* cursorPosition = nullptr;
+    SbVec2f normalizedCursorPosition;
+    if (action && action->getEvent()) {
+        normalizedCursorPosition = action->getEvent()->getNormalizedPosition(
+            action->getViewportRegion()
+        );
+        cursorPosition = &normalizedCursorPosition;
+    }
     auto pickedIndex = SelectionPickPolicy::choosePreferredPick(
-        getPickCandidates(ret, this->pcDocument)
+        getPickCandidates(ret, this->pcDocument, cursorPosition)
     );
     auto itPicked = ret.begin() + pickedIndex;
 

--- a/src/Gui/Selection/SoFCUnifiedSelection.cpp
+++ b/src/Gui/Selection/SoFCUnifiedSelection.cpp
@@ -119,7 +119,7 @@ SoFullPath* Gui::SoFCUnifiedSelection::currentHighlightPath = nullptr;
 namespace
 {
 
-float getCursorDistanceSquared(const SoPickedPoint* pickedPoint, const SbVec2f& cursorPosition)
+float getProjectedCursorDistanceSquared(const SoPickedPoint* pickedPoint, const SbVec2f& cursorPosition)
 {
     if (!pickedPoint) {
         return std::numeric_limits<float>::infinity();
@@ -138,6 +138,149 @@ float getCursorDistanceSquared(const SoPickedPoint* pickedPoint, const SbVec2f& 
     const auto dx = imagePoint[0] - cursorPosition[0];
     const auto dy = imagePoint[1] - cursorPosition[1];
     return dx * dx + dy * dy;
+}
+
+struct SelectionPickContextStorage
+{
+    SelectionPickContextStorage() = default;
+    SelectionPickContextStorage(const SelectionPickContextStorage&) = delete;
+    SelectionPickContextStorage& operator=(const SelectionPickContextStorage&) = delete;
+    SelectionPickContextStorage(SelectionPickContextStorage&&) = delete;
+    SelectionPickContextStorage& operator=(SelectionPickContextStorage&&) = delete;
+
+    void populate(const Gui::Document* document, SoHandleEventAction* action)
+    {
+        selectionPickContext = SelectionPickContext {};
+        normalizedCursorPosition.reset();
+        eventPosition.reset();
+
+        if (document) {
+            selectionPickContext.gate = Selection().getSelectionGate(document->getDocument());
+        }
+        if (action) {
+            selectionPickContext.repick.sceneRoot = action->getCurPath()
+                ? action->getCurPath()->getHead()
+                : nullptr;
+            selectionPickContext.repick.viewportRegion = &action->getViewportRegion();
+            selectionPickContext.repick.pickRadius = action->getPickRadius();
+        }
+        if (action && action->getEvent()) {
+            normalizedCursorPosition = action->getEvent()->getNormalizedPosition(
+                action->getViewportRegion()
+            );
+            eventPosition = action->getEvent()->getPosition();
+        }
+
+        refreshPointers();
+    }
+
+    const SbVec2f* normalizedCursorPositionPtr() const
+    {
+        return selectionPickContext.normalizedCursorPosition;
+    }
+
+    const SelectionPickContext* pickContext() const
+    {
+        return &selectionPickContext;
+    }
+
+private:
+    void refreshPointers()
+    {
+        selectionPickContext.normalizedCursorPosition = normalizedCursorPosition
+            ? &*normalizedCursorPosition
+            : nullptr;
+        selectionPickContext.repick.eventPosition = eventPosition ? &*eventPosition : nullptr;
+    }
+
+    // SelectionPickContext carries raw pointers into these optionals, so this storage must stay
+    // alive and must not move while view providers inspect the context.
+    SelectionPickContext selectionPickContext;
+    std::optional<SbVec2f> normalizedCursorPosition;
+    std::optional<SbVec2s> eventPosition;
+};
+
+bool resolveDetailPathForElement(
+    ViewProviderDocumentObject* vpd,
+    const std::string& element,
+    SoFullPath* detailPath,
+    SoFullPath*& path,
+    const SoDetail*& det,
+    SoDetail*& ownedDetail
+)
+{
+    // View providers may translate the logical element returned from picking into a different
+    // detail/path pair used for Coin highlighting and selection actions.
+    detailPath->truncate(0);
+    SoDetail* detCandidate = nullptr;
+    if (vpd->getDetailPath(element.c_str(), detailPath, true, detCandidate)
+        && detailPath->getLength()) {
+        path = detailPath;
+        det = detCandidate;
+        ownedDetail = detCandidate;
+        return true;
+    }
+
+    delete detCandidate;
+    return false;
+}
+
+void maybeResolvePromotedSelectionTarget(
+    ViewProviderDocumentObject* vpd,
+    bool pickedElementWasPromoted,
+    bool ctrlDown,
+    bool hasNext,
+    SoSelectionElementAction::Type type,
+    const std::string& subName,
+    SoFullPath* detailPath,
+    SoFullPath*& path,
+    const SoDetail*& det,
+    SoDetail*& ownedDetail
+)
+{
+    // If the view provider promoted the raw picked element, rebuild the visual action target from
+    // the promoted sub-element before highlighting.
+    if (!pickedElementWasPromoted || ctrlDown || hasNext || type == SoSelectionElementAction::None) {
+        return;
+    }
+
+    resolveDetailPathForElement(vpd, subName, detailPath, path, det, ownedDetail);
+}
+
+std::optional<std::string> getGateAllowedHierarchyAscentTarget(
+    ViewProviderDocumentObject* vpd,
+    const std::string& selectedSubName
+)
+{
+    if (!vpd || selectedSubName.empty()) {
+        return {};
+    }
+
+    // The convention of dot-separated SubName demands a mandatory ending dot for every object
+    // name reference inside SubName. Whole-object selections therefore need to skip the final dot
+    // and search for the parent object's ending dot.
+    const std::string normalizedSelectedSubName = Data::newElementName(selectedSubName.c_str());
+    std::string nextSubName;
+    size_t next = normalizedSelectedSubName.rfind('.');
+    if (next != std::string::npos && next != 0) {
+        if (next == normalizedSelectedSubName.size() - 1) {
+            next = normalizedSelectedSubName.rfind('.', next - 1);
+        }
+        if (next != std::string::npos) {
+            nextSubName = normalizedSelectedSubName.substr(0, next + 1);
+        }
+    }
+
+    if (nextSubName.empty() && normalizedSelectedSubName.empty()) {
+        return {};
+    }
+
+    if (!Selection()
+             .testSelection(vpd->getObject()->getDocument(), vpd->getObject(), nextSubName.c_str())) {
+        return {};
+    }
+
+    return nextSubName;
 }
 
 }  // namespace
@@ -515,7 +658,7 @@ SelectionPickPolicy::Candidate SoFCUnifiedSelection::getPickCandidate(
         candidate.closeToFirst = info.pp->getPoint().equals(firstPicked->pp->getPoint(), 0.2F);
     }
     if (cursorPosition) {
-        candidate.cursorDistanceSquared = getCursorDistanceSquared(info.pp, *cursorPosition);
+        candidate.cursorDistanceSquared = getProjectedCursorDistanceSquared(info.pp, *cursorPosition);
     }
 
     return candidate;
@@ -542,16 +685,12 @@ bool SoFCUnifiedSelection::canFinalizeSinglePick(const std::vector<PickedInfo>& 
     return SelectionPickPolicy::canFinalizeSinglePick(getPickCandidates(picked, nullptr));
 }
 
-bool SoFCUnifiedSelection::shouldExpandPickRadius(const std::vector<PickedInfo>& picked)
-{
-    return SelectionPickPolicy::shouldExpandPickRadius(getPickCandidates(picked, nullptr));
-}
-
 std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::collectPickedList(
     const SoPickedPointList& points,
     const SoPath* actionPath,
     bool singlePick,
-    bool copyPickedPoints
+    bool copyPickedPoints,
+    const SelectionPickContext* pickContext
 ) const
 {
     ViewProvider* last_vp = nullptr;
@@ -595,7 +734,7 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::collectPicke
             }
             break;
         }
-        if (!info.vpd->getElementPicked(info.pp, info.element)) {
+        if (!info.vpd->getElementPicked(info.pp, info.element, pickContext)) {
             continue;
         }
 
@@ -634,13 +773,21 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getExpandedP
     pickAction.setPickAll(true);
     pickAction.apply(sceneRoot);
 
-    auto expanded = collectPickedList(pickAction.getPickedPointList(), actionPath, false, true);
+    SelectionPickContextStorage pickContext;
+    pickContext.populate(this->pcDocument, action);
+    auto expanded = collectPickedList(
+        pickAction.getPickedPointList(),
+        actionPath,
+        false,
+        true,
+        pickContext.pickContext()
+    );
     if (expanded.empty()) {
         return {};
     }
 
-    const auto cursorPosition = action->getEvent()->getNormalizedPosition(action->getViewportRegion());
-    auto candidates = getPickCandidates(expanded, this->pcDocument, &cursorPosition);
+    auto candidates
+        = getPickCandidates(expanded, this->pcDocument, pickContext.normalizedCursorPositionPtr());
     if (SelectionPickPolicy::shouldExpandPickRadius(candidates)) {
         return {};
     }
@@ -654,9 +801,17 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedLis
     bool singlePick
 ) const
 {
-    auto ret = collectPickedList(action->getPickedPointList(), action->getCurPath(), singlePick);
+    SelectionPickContextStorage pickContext;
+    pickContext.populate(this->pcDocument, action);
+    auto ret = collectPickedList(
+        action->getPickedPointList(),
+        action->getCurPath(),
+        singlePick,
+        false,
+        pickContext.pickContext()
+    );
 
-    if (singlePick && shouldExpandPickRadius(ret)) {
+    if (singlePick && SelectionPickPolicy::shouldExpandPickRadius(getPickCandidates(ret, nullptr))) {
         auto expanded = getExpandedPickedList(action);
         if (!expanded.empty()) {
             return expanded;
@@ -670,17 +825,9 @@ std::vector<SoFCUnifiedSelection::PickedInfo> SoFCUnifiedSelection::getPickedLis
     // To identify the picking of lines in a concave area we have to get all intersection points.
     // If the preferred point is rejected by the active selection gate, choose the nearest allowed
     // candidate still inside the viewer pick radius.
-    const SbVec2f* cursorPosition = nullptr;
-    SbVec2f normalizedCursorPosition;
-    if (action && action->getEvent()) {
-        normalizedCursorPosition = action->getEvent()->getNormalizedPosition(
-            action->getViewportRegion()
-        );
-        cursorPosition = &normalizedCursorPosition;
-    }
-    auto pickedIndex = SelectionPickPolicy::choosePreferredPick(
-        getPickCandidates(ret, this->pcDocument, cursorPosition)
-    );
+    auto candidates
+        = getPickCandidates(ret, this->pcDocument, pickContext.normalizedCursorPositionPtr());
+    auto pickedIndex = SelectionPickPolicy::choosePreferredPick(candidates);
     auto itPicked = ret.begin() + pickedIndex;
 
     if (singlePick) {
@@ -953,15 +1100,19 @@ bool SoFCUnifiedSelection::setPreselect(const PickedInfo& info)
     }
 
     const auto& pt = info.pp->getPoint();
-    return setPreselect(
-        Gui::toFullPath(info.pp->getPath()),
-        info.pp->getDetail(),
-        info.vpd,
-        info.element.c_str(),
-        pt[0],
-        pt[1],
-        pt[2]
-    );
+    const SoDetail* det = info.pp->getDetail();
+    SoDetail* detResolved = nullptr;
+    auto path = Gui::toFullPath(info.pp->getPath());
+    if (info.vpd) {
+        std::string rawElement;
+        if (info.vpd->getElementPicked(info.pp, rawElement) && rawElement != info.element) {
+            resolveDetailPathForElement(info.vpd, info.element, detailPath, path, det, detResolved);
+        }
+    }
+
+    bool highlighted = setPreselect(path, det, info.vpd, info.element.c_str(), pt[0], pt[1], pt[2]);
+    delete detResolved;
+    return highlighted;
 }
 
 bool SoFCUnifiedSelection::setPreselect(
@@ -1092,6 +1243,9 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
     static char buf[513];
     auto subName = info.element;
     std::string objectName = objname;
+    std::string rawElement;
+    bool pickedElementWasPromoted = vpd->getElementPicked(pp, rawElement)
+        && rawElement != info.element;
 
     if (ctrlDown) {
         if (Gui::Selection().isSelected(docname, objname, info.element.c_str(), ResolveMode::NoResolve)) {
@@ -1133,11 +1287,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
 
                 getMainWindow()->showMessage(QString::fromLatin1(buf));
             }
-            detailPath->truncate(0);
-            if (vpd->getDetailPath(info.element.c_str(), detailPath, true, detNext)
-                && detailPath->getLength()) {
-                pPath = detailPath;
-                det = detNext;
+            if (resolveDetailPathForElement(vpd, info.element, detailPath, pPath, det, detNext)) {
                 FC_TRACE("select next " << objectName << ", " << subName);
                 if (ok) {
                     type = hasNext ? SoSelectionElementAction::All : SoSelectionElementAction::Append;
@@ -1168,6 +1318,7 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
         // We need to convert the short name in the selection to a full element path to look it up
         // Ex:  Body.Pad.Face9  to Body.Pad.;g3;SKT;:H12dc,E;FAC;:H12dc:4,F;:G0;XTR;:H12dc:8,F.Face9
         getFullSubElementName(subName);
+        const auto clickedSubName = subName;
         std::string subSelected
             = Gui::Selection().getSelectedElement(vpd->getObject(), subName.c_str());
 
@@ -1175,37 +1326,16 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
             "select " << (!subSelected.empty() ? subSelected : "'null'") << ", " << objectName
                       << ", " << subName
         );
-        std::string newElement;
         if (!subSelected.empty()) {
-            newElement = Data::newElementName(subSelected.c_str());
-            subSelected = newElement.c_str();
-            std::string nextsub;
-            size_t next = subSelected.rfind('.');
-            if (next != std::string::npos && next != 0) {
-                if (next == subSelected.size() - 1) {
-                    // The convention of dot separated SubName demands a mandatory
-                    // ending dot for every object name reference inside SubName.
-                    // The non-object sub-element, however, must not end with a dot.
-                    // So, next[1]==0 here means current selection is a whole object
-                    // selection (because no sub-element), so we shall search
-                    // upwards for the second last dot, which is the end of the
-                    // parent name of the current selected object
-                    next = subSelected.rfind('.', next - 1);
-                }
-                if (next != std::string::npos) {
-                    nextsub = subSelected.substr(0, next + 1);
-                }
-            }
-            if (!nextsub.empty() || !subSelected.empty()) {
+            if (auto nextSubName = getGateAllowedHierarchyAscentTarget(vpd, subSelected)) {
                 hasNext = true;
-                subName = nextsub;
-                detailPath->truncate(0);
-                if (vpd->getDetailPath(subName.c_str(), detailPath, true, detNext)
-                    && detailPath->getLength()) {
-                    pPath = detailPath;
-                    det = detNext;
+                subName = *nextSubName;
+                if (resolveDetailPathForElement(vpd, subName, detailPath, pPath, det, detNext)) {
                     FC_TRACE("select next " << objectName << ", " << subName);
                 }
+            }
+            else {
+                subName = clickedSubName;
             }
         }
 
@@ -1243,6 +1373,19 @@ bool SoFCUnifiedSelection::setSelection(const std::vector<PickedInfo>& infos, bo
             getMainWindow()->showMessage(QString::fromLatin1(buf));
         }
     }
+
+    maybeResolvePromotedSelectionTarget(
+        vpd,
+        pickedElementWasPromoted,
+        ctrlDown,
+        hasNext,
+        type,
+        subName,
+        detailPath,
+        pPath,
+        det,
+        detNext
+    );
 
     if (pPath) {
         FC_TRACE("applying action");

--- a/src/Gui/Selection/SoFCUnifiedSelection.h
+++ b/src/Gui/Selection/SoFCUnifiedSelection.h
@@ -25,6 +25,7 @@
 
 #include <cstddef>
 #include <list>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -61,6 +62,7 @@ struct Candidate
 };
 
 GuiExport bool canFinalizeSinglePick(const std::vector<Candidate>& picked);
+GuiExport bool shouldExpandPickRadius(const std::vector<Candidate>& picked);
 GuiExport std::size_t choosePreferredPick(const std::vector<Candidate>& picked);
 
 }  // namespace SelectionPickPolicy
@@ -153,6 +155,7 @@ private:
     struct PickedInfo
     {
         const SoPickedPoint* pp {nullptr};
+        std::shared_ptr<const SoPickedPoint> ownedPoint;
         ViewProviderDocumentObject* vpd {nullptr};
         std::string element;
     };
@@ -169,6 +172,7 @@ private:
         const Document*
     );
     static bool canFinalizeSinglePick(const std::vector<PickedInfo>&);
+    static bool shouldExpandPickRadius(const std::vector<PickedInfo>&);
 
     bool setPreselect(const PickedInfo&);
     bool setPreselect(
@@ -182,6 +186,13 @@ private:
     );
     bool setSelection(const std::vector<PickedInfo>&, bool ctrlDown = false);
 
+    std::vector<PickedInfo> collectPickedList(
+        const SoPickedPointList& points,
+        const SoPath* actionPath,
+        bool singlePick,
+        bool copyPickedPoints = false
+    ) const;
+    std::vector<PickedInfo> getExpandedPickedList(SoHandleEventAction* action) const;
     std::vector<PickedInfo> getPickedList(SoHandleEventAction* action, bool singlePick) const;
 
     Gui::Document* pcDocument {nullptr};

--- a/src/Gui/Selection/SoFCUnifiedSelection.h
+++ b/src/Gui/Selection/SoFCUnifiedSelection.h
@@ -51,6 +51,8 @@ class SbVec2f;
 namespace Gui
 {
 
+struct SelectionPickContext;
+
 namespace SelectionPickPolicy
 {
 
@@ -76,6 +78,7 @@ GuiExport std::size_t choosePreferredPick(const std::vector<Candidate>& picked);
 class Document;
 class ViewProviderDocumentObject;
 class SoFCUnifiedSelectionTestAccess;
+class SelectionGate;
 
 class AutoPreselection
 {
@@ -182,7 +185,6 @@ private:
         const SbVec2f* cursorPosition = nullptr
     );
     static bool canFinalizeSinglePick(const std::vector<PickedInfo>&);
-    static bool shouldExpandPickRadius(const std::vector<PickedInfo>&);
 
     bool setPreselect(const PickedInfo&);
     bool setPreselect(
@@ -200,7 +202,8 @@ private:
         const SoPickedPointList& points,
         const SoPath* actionPath,
         bool singlePick,
-        bool copyPickedPoints = false
+        bool copyPickedPoints = false,
+        const SelectionPickContext* pickContext = nullptr
     ) const;
     std::vector<PickedInfo> getExpandedPickedList(SoHandleEventAction* action) const;
     std::vector<PickedInfo> getPickedList(SoHandleEventAction* action, bool singlePick) const;

--- a/src/Gui/Selection/SoFCUnifiedSelection.h
+++ b/src/Gui/Selection/SoFCUnifiedSelection.h
@@ -25,7 +25,9 @@
 
 #include <cstddef>
 #include <list>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -43,6 +45,7 @@
 class SoFullPath;
 class SoPickedPoint;
 class SoDetail;
+class SbVec2f;
 
 
 namespace Gui
@@ -59,16 +62,20 @@ struct Candidate
     bool isAnnotation {false};
     bool hasGate {false};
     bool passesGate {false};
+    // Used only when resolving a blocked-pick fallback.
+    float cursorDistanceSquared {std::numeric_limits<float>::infinity()};
 };
 
 GuiExport bool canFinalizeSinglePick(const std::vector<Candidate>& picked);
 GuiExport bool shouldExpandPickRadius(const std::vector<Candidate>& picked);
+GuiExport std::optional<std::size_t> chooseAllowedFallbackPick(const std::vector<Candidate>& picked);
 GuiExport std::size_t choosePreferredPick(const std::vector<Candidate>& picked);
 
 }  // namespace SelectionPickPolicy
 
 class Document;
 class ViewProviderDocumentObject;
+class SoFCUnifiedSelectionTestAccess;
 
 class AutoPreselection
 {
@@ -145,6 +152,7 @@ public:
     static bool hasHighlight();
 
     friend class View3DInventorViewer;
+    friend class SoFCUnifiedSelectionTestAccess;
 
 protected:
     ~SoFCUnifiedSelection() override;
@@ -165,11 +173,13 @@ private:
     static SelectionPickPolicy::Candidate getPickCandidate(
         const PickedInfo&,
         const Document*,
-        const PickedInfo* firstPicked = nullptr
+        const PickedInfo* firstPicked = nullptr,
+        const SbVec2f* cursorPosition = nullptr
     );
     static std::vector<SelectionPickPolicy::Candidate> getPickCandidates(
         const std::vector<PickedInfo>&,
-        const Document*
+        const Document*,
+        const SbVec2f* cursorPosition = nullptr
     );
     static bool canFinalizeSinglePick(const std::vector<PickedInfo>&);
     static bool shouldExpandPickRadius(const std::vector<PickedInfo>&);

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -1015,6 +1015,26 @@ bool ViewProvider::getElementPicked(const SoPickedPoint* pp, std::string& subnam
             return true;
         }
     }
+    return resolvePickedElementFromDetail(pp, subname);
+}
+
+bool ViewProvider::getElementPicked(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const SelectionPickContext* pickContext
+) const
+{
+    auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
+    for (Gui::ViewProviderExtension* ext : vector) {
+        if (ext->extensionGetElementPicked(pp, subname, pickContext)) {
+            return true;
+        }
+    }
+    return resolvePickedElementFromDetail(pp, subname);
+}
+
+bool ViewProvider::resolvePickedElementFromDetail(const SoPickedPoint* pp, std::string& subname) const
+{
     subname = getElement(pp ? pp->getDetail() : nullptr);
     return true;
 }

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -1009,16 +1009,19 @@ std::vector<App::DocumentObject*> ViewProvider::claimChildren3D() const
 
 bool ViewProvider::getElementPicked(const SoPickedPoint* pp, std::string& subname) const
 {
-    auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
-    for (Gui::ViewProviderExtension* ext : vector) {
-        if (ext->extensionGetElementPicked(pp, subname)) {
-            return true;
-        }
-    }
-    return resolvePickedElementFromDetail(pp, subname);
+    return getElementPicked(pp, subname, nullptr);
 }
 
 bool ViewProvider::getElementPicked(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const SelectionPickContext* pickContext
+) const
+{
+    return resolvePickedElement(pp, subname, pickContext);
+}
+
+bool ViewProvider::resolvePickedElement(
     const SoPickedPoint* pp,
     std::string& subname,
     const SelectionPickContext* pickContext

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -26,6 +26,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_set>
 #include <QIcon>
 #include <fastsignals/signal.h>
 #include <boost/intrusive_ptr.hpp>
@@ -38,7 +39,9 @@
 #include "TreeItemMode.h"
 
 class SbVec2s;
+class SbVec2f;
 class SbVec3f;
+class SbViewportRegion;
 class SoNode;
 class SoPath;
 class SoSeparator;
@@ -74,7 +77,35 @@ class View3DInventorViewer;
 class ViewProviderPy;
 class ObjectItem;
 class MDIView;
+class Document;
 class SelectionChanges;
+class SelectionGate;
+
+/// Additional single-pick context. All pointers are borrowed for the duration of a single pick
+/// resolution call. Callers may pass null when they only need legacy detail-to-subelement
+/// resolution.
+struct GuiExport SelectionPickContext
+{
+    const SelectionGate* gate {nullptr};
+
+    // Normalized cursor position in the current viewport.
+    const SbVec2f* normalizedCursorPosition {nullptr};
+
+    struct RepickInputs
+    {
+        // Original pick inputs, for view providers that need to repick against the scene to
+        // resolve gated subelement alternatives.
+        SoNode* sceneRoot {nullptr};
+        const SbViewportRegion* viewportRegion {nullptr};
+        const SbVec2s* eventPosition {nullptr};
+        float pickRadius {0.0F};
+
+        bool isValid() const
+        {
+            return sceneRoot && viewportRegion && eventPosition;
+        }
+    } repick;
+};
 
 enum ViewStatus
 {
@@ -281,8 +312,23 @@ public:
     /// called when the selection changes for the view provider
     virtual void onSelectionChanged(const SelectionChanges&)
     {}
-    /// return a hit element given the picked point which contains the full node path
-    virtual bool getElementPicked(const SoPickedPoint*, std::string& subname) const;
+    /// Convenience wrapper for callers that do not need pick context.
+    bool getElementPicked(const SoPickedPoint*, std::string& subname) const;
+    /// Convenience wrapper for callers that do have pick context.
+    bool getElementPicked(
+        const SoPickedPoint*,
+        std::string& subname,
+        const SelectionPickContext* pickContext
+    ) const;
+    /// Canonical virtual hook for single-pick resolution. Override this instead of the
+    /// getElementPicked() wrappers. \a pickContext may be null; when present it carries the
+    /// normalized cursor position plus the original pick action inputs for view-provider-specific
+    /// recovery.
+    virtual bool resolvePickedElement(
+        const SoPickedPoint*,
+        std::string& subname,
+        const SelectionPickContext* pickContext
+    ) const;
     /** Return additional sub-element names related to a picked element.
      *
      * Lets a view provider expand a single pick into a set of logically related
@@ -652,6 +698,10 @@ public:
     };
 
 protected:
+    // Resolve the picked subelement directly from the Coin detail without consulting extensions
+    // or virtual overloads. Derived classes can use this as a recursion-free fallback.
+    bool resolvePickedElementFromDetail(const SoPickedPoint*, std::string& subname) const;
+
     /// is called by the document when the provider goes in edit mode
     virtual bool setEdit(int ModNum);
     /// is called when you lose the edit mode

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -668,9 +668,18 @@ bool ViewProviderDocumentObject::showInTree() const
 
 bool ViewProviderDocumentObject::getElementPicked(const SoPickedPoint* pp, std::string& subname) const
 {
+    return getElementPicked(pp, subname, nullptr);
+}
+
+bool ViewProviderDocumentObject::getElementPicked(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const SelectionPickContext* pickContext
+) const
+{
     auto vector = getExtensionsDerivedFromType<Gui::ViewProviderExtension>();
     for (Gui::ViewProviderExtension* ext : vector) {
-        if (ext->extensionGetElementPicked(pp, subname)) {
+        if (ext->extensionGetElementPicked(pp, subname, pickContext)) {
             return true;
         }
     }
@@ -679,7 +688,7 @@ bool ViewProviderDocumentObject::getElementPicked(const SoPickedPoint* pp, std::
     int idx;
     if (!childRoot || (idx = pcModeSwitch->whichChild.getValue()) < 0
         || pcModeSwitch->getChild(idx) != childRoot) {
-        return ViewProvider::getElementPicked(pp, subname);
+        return resolvePickedElementFromDetail(pp, subname);
     }
 
     SoPath* path = pp->getPath();
@@ -697,7 +706,7 @@ bool ViewProviderDocumentObject::getElementPicked(const SoPickedPoint* pp, std::
     }
     std::ostringstream str;
     str << obj->getNameInDocument() << '.';
-    if (vp->getElementPicked(pp, subname)) {
+    if (vp->getElementPicked(pp, subname, pickContext)) {
         str << subname;
     }
     subname = str.str();

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -666,12 +666,7 @@ bool ViewProviderDocumentObject::showInTree() const
     return ShowInTree.getValue();
 }
 
-bool ViewProviderDocumentObject::getElementPicked(const SoPickedPoint* pp, std::string& subname) const
-{
-    return getElementPicked(pp, subname, nullptr);
-}
-
-bool ViewProviderDocumentObject::getElementPicked(
+bool ViewProviderDocumentObject::resolvePickedElement(
     const SoPickedPoint* pp,
     std::string& subname,
     const SelectionPickContext* pickContext
@@ -691,6 +686,8 @@ bool ViewProviderDocumentObject::getElementPicked(
         return resolvePickedElementFromDetail(pp, subname);
     }
 
+    // Document-object providers can expose child providers inside their child root. Delegate the
+    // actual element resolution to that child and prefix the owning object name.
     SoPath* path = pp->getPath();
     idx = path->findNode(childRoot);
     if (idx < 0 || idx + 1 >= path->getLength()) {

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -117,9 +117,7 @@ public:
     /// Get the python wrapper for that ViewProvider
     PyObject* getPyObject() override;
 
-    /// return a hit element given the picked point which contains the full node path
-    bool getElementPicked(const SoPickedPoint*, std::string& subname) const override;
-    bool getElementPicked(
+    bool resolvePickedElement(
         const SoPickedPoint*,
         std::string& subname,
         const SelectionPickContext* pickContext

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -119,6 +119,11 @@ public:
 
     /// return a hit element given the picked point which contains the full node path
     bool getElementPicked(const SoPickedPoint*, std::string& subname) const override;
+    bool getElementPicked(
+        const SoPickedPoint*,
+        std::string& subname,
+        const SelectionPickContext* pickContext
+    ) const override;
     /// return the coin node detail and path to the node of the subname
     bool getDetailPath(const char* subname, SoFullPath* pPath, bool append, SoDetail*& det) const override;
 

--- a/src/Gui/ViewProviderExtension.h
+++ b/src/Gui/ViewProviderExtension.h
@@ -189,19 +189,19 @@ public:
     virtual void extensionFinishRestoring()
     {}
 
-    virtual bool extensionGetElementPicked(const SoPickedPoint*, std::string&) const
+    bool extensionGetElementPicked(const SoPickedPoint* pp, std::string& subname) const
     {
-        return false;
+        return extensionGetElementPicked(pp, subname, nullptr);
     }
-    /// Context-aware extension hook; \a pickContext may be null when callers only need the legacy
-    /// pick resolution.
+    /// Canonical extension hook for single-pick resolution. \a pickContext may be null when
+    /// callers only need the legacy pick resolution.
     virtual bool extensionGetElementPicked(
-        const SoPickedPoint* pp,
-        std::string& subname,
+        const SoPickedPoint*,
+        std::string&,
         const SelectionPickContext* /*pickContext*/
     ) const
     {
-        return extensionGetElementPicked(pp, subname);
+        return false;
     }
     virtual bool extensionGetDetailPath(const char*, SoFullPath*, SoDetail*&) const
     {

--- a/src/Gui/ViewProviderExtension.h
+++ b/src/Gui/ViewProviderExtension.h
@@ -32,6 +32,7 @@ class SoFullPath;
 class SoGroup;
 class SoPickedPoint;
 class SoSeparator;
+class SbVec2f;
 
 class QMenu;
 class QObject;
@@ -41,6 +42,8 @@ namespace Gui
 
 class ViewProvider;
 class ViewProviderDocumentObject;
+class SelectionGate;
+struct SelectionPickContext;
 
 /**
  * @brief Extension with special viewprovider calls
@@ -189,6 +192,16 @@ public:
     virtual bool extensionGetElementPicked(const SoPickedPoint*, std::string&) const
     {
         return false;
+    }
+    /// Context-aware extension hook; \a pickContext may be null when callers only need the legacy
+    /// pick resolution.
+    virtual bool extensionGetElementPicked(
+        const SoPickedPoint* pp,
+        std::string& subname,
+        const SelectionPickContext* /*pickContext*/
+    ) const
+    {
+        return extensionGetElementPicked(pp, subname);
     }
     virtual bool extensionGetDetailPath(const char*, SoFullPath*, SoDetail*&) const
     {

--- a/src/Gui/ViewProviderFeaturePython.h
+++ b/src/Gui/ViewProviderFeaturePython.h
@@ -233,8 +233,10 @@ public:
 
 private:
     template<typename Fallback>
-    bool dispatchGetElementPicked(const SoPickedPoint* pp, std::string& subname, Fallback&& fallback) const
+    bool dispatchResolvePickedElement(const SoPickedPoint* pp, std::string& subname, Fallback&& fallback) const
     {
+        // Python view providers still expose the legacy getElementPicked() hook. If it is not
+        // implemented, continue through the C++ context-aware resolution path.
         const auto ret = imp->getElementPicked(pp, subname);
         if (ret == ViewProviderFeaturePythonImp::NotImplemented) {
             return fallback();
@@ -323,20 +325,14 @@ public:
     {
         return imp->onSelectionChanged(changes);
     }
-    bool getElementPicked(const SoPickedPoint* pp, std::string& subname) const override
-    {
-        return dispatchGetElementPicked(pp, subname, [&]() {
-            return ViewProviderT::getElementPicked(pp, subname);
-        });
-    }
-    bool getElementPicked(
+    bool resolvePickedElement(
         const SoPickedPoint* pp,
         std::string& subname,
         const SelectionPickContext* pickContext
     ) const override
     {
-        return dispatchGetElementPicked(pp, subname, [&]() {
-            return ViewProviderT::getElementPicked(pp, subname, pickContext);
+        return dispatchResolvePickedElement(pp, subname, [&]() {
+            return ViewProviderT::resolvePickedElement(pp, subname, pickContext);
         });
     }
     std::string getElement(const SoDetail* det) const override

--- a/src/Gui/ViewProviderFeaturePython.h
+++ b/src/Gui/ViewProviderFeaturePython.h
@@ -231,6 +231,18 @@ public:
         delete imp;
     }
 
+private:
+    template<typename Fallback>
+    bool dispatchGetElementPicked(const SoPickedPoint* pp, std::string& subname, Fallback&& fallback) const
+    {
+        const auto ret = imp->getElementPicked(pp, subname);
+        if (ret == ViewProviderFeaturePythonImp::NotImplemented) {
+            return fallback();
+        }
+        return ret == ViewProviderFeaturePythonImp::Accepted;
+    }
+
+public:
     // Returns the icon
     QIcon getIcon() const override
     {
@@ -313,14 +325,19 @@ public:
     }
     bool getElementPicked(const SoPickedPoint* pp, std::string& subname) const override
     {
-        auto ret = imp->getElementPicked(pp, subname);
-        if (ret == ViewProviderFeaturePythonImp::NotImplemented) {
+        return dispatchGetElementPicked(pp, subname, [&]() {
             return ViewProviderT::getElementPicked(pp, subname);
-        }
-        else if (ret == ViewProviderFeaturePythonImp::Accepted) {
-            return true;
-        }
-        return false;
+        });
+    }
+    bool getElementPicked(
+        const SoPickedPoint* pp,
+        std::string& subname,
+        const SelectionPickContext* pickContext
+    ) const override
+    {
+        return dispatchGetElementPicked(pp, subname, [&]() {
+            return ViewProviderT::getElementPicked(pp, subname, pickContext);
+        });
     }
     std::string getElement(const SoDetail* det) const override
     {

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -588,7 +588,13 @@ public:
         this->nodeMap.swap(nodeMap);
     }
 
-    bool getElementPicked(bool addname, int type, const SoPickedPoint* pp, std::ostream& str) const
+    bool getElementPicked(
+        bool addname,
+        int type,
+        const SoPickedPoint* pp,
+        std::ostream& str,
+        const Gui::SelectionPickContext* pickContext
+    ) const
     {
         if (!pp || !isLinked()) {
             return false;
@@ -610,11 +616,11 @@ public:
             if (it == nodeMap.end()) {
                 return false;
             }
-            return it->second->getElementPicked(true, LinkView::SnapshotChild, pp, str);
+            return it->second->getElementPicked(true, LinkView::SnapshotChild, pp, str, pickContext);
         }
         else {
             std::string subname;
-            if (!pcLinked->getElementPicked(pp, subname)) {
+            if (!pcLinked->getElementPicked(pp, subname, pickContext)) {
                 return false;
             }
             str << subname;
@@ -1643,6 +1649,15 @@ void LinkView::updateLink()
 
 bool LinkView::linkGetElementPicked(const SoPickedPoint* pp, std::string& subname) const
 {
+    return linkGetElementPicked(pp, subname, nullptr);
+}
+
+bool LinkView::linkGetElementPicked(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const SelectionPickContext* pickContext
+) const
+{
     std::ostringstream ss;
     CoinPtr<SoPath> path {pp->getPath()};
     if (!nodeArray.empty()) {
@@ -1683,7 +1698,7 @@ bool LinkView::linkGetElementPicked(const SoPickedPoint* pp, std::string& subnam
         }
 
         if (info.isLinked()) {
-            if (!info.linkInfo->getElementPicked(false, childType, pp, ss)) {
+            if (!info.linkInfo->getElementPicked(false, childType, pp, ss, pickContext)) {
                 return false;
             }
             subname = ss.str();
@@ -1696,7 +1711,7 @@ bool LinkView::linkGetElementPicked(const SoPickedPoint* pp, std::string& subnam
     }
 
     if (nodeType >= 0) {
-        if (linkInfo->getElementPicked(false, nodeType, pp, ss)) {
+        if (linkInfo->getElementPicked(false, nodeType, pp, ss, pickContext)) {
             subname = ss.str();
             return true;
         }
@@ -1714,7 +1729,7 @@ bool LinkView::linkGetElementPicked(const SoPickedPoint* pp, std::string& subnam
         }
 
         std::ostringstream ss2;
-        if (!sub.linkInfo->getElementPicked(false, SnapshotTransform, pp, ss2)) {
+        if (!sub.linkInfo->getElementPicked(false, SnapshotTransform, pp, ss2, pickContext)) {
             return false;
         }
         const std::string& element = ss2.str();
@@ -2841,6 +2856,15 @@ bool ViewProviderLink::canDragAndDropObject(App::DocumentObject* obj) const
 
 bool ViewProviderLink::getElementPicked(const SoPickedPoint* pp, std::string& subname) const
 {
+    return getElementPicked(pp, subname, nullptr);
+}
+
+bool ViewProviderLink::getElementPicked(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const SelectionPickContext* pickContext
+) const
+{
     if (!isSelectable()) {
         return false;
     }
@@ -2852,10 +2876,10 @@ bool ViewProviderLink::getElementPicked(const SoPickedPoint* pp, std::string& su
         auto path = pp->getPath();
         int idx = path->findNode(childVpLink->getSnapshot(LinkView::SnapshotTransform));
         if (idx >= 0) {
-            return childVp->getElementPicked(pp, subname);
+            return childVp->getElementPicked(pp, subname, pickContext);
         }
     }
-    bool ret = linkView->linkGetElementPicked(pp, subname);
+    bool ret = linkView->linkGetElementPicked(pp, subname, pickContext);
     if (!ret) {
         return ret;
     }

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2854,12 +2854,7 @@ bool ViewProviderLink::canDragAndDropObject(App::DocumentObject* obj) const
     return false;
 }
 
-bool ViewProviderLink::getElementPicked(const SoPickedPoint* pp, std::string& subname) const
-{
-    return getElementPicked(pp, subname, nullptr);
-}
-
-bool ViewProviderLink::getElementPicked(
+bool ViewProviderLink::resolvePickedElement(
     const SoPickedPoint* pp,
     std::string& subname,
     const SelectionPickContext* pickContext

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -256,8 +256,7 @@ public:
     void updateData(const App::Property*) override;
     void onChanged(const App::Property* prop) override;
     std::vector<App::DocumentObject*> claimChildren() const override;
-    bool getElementPicked(const SoPickedPoint*, std::string&) const override;
-    bool getElementPicked(
+    bool resolvePickedElement(
         const SoPickedPoint*,
         std::string&,
         const SelectionPickContext* pickContext

--- a/src/Gui/ViewProviderLink.h
+++ b/src/Gui/ViewProviderLink.h
@@ -174,6 +174,11 @@ public:
 
     bool linkGetDetailPath(const char*, SoFullPath*, SoDetail*&) const;
     bool linkGetElementPicked(const SoPickedPoint*, std::string&) const;
+    bool linkGetElementPicked(
+        const SoPickedPoint*,
+        std::string&,
+        const SelectionPickContext* pickContext
+    ) const;
 
     void setElementVisible(int index, bool visible);
     bool isElementVisible(int index) const;
@@ -252,6 +257,11 @@ public:
     void onChanged(const App::Property* prop) override;
     std::vector<App::DocumentObject*> claimChildren() const override;
     bool getElementPicked(const SoPickedPoint*, std::string&) const override;
+    bool getElementPicked(
+        const SoPickedPoint*,
+        std::string&,
+        const SelectionPickContext* pickContext
+    ) const override;
     bool getDetailPath(const char*, SoFullPath*, bool, SoDetail*&) const override;
 
     void finishRestoring() override;

--- a/src/Gui/ViewProviderPlacement.cpp
+++ b/src/Gui/ViewProviderPlacement.cpp
@@ -101,21 +101,16 @@ void ViewProviderPlacement::updateData(const App::Property* prop)
     ViewProviderGeometryObject::updateData(prop);
 }
 
-bool ViewProviderPlacement::getElementPicked(const SoPickedPoint* pp, std::string& subname) const
-{
-    if (!Axis) {
-        return false;
-    }
-    return Axis->getElementPicked(pp, subname);
-}
-
-bool ViewProviderPlacement::getElementPicked(
+bool ViewProviderPlacement::resolvePickedElement(
     const SoPickedPoint* pp,
     std::string& subname,
     const SelectionPickContext*
 ) const
 {
-    return getElementPicked(pp, subname);
+    if (!Axis) {
+        return false;
+    }
+    return Axis->getElementPicked(pp, subname);
 }
 
 bool ViewProviderPlacement::getDetailPath(

--- a/src/Gui/ViewProviderPlacement.cpp
+++ b/src/Gui/ViewProviderPlacement.cpp
@@ -109,6 +109,15 @@ bool ViewProviderPlacement::getElementPicked(const SoPickedPoint* pp, std::strin
     return Axis->getElementPicked(pp, subname);
 }
 
+bool ViewProviderPlacement::getElementPicked(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const SelectionPickContext*
+) const
+{
+    return getElementPicked(pp, subname);
+}
+
 bool ViewProviderPlacement::getDetailPath(
     const char* subname,
     SoFullPath* pPath,

--- a/src/Gui/ViewProviderPlacement.h
+++ b/src/Gui/ViewProviderPlacement.h
@@ -44,6 +44,8 @@ class GuiExport ViewProviderPlacement: public ViewProviderGeometryObject
     PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderPlacement);
 
 public:
+    using ViewProviderGeometryObject::getElementPicked;
+
     /// Constructor
     ViewProviderPlacement();
     ~ViewProviderPlacement() override;
@@ -62,6 +64,11 @@ public:
     bool isSelectable() const override;
 
     bool getElementPicked(const SoPickedPoint* pp, std::string& subname) const override;
+    bool getElementPicked(
+        const SoPickedPoint* pp,
+        std::string& subname,
+        const SelectionPickContext* pickContext
+    ) const override;
     bool getDetailPath(const char*, SoFullPath*, bool, SoDetail*&) const override;
 
 protected:

--- a/src/Gui/ViewProviderPlacement.h
+++ b/src/Gui/ViewProviderPlacement.h
@@ -44,8 +44,6 @@ class GuiExport ViewProviderPlacement: public ViewProviderGeometryObject
     PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderPlacement);
 
 public:
-    using ViewProviderGeometryObject::getElementPicked;
-
     /// Constructor
     ViewProviderPlacement();
     ~ViewProviderPlacement() override;
@@ -63,8 +61,7 @@ public:
     /// indicates if the ViewProvider can be selected
     bool isSelectable() const override;
 
-    bool getElementPicked(const SoPickedPoint* pp, std::string& subname) const override;
-    bool getElementPicked(
+    bool resolvePickedElement(
         const SoPickedPoint* pp,
         std::string& subname,
         const SelectionPickContext* pickContext

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -50,15 +50,26 @@
 
 #include <QAction>
 #include <QMenu>
-#include <sstream>
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <optional>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
 
+#include <Inventor/SbLinear.h>
+#include <Inventor/SoPath.h>
 #include <Inventor/SoPickedPoint.h>
+#include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/details/SoFaceDetail.h>
 #include <Inventor/details/SoLineDetail.h>
 #include <Inventor/details/SoPointDetail.h>
 #include <Inventor/errors/SoDebugError.h>
 #include <Inventor/nodes/SoCoordinate3.h>
 #include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoIndexedFaceSet.h>
 #include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoMaterialBinding.h>
 #include <Inventor/nodes/SoNormal.h>
@@ -74,10 +85,12 @@
 #include <Base/Console.h>
 #include <Base/Parameter.h>
 #include <Base/TimeInfo.h>
+#include <Base/Tools2D.h>
 #include <Base/Tools.h>
 
 #include <Gui/BitmapFactory.h>
 #include <Gui/Control.h>
+#include <Gui/Selection/Selection.h>
 #include <Gui/Selection/SoFCSelectionAction.h>
 #include <Gui/Selection/SoFCUnifiedSelection.h>
 #include <Gui/ViewParams.h>
@@ -99,6 +112,631 @@ FC_LOG_LEVEL_INIT("Part", true, true)
 using namespace PartGui;
 
 PROPERTY_SOURCE(PartGui::ViewProviderPartExt, Gui::ViewProviderGeometryObject)
+
+namespace
+{
+
+// Gate checks and candidate discovery
+
+bool containsGatedType(const std::unordered_set<std::string>& gatedTypes, const char* type)
+{
+    return type && gatedTypes.find(type) != gatedTypes.end();
+}
+
+bool isFaceOnlyGate(const std::unordered_set<std::string>& gatedTypes)
+{
+    return containsGatedType(gatedTypes, "Face") && !containsGatedType(gatedTypes, "Edge")
+        && !containsGatedType(gatedTypes, "Vertex");
+}
+
+struct ProjectedImagePoint
+{
+    Base::Vector2d position;
+    double depth;
+};
+
+ProjectedImagePoint projectToImagePoint(const Base::Vector3d& point, const SbMatrix& objectToImage)
+{
+    SbVec3f imagePoint(
+        static_cast<float>(point.x),
+        static_cast<float>(point.y),
+        static_cast<float>(point.z)
+    );
+    objectToImage.multVecMatrix(imagePoint, imagePoint);
+    return {{0.5 * imagePoint[0] + 0.5, 0.5 * imagePoint[1] + 0.5}, imagePoint[2]};
+}
+
+double cross2d(const Base::Vector2d& lhs, const Base::Vector2d& rhs)
+{
+    return lhs.x * rhs.y - lhs.y * rhs.x;
+}
+
+bool pointInTriangle2d(
+    const Base::Vector2d& point,
+    const Base::Vector2d& a,
+    const Base::Vector2d& b,
+    const Base::Vector2d& c
+)
+{
+    constexpr double edgeTolerance = 1.0e-9;
+    const auto ab = cross2d(b - a, point - a);
+    const auto bc = cross2d(c - b, point - b);
+    const auto ca = cross2d(a - c, point - c);
+    const bool hasNegative = ab < -edgeTolerance || bc < -edgeTolerance || ca < -edgeTolerance;
+    const bool hasPositive = ab > edgeTolerance || bc > edgeTolerance || ca > edgeTolerance;
+    return !(hasNegative && hasPositive);
+}
+
+struct ProjectedTriangleScore
+{
+    double distanceSquared;
+    double depth;
+};
+
+struct ProjectedFaceScore
+{
+    ProjectedTriangleScore score;
+    int faceIndex;
+};
+
+bool isBetterProjectedScore(const ProjectedTriangleScore& lhs, const ProjectedTriangleScore& rhs)
+{
+    constexpr double distanceTolerance = 1.0e-9;
+    constexpr double depthTolerance = 1.0e-6;
+
+    const auto distanceDelta = lhs.distanceSquared - rhs.distanceSquared;
+    if (std::abs(distanceDelta) > distanceTolerance) {
+        return distanceDelta < 0.0;
+    }
+
+    // Image-space Z preserves front-to-back ordering after projection, so use it to break
+    // screen-space ties between neighboring faces.
+    const auto depthDelta = lhs.depth - rhs.depth;
+    if (std::abs(depthDelta) > depthTolerance) {
+        return depthDelta < 0.0;
+    }
+
+    return false;
+}
+
+bool isBetterProjectedFaceScore(const ProjectedFaceScore& lhs, const ProjectedFaceScore& rhs)
+{
+    if (isBetterProjectedScore(lhs.score, rhs.score)) {
+        return true;
+    }
+    if (isBetterProjectedScore(rhs.score, lhs.score)) {
+        return false;
+    }
+    return lhs.faceIndex < rhs.faceIndex;
+}
+
+ProjectedTriangleScore projectToSegmentScore(
+    const Base::Vector2d& point,
+    const ProjectedImagePoint& start,
+    const ProjectedImagePoint& end
+)
+{
+    constexpr double segmentTolerance = 1.0e-12;
+    const auto segment = end.position - start.position;
+    const auto lengthSquared = segment.Sqr();
+    if (lengthSquared <= segmentTolerance) {
+        return {(point - start.position).Sqr(), start.depth};
+    }
+
+    const auto t = std::clamp(((point - start.position) * segment) / lengthSquared, 0.0, 1.0);
+    const auto closest = start.position + segment * t;
+    return {
+        (point - closest).Sqr(),
+        start.depth + t * (end.depth - start.depth),
+    };
+}
+
+std::optional<std::array<double, 3>> getTriangleBarycentricWeights(
+    const Base::Vector2d& point,
+    const Base::Vector2d& a,
+    const Base::Vector2d& b,
+    const Base::Vector2d& c
+)
+{
+    constexpr double triangleTolerance = 1.0e-12;
+    const auto denominator = cross2d(b - a, c - a);
+    if (std::abs(denominator) <= triangleTolerance) {
+        return {};
+    }
+
+    const auto beta = cross2d(point - a, c - a) / denominator;
+    const auto gamma = cross2d(b - a, point - a) / denominator;
+    return std::array<double, 3> {1.0 - beta - gamma, beta, gamma};
+}
+
+ProjectedTriangleScore projectToTriangleScore(
+    const Base::Vector2d& point,
+    const ProjectedImagePoint& a,
+    const ProjectedImagePoint& b,
+    const ProjectedImagePoint& c
+)
+{
+    if (pointInTriangle2d(point, a.position, b.position, c.position)) {
+        if (auto weights = getTriangleBarycentricWeights(point, a.position, b.position, c.position)) {
+            return {
+                0.0,
+                (*weights)[0] * a.depth + (*weights)[1] * b.depth + (*weights)[2] * c.depth,
+            };
+        }
+    }
+
+    auto bestScore = projectToSegmentScore(point, a, b);
+    const auto bcScore = projectToSegmentScore(point, b, c);
+    if (isBetterProjectedScore(bcScore, bestScore)) {
+        bestScore = bcScore;
+    }
+    const auto caScore = projectToSegmentScore(point, c, a);
+    if (isBetterProjectedScore(caScore, bestScore)) {
+        bestScore = caScore;
+    }
+    return bestScore;
+}
+
+struct SampleOffset
+{
+    int dx;
+    int dy;
+    int distanceSquared;
+};
+
+struct FaceHitScore
+{
+    int faceIndex;
+    int distanceSquared;
+    int hits;
+    double bestRayDistance;
+};
+
+bool isBetterFaceHitScore(const FaceHitScore& lhs, const FaceHitScore& rhs)
+{
+    if (lhs.distanceSquared != rhs.distanceSquared) {
+        return lhs.distanceSquared < rhs.distanceSquared;
+    }
+    if (lhs.hits != rhs.hits) {
+        return lhs.hits > rhs.hits;
+    }
+    constexpr double rayDistanceTolerance = 1.0e-6;
+    if (std::abs(lhs.bestRayDistance - rhs.bestRayDistance) > rayDistanceTolerance) {
+        return lhs.bestRayDistance < rhs.bestRayDistance;
+    }
+    return lhs.faceIndex < rhs.faceIndex;
+}
+
+struct FaceTriangleGeometry
+{
+    int faceIndex;
+    std::vector<std::array<Base::Vector3d, 3>> triangles;
+};
+
+class FaceGatePromotionResolver
+{
+public:
+    // Face-only gates should treat an edge or vertex hover as intent for a nearby visible face.
+    // Topology gives the small candidate set, and scene rays through the pick-radius neighborhood
+    // choose the visible face without trusting Coin's raw hit ordering.
+    FaceGatePromotionResolver(
+        const Part::TopoShape& shape,
+        const std::string& element,
+        const SoPickedPoint& pickedPoint,
+        const Gui::SelectionPickContext& pickContext
+    )
+        : shape(shape)
+        , element(element)
+        , pickedPoint(pickedPoint)
+        , pickContext(pickContext)
+        , cursorPosition(
+              (*pickContext.normalizedCursorPosition)[0],
+              (*pickContext.normalizedCursorPosition)[1]
+          )
+    {}
+
+    std::optional<std::string> promote() const
+    {
+        const auto faceIndices = collectPromotedFaceIndices();
+        if (faceIndices.empty()) {
+            return {};
+        }
+
+        if (hasNeighborhoodContext()) {
+            return findVisibleCandidateFaceElement(faceIndices);
+        }
+
+        return findProjectedCandidateFaceElement(faceIndices);
+    }
+
+private:
+    struct RingHitSummary
+    {
+        int hits {0};
+        double bestRayDistance {std::numeric_limits<double>::infinity()};
+    };
+
+    std::vector<std::array<Base::Vector3d, 3>> collectFaceTriangles(int faceIndex) const
+    {
+        auto faceShape = shape.getSubTopoShape(TopAbs_FACE, faceIndex, true);
+        if (faceShape.isNull()) {
+            return {};
+        }
+
+        std::vector<Base::Vector3d> points;
+        std::vector<Data::ComplexGeoData::Facet> facets;
+        faceShape.getFaces(points, facets, faceShape.getAccuracy());
+        if (points.empty() || facets.empty()) {
+            return {};
+        }
+
+        std::vector<std::array<Base::Vector3d, 3>> triangles;
+        triangles.reserve(facets.size());
+        for (const auto& facet : facets) {
+            if (facet.I1 >= points.size() || facet.I2 >= points.size() || facet.I3 >= points.size()) {
+                continue;
+            }
+
+            triangles.push_back({
+                points[facet.I1],
+                points[facet.I2],
+                points[facet.I3],
+            });
+        }
+
+        return triangles;
+    }
+
+    std::vector<int> collectPromotedFaceIndices() const
+    {
+        const auto subShape = shape.findShape(element.c_str());
+        if (subShape.IsNull()) {
+            return {};
+        }
+
+        std::set<int> faceIndices;
+        const auto ancestors = shape.findAncestors(subShape, TopAbs_FACE);
+        faceIndices.insert(ancestors.begin(), ancestors.end());
+        return {faceIndices.begin(), faceIndices.end()};
+    }
+
+    static std::vector<SampleOffset> collectSampleOffsets(float pickRadius)
+    {
+        const int maxOffset = std::max(1, static_cast<int>(std::ceil(pickRadius)));
+        std::vector<SampleOffset> offsets;
+        offsets.reserve((2 * maxOffset + 1) * (2 * maxOffset + 1));
+
+        // Exclude the center sample: the raw pick already hit the edge or vertex there. Neighboring
+        // samples recover the adjacent face that is actually visible inside the pick radius.
+        for (int dy = -maxOffset; dy <= maxOffset; ++dy) {
+            for (int dx = -maxOffset; dx <= maxOffset; ++dx) {
+                const int distanceSquared = dx * dx + dy * dy;
+                if (distanceSquared > maxOffset * maxOffset || distanceSquared == 0) {
+                    continue;
+                }
+                offsets.push_back({dx, dy, distanceSquared});
+            }
+        }
+
+        std::ranges::sort(offsets, [](const SampleOffset& lhs, const SampleOffset& rhs) {
+            if (lhs.distanceSquared != rhs.distanceSquared) {
+                return lhs.distanceSquared < rhs.distanceSquared;
+            }
+            if (lhs.dy != rhs.dy) {
+                return lhs.dy < rhs.dy;
+            }
+            return lhs.dx < rhs.dx;
+        });
+        return offsets;
+    }
+
+    std::vector<FaceTriangleGeometry> buildCandidateFaceGeometry(const std::vector<int>& faceIndices) const
+    {
+        std::vector<FaceTriangleGeometry> geometries;
+        geometries.reserve(faceIndices.size());
+        for (int faceIndex : faceIndices) {
+            FaceTriangleGeometry geometry {faceIndex, collectFaceTriangles(faceIndex)};
+            if (!geometry.triangles.empty()) {
+                geometries.push_back(std::move(geometry));
+            }
+        }
+
+        return geometries;
+    }
+
+    std::optional<std::pair<Base::Vector3d, Base::Vector3d>> getSceneRayAtSample(
+        const SbVec2s& samplePosition
+    ) const
+    {
+        if (!pickContext.repick.isValid()) {
+            return {};
+        }
+
+        SoRayPickAction rayPick(*pickContext.repick.viewportRegion);
+        rayPick.setPoint(samplePosition);
+        rayPick.setRadius(0.0F);
+        rayPick.setPickAll(false);
+        rayPick.apply(pickContext.repick.sceneRoot);
+        rayPick.computeWorldSpaceRay();
+
+        const auto& line = rayPick.getLine();
+        const SbVec3f origin = line.getPosition();
+        SbVec3f direction = line.getDirection();
+        if (direction.equals(SbVec3f(0.0f, 0.0f, 0.0f), 1.0e-12f)) {
+            return {};
+        }
+        direction.normalize();
+
+        return std::pair {
+            Base::Vector3d(origin[0], origin[1], origin[2]),
+            Base::Vector3d(direction[0], direction[1], direction[2]),
+        };
+    }
+
+    static std::optional<double> intersectRayWithTriangle(
+        const Base::Vector3d& origin,
+        const Base::Vector3d& direction,
+        const std::array<Base::Vector3d, 3>& triangle
+    )
+    {
+        constexpr double epsilon = 1.0e-12;
+
+        const auto edge1 = triangle[1] - triangle[0];
+        const auto edge2 = triangle[2] - triangle[0];
+        const auto pvec = direction % edge2;
+        const auto det = edge1 * pvec;
+        if (std::abs(det) <= epsilon) {
+            return {};
+        }
+
+        const auto invDet = 1.0 / det;
+        const auto tvec = origin - triangle[0];
+        const auto u = (tvec * pvec) * invDet;
+        if (u < 0.0 || u > 1.0) {
+            return {};
+        }
+
+        const auto qvec = tvec % edge1;
+        const auto v = (direction * qvec) * invDet;
+        if (v < 0.0 || (u + v) > 1.0) {
+            return {};
+        }
+
+        const auto t = (edge2 * qvec) * invDet;
+        if (t <= epsilon) {
+            return {};
+        }
+
+        return t;
+    }
+
+    static std::optional<double> getClosestFaceRayDistance(
+        const FaceTriangleGeometry& geometry,
+        const Base::Vector3d& origin,
+        const Base::Vector3d& direction
+    )
+    {
+        std::optional<double> bestDistance;
+        for (const auto& triangle : geometry.triangles) {
+            if (auto distance = intersectRayWithTriangle(origin, direction, triangle)) {
+                if (!bestDistance || *distance < *bestDistance) {
+                    bestDistance = *distance;
+                }
+            }
+        }
+
+        return bestDistance;
+    }
+
+    std::optional<std::string> findVisibleCandidateFaceElement(const std::vector<int>& faceIndices) const
+    {
+        if (faceIndices.empty() || !pickContext.repick.isValid()) {
+            return {};
+        }
+
+        const auto geometries = buildCandidateFaceGeometry(faceIndices);
+        if (geometries.empty()) {
+            return {};
+        }
+
+        const auto offsets = collectSampleOffsets(pickContext.repick.pickRadius);
+        if (offsets.empty()) {
+            return {};
+        }
+
+        const auto viewportOrigin = pickContext.repick.viewportRegion->getViewportOriginPixels();
+        const auto viewportSize = pickContext.repick.viewportRegion->getViewportSizePixels();
+        if (viewportSize[0] <= 0 || viewportSize[1] <= 0) {
+            return {};
+        }
+
+        std::size_t offsetIndex = 0;
+        while (offsetIndex < offsets.size()) {
+            const int ringDistanceSquared = offsets[offsetIndex].distanceSquared;
+            std::unordered_map<int, RingHitSummary> ringHits;
+            std::size_t ringEnd = offsetIndex;
+
+            while (ringEnd < offsets.size()
+                   && offsets[ringEnd].distanceSquared == ringDistanceSquared) {
+                const auto& offset = offsets[ringEnd];
+                const int sampleX = pickContext.repick.eventPosition->getValue()[0] + offset.dx;
+                const int sampleY = pickContext.repick.eventPosition->getValue()[1] + offset.dy;
+                if (sampleX >= viewportOrigin[0] && sampleY >= viewportOrigin[1]
+                    && sampleX < viewportOrigin[0] + viewportSize[0]
+                    && sampleY < viewportOrigin[1] + viewportSize[1]) {
+                    const SbVec2s samplePosition(
+                        static_cast<short>(sampleX),
+                        static_cast<short>(sampleY)
+                    );
+                    if (auto ray = getSceneRayAtSample(samplePosition)) {
+                        std::optional<FaceHitScore> visibleHit;
+                        for (const auto& geometry : geometries) {
+                            if (auto distance
+                                = getClosestFaceRayDistance(geometry, ray->first, ray->second)) {
+                                FaceHitScore hit {
+                                    geometry.faceIndex,
+                                    ringDistanceSquared,
+                                    1,
+                                    *distance,
+                                };
+                                if (!visibleHit || hit.bestRayDistance < visibleHit->bestRayDistance) {
+                                    visibleHit = hit;
+                                }
+                            }
+                        }
+
+                        if (visibleHit) {
+                            auto& summary = ringHits[visibleHit->faceIndex];
+                            summary.hits += 1;
+                            summary.bestRayDistance
+                                = std::min(summary.bestRayDistance, visibleHit->bestRayDistance);
+                        }
+                    }
+                }
+                ++ringEnd;
+            }
+
+            if (!ringHits.empty()) {
+                std::optional<FaceHitScore> bestScore;
+                for (const auto& [faceIndex, summary] : ringHits) {
+                    FaceHitScore score {
+                        faceIndex,
+                        ringDistanceSquared,
+                        summary.hits,
+                        summary.bestRayDistance,
+                    };
+                    if (!bestScore || isBetterFaceHitScore(score, *bestScore)) {
+                        bestScore = score;
+                    }
+                }
+
+                if (bestScore) {
+                    return std::string("Face") + std::to_string(bestScore->faceIndex);
+                }
+            }
+
+            offsetIndex = ringEnd;
+        }
+
+        return {};
+    }
+
+    std::optional<std::string> findProjectedCandidateFaceElement(const std::vector<int>& faceIndices) const
+    {
+        const SoNode* imageSpaceNode = nullptr;
+        if (const auto* path = pickedPoint.getPath()) {
+            imageSpaceNode = path->getHead();
+        }
+        const auto& objectToImage = pickedPoint.getObjectToImage(imageSpaceNode);
+
+        std::optional<ProjectedFaceScore> bestFace;
+        for (int faceIndex : faceIndices) {
+            const auto triangles = collectFaceTriangles(faceIndex);
+            if (triangles.empty()) {
+                continue;
+            }
+
+            std::optional<ProjectedTriangleScore> bestTriangleScore;
+            for (const auto& triangle : triangles) {
+                const auto triangleScore = projectToTriangleScore(
+                    cursorPosition,
+                    projectToImagePoint(triangle[0], objectToImage),
+                    projectToImagePoint(triangle[1], objectToImage),
+                    projectToImagePoint(triangle[2], objectToImage)
+                );
+                if (!bestTriangleScore.has_value()
+                    || isBetterProjectedScore(triangleScore, *bestTriangleScore)) {
+                    bestTriangleScore = triangleScore;
+                }
+            }
+
+            if (!bestTriangleScore.has_value()) {
+                continue;
+            }
+
+            const ProjectedFaceScore faceScore {*bestTriangleScore, faceIndex};
+            if (!bestFace.has_value() || isBetterProjectedFaceScore(faceScore, *bestFace)) {
+                bestFace = faceScore;
+            }
+        }
+
+        if (!bestFace.has_value()) {
+            return {};
+        }
+
+        return std::string("Face") + std::to_string(bestFace->faceIndex);
+    }
+
+    bool hasNeighborhoodContext() const
+    {
+        return pickContext.repick.isValid();
+    }
+
+    const Part::TopoShape& shape;
+    const std::string& element;
+    const SoPickedPoint& pickedPoint;
+    const Gui::SelectionPickContext& pickContext;
+    Base::Vector2d cursorPosition;
+};
+
+// Top-level face-only gate promotion
+
+std::optional<std::string> promoteFaceOnlyGatePick(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    const SoPickedPoint* pickedPoint,
+    const std::string& element,
+    const Gui::SelectionPickContext* pickContext
+)
+{
+    const auto* gate = pickContext ? pickContext->gate : nullptr;
+    const auto* normalizedCursorPosition = pickContext ? pickContext->normalizedCursorPosition
+                                                       : nullptr;
+    if (!gate || element.empty()) {
+        return {};
+    }
+
+    auto* feature = viewProvider.getObject<Part::Feature>();
+    if (!feature) {
+        return {};
+    }
+
+    const auto* geometry = feature->getPropertyOfGeometry();
+    const auto* complexData = geometry ? geometry->getComplexData() : nullptr;
+    if (!complexData) {
+        return {};
+    }
+
+    const auto gatedTypes = gate->getGatedTypes(complexData->getElementTypes());
+    if (gatedTypes.empty()) {
+        return {};
+    }
+
+    if (!isFaceOnlyGate(gatedTypes)) {
+        return {};
+    }
+
+    const auto elementType = Part::TopoShape::getElementTypeAndIndex(element.c_str()).first;
+    if (elementType != "Edge" && elementType != "Vertex") {
+        return {};
+    }
+
+    try {
+        if (!pickedPoint || !normalizedCursorPosition) {
+            return {};
+        }
+
+        // Keep the rendered shape alive for the resolver; it stores a reference while collecting
+        // topology and face triangles.
+        const auto renderedShape = viewProvider.getRenderedShape();
+        const FaceGatePromotionResolver resolver(renderedShape, element, *pickedPoint, *pickContext);
+        return resolver.promote();
+    }
+    catch (...) {
+        return {};
+    }
+}
+
+}  // namespace
 
 
 //**************************************************************************
@@ -590,6 +1228,22 @@ std::string ViewProviderPartExt::getElement(const SoDetail* detail) const
     }
 
     return str.str();
+}
+
+bool ViewProviderPartExt::resolvePickedElement(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const Gui::SelectionPickContext* pickContext
+) const
+{
+    if (!ViewProviderGeometryObject::resolvePickedElement(pp, subname, pickContext)) {
+        return false;
+    }
+    if (auto faceElement = promoteFaceOnlyGatePick(*this, pp, subname, pickContext)) {
+        subname = *faceElement;
+    }
+
+    return true;
 }
 
 SoDetail* ViewProviderPartExt::getDetail(const char* subelement) const

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -70,6 +70,8 @@ class PartGuiExport ViewProviderPartExt: public Gui::ViewProviderGeometryObject
     PROPERTY_HEADER_WITH_OVERRIDE(PartGui::ViewProviderPartExt);
 
 public:
+    using Gui::ViewProviderGeometryObject::getElementPicked;
+
     /// constructor
     ViewProviderPartExt();
     /// destructor
@@ -121,6 +123,11 @@ public:
         return true;
     }
     /// return a hit element to the selection path or 0
+    bool resolvePickedElement(
+        const SoPickedPoint*,
+        std::string& subname,
+        const Gui::SelectionPickContext* pickContext
+    ) const override;
     std::string getElement(const SoDetail*) const override;
     SoDetail* getDetail(const char*) const override;
     std::vector<Base::Vector3d> getModelPoints(const SoPickedPoint*) const override;

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3813,7 +3813,11 @@ void SketcherGui::ViewProviderSketch::finishRestoring()
 }
 
 // clang-format on
-bool ViewProviderSketch::getElementPicked(const SoPickedPoint* pp, std::string& subname) const
+bool ViewProviderSketch::resolvePickedElement(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const Gui::SelectionPickContext*
+) const
 {
     if (pp->getPath()->containsNode(pcSketchFaces) && !isInEditMode()) {
         if (ViewProvider2DObject::getElementPicked(pp, subname)) {
@@ -3829,15 +3833,6 @@ bool ViewProviderSketch::getElementPicked(const SoPickedPoint* pp, std::string& 
     }
 
     return ViewProvider2DObject::getElementPicked(pp, subname);
-}
-
-bool ViewProviderSketch::getElementPicked(
-    const SoPickedPoint* pp,
-    std::string& subname,
-    const Gui::SelectionPickContext*
-) const
-{
-    return getElementPicked(pp, subname);
 }
 
 std::vector<std::pair<std::string, std::string>> ViewProviderSketch::getRelatedElements(

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3831,6 +3831,15 @@ bool ViewProviderSketch::getElementPicked(const SoPickedPoint* pp, std::string& 
     return ViewProvider2DObject::getElementPicked(pp, subname);
 }
 
+bool ViewProviderSketch::getElementPicked(
+    const SoPickedPoint* pp,
+    std::string& subname,
+    const Gui::SelectionPickContext*
+) const
+{
+    return getElementPicked(pp, subname);
+}
+
 std::vector<std::pair<std::string, std::string>> ViewProviderSketch::getRelatedElements(
     const std::string& subname,
     const SbVec3f& pickPoint

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -526,6 +526,8 @@ public:
     };
 
 public:
+    using PartGui::ViewProvider2DObject::getElementPicked;
+
     /// constructor
     ViewProviderSketch();
     /// destructor
@@ -812,6 +814,11 @@ protected:
     void finishRestoring() override;
 
     bool getElementPicked(const SoPickedPoint* pp, std::string& subname) const override;
+    bool getElementPicked(
+        const SoPickedPoint* pp,
+        std::string& subname,
+        const Gui::SelectionPickContext* pickContext
+    ) const override;
     std::vector<std::pair<std::string, std::string>> getRelatedElements(
         const std::string& subname,
         const SbVec3f& pickPoint

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -526,8 +526,6 @@ public:
     };
 
 public:
-    using PartGui::ViewProvider2DObject::getElementPicked;
-
     /// constructor
     ViewProviderSketch();
     /// destructor
@@ -813,8 +811,7 @@ protected:
     void startRestoring() override;
     void finishRestoring() override;
 
-    bool getElementPicked(const SoPickedPoint* pp, std::string& subname) const override;
-    bool getElementPicked(
+    bool resolvePickedElement(
         const SoPickedPoint* pp,
         std::string& subname,
         const Gui::SelectionPickContext* pickContext

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -24,4 +24,6 @@ target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main
     FreeCADApp
     FreeCADGui
+    Part
+    PartGui
 )

--- a/tests/src/Gui/SelectionTest.cpp
+++ b/tests/src/Gui/SelectionTest.cpp
@@ -2,8 +2,20 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <limits>
 #include <string>
 #include <vector>
+
+#include <Inventor/SoDB.h>
+#include <Inventor/SoPickedPoint.h>
+#include <Inventor/SbViewportRegion.h>
+#include <Inventor/actions/SoRayPickAction.h>
+#include <Inventor/events/SoLocation2Event.h>
+#include <Inventor/nodes/SoCube.h>
+#include <Inventor/nodes/SoOrthographicCamera.h>
+#include <Inventor/nodes/SoSeparator.h>
+#include <Inventor/nodes/SoTranslation.h>
 
 #include <src/App/InitApplication.h>
 
@@ -42,6 +54,7 @@ protected:
     static void SetUpTestSuite()
     {
         tests::initApplication();
+        SoDB::init();
     }
 
     void SetUp() override
@@ -76,7 +89,8 @@ Gui::SelectionPickPolicy::Candidate pickCandidate(
     int priority,
     bool closeToFirst,
     bool hasGate,
-    bool passesGate
+    bool passesGate,
+    float cursorDistanceSquared = std::numeric_limits<float>::infinity()
 )
 {
     Gui::SelectionPickPolicy::Candidate candidate;
@@ -85,10 +99,78 @@ Gui::SelectionPickPolicy::Candidate pickCandidate(
     candidate.closeToFirst = closeToFirst;
     candidate.hasGate = hasGate;
     candidate.passesGate = passesGate;
+    candidate.cursorDistanceSquared = cursorDistanceSquared;
     return candidate;
 }
 
+SbVec2f normalizedPosition(const SbVec2s& cursorPosition, const SbViewportRegion& viewportRegion)
+{
+    SoLocation2Event event;
+    event.setPosition(cursorPosition);
+    return event.getNormalizedPosition(viewportRegion);
+}
+
+std::shared_ptr<const SoPickedPoint> pickCubePoint(
+    float xTranslation,
+    const SbVec2s& pickPosition,
+    const SbViewportRegion& viewportRegion
+)
+{
+    auto root = new SoSeparator;
+    root->ref();
+
+    auto camera = new SoOrthographicCamera;
+    camera->position.setValue(0.0F, 0.0F, 5.0F);
+    camera->nearDistance = 1.0F;
+    camera->farDistance = 10.0F;
+    camera->height = 2.0F;
+    root->addChild(camera);
+
+    auto transform = new SoTranslation;
+    transform->translation.setValue(xTranslation, 0.0F, 0.0F);
+    root->addChild(transform);
+
+    auto cube = new SoCube;
+    cube->width = 0.2F;
+    cube->height = 0.2F;
+    cube->depth = 0.2F;
+    root->addChild(cube);
+
+    SoRayPickAction pickAction(viewportRegion);
+    pickAction.setPoint(pickPosition);
+    pickAction.setRadius(1.0F);
+    pickAction.apply(root);
+
+    std::shared_ptr<const SoPickedPoint> pickedPoint;
+    if (auto* point = pickAction.getPickedPoint()) {
+        pickedPoint = std::shared_ptr<const SoPickedPoint>(new SoPickedPoint(*point));
+    }
+
+    root->unref();
+    return pickedPoint;
+}
+
 }  // namespace
+
+namespace Gui
+{
+
+class SoFCUnifiedSelectionTestAccess
+{
+public:
+    static SelectionPickPolicy::Candidate getPickCandidate(
+        const std::shared_ptr<const SoPickedPoint>& pickedPoint,
+        const SbVec2f& cursorPosition
+    )
+    {
+        SoFCUnifiedSelection::PickedInfo info;
+        info.ownedPoint = pickedPoint;
+        info.pp = info.ownedPoint.get();
+        return SoFCUnifiedSelection::getPickCandidate(info, nullptr, nullptr, &cursorPosition);
+    }
+};
+
+}  // namespace Gui
 
 TEST_F(SelectionTest, testSelectionAllowsObjectsWhenNoGateIsInstalled)
 {
@@ -184,6 +266,88 @@ TEST(SelectionPickPolicyTest, choosesAllowedCandidateWhenPreferredPickIsRejected
     };
 
     EXPECT_EQ(Gui::SelectionPickPolicy::choosePreferredPick(candidates), 1U);
+}
+
+TEST(SelectionPickPolicyTest, choosesNearestAllowedCandidateWhenPreferredPickIsRejected)
+{
+    int blockedOwner {};
+    int fartherOwner {};
+    int nearerOwner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&blockedOwner, 1, true, true, false, 0.0F),
+        pickCandidate(&fartherOwner, 0, true, true, true, 0.09F),
+        pickCandidate(&nearerOwner, 0, true, true, true, 0.01F),
+    };
+
+    EXPECT_EQ(Gui::SelectionPickPolicy::choosePreferredPick(candidates), 2U);
+}
+
+TEST(SelectionPickPolicyTest, choosesHigherPriorityFallbackWhenDistancesAreEquivalent)
+{
+    int lowerPriorityOwner {};
+    int higherPriorityOwner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&lowerPriorityOwner, 1, true, true, true, 0.0100000F),
+        pickCandidate(&higherPriorityOwner, 2, true, true, true, 0.0100005F),
+    };
+
+    auto fallback = Gui::SelectionPickPolicy::chooseAllowedFallbackPick(candidates);
+    ASSERT_TRUE(fallback.has_value());
+    EXPECT_EQ(*fallback, 1U);
+}
+
+TEST(SelectionPickPolicyTest, choosesAnnotationFallbackWhenPriorityAndDistanceAreEquivalent)
+{
+    int regularOwner {};
+    int annotationOwner {};
+    auto regular = pickCandidate(&regularOwner, 1, true, true, true, 0.0200000F);
+    auto annotation = pickCandidate(&annotationOwner, 1, true, true, true, 0.0200005F);
+    annotation.isAnnotation = true;
+
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {regular, annotation};
+
+    auto fallback = Gui::SelectionPickPolicy::chooseAllowedFallbackPick(candidates);
+    ASSERT_TRUE(fallback.has_value());
+    EXPECT_EQ(*fallback, 1U);
+}
+
+TEST(SelectionPickPolicyTest, choosesAllowedFallbackCandidateUsingRealPickedPointDistances)
+{
+    const SbViewportRegion viewportRegion {SbVec2s {100, 100}};
+    const SbVec2s cursorPosition {50, 50};
+
+    auto nearerPoint = pickCubePoint(0.0F, cursorPosition, viewportRegion);
+    auto fartherPoint = pickCubePoint(0.4F, SbVec2s {70, 50}, viewportRegion);
+
+    ASSERT_NE(nearerPoint, nullptr);
+    ASSERT_NE(fartherPoint, nullptr);
+
+    const auto normalizedCursorPosition = normalizedPosition(cursorPosition, viewportRegion);
+    auto nearerCandidate = Gui::SoFCUnifiedSelectionTestAccess::getPickCandidate(
+        nearerPoint,
+        normalizedCursorPosition
+    );
+    auto fartherCandidate = Gui::SoFCUnifiedSelectionTestAccess::getPickCandidate(
+        fartherPoint,
+        normalizedCursorPosition
+    );
+
+    nearerCandidate.hasGate = true;
+    nearerCandidate.passesGate = true;
+    fartherCandidate.hasGate = true;
+    fartherCandidate.passesGate = true;
+
+    int blockedOwner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&blockedOwner, 1, true, true, false, 0.0F),
+        fartherCandidate,
+        nearerCandidate,
+    };
+
+    auto fallback = Gui::SelectionPickPolicy::chooseAllowedFallbackPick(candidates);
+    ASSERT_TRUE(fallback.has_value());
+    EXPECT_LT(nearerCandidate.cursorDistanceSquared, fartherCandidate.cursorDistanceSquared);
+    EXPECT_EQ(*fallback, 2U);
 }
 
 TEST(SelectionPickPolicyTest, preservesPriorityChoiceWithinFirstOwner)

--- a/tests/src/Gui/SelectionTest.cpp
+++ b/tests/src/Gui/SelectionTest.cpp
@@ -2,16 +2,26 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <memory>
 #include <limits>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <set>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include <Inventor/SoDB.h>
+#include <Inventor/SoInteraction.h>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/SbViewportRegion.h>
+#include <Inventor/SbRotation.h>
+#include <Inventor/SoType.h>
 #include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/events/SoLocation2Event.h>
+#include <Inventor/nodekits/SoNodeKit.h>
 #include <Inventor/nodes/SoCube.h>
 #include <Inventor/nodes/SoOrthographicCamera.h>
 #include <Inventor/nodes/SoSeparator.h>
@@ -22,8 +32,23 @@
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentObject.h>
+#include <Base/Type.h>
+#include <Base/Interpreter.h>
+#include <Gui/Application.h>
+#include <Gui/SoFCDB.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/Selection/SoFCUnifiedSelection.h>
+#include <Mod/Part/App/AttachExtension.h>
+#include <Mod/Part/App/FeaturePartBox.h>
+#include <Mod/Part/App/PartFeature.h>
+#include <Mod/Part/App/PrimitiveFeature.h>
+#include <Mod/Part/App/PropertyTopoShape.h>
+#include <Mod/Part/App/TopoShape.h>
+#include <Mod/Part/Gui/SoBrepEdgeSet.h>
+#include <Mod/Part/Gui/SoBrepFaceSet.h>
+#include <Mod/Part/Gui/SoBrepPointSet.h>
+#include <Mod/Part/Gui/ViewProviderExt.h>
+#include <QApplication>
 
 namespace
 {
@@ -46,6 +71,196 @@ public:
 
 private:
     std::string _allowedName;
+};
+
+class FaceOnlyGate: public Gui::SelectionGate
+{
+public:
+    bool allow(App::Document*, App::DocumentObject*, const char* subname) override
+    {
+        return subname && std::string_view(subname).starts_with("Face");
+    }
+
+    std::unordered_set<std::string> getGatedTypes(
+        const std::vector<const char*>& allTypesForGeometry
+    ) const override
+    {
+        std::unordered_set<std::string> gatedTypes;
+        for (const auto* type : allTypesForGeometry) {
+            if (type && std::string_view(type) == "Face") {
+                gatedTypes.emplace(type);
+            }
+        }
+        return gatedTypes;
+    }
+};
+
+struct DocumentGuard
+{
+    explicit DocumentGuard(std::string name)
+        : name(std::move(name))
+    {}
+
+    ~DocumentGuard()
+    {
+        if (App::GetApplication().getDocument(name.c_str())) {
+            App::GetApplication().closeDocument(name.c_str());
+        }
+    }
+
+    std::string name;
+};
+
+struct SelectionGuard
+{
+    explicit SelectionGuard(std::string documentName)
+        : documentName(std::move(documentName))
+    {}
+
+    ~SelectionGuard()
+    {
+        Gui::SelectionLogDisabler disableSelectionLog(true);
+        Gui::Selection().rmvSelectionGate(documentName.c_str());
+        Gui::Selection().clearSelection(documentName.c_str());
+    }
+
+    std::string documentName;
+};
+
+struct EdgePromotionProbe
+{
+    SbVec2s position;
+    std::string rawEdge;
+    std::string visibleFace;
+};
+
+struct FacePickProbe
+{
+    SbVec2s position;
+    std::shared_ptr<const SoPickedPoint> pickedPoint;
+};
+
+std::set<std::string> collectVisibleFaceElements(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    SoNode* sceneRoot,
+    const SbViewportRegion& viewportRegion
+);
+
+std::optional<EdgePromotionProbe> findSilhouetteEdgePromotionProbe(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    const Part::TopoShape& shape,
+    SoNode* sceneRoot,
+    const SbViewportRegion& viewportRegion,
+    const std::set<std::string>& visibleFaces
+);
+
+std::optional<FacePickProbe> findRawFacePickProbe(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    SoNode* sceneRoot,
+    const SbViewportRegion& viewportRegion,
+    const std::string& faceElement
+);
+
+std::string summarizeRawEdgeCandidates(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    const Part::TopoShape& shape,
+    SoNode* sceneRoot,
+    const SbViewportRegion& viewportRegion,
+    const std::set<std::string>& visibleFaces
+);
+
+struct PartSelectionScene
+{
+    explicit PartSelectionScene(const char* documentPrefix)
+        : docName(App::GetApplication().getUniqueDocumentName(documentPrefix))
+        , documentGuard(docName)
+        , selectionGuard(docName)
+    {}
+
+    ~PartSelectionScene()
+    {
+        if (root) {
+            root->unref();
+        }
+    }
+
+    void initialize()
+    {
+        App::DocumentInitFlags createFlags;
+        createFlags.createView = false;
+        doc = App::GetApplication().newDocument(docName.c_str(), "testUser", createFlags);
+        if (!doc) {
+            return;
+        }
+
+        auto* boxObject = doc->addObject("Part::Box", "Box");
+        box = freecad_cast<Part::Box*>(boxObject);
+        if (!box) {
+            return;
+        }
+
+        box->Length.setValue(10.0);
+        box->Width.setValue(10.0);
+        box->Height.setValue(10.0);
+        doc->recompute();
+
+        viewProvider = Gui::Application::Instance->getViewProvider<PartGui::ViewProviderPartExt>(box);
+        if (!viewProvider) {
+            return;
+        }
+
+        viewProvider->setDisplayMode("Flat Lines");
+
+        root = new SoSeparator;
+        root->ref();
+
+        auto* camera = new SoOrthographicCamera;
+        const SbVec3f cameraPosition(-18.0F, -16.0F, 18.0F);
+        const SbVec3f cameraTarget(5.0F, 5.0F, 5.0F);
+        camera->position.setValue(cameraPosition);
+        camera->pointAt(cameraTarget, SbVec3f(0.0F, 0.0F, 1.0F));
+        camera->focalDistance = (cameraTarget - cameraPosition).length();
+        camera->nearDistance = 1.0F;
+        camera->farDistance = 100.0F;
+        camera->height = 40.0F;
+        root->addChild(camera);
+        root->addChild(viewProvider->getRoot());
+
+        renderedShape = viewProvider->getRenderedShape();
+        visibleFaces = collectVisibleFaceElements(*viewProvider, root, viewportRegion);
+    }
+
+    std::optional<EdgePromotionProbe> findSilhouetteEdgeProbe() const
+    {
+        return findSilhouetteEdgePromotionProbe(
+            *viewProvider,
+            renderedShape,
+            root,
+            viewportRegion,
+            visibleFaces
+        );
+    }
+
+    std::optional<FacePickProbe> findRawFacePick(const std::string& faceElement) const
+    {
+        return findRawFacePickProbe(*viewProvider, root, viewportRegion, faceElement);
+    }
+
+    std::string summarizeRawEdges() const
+    {
+        return summarizeRawEdgeCandidates(*viewProvider, renderedShape, root, viewportRegion, visibleFaces);
+    }
+
+    std::string docName;
+    DocumentGuard documentGuard;
+    SelectionGuard selectionGuard;
+    App::Document* doc {};
+    Part::Box* box {};
+    PartGui::ViewProviderPartExt* viewProvider {};
+    SoSeparator* root {};
+    SbViewportRegion viewportRegion {SbVec2s {240, 240}};
+    Part::TopoShape renderedShape;
+    std::set<std::string> visibleFaces;
 };
 
 class SelectionTest: public ::testing::Test
@@ -71,6 +286,7 @@ protected:
 
     void TearDown() override
     {
+        Gui::SelectionLogDisabler disableSelectionLog(true);
         Gui::Selection().rmvSelectionGate(_docName.c_str());
         Gui::Selection().clearSelection(_docName.c_str());
         if (App::GetApplication().getDocument(_docName.c_str())) {
@@ -83,6 +299,44 @@ protected:
     App::DocumentObject* _allowedObject {};
     App::DocumentObject* _rejectedObject {};
 };
+
+class PartSelectionPromotionTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+        if (!qApp) {
+            qputenv("QT_QPA_PLATFORM", QByteArray("offscreen"));
+            static int argc = 1;
+            static char appName[] = "Gui_tests_run";
+            static char* argv[] = {appName, nullptr};
+            qtApp = new QApplication(argc, argv);
+        }
+        if (Base::Type::fromName("Gui::BaseView").isBad()) {
+            Gui::Application::initApplication();
+        }
+        if (!Gui::Application::Instance) {
+            guiApp = new Gui::Application(true);
+        }
+        if (!SoDB::isInitialized()) {
+            SoDB::init();
+            SoNodeKit::init();
+            SoInteraction::init();
+        }
+        if (!Gui::SoFCDB::isInitialized()) {
+            Gui::SoFCDB::init();
+        }
+        static const bool partGuiLoaded = Base::Interpreter().loadModule("PartGui");
+        ASSERT_TRUE(partGuiLoaded);
+    }
+
+    static Gui::Application* guiApp;
+    static QApplication* qtApp;
+};
+
+Gui::Application* PartSelectionPromotionTest::guiApp = nullptr;
+QApplication* PartSelectionPromotionTest::qtApp = nullptr;
 
 Gui::SelectionPickPolicy::Candidate pickCandidate(
     const void* owner,
@@ -150,6 +404,209 @@ std::shared_ptr<const SoPickedPoint> pickCubePoint(
     return pickedPoint;
 }
 
+std::shared_ptr<const SoPickedPoint> pickScenePoint(
+    SoNode* root,
+    const SbViewportRegion& viewportRegion,
+    const SbVec2s& pickPosition,
+    float pickRadius
+)
+{
+    SoRayPickAction pickAction(viewportRegion);
+    pickAction.setPoint(pickPosition);
+    pickAction.setRadius(pickRadius);
+    pickAction.apply(root);
+
+    std::shared_ptr<const SoPickedPoint> pickedPoint;
+    if (auto* point = pickAction.getPickedPoint()) {
+        pickedPoint = std::shared_ptr<const SoPickedPoint>(new SoPickedPoint(*point));
+    }
+
+    return pickedPoint;
+}
+
+bool hasElementType(const std::string& element, const char* typeName)
+{
+    return element.rfind(typeName, 0) == 0;
+}
+
+std::vector<std::string> getAdjacentFaceElements(const Part::TopoShape& shape, const std::string& element)
+{
+    const auto edgeShape = shape.findShape(element.c_str());
+    if (edgeShape.IsNull()) {
+        return {};
+    }
+
+    std::vector<std::string> adjacentFaces;
+    for (const auto faceIndex : shape.findAncestors(edgeShape, TopAbs_FACE)) {
+        adjacentFaces.emplace_back("Face" + std::to_string(faceIndex));
+    }
+    return adjacentFaces;
+}
+
+template<typename ContainerT>
+std::string joinElements(const ContainerT& container)
+{
+    std::string result = "[";
+    bool first = true;
+    for (const auto& element : container) {
+        if (!first) {
+            result += ", ";
+        }
+        result += element;
+        first = false;
+    }
+    result += "]";
+    return result;
+}
+
+std::set<std::string> collectVisibleFaceElements(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    SoNode* sceneRoot,
+    const SbViewportRegion& viewportRegion
+)
+{
+    std::set<std::string> visibleFaces;
+    const auto viewportSize = viewportRegion.getViewportSizePixels();
+    for (int y = 20; y < viewportSize[1] - 20; y += 2) {
+        for (int x = 20; x < viewportSize[0] - 20; x += 2) {
+            const SbVec2s pickPosition(static_cast<short>(x), static_cast<short>(y));
+            auto pickedPoint = pickScenePoint(sceneRoot, viewportRegion, pickPosition, 1.0F);
+            if (!pickedPoint) {
+                continue;
+            }
+
+            std::string rawElement;
+            if (viewProvider.getElementPicked(pickedPoint.get(), rawElement)
+                && hasElementType(rawElement, "Face")) {
+                visibleFaces.insert(rawElement);
+            }
+        }
+    }
+
+    return visibleFaces;
+}
+
+std::optional<EdgePromotionProbe> findSilhouetteEdgePromotionProbe(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    const Part::TopoShape& shape,
+    SoNode* sceneRoot,
+    const SbViewportRegion& viewportRegion,
+    const std::set<std::string>& visibleFaces
+)
+{
+    const auto viewportSize = viewportRegion.getViewportSizePixels();
+    for (int step : {2, 1}) {
+        for (int y = 20; y < viewportSize[1] - 20; y += step) {
+            for (int x = 20; x < viewportSize[0] - 20; x += step) {
+                const SbVec2s pickPosition(static_cast<short>(x), static_cast<short>(y));
+                auto pickedPoint = pickScenePoint(sceneRoot, viewportRegion, pickPosition, 1.0F);
+                if (!pickedPoint) {
+                    continue;
+                }
+
+                std::string rawElement;
+                if (!viewProvider.getElementPicked(pickedPoint.get(), rawElement)
+                    || !hasElementType(rawElement, "Edge")) {
+                    continue;
+                }
+
+                const auto adjacentFaces = getAdjacentFaceElements(shape, rawElement);
+                if (adjacentFaces.size() != 2) {
+                    continue;
+                }
+
+                std::optional<std::string> visibleFace;
+                for (const auto& face : adjacentFaces) {
+                    if (visibleFaces.contains(face)) {
+                        if (visibleFace) {
+                            visibleFace.reset();
+                            break;
+                        }
+                        visibleFace = face;
+                    }
+                }
+
+                if (visibleFace) {
+                    return EdgePromotionProbe {pickPosition, rawElement, *visibleFace};
+                }
+            }
+        }
+    }
+
+    return {};
+}
+
+std::optional<FacePickProbe> findRawFacePickProbe(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    SoNode* sceneRoot,
+    const SbViewportRegion& viewportRegion,
+    const std::string& faceElement
+)
+{
+    const auto viewportSize = viewportRegion.getViewportSizePixels();
+    for (int step : {2, 1}) {
+        for (int y = 20; y < viewportSize[1] - 20; y += step) {
+            for (int x = 20; x < viewportSize[0] - 20; x += step) {
+                const SbVec2s pickPosition(static_cast<short>(x), static_cast<short>(y));
+                auto pickedPoint = pickScenePoint(sceneRoot, viewportRegion, pickPosition, 1.0F);
+                if (!pickedPoint) {
+                    continue;
+                }
+
+                std::string rawElement;
+                if (viewProvider.getElementPicked(pickedPoint.get(), rawElement)
+                    && rawElement == faceElement) {
+                    return FacePickProbe {pickPosition, std::move(pickedPoint)};
+                }
+            }
+        }
+    }
+
+    return {};
+}
+
+std::string summarizeRawEdgeCandidates(
+    const PartGui::ViewProviderPartExt& viewProvider,
+    const Part::TopoShape& shape,
+    SoNode* sceneRoot,
+    const SbViewportRegion& viewportRegion,
+    const std::set<std::string>& visibleFaces
+)
+{
+    std::ostringstream stream;
+    const auto viewportSize = viewportRegion.getViewportSizePixels();
+    int reportedEdges = 0;
+    for (int y = 20; y < viewportSize[1] - 20 && reportedEdges < 8; y += 4) {
+        for (int x = 20; x < viewportSize[0] - 20 && reportedEdges < 8; x += 4) {
+            const SbVec2s pickPosition(static_cast<short>(x), static_cast<short>(y));
+            auto pickedPoint = pickScenePoint(sceneRoot, viewportRegion, pickPosition, 1.0F);
+            if (!pickedPoint) {
+                continue;
+            }
+
+            std::string rawElement;
+            if (!viewProvider.getElementPicked(pickedPoint.get(), rawElement)
+                || !hasElementType(rawElement, "Edge")) {
+                continue;
+            }
+
+            const auto adjacentFaces = getAdjacentFaceElements(shape, rawElement);
+            stream << rawElement << '@' << x << ',' << y
+                   << " adjacent=" << joinElements(adjacentFaces) << " visible=";
+
+            std::vector<std::string> visibleAdjacentFaces;
+            for (const auto& face : adjacentFaces) {
+                if (visibleFaces.contains(face)) {
+                    visibleAdjacentFaces.push_back(face);
+                }
+            }
+            stream << joinElements(visibleAdjacentFaces) << "; ";
+            ++reportedEdges;
+        }
+    }
+    return stream.str();
+}
+
 }  // namespace
 
 namespace Gui
@@ -167,6 +624,23 @@ public:
         info.ownedPoint = pickedPoint;
         info.pp = info.ownedPoint.get();
         return SoFCUnifiedSelection::getPickCandidate(info, nullptr, nullptr, &cursorPosition);
+    }
+
+    static bool setSelection(
+        SoFCUnifiedSelection& selectionNode,
+        const std::shared_ptr<const SoPickedPoint>& pickedPoint,
+        ViewProviderDocumentObject* vpd,
+        const std::string& element,
+        bool ctrlDown = false
+    )
+    {
+        std::vector<SoFCUnifiedSelection::PickedInfo> infos(1);
+        auto& info = infos.front();
+        info.ownedPoint = pickedPoint;
+        info.pp = info.ownedPoint.get();
+        info.vpd = vpd;
+        info.element = element;
+        return selectionNode.setSelection(infos, ctrlDown);
     }
 };
 
@@ -373,4 +847,96 @@ TEST(SelectionPickPolicyTest, keepsPreferredPickWhenNoCandidatePassesGate)
     };
 
     EXPECT_EQ(Gui::SelectionPickPolicy::choosePreferredPick(candidates), 0U);
+}
+
+TEST_F(PartSelectionPromotionTest, promotesSilhouetteEdgeToVisibleFaceForFaceOnlyGate)
+{
+    PartSelectionScene scene("part_selection_test");
+    scene.initialize();
+    ASSERT_NE(scene.doc, nullptr);
+    ASSERT_NE(scene.box, nullptr);
+    ASSERT_NE(scene.viewProvider, nullptr);
+    ASSERT_FALSE(scene.renderedShape.isNull());
+
+    // Derive the visible face from the actual rendered view so the test checks
+    // face-filter promotion behavior instead of relying on face numbering.
+    const auto probe = scene.findSilhouetteEdgeProbe();
+    ASSERT_TRUE(probe.has_value()) << "visibleFaces=" << joinElements(scene.visibleFaces)
+                                   << " rawEdges=" << scene.summarizeRawEdges();
+
+    const auto pickedPoint = pickScenePoint(scene.root, scene.viewportRegion, probe->position, 1.0F);
+    ASSERT_NE(pickedPoint, nullptr);
+
+    FaceOnlyGate gate;
+    const auto normalizedCursorPosition = normalizedPosition(probe->position, scene.viewportRegion);
+    Gui::SelectionPickContext pickContext;
+    pickContext.gate = &gate;
+    pickContext.normalizedCursorPosition = &normalizedCursorPosition;
+    pickContext.repick.sceneRoot = scene.root;
+    pickContext.repick.viewportRegion = &scene.viewportRegion;
+    pickContext.repick.eventPosition = &probe->position;
+    pickContext.repick.pickRadius = 1.0F;
+
+    std::string promotedElement = probe->rawEdge;
+    ASSERT_TRUE(scene.viewProvider->getElementPicked(pickedPoint.get(), promotedElement, &pickContext));
+    EXPECT_EQ(promotedElement, probe->visibleFace);
+}
+
+TEST_F(PartSelectionPromotionTest, keepsFaceSelectionWhenHierarchyAscentIsBlockedByFaceOnlyGate)
+{
+    PartSelectionScene scene("part_selection_test");
+    scene.initialize();
+    ASSERT_NE(scene.doc, nullptr);
+    ASSERT_NE(scene.box, nullptr);
+    ASSERT_NE(scene.viewProvider, nullptr);
+    ASSERT_FALSE(scene.renderedShape.isNull());
+
+    const auto probe = scene.findSilhouetteEdgeProbe();
+    ASSERT_TRUE(probe.has_value()) << "visibleFaces=" << joinElements(scene.visibleFaces)
+                                   << " rawEdges=" << scene.summarizeRawEdges();
+
+    const auto facePick = scene.findRawFacePick(probe->visibleFace);
+    ASSERT_TRUE(facePick.has_value()) << "visibleFaces=" << joinElements(scene.visibleFaces)
+                                      << " targetFace=" << probe->visibleFace;
+
+    Gui::Selection()
+        .addSelectionGate(new FaceOnlyGate, Gui::ResolveMode::NoResolve, scene.docName.c_str());
+    EXPECT_FALSE(Gui::Selection().testSelection(scene.doc, scene.box, nullptr));
+
+    auto* selectionNode = new Gui::SoFCUnifiedSelection;
+    selectionNode->ref();
+    Gui::SelectionLogDisabler disableSelectionLog(true);
+
+    ASSERT_TRUE(
+        Gui::SoFCUnifiedSelectionTestAccess::setSelection(
+            *selectionNode,
+            facePick->pickedPoint,
+            scene.viewProvider,
+            probe->visibleFace
+        )
+    );
+    EXPECT_TRUE(
+        Gui::Selection().isSelected(scene.box, probe->visibleFace.c_str(), Gui::ResolveMode::NoResolve)
+    );
+
+    // A repeated click on the same face should not escalate to an object selection
+    // when the active face-only gate would reject that parent target.
+    ASSERT_TRUE(
+        Gui::SoFCUnifiedSelectionTestAccess::setSelection(
+            *selectionNode,
+            facePick->pickedPoint,
+            scene.viewProvider,
+            probe->visibleFace
+        )
+    );
+    EXPECT_TRUE(
+        Gui::Selection().isSelected(scene.box, probe->visibleFace.c_str(), Gui::ResolveMode::NoResolve)
+    );
+    EXPECT_FALSE(Gui::Selection().isSelected(scene.box, nullptr, Gui::ResolveMode::NoResolve));
+    EXPECT_EQ(
+        Gui::Selection().getSelectedElement(scene.box, probe->visibleFace.c_str()),
+        probe->visibleFace
+    );
+
+    selectionNode->unref();
 }

--- a/tests/src/Gui/SelectionTest.cpp
+++ b/tests/src/Gui/SelectionTest.cpp
@@ -120,6 +120,16 @@ TEST(SelectionPickPolicyTest, canFinalizeSinglePickWhenNoGateIsInstalled)
     EXPECT_TRUE(Gui::SelectionPickPolicy::canFinalizeSinglePick(candidates));
 }
 
+TEST(SelectionPickPolicyTest, doesNotExpandPickRadiusWhenNoGateIsInstalled)
+{
+    int owner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&owner, 0, true, false, true),
+    };
+
+    EXPECT_FALSE(Gui::SelectionPickPolicy::shouldExpandPickRadius(candidates));
+}
+
 TEST(SelectionPickPolicyTest, continuesSinglePickWhenGateRejectedAllCurrentCandidates)
 {
     int owner {};
@@ -128,6 +138,40 @@ TEST(SelectionPickPolicyTest, continuesSinglePickWhenGateRejectedAllCurrentCandi
     };
 
     EXPECT_FALSE(Gui::SelectionPickPolicy::canFinalizeSinglePick(candidates));
+}
+
+TEST(SelectionPickPolicyTest, expandsPickRadiusWhenGateRejectedAllCurrentCandidates)
+{
+    int owner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&owner, 0, true, true, false),
+    };
+
+    EXPECT_TRUE(Gui::SelectionPickPolicy::shouldExpandPickRadius(candidates));
+}
+
+TEST(SelectionPickPolicyTest, doesNotExpandPickRadiusWhenCurrentPickAlreadyPassesGate)
+{
+    int firstOwner {};
+    int secondOwner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&firstOwner, 1, true, true, false),
+        pickCandidate(&secondOwner, 0, true, true, true),
+    };
+
+    EXPECT_FALSE(Gui::SelectionPickPolicy::shouldExpandPickRadius(candidates));
+}
+
+TEST(SelectionPickPolicyTest, doesNotExpandPickRadiusWhenAnotherSelectableCandidateIsPresent)
+{
+    int firstOwner {};
+    int secondOwner {};
+    std::vector<Gui::SelectionPickPolicy::Candidate> candidates {
+        pickCandidate(&firstOwner, 1, true, true, false),
+        pickCandidate(&secondOwner, 0, true, false, true),
+    };
+
+    EXPECT_FALSE(Gui::SelectionPickPolicy::shouldExpandPickRadius(candidates));
 }
 
 TEST(SelectionPickPolicyTest, choosesAllowedCandidateWhenPreferredPickIsRejected)


### PR DESCRIPTION
Follow-up to #29705.

This PR improves gated single-pick behavior without changing ordinary ungated picking.

## Summary

There are two related changes here:

1. When the normal single-pick path is blocked by the active selection filter and the current pick list contains no allowed candidate, do one wider fallback pick.
2. For `Part` face-only filters, allow raw edge/vertex hits to resolve to the visible adjacent face instead of relying on Coin’s raw hit ordering.

This keeps the generic selection logic in `Gui` and the shape-specific face decision logic in `Part`.

## Behavior

The single-pick flow is now:

1. Use the normal picked-point list.
2. If an active selection filter rejects all candidates in that list, do a second wider single-pick search.
3. If that wider pass finds allowed candidates, choose the nearest allowed fallback hit.
4. Otherwise keep the existing blocked-selection behavior.

For `Part` face-only filters:

1. If the raw hit is already a face, keep it.
2. If the raw hit is an edge or vertex, gather adjacent candidate faces from topology.
3. Choose the visible adjacent face from rendered geometry within the pick neighborhood.
4. If no visible adjacent face can be resolved, keep the existing blocked-selection behavior.

The widened fallback currently uses `2x` the current viewer pick radius.

## Scope

This is intentionally limited to selection-filter behavior.

It does not change ordinary picking when:
- there is no active selection filter, or
- the current pick list already contains a valid allowed candidate.

## Implementation Notes

- `Gui` now threads generic pick context through the `ViewProvider` single-pick path.
- `Part` uses that context to implement face-only recovery locally, where topology and rendered-face geometry are available.
- Blocked fallback ranking now uses nearest allowed hit rather than the first allowed Coin hit.
- Repeated clicks on an already selected face under a face-only gate no longer escalate to a blocked parent-object selection.

