### PR TITLE
Mesh: Refactor MeshKernel::AddFacets

### DIFF
--- a/src/Mod/Mesh/App/Core/MeshKernel.cpp
+++ b/src/Mod/Mesh/App/Core/MeshKernel.cpp
@@ -191,25 +191,36 @@ void MeshKernel::AddFacets(const std::vector<MeshGeomFacet>& rclFAry)
 
 unsigned long MeshKernel::AddFacets(const std::vector<MeshFacet>& rclFAry, bool checkManifolds)
 {
+    // if the manifold check shouldn't be done then just add all faces
+    if (!checkManifolds) {
+        return AddFacets(rclFAry);
+    }
+
+    return AddFacetsIfValid(rclFAry);
+}
+
+
+unsigned long MeshKernel::AddFacets(const std::vector<MeshFacet>& rclFAry)
+{
+    FacetIndex countFacets = CountFacets();
+    FacetIndex countValid = rclFAry.size();
+    _aclFacetArray.reserve(countFacets + countValid);
+
+    // just add all faces now
+    for (const auto& pF : rclFAry) {
+        _aclFacetArray.push_back(pF);
+    }
+
+    RebuildNeighbours(countFacets);
+    return _aclFacetArray.size();
+}
+
+unsigned long MeshKernel::AddFacetsIfValid(const std::vector<MeshFacet>& rclFAry)
+{
     // Build map of edges of the referencing facets we want to append
 #ifdef FC_DEBUG
     [[maybe_unused]] unsigned long countPoints = CountPoints();
 #endif
-
-    // if the manifold check shouldn't be done then just add all faces
-    if (!checkManifolds) {
-        FacetIndex countFacets = CountFacets();
-        FacetIndex countValid = rclFAry.size();
-        _aclFacetArray.reserve(countFacets + countValid);
-
-        // just add all faces now
-        for (const auto& pF : rclFAry) {
-            _aclFacetArray.push_back(pF);
-        }
-
-        RebuildNeighbours(countFacets);
-        return _aclFacetArray.size();
-    }
 
     this->_aclPointArray.ResetInvalid();
     FacetIndex k = CountFacets();

--- a/src/Mod/Mesh/App/Core/MeshKernel.h
+++ b/src/Mod/Mesh/App/Core/MeshKernel.h
@@ -495,6 +495,10 @@ protected:
     inline Base::Vector3f GetGravityPoint(const MeshFacet& rclFacet) const;
 
 private:
+    unsigned long AddFacets(const std::vector<MeshFacet>& rclFAry);
+    unsigned long AddFacetsIfValid(const std::vector<MeshFacet>& rclFAry);
+
+private:
     MeshPointArray _aclPointArray;        /**< Holds the array of geometric points. */
     MeshFacetArray _aclFacetArray;        /**< Holds the array of facets. */
     mutable Base::BoundBox3f _clBoundBox; /**< The current calculated bounding box. */

--- a/src/Mod/Mesh/Gui/Command.cpp
+++ b/src/Mod/Mesh/Gui/Command.cpp
@@ -757,21 +757,19 @@ CmdMeshAddFacet::CmdMeshAddFacet()
 
 void CmdMeshAddFacet::activated(int)
 {
-    std::vector<App::DocumentObject*> docObj = Gui::Selection().getObjectsOfType(
-        Mesh::Feature::getClassTypeId()
-    );
-    for (auto it : docObj) {
-        Gui::Document* doc = Gui::Application::Instance->getDocument(it->getDocument());
-        Gui::MDIView* view = doc->getActiveView();
-        if (view->isDerivedFrom<Gui::View3DInventor>()) {
-            MeshGui::MeshFaceAddition* edit = new MeshGui::MeshFaceAddition(
-                static_cast<Gui::View3DInventor*>(view)
-            );
-            edit->startEditing(
-                static_cast<MeshGui::ViewProviderMesh*>(Gui::Application::Instance->getViewProvider(it))
-            );
-            break;
-        }
+    auto meshes = Gui::Selection().getObjectsOfType<Mesh::Feature>();
+    if (meshes.size() != 1) {
+        return;
+    }
+
+    auto meshObj = meshes.front();
+    Gui::Document* doc = Gui::Application::Instance->getDocument(meshObj->getDocument());
+    Gui::MDIView* view = doc->getActiveView();
+    if (view->isDerivedFrom<Gui::View3DInventor>()) {
+        auto edit = new MeshGui::MeshFaceAddition(static_cast<Gui::View3DInventor*>(view));
+        edit->startEditing(
+            static_cast<MeshGui::ViewProviderMesh*>(Gui::Application::Instance->getViewProvider(meshObj))
+        );
     }
 }
 

--- a/src/Mod/Mesh/Gui/MeshEditor.cpp
+++ b/src/Mod/Mesh/Gui/MeshEditor.cpp
@@ -48,9 +48,11 @@
 
 #include <App/Application.h>
 #include <App/Document.h>
+#include <Gui/MainWindow.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
 #include <Gui/WaitCursor.h>
+#include <Gui/Widgets.h>
 #include <Mod/Mesh/App/Core/Algorithm.h>
 #include <Mod/Mesh/App/MeshFeature.h>
 
@@ -240,9 +242,20 @@ void MeshFaceAddition::addFace()
     f._aulPoints[2] = faceView->index[2];
     std::vector<MeshCore::MeshFacet> faces;
     faces.push_back(f);
+    auto numFaces = mesh->countFacets();
     mesh->addFacets(faces, true);
     mf->Mesh.finishEditing();
-    doc->commitTransaction();
+    if (mesh->countFacets() > numFaces) {
+        doc->commitTransaction();
+    }
+    else {
+        doc->abortTransaction();
+        auto label = new Gui::StatusWidget(Gui::getMainWindow());
+        label->setAttribute(Qt::WA_DeleteOnClose);
+        label->setStatusText(tr("Cannot add triangle to avoid non-manifolds."));
+        label->show();
+        QTimer::singleShot(3000, label, &Gui::StatusWidget::close);
+    }
 
     clearPoints();
 }


### PR DESCRIPTION
Cherry-pick from https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_28362

The command may correctly refuse to add the triangle but it doesn't show
a reason about why it fails. Now there is shown a status widget for a
while about the reason.

This fixes https://github.com/FreeCAD/FreeCAD/issues/28362