### PR TITLE
CAM: Add Linking generator to Engrave and Deburr Operations.

### DIFF
--- a/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/PageHeightsEdit.ui
@@ -65,6 +65,59 @@
     </widget>
    </item>
    <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBoxLinking">
+     <property name="title">
+      <string>Linking</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayoutLinking">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelCollisionAvoidanceStrategy">
+        <property name="text">
+         <string>Collision Avoidance Strategy</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="CollisionAvoidanceStrategy">
+        <property name="toolTip">
+         <string>How collision detection is performed when the tool moves between features.
+
+Retract Height: No collision detection, uses retract height for rapid moves between areas
+Clearance Height: No collision detection, uses clearance height for rapid moves between areas
+Line of Sight: fastest - checks the path centerline.
+Tool Diameter: balanced - checks clearance using the tool diameter.
+Tool Shape: safest - checks clearance using the cross section of the tool shape
+          </string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelCollisionClearance">
+        <property name="text">
+         <string>Collision Clearance</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="Gui::QuantitySpinBox" name="CollisionClearance">
+        <property name="toolTip">
+         <string>Minimum clearance distance between the tool and any solid during linking moves. Applies to all linking modes.</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>999999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/Mod/CAM/Path/Base/SetupSheet.py
+++ b/src/Mod/CAM/Path/Base/SetupSheet.py
@@ -395,6 +395,7 @@ class SetupSheet:
             for prop in op.properties():
                 propName = OpPropertyName(opName, prop)
                 if hasattr(self.obj, propName):
+                    obj.setExpression(prop, None)  # clear any bound expression first
                     setattr(obj, prop, getattr(self.obj, propName))
         except Exception:
             Path.Log.info("SetupSheet has no support for {}".format(opName))

--- a/src/Mod/CAM/Path/Base/SetupSheet.py
+++ b/src/Mod/CAM/Path/Base/SetupSheet.py
@@ -56,6 +56,7 @@ class Template:
     Fixtures = "Fixtures"
     OrderOutputBy = "OrderOutputBy"
     SplitOutput = "SplitOutput"
+    CollisionAvoidanceStrategy = "CollisionAvoidanceStrategy"
 
     All = [
         HorizRapid,
@@ -68,6 +69,7 @@ class Template:
         StartDepthExpression,
         FinalDepthExpression,
         StepDownExpression,
+        CollisionAvoidanceStrategy,
     ]
 
 
@@ -104,7 +106,16 @@ class SetupSheet:
     DefaultFinalDepthExpression = "OpFinalDepth"
     DefaultStepDownExpression = "OpToolDiameter"
 
+    DefaultCollisionAvoidanceStrategy = "Retract Height"
+
     DefaultCoolantModes = ["None", "Flood", "Mist"]
+    DefaultCollisionAvoidanceStrategies = [
+        "Clearance Height",
+        "Retract Height",
+        "Line of Sight",
+        "Tool Diameter",
+        "Tool Shape",
+    ]
 
     def __init__(self, obj):
         self.obj = obj
@@ -202,6 +213,18 @@ class SetupSheet:
         obj.CoolantModes = self.DefaultCoolantModes
         obj.CoolantMode = self.DefaultCoolantModes
 
+        obj.addProperty(
+            "App::PropertyEnumeration",
+            "CollisionAvoidanceStrategy",
+            "Linking",
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Default collision avoidance strategy for new operations.",
+            ),
+        )
+        obj.CollisionAvoidanceStrategy = self.DefaultCollisionAvoidanceStrategies
+        obj.CollisionAvoidanceStrategy = self.DefaultCollisionAvoidanceStrategy
+
         obj.Proxy = self
 
     def dumps(self):
@@ -298,6 +321,7 @@ class SetupSheet:
             attrs[Template.SafeHeightExpression] = self.obj.SafeHeightExpression
             attrs[Template.ClearanceHeightOffset] = self.obj.ClearanceHeightOffset.UserString
             attrs[Template.ClearanceHeightExpression] = self.obj.ClearanceHeightExpression
