### PR TITLE
Python Types: Add missing readyType()

### DIFF
--- a/src/Base/Interpreter.cpp
+++ b/src/Base/Interpreter.cpp
@@ -203,6 +203,7 @@ public:
         behaviors().doc("Python standard output");
         add_varargs_method("write", &PythonStdOutput::write, "write()");
         add_varargs_method("flush", &PythonStdOutput::flush, "flush()");
+        behaviors().readyType();
     }
 
     PythonStdOutput() = default;

--- a/src/Gui/MDIViewPy.cpp
+++ b/src/Gui/MDIViewPy.cpp
@@ -64,6 +64,7 @@ void MDIViewPy::init_type()
         "getActiveObject(name,resolve=True)\nreturns the active object for the given type"
     );
     add_varargs_method("cast_to_base", &MDIViewPy::cast_to_base, "cast_to_base() cast to MDIView class");
+    behaviors().readyType();
 }
 
 PyObject* MDIViewPy::extension_object_new(struct _typeobject* /*type*/, PyObject* /*args*/, PyObject* /*kwds*/)

--- a/src/Gui/MainWindowPy.cpp
+++ b/src/Gui/MainWindowPy.cpp
@@ -56,6 +56,7 @@ void MainWindowPy::init_type()
     add_varargs_method("removeWindow", &MainWindowPy::removeWindow, "removeWindow(MDIView)");
     add_varargs_method("showHint", &MainWindowPy::showHint, "showHint(hint)");
     add_varargs_method("hideHint", &MainWindowPy::hideHint, "hideHint()");
+    behaviors().readyType();
 }
 
 PyObject* MainWindowPy::extension_object_new(struct _typeobject* /*type*/, PyObject* /*args*/, PyObject* /*kwds*/)

--- a/src/Gui/Placement.cpp
+++ b/src/Gui/Placement.cpp
@@ -1320,6 +1320,7 @@ void TaskPlacementPy::init_type()
     add_varargs_method("getStandardButtons", &TaskPlacementPy::getStandardButtons,
                        "getStandardButtons()");
     // clang-format on
+    behaviors().readyType();
 }
 
 PyObject* TaskPlacementPy::PyMake(struct _typeobject* type, PyObject* args, PyObject* kwds)

--- a/src/Gui/PythonConsolePy.cpp
+++ b/src/Gui/PythonConsolePy.cpp
@@ -36,6 +36,7 @@ void PythonStdout::init_type()
     add_varargs_method("write", &PythonStdout::write, "write()");
     add_varargs_method("flush", &PythonStdout::flush, "flush()");
     add_noargs_method("isatty", &PythonStdout::isatty, "isatty()");
+    behaviors().readyType();
 }
 
 PythonStdout::PythonStdout(PythonConsole* pc)
@@ -97,6 +98,7 @@ void PythonStderr::init_type()
     add_varargs_method("write", &PythonStderr::write, "write()");
     add_varargs_method("flush", &PythonStderr::flush, "flush()");
     add_noargs_method("isatty", &PythonStderr::isatty, "isatty()");
+    behaviors().readyType();
 }
 
 PythonStderr::PythonStderr(PythonConsole* pc)
@@ -158,6 +160,7 @@ void OutputStdout::init_type()
     add_varargs_method("write", &OutputStdout::write, "write()");
     add_varargs_method("flush", &OutputStdout::flush, "flush()");
     add_noargs_method("isatty", &OutputStdout::isatty, "isatty()");
+    behaviors().readyType();
 }
 
 OutputStdout::OutputStdout() = default;
@@ -217,6 +220,7 @@ void OutputStderr::init_type()
     add_varargs_method("write", &OutputStderr::write, "write()");
     add_varargs_method("flush", &OutputStderr::flush, "flush()");
     add_noargs_method("isatty", &OutputStderr::isatty, "isatty()");
+    behaviors().readyType();
 }
 
 OutputStderr::OutputStderr() = default;
@@ -275,6 +279,7 @@ void PythonStdin::init_type()
     behaviors().supportRepr();
     behaviors().supportGetattr();
     add_varargs_method("readline", &PythonStdin::readline, "readline()");
+    behaviors().readyType();
 }
 
 PythonStdin::PythonStdin(PythonConsole* pc)

--- a/src/Gui/PythonDebugger.cpp
+++ b/src/Gui/PythonDebugger.cpp
@@ -178,6 +178,7 @@ void PythonDebugStdout::init_type()
     behaviors().supportRepr();
     add_varargs_method("write", &PythonDebugStdout::write, "write to stdout");
     add_varargs_method("flush", &PythonDebugStdout::flush, "flush the output");
+    behaviors().readyType();
 }
 
 PythonDebugStdout::PythonDebugStdout() = default;
@@ -218,6 +219,7 @@ void PythonDebugStderr::init_type()
     // you must have overwritten the virtual functions
     behaviors().supportRepr();
     add_varargs_method("write", &PythonDebugStderr::write, "write to stderr");
