### PR TITLE
Gui: Don't pass zero-length direction vector

### DIFF
--- a/src/Gui/Inventor/SoNaviCube.cpp
+++ b/src/Gui/Inventor/SoNaviCube.cpp
@@ -558,7 +558,7 @@ void SoNaviCube::rebuildButtonFaces() const
     addButtonFace(PickId::ArrowLeft, SbVec3f(0, 0, 1));
     addButtonFace(PickId::ArrowRight, SbVec3f(0, 0, -1));
     addButtonFace(PickId::DotBackside, SbVec3f(0, 1, 0));
-    addButtonFace(PickId::ViewMenu);
+    addButtonFace(PickId::ViewMenu, SbVec3f(0, 0, 0));
 }
 
 void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
@@ -625,5 +625,6 @@ void SoNaviCube::addButtonFace(PickId pickId, const SbVec3f& direction) const
         }
     }
     face.type = FaceType::Button;
-    face.rotation = SbRotation(direction, 1).inverse();
+    face.rotation = direction.sqrLength() > 0.0F ? SbRotation(direction, 1.0F).inverse()
+                                                 : SbRotation();
 }

--- a/src/Gui/Inventor/SoNaviCube.h
+++ b/src/Gui/Inventor/SoNaviCube.h
@@ -155,7 +155,7 @@ private:
     void rebuildGeometry() const;
     void addCubeFace(const SbVec3f& x, const SbVec3f& z, FaceType type, PickId pickId, float rotZ) const;
     void rebuildButtonFaces() const;
-    void addButtonFace(PickId pickId, const SbVec3f& direction = SbVec3f(0, 0, 0)) const;
+    void addButtonFace(PickId pickId, const SbVec3f& direction) const;
 
 private:
     float m_Chamfer {0.12F};


### PR DESCRIPTION
When given a zero-length direction vector Coin falls back to the identity rotation: just do that explicitly instead. Silences 'axis parameter has zero length' debug-mode warnings.