+            attrs[Template.CollisionAvoidanceStrategy] = self.obj.CollisionAvoidanceStrategy
 
         if includeDepths:
             attrs[Template.StartDepthExpression] = self.obj.StartDepthExpression
@@ -394,6 +418,19 @@ class SetupSheet:
                 QT_TRANSLATE_NOOP("App::Property", "Default coolant mode."),
             )
             obj.CoolantMode = self.DefaultCoolantModes
+
+        if not hasattr(obj, "CollisionAvoidanceStrategy"):
+            obj.addProperty(
+                "App::PropertyEnumeration",
+                "CollisionAvoidanceStrategy",
+                "Linking",
+                QT_TRANSLATE_NOOP(
+                    "App::Property",
+                    "Default collision avoidance strategy for new operations.",
+                ),
+            )
+            obj.CollisionAvoidanceStrategy = self.DefaultCollisionAvoidanceStrategies
+            obj.CollisionAvoidanceStrategy = self.DefaultCollisionAvoidanceStrategy
 
 
 def Create(name="SetupSheet"):

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -1217,3 +1217,10 @@ def getCycleTimeEstimate(obj):
     cycleTime = time.strftime("%H:%M:%S", time.gmtime(seconds))
 
     return cycleTime
+
+
+def SetupPropertiesLinking():
+    setup = []
+    setup.append("CollisionAvoidanceStrategy")
+    setup.append("CollisionClearance")
+    return setup

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -679,6 +679,7 @@ class ObjectOp(object):
 
         if FeatureLinking & features:
             obj.CollisionAvoidanceStrategy = job.SetupSheet.CollisionAvoidanceStrategy
+            self.applyExpression(obj, "CollisionClearance", "OpToolDiameter")
 
         self.opSetDefaultValues(obj, job)
         return job

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -173,6 +173,13 @@ class ObjectOp(object):
                 "\nTool Shape: safest - checks clearance using the cross section of the tool shape",
             ),
         )
+        obj.CollisionAvoidanceStrategy = [
+            "Clearance Height",
+            "Retract Height",
+            "Line of Sight",
+            "Tool Diameter",
+            "Tool Shape",
+        ]
         obj.addProperty(
             "App::PropertyLength",
             "CollisionClearance",
@@ -403,13 +410,6 @@ class ObjectOp(object):
                 (translate("CAM_Operation", "None"), "None"),
                 (translate("CAM_Operation", "Flood"), "Flood"),
                 (translate("CAM_Operation", "Mist"), "Mist"),
-            ],
-            "CollisionAvoidanceStrategy": [
-                (translate("CAM_Operation", "Clearance Height"), "Clearance Height"),
-                (translate("CAM_Operation", "Retract Height"), "Retract Height"),
-                (translate("CAM_Operation", "Line of Sight"), "Line of Sight"),
-                (translate("CAM_Operation", "Tool Diameter"), "Tool Diameter"),
-                (translate("CAM_Operation", "Tool Shape"), "Tool Shape"),
             ],
         }
 
@@ -678,8 +678,7 @@ class ObjectOp(object):
             obj.UseStartPoint = False
 
         if FeatureLinking & features:
-            obj.CollisionAvoidanceStrategy = "Clearance Height"
-            self.applyExpression(obj, "CollisionClearance", "OpToolDiameter")
+            obj.CollisionAvoidanceStrategy = job.SetupSheet.CollisionAvoidanceStrategy
 
         self.opSetDefaultValues(obj, job)
         return job

--- a/src/Mod/CAM/Path/Op/Deburr.py
+++ b/src/Mod/CAM/Path/Op/Deburr.py
@@ -427,11 +427,9 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
 
 
 def SetupProperties():
-    setup = []
+    setup = PathOp.SetupPropertiesLinking()
     setup.append("Width")
     setup.append("ExtraDepth")
-    setup.append("CollisionAvoidanceStrategy")
-    setup.append("CollisionClearance")
     return setup
 
 

