### PR TITLE
Gui: Fix possible crash when opening by drag and drop

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -854,7 +854,7 @@ void Application::open(const char* FileName, const char* Module)
             getMainWindow()->appendRecentFile(filename);
             FileDialog::setWorkingDirectory(filename);
         }
-        catch (const Base::PyException& e) {
+        catch (const Base::Exception& e) {
             // Usually thrown if the file is invalid somehow
             e.reportException();
         }
@@ -961,7 +961,7 @@ void Application::importFrom(const char* FileName, const char* DocName, const ch
             }
             FileDialog::setWorkingDirectory(filename);
         }
-        catch (const Base::PyException& e) {
+        catch (const Base::Exception& e) {
             // Usually thrown if the file is invalid somehow
             e.reportException();
         }


### PR DESCRIPTION
Cherry-picked from https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_crash_draganddrop

Inside Application::importFrom() handle all Base::Exception types and not only Base::PyException. This is needed to avoid that excpetions end up in GUIApplication::notify() which is known to cause a crash on macOS.
