### PR TITLE
Base: refactor `ParameterGrp` string param functions

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupPython.cmake
+++ b/cMake/FreeCAD_Helpers/SetupPython.cmake
@@ -19,4 +19,12 @@ macro(SetupPython)
     set(PYTHON_VERSION_PATCH ${Python3_VERSION_PATCH})
     set(PYTHONINTERP_FOUND ${Python3_Interpreter_FOUND})
 
+    # Python prior to 3.13 requires PY_SSIZE_T_CLEAN to be defined so the
+    # pointer + length variant of argument parsing (e.g. "s#") can work,
+    # as prior versions used to return an int size instead of Py_ssize_t.
+    # See: https://docs.python.org/3.13/c-api/arg.html#strings-and-buffers
+    if (${Python3_VERSION} VERSION_LESS "3.13")
+         add_definitions(-DPY_SSIZE_T_CLEAN)
+    endif()
+
 endmacro(SetupPython)

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2929,7 +2929,8 @@ void Application::initConfig(int argc, char ** argv)
     }
 
     // Change application tmp. directory
-    std::string tmpPath = _pcUserParamMngr->GetGroup("BaseApp/Preferences/General")->GetASCII("TempPath");
+    std::string tmpPath
+        = _pcUserParamMngr->GetGroup("BaseApp/Preferences/General")->getString("TempPath");
     Base::FileInfo di(tmpPath);
     if (di.exists() && di.isDir()) {
         mConfig["AppTempPath"] = tmpPath + PATHSEP;

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -2937,7 +2937,8 @@ void Application::initConfig(int argc, char ** argv)
     }
 
     // Change application tmp. directory
-    std::string tmpPath = _pcUserParamMngr->GetGroup("BaseApp/Preferences/General")->GetASCII("TempPath");
+    std::string tmpPath
+        = _pcUserParamMngr->GetGroup("BaseApp/Preferences/General")->getString("TempPath");
     Base::FileInfo di(tmpPath);
     if (di.exists() && di.isDir()) {
         mConfig["AppTempPath"] = tmpPath + PATHSEP;

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -557,8 +557,8 @@ public:
      * // getting standard parameter
      * Base::Reference<ParameterGrp> group = App::GetApplication()
      *     .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Raytracing");
-     * std::string projectPath = group->GetASCII("ProjectPath", "");
-     * std::string cameraName = group->GetASCII("CameraName", "TempCamera.inc");
+     * std::string projectPath = group->getString("ProjectPath", "");
+     * std::string cameraName = group->getString("CameraName", "TempCamera.inc");
      * @endcode
      *
      * @param[in] sName The fully qualified path of the parameter group.

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -749,7 +749,7 @@ PyObject* ApplicationPy::sGetUserMacroDir(PyObject* /*self*/, PyObject* args)
     if (Base::asBoolean(actual)) {
         macroDir = App::GetApplication()
                        .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
-                       ->GetASCII("MacroPath", macroDir.c_str());
+                       ->getString("MacroPath", macroDir);
         std::replace(macroDir.begin(), macroDir.end(), '/', PATHSEP);
     }
 

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -965,11 +965,10 @@ Document::Document(const char* documentName)
     std::string CreationDateString = Base::Tools::currentDateTimeString();
     std::string Author = GetApplication()
                              .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-                             ->GetASCII("prefAuthor", "");
-    std::string AuthorComp =
-        GetApplication()
-            .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-            ->GetASCII("prefCompany", "");
+                             ->getString("prefAuthor", "");
+    std::string AuthorComp = GetApplication()
+                                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
+                                 ->getString("prefCompany", "");
     ADD_PROPERTY_TYPE(Label, ("Unnamed"), 0, Prop_ReadOnly, "The name of the document");
     ADD_PROPERTY_TYPE(FileName,
                       (""),
@@ -1009,12 +1008,12 @@ Document::Document(const char* documentName)
     auto paramGrp {GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Document")};
     auto index = static_cast<int>(paramGrp->GetInt("prefLicenseType", 0));
-    auto name = "";
+    std::string name;
     std::string licenseUrl = "";
     if (index >= 0 && index < countOfLicenses) {
         name = licenseItems.at(index).at(posnOfFullName);
         auto url = licenseItems.at(index).at(posnOfUrl);
-        licenseUrl = (paramGrp->GetASCII("prefLicenseUrl", url));
+        licenseUrl = (paramGrp->getString("prefLicenseUrl", url));
     }
     ADD_PROPERTY_TYPE(License, (name), 0, Prop_None, "License string of the Item");
     ADD_PROPERTY_TYPE(LicenseURL,
@@ -1934,10 +1933,11 @@ bool Document::save()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
                 ->GetBool("prefSetAuthorOnSave", false);
         if (saveAuthor) {
-            const std::string Author =
-                GetApplication()
-                    .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-                    ->GetASCII("prefAuthor", "");
+            const std::string Author = GetApplication()
+                                           .GetParameterGroupByPath(
+                                               "User parameter:BaseApp/Preferences/Document"
+                                           )
+                                           ->getString("prefAuthor", "");
             LastModifiedBy.setValue(Author.c_str());
         }
 
@@ -2071,10 +2071,11 @@ bool Document::saveToFile(const char* filename) const
             GetApplication()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
                 ->GetBool("UseFCBakExtension", true);
-        std::string saveBackupDateFormat =
-            GetApplication()
-                .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-                ->GetASCII("SaveBackupDateFormat", "%Y%m%d-%H%M%S");
+        std::string saveBackupDateFormat = GetApplication()
+                                               .GetParameterGroupByPath(
+                                                   "User parameter:BaseApp/Preferences/Document"
+                                               )
+                                               ->getString("SaveBackupDateFormat", "%Y%m%d-%H%M%S");
 
         BackupPolicy backupPolicy;
         if (useFCBakExtension) {

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -965,11 +965,10 @@ Document::Document(const char* documentName)
     std::string CreationDateString = Base::Tools::currentDateTimeString();
     std::string Author = GetApplication()
                              .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-                             ->GetASCII("prefAuthor", "");
-    std::string AuthorComp =
-        GetApplication()
-            .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-            ->GetASCII("prefCompany", "");
+                             ->getString("prefAuthor", "");
+    std::string AuthorComp = GetApplication()
+                                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
+                                 ->getString("prefCompany", "");
     ADD_PROPERTY_TYPE(Label, ("Unnamed"), 0, Prop_ReadOnly, "The name of the document");
     ADD_PROPERTY_TYPE(FileName,
                       (""),
@@ -1009,12 +1008,12 @@ Document::Document(const char* documentName)
     auto paramGrp {GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Document")};
     auto index = static_cast<int>(paramGrp->GetInt("prefLicenseType", 0));
-    auto name = "";
+    std::string name;
     std::string licenseUrl = "";
     if (index >= 0 && index < countOfLicenses) {
         name = licenseItems.at(index).at(posnOfFullName);
         auto url = licenseItems.at(index).at(posnOfUrl);
-        licenseUrl = (paramGrp->GetASCII("prefLicenseUrl", url));
+        licenseUrl = (paramGrp->getString("prefLicenseUrl", url));
     }
     ADD_PROPERTY_TYPE(License, (name), 0, Prop_None, "License string of the Item");
     ADD_PROPERTY_TYPE(LicenseURL,
@@ -1946,10 +1945,11 @@ bool Document::save()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
                 ->GetBool("prefSetAuthorOnSave", false);
         if (saveAuthor) {
-            const std::string Author =
-                GetApplication()
-                    .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-                    ->GetASCII("prefAuthor", "");
+            const std::string Author = GetApplication()
+                                           .GetParameterGroupByPath(
+                                               "User parameter:BaseApp/Preferences/Document"
+                                           )
+                                           ->getString("prefAuthor", "");
             LastModifiedBy.setValue(Author.c_str());
         }
 
@@ -2083,10 +2083,11 @@ bool Document::saveToFile(const char* filename) const
             GetApplication()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
                 ->GetBool("UseFCBakExtension", true);
-        std::string saveBackupDateFormat =
-            GetApplication()
-                .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-                ->GetASCII("SaveBackupDateFormat", "%Y%m%d-%H%M%S");
+        std::string saveBackupDateFormat = GetApplication()
+                                               .GetParameterGroupByPath(
+                                                   "User parameter:BaseApp/Preferences/Document"
+                                               )
+                                               ->getString("SaveBackupDateFormat", "%Y%m%d-%H%M%S");
 
         BackupPolicy backupPolicy;
         if (useFCBakExtension) {

--- a/src/App/License.h
+++ b/src/App/License.h
@@ -26,7 +26,8 @@
 
 #include <array>
 #include <cstring>
-#include <string>
+#include <string_view>
+
 #include <Base/Tools.h>
 
 namespace App
@@ -37,7 +38,7 @@ namespace App
  * See also https://spdx.org/licenses/
  */
 constexpr int colsInArray = 3;
-using TLicenseArr = std::array<const char*, colsInArray>;
+using TLicenseArr = std::array<std::string_view, colsInArray>;
 constexpr int posnOfIdentifier = 0;
 constexpr int posnOfFullName = 1;
 constexpr int posnOfUrl = 2;
@@ -72,7 +73,7 @@ int constexpr findLicense(const char* identifier)
         return -1;
     }
     for (int i = 0; i < countOfLicenses; i++) {
-        if (strcmp(licenseItems.at(i).at(posnOfIdentifier), identifier) == 0) {
+        if (licenseItems.at(i).at(posnOfIdentifier) == identifier) {
             return i;
         }
     }

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -226,10 +226,10 @@ void ParameterGrp::insertTo(const Base::Reference<ParameterGrp>& Grp)
     }
 
     // copy strings
-    std::vector<std::pair<std::string, std::string>> StringMap = GetASCIIMap();
+    std::vector<std::pair<std::string, std::string>> StringMap = getAllStringsMap();
     std::vector<std::pair<std::string, std::string>>::iterator It2;
     for (It2 = StringMap.begin(); It2 != StringMap.end(); ++It2) {
-        Grp->SetASCII(It2->first.c_str(), It2->second.c_str());
+        Grp->setString(It2->first, It2->second);
     }
 
     // copy bool
@@ -318,9 +318,9 @@ void ParameterGrp::revert(const Base::Reference<ParameterGrp>& Grp)
         }
     }
 
-    for (const auto& v : Grp->GetASCIIMap()) {
-        if (GetASCII(v.first.c_str(), v.second.c_str()) == v.second) {
-            RemoveASCII(v.first.c_str());
+    for (const auto& v : Grp->getAllStringsMap()) {
+        if (getString(v.first, v.second) == v.second) {
+            removeString(v.first);
         }
     }
 
@@ -349,16 +349,16 @@ void ParameterGrp::revert(const Base::Reference<ParameterGrp>& Grp)
     }
 }
 
-DOMElement* ParameterGrp::CreateElement(DOMElement* Start, const char* Type, const char* Name)
+DOMElement* ParameterGrp::CreateElement(DOMElement* start, std::string_view type, std::string_view name)
 {
-    if (XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm()) != 0
-        && XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
+    if (XMLString::compareString(start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm()) != 0
+        && XMLString::compareString(start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
             != 0) {
         Base::Console().warning(
             "CreateElement: %s cannot have the element %s of type %s\n",
-            StrX(Start->getNodeName()).c_str(),
-            Name,
-            Type
+            StrX(start->getNodeName()).c_str(),
+            name,
+            type
         );
         return nullptr;
     }
@@ -368,11 +368,11 @@ DOMElement* ParameterGrp::CreateElement(DOMElement* Start, const char* Type, con
         _Parent->_GetGroup(_cName.c_str());
     }
 
-    DOMDocument* pDocument = Start->getOwnerDocument();
+    DOMDocument* pDocument = start->getOwnerDocument();
 
-    auto pcElem = pDocument->createElement(XStr(Type).unicodeForm());
-    pcElem->setAttribute(XStrLiteral("Name").unicodeForm(), XStr(Name).unicodeForm());
-    Start->appendChild(pcElem);
+    auto pcElem = pDocument->createElement(XStr(type).unicodeForm());
+    pcElem->setAttribute(XStrLiteral("Name").unicodeForm(), XStr(name).unicodeForm());
+    start->appendChild(pcElem);
 
     return pcElem;
 }
@@ -570,7 +570,8 @@ void ParameterGrp::SetAttribute(ParamType Type, const char* Name, const char* Va
         case ParamType::FCFloat:
             return _SetAttribute(Type, Name, Value);
         case ParamType::FCText:
-            return SetASCII(Name, Value);
+            // TODO: make SetAttribute take string_views and remove these conversions
+            return _setString(std::string_view {Name}, std::string_view {Value ? Value : ""});
         case ParamType::FCGroup:
             RenameGrp(Name, Value);
             break;
@@ -589,7 +590,8 @@ void ParameterGrp::RemoveAttribute(ParamType Type, const char* Name)
         case ParamType::FCUInt:
             return RemoveUnsigned(Name);
         case ParamType::FCText:
-            return RemoveASCII(Name);
+            // TODO: make RemoveAttribute take string_views and remove this conversion
+            return removeString(std::string_view {Name});
         case ParamType::FCFloat:
             return RemoveFloat(Name);
         case ParamType::FCGroup:
@@ -621,7 +623,8 @@ const char* ParameterGrp::GetAttribute(
     }
 
     if (Type == ParamType::FCText) {
-        Value = GetASCII(Name, Default);
+        // TODO: make GetAttribute take string_views and remove these conversions
+        Value = _getString(std::string_view {Name}, std::string_view {Default ? Default : ""});
     }
     else if (Type != ParamType::FCGroup) {
         Value = StrX(pcElem->getAttribute(XStrLiteral("Value").unicodeForm())).c_str();
@@ -1018,61 +1021,61 @@ std::vector<std::pair<std::string, double>> ParameterGrp::GetFloatMap(const char
 }
 
 
-void ParameterGrp::SetASCII(const char* Name, const char* sValue)
+void ParameterGrp::_setString(std::string_view name, std::string_view value)
 {
     if (!_pGroupNode) {
         if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
-            FC_WARN("Setting attribute " << "FCText:" << Name << " in an orphan group " << _cName);
+            FC_WARN("Setting attribute " << "FCText:" << name << " in an orphan group " << _cName);
         }
         return;
     }
     if (_Clearing) {
         if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
-            FC_WARN("Adding attribute " << "FCText:" << Name << " while clearing " << GetPath());
+            FC_WARN("Adding attribute " << "FCText:" << name << " while clearing " << GetPath());
         }
         return;
     }
 
     bool isNew = false;
-    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", Name);
+    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", name);
     if (!pcElem) {
-        pcElem = CreateElement(_pGroupNode, "FCText", Name);
+        pcElem = CreateElement(_pGroupNode, "FCText", name);
         isNew = true;
     }
     if (pcElem) {
+        // TODO: remove when _Notify() & Notify() can take string_views
+        std::string terminatedName {name};
+        std::string terminatedValue {value};
         // and set the value
         DOMNode* pcElem2 = pcElem->getFirstChild();
         if (!pcElem2) {
             DOMDocument* pDocument = _pGroupNode->getOwnerDocument();
-            DOMText* pText = pDocument->createTextNode(XUTF8Str(sValue).unicodeForm());
+            DOMText* pText = pDocument->createTextNode(XUTF8Str(value).unicodeForm());
             pcElem->appendChild(pText);
-            if (isNew || sValue[0] != 0) {
-                _Notify(ParamType::FCText, Name, sValue);
+            if (isNew || (value.size() > 0 && value[0] != 0)) {
+                _Notify(ParamType::FCText, terminatedName.c_str(), terminatedValue.c_str());
             }
         }
-        else if (strcmp(StrXUTF8(pcElem2->getNodeValue()).c_str(), sValue) != 0) {
-            pcElem2->setNodeValue(XUTF8Str(sValue).unicodeForm());
-            _Notify(ParamType::FCText, Name, sValue);
+        else if (StrXUTF8(pcElem2->getNodeValue()).str != value) {
+            pcElem2->setNodeValue(XUTF8Str(value).unicodeForm());
+            _Notify(ParamType::FCText, terminatedName.c_str(), terminatedValue.c_str());
         }
         // trigger observer
-        Notify(Name);
+        Notify(terminatedName.c_str());
     }
 }
 
-std::string ParameterGrp::GetASCII(const char* Name, const char* pPreset) const
+std::string ParameterGrp::_getString(std::string_view name, std::string_view fallback) const
 {
     if (!_pGroupNode) {
-        return pPreset ? pPreset : "";
+        return std::string {fallback};
     }
 
     // check if Element in group
-    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", Name);
+    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", name);
     // if not return preset
     if (!pcElem) {
-        if (!pPreset) {
-            return {};
-        }
-        return {pPreset};
+        return std::string {fallback};
     }
     // if yes check the value and return
     DOMNode* pcElem2 = pcElem->getFirstChild();
@@ -1082,7 +1085,7 @@ std::string ParameterGrp::GetASCII(const char* Name, const char* pPreset) const
     return {};
 }
 
-std::vector<std::string> ParameterGrp::GetASCIIs(const char* sFilter) const
+std::vector<std::string> ParameterGrp::_getAllStrings(std::string_view filter) const
 {
     std::vector<std::string> vrValues;
     if (!_pGroupNode) {
@@ -1095,7 +1098,7 @@ std::vector<std::string> ParameterGrp::GetASCIIs(const char* sFilter) const
     while (pcTemp) {
         Name = StrXUTF8(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
-        if (!sFilter || Name.find(sFilter) != std::string::npos) {
+        if (filter.empty() || Name.find(filter) != std::string::npos) {
             // retrieve the text element
             DOMNode* pcElem2 = pcTemp->getFirstChild();
             if (pcElem2) {
@@ -1111,7 +1114,9 @@ std::vector<std::string> ParameterGrp::GetASCIIs(const char* sFilter) const
     return vrValues;
 }
 
-std::vector<std::pair<std::string, std::string>> ParameterGrp::GetASCIIMap(const char* sFilter) const
+std::vector<std::pair<std::string, std::string>> ParameterGrp::_getAllStringsMap(
+    std::string_view filter
+) const
 {
     std::vector<std::pair<std::string, std::string>> vrValues;
     if (!_pGroupNode) {
@@ -1124,7 +1129,7 @@ std::vector<std::pair<std::string, std::string>> ParameterGrp::GetASCIIMap(const
     while (pcTemp) {
         Name = StrXUTF8(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
-        if (!sFilter || Name.find(sFilter) != std::string::npos) {
+        if (filter.empty() || Name.find(filter) != std::string::npos) {
             // retrieve the text element
             DOMNode* pcElem2 = pcTemp->getFirstChild();
             if (pcElem2) {
@@ -1146,14 +1151,14 @@ std::vector<std::pair<std::string, std::string>> ParameterGrp::GetASCIIMap(const
 //**************************************************************************
 // Access methods
 
-void ParameterGrp::RemoveASCII(const char* Name)
+void ParameterGrp::_removeString(std::string_view name)
 {
     if (!_pGroupNode) {
         return;
     }
 
     // check if Element in group
-    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", Name);
+    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", name);
     // if not return
     if (!pcElem) {
         return;
@@ -1162,9 +1167,11 @@ void ParameterGrp::RemoveASCII(const char* Name)
     DOMNode* node = _pGroupNode->removeChild(pcElem);
     node->release();
 
+    // TODO: remove when _Notify() & Notify() can take string_views
+    std::string terminatedName {name};
     // trigger observer
-    _Notify(ParamType::FCText, Name, nullptr);
-    Notify(Name);
+    _Notify(ParamType::FCText, terminatedName.c_str(), nullptr);
+    Notify(terminatedName.c_str());
 }
 
 void ParameterGrp::RemoveBool(const char* Name)
@@ -1438,29 +1445,29 @@ bool ParameterGrp::ShouldRemove() const
     });
 }
 
-DOMElement* ParameterGrp::FindElement(DOMElement* Start, const char* Type, const char* Name) const
+DOMElement* ParameterGrp::FindElement(DOMElement* start, std::string_view type, std::string_view name) const
 {
-    if (XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm()) != 0
-        && XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
+    if (XMLString::compareString(start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm()) != 0
+        && XMLString::compareString(start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
             != 0) {
         Base::Console().warning(
             "FindElement: %s cannot have the element %s of type %s\n",
-            StrX(Start->getNodeName()).c_str(),
-            Name,
-            Type
+            StrX(start->getNodeName()).c_str(),
+            name,
+            type
         );
         return nullptr;
     }
-    const XStr xType(Type);
-    const XStr xName(Name);
-    for (DOMNode* clChild = Start->getFirstChild(); clChild != nullptr;
+    const XStr xType(type);
+    const XStr xName(name);
+    for (DOMNode* clChild = start->getFirstChild(); clChild != nullptr;
          clChild = clChild->getNextSibling()) {
         if (clChild->getNodeType() == DOMNode::ELEMENT_NODE) {
             // the right node Type
             if (!XMLString::compareString(xType.unicodeForm(), clChild->getNodeName())) {
                 auto attrs = clChild->getAttributes();
                 if (attrs->getLength() > 0) {
-                    if (Name) {
+                    if (!name.empty()) {
                         DOMNode* attr = attrs->getNamedItem(XStrLiteral("Name").unicodeForm());
                         if (attr
                             && !XMLString::compareString(xName.unicodeForm(), attr->getNodeValue())) {
@@ -1568,7 +1575,7 @@ void ParameterGrp::NotifyAll()
     }
 
     // get all strings and notify
-    std::vector<std::pair<std::string, std::string>> StringMap = GetASCIIMap();
+    std::vector<std::pair<std::string, std::string>> StringMap = getAllStringsMap();
     for (const auto& it : StringMap) {
         Notify(it.first.c_str());
     }

--- a/src/Base/Parameter.cpp
+++ b/src/Base/Parameter.cpp
@@ -226,10 +226,10 @@ void ParameterGrp::insertTo(const Base::Reference<ParameterGrp>& Grp)
     }
 
     // copy strings
-    std::vector<std::pair<std::string, std::string>> StringMap = GetASCIIMap();
+    std::vector<std::pair<std::string, std::string>> StringMap = getAllStringsMap();
     std::vector<std::pair<std::string, std::string>>::iterator It2;
     for (It2 = StringMap.begin(); It2 != StringMap.end(); ++It2) {
-        Grp->SetASCII(It2->first.c_str(), It2->second.c_str());
+        Grp->setString(It2->first, It2->second);
     }
 
     // copy bool
@@ -318,9 +318,9 @@ void ParameterGrp::revert(const Base::Reference<ParameterGrp>& Grp)
         }
     }
 
-    for (const auto& v : Grp->GetASCIIMap()) {
-        if (GetASCII(v.first.c_str(), v.second.c_str()) == v.second) {
-            RemoveASCII(v.first.c_str());
+    for (const auto& v : Grp->getAllStringsMap()) {
+        if (getString(v.first, v.second) == v.second) {
+            removeString(v.first);
         }
     }
 
@@ -349,16 +349,16 @@ void ParameterGrp::revert(const Base::Reference<ParameterGrp>& Grp)
     }
 }
 
-DOMElement* ParameterGrp::CreateElement(DOMElement* Start, const char* Type, const char* Name)
+DOMElement* ParameterGrp::CreateElement(DOMElement* start, std::string_view type, std::string_view name)
 {
-    if (XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm()) != 0
-        && XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
+    if (XMLString::compareString(start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm()) != 0
+        && XMLString::compareString(start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
             != 0) {
         Base::Console().warning(
             "CreateElement: %s cannot have the element %s of type %s\n",
-            StrX(Start->getNodeName()).c_str(),
-            Name,
-            Type
+            StrX(start->getNodeName()).c_str(),
+            name,
+            type
         );
         return nullptr;
     }
@@ -368,11 +368,11 @@ DOMElement* ParameterGrp::CreateElement(DOMElement* Start, const char* Type, con
         _Parent->_GetGroup(_cName.c_str());
     }
 
-    DOMDocument* pDocument = Start->getOwnerDocument();
+    DOMDocument* pDocument = start->getOwnerDocument();
 
-    auto pcElem = pDocument->createElement(XStr(Type).unicodeForm());
-    pcElem->setAttribute(XStrLiteral("Name").unicodeForm(), XStr(Name).unicodeForm());
-    Start->appendChild(pcElem);
+    auto pcElem = pDocument->createElement(XStr(type).unicodeForm());
+    pcElem->setAttribute(XStrLiteral("Name").unicodeForm(), XStr(name).unicodeForm());
+    start->appendChild(pcElem);
 
     return pcElem;
 }
@@ -570,7 +570,8 @@ void ParameterGrp::SetAttribute(ParamType Type, const char* Name, const char* Va
         case ParamType::FCFloat:
             return _SetAttribute(Type, Name, Value);
         case ParamType::FCText:
-            return SetASCII(Name, Value);
+            // TODO: make SetAttribute take string_views and remove these conversions
+            return _setString(std::string_view {Name}, std::string_view {Value ? Value : ""});
         case ParamType::FCGroup:
             RenameGrp(Name, Value);
             break;
@@ -589,7 +590,8 @@ void ParameterGrp::RemoveAttribute(ParamType Type, const char* Name)
         case ParamType::FCUInt:
             return RemoveUnsigned(Name);
         case ParamType::FCText:
-            return RemoveASCII(Name);
+            // TODO: make RemoveAttribute take string_views and remove this conversion
+            return removeString(std::string_view {Name});
         case ParamType::FCFloat:
             return RemoveFloat(Name);
         case ParamType::FCGroup:
@@ -623,7 +625,8 @@ const char* ParameterGrp::GetAttribute(
     }
 
     if (Type == ParamType::FCText) {
-        Value = GetASCII(Name, Default);
+        // TODO: make GetAttribute take string_views and remove these conversions
+        Value = _getString(std::string_view {Name}, std::string_view {Default ? Default : ""});
     }
     else if (Type != ParamType::FCGroup) {
         Value = StrX(pcElem->getAttribute(XStrLiteral("Value").unicodeForm())).c_str();
@@ -663,7 +666,7 @@ std::vector<std::pair<std::string, std::string>> ParameterGrp::GetAttributeMap(
                 res.emplace_back(Name, std::string());
             }
             else if (Type == ParamType::FCText) {
-                res.emplace_back(Name, GetASCII(Name.c_str()));
+                res.emplace_back(Name, getString(Name));
             }
             else {
                 res.emplace_back(
@@ -1023,61 +1026,67 @@ std::vector<std::pair<std::string, double>> ParameterGrp::GetFloatMap(const char
 }
 
 
-void ParameterGrp::SetASCII(const char* Name, const char* sValue)
+void ParameterGrp::_setString(std::string_view name, std::string_view value)
 {
     if (!_pGroupNode) {
         if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
-            FC_WARN("Setting attribute " << "FCText:" << Name << " in an orphan group " << _cName);
+            FC_WARN("Setting attribute " << "FCText:" << name << " in an orphan group " << _cName);
         }
         return;
     }
     if (_Clearing) {
         if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
-            FC_WARN("Adding attribute " << "FCText:" << Name << " while clearing " << GetPath());
+            FC_WARN("Adding attribute " << "FCText:" << name << " while clearing " << GetPath());
         }
         return;
     }
+    if (name.find('\0') != std::string_view::npos) {
+        throw Base::ValueError("Parameter name cannot contain embedded null characters");
+    }
+    if (value.find('\0') != std::string_view::npos) {
+        throw Base::ValueError("Parameter value cannot contain embedded null characters");
+    }
 
     bool isNew = false;
-    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", Name);
+    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", name);
     if (!pcElem) {
-        pcElem = CreateElement(_pGroupNode, "FCText", Name);
+        pcElem = CreateElement(_pGroupNode, "FCText", name);
         isNew = true;
     }
     if (pcElem) {
+        // TODO: remove when _Notify() & Notify() can take string_views
+        std::string terminatedName {name};
+        std::string terminatedValue {value};
         // and set the value
         DOMNode* pcElem2 = pcElem->getFirstChild();
         if (!pcElem2) {
             DOMDocument* pDocument = _pGroupNode->getOwnerDocument();
-            DOMText* pText = pDocument->createTextNode(XUTF8Str(sValue).unicodeForm());
+            DOMText* pText = pDocument->createTextNode(XUTF8Str(value).unicodeForm());
             pcElem->appendChild(pText);
-            if (isNew || sValue[0] != 0) {
-                _Notify(ParamType::FCText, Name, sValue);
+            if (isNew || (value.size() > 0 && value[0] != 0)) {
+                _Notify(ParamType::FCText, terminatedName.c_str(), terminatedValue.c_str());
             }
         }
-        else if (strcmp(StrXUTF8(pcElem2->getNodeValue()).c_str(), sValue) != 0) {
-            pcElem2->setNodeValue(XUTF8Str(sValue).unicodeForm());
-            _Notify(ParamType::FCText, Name, sValue);
+        else if (StrXUTF8(pcElem2->getNodeValue()).str != value) {
+            pcElem2->setNodeValue(XUTF8Str(value).unicodeForm());
+            _Notify(ParamType::FCText, terminatedName.c_str(), terminatedValue.c_str());
         }
         // trigger observer
-        Notify(Name);
+        Notify(terminatedName.c_str());
     }
 }
 
-std::string ParameterGrp::GetASCII(const char* Name, const char* pPreset) const
+std::string ParameterGrp::_getString(std::string_view name, std::string_view fallback) const
 {
     if (!_pGroupNode) {
-        return pPreset ? pPreset : "";
+        return std::string {fallback};
     }
 
     // check if Element in group
-    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", Name);
+    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", name);
     // if not return preset
     if (!pcElem) {
-        if (!pPreset) {
-            return {};
-        }
-        return {pPreset};
+        return std::string {fallback};
     }
     // if yes check the value and return
     DOMNode* pcElem2 = pcElem->getFirstChild();
@@ -1087,7 +1096,7 @@ std::string ParameterGrp::GetASCII(const char* Name, const char* pPreset) const
     return {};
 }
 
-std::vector<std::string> ParameterGrp::GetASCIIs(const char* sFilter) const
+std::vector<std::string> ParameterGrp::_getAllStrings(std::string_view filter) const
 {
     std::vector<std::string> vrValues;
     if (!_pGroupNode) {
@@ -1100,7 +1109,7 @@ std::vector<std::string> ParameterGrp::GetASCIIs(const char* sFilter) const
     while (pcTemp) {
         Name = StrXUTF8(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
-        if (!sFilter || Name.find(sFilter) != std::string::npos) {
+        if (filter.empty() || Name.find(filter) != std::string::npos) {
             // retrieve the text element
             DOMNode* pcElem2 = pcTemp->getFirstChild();
             if (pcElem2) {
@@ -1116,7 +1125,9 @@ std::vector<std::string> ParameterGrp::GetASCIIs(const char* sFilter) const
     return vrValues;
 }
 
-std::vector<std::pair<std::string, std::string>> ParameterGrp::GetASCIIMap(const char* sFilter) const
+std::vector<std::pair<std::string, std::string>> ParameterGrp::_getAllStringsMap(
+    std::string_view filter
+) const
 {
     std::vector<std::pair<std::string, std::string>> vrValues;
     if (!_pGroupNode) {
@@ -1129,7 +1140,7 @@ std::vector<std::pair<std::string, std::string>> ParameterGrp::GetASCIIMap(const
     while (pcTemp) {
         Name = StrXUTF8(pcTemp->getAttribute(XStrLiteral("Name").unicodeForm())).c_str();
         // check on filter condition
-        if (!sFilter || Name.find(sFilter) != std::string::npos) {
+        if (filter.empty() || Name.find(filter) != std::string::npos) {
             // retrieve the text element
             DOMNode* pcElem2 = pcTemp->getFirstChild();
             if (pcElem2) {
@@ -1151,14 +1162,14 @@ std::vector<std::pair<std::string, std::string>> ParameterGrp::GetASCIIMap(const
 //**************************************************************************
 // Access methods
 
-void ParameterGrp::RemoveASCII(const char* Name)
+void ParameterGrp::_removeString(std::string_view name)
 {
     if (!_pGroupNode) {
         return;
     }
 
     // check if Element in group
-    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", Name);
+    DOMElement* pcElem = FindElement(_pGroupNode, "FCText", name);
     // if not return
     if (!pcElem) {
         return;
@@ -1167,9 +1178,11 @@ void ParameterGrp::RemoveASCII(const char* Name)
     DOMNode* node = _pGroupNode->removeChild(pcElem);
     node->release();
 
+    // TODO: remove when _Notify() & Notify() can take string_views
+    std::string terminatedName {name};
     // trigger observer
-    _Notify(ParamType::FCText, Name, nullptr);
-    Notify(Name);
+    _Notify(ParamType::FCText, terminatedName.c_str(), nullptr);
+    Notify(terminatedName.c_str());
 }
 
 void ParameterGrp::RemoveBool(const char* Name)
@@ -1443,29 +1456,29 @@ bool ParameterGrp::ShouldRemove() const
     });
 }
 
-DOMElement* ParameterGrp::FindElement(DOMElement* Start, const char* Type, const char* Name) const
+DOMElement* ParameterGrp::FindElement(DOMElement* start, std::string_view type, std::string_view name) const
 {
-    if (XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm()) != 0
-        && XMLString::compareString(Start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
+    if (XMLString::compareString(start->getNodeName(), XStrLiteral("FCParamGroup").unicodeForm()) != 0
+        && XMLString::compareString(start->getNodeName(), XStrLiteral("FCParameters").unicodeForm())
             != 0) {
         Base::Console().warning(
             "FindElement: %s cannot have the element %s of type %s\n",
-            StrX(Start->getNodeName()).c_str(),
-            Name,
-            Type
+            StrX(start->getNodeName()).c_str(),
+            name,
+            type
         );
         return nullptr;
     }
-    const XStr xType(Type);
-    const XStr xName(Name);
-    for (DOMNode* clChild = Start->getFirstChild(); clChild != nullptr;
+    const XStr xType(type);
+    const XStr xName(name);
+    for (DOMNode* clChild = start->getFirstChild(); clChild != nullptr;
          clChild = clChild->getNextSibling()) {
         if (clChild->getNodeType() == DOMNode::ELEMENT_NODE) {
             // the right node Type
             if (!XMLString::compareString(xType.unicodeForm(), clChild->getNodeName())) {
                 auto attrs = clChild->getAttributes();
                 if (attrs->getLength() > 0) {
-                    if (Name) {
+                    if (!name.empty()) {
                         DOMNode* attr = attrs->getNamedItem(XStrLiteral("Name").unicodeForm());
                         if (attr
                             && !XMLString::compareString(xName.unicodeForm(), attr->getNodeValue())) {
@@ -1573,7 +1586,7 @@ void ParameterGrp::NotifyAll()
     }
 
     // get all strings and notify
-    std::vector<std::pair<std::string, std::string>> StringMap = GetASCIIMap();
+    std::vector<std::pair<std::string, std::string>> StringMap = getAllStringsMap();
     for (const auto& it : StringMap) {
         Notify(it.first.c_str());
     }

--- a/src/Base/Parameter.h
+++ b/src/Base/Parameter.h
@@ -48,8 +48,13 @@ using PyObject = struct _object;
 # undef isalnum
 #endif
 
+#include <concepts>
 #include <map>
+#include <string>
+#include <string_view>
+#include <type_traits>
 #include <vector>
+
 #include <fastsignals/signal.h>
 #include <xercesc/util/XercesDefs.hpp>
 
@@ -75,6 +80,10 @@ class InputSource;
 }  // namespace XERCES_CPP_NAMESPACE
 
 class ParameterManager;
+
+template<class T>
+concept NonPointerStringView = std::convertible_to<T, std::string_view>
+    && !std::is_pointer_v<std::remove_reference_t<T>>;
 
 /** The parameter container class
  *  This is the base class of all classes handle parameter.
@@ -377,25 +386,54 @@ public:
 
     /** @name methods for String handling */
     //@{
-    /// set a string value
-    void SetASCII(const char* Name, const char* sValue);
-    /// set a string value
-    void SetASCII(const char* Name, const std::string& sValue)
-    {
-        SetASCII(Name, sValue.c_str());
-    }
-    /// read a string values
-    std::string GetASCII(const char* Name, const char* pPreset = nullptr) const;
-    /// remove a string value from this group
-    void RemoveASCII(const char* Name);
-    /** Return all string elements in this group as a vector of strings
-     *  Its also possible to set a filter criteria.
-     *  @param sFilter only strings which name includes sFilter are put in the vector
-     *  @return std::vector of std::strings
+    /** Set a string parameter's value.
+     * @param name Name of the parameter.
+     * @param value Value string to assign.
      */
-    std::vector<std::string> GetASCIIs(const char* sFilter = nullptr) const;
-    /// Same as GetASCIIs() but with key,value map
-    std::vector<std::pair<std::string, std::string>> GetASCIIMap(const char* sFilter = nullptr) const;
+    template<NonPointerStringView N = std::string_view, NonPointerStringView V = std::string_view>
+    inline void setString(N&& name, V&& value)
+    {
+        _setString({std::forward<N>(name)}, {std::forward<V>(value)});
+    }
+    /** Read a string parameter's value.
+     * @param name Name of the parameter.
+     * @param fallback Value to return if the parameter is not found.
+     * @returns Parameter value or its fallback.
+     */
+    template<NonPointerStringView N = std::string_view, NonPointerStringView F = std::string_view>
+    [[nodiscard]]
+    inline std::string getString(N&& name, F&& fallback = {}) const
+    {
+        return _getString({std::forward<N>(name)}, {std::forward<F>(fallback)});
+    }
+    /** Remove a string parameter from this group.
+     * @param name Name of the parameter to remove.
+     */
+    template<NonPointerStringView N = std::string_view>
+    inline void removeString(N&& name)
+    {
+        _removeString({std::forward<N>(name)});
+    }
+    /** Get the values of all string parameters in this group.
+     * @param filter String a parameter must contain to be considered.
+     * @return Vector of parameters' values.
+     */
+    template<NonPointerStringView F = std::string_view>
+    [[nodiscard]]
+    std::vector<std::string> getAllStrings(F&& filter = {}) const
+    {
+        return _getAllStrings({std::forward<F>(filter)});
+    }
+    /** Get the names and values of all string parameters in this group.
+     * @param filter String a parameter must contain to be considered.
+     * @return Vector of pairs of parameters' names (first) and values (second).
+     */
+    template<NonPointerStringView F = std::string_view>
+    [[nodiscard]]
+    std::vector<std::pair<std::string, std::string>> getAllStringsMap(F&& filter = {}) const
+    {
+        return _getAllStringsMap({std::forward<F>(filter)});
+    }
     //@}
 
     friend class ParameterManager;
@@ -441,6 +479,14 @@ protected:
     void _SetAttribute(ParamType Type, const char* Name, const char* Value);
     void _Notify(ParamType Type, const char* Name, const char* Value);
 
+    void _setString(std::string_view name, std::string_view value);
+    std::string _getString(std::string_view name, std::string_view fallback = {}) const;
+    void _removeString(std::string_view name);
+    std::vector<std::string> _getAllStrings(std::string_view filter = {}) const;
+    std::vector<std::pair<std::string, std::string>> _getAllStringsMap(
+        std::string_view filter = {}
+    ) const;
+
     XERCES_CPP_NAMESPACE::DOMElement* FindNextElement(
         XERCES_CPP_NAMESPACE::DOMNode* Prev,
         const char* Type
@@ -453,9 +499,9 @@ protected:
      *  If the names not given it returns the first occurrence of Type.
      */
     XERCES_CPP_NAMESPACE::DOMElement* FindElement(
-        XERCES_CPP_NAMESPACE::DOMElement* Start,
-        const char* Type,
-        const char* Name = nullptr
+        XERCES_CPP_NAMESPACE::DOMElement* start,
+        std::string_view type,
+        std::string_view name = {}
     ) const;
 
     /** Find an element specified by Type and Name or create it if not found
@@ -470,9 +516,9 @@ protected:
     );
 
     XERCES_CPP_NAMESPACE::DOMElement* CreateElement(
-        XERCES_CPP_NAMESPACE::DOMElement* Start,
-        const char* Type,
-        const char* Name
+        XERCES_CPP_NAMESPACE::DOMElement* start,
+        std::string_view type,
+        std::string_view name
     );
 
     /** Find an attribute specified by Name

--- a/src/Base/ParameterObserver.h
+++ b/src/Base/ParameterObserver.h
@@ -211,13 +211,13 @@ public:
         explicit String(const value_type& d)
             : BaseType {d}
         {}
-        void fetch(const ParameterGrp::handle& handle, const char* key)
+        void fetch(const ParameterGrp::handle& handle, std::string_view key)
         {
-            _value = handle->GetASCII(key, std::get<value_type>(_default).c_str());
+            _value = handle->getString(key, std::get<value_type>(_default));
         }
-        void setParameter(const ParameterGrp::handle& handle, const char* key, const Type& value)
+        void setParameter(const ParameterGrp::handle& handle, std::string_view key, const Type& value)
         {
-            handle->SetASCII(key, std::get<value_type>(value).c_str());
+            handle->setString(key, std::get<value_type>(value));
         }
     };
 

--- a/src/Base/ParameterPy.cpp
+++ b/src/Base/ParameterPy.cpp
@@ -506,35 +506,50 @@ Py::Object ParameterGrpPy::getFloats(const Py::Tuple& args)
 
 Py::Object ParameterGrpPy::setString(const Py::Tuple& args)
 {
-    char* pstr = nullptr;
-    char* str = nullptr;
-    if (!PyArg_ParseTuple(args.ptr(), "ss", &pstr, &str)) {
+    const char* name = nullptr;
+    Py_ssize_t nameLength = 0;
+    const char* value = nullptr;
+    Py_ssize_t valueLength = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "s#s#", &name, &nameLength, &value, &valueLength)) {
         throw Py::Exception();
     }
 
-    _cParamGrp->SetASCII(pstr, str);
+    try {
+        _cParamGrp->setString({name, size_t(nameLength)}, {value, size_t(valueLength)});
+    }
+    catch (const Base::Exception& e) {
+        e.setPyException();
+        throw Py::Exception();
+    }
     return Py::None();
 }
 
 Py::Object ParameterGrpPy::getString(const Py::Tuple& args)
 {
-    char* pstr = nullptr;
-    const char* str = "";
-    if (!PyArg_ParseTuple(args.ptr(), "s|s", &pstr, &str)) {
+    const char* name = nullptr;
+    Py_ssize_t nameLength = 0;
+    const char* fallback = nullptr;
+    Py_ssize_t fallbackLength = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "s#|s#", &name, &nameLength, &fallback, &fallbackLength)) {
         throw Py::Exception();
     }
 
-    return Py::String(_cParamGrp->GetASCII(pstr, str));  // NOLINT
+    return Py::String(
+        _cParamGrp->getString({name, size_t(nameLength)}, {fallback, size_t(fallbackLength)})
+    );  // NOLINT
 }
 
 Py::Object ParameterGrpPy::getStrings(const Py::Tuple& args)
 {
-    char* filter = nullptr;
-    if (!PyArg_ParseTuple(args.ptr(), "|s", &filter)) {
+    const char* filter = nullptr;
+    Py_ssize_t filterLength = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "|s#", &filter, &filterLength)) {
         throw Py::Exception();
     }
 
-    std::vector<std::pair<std::string, std::string>> map = _cParamGrp->GetASCIIMap(filter);
+    std::vector<std::pair<std::string, std::string>> map = _cParamGrp->getAllStringsMap(
+        {filter, size_t(filterLength)}
+    );
     Py::List list;
     for (const auto& it : map) {
         list.append(Py::String(it.first));
@@ -600,12 +615,13 @@ Py::Object ParameterGrpPy::remFloat(const Py::Tuple& args)
 
 Py::Object ParameterGrpPy::remString(const Py::Tuple& args)
 {
-    char* pstr = nullptr;
-    if (!PyArg_ParseTuple(args.ptr(), "s", &pstr)) {
+    const char* name = nullptr;
+    Py_ssize_t nameLength = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "s#", &name, &nameLength)) {
         throw Py::Exception();
     }
 
-    _cParamGrp->RemoveASCII(pstr);
+    _cParamGrp->removeString({name, size_t(nameLength)});
     return Py::None();
 }
 
@@ -816,7 +832,7 @@ Py::Object ParameterGrpPy::getContents(const Py::Tuple& args)
 
     Py::List list;
     // filling up Text nodes
-    std::vector<std::pair<std::string, std::string>> mcTextMap = _cParamGrp->GetASCIIMap();
+    std::vector<std::pair<std::string, std::string>> mcTextMap = _cParamGrp->getAllStringsMap();
     for (const auto& it : mcTextMap) {
         Py::Tuple t2(3);
         t2.setItem(0, Py::String("String"));

--- a/src/Base/ParameterPy.cpp
+++ b/src/Base/ParameterPy.cpp
@@ -506,35 +506,44 @@ Py::Object ParameterGrpPy::getFloats(const Py::Tuple& args)
 
 Py::Object ParameterGrpPy::setString(const Py::Tuple& args)
 {
-    char* pstr = nullptr;
-    char* str = nullptr;
-    if (!PyArg_ParseTuple(args.ptr(), "ss", &pstr, &str)) {
+    const char* name = nullptr;
+    Py_ssize_t nameLength = 0;
+    const char* value = nullptr;
+    Py_ssize_t valueLength = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "s#s#", &name, &nameLength, &value, &valueLength)) {
         throw Py::Exception();
     }
 
-    _cParamGrp->SetASCII(pstr, str);
+    _cParamGrp->setString({name, size_t(nameLength)}, {value, size_t(valueLength)});
     return Py::None();
 }
 
 Py::Object ParameterGrpPy::getString(const Py::Tuple& args)
 {
-    char* pstr = nullptr;
-    const char* str = "";
-    if (!PyArg_ParseTuple(args.ptr(), "s|s", &pstr, &str)) {
+    const char* name = nullptr;
+    Py_ssize_t nameLength = 0;
+    const char* fallback = nullptr;
+    Py_ssize_t fallbackLength = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "s#|s#", &name, &nameLength, &fallback, &fallbackLength)) {
         throw Py::Exception();
     }
 
-    return Py::String(_cParamGrp->GetASCII(pstr, str));  // NOLINT
+    return Py::String(
+        _cParamGrp->getString({name, size_t(nameLength)}, {fallback, size_t(fallbackLength)})
+    );  // NOLINT
 }
 
 Py::Object ParameterGrpPy::getStrings(const Py::Tuple& args)
 {
-    char* filter = nullptr;
-    if (!PyArg_ParseTuple(args.ptr(), "|s", &filter)) {
+    const char* filter = nullptr;
+    Py_ssize_t filterLength = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "|s#", &filter, &filterLength)) {
         throw Py::Exception();
     }
 
-    std::vector<std::pair<std::string, std::string>> map = _cParamGrp->GetASCIIMap(filter);
+    std::vector<std::pair<std::string, std::string>> map = _cParamGrp->getAllStringsMap(
+        {filter, size_t(filterLength)}
+    );
     Py::List list;
     for (const auto& it : map) {
         list.append(Py::String(it.first));
@@ -600,12 +609,13 @@ Py::Object ParameterGrpPy::remFloat(const Py::Tuple& args)
 
 Py::Object ParameterGrpPy::remString(const Py::Tuple& args)
 {
-    char* pstr = nullptr;
-    if (!PyArg_ParseTuple(args.ptr(), "s", &pstr)) {
+    const char* name = nullptr;
+    Py_ssize_t nameLength = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "s#", &name, &nameLength)) {
         throw Py::Exception();
     }
 
-    _cParamGrp->RemoveASCII(pstr);
+    _cParamGrp->removeString({name, size_t(nameLength)});
     return Py::None();
 }
 
@@ -816,7 +826,7 @@ Py::Object ParameterGrpPy::getContents(const Py::Tuple& args)
 
     Py::List list;
     // filling up Text nodes
-    std::vector<std::pair<std::string, std::string>> mcTextMap = _cParamGrp->GetASCIIMap();
+    std::vector<std::pair<std::string, std::string>> mcTextMap = _cParamGrp->getAllStringsMap();
     for (const auto& it : mcTextMap) {
         Py::Tuple t2(3);
         t2.setItem(0, Py::String("String"));

--- a/src/Base/XMLTools.cpp
+++ b/src/Base/XMLTools.cpp
@@ -82,10 +82,10 @@ std::string XMLTools::toStdString(const XMLCh* const toTranscode)
     return str;
 }
 
-std::basic_string<XMLCh> XMLTools::toXMLString(const char* const fromTranscode)
+std::basic_string<XMLCh> XMLTools::toXMLString(std::string_view fromTranscode)
 {
     std::basic_string<XMLCh> str;
-    if (!fromTranscode) {
+    if (fromTranscode.empty()) {
         return str;
     }
 
@@ -93,11 +93,11 @@ std::basic_string<XMLCh> XMLTools::toXMLString(const char* const fromTranscode)
 
     static XMLCh outBuff[128];
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    const XMLByte* xmlBytes = reinterpret_cast<const XMLByte*>(fromTranscode);
+    const XMLByte* xmlBytes = reinterpret_cast<const XMLByte*>(fromTranscode.data());
     XMLSize_t outputLength = 0;
     XMLSize_t eaten = 0;
     XMLSize_t offset = 0;
-    XMLSize_t inputLength = std::string(fromTranscode).size();
+    XMLSize_t inputLength = fromTranscode.size();
 
     unsigned char* charSizes = new unsigned char[inputLength];
     while (inputLength) {

--- a/src/Base/XMLTools.h
+++ b/src/Base/XMLTools.h
@@ -26,12 +26,16 @@
 
 #pragma once
 
+#include <FCGlobal.h>
+
 #include <memory>
 #include <ostream>
-#include <xercesc/util/TransService.hpp>
-#include <xercesc/framework/MemoryManager.hpp>
+#include <string>
+#include <string_view>
 
-#include <FCGlobal.h>
+#include <xercesc/framework/MemoryManager.hpp>
+#include <xercesc/util/TransService.hpp>
+
 
 namespace XERCES_CPP_NAMESPACE
 {
@@ -45,7 +49,7 @@ class BaseExport XMLTools
 {
 public:
     static std::string toStdString(const XMLCh* const toTranscode);
-    static std::basic_string<XMLCh> toXMLString(const char* const fromTranscode);
+    static std::basic_string<XMLCh> toXMLString(std::string_view fromTranscode);
     static std::string escapeXml(const std::string& input);
     static void initialize();
     static void terminate();
@@ -163,6 +167,8 @@ public:
     ///  Constructors and Destructor
     explicit XStr(const char* const toTranscode);
     explicit XStr(const char* const toTranscode, XERCES_CPP_NAMESPACE::MemoryManager* memMgr);
+    explicit XStr(std::string_view toTranscode);
+    explicit XStr(std::string_view toTranscode, XERCES_CPP_NAMESPACE::MemoryManager* memMgr);
     ~XStr();
 
 
@@ -183,6 +189,17 @@ inline XStr::XStr(const char* const toTranscode)
 
 inline XStr::XStr(const char* const toTranscode, XERCES_CPP_NAMESPACE_QUALIFIER MemoryManager* memMgr)
     : fUnicodeForm(XERCES_CPP_NAMESPACE::XMLString::transcode(toTranscode, memMgr))
+    , memMgr(memMgr)
+{}
+
+inline XStr::XStr(std::string_view toTranscode)
+    : XStr(toTranscode, XERCES_CPP_NAMESPACE::XMLPlatformUtils::fgMemoryManager)
+{}
+
+inline XStr::XStr(std::string_view toTranscode, XERCES_CPP_NAMESPACE_QUALIFIER MemoryManager* memMgr)
+    : fUnicodeForm(
+          XERCES_CPP_NAMESPACE::XMLString::transcode(std::string {toTranscode}.c_str(), memMgr)
+      )
     , memMgr(memMgr)
 {}
 
@@ -221,7 +238,7 @@ inline const XMLCh* XStr::unicodeForm() const
 class XUTF8Str
 {
 public:
-    explicit XUTF8Str(const char* const fromTranscode);
+    explicit XUTF8Str(std::string_view fromTranscode);
     ~XUTF8Str();
 
     /// Getter method
@@ -233,7 +250,7 @@ private:
     std::basic_string<XMLCh> str;
 };
 
-inline XUTF8Str::XUTF8Str(const char* const fromTranscode)
+inline XUTF8Str::XUTF8Str(std::string_view fromTranscode)
 {
     str = XMLTools::toXMLString(fromTranscode);
 }

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -1056,7 +1056,7 @@ void RecentFilesAction::restore()
         action->setVisible(false);
         recentFileActions.append(action);
     }
-    std::vector<std::string> MRU = hGrp->GetASCIIs("MRU");
+    std::vector<std::string> MRU = hGrp->getAllStrings("MRU");
     QStringList files;
     for (const auto& it : MRU) {
         auto filePath = QString::fromUtf8(it.c_str());
@@ -1082,7 +1082,7 @@ void RecentFilesAction::save()
         if (value.isEmpty()) {
             break;
         }
-        hGrp->SetASCII(key.toLatin1(), value.toUtf8());
+        hGrp->setString(QStringLiteral("MRU%1").arg(index).toStdString(), value.toStdString());
     }
 
     Base::StateLocker guard(_pimpl->updating);
@@ -1134,7 +1134,7 @@ void RecentMacrosAction::setFiles(const QStringList& files)
                                     .GetGroup("BaseApp")
                                     ->GetGroup("Preferences")
                                     ->GetGroup("RecentMacros");
-    this->shortcut_modifiers = hGrp->GetASCII("ShortcutModifiers", "Ctrl+Shift+");
+    this->shortcut_modifiers = hGrp->getString("ShortcutModifiers", "Ctrl+Shift+");
     this->shortcut_count = std::min<int>(hGrp->GetInt("ShortcutCount", 3), 9);  // max = 9, e.g.
                                                                                 // Ctrl+Shift+9
     this->visibleItems = hGrp->GetInt("RecentMacros", 12);
@@ -1293,10 +1293,10 @@ void RecentMacrosAction::restore()
     }
     resizeList(hGrp->GetInt("RecentMacros"));
 
-    std::vector<std::string> MRU = hGrp->GetASCIIs("MRU");
+    std::vector<std::string> MRU = hGrp->getAllStrings("MRU");
     QStringList files;
     for (auto& filename : MRU) {
-        files.append(QString::fromUtf8(filename.c_str()));
+        files.append(QString::fromStdString(filename));
     }
     setFiles(files);
 }
@@ -1316,17 +1316,16 @@ void RecentMacrosAction::save()
     QList<QAction*> recentFiles = groupAction()->actions();
     int num = std::min<int>(count, recentFiles.count());
     for (int index = 0; index < num; index++) {
-        QString key = QStringLiteral("MRU%1").arg(index);
         QString value = recentFiles[index]->toolTip();
         if (value.isEmpty()) {
             break;
         }
-        hGrp->SetASCII(key.toLatin1(), value.toUtf8());
+        hGrp->setString(QStringLiteral("MRU%1").arg(index).toStdString(), value.toStdString());
     }
 
     hGrp->SetInt("RecentMacros", count);  // restore
     hGrp->SetInt("ShortcutCount", this->shortcut_count);
-    hGrp->SetASCII("ShortcutModifiers", this->shortcut_modifiers.c_str());
+    hGrp->setString("ShortcutModifiers", this->shortcut_modifiers);
 }
 
 // --------------------------------------------------------------------

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -442,12 +442,11 @@ void Application::initStyleParameterManager()
             "User parameter:BaseApp/Preferences/MainWindow"
         );
 
-        if (const std::string& path = hMainWindowGrp->GetASCII("ThemeStyleParametersFile");
-            !path.empty()) {
+        if (const auto path = hMainWindowGrp->getString("ThemeStyleParametersFile"); !path.empty()) {
             return path;
         }
 
-        return fmt::format("qss:parameters/{}.yaml", hMainWindowGrp->GetASCII("Theme", "Classic"));
+        return fmt::format("qss:parameters/{}.yaml", hMainWindowGrp->getString("Theme", "Classic"));
     };
 
     auto themeParametersSource = new StyleParameters::YamlParameterSource(
@@ -463,7 +462,7 @@ void Application::initStyleParameterManager()
             themeParametersSource->changeFilePath(deduceParametersFilePath());
             styleParameterManager()->reload();
 
-            std::string sheet = hGrp->GetASCII("StyleSheet");
+            std::string sheet = hGrp->getString("StyleSheet");
             bool tiledBG = hGrp->GetBool("TiledBackground", false);
 
             setStyleSheet(QString::fromStdString(sheet), tiledBG);
@@ -538,7 +537,7 @@ Application::Application(bool GUIenabled)
         hPGrp = hPGrp->GetGroup("Preferences")->GetGroup("General");
         QString lang = QLocale::languageToString(QLocale().language());
         Translator::instance()->activateLanguage(
-            hPGrp->GetASCII("Language", (const char*)lang.toLatin1()).c_str());
+            hPGrp->getString("Language", lang.toStdString()));
         GetWidgetFactorySupplier();
 
         // Coin3d disables VBO support for some (typically very old) drivers and hardware.
@@ -1969,7 +1968,7 @@ bool Application::activateWorkbench(const char* name)
                 std::string nameWb = newWb->name();
                 App::GetApplication()
                     .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                    ->SetASCII("LastModule", nameWb.c_str());
+                    ->setString("LastModule", nameWb);
             }
             newWb->activated();
         }

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -438,12 +438,11 @@ void Application::initStyleParameterManager()
             "User parameter:BaseApp/Preferences/MainWindow"
         );
 
-        if (const std::string& path = hMainWindowGrp->GetASCII("ThemeStyleParametersFile");
-            !path.empty()) {
+        if (const auto path = hMainWindowGrp->getString("ThemeStyleParametersFile"); !path.empty()) {
             return path;
         }
 
-        return fmt::format("qss:parameters/{}.yaml", hMainWindowGrp->GetASCII("Theme", "Classic"));
+        return fmt::format("qss:parameters/{}.yaml", hMainWindowGrp->getString("Theme", "Classic"));
     };
 
     auto themeParametersSource = new StyleParameters::YamlParameterSource(
@@ -459,7 +458,7 @@ void Application::initStyleParameterManager()
             themeParametersSource->changeFilePath(deduceParametersFilePath());
             styleParameterManager()->reload();
 
-            std::string sheet = hGrp->GetASCII("StyleSheet");
+            std::string sheet = hGrp->getString("StyleSheet");
             bool tiledBG = hGrp->GetBool("TiledBackground", false);
 
             setStyleSheet(QString::fromStdString(sheet), tiledBG);
@@ -534,7 +533,7 @@ Application::Application(bool GUIenabled)
         hPGrp = hPGrp->GetGroup("Preferences")->GetGroup("General");
         QString lang = QLocale::languageToString(QLocale().language());
         Translator::instance()->activateLanguage(
-            hPGrp->GetASCII("Language", (const char*)lang.toLatin1()).c_str());
+            hPGrp->getString("Language", lang.toStdString()));
         GetWidgetFactorySupplier();
 
         // Coin3d disables VBO support for some (typically very old) drivers and hardware.
@@ -1962,7 +1961,7 @@ bool Application::activateWorkbench(const char* name)
                 std::string nameWb = newWb->name();
                 App::GetApplication()
                     .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                    ->SetASCII("LastModule", nameWb.c_str());
+                    ->setString("LastModule", nameWb);
             }
             newWb->activated();
         }

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -786,7 +786,7 @@ PyObject* ApplicationPy::sOpen(PyObject* /*self*/, PyObject* args)
         FileHandler handler(fileName);
         if (!handler.openFile()) {
             QString ext = handler.extension();
-            Base::Console().error("File type '%s' not supported\n", ext.toLatin1().constData());
+            Base::Console().error("File type '%s' not supported\n", ext.toUtf8().constData());
         }
     }
     PY_CATCH;
@@ -811,7 +811,7 @@ PyObject* ApplicationPy::sInsert(PyObject* /*self*/, PyObject* args)
         FileHandler handler(fileName);
         if (!handler.importFile(std::string(DocName ? DocName : ""))) {
             QString ext = handler.extension();
-            Base::Console().error("File type '%s' not supported\n", ext.toLatin1().constData());
+            Base::Console().error("File type '%s' not supported\n", ext.toUtf8().constData());
         }
     }
     PY_CATCH;
@@ -912,7 +912,7 @@ PyObject* ApplicationPy::sExport(PyObject* /*self*/, PyObject* args)
             }
         }
         else {
-            Base::Console().error("File type '%s' not supported\n", ext.toLatin1().constData());
+            Base::Console().error("File type '%s' not supported\n", ext.toUtf8().constData());
         }
     }
     PY_CATCH;

--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -111,9 +111,9 @@ void BitmapFactoryInst::restoreCustomPaths()
     Base::Reference<ParameterGrp> group = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Bitmaps"
     );
-    std::vector<std::string> paths = group->GetASCIIs("CustomPath");
+    std::vector<std::string> paths = group->getAllStrings("CustomPath");
     for (auto& path : paths) {
-        addPath(QString::fromUtf8(path.c_str()));
+        addPath(QString::fromStdString(path));
     }
 }
 

--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -116,9 +116,9 @@ void BitmapFactoryInst::restoreCustomPaths()
     Base::Reference<ParameterGrp> group = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Bitmaps"
     );
-    std::vector<std::string> paths = group->GetASCIIs("CustomPath");
+    std::vector<std::string> paths = group->getAllStrings("CustomPath");
     for (auto& path : paths) {
-        addPath(QString::fromUtf8(path.c_str()));
+        addPath(QString::fromStdString(path));
     }
 }
 
@@ -139,7 +139,7 @@ void Gui::BitmapFactoryInst::configureExternalTheme()
 
     d->externalThemeEnabled = group->GetBool("Enabled", false);
     d->preferExternal = group->GetBool("PreferExternal", true);
-    QString path = QString::fromUtf8(group->GetASCII("Path", "").c_str());
+    QString path = QString::fromStdString(group->getString("Path", ""));
 
     const auto isEnabledValue = [](const QString& value) {
         const QString normalized = value.trimmed().toLower();

--- a/src/Gui/Camera.cpp
+++ b/src/Gui/Camera.cpp
@@ -170,7 +170,10 @@ SbRotation Camera::defaultOrientation(const char* fallbackView)
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    return rotation(hGrp->getString("NewDocumentCameraOrientation", std::string_view {fallbackView}), Top);
+    return rotation(
+        hGrp->getString("NewDocumentCameraOrientation", std::string_view {fallbackView}),
+        Top
+    );
 }
 
 bool Camera::rotationsMatch(const SbRotation& lhs, const SbRotation& rhs, float squaredTolerance)

--- a/src/Gui/Camera.cpp
+++ b/src/Gui/Camera.cpp
@@ -170,7 +170,7 @@ SbRotation Camera::defaultOrientation(const char* fallbackView)
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    return rotation(hGrp->GetASCII("NewDocumentCameraOrientation", fallbackView), Top);
+    return rotation(hGrp->getString("NewDocumentCameraOrientation", std::string_view {fallbackView}), Top);
 }
 
 bool Camera::rotationsMatch(const SbRotation& lhs, const SbRotation& rhs, float squaredTolerance)

--- a/src/Gui/Camera.cpp
+++ b/src/Gui/Camera.cpp
@@ -176,7 +176,10 @@ SbRotation Camera::defaultOrientation(const char* fallbackView)
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    return rotation(hGrp->GetASCII("NewDocumentCameraOrientation", fallbackView), Top);
+    return rotation(
+        hGrp->getString("NewDocumentCameraOrientation", std::string_view {fallbackView}),
+        Top
+    );
 }
 
 bool Camera::rotationsMatch(const SbRotation& lhs, const SbRotation& rhs, float squaredTolerance)

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -1302,9 +1302,9 @@ void MacroCommand::activated(int iMsg)
 
         cMacroPath = App::GetApplication()
                          .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
-                         ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+                         ->getString("MacroPath", App::Application::getUserMacroDir());
 
-        d = QDir(QString::fromUtf8(cMacroPath.c_str()));
+        d = QDir(QString::fromStdString(cMacroPath));
     }
     else {
         QString dirstr = QString::fromStdString(App::Application::getHomePath())
@@ -1363,15 +1363,16 @@ void MacroCommand::load()
         std::vector<Base::Reference<ParameterGrp>> macros = hGrp->GetGroups();
         for (const auto& it : macros) {
             auto macro = new MacroCommand(it->GetGroupName());
-            macro->setScriptName(it->GetASCII("Script").c_str());
-            macro->setMenuText(it->GetASCII("Menu").c_str());
-            macro->setToolTipText(it->GetASCII("Tooltip").c_str());
-            macro->setWhatsThis(it->GetASCII("WhatsThis").c_str());
-            macro->setStatusTip(it->GetASCII("Statustip").c_str());
-            if (it->GetASCII("Pixmap", "nix") != "nix") {
-                macro->setPixmap(it->GetASCII("Pixmap").c_str());
+            // TODO: make scriptName etc store string_views and remove the conversions
+            macro->setScriptName(it->getString("Script").c_str());
+            macro->setMenuText(it->getString("Menu").c_str());
+            macro->setToolTipText(it->getString("Tooltip").c_str());
+            macro->setWhatsThis(it->getString("WhatsThis").c_str());
+            macro->setStatusTip(it->getString("Statustip").c_str());
+            if (it->getString("Pixmap", "nix") != "nix") {
+                macro->setPixmap(it->getString("Pixmap").c_str());
             }
-            macro->setAccel(it->GetASCII("Accel", nullptr).c_str());
+            macro->setAccel(it->getString("Accel").c_str());
             macro->systemMacro = it->GetBool("System", false);
             Application::Instance->commandManager().addCommand(macro);
         }
@@ -1390,13 +1391,29 @@ void MacroCommand::save()
         for (const auto& it : macros) {
             auto macro = (MacroCommand*)it;
             ParameterGrp::handle hMacro = hGrp->GetGroup(macro->getName());
-            hMacro->SetASCII("Script", macro->getScriptName());
-            hMacro->SetASCII("Menu", macro->getMenuText());
-            hMacro->SetASCII("Tooltip", macro->getToolTipText());
-            hMacro->SetASCII("WhatsThis", macro->getWhatsThis());
-            hMacro->SetASCII("Statustip", macro->getStatusTip());
-            hMacro->SetASCII("Pixmap", macro->getPixmap());
-            hMacro->SetASCII("Accel", macro->getAccel());
+            // TODO: make scriptName etc store string_views and remove the conversions
+            hMacro->setString(
+                "Script",
+                std::string_view {macro->getScriptName() ? macro->getScriptName() : ""}
+            );
+            hMacro->setString(
+                "Menu",
+                std::string_view {macro->getMenuText() ? macro->getMenuText() : ""}
+            );
+            hMacro->setString(
+                "Tooltip",
+                std::string_view {macro->getToolTipText() ? macro->getToolTipText() : ""}
+            );
+            hMacro->setString(
+                "WhatsThis",
+                std::string_view {macro->getWhatsThis() ? macro->getWhatsThis() : ""}
+            );
+            hMacro->setString(
+                "Statustip",
+                std::string_view {macro->getStatusTip() ? macro->getStatusTip() : ""}
+            );
+            hMacro->setString("Pixmap", std::string_view {macro->getPixmap() ? macro->getPixmap() : ""});
+            hMacro->setString("Accel", std::string_view {macro->getAccel() ? macro->getAccel() : ""});
             hMacro->SetBool("System", macro->systemMacro);
         }
     }

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -302,7 +302,7 @@ void StdCmdImport::activated(int iMsg)
                                               .GetGroup("BaseApp")
                                               ->GetGroup("Preferences")
                                               ->GetGroup("General");
-    const auto lastImportFilterName = QString::fromStdString(hPath->GetASCII("FileImportFilter"));
+    const auto lastImportFilterName = QString::fromStdString(hPath->getString("FileImportFilter"));
     qsizetype selectedFilterIndex = -1;
     for (qsizetype i = 0; i < formatList.size(); ++i) {
         if (formatList[i].name == lastImportFilterName) {
@@ -320,7 +320,7 @@ void StdCmdImport::activated(int iMsg)
     );
     if (!fileList.isEmpty()) {
         const auto& selectedFilter = formatList[selectedFilterIndex];
-        hPath->SetASCII("FileImportFilter", selectedFilter.name.toUtf8());
+        hPath->setString("FileImportFilter", selectedFilter.name.toStdString());
         SelectModule::Dict dict
             = SelectModule::importHandler(fileList, selectedFilter.toFilterString());
 
@@ -330,7 +330,7 @@ void StdCmdImport::activated(int iMsg)
             getGuiApplication()->importFrom(
                 it.key().toUtf8(),
                 getActiveGuiDocument()->getDocument()->getName(),
-                it.value().toLatin1()
+                it.value().toUtf8()
             );
         }
 
@@ -399,14 +399,14 @@ QString createDefaultExportBasename()
         exportFormatString = QString::fromStdString(
             App::GetApplication()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                ->GetASCII("ExportDefaultFilenameSingle", "%F-%P-")
+                ->getString("ExportDefaultFilenameSingle", "%F-%P-")
         );
     }
     else {
         exportFormatString = QString::fromStdString(
             App::GetApplication()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                ->GetASCII("ExportDefaultFilenameMultiple", "%F")
+                ->getString("ExportDefaultFilenameMultiple", "%F")
         );
     }
 
@@ -544,7 +544,7 @@ void StdCmdExport::activated(int iMsg)
                                               ->GetGroup("Preferences")
                                               ->GetGroup("General");
     const auto lastExportFilterName = QString::fromStdString(
-        !exportInfo.filterName.empty() ? exportInfo.filterName : hPath->GetASCII("FileExportFilter")
+        !exportInfo.filterName.empty() ? exportInfo.filterName : hPath->getString("FileExportFilter")
     );
     qsizetype selectedFilterIndex = -1;
     for (qsizetype i = 0; i < filterList.size(); ++i) {
@@ -607,13 +607,13 @@ void StdCmdExport::activated(int iMsg)
     );
     if (!filename.isEmpty()) {
         const auto& selectedFilter = filterList[selectedFilterIndex];
-        hPath->SetASCII("FileExportFilter", selectedFilter.name.toLatin1().constData());
+        hPath->setString("FileExportFilter", selectedFilter.name.toStdString());
 
         SelectModule::Dict dict
             = SelectModule::exportHandler(filename, selectedFilter.toFilterString());
         // export the files with the associated modules
         for (SelectModule::Dict::iterator it = dict.begin(); it != dict.end(); ++it) {
-            getGuiApplication()->exportTo(it.key().toUtf8(), doc->getName(), it.value().toLatin1());
+            getGuiApplication()->exportTo(it.key().toUtf8(), doc->getName(), it.value().toUtf8());
         }
 
         // Keep a record of if the user used our suggested generated filename. If they

--- a/src/Gui/CommandFeat.cpp
+++ b/src/Gui/CommandFeat.cpp
@@ -333,21 +333,21 @@ void StdCmdSendToPythonConsole::activated(int iMsg)
         QString cmd = QLatin1String(
             "try:\n    del(doc,lnk,obj,shp,sub,subs)\nexcept Exception:\n    pass\n"
         );
-        Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
+        Gui::Command::runCommand(Gui::Command::Gui, cmd.toUtf8());
         cmd = QStringLiteral("doc = App.getDocument(\"%1\")").arg(docname);
-        Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
+        Gui::Command::runCommand(Gui::Command::Gui, cmd.toUtf8());
         // support links
         if (obj->isDerivedFrom<App::Link>()) {
             cmd = QStringLiteral("lnk = doc.getObject(\"%1\")").arg(objname);
-            Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
+            Gui::Command::runCommand(Gui::Command::Gui, cmd.toUtf8());
             cmd = QStringLiteral("obj = lnk.getLinkedObject()");
-            Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
+            Gui::Command::runCommand(Gui::Command::Gui, cmd.toUtf8());
             const auto link = static_cast<const App::Link*>(obj);
             obj = link->getLinkedObject();
         }
         else {
             cmd = QStringLiteral("obj = doc.getObject(\"%1\")").arg(objname);
-            Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
+            Gui::Command::runCommand(Gui::Command::Gui, cmd.toUtf8());
         }
         if (obj->isDerivedFrom<App::GeoFeature>()) {
             const auto geoObj = static_cast<const App::GeoFeature*>(obj);
@@ -355,12 +355,12 @@ void StdCmdSendToPythonConsole::activated(int iMsg)
             if (geo) {
                 cmd = QStringLiteral("shp = obj.")
                     + QLatin1String(geo->getName());  //"Shape", "Mesh", "Points", etc.
-                Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
+                Gui::Command::runCommand(Gui::Command::Gui, cmd.toUtf8());
                 if (sels[0].hasSubNames()) {
                     std::vector<std::string> subnames = sels[0].getSubNames();
                     QString subname = QString::fromLatin1(subnames[0].c_str());
                     cmd = QStringLiteral("sub = obj.getSubObject(\"%1\")").arg(subname);
-                    Gui::Command::runCommand(Gui::Command::Gui, cmd.toLatin1());
+                    Gui::Command::runCommand(Gui::Command::Gui, cmd.toUtf8());
                     if (subnames.size() > 1) {
                         std::ostringstream strm;
                         strm << "subs = [";

--- a/src/Gui/CommandMacro.cpp
+++ b/src/Gui/CommandMacro.cpp
@@ -191,7 +191,7 @@ void StdCmdMacrosFolder::activated(int iMsg)
     Q_UNUSED(iMsg);
     std::string macroDir = App::GetApplication()
                                .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
-                               ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+                               ->getString("MacroPath", App::Application::getUserMacroDir());
     std::ranges::replace(macroDir, '/', PATHSEP);
     QString path = QString::fromStdString(macroDir);
     QUrl url = QUrl::fromLocalFile(path);

--- a/src/Gui/CommandStd.cpp
+++ b/src/Gui/CommandStd.cpp
@@ -86,7 +86,7 @@ void StdCmdWorkbench::activated(int i)
     try {
         Workbench* w = WorkbenchManager::instance()->active();
         QList<QAction*> items = static_cast<WorkbenchGroup*>(_pcAction)->actions();
-        std::string switch_to = (const char*)items[i]->objectName().toLatin1();
+        std::string switch_to = items[i]->objectName().toStdString();
         if (w) {
             std::string current_w = w->name();
             if (switch_to == current_w) {
@@ -622,8 +622,8 @@ void StdCmdOnlineHelpWebsite::activated(int iMsg)
     ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Websites"
     );
-    std::string url = hURLGrp->GetASCII("OnlineHelp", defaulturl.c_str());
-    hURLGrp->SetASCII("OnlineHelp", url.c_str());
+    std::string url = hURLGrp->getString("OnlineHelp", defaulturl);
+    hURLGrp->setString("OnlineHelp", url);
     OpenURLInBrowser(url.c_str());
 }
 
@@ -651,8 +651,8 @@ void StdCmdFreeCADDonation::activated(int iMsg)
     ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Websites"
     );
-    std::string url = hURLGrp->GetASCII("DonatePage", "https://www.freecad.org/sponsor");
-    hURLGrp->SetASCII("DonatePage", url.c_str());
+    std::string url = hURLGrp->getString("DonatePage", "https://www.freecad.org/sponsor");
+    hURLGrp->setString("DonatePage", url);
     OpenURLInBrowser(url.c_str());
 }
 
@@ -685,9 +685,10 @@ void StdCmdDevHandbook::activated(int iMsg)
     ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Websites"
     );
-    std::string url = hURLGrp->GetASCII("DevHandbook", "https://freecad.github.io/DevelopersHandbook/");
+    std::string url
+        = hURLGrp->getString("DevHandbook", "https://freecad.github.io/DevelopersHandbook/");
 
-    hURLGrp->SetASCII("DevHandbook", url.c_str());
+    hURLGrp->setString("DevHandbook", url);
     OpenURLInBrowser(url.c_str());
 }
 
@@ -717,8 +718,8 @@ void StdCmdFreeCADWebsite::activated(int iMsg)
     ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Websites"
     );
-    std::string url = hURLGrp->GetASCII("WebPage", defaulturl.c_str());
-    hURLGrp->SetASCII("WebPage", url.c_str());
+    std::string url = hURLGrp->getString("WebPage", defaulturl);
+    hURLGrp->setString("WebPage", url);
     OpenURLInBrowser(url.c_str());
 }
 
@@ -749,8 +750,8 @@ void StdCmdFreeCADUserHub::activated(int iMsg)
     ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Websites"
     );
-    std::string url = hURLGrp->GetASCII("Documentation", defaulturl.c_str());
-    hURLGrp->SetASCII("Documentation", url.c_str());
+    std::string url = hURLGrp->getString("Documentation", defaulturl);
+    hURLGrp->setString("Documentation", url);
     OpenURLInBrowser(url.c_str());
 }
 
@@ -780,8 +781,8 @@ void StdCmdFreeCADForum::activated(int iMsg)
     ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Websites"
     );
-    std::string url = hURLGrp->GetASCII("UserForum", defaulturl.c_str());
-    hURLGrp->SetASCII("UserForum", url.c_str());
+    std::string url = hURLGrp->getString("UserForum", defaulturl);
+    hURLGrp->setString("UserForum", url);
     OpenURLInBrowser(url.c_str());
 }
 
@@ -809,8 +810,8 @@ void StdCmdReportBug::activated(int iMsg)
     ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Websites"
     );
-    std::string url = hURLGrp->GetASCII("IssuesPage", "https://github.com/FreeCAD/FreeCAD/issues");
-    hURLGrp->SetASCII("IssuesPage", url.c_str());
+    std::string url = hURLGrp->getString("IssuesPage", "https://github.com/FreeCAD/FreeCAD/issues");
+    hURLGrp->setString("IssuesPage", url);
     OpenURLInBrowser(url.c_str());
 }
 

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -490,7 +490,7 @@ void StdCmdFreezeViews::onSaveViews()
                 viewPos = lines.join(QStringLiteral(" "));
             }
 
-            str << "    <Camera settings=\"" << viewPos.toLatin1().constData() << "\"/>\n";
+            str << "    <Camera settings=\"" << viewPos.toUtf8().constData() << "\"/>\n";
         }
 
         str << "  </Views>\n";
@@ -555,7 +555,7 @@ void StdCmdFreezeViews::onRestoreViews()
     // evaluate the XML content
     if (!xmlDocument.setContent(&file, true, &errorStr, &errorLine, &errorColumn)) {
         std::cerr << "Parse error in XML content at line " << errorLine << ", column "
-                  << errorColumn << ": " << (const char*)errorStr.toLatin1() << std::endl;
+                  << errorColumn << ": " << (const char*)errorStr.toUtf8() << std::endl;
         return;
     }
 #endif
@@ -2137,13 +2137,13 @@ void StdViewScreenShot::activated(int iMsg)
                                                  .GetGroup("BaseApp")
                                                  ->GetGroup("Preferences")
                                                  ->GetGroup("General");
-        QString ext = QString::fromLatin1(hExt->GetASCII("OffscreenImageFormat").c_str());
+        QString ext = QString::fromStdString(hExt->getString("OffscreenImageFormat"));
         int backtype = hExt->GetInt("OffscreenImageBackground", 0);
 
         Base::Reference<ParameterGrp> methodGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/View"
         );
-        QByteArray method = methodGrp->GetASCII("SavePicture").c_str();
+        auto method = QByteArray::fromStdString(methodGrp->getString("SavePicture"));
 
         QStringList filter;
         QString selFilter;
@@ -2202,10 +2202,10 @@ void StdViewScreenShot::activated(int iMsg)
                 }
             }
 
-            hExt->SetASCII("OffscreenImageFormat", (const char*)format.toLatin1());
+            hExt->setString("OffscreenImageFormat", format.toStdString());
 
             method = opt->method();
-            methodGrp->SetASCII("SavePicture", method.constData());
+            methodGrp->setString("SavePicture", {method.data(), size_t(method.size())});
 
             // which background chosen
             const char* background;
@@ -3916,7 +3916,7 @@ void StdCmdToggleBottomPanels::activated(int iMsg)
         // No visible bottom panels: restore the previously hidden ones. The default covers a fresh
         // install with no saved state.
         const auto savedNames = QString::fromStdString(
-            hGrp->GetASCII("HiddenBottomWidgets", "Python console;;Report view")
+            hGrp->getString("HiddenBottomWidgets", "Python console;;Report view")
         );
         QStringList panelNamesToRestore = savedNames.split(QStringLiteral(";;"));
 
@@ -3942,7 +3942,10 @@ void StdCmdToggleBottomPanels::activated(int iMsg)
             panelNamesToSave.append(panel->objectName());
         }
 
-        hGrp->SetASCII("HiddenBottomWidgets", panelNamesToSave.join(QStringLiteral(";;")).toStdString());
+        hGrp->setString(
+            "HiddenBottomWidgets",
+            panelNamesToSave.join(QStringLiteral(";;")).toStdString()
+        );
     }
 
     // Sync the checked state of the menu action
@@ -4329,11 +4332,11 @@ void CreateViewStdCommands()
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    if (hGrp->GetASCII("GestureRollFwdCommand").empty()) {
-        hGrp->SetASCII("GestureRollFwdCommand", "Std_SelForward");
+    if (hGrp->getString("GestureRollFwdCommand").empty()) {
+        hGrp->setString("GestureRollFwdCommand", "Std_SelForward");
     }
-    if (hGrp->GetASCII("GestureRollBackCommand").empty()) {
-        hGrp->SetASCII("GestureRollBackCommand", "Std_SelBack");
+    if (hGrp->getString("GestureRollBackCommand").empty()) {
+        hGrp->setString("GestureRollBackCommand", "Std_SelBack");
     }
     // NOLINTEND
 }

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -490,7 +490,7 @@ void StdCmdFreezeViews::onSaveViews()
                 viewPos = lines.join(QStringLiteral(" "));
             }
 
-            str << "    <Camera settings=\"" << viewPos.toLatin1().constData() << "\"/>\n";
+            str << "    <Camera settings=\"" << viewPos.toUtf8().constData() << "\"/>\n";
         }
 
         str << "  </Views>\n";
@@ -555,7 +555,7 @@ void StdCmdFreezeViews::onRestoreViews()
     // evaluate the XML content
     if (!xmlDocument.setContent(&file, true, &errorStr, &errorLine, &errorColumn)) {
         std::cerr << "Parse error in XML content at line " << errorLine << ", column "
-                  << errorColumn << ": " << (const char*)errorStr.toLatin1() << std::endl;
+                  << errorColumn << ": " << (const char*)errorStr.toUtf8() << std::endl;
         return;
     }
 #endif
@@ -2105,13 +2105,13 @@ void StdViewScreenShot::activated(int iMsg)
                                                  .GetGroup("BaseApp")
                                                  ->GetGroup("Preferences")
                                                  ->GetGroup("General");
-        QString ext = QString::fromLatin1(hExt->GetASCII("OffscreenImageFormat").c_str());
+        QString ext = QString::fromStdString(hExt->getString("OffscreenImageFormat"));
         int backtype = hExt->GetInt("OffscreenImageBackground", 0);
 
         Base::Reference<ParameterGrp> methodGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/View"
         );
-        QByteArray method = methodGrp->GetASCII("SavePicture").c_str();
+        auto method = QByteArray::fromStdString(methodGrp->getString("SavePicture"));
 
         QStringList filter;
         QString selFilter;
@@ -2170,10 +2170,10 @@ void StdViewScreenShot::activated(int iMsg)
                 }
             }
 
-            hExt->SetASCII("OffscreenImageFormat", (const char*)format.toLatin1());
+            hExt->setString("OffscreenImageFormat", format.toStdString());
 
             method = opt->method();
-            methodGrp->SetASCII("SavePicture", method.constData());
+            methodGrp->setString("SavePicture", {method.data(), size_t(method.size())});
 
             // which background chosen
             const char* background;
@@ -3884,7 +3884,7 @@ void StdCmdToggleBottomPanels::activated(int iMsg)
         // No visible bottom panels: restore the previously hidden ones. The default covers a fresh
         // install with no saved state.
         const auto savedNames = QString::fromStdString(
-            hGrp->GetASCII("HiddenBottomWidgets", "Python console;;Report view")
+            hGrp->getString("HiddenBottomWidgets", "Python console;;Report view")
         );
         QStringList panelNamesToRestore = savedNames.split(QStringLiteral(";;"));
 
@@ -3910,7 +3910,10 @@ void StdCmdToggleBottomPanels::activated(int iMsg)
             panelNamesToSave.append(panel->objectName());
         }
 
-        hGrp->SetASCII("HiddenBottomWidgets", panelNamesToSave.join(QStringLiteral(";;")).toStdString());
+        hGrp->setString(
+            "HiddenBottomWidgets",
+            panelNamesToSave.join(QStringLiteral(";;")).toStdString()
+        );
     }
 
     // Sync the checked state of the menu action
@@ -4296,11 +4299,11 @@ void CreateViewStdCommands()
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    if (hGrp->GetASCII("GestureRollFwdCommand").empty()) {
-        hGrp->SetASCII("GestureRollFwdCommand", "Std_SelForward");
+    if (hGrp->getString("GestureRollFwdCommand").empty()) {
+        hGrp->setString("GestureRollFwdCommand", "Std_SelForward");
     }
-    if (hGrp->GetASCII("GestureRollBackCommand").empty()) {
-        hGrp->SetASCII("GestureRollBackCommand", "Std_SelBack");
+    if (hGrp->getString("GestureRollBackCommand").empty()) {
+        hGrp->setString("GestureRollBackCommand", "Std_SelBack");
     }
     // NOLINTEND
 }

--- a/src/Gui/DAGView/DAGModelGraph.h
+++ b/src/Gui/DAGView/DAGModelGraph.h
@@ -163,7 +163,7 @@ public:
     void operator()(std::ostream& out, const VertexW& vertexW) const
     {
         out << "[label=\"";
-        out << graphVW[vertexW].text->toPlainText().toLatin1().data();
+        out << graphVW[vertexW].text->toPlainText().toUtf8().constData();
         out << "\"]";
     }
 

--- a/src/Gui/Dialogs/DlgActionsImp.cpp
+++ b/src/Gui/Dialogs/DlgActionsImp.cpp
@@ -63,7 +63,7 @@ DlgCustomActionsImp::DlgCustomActionsImp(QWidget* parent)
     // search for all macros
     std::string cMacroPath = App::GetApplication()
                                  .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
-                                 ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+                                 ->getString("MacroPath", App::Application::getUserMacroDir());
 
     QDir d(QString::fromUtf8(cMacroPath.c_str()), QLatin1String("*.FCMacro *.py"));
     for (unsigned int i = 0; i < d.count(); i++) {
@@ -247,7 +247,7 @@ void DlgCustomActionsImp::onButtonAddActionClicked()
 
     // search for the command in the manager
     CommandManager& rclMan = Application::Instance->commandManager();
-    QByteArray actionName = QString::fromStdString(rclMan.newMacroName()).toLatin1();
+    auto actionName = QByteArray::fromStdString(rclMan.newMacroName());
     auto macro = new MacroCommand(
         actionName,
         ui->actionMacros->itemData(ui->actionMacros->currentIndex()).toBool()
@@ -453,10 +453,10 @@ void IconDialog::onAddIconPath()
     Base::Reference<ParameterGrp> group = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Bitmaps"
     );
-    std::vector<std::string> paths = group->GetASCIIs("CustomPath");
+    std::vector<std::string> paths = group->getAllStrings("CustomPath");
     QStringList pathList;
     for (const auto& path : paths) {
-        pathList << QString::fromUtf8(path.c_str());
+        pathList << QString::fromStdString(path);
     }
 
     IconFolders dlg(pathList, this);
@@ -470,7 +470,7 @@ void IconDialog::onAddIconPath()
         for (QStringList::iterator it = paths.begin(); it != paths.end(); ++it, ++index) {
             std::stringstream str;
             str << "CustomPath" << index;
-            group->SetASCII(str.str().c_str(), (const char*)it->toUtf8());
+            group->setString(str.str(), it->toStdString());
         }
 
         QStringList search = BitmapFactory().getPaths();

--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -224,7 +224,7 @@ void DlgAddProperty::populateGroup(EditFinishedComboBox& comboBox, const App::Pr
     auto paramGroup = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/PropertyView"
     );
-    std::string lastGroup = paramGroup->GetASCII("NewPropertyGroup");
+    std::string lastGroup = paramGroup->getString("NewPropertyGroup");
 
     std::vector<App::Property*> properties;
     container->getPropertyList(properties);
@@ -316,7 +316,7 @@ void DlgAddProperty::initializeTypes()
         "User parameter:BaseApp/Preferences/PropertyView"
     );
     auto lastType = Base::Type::fromName(
-        paramGroup->GetASCII("NewPropertyType", "App::PropertyLength").c_str()
+        paramGroup->getString("NewPropertyType", "App::PropertyLength").c_str()
     );
     if (lastType.isBad()) {
         lastType = App::PropertyLength::getClassTypeId();
@@ -1058,8 +1058,8 @@ void DlgAddProperty::accept()
     auto paramGroup = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/PropertyView"
     );
-    paramGroup->SetASCII("NewPropertyType", type.c_str());
-    paramGroup->SetASCII("NewPropertyGroup", group.c_str());
+    paramGroup->setString("NewPropertyType", type);
+    paramGroup->setString("NewPropertyGroup", group);
 
     clearFields();
     ui->lineEditName->setFocus();

--- a/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
+++ b/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
@@ -132,8 +132,8 @@ void ButtonModel::load3DConnexionButtonMapping(boost::property_tree::ptree Butto
                 Base::Reference<ParameterGrp> newGroup;
 
                 newGroup = spaceballButtonGroup()->GetGroup(ButtonCode.c_str());
-                newGroup->SetASCII("Command", ButtonCommand.c_str());
-                newGroup->SetASCII("Description", ButtonDescription.c_str());
+                newGroup->setString("Command", ButtonCommand);
+                newGroup->setString("Description", ButtonDescription);
             }
         }
     }
@@ -211,7 +211,7 @@ QVariant ButtonModel::data(const QModelIndex& index, int role) const
                                        // QIcon first
     }
     if (role == Qt::UserRole) {
-        return {QString::fromStdString(groupVector.at(index.row())->GetASCII("Command"))};
+        return {QString::fromStdString(groupVector.at(index.row())->getString("Command"))};
     }
     if (role == Qt::SizeHintRole) {
         return {QSize(32, 32)};
@@ -229,8 +229,8 @@ void ButtonModel::insertButtonRows(int number)
         Base::Reference<ParameterGrp> newGroup = spaceballButtonGroup()->GetGroup(
             groupName.toLatin1()
         );  // builds the group.
-        newGroup->SetASCII("Command", "");
-        newGroup->SetASCII("Description", "");
+        newGroup->setString("Command", "");
+        newGroup->setString("Description", "");
     }
     endInsertRows();
     return;
@@ -239,7 +239,7 @@ void ButtonModel::insertButtonRows(int number)
 void ButtonModel::setCommand(int row, QString command)
 {
     GroupVector groupVector = spaceballButtonGroup()->GetGroups();
-    groupVector.at(row)->SetASCII("Command", command.toLatin1());
+    groupVector.at(row)->setString("Command", command.toStdString());
 }
 
 void ButtonModel::goButtonPress(int number)
@@ -255,8 +255,8 @@ void ButtonModel::goMacroRemoved(const QByteArray& macroName)
 {
     GroupVector groupVector = spaceballButtonGroup()->GetGroups();
     for (auto& it : groupVector) {
-        if (std::string(macroName.data()) == it->GetASCII("Command")) {
-            it->SetASCII("Command", "");
+        if (std::string(macroName.data()) == it->getString("Command")) {
+            it->setString("Command", "");
         }
     }
 }
@@ -287,7 +287,7 @@ QString ButtonModel::getLabel(const int& number) const
         QString numberString;
         numberString.setNum(number);
         QString desc = QString::fromStdString(
-            spaceballButtonGroup()->GetGroup(numberString.toLatin1())->GetASCII("Description", "")
+            spaceballButtonGroup()->GetGroup(numberString.toLatin1())->getString("Description", "")
         );
         if (desc.length()) {
             desc = QStringLiteral(" \"") + desc + QStringLiteral("\"");
@@ -816,7 +816,7 @@ void DlgCustomizeSpaceball::setupLayout()
             .GetUserParameter()
             .GetGroup("BaseApp")
             ->GetGroup("Spaceball")
-            ->GetASCII("Model", "")
+            ->getString("Model", "")
     );
     if (model.length() > 0) {
         devModel->setCurrentIndex(devModel->findText(model));
@@ -864,13 +864,13 @@ void DlgCustomizeSpaceball::goClear()
     commandView->setDisabled(true);
     // buttonModel->goClear();
 
-    QByteArray currentDevice = devModel->currentText().toLocal8Bit();
+    const auto currentDevice = devModel->currentText().toStdString();
     App::GetApplication()
         .GetUserParameter()
         .GetGroup("BaseApp")
         ->GetGroup("Spaceball")
-        ->SetASCII("Model", currentDevice.data());
-    buttonModel->loadConfig(currentDevice.data());
+        ->getString("Model", currentDevice);
+    buttonModel->loadConfig(currentDevice.c_str());
 }
 
 void DlgCustomizeSpaceball::goPrint()

--- a/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
+++ b/src/Gui/Dialogs/DlgCustomizeSpaceball.cpp
@@ -132,8 +132,8 @@ void ButtonModel::load3DConnexionButtonMapping(boost::property_tree::ptree Butto
                 Base::Reference<ParameterGrp> newGroup;
 
                 newGroup = spaceballButtonGroup()->GetGroup(ButtonCode.c_str());
-                newGroup->SetASCII("Command", ButtonCommand.c_str());
-                newGroup->SetASCII("Description", ButtonDescription.c_str());
+                newGroup->setString("Command", ButtonCommand);
+                newGroup->setString("Description", ButtonDescription);
             }
         }
     }
@@ -211,7 +211,7 @@ QVariant ButtonModel::data(const QModelIndex& index, int role) const
                                        // QIcon first
     }
     if (role == Qt::UserRole) {
-        return {QString::fromStdString(groupVector.at(index.row())->GetASCII("Command"))};
+        return {QString::fromStdString(groupVector.at(index.row())->getString("Command"))};
     }
     if (role == Qt::SizeHintRole) {
         return {QSize(32, 32)};
@@ -229,8 +229,8 @@ void ButtonModel::insertButtonRows(int number)
         Base::Reference<ParameterGrp> newGroup = spaceballButtonGroup()->GetGroup(
             groupName.toLatin1()
         );  // builds the group.
-        newGroup->SetASCII("Command", "");
-        newGroup->SetASCII("Description", "");
+        newGroup->setString("Command", "");
+        newGroup->setString("Description", "");
     }
     endInsertRows();
     return;
@@ -239,7 +239,7 @@ void ButtonModel::insertButtonRows(int number)
 void ButtonModel::setCommand(int row, QString command)
 {
     GroupVector groupVector = spaceballButtonGroup()->GetGroups();
-    groupVector.at(row)->SetASCII("Command", command.toLatin1());
+    groupVector.at(row)->setString("Command", command.toStdString());
 }
 
 void ButtonModel::goButtonPress(int number)
@@ -255,8 +255,8 @@ void ButtonModel::goMacroRemoved(const QByteArray& macroName)
 {
     GroupVector groupVector = spaceballButtonGroup()->GetGroups();
     for (auto& it : groupVector) {
-        if (std::string(macroName.data()) == it->GetASCII("Command")) {
-            it->SetASCII("Command", "");
+        if (std::string(macroName.data()) == it->getString("Command")) {
+            it->setString("Command", "");
         }
     }
 }
@@ -287,7 +287,7 @@ QString ButtonModel::getLabel(const int& number) const
         QString numberString;
         numberString.setNum(number);
         QString desc = QString::fromStdString(
-            spaceballButtonGroup()->GetGroup(numberString.toLatin1())->GetASCII("Description", "")
+            spaceballButtonGroup()->GetGroup(numberString.toLatin1())->getString("Description", "")
         );
         if (desc.length()) {
             desc = QStringLiteral(" \"") + desc + QStringLiteral("\"");
@@ -816,7 +816,7 @@ void DlgCustomizeSpaceball::setupLayout()
             .GetUserParameter()
             .GetGroup("BaseApp")
             ->GetGroup("Spaceball")
-            ->GetASCII("Model", "")
+            ->getString("Model", "")
     );
     if (model.length() > 0) {
         devModel->setCurrentIndex(devModel->findText(model));
@@ -864,13 +864,13 @@ void DlgCustomizeSpaceball::goClear()
     commandView->setDisabled(true);
     // buttonModel->goClear();
 
-    QByteArray currentDevice = devModel->currentText().toLocal8Bit();
+    const auto currentDevice = devModel->currentText().toStdString();
     App::GetApplication()
         .GetUserParameter()
         .GetGroup("BaseApp")
         ->GetGroup("Spaceball")
-        ->SetASCII("Model", currentDevice.data());
-    buttonModel->loadConfig(currentDevice.data());
+        ->setString("Model", currentDevice);
+    buttonModel->loadConfig(currentDevice.c_str());
 }
 
 void DlgCustomizeSpaceball::goPrint()

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -565,9 +565,9 @@ static void storePreferences(
     auto paramExpressionEditor = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/ExpressionEditor"
     );
-    paramExpressionEditor->SetASCII("LastDocument", nameDoc);
-    paramExpressionEditor->SetASCII("LastVarSet", nameVarSet);
-    paramExpressionEditor->SetASCII("LastGroup", nameGroup);
+    paramExpressionEditor->setString("LastDocument", nameDoc);
+    paramExpressionEditor->setString("LastVarSet", nameVarSet);
+    paramExpressionEditor->setString("LastGroup", nameGroup);
 }
 
 static const App::NumberExpression* toNumberExpr(const App::Expression* expr)
@@ -689,7 +689,7 @@ static App::Document* getPreselectedDocument()
     auto paramExpressionEditor = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/ExpressionEditor"
     );
-    std::string lastDoc = paramExpressionEditor->GetASCII("LastDocument", "");
+    std::string lastDoc = paramExpressionEditor->getString("LastDocument", "");
 
     if (lastDoc.empty()) {
         return App::GetApplication().getActiveDocument();
@@ -709,7 +709,7 @@ int DlgExpressionInput::getVarSetIndex(const App::Document* doc) const
     auto paramExpressionEditor = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/ExpressionEditor"
     );
-    std::string lastVarSet = paramExpressionEditor->GetASCII("LastVarSet", "VarSet");
+    std::string lastVarSet = paramExpressionEditor->getString("LastVarSet", "VarSet");
 
     auto* model = qobject_cast<QStandardItemModel*>(ui->comboBoxVarSet->model());
     for (int i = 0; i < model->rowCount(); ++i) {
@@ -867,7 +867,7 @@ void DlgExpressionInput::preselectGroup()
     auto paramExpressionEditor = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/ExpressionEditor"
     );
-    std::string lastGroup = paramExpressionEditor->GetASCII("LastGroup", "");
+    std::string lastGroup = paramExpressionEditor->getString("LastGroup", "");
 
     if (lastGroup.empty()) {
         return;

--- a/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
+++ b/src/Gui/Dialogs/DlgMacroExecuteImp.cpp
@@ -111,11 +111,9 @@ DlgMacroExecuteImp::DlgMacroExecuteImp(QWidget* parent, Qt::WindowFlags fl)
     // retrieve the macro path from parameter or use the user data as default
     {
         QSignalBlocker blocker(ui->fileChooser);
-        std::string path = getWindowParameter()->GetASCII(
-            "MacroPath",
-            App::Application::getUserMacroDir().c_str()
-        );
-        this->macroPath = QString::fromUtf8(path.c_str());
+        std::string path
+            = getWindowParameter()->getString("MacroPath", App::Application::getUserMacroDir());
+        this->macroPath = QString::fromStdString(path);
         ui->fileChooser->setFileName(this->macroPath);
     }
 
@@ -434,12 +432,12 @@ void DlgMacroExecuteImp::onFileChooserFileNameChanged(const QString& fn)
         }
         if (chosenPath != userMacroDir) {
             // Save the path in the parameters, but only if it is NOT the default value
-            getWindowParameter()->SetASCII("MacroPath", fn.toUtf8());
+            getWindowParameter()->setString("MacroPath", fn.toStdString());
         }
         else {
             // If the user specifically chose the default path, actually remove the setting (this
             // could happen if the user was trying to "undo" setting a custom path).
-            getWindowParameter()->RemoveASCII("MacroPath");
+            getWindowParameter()->removeString("MacroPath");
         }
         // fill the list box
         fillUpList();
@@ -1130,7 +1128,7 @@ void DlgMacroExecuteImp::onFolderButtonClicked()
 {
     std::string macroDir = App::GetApplication()
                                .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
-                               ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+                               ->getString("MacroPath", App::Application::getUserMacroDir());
     std::ranges::replace(macroDir, '/', PATHSEP);
     QString path = QString::fromStdString(macroDir);
     QUrl url = QUrl::fromLocalFile(path);

--- a/src/Gui/Dialogs/DlgMacroRecordImp.cpp
+++ b/src/Gui/Dialogs/DlgMacroRecordImp.cpp
@@ -55,8 +55,8 @@ DlgMacroRecordImp::DlgMacroRecordImp(QWidget* parent, Qt::WindowFlags fl)
     setupConnections();
 
     // get the macro home path
-    this->macroPath = QString::fromUtf8(
-        getWindowParameter()->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str()).c_str()
+    this->macroPath = QString::fromStdString(
+        getWindowParameter()->getString("MacroPath", App::Application::getUserMacroDir())
     );
     this->macroPath = QDir::toNativeSeparators(QDir(this->macroPath).path() + QDir::separator());
 
@@ -202,11 +202,11 @@ void DlgMacroRecordImp::onButtonChooseDirClicked()
             userMacroDir = userMacroDir.parent_path();
         }
         if (chosenPath != userMacroDir) {
-            getWindowParameter()->SetASCII("MacroPath", macroPath.toUtf8());
+            getWindowParameter()->setString("MacroPath", macroPath.toStdString());
         }
-        else if (getWindowParameter()->GetASCII("MacroPath", "UNSET") != "UNSET") {
+        else if (getWindowParameter()->getString("MacroPath", "UNSET") != "UNSET") {
             // If the new path IS the default path, remove any existing storage of the path
-            getWindowParameter()->RemoveASCII("MacroPath");
+            getWindowParameter()->removeString("MacroPath");
         }
     }
 }

--- a/src/Gui/Dialogs/DlgParameterFind.cpp
+++ b/src/Gui/Dialogs/DlgParameterFind.cpp
@@ -140,7 +140,7 @@ bool DlgParameterFind::matches(QTreeWidgetItem* item, const Options& opt) const
         auto intMap = hGrp->GetIntMap();
         auto uintMap = hGrp->GetUnsignedMap();
         auto floatMap = hGrp->GetFloatMap();
-        auto asciiMap = hGrp->GetASCIIMap();
+        auto stringMap = hGrp->getAllStringsMap();
 
         // check the name of an entry in the group
         if (opt.name) {
@@ -169,8 +169,8 @@ bool DlgParameterFind::matches(QTreeWidgetItem* item, const Options& opt) const
                         return true;
                     }
                 }
-                for (const auto& it : asciiMap) {
-                    QString text = QString::fromUtf8(it.first.c_str());
+                for (const auto& it : stringMap) {
+                    QString text = QString::fromStdString(it.first);
                     if (text.compare(opt.text, Qt::CaseInsensitive) == 0) {
                         return true;
                     }
@@ -201,8 +201,8 @@ bool DlgParameterFind::matches(QTreeWidgetItem* item, const Options& opt) const
                         return true;
                     }
                 }
-                for (const auto& it : asciiMap) {
-                    QString text = QString::fromUtf8(it.first.c_str());
+                for (const auto& it : stringMap) {
+                    QString text = QString::fromStdString(it.first);
                     if (text.indexOf(opt.text, 0, Qt::CaseInsensitive) >= 0) {
                         return true;
                     }
@@ -213,16 +213,16 @@ bool DlgParameterFind::matches(QTreeWidgetItem* item, const Options& opt) const
         // check the value of an entry in the group
         if (opt.value) {
             if (opt.match) {
-                for (const auto& it : asciiMap) {
-                    QString text = QString::fromUtf8(it.second.c_str());
+                for (const auto& it : stringMap) {
+                    QString text = QString::fromStdString(it.second);
                     if (text.compare(opt.text, Qt::CaseInsensitive) == 0) {
                         return true;
                     }
                 }
             }
             else {
-                for (const auto& it : asciiMap) {
-                    QString text = QString::fromUtf8(it.second.c_str());
+                for (const auto& it : stringMap) {
+                    QString text = QString::fromStdString(it.second);
                     if (text.indexOf(opt.text, 0, Qt::CaseInsensitive) >= 0) {
                         return true;
                     }

--- a/src/Gui/Dialogs/DlgParameterImp.cpp
+++ b/src/Gui/Dialogs/DlgParameterImp.cpp
@@ -285,7 +285,7 @@ void DlgParameterImp::showEvent(QShowEvent*)
     ParameterGrp::handle hGrp
         = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences");
     hGrp = hGrp->GetGroup("ParameterEditor");
-    std::string buf = hGrp->GetASCII("Geometry", "");
+    std::string buf = hGrp->getString("Geometry", "");
     if (!buf.empty()) {
         int x1, y1, x2, y2;
         char sep;
@@ -313,12 +313,12 @@ void DlgParameterImp::closeEvent(QCloseEvent*)
         }
 
         QString path = paths.join(QLatin1String("."));
-        hGrp->SetASCII("LastParameterGroup", (const char*)path.toUtf8());
+        hGrp->setString("LastParameterGroup", path.toStdString());
         // save geometry of window
         const QRect& r = this->geometry();
         std::stringstream str;
         str << "(" << r.left() << "," << r.top() << "," << r.right() << "," << r.bottom() << ")";
-        hGrp->SetASCII("Geometry", str.str().c_str());
+        hGrp->setString("Geometry", str.str());
     }
 }
 
@@ -331,11 +331,11 @@ void DlgParameterImp::onGroupSelected(QTreeWidgetItem* item)
         static_cast<ParameterValue*>(paramValue)->setCurrentGroup(_hcGrp);
 
         // filling up Text nodes
-        std::vector<std::pair<std::string, std::string>> mcTextMap = _hcGrp->GetASCIIMap();
+        std::vector<std::pair<std::string, std::string>> mcTextMap = _hcGrp->getAllStringsMap();
         for (const auto& It2 : mcTextMap) {
             (void)new ParameterText(
                 paramValue,
-                QString::fromUtf8(It2.first.c_str()),
+                QString::fromStdString(It2.first),
                 It2.second.c_str(),
                 _hcGrp
             );
@@ -407,7 +407,7 @@ void DlgParameterImp::onChangeParameterSet(int itemPos)
     ParameterGrp::handle hGrp
         = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences");
     hGrp = hGrp->GetGroup("ParameterEditor");
-    QString path = QString::fromUtf8(hGrp->GetASCII("LastParameterGroup").c_str());
+    QString path = QString::fromStdString(hGrp->getString("LastParameterGroup"));
     QStringList paths = path.split(QLatin1String("."), Qt::SkipEmptyParts);
 
     QTreeWidgetItem* parent = nullptr;
@@ -821,9 +821,9 @@ void ParameterValue::onCreateTextItem()
         return;
     }
 
-    std::vector<std::pair<std::string, std::string>> smap = _hcGrp->GetASCIIMap();
+    std::vector<std::pair<std::string, std::string>> smap = _hcGrp->getAllStringsMap();
     for (const auto& it : smap) {
-        if (name == QLatin1String(it.first.c_str())) {
+        if (name == QString::fromStdString(it.first)) {
             QMessageBox::critical(
                 this,
                 tr("Existing Item"),
@@ -1196,25 +1196,25 @@ void ParameterText::changeValue()
     );
     if (ok) {
         setText(2, txt);
-        _hcGrp->SetASCII(text(0).toLatin1(), txt.toUtf8());
+        _hcGrp->setString(text(0).toStdString(), txt.toStdString());
     }
 }
 
 void ParameterText::removeFromGroup()
 {
-    _hcGrp->RemoveASCII(text(0).toLatin1());
+    _hcGrp->removeString(text(0).toStdString());
 }
 
 void ParameterText::replace(const QString& oldName, const QString& newName)
 {
-    std::string val = _hcGrp->GetASCII(oldName.toLatin1());
-    _hcGrp->RemoveASCII(oldName.toLatin1());
-    _hcGrp->SetASCII(newName.toLatin1(), val.c_str());
+    std::string val = _hcGrp->getString(oldName.toStdString());
+    _hcGrp->removeString(oldName.toStdString());
+    _hcGrp->setString(newName.toStdString(), val);
 }
 
 void ParameterText::appendToGroup()
 {
-    _hcGrp->SetASCII(text(0).toLatin1(), text(2).toUtf8());
+    _hcGrp->setString(text(0).toStdString(), text(2).toStdString());
 }
 
 // --------------------------------------------------------------------

--- a/src/Gui/Dialogs/DlgParameterImp.cpp
+++ b/src/Gui/Dialogs/DlgParameterImp.cpp
@@ -285,7 +285,7 @@ void DlgParameterImp::showEvent(QShowEvent*)
     ParameterGrp::handle hGrp
         = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences");
     hGrp = hGrp->GetGroup("ParameterEditor");
-    std::string buf = hGrp->GetASCII("Geometry", "");
+    std::string buf = hGrp->getString("Geometry", "");
     if (!buf.empty()) {
         int x1, y1, x2, y2;
         char sep;
@@ -313,12 +313,12 @@ void DlgParameterImp::closeEvent(QCloseEvent*)
         }
 
         QString path = paths.join(QLatin1String("."));
-        hGrp->SetASCII("LastParameterGroup", (const char*)path.toUtf8());
+        hGrp->setString("LastParameterGroup", path.toStdString());
         // save geometry of window
         const QRect& r = this->geometry();
         std::stringstream str;
         str << "(" << r.left() << "," << r.top() << "," << r.right() << "," << r.bottom() << ")";
-        hGrp->SetASCII("Geometry", str.str().c_str());
+        hGrp->setString("Geometry", str.str());
     }
 }
 
@@ -331,11 +331,11 @@ void DlgParameterImp::onGroupSelected(QTreeWidgetItem* item)
         static_cast<ParameterValue*>(paramValue)->setCurrentGroup(_hcGrp);
 
         // filling up Text nodes
-        std::vector<std::pair<std::string, std::string>> mcTextMap = _hcGrp->GetASCIIMap();
+        std::vector<std::pair<std::string, std::string>> mcTextMap = _hcGrp->getAllStringsMap();
         for (const auto& It2 : mcTextMap) {
             (void)new ParameterText(
                 paramValue,
-                QString::fromUtf8(It2.first.c_str()),
+                QString::fromStdString(It2.first),
                 It2.second.c_str(),
                 _hcGrp
             );
@@ -406,7 +406,7 @@ void DlgParameterImp::onChangeParameterSet(int itemPos)
     ParameterGrp::handle hGrp
         = App::GetApplication().GetUserParameter().GetGroup("BaseApp")->GetGroup("Preferences");
     hGrp = hGrp->GetGroup("ParameterEditor");
-    QString path = QString::fromUtf8(hGrp->GetASCII("LastParameterGroup").c_str());
+    QString path = QString::fromStdString(hGrp->getString("LastParameterGroup"));
     QStringList paths = path.split(QLatin1String("."), Qt::SkipEmptyParts);
 
     QTreeWidgetItem* parent = nullptr;
@@ -820,9 +820,9 @@ void ParameterValue::onCreateTextItem()
         return;
     }
 
-    std::vector<std::pair<std::string, std::string>> smap = _hcGrp->GetASCIIMap();
+    std::vector<std::pair<std::string, std::string>> smap = _hcGrp->getAllStringsMap();
     for (const auto& it : smap) {
-        if (name == QLatin1String(it.first.c_str())) {
+        if (name == QString::fromStdString(it.first)) {
             QMessageBox::critical(
                 this,
                 tr("Existing Item"),
@@ -1195,25 +1195,25 @@ void ParameterText::changeValue()
     );
     if (ok) {
         setText(2, txt);
-        _hcGrp->SetASCII(text(0).toLatin1(), txt.toUtf8());
+        _hcGrp->setString(text(0).toStdString(), txt.toStdString());
     }
 }
 
 void ParameterText::removeFromGroup()
 {
-    _hcGrp->RemoveASCII(text(0).toLatin1());
+    _hcGrp->removeString(text(0).toStdString());
 }
 
 void ParameterText::replace(const QString& oldName, const QString& newName)
 {
-    std::string val = _hcGrp->GetASCII(oldName.toLatin1());
-    _hcGrp->RemoveASCII(oldName.toLatin1());
-    _hcGrp->SetASCII(newName.toLatin1(), val.c_str());
+    std::string val = _hcGrp->getString(oldName.toStdString());
+    _hcGrp->removeString(oldName.toStdString());
+    _hcGrp->setString(newName.toStdString(), val);
 }
 
 void ParameterText::appendToGroup()
 {
-    _hcGrp->SetASCII(text(0).toLatin1(), text(2).toUtf8());
+    _hcGrp->setString(text(0).toStdString(), text(2).toStdString());
 }
 
 // --------------------------------------------------------------------

--- a/src/Gui/Dialogs/DlgProjectInformationImp.cpp
+++ b/src/Gui/Dialogs/DlgProjectInformationImp.cpp
@@ -103,9 +103,9 @@ DlgProjectInformationImp::DlgProjectInformationImp(App::Document* doc, QWidget* 
 
     // load comboBox with license names
     for (const auto& item : App::licenseItems) {
-        const char* name {item.at(App::posnOfFullName)};
-        QString translated = QApplication::translate("Gui::Dialog::DlgSettingsDocument", name);
-        ui->comboLicense->addItem(translated, QByteArray(name));
+        const auto& name {item.at(App::posnOfFullName)};
+        QString translated = QApplication::translate("Gui::Dialog::DlgSettingsDocument", name.data());
+        ui->comboLicense->addItem(translated, QByteArray {name.data(), int(name.size())});
     }
 
     // set default position to match document
@@ -178,8 +178,9 @@ void DlgProjectInformationImp::accept()
 void DlgProjectInformationImp::onLicenseTypeChanged(int index)
 {
     const char* url {
-        index >= 0 && index < App::countOfLicenses ? App::licenseItems.at(index).at(App::posnOfUrl)
-                                                   : _doc->LicenseURL.getValue()
+        index >= 0 && index < App::countOfLicenses
+            ? App::licenseItems.at(index).at(App::posnOfUrl).data()
+            : _doc->LicenseURL.getValue()
     };
 
     ui->lineEditLicenseURL->setText(QString::fromLatin1(url));

--- a/src/Gui/Dialogs/DlgToolbarsImp.cpp
+++ b/src/Gui/Dialogs/DlgToolbarsImp.cpp
@@ -213,7 +213,7 @@ void DlgCustomToolbars::importCustomToolbars(const QByteArray& name)
         toplevel->setCheckState(0, (active ? Qt::Checked : Qt::Unchecked));
 
         // get the elements of the subgroups
-        std::vector<std::pair<std::string, std::string>> items = hGrp->GetASCIIMap();
+        std::vector<std::pair<std::string, std::string>> items = hGrp->getAllStringsMap();
         for (const auto& it2 : items) {
             // since we have stored the separators to the user parameters as (key, pair) we had to
             // make sure to use a unique key because otherwise we cannot store more than
@@ -225,7 +225,7 @@ void DlgCustomToolbars::importCustomToolbars(const QByteArray& name)
                 item->setSizeHint(0, QSize(32, 32));
             }
             else if (it2.first == "Name") {
-                QString toolbarName = QString::fromUtf8(it2.second.c_str());
+                QString toolbarName = QString::fromStdString(it2.second);
                 toplevel->setText(0, toolbarName);
             }
             else {
@@ -266,9 +266,9 @@ void DlgCustomToolbars::exportCustomToolbars(const QByteArray& workbench)
     for (int i = 0; i < ui->toolbarTreeWidget->topLevelItemCount(); i++) {
         QTreeWidgetItem* toplevel = ui->toolbarTreeWidget->topLevelItem(i);
         QString groupName = QStringLiteral("Custom_%1").arg(i + 1);
-        QByteArray toolbarName = toplevel->text(0).toUtf8();
+        auto toolbarName = toplevel->text(0).toStdString();
         ParameterGrp::handle hToolGrp = hGrp->GetGroup(groupName.toLatin1());
-        hToolGrp->SetASCII("Name", toolbarName.constData());
+        hToolGrp->setString("Name", toolbarName);
         hToolGrp->SetBool("Active", toplevel->checkState(0) == Qt::Checked);
 
         // since we store the separators to the user parameters as (key, pair) we must
@@ -281,16 +281,20 @@ void DlgCustomToolbars::exportCustomToolbars(const QByteArray& workbench)
             if (commandName == "Separator") {
                 QByteArray key = commandName + QByteArray::number(suffixSeparator);
                 suffixSeparator++;
-                hToolGrp->SetASCII(key, commandName);
+                hToolGrp->setString(key.toStdString(), commandName.toStdString());
             }
             else {
                 Command* pCmd = rMgr.getCommandByName(commandName);
                 if (pCmd) {
-                    hToolGrp->SetASCII(pCmd->getName(), pCmd->getAppModuleName());
+                    // TODO: make name & appModuleName be std::strings and remove these conversions
+                    hToolGrp->setString(
+                        std::string_view {pCmd->getName()},
+                        std::string_view {pCmd->getAppModuleName() ? pCmd->getAppModuleName() : ""}
+                    );
                 }
                 else {
                     QByteArray moduleName = child->data(0, Qt::WhatsThisPropertyRole).toByteArray();
-                    hToolGrp->SetASCII(commandName, moduleName);
+                    hToolGrp->setString(commandName.toStdString(), moduleName.toStdString());
                 }
             }
         }

--- a/src/Gui/DownloadItem.cpp
+++ b/src/Gui/DownloadItem.cpp
@@ -294,7 +294,7 @@ QString DownloadItem::getDownloadDirectory() const
                                               .GetGroup("BaseApp")
                                               ->GetGroup("Preferences")
                                               ->GetGroup("General");
-    std::string dir = hPath->GetASCII("DownloadPath", "");
+    std::string dir = hPath->getString("DownloadPath", "");
     if (!dir.empty()) {
         dirPath = QString::fromUtf8(dir.c_str());
     }

--- a/src/Gui/FileDialog.cpp
+++ b/src/Gui/FileDialog.cpp
@@ -922,12 +922,12 @@ QString FileDialog::restoreLocation()
                                               .GetGroup("BaseApp")
                                               ->GetGroup("Preferences")
                                               ->GetGroup("General");
-    std::string dir = hPath->GetASCII("FileOpenSavePath", path.c_str());
-    QFileInfo fi(QString::fromUtf8(dir.c_str()));
+    std::string dir = hPath->getString("FileOpenSavePath", path);
+    QFileInfo fi(QString::fromStdString(dir));
     if (!fi.exists()) {
         dir = path;
     }
-    return QString::fromUtf8(dir.c_str());
+    return QString::fromStdString(dir);
 }
 
 /*!
@@ -941,7 +941,7 @@ void FileDialog::saveLocation(const QString& dirName)
                                               .GetGroup("BaseApp")
                                               ->GetGroup("Preferences")
                                               ->GetGroup("General");
-    hPath->SetASCII("FileOpenSavePath", dirName.toUtf8());
+    hPath->setString("FileOpenSavePath", dirName.toStdString());
 }
 
 // ======================================================================

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -308,7 +308,7 @@ void GraphvizView::updateSvgItem(const App::Document& doc)
     flatArgs << QLatin1String("-c2 -l2");
     auto dot = QStringLiteral("dot");
     auto unflatten = QStringLiteral("unflatten");
-    auto path = QString::fromUtf8(hGrp->GetASCII("Graphviz").c_str());
+    auto path = QString::fromStdString(hGrp->getString("Graphviz"));
     bool pathChanged = false;
     QDir dir;
     if (!path.isEmpty()) {
@@ -361,7 +361,7 @@ void GraphvizView::updateSvgItem(const App::Document& doc)
         }
         else {
             if (pathChanged) {
-                hGrp->SetASCII("Graphviz", (const char*)path.toUtf8());
+                hGrp->setString("Graphviz", path.toStdString());
             }
             break;
         }
@@ -430,9 +430,9 @@ QByteArray GraphvizView::exportGraph(const QString& format)
     flatArgs << QLatin1String("-c2 -l2");
 
 #ifdef FC_OS_LINUX
-    QString path = QString::fromUtf8(hGrp->GetASCII("Graphviz", "/usr/bin").c_str());
+    QString path = QString::fromStdString(hGrp->getString("Graphviz", "/usr/bin"));
 #else
-    QString path = QString::fromUtf8(hGrp->GetASCII("Graphviz").c_str());
+    QString path = QString::fromStdString(hGrp->getString("Graphviz"));
 #endif
 
 #ifdef FC_OS_WIN32

--- a/src/Gui/GraphvizView.cpp
+++ b/src/Gui/GraphvizView.cpp
@@ -306,7 +306,7 @@ void GraphvizView::updateSvgItem(const App::Document& doc)
     flatArgs << QLatin1String("-c2 -l2");
     auto dot = QStringLiteral("dot");
     auto unflatten = QStringLiteral("unflatten");
-    auto path = QString::fromUtf8(hGrp->GetASCII("Graphviz").c_str());
+    auto path = QString::fromStdString(hGrp->getString("Graphviz"));
     bool pathChanged = false;
     QDir dir;
     if (!path.isEmpty()) {
@@ -359,7 +359,7 @@ void GraphvizView::updateSvgItem(const App::Document& doc)
         }
         else {
             if (pathChanged) {
-                hGrp->SetASCII("Graphviz", (const char*)path.toUtf8());
+                hGrp->setString("Graphviz", path.toStdString());
             }
             break;
         }
@@ -428,9 +428,9 @@ QByteArray GraphvizView::exportGraph(const QString& format)
     flatArgs << QLatin1String("-c2 -l2");
 
 #ifdef FC_OS_LINUX
-    QString path = QString::fromUtf8(hGrp->GetASCII("Graphviz", "/usr/bin").c_str());
+    QString path = QString::fromStdString(hGrp->getString("Graphviz", "/usr/bin"));
 #else
-    QString path = QString::fromUtf8(hGrp->GetASCII("Graphviz").c_str());
+    QString path = QString::fromStdString(hGrp->getString("Graphviz"));
 #endif
 
 #ifdef FC_OS_WIN32

--- a/src/Gui/InputField.cpp
+++ b/src/Gui/InputField.cpp
@@ -362,12 +362,12 @@ void InputField::pushToHistory(const QString& valueq)
         for (int i = HistorySize - 1; i >= 0; i--) {
             snprintf(hist1, 20, "Hist%i", i + 1);
             snprintf(hist0, 20, "Hist%i", i);
-            std::string tHist = _handle->GetASCII(hist0, "");
+            std::string tHist = _handle->getString(hist0, "");
             if (!tHist.empty()) {
-                _handle->SetASCII(hist1, tHist.c_str());
+                _handle->setString(hist1, tHist);
             }
         }
-        _handle->SetASCII("Hist0", value.c_str());
+        _handle->setString("Hist0", value);
     }
 }
 
@@ -380,9 +380,9 @@ std::vector<QString> InputField::getHistory()
         char hist[21];
         for (int i = 0; i < HistorySize; i++) {
             snprintf(hist, 20, "Hist%i", i);
-            tmp = _handle->GetASCII(hist, "");
+            tmp = _handle->getString(hist, "");
             if (!tmp.empty()) {
-                res.push_back(QString::fromUtf8(tmp.c_str()));
+                res.push_back(QString::fromStdString(tmp));
             }
             else {
                 break;  // end of history reached
@@ -416,12 +416,12 @@ void InputField::pushToSavedValues(const QString& valueq)
         for (int i = SaveSize - 1; i >= 0; i--) {
             snprintf(hist1, 20, "Save%i", i + 1);
             snprintf(hist0, 20, "Save%i", i);
-            std::string tHist = _handle->GetASCII(hist0, "");
+            std::string tHist = _handle->getString(hist0, "");
             if (!tHist.empty()) {
-                _handle->SetASCII(hist1, tHist.c_str());
+                _handle->setString(hist1, tHist);
             }
         }
-        _handle->SetASCII("Save0", value.c_str());
+        _handle->setString("Save0", value);
     }
 }
 
@@ -434,9 +434,9 @@ std::vector<QString> InputField::getSavedValues()
         char hist[21];
         for (int i = 0; i < SaveSize; i++) {
             snprintf(hist, 20, "Save%i", i);
-            tmp = _handle->GetASCII(hist, "");
+            tmp = _handle->getString(hist, "");
             if (!tmp.empty()) {
-                res.push_back(QString::fromUtf8(tmp.c_str()));
+                res.push_back(QString::fromStdString(tmp));
             }
             else {
                 break;  // end of history reached

--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -259,7 +259,7 @@ Translator::Translator()
     d->mapLanguageTopLevelDomain[QT_TR_NOOP("Hebrew")] = "he";
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General");
-    auto entries = hGrp->GetASCII("AdditionalLanguageDomainEntries", "");
+    auto entries = hGrp->getString("AdditionalLanguageDomainEntries", "");
     // The format of the entries is "Language Name 1"="code1";"Language Name 2"="code2";...
     // Example: <FCText Name="AdditionalLanguageDomainEntries">"Romanian"="ro";"Polish"="pl";</FCText>
     QRegularExpression matchingRE(QStringLiteral("\"(.*[^\\s]+.*)\"\\s*=\\s*\"([^\\s]+)\";?"));
@@ -324,12 +324,12 @@ TStringMap Translator::supportedLocales() const
     return d->mapSupportedLocales;
 }
 
-void Translator::activateLanguage(const char* lang)
+void Translator::activateLanguage(std::string lang)
 {
     removeTranslators();  // remove the currently installed translators
-    d->activatedLanguage = lang;
+    d->activatedLanguage = std::move(lang);
     const TLanguageList languages = supportedLanguages();
-    if (std::ranges::find(languages, lang) != languages.end()) {
+    if (std::ranges::find(languages, d->activatedLanguage) != languages.end()) {
         refresh();
     }
 }
@@ -362,7 +362,7 @@ void Translator::applyLocaleFormattingPreference() const
             break;
         case LocaleFormattingPreference::SelectedLanguage:
             // Language must be activated before locale changes can follow it.
-            setLocale(hGrp->GetASCII("Language", activeLanguage().c_str()));
+            setLocale(hGrp->getString("Language", activeLanguage()));
             break;
         case LocaleFormattingPreference::CLocale:
             setLocale("C");
@@ -425,13 +425,13 @@ QStringList Translator::directories() const
     QStringList list;
     auto dir = App::GetApplication()
                    .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                   ->GetASCII("AdditionalTranslationsDirectory", "");
+                   ->getString("AdditionalTranslationsDirectory", "");
     if (!dir.empty()) {
         list.push_back(QString::fromStdString(dir));
     }
-    QDir home(QString::fromUtf8(App::Application::getUserAppDataDir().c_str()));
+    QDir home(QString::fromStdString(App::Application::getUserAppDataDir()));
     list.push_back(home.absoluteFilePath(QLatin1String("translations")));
-    QDir resc(QString::fromUtf8(App::Application::getResourceDir().c_str()));
+    QDir resc(QString::fromStdString(App::Application::getResourceDir()));
     list.push_back(resc.absoluteFilePath(QLatin1String("translations")));
     list.push_back(QLatin1String(":/translations"));
 

--- a/src/Gui/Language/Translator.cpp
+++ b/src/Gui/Language/Translator.cpp
@@ -258,7 +258,7 @@ Translator::Translator()
     d->mapLanguageTopLevelDomain[QT_TR_NOOP("Lao")] = "lo";
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General");
-    auto entries = hGrp->GetASCII("AdditionalLanguageDomainEntries", "");
+    auto entries = hGrp->getString("AdditionalLanguageDomainEntries", "");
     // The format of the entries is "Language Name 1"="code1";"Language Name 2"="code2";...
     // Example: <FCText Name="AdditionalLanguageDomainEntries">"Romanian"="ro";"Polish"="pl";</FCText>
     QRegularExpression matchingRE(QStringLiteral("\"(.*[^\\s]+.*)\"\\s*=\\s*\"([^\\s]+)\";?"));
@@ -323,12 +323,12 @@ TStringMap Translator::supportedLocales() const
     return d->mapSupportedLocales;
 }
 
-void Translator::activateLanguage(const char* lang)
+void Translator::activateLanguage(std::string lang)
 {
     removeTranslators();  // remove the currently installed translators
-    d->activatedLanguage = lang;
+    d->activatedLanguage = std::move(lang);
     const TLanguageList languages = supportedLanguages();
-    if (std::ranges::find(languages, lang) != languages.end()) {
+    if (std::ranges::find(languages, d->activatedLanguage) != languages.end()) {
         refresh();
     }
 }
@@ -361,7 +361,7 @@ void Translator::applyLocaleFormattingPreference() const
             break;
         case LocaleFormattingPreference::SelectedLanguage:
             // Language must be activated before locale changes can follow it.
-            setLocale(hGrp->GetASCII("Language", activeLanguage().c_str()));
+            setLocale(hGrp->getString("Language", activeLanguage()));
             break;
         case LocaleFormattingPreference::CLocale:
             setLocale("C");
@@ -424,13 +424,13 @@ QStringList Translator::directories() const
     QStringList list;
     auto dir = App::GetApplication()
                    .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                   ->GetASCII("AdditionalTranslationsDirectory", "");
+                   ->getString("AdditionalTranslationsDirectory", "");
     if (!dir.empty()) {
         list.push_back(QString::fromStdString(dir));
     }
-    QDir home(QString::fromUtf8(App::Application::getUserAppDataDir().c_str()));
+    QDir home(QString::fromStdString(App::Application::getUserAppDataDir()));
     list.push_back(home.absoluteFilePath(QLatin1String("translations")));
-    QDir resc(QString::fromUtf8(App::Application::getResourceDir().c_str()));
+    QDir resc(QString::fromStdString(App::Application::getResourceDir()));
     list.push_back(resc.absoluteFilePath(QLatin1String("translations")));
     list.push_back(QLatin1String(":/translations"));
 

--- a/src/Gui/Language/Translator.h
+++ b/src/Gui/Language/Translator.h
@@ -76,7 +76,7 @@ public:
     //@}
 
     /** Activates the specified language \a lang if available. */
-    void activateLanguage(const char* lang);
+    void activateLanguage(std::string lang);
     /* Reloads the translators */
     void refresh();
     /** Returns the currently installed language. If no language is installed an empty string is

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -416,7 +416,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
 
     d->restoreStateTimer.setSingleShot(true);
     connect(&d->restoreStateTimer, &QTimer::timeout, [this]() {
-        d->restoreWindowState(QByteArray::fromBase64(d->hGrp->GetASCII("MainWindowState").c_str()));
+        d->restoreWindowState(QByteArray::fromBase64(d->hGrp->getString("MainWindowState").c_str()));
         ToolBarManager::getInstance()->restoreState();
         OverlayManager::instance()->reload(OverlayManager::ReloadMode::ReloadResume);
     });
@@ -1277,7 +1277,7 @@ bool MainWindow::event(QEvent* e)
         QByteArray groupName(QVariant(buttonEvent->buttonNumber()).toByteArray());
         if (group->HasGroup(groupName.data())) {
             ParameterGrp::handle commandGroup = group->GetGroup(groupName.data());
-            std::string commandName(commandGroup->GetASCII("Command"));
+            std::string commandName = commandGroup->getString("Command");
             if (commandName.empty()) {
                 return true;
             }
@@ -2143,14 +2143,14 @@ void MainWindow::loadWindowSettings()
     config.endGroup();
 
     // Read stored values from user parameters
-    std::istringstream iss(d->hGrp->GetASCII("Geometry"));
+    std::istringstream iss(d->hGrp->getString("Geometry"));
     if (int x, y, w, h; iss >> x >> y >> w >> h) {
         winPos = QPoint(x, y);
         winSize = QSize(w, h);
     }
     max = d->hGrp->GetBool("Maximized", max);
     showStatusBar = d->hGrp->GetBool("StatusBar", showStatusBar);
-    if (auto wstate = d->hGrp->GetASCII("MainWindowState"); !wstate.empty()) {
+    if (auto wstate = d->hGrp->getString("MainWindowState"); !wstate.empty()) {
         windowState = QByteArray::fromBase64(wstate.c_str());
     }
 
@@ -2268,12 +2268,12 @@ void MainWindow::saveWindowSettings(bool canDelay)
     Base::ConnectionBlocker block(d->connParam);
     d->hGrp->SetBool("Maximized", this->isMaximized());
     d->hGrp->SetBool("StatusBar", this->statusBar()->isVisible());
-    d->hGrp->SetASCII("MainWindowState", this->saveState().toBase64().constData());
+    d->hGrp->setString("MainWindowState", this->saveState().toBase64().toStdString());
 
     std::ostringstream ss;
     QRect rect(this->pos(), this->size());
     ss << rect.left() << " " << rect.top() << " " << rect.width() << " " << rect.height();
-    d->hGrp->SetASCII("Geometry", ss.str().c_str());
+    d->hGrp->setString("Geometry", ss.str());
 
     DockWindowManager::instance()->saveState();
     OverlayManager::instance()->save();

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -416,7 +416,7 @@ MainWindow::MainWindow(QWidget* parent, Qt::WindowFlags f)
 
     d->restoreStateTimer.setSingleShot(true);
     connect(&d->restoreStateTimer, &QTimer::timeout, [this]() {
-        d->restoreWindowState(QByteArray::fromBase64(d->hGrp->GetASCII("MainWindowState").c_str()));
+        d->restoreWindowState(QByteArray::fromBase64(d->hGrp->getString("MainWindowState").c_str()));
         ToolBarManager::getInstance()->restoreState();
         OverlayManager::instance()->reload(OverlayManager::ReloadMode::ReloadResume);
     });
@@ -1280,7 +1280,7 @@ bool MainWindow::event(QEvent* e)
         QByteArray groupName(QVariant(buttonEvent->buttonNumber()).toByteArray());
         if (group->HasGroup(groupName.data())) {
             ParameterGrp::handle commandGroup = group->GetGroup(groupName.data());
-            std::string commandName(commandGroup->GetASCII("Command"));
+            std::string commandName = commandGroup->getString("Command");
             if (commandName.empty()) {
                 return true;
             }
@@ -2146,14 +2146,14 @@ void MainWindow::loadWindowSettings()
     config.endGroup();
 
     // Read stored values from user parameters
-    std::istringstream iss(d->hGrp->GetASCII("Geometry"));
+    std::istringstream iss(d->hGrp->getString("Geometry"));
     if (int x, y, w, h; iss >> x >> y >> w >> h) {
         winPos = QPoint(x, y);
         winSize = QSize(w, h);
     }
     max = d->hGrp->GetBool("Maximized", max);
     showStatusBar = d->hGrp->GetBool("StatusBar", showStatusBar);
-    if (auto wstate = d->hGrp->GetASCII("MainWindowState"); !wstate.empty()) {
+    if (auto wstate = d->hGrp->getString("MainWindowState"); !wstate.empty()) {
         windowState = QByteArray::fromBase64(wstate.c_str());
     }
 
@@ -2271,12 +2271,12 @@ void MainWindow::saveWindowSettings(bool canDelay)
     Base::ConnectionBlocker block(d->connParam);
     d->hGrp->SetBool("Maximized", this->isMaximized());
     d->hGrp->SetBool("StatusBar", this->statusBar()->isVisible());
-    d->hGrp->SetASCII("MainWindowState", this->saveState().toBase64().constData());
+    d->hGrp->setString("MainWindowState", this->saveState().toBase64().toStdString());
 
     std::ostringstream ss;
     QRect rect(this->pos(), this->size());
     ss << rect.left() << " " << rect.top() << " " << rect.width() << " " << rect.height();
-    d->hGrp->SetASCII("Geometry", ss.str().c_str());
+    d->hGrp->setString("Geometry", ss.str());
 
     DockWindowManager::instance()->saveState();
     OverlayManager::instance()->save();

--- a/src/Gui/Navigation/GestureNavigationStyle.cpp
+++ b/src/Gui/Navigation/GestureNavigationStyle.cpp
@@ -1104,7 +1104,7 @@ void GestureNavigationStyle::onRollGesture(int direction)
         }
         cmd = App::GetApplication()
                   .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
-                  ->GetASCII("GestureRollFwdCommand");
+                  ->getString("GestureRollFwdCommand");
     }
     else if (direction == -1) {
         if (logging) {
@@ -1112,7 +1112,7 @@ void GestureNavigationStyle::onRollGesture(int direction)
         }
         cmd = App::GetApplication()
                   .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
-                  ->GetASCII("GestureRollBackCommand");
+                  ->getString("GestureRollBackCommand");
     }
     if (cmd.empty()) {
         return;

--- a/src/Gui/NetworkRetriever.cpp
+++ b/src/Gui/NetworkRetriever.cpp
@@ -456,8 +456,8 @@ void StdCmdDownloadOnlineHelp::activated(int iMsg)
     if (!wget->isDownloading()) {
         ParameterGrp::handle hGrp = App::GetApplication().GetUserParameter().GetGroup("BaseApp");
         hGrp = hGrp->GetGroup("Preferences")->GetGroup("OnlineHelp");
-        std::string url = hGrp->GetASCII("DownloadURL", "www.freecad.org/wiki/");
-        std::string prx = hGrp->GetASCII("ProxyText", "");
+        std::string url = hGrp->getString("DownloadURL", "www.freecad.org/wiki/");
+        std::string prx = hGrp->getString("ProxyText", "");
         bool bUseProxy = hGrp->GetBool("UseProxy", false);
         bool bAuthor = hGrp->GetBool("Authorize", false);
 
@@ -477,7 +477,7 @@ void StdCmdDownloadOnlineHelp::activated(int iMsg)
                 }
             }
 
-            wget->setProxy(QString::fromLatin1(prx.c_str()), username, password);
+            wget->setProxy(QString::fromStdString(prx), username, password);
         }
 
         int loop = 3;
@@ -489,7 +489,7 @@ void StdCmdDownloadOnlineHelp::activated(int iMsg)
         ParameterGrp::handle hURLGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/OnlineHelp"
         );
-        path = QString::fromUtf8(hURLGrp->GetASCII("DownloadLocation", path.toLatin1()).c_str());
+        path = QString::fromStdString(hURLGrp->getString("DownloadLocation", path.toStdString()));
 
         while (loop > 0) {
             loop--;
@@ -543,7 +543,7 @@ void StdCmdDownloadOnlineHelp::activated(int iMsg)
         }
 
         if (canStart) {
-            bool ok = wget->startDownload(QString::fromLatin1(url.c_str()));
+            bool ok = wget->startDownload(QString::fromStdString(url));
             if (!ok) {
                 Base::Console().error("The tool 'wget' could not be found. Check the installation.");
             }

--- a/src/Gui/OverlayManager.cpp
+++ b/src/Gui/OverlayManager.cpp
@@ -148,9 +148,9 @@ public:
 private:
     QString detectOverlayStyleSheetFileName() const
     {
-        QString mainStyleSheet = QString::fromUtf8(handle->GetASCII("StyleSheet").c_str());
-        QString overlayStyleSheet = QString::fromUtf8(
-            handle->GetASCII("OverlayActiveStyleSheet").c_str()
+        QString mainStyleSheet = QString::fromStdString(handle->getString("StyleSheet"));
+        QString overlayStyleSheet = QString::fromStdString(
+            handle->getString("OverlayActiveStyleSheet")
         );
 
         if (overlayStyleSheet.isEmpty()) {

--- a/src/Gui/OverlayWidgets.cpp
+++ b/src/Gui/OverlayWidgets.cpp
@@ -480,7 +480,7 @@ void OverlayTabWidget::refreshIcons()
 {
     auto curStyleSheet = App::GetApplication()
                              .GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")
-                             ->GetASCII("StyleSheet", "None");
+                             ->getString("StyleSheet", "None");
 
     QPixmap pxAutoHide;
 
@@ -804,13 +804,15 @@ void OverlayTabWidget::restore(ParameterGrp::handle handle)
     // If overlay was ever used and disabled by the user it should respect that choice
     if (handle->GetInt("Width", 0) != 0 || handle->GetInt("Height", 0) != 0) {
         // save current value with old default to prevent layout change
-        handle->SetASCII("Widgets", handle->GetASCII("Widgets", ""));
+        handle->setString("Widgets", handle->getString("Widgets", ""));
     }
 
-    std::string widgets
-        = handle->GetASCII("Widgets", getDockArea() == Qt::RightDockWidgetArea ? "Tasks," : "");
+    std::string widgets = handle->getString(
+        "Widgets",
+        std::string_view {getDockArea() == Qt::RightDockWidgetArea ? "Tasks," : ""}
+    );
 
-    for (auto& name : QString::fromUtf8(widgets.c_str()).split(QLatin1Char(','))) {
+    for (auto& name : QString::fromStdString(widgets).split(QLatin1Char(','))) {
         if (name.isEmpty()) {
             continue;
         }
@@ -877,10 +879,10 @@ void OverlayTabWidget::restore(ParameterGrp::handle handle)
     setTransparent(handle->GetBool("Transparent", getDockArea() == Qt::RightDockWidgetArea));
 
     _sizemap.clear();
-    std::string savedSizes = handle->GetASCII("Sizes", "");
+    std::string savedSizes = handle->getString("Sizes", "");
     QList<int> sizes;
     int idx = 0;
-    for (auto& size : QString::fromUtf8(savedSizes.c_str()).split(QLatin1Char(','))) {
+    for (auto& size : QString::fromStdString(savedSizes).split(QLatin1Char(','))) {
         sizes.append(size.toInt());
         _sizemap[dockWidget(idx++)] = sizes.back();
     }
@@ -922,8 +924,8 @@ void OverlayTabWidget::saveTabs()
         _sizemap[dock] = sizes[i];
     }
     Base::StateLocker lock(_saving);
-    hGrp->SetASCII("Widgets", os.str().c_str());
-    hGrp->SetASCII("Sizes", os2.str().c_str());
+    hGrp->setString("Widgets", os.str());
+    hGrp->setString("Sizes", os2.str());
     FC_LOG("save " << objectName().toUtf8().constData() << " " << os2.str());
 }
 
@@ -970,7 +972,7 @@ void OverlayTabWidget::syncAutoMode()
 {
     auto curStyleSheet = App::GetApplication()
                              .GetParameterGroupByPath("User parameter:BaseApp/Preferences/MainWindow")
-                             ->GetASCII("StyleSheet", "None");
+                             ->getString("StyleSheet", "None");
 
     QAction* action = nullptr;
     switch (autoMode) {

--- a/src/Gui/PrefWidgets.cpp
+++ b/src/Gui/PrefWidgets.cpp
@@ -268,7 +268,9 @@ void PrefLineEdit::restorePreferences()
     }
 
     QString text = this->text();
-    text = QString::fromUtf8(getWindowParameter()->GetASCII(entryName(), text.toUtf8()).c_str());
+    text = QString::fromStdString(
+        getWindowParameter()->getString(entryName().toStdString(), text.toStdString())
+    );
     setText(text);
 }
 
@@ -279,7 +281,7 @@ void PrefLineEdit::savePreferences()
         return;
     }
 
-    getWindowParameter()->SetASCII(entryName(), text().toUtf8());
+    getWindowParameter()->setString(entryName().toStdString(), text().toStdString());
 }
 
 // --------------------------------------------------------------------
@@ -299,7 +301,9 @@ void PrefTextEdit::restorePreferences()
     }
 
     QString text = this->toPlainText();
-    text = QString::fromUtf8(getWindowParameter()->GetASCII(entryName(), text.toUtf8()).c_str());
+    text = QString::fromStdString(
+        getWindowParameter()->getString(entryName().toStdString(), text.toStdString())
+    );
     setText(text);
 }
 
@@ -311,7 +315,7 @@ void PrefTextEdit::savePreferences()
     }
 
     QString text = this->toPlainText();
-    getWindowParameter()->SetASCII(entryName(), text.toUtf8());
+    getWindowParameter()->setString(entryName().toStdString(), text.toStdString());
 }
 
 // --------------------------------------------------------------------
@@ -330,8 +334,8 @@ void PrefFileChooser::restorePreferences()
         return;
     }
 
-    QString txt = QString::fromUtf8(
-        getWindowParameter()->GetASCII(entryName(), fileName().toUtf8()).c_str()
+    QString txt = QString::fromStdString(
+        getWindowParameter()->getString(entryName().toStdString(), fileName().toStdString())
     );
     setFileName(txt);
 }
@@ -343,7 +347,7 @@ void PrefFileChooser::savePreferences()
         return;
     }
 
-    getWindowParameter()->SetASCII(entryName(), fileName().toUtf8());
+    getWindowParameter()->setString(entryName().toStdString(), fileName().toStdString());
 }
 
 // --------------------------------------------------------------------
@@ -405,15 +409,18 @@ void PrefComboBox::restorePreferences()
             break;
         case QMetaType::QString:
             index = findText(
-                QString::fromUtf8(
-                    getWindowParameter()->GetASCII(entryName(), m_DefaultText.toUtf8().constData()).c_str()
+                QString::fromStdString(
+                    getWindowParameter()->getString(entryName().toStdString(), m_DefaultText.toStdString())
                 )
             );
             break;
         case QMetaType::QByteArray:
-            index = findData(QByteArray(
-                getWindowParameter()->GetASCII(entryName(), m_Default.toByteArray().constData()).c_str()
-            ));
+            index = findData(
+                QByteArray::fromStdString(
+                    getWindowParameter()
+                        ->getString(entryName().toStdString(), m_Default.toByteArray().toStdString())
+                )
+            );
             break;
         default:
             index = getWindowParameter()->GetInt(entryName(), m_DefaultIndex);
@@ -447,10 +454,13 @@ void PrefComboBox::savePreferences()
             getWindowParameter()->SetFloat(entryName(), currentData().toDouble());
             break;
         case QMetaType::QString:
-            getWindowParameter()->SetASCII(entryName(), currentText().toUtf8().constData());
+            getWindowParameter()->setString(entryName().toStdString(), currentText().toStdString());
             break;
         case QMetaType::QByteArray:
-            getWindowParameter()->SetASCII(entryName(), currentData().toByteArray().constData());
+            getWindowParameter()->setString(
+                entryName().toStdString(),
+                currentData().toByteArray().toStdString()
+            );
             break;
         default:
             getWindowParameter()->SetInt(entryName(), currentIndex());
@@ -695,16 +705,16 @@ public:
 
     void restoreHistory(ParameterGrp::handle hGrp)
     {
-        std::vector<std::string> hist = hGrp->GetASCIIs("Hist");
+        std::vector<std::string> hist = hGrp->getAllStrings("Hist");
         for (const auto& it : hist) {
             history.append(QString::fromStdString(it));
         }
     }
     void clearHistory(ParameterGrp::handle hGrp)
     {
-        std::vector<std::string> hist = hGrp->GetASCIIs("Hist");
+        std::vector<std::string> hist = hGrp->getAllStrings("Hist");
         for (const auto& it : hist) {
-            hGrp->RemoveASCII(it.c_str());
+            hGrp->removeString(it);
         }
     }
     void saveHistory(ParameterGrp::handle hGrp)
@@ -715,7 +725,7 @@ public:
         for (int i = 0; i < list.size(); i++) {
             QByteArray key("Hist");
             key.append(QByteArray::number(i));
-            hGrp->SetASCII(key, list[i].toUtf8());
+            hGrp->setString(key.toStdString(), list[i].toStdString());
         }
     }
 };
@@ -797,7 +807,9 @@ void PrefQuantitySpinBox::restorePreferences()
     }
 
     QString text = this->text();
-    text = QString::fromUtf8(getWindowParameter()->GetASCII(entryName(), text.toUtf8()).c_str());
+    text = QString::fromStdString(
+        getWindowParameter()->getString(entryName().toStdString(), text.toStdString())
+    );
     lineEdit()->setText(text);
 
     // Restore history
@@ -813,7 +825,7 @@ void PrefQuantitySpinBox::savePreferences()
         return;
     }
 
-    getWindowParameter()->SetASCII(entryName(), text().toUtf8());
+    getWindowParameter()->setString(entryName().toStdString(), text().toStdString());
 
     // Save history
     auto hGrp = getWindowParameter()->GetGroup(d->getHistoryGroupName(entryName()));
@@ -874,8 +886,10 @@ void PrefFontBox::restorePreferences()
     QFont currFont = currentFont();  // QFont from selector widget
     QString currName = currFont.family();
 
-    std::string prefName
-        = getWindowParameter()->GetASCII(entryName(), currName.toUtf8());  // font name from cfg file
+    std::string prefName = getWindowParameter()->getString(
+        entryName().toStdString(),
+        currName.toStdString()
+    );  // font name from cfg file
 
     currFont.setFamily(QString::fromStdString(prefName));
     setCurrentFont(currFont);  // set selector widget to name from cfg file
@@ -890,7 +904,7 @@ void PrefFontBox::savePreferences()
 
     QFont currFont = currentFont();
     QString currName = currFont.family();
-    getWindowParameter()->SetASCII(entryName(), currName.toUtf8());
+    getWindowParameter()->setString(entryName().toStdString(), currName.toStdString());
 }
 
 // --------------------------------------------------------------------

--- a/src/Gui/PreferencePackManager.cpp
+++ b/src/Gui/PreferencePackManager.cpp
@@ -425,8 +425,8 @@ bool PreferencePackManager::isVisible(
         hiddenPacks.begin(),
         hiddenPacks.end(),
         [addonName, preferencePackName](ParameterGrp::handle handle) {
-            return (handle->GetASCII("addonName", "") == addonName)
-                && (handle->GetASCII("preferencePackName", "") == preferencePackName);
+            return (handle->getString("addonName", "") == addonName)
+                && (handle->getString("preferencePackName", "") == preferencePackName);
         }
     );
     if (hiddenPack == hiddenPacks.end()) {
@@ -453,15 +453,15 @@ void PreferencePackManager::toggleVisibility(
         hiddenPacks.begin(),
         hiddenPacks.end(),
         [addonName, preferencePackName](ParameterGrp::handle handle) {
-            return (handle->GetASCII("addonName", "") == addonName)
-                && (handle->GetASCII("preferencePackName", "") == preferencePackName);
+            return (handle->getString("addonName", "") == addonName)
+                && (handle->getString("preferencePackName", "") == preferencePackName);
         }
     );
     if (hiddenPack == hiddenPacks.end()) {
         auto name = findUnusedName("PreferencePack", pref);
         auto group = pref->GetGroup(name.c_str());
-        group->SetASCII("addonName", addonName.c_str());
-        group->SetASCII("preferencePackName", preferencePackName.c_str());
+        group->setString("addonName", addonName);
+        group->setString("preferencePackName", preferencePackName);
     }
     else {
         auto groupName = (*hiddenPack)->GetGroupName();
@@ -533,10 +533,10 @@ static void copyTemplateParameters(
         outputGroup->SetFloat(kv.first.c_str(), currentValue);
     }
 
-    auto asciiMap = templateGroup->GetASCIIMap();
+    auto asciiMap = templateGroup->getAllStringsMap();
     for (const auto& kv : asciiMap) {
-        auto currentValue = userParameterHandle->GetASCII(kv.first.c_str(), kv.second.c_str());
-        outputGroup->SetASCII(kv.first.c_str(), currentValue.c_str());
+        auto currentValue = userParameterHandle->getString(kv.first, kv.second);
+        outputGroup->setString(kv.first, currentValue);
     }
 
     // Recurse...

--- a/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsDocumentImp.cpp
@@ -220,7 +220,7 @@ void DlgSettingsDocumentImp::addLicenseTypes()
 
     ui->prefLicenseType->clear();
     for (const auto& licenseItem : App::licenseItems) {
-        add(licenseItem.at(App::posnOfFullName));
+        add(licenseItem.at(App::posnOfFullName).data());
     }
     add("Other");
 }
@@ -232,8 +232,8 @@ void DlgSettingsDocumentImp::onLicenseTypeChanged(int index)
 {
     if (index >= 0 && index < App::countOfLicenses) {
         // existing license
-        const char* url {App::licenseItems.at(index).at(App::posnOfUrl)};
-        ui->prefLicenseUrl->setText(QString::fromLatin1(url));
+        const auto url = App::licenseItems.at(index).at(App::posnOfUrl);
+        ui->prefLicenseUrl->setText(QString::fromUtf8(url.data(), url.size()));
         ui->prefLicenseUrl->setReadOnly(true);
     }
     else {

--- a/src/Gui/PreferencePages/DlgSettingsEditor.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsEditor.cpp
@@ -232,7 +232,7 @@ void DlgSettingsEditor::saveSettings()
         hGrp->SetUnsigned(textType.toLatin1(), col);
     }
     hGrp->SetInt("FontSize", ui->fontSize->value());
-    hGrp->SetASCII("Font", ui->fontFamily->currentText().toLatin1());
+    hGrp->setString("Font", ui->fontFamily->currentText().toStdString());
 
     setEditorTabWidth(ui->tabSize->value());
 }
@@ -278,7 +278,7 @@ void DlgSettingsEditor::loadSettings()
     ui->fontSize->setValue(10);
     ui->fontSize->setValue(hGrp->GetInt("FontSize", ui->fontSize->value()));
 
-    QByteArray defaultMonospaceFont = getMonospaceFont().family().toLatin1();
+    const auto defaultMonospaceFont = getMonospaceFont().family().toStdString();
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     QStringList familyNames = QFontDatabase().families(QFontDatabase::Any);
@@ -314,7 +314,7 @@ void DlgSettingsEditor::loadSettings()
     ui->fontFamily->setProperty("doNotSearch", true);
 
     int index = fixedFamilyNames.indexOf(
-        QString::fromLatin1(hGrp->GetASCII("Font", defaultMonospaceFont).c_str())
+        QString::fromStdString(hGrp->getString("Font", defaultMonospaceFont))
     );
     if (index < 0) {
         index = 0;
@@ -335,7 +335,7 @@ void DlgSettingsEditor::resetSettingsToDefaults()
     // reset "FontSize" parameter
     hGrp->RemoveInt("FontSize");
     // reset "Font" parameter
-    hGrp->RemoveASCII("Font");
+    hGrp->removeString("Font");
 
     // finally reset all the parameters associated to Gui::Pref* widgets
     PreferencePage::resetSettingsToDefaults();

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -174,11 +174,12 @@ bool DlgSettingsGeneral::setLanguage()
 {
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
     QString lang = QLocale::languageToString(QLocale().language());
-    QByteArray language = hGrp->GetASCII("Language", (const char*)lang.toLatin1()).c_str();
-    QByteArray current = ui->Languages->itemData(ui->Languages->currentIndex()).toByteArray();
+    const auto language = hGrp->getString("Language", lang.toStdString());
+    const auto current
+        = ui->Languages->itemData(ui->Languages->currentIndex()).toByteArray().toStdString();
     if (current != language) {
-        hGrp->SetASCII("Language", current.constData());
-        Translator::instance()->activateLanguage(current.constData());
+        hGrp->setString("Language", current);
+        Translator::instance()->activateLanguage(current);
         return true;
     }
     return false;
@@ -313,7 +314,7 @@ void DlgSettingsGeneral::loadSettings()
     // search for the language files
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
     auto langToStr = Translator::instance()->activeLanguage();
-    QByteArray language = hGrp->GetASCII("Language", langToStr.c_str()).c_str();
+    auto language = QByteArray::fromStdString(hGrp->getString("Language", langToStr));
 
     localeIndex = ui->UseLocaleFormatting->currentIndex();
 
@@ -381,7 +382,7 @@ void DlgSettingsGeneral::resetSettingsToDefaults()
         "User parameter:BaseApp/Preferences/MainWindow"
     );
     // reset "Theme" parameter
-    hGrp->RemoveASCII("Theme");
+    hGrp->removeString("Theme");
     // reset "TiledBackground" parameter
     hGrp->RemoveBool("TiledBackground");
 
@@ -398,7 +399,7 @@ void DlgSettingsGeneral::resetSettingsToDefaults()
 
     hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
     // reset "Language" parameter
-    hGrp->RemoveASCII("Language");
+    hGrp->removeString("Language");
     // reset "ToolbarIconSize" parameter
     hGrp->RemoveInt("ToolbarIconSize");
 
@@ -413,7 +414,7 @@ void DlgSettingsGeneral::saveThemes()
     );
 
     // First we check if the theme has actually changed.
-    std::string previousTheme = hGrp->GetASCII("Theme", "").c_str();
+    std::string previousTheme = hGrp->getString("Theme", "");
     std::string newTheme = ui->themesCombobox->currentText().toStdString();
 
     if (previousTheme == newTheme) {
@@ -422,7 +423,7 @@ void DlgSettingsGeneral::saveThemes()
     }
 
     // Save the name of the theme
-    hGrp->SetASCII("Theme", newTheme);
+    hGrp->setString("Theme", newTheme);
 
     // Then we apply the themepack.
     Application::Instance->prefPackManager()->rescan();
@@ -452,11 +453,11 @@ void DlgSettingsGeneral::loadThemes()
         "User parameter:BaseApp/Preferences/MainWindow"
     );
 
-    QString currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+    QString currentTheme = QString::fromStdString(hGrp->getString("Theme", ""));
 
     Application::Instance->prefPackManager()->rescan();
     auto packs = Application::Instance->prefPackManager()->preferencePacks();
-    QString currentStyleSheet = QString::fromLatin1(hGrp->GetASCII("StyleSheet", "").c_str());
+    QString currentStyleSheet = QString::fromStdString(hGrp->getString("StyleSheet", ""));
     QFileInfo fi(currentStyleSheet);
     currentStyleSheet = fi.baseName();
     QString themeClassic = QStringLiteral("classic");  // handle the upcoming name change
@@ -478,12 +479,12 @@ void DlgSettingsGeneral::loadThemes()
     if (currentTheme.isEmpty()) {
         if (!currentStyleSheet.isEmpty() && !similarTheme.isEmpty()) {  // a user upgrading from
                                                                         // 0.21 or earlier
-            hGrp->SetASCII("Theme", similarTheme.toStdString());
-            currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+            hGrp->setString("Theme", similarTheme.toStdString());
+            currentTheme = QString::fromStdString(hGrp->getString("Theme", ""));
         }
         else {  // a brand new user
-            hGrp->SetASCII("Theme", themeClassic.toStdString());
-            currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+            hGrp->setString("Theme", themeClassic.toStdString());
+            currentTheme = QString::fromStdString(hGrp->getString("Theme", ""));
         }
     }
 

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -174,11 +174,12 @@ bool DlgSettingsGeneral::setLanguage()
 {
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
     QString lang = QLocale::languageToString(QLocale().language());
-    QByteArray language = hGrp->GetASCII("Language", (const char*)lang.toLatin1()).c_str();
-    QByteArray current = ui->Languages->itemData(ui->Languages->currentIndex()).toByteArray();
+    const auto language = hGrp->getString("Language", lang.toStdString());
+    const auto current
+        = ui->Languages->itemData(ui->Languages->currentIndex()).toByteArray().toStdString();
     if (current != language) {
-        hGrp->SetASCII("Language", current.constData());
-        Translator::instance()->activateLanguage(current.constData());
+        hGrp->setString("Language", current);
+        Translator::instance()->activateLanguage(std::move(language));
         return true;
     }
     return false;
@@ -311,7 +312,7 @@ void DlgSettingsGeneral::loadSettings()
     // search for the language files
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
     auto langToStr = Translator::instance()->activeLanguage();
-    QByteArray language = hGrp->GetASCII("Language", langToStr.c_str()).c_str();
+    auto language = QByteArray::fromStdString(hGrp->getString("Language", langToStr));
 
     localeIndex = ui->UseLocaleFormatting->currentIndex();
 
@@ -379,7 +380,7 @@ void DlgSettingsGeneral::resetSettingsToDefaults()
         "User parameter:BaseApp/Preferences/MainWindow"
     );
     // reset "Theme" parameter
-    hGrp->RemoveASCII("Theme");
+    hGrp->removeString("Theme");
     // reset "TiledBackground" parameter
     hGrp->RemoveBool("TiledBackground");
 
@@ -396,7 +397,7 @@ void DlgSettingsGeneral::resetSettingsToDefaults()
 
     hGrp = WindowParameter::getDefaultParameter()->GetGroup("General");
     // reset "Language" parameter
-    hGrp->RemoveASCII("Language");
+    hGrp->removeString("Language");
     // reset "ToolbarIconSize" parameter
     hGrp->RemoveInt("ToolbarIconSize");
 
@@ -411,7 +412,7 @@ void DlgSettingsGeneral::saveThemes()
     );
 
     // First we check if the theme has actually changed.
-    std::string previousTheme = hGrp->GetASCII("Theme", "").c_str();
+    std::string previousTheme = hGrp->getString("Theme", "");
     std::string newTheme = ui->themesCombobox->currentText().toStdString();
 
     if (previousTheme == newTheme) {
@@ -420,7 +421,7 @@ void DlgSettingsGeneral::saveThemes()
     }
 
     // Save the name of the theme
-    hGrp->SetASCII("Theme", newTheme);
+    hGrp->setString("Theme", newTheme);
 
     // Then we apply the themepack.
     Application::Instance->prefPackManager()->rescan();
@@ -450,11 +451,11 @@ void DlgSettingsGeneral::loadThemes()
         "User parameter:BaseApp/Preferences/MainWindow"
     );
 
-    QString currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+    QString currentTheme = QString::fromStdString(hGrp->getString("Theme", ""));
 
     Application::Instance->prefPackManager()->rescan();
     auto packs = Application::Instance->prefPackManager()->preferencePacks();
-    QString currentStyleSheet = QString::fromLatin1(hGrp->GetASCII("StyleSheet", "").c_str());
+    QString currentStyleSheet = QString::fromStdString(hGrp->getString("StyleSheet", ""));
     QFileInfo fi(currentStyleSheet);
     currentStyleSheet = fi.baseName();
     QString themeClassic = QStringLiteral("classic");  // handle the upcoming name change
@@ -476,12 +477,12 @@ void DlgSettingsGeneral::loadThemes()
     if (currentTheme.isEmpty()) {
         if (!currentStyleSheet.isEmpty() && !similarTheme.isEmpty()) {  // a user upgrading from
                                                                         // 0.21 or earlier
-            hGrp->SetASCII("Theme", similarTheme.toStdString());
-            currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+            hGrp->setString("Theme", similarTheme.toStdString());
+            currentTheme = QString::fromStdString(hGrp->getString("Theme", ""));
         }
         else {  // a brand new user
-            hGrp->SetASCII("Theme", themeClassic.toStdString());
-            currentTheme = QString::fromLatin1(hGrp->GetASCII("Theme", "").c_str());
+            hGrp->setString("Theme", themeClassic.toStdString());
+            currentTheme = QString::fromStdString(hGrp->getString("Theme", ""));
         }
     }
 

--- a/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsLightSources.cpp
@@ -287,7 +287,7 @@ void DlgSettingsLightSources::saveSettings()
     const auto saveAngles = [this](
                                 QuantitySpinBox* horizontalAngleSpinBox,
                                 QuantitySpinBox* verticalAngleSpinBox,
-                                const char* parameter
+                                std::string_view parameter
                             ) {
         try {
             const auto direction = azimuthElevationToDirection(
@@ -295,7 +295,7 @@ void DlgSettingsLightSources::saveSettings()
                 verticalAngleSpinBox->rawValue()
             );
 
-            hGrp->SetASCII(parameter, Base::vectorToString(Base::convertTo<Base::Vector3f>(direction)));
+            hGrp->setString(parameter, Base::vectorToString(Base::convertTo<Base::Vector3f>(direction)));
         }
         catch (...) {
         }
@@ -317,10 +317,10 @@ void DlgSettingsLightSources::loadSettings()
     const auto loadAngles = [this](
                                 QuantitySpinBox* horizontalAngleSpinBox,
                                 QuantitySpinBox* verticalAngleSpinBox,
-                                const char* parameter
+                                std::string_view parameter
                             ) {
         try {
-            const auto direction = Base::stringToVector(hGrp->GetASCII(parameter));
+            const auto direction = Base::stringToVector(hGrp->getString(parameter));
             const auto [azimuth, elevation] = directionToAzimuthElevation(
                 Base::convertTo<Base::Vector3d>(direction)
             );
@@ -341,9 +341,9 @@ void DlgSettingsLightSources::resetSettingsToDefaults()
 {
     PreferencePage::resetSettingsToDefaults();
 
-    hGrp->RemoveASCII("HeadlightDirection");
-    hGrp->RemoveASCII("BacklightDirection");
-    hGrp->RemoveASCII("FillLightDirection");
+    hGrp->removeString("HeadlightDirection");
+    hGrp->removeString("BacklightDirection");
+    hGrp->removeString("FillLightDirection");
 
     loadSettings();
     configureViewer();

--- a/src/Gui/PreferencePages/DlgSettingsMacroImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsMacroImp.cpp
@@ -81,7 +81,7 @@ void DlgSettingsMacroImp::saveSettings()
     ui->MacroPath_2->onSave();
     ui->RecentMacros->onSave();
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("RecentMacros");
-    hGrp->SetASCII("ShortcutModifiers", qPrintable(ui->ShortcutModifiers->text()));
+    hGrp->setString("ShortcutModifiers", ui->ShortcutModifiers->text().toStdString());
     ui->ShortcutCount->onSave();
     setRecentMacroSize();
 }
@@ -98,7 +98,7 @@ void DlgSettingsMacroImp::loadSettings()
     ui->RecentMacros->onRestore();
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("RecentMacros");
     ui->ShortcutModifiers->setText(
-        QString::fromStdString(hGrp->GetASCII("ShortcutModifiers", "Ctrl+Shift+"))
+        QString::fromStdString(hGrp->getString("ShortcutModifiers", "Ctrl+Shift+"))
     );
     ui->ShortcutCount->onRestore();
 }
@@ -108,7 +108,7 @@ void DlgSettingsMacroImp::resetSettingsToDefaults()
     ParameterGrp::handle hGrp;
     hGrp = WindowParameter::getDefaultParameter()->GetGroup("RecentMacros");
     // reset "ShortcutModifiers" parameter
-    hGrp->RemoveASCII("ShortcutModifiers");
+    hGrp->removeString("ShortcutModifiers");
 
     // finally reset all the parameters associated to Gui::Pref* widgets
     PreferencePage::resetSettingsToDefaults();

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -92,7 +92,7 @@ void DlgSettingsNavigation::saveSettings()
     );
     QVariant data
         = ui->comboNavigationStyle->itemData(ui->comboNavigationStyle->currentIndex(), Qt::UserRole);
-    hGrp->SetASCII("NavigationStyle", (const char*)data.toByteArray());
+    hGrp->setString("NavigationStyle", data.toByteArray().toStdString());
 
     int orbitStyle = ui->comboOrbitStyle->currentData().toInt();
     hGrp->SetInt("OrbitStyle", orbitStyle);
@@ -131,7 +131,7 @@ void DlgSettingsNavigation::saveSettings()
     hGrp->SetBool("UseNavigationAnimations", useNavigationAnimations);
 
     QVariant camera = ui->comboNewDocView->itemData(ui->comboNewDocView->currentIndex(), Qt::UserRole);
-    hGrp->SetASCII("NewDocumentCameraOrientation", (const char*)camera.toByteArray());
+    hGrp->setString("NewDocumentCameraOrientation", camera.toByteArray().toStdString());
     if (camera == QByteArray("Custom")) {
         ParameterGrp::handle hCustom = hGrp->GetGroup("Custom");
         hCustom->SetFloat("Q0", q0);
@@ -141,10 +141,10 @@ void DlgSettingsNavigation::saveSettings()
     }
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/NaviCube");
     if (ui->naviCubeFontName->currentIndex()) {
-        hGrp->SetASCII("FontString", ui->naviCubeFontName->currentText().toLatin1());
+        hGrp->setString("FontString", ui->naviCubeFontName->currentText().toStdString());
     }
     else {
-        hGrp->RemoveASCII("FontString");
+        hGrp->removeString("FontString");
     }
 }
 
@@ -173,10 +173,8 @@ void DlgSettingsNavigation::loadSettings()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    std::string model = hGrp->GetASCII(
-        "NavigationStyle",
-        std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
-    );
+    std::string model
+        = hGrp->getString("NavigationStyle", CADNavigationStyle::getClassTypeId().getName());
     int index = ui->comboNavigationStyle->findData(QByteArray(model.c_str()));
     if (index > -1) {
         ui->comboNavigationStyle->setCurrentIndex(index);
@@ -217,7 +215,7 @@ void DlgSettingsNavigation::loadSettings()
     ui->naviCubeFontName->setProperty("doNotSearch", true);
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/NaviCube");
-    int indexFamilyNames = familyNames.indexOf(QString::fromStdString(hGrp->GetASCII("FontString")));
+    int indexFamilyNames = familyNames.indexOf(QString::fromStdString(hGrp->getString("FontString")));
     ui->naviCubeFontName->setCurrentIndex(indexFamilyNames + 1);
 }
 
@@ -237,8 +235,8 @@ void DlgSettingsNavigation::addOrientations()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    std::string camera = hGrp->GetASCII("NewDocumentCameraOrientation", "Trimetric");
-    int index = ui->comboNewDocView->findData(QByteArray(camera.c_str()));
+    std::string camera = hGrp->getString("NewDocumentCameraOrientation", "Trimetric");
+    int index = ui->comboNewDocView->findData(QByteArray::fromStdString(camera));
     if (index > -1) {
         ui->comboNewDocView->setCurrentIndex(index);
     }
@@ -277,7 +275,7 @@ void DlgSettingsNavigation::resetSettingsToDefaults()
     ParameterGrp::handle hGrp;
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
     // reset "NavigationStyle" parameter
-    hGrp->RemoveASCII("NavigationStyle");
+    hGrp->removeString("NavigationStyle");
     // reset "OrbitStyle" parameter
     hGrp->RemoveInt("OrbitStyle");
     // reset "RotationMode" parameter
@@ -289,7 +287,7 @@ void DlgSettingsNavigation::resetSettingsToDefaults()
     // reset "UseNavigationAnimations" parameter
     hGrp->RemoveBool("UseNavigationAnimations");
     // reset "NewDocumentCameraOrientation" parameter
-    hGrp->RemoveASCII("NewDocumentCameraOrientation");
+    hGrp->removeString("NewDocumentCameraOrientation");
 
     hGrp = hGrp->GetGroup("Custom");
     // reset "Q0" parameter

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -87,7 +87,7 @@ void DlgSettingsNavigation::saveSettings()
     );
     QVariant data
         = ui->comboNavigationStyle->itemData(ui->comboNavigationStyle->currentIndex(), Qt::UserRole);
-    hGrp->SetASCII("NavigationStyle", (const char*)data.toByteArray());
+    hGrp->setString("NavigationStyle", data.toByteArray().toStdString());
 
     int index = ui->comboOrbitStyle->currentIndex();
     hGrp->SetInt("OrbitStyle", index);
@@ -126,7 +126,7 @@ void DlgSettingsNavigation::saveSettings()
     hGrp->SetBool("UseNavigationAnimations", useNavigationAnimations);
 
     QVariant camera = ui->comboNewDocView->itemData(ui->comboNewDocView->currentIndex(), Qt::UserRole);
-    hGrp->SetASCII("NewDocumentCameraOrientation", (const char*)camera.toByteArray());
+    hGrp->setString("NewDocumentCameraOrientation", camera.toByteArray().toStdString());
     if (camera == QByteArray("Custom")) {
         ParameterGrp::handle hCustom = hGrp->GetGroup("Custom");
         hCustom->SetFloat("Q0", q0);
@@ -136,10 +136,10 @@ void DlgSettingsNavigation::saveSettings()
     }
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/NaviCube");
     if (ui->naviCubeFontName->currentIndex()) {
-        hGrp->SetASCII("FontString", ui->naviCubeFontName->currentText().toLatin1());
+        hGrp->setString("FontString", ui->naviCubeFontName->currentText().toStdString());
     }
     else {
-        hGrp->RemoveASCII("FontString");
+        hGrp->removeString("FontString");
     }
 }
 
@@ -168,10 +168,8 @@ void DlgSettingsNavigation::loadSettings()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    std::string model = hGrp->GetASCII(
-        "NavigationStyle",
-        std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
-    );
+    std::string model
+        = hGrp->getString("NavigationStyle", CADNavigationStyle::getClassTypeId().getName());
     int index = ui->comboNavigationStyle->findData(QByteArray(model.c_str()));
     if (index > -1) {
         ui->comboNavigationStyle->setCurrentIndex(index);
@@ -212,7 +210,7 @@ void DlgSettingsNavigation::loadSettings()
     ui->naviCubeFontName->setProperty("doNotSearch", true);
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/NaviCube");
-    int indexFamilyNames = familyNames.indexOf(QString::fromStdString(hGrp->GetASCII("FontString")));
+    int indexFamilyNames = familyNames.indexOf(QString::fromStdString(hGrp->getString("FontString")));
     ui->naviCubeFontName->setCurrentIndex(indexFamilyNames + 1);
 }
 
@@ -232,8 +230,8 @@ void DlgSettingsNavigation::addOrientations()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    std::string camera = hGrp->GetASCII("NewDocumentCameraOrientation", "Trimetric");
-    int index = ui->comboNewDocView->findData(QByteArray(camera.c_str()));
+    std::string camera = hGrp->getString("NewDocumentCameraOrientation", "Trimetric");
+    int index = ui->comboNewDocView->findData(QByteArray::fromStdString(camera));
     if (index > -1) {
         ui->comboNewDocView->setCurrentIndex(index);
     }
@@ -272,7 +270,7 @@ void DlgSettingsNavigation::resetSettingsToDefaults()
     ParameterGrp::handle hGrp;
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
     // reset "NavigationStyle" parameter
-    hGrp->RemoveASCII("NavigationStyle");
+    hGrp->removeString("NavigationStyle");
     // reset "OrbitStyle" parameter
     hGrp->RemoveInt("OrbitStyle");
     // reset "RotationMode" parameter
@@ -284,7 +282,7 @@ void DlgSettingsNavigation::resetSettingsToDefaults()
     // reset "UseNavigationAnimations" parameter
     hGrp->RemoveBool("UseNavigationAnimations");
     // reset "NewDocumentCameraOrientation" parameter
-    hGrp->RemoveASCII("NewDocumentCameraOrientation");
+    hGrp->removeString("NewDocumentCameraOrientation");
 
     hGrp = hGrp->GetGroup("Custom");
     // reset "Q0" parameter

--- a/src/Gui/PreferencePages/DlgSettingsUI.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsUI.cpp
@@ -166,7 +166,10 @@ void DlgSettingsUI::populateStylesheets(
         combo->addItem(it.key(), it.value());
     }
 
-    QString selectedStyleSheet = QString::fromUtf8(hGrp->GetASCII(key).c_str());
+    // TODO: make populateStylesheets take string_views and remove the conversion
+    QString selectedStyleSheet = QString::fromStdString(
+        hGrp->getString(std::string_view {key ? key : ""})
+    );
     int index = combo->findData(selectedStyleSheet);
 
     // might be an absolute path name

--- a/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsWorkbenchesImp.cpp
@@ -339,8 +339,8 @@ void DlgSettingsWorkbenchesImp::saveSettings()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Workbenches"
     );
-    hGrp->SetASCII("Ordered", orderedStr.str().c_str());
-    hGrp->SetASCII("Disabled", disabledStr.str().c_str());
+    hGrp->setString("Ordered", orderedStr.str());
+    hGrp->setString("Disabled", disabledStr.str());
 
     // Update the list of workbenches in the WorkbenchGroup and in the WorkbenchComboBox & workbench
     // QMenu
@@ -348,7 +348,7 @@ void DlgSettingsWorkbenchesImp::saveSettings()
 
     App::GetApplication()
         .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-        ->SetASCII("BackgroundAutoloadModules", autoloadStr.str().c_str());
+        ->setString("BackgroundAutoloadModules", autoloadStr.str());
 
     saveWorkbenchSelector();
 
@@ -357,7 +357,7 @@ void DlgSettingsWorkbenchesImp::saveSettings()
     QString startWbName = data.toString();
     App::GetApplication()
         .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-        ->SetASCII("AutoloadModule", startWbName.toLatin1());
+        ->setString("AutoloadModule", startWbName.toStdString());
 
     ui->CheckBox_WbByTab->onSave();
 }
@@ -371,12 +371,12 @@ void DlgSettingsWorkbenchesImp::loadSettings()
     std::string start = App::Application::Config()["StartWorkbench"];
     _startupModule = App::GetApplication()
                          .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                         ->GetASCII("AutoloadModule", start.c_str());
+                         ->getString("AutoloadModule", start);
 
     // The second autoload setting does a background autoload of any number of other modules
     std::string autoloadCSV = App::GetApplication()
                                   .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                                  ->GetASCII("BackgroundAutoloadModules", "");
+                                  ->getString("BackgroundAutoloadModules", "");
 
     // Tokenize the comma-separated list
     _backgroundAutoloadedModules.clear();
@@ -403,19 +403,19 @@ void DlgSettingsWorkbenchesImp::resetSettingsToDefaults()
     hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Workbenches"
     );
-    hGrp->RemoveASCII("Ordered");
-    hGrp->RemoveASCII("Disabled");
-    hGrp->RemoveASCII("WorkbenchSelectorType");
-    hGrp->RemoveASCII("WorkbenchSelectorItem");
+    hGrp->removeString("Ordered");
+    hGrp->removeString("Disabled");
+    hGrp->removeString("WorkbenchSelectorType");
+    hGrp->removeString("WorkbenchSelectorItem");
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General");
-    hGrp->RemoveASCII("BackgroundAutoloadModules");
-    hGrp->RemoveASCII("AutoloadModule");
+    hGrp->removeString("BackgroundAutoloadModules");
+    hGrp->removeString("AutoloadModule");
 
     hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow"
     );
-    hGrp->RemoveASCII("WSPosition");
+    hGrp->removeString("WSPosition");
 
     // finally reset all the parameters associated to Gui::Pref* widgets
     PreferencePage::resetSettingsToDefaults();
@@ -475,7 +475,7 @@ QStringList DlgSettingsWorkbenchesImp::getEnabledWorkbenches()
     hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Workbenches"
     );
-    wbs_ordered = QString::fromStdString(hGrp->GetASCII("Ordered", ""));
+    wbs_ordered = QString::fromStdString(hGrp->getString("Ordered", ""));
 
     wbs_ordered_list = wbs_ordered.split(QLatin1String(","), Qt::SkipEmptyParts);
 
@@ -516,7 +516,7 @@ QStringList DlgSettingsWorkbenchesImp::getDisabledWorkbenches()
     hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Workbenches"
     );
-    disabled_wbs = QString::fromStdString(hGrp->GetASCII(
+    disabled_wbs = QString::fromStdString(hGrp->getString(
         "Disabled",
         "NoneWorkbench,TestWorkbench,InspectionWorkbench,RobotWorkbench,OpenSCADWorkbench"
     ));
@@ -725,7 +725,7 @@ void DlgSettingsWorkbenchesImp::sortEnabledWorkbenches()
     hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Workbenches"
     );
-    hGrp->SetASCII("Ordered", "");
+    hGrp->setString("Ordered", "");
 
     buildWorkbenchList();
 }

--- a/src/Gui/ProgramInformation.cpp
+++ b/src/Gui/ProgramInformation.cpp
@@ -43,12 +43,12 @@ void ProgramInformation::getStyleInformation(std::stringstream& str)
     );
 
     // Add Stylesheet/Theme/Qtstyle information
-    std::string styleSheet = hGrp->GetASCII("StyleSheet");
-    std::string theme = hGrp->GetASCII("Theme");
+    std::string styleSheet = hGrp->getString("StyleSheet");
+    std::string theme = hGrp->getString("Theme");
 #if QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)
     std::string style = qApp->style()->name().toStdString();
 #else
-    std::string style = hGrp->GetASCII("QtStyle");
+    std::string style = hGrp->getString("QtStyle");
     if (style.empty()) {
         style = "Qt default";
     }
@@ -69,7 +69,7 @@ void ProgramInformation::getNavigationStyleInformation(std::stringstream& str)
         "User parameter:BaseApp/Preferences/View"
     );
 
-    const std::string navStyle = hGrp->GetASCII("NavigationStyle", "Gui::CADNavigationStyle");
+    const std::string navStyle = hGrp->getString("NavigationStyle", "Gui::CADNavigationStyle");
     constexpr auto orbitStyle = std::to_array<std::string_view>(
         {"Turntable", "Trackball", "Free Turntable", "Trackball Classic", "Rounded Arcball"}
     );

--- a/src/Gui/PythonConsole.cpp
+++ b/src/Gui/PythonConsole.cpp
@@ -1403,11 +1403,11 @@ void PythonConsole::onClearConsole()
 
 void PythonConsole::onSaveHistoryAs()
 {
-    QString cMacroPath = QString::fromUtf8(
-        getDefaultParameter()
-            ->GetGroup("Macro")
-            ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str())
-            .c_str()
+    QString cMacroPath = QString::fromStdString(
+        getDefaultParameter()->GetGroup("Macro")->getString(
+            "MacroPath",
+            App::Application::getUserMacroDir()
+        )
     );
     QString fn = FileDialog::getSaveFileName(
         this,

--- a/src/Gui/ReportView.cpp
+++ b/src/Gui/ReportView.cpp
@@ -484,7 +484,7 @@ void ReportOutput::restoreFont()
         "User parameter:BaseApp/Preferences/Editor"
     );
     int fontSize = hPrefGrp->GetInt("FontSize", 10);
-    auto serifFont = hPrefGrp->GetASCII("Font");
+    auto serifFont = hPrefGrp->getString("Font");
     if (serifFont.empty()) {
         font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
         font.setPointSize(fontSize);
@@ -921,7 +921,7 @@ void ReportOutput::OnChange(Base::Subject<const char*>& rCaller, const char* sRe
     else if (strcmp(sReason, "FontSize") == 0 || strcmp(sReason, "Font") == 0) {
         int fontSize = rclGrp.GetInt("FontSize", 10);
         QFont font;
-        auto fontName = rclGrp.GetASCII("Font");
+        auto fontName = rclGrp.getString("Font");
         if (fontName.empty()) {
             font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
             font.setPointSize(fontSize);

--- a/src/Gui/ShortcutManager.cpp
+++ b/src/Gui/ShortcutManager.cpp
@@ -132,7 +132,8 @@ void ShortcutManager::reset(const char* cmd)
 {
     if (!Base::Tools::isNullOrEmpty(cmd)) {
         QKeySequence oldShortcut = getShortcut(cmd);
-        hShortcuts->RemoveASCII(cmd);
+        // TODO: make reset take a string_view and remove the conversion
+        hShortcuts->removeString(std::string_view {cmd});
         if (oldShortcut != getShortcut(cmd)) {
             shortcutChanged(cmd, oldShortcut);
         }
@@ -167,6 +168,7 @@ void ShortcutManager::resetAll()
 
 QString ShortcutManager::getShortcut(const char* cmdName, const char* accel)
 {
+    // TODO: make getShortcut take string_views and remove the conversions
     if (!accel) {
         if (auto cmd = Application::Instance->commandManager().getCommandByName(cmdName)) {
             accel = cmd->getAccel();
@@ -177,7 +179,9 @@ QString ShortcutManager::getShortcut(const char* cmdName, const char* accel)
     }
     QString shortcut;
     if (cmdName) {
-        shortcut = QString::fromLatin1(hShortcuts->GetASCII(cmdName, accel).c_str());
+        shortcut = QString::fromStdString(
+            hShortcuts->getString(std::string_view {cmdName}, std::string_view {accel ? accel : ""})
+        );
     }
     else {
         shortcut = QString::fromLatin1(accel);
@@ -187,6 +191,7 @@ QString ShortcutManager::getShortcut(const char* cmdName, const char* accel)
 
 void ShortcutManager::setShortcut(const char* cmdName, const char* accel)
 {
+    // TODO: make setShortcut take string_views and remove the conversions
     if (!Base::Tools::isNullOrEmpty(cmdName)) {
         setTopPriority(cmdName);
         if (!accel) {
@@ -199,11 +204,11 @@ void ShortcutManager::setShortcut(const char* cmdName, const char* accel)
             }
             if (QKeySequence(QString::fromLatin1(accel))
                 == QKeySequence(QString::fromLatin1(defaultAccel))) {
-                hShortcuts->RemoveASCII(cmdName);
+                hShortcuts->removeString(std::string_view {cmdName});
                 return;
             }
         }
-        hShortcuts->SetASCII(cmdName, accel);
+        hShortcuts->setString(std::string_view {cmdName}, std::string_view {accel ? accel : ""});
     }
 }
 

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -159,8 +159,8 @@ void StartupProcess::setImagePaths()
 {
     // set search paths for images
     QStringList imagePaths;
-    imagePaths << QString::fromUtf8((App::Application::getUserAppDataDir() + "Gui/images").c_str())
-               << QString::fromUtf8((App::Application::getUserAppDataDir() + "pixmaps").c_str())
+    imagePaths << QString::fromStdString(App::Application::getUserAppDataDir() + "Gui/images")
+               << QString::fromStdString(App::Application::getUserAppDataDir() + "pixmaps")
                << QLatin1String(":/icons");
     QDir::setSearchPaths(QStringLiteral("images"), imagePaths);
 }
@@ -181,16 +181,16 @@ void StartupProcess::setThemePaths()
         "User parameter:BaseApp/Preferences/Bitmaps/Theme"
     );
 
-    std::string searchpath = hTheme->GetASCII("SearchPath");
+    std::string searchpath = hTheme->getString("SearchPath");
     if (!searchpath.empty()) {
         QStringList searchPaths = QIcon::themeSearchPaths();
-        searchPaths.prepend(QString::fromUtf8(searchpath.c_str()));
+        searchPaths.prepend(QString::fromStdString(searchpath));
         QIcon::setThemeSearchPaths(searchPaths);
     }
 
-    std::string name = hTheme->GetASCII("Name");
+    std::string name = hTheme->getString("Name");
     if (!name.empty()) {
-        QIcon::setThemeName(QString::fromLatin1(name.c_str()));
+        QIcon::setThemeName(QString::fromStdString(name));
     }
 }
 
@@ -320,7 +320,7 @@ void StartupPostProcess::setQtStyle()
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("MainWindow");
 
     const auto setStyleFromParameters = [hGrp]() {
-        const auto style = hGrp->GetASCII("QtStyle");
+        const auto style = hGrp->getString("QtStyle");
 
         Application::Instance->setStyle(QString::fromStdString(style));
     };
@@ -479,14 +479,14 @@ void StartupPostProcess::activateWorkbench()
 {
     // Activate the correct workbench
     std::string start = App::Application::Config()["StartWorkbench"];
-    Base::Console().log("Init: Activating default workbench %s\n", start.c_str());
+    Base::Console().log("Init: Activating default workbench %s\n", start);
     std::string autoload = App::GetApplication()
                                .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                               ->GetASCII("AutoloadModule", start.c_str());
+                               ->getString("AutoloadModule", start);
     if ("$LastModule" == autoload) {
         start = App::GetApplication()
                     .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                    ->GetASCII("LastModule", start.c_str());
+                    ->getString("LastModule", start);
     }
     else {
         start = autoload;
@@ -494,17 +494,17 @@ void StartupPostProcess::activateWorkbench()
     // if the auto workbench is not visible then force to use the default workbech
     // and replace the wrong entry in the parameters
     QStringList wb = guiApp.workbenches();
-    if (!wb.contains(QString::fromLatin1(start.c_str()))) {
+    if (!wb.contains(QString::fromStdString(start))) {
         start = App::Application::Config()["StartWorkbench"];
         if ("$LastModule" == autoload) {
             App::GetApplication()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                ->SetASCII("LastModule", start.c_str());
+                ->setString("LastModule", start);
         }
         else {
             App::GetApplication()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                ->SetASCII("AutoloadModule", start.c_str());
+                ->setString("AutoloadModule", start);
         }
     }
 
@@ -532,7 +532,7 @@ void StartupPostProcess::setStyleSheet()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow"
     );
-    std::string style = hGrp->GetASCII("StyleSheet");
+    std::string style = hGrp->getString("StyleSheet");
     if (style.empty()) {
         // check the branding settings
         const auto& config = App::Application::Config();
@@ -555,7 +555,7 @@ void StartupPostProcess::autoloadModules(const QStringList& wb)
     // displayed to the user immediately
     std::string autoloadCSV = App::GetApplication()
                                   .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                                  ->GetASCII("BackgroundAutoloadModules", "");
+                                  ->getString("BackgroundAutoloadModules", "");
 
     // Tokenize the comma-separated list and load the requested workbenches if they exist in this
     // installation
@@ -605,7 +605,7 @@ void StartupPostProcess::checkParameters()
             && (newDefaultPath.parent_path().filename() == versionString)) {
             std::filesystem::path oldDefaultPath {newDefaultPath.parent_path().parent_path() / "Macro"};
             std::filesystem::path macroDir
-                = macroPrefs->GetASCII("MacroPath", newDefaultPath.string().c_str());
+                = macroPrefs->getString("MacroPath", newDefaultPath.string());
             if (macroDir.filename().empty()) {
                 macroDir = macroDir.parent_path();
             }
@@ -613,7 +613,7 @@ void StartupPostProcess::checkParameters()
                 Base::Console().warning(
                     "Removing 'MacroPath' parameter in order to default to the new versioned path\n"
                 );
-                macroPrefs->RemoveASCII("MacroPath");
+                macroPrefs->removeString("MacroPath");
             }
         }
         macroPrefs->SetBool("MacroPathCheckedForMigrationTov1-1", true);

--- a/src/Gui/StartupProcess.cpp
+++ b/src/Gui/StartupProcess.cpp
@@ -159,8 +159,8 @@ void StartupProcess::setImagePaths()
 {
     // set search paths for images
     QStringList imagePaths;
-    imagePaths << QString::fromUtf8((App::Application::getUserAppDataDir() + "Gui/images").c_str())
-               << QString::fromUtf8((App::Application::getUserAppDataDir() + "pixmaps").c_str())
+    imagePaths << QString::fromStdString(App::Application::getUserAppDataDir() + "Gui/images")
+               << QString::fromStdString(App::Application::getUserAppDataDir() + "pixmaps")
                << QLatin1String(":/icons");
     QDir::setSearchPaths(QStringLiteral("images"), imagePaths);
 }
@@ -181,16 +181,16 @@ void StartupProcess::setThemePaths()
         "User parameter:BaseApp/Preferences/Bitmaps/Theme"
     );
 
-    std::string searchpath = hTheme->GetASCII("SearchPath");
+    std::string searchpath = hTheme->getString("SearchPath");
     if (!searchpath.empty()) {
         QStringList searchPaths = QIcon::themeSearchPaths();
-        searchPaths.prepend(QString::fromUtf8(searchpath.c_str()));
+        searchPaths.prepend(QString::fromStdString(searchpath));
         QIcon::setThemeSearchPaths(searchPaths);
     }
 
-    std::string name = hTheme->GetASCII("Name");
+    std::string name = hTheme->getString("Name");
     if (!name.empty()) {
-        QIcon::setThemeName(QString::fromLatin1(name.c_str()));
+        QIcon::setThemeName(QString::fromStdString(name));
     }
 }
 
@@ -318,7 +318,7 @@ void StartupPostProcess::setQtStyle()
     ParameterGrp::handle hGrp = WindowParameter::getDefaultParameter()->GetGroup("MainWindow");
 
     const auto setStyleFromParameters = [hGrp]() {
-        const auto style = hGrp->GetASCII("QtStyle");
+        const auto style = hGrp->getString("QtStyle");
 
         Application::Instance->setStyle(QString::fromStdString(style));
     };
@@ -477,14 +477,14 @@ void StartupPostProcess::activateWorkbench()
 {
     // Activate the correct workbench
     std::string start = App::Application::Config()["StartWorkbench"];
-    Base::Console().log("Init: Activating default workbench %s\n", start.c_str());
+    Base::Console().log("Init: Activating default workbench %s\n", start);
     std::string autoload = App::GetApplication()
                                .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                               ->GetASCII("AutoloadModule", start.c_str());
+                               ->getString("AutoloadModule", start);
     if ("$LastModule" == autoload) {
         start = App::GetApplication()
                     .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                    ->GetASCII("LastModule", start.c_str());
+                    ->getString("LastModule", start);
     }
     else {
         start = autoload;
@@ -492,17 +492,17 @@ void StartupPostProcess::activateWorkbench()
     // if the auto workbench is not visible then force to use the default workbech
     // and replace the wrong entry in the parameters
     QStringList wb = guiApp.workbenches();
-    if (!wb.contains(QString::fromLatin1(start.c_str()))) {
+    if (!wb.contains(QString::fromStdString(start))) {
         start = App::Application::Config()["StartWorkbench"];
         if ("$LastModule" == autoload) {
             App::GetApplication()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                ->SetASCII("LastModule", start.c_str());
+                ->setString("LastModule", start);
         }
         else {
             App::GetApplication()
                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                ->SetASCII("AutoloadModule", start.c_str());
+                ->setString("AutoloadModule", start);
         }
     }
 
@@ -530,7 +530,7 @@ void StartupPostProcess::setStyleSheet()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow"
     );
-    std::string style = hGrp->GetASCII("StyleSheet");
+    std::string style = hGrp->getString("StyleSheet");
     if (style.empty()) {
         // check the branding settings
         const auto& config = App::Application::Config();
@@ -553,7 +553,7 @@ void StartupPostProcess::autoloadModules(const QStringList& wb)
     // displayed to the user immediately
     std::string autoloadCSV = App::GetApplication()
                                   .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                                  ->GetASCII("BackgroundAutoloadModules", "");
+                                  ->getString("BackgroundAutoloadModules", "");
 
     // Tokenize the comma-separated list and load the requested workbenches if they exist in this
     // installation
@@ -603,7 +603,7 @@ void StartupPostProcess::checkParameters()
             && (newDefaultPath.parent_path().filename() == versionString)) {
             std::filesystem::path oldDefaultPath {newDefaultPath.parent_path().parent_path() / "Macro"};
             std::filesystem::path macroDir
-                = macroPrefs->GetASCII("MacroPath", newDefaultPath.string().c_str());
+                = macroPrefs->getString("MacroPath", newDefaultPath.string());
             if (macroDir.filename().empty()) {
                 macroDir = macroDir.parent_path();
             }
@@ -611,7 +611,7 @@ void StartupPostProcess::checkParameters()
                 Base::Console().warning(
                     "Removing 'MacroPath' parameter in order to default to the new versioned path\n"
                 );
-                macroPrefs->RemoveASCII("MacroPath");
+                macroPrefs->removeString("MacroPath");
             }
         }
         macroPrefs->SetBool("MacroPathCheckedForMigrationTov1-1", true);

--- a/src/Gui/StyleParameters/ParameterManager.cpp
+++ b/src/Gui/StyleParameters/ParameterManager.cpp
@@ -181,7 +181,7 @@ std::list<Parameter> UserParameterSource::all() const
 {
     std::list<Parameter> result;
 
-    for (const auto& [token, value] : hGrp->GetASCIIMap()) {
+    for (const auto& [token, value] : hGrp->getAllStringsMap()) {
         result.push_back({
             .name = token,
             .value = value,
@@ -193,7 +193,7 @@ std::list<Parameter> UserParameterSource::all() const
 
 std::optional<Parameter> UserParameterSource::get(const std::string& name) const
 {
-    if (auto value = hGrp->GetASCII(name.c_str(), ""); !value.empty()) {
+    if (auto value = hGrp->getString(name, ""); !value.empty()) {
         return Parameter {
             .name = name,
             .value = value,
@@ -205,12 +205,12 @@ std::optional<Parameter> UserParameterSource::get(const std::string& name) const
 
 void UserParameterSource::define(const Parameter& parameter)
 {
-    hGrp->SetASCII(parameter.name.c_str(), parameter.value);
+    hGrp->setString(parameter.name, parameter.value);
 }
 
 void UserParameterSource::remove(const std::string& name)
 {
-    hGrp->RemoveASCII(name.c_str());
+    hGrp->removeString(name);
 }
 
 YamlParameterSource::YamlParameterSource(const std::string& filePath, const Metadata& metadata)

--- a/src/Gui/StyleParameters/ParameterManager.cpp
+++ b/src/Gui/StyleParameters/ParameterManager.cpp
@@ -219,7 +219,7 @@ std::list<Parameter> UserParameterSource::all() const
 {
     std::list<Parameter> result;
 
-    for (const auto& [token, value] : hGrp->GetASCIIMap()) {
+    for (const auto& [token, value] : hGrp->getAllStringsMap()) {
         result.push_back({
             .name = token,
             .value = value,
@@ -231,7 +231,7 @@ std::list<Parameter> UserParameterSource::all() const
 
 std::optional<Parameter> UserParameterSource::get(const std::string& name) const
 {
-    if (auto value = hGrp->GetASCII(name.c_str(), ""); !value.empty()) {
+    if (auto value = hGrp->getString(name, ""); !value.empty()) {
         return Parameter {
             .name = name,
             .value = value,
@@ -243,12 +243,12 @@ std::optional<Parameter> UserParameterSource::get(const std::string& name) const
 
 void UserParameterSource::define(const Parameter& parameter)
 {
-    hGrp->SetASCII(parameter.name.c_str(), parameter.value);
+    hGrp->setString(parameter.name, parameter.value);
 }
 
 void UserParameterSource::remove(const std::string& name)
 {
-    hGrp->RemoveASCII(name.c_str());
+    hGrp->removeString(name);
 }
 
 YamlParameterSource::YamlParameterSource(const std::string& filePath, const Metadata& metadata)

--- a/src/Gui/TextEdit.cpp
+++ b/src/Gui/TextEdit.cpp
@@ -511,7 +511,7 @@ void TextEditor::OnChange(Base::Subject<const char*>& rCaller, const char* sReas
         int fontSize = hPrefGrp->GetInt("FontSize", 10);
 #endif
         QFont font;
-        auto fontName = hPrefGrp->GetASCII("Font");
+        auto fontName = hPrefGrp->getString("Font");
         if (fontName.empty()) {
             font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
             font.setPointSize(fontSize);

--- a/src/Gui/TextEdit.cpp
+++ b/src/Gui/TextEdit.cpp
@@ -474,7 +474,7 @@ void TextEditor::OnChange(Base::Subject<const char*>& rCaller, const char* sReas
         int fontSize = hPrefGrp->GetInt("FontSize", 10);
 #endif
         QFont font;
-        auto fontName = hPrefGrp->GetASCII("Font");
+        auto fontName = hPrefGrp->getString("Font");
         if (fontName.empty()) {
             font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
             font.setPointSize(fontSize);

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -865,7 +865,7 @@ void View3DInventor::customEvent(QEvent* e)
             "User parameter:BaseApp/Preferences/View"
         );
         if (hGrp->GetBool("SameStyleForAllViews", true)) {
-            hGrp->SetASCII("NavigationStyle", std::string {se->style().getName()}.c_str());
+            hGrp->setString("NavigationStyle", se->style().getName());
         }
         else {
             _viewer->setNavigationType(se->style());

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -875,7 +875,7 @@ void View3DInventor::customEvent(QEvent* e)
             "User parameter:BaseApp/Preferences/View"
         );
         if (hGrp->GetBool("SameStyleForAllViews", true)) {
-            hGrp->SetASCII("NavigationStyle", std::string {se->style().getName()}.c_str());
+            hGrp->setString("NavigationStyle", se->style().getName());
         }
         else {
             _viewer->setNavigationType(se->style());

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2081,7 +2081,7 @@ void View3DInventorViewer::updateFPSLabel()
     ParameterGrp::handle hGrpOverlayL = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
     );
-    int xOffset = hGrpOverlayL->GetASCII("Widgets", "").empty() ? 10 : fpsCounter->width() + 20;
+    int xOffset = hGrpOverlayL->getString("Widgets").empty() ? 10 : fpsCounter->width() + 20;
     fpsCounter->move(xOffset, height() - fpsCounter->height() - 5);
 }
 
@@ -2440,7 +2440,7 @@ void View3DInventorViewer::savePicture(
     // Otherwise (Default) -- Qt's FBO used for offscreen rendering
     std::string saveMethod = App::GetApplication()
                                  .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
-                                 ->GetASCII("SavePicture");
+                                 ->getString("SavePicture");
 
     bool useFramebufferObject = false;
     bool useGrabFramebuffer = false;
@@ -2910,7 +2910,7 @@ GLenum View3DInventorViewer::getInternalTextureFormat()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    std::string format = hGrp->GetASCII("InternalTextureFormat", "Default");
+    std::string format = hGrp->getString("InternalTextureFormat", "Default");
 
     // NOLINTBEGIN
     if (format == "GL_RGB") {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -2082,7 +2082,7 @@ void View3DInventorViewer::updateFPSLabel()
     ParameterGrp::handle hGrpOverlayL = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/MainWindow/DockWindows/OverlayLeft"
     );
-    int xOffset = hGrpOverlayL->GetASCII("Widgets", "").empty() ? 10 : fpsCounter->width() + 20;
+    int xOffset = hGrpOverlayL->getString("Widgets").empty() ? 10 : fpsCounter->width() + 20;
     fpsCounter->move(xOffset, height() - fpsCounter->height() - 5);
 }
 
@@ -2441,7 +2441,7 @@ void View3DInventorViewer::savePicture(
     // Otherwise (Default) -- Qt's FBO used for offscreen rendering
     std::string saveMethod = App::GetApplication()
                                  .GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
-                                 ->GetASCII("SavePicture");
+                                 ->getString("SavePicture");
 
     bool useFramebufferObject = false;
     bool useGrabFramebuffer = false;
@@ -2911,7 +2911,7 @@ GLenum View3DInventorViewer::getInternalTextureFormat()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    std::string format = hGrp->GetASCII("InternalTextureFormat", "Default");
+    std::string format = hGrp->getString("InternalTextureFormat", "Default");
 
     // NOLINTBEGIN
     if (format == "GL_RGB") {

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -145,7 +145,7 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     }
     else if (strcmp(Reason, "HeadlightDirection") == 0) {
         try {
-            std::string pos = rGrp.GetASCII("HeadlightDirection", defaultHeadLightDirection);
+            std::string pos = rGrp.getString("HeadlightDirection", defaultHeadLightDirection);
             if (!pos.empty()) {
                 Base::Vector3f dir = Base::stringToVector(pos);
                 for (auto _viewer : _viewers) {
@@ -179,7 +179,7 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     }
     else if (strcmp(Reason, "BacklightDirection") == 0) {
         try {
-            std::string pos = rGrp.GetASCII("BacklightDirection", defaultBackLightDirection);
+            std::string pos = rGrp.getString("BacklightDirection", defaultBackLightDirection);
             if (!pos.empty()) {
                 Base::Vector3f dir = Base::stringToVector(pos);
                 for (auto _viewer : _viewers) {
@@ -214,7 +214,7 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     }
     else if (strcmp(Reason, "FillLightDirection") == 0) {
         try {
-            std::string pos = rGrp.GetASCII("FillLightDirection", defaultFillLightDirection);
+            std::string pos = rGrp.getString("FillLightDirection", defaultFillLightDirection);
             if (!pos.empty()) {
                 Base::Vector3f dir = Base::stringToVector(pos);
                 for (auto _viewer : _viewers) {
@@ -280,10 +280,8 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     else if (strcmp(Reason, "NavigationStyle") == 0) {
         if (!ignoreNavigationStyle) {
             // check whether the simple or the full mouse model is used
-            std::string model = rGrp.GetASCII(
-                "NavigationStyle",
-                std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
-            );
+            std::string model
+                = rGrp.getString("NavigationStyle", CADNavigationStyle::getClassTypeId().getName());
             Base::Type type = Base::Type::fromName(model.c_str());
             for (auto _viewer : _viewers) {
                 _viewer->setNavigationType(type);
@@ -623,7 +621,7 @@ void NaviCubeSettings::parameterChanged(const char* Name)
         nc->setFontZoom(hGrp->GetFloat("FontZoom", 0.3));
     }
     else if (strcmp(Name, "FontString") == 0) {
-        nc->setFont(hGrp->GetASCII("FontString"));
+        nc->setFont(hGrp->getString("FontString"));
     }
     else if (strcmp(Name, "FontWeight") == 0) {
         nc->setFontWeight(hGrp->GetInt("FontWeight", 0));
@@ -663,18 +661,12 @@ void NaviCubeSettings::parameterChanged(const char* Name)
         || strcmp(Name, "TextLeft") == 0 || strcmp(Name, "TextRight") == 0
     ) {
         std::vector<std::string> labels;
-        QByteArray frontByteArray = tr("FRONT").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextFront", frontByteArray.constData()));
-        QByteArray topByteArray = tr("TOP").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextTop", topByteArray.constData()));
-        QByteArray rightByteArray = tr("RIGHT").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextRight", rightByteArray.constData()));
-        QByteArray rearByteArray = tr("REAR").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextRear", rearByteArray.constData()));
-        QByteArray bottomByteArray = tr("BOTTOM").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextBottom", bottomByteArray.constData()));
-        QByteArray leftByteArray = tr("LEFT").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextLeft", leftByteArray.constData()));
+        labels.push_back(hGrp->getString("TextFront", tr("FRONT").toStdString()));
+        labels.push_back(hGrp->getString("TextTop", tr("TOP").toStdString()));
+        labels.push_back(hGrp->getString("TextRight", tr("RIGHT").toStdString()));
+        labels.push_back(hGrp->getString("TextRear", tr("REAR").toStdString()));
+        labels.push_back(hGrp->getString("TextBottom", tr("BOTTOM").toStdString()));
+        labels.push_back(hGrp->getString("TextLeft", tr("LEFT").toStdString()));
         nc->setNaviCubeLabels(labels);
     }
     _viewer->getSoRenderManager()->scheduleRedraw();

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -144,7 +144,7 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     }
     else if (strcmp(Reason, "HeadlightDirection") == 0) {
         try {
-            std::string pos = rGrp.GetASCII("HeadlightDirection", defaultHeadLightDirection);
+            std::string pos = rGrp.getString("HeadlightDirection", defaultHeadLightDirection);
             if (!pos.empty()) {
                 Base::Vector3f dir = Base::stringToVector(pos);
                 for (auto _viewer : _viewers) {
@@ -178,7 +178,7 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     }
     else if (strcmp(Reason, "BacklightDirection") == 0) {
         try {
-            std::string pos = rGrp.GetASCII("BacklightDirection", defaultBackLightDirection);
+            std::string pos = rGrp.getString("BacklightDirection", defaultBackLightDirection);
             if (!pos.empty()) {
                 Base::Vector3f dir = Base::stringToVector(pos);
                 for (auto _viewer : _viewers) {
@@ -213,7 +213,7 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     }
     else if (strcmp(Reason, "FillLightDirection") == 0) {
         try {
-            std::string pos = rGrp.GetASCII("FillLightDirection", defaultFillLightDirection);
+            std::string pos = rGrp.getString("FillLightDirection", defaultFillLightDirection);
             if (!pos.empty()) {
                 Base::Vector3f dir = Base::stringToVector(pos);
                 for (auto _viewer : _viewers) {
@@ -279,10 +279,8 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     else if (strcmp(Reason, "NavigationStyle") == 0) {
         if (!ignoreNavigationStyle) {
             // check whether the simple or the full mouse model is used
-            std::string model = rGrp.GetASCII(
-                "NavigationStyle",
-                std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
-            );
+            std::string model
+                = rGrp.getString("NavigationStyle", CADNavigationStyle::getClassTypeId().getName());
             Base::Type type = Base::Type::fromName(model.c_str());
             for (auto _viewer : _viewers) {
                 _viewer->setNavigationType(type);
@@ -617,7 +615,7 @@ void NaviCubeSettings::parameterChanged(const char* Name)
         nc->setFontZoom(hGrp->GetFloat("FontZoom", 0.3));
     }
     else if (strcmp(Name, "FontString") == 0) {
-        nc->setFont(hGrp->GetASCII("FontString"));
+        nc->setFont(hGrp->getString("FontString"));
     }
     else if (strcmp(Name, "FontWeight") == 0) {
         nc->setFontWeight(hGrp->GetInt("FontWeight", 0));
@@ -657,18 +655,12 @@ void NaviCubeSettings::parameterChanged(const char* Name)
         || strcmp(Name, "TextLeft") == 0 || strcmp(Name, "TextRight") == 0
     ) {
         std::vector<std::string> labels;
-        QByteArray frontByteArray = tr("FRONT").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextFront", frontByteArray.constData()));
-        QByteArray topByteArray = tr("TOP").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextTop", topByteArray.constData()));
-        QByteArray rightByteArray = tr("RIGHT").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextRight", rightByteArray.constData()));
-        QByteArray rearByteArray = tr("REAR").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextRear", rearByteArray.constData()));
-        QByteArray bottomByteArray = tr("BOTTOM").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextBottom", bottomByteArray.constData()));
-        QByteArray leftByteArray = tr("LEFT").toUtf8();
-        labels.push_back(hGrp->GetASCII("TextLeft", leftByteArray.constData()));
+        labels.push_back(hGrp->getString("TextFront", tr("FRONT").toStdString()));
+        labels.push_back(hGrp->getString("TextTop", tr("TOP").toStdString()));
+        labels.push_back(hGrp->getString("TextRight", tr("RIGHT").toStdString()));
+        labels.push_back(hGrp->getString("TextRear", tr("REAR").toStdString()));
+        labels.push_back(hGrp->getString("TextBottom", tr("BOTTOM").toStdString()));
+        labels.push_back(hGrp->getString("TextLeft", tr("LEFT").toStdString()));
         nc->setNaviCubeLabels(labels);
     }
     _viewer->getSoRenderManager()->scheduleRedraw();

--- a/src/Gui/View3DSettings.h
+++ b/src/Gui/View3DSettings.h
@@ -32,9 +32,12 @@ class View3DInventorViewer;
 class GuiExport View3DSettings: public ParameterGrp::ObserverType
 {
 public:
-    static constexpr auto defaultHeadLightDirection = "(0.6841049,-0.12062616,-0.7193398)";
-    static constexpr auto defaultFillLightDirection = "(-0.6403416,0.7631294,0.087155744)";
-    static constexpr auto defaultBackLightDirection = "(-0.7544065,-0.63302225,-0.17364818)";
+    static constexpr std::string_view defaultHeadLightDirection
+        = "(0.6841049,-0.12062616,-0.7193398)";
+    static constexpr std::string_view defaultFillLightDirection
+        = "(-0.6403416,0.7631294,0.087155744)";
+    static constexpr std::string_view defaultBackLightDirection
+        = "(-0.7544065,-0.63302225,-0.17364818)";
 
     View3DSettings(ParameterGrp::handle hGrp, View3DInventorViewer*);
     View3DSettings(ParameterGrp::handle hGrp, const std::vector<View3DInventorViewer*>&);

--- a/src/Gui/ViewProviderTextDocument.cpp
+++ b/src/Gui/ViewProviderTextDocument.cpp
@@ -56,14 +56,13 @@ ViewProviderTextDocument::ViewProviderTextDocument()
 
     QFont font;
     font.setFamily(
-        QString::fromLatin1(
+        QString::fromStdString(
             App::GetApplication()
                 .GetUserParameter()
                 .GetGroup("BaseApp")
                 ->GetGroup("Preferences")
                 ->GetGroup("Editor")
-                ->GetASCII("Font", font.family().toLatin1())
-                .c_str()
+                ->getString("Font", font.family().toStdString())
         )
     );
     font.setPointSize(

--- a/src/Gui/Widgets.cpp
+++ b/src/Gui/Widgets.cpp
@@ -1005,7 +1005,7 @@ void StatefulLabel::setState(QString state)
             }
 
             // If not, try to see if there's an entire style string set as ASCII:
-            auto availableStringPrefs = _parameterGroup->GetASCIIMap();
+            auto availableStringPrefs = _parameterGroup->getAllStringsMap();
             for (const auto& stringEntry : availableStringPrefs) {
                 if (stringEntry.first == entry->second.preferenceString) {
                     QString css = QStringLiteral("Gui--StatefulLabel{ %1 }")

--- a/src/Gui/Workbench.cpp
+++ b/src/Gui/Workbench.cpp
@@ -303,7 +303,7 @@ void Workbench::setupCustomToolbars(ToolBarItem* root, const Base::Reference<Par
 
         // get the elements of the subgroups
         std::vector<std::pair<std::string, std::string>> items
-            = hGrp->GetGroup(it->GetGroupName())->GetASCIIMap();
+            = hGrp->GetGroup(it->GetGroupName())->getAllStringsMap();
         for (const auto& item : items) {
             if (item.first.substr(0, separator.size()) == separator) {
                 *bar << "Separator";

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -264,8 +264,8 @@ int main(int argc, char** argv)
                 "User parameter:BaseApp/Preferences/View"
             );
             // if not already defined do it now (for the very first start)
-            std::string style = hGrp->GetASCII("NavigationStyle", it->second.c_str());
-            hGrp->SetASCII("NavigationStyle", style.c_str());
+            std::string style = hGrp->getString("NavigationStyle", it->second);
+            hGrp->setString("NavigationStyle", style);
         }
 
         Gui::Application::initApplication();

--- a/src/Main/MainGui.cpp
+++ b/src/Main/MainGui.cpp
@@ -267,8 +267,8 @@ int main(int argc, char** argv)
                 "User parameter:BaseApp/Preferences/View"
             );
             // if not already defined do it now (for the very first start)
-            std::string style = hGrp->GetASCII("NavigationStyle", it->second.c_str());
-            hGrp->SetASCII("NavigationStyle", style.c_str());
+            std::string style = hGrp->getString("NavigationStyle", it->second);
+            hGrp->setString("NavigationStyle", style);
         }
 
         Gui::Application::initApplication();

--- a/src/Mod/Assembly/App/BomObject.cpp
+++ b/src/Mod/Assembly/App/BomObject.cpp
@@ -152,7 +152,7 @@ void BomObject::generateBOM()
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Assembly"
     );
-    mirroredSuffix = hGrp->GetASCII("BomMirroredSuffix", " (mirrored)");
+    mirroredSuffix = hGrp->getString("BomMirroredSuffix", " (mirrored)");
 
     // Populate headers
     for (auto& columnName : columnsNames.getValues()) {

--- a/src/Mod/CAM/Gui/AppPathGuiPy.cpp
+++ b/src/Mod/CAM/Gui/AppPathGuiPy.cpp
@@ -92,7 +92,7 @@ private:
             std::string cMacroPath
                 = App::GetApplication()
                       .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
-                      ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+                      ->getString("MacroPath", App::Application::getUserMacroDir());
             QDir dir2(QString::fromUtf8(cMacroPath.c_str()), QStringLiteral("*_pre.py"));
             QFileInfoList list = dir1.entryInfoList();
             list << dir2.entryInfoList();
@@ -168,7 +168,7 @@ private:
             std::string cMacroPath
                 = App::GetApplication()
                       .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
-                      ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+                      ->getString("MacroPath", App::Application::getUserMacroDir());
             QDir dir2(QString::fromUtf8(cMacroPath.c_str()), QStringLiteral("*_pre.py"));
             QFileInfoList list = dir1.entryInfoList();
             list << dir2.entryInfoList();
@@ -256,7 +256,7 @@ private:
             std::string cMacroPath
                 = App::GetApplication()
                       .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Macro")
-                      ->GetASCII("MacroPath", App::Application::getUserMacroDir().c_str());
+                      ->getString("MacroPath", App::Application::getUserMacroDir());
             QDir dir2(QString::fromUtf8(cMacroPath.c_str()), QStringLiteral("*_post.py"));
             QFileInfoList list = dir1.entryInfoList();
             list << dir2.entryInfoList();

--- a/src/Mod/Cloud/App/AppCloud.cpp
+++ b/src/Mod/Cloud/App/AppCloud.cpp
@@ -1,0 +1,1558 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/***************************************************************************
+ *   Copyright (c) 2019 Jean-Marie Verdun         jmverdun3@gmail.com      *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <FCConfig.h>
+
+
+#include <limits>
+
+#if defined(FC_OS_WIN32)
+# include <Windows.h>
+# include <cstdint>
+#endif
+
+#include <openssl/hmac.h>
+#include <openssl/md5.h>
+#include <openssl/pem.h>
+#include <openssl/sha.h>
+
+#include <curl/curl.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/DocumentPy.h>
+#include <Base/Console.h>
+#include <Base/Tools.h>
+#include <Base/PyObjectBase.h>
+
+#include <CXX/Extensions.hxx>
+#include <CXX/Objects.hxx>
+
+#include "AppCloud.h"
+
+
+using namespace App;
+using namespace std;
+using namespace boost::placeholders;
+XERCES_CPP_NAMESPACE_USE
+
+/* Python entry */
+PyMOD_INIT_FUNC(Cloud)
+{
+    PyObject* mod = Cloud::initModule();
+    Base::Console().log("Loading Cloud module... done\n");
+    PyMOD_Return(mod);
+}
+
+Py::Object Cloud::Module::sCloudURL(const Py::Tuple& args)
+{
+    char* URL;
+    if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &URL)) {
+        throw Py::Exception();
+    }
+
+    std::string strURL = URL;
+    PyMem_Free(URL);
+    if (this->URL.getStrValue() != strURL) {
+        this->URL.setValue(strURL);
+    }
+
+    return Py::None();
+}
+
+Py::Object Cloud::Module::sCloudTokenAuth(const Py::Tuple& args)
+{
+    char* TokenAuth;
+    if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &TokenAuth)) {
+        throw Py::Exception();
+    }
+
+    std::string strTokenAuth = TokenAuth;
+    PyMem_Free(TokenAuth);
+    if (this->TokenAuth.getStrValue() != strTokenAuth) {
+        this->TokenAuth.setValue(strTokenAuth);
+    }
+
+    return Py::None();
+}
+
+Py::Object Cloud::Module::sCloudTokenSecret(const Py::Tuple& args)
+{
+    char* TokenSecret;
+    if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &TokenSecret)) {
+        throw Py::Exception();
+    }
+
+    std::string strTokenSecret = TokenSecret;
+    PyMem_Free(TokenSecret);
+    if (this->TokenSecret.getStrValue() != strTokenSecret) {
+        this->TokenSecret.setValue(strTokenSecret);
+    }
+
+    return Py::None();
+}
+
+Py::Object Cloud::Module::sCloudTCPPort(const Py::Tuple& args)
+{
+    char* TCPPort;
+    if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &TCPPort)) {
+        throw Py::Exception();
+    }
+
+    std::string strTCPPort = TCPPort;
+    PyMem_Free(TCPPort);
+    if (this->TCPPort.getStrValue() != strTCPPort) {
+        this->TCPPort.setValue(strTCPPort);
+    }
+
+    return Py::None();
+}
+
+Py::Object Cloud::Module::sCloudSave(const Py::Tuple& args)
+{
+    char* pDoc;
+    if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &pDoc)) {
+        throw Py::Exception();
+    }
+
+    std::string strpDoc = pDoc;
+    PyMem_Free(pDoc);
+    cloudSave(strpDoc.c_str());
+
+    return Py::None();
+}
+
+
+Py::Object Cloud::Module::sCloudRestore(const Py::Tuple& args)
+{
+    char* pDoc;
+    if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &pDoc)) {
+        throw Py::Exception();
+    }
+
+    std::string strpDoc = pDoc;
+    PyMem_Free(pDoc);
+    cloudRestore(strpDoc.c_str());
+
+    return Py::None();
+}
+
+Py::Object Cloud::Module::sCloudProtocolVersion(const Py::Tuple& args)
+{
+    char* ProtocolVersion;
+    if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &ProtocolVersion)) {
+        throw Py::Exception();
+    }
+
+    std::string strProtocolVersion = ProtocolVersion;
+    PyMem_Free(ProtocolVersion);
+    if (this->ProtocolVersion.getStrValue() != strProtocolVersion) {
+        this->ProtocolVersion.setValue(strProtocolVersion);
+    }
+
+    return Py::None();
+}
+
+Py::Object Cloud::Module::sCloudRegion(const Py::Tuple& args)
+{
+    char* Region;
+    if (!PyArg_ParseTuple(args.ptr(), "et", "utf-8", &Region)) {
+        throw Py::Exception();
+    }
+
+    std::string strRegion = Region;
+    PyMem_Free(Region);
+    if (this->Region.getStrValue() != strRegion) {
+        this->Region.setValue(strRegion);
+    }
+
+    return Py::None();
+}
+
+struct data_buffer
+{
+    const char* ptr;
+    size_t remaining_size;
+};
+
+static size_t read_callback(void* ptr, size_t size, size_t nmemb, void* stream)
+{
+
+    struct data_buffer* local_ptr = (struct data_buffer*)stream;
+    size_t data_to_transfer = size * nmemb;
+
+    if (local_ptr->remaining_size) {
+        // copy as much as possible from the source to the destination
+        size_t copy_this_much = local_ptr->remaining_size;
+        if (copy_this_much > data_to_transfer) {
+            copy_this_much = data_to_transfer;
+        }
+        memcpy(ptr, local_ptr->ptr, copy_this_much);
+
+        local_ptr->ptr += copy_this_much;
+        local_ptr->remaining_size -= copy_this_much;
+        return copy_this_much;
+    }
+
+    return 0;
+}
+
+void Cloud::CloudWriter::checkXML(DOMNode* node)
+{
+    if (node) {
+        switch (node->getNodeType()) {
+            case DOMNode::ELEMENT_NODE:
+                checkElement(static_cast<DOMElement*>(node));
+                break;
+            case DOMNode::TEXT_NODE:
+                checkText(static_cast<DOMText*>(node));
+                break;
+            default:
+                break;
+        }
+        DOMNode* child = node->getFirstChild();
+        while (child) {
+            DOMNode* next = child->getNextSibling();
+            checkXML(child);
+            child = next;
+        }
+    }
+}
+
+void Cloud::CloudWriter::checkElement(DOMElement* element)
+{
+    char* name = XMLString::transcode(element->getTagName());
+    if (strcmp(name, "Code") == 0) {
+        print = 1;
+    }
+    XMLString::release(&name);
+}
+
+void Cloud::CloudWriter::checkText(DOMText* text)
+{
+
+    XMLCh* buffer = new XMLCh[XMLString::stringLen(text->getData()) + 1];
+    XMLString::copyString(buffer, text->getData());
+    XMLString::trim(buffer);
+    char* content = XMLString::transcode(buffer);
+    delete[] buffer;
+    if (print) {
+        strcpy(errorCode, content);
+    }
+    print = 0;
+    XMLString::release(&content);
+}
+
+
+void Cloud::CloudWriter::createBucket()
+{
+    struct Cloud::AmzData* RequestData;
+    struct Cloud::AmzDatav4* RequestDatav4;
+    CURL* curl;
+    CURLcode res;
+
+    struct data_buffer curl_buffer;
+
+    char path[1024];
+    sprintf(path, "/%s/", this->Bucket);
+    std::string strURL(this->URL);
+    eraseSubStr(strURL, "http://");
+    eraseSubStr(strURL, "https://");
+
+    if (this->ProtocolVersion == "2") {
+        RequestData
+            = Cloud::ComputeDigestAmzS3v2("PUT", "application/xml", path, this->TokenSecret, nullptr, 0);
+    }
+    else {
+        RequestDatav4 = Cloud::ComputeDigestAmzS3v4(
+            "PUT",
+            strURL.c_str(),
+            "application/xml",
+            path,
+            this->TokenSecret,
+            nullptr,
+            0,
+            nullptr,
+            this->Region
+        );
+    }
+
+    // Let's build the Header and call to curl
+    curl_global_init(CURL_GLOBAL_ALL);
+    curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
+
+    if (curl) {
+        struct curl_slist* chunk = nullptr;
+        char URL[256];
+        // Let's build our own header
+        std::string strURL(this->URL);
+        eraseSubStr(strURL, "http://");
+        eraseSubStr(strURL, "https://");
+        if (this->ProtocolVersion == "2") {
+            chunk = Cloud::BuildHeaderAmzS3v2(strURL.c_str(), this->TCPPort, this->TokenAuth, RequestData);
+            delete RequestData;
+        }
+        else {
+            chunk = Cloud::BuildHeaderAmzS3v4(strURL.c_str(), this->TokenAuth, RequestDatav4);
+            delete RequestDatav4;
+        }
+
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
+
+        // Lets build the URL for our Curl call
+
+        sprintf(URL, "%s:%s/%s/", this->URL, this->TCPPort, this->Bucket);
+        curl_easy_setopt(curl, CURLOPT_URL, URL);
+
+        curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+        curl_easy_setopt(curl, CURLOPT_PUT, 1L);
+        // curl read a file not a memory buffer (it shall be able to do it)
+        curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+
+        curl_buffer.ptr = nullptr;
+        curl_buffer.remaining_size = (size_t)0;
+
+        curl_easy_setopt(curl, CURLOPT_READDATA, &curl_buffer);
+
+        curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)0);
+        res = curl_easy_perform(curl);
+        if (res != CURLE_OK) {
+            fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+        }
+        curl_easy_cleanup(curl);
+    }
+}
+
+
+struct Cloud::AmzDatav4* Cloud::ComputeDigestAmzS3v4(
+    char* operation,
+    const char* server,
+    char* data_type,
+    const char* target,
+    const char* Secret,
+    const char* ptr,
+    long size,
+    char* parameters,
+    std::string Region
+)
+{
+    struct AmzDatav4* returnData;
+    returnData = new Cloud::AmzDatav4;
+    struct tm* tm;
+    char* canonical_request;
+    char* canonicalRequestHash;
+    char* stringToSign;
+
+    strcpy(returnData->ContentType, data_type);
+
+#if defined(FC_OS_WIN32)
+    _putenv("TZ=GMT");
+    time_t rawtime;
+
+    time(&rawtime);
+    tm = localtime(&rawtime);
+#else
+    struct timeval tv;
+    setenv("TZ", "GMT", 1);
+    gettimeofday(&tv, nullptr);
+    tm = localtime(&tv.tv_sec);
+#endif
+    strftime(returnData->dateFormattedD, 256, "%Y%m%d", tm);
+    strftime(returnData->dateFormattedS, 256, "%Y%m%dT%H%M%SZ", tm);
+    returnData->MD5 = nullptr;
+
+    // We must evaluate the canonical request
+    canonical_request = (char*)malloc(4096 * (sizeof(char*)));
+    strcpy(canonical_request, operation);
+    strcat(canonical_request, "\n");
+    strcat(canonical_request, target);
+    strcat(canonical_request, "\n");
+    if (parameters == nullptr) {
+        strcat(canonical_request, "\n");
+    }
+    else {
+        strcat(canonical_request, parameters);
+        strcat(canonical_request, "\n");
+    }
+    strcat(canonical_request, "host:");
+    strcat(canonical_request, server);
+    strcat(canonical_request, "\n");
+    strcat(canonical_request, "x-amz-date:");
+    strcat(canonical_request, returnData->dateFormattedS);
+    strcat(canonical_request, "\n\n");
+    strcat(canonical_request, "host;x-amz-date\n");
+    // We must add there the file SHA256 Hash
+    returnData->SHA256Sum = nullptr;
+    if (strcmp(operation, "PUT") == 0) {
+        if (ptr != nullptr) {
+            returnData->SHA256Sum = Cloud::SHA256Sum(ptr, size);
+            strcat(canonical_request, returnData->SHA256Sum);
+        }
+        else {
+            strcat(canonical_request, "UNSIGNED-PAYLOAD");
+        }
+    }
+    else {
+        strcat(canonical_request, "UNSIGNED-PAYLOAD");
+    }
+    canonicalRequestHash = Cloud::SHA256Sum(canonical_request, strlen(canonical_request));
+    // returnData->digest = string(digest);
+
+
+    // We need now to sign a string which contain the digest
+    // The format is as follow
+    // ${authType}
+    // ${dateValueL}
+    // ${dateValueS}/${Region}/${service}/aws4_request
+    // ${canonicalRequestHash}"
+
+    stringToSign = (char*)malloc(4096 * sizeof(char));
+    strcat(stringToSign, "AWS4-HMAC-SHA256");
+    strcat(stringToSign, "\n");
+    strcat(stringToSign, returnData->dateFormattedS);
+    strcat(stringToSign, "\n");
+    strcat(stringToSign, returnData->dateFormattedD);
+    strcat(stringToSign, "/us/s3/aws4_request");
+    strcat(stringToSign, "\n");
+    strcat(stringToSign, canonicalRequestHash);
+    strcat(stringToSign, "\0");
+
+    // We must now compute the signature
+    // Everything starts with the secret key and an SHA256 HMAC encryption
+    char kSecret[256];
+    unsigned char *kDate, *kRegion, *kService, *kSigned, *kSigning;
+
+    strcpy(kSecret, "AWS4");
+    strcat(kSecret, Secret);
+    unsigned int HMACLength;
+
+    std::string temporary;
+
+    kDate = HMAC(
+        EVP_sha256(),
+        kSecret,
+        strlen(kSecret),
+        (const unsigned char*)returnData->dateFormattedD,
+        strlen(returnData->dateFormattedD),
+        nullptr,
+        &HMACLength
+    );
+
+    temporary = getHexValue(kDate, HMACLength);
+    temporary = getHexValue(kDate, HMACLength);
+
+    // We can now compute the remaining parts
+    kRegion = HMAC(
+        EVP_sha256(),
+        kDate,
+        HMACLength,
+        (const unsigned char*)Region.c_str(),
+        strlen(Region.c_str()),
+        nullptr,
+        &HMACLength
+    );
+
+    temporary = getHexValue(kRegion, HMACLength);
+
+    kService = HMAC(
+        EVP_sha256(),
+        kRegion,
+        HMACLength,
+        (const unsigned char*)"s3",
+        strlen("s3"),
+        nullptr,
+        &HMACLength
+    );
+
+    temporary = getHexValue(kService, HMACLength);
+
+    kSigning = HMAC(
+        EVP_sha256(),
+        kService,
+        HMACLength,
+        (const unsigned char*)"aws4_request",
+        strlen("aws4_request"),
+        nullptr,
+        &HMACLength
+    );
+
+    temporary = getHexValue(kService, HMACLength);
+
+
+    kSigned = HMAC(
+        EVP_sha256(),
+        kSigning,
+        HMACLength,
+        (const unsigned char*)stringToSign,
+        strlen(stringToSign),
+        nullptr,
+        &HMACLength
+    );
+
+    temporary = getHexValue(kSigned, HMACLength);
+
+    returnData->digest = string(temporary);
+    returnData->Region = Region;
+    free(canonical_request);
+    return (returnData);
+}
+
+std::string Cloud::getHexValue(unsigned char* input, unsigned int HMACLength)
+{
+    char* Hex;
+    unsigned char* ptr = input;
+    std::string resultReadable;
+    Hex = (char*)malloc(HMACLength * 2 * sizeof(char) + 1);
+    for (unsigned int i = 0; i < HMACLength; i++) {
+        sprintf(Hex, "%02x", *ptr);
+        ptr++;
+        Hex[2] = '\0';
+        resultReadable += Hex;
+    }
+    return resultReadable;
+}
+
+struct Cloud::AmzData* Cloud::ComputeDigestAmzS3v2(
+    char* operation,
+    char* data_type,
+    const char* target,
+    const char* Secret,
+    const char* ptr,
+    long size
+)
+{
+    struct AmzData* returnData;
+    // struct timeval tv;
+    struct tm* tm;
+    char date_formatted[256];
+    char StringToSign[1024];
+    unsigned char* digest;
+    unsigned int HMACLength;
+    // Amazon S3 and Swift require the timezone to be define to GMT.
+    // As to simplify the conversion this is performed through the TZ
+    // environment variable and a call to localtime as to convert output of gettimeofday
+    returnData = new Cloud::AmzData;
+    strcpy(returnData->ContentType, data_type);
+#if defined(FC_OS_WIN32)
+    _putenv("TZ=GMT");
+    time_t rawtime;
+
+    time(&rawtime);
+    tm = localtime(&rawtime);
+#else
+    struct timeval tv;
+    setenv("TZ", "GMT", 1);
+    gettimeofday(&tv, nullptr);
+    tm = localtime(&tv.tv_sec);
+#endif
+    strftime(date_formatted, 256, "%a, %d %b %Y %T %z", tm);
+    returnData->MD5 = nullptr;
+    if (strcmp(operation, "PUT") == 0) {
+        if (ptr != nullptr) {
+            returnData->MD5 = Cloud::MD5Sum(ptr, size);
+            sprintf(
+                StringToSign,
+                "%s\n%s\n%s\n%s\n%s",
+                operation,
+                returnData->MD5,
+                data_type,
+                date_formatted,
+                target
+            );
+        }
+        else {
+            sprintf(StringToSign, "%s\n\n%s\n%s\n%s", operation, data_type, date_formatted, target);
+        }
+    }
+    else {
+        sprintf(StringToSign, "%s\n\n%s\n%s\n%s", operation, data_type, date_formatted, target);
+    }
+    // We have to use HMAC encoding and SHA1
+    digest = HMAC(
+        EVP_sha1(),
+        Secret,
+        strlen(Secret),
+        (const unsigned char*)&StringToSign,
+        strlen(StringToSign),
+        nullptr,
+        &HMACLength
+    );
+    returnData->digest = Base::base64_encode(digest, HMACLength);
+    strcpy(returnData->dateFormatted, date_formatted);
+    return returnData;
+}
+
+char* Cloud::SHA256Sum(const char* ptr, long size)
+{
+    char* output;
+    std::string local;
+    std::string resultReadable;
+    unsigned char result[SHA256_DIGEST_LENGTH];
+    output = (char*)malloc(2 * SHA256_DIGEST_LENGTH * sizeof(char) + 1);
+    SHA256((unsigned char*)ptr, size, result);
+
+    strcpy(output, getHexValue(result, SHA256_DIGEST_LENGTH).c_str());
+
+    return (output);
+}
+
+char* Cloud::MD5Sum(const char* ptr, long size)
+{
+    char* output;
+    std::string local;
+    unsigned char result[MD5_DIGEST_LENGTH];
+    output = (char*)malloc(2 * MD5_DIGEST_LENGTH * sizeof(char) + 1);
+    MD5((unsigned char*)ptr, size, result);
+    local = Base::base64_encode(result, MD5_DIGEST_LENGTH);
+    strcpy(output, local.c_str());
+    return (output);
+}
+
+struct curl_slist* Cloud::BuildHeaderAmzS3v4(
+    const char* URL,
+    const char* PublicKey,
+    struct Cloud::AmzDatav4* Data
+)
+{
+    char header_data[1024];
+    struct curl_slist* chunk = nullptr;
+
+    // Build the Host: entry
+    sprintf(header_data, "Host: %s", URL);
+    chunk = curl_slist_append(chunk, header_data);
+
+    // Build the Date entry
+
+    sprintf(header_data, "X-Amz-Date: %s", Data->dateFormattedS);
+    chunk = curl_slist_append(chunk, header_data);
+
+    // Build the Content-Type entry
+
+    sprintf(header_data, "Content-Type:%s", Data->ContentType);
+    chunk = curl_slist_append(chunk, header_data);
+
+    // If ptr is not null we must compute the MD5-Sum as to validate later the ETag
+    // and add the MD5-Content: entry to the header
+    if (Data->MD5 != nullptr) {
+        sprintf(header_data, "Content-MD5: %s", Data->MD5);
+        chunk = curl_slist_append(chunk, header_data);
+        // We don't need it anymore we can free it
+        free((void*)Data->MD5);
+    }
+
+    if (Data->SHA256Sum != nullptr) {
+        sprintf(header_data, "x-amz-content-sha256: %s", Data->SHA256Sum);
+        chunk = curl_slist_append(chunk, header_data);
+        // We don't need it anymore we can free it
+        free((void*)Data->SHA256Sum);
+    }
+    else {
+        chunk = curl_slist_append(chunk, "x-amz-content-sha256: UNSIGNED-PAYLOAD");
+    }
+
+    // build the Auth entry
+    sprintf(
+        header_data,
+        "Authorization: AWS4-HMAC-SHA256 Credential=%s/%s/%s/%s/aws4_request, "
+        "SignedHeaders=%s, Signature=%s",
+        PublicKey,
+        Data->dateFormattedD,
+        "us",
+        "s3",
+        "host;x-amz-date",
+        Data->digest.c_str()
+    );
+    chunk = curl_slist_append(chunk, header_data);
+
+    return chunk;
+}
+
+struct curl_slist* Cloud::BuildHeaderAmzS3v2(
+    const char* URL,
+    const char* TCPPort,
+    const char* PublicKey,
+    struct Cloud::AmzData* Data
+)
+{
+    char header_data[1024];
+    struct curl_slist* chunk = nullptr;
+
+    // Build the Host: entry
+
+    sprintf(header_data, "Host: %s:%s", URL, TCPPort);
+    chunk = curl_slist_append(chunk, header_data);
+    // Build the Date entry
+
+    sprintf(header_data, "Date: %s", Data->dateFormatted);
+    chunk = curl_slist_append(chunk, header_data);
+    // Build the Content-Type entry
+
+    sprintf(header_data, "Content-Type:%s", Data->ContentType);
+    chunk = curl_slist_append(chunk, header_data);
+
+    // If ptr is not null we must compute the MD5-Sum as to validate later the ETag
+    // and add the MD5-Content: entry to the header
+    if (Data->MD5 != nullptr) {
+        sprintf(header_data, "Content-MD5: %s", Data->MD5);
+        chunk = curl_slist_append(chunk, header_data);
+        // We don't need it anymore we can free it
+        free((void*)Data->MD5);
+    }
+
+    // build the Auth entry
+
+    sprintf(header_data, "Authorization: AWS %s:%s", PublicKey, Data->digest.c_str());
+    chunk = curl_slist_append(chunk, header_data);
+
+    return chunk;
+}
+
+Cloud::CloudWriter::CloudWriter(
+    const char* URL,
+    const char* TokenAuth,
+    const char* TokenSecret,
+    const char* TCPPort,
+    const char* Bucket,
+    std::string ProtocolVersion,
+    std::string Region
+)
+{
+    struct Cloud::AmzData* RequestData;
+    struct Cloud::AmzDatav4* RequestDatav4;
+    CURL* curl;
+    CURLcode res;
+
+    std::string s;
+
+    this->URL = URL;
+    this->TokenAuth = TokenAuth;
+    this->TokenSecret = TokenSecret;
+    this->TCPPort = TCPPort;
+    this->Bucket = Bucket;
+    if (!ProtocolVersion.empty()) {
+        this->ProtocolVersion = ProtocolVersion;
+    }
+    else {
+        this->ProtocolVersion = "2";
+    }
+    this->Region = Region;
+    this->FileName = "";
+    char path[1024];
+    sprintf(path, "/%s/", this->Bucket);
+    std::string strURL(this->URL);
+    eraseSubStr(strURL, "http://");
+    eraseSubStr(strURL, "https://");
+    if (this->ProtocolVersion == "2") {
+        RequestData
+            = Cloud::ComputeDigestAmzS3v2("GET", "application/xml", path, this->TokenSecret, nullptr, 0);
+    }
+    else {
+        RequestDatav4 = Cloud::ComputeDigestAmzS3v4(
+            "GET",
+            strURL.c_str(),
+            "application/xml",
+            path,
+            this->TokenSecret,
+            nullptr,
+            0,
+            nullptr,
+            this->Region
+        );
+    }
+    // Let's build the Header and call to curl
+    curl_global_init(CURL_GLOBAL_ALL);
+    curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
+    if (curl) {
+        // Let's build our own header
+        struct curl_slist* chunk = nullptr;
+        char URL[256];
+        std::string strURL(this->URL);
+        eraseSubStr(strURL, "http://");
+        eraseSubStr(strURL, "https://");
+        if (this->ProtocolVersion == "2") {
+            chunk = Cloud::BuildHeaderAmzS3v2(strURL.c_str(), this->TCPPort, this->TokenAuth, RequestData);
+            delete RequestData;
+        }
+        else {
+            chunk = Cloud::BuildHeaderAmzS3v4(strURL.c_str(), this->TokenAuth, RequestDatav4);
+            delete RequestDatav4;
+        }
+
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
+
+        // Lets build the URL for our Curl call
+
+        sprintf(URL, "%s:%s/%s/", this->URL, this->TCPPort, this->Bucket);
+        curl_easy_setopt(curl, CURLOPT_URL, URL);
+
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWrite_CallbackFunc_StdString);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+        // curl read a file not a memory buffer (it shall be able to do it)
+        res = curl_easy_perform(curl);
+        if (res != CURLE_OK) {
+            fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+        }
+        curl_easy_cleanup(curl);
+        createBucket();
+        // Lets dump temporarily for debug purposes of s3v4 implementation
+        std::stringstream input(s);
+
+        try {
+            XMLPlatformUtils::Initialize();
+        }
+        catch (const XMLException& toCatch) {
+            char* message = XMLString::transcode(toCatch.getMessage());
+            cout << "Error during initialization! :\n" << message << "\n";
+            XMLString::release(&message);
+            return;
+        }
+
+        XercesDOMParser* parser = new XercesDOMParser();
+        parser->setValidationScheme(XercesDOMParser::Val_Always);
+        parser->setDoNamespaces(true);
+
+        xercesc::MemBufInputSource myxml_buf(
+            (const XMLByte* const)s.c_str(),
+            s.size(),
+            "myxml (in memory)"
+        );
+
+        parser->parse(myxml_buf);
+        auto* dom = parser->getDocument();
+        // Is there an Error entry into the document ?
+        // if yes, then we must create the Bucket
+        checkXML(dom);
+        if (strcmp(errorCode, "NoSuchBucket") == 0) {
+            // we must create the Bucket using a PUT request
+            createBucket();
+        }
+    }
+}
+
+Cloud::CloudWriter::~CloudWriter()
+{}
+
+size_t Cloud::CurlWrite_CallbackFunc_StdString(void* contents, size_t size, size_t nmemb, std::string* s)
+{
+    size_t newLength = size * nmemb;
+    try {
+        s->append((char*)contents, newLength);
+    }
+    catch (std::bad_alloc&) {
+        // handle memory problem
+        return 0;
+    }
+    return newLength;
+}
+
+void Cloud::CloudReader::checkElement(DOMElement* element)
+{
+    char* name = XMLString::transcode(element->getTagName());
+    if (strcmp(name, "Key") == 0) {
+        file = 1;
+    }
+    if (strcmp(name, "NextContinuationToken") == 0) {
+        continuation = 1;
+    }
+    if (strcmp(name, "IsTruncated") == 0) {
+        truncated = 1;
+    }
+    XMLString::release(&name);
+}
+
+void Cloud::CloudReader::checkText(DOMText* text)
+{
+
+    XMLCh* buffer = new XMLCh[XMLString::stringLen(text->getData()) + 1];
+    XMLString::copyString(buffer, text->getData());
+    XMLString::trim(buffer);
+    struct Cloud::CloudReader::FileEntry* new_entry;
+    char* content = XMLString::transcode(buffer);
+    delete[] buffer;
+    if (file) {
+        new_entry = new Cloud::CloudReader::FileEntry;
+        strcpy(new_entry->FileName, content);
+        Cloud::CloudReader::FileList.push_back(new_entry);
+    }
+    file = 0;
+    if (continuation == 1) {
+        strcpy(Cloud::CloudReader::NextFileName, content);
+        continuation = 0;
+    }
+    if (truncated == 1) {
+        if (strncmp(content, "true", 4) != 0) {
+            truncated = 0;
+        }
+        else {
+            truncated = 2;
+        }
+    }
+    XMLString::release(&content);
+}
+
+void Cloud::CloudReader::addFile(struct Cloud::CloudReader::FileEntry* new_entry)
+{
+    Cloud::CloudReader::FileList.push_back(new_entry);
+}
+
+void Cloud::CloudReader::checkXML(DOMNode* node)
+{
+    if (node) {
+        switch (node->getNodeType()) {
+            case DOMNode::ELEMENT_NODE:
+                checkElement(static_cast<DOMElement*>(node));
+                break;
+            case DOMNode::TEXT_NODE:
+                checkText(static_cast<DOMText*>(node));
+                break;
+            default:
+                break;
+        }
+        DOMNode* child = node->getFirstChild();
+        while (child) {
+            DOMNode* next = child->getNextSibling();
+            checkXML(child);
+            child = next;
+        }
+    }
+}
+
+
+Cloud::CloudReader::~CloudReader()
+{}
+
+Cloud::CloudReader::CloudReader(
+    const char* URL,
+    const char* TokenAuth,
+    const char* TokenSecret,
+    const char* TCPPort,
+    const char* Bucket,
+    std::string ProtocolVersion,
+    std::string Region
+)
+{
+    struct Cloud::AmzData* RequestData;
+    struct Cloud::AmzDatav4* RequestDatav4;
+    CURL* curl;
+    CURLcode res;
+    bool GetBucketContentList = true;
+    struct curl_slist* chunk = nullptr;
+    char parameters[1024];
+
+
+    this->URL = URL;
+    this->TokenAuth = TokenAuth;
+    this->TokenSecret = TokenSecret;
+    this->TCPPort = TCPPort;
+    this->Bucket = Bucket;
+    if (!ProtocolVersion.empty()) {
+        this->ProtocolVersion = ProtocolVersion;
+    }
+    else {
+        this->ProtocolVersion = "2";
+    }
+    this->Region = Region;
+
+    char path[1024];
+    sprintf(path, "/%s/", this->Bucket);
+    Cloud::CloudReader::NextFileName = (char*)malloc(sizeof(char) * 1024);
+    for (int i = 0; i < 1024; i++) {
+        NextFileName[i] = '\0';
+    }
+
+
+    // Let's build the Header and call to curl
+    curl_global_init(CURL_GLOBAL_ALL);
+    while (GetBucketContentList) {
+        std::string s;
+        curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+        curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
+        if (curl) {
+            // Let's build our own header
+            char URL[256];
+            std::string strURL(this->URL);
+            eraseSubStr(strURL, "http://");
+            eraseSubStr(strURL, "https://");
+            if (strlen(NextFileName) == 0) {
+                sprintf(parameters, "list-type=2");
+            }
+            else {
+                sprintf(parameters, "list-type=2&continuation-token=%s", NextFileName);
+            }
+            sprintf(URL, "%s:%s/%s/?%s", this->URL, this->TCPPort, this->Bucket, parameters);
+            curl_easy_setopt(curl, CURLOPT_URL, URL);
+
+            if (this->ProtocolVersion == "2") {
+                RequestData = Cloud::ComputeDigestAmzS3v2(
+                    "GET",
+                    "application/xml",
+                    path,
+                    this->TokenSecret,
+                    nullptr,
+                    0
+                );
+                chunk = Cloud::BuildHeaderAmzS3v2(
+                    strURL.c_str(),
+                    this->TCPPort,
+                    this->TokenAuth,
+                    RequestData
+                );
+                delete RequestData;
+            }
+            else {
+                RequestDatav4 = Cloud::ComputeDigestAmzS3v4(
+                    "GET",
+                    strURL.c_str(),
+                    "application/xml",
+                    path,
+                    this->TokenSecret,
+                    nullptr,
+                    0,
+                    (char*)&parameters[0],
+                    this->Region
+                );
+                chunk = Cloud::BuildHeaderAmzS3v4(strURL.c_str(), this->TokenAuth, RequestDatav4);
+                delete RequestDatav4;
+            }
+            curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
+
+            curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWrite_CallbackFunc_StdString);
+            curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+            // curl read a file not a memory buffer (it shall be able to do it)
+
+            res = curl_easy_perform(curl);
+
+            for (int i = 0; i < 1024; i++) {
+                NextFileName[i] = '\0';
+            }
+            if (res != CURLE_OK) {
+                fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+            }
+            curl_easy_cleanup(curl);
+
+
+            std::stringstream input(s);
+
+            try {
+                XMLPlatformUtils::Initialize();
+            }
+            catch (const XMLException& toCatch) {
+                char* message = XMLString::transcode(toCatch.getMessage());
+                cout << "Error during initialization! :\n" << message << "\n";
+                XMLString::release(&message);
+                return;
+            }
+
+            XercesDOMParser* parser = new XercesDOMParser();
+            parser->setValidationScheme(XercesDOMParser::Val_Always);
+            parser->setDoNamespaces(true);
+
+            xercesc::MemBufInputSource myxml_buf(
+                (const XMLByte* const)s.c_str(),
+                s.size(),
+                "myxml (in memory)"
+            );
+
+            parser->parse(myxml_buf);
+            auto* dom = parser->getDocument();
+            checkXML(dom);
+        }
+        if (truncated == 0) {
+            GetBucketContentList = false;
+        }
+        else {
+            truncated = 0;
+            continuation = 0;
+            file = 0;
+        }
+    }
+}
+
+void Cloud::CloudReader::DownloadFile(Cloud::CloudReader::FileEntry* entry)
+{
+    struct Cloud::AmzData* RequestData;
+    struct Cloud::AmzDatav4* RequestDatav4;
+    CURL* curl;
+    CURLcode res;
+
+    std::string s;
+
+    // We must get the directory content
+    char path[1024];
+    sprintf(path, "/%s/%s", this->Bucket, entry->FileName);
+    std::string strURL(this->URL);
+    eraseSubStr(strURL, "http://");
+    eraseSubStr(strURL, "https://");
+    if (this->ProtocolVersion == "2") {
+        RequestData = Cloud::ComputeDigestAmzS3v2(
+            "GET",
+            "application/octet-stream",
+            path,
+            this->TokenSecret,
+            nullptr,
+            0
+        );
+    }
+    else {
+        RequestDatav4 = Cloud::ComputeDigestAmzS3v4(
+            "GET",
+            strURL.c_str(),
+            "application/octet-stream",
+            path,
+            this->TokenSecret,
+            nullptr,
+            0,
+            nullptr,
+            this->Region
+        );
+    }
+
+    // Let's build the Header and call to curl
+    curl_global_init(CURL_GLOBAL_ALL);
+    curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
+    if (curl) {
+        struct curl_slist* chunk = nullptr;
+        char URL[256];
+        // Let's build our own header
+        std::string strURL(this->URL);
+        eraseSubStr(strURL, "http://");
+        eraseSubStr(strURL, "https://");
+        if (this->ProtocolVersion == "2") {
+            chunk = Cloud::BuildHeaderAmzS3v2(strURL.c_str(), this->TCPPort, this->TokenAuth, RequestData);
+            delete RequestData;
+        }
+        else {
+            chunk = Cloud::BuildHeaderAmzS3v4(strURL.c_str(), this->TokenAuth, RequestDatav4);
+            delete RequestDatav4;
+        }
+
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
+
+        sprintf(URL, "%s:%s/%s/%s", this->URL, this->TCPPort, this->Bucket, entry->FileName);
+        curl_easy_setopt(curl, CURLOPT_URL, URL);
+
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, CurlWrite_CallbackFunc_StdString);
+        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &s);
+        // curl read a file not a memory buffer (it shall be able to do it)
+
+        res = curl_easy_perform(curl);
+        if (res != CURLE_OK) {
+            fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+        }
+        curl_easy_cleanup(curl);
+
+        entry->FileStream << s;
+    }
+}
+
+struct Cloud::CloudReader::FileEntry* Cloud::CloudReader::GetEntry(std::string FileName)
+{
+    struct Cloud::CloudReader::FileEntry* current_entry = nullptr;
+    list<FileEntry*>::const_iterator it1;
+
+    for (it1 = FileList.begin(); it1 != FileList.end(); ++it1) {
+        if (strcmp(FileName.c_str(), (*it1)->FileName) == 0) {
+            current_entry = (*it1);
+            break;
+        }
+    }
+
+    if (current_entry != nullptr) {
+        (*it1)->touch = 1;
+        DownloadFile(*it1);
+    }
+
+    return (current_entry);
+}
+
+int Cloud::CloudReader::isTouched(std::string FileName)
+{
+    list<FileEntry*>::const_iterator it1;
+    for (it1 = FileList.begin(); it1 != FileList.end(); ++it1) {
+        if (strcmp(FileName.c_str(), (*it1)->FileName) == 0) {
+            if ((*it1)->touch) {
+                return (1);
+            }
+            else {
+                return (0);
+            }
+        }
+    }
+    return (0);
+}
+
+void Cloud::eraseSubStr(std::string& Str, const std::string& toErase)
+{
+    size_t pos = Str.find(toErase);
+    if (pos != std::string::npos) {
+        Str.erase(pos, toErase.length());
+    }
+}
+
+
+void Cloud::CloudWriter::putNextEntry(const char* file)
+{
+    this->FileName = file;
+    this->FileStream.str("");
+    this->FileStream << std::fixed;
+    this->FileStream.precision(std::numeric_limits<double>::digits10 + 1);
+    this->FileStream.setf(ios::fixed, ios::floatfield);
+    this->FileStream.imbue(std::locale::classic());
+}
+
+bool Cloud::CloudWriter::shouldWrite(const std::string&, const Base::Persistence*) const
+{
+    return true;
+}
+
+void Cloud::CloudWriter::pushCloud(const char* FileName, const char* data, long size)
+{
+    struct Cloud::AmzData* RequestData;
+    struct Cloud::AmzDatav4* RequestDatav4;
+    CURL* curl;
+    CURLcode res;
+    struct data_buffer curl_buffer;
+
+    char path[1024];
+    sprintf(path, "/%s/%s", this->Bucket, FileName);
+
+    std::string strURL(this->URL);
+    eraseSubStr(strURL, "http://");
+    eraseSubStr(strURL, "https://");
+    if (this->ProtocolVersion == "2") {
+        RequestData = Cloud::ComputeDigestAmzS3v2(
+            "PUT",
+            "application/octet-stream",
+            path,
+            this->TokenSecret,
+            data,
+            size
+        );
+    }
+    else {
+        RequestDatav4 = Cloud::ComputeDigestAmzS3v4(
+            "PUT",
+            strURL.c_str(),
+            "application/octet-stream",
+            path,
+            this->TokenSecret,
+            data,
+            size,
+            nullptr,
+            this->Region
+        );
+    }
+
+    // Let's build the Header and call to curl
+    curl_global_init(CURL_GLOBAL_ALL);
+    curl = curl_easy_init();
+#ifdef ALLOW_SELF_SIGNED_CERTIFICATE
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0);
+    curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0);
+#endif
+    if (curl) {
+        struct curl_slist* chunk = nullptr;
+        char URL[256];
+        // Let's build our own header
+        std::string strURL(this->URL);
+        eraseSubStr(strURL, "http://");
+        eraseSubStr(strURL, "https://");
+        if (this->ProtocolVersion == "2") {
+            chunk = Cloud::BuildHeaderAmzS3v2(strURL.c_str(), this->TCPPort, this->TokenAuth, RequestData);
+            delete RequestData;
+        }
+        else {
+            chunk = Cloud::BuildHeaderAmzS3v4(strURL.c_str(), this->TokenAuth, RequestDatav4);
+            delete RequestDatav4;
+        }
+
+        curl_easy_setopt(curl, CURLOPT_HTTPHEADER, chunk);
+
+        // Lets build the URL for our Curl call
+
+        sprintf(URL, "%s:%s/%s/%s", this->URL, this->TCPPort, this->Bucket, FileName);
+        curl_easy_setopt(curl, CURLOPT_URL, URL);
+
+        curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+        curl_easy_setopt(curl, CURLOPT_PUT, 1L);
+        // curl read a file not a memory buffer (it shall be able to do it)
+        curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+        curl_buffer.ptr = data;
+        curl_buffer.remaining_size = (size_t)size;
+
+        curl_easy_setopt(curl, CURLOPT_READDATA, &curl_buffer);
+
+        curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)size);
+
+
+        res = curl_easy_perform(curl);
+        if (res != CURLE_OK) {
+            fprintf(stderr, "curl_easy_perform() failed: %s\n", curl_easy_strerror(res));
+        }
+        curl_easy_cleanup(curl);
+    }
+}
+
+void Cloud::CloudWriter::writeFiles(void)
+{
+    // use a while loop because it is possible that while
+    // processing the files, new ones can be added
+    std::string tmp = "";
+    char* cstr;
+    size_t index = 0;
+    if (strlen(this->FileName.c_str()) > 1) {
+        // We must push the current buffer
+        const std::string tmp = this->FileStream.str();
+        const char* cstr = tmp.data();
+        pushCloud((const char*)this->FileName.c_str(), cstr, tmp.size());
+    }
+    while (index < FileList.size()) {
+        FileEntry entry = FileList.begin()[index];
+
+        if (shouldWrite(entry.FileName, entry.Object)) {
+            this->FileStream.str("");
+            this->FileStream.precision(std::numeric_limits<double>::digits10 + 1);
+            this->FileStream.setf(ios::fixed, ios::floatfield);
+            this->FileStream.imbue(std::locale::classic());
+            entry.Object->SaveDocFile(*this);
+            tmp = this->FileStream.str();
+            cstr = (char*)tmp.data();
+            pushCloud((const char*)entry.FileName.c_str(), (const char*)cstr, tmp.size());
+            this->FileStream.str("");
+        }
+
+        index++;
+    }
+}
+
+
+bool Cloud::Module::cloudSave(const char* BucketName)
+{
+    Document* doc = GetApplication().getActiveDocument();
+
+    auto hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Document"
+    );
+
+    // Save the name of the tip object in order to handle in Restore()
+    if (doc->Tip.getValue()) {
+        doc->TipName.setValue(doc->Tip.getValue()->getNameInDocument());
+    }
+
+    std::string LastModifiedDateString = Base::Tools::currentDateTimeString();
+    doc->LastModifiedDate.setValue(LastModifiedDateString.c_str());
+    // set author if needed
+    bool saveAuthor = App::GetApplication()
+                          .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
+                          ->GetBool("prefSetAuthorOnSave", false);
+    if (saveAuthor) {
+        std::string Author = App::GetApplication()
+                                 .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
+                                 ->getString("prefAuthor", "");
+        doc->LastModifiedBy.setValue(Author.c_str());
+    }
+    if (strcmp(BucketName, doc->Label.getValue()) != 0) {
+        doc->Label.setValue(BucketName);
+    }
+
+    Cloud::CloudWriter mywriter(
+        (const char*)this->URL.getStrValue().c_str(),
+        (const char*)this->TokenAuth.getStrValue().c_str(),
+        (const char*)this->TokenSecret.getStrValue().c_str(),
+        (const char*)this->TCPPort.getStrValue().c_str(),
+        BucketName,
+        (const char*)this->ProtocolVersion.getStrValue().c_str(),
+        this->Region.getStrValue()
+    );
+
+    mywriter.putNextEntry("Document.xml");
+
+    if (hGrp->GetBool("SaveBinaryBrep", false)) {
+        mywriter.setMode("BinaryBrep");
+    }
+    mywriter.Stream() << "<?xml version='1.0' encoding='utf-8'?>" << endl
+                      << "<!--" << endl
+                      << " FreeCAD Document, see https://www.freecad.org for more information..."
+                      << endl
+                      << "-->" << endl;
+    doc->Save(mywriter);
+
+    // Special handling for Gui document.
+    doc->signalSaveDocument(mywriter);
+
+    // write additional files
+    mywriter.writeFiles();
+
+    return (true);
+}
+
+void readFiles(Cloud::CloudReader reader, Base::XMLReader* xmlreader)
+{
+    // It's possible that not all objects inside the document could be created, e.g. if a module
+    // is missing that would know these object types. So, there may be data files inside the Cloud
+    // file that cannot be read. We simply ignore these files.
+    // On the other hand, however, it could happen that a file should be read that is not part of
+    // the zip file. This happens e.g. if a document is written without GUI up but is read with GUI
+    // up. In this case the associated GUI document asks for its file which is not part of the
+    // file, then.
+    // In either case it's guaranteed that the order of the files is kept.
+
+    std::vector<Base::XMLReader::FileEntry>::const_iterator it = xmlreader->FileList.begin();
+    while (it != xmlreader->FileList.end()) {
+        if (reader.isTouched(it->FileName.c_str()) == 0) {
+            Base::Reader localreader(
+                reader.GetEntry(it->FileName.c_str())->FileStream,
+                it->FileName,
+                xmlreader->FileVersion
+            );
+            // for debugging only purpose
+            if (false) {
+                std::stringstream ss;
+                ss << localreader.getStream().rdbuf();
+                auto aString = ss.str();
+                aString = "";
+            }
+            it->Object->RestoreDocFile(localreader);
+            if (localreader.getLocalReader() != nullptr) {
+                readFiles(reader, localreader.getLocalReader().get());
+            }
+        }
+        it++;
+    }
+}
+
+void Cloud::Module::LinkXSetValue(std::string filename)
+{
+    // Need to check if the document exist
+    // if not we have to create a new one
+    // and Restore the associated Document
+    //
+    std::vector<Document*> Documents;
+    Documents = App::GetApplication().getDocuments();
+    for (std::vector<Document*>::iterator it = Documents.begin(); it != Documents.end(); it++) {
+        if ((*it)->FileName.getValue() == filename) {
+            // The document exist
+            // we can exit
+            return;
+        }
+    }
+
+    size_t header = filename.find_first_of(":");
+    string protocol = filename.substr(0, header);
+    string url_new = filename.substr(header + 3);  // url_new is the url excluding the http part
+    size_t part2 = url_new.find_first_of("/");
+    string path = url_new.substr(part2 + 1);
+    // Starting from here the Document doesn't exist we must create it
+    // and make it the active Document before Restoring
+    App::Document* newDoc;
+    string newName;
+    Document* currentDoc = GetApplication().getActiveDocument();
+    newName = GetApplication().getUniqueDocumentName("unnamed");
+    newDoc = GetApplication().newDocument(newName.c_str(), (const char*)path.c_str(), true);
+    GetApplication().setActiveDocument(newDoc);
+    this->cloudRestore((const char*)path.c_str());
+    GetApplication().setActiveDocument(currentDoc);
+}
+
+bool Cloud::Module::cloudRestore(const char* BucketName)
+{
+
+    Document* doc = GetApplication().getActiveDocument();
+    // clean up if the document is not empty
+    // !TODO: mind exceptions while restoring!
+    doc->signalLinkXsetValue.connect(boost::bind(&Cloud::Module::LinkXSetValue, this, _1));
+
+    doc->clearUndos();
+
+    doc->clearDocument();
+
+    std::stringstream oss;
+
+    Cloud::CloudReader myreader(
+        (const char*)this->URL.getStrValue().c_str(),
+        (const char*)this->TokenAuth.getStrValue().c_str(),
+        (const char*)this->TokenSecret.getStrValue().c_str(),
+        (const char*)this->TCPPort.getStrValue().c_str(),
+        BucketName,
+        (const char*)this->ProtocolVersion.getStrValue().c_str(),
+        this->Region.getStrValue()
+    );
+
+    // we shall pass there the initial Document.xml file
+
+    Base::XMLReader reader("Document.xml", myreader.GetEntry("Document.xml")->FileStream);
+
+    if (!reader.isValid()) {
+        throw Base::FileException("Error reading Document.xml file", "Document.xml");
+    }
+
+
+    GetApplication().signalStartRestoreDocument(*doc);
+    doc->setStatus(Document::Restoring, true);
+
+    try {
+        doc->Restore(reader);
+    }
+    catch (const Base::Exception& e) {
+        Base::Console().error("Invalid Document.xml: %s\n", e.what());
+    }
+
+    // Special handling for Gui document, the view representations must already
+    // exist, what is done in Restore().
+    // Note: This file doesn't need to be available if the document has been created
+    // without GUI. But if available then follow after all data files of the App document.
+
+    doc->signalRestoreDocument(reader);
+
+    readFiles(myreader, &reader);
+
+    // reset all touched
+
+    doc->afterRestore(true);
+
+    GetApplication().signalFinishRestoreDocument(*doc);
+    doc->setStatus(Document::Restoring, false);
+    doc->Label.setValue(BucketName);
+    // The FileName shall be an URI format
+    string uri;
+    uri = this->URL.getStrValue() + ":" + this->TCPPort.getStrValue() + "/" + string(BucketName);
+    doc->FileName.setValue(uri);
+    doc->signalLinkXsetValue.disconnect(boost::bind(&Cloud::Module::LinkXSetValue, this, _1));
+    return (true);
+}

--- a/src/Mod/Fem/App/AppFemPy.cpp
+++ b/src/Mod/Fem/App/AppFemPy.cpp
@@ -248,8 +248,8 @@ private:
                     if (file.hasExtension({"vtk", "vtu"})) {
                         // get VTK prefs
                         ParameterGrp::handle g = hGrp->GetGroup("InOutVtk");
-                        std::string level = g->GetASCII("MeshExportLevel", "Highest");
-                        femMesh.writeVTK(file.filePath().c_str(), level == "Highest" ? true : false);
+                        std::string level = g->getString("MeshExportLevel", "Highest");
+                        femMesh.writeVTK(file.filePath(), level == "Highest" ? true : false);
                     }
                     else if (file.hasExtension("inp")) {
                         // get Abaqus inp prefs

--- a/src/Mod/Fem/App/AppFemPy.cpp
+++ b/src/Mod/Fem/App/AppFemPy.cpp
@@ -250,8 +250,8 @@ private:
                     if (file.hasExtension({"vtk", "vtu"})) {
                         // get VTK prefs
                         ParameterGrp::handle g = hGrp->GetGroup("InOutVtk");
-                        std::string level = g->GetASCII("MeshExportLevel", "Highest");
-                        femMesh.writeVTK(file.filePath().c_str(), level == "Highest" ? true : false);
+                        std::string level = g->getString("MeshExportLevel", "Highest");
+                        femMesh.writeVTK(file.filePath(), level == "Highest" ? true : false);
                     }
                     else if (file.hasExtension("inp")) {
                         // get Abaqus inp prefs

--- a/src/Mod/Fem/App/FemTools.cpp
+++ b/src/Mod/Fem/App/FemTools.cpp
@@ -324,7 +324,7 @@ std::string Fem::Tools::checkIfBinaryExists(
     else {
         auto binaryPathString = prefBinaryName + "BinaryPath";
         // use binary path from settings, fall back to system path if not defined
-        auto binaryPath = hGrp->GetASCII(binaryPathString.c_str(), binaryName.c_str());
+        auto binaryPath = hGrp->getString(binaryPathString, binaryName);
         QString executablePath = QStandardPaths::findExecutable(
             QString::fromLatin1(binaryPath.c_str())
         );

--- a/src/Mod/Fem/App/FemTools.cpp
+++ b/src/Mod/Fem/App/FemTools.cpp
@@ -326,7 +326,7 @@ std::string Fem::Tools::checkIfBinaryExists(
     else {
         auto binaryPathString = prefBinaryName + "BinaryPath";
         // use binary path from settings, fall back to system path if not defined
-        auto binaryPath = hGrp->GetASCII(binaryPathString.c_str(), binaryName.c_str());
+        auto binaryPath = hGrp->getString(binaryPathString, binaryName);
         QString executablePath = QStandardPaths::findExecutable(
             QString::fromLatin1(binaryPath.c_str())
         );

--- a/src/Mod/Fem/Gui/DlgSettingsFemGmshImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemGmshImp.cpp
@@ -110,7 +110,7 @@ void DlgSettingsFemGmshImp::populateLogVerbosity()
 
     // set default index
     auto hGrp = ui->cb_log_verbosity->getWindowParameter();
-    std::string current = hGrp->GetASCII(ui->cb_log_verbosity->entryName(), "3");
+    std::string current = hGrp->getString(ui->cb_log_verbosity->entryName().toStdString(), "3");
     int index = ui->cb_log_verbosity->findData(QByteArray::fromStdString(current));
     ui->cb_log_verbosity->setCurrentIndex(index);
 }

--- a/src/Mod/Fem/Gui/DlgSettingsFemGmshImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemGmshImp.cpp
@@ -112,7 +112,7 @@ void DlgSettingsFemGmshImp::populateLogVerbosity()
 
     // set default index
     auto hGrp = ui->cb_log_verbosity->getWindowParameter();
-    std::string current = hGrp->GetASCII(ui->cb_log_verbosity->entryName(), "3");
+    std::string current = hGrp->getString(ui->cb_log_verbosity->entryName().toStdString(), "3");
     int index = ui->cb_log_verbosity->findData(QByteArray::fromStdString(current));
     ui->cb_log_verbosity->setCurrentIndex(index);
 }

--- a/src/Mod/Fem/Gui/DlgSettingsFemInOutVtkImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemInOutVtkImp.cpp
@@ -84,7 +84,7 @@ void DlgSettingsFemInOutVtkImp::populateExportLevel() const
 
     // set default index
     auto hGrp = ui->cb_export_level->getWindowParameter();
-    std::string current = hGrp->GetASCII(ui->cb_export_level->entryName(), "Highest");
+    std::string current = hGrp->getString(ui->cb_export_level->entryName().toStdString(), "Highest");
     int index = ui->cb_export_level->findData(QByteArray::fromStdString(current));
     ui->cb_export_level->setCurrentIndex(index);
 }

--- a/src/Mod/Fem/Gui/DlgSettingsFemInOutVtkImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemInOutVtkImp.cpp
@@ -86,7 +86,7 @@ void DlgSettingsFemInOutVtkImp::populateExportLevel() const
 
     // set default index
     auto hGrp = ui->cb_export_level->getWindowParameter();
-    std::string current = hGrp->GetASCII(ui->cb_export_level->entryName(), "Highest");
+    std::string current = hGrp->getString(ui->cb_export_level->entryName().toStdString(), "Highest");
     int index = ui->cb_export_level->findData(QByteArray::fromStdString(current));
     ui->cb_export_level->setCurrentIndex(index);
 }

--- a/src/Mod/Fem/Gui/DlgSettingsFemZ88Imp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemZ88Imp.cpp
@@ -95,7 +95,7 @@ void DlgSettingsFemZ88Imp::populateSolverType()
 
     // set default index
     auto hGrp = ui->cmb_solver->getWindowParameter();
-    std::string current = hGrp->GetASCII(ui->cmb_solver->entryName(), "sorcg");
+    std::string current = hGrp->getString(ui->cmb_solver->entryName().toStdString(), "sorcg");
     int index = ui->cmb_solver->findData(QByteArray::fromStdString(current));
     ui->cmb_solver->setCurrentIndex(index);
 }

--- a/src/Mod/Fem/Gui/DlgSettingsFemZ88Imp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemZ88Imp.cpp
@@ -97,7 +97,7 @@ void DlgSettingsFemZ88Imp::populateSolverType()
 
     // set default index
     auto hGrp = ui->cmb_solver->getWindowParameter();
-    std::string current = hGrp->GetASCII(ui->cmb_solver->entryName(), "sorcg");
+    std::string current = hGrp->getString(ui->cmb_solver->entryName().toStdString(), "sorcg");
     int index = ui->cmb_solver->findData(QByteArray::fromStdString(current));
     ui->cmb_solver->setCurrentIndex(index);
 }

--- a/src/Mod/Import/App/WriterStep.cpp
+++ b/src/Mod/Import/App/WriterStep.cpp
@@ -69,9 +69,9 @@ void WriterStep::write(Handle(TDocStd_Document) hDoc) const  // NOLINT
     // https://forum.freecad.org/viewtopic.php?f=8&t=52967
     makeHeader.SetAuthorValue(
         1,
-        new TCollection_HAsciiString(hGrp->GetASCII("Author", "Author").c_str())
+        new TCollection_HAsciiString(hGrp->getString("Author", "Author").c_str())
     );
-    makeHeader.SetOrganizationValue(1, new TCollection_HAsciiString(hGrp->GetASCII("Company").c_str()));
+    makeHeader.SetOrganizationValue(1, new TCollection_HAsciiString(hGrp->getString("Company").c_str()));
     makeHeader.SetOriginatingSystem(
         new TCollection_HAsciiString(App::Application::getExecutableName().c_str())
     );

--- a/src/Mod/Import/Gui/AppImportGuiPy.cpp
+++ b/src/Mod/Import/Gui/AppImportGuiPy.cpp
@@ -592,7 +592,10 @@ private:
                 ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
                     "User parameter:BaseApp/Preferences/Mod/Part/STEP"
                 );
-                std::string scheme = hGrp->GetASCII("Scheme", Part::Interface::writeStepScheme());
+                std::string scheme = hGrp->getString(
+                    "Scheme",
+                    std::string_view {Part::Interface::writeStepScheme()}
+                );
                 std::list<std::string> supported = Part::supportedSTEPSchemes();
                 if (std::ranges::find(supported, scheme) != supported.end()) {
                     Part::Interface::writeStepScheme(scheme.c_str());

--- a/src/Mod/Material/App/ExternalManager.cpp
+++ b/src/Mod/Material/App/ExternalManager.cpp
@@ -80,7 +80,7 @@ void ExternalManager::getConfiguration()
 {
     // _hGrp = App::GetApplication().GetParameterGroupByPath(
     //     "User parameter:BaseApp/Preferences/Mod/Material/ExternalInterface");
-    auto current = _hGrp->GetASCII("Current", "None");
+    auto current = _hGrp->getString("Current", "None");
     if (current == "None") {
         _moduleName = "";
         _className = "";
@@ -90,8 +90,8 @@ void ExternalManager::getConfiguration()
             "User parameter:BaseApp/Preferences/Mod/Material/ExternalInterface/Interfaces/"
             + current;
         auto hGrp = App::GetApplication().GetParameterGroupByPath(groupName.c_str());
-        _moduleName = hGrp->GetASCII("Module", "");
-        _className = hGrp->GetASCII("Class", "");
+        _moduleName = hGrp->getString("Module", "");
+        _className = hGrp->getString("Class", "");
     }
 }
 

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -212,7 +212,7 @@ QString MaterialManager::defaultMaterialUUID()
     // Make this a preference
     auto param = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Material");
-    auto uuid = param->GetASCII("DefaultMaterial", "7f9fd73b-50c9-41d8-b7b2-575a030c1eeb");
+    auto uuid = param->getString("DefaultMaterial", "7f9fd73b-50c9-41d8-b7b2-575a030c1eeb");
     return QString::fromStdString(uuid);
 }
 

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -213,7 +213,7 @@ QString MaterialManager::defaultMaterialUUID()
     // Make this a preference
     auto param = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Material");
-    auto uuid = param->GetASCII("DefaultMaterial", "7f9fd73b-50c9-41d8-b7b2-575a030c1eeb");
+    auto uuid = param->getString("DefaultMaterial", "7f9fd73b-50c9-41d8-b7b2-575a030c1eeb");
     return QString::fromStdString(uuid);
 }
 

--- a/src/Mod/Material/App/MaterialManagerLocal.cpp
+++ b/src/Mod/Material/App/MaterialManagerLocal.cpp
@@ -543,8 +543,8 @@ MaterialManagerLocal::getConfiguredLibraries()
         for (auto& group : moduleParam->GetGroups()) {
             // auto module = moduleParam->GetGroup(group->GetGroupName());
             auto moduleName = QString::fromStdString(group->GetGroupName());
-            auto materialDir = QString::fromStdString(group->GetASCII("ModuleDir", ""));
-            auto materialIcon = QString::fromStdString(group->GetASCII("ModuleIcon", ""));
+            auto materialDir = QString::fromStdString(group->getString("ModuleDir", ""));
+            auto materialIcon = QString::fromStdString(group->getString("ModuleIcon", ""));
             auto materialReadOnly = group->GetBool("ModuleReadOnly", true);
 
             if (materialDir.length() > 0) {
@@ -584,7 +584,7 @@ MaterialManagerLocal::getConfiguredLibraries()
     }
 
     if (useMatFromCustomDir) {
-        QString resourceDir = QString::fromStdString(param->GetASCII("CustomMaterialsDir", ""));
+        QString resourceDir = QString::fromStdString(param->getString("CustomMaterialsDir", ""));
         if (!resourceDir.isEmpty()) {
             QDir materialDir(resourceDir);
             if (materialDir.exists()) {

--- a/src/Mod/Material/App/ModelLoader.cpp
+++ b/src/Mod/Material/App/ModelLoader.cpp
@@ -382,8 +382,8 @@ void ModelLoader::getModelLibraries()
         for (auto& group : moduleParam->GetGroups()) {
             // auto module = moduleParam->GetGroup(group->GetGroupName());
             auto moduleName = QString::fromStdString(group->GetGroupName());
-            auto modelDir = QString::fromStdString(group->GetASCII("ModuleModelDir", ""));
-            auto modelIcon = QString::fromStdString(group->GetASCII("ModuleIcon", ""));
+            auto modelDir = QString::fromStdString(group->getString("ModuleModelDir", ""));
+            auto modelIcon = QString::fromStdString(group->getString("ModuleIcon", ""));
 
             if (modelDir.length() > 0) {
                 QDir dir(modelDir);
@@ -411,7 +411,7 @@ void ModelLoader::getModelLibraries()
     }
 
     if (useMatFromCustomDir) {
-        QString resourceDir = QString::fromStdString(param->GetASCII("CustomMaterialsDir", ""));
+        QString resourceDir = QString::fromStdString(param->getString("CustomMaterialsDir", ""));
         if (!resourceDir.isEmpty()) {
             QDir materialDir(resourceDir);
             if (materialDir.exists()) {

--- a/src/Mod/Material/Gui/DlgSettingsExternal.cpp
+++ b/src/Mod/Material/Gui/DlgSettingsExternal.cpp
@@ -52,7 +52,7 @@ void DlgSettingsExternal::saveSettings()
 
     bool useExternal = ui->groupExternal->isChecked();
     hGrp->SetBool("UseExternal", useExternal);
-    hGrp->SetASCII("Current", ui->comboInterface->currentText().toStdString());
+    hGrp->setString("Current", ui->comboInterface->currentText().toStdString());
 }
 
 QString DlgSettingsExternal::toPerCent(double value) const
@@ -101,7 +101,7 @@ void DlgSettingsExternal::loadInterfaces()
     }
 
     hGrp = App::GetApplication().GetParameterGroupByPath(getPreferences().c_str());
-    auto current = hGrp->GetASCII("Current", "None");
+    auto current = hGrp->getString("Current", "None");
     ui->comboInterface->setCurrentText(QString::fromStdString(current));
 }
 

--- a/src/Mod/Material/Gui/MaterialTreeWidget.cpp
+++ b/src/Mod/Material/Gui/MaterialTreeWidget.cpp
@@ -417,7 +417,7 @@ void MaterialTreeWidget::getFavorites()
     auto count = param->GetInt("Favorites", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("FAV%1").arg(i);
-        QString uuid = QString::fromStdString(param->GetASCII(key.toStdString().c_str(), ""));
+        QString uuid = QString::fromStdString(param->getString(key.toStdString(), ""));
         if (_filter.modelIncluded(uuid)) {
             _favorites.push_back(uuid);
         }
@@ -434,7 +434,7 @@ void MaterialTreeWidget::getRecents()
     auto count = param->GetInt("Recent", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("MRU%1").arg(i);
-        QString uuid = QString::fromStdString(param->GetASCII(key.toStdString().c_str(), ""));
+        QString uuid = QString::fromStdString(param->getString(key.toStdString(), ""));
         if (_filter.modelIncluded(uuid)) {
             _recents.push_back(uuid);
         }
@@ -450,7 +450,7 @@ void MaterialTreeWidget::saveRecents()
     int count = param->GetInt("Recent", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("MRU%1").arg(i);
-        param->RemoveASCII(key.toStdString().c_str());
+        param->removeString(key.toStdString());
     }
 
     // Add the current values
@@ -462,7 +462,7 @@ void MaterialTreeWidget::saveRecents()
     int j = 0;
     for (auto& recent : _recents) {
         QString key = QStringLiteral("MRU%1").arg(j);
-        param->SetASCII(key.toStdString().c_str(), recent.toStdString());
+        param->setString(key.toStdString(), recent.toStdString());
 
         j++;
         if (j >= size) {
@@ -769,8 +769,8 @@ void PrefMaterialTreeWidget::restorePreferences()
         return;
     }
 
-    const char* defaultUuid = "7f9fd73b-50c9-41d8-b7b2-575a030c1eeb";
-    QString uuid = QString::fromStdString(getWindowParameter()->GetASCII(entryName(), defaultUuid));
+    constexpr std::string_view defaultUuid = "7f9fd73b-50c9-41d8-b7b2-575a030c1eeb";
+    QString uuid = QString::fromStdString(getWindowParameter()->getString(entryName().toStdString(), defaultUuid));
     setMaterial(uuid);
 }
 
@@ -781,5 +781,5 @@ void PrefMaterialTreeWidget::savePreferences()
         return;
     }
 
-    getWindowParameter()->SetASCII(entryName(), getMaterialUUID().toStdString());
+    getWindowParameter()->setString(entryName().toStdString(), getMaterialUUID().toStdString());
 }

--- a/src/Mod/Material/Gui/MaterialsEditor.cpp
+++ b/src/Mod/Material/Gui/MaterialsEditor.cpp
@@ -180,7 +180,7 @@ void MaterialsEditor::getFavorites()
     int count = param->GetInt("Favorites", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("FAV%1").arg(i);
-        QString uuid = QString::fromStdString(param->GetASCII(key.toStdString().c_str(), ""));
+        QString uuid = QString::fromStdString(param->getString(key.toStdString(), ""));
         if (_filter.modelIncluded(uuid)) {
             _favorites.push_back(uuid);
         }
@@ -196,7 +196,7 @@ void MaterialsEditor::saveFavorites()
     int count = param->GetInt("Favorites", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("FAV%1").arg(i);
-        param->RemoveASCII(key.toStdString().c_str());
+        param->removeString(key.toStdString());
     }
 
     // Add the current values
@@ -204,7 +204,7 @@ void MaterialsEditor::saveFavorites()
     int j = 0;
     for (auto& favorite : _favorites) {
         QString key = QStringLiteral("FAV%1").arg(j);
-        param->SetASCII(key.toStdString().c_str(), favorite.toStdString());
+        param->setString(key.toStdString(), favorite.toStdString());
 
         j++;
     }
@@ -258,7 +258,7 @@ void MaterialsEditor::getRecents()
     int count = param->GetInt("Recent", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("MRU%1").arg(i);
-        QString uuid = QString::fromStdString(param->GetASCII(key.toStdString().c_str(), ""));
+        QString uuid = QString::fromStdString(param->getString(key.toStdString(), ""));
         if (_filter.modelIncluded(uuid)) {
             _recents.push_back(uuid);
         }
@@ -274,7 +274,7 @@ void MaterialsEditor::saveRecents()
     int count = param->GetInt("Recent", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("MRU%1").arg(i);
-        param->RemoveASCII(key.toStdString().c_str());
+        param->removeString(key.toStdString());
     }
 
     // Add the current values
@@ -286,7 +286,7 @@ void MaterialsEditor::saveRecents()
     int j = 0;
     for (auto& recent : _recents) {
         QString key = QStringLiteral("MRU%1").arg(j);
-        param->SetASCII(key.toStdString().c_str(), recent.toStdString());
+        param->setString(key.toStdString(), recent.toStdString());
 
         j++;
         if (j >= size) {
@@ -484,17 +484,17 @@ void MaterialsEditor::setMaterialDefaults()
     _material->setName(tr("Unnamed"));
     std::string Author = App::GetApplication()
                              .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-                             ->GetASCII("prefAuthor", "");
+                             ->getString("prefAuthor", "");
     _material->setAuthor(QString::fromStdString(Author));
 
     // license stuff
     auto paramGrp {App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Document")};
     auto index = static_cast<int>(paramGrp->GetInt("prefLicenseType", 0));
-    const char* name = App::licenseItems.at(index).at(App::posnOfFullName);
+    const auto name = App::licenseItems.at(index).at(App::posnOfFullName);
     // const char* url = App::licenseItems.at(index).at(App::posnOfUrl);
-    // std::string licenseUrl = (paramGrp->GetASCII("prefLicenseUrl", url));
-    _material->setLicense(QLatin1String(name));
+    // std::string licenseUrl = (paramGrp->getString("prefLicenseUrl", url));
+    _material->setLicense(QString::fromUtf8(name.data(), name.size()));
 
     // Empty materials will have no parent
     Materials::MaterialManager::getManager().dereference(_material);

--- a/src/Mod/Material/Gui/ModelSelect.cpp
+++ b/src/Mod/Material/Gui/ModelSelect.cpp
@@ -85,7 +85,7 @@ void ModelSelect::getFavorites()
     int count = param->GetInt("Favorites", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("FAV%1").arg(i);
-        QString uuid = QString::fromStdString(param->GetASCII(key.toStdString().c_str(), ""));
+        QString uuid = QString::fromStdString(param->getString(key.toStdString(), ""));
         _favorites.push_back(uuid);
     }
 }
@@ -99,7 +99,7 @@ void ModelSelect::saveFavorites()
     int count = param->GetInt("Favorites", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("FAV%1").arg(i);
-        param->RemoveASCII(key.toStdString().c_str());
+        param->removeString(key.toStdString());
     }
 
     // Add the current values
@@ -107,7 +107,7 @@ void ModelSelect::saveFavorites()
     int j = 0;
     for (auto& favorite : _favorites) {
         QString key = QStringLiteral("FAV%1").arg(j);
-        param->SetASCII(key.toStdString().c_str(), favorite.toStdString());
+        param->setString(key.toStdString(), favorite.toStdString());
 
         j++;
     }
@@ -152,7 +152,7 @@ void ModelSelect::getRecents()
     int count = param->GetInt("Recent", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("MRU%1").arg(i);
-        QString uuid = QString::fromStdString(param->GetASCII(key.toStdString().c_str(), ""));
+        QString uuid = QString::fromStdString(param->getString(key.toStdString(), ""));
         _recents.push_back(uuid);
     }
 }
@@ -166,7 +166,7 @@ void ModelSelect::saveRecents()
     int count = param->GetInt("Recent", 0);
     for (int i = 0; static_cast<long>(i) < count; i++) {
         QString key = QStringLiteral("MRU%1").arg(i);
-        param->RemoveASCII(key.toStdString().c_str());
+        param->removeString(key.toStdString());
     }
 
     // Add the current values
@@ -178,7 +178,7 @@ void ModelSelect::saveRecents()
     int j = 0;
     for (auto& recent : _recents) {
         QString key = QStringLiteral("MRU%1").arg(j);
-        param->SetASCII(key.toStdString().c_str(), recent.toStdString());
+        param->setString(key.toStdString(), recent.toStdString());
 
         j++;
         if (j >= size) {

--- a/src/Mod/Mesh/App/AppMesh.cpp
+++ b/src/Mod/Mesh/App/AppMesh.cpp
@@ -64,7 +64,7 @@ PyMOD_INIT_FUNC(Mesh)
         "User parameter:BaseApp/Preferences/Mod/Mesh"
     );
     ParameterGrp::handle asy = handle->GetGroup("Asymptote");
-    MeshCore::MeshOutput::SetAsymptoteSize(asy->GetASCII("Width", "500"), asy->GetASCII("Height"));
+    MeshCore::MeshOutput::SetAsymptoteSize(asy->getString("Width", "500"), asy->getString("Height"));
 
     // clang-format off
     // add mesh elements

--- a/src/Mod/Mesh/Gui/DlgSettingsImportExportImp.cpp
+++ b/src/Mod/Mesh/Gui/DlgSettingsImportExportImp.cpp
@@ -61,8 +61,8 @@ void DlgSettingsImportExport::saveSettings()
     ui->export3mfModel->onSave();
 
     ParameterGrp::handle asy = handle->GetGroup("Asymptote");
-    asy->SetASCII("Width", ui->asymptoteWidth->text().toLatin1());
-    asy->SetASCII("Height", ui->asymptoteHeight->text().toLatin1());
+    asy->setString("Width", ui->asymptoteWidth->text().toStdString());
+    asy->setString("Height", ui->asymptoteHeight->text().toStdString());
 
     MeshCore::MeshOutput::SetAsymptoteSize(
         ui->asymptoteWidth->text().toStdString(),
@@ -83,8 +83,8 @@ void DlgSettingsImportExport::loadSettings()
     ui->export3mfModel->onRestore();
 
     ParameterGrp::handle asy = handle->GetGroup("Asymptote");
-    ui->asymptoteWidth->setText(QString::fromStdString(asy->GetASCII("Width")));
-    ui->asymptoteHeight->setText(QString::fromStdString(asy->GetASCII("Height")));
+    ui->asymptoteWidth->setText(QString::fromStdString(asy->getString("Width")));
+    ui->asymptoteHeight->setText(QString::fromStdString(asy->getString("Height")));
 }
 
 /**

--- a/src/Mod/Part/App/IGES/ImportExportSettings.cpp
+++ b/src/Mod/Part/App/IGES/ImportExportSettings.cpp
@@ -76,23 +76,25 @@ void ImportExportSettings::setUnit(Interface::Unit unit)
 
 std::string ImportExportSettings::getCompany() const
 {
-    return pGroup->GetASCII("Company", Part::Interface::writeIgesHeaderCompany());
+    return pGroup->getString("Company", std::string_view {Part::Interface::writeIgesHeaderCompany()});
 }
 
 void ImportExportSettings::setCompany(const char* name)
 {
-    pGroup->SetASCII("Company", name);
+    // TODO: make setCompany take a string_view and remove the conversion
+    pGroup->setString("Company", std::string_view {name});
     Part::Interface::writeIgesHeaderCompany(name);
 }
 
 std::string ImportExportSettings::getAuthor() const
 {
-    return pGroup->GetASCII("Author", Part::Interface::writeIgesHeaderAuthor());
+    return pGroup->getString("Author", std::string_view {Part::Interface::writeIgesHeaderAuthor()});
 }
 
 void ImportExportSettings::setAuthor(const char* name)
 {
-    pGroup->SetASCII("Author", name);
+    // TODO: make setAuthor take a string_view and remove the conversion
+    pGroup->setString("Author", std::string_view {name});
     Part::Interface::writeIgesHeaderAuthor(name);
 }
 

--- a/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
+++ b/src/Mod/Part/App/OCAF/ImportExportSettings.cpp
@@ -84,11 +84,13 @@ void ImportExportSettings::initIGES(Base::Reference<ParameterGrp> hGrp)
     int value = Interface_Static::IVal("write.iges.brep.mode");
     bool brep = hIgesGrp->GetBool("BrepMode", value > 0);
     Interface_Static::SetIVal("write.iges.brep.mode", brep ? 1 : 0);
-    Interface_Static::SetCVal("write.iges.header.company", hIgesGrp->GetASCII("Company").c_str());
-    Interface_Static::SetCVal("write.iges.header.author", hIgesGrp->GetASCII("Author").c_str());
+    Interface_Static::SetCVal("write.iges.header.company", hIgesGrp->getString("Company").c_str());
+    Interface_Static::SetCVal("write.iges.header.author", hIgesGrp->getString("Author").c_str());
     Interface_Static::SetCVal(
         "write.iges.header.product",
-        hIgesGrp->GetASCII("Product", Interface_Static::CVal("write.iges.header.product")).c_str()
+        hIgesGrp
+            ->getString("Product", std::string_view {Interface_Static::CVal("write.iges.header.product")})
+            .c_str()
     );
 
     int unitIges = hIgesGrp->GetInt("Unit", 0);
@@ -147,11 +149,16 @@ void ImportExportSettings::initSTEP(Base::Reference<ParameterGrp> hGrp)
             break;
     }
 
-    std::string ap = hStepGrp->GetASCII("Scheme", Interface_Static::CVal("write.step.schema"));
+    std::string ap = hStepGrp->getString(
+        "Scheme",
+        std::string_view {Interface_Static::CVal("write.step.schema")}
+    );
     Interface_Static::SetCVal("write.step.schema", ap.c_str());
     Interface_Static::SetCVal(
         "write.step.product.name",
-        hStepGrp->GetASCII("Product", Interface_Static::CVal("write.step.product.name")).c_str()
+        hStepGrp
+            ->getString("Product", std::string_view {Interface_Static::CVal("write.step.product.name")})
+            .c_str()
     );
 }
 

--- a/src/Mod/Part/App/STEP/ImportExportSettings.cpp
+++ b/src/Mod/Part/App/STEP/ImportExportSettings.cpp
@@ -82,12 +82,13 @@ bool ImportExportSettings::getWriteSurfaceCurveMode() const
 
 std::string ImportExportSettings::getScheme() const
 {
-    return pGroup->GetASCII("Scheme", Interface_Static::CVal("write.step.schema"));
+    return pGroup->getString("Scheme", std::string_view {Interface_Static::CVal("write.step.schema")});
 }
 
 void ImportExportSettings::setScheme(const char* scheme)
 {
-    pGroup->SetASCII("Scheme", scheme);
+    // TODO: make setScheme take a string_view and remove the conversion
+    pGroup->setString("Scheme", std::string_view {scheme});
     Interface_Static::SetCVal("write.step.schema", scheme);
 }
 
@@ -104,22 +105,24 @@ void ImportExportSettings::setUnit(Interface::Unit unit)
 
 std::string ImportExportSettings::getCompany() const
 {
-    return pGroup->GetASCII("Company");
+    return pGroup->getString("Company");
 }
 
 void ImportExportSettings::setCompany(const char* name)
 {
-    pGroup->SetASCII("Company", name);
+    // TODO: make setCompany take a string_view and remove the conversion
+    pGroup->setString("Company", std::string_view {name});
 }
 
 std::string ImportExportSettings::getAuthor() const
 {
-    return pGroup->GetASCII("Author");
+    return pGroup->getString("Author");
 }
 
 void ImportExportSettings::setAuthor(const char* name)
 {
-    pGroup->SetASCII("Author", name);
+    // TODO: make setAuthor take a string_view and remove the conversion
+    pGroup->setString("Author", std::string_view {name});
 }
 
 std::string ImportExportSettings::getProductName() const

--- a/src/Mod/Part/App/WireJoiner.cpp
+++ b/src/Mod/Part/App/WireJoiner.cpp
@@ -158,7 +158,7 @@ public:
         : catchObject(
               App::GetApplication()
                   .GetParameterGroupByPath("User parameter:BaseApp/Preferences/WireJoiner")
-                  ->GetASCII("ObjectName")
+                  ->getString("ObjectName")
           )
         , catchIteration(
               static_cast<int>(

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -758,7 +758,7 @@ void EditModeCoinManager::ParameterObserver::updateConstraintPresentationParamet
     Client.constraintParameters.bHideUnits = hGrpskg->GetBool("HideUnits", false);
     Client.constraintParameters.bShowDimensionalName = hGrpskg->GetBool("ShowDimensionalName", true);
     Client.constraintParameters.sDimensionalStringFormat = QString::fromStdString(
-        hGrpskg->GetASCII("DimensionalStringFormat", "%N = %V")
+        hGrpskg->getString("DimensionalStringFormat", "%N = %V")
     );
 }
 
@@ -2105,7 +2105,7 @@ void EditModeCoinManager::updateElementSizeParameters()
     int markerSize = hGrp->GetInt("MarkerSize", 7);
 
     drawingParameters.labelFontName = QString::fromStdString(
-        hGrp->GetASCII("EditSketcherFontName", "")
+        hGrp->getString("EditSketcherFontName")
     );
 
     int defaultFontSizePixels = defaultApplicationFontSizePixels();  // returns height in pixels,

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -2104,9 +2104,7 @@ void EditModeCoinManager::updateElementSizeParameters()
 
     int markerSize = hGrp->GetInt("MarkerSize", 7);
 
-    drawingParameters.labelFontName = QString::fromStdString(
-        hGrp->getString("EditSketcherFontName")
-    );
+    drawingParameters.labelFontName = QString::fromStdString(hGrp->getString("EditSketcherFontName"));
 
     int defaultFontSizePixels = defaultApplicationFontSizePixels();  // returns height in pixels,
                                                                      // not points

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -779,7 +779,7 @@ void EditModeCoinManager::ParameterObserver::updateConstraintPresentationParamet
     Client.constraintParameters.bHideUnits = hGrpskg->GetBool("HideUnits", false);
     Client.constraintParameters.bShowDimensionalName = hGrpskg->GetBool("ShowDimensionalName", true);
     Client.constraintParameters.sDimensionalStringFormat = QString::fromStdString(
-        hGrpskg->GetASCII("DimensionalStringFormat", "%N = %V")
+        hGrpskg->getString("DimensionalStringFormat", "%N = %V")
     );
 }
 
@@ -2116,9 +2116,7 @@ void EditModeCoinManager::updateElementSizeParameters()
 
     int markerSize = hGrp->GetInt("MarkerSize", 7);
 
-    drawingParameters.labelFontName = QString::fromStdString(
-        hGrp->GetASCII("EditSketcherFontName", "")
-    );
+    drawingParameters.labelFontName = QString::fromStdString(hGrp->getString("EditSketcherFontName"));
 
     int defaultFontSizePixels = defaultApplicationFontSizePixels();  // returns height in pixels,
                                                                      // not points

--- a/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherSolverAdvanced.cpp
@@ -291,9 +291,15 @@ void TaskSketcherSolverAdvanced::updateDefaultMethodParameters()
             ui->lineEditSolverParam1->setEnabled(true);
             ui->lineEditSolverParam2->setEnabled(true);
             ui->lineEditSolverParam3->setEnabled(true);
-            double eps = ::atof(hGrp->GetASCII("LM_eps", QString::number(LM_EPS).toUtf8()).c_str());
-            double eps1 = ::atof(hGrp->GetASCII("LM_eps1", QString::number(LM_EPS1).toUtf8()).c_str());
-            double tau = ::atof(hGrp->GetASCII("LM_tau", QString::number(LM_TAU).toUtf8()).c_str());
+            double eps = ::atof(
+                hGrp->getString("LM_eps", QString::number(LM_EPS).toStdString()).c_str()
+            );
+            double eps1 = ::atof(
+                hGrp->getString("LM_eps1", QString::number(LM_EPS1).toStdString()).c_str()
+            );
+            double tau = ::atof(
+                hGrp->getString("LM_tau", QString::number(LM_TAU).toStdString()).c_str()
+            );
             ui->lineEditSolverParam1->setText(
                 QString::number(eps).remove(
                     QStringLiteral("+").replace(QStringLiteral("e0"), QStringLiteral("E")).toUpper()
@@ -330,9 +336,15 @@ void TaskSketcherSolverAdvanced::updateDefaultMethodParameters()
             ui->lineEditSolverParam1->setEnabled(true);
             ui->lineEditSolverParam2->setEnabled(true);
             ui->lineEditSolverParam3->setEnabled(true);
-            double tolg = ::atof(hGrp->GetASCII("DL_tolg", QString::number(DL_TOLG).toUtf8()).c_str());
-            double tolx = ::atof(hGrp->GetASCII("DL_tolx", QString::number(DL_TOLX).toUtf8()).c_str());
-            double tolf = ::atof(hGrp->GetASCII("DL_tolf", QString::number(DL_TOLF).toUtf8()).c_str());
+            double tolg = ::atof(
+                hGrp->getString("DL_tolg", QString::number(DL_TOLG).toStdString()).c_str()
+            );
+            double tolx = ::atof(
+                hGrp->getString("DL_tolx", QString::number(DL_TOLX).toStdString()).c_str()
+            );
+            double tolf = ::atof(
+                hGrp->getString("DL_tolf", QString::number(DL_TOLF).toStdString()).c_str()
+            );
             ui->lineEditSolverParam1->setText(
                 QString::number(tolg).remove(
                     QStringLiteral("+").replace(QStringLiteral("e0"), QStringLiteral("E")).toUpper()
@@ -396,13 +408,13 @@ void TaskSketcherSolverAdvanced::updateRedundantMethodParameters()
             ui->lineEditRedundantSolverParam2->setEnabled(true);
             ui->lineEditRedundantSolverParam3->setEnabled(true);
             double eps = ::atof(
-                hGrp->GetASCII("Redundant_LM_eps", QString::number(LM_EPS).toUtf8()).c_str()
+                hGrp->getString("Redundant_LM_eps", QString::number(LM_EPS).toStdString()).c_str()
             );
             double eps1 = ::atof(
-                hGrp->GetASCII("Redundant_LM_eps1", QString::number(LM_EPS1).toUtf8()).c_str()
+                hGrp->getString("Redundant_LM_eps1", QString::number(LM_EPS1).toStdString()).c_str()
             );
             double tau = ::atof(
-                hGrp->GetASCII("Redundant_LM_tau", QString::number(LM_TAU).toUtf8()).c_str()
+                hGrp->getString("Redundant_LM_tau", QString::number(LM_TAU).toStdString()).c_str()
             );
             ui->lineEditRedundantSolverParam1->setText(
                 QString::number(eps).remove(
@@ -436,13 +448,13 @@ void TaskSketcherSolverAdvanced::updateRedundantMethodParameters()
             ui->lineEditRedundantSolverParam2->setEnabled(true);
             ui->lineEditRedundantSolverParam3->setEnabled(true);
             double tolg = ::atof(
-                hGrp->GetASCII("Redundant_DL_tolg", QString::number(DL_TOLG).toUtf8()).c_str()
+                hGrp->getString("Redundant_DL_tolg", QString::number(DL_TOLG).toStdString()).c_str()
             );
             double tolx = ::atof(
-                hGrp->GetASCII("Redundant_DL_tolx", QString::number(DL_TOLX).toUtf8()).c_str()
+                hGrp->getString("Redundant_DL_tolx", QString::number(DL_TOLX).toStdString()).c_str()
             );
             double tolf = ::atof(
-                hGrp->GetASCII("Redundant_DL_tolf", QString::number(DL_TOLF).toUtf8()).c_str()
+                hGrp->getString("Redundant_DL_tolf", QString::number(DL_TOLF).toStdString()).c_str()
             );
             ui->lineEditRedundantSolverParam1->setText(
                 QString::number(tolg).remove(
@@ -809,18 +821,18 @@ void TaskSketcherSolverAdvanced::onPushButtonDefaultsClicked(bool checked /* = f
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Sketcher/SolverAdvanced"
     );
-    hGrp->SetASCII("LM_eps", QString::number(LM_EPS).toUtf8());
-    hGrp->SetASCII("LM_eps1", QString::number(LM_EPS1).toUtf8());
-    hGrp->SetASCII("LM_tau", QString::number(LM_TAU).toUtf8());
-    hGrp->SetASCII("DL_tolg", QString::number(DL_TOLG).toUtf8());
-    hGrp->SetASCII("DL_tolx", QString::number(DL_TOLX).toUtf8());
-    hGrp->SetASCII("DL_tolf", QString::number(DL_TOLF).toUtf8());
-    hGrp->SetASCII("Redundant_LM_eps", QString::number(LM_EPS).toUtf8());
-    hGrp->SetASCII("Redundant_LM_eps1", QString::number(LM_EPS1).toUtf8());
-    hGrp->SetASCII("Redundant_LM_tau", QString::number(LM_TAU).toUtf8());
-    hGrp->SetASCII("Redundant_DL_tolg", QString::number(DL_TOLG).toUtf8());
-    hGrp->SetASCII("Redundant_DL_tolx", QString::number(DL_TOLX).toUtf8());
-    hGrp->SetASCII("Redundant_DL_tolf", QString::number(DL_TOLF).toUtf8());
+    hGrp->setString("LM_eps", QString::number(LM_EPS).toStdString());
+    hGrp->setString("LM_eps1", QString::number(LM_EPS1).toStdString());
+    hGrp->setString("LM_tau", QString::number(LM_TAU).toStdString());
+    hGrp->setString("DL_tolg", QString::number(DL_TOLG).toStdString());
+    hGrp->setString("DL_tolx", QString::number(DL_TOLX).toStdString());
+    hGrp->setString("DL_tolf", QString::number(DL_TOLF).toStdString());
+    hGrp->setString("Redundant_LM_eps", QString::number(LM_EPS).toStdString());
+    hGrp->setString("Redundant_LM_eps1", QString::number(LM_EPS1).toStdString());
+    hGrp->setString("Redundant_LM_tau", QString::number(LM_TAU).toStdString());
+    hGrp->setString("Redundant_DL_tolg", QString::number(DL_TOLG).toStdString());
+    hGrp->setString("Redundant_DL_tolx", QString::number(DL_TOLX).toStdString());
+    hGrp->setString("Redundant_DL_tolf", QString::number(DL_TOLF).toStdString());
     // Set other settings
     hGrp->SetInt("DefaultSolver", DEFAULT_SOLVER);
     hGrp->SetInt("DogLegGaussStep", DEFAULT_DOGLEG_GAUSS_STEP);
@@ -830,10 +842,10 @@ void TaskSketcherSolverAdvanced::onPushButtonDefaultsClicked(bool checked /* = f
     hGrp->SetInt("RedundantSolverMaxIterations", MAX_ITER);
     hGrp->SetBool("SketchSizeMultiplier", MAX_ITER_MULTIPLIER);
     hGrp->SetBool("RedundantSketchSizeMultiplier", MAX_ITER_MULTIPLIER);
-    hGrp->SetASCII("Convergence", QString::number(CONVERGENCE).toUtf8());
-    hGrp->SetASCII("RedundantConvergence", QString::number(CONVERGENCE).toUtf8());
+    hGrp->setString("Convergence", QString::number(CONVERGENCE).toStdString());
+    hGrp->setString("RedundantConvergence", QString::number(CONVERGENCE).toStdString());
     hGrp->SetInt("QRMethod", DEFAULT_QRSOLVER);
-    hGrp->SetASCII("QRPivotThreshold", QString::number(QR_PIVOT_THRESHOLD).toUtf8());
+    hGrp->setString("QRPivotThreshold", QString::number(QR_PIVOT_THRESHOLD).toStdString());
     hGrp->SetInt("DebugMode", DEFAULT_SOLVER_DEBUG);
 
     ui->comboBoxDefaultSolver->onRestore();

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -218,7 +218,7 @@ void ViewProviderSketch::ParameterObserver::updateGridSize(const std::string& st
         "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
 
     Client.GridSize.setValue(
-        Base::Quantity::parse(hGrp->GetGroup("GridSize")->GetASCII("GridSize", "10.0"))
+        Base::Quantity::parse(hGrp->GetGroup("GridSize")->getString("GridSize", "10.0"))
             .getValue());
 }
 

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -219,7 +219,7 @@ void ViewProviderSketch::ParameterObserver::updateGridSize(const std::string& st
         "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
 
     Client.GridSize.setValue(
-        Base::Quantity::parse(hGrp->GetGroup("GridSize")->GetASCII("GridSize", "10.0"))
+        Base::Quantity::parse(hGrp->GetGroup("GridSize")->getString("GridSize", "10.0"))
             .getValue());
 }
 

--- a/src/Mod/Start/App/CustomFolderModel.cpp
+++ b/src/Mod/Start/App/CustomFolderModel.cpp
@@ -38,7 +38,7 @@ CustomFolderModel::CustomFolderModel(QObject* parent)
         "User parameter:BaseApp/Preferences/Mod/Start"
     );
 
-    _customFolderPathSpec = QString::fromStdString(parameterGroup->GetASCII("CustomFolder", ""));
+    _customFolderPathSpec = QString::fromStdString(parameterGroup->getString("CustomFolder", ""));
 
     _showOnlyFCStd = parameterGroup->GetBool("ShowOnlyFCStd", false);
 }

--- a/src/Mod/Start/App/RecentFilesModel.cpp
+++ b/src/Mod/Start/App/RecentFilesModel.cpp
@@ -42,7 +42,7 @@ void RecentFilesModel::loadRecentFiles()
     auto numRows {_parameterGroup->GetInt("RecentFiles", 0)};
     for (int i = 0; i < numRows; ++i) {
         auto entry = fmt::format("MRU{}", i);
-        auto path = _parameterGroup->GetASCII(entry.c_str(), "");
+        auto path = _parameterGroup->getString(entry, "");
         addFile(QString::fromStdString(path));
     }
     endResetModel();

--- a/src/Mod/Start/App/RecentFilesModel.cpp
+++ b/src/Mod/Start/App/RecentFilesModel.cpp
@@ -40,7 +40,7 @@ void RecentFilesModel::loadRecentFiles()
     beginResetModel();
     clear();
     const auto maxRows {_parameterGroup->GetInt("RecentFiles", 0)};  // really like "MaxRecentFiles"
-    for (const auto& path : _parameterGroup->GetASCIIs("MRU")) {
+    for (const auto& path : _parameterGroup->getAllStrings("MRU")) {
         if (rowCount() >= maxRows) {
             // Really shouldn't ever happen -- something got corrupted
             break;

--- a/src/Mod/Start/App/ThumbnailSource.cpp
+++ b/src/Mod/Start/App/ThumbnailSource.cpp
@@ -82,7 +82,7 @@ static QString getF3dPath()
     const ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start"
     );
-    return QString::fromUtf8(hGrp->GetASCII("f3d", "f3d").c_str());
+    return QString::fromStdString(hGrp->getString("f3d", "f3d"));
 }
 
 static QStringList getF3DOptions(const QString& f3dPath)

--- a/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
+++ b/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
@@ -100,7 +100,7 @@ gsl::owner<QComboBox*> GeneralSettingsWidget::createLanguageComboBox()
         "User parameter:BaseApp/Preferences/General"
     );
     auto langToStr = Gui::Translator::instance()->activeLanguage();
-    QByteArray language = hGrp->GetASCII("Language", langToStr.c_str()).c_str();
+    QByteArray language = hGrp->getString("Language", langToStr).c_str();
     auto comboBox = gsl::owner<QComboBox*>(new QComboBox);
     comboBox->addItem(QStringLiteral("English"), QByteArray("English"));
     Gui::TStringMap list = Gui::Translator::instance()->supportedLocales();
@@ -182,7 +182,7 @@ void GeneralSettingsWidget::onLanguageChanged(int index)
         "User parameter:BaseApp/Preferences/General"
     );
     auto langToStr = Gui::Translator::instance()->activeLanguage();
-    hGrp->SetASCII("Language", langToStr.c_str());
+    hGrp->setString("Language", langToStr);
 }
 
 void GeneralSettingsWidget::onUnitSystemChanged(int index)
@@ -206,7 +206,7 @@ void GeneralSettingsWidget::onNavigationStyleChanged(int index)
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    hGrp->SetASCII("NavigationStyle", navStyleName.constData());
+    hGrp->setString("NavigationStyle", navStyleName.toStdString());
 }
 
 bool GeneralSettingsWidget::eventFilter(QObject* object, QEvent* event)
@@ -242,10 +242,8 @@ void GeneralSettingsWidget::retranslateUi()
     ParameterGrp::handle hGrpNav = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    auto navStyleName = hGrpNav->GetASCII(
-        "NavigationStyle",
-        std::string {Gui::CADNavigationStyle::getClassTypeId().getName()}.c_str()
-    );
+    auto navStyleName
+        = hGrpNav->getString("NavigationStyle", Gui::CADNavigationStyle::getClassTypeId().getName());
     std::map<Base::Type, std::string> styles = Gui::UserNavigationStyle::getUserFriendlyNames();
     for (const auto& style : styles) {
         QByteArray data(style.first.getName());

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -80,7 +80,7 @@ StartView::StartView(QWidget* parent)
     auto showExamples = hGrp->GetBool("ShowExamples", true);
 
     // Verify that the folder specified in preferences is available before showing it
-    std::string customFolder(hGrp->GetASCII("CustomFolder", ""));
+    std::string customFolder(hGrp->getString("CustomFolder", ""));
     bool showCustomFolder = false;
     if (!customFolder.empty()) {
         showCustomFolder = true;
@@ -379,11 +379,11 @@ void StartView::postStart(PostStartBehavior behavior)
     );
 
     if (behavior == PostStartBehavior::switchWorkbench) {
-        auto wb = hGrp->GetASCII("AutoloadModule", "");
+        auto wb = hGrp->getString("AutoloadModule", "");
         if (wb == "$LastModule") {
             wb = App::GetApplication()
                      .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                     ->GetASCII("LastModule", "");
+                     ->getString("LastModule", "");
         }
         if (!wb.empty()) {
             Gui::Application::Instance->activateWorkbench(wb.c_str());
@@ -526,7 +526,7 @@ void StartView::retranslateUi()
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start"
     );
-    std::string customFolder(hGrp->GetASCII("CustomFolder", ""));
+    std::string customFolder(hGrp->getString("CustomFolder", ""));
     if (!customFolder.empty() && _customFolderLabel) {
         if (hGrp->GetBool("ShortCustomFolder", true)) {
             _customFolderLabel->setToolTip(QString::fromUtf8(customFolder.c_str()));

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -82,7 +82,7 @@ StartView::StartView(QWidget* parent)
     auto showExamples = hGrp->GetBool("ShowExamples", true);
 
     // Verify that the folder specified in preferences is available before showing it
-    std::string customFolder(hGrp->GetASCII("CustomFolder", ""));
+    std::string customFolder(hGrp->getString("CustomFolder", ""));
     bool showCustomFolder = false;
     if (!customFolder.empty()) {
         showCustomFolder = true;
@@ -397,11 +397,11 @@ void StartView::postStart(PostStartBehavior behavior)
     );
 
     if (behavior == PostStartBehavior::switchWorkbench) {
-        auto wb = hGrp->GetASCII("AutoloadModule", "");
+        auto wb = hGrp->getString("AutoloadModule", "");
         if (wb == "$LastModule") {
             wb = App::GetApplication()
                      .GetParameterGroupByPath("User parameter:BaseApp/Preferences/General")
-                     ->GetASCII("LastModule", "");
+                     ->getString("LastModule", "");
         }
         if (!wb.empty()) {
             Gui::Application::Instance->activateWorkbench(wb.c_str());
@@ -544,7 +544,7 @@ void StartView::retranslateUi()
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start"
     );
-    std::string customFolder(hGrp->GetASCII("CustomFolder", ""));
+    std::string customFolder(hGrp->getString("CustomFolder", ""));
     if (!customFolder.empty() && _customFolderLabel) {
         if (hGrp->GetBool("ShortCustomFolder", true)) {
             _customFolderLabel->setToolTip(QString::fromUtf8(customFolder.c_str()));

--- a/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
+++ b/src/Mod/Start/Gui/ThemeSelectorWidget.cpp
@@ -124,7 +124,7 @@ void ThemeSelectorWidget::setupButtons(QBoxLayout* layout)
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow"
     );
-    auto styleSheetName = QString::fromStdString(hGrp->GetASCII("StyleSheet"));
+    auto styleSheetName = QString::fromStdString(hGrp->getString("StyleSheet"));
     for (const auto& theme : themeMap) {
         auto button = gsl::owner<QToolButton*>(new QToolButton());
 
@@ -198,12 +198,12 @@ void ThemeSelectorWidget::preselectThemeFromSystemSettings()
         return;
     }
 
-    auto nullStyle("<N/A>");
+    constexpr std::string_view nullStyle {"<N/A>"};
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow"
     );
-    auto styleSheetName = QString::fromStdString(hGrp->GetASCII("StyleSheet", nullStyle));
-    if (styleSheetName == QString::fromStdString(nullStyle)) {
+    const auto styleSheetName = hGrp->getString("StyleSheet", nullStyle);
+    if (styleSheetName == nullStyle) {
         auto theme = isSystemInDarkMode() ? Theme::Dark : Theme::Light;
         themeChanged(theme);
     }

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -592,7 +592,8 @@ std::string DrawGeomHatch::prefGeomHatchFile()
 std::string DrawGeomHatch::prefGeomHatchName()
 {
     std::string defaultNamePattern = "Diamond";
-    std::string result = Preferences::getPreferenceGroup("PAT")->GetASCII("NamePattern", defaultNamePattern.c_str());
+    std::string result
+        = Preferences::getPreferenceGroup("PAT")->getString("NamePattern", defaultNamePattern);
     if (result.empty()) {
         return defaultNamePattern;
     }

--- a/src/Mod/TechDraw/App/DrawGeomHatch.cpp
+++ b/src/Mod/TechDraw/App/DrawGeomHatch.cpp
@@ -594,7 +594,8 @@ std::string DrawGeomHatch::prefGeomHatchFile()
 std::string DrawGeomHatch::prefGeomHatchName()
 {
     std::string defaultNamePattern = "Diamond";
-    std::string result = Preferences::getPreferenceGroup("PAT")->GetASCII("NamePattern", defaultNamePattern.c_str());
+    std::string result
+        = Preferences::getPreferenceGroup("PAT")->getString("NamePattern", defaultNamePattern);
     if (result.empty()) {
         return defaultNamePattern;
     }

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -2163,8 +2163,9 @@ std::string DrawViewDimension::getPrefixForDimType() const
     }
 
     if (Type.isValue("Diameter")) {
-        return std::string(Preferences::getPreferenceGroup("Dimensions")
-                               ->GetASCII("DiameterSymbol", "\xe2\x8c\x80"));  // Diameter symbol
+        return std::string(
+            Preferences::getPreferenceGroup("Dimensions")->getString("DiameterSymbol", "\xe2\x8c\x80")
+        );  // Diameter symbol
     }
 
     return "";

--- a/src/Mod/TechDraw/App/DrawViewDimension.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDimension.cpp
@@ -2181,8 +2181,9 @@ std::string DrawViewDimension::getPrefixForDimType() const
     }
 
     if (Type.isValue("Diameter")) {
-        return std::string(Preferences::getPreferenceGroup("Dimensions")
-                               ->GetASCII("DiameterSymbol", "\xe2\x8c\x80"));  // Diameter symbol
+        return std::string(
+            Preferences::getPreferenceGroup("Dimensions")->getString("DiameterSymbol", "\xe2\x8c\x80")
+        );  // Diameter symbol
     }
 
     return "";

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -51,7 +51,7 @@ Base::Reference<ParameterGrp> Preferences::getPreferenceGroup(const char* Name)
 
 std::string Preferences::labelFont()
 {
-    return getPreferenceGroup("Labels")->GetASCII("LabelFont", "osifont");
+    return getPreferenceGroup("Labels")->getString("LabelFont", "osifont");
 }
 
 QString Preferences::labelFontQString()
@@ -196,7 +196,7 @@ QString Preferences::defaultTemplate()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Templates/";
     std::string defaultFileName = defaultDir + "Default_Template_A4_Landscape.svg";
-    std::string prefFileName = getPreferenceGroup("Files")->GetASCII("TemplateFile", defaultFileName.c_str());
+    std::string prefFileName = getPreferenceGroup("Files")->getString("TemplateFile", defaultFileName);
     if (prefFileName.empty()) {
         prefFileName = defaultFileName;
     }
@@ -212,7 +212,7 @@ QString Preferences::defaultTemplate()
 QString Preferences::defaultTemplateDir()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Templates";
-    std::string prefTemplateDir = getPreferenceGroup("Files")->GetASCII("TemplateDir", defaultDir.c_str());
+    std::string prefTemplateDir = getPreferenceGroup("Files")->getString("TemplateDir", defaultDir);
     if (prefTemplateDir.empty()) {
         prefTemplateDir = defaultDir;
     }
@@ -230,7 +230,7 @@ std::string Preferences::lineGroupFile()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/LineGroup/";
     std::string defaultFileName = defaultDir + "LineGroup.csv";
-    std::string lgFileName = getPreferenceGroup("Files")->GetASCII("LineGroupFile", defaultFileName.c_str());
+    std::string lgFileName = getPreferenceGroup("Files")->getString("LineGroupFile", defaultFileName);
     if (lgFileName.empty()) {
         lgFileName = defaultFileName;
     }
@@ -244,7 +244,7 @@ std::string Preferences::lineGroupFile()
 
 std::string Preferences::formatSpec()
 {
-    return getPreferenceGroup("Dimensions")->GetASCII("formatSpec", "%.2w");
+    return getPreferenceGroup("Dimensions")->getString("formatSpec", "%.2w");
 }
 
 int Preferences::altDecimals()
@@ -271,7 +271,7 @@ bool Preferences::showDetailHighlight()
 QString Preferences::defaultSymbolDir()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Symbols";
-    std::string prefSymbolDir = getPreferenceGroup("Files")->GetASCII("DirSymbol", defaultDir.c_str());
+    std::string prefSymbolDir = getPreferenceGroup("Files")->getString("DirSymbol", defaultDir);
     if (prefSymbolDir.empty()) {
         prefSymbolDir = defaultDir;
     }
@@ -289,7 +289,7 @@ std::string Preferences::svgFile()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Patterns/";
     std::string defaultFileName = defaultDir + "simple.svg";
-    std::string prefHatchFile = getPreferenceGroup("Files")->GetASCII("FileHatch", defaultFileName.c_str());
+    std::string prefHatchFile = getPreferenceGroup("Files")->getString("FileHatch", defaultFileName);
     if (prefHatchFile.empty()) {
         prefHatchFile = defaultFileName;
     }
@@ -305,7 +305,7 @@ std::string Preferences::patFile()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/PAT/";
     std::string defaultFileName = defaultDir + "FCPAT.pat";
-    std::string prefHatchFile = getPreferenceGroup("PAT")->GetASCII("FilePattern", defaultFileName.c_str());
+    std::string prefHatchFile = getPreferenceGroup("PAT")->getString("FilePattern", defaultFileName);
     if (prefHatchFile.empty()) {
         prefHatchFile = defaultFileName;
     }
@@ -322,7 +322,7 @@ std::string Preferences::bitmapFill()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Patterns/";
     std::string defaultFileName = defaultDir + "default.png";
-    std::string prefBitmapFile = getPreferenceGroup("Files")->GetASCII("BitmapFill", defaultFileName.c_str());
+    std::string prefBitmapFile = getPreferenceGroup("Files")->getString("BitmapFill", defaultFileName);
     if (prefBitmapFile.empty()) {
         prefBitmapFile = defaultFileName;
     }
@@ -481,14 +481,14 @@ void Preferences::setLineStandard(int index)
 std::string Preferences::lineDefinitionLocation()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/LineGroup/";
-    std::string prefDir = getPreferenceGroup("Files")->GetASCII("LineDefLocation", defaultDir.c_str());
+    std::string prefDir = getPreferenceGroup("Files")->getString("LineDefLocation", defaultDir);
     return prefDir;
 }
 
 std::string Preferences::lineElementsLocation()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/LineGroup/";
-    std::string prefDir = getPreferenceGroup("Files")->GetASCII("LineElementLocation", defaultDir.c_str());
+    std::string prefDir = getPreferenceGroup("Files")->getString("LineElementLocation", defaultDir);
     return prefDir;
 }
 

--- a/src/Mod/TechDraw/App/Preferences.cpp
+++ b/src/Mod/TechDraw/App/Preferences.cpp
@@ -53,7 +53,7 @@ Base::Reference<ParameterGrp> Preferences::getPreferenceGroup(const char* Name)
 
 std::string Preferences::labelFont()
 {
-    return getPreferenceGroup("Labels")->GetASCII("LabelFont", "osifont");
+    return getPreferenceGroup("Labels")->getString("LabelFont", "osifont");
 }
 
 QString Preferences::labelFontQString()
@@ -198,7 +198,7 @@ QString Preferences::defaultTemplate()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Templates/";
     std::string defaultFileName = defaultDir + "Default_Template_A4_Landscape.svg";
-    std::string prefFileName = getPreferenceGroup("Files")->GetASCII("TemplateFile", defaultFileName.c_str());
+    std::string prefFileName = getPreferenceGroup("Files")->getString("TemplateFile", defaultFileName);
     if (prefFileName.empty()) {
         prefFileName = defaultFileName;
     }
@@ -214,7 +214,7 @@ QString Preferences::defaultTemplate()
 QString Preferences::defaultTemplateDir()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Templates";
-    std::string prefTemplateDir = getPreferenceGroup("Files")->GetASCII("TemplateDir", defaultDir.c_str());
+    std::string prefTemplateDir = getPreferenceGroup("Files")->getString("TemplateDir", defaultDir);
     if (prefTemplateDir.empty()) {
         prefTemplateDir = defaultDir;
     }
@@ -232,7 +232,7 @@ std::string Preferences::lineGroupFile()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/LineGroup/";
     std::string defaultFileName = defaultDir + "LineGroup.csv";
-    std::string lgFileName = getPreferenceGroup("Files")->GetASCII("LineGroupFile", defaultFileName.c_str());
+    std::string lgFileName = getPreferenceGroup("Files")->getString("LineGroupFile", defaultFileName);
     if (lgFileName.empty()) {
         lgFileName = defaultFileName;
     }
@@ -246,7 +246,7 @@ std::string Preferences::lineGroupFile()
 
 std::string Preferences::formatSpec()
 {
-    return getPreferenceGroup("Dimensions")->GetASCII("formatSpec", "%.2w");
+    return getPreferenceGroup("Dimensions")->getString("formatSpec", "%.2w");
 }
 
 int Preferences::altDecimals()
@@ -273,7 +273,7 @@ bool Preferences::showDetailHighlight()
 QString Preferences::defaultSymbolDir()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Symbols";
-    std::string prefSymbolDir = getPreferenceGroup("Files")->GetASCII("DirSymbol", defaultDir.c_str());
+    std::string prefSymbolDir = getPreferenceGroup("Files")->getString("DirSymbol", defaultDir);
     if (prefSymbolDir.empty()) {
         prefSymbolDir = defaultDir;
     }
@@ -291,7 +291,7 @@ std::string Preferences::svgFile()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Patterns/";
     std::string defaultFileName = defaultDir + "simple.svg";
-    std::string prefHatchFile = getPreferenceGroup("Files")->GetASCII("FileHatch", defaultFileName.c_str());
+    std::string prefHatchFile = getPreferenceGroup("Files")->getString("FileHatch", defaultFileName);
     if (prefHatchFile.empty()) {
         prefHatchFile = defaultFileName;
     }
@@ -307,7 +307,7 @@ std::string Preferences::patFile()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/PAT/";
     std::string defaultFileName = defaultDir + "FCPAT.pat";
-    std::string prefHatchFile = getPreferenceGroup("PAT")->GetASCII("FilePattern", defaultFileName.c_str());
+    std::string prefHatchFile = getPreferenceGroup("PAT")->getString("FilePattern", defaultFileName);
     if (prefHatchFile.empty()) {
         prefHatchFile = defaultFileName;
     }
@@ -324,7 +324,7 @@ std::string Preferences::bitmapFill()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Patterns/";
     std::string defaultFileName = defaultDir + "default.png";
-    std::string prefBitmapFile = getPreferenceGroup("Files")->GetASCII("BitmapFill", defaultFileName.c_str());
+    std::string prefBitmapFile = getPreferenceGroup("Files")->getString("BitmapFill", defaultFileName);
     if (prefBitmapFile.empty()) {
         prefBitmapFile = defaultFileName;
     }
@@ -483,14 +483,14 @@ void Preferences::setLineStandard(int index)
 std::string Preferences::lineDefinitionLocation()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/LineGroup/";
-    std::string prefDir = getPreferenceGroup("Files")->GetASCII("LineDefLocation", defaultDir.c_str());
+    std::string prefDir = getPreferenceGroup("Files")->getString("LineDefLocation", defaultDir);
     return prefDir;
 }
 
 std::string Preferences::lineElementsLocation()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/LineGroup/";
-    std::string prefDir = getPreferenceGroup("Files")->GetASCII("LineElementLocation", defaultDir.c_str());
+    std::string prefDir = getPreferenceGroup("Files")->getString("LineElementLocation", defaultDir);
     return prefDir;
 }
 

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -90,8 +90,8 @@ void DrawGuiUtil::loadArrowBox(QComboBox* qcb)
     auto mwGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow");
 
-    auto curStyleSheet = mwGrp->GetASCII("StyleSheet", "None");
-    auto curTheme = mwGrp->GetASCII("Theme", "None");
+    auto curStyleSheet = mwGrp->getString("StyleSheet", "None");
+    auto curTheme = mwGrp->getString("Theme", "None");
 
     int i = 0;
     for (; i < ArrowPropEnum::ArrowCount; i++) {
@@ -116,8 +116,8 @@ void DrawGuiUtil::loadBalloonShapeBox(QComboBox* qballooncb)
     auto mwGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow");
 
-    auto curStyleSheet = mwGrp->GetASCII("StyleSheet", "None");
-    auto curTheme = mwGrp->GetASCII("Theme", "None");
+    auto curStyleSheet = mwGrp->getString("StyleSheet", "None");
+    auto curTheme = mwGrp->getString("Theme", "None");
 
     int i = 0;
     for (; i < BalloonPropEnum::BalloonCount; i++) {
@@ -142,8 +142,8 @@ void DrawGuiUtil::loadMattingStyleBox(QComboBox* qmattingcb)
     auto mwGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow");
 
-    auto curStyleSheet = mwGrp->GetASCII("StyleSheet", "None");
-    auto curTheme = mwGrp->GetASCII("Theme", "None");
+    auto curStyleSheet = mwGrp->getString("StyleSheet", "None");
+    auto curTheme = mwGrp->getString("Theme", "None");
 
     int i = 0;
     for (; i < MattingPropEnum::MattingCount; i++) {
@@ -236,8 +236,8 @@ QIcon DrawGuiUtil::iconForLine(size_t lineNumber,
     auto mwGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow");
 
-    auto curStyleSheet = mwGrp->GetASCII("StyleSheet", "None");
-    auto curTheme = mwGrp->GetASCII("Theme", "None");
+    auto curStyleSheet = mwGrp->getString("StyleSheet", "None");
+    auto curTheme = mwGrp->getString("Theme", "None");
 
     QColor textColor{Qt::black};
     if (isStyleSheetDark(curStyleSheet) || isStyleSheetDark(curTheme)) {

--- a/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
+++ b/src/Mod/TechDraw/Gui/DrawGuiUtil.cpp
@@ -92,8 +92,8 @@ void DrawGuiUtil::loadArrowBox(QComboBox* qcb)
     auto mwGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow");
 
-    auto curStyleSheet = mwGrp->GetASCII("StyleSheet", "None");
-    auto curTheme = mwGrp->GetASCII("Theme", "None");
+    auto curStyleSheet = mwGrp->getString("StyleSheet", "None");
+    auto curTheme = mwGrp->getString("Theme", "None");
 
     int i = 0;
     for (; i < ArrowPropEnum::ArrowCount; i++) {
@@ -118,8 +118,8 @@ void DrawGuiUtil::loadBalloonShapeBox(QComboBox* qballooncb)
     auto mwGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow");
 
-    auto curStyleSheet = mwGrp->GetASCII("StyleSheet", "None");
-    auto curTheme = mwGrp->GetASCII("Theme", "None");
+    auto curStyleSheet = mwGrp->getString("StyleSheet", "None");
+    auto curTheme = mwGrp->getString("Theme", "None");
 
     int i = 0;
     for (; i < BalloonPropEnum::BalloonCount; i++) {
@@ -144,8 +144,8 @@ void DrawGuiUtil::loadMattingStyleBox(QComboBox* qmattingcb)
     auto mwGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow");
 
-    auto curStyleSheet = mwGrp->GetASCII("StyleSheet", "None");
-    auto curTheme = mwGrp->GetASCII("Theme", "None");
+    auto curStyleSheet = mwGrp->getString("StyleSheet", "None");
+    auto curTheme = mwGrp->getString("Theme", "None");
 
     int i = 0;
     for (; i < MattingPropEnum::MattingCount; i++) {
@@ -238,8 +238,8 @@ QIcon DrawGuiUtil::iconForLine(size_t lineNumber,
     auto mwGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/MainWindow");
 
-    auto curStyleSheet = mwGrp->GetASCII("StyleSheet", "None");
-    auto curTheme = mwGrp->GetASCII("Theme", "None");
+    auto curStyleSheet = mwGrp->getString("StyleSheet", "None");
+    auto curTheme = mwGrp->getString("Theme", "None");
 
     QColor textColor{Qt::black};
     if (isStyleSheetDark(curStyleSheet) || isStyleSheetDark(curTheme)) {

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -181,7 +181,8 @@ QString PreferencesGui::weldingDirectory()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Symbols/Welding/AWS/";
 
-    std::string symbolDir = Preferences::getPreferenceGroup("Files")->GetASCII("WeldingDir", defaultDir.c_str());
+    std::string symbolDir
+        = Preferences::getPreferenceGroup("Files")->getString("WeldingDir", defaultDir);
     if (symbolDir.empty()) {
         symbolDir = defaultDir;
     }

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -183,7 +183,8 @@ QString PreferencesGui::weldingDirectory()
 {
     std::string defaultDir = App::Application::getResourceDir() + "Mod/TechDraw/Symbols/Welding/AWS/";
 
-    std::string symbolDir = Preferences::getPreferenceGroup("Files")->GetASCII("WeldingDir", defaultDir.c_str());
+    std::string symbolDir
+        = Preferences::getPreferenceGroup("Files")->getString("WeldingDir", defaultDir);
     if (symbolDir.empty()) {
         symbolDir = defaultDir;
     }

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -104,9 +104,9 @@ public:
     {
         const ParameterGrp& rGrp = static_cast<ParameterGrp&>(rCaller);
         if (strcmp(Reason, "NavigationStyle") == 0) {
-            std::string model = rGrp.GetASCII(
+            std::string model = rGrp.getString(
                 "NavigationStyle",
-                std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
+                CADNavigationStyle::getClassTypeId().getName()
             );
             page->setNavigationStyle(model);
         }
@@ -616,9 +616,9 @@ std::string QGVPage::getNavStyleParameter()
 {
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    std::string model = hGrp->GetASCII(
+    std::string model = hGrp->getString(
         "NavigationStyle",
-        std::string {NavigationStyle::getClassTypeId().getName()}.c_str()
+        NavigationStyle::getClassTypeId().getName()
     );
     return model;
 }

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -106,9 +106,9 @@ public:
     {
         const ParameterGrp& rGrp = static_cast<ParameterGrp&>(rCaller);
         if (strcmp(Reason, "NavigationStyle") == 0) {
-            std::string model = rGrp.GetASCII(
+            std::string model = rGrp.getString(
                 "NavigationStyle",
-                std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
+                CADNavigationStyle::getClassTypeId().getName()
             );
             page->setNavigationStyle(model);
         }
@@ -627,9 +627,9 @@ std::string QGVPage::getNavStyleParameter()
 {
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    std::string model = hGrp->GetASCII(
+    std::string model = hGrp->getString(
         "NavigationStyle",
-        std::string {NavigationStyle::getClassTypeId().getName()}.c_str()
+        NavigationStyle::getClassTypeId().getName()
     );
     return model;
 }

--- a/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.cpp
@@ -145,9 +145,12 @@ TaskSurfaceFinishSymbols::TaskSurfaceFinishSymbols(const std::string &ownerName)
 QColor TaskSurfaceFinishSymbols::getPenColor()
 {
     // TODO: should be dependent on global API giving pen color - not from hacking stylesheet name
-    const std::string stylesheetName = App::GetApplication().GetParameterGroupByPath
-        ("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("StyleSheet");
-    if(boost::icontains(stylesheetName, "dark")) {
+    const std::string stylesheetName = App::GetApplication()
+                                           .GetParameterGroupByPath(
+                                               "User parameter:BaseApp/Preferences/MainWindow"
+                                           )
+                                           ->getString("StyleSheet");
+    if (boost::icontains(stylesheetName, "dark")) {
         return Qt::white;
     }
     return Qt::black;

--- a/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.cpp
+++ b/src/Mod/TechDraw/Gui/TaskSurfaceFinishSymbols.cpp
@@ -147,9 +147,12 @@ TaskSurfaceFinishSymbols::TaskSurfaceFinishSymbols(const std::string &ownerName)
 QColor TaskSurfaceFinishSymbols::getPenColor()
 {
     // TODO: should be dependent on global API giving pen color - not from hacking stylesheet name
-    const std::string stylesheetName = App::GetApplication().GetParameterGroupByPath
-        ("User parameter:BaseApp/Preferences/MainWindow")->GetASCII("StyleSheet");
-    if(boost::icontains(stylesheetName, "dark")) {
+    const std::string stylesheetName = App::GetApplication()
+                                           .GetParameterGroupByPath(
+                                               "User parameter:BaseApp/Preferences/MainWindow"
+                                           )
+                                           ->getString("StyleSheet");
+    if (boost::icontains(stylesheetName, "dark")) {
         return Qt::white;
     }
     return Qt::black;

--- a/tests/src/App/License.cpp
+++ b/tests/src/App/License.cpp
@@ -33,16 +33,16 @@ TEST(License, direct)
         "Creative Commons Attribution 4.0",
         "https://creativecommons.org/licenses/by/4.0/"
     };
-    EXPECT_STREQ(App::licenseItems.at(posn).at(0), tt.at(0));
-    EXPECT_STREQ(App::licenseItems.at(posn).at(1), tt.at(1));
-    EXPECT_STREQ(App::licenseItems.at(posn).at(2), tt.at(2));
+    EXPECT_EQ(App::licenseItems.at(posn).at(0), tt.at(0));
+    EXPECT_EQ(App::licenseItems.at(posn).at(1), tt.at(1));
+    EXPECT_EQ(App::licenseItems.at(posn).at(2), tt.at(2));
 }
 
 TEST(License, findLicenseByIdent)
 {
     App::TLicenseArr arr {App::licenseItems.at(App::findLicense("CC_BY_40"))};
 
-    EXPECT_STREQ(arr.at(App::posnOfIdentifier), "CC_BY_40");
-    EXPECT_STREQ(arr.at(App::posnOfFullName), "Creative Commons Attribution 4.0");
-    EXPECT_STREQ(arr.at(App::posnOfUrl), "https://creativecommons.org/licenses/by/4.0/");
+    EXPECT_EQ(arr.at(App::posnOfIdentifier), "CC_BY_40");
+    EXPECT_EQ(arr.at(App::posnOfFullName), "Creative Commons Attribution 4.0");
+    EXPECT_EQ(arr.at(App::posnOfUrl), "https://creativecommons.org/licenses/by/4.0/");
 }

--- a/tests/src/Base/Parameter.cpp
+++ b/tests/src/Base/Parameter.cpp
@@ -241,20 +241,20 @@ TEST_F(ParameterTest, TestString)
 {
     auto cfg = getCreateConfig();
     auto grp = cfg->GetGroup("TopLevelGroup");
-    grp->SetASCII("Parameter1", "Value1");
-    grp->SetASCII("Parameter2", "Value2");
-    EXPECT_EQ(grp->GetASCII("Parameter1", "Value3"), "Value1");
-    EXPECT_EQ(grp->GetASCII("Parameter3", "Value3"), "Value3");
-    EXPECT_EQ(grp->GetASCII("Parameter3", "Value4"), "Value4");
+    grp->setString("Parameter1", "Value1");
+    grp->setString("Parameter2", "Value2");
+    EXPECT_EQ(grp->getString("Parameter1", "Value3"), "Value1");
+    EXPECT_EQ(grp->getString("Parameter3", "Value3"), "Value3");
+    EXPECT_EQ(grp->getString("Parameter3", "Value4"), "Value4");
 
-    EXPECT_TRUE(grp->GetASCIIs("Test").empty());
-    EXPECT_EQ(grp->GetASCIIs().size(), 2);
-    EXPECT_EQ(grp->GetASCIIs().at(0), "Value1");
-    EXPECT_EQ(grp->GetASCIIs().at(1), "Value2");
-    EXPECT_EQ(grp->GetASCIIMap().size(), 2);
+    EXPECT_TRUE(grp->getAllStrings("Test").empty());
+    EXPECT_EQ(grp->getAllStrings().size(), 2);
+    EXPECT_EQ(grp->getAllStrings().at(0), "Value1");
+    EXPECT_EQ(grp->getAllStrings().at(1), "Value2");
+    EXPECT_EQ(grp->getAllStringsMap().size(), 2);
 
-    grp->RemoveASCII("Parameter1");
-    EXPECT_EQ(grp->GetASCIIs().size(), 1);
+    grp->removeString("Parameter1");
+    EXPECT_EQ(grp->getAllStrings().size(), 1);
 }
 
 TEST_F(ParameterTest, TestCopy)

--- a/tests/src/Base/Parameter.cpp
+++ b/tests/src/Base/Parameter.cpp
@@ -250,20 +250,31 @@ TEST_F(ParameterTest, TestString)
 {
     auto cfg = getCreateConfig();
     auto grp = cfg->GetGroup("TopLevelGroup");
-    grp->SetASCII("Parameter1", "Value1");
-    grp->SetASCII("Parameter2", "Value2");
-    EXPECT_EQ(grp->GetASCII("Parameter1", "Value3"), "Value1");
-    EXPECT_EQ(grp->GetASCII("Parameter3", "Value3"), "Value3");
-    EXPECT_EQ(grp->GetASCII("Parameter3", "Value4"), "Value4");
+    grp->setString("Parameter1", "Value1");
+    grp->setString("Parameter2", "Value2");
+    EXPECT_EQ(grp->getString("Parameter1", "Value3"), "Value1");
+    EXPECT_EQ(grp->getString("Parameter3", "Value3"), "Value3");
+    EXPECT_EQ(grp->getString("Parameter3", "Value4"), "Value4");
 
-    EXPECT_TRUE(grp->GetASCIIs("Test").empty());
-    EXPECT_EQ(grp->GetASCIIs().size(), 2);
-    EXPECT_EQ(grp->GetASCIIs().at(0), "Value1");
-    EXPECT_EQ(grp->GetASCIIs().at(1), "Value2");
-    EXPECT_EQ(grp->GetASCIIMap().size(), 2);
+    EXPECT_TRUE(grp->getAllStrings("Test").empty());
+    EXPECT_EQ(grp->getAllStrings().size(), 2);
+    EXPECT_EQ(grp->getAllStrings().at(0), "Value1");
+    EXPECT_EQ(grp->getAllStrings().at(1), "Value2");
+    EXPECT_EQ(grp->getAllStringsMap().size(), 2);
 
-    grp->RemoveASCII("Parameter1");
-    EXPECT_EQ(grp->GetASCIIs().size(), 1);
+    grp->removeString("Parameter1");
+    EXPECT_EQ(grp->getAllStrings().size(), 1);
+}
+
+TEST_F(ParameterTest, TestStringEmbeddedNulls)
+{
+    using namespace std::literals::string_view_literals;
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    grp->setString("Parameter1"sv, "Value1"sv);
+    EXPECT_THROW(grp->setString("Param\0eter1"sv, "Value1"sv), Base::ValueError);
+    EXPECT_THROW(grp->setString("Parameter1"sv, "Va\0lue1"sv), Base::ValueError);
+    EXPECT_THROW(grp->setString("Param\0eter1"sv, "Va\0lue1"sv), Base::ValueError);
 }
 
 TEST_F(ParameterTest, TestColor)
@@ -396,7 +407,7 @@ TEST_F(ParameterTest, TestSaveRestoreRef)
     grp->SetInt("Int", -42);
     grp->SetColor("Color", Base::Color(1.0, 0.5, 0.3));
     grp->SetUnsigned("Unsigned", 42);
-    grp->SetASCII("String", "param");
+    grp->setString("String", "param");
     cfg->CheckDocument();
 
     std::string fn = getFileName();
@@ -409,7 +420,7 @@ TEST_F(ParameterTest, TestSaveRestoreRef)
     EXPECT_EQ(grp->GetInt("Int"), -42);
     EXPECT_EQ(grp->GetColor("Color"), Base::Color(1.0, 0.5, 0.3));
     EXPECT_EQ(grp->GetUnsigned("Unsigned"), 42);
-    EXPECT_EQ(grp->GetASCII("String"), "param");
+    EXPECT_EQ(grp->getString("String"), "param");
 
     grp2->SetFloat("Float", 2.0);
     cfg->exportTo(fn.c_str());
@@ -439,14 +450,14 @@ TEST_F(ParameterTest, TestClear)
 {
     auto cfg = getCreateConfig();
     auto grp = cfg->GetGroup("TopLevelGroup/Sub1/Sub2");
-    grp->SetASCII("String", "str");
+    grp->setString("String", "str");
     auto subGrp = grp->GetGroup("Sub");
     subGrp->SetUnsigned("Value", 41);
     grp->Clear();
 
     // Group is still referenced, not deleted
     EXPECT_TRUE(grp->HasGroup("Sub"));
-    EXPECT_EQ(grp->GetASCII("String", "default"), "default");
+    EXPECT_EQ(grp->getString("String", "default"), "default");
     EXPECT_EQ(subGrp->GetUnsigned("Value", 1), 1);
 
     // Remove reference
@@ -477,7 +488,7 @@ TEST_F(ParameterTest, TestGetSetAttribute)
     EXPECT_EQ(mapGrp[0].second, "");
 
     grp->SetAttribute(ParameterGrp::ParamType::FCText, "String1", "myString");
-    EXPECT_EQ(grp->GetASCII("String1"), "myString");
+    EXPECT_EQ(grp->getString("String1"), "myString");
     grp->GetAttribute(ParameterGrp::ParamType::FCText, "String1", value, "default");
     EXPECT_EQ(value, "myString");
 
@@ -506,7 +517,7 @@ TEST_F(ParameterTest, TestGetParameterNames)
     auto cfg = getCreateConfig();
     auto grp = cfg->GetGroup("TopLevelGroup/Sub1/Sub2");
 
-    grp->SetASCII("String", "test");
+    grp->setString("String", "test");
     grp->SetFloat("Float", 1.0);
     auto names = grp->GetParameterNames();
     EXPECT_EQ(names.size(), 2);
@@ -589,7 +600,7 @@ TEST_F(ParameterTest, TestNotifyAll)
 {
     auto cfg = getCreateConfig();
     auto grp = cfg->GetGroup("TopLevelGroup/Sub1/Sub2");
-    grp->SetASCII("String", "str");
+    grp->setString("String", "str");
     grp->SetFloat("Float", 2.0);
 
     auto& obs = getObserver();

--- a/tests/src/Base/ParameterObserver.cpp
+++ b/tests/src/Base/ParameterObserver.cpp
@@ -191,7 +191,7 @@ TEST_F(ParameterObserverTest, TestString)
     obs.setStringParameter("World");
     EXPECT_EQ(obs.getStringParameter(), "World");
 
-    EXPECT_EQ(grp->GetASCII("StringParameter"), "World");
+    EXPECT_EQ(grp->getString("StringParameter"), "World");
 }
 
 TEST_F(ParameterObserverTest, TestHashKey)

--- a/tests/src/Mod/Material/App/TestMaterialFilter.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialFilter.cpp
@@ -54,14 +54,14 @@ protected:
         ParameterGrp::handle hGrp =
             App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Material/Resources");
 
-        _customDir = hGrp->GetASCII("CustomMaterialsDir", "");
+        _customDir = hGrp->getString("CustomMaterialsDir", "");
         _useBuiltInDir = hGrp->GetBool("UseBuiltInMaterials", true);
         _useWorkbenchDir = hGrp->GetBool("UseMaterialsFromWorkbenches", true);
         _useUserDir = hGrp->GetBool("UseMaterialsFromConfigDir", true);
         _useCustomDir = hGrp->GetBool("UseMaterialsFromCustomDir", false);
 
         std::string testPath = App::Application::getHomePath() + "/tests/Materials/";
-        hGrp->SetASCII("CustomMaterialsDir", testPath);
+        hGrp->setString("CustomMaterialsDir", testPath);
         hGrp->SetBool("UseBuiltInMaterials", false);
         hGrp->SetBool("UseMaterialsFromWorkbenches", false);
         hGrp->SetBool("UseMaterialsFromConfigDir", false);
@@ -85,7 +85,7 @@ protected:
             App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Material/Resources");
 
         // Restore preferences
-        hGrp->SetASCII("CustomMaterialsDir", _customDir);
+        hGrp->setString("CustomMaterialsDir", _customDir);
         hGrp->SetBool("UseBuiltInMaterials", _useBuiltInDir);
         hGrp->SetBool("UseMaterialsFromWorkbenches", _useWorkbenchDir);
         hGrp->SetBool("UseMaterialsFromConfigDir", _useUserDir);


### PR DESCRIPTION
> [!NOTE]
> This is for the most part an exploratory PR. If not outright merged at some point it should serve as a basis for further `ParameterGrp` refactors

* `{Get,Set}ASCII` names imply the strings are ASCII. They're not. Replaces the names with `{get,set}String` to be more representative.
* The developers' handbook mandates camelCase names.
* Change `GetASCIIs` and `GetASCIIMap` to the clearer `getAllStrings` and `getAllStringsMap` respectively
* Better documentation
* Taking `(const) char*` means string lengths have to be recomputed each time, where `std::string_view`s do not (they're just a fat pointer)
* Taking pointers leaves open the completely undocumented possibility of passing `nullptr`. To that end the refactored functions are templated to allow anything that converts into `string_view`s (including literals which are arrays) that is *specifically not* a pointer, also making practises like passing `.c_str()` directly impossible.
* Updates all call sites of the refactored functions and evens out most string conversions that were performed on them; notably missed `QString::fromStdString` opportunities.
* Some TODO comments are purposefully left over for later `const char*` -> `std::string(_view)` refactors in other parts of the code base
