### PR TITLE
QSint: Don't use Up/Down keys for focus change

### DIFF
--- a/src/Gui/QSint/actionpanel/taskgroup_p.cpp
+++ b/src/Gui/QSint/actionpanel/taskgroup_p.cpp
@@ -85,24 +85,24 @@ QPixmap TaskGroup::transparentRender()
 
 void TaskGroup::keyPressEvent ( QKeyEvent * event )
 {
-  switch (event->key())
-  {
-    case Qt::Key_Down:
-    {
-      QKeyEvent ke(QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier);
-      QApplication::sendEvent(this, &ke);
-      return;
-    }
-
-    case Qt::Key_Up:
-    {
-      QKeyEvent ke(QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier);
-      QApplication::sendEvent(this, &ke);
-      return;
-    }
-
-    default:;
-  }
+//  switch (event->key())
+//  {
+//    case Qt::Key_Down:
+//    {
+//      QKeyEvent ke(QEvent::KeyPress, Qt::Key_Tab, Qt::NoModifier);
+//      QApplication::sendEvent(this, &ke);
+//      return;
+//    }
+//
+//    case Qt::Key_Up:
+//    {
+//      QKeyEvent ke(QEvent::KeyPress, Qt::Key_Tab, Qt::ShiftModifier);
+//      QApplication::sendEvent(this, &ke);
+//      return;
+//    }
+//
+//    default:;
+//  }
 
   BaseClass::keyPressEvent(event);
 }


### PR DESCRIPTION
Cherry-pick https://codeberg.org/wwmayer/FreeCAD11/commit/4e66bc733a705b9dfbe80e38948a9fbcc8b793a3


Don't use Up/Down arrow keys because this may set focus to undesired widgets.

This fixes #28345
