### PR TITLE
Gui: Tree view icon size changes

### DIFF
--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -698,6 +698,10 @@ QIcon BitmapFactoryInst::mergePixmap(
     QIcon overlayedIcon;
 
     int w = QApplication::style()->pixelMetric(QStyle::PM_ListViewIconSize);
+    auto sizes = base.availableSizes();
+    if (sizes.size() == 1) {
+        w = sizes.front().width();
+    }
 
     overlayedIcon.addPixmap(
         Gui::BitmapFactory().merge(base.pixmap(w, w, QIcon::Normal, QIcon::Off), px, position),

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -487,8 +487,10 @@ void TreeWidgetItemDelegate::initStyleOption(QStyleOptionViewItem* option, const
     QSize size = option->icon.actualSize(QSize(0xffff, 0xffff));
 
     if (size.height() > 0) {
-        option->decorationSize
-            = QSize(size.width() * TreeWidget::iconSize() / size.height(), TreeWidget::iconSize());
+        option->decorationSize = QSize(
+            size.width() * TreeWidget::getIconSize() / size.height(),
+            TreeWidget::getIconSize()
+        );
     }
 
     if (isOnlyNameColumnDisplayed()) {
@@ -1639,7 +1641,7 @@ static int& treeIconSize()
     static int _treeIconSize = -1;
 
     if (_treeIconSize < 0) {
-        _treeIconSize = TreeParams::getIconSize();
+        _treeIconSize = static_cast<int>(TreeParams::getIconSize());
     }
     return _treeIconSize;
 }
@@ -1651,28 +1653,28 @@ int TreeWidget::iconHeight() const
 
 void TreeWidget::setIconHeight(int height)
 {
-    if (treeIconSize() == height) {
-        return;
-    }
-
     treeIconSize() = height;
     if (treeIconSize() <= 0) {
-        treeIconSize() = std::max(10, iconSize());
+        treeIconSize() = std::max(10, getIconSize());
     }
 
+    QSize newSize(treeIconSize(), treeIconSize());
     for (auto tree : Instances) {
-        tree->setIconSize(QSize(treeIconSize(), treeIconSize()));
+        if (tree->iconSize().width() != newSize.width()) {
+            tree->setIconSize(newSize);
+        }
     }
 }
 
-int TreeWidget::iconSize()
+int TreeWidget::getIconSize()
 {
     static int defaultSize;
     if (defaultSize == 0) {
         auto tree = instance();
         if (tree) {
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-            defaultSize = tree->viewOptions().decorationSize.width();
+            QStyleOptionViewItem opt = tree->viewOptions();
+            defaultSize = opt.decorationSize.width();
 #else
             QStyleOptionViewItem opt;
             tree->initViewItemOption(&opt);
@@ -2005,7 +2007,7 @@ void TreeWidget::mousePressEvent(QMouseEvent* event)
             iconRect.adjust(margin, 0, 0, 0);
 
             // We are interested in the first icon (visibility icon)
-            iconRect.setWidth(iconSize());
+            iconRect.setWidth(getIconSize());
 
             // If the visibility icon was clicked, toggle the DocumentObject visibility
             if (iconRect.contains(mousePos)) {
@@ -6301,7 +6303,8 @@ void DocumentObjectItem::generateIcon(int currentStatus, QIcon::Mode mode, QIcon
     QIcon icon_org = object()->getIcon();
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    int w = getTree()->viewOptions().decorationSize.width();
+    QStyleOptionViewItem opt = getTree()->viewOptions();
+    int w = opt.decorationSize.width();
 #else
     QStyleOptionViewItem opt;
     getTree()->initViewItemOption(&opt);

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -71,7 +71,7 @@ public:
     void selectLinkedObject(App::DocumentObject* linked);
     void selectAllLinks(App::DocumentObject* obj);
     void expandSelectedItems(TreeItemMode mode);
-    static int iconSize();
+    static int getIconSize();
 
     int iconHeight() const;
     void setIconHeight(int height);


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Cherry-picked from https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_17527

Rename method TreeWidget::iconSize() to TreeWidget::getIconSize()
because it overrides the non-virtual method of the base class.

Fix TreeWidget::setIconHeight() to not compare the passed height with
the value of the internally called treeIconSize() because the very first
time they are equal so that the actual iconSize of the tree widget won't
be changed.

This fixes https://github.com/FreeCAD/FreeCAD/issues/17527 and
fixes https://github.com/FreeCAD/FreeCAD/issues/17061