+    behaviors().readyType();
 }
 
 PythonDebugStderr::PythonDebugStderr() = default;
@@ -253,6 +255,7 @@ void PythonDebugExcept::init_type()
     // you must have overwritten the virtual functions
     behaviors().supportRepr();
     add_varargs_method("fc_excepthook", &PythonDebugExcept::excepthook, "Custom exception handler");
+    behaviors().readyType();
 }
 
 PythonDebugExcept::PythonDebugExcept() = default;

--- a/src/Gui/PythonDebugger.cpp
+++ b/src/Gui/PythonDebugger.cpp
@@ -293,6 +293,13 @@ public:
         , depth(0)
     {}
     ~PythonDebuggerPy() override = default;
+
+    static void init_type()
+    {
+        behaviors().name("PythonDebuggerPy");
+        behaviors().doc("Internal Python debugger state object");
+        behaviors().readyType();
+    };
     PythonDebugger* dbg;
     int depth;
 };
@@ -331,6 +338,7 @@ struct PythonDebuggerP
     explicit PythonDebuggerP(PythonDebugger* that)
     {
         Base::PyGILStateLocker lock;
+        PythonDebuggerPy::init_type();
         out_n = new PythonDebugStdout();
         err_n = new PythonDebugStderr();
         pypde = new PythonDebugExcept();

--- a/src/Gui/TaskView/TaskDialogPython.cpp
+++ b/src/Gui/TaskView/TaskDialogPython.cpp
@@ -130,6 +130,7 @@ void ControlPy::init_type()
         "show the Model panel\n"
         "showModelView()"
     );
+    behaviors().readyType();
 }
 
 ControlPy::ControlPy() = default;
@@ -494,6 +495,7 @@ void TaskDialogPy::init_type()
     );
     add_varargs_method("accept", &TaskDialogPy::accept, "Accept the task dialog");
     add_varargs_method("reject", &TaskDialogPy::reject, "Reject the task dialog");
+    behaviors().readyType();
 }
 
 TaskDialogPy::TaskDialogPy(TaskDialog* dlg)

--- a/src/Gui/UiLoader.cpp
+++ b/src/Gui/UiLoader.cpp
@@ -579,6 +579,7 @@ void UiLoaderPy::init_type()
     );
     add_varargs_method("setWorkingDirectory", &UiLoaderPy::setWorkingDirectory, "setWorkingDirectory()");
     add_varargs_method("workingDirectory", &UiLoaderPy::workingDirectory, "workingDirectory()");
+    behaviors().readyType();
 }
 
 UiLoaderPy::UiLoaderPy()

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -363,6 +363,7 @@ void View3DInventorPy::init_type()
         &View3DInventorPy::cast_to_base,
         "cast_to_base() cast to MDIView class"
     );
+    behaviors().readyType();
 }
 
 View3DInventorPy::View3DInventorPy(View3DInventor* vi)

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -187,6 +187,7 @@ void View3DInventorViewerPy::init_type()
         "getNavigationStyle() -> NavigationStyle\n"
         "Returns the current viewer navigation style class.\n"
     );
+    behaviors().readyType();
 }
 
 View3DInventorViewerPy::View3DInventorViewerPy(View3DInventorViewer* vi)

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -407,6 +407,7 @@ void PyResource::init_type()
     add_varargs_method("setValue", &PyResource::setValue);
     add_varargs_method("show", &PyResource::show);
     add_varargs_method("connect", &PyResource::connect);
+    behaviors().readyType();
 }
 
 PyResource::PyResource()

--- a/src/Mod/Test/Gui/UnitTestPy.cpp
+++ b/src/Mod/Test/Gui/UnitTestPy.cpp
@@ -56,6 +56,7 @@ void UnitTestDialogPy::init_type()
     add_varargs_method("updateGUI", &UnitTestDialogPy::updateGUI, "updateGUI");
     add_varargs_method("addUnitTest", &UnitTestDialogPy::addUnitTest, "addUnitTest");
     add_varargs_method("clearUnitTests", &UnitTestDialogPy::clearUnitTests, "clearUnitTests");
+    behaviors().readyType();
 }
 
 UnitTestDialogPy::UnitTestDialogPy() = default;


### PR DESCRIPTION
I'm working on getting full Debug mode working on Windows, and one of the errors I have run across is that many of our Python types' `init_type` methods do not call `readyType()` at the end. As of Python 3.12 (and [PEP 683](https://peps.python.org/pep-0683/) if my understanding is correct) this is now a firm requirement, but it's not caught automatically unless Python was compiled in Debug mode, which then lets this assertion trigger (in pycore_object.h):
```C++
    assert(_PyType_HasFeature(typeobj, Py_TPFLAGS_HEAPTYPE) || _Py_IsImmortal(typeobj));
```

I grepped our codebase for `::init_type()` and made sure that all of them had the `readyType()` call in them. This PR adds those that were missing it.

ETA: Also added an `init_type` method with a `readyType()` call to one class that didn't have it all. With these changes, FreeCAD will now launch when linked against a debug-mode-compiled Python 3.14.