### PR TITLE
PD: Improve revolution / groove feature

### DIFF
--- a/src/Mod/Part/App/PartFeature.h
+++ b/src/Mod/Part/App/PartFeature.h
@@ -319,6 +319,12 @@ PartExport std::vector<cutTopoShapeFaces> findAllFacesCutBy(
     const gp_Ax1& axis
 );
 
+PartExport std::vector<cutTopoShapeFaces> findAllFacesCutBy(
+    const TopoShape& shape,
+    const TopoShape& face,
+    const gp_Ax1& axis
+);
+
 /**
  * Check for intersection between the two shapes. Only solids are guaranteed to work properly
  * There are two modes:

--- a/src/Mod/PartDesign/App/FeatureRevolved.cpp
+++ b/src/Mod/PartDesign/App/FeatureRevolved.cpp
@@ -160,20 +160,13 @@ App::DocumentObjectExecReturn* Revolved::tryExecuteRevolved(Part::RevolMode revo
 
     supportface.move(invObjLoc);
 
-    if (method == RevolMethod::ToFirst
-        || (method == RevolMethod::ToLast && revolMode == Part::RevolMode::FuseWithBase)) {
+    if (method == RevolMethod::ToFirst || method == RevolMethod::ToLast) {
         TopoShape upToFace;
         gp_Ax1 axis(pnt, dir);
         if (Reversed.getValue()) {
             axis.Reverse();
         }
-        getUpToFace(
-            upToFace,
-            base,
-            sketchshape,
-            method == RevolMethod::ToFirst ? "UpToFirst" : "UpToLast",
-            axis
-        );
+        getUpToFace(upToFace, base, sketchshape, stringFromMethod(method), axis);
         result = tryToRevolveToFace(upToFace, pnt, dir, base, supportface, sketchshape, revolMode);
     }
     else if (method == RevolMethod::ToFace) {
@@ -308,6 +301,41 @@ void Revolved::updateAxis()
 
     Base.setValue(base);
     Axis.setValue(dir);
+}
+
+// clang-format off
+static constexpr auto numMethods {6};
+static constexpr std::array<std::tuple<std::string_view, Revolved::RevolMethod>, numMethods>
+revolMethods {{
+    {"Angle",      Revolved::RevolMethod::Angle},
+    {"UpToLast",   Revolved::RevolMethod::ToLast},
+    {"ThroughAll", Revolved::RevolMethod::ThroughAll},
+    {"UpToFirst",  Revolved::RevolMethod::ToFirst},
+    {"UpToFace",   Revolved::RevolMethod::ToFace},
+    {"TwoAngles",  Revolved::RevolMethod::TwoAngles},
+}};
+// clang-format on
+
+Revolved::RevolMethod Revolved::methodFromString(const std::string& methodStr)
+{
+    for (const auto& [str, type] : revolMethods) {
+        if (str == methodStr) {
+            return type;
+        }
+    }
+
+    throw Base::ValueError("Revolved: No such method");
+}
+
+std::string Revolved::stringFromMethod(Revolved::RevolMethod methodType)
+{
+    for (const auto& [str, type] : revolMethods) {
+        if (type == methodType) {
+            return std::string(str);
+        }
+    }
+
+    throw Base::ValueError("Revolved: No such method");
 }
 
 void Revolved::generateRevolution(

--- a/src/Mod/PartDesign/App/FeatureRevolved.h
+++ b/src/Mod/PartDesign/App/FeatureRevolved.h
@@ -99,6 +99,9 @@ private:
     /// updates Axis from ReferenceAxis
     void updateAxis();
 
+    RevolMethod methodFromString(const std::string& methodStr);
+    std::string stringFromMethod(RevolMethod methodType);
+
     virtual TopoShape makeShape(const TopoShape& base, const TopoShape& revolve) const = 0;
     virtual bool suggestReversedAngle(double angle) const = 0;
 


### PR DESCRIPTION
Cherry-picked https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_27403

Implement the ToFirst and ToLast option for revolution / groove.

This fixes https://github.com/FreeCAD/FreeCAD/issues/27403


<img width="960" height="463" alt="Bildschirmfoto 2026-05-08 um 21 40 01" src="https://github.com/user-attachments/assets/41b4dc92-ab4b-42ba-9aea-18263f332068" />
