### PR TITLE
Gui: Fix SplashScreen-induced app startup slowdown

### DIFF
--- a/src/Gui/SplashScreen.cpp
+++ b/src/Gui/SplashScreen.cpp
@@ -239,6 +239,34 @@ SplashScreen::~SplashScreen()
     delete messages;
 }
 
+// Whenever QSplashScreen gets a QEvent::Show or is about to be finish()ed, it will start
+// waiting for its window to be displayed and puts the main thread to sleep repeatedly as
+// long as it isn't reported as such. (see qtbase@52a4103 src/widgets/widgets/qsplashscreen.cpp:214)
+// Problem is QWidget::show() triggers QWidgetPrivate::setVisible() in turn sending a QEvent::Show,
+// but by that point the underlying QWindow may not have been flagged as visible yet.
+// On Linux with either X11 or Wayland, this disturbs the event loop, and QWindow visibility
+// will never be reported as these protocols require explicit flushing and event pulling from said
+// event loop, thus making the QSplashScreen waitForWidgetMapped() function wait for its default
+// timeout of 1000 ms, delaying the entire app's startup by a whole second or more.
+// Override SplashScreen::event() and QSplashScreen::finish() to bypass this entirely.
+// The window's visibility status is up to the event loops and compositors, it is out of our
+// control, so don't bother.
+
+void SplashScreen::finish(QWidget* w)
+{
+    Q_UNUSED(w);
+    close();
+}
+
+bool SplashScreen::event(QEvent* e)
+{
+    if (e->type() == QEvent::Show) {
+        // Bypass QSplashScreen::event for Show events specifically
+        return QWidget::event(e);  // NOLINT(bugprone-parent-virtual-call)
+    }
+    return QSplashScreen::event(e);
+}
+
 /**
  * Draws the contents of the splash screen using painter \a painter. The default
  * implementation draws the message passed by message().

--- a/src/Gui/SplashScreen.h
+++ b/src/Gui/SplashScreen.h
@@ -41,11 +41,14 @@ public:
     explicit SplashScreen(const QPixmap& pixmap = QPixmap(), Qt::WindowFlags f = Qt::WindowFlags());
     ~SplashScreen() override;
 
+    void finish(QWidget* w);
+
     void setShowMessages(bool on);
 
     static QPixmap splashImage();
 
 protected:
+    bool event(QEvent* e) override;
     void drawContents(QPainter* painter) override;
 
 private:

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -469,6 +469,11 @@ void StartupPostProcess::showMainWindow()
         throw;
     }
 
+    // Finish processing all events, including initializations, before
+    // hiding the splash and showing the main window
+    QCoreApplication::processEvents(QEventLoop::AllEvents);
+    QCoreApplication::sendPostedEvents();
+
     // stop splash screen and set immediately the active window that may be of interest
     // for scripts using Python binding for Qt
     mainWindow->stopSplasher();


### PR DESCRIPTION
Whenever `QSplashScreen` gets a `QEvent::Show` or is about to be `finish()`ed, it will start waiting for its window to be displayed and puts the main thread to sleep repeatedly as long as it isn't reported as such. (see [qtbase@52a4103 src/widgets/widgets/qsplashscreen.cpp:214](https://github.com/qt/qtbase/blob/52a4103af1d7e09c976bb689aab6c81e48dc063e/src/widgets/widgets/qsplashscreen.cpp#L214))
Problem is `QWidget::show()` triggers `QWidgetPrivate::setVisible()` in turn sending a `QEvent::Show`, but by that point the underlying `QWindow` may not have been flagged as visible yet.
On Linux with either X11 or Wayland, this disturbs the event loop, and `QWindow` visibility will never be reported as these protocols require explicit flushing and event pulling from said event loop, thus making the `QSplashScreen` `waitForWidgetMapped()` function wait for its default timeout of 1000 ms, delaying the entire app's startup by a whole second or more.
Override `SplashScreen::event()` and `QSplashScreen::finish()` to bypass this entirely.
The window's visibility status is up to the event loops and compositors, it is out of our control, so don't bother.

## Before
5.2 seconds to reach interactive/idle
<img width="1872" height="210" alt="splash2_before" src="https://github.com/user-attachments/assets/ee51a4d4-d276-4d73-817a-db155e8bb6f0" />

## After
3.51 seconds to reach interactive/idle
<img width="1872" height="210" alt="splash2_after" src="https://github.com/user-attachments/assets/c6030330-b5df-4557-b521-2b122e14fde1" />

> [!NOTE]  
> Testing requested on macOS, as I don't own a Mac device. Shouldn't be adversely affected however, as waiting for splash display isn't a *fundamental* part of its operation; it'll show up whenever the system makes it show up anyway.