### PR TITLE
CI: Always let CI run on every push to main, never cancel those

### DIFF
--- a/.github/workflows/CI_approved.yml
+++ b/.github/workflows/CI_approved.yml
@@ -103,12 +103,16 @@ jobs:
               return;
             }
 
-            // For code changes and non-PR events, cancel older runs for the
-            // same branch so we do not waste resources on stale code.
-            const branch = isPR
-              ? context.payload.pull_request.head.ref
-              : context.ref.replace('refs/heads/', '');
+            // For non-PR events (basically just push to main/releases and workflow_dispatch), each commit
+            // gets its own run to help pinpoint any failures to a specific commit.
+            if (!isPR) {
+              core.setOutput('should-run', 'true');
+              return;
+            }
 
+            // For PR code changes (synchronize/opened/reopened), cancel older runs on the same head ref so we don't
+            // waste CI resources on stale code.
+            const branch = context.payload.pull_request.head.ref;
             for (const status of ['in_progress', 'queued']) {
               const { data: { workflow_runs: runs } } = await github.rest.actions.listWorkflowRuns({
                 owner: context.repo.owner,


### PR DESCRIPTION
The current CI workflow is too aggressive with its attempts to cancel stale CI runs, and currently cancels runs on changes to main: I don't think that's desirable, if there's a CI failure on main we want to be able to pinpoint exactly which commit did it. Cancellations show up in the UI as failures (the little red X).