### PR TITLE
Gui: Only set style-sheet if it has actually changed. Simplify overlay style-sheet.

### DIFF
--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -1563,8 +1563,17 @@ void OverlayTabWidget::setOverlayMode(bool enable)
     }
     setProperty("transparent", option != OverlayOption::Disable);
 
-    proxyWidget->setStyleSheet(stylesheet);
-    this->setStyleSheet(stylesheet);
+    auto refreshStyleSheet = [](QWidget* w, const QString& s) {
+        if (w->styleSheet() != s) {
+            w->setStyleSheet(s);
+        }
+        else {
+            w->style()->unpolish(w);
+            w->style()->polish(w);
+        }
+    };
+    refreshStyleSheet(proxyWidget, stylesheet);
+    refreshStyleSheet(this, stylesheet);
     setOverlayMode(this, option);
 
     _graphicsEffect->setEnabled(effectEnabled() && (enable || isTransparent()));

--- a/src/Gui/Stylesheets/overlay/Freecad Overlay.qss
+++ b/src/Gui/Stylesheets/overlay/Freecad Overlay.qss
@@ -45,19 +45,11 @@ Gui--PropertyEditor--PropertyEditor {
   qproperty-itemBackground: @TextEditFieldBackgroundColor;
 }
 
-Gui--OverlayTabWidget[transparent="false"]  Gui--TreePanel QTreeView::item {
+Gui--OverlayTabWidget Gui--TreePanel QTreeView::item {
   color: @TextForegroundColor;
 }
 
-Gui--OverlayTabWidget[transparent="false"]  Gui--TreePanel QTreeView::item:disabled {
-  color: @TextDisabledColor;
-}
-
-Gui--OverlayTabWidget[transparent="true"] Gui--TreePanel QTreeView::item {
-  color: @TextForegroundColor;
-}
-
-Gui--OverlayTabWidget[transparent="true"] Gui--TreePanel QTreeView::item:disabled {
+Gui--OverlayTabWidget Gui--TreePanel QTreeView::item:disabled {
   color: @TextDisabledColor;
 }
 


### PR DESCRIPTION
Fixes #23661 

The problem seems to be that in `OverlayTabWidget::setOverlayMode` which is invoked from `OverlayManager::Private::onTimer()` the style-sheet is reapplied presumably to have the change to the `transparent`-property picked up. But according to the [Qt faq](https://wiki.qt.io/Technical_FAQ#How_can_my_stylesheet_account_for_custom_properties.3F) this is an expensive way to force such an update. Instead unpolish/polish should be used. This change uses the expensive way if the style-sheet has changed (as it has the first time) and the cheap way otherwise.

Looking at the qss rules for transparent =true and =false it turns out that they are identical. So the rules are merged. So the property could perhaps be removed, but I guess others could have made custom themes that uses that property.

When testing don't confuse symptoms from #28630 that are unrelated.