--- a/src/Mod/CAM/Path/Op/Deburr.py
+++ b/src/Mod/CAM/Path/Op/Deburr.py
@@ -115,6 +115,7 @@ class ObjectDeburr(PathEngraveBase.ObjectOp):
             | PathOp.FeatureBaseFaces
             | PathOp.FeatureCoolant
             | PathOp.FeatureBaseGeometry
+            | PathOp.FeatureLinking
         )
 
     def initOperation(self, obj):
@@ -429,6 +430,8 @@ def SetupProperties():
     setup = []
     setup.append("Width")
     setup.append("ExtraDepth")
+    setup.append("CollisionAvoidanceStrategy")
+    setup.append("CollisionClearance")
     return setup
 
 

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -568,7 +568,7 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
 
 
 def SetupProperties():
-    setup = []
+    setup = PathOp.SetupPropertiesLinking()
     setup.append("Strategy")
     setup.append("PeckDepth")
     setup.append("PeckEnabled")
@@ -577,8 +577,6 @@ def SetupProperties():
     setup.append("AddTipLength")
     setup.append("ExtraOffset")
     setup.append("KeepToolDown")
-    setup.append("CollisionAvoidanceStrategy")
-    setup.append("CollisionClearance")
     return setup
 
 

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -577,6 +577,8 @@ def SetupProperties():
     setup.append("AddTipLength")
     setup.append("ExtraOffset")
     setup.append("KeepToolDown")
+    setup.append("CollisionAvoidanceStrategy")
+    setup.append("CollisionClearance")
     return setup
 
 

--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -198,7 +198,9 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
 
 
 def SetupProperties():
-    return ["StartVertex", "CollisionAvoidanceStrategy", "CollisionClearance"]
+    setup = PathOp.SetupPropertiesLinking()
+    setup.append("StartVertex")
+    return setup
 
 
 def Create(name, obj=None, parentJob=None):

--- a/src/Mod/CAM/Path/Op/Engrave.py
+++ b/src/Mod/CAM/Path/Op/Engrave.py
@@ -59,6 +59,7 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
             | PathOp.FeatureStepDown
             | PathOp.FeatureBaseEdges
             | PathOp.FeatureCoolant
+            | PathOp.FeatureLinking
         )
 
     def setupAdditionalProperties(self, obj):
@@ -197,7 +198,7 @@ class ObjectEngrave(PathEngraveBase.ObjectOp):
 
 
 def SetupProperties():
-    return ["StartVertex"]
+    return ["StartVertex", "CollisionAvoidanceStrategy", "CollisionClearance"]
 
 
 def Create(name, obj=None, parentJob=None):

--- a/src/Mod/CAM/Path/Op/EngraveBase.py
+++ b/src/Mod/CAM/Path/Op/EngraveBase.py
@@ -24,6 +24,7 @@
 from lazy_loader.lazy_loader import LazyLoader
 import FreeCAD
 import Path
+import Path.Base.Generator.linking as linking
 import Path.Op.Base as PathOp
 import Path.Op.Util as PathOpUtil
 import PathScripts.PathUtils as PathUtils
@@ -68,6 +69,33 @@ class ObjectOp(PathOp.ObjectOp):
         tol = self.job.GeometryTolerance.Value if getattr(self, "job", None) else 0.01
         biDir = getattr(obj, "CutPattern", None) == "Bidirectional"
 
