### PR TITLE
Part: Fix multiple calls of ShapeFix_Face::Perform()

### DIFF
--- a/src/Mod/Part/App/modelRefine.cpp
+++ b/src/Mod/Part/App/modelRefine.cpp
@@ -509,11 +509,13 @@ const TopoDS_Face fixFace(const TopoDS_Face& f)
         return dummy;
     }
     faceFixer.FixMissingSeam();
+    faceFixer.SetContext(new ShapeBuild_ReShape());
     faceFixer.Perform();
     if (faceFixer.Status(ShapeExtend_FAIL)) {
         return dummy;
     }
     faceFixer.FixOrientation();
+    faceFixer.SetContext(new ShapeBuild_ReShape());
     faceFixer.Perform();
     if (faceFixer.Status(ShapeExtend_FAIL)) {
         return dummy;


### PR DESCRIPTION
Cherry-picked from https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_23975

To prevent ShapeFix_Face from crashing reset the reshape context before calling Perform().

This fixes https://github.com/FreeCAD/FreeCAD/issues/23975
