### PR TITLE
Gui: Disable drag and drop of coordinate system

### DIFF
--- a/src/Gui/ViewProviderCoordinateSystem.h
+++ b/src/Gui/ViewProviderCoordinateSystem.h
@@ -94,7 +94,8 @@ public:
         return false;
     }
 
-    bool canDropObjects() const override {
+    bool canDropObjects() const override
+    {
         return false;
     }
 

--- a/src/Gui/ViewProviderCoordinateSystem.h
+++ b/src/Gui/ViewProviderCoordinateSystem.h
@@ -94,6 +94,10 @@ public:
         return false;
     }
 
+    bool canDropObjects() const override {
+        return false;
+    }
+
     /// Returns default size. Use this if it is not possible to determine appropriate size by other means
     static double defaultSize();
 


### PR DESCRIPTION
Cherry-picked from https://codeberg.org/wwmayer/FreeCAD11/commits/branch/fix_cs_dnd 

This avoids multiple thrown exceptions when dropping a moved object on the origin:
<Exception> LocalCoordinateSystem "Unnamed#Origin" doesn't contain feature with role "Sketch".

Partially described in https://github.com/FreeCAD/FreeCAD/issues/29475