+        # Prepare linking arguments for wire-to-wire collision-aware transitions
+        solids = []
+        if getattr(self, "job", None) and hasattr(self.job, "Model"):
+            solids = [base.Shape for base in self.job.Model.Group if hasattr(base, "Shape")]
+        linking_kwargs = {
+            "start_position": None,
+            "target_position": None,
+            "local_clearance": obj.SafeHeight.Value,
+            "global_clearance": obj.ClearanceHeight.Value,
+            "solids": None,
+            "tool_shape": None,
+            "tool_diameter": None,
+            "collision_clearance": obj.CollisionClearance.Value,
+        }
+        if obj.CollisionAvoidanceStrategy == "Clearance Height":
+            linking_kwargs["local_clearance"] = obj.ClearanceHeight.Value
+        elif obj.CollisionAvoidanceStrategy == "Retract Height":
+            pass
+        elif obj.CollisionAvoidanceStrategy == "Line of Sight":
+            linking_kwargs["solids"] = solids
+        elif obj.CollisionAvoidanceStrategy == "Tool Diameter":
+            linking_kwargs["solids"] = solids
+            linking_kwargs["tool_diameter"] = obj.ToolController.Tool.Diameter.Value
+        elif obj.CollisionAvoidanceStrategy == "Tool Shape":
+            linking_kwargs["solids"] = solids
+            linking_kwargs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
+
         if getattr(obj, "Approximation", False):
             wires = [PathOpUtil.approximateWire(w, tolerance=tol) for w in wires]
 
@@ -87,6 +115,8 @@ class ObjectOp(PathOp.ObjectOp):
             locations = PathUtils.sort_locations(locations, ["x", "y"])
             wires = [j["wire"] for j in locations]
 
+        tool_pos = None  # tracks tool position between entry moves
+
         for wire in wires:
             reverseDir = False
             edges = wire.Edges
@@ -98,21 +128,30 @@ class ObjectOp(PathOp.ObjectOp):
 
             for indexZ, z in enumerate(zValues):
                 Path.Log.debug(z)
+
                 if indexZ == 0 or (not wire.isClosed() and not biDir):
                     Path.Log.debug("processing first edge entry")
-                    # Add moves to first point of wire
-                    self.commandlist.append(Path.Command("G0", {"Z": obj.ClearanceHeight.Value}))
-                    self.commandlist.append(
-                        Path.Command("G0", {"X": startPoint.x, "Y": startPoint.y})
-                    )
-                    self.commandlist.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
+                    if tool_pos is None:
+                        # Very first entry in the operation: retract to clearance height
+                        self.commandlist.append(
+                            Path.Command("G0", {"Z": obj.ClearanceHeight.Value})
+                        )
+                        self.commandlist.append(
+                            Path.Command("G0", {"X": startPoint.x, "Y": startPoint.y})
+                        )
+                        self.commandlist.append(Path.Command("G0", {"Z": obj.SafeHeight.Value}))
+                    else:
+                        # Subsequent entries: use linking generator to find optimal retract height
+                        target = FreeCAD.Vector(startPoint.x, startPoint.y, obj.SafeHeight.Value)
+                        linking_kwargs["start_position"] = tool_pos
+                        linking_kwargs["target_position"] = target
+                        moves = linking.get_linking_moves(**linking_kwargs)
+                        self.commandlist.extend(moves)
                     lastPoint = startPoint
 
                 self.appendCommand(Path.Command("G1", {"Z": startPoint.z}), z, relZ, self.vertFeed)
 
-                edgesDir = reversed(edges) if reverseDir and indexZ else edges
-                for edge in edgesDir:
-
+                for edge in (reversed(edges) if reverseDir and indexZ else edges):
                     if len(edges) == 1:
                         # wire with one edge
                         flip = reverseDir
@@ -129,6 +168,11 @@ class ObjectOp(PathOp.ObjectOp):
                     for cmd in Path.Geom.cmdsForEdge(edge, flip=flip, tol=tol):
                         # Add gcode for edge
                         self.appendCommand(cmd, z, relZ, self.horizFeed)
+
+                # Track tool position for the next entry move.
+                # Use SafeHeight so the linking check only evaluates the horizontal
+                # traverse, not the retract from cutting depth through the stock.
+                tool_pos = FreeCAD.Vector(lastPoint.x, lastPoint.y, obj.SafeHeight.Value)
 
                 if biDir and not wire.isClosed():
                     reverseDir = not reverseDir

