### PR TITLE
Gui: Refresh overlay manager when refreshing style-sheets

### DIFF
--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -479,6 +479,7 @@ void Application::initStyleParameterManager()
             bool tiledBG = hGrp->GetBool("TiledBackground", false);
 
             setStyleSheet(QString::fromStdString(sheet), tiledBG);
+            OverlayManager::instance()->refresh(nullptr, true);
         }
     );
 


### PR DESCRIPTION
Fixes #28630

In the lambda in `Application.cpp` the first bad commit a09de19 replaces `reloadStyleSheet` with some code. If the compare that code to the contents of [`reloadStyleSheet`](https://github.com/FreeCAD/FreeCAD/blob/d1a54ff605cea3dce8385fe613877bae4473fb4b/src/Gui/Application.cpp#L2896) one line `OverlayManager::instance()->refresh(nullptr, true);` is missing. Adding this fixes the issue.