### PR TITLE
App: rename `Application::applicationPid` to `uniqueInstanceId`

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -41,7 +41,6 @@
 # include <boost/scope_exit.hpp>
 # include <chrono>
 # include <optional>
-# include <random>
 # include <memory>
 # include <utility>
 # include <set>
@@ -1342,19 +1341,18 @@ Application::TransactionSignaller::~TransactionSignaller() {
     }
 }
 
-int64_t Application::applicationPid()
+int64_t Application::uniqueInstanceId()
 {
-    static int64_t randomNumber = []() {
+    static int64_t uniqueId = []() {
         const auto tp = std::chrono::high_resolution_clock::now();
         const auto dur = tp.time_since_epoch();
-        const auto seed = dur.count();
-        std::mt19937 generator(static_cast<unsigned>(seed));
-        constexpr int64_t minValue {1};
-        constexpr int64_t maxValue {1000000};
-        std::uniform_int_distribution<int64_t> distribution(minValue, maxValue);
-        return distribution(generator);
+        // Mix up the bits. Smallest implementation of a xorshift64 there is.
+        auto hash = static_cast<int64_t>(dur.count());
+        hash ^= hash << 7;
+        hash ^= hash >> 9;
+        return hash & 0x7FFFFFFFFFFFFFFFULL;
     }();
-    return randomNumber;
+    return uniqueId;
 }
 
 std::string Application::getHomePath()

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -775,8 +775,8 @@ public:
     /// Get the argument values that were provided at the start of the application.
     static char** GetARGV(){return _argv;}
 
-    /// Get the application process id.
-    static int64_t applicationPid();
+    /// Get a constant unique ID specific to this application instance.
+    static int64_t uniqueInstanceId();
     /// @}
 
     /**

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -1111,7 +1111,7 @@ std::string Document::getTransientDirectoryName(const std::string& uuid,
 #endif
     out << Application::getUserCachePath() << Application::getExecutableName() << "_Doc_"
         << uuid << "_" << hash.result().toHex().left(6).constData() << "_"
-        << Application::applicationPid();
+        << Application::uniqueInstanceId();
     return out.str();
 }
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -2552,7 +2552,7 @@ void tryRunEventLoop(GUISingleApplication& mainApp)
 {
     std::stringstream out;
     out << App::Application::getUserCachePath() << App::Application::getExecutableName() << "_"
-        << App::Application::applicationPid() << ".lock";
+        << App::Application::uniqueInstanceId() << ".lock";
 
     // open a lock file with the PID
     Base::FileInfo fi(out.str());

--- a/src/Gui/DocumentRecovery.cpp
+++ b/src/Gui/DocumentRecovery.cpp
@@ -806,8 +806,8 @@ void DocumentRecoveryHandler::checkForPreviousCrashes(
     for (const QFileInfo& it : locks) {
         QString bn = it.baseName();
         // ignore the lock file for this instance
-        QString pid = QString::number(App::Application::applicationPid());
-        if (bn.startsWith(exeName) && bn.indexOf(pid) < 0) {
+        QString uiid = QString::number(App::Application::uniqueInstanceId());
+        if (bn.startsWith(exeName) && bn.indexOf(uiid) < 0) {
             QString fn = it.absoluteFilePath();
 
 #if !defined(FC_OS_WIN32) || (BOOST_VERSION < 107600)
@@ -817,11 +817,11 @@ void DocumentRecoveryHandler::checkForPreviousCrashes(
 #endif
             if (flock.try_lock()) {
                 // OK, this file is a leftover from a previous crash
-                QString crashed_pid = bn.mid(exeName.length() + 1);
-                // search for transient directories with this PID
+                QString crashedUiid = bn.mid(exeName.length() + 1);
+                // search for transient directories with this UIID
                 QString filter;
                 QTextStream str(&filter);
-                str << exeName << "_Doc_*_" << crashed_pid;
+                str << exeName << "_Doc_*_" << crashedUiid;
                 tmp.setNameFilters(QStringList() << filter);
                 tmp.setFilter(QDir::Dirs);
                 QList<QFileInfo> dirs = tmp.entryInfoList();


### PR DESCRIPTION
* `applicationPid()` hasn't returned the app's process ID since 8b1c358cb55e293a638eeb0020777bfd56bdaf47, so the name and comment were misleading
* mt19937 is absolutely overkill for what is in essence just hashing
* Reduces execution time, from thousands of cycles to initialize and rotate the 5 KiB mt19937 stack buffer, to merely 2 bit shifts
* Reduces code size tenfold, for GCC x86_64 -O3 that's
  * From 1421 bytes
    * 85 for the main function body
    * 160 for the non-inlined closure because `<random>` facilities aren't `noexcept`
    * 545 for the the Mersenne Twister engine
    * 631 for the uniform distribution
  * To 105 for the whole function