--- a/src/Mod/CAM/Path/Op/Gui/Base.py
+++ b/src/Mod/CAM/Path/Op/Gui/Base.py
@@ -1115,25 +1115,60 @@ class TaskPanelHeightsPage(TaskPanelPage):
             self.form.clearanceHeight, obj, "ClearanceHeight"
         )
 
+        if PathOp.FeatureLinking & self.features:
+            self.CollisionClearance = PathGuiUtil.QuantitySpinBox(
+                self.form.CollisionClearance, obj, "CollisionClearance"
+            )
+            for mode in [
+                "Clearance Height",
+                "Retract Height",
+                "Line of Sight",
+                "Tool Diameter",
+                "Tool Shape",
+            ]:
+                self.form.CollisionAvoidanceStrategy.addItem(translate("CAM_Operation", mode), mode)
+        else:
+            self.form.groupBoxLinking.hide()
+
     def getTitle(self, obj):
         return translate("PathOp", "Heights")
 
     def getFields(self, obj):
         self.safeHeight.updateProperty()
         self.clearanceHeight.updateProperty()
+        if PathOp.FeatureLinking & self.features:
+            self.CollisionClearance.updateProperty()
+            mode = self.form.CollisionAvoidanceStrategy.currentData()
+            if mode and obj.CollisionAvoidanceStrategy != mode:
+                obj.CollisionAvoidanceStrategy = mode
 
     def setFields(self, obj):
         self.safeHeight.updateWidget()
         self.clearanceHeight.updateWidget()
+        if PathOp.FeatureLinking & self.features:
+            self.CollisionClearance.updateWidget()
+            index = self.form.CollisionAvoidanceStrategy.findData(obj.CollisionAvoidanceStrategy)
+            if index >= 0:
+                self.form.CollisionAvoidanceStrategy.blockSignals(True)
+                self.form.CollisionAvoidanceStrategy.setCurrentIndex(index)
+                self.form.CollisionAvoidanceStrategy.blockSignals(False)
 
     def getSignalsForUpdate(self, obj):
         signals = []
         signals.append(self.form.safeHeight.editingFinished)
         signals.append(self.form.clearanceHeight.editingFinished)
+        if PathOp.FeatureLinking & self.features:
+            signals.append(self.form.CollisionClearance.editingFinished)
+            signals.append(self.form.CollisionAvoidanceStrategy.currentIndexChanged)
         return signals
 
     def pageUpdateData(self, obj, prop):
-        if prop in ["SafeHeight", "ClearanceHeight"]:
+        if prop in [
+            "SafeHeight",
+            "ClearanceHeight",
+            "CollisionAvoidanceStrategy",
+            "CollisionClearance",
+        ]:
             self.setFields(obj)
 
 

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -917,7 +917,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
 def SetupProperties():
     """Returns property names for which the "Setup Sheet" should provide defaults."""
-    setup = []
+    setup = PathOp.SetupPropertiesLinking()
     setup.append("CutMode")
     setup.append("StartAt")
     setup.append("StepOver")

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -713,7 +713,7 @@ def Create(name, obj=None, parentJob=None):
 
 def SetupProperties():
     """SetupProperties() ... Return list of properties required for the operation."""
-    setup = []
+    setup = PathOp.SetupPropertiesLinking()
     setup.append("CutMode")
     setup.append("ClearingPattern")
     setup.append("Angle")


### PR DESCRIPTION
This PR Adds the linking generator to the Engrave and Deburr operations so that the safe height is used for linking moves instead of the clearance height. This is important because the clearance height is often much higher than the safe height, and using it for linking can cause the machine to take much longer to complete the operation. Especially for engrave operations which often have lots of small moves, between cuts, and short linking moves.
    
This PR also adds the Linking mode and Safety Margin options to the Tasks Panel Heights section. The Drilling and Helix operations already using the Linking generator, so this adds those options to those operations as well.

<img width="1429" height="678" alt="image" src="https://github.com/user-attachments/assets/d52bd1d3-6650-4b4e-9cf0-695df3f40b33" />
