### PR TITLE
App: Fix crash in GeoFeaturePy::getGlobalPlacementOf

### DIFF
--- a/src/App/GeoFeaturePyImp.cpp
+++ b/src/App/GeoFeaturePyImp.cpp
@@ -63,9 +63,14 @@ PyObject* GeoFeaturePy::getGlobalPlacementOf(PyObject* args)
 
     PyObject* pyTargetObj {nullptr};
     PyObject* pyRootObj {nullptr};
-    char* pname;
+    char* pname {nullptr};
 
-    if (!PyArg_ParseTuple(args, "OOs", &pyTargetObj, &pyRootObj, &pname)) {
+    if (!PyArg_ParseTuple(args, "O!O!s",
+                          &DocumentObjectPy::Type,
+                          &pyTargetObj,
+                          &DocumentObjectPy::Type,
+                          &pyRootObj,
+                          &pname)) {
         return nullptr;
     }
     auto* targetObj = static_cast<App::DocumentObjectPy*>(pyTargetObj)->getDocumentObjectPtr();


### PR DESCRIPTION
Cherry-picked from https://codeberg.org/xCAD/FreeCAD11/pulls/182/commits/ba7c5580c3f283c422e0c4cce335b6f25a9a3a08

Make sure that the expected types are verified.

The error is reported here:
https://forum.freecad.org/viewtopic.php?t=105224
