### PR TITLE
PD: Fix crash when rejecting the dialog

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -285,14 +285,13 @@ struct DocumentP
     {
         _editingObject = sobj;
         _editMode = ModNum;
-        _editViewProvider = svp;  // Used to resolve start editing (find the document in edit from
-                                  // within the viewprovider)
+        std::string fullname = sobj->getFullName();
         _editViewProvider = svp->startEditing(ModNum);
         if (!_editViewProvider) {
             _editViewProviderParent = nullptr;
             _editObjs.clear();
             _editingObject = nullptr;
-            FC_LOG("object '" << sobj->getFullName() << "' refuse to edit");
+            FC_LOG("object '" << fullname << "' refuse to edit");
             return false;
         }
 

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -39,7 +39,9 @@
 #include "ActionFunction.h"
 #include "Application.h"
 #include "Command.h"
+#include "Control.h"
 #include "Document.h"
+#include "DocumentObserver.h"
 #include "MDIView.h"
 #include "SoFCUnifiedSelection.h"
 #include "Tree.h"
@@ -300,6 +302,21 @@ void ViewProviderDocumentObject::addDefaultAction(QMenu* menu, const QString& te
     act->setData(QVariant((int)ViewProvider::Default));
     auto func = new Gui::ActionFunction(menu);
     func->trigger(act, [this]() { this->startDefaultEditMode(); });
+}
+
+bool ViewProviderDocumentObject::tryCloseDialog(Gui::TaskView::TaskDialog* dlg)
+{
+    if (dlg->canClose()) {
+        Gui::ViewProviderWeakPtrT self(this);
+        Gui::Control().reject();
+        if (self.expired()) {
+            Base::Console().Warning("Closing the dialog has deleted the feature.\n");
+            return false;
+        }
+        return true;
+    }
+
+    return false;
 }
 
 void ViewProviderDocumentObject::setModeSwitch()

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -310,7 +310,7 @@ bool ViewProviderDocumentObject::tryCloseDialog(Gui::TaskView::TaskDialog* dlg)
         Gui::ViewProviderWeakPtrT self(this);
         Gui::Control().reject();
         if (self.expired()) {
-            Base::Console().Warning("Closing the dialog has deleted the feature.\n");
+            Base::Console().warning("Closing the dialog has deleted the feature.\n");
             return false;
         }
         return true;

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -46,6 +46,11 @@ namespace Gui
 class MDIView;
 class Document;
 
+namespace TaskView
+{
+class TaskDialog;
+}
+
 class GuiExport ViewProviderDocumentObject: public ViewProvider
 {
     PROPERTY_HEADER_WITH_OVERRIDE(Gui::ViewProviderDocumentObject);
@@ -252,6 +257,8 @@ protected:
 
     /** Adds a menu item and bind it with \ref startDefaultEditMode().  */
     void addDefaultAction(QMenu*, const QString&);
+
+    bool tryCloseDialog(Gui::TaskView::TaskDialog* dlg);
 
 protected:
     App::DocumentObject* pcObject {nullptr};

--- a/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderAnalysis.cpp
@@ -180,13 +180,7 @@ bool ViewProviderFemAnalysis::setEdit(int ModNum)
         // if (padDlg && anaDlg->getPadView() != this)
         //     padDlg = 0; // another pad left open its task panel
         // if (dlg && !padDlg) {
-        //     QMessageBox msgBox;
-        //     msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-        //     msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-        //     msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        //     msgBox.setDefaultButton(QMessageBox::Yes);
-        //     int ret = msgBox.exec();
-        //     if (ret == QMessageBox::Yes)
+        //     if (dlg->canClose())
         //         Gui::Control().closeDialog();
         //     else
         //         return false;
@@ -229,7 +223,7 @@ bool ViewProviderFemAnalysis::canDragObject(App::DocumentObject* obj) const
         return false;
     }
 
-    // clang-format off: keep line breaks for readability
+    // clang-format off
     if (obj->isDerivedFrom<Fem::FemMeshObject>()
         || obj->isDerivedFrom<Fem::FemSolverObject>()
         || obj->isDerivedFrom<Fem::FemResultObject>()

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -151,13 +151,7 @@ bool ViewProviderFemPostFunction::setEdit(int ModNum)
             postDlg = nullptr;  // another pad left open its task panel
         }
         if (dlg && !postDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().reject();
             }
             else {

--- a/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostFunction.cpp
@@ -151,10 +151,7 @@ bool ViewProviderFemPostFunction::setEdit(int ModNum)
             postDlg = nullptr;  // another pad left open its task panel
         }
         if (dlg && !postDlg) {
-            if (dlg->canClose()) {
-                Gui::Control().reject();
-            }
-            else {
+            if (!tryCloseDialog(dlg)) {
                 return false;
             }
         }

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -895,10 +895,7 @@ bool ViewProviderFemPostObject::setEdit(int ModNum)
             postDlg = nullptr;  // another pad left open its task panel
         }
         if (dlg && !postDlg) {
-            if (dlg->canClose()) {
-                Gui::Control().reject();
-            }
-            else {
+            if (!tryCloseDialog(dlg)) {
                 return false;
             }
         }

--- a/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
+++ b/src/Mod/Fem/Gui/ViewProviderFemPostObject.cpp
@@ -895,13 +895,7 @@ bool ViewProviderFemPostObject::setEdit(int ModNum)
             postDlg = nullptr;  // another pad left open its task panel
         }
         if (dlg && !postDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Do you want to close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().reject();
             }
             else {

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -1138,13 +1138,7 @@ void prepareProfileBased(
         PartDesignGui::TaskDlgFeaturePick* pickDlg
             = qobject_cast<PartDesignGui::TaskDlgFeaturePick*>(dlg);
         if (dlg && !pickDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().closeDialog();
             }
             else {

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -756,13 +756,7 @@ private:
         PartDesignGui::TaskDlgFeaturePick* pickDlg
             = qobject_cast<PartDesignGui::TaskDlgFeaturePick*>(dlg);
         if (dlg && !pickDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().closeDialog();
             }
             else {

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -37,6 +37,7 @@
 #include <Gui/CommandT.h>
 #include <Gui/Control.h>
 #include <Gui/Document.h>
+#include <Gui/DocumentObserver.h>
 #include <Gui/Selection/SoFCUnifiedSelection.h>
 #include <Gui/Inventor/So3DAnnotation.h>
 #include <Gui/MainWindow.h>
@@ -138,9 +139,14 @@ bool ViewProvider::setEdit(int ModNum)
             msgBox.setInformativeText(QObject::tr("Close this dialog?"));
             msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
             msgBox.setDefaultButton(QMessageBox::Yes);
-
-            if (msgBox.exec() == QMessageBox::Yes) {
+            int ret = msgBox.exec();
+            if (ret == QMessageBox::Yes) {
+                Gui::ViewProviderWeakPtrT that(this);
                 Gui::Control().reject();
+                if (that.expired()) {
+                    Base::Console().Warning("Closing the dialog has deleted the feature.\n");
+                    return false;
+                }
             }
             else {
                 return false;

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -134,13 +134,7 @@ bool ViewProvider::setEdit(int ModNum)
             featureDlg = nullptr;  // another feature left open its task panel
         }
         if (dlg && !featureDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::ViewProviderWeakPtrT that(this);
                 Gui::Control().reject();
                 if (that.expired()) {

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -37,7 +37,6 @@
 #include <Gui/CommandT.h>
 #include <Gui/Control.h>
 #include <Gui/Document.h>
-#include <Gui/DocumentObserver.h>
 #include <Gui/Selection/SoFCUnifiedSelection.h>
 #include <Gui/Inventor/So3DAnnotation.h>
 #include <Gui/MainWindow.h>
@@ -134,15 +133,7 @@ bool ViewProvider::setEdit(int ModNum)
             featureDlg = nullptr;  // another feature left open its task panel
         }
         if (dlg && !featureDlg) {
-            if (dlg->canClose()) {
-                Gui::ViewProviderWeakPtrT that(this);
-                Gui::Control().reject();
-                if (that.expired()) {
-                    Base::Console().Warning("Closing the dialog has deleted the feature.\n");
-                    return false;
-                }
-            }
-            else {
+            if (!tryCloseDialog(dlg)) {
                 return false;
             }
         }

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
@@ -255,13 +255,7 @@ bool ViewProviderDatum::setEdit(int ModNum)
             datumDlg = nullptr;  // another datum feature left open its task panel
         }
         if (dlg && !datumDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().closeDialog();
             }
             else {

--- a/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDatum.cpp
@@ -255,10 +255,7 @@ bool ViewProviderDatum::setEdit(int ModNum)
             datumDlg = nullptr;  // another datum feature left open its task panel
         }
         if (dlg && !datumDlg) {
-            if (dlg->canClose()) {
-                Gui::Control().closeDialog();
-            }
-            else {
+            if (!tryCloseDialog(dlg)) {
                 return false;
             }
         }

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -93,13 +93,7 @@ bool ViewProviderShapeBinder::setEdit(int ModNum)
         Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
         TaskDlgShapeBinder* sbDlg = qobject_cast<TaskDlgShapeBinder*>(dlg);
         if (dlg && !sbDlg) {
-            QMessageBox msgBox(Gui::getMainWindow());
-            msgBox.setText(QObject::tr("A dialog is already open in the task panel"));
-            msgBox.setInformativeText(QObject::tr("Close this dialog?"));
-            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            msgBox.setDefaultButton(QMessageBox::Yes);
-            int ret = msgBox.exec();
-            if (ret == QMessageBox::Yes) {
+            if (dlg->canClose()) {
                 Gui::Control().reject();
             }
             else {

--- a/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderShapeBinder.cpp
@@ -93,10 +93,7 @@ bool ViewProviderShapeBinder::setEdit(int ModNum)
         Gui::TaskView::TaskDialog* dlg = Gui::Control().activeDialog();
         TaskDlgShapeBinder* sbDlg = qobject_cast<TaskDlgShapeBinder*>(dlg);
         if (dlg && !sbDlg) {
-            if (dlg->canClose()) {
-                Gui::Control().reject();
-            }
-            else {
+            if (!tryCloseDialog(dlg)) {
                 return false;
             }
         }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3619,10 +3619,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
         sketchDlg = nullptr;// another sketch left open its task panel
     }
     if (dlg && !sketchDlg) {
-        if (dlg->canClose()) {
-            Gui::Control().closeDialog();
-        }
-        else {
+        if (!tryCloseDialog(dlg)) {
             return false;
         }
     }

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -3619,13 +3619,7 @@ bool ViewProviderSketch::setEdit(int ModNum)
         sketchDlg = nullptr;// another sketch left open its task panel
     }
     if (dlg && !sketchDlg) {
-        QMessageBox msgBox(Gui::getMainWindow());
-        msgBox.setText(tr("A dialog is already open in the task panel"));
-        msgBox.setInformativeText(tr("Close this dialog?"));
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        msgBox.setDefaultButton(QMessageBox::Yes);
-        int ret = msgBox.exec();
-        if (ret == QMessageBox::Yes) {
+        if (dlg->canClose()) {
             Gui::Control().closeDialog();
         }
         else {


### PR DESCRIPTION
Cherry-pick https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_27865

Rejecting the currently open dialog may lead to the destruction of the
about to be edited feature which isn't handled and causes a segfault.

To fix the crash add a self-check and if needed return from the
function.

This fixes https://github.com/FreeCAD/FreeCAD/issues/27865