### PR TITLE
Cherry-picks ParameterObserver

### DIFF
--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -25,6 +25,7 @@
 
 #include <cassert>
 #include <xercesc/util/PlatformUtils.hpp>
+#include <xercesc/util/ParseException.hpp>
 #include <xercesc/util/XercesVersion.hpp>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/dom/DOMImplementation.hpp>
@@ -80,6 +81,39 @@ public:
     }
 };
 
+std::map<std::string, std::string> initMap()
+{
+    // clang-format off
+    std::map<std::string, std::string> propMap = {{"Comment", ""},
+                                                  {"Company", ""},
+                                                  {"CreatedBy", ""},
+                                                  {"CreationDate", ""},
+                                                  {"Label", ""},
+                                                  {"LastModifiedBy", ""},
+                                                  {"LastModifiedDate", ""},
+                                                  {"License", ""},
+                                                  {"LicenseURL", ""},
+                                                  {"Uid", ""}};
+    return propMap;
+    // clang-format on
+}
+
+std::string readValue(DOMNode* node)
+{
+    if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
+        if (DOMElement* child =
+            static_cast<DOMElement*>(node)->getFirstElementChild()) {  // NOLINT
+            if (DOMNode* nameAttr =
+                child->getAttributes()->getNamedItem(XStrLiteral("value").unicodeForm())) {
+                std::string value = StrX(nameAttr->getNodeValue()).c_str();
+                return value;
+            }
+        }
+    }
+
+    return {};
+}
+
 class DocumentMetadata
 {
 public:
@@ -127,22 +161,6 @@ private:
             }
         }
     }
-    static std::map<std::string, std::string> initMap()
-    {
-        // clang-format off
-        std::map<std::string, std::string> propMap = {{"Comment", ""},
-                                                      {"Company", ""},
-                                                      {"CreatedBy", ""},
-                                                      {"CreationDate", ""},
-                                                      {"Label", ""},
-                                                      {"LastModifiedBy", ""},
-                                                      {"LastModifiedDate", ""},
-                                                      {"License", ""},
-                                                      {"LicenseURL", ""},
-                                                      {"Uid", ""}};
-        return propMap;
-        // clang-format on
-    }
 
     void setMetadata(const std::map<std::string, std::string>& propMap)
     {
@@ -170,25 +188,111 @@ private:
         }
     }
 
-    static std::string readValue(DOMNode* node)
+private:
+    XERCES_CPP_NAMESPACE::DOMDocument* xmlDocument;
+    ProjectFile::Metadata metadata;
+};
+
+class MetaDataParser : public DOMLSParserFilter
+{
+    ProjectFile::Metadata& metadata;
+    std::map<std::string, std::string> propMap;
+    std::string currentProperty;
+
+public:
+    explicit MetaDataParser(ProjectFile::Metadata& metadata)
+        : metadata{metadata}
     {
-        if (node->getNodeType() == DOMNode::ELEMENT_NODE) {
-            if (DOMElement* child =
-                    static_cast<DOMElement*>(node)->getFirstElementChild()) {  // NOLINT
-                if (DOMNode* nameAttr =
-                        child->getAttributes()->getNamedItem(XStrLiteral("value").unicodeForm())) {
-                    std::string value = StrX(nameAttr->getNodeValue()).c_str();
-                    return value;
+        propMap = initMap();
+    }
+
+    ~MetaDataParser() override
+    {
+        setMetadata(propMap);
+    }
+
+    void setMetadata(const std::map<std::string, std::string>& propMap)
+    {
+        metadata.comment = propMap.at("Comment");
+        metadata.company = propMap.at("Company");
+        metadata.createdBy = propMap.at("CreatedBy");
+        metadata.creationDate = propMap.at("CreationDate");
+        metadata.label = propMap.at("Label");
+        metadata.lastModifiedBy = propMap.at("LastModifiedBy");
+        metadata.lastModifiedDate = propMap.at("LastModifiedDate");
+        metadata.license = propMap.at("License");
+        metadata.licenseURL = propMap.at("LicenseURL");
+        metadata.uuid = propMap.at("Uid");
+    }
+
+    FilterAction acceptNode([[maybe_unused]]DOMNode* node) override
+    {
+        return DOMLSParserFilter::FILTER_ACCEPT;
+    }
+
+    FilterAction startElement(DOMElement* node) override
+    {
+        std::array property = {chLatin_P,
+                               chLatin_r,
+                               chLatin_o,
+                               chLatin_p,
+                               chLatin_e,
+                               chLatin_r,
+                               chLatin_t,
+                               chLatin_y,
+                               chNull};
+        if (XMLString::equals(node->getNodeName(), property.data())) {
+            std::array name = {chLatin_n,
+                               chLatin_a,
+                               chLatin_m,
+                               chLatin_e,
+                               chNull};
+            if (DOMAttr* attr = node->getAttributeNode(name.data())) {
+                std::string value = StrX(attr->getNodeValue()).c_str();
+                auto it = propMap.find(value);
+                if (it != propMap.end()) {
+                    currentProperty = value;
+                }
+                else {
+                    currentProperty.clear();
                 }
             }
         }
 
-        return {};
+        std::array string = {chLatin_S,
+                             chLatin_t,
+                             chLatin_r,
+                             chLatin_i,
+                             chLatin_n,
+                             chLatin_g,
+                             chNull};
+        if (XMLString::equals(node->getNodeName(), string.data())) {
+            if (!currentProperty.empty()) {
+                propMap[currentProperty] = readValue(node->getParentNode());
+                currentProperty.clear();
+            }
+        }
+
+        // This is the node after the 'Properties' element of the document
+        std::array Objects = {chLatin_O,
+                              chLatin_b,
+                              chLatin_j,
+                              chLatin_e,
+                              chLatin_c,
+                              chLatin_t,
+                              chLatin_s,
+                              chNull};
+        if (XMLString::equals(node->getNodeName(), Objects.data())) {
+            ThrowXML(ParseException,XMLExcepts::Parser_Parse1);
+        }
+
+        return DOMLSParserFilter::FILTER_ACCEPT;
     }
 
-private:
-    XERCES_CPP_NAMESPACE::DOMDocument* xmlDocument;
-    ProjectFile::Metadata metadata;
+    DOMNodeFilter::ShowType getWhatToShow() const override
+    {
+        return DOMNodeFilter::SHOW_ALL;
+    }
 };
 }  // namespace
 
@@ -235,6 +339,7 @@ bool ProjectFile::loadDocument()
 
         try {
             Base::StdInputSource inputSource(*str, stdFile.c_str());
+
             parser->parse(inputSource);
             if (parser->getErrorCount() > 0) {
                 return false;
@@ -253,10 +358,64 @@ bool ProjectFile::loadDocument()
     return false;
 }
 
+ProjectFile::Metadata ProjectFile::parseMetadata() const
+{
+    auto project = ZipTools::open(stdFile);
+    if (!project) {
+        return {};
+    }
+
+    ProjectFile::Metadata meta;
+    std::unique_ptr<std::istream> str(project->getInputStream("Document.xml"));
+    if (str) {
+        static const std::array gLS = { chLatin_L, chLatin_S, chNull };
+
+        DOMImplementation* impl = DOMImplementationRegistry::getDOMImplementation(gLS.data());
+        DOMLSParser* domBuilder = impl->createLSParser(DOMImplementationLS::MODE_SYNCHRONOUS, nullptr);
+        DOMLSInput* input = impl->createLSInput();
+
+        try {
+            Base::StdInputSource inputSource(*str, stdFile.c_str());
+
+            input->setByteStream(&inputSource);
+            MetaDataParser filter(meta);
+            domBuilder->setFilter(&filter);
+            domBuilder->getDomConfig()->setParameter(XMLUni::fgDOMEntities, false);
+            domBuilder->parse(input);
+        }
+        catch (const XMLException&) {
+            // Do nothing
+        }
+        catch (const DOMException&) {
+            // Do nothing
+        }
+
+        input->release();
+        domBuilder->release();
+    }
+
+    return meta;
+}
+
+bool ProjectFile::isValid() const
+{
+    if (xmlDocument) {
+        return true;  // already loaded
+    }
+
+    auto project = ZipTools::open(stdFile);
+    if (!project) {
+        return false;
+    }
+
+    std::unique_ptr<std::istream> str(project->getInputStream("Document.xml"));
+    return static_cast<bool>(str);
+}
+
 ProjectFile::Metadata ProjectFile::getMetadata() const
 {
     if (!xmlDocument) {
-        return {};
+        return parseMetadata();
     }
 
     DocumentMetadata reader(xmlDocument);

--- a/src/App/ProjectFile.cpp
+++ b/src/App/ProjectFile.cpp
@@ -397,21 +397,6 @@ ProjectFile::Metadata ProjectFile::parseMetadata() const
     return meta;
 }
 
-bool ProjectFile::isValid() const
-{
-    if (xmlDocument) {
-        return true;  // already loaded
-    }
-
-    auto project = ZipTools::open(stdFile);
-    if (!project) {
-        return false;
-    }
-
-    std::unique_ptr<std::istream> str(project->getInputStream("Document.xml"));
-    return static_cast<bool>(str);
-}
-
 ProjectFile::Metadata ProjectFile::getMetadata() const
 {
     if (!xmlDocument) {

--- a/src/App/ProjectFile.h
+++ b/src/App/ProjectFile.h
@@ -116,6 +116,10 @@ public:
      */
     bool loadDocument();
     /**
+     * If the project starts with a Document.xml file it's considered as valid.
+     */
+    bool isValid() const;
+    /**
      * Return the meta data of the loaded document.
      */
     Metadata getMetadata() const;
@@ -200,6 +204,7 @@ public:
     bool replaceProjectFile(const std::string& name, bool keepfile = false);
 
 private:
+    Metadata parseMetadata() const;
     void findFiles(XERCES_CPP_NAMESPACE::DOMNode*, std::list<std::string>&) const;
     void findFiles(XERCES_CPP_NAMESPACE::DOMNode*, std::list<PropertyFile>&) const;
 

--- a/src/App/ProjectFile.h
+++ b/src/App/ProjectFile.h
@@ -116,10 +116,6 @@ public:
      */
     bool loadDocument();
     /**
-     * If the project starts with a Document.xml file it's considered as valid.
-     */
-    bool isValid() const;
-    /**
      * Return the meta data of the loaded document.
      */
     Metadata getMetadata() const;

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -198,6 +198,7 @@ SET(FreeCADBase_CPP_SRCS
     Observer.cpp
     Parameter.xsd
     Parameter.cpp
+    ParameterObserver.cpp
     ParameterPy.cpp
     Persistence.cpp
     PersistencePyImp.cpp
@@ -268,6 +269,7 @@ SET(FreeCADBase_HPP_SRCS
     Matrix.h
     Observer.h
     Parameter.h
+    ParameterObserver.h
     Persistence.h
     Placement.h
     Precision.h

--- a/src/Base/ParameterObserver.cpp
+++ b/src/Base/ParameterObserver.cpp
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2025 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+#include <string_view>
+
+#include "ParameterObserver.h"
+
+using namespace Base;
+
+ParameterObserver::ParameterObserver() = default;
+
+void ParameterObserver::attachToParameter(ParameterGrp::handle parameter)
+{
+    handle = parameter;
+    handle->Attach(this);
+}
+
+void ParameterObserver::initParameters()
+{
+    for (const auto& it : parameters) {
+        this->OnChange(*handle, it.first);
+    }
+}
+
+void ParameterObserver::OnChange(Base::Subject<const char*>& subject, const char* sReason)
+{
+    std::ignore = subject;
+    if (!sReason) {
+        return;
+    }
+    auto it = parameters.find(sReason);
+    if (it == parameters.end()) {
+        return;
+    }
+    it->second.fetch(handle, sReason);
+}
+
+void ParameterObserver::addParameter(const char* key, const Object& value)
+{
+    parameters.emplace(key, value);
+}
+
+void ParameterObserver::setBoolean(const char* key, bool value)
+{
+    setValue(key, value);
+}
+
+bool ParameterObserver::getBoolean(const char* key) const
+{
+    return getValue<bool>(key);
+}
+
+bool ParameterObserver::getDefaultBoolean(const char* key) const
+{
+    return getDefault<bool>(key);
+}
+
+void ParameterObserver::setInt(const char* key, long value)
+{
+    setValue(key, value);
+}
+
+long ParameterObserver::getInt(const char* key) const
+{
+    return getValue<long>(key);
+}
+
+long ParameterObserver::getDefaultInt(const char* key) const
+{
+    return getDefault<long>(key);
+}
+
+void ParameterObserver::setUnsigned(const char* key, unsigned long value)
+{
+    setValue(key, value);
+}
+
+unsigned long ParameterObserver::getUnsigned(const char* key) const
+{
+    return getValue<unsigned long>(key);
+}
+
+unsigned long ParameterObserver::getDefaultUnsigned(const char* key) const
+{
+    return getDefault<unsigned long>(key);
+}
+
+void ParameterObserver::setFloat(const char* key, double value)
+{
+    setValue(key, value);
+}
+
+double ParameterObserver::getFloat(const char* key) const
+{
+    return getValue<double>(key);
+}
+
+double ParameterObserver::getDefaultFloat(const char* key) const
+{
+    return getDefault<double>(key);
+}
+
+void ParameterObserver::setString(const char* key, const char* value)
+{
+    setValue<std::string>(key, value);
+}
+
+std::string ParameterObserver::getString(const char* key) const
+{
+    return getValue<std::string>(key);
+}
+
+std::string ParameterObserver::getDefaultString(const char* key) const
+{
+    return getDefault<std::string>(key);
+}
+
+std::size_t ParameterObserver::Hasher::operator()(const char* s) const
+{
+    if (!s) {
+        return 0;
+    }
+
+    std::string_view view(s);
+    return boost::hash_range(view.begin(), view.end());
+}
+
+bool ParameterObserver::Hasher::operator()(const char* a, const char* b) const
+{
+    if (!a) {
+        return !b;
+    }
+    if (!b) {
+        return false;
+    }
+    return std::strcmp(a, b) == 0;
+}

--- a/src/Base/ParameterObserver.cpp
+++ b/src/Base/ParameterObserver.cpp
@@ -30,6 +30,13 @@ using namespace Base;
 
 ParameterObserver::ParameterObserver() = default;
 
+ParameterObserver::~ParameterObserver()
+{
+    if (handle) {
+        handle->Detach(this);
+    }
+}
+
 void ParameterObserver::attachToParameter(ParameterGrp::handle parameter)
 {
     handle = parameter;

--- a/src/Base/ParameterObserver.cpp
+++ b/src/Base/ParameterObserver.cpp
@@ -135,24 +135,3 @@ std::string ParameterObserver::getDefaultString(const char* key) const
 {
     return getDefault<std::string>(key);
 }
-
-std::size_t ParameterObserver::Hasher::operator()(const char* s) const
-{
-    if (!s) {
-        return 0;
-    }
-
-    std::string_view view(s);
-    return boost::hash_range(view.begin(), view.end());
-}
-
-bool ParameterObserver::Hasher::operator()(const char* a, const char* b) const
-{
-    if (!a) {
-        return !b;
-    }
-    if (!b) {
-        return false;
-    }
-    return std::strcmp(a, b) == 0;
-}

--- a/src/Base/ParameterObserver.h
+++ b/src/Base/ParameterObserver.h
@@ -26,9 +26,11 @@
 
 #include <Base/Parameter.h>
 #include <FCGlobal.h>
+#include <cstring>
 #include <variant>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <unordered_map>
 
@@ -222,8 +224,20 @@ public:
 private:
     struct Hasher
     {
-        std::size_t operator()(const char* s) const;
-        bool operator()(const char* a, const char* b) const;
+        std::size_t operator()(const char* s) const
+        {
+            return s ? std::hash<std::string_view> {}(s) : 0;
+        }
+        bool operator()(const char* a, const char* b) const
+        {
+            if (!a) {
+                return !b;
+            }
+            if (!b) {
+                return false;
+            }
+            return std::strcmp(a, b) == 0;
+        }
     };
     std::unordered_map<const char*, Object, Hasher, Hasher> parameters;
     ParameterGrp::handle handle;
@@ -232,6 +246,10 @@ protected:
     ParameterObserver();
 
     void attachToParameter(ParameterGrp::handle parameter);
+    ParameterGrp::handle getHandle() const
+    {
+        return handle;
+    }
     void initParameters();
     void OnChange(Base::Subject<const char*>& subject, const char* sReason) override;
     void addParameter(const char* key, const Object& value);

--- a/src/Base/ParameterObserver.h
+++ b/src/Base/ParameterObserver.h
@@ -244,6 +244,7 @@ private:
 
 protected:
     ParameterObserver();
+    ~ParameterObserver() override;
 
     void attachToParameter(ParameterGrp::handle parameter);
     ParameterGrp::handle getHandle() const

--- a/src/Base/ParameterObserver.h
+++ b/src/Base/ParameterObserver.h
@@ -268,6 +268,11 @@ protected:
             str << "Wrong cast of parameter " << key << '\n';
             throw Base::TypeError(str.str());
         }
+        catch (const std::exception&) {
+            std::stringstream str;
+            str << "Unknown parameter " << key << '\n';
+            throw Base::IndexError(str.str());
+        }
     }
     template<typename T>
     T getValue(const char* key) const
@@ -296,6 +301,11 @@ protected:
             std::stringstream str;
             str << "Wrong cast of parameter " << key << '\n';
             throw Base::TypeError(str.str());
+        }
+        catch (const std::exception&) {
+            std::stringstream str;
+            str << "Unknown parameter " << key << '\n';
+            throw Base::IndexError(str.str());
         }
     }
 };

--- a/src/Base/ParameterObserver.h
+++ b/src/Base/ParameterObserver.h
@@ -363,8 +363,6 @@ struct type_traits<std::string>
     using value_type = ParameterObserver::String;
 };
 
-}  // namespace Base
-
 template<typename T>
 struct type_from_member;
 
@@ -379,6 +377,8 @@ constexpr bool is_getter = std::is_same<T, R (type_from_member<T>::type::*)() co
 
 template<typename T, typename A>
 constexpr bool is_setter = std::is_same<T, void (type_from_member<T>::type::*)(A)>::value;
+
+}  // namespace Base
 
 #define FC_PARAM_GETSET_IMP(_class, _name, _ctype) \
     _ctype _class::get##_name() const \

--- a/src/Base/ParameterObserver.h
+++ b/src/Base/ParameterObserver.h
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2025 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef BASE_PARAMETEROBSERVER_H
+#define BASE_PARAMETEROBSERVER_H
+
+#include <Base/Parameter.h>
+#include <FCGlobal.h>
+#include <variant>
+#include <memory>
+#include <string>
+#include <sstream>
+#include <unordered_map>
+
+namespace Base
+{
+
+class BaseExport ParameterObserver: public ParameterGrp::ObserverType
+{
+protected:
+    using Type = std::variant<bool, long, unsigned long, double, std::string>;
+    class Object
+    {
+
+    public:
+        template<typename T>
+        Object(T&& obj)  // NOLINT
+            : object(std::make_shared<Model<T>>(std::forward<T>(obj)))
+        {}
+
+        void fetch(const ParameterGrp::handle& handle, const char* key)
+        {
+            object->fetch(handle, key);
+        }
+        void setParameter(const ParameterGrp::handle& handle, const char* key, const Type& value)
+        {
+            object->setParameter(handle, key, value);
+        }
+        Type value() const
+        {
+            return object->value();
+        }
+        Type defaultValue() const
+        {
+            return object->defaultValue();
+        }
+        void setValue(const Type& value)
+        {
+            object->setValue(value);
+        }
+
+        struct Concept  // NOLINT
+        {
+            virtual ~Concept() = default;
+            virtual void fetch(const ParameterGrp::handle&, const char* key) = 0;
+            virtual void setParameter(
+                const ParameterGrp::handle& handle,
+                const char* key,
+                const Type& value
+            ) = 0;
+            virtual Type value() const = 0;
+            virtual Type defaultValue() const = 0;
+            virtual void setValue(const Type&) = 0;
+        };
+
+        template<typename T>
+        struct Model: Concept
+        {
+            explicit Model(const T& t)
+                : object(t)
+            {}
+            void fetch(const ParameterGrp::handle& handle, const char* key) override
+            {
+                object.fetch(handle, key);
+            }
+            void setParameter(const ParameterGrp::handle& handle, const char* key, const Type& value) override
+            {
+                object.setParameter(handle, key, value);
+            }
+            Type value() const override
+            {
+                return object.value();
+            }
+            Type defaultValue() const override
+            {
+                return object.defaultValue();
+            }
+            void setValue(const Type& v) override
+            {
+                object.setValue(v);
+            }
+
+        private:
+            T object;
+        };
+
+        std::shared_ptr<Concept> object;
+    };
+
+public:
+    struct BaseType
+    {
+        Type _value, _default;
+        explicit BaseType(const Type& d)
+            : _value(d)
+            , _default(d)
+        {}
+        Type value() const
+        {
+            return _value;
+        }
+        Type defaultValue() const
+        {
+            return _default;
+        }
+        void setValue(const Type& v)
+        {
+            _value = v;
+        }
+    };
+
+    struct Bool: BaseType
+    {
+        using value_type = bool;
+        explicit Bool(value_type d)
+            : BaseType {d}
+        {}
+        void fetch(const ParameterGrp::handle& handle, const char* key)
+        {
+            _value = handle->GetBool(key, std::get<value_type>(_default));
+        }
+        void setParameter(const ParameterGrp::handle& handle, const char* key, const Type& value)
+        {
+            handle->SetBool(key, std::get<value_type>(value));
+        }
+    };
+
+    struct Int: BaseType
+    {
+        using value_type = long;
+        explicit Int(value_type d)
+            : BaseType {d}
+        {}
+        void fetch(const ParameterGrp::handle& handle, const char* key)
+        {
+            _value = handle->GetInt(key, std::get<value_type>(_default));
+        }
+        void setParameter(const ParameterGrp::handle& handle, const char* key, const Type& value)
+        {
+            handle->SetInt(key, std::get<value_type>(value));
+        }
+    };
+
+    struct Unsigned: BaseType
+    {
+        using value_type = unsigned long;
+        explicit Unsigned(value_type d)
+            : BaseType {d}
+        {}
+        void fetch(const ParameterGrp::handle& handle, const char* key)
+        {
+            _value = handle->GetUnsigned(key, std::get<value_type>(_default));
+        }
+        void setParameter(const ParameterGrp::handle& handle, const char* key, const Type& value)
+        {
+            handle->SetUnsigned(key, std::get<value_type>(value));
+        }
+    };
+
+    struct Double: BaseType
+    {
+        using value_type = double;
+        explicit Double(value_type d)
+            : BaseType {d}
+        {}
+        void fetch(const ParameterGrp::handle& handle, const char* key)
+        {
+            _value = handle->GetFloat(key, std::get<value_type>(_default));
+        }
+        void setParameter(const ParameterGrp::handle& handle, const char* key, const Type& value)
+        {
+            handle->SetFloat(key, std::get<value_type>(value));
+        }
+    };
+
+    struct String: BaseType
+    {
+        using value_type = std::string;
+        explicit String(const value_type& d)
+            : BaseType {d}
+        {}
+        void fetch(const ParameterGrp::handle& handle, const char* key)
+        {
+            _value = handle->GetASCII(key, std::get<value_type>(_default).c_str());
+        }
+        void setParameter(const ParameterGrp::handle& handle, const char* key, const Type& value)
+        {
+            handle->SetASCII(key, std::get<value_type>(value).c_str());
+        }
+    };
+
+private:
+    struct Hasher
+    {
+        std::size_t operator()(const char* s) const;
+        bool operator()(const char* a, const char* b) const;
+    };
+    std::unordered_map<const char*, Object, Hasher, Hasher> parameters;
+    ParameterGrp::handle handle;
+
+protected:
+    ParameterObserver();
+
+    void attachToParameter(ParameterGrp::handle parameter);
+    void initParameters();
+    void OnChange(Base::Subject<const char*>& subject, const char* sReason) override;
+    void addParameter(const char* key, const Object& value);
+
+    void setBoolean(const char* key, bool value);
+    bool getBoolean(const char* key) const;
+    bool getDefaultBoolean(const char* key) const;
+
+    void setInt(const char* key, long value);
+    long getInt(const char* key) const;
+    long getDefaultInt(const char* key) const;
+
+    void setUnsigned(const char* key, unsigned long value);
+    unsigned long getUnsigned(const char* key) const;
+    unsigned long getDefaultUnsigned(const char* key) const;
+
+    void setFloat(const char* key, double value);
+    double getFloat(const char* key) const;
+    double getDefaultFloat(const char* key) const;
+
+    void setString(const char* key, const char* value);
+    std::string getString(const char* key) const;
+    std::string getDefaultString(const char* key) const;
+
+    template<typename T>
+    void setValue(const char* key, const T& value)
+    {
+        try {
+            parameters.at(key).setParameter(handle, key, value);
+            parameters.at(key).setValue(value);
+        }
+        catch (const std::bad_variant_access&) {
+            std::stringstream str;
+            str << "Wrong cast of parameter " << key << '\n';
+            throw Base::TypeError(str.str());
+        }
+    }
+    template<typename T>
+    T getValue(const char* key) const
+    {
+        try {
+            return std::get<T>(parameters.at(key).value());
+        }
+        catch (const std::bad_variant_access&) {
+            std::stringstream str;
+            str << "Wrong cast of parameter " << key << '\n';
+            throw Base::TypeError(str.str());
+        }
+        catch (const std::exception&) {
+            std::stringstream str;
+            str << "Unknown parameter " << key << '\n';
+            throw Base::IndexError(str.str());
+        }
+    }
+    template<typename T>
+    T getDefault(const char* key) const
+    {
+        try {
+            return std::get<T>(parameters.at(key).defaultValue());
+        }
+        catch (const std::bad_variant_access&) {
+            std::stringstream str;
+            str << "Wrong cast of parameter " << key << '\n';
+            throw Base::TypeError(str.str());
+        }
+    }
+};
+
+template<class T>
+struct type_traits
+{
+};
+
+template<>
+struct type_traits<bool>
+{
+    using value_type = ParameterObserver::Bool;
+};
+
+template<>
+struct type_traits<long>
+{
+    using value_type = ParameterObserver::Int;
+};
+
+template<>
+struct type_traits<unsigned long>
+{
+    using value_type = ParameterObserver::Unsigned;
+};
+
+template<>
+struct type_traits<double>
+{
+    using value_type = ParameterObserver::Double;
+};
+
+template<>
+struct type_traits<std::string>
+{
+    using value_type = ParameterObserver::String;
+};
+
+}  // namespace Base
+
+template<typename T>
+struct type_from_member;
+
+template<typename M, typename T>
+struct type_from_member<M T::*>
+{
+    using type = T;
+};
+
+template<typename T, typename R>
+constexpr bool is_getter = std::is_same<T, R (type_from_member<T>::type::*)() const>::value;
+
+template<typename T, typename A>
+constexpr bool is_setter = std::is_same<T, void (type_from_member<T>::type::*)(A)>::value;
+
+#define FC_PARAM_GETSET_IMP(_class, _name, _ctype) \
+    _ctype _class::get##_name() const \
+    { \
+        return getValue<_ctype>(#_name); \
+    } \
+\
+    void _class::set##_name(_ctype v) \
+    { \
+        setValue(#_name, v); \
+    }
+
+#endif  // BASE_PARAMETEROBSERVER_H

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -98,6 +98,7 @@
 #include "Selection.h"
 #include "SelectionFilterPy.h"
 #include "SoQtOffscreenRendererPy.h"
+#include "SpaceMouseParameter.h"
 #include "SplitView3DInventor.h"
 #include "StartupProcess.h"
 #include "TaskView/TaskView.h"
@@ -2723,16 +2724,13 @@ void Application::init3DMouse(MainWindow* mainWindow, QApplication* qtApp)
 {
     Instance->pNavlibInterface = nullptr;
 #ifdef USE_3DCONNEXION_NAVLIB
-    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/View"
-    );
     if (NlErrorCode) {
         Base::Console().log("Init: 3Dconnexion driver not installed\n");
     }
     else {
         Base::Console().log("Init: 3Dconnexion Navigation Framework present\n");
     }
-    if (!hViewGrp->GetBool("LegacySpaceMouseDevices", false)) {
+    if (!SpaceMouseParameter::instance()->getLegacySpaceMouseDevices()) {
         if (!NlErrorCode) {
             // Instantiate the 3Dconnexion controller
             Instance->pNavlibInterface = new NavlibInterface();

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -1213,6 +1213,7 @@ SET(Params_CPP_SRCS
     OverlayParams.cpp
     ParamHandler.cpp
     ViewParams.cpp
+    SpaceMouseParameter.cpp
 )
 
 SET(Params_HPP_SRCS
@@ -1220,6 +1221,7 @@ SET(Params_HPP_SRCS
     OverlayParams.h
     ParamHandler.cpp
     ViewParams.h
+    SpaceMouseParameter.h
 )
 
 SET(Params_SRCS

--- a/src/Gui/CommandT.h
+++ b/src/Gui/CommandT.h
@@ -80,6 +80,11 @@ public:
     }
 };
 
+inline const char* asString(bool value)
+{
+    return value ? "True" : "False";
+}
+
 /** @defgroup CommandFuncs Helper functions for running commands through Python interpreter */
 //@{
 

--- a/src/Gui/GuiApplicationNativeEventAware.cpp
+++ b/src/Gui/GuiApplicationNativeEventAware.cpp
@@ -30,6 +30,7 @@
 #include "Application.h"
 #include "GuiApplicationNativeEventAware.h"
 #include "SpaceballEvent.h"
+#include "SpaceMouseParameter.h"
 
 
 #if defined(_USE_3DCONNEXION_SDK) || defined(SPNAV_FOUND)
@@ -72,10 +73,7 @@ void Gui::GUIApplicationNativeEventAware::initSpaceball(QMainWindow* window)
 {
 #if defined(_USE_3DCONNEXION_SDK) || defined(SPNAV_FOUND)
 # if defined(USE_3DCONNEXION_NAVLIB)
-    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/View"
-    );
-    if (nativeEvent && hViewGrp->GetBool("LegacySpaceMouseDevices", false)) {
+    if (nativeEvent && SpaceMouseParameter::instance()->getLegacySpaceMouseDevices()) {
         // Even though Navlib is enabled, process native events to support legacy devices.
         nativeEvent->initSpaceball(window);
     }

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -35,6 +35,7 @@
 #include <Gui/Navigation/NavigationStyle.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
+#include <Gui/SpaceMouseParameter.h>
 
 #include "DlgSettingsNavigation.h"
 #include "ui_DlgSettingsNavigation.h"
@@ -67,6 +68,9 @@ DlgSettingsNavigation::DlgSettingsNavigation(QWidget* parent)
     ui->spaceMouseDevice->setHidden(true);
     ui->legacySpaceMouseDevices->setHidden(true);
 #endif
+    ui->legacySpaceMouseDevices->setChecked(
+        SpaceMouseParameter::instance()->getLegacySpaceMouseDevices()
+    );
 }
 
 /**

--- a/src/Gui/SpaceMouseParameter.cpp
+++ b/src/Gui/SpaceMouseParameter.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2025 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+#include <App/Application.h>
+#include "SpaceMouseParameter.h"
+
+using namespace Gui;
+
+void SpaceMouseParameter::setup()
+{
+    static_assert(is_getter<decltype(&SpaceMouseParameter::getLegacySpaceMouseDevices),
+                            Bool::value_type>, "Mismatching signature");
+    static_assert(is_setter<decltype(&SpaceMouseParameter::setLegacySpaceMouseDevices),
+                            Bool::value_type>, "Mismatching signature");
+
+#if defined(SPNAV_FOUND)
+    addParameter("LegacySpaceMouseDevices", Bool{true});
+#else
+    addParameter("LegacySpaceMouseDevices", Bool{false});
+#endif
+}
+
+SpaceMouseParameter::SpaceMouseParameter()
+{
+  attachToParameter(App::GetApplication().GetParameterGroupByPath(
+      "User parameter:BaseApp/Preferences/View"));
+  setup();
+  initParameters();
+}
+
+SpaceMouseParameter* SpaceMouseParameter::instance()
+{
+    static SpaceMouseParameter view;
+    return &view;
+}
+
+bool SpaceMouseParameter::getLegacySpaceMouseDevices() const
+{
+    return getValue<bool>("LegacySpaceMouseDevices");
+}
+
+void SpaceMouseParameter::setLegacySpaceMouseDevices(bool v)
+{
+    setValue("LegacySpaceMouseDevices", v);
+}

--- a/src/Gui/SpaceMouseParameter.cpp
+++ b/src/Gui/SpaceMouseParameter.cpp
@@ -29,24 +29,29 @@ using namespace Gui;
 
 void SpaceMouseParameter::setup()
 {
-    static_assert(is_getter<decltype(&SpaceMouseParameter::getLegacySpaceMouseDevices),
-                            Bool::value_type>, "Mismatching signature");
-    static_assert(is_setter<decltype(&SpaceMouseParameter::setLegacySpaceMouseDevices),
-                            Bool::value_type>, "Mismatching signature");
+    static_assert(
+        Base::is_getter<decltype(&SpaceMouseParameter::getLegacySpaceMouseDevices), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&SpaceMouseParameter::setLegacySpaceMouseDevices), Bool::value_type>,
+        "Mismatching signature"
+    );
 
 #if defined(SPNAV_FOUND)
-    addParameter("LegacySpaceMouseDevices", Bool{true});
+    addParameter("LegacySpaceMouseDevices", Bool {true});
 #else
-    addParameter("LegacySpaceMouseDevices", Bool{false});
+    addParameter("LegacySpaceMouseDevices", Bool {false});
 #endif
 }
 
 SpaceMouseParameter::SpaceMouseParameter()
 {
-  attachToParameter(App::GetApplication().GetParameterGroupByPath(
-      "User parameter:BaseApp/Preferences/View"));
-  setup();
-  initParameters();
+    attachToParameter(
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+    );
+    setup();
+    initParameters();
 }
 
 SpaceMouseParameter* SpaceMouseParameter::instance()

--- a/src/Gui/SpaceMouseParameter.h
+++ b/src/Gui/SpaceMouseParameter.h
@@ -27,9 +27,10 @@
 
 #include <Base/ParameterObserver.h>
 
-namespace Gui {
+namespace Gui
+{
 
-class GuiExport SpaceMouseParameter : public Base::ParameterObserver
+class GuiExport SpaceMouseParameter: public Base::ParameterObserver
 {
 public:
     SpaceMouseParameter();
@@ -42,6 +43,6 @@ private:
     void setup();
 };
 
-} // namespace Gui
+}  // namespace Gui
 
-#endif // GUI_SPACEMOUSE_PARAMS_H
+#endif  // GUI_SPACEMOUSE_PARAMS_H

--- a/src/Gui/SpaceMouseParameter.h
+++ b/src/Gui/SpaceMouseParameter.h
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2025 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef GUI_SPACEMOUSE_PARAMS_H
+#define GUI_SPACEMOUSE_PARAMS_H
+
+
+#include <Base/ParameterObserver.h>
+
+namespace Gui {
+
+class GuiExport SpaceMouseParameter : public Base::ParameterObserver
+{
+public:
+    SpaceMouseParameter();
+    static SpaceMouseParameter* instance();
+
+    bool getLegacySpaceMouseDevices() const;
+    void setLegacySpaceMouseDevices(bool v);
+
+private:
+    void setup();
+};
+
+} // namespace Gui
+
+#endif // GUI_SPACEMOUSE_PARAMS_H

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -1256,6 +1256,9 @@ void View3DInventorViewer::init()
     );
 
     naviCube = new NaviCube(this);
+    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/View"
+    );
     naviCubeEnabled = hViewGrp->GetBool("ShowNaviCube", true);
     syncNaviCubeVisibility();
 

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -145,6 +145,7 @@
 #include "SoFCVectorizeU3DAction.h"
 #include "SoTouchEvents.h"
 #include "SpaceballEvent.h"
+#include "SpaceMouseParameter.h"
 #include "View3DInventorRiftViewer.h"
 #include "View3DViewerPy.h"
 #include "ViewParams.h"
@@ -1225,11 +1226,8 @@ void View3DInventorViewer::init()
     // filter a few qt events
     viewerEventFilter = new ViewerEventFilter;
     installEventFilter(viewerEventFilter);
-    ParameterGrp::handle hViewGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/View"
-    );
 #if defined(USE_3DCONNEXION_NAVLIB)
-    if (hViewGrp->GetBool("LegacySpaceMouseDevices", false)) {
+    if (SpaceMouseParameter::instance()->getLegacySpaceMouseDevices()) {
         getEventFilter()->registerInputDevice(new SpaceNavigatorDevice);
     }
 #else

--- a/src/Gui/ViewParams.cpp
+++ b/src/Gui/ViewParams.cpp
@@ -29,272 +29,272 @@ using namespace Gui;
 void ViewParams::setup()
 {
     static_assert(
-        is_getter<decltype(&ViewParams::getUseNewSelection), Bool::value_type>,
+        Base::is_getter<decltype(&ViewParams::getUseNewSelection), Bool::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setUseNewSelection), Bool::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getUseSelectionRoot), Bool::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setUseSelectionRoot), Bool::value_type>,
+        Base::is_setter<decltype(&ViewParams::setUseNewSelection), Bool::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getEnableSelection), Bool::value_type>,
+        Base::is_getter<decltype(&ViewParams::getUseSelectionRoot), Bool::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setEnableSelection), Bool::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getRenderCache), Int::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setRenderCache), Int::value_type>,
+        Base::is_setter<decltype(&ViewParams::setUseSelectionRoot), Bool::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getRandomColor), Bool::value_type>,
+        Base::is_getter<decltype(&ViewParams::getEnableSelection), Bool::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setRandomColor), Bool::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getBoundingBoxColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setBoundingBoxColor), Unsigned::value_type>,
+        Base::is_setter<decltype(&ViewParams::setEnableSelection), Bool::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getAnnotationTextColor), Unsigned::value_type>,
+        Base::is_getter<decltype(&ViewParams::getRenderCache), Int::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setAnnotationTextColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getMarkerSize), Int::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setMarkerSize), Int::value_type>,
+        Base::is_setter<decltype(&ViewParams::setRenderCache), Int::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getDefaultLinkColor), Unsigned::value_type>,
+        Base::is_getter<decltype(&ViewParams::getRandomColor), Bool::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setDefaultLinkColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getDefaultShapeLineColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setDefaultShapeLineColor), Unsigned::value_type>,
+        Base::is_setter<decltype(&ViewParams::setRandomColor), Bool::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getDefaultShapeVertexColor), Unsigned::value_type>,
+        Base::is_getter<decltype(&ViewParams::getBoundingBoxColor), Unsigned::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setDefaultShapeVertexColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getDefaultShapeColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setDefaultShapeColor), Unsigned::value_type>,
+        Base::is_setter<decltype(&ViewParams::setBoundingBoxColor), Unsigned::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getDefaultShapeTransparency), Int::value_type>,
+        Base::is_getter<decltype(&ViewParams::getAnnotationTextColor), Unsigned::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setDefaultShapeTransparency), Int::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getDefaultShapeLineWidth), Int::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setDefaultShapeLineWidth), Int::value_type>,
+        Base::is_setter<decltype(&ViewParams::setAnnotationTextColor), Unsigned::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getDefaultShapePointSize), Int::value_type>,
+        Base::is_getter<decltype(&ViewParams::getMarkerSize), Int::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setDefaultShapePointSize), Int::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getCoinCycleCheck), Bool::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setCoinCycleCheck), Bool::value_type>,
+        Base::is_setter<decltype(&ViewParams::setMarkerSize), Int::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getEnablePropertyViewForInactiveDocument), Bool::value_type>,
+        Base::is_getter<decltype(&ViewParams::getDefaultLinkColor), Unsigned::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setEnablePropertyViewForInactiveDocument), Bool::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getShowSelectionBoundingBox), Bool::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setShowSelectionBoundingBox), Bool::value_type>,
+        Base::is_setter<decltype(&ViewParams::setDefaultLinkColor), Unsigned::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getPropertyViewTimer), Unsigned::value_type>,
+        Base::is_getter<decltype(&ViewParams::getDefaultShapeLineColor), Unsigned::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setPropertyViewTimer), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getAxisXColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setAxisXColor), Unsigned::value_type>,
+        Base::is_setter<decltype(&ViewParams::setDefaultShapeLineColor), Unsigned::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getAxisYColor), Unsigned::value_type>,
+        Base::is_getter<decltype(&ViewParams::getDefaultShapeVertexColor), Unsigned::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setAxisYColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getAxisZColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setAxisZColor), Unsigned::value_type>,
+        Base::is_setter<decltype(&ViewParams::setDefaultShapeVertexColor), Unsigned::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getOriginColor), Unsigned::value_type>,
+        Base::is_getter<decltype(&ViewParams::getDefaultShapeColor), Unsigned::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setOriginColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getNeutralColor), Unsigned::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setNeutralColor), Unsigned::value_type>,
+        Base::is_setter<decltype(&ViewParams::setDefaultShapeColor), Unsigned::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getPlacementIndicatorScale), Double::value_type>,
+        Base::is_getter<decltype(&ViewParams::getDefaultShapeTransparency), Int::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setPlacementIndicatorScale), Double::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getDraggerScale), Double::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setDraggerScale), Double::value_type>,
+        Base::is_setter<decltype(&ViewParams::setDefaultShapeTransparency), Int::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getDatumScale), Double::value_type>,
+        Base::is_getter<decltype(&ViewParams::getDefaultShapeLineWidth), Int::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setDatumScale), Double::value_type>,
-        "Mismatching signature"
-    );
-
-    static_assert(
-        is_getter<decltype(&ViewParams::getDatumPlaneSize), Double::value_type>,
-        "Mismatching signature"
-    );
-    static_assert(
-        is_setter<decltype(&ViewParams::setDatumPlaneSize), Double::value_type>,
+        Base::is_setter<decltype(&ViewParams::setDefaultShapeLineWidth), Int::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getDatumLineSize), Double::value_type>,
+        Base::is_getter<decltype(&ViewParams::getDefaultShapePointSize), Int::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setDatumLineSize), Double::value_type>,
+        Base::is_setter<decltype(&ViewParams::setDefaultShapePointSize), Int::value_type>,
         "Mismatching signature"
     );
 
     static_assert(
-        is_getter<decltype(&ViewParams::getDatumTemporaryScaleFactor), Double::value_type>,
+        Base::is_getter<decltype(&ViewParams::getCoinCycleCheck), Bool::value_type>,
         "Mismatching signature"
     );
     static_assert(
-        is_setter<decltype(&ViewParams::setDatumTemporaryScaleFactor), Double::value_type>,
+        Base::is_setter<decltype(&ViewParams::setCoinCycleCheck), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getEnablePropertyViewForInactiveDocument), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setEnablePropertyViewForInactiveDocument), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getShowSelectionBoundingBox), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setShowSelectionBoundingBox), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getPropertyViewTimer), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setPropertyViewTimer), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getAxisXColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setAxisXColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getAxisYColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setAxisYColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getAxisZColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setAxisZColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getOriginColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setOriginColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getNeutralColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setNeutralColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getPlacementIndicatorScale), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setPlacementIndicatorScale), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getDraggerScale), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setDraggerScale), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getDatumScale), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setDatumScale), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getDatumPlaneSize), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setDatumPlaneSize), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getDatumLineSize), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setDatumLineSize), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        Base::is_getter<decltype(&ViewParams::getDatumTemporaryScaleFactor), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        Base::is_setter<decltype(&ViewParams::setDatumTemporaryScaleFactor), Double::value_type>,
         "Mismatching signature"
     );
 

--- a/src/Gui/ViewParams.cpp
+++ b/src/Gui/ViewParams.cpp
@@ -20,43 +20,627 @@
  *                                                                          *
  ****************************************************************************/
 
-
+#include "PreCompiled.h"
 #include <App/Application.h>
 #include "ViewParams.h"
 
 using namespace Gui;
 
-ViewParams::ViewParams()
+void ViewParams::setup()
 {
-    handle = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    handle->Attach(this);
-#undef FC_VIEW_PARAM
-#define FC_VIEW_PARAM(_name, _ctype, _type, _def) _name = handle->Get##_type(#_name, _def);
+    static_assert(
+        is_getter<decltype(&ViewParams::getUseNewSelection), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setUseNewSelection), Bool::value_type>,
+        "Mismatching signature"
+    );
 
-    FC_VIEW_PARAMS
+    static_assert(
+        is_getter<decltype(&ViewParams::getUseSelectionRoot), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setUseSelectionRoot), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getEnableSelection), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setEnableSelection), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getRenderCache), Int::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setRenderCache), Int::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getRandomColor), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setRandomColor), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getBoundingBoxColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setBoundingBoxColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getAnnotationTextColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setAnnotationTextColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getMarkerSize), Int::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setMarkerSize), Int::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDefaultLinkColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDefaultLinkColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDefaultShapeLineColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDefaultShapeLineColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDefaultShapeVertexColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDefaultShapeVertexColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDefaultShapeColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDefaultShapeColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDefaultShapeTransparency), Int::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDefaultShapeTransparency), Int::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDefaultShapeLineWidth), Int::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDefaultShapeLineWidth), Int::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDefaultShapePointSize), Int::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDefaultShapePointSize), Int::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getCoinCycleCheck), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setCoinCycleCheck), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getEnablePropertyViewForInactiveDocument), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setEnablePropertyViewForInactiveDocument), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getShowSelectionBoundingBox), Bool::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setShowSelectionBoundingBox), Bool::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getPropertyViewTimer), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setPropertyViewTimer), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getAxisXColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setAxisXColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getAxisYColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setAxisYColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getAxisZColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setAxisZColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getOriginColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setOriginColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getNeutralColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setNeutralColor), Unsigned::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getPlacementIndicatorScale), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setPlacementIndicatorScale), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDraggerScale), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDraggerScale), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDatumScale), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDatumScale), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDatumPlaneSize), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDatumPlaneSize), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDatumLineSize), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDatumLineSize), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    static_assert(
+        is_getter<decltype(&ViewParams::getDatumTemporaryScaleFactor), Double::value_type>,
+        "Mismatching signature"
+    );
+    static_assert(
+        is_setter<decltype(&ViewParams::setDatumTemporaryScaleFactor), Double::value_type>,
+        "Mismatching signature"
+    );
+
+    addParameter("UseNewSelection", Bool {true});
+    addParameter("UseSelectionRoot", Bool {true});
+    addParameter("EnableSelection", Bool {true});
+    addParameter("RenderCache", Int {0});
+    addParameter("RandomColor", Bool {false});
+    addParameter("BoundingBoxColor", Unsigned {4294967295UL});
+    addParameter("AnnotationTextColor", Unsigned {4294967295UL});
+    addParameter("MarkerSize", Int {9});
+    addParameter("DefaultLinkColor", Unsigned {0x66FFFF00});
+    addParameter("DefaultShapeLineColor", Unsigned {421075455UL});
+    addParameter("DefaultShapeVertexColor", Unsigned {421075455UL});
+    addParameter("DefaultShapeColor", Unsigned {0xCCCCCC00});
+    addParameter("DefaultShapeTransparency", Int {0});
+    addParameter("DefaultShapeLineWidth", Int {2});
+    addParameter("DefaultShapePointSize", Int {2});
+    addParameter("CoinCycleCheck", Bool {true});
+    addParameter("EnablePropertyViewForInactiveDocument", Bool {true});
+    addParameter("ShowSelectionBoundingBox", Bool {false});
+    addParameter("PropertyViewTimer", Unsigned {100});
+    addParameter("AxisXColor", Unsigned {0xCC333300});
+    addParameter("AxisYColor", Unsigned {0x33CC3300});
+    addParameter("AxisZColor", Unsigned {0x3333CC00});
+    addParameter("OriginColor", Unsigned {0xFBD62900});
+    addParameter("NeutralColor", Unsigned {0xB3B38000});
+    addParameter("PlacementIndicatorScale", Double {40.0});
+    addParameter("DraggerScale", Double {0.03});
+    addParameter("DatumScale", Double {100.0});
+    addParameter("DatumPlaneSize", Double {62.0});
+    addParameter("DatumLineSize", Double {70.0});
+    addParameter("DatumTemporaryScaleFactor", Double {2.0});
 }
 
-ViewParams::~ViewParams() = default;
-
-void ViewParams::OnChange(Base::Subject<const char*>&, const char* sReason)
+ViewParams::ViewParams()
 {
-    if (!sReason) {
-        return;
-    }
-#undef FC_VIEW_PARAM
-#define FC_VIEW_PARAM(_name, _ctype, _type, _def) \
-    if (strcmp(sReason, #_name) == 0) { \
-        _name = handle->Get##_type(#_name, _def); \
-        return; \
-    }
-    FC_VIEW_PARAMS
+    attachToParameter(
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View")
+    );
+    setup();
+    initParameters();
 }
 
 ViewParams* ViewParams::instance()
 {
-    static ViewParams* inst;
-    if (!inst) {
-        inst = new ViewParams;
-    }
-    return inst;
+    static ViewParams view;
+    return &view;
+}
+
+bool ViewParams::getUseNewSelection() const
+{
+    return getValue<bool>("UseNewSelection");
+}
+
+void ViewParams::setUseNewSelection(bool v)
+{
+    setValue("UseNewSelection", v);
+}
+
+bool ViewParams::getUseSelectionRoot() const
+{
+    return getValue<bool>("UseSelectionRoot");
+}
+
+void ViewParams::setUseSelectionRoot(bool v)
+{
+    setValue("UseSelectionRoot", v);
+}
+
+bool ViewParams::getEnableSelection() const
+{
+    return getValue<bool>("EnableSelection");
+}
+
+void ViewParams::setEnableSelection(bool v)
+{
+    setValue("EnableSelection", v);
+}
+
+long ViewParams::getRenderCache() const
+{
+    return getValue<long>("RenderCache");
+}
+
+void ViewParams::setRenderCache(long v)
+{
+    setValue("RenderCache", v);
+}
+
+bool ViewParams::getRandomColor() const
+{
+    return getValue<bool>("RandomColor");
+}
+
+void ViewParams::setRandomColor(bool v)
+{
+    setValue("RandomColor", v);
+}
+
+unsigned long ViewParams::getBoundingBoxColor() const
+{
+    return getValue<unsigned long>("BoundingBoxColor");
+}
+
+void ViewParams::setBoundingBoxColor(unsigned long v)
+{
+    setValue("BoundingBoxColor", v);
+}
+
+unsigned long ViewParams::getAnnotationTextColor() const
+{
+    return getValue<unsigned long>("AnnotationTextColor");
+}
+
+void ViewParams::setAnnotationTextColor(unsigned long v)
+{
+    setValue("AnnotationTextColor", v);
+}
+
+long ViewParams::getMarkerSize() const
+{
+    return getValue<long>("MarkerSize");
+}
+
+void ViewParams::setMarkerSize(long v)
+{
+    setValue("MarkerSize", v);
+}
+
+unsigned long ViewParams::getDefaultLinkColor() const
+{
+    return getValue<unsigned long>("DefaultLinkColor");
+}
+
+void ViewParams::setDefaultLinkColor(unsigned long v)
+{
+    setValue("DefaultLinkColor", v);
+}
+
+unsigned long ViewParams::getDefaultShapeLineColor() const
+{
+    return getValue<unsigned long>("DefaultShapeLineColor");
+}
+
+void ViewParams::setDefaultShapeLineColor(unsigned long v)
+{
+    setValue("DefaultShapeLineColor", v);
+}
+
+unsigned long ViewParams::getDefaultShapeVertexColor() const
+{
+    return getValue<unsigned long>("DefaultShapeVertexColor");
+}
+
+void ViewParams::setDefaultShapeVertexColor(unsigned long v)
+{
+    setValue("DefaultShapeVertexColor", v);
+}
+
+unsigned long ViewParams::getDefaultShapeColor() const
+{
+    return getValue<unsigned long>("DefaultShapeColor");
+}
+
+void ViewParams::setDefaultShapeColor(unsigned long v)
+{
+    setValue("DefaultShapeColor", v);
+}
+
+long ViewParams::getDefaultShapeTransparency() const
+{
+    return getValue<long>("DefaultShapeTransparency");
+}
+
+void ViewParams::setDefaultShapeTransparency(long v)
+{
+    setValue("DefaultShapeTransparency", v);
+}
+
+long ViewParams::getDefaultShapeLineWidth() const
+{
+    return getValue<long>("DefaultShapeLineWidth");
+}
+
+void ViewParams::setDefaultShapeLineWidth(long v)
+{
+    setValue("DefaultShapeLineWidth", v);
+}
+
+long ViewParams::getDefaultShapePointSize() const
+{
+    return getValue<long>("DefaultShapePointSize");
+}
+
+void ViewParams::setDefaultShapePointSize(long v)
+{
+    setValue("DefaultShapePointSize", v);
+}
+
+bool ViewParams::getCoinCycleCheck() const
+{
+    return getValue<bool>("CoinCycleCheck");
+}
+
+void ViewParams::setCoinCycleCheck(bool v)
+{
+    setValue("CoinCycleCheck", v);
+}
+
+bool ViewParams::getEnablePropertyViewForInactiveDocument() const
+{
+    return getValue<bool>("EnablePropertyViewForInactiveDocument");
+}
+
+void ViewParams::setEnablePropertyViewForInactiveDocument(bool v)
+{
+    setValue("EnablePropertyViewForInactiveDocument", v);
+}
+
+bool ViewParams::getShowSelectionBoundingBox() const
+{
+    return getValue<bool>("ShowSelectionBoundingBox");
+}
+
+void ViewParams::setShowSelectionBoundingBox(bool v)
+{
+    setValue("ShowSelectionBoundingBox", v);
+}
+
+unsigned long ViewParams::getPropertyViewTimer() const
+{
+    return getValue<unsigned long>("PropertyViewTimer");
+}
+
+void ViewParams::setPropertyViewTimer(unsigned long v)
+{
+    setValue("PropertyViewTimer", v);
+}
+
+unsigned long ViewParams::getAxisXColor() const
+{
+    return getValue<unsigned long>("AxisXColor");
+}
+
+void ViewParams::setAxisXColor(unsigned long v)
+{
+    setValue("AxisXColor", v);
+}
+
+unsigned long ViewParams::getAxisYColor() const
+{
+    return getValue<unsigned long>("AxisYColor");
+}
+
+void ViewParams::setAxisYColor(unsigned long v)
+{
+    setValue("AxisYColor", v);
+}
+
+unsigned long ViewParams::getAxisZColor() const
+{
+    return getValue<unsigned long>("AxisZColor");
+}
+
+void ViewParams::setAxisZColor(unsigned long v)
+{
+    setValue("AxisZColor", v);
+}
+
+unsigned long ViewParams::getOriginColor() const
+{
+    return getValue<unsigned long>("OriginColor");
+}
+
+void ViewParams::setOriginColor(unsigned long v)
+{
+    setValue("OriginColor", v);
+}
+
+unsigned long ViewParams::getNeutralColor() const
+{
+    return getValue<unsigned long>("NeutralColor");
+}
+
+void ViewParams::setNeutralColor(unsigned long v)
+{
+    setValue("NeutralColor", v);
+}
+
+double ViewParams::getPlacementIndicatorScale() const
+{
+    return getValue<double>("PlacementIndicatorScale");
+}
+
+void ViewParams::setPlacementIndicatorScale(double v)
+{
+    setValue("PlacementIndicatorScale", v);
+}
+
+double ViewParams::getDraggerScale() const
+{
+    return getValue<double>("DraggerScale");
+}
+
+void ViewParams::setDraggerScale(double v)
+{
+    setValue("DraggerScale", v);
+}
+
+double ViewParams::getDatumScale() const
+{
+    return getValue<double>("DatumScale");
+}
+
+void ViewParams::setDatumScale(double v)
+{
+    setValue("DatumScale", v);
+}
+
+double ViewParams::getDatumPlaneSize() const
+{
+    return getValue<double>("DatumPlaneSize");
+}
+
+void ViewParams::setDatumPlaneSize(double v)
+{
+    setValue("DatumPlaneSize", v);
+}
+
+double ViewParams::getDatumLineSize() const
+{
+    return getValue<double>("DatumLineSize");
+}
+
+void ViewParams::setDatumLineSize(double v)
+{
+    setValue("DatumLineSize", v);
+}
+
+double ViewParams::getDatumTemporaryScaleFactor() const
+{
+    return getValue<double>("DatumTemporaryScaleFactor");
+}
+
+void ViewParams::setDatumTemporaryScaleFactor(double v)
+{
+    setValue("DatumTemporaryScaleFactor", v);
 }

--- a/src/Gui/ViewParams.h
+++ b/src/Gui/ViewParams.h
@@ -33,6 +33,7 @@ class GuiExport ViewParams: public Base::ParameterObserver
 public:
     ViewParams();
     static ViewParams* instance();
+    using Base::ParameterObserver::getHandle;
 
     bool getUseNewSelection() const;
     void setUseNewSelection(bool v);

--- a/src/Gui/ViewParams.h
+++ b/src/Gui/ViewParams.h
@@ -23,82 +23,109 @@
 #pragma once
 
 
-#include <Base/Parameter.h>
+#include <Base/ParameterObserver.h>
 
 namespace Gui
 {
 
-/** Convenient class to obtain view provider related parameters
- *
- * The parameters are under group "User parameter:BaseApp/Preferences/View"
- */
-class GuiExport ViewParams: public ParameterGrp::ObserverType
+class GuiExport ViewParams: public Base::ParameterObserver
 {
 public:
     ViewParams();
-    ~ViewParams() override;
-    void OnChange(Base::Subject<const char*>&, const char* sReason) override;
     static ViewParams* instance();
 
-    ParameterGrp::handle getHandle()
-    {
-        return handle;
-    }
+    bool getUseNewSelection() const;
+    void setUseNewSelection(bool v);
 
-#define FC_VIEW_PARAMS \
-    FC_VIEW_PARAM(UseNewSelection, bool, Bool, true) \
-    FC_VIEW_PARAM(UseSelectionRoot, bool, Bool, true) \
-    FC_VIEW_PARAM(EnableSelection, bool, Bool, true) \
-    FC_VIEW_PARAM(RenderCache, int, Int, 0) \
-    FC_VIEW_PARAM(RandomColor, bool, Bool, false) \
-    FC_VIEW_PARAM(BoundingBoxColor, unsigned long, Unsigned, 4294967295UL) \
-    FC_VIEW_PARAM(AnnotationTextColor, unsigned long, Unsigned, 4294967295UL) \
-    FC_VIEW_PARAM(MarkerSize, int, Int, 9) \
-    FC_VIEW_PARAM(DefaultLinkColor, unsigned long, Unsigned, 0x66FFFF00) \
-    FC_VIEW_PARAM(DefaultShapeLineColor, unsigned long, Unsigned, 421075455UL) \
-    FC_VIEW_PARAM(DefaultShapeVertexColor, unsigned long, Unsigned, 421075455UL) \
-    FC_VIEW_PARAM(DefaultShapeColor, unsigned long, Unsigned, 0xCCCCCC00) \
-    FC_VIEW_PARAM(DefaultShapeTransparency, int, Int, 0) \
-    FC_VIEW_PARAM(DefaultShapeLineWidth, int, Int, 2) \
-    FC_VIEW_PARAM(DefaultShapePointSize, int, Int, 2) \
-    FC_VIEW_PARAM(CoinCycleCheck, bool, Bool, true) \
-    FC_VIEW_PARAM(EnablePropertyViewForInactiveDocument, bool, Bool, true) \
-    FC_VIEW_PARAM(ShowSelectionBoundingBox, bool, Bool, false) \
-    FC_VIEW_PARAM(PropertyViewTimer, unsigned long, Unsigned, 100) \
-    FC_VIEW_PARAM(AxisXColor, unsigned long, Unsigned, 0xCC333300) \
-    FC_VIEW_PARAM(AxisYColor, unsigned long, Unsigned, 0x33CC3300) \
-    FC_VIEW_PARAM(AxisZColor, unsigned long, Unsigned, 0x3333CC00) \
-    FC_VIEW_PARAM(OriginColor, unsigned long, Unsigned, 0xFBD62900) \
-    FC_VIEW_PARAM(NeutralColor, unsigned long, Unsigned, 0xB3B38000) \
-    FC_VIEW_PARAM(PlacementIndicatorScale, double, Float, 40.0) \
-    FC_VIEW_PARAM(DraggerScale, double, Float, 0.03) \
-    FC_VIEW_PARAM(DatumScale, double, Float, 100.0) \
-    FC_VIEW_PARAM(DatumPlaneSize, double, Float, 62.0) \
-    FC_VIEW_PARAM(DatumLineSize, double, Float, 70.0) \
-    FC_VIEW_PARAM(DatumTemporaryScaleFactor, double, Float, 2.0)
+    bool getUseSelectionRoot() const;
+    void setUseSelectionRoot(bool v);
 
-#undef FC_VIEW_PARAM
-#define FC_VIEW_PARAM(_name, _ctype, _type, _def) \
-    _ctype get##_name() const \
-    { \
-        return _name; \
-    } \
-    void set##_name(_ctype _v) \
-    { \
-        handle->Set##_type(#_name, _v); \
-        _name = _v; \
-    }
+    bool getEnableSelection() const;
+    void setEnableSelection(bool v);
 
-    FC_VIEW_PARAMS
+    long getRenderCache() const;
+    void setRenderCache(long);
+
+    bool getRandomColor() const;
+    void setRandomColor(bool);
+
+    unsigned long getBoundingBoxColor() const;
+    void setBoundingBoxColor(unsigned long);
+
+    unsigned long getAnnotationTextColor() const;
+    void setAnnotationTextColor(unsigned long);
+
+    long getMarkerSize() const;
+    void setMarkerSize(long);
+
+    unsigned long getDefaultLinkColor() const;
+    void setDefaultLinkColor(unsigned long);
+
+    unsigned long getDefaultShapeLineColor() const;
+    void setDefaultShapeLineColor(unsigned long);
+
+    unsigned long getDefaultShapeVertexColor() const;
+    void setDefaultShapeVertexColor(unsigned long);
+
+    unsigned long getDefaultShapeColor() const;
+    void setDefaultShapeColor(unsigned long);
+
+    long getDefaultShapeTransparency() const;
+    void setDefaultShapeTransparency(long);
+
+    long getDefaultShapeLineWidth() const;
+    void setDefaultShapeLineWidth(long);
+
+    long getDefaultShapePointSize() const;
+    void setDefaultShapePointSize(long);
+
+    bool getCoinCycleCheck() const;
+    void setCoinCycleCheck(bool);
+
+    bool getEnablePropertyViewForInactiveDocument() const;
+    void setEnablePropertyViewForInactiveDocument(bool);
+
+    bool getShowSelectionBoundingBox() const;
+    void setShowSelectionBoundingBox(bool);
+
+    unsigned long getPropertyViewTimer() const;
+    void setPropertyViewTimer(unsigned long);
+
+    unsigned long getAxisXColor() const;
+    void setAxisXColor(unsigned long);
+
+    unsigned long getAxisYColor() const;
+    void setAxisYColor(unsigned long);
+
+    unsigned long getAxisZColor() const;
+    void setAxisZColor(unsigned long);
+
+    unsigned long getOriginColor() const;
+    void setOriginColor(unsigned long);
+
+    unsigned long getNeutralColor() const;
+    void setNeutralColor(unsigned long);
+
+    double getPlacementIndicatorScale() const;
+    void setPlacementIndicatorScale(double);
+
+    double getDraggerScale() const;
+    void setDraggerScale(double);
+
+    double getDatumScale() const;
+    void setDatumScale(double);
+
+    double getDatumPlaneSize() const;
+    void setDatumPlaneSize(double);
+
+    double getDatumLineSize() const;
+    void setDatumLineSize(double);
+
+    double getDatumTemporaryScaleFactor() const;
+    void setDatumTemporaryScaleFactor(double);
 
 private:
-#undef FC_VIEW_PARAM
-#define FC_VIEW_PARAM(_name, _ctype, _type, _def) _ctype _name;
-
-    FC_VIEW_PARAMS
-    ParameterGrp::handle handle;
+    void setup();
 };
-
-#undef FC_VIEW_PARAM
 
 }  // namespace Gui

--- a/src/Mod/PartDesign/App/CMakeLists.txt
+++ b/src/Mod/PartDesign/App/CMakeLists.txt
@@ -113,6 +113,8 @@ SET(Module_SRCS
     PreCompiled.h
     Measure.cpp
     Measure.h
+    PartDesignParameter.cpp
+    PartDesignParameter.h
 )
 SOURCE_GROUP("Module" FILES ${Module_SRCS})
 

--- a/src/Mod/PartDesign/App/PartDesignParameter.cpp
+++ b/src/Mod/PartDesign/App/PartDesignParameter.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+#include <App/Application.h>
+#include "PartDesignParameter.h"
+
+using namespace PartDesign;
+
+void PartDesignParameter::setup()
+{
+    // NOLINTBEGIN
+    addParameter("AllowCompoundDefault", Bool{true});
+    // NOLINTEND
+}
+
+PartDesignParameter::PartDesignParameter()
+{
+    attachToParameter(App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/PartDesign"));
+    setup();
+    initParameters();
+}
+
+PartDesignParameter* PartDesignParameter::instance()
+{
+    static PartDesignParameter param;
+    return &param;
+}
+
+FC_PARAM_GETSET_IMP(PartDesignParameter, AllowCompoundDefault, bool)

--- a/src/Mod/PartDesign/App/PartDesignParameter.cpp
+++ b/src/Mod/PartDesign/App/PartDesignParameter.cpp
@@ -30,14 +30,15 @@ using namespace PartDesign;
 void PartDesignParameter::setup()
 {
     // NOLINTBEGIN
-    addParameter("AllowCompoundDefault", Bool{true});
+    addParameter("AllowCompoundDefault", Bool {true});
     // NOLINTEND
 }
 
 PartDesignParameter::PartDesignParameter()
 {
-    attachToParameter(App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/PartDesign"));
+    attachToParameter(
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/PartDesign")
+    );
     setup();
     initParameters();
 }

--- a/src/Mod/PartDesign/App/PartDesignParameter.h
+++ b/src/Mod/PartDesign/App/PartDesignParameter.h
@@ -35,7 +35,7 @@ namespace PartDesign
  *
  * The parameters are under group "User parameter:BaseApp/Preferences/Mod/PartDesign"
  */
-class PartDesignExport PartDesignParameter : public Base::ParameterObserver
+class PartDesignExport PartDesignParameter: public Base::ParameterObserver
 {
 public:
     PartDesignParameter();
@@ -48,6 +48,6 @@ private:
     void setup();
 };
 
-} // namespace PartDesign
+}  // namespace PartDesign
 
-#endif // PARTDESIGN_PARAMETER_H
+#endif  // PARTDESIGN_PARAMETER_H

--- a/src/Mod/PartDesign/App/PartDesignParameter.h
+++ b/src/Mod/PartDesign/App/PartDesignParameter.h
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef PARTDESIGN_PARAMETER_H
+#define PARTDESIGN_PARAMETER_H
+
+
+#include <Base/ParameterObserver.h>
+#include <Mod/PartDesign/PartDesignGlobal.h>
+
+namespace PartDesign
+{
+
+/** Convenient class to obtain PartDesign related parameters
+ *
+ * The parameters are under group "User parameter:BaseApp/Preferences/Mod/PartDesign"
+ */
+class PartDesignExport PartDesignParameter : public Base::ParameterObserver
+{
+public:
+    PartDesignParameter();
+    static PartDesignParameter* instance();
+
+    bool getAllowCompoundDefault() const;
+    void setAllowCompoundDefault(bool v);
+
+private:
+    void setup();
+};
+
+} // namespace PartDesign
+
+#endif // PARTDESIGN_PARAMETER_H

--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -56,6 +56,7 @@
 #include <Mod/PartDesign/App/DatumPoint.h>
 #include <Mod/PartDesign/App/FeatureDressUp.h>
 #include <Mod/PartDesign/App/ShapeBinder.h>
+#include <Mod/PartDesign/App/PartDesignParameter.h>
 
 #include "DlgActiveBody.h"
 #include "ReferenceSelection.h"
@@ -515,6 +516,7 @@ void CmdPartDesignClone::activated(int iMsg)
         auto objCmd = getObjectCmd(obj);
         std::string cloneName = getUniqueObjectName("Clone", obj);
         std::string bodyName = getUniqueObjectName("Body", obj);
+        bool allowCompound = PartDesign::PartDesignParameter::instance()->getAllowCompoundDefault();
 
         // Create body and clone
         Gui::cmdAppDocument(
@@ -529,19 +531,13 @@ void CmdPartDesignClone::activated(int iMsg)
         auto bodyObj = obj->getDocument()->getObject(bodyName.c_str());
         auto cloneObj = obj->getDocument()->getObject(cloneName.c_str());
 
-        Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup(
-            "BaseApp/Preferences/Mod/PartDesign"
-        );
-
-        bool allowCompound = hGrp->GetBool("AllowCompoundDefault", true);
-
         // In the first step set the group link and tip of the body
-        Gui::cmdAppObject(bodyObj, std::stringstream() << "Group = [" << getObjectCmd(cloneObj) << "]");
-        Gui::cmdAppObject(bodyObj, std::stringstream() << "Tip = " << getObjectCmd(cloneObj));
         Gui::cmdAppObject(
             bodyObj,
-            std::stringstream() << "AllowCompound = " << (allowCompound ? "True" : "False")
+            std::stringstream() << "AllowCompound = " << Gui::asString(allowCompound)
         );
+        Gui::cmdAppObject(bodyObj, std::stringstream() << "Group = [" << getObjectCmd(cloneObj) << "]");
+        Gui::cmdAppObject(bodyObj, std::stringstream() << "Tip = " << getObjectCmd(cloneObj));
 
         // In the second step set the link of the base feature
         Gui::cmdAppObject(cloneObj, std::stringstream() << "BaseFeature = " << objCmd);

--- a/src/Mod/PartDesign/Gui/CommandBody.cpp
+++ b/src/Mod/PartDesign/Gui/CommandBody.cpp
@@ -35,7 +35,7 @@
 #include <App/Part.h>
 #include <Base/Console.h>
 #include <Base/Tools.h>
-#include <Gui/Command.h>
+#include <Gui/CommandT.h>
 #include <Gui/Control.h>
 #include <Gui/Document.h>
 #include <Gui/Application.h>
@@ -45,6 +45,7 @@
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/FeatureBase.h>
 #include <Mod/PartDesign/App/FeatureSketchBased.h>
+#include <Mod/PartDesign/App/PartDesignParameter.h>
 
 #include "TaskFeaturePick.h"
 #include "Utils.h"
@@ -110,11 +111,7 @@ void CmdPartDesignBody::activated(int iMsg)
     App::DocumentObject* baseFeature = nullptr;
     bool addtogroup = false;
 
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup(
-        "BaseApp/Preferences/Mod/PartDesign"
-    );
-
-    bool allowCompound = hGrp->GetBool("AllowCompoundDefault", true);
+    bool allowCompound = PartDesign::PartDesignParameter::instance()->getAllowCompoundDefault();
 
     if (!features.empty()) {
         if (features.size() == 1) {
@@ -237,7 +234,7 @@ void CmdPartDesignBody::activated(int iMsg)
         Doc,
         "App.ActiveDocument.getObject('%s').AllowCompound = %s",
         bodyString,
-        allowCompound ? "True" : "False"
+        Gui::asString(allowCompound)
     );
     if (baseFeature) {
         if (partOfBaseFeature) {
@@ -565,12 +562,7 @@ void CmdPartDesignMigrate::activated(int iMsg)
         std::string bodyName = getUniqueObjectName(
             std::string(chainIt->back()->getNameInDocument()).append("Body").c_str()
         );
-
-        Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup(
-            "BaseApp/Preferences/Mod/PartDesign"
-        );
-
-        bool allowCompound = hGrp->GetBool("AllowCompoundDefault", true);
+        bool allowCompound = PartDesign::PartDesignParameter::instance()->getAllowCompoundDefault();
 
         // Create a body for the chain
         doCommand(Doc, "App.activeDocument().addObject('PartDesign::Body','%s')", bodyName.c_str());
@@ -578,7 +570,7 @@ void CmdPartDesignMigrate::activated(int iMsg)
             Doc,
             "App.ActiveDocument.getObject('%s').AllowCompound = %s",
             bodyName.c_str(),
-            allowCompound ? "True" : "False"
+            Gui::asString(allowCompound)
         );
         doCommand(
             Doc,

--- a/src/Mod/PartDesign/Gui/Utils.cpp
+++ b/src/Mod/PartDesign/Gui/Utils.cpp
@@ -38,6 +38,7 @@
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/PartDesign/App/Feature.h>
 #include <Mod/PartDesign/App/FeatureSketchBased.h>
+#include <Mod/PartDesign/App/PartDesignParameter.h>
 #include <Mod/Sketcher/App/SketchObject.h>
 
 #include "Utils.h"
@@ -215,11 +216,7 @@ void needActiveBodyError()
 
 PartDesign::Body* makeBody(App::Document* doc)
 {
-    Base::Reference<ParameterGrp> hGrp = App::GetApplication().GetUserParameter().GetGroup(
-        "BaseApp/Preferences/Mod/PartDesign"
-    );
-
-    bool allowCompound = hGrp->GetBool("AllowCompoundDefault", true);
+    bool allowCompound = PartDesign::PartDesignParameter::instance()->getAllowCompoundDefault();
 
     // This is intended as a convenience when starting a new document.
     auto bodyName(doc->getUniqueObjectName("Body"));
@@ -234,7 +231,7 @@ PartDesign::Body* makeBody(App::Document* doc)
         "App.getDocument('%s').getObject('%s').AllowCompound = %s",
         doc->getName(),
         bodyName.c_str(),
-        allowCompound ? "True" : "False"
+        Gui::asString(allowCompound)
     );
 
 

--- a/src/Mod/Spreadsheet/App/CMakeLists.txt
+++ b/src/Mod/Spreadsheet/App/CMakeLists.txt
@@ -31,6 +31,8 @@ set(Spreadsheet_SRCS
     SheetPyImp.cpp
     SheetObserver.cpp
     SheetObserver.h
+    SheetParameter.cpp
+    SheetParameter.h
     Utils.cpp
     Utils.h
     AppSpreadsheet.cpp

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -420,6 +420,18 @@ void Cell::setAlignment(int _alignment)
     }
 }
 
+void Cell::_setAlignment(int _alignment)
+{
+    if (_alignment != alignment) {
+        alignment = _alignment;
+        setUsed(
+            ALIGNMENT_SET,
+            alignment != (ALIGNMENT_HIMPLIED | ALIGNMENT_LEFT | ALIGNMENT_VIMPLIED | ALIGNMENT_VCENTER)
+        );
+        setDirty();
+    }
+}
+
 /**
  * Get alignment.
  *
@@ -449,6 +461,15 @@ void Cell::setStyle(const std::set<std::string>& _style)
     }
 }
 
+void Cell::_setStyle(const std::set<std::string>& _style)
+{
+    if (_style != style) {
+        style = _style;
+        setUsed(STYLE_SET, !style.empty());
+        setDirty();
+    }
+}
+
 /**
  * Get the style of the cell.
  *
@@ -475,6 +496,15 @@ void Cell::setForeground(const Base::Color& color)
         setDirty();
 
         signaller.tryInvoke();
+    }
+}
+
+void Cell::_setForeground(const Base::Color& color)
+{
+    if (color != foregroundColor) {
+        foregroundColor = color;
+        setUsed(FOREGROUND_COLOR_SET, foregroundColor != Base::Color(0, 0, 0, 1));
+        setDirty();
     }
 }
 
@@ -516,6 +546,15 @@ void Cell::setBackground(const Base::Color& color)
         setDirty();
 
         signaller.tryInvoke();
+    }
+}
+
+void Cell::_setBackground(const Base::Color& color)
+{
+    if (color != backgroundColor) {
+        backgroundColor = color;
+        setUsed(BACKGROUND_COLOR_SET, backgroundColor != Base::Color(1, 1, 1, 0));
+        setDirty();
     }
 }
 
@@ -571,6 +610,27 @@ void Cell::setDisplayUnit(const std::string& unit)
         setDirty();
 
         signaller.tryInvoke();
+    }
+}
+
+void Cell::_setDisplayUnit(const std::string& unit)
+{
+    DisplayUnit newDisplayUnit;
+    if (!unit.empty()) {
+        std::shared_ptr<App::UnitExpression> e(
+            ExpressionParser::parseUnit(owner->sheet(), unit.c_str())
+        );
+
+        if (!e) {
+            throw Base::UnitsMismatchError("Invalid unit");
+        }
+        newDisplayUnit = DisplayUnit(unit, e->getUnit(), e->getScaler());
+    }
+
+    if (newDisplayUnit != displayUnit) {
+        displayUnit = std::move(newDisplayUnit);
+        setUsed(DISPLAY_UNIT_SET, !displayUnit.isEmpty());
+        setDirty();
     }
 }
 
@@ -638,6 +698,13 @@ void Cell::setComputedUnit(const Base::Unit& unit)
     setDirty();
 
     signaller.tryInvoke();
+}
+
+void Cell::_setComputedUnit(const Base::Unit& unit)
+{
+    computedUnit = unit;
+    setUsed(COMPUTED_UNIT_SET, !computedUnit.isEmpty());
+    setDirty();
 }
 
 /**

--- a/src/Mod/Spreadsheet/App/Cell.cpp
+++ b/src/Mod/Spreadsheet/App/Cell.cpp
@@ -703,7 +703,7 @@ void Cell::setComputedUnit(const Base::Unit& unit)
 void Cell::_setComputedUnit(const Base::Unit& unit)
 {
     computedUnit = unit;
-    setUsed(COMPUTED_UNIT_SET, !computedUnit.isEmpty());
+    setUsed(COMPUTED_UNIT_SET, computedUnit != Base::Unit());
     setDirty();
 }
 

--- a/src/Mod/Spreadsheet/App/Cell.h
+++ b/src/Mod/Spreadsheet/App/Cell.h
@@ -169,6 +169,13 @@ public:
     static Base::Color decodeColor(const std::string& color, const Base::Color& defaultColor);
 
 private:
+    void _setAlignment(int _alignment);
+    void _setStyle(const std::set<std::string>& _style);
+    void _setForeground(const Base::Color& color);
+    void _setBackground(const Base::Color& color);
+    void _setDisplayUnit(const std::string& unit);
+    void _setComputedUnit(const Base::Unit& unit);
+
     void setParseException(const std::string& e);
 
     void setExpression(App::ExpressionPtr&& expr);

--- a/src/Mod/Spreadsheet/App/PropertySheet.cpp
+++ b/src/Mod/Spreadsheet/App/PropertySheet.cpp
@@ -722,6 +722,21 @@ void PropertySheet::setAlignment(CellAddress address, int _alignment)
     cell->setAlignment(_alignment);
 }
 
+void PropertySheet::setAlignment(Range range, int _alignment)
+{
+    PropertySheet::AtomicPropertyChange signaller(*this);
+    do {
+        CellAddress address = *range;
+        if (Cell* cell = nonNullCellAt(address)) {
+            if (cell->address == address) {
+                cell->_setAlignment(_alignment);
+            }
+        }
+    } while (range.next());
+
+    signaller.tryInvoke();
+}
+
 void PropertySheet::setStyle(CellAddress address, const std::set<std::string>& _style)
 {
     Cell* cell = nonNullCellAt(address);
@@ -729,11 +744,35 @@ void PropertySheet::setStyle(CellAddress address, const std::set<std::string>& _
     cell->setStyle(_style);
 }
 
+void PropertySheet::setStyle(Range range, const std::set<std::string>& _style)
+{
+    PropertySheet::AtomicPropertyChange signaller(*this);
+    do {
+        if (Cell* cell = nonNullCellAt(*range)) {
+            cell->_setStyle(_style);
+        }
+    } while (range.next());
+
+    signaller.tryInvoke();
+}
+
 void PropertySheet::setForeground(CellAddress address, const Base::Color& color)
 {
     Cell* cell = nonNullCellAt(address);
     assert(cell);
     cell->setForeground(color);
+}
+
+void PropertySheet::setForeground(Range range, const Base::Color& color)
+{
+    PropertySheet::AtomicPropertyChange signaller(*this);
+    do {
+        if (Cell* cell = nonNullCellAt(*range)) {
+            cell->_setForeground(color);
+        }
+    } while (range.next());
+
+    signaller.tryInvoke();
 }
 
 void PropertySheet::clearForeground(CellAddress address)
@@ -750,6 +789,18 @@ void PropertySheet::setBackground(CellAddress address, const Base::Color& color)
     cell->setBackground(color);
 }
 
+void PropertySheet::setBackground(Range range, const Base::Color& color)
+{
+    PropertySheet::AtomicPropertyChange signaller(*this);
+    do {
+        if (Cell* cell = nonNullCellAt(*range)) {
+            cell->_setBackground(color);
+        }
+    } while (range.next());
+
+    signaller.tryInvoke();
+}
+
 void PropertySheet::clearBackground(CellAddress address)
 {
     Cell* cell = nonNullCellAt(address);
@@ -762,6 +813,18 @@ void PropertySheet::setDisplayUnit(CellAddress address, const std::string& unit)
     Cell* cell = nonNullCellAt(address);
     assert(cell);
     cell->setDisplayUnit(unit);
+}
+
+void PropertySheet::setDisplayUnit(Range range, const std::string& unit)
+{
+    PropertySheet::AtomicPropertyChange signaller(*this);
+    do {
+        if (Cell* cell = nonNullCellAt(*range)) {
+            cell->_setDisplayUnit(unit);
+        }
+    } while (range.next());
+
+    signaller.tryInvoke();
 }
 
 
@@ -824,6 +887,18 @@ void PropertySheet::setComputedUnit(CellAddress address, const Base::Unit& unit)
     Cell* cell = nonNullCellAt(address);
     assert(cell);
     cell->setComputedUnit(unit);
+}
+
+void PropertySheet::setComputedUnit(Range range, const Base::Unit& unit)
+{
+    PropertySheet::AtomicPropertyChange signaller(*this);
+    do {
+        if (Cell* cell = nonNullCellAt(*range)) {
+            cell->_setComputedUnit(unit);
+        }
+    } while (range.next());
+
+    signaller.tryInvoke();
 }
 
 void PropertySheet::setSpans(CellAddress address, int rows, int columns)

--- a/src/Mod/Spreadsheet/App/PropertySheet.h
+++ b/src/Mod/Spreadsheet/App/PropertySheet.h
@@ -112,22 +112,28 @@ public:
     void setContent(App::CellAddress address, const char* value);
 
     void setAlignment(App::CellAddress address, int _alignment);
+    void setAlignment(App::Range range, int _alignment);
 
     void setStyle(App::CellAddress address, const std::set<std::string>& _style);
+    void setStyle(App::Range address, const std::set<std::string>& _style);
 
     void setForeground(App::CellAddress address, const Base::Color& color);
+    void setForeground(App::Range range, const Base::Color& color);
 
     void clearForeground(App::CellAddress address);
 
     void setBackground(App::CellAddress address, const Base::Color& color);
+    void setBackground(App::Range range, const Base::Color& color);
 
     void clearBackground(App::CellAddress address);
 
     void setDisplayUnit(App::CellAddress address, const std::string& unit);
+    void setDisplayUnit(App::Range range, const std::string& unit);
 
     void setAlias(App::CellAddress address, const std::string& alias);
 
     void setComputedUnit(App::CellAddress address, const Base::Unit& unit);
+    void setComputedUnit(App::Range range, const Base::Unit& unit);
 
     void setSpans(App::CellAddress address, int rows, int columns);
 

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -51,6 +51,7 @@
 
 #include "Sheet.h"
 #include "SheetObserver.h"
+#include "SheetParameter.h"
 #include "SheetPy.h"
 
 
@@ -162,12 +163,10 @@ void Sheet::clearAll()
 bool Sheet::getCharsFromPrefs(char& delim, char& quote, char& escape, std::string& errMsg)
 {
     bool isValid = true;
-    ParameterGrp::handle group = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Spreadsheet"
-    );
-    QString delimiter = QString::fromStdString(group->GetASCII("ImportExportDelimiter", "tab"));
-    QString quoteChar = QString::fromStdString(group->GetASCII("ImportExportQuoteCharacter", "\""));
-    QString escapeChar = QString::fromStdString(group->GetASCII("ImportExportEscapeCharacter", "\\"));
+    auto param = SheetParameter::instance();
+    QString delimiter = QString::fromStdString(param->getImportExportDelimiter());
+    QString quoteChar = QString::fromStdString(param->getImportExportQuoteCharacter());
+    QString escapeChar = QString::fromStdString(param->getImportExportEscapeCharacter());
 
     delim = delimiter.size() == 1 ? delimiter[0].toLatin1() : '\0';
     if (delimiter.compare(QLatin1String("tab"), Qt::CaseInsensitive) == 0

--- a/src/Mod/Spreadsheet/App/Sheet.cpp
+++ b/src/Mod/Spreadsheet/App/Sheet.cpp
@@ -1492,6 +1492,17 @@ void Sheet::setAlignment(CellAddress address, int alignment)
 }
 
 /**
+ * @brief Set alignment of content in cells part of \a range to \a alignment.
+ * @param range Range of cells
+ * @param alignment New alignment
+ */
+
+void Sheet::setAlignment(App::Range range, int alignment)
+{
+    cells.setAlignment(range, alignment);
+}
+
+/**
  * @brief Set style of cell at \a address to \a style.
  * @param address Address of cell
  * @param style New style
@@ -1503,6 +1514,17 @@ void Sheet::setStyle(CellAddress address, const std::set<std::string>& style)
 }
 
 /**
+ * @brief Set style of cells of \a range to \a style.
+ * @param range Range of cells
+ * @param style New style
+ */
+
+void Sheet::setStyle(Range range, const std::set<std::string>& style)
+{
+    cells.setStyle(range, style);
+}
+
+/**
  * @brief Set foreground (text color) of cell at address \a address to \a color.
  * @param address Address of cell
  * @param color New color
@@ -1511,6 +1533,17 @@ void Sheet::setStyle(CellAddress address, const std::set<std::string>& style)
 void Sheet::setForeground(CellAddress address, const Color& color)
 {
     cells.setForeground(address, color);
+}
+
+/**
+ * @brief Set foreground (text color) of cells part of \a range to \a color.
+ * @param range Range of cells
+ * @param alignment New color
+ */
+
+void Sheet::setForeground(App::Range range, const Color& color)
+{
+    cells.setForeground(range, color);
 }
 
 /**
@@ -1535,6 +1568,17 @@ void Sheet::setBackground(CellAddress address, const Color& color)
 }
 
 /**
+ * @brief Set background color of cells part of \a range to \a color.
+ * @param range Range of cells
+ * @param alignment New color
+ */
+
+void Sheet::setBackground(App::Range range, const Color& color)
+{
+    cells.setBackground(range, color);
+}
+
+/**
  * @brief Clears background color of cell at address \a address.
  * @param address Address of cell
  */
@@ -1556,6 +1600,17 @@ void Sheet::setDisplayUnit(CellAddress address, const std::string& unit)
 }
 
 /**
+ * @brief Set display unit for cells part of \a range to \a unit.
+ * @param range Range of cells
+ * @param unit New unit
+ */
+
+void Sheet::setDisplayUnit(App::Range range, const std::string& unit)
+{
+    cells.setDisplayUnit(range, unit);
+}
+
+/**
  * @brief Set computed unit for cell at address \a address to \a unit.
  * @param address Address of cell
  * @param unit New unit.
@@ -1564,6 +1619,17 @@ void Sheet::setDisplayUnit(CellAddress address, const std::string& unit)
 void Sheet::setComputedUnit(CellAddress address, const Base::Unit& unit)
 {
     cells.setComputedUnit(address, unit);
+}
+
+/**
+ * @brief Set computed unit for cells part of \a range to \a unit.
+ * @param address Address of cell
+ * @param unit New unit.
+ */
+
+void Sheet::setComputedUnit(App::Range range, const Base::Unit& unit)
+{
+    cells.setComputedUnit(range, unit);
 }
 
 /**

--- a/src/Mod/Spreadsheet/App/Sheet.h
+++ b/src/Mod/Spreadsheet/App/Sheet.h
@@ -165,20 +165,26 @@ public:
     void setContent(App::CellAddress address, const char* value);
 
     void setAlignment(App::CellAddress address, int alignment);
+    void setAlignment(App::Range range, int alignment);
 
     void setStyle(App::CellAddress address, const std::set<std::string>& style);
+    void setStyle(App::Range range, const std::set<std::string>& style);
 
     void setForeground(App::CellAddress address, const Base::Color& color);
+    void setForeground(App::Range range, const Base::Color& color);
 
     void clearForeground(App::CellAddress address);
 
     void setBackground(App::CellAddress address, const Base::Color& color);
+    void setBackground(App::Range range, const Base::Color& color);
 
     void clearBackground(App::CellAddress address);
 
     void setDisplayUnit(App::CellAddress address, const std::string& unit);
+    void setDisplayUnit(App::Range range, const std::string& unit);
 
     void setComputedUnit(App::CellAddress address, const Base::Unit& unit);
+    void setComputedUnit(App::Range range, const Base::Unit& unit);
 
     void setAlias(App::CellAddress address, const std::string& alias);
 

--- a/src/Mod/Spreadsheet/App/SheetParameter.cpp
+++ b/src/Mod/Spreadsheet/App/SheetParameter.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2025 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+#include <App/Application.h>
+#include "SheetParameter.h"
+
+using namespace Spreadsheet;
+
+void SheetParameter::setup()
+{
+    // NOLINTBEGIN
+    addParameter("ImportExportDelimiter", String {"tab"});
+    addParameter("ImportExportQuoteCharacter", String {"\""});
+    addParameter("ImportExportEscapeCharacter", String {"\\"});
+    addParameter("AliasedCellBackgroundColor", String {"#feff9e"});
+    addParameter("TextColor", String {"#000000"});
+    addParameter("PositiveNumberColor", String {"#000000"});
+    addParameter("NegativeNumberColor", String {"#000000"});
+    addParameter("DisplayAliasFormatString", String {"%V = %A"});
+    addParameter("showAliasName", Bool {false});
+    addParameter("SwitchToWB", Bool {true});
+    addParameter("DefaultZoomLevel", Int {100});
+    // NOLINTEND
+}
+
+SheetParameter::SheetParameter()
+{
+    attachToParameter(
+        App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Mod/Spreadsheet")
+    );
+    setup();
+    initParameters();
+}
+
+SheetParameter* SheetParameter::instance()
+{
+    static SheetParameter param;
+    return &param;
+}
+
+FC_PARAM_GETSET_IMP(SheetParameter, ImportExportDelimiter, std::string)        // NOLINT
+FC_PARAM_GETSET_IMP(SheetParameter, ImportExportQuoteCharacter, std::string)   // NOLINT
+FC_PARAM_GETSET_IMP(SheetParameter, ImportExportEscapeCharacter, std::string)  // NOLINT
+FC_PARAM_GETSET_IMP(SheetParameter, AliasedCellBackgroundColor, std::string)   // NOLINT
+FC_PARAM_GETSET_IMP(SheetParameter, TextColor, std::string)                    // NOLINT
+FC_PARAM_GETSET_IMP(SheetParameter, PositiveNumberColor, std::string)          // NOLINT
+FC_PARAM_GETSET_IMP(SheetParameter, NegativeNumberColor, std::string)          // NOLINT
+FC_PARAM_GETSET_IMP(SheetParameter, DisplayAliasFormatString, std::string)     // NOLINT
+FC_PARAM_GETSET_IMP(SheetParameter, DefaultZoomLevel, long)
+
+bool SheetParameter::getShowAliasName() const
+{
+    return getValue<bool>("showAliasName");
+}
+
+void SheetParameter::setShowAliasName(bool v)
+{
+    setValue("showAliasName", v);
+}
+
+bool SheetParameter::getSwitchToWorkbench() const
+{
+    return getValue<bool>("SwitchToWB");
+}
+
+void SheetParameter::setSwitchToWorkbench(bool v)
+{
+    setValue("SwitchToWB", v);
+}

--- a/src/Mod/Spreadsheet/App/SheetParameter.cpp
+++ b/src/Mod/Spreadsheet/App/SheetParameter.cpp
@@ -41,6 +41,8 @@ void SheetParameter::setup()
     addParameter("showAliasName", Bool {false});
     addParameter("SwitchToWB", Bool {true});
     addParameter("DefaultZoomLevel", Int {100});
+    addParameter("MaximumRowCount", Int {1024});
+    addParameter("MaximumColumnCount", Int {26});
     // NOLINTEND
 }
 
@@ -68,6 +70,8 @@ FC_PARAM_GETSET_IMP(SheetParameter, PositiveNumberColor, std::string)          /
 FC_PARAM_GETSET_IMP(SheetParameter, NegativeNumberColor, std::string)          // NOLINT
 FC_PARAM_GETSET_IMP(SheetParameter, DisplayAliasFormatString, std::string)     // NOLINT
 FC_PARAM_GETSET_IMP(SheetParameter, DefaultZoomLevel, long)
+FC_PARAM_GETSET_IMP(SheetParameter, MaximumRowCount, long)
+FC_PARAM_GETSET_IMP(SheetParameter, MaximumColumnCount, long)
 
 bool SheetParameter::getShowAliasName() const
 {

--- a/src/Mod/Spreadsheet/App/SheetParameter.h
+++ b/src/Mod/Spreadsheet/App/SheetParameter.h
@@ -74,6 +74,12 @@ public:
     long getDefaultZoomLevel() const;
     void setDefaultZoomLevel(long);
 
+    long getMaximumRowCount() const;
+    void setMaximumRowCount(long);
+
+    long getMaximumColumnCount() const;
+    void setMaximumColumnCount(long);
+
 private:
     void setup();
 };

--- a/src/Mod/Spreadsheet/App/SheetParameter.h
+++ b/src/Mod/Spreadsheet/App/SheetParameter.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2025 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#ifndef SHEETPARAMETER_H
+#define SHEETPARAMETER_H
+
+
+#include <Base/ParameterObserver.h>
+#include <Mod/Spreadsheet/SpreadsheetGlobal.h>
+
+namespace Spreadsheet
+{
+
+/** Convenient class to obtain sheet related parameters
+ *
+ * The parameters are under group "User parameter:BaseApp/Preferences/Mod/Spreadsheet"
+ */
+class SpreadsheetExport SheetParameter: public Base::ParameterObserver
+{
+public:
+    SheetParameter();
+    static SheetParameter* instance();
+
+    std::string getImportExportDelimiter() const;
+    void setImportExportDelimiter(std::string v);
+
+    std::string getImportExportQuoteCharacter() const;
+    void setImportExportQuoteCharacter(std::string v);
+
+    std::string getImportExportEscapeCharacter() const;
+    void setImportExportEscapeCharacter(std::string v);
+
+    std::string getAliasedCellBackgroundColor() const;
+    void setAliasedCellBackgroundColor(std::string v);
+
+    std::string getTextColor() const;
+    void setTextColor(std::string v);
+
+    std::string getPositiveNumberColor() const;
+    void setPositiveNumberColor(std::string v);
+
+    std::string getNegativeNumberColor() const;
+    void setNegativeNumberColor(std::string v);
+
+    std::string getDisplayAliasFormatString() const;
+    void setDisplayAliasFormatString(std::string v);
+
+    bool getShowAliasName() const;
+    void setShowAliasName(bool v);
+
+    bool getSwitchToWorkbench() const;
+    void setSwitchToWorkbench(bool v);
+
+    long getDefaultZoomLevel() const;
+    void setDefaultZoomLevel(long);
+
+private:
+    void setup();
+};
+
+}  // namespace Spreadsheet
+
+#endif  // SHEETPARAMETER_H

--- a/src/Mod/Spreadsheet/App/SheetPyImp.cpp
+++ b/src/Mod/Spreadsheet/App/SheetPyImp.cpp
@@ -391,9 +391,7 @@ PyObject* SheetPy::setStyle(PyObject* args)
 
     if (strcmp(options, "replace") == 0) {
         Range rangeIter(cell);
-        do {
-            getSheetPtr()->setStyle(*rangeIter, style);
-        } while (rangeIter.next());
+        getSheetPtr()->setStyle(rangeIter, style);
     }
     else if (strcmp(options, "add") == 0) {
         Range rangeIter(cell);
@@ -522,9 +520,7 @@ PyObject* SheetPy::setDisplayUnit(PyObject* args)
     try {
         Range rangeIter(cell);
 
-        do {
-            getSheetPtr()->setDisplayUnit(*rangeIter, value);
-        } while (rangeIter.next());
+        getSheetPtr()->setDisplayUnit(rangeIter, value);
     }
     catch (const Base::Exception& e) {
         PyErr_SetString(PyExc_ValueError, e.what());
@@ -693,9 +689,7 @@ PyObject* SheetPy::setAlignment(PyObject* args)
     if (strcmp(options, "replace") == 0) {
         Range rangeIter(cell);
 
-        do {
-            getSheetPtr()->setAlignment(*rangeIter, alignment);
-        } while (rangeIter.next());
+        getSheetPtr()->setAlignment(rangeIter, alignment);
     }
     else if (strcmp(options, "keep") == 0) {
         Range rangeIter(cell);
@@ -823,9 +817,7 @@ PyObject* SheetPy::setForeground(PyObject* args)
         decodeColor(value, c);
 
         Range rangeIter(range);
-        do {
-            getSheetPtr()->setForeground(*rangeIter, c);
-        } while (rangeIter.next());
+        getSheetPtr()->setForeground(rangeIter, c);
         Py_Return;
     }
     catch (const Base::TypeError& e) {
@@ -912,9 +904,7 @@ PyObject* SheetPy::setBackground(PyObject* args)
         decodeColor(value, c);
         Range rangeIter(strAddress);
 
-        do {
-            getSheetPtr()->setBackground(*rangeIter, c);
-        } while (rangeIter.next());
+        getSheetPtr()->setBackground(rangeIter, c);
         Py_Return;
     }
     catch (const Base::TypeError& e) {

--- a/src/Mod/Spreadsheet/Gui/DlgSettings.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgSettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>392</width>
-    <height>282</height>
+    <width>452</width>
+    <height>394</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,100 +19,7 @@
   <property name="windowTitle">
    <string>Spreadsheet</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout_2">
-   <item row="1" column="0">
-    <widget class="QGroupBox" name="groupBox1">
-     <property name="title">
-      <string>Display Settings</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <widget class="Gui::PrefCheckBox" name="checkBoxShowAlias">
-        <property name="toolTip">
-         <string>Uses the custom presentation to display cell string</string>
-        </property>
-        <property name="text">
-         <string>Show alias in cell with format</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>showAliasName</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Spreadsheet</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="Gui::PrefSpinBox" name="dZLSpinBox">
-        <property name="toolTip">
-         <string>Defines a default zoom level for table view from 60% to 160%</string>
-        </property>
-        <property name="suffix">
-         <string>%</string>
-        </property>
-        <property name="minimum">
-         <number>60</number>
-        </property>
-        <property name="maximum">
-         <number>160</number>
-        </property>
-        <property name="singleStep">
-         <number>10</number>
-        </property>
-        <property name="value">
-         <number>100</number>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>DefaultZoomLevel</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Spreadsheet</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="dZLLabel">
-        <property name="text">
-         <string>Default zoom level</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="Gui::PrefLineEdit" name="formatString">
-        <property name="toolTip">
-         <string>The format of the custom cell string presentation.
-Defaults to: %V = %A
-
-%A - alias name
-%V - cell value</string>
-        </property>
-        <property name="text">
-         <string notr="true">%V = %A</string>
-        </property>
-        <property name="prefEntry" stdset="0">
-         <cstring>DisplayAliasFormatString</cstring>
-        </property>
-        <property name="prefPath" stdset="0">
-         <cstring>Mod/Spreadsheet</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <spacer name="horizontalSpacer1">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
+  <layout class="QGridLayout" name="gridLayout_4">
    <item row="0" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
@@ -243,7 +150,129 @@ Defaults to: %V = %A
      </layout>
     </widget>
    </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Cells</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="comboBoxColumns"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Maximum number of columns</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="comboBoxRows"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Maximum numbers of rows</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
    <item row="2" column="0">
+    <widget class="QGroupBox" name="groupBox1">
+     <property name="title">
+      <string>Display Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="Gui::PrefCheckBox" name="checkBoxShowAlias">
+        <property name="toolTip">
+         <string>If checked, use the custom presentation to display cell string.</string>
+        </property>
+        <property name="text">
+         <string>Show alias in cell with format</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>showAliasName</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Spreadsheet</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="Gui::PrefSpinBox" name="dZLSpinBox">
+        <property name="toolTip">
+         <string>Set a zoom level for table view from 60% to 160%.</string>
+        </property>
+        <property name="suffix">
+         <string>%</string>
+        </property>
+        <property name="minimum">
+         <number>60</number>
+        </property>
+        <property name="maximum">
+         <number>160</number>
+        </property>
+        <property name="singleStep">
+         <number>10</number>
+        </property>
+        <property name="value">
+         <number>100</number>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DefaultZoomLevel</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Spreadsheet</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="dZLLabel">
+        <property name="text">
+         <string>Default zoom level:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="Gui::PrefLineEdit" name="formatString">
+        <property name="toolTip">
+         <string>The format of the custom cell string presentation.
+Defaults to: %V = %A
+
+%A - alias name
+%V - cell value</string>
+        </property>
+        <property name="text">
+         <string notr="true">%V = %A</string>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>DisplayAliasFormatString</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Spreadsheet</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <spacer name="horizontalSpacer1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -261,6 +290,11 @@ Defaults to: %V = %A
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>Gui::PrefSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+  <customwidget>
    <class>Gui::PrefCheckBox</class>
    <extends>QCheckBox</extends>
    <header>Gui/PrefWidgets.h</header>
@@ -268,11 +302,6 @@ Defaults to: %V = %A
   <customwidget>
    <class>Gui::PrefComboBox</class>
    <extends>QComboBox</extends>
-   <header>Gui/PrefWidgets.h</header>
-  </customwidget>
-  <customwidget>
-   <class>Gui::PrefSpinBox</class>
-   <extends>QSpinBox</extends>
    <header>Gui/PrefWidgets.h</header>
   </customwidget>
   <customwidget>
@@ -285,6 +314,8 @@ Defaults to: %V = %A
   <tabstop>delimiterComboBox</tabstop>
   <tabstop>quoteCharLineEdit</tabstop>
   <tabstop>escapeCharLineEdit</tabstop>
+  <tabstop>comboBoxRows</tabstop>
+  <tabstop>comboBoxColumns</tabstop>
   <tabstop>dZLSpinBox</tabstop>
   <tabstop>checkBoxShowAlias</tabstop>
   <tabstop>formatString</tabstop>

--- a/src/Mod/Spreadsheet/Gui/DlgSettings.ui
+++ b/src/Mod/Spreadsheet/Gui/DlgSettings.ui
@@ -172,7 +172,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Maximum numbers of rows</string>
+         <string>Maximum number of rows</string>
         </property>
        </widget>
       </item>
@@ -188,7 +188,7 @@
       <item row="1" column="0">
        <widget class="Gui::PrefCheckBox" name="checkBoxShowAlias">
         <property name="toolTip">
-         <string>If checked, use the custom presentation to display cell string.</string>
+         <string>Displays the cell alias using the custom format.</string>
         </property>
         <property name="text">
          <string>Show alias in cell with format</string>
@@ -204,7 +204,7 @@
       <item row="0" column="2">
        <widget class="Gui::PrefSpinBox" name="dZLSpinBox">
         <property name="toolTip">
-         <string>Set a zoom level for table view from 60% to 160%.</string>
+         <string>Sets the table view zoom level from 60% to 160%.</string>
         </property>
         <property name="suffix">
          <string>%</string>
@@ -232,7 +232,7 @@
       <item row="0" column="0">
        <widget class="QLabel" name="dZLLabel">
         <property name="text">
-         <string>Default zoom level:</string>
+         <string>Default zoom level</string>
         </property>
        </widget>
       </item>

--- a/src/Mod/Spreadsheet/Gui/DlgSettingsImp.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSettingsImp.cpp
@@ -39,6 +39,16 @@ DlgSettingsImp::DlgSettingsImp(QWidget* parent)
     , ui(new Ui_DlgSettings)
 {
     ui->setupUi(this);
+    ui->dZLSpinBox->setDisabled(true);
+
+    for (int row : {256, 512, 1024, 2048, 4096, 8192, 16384}) {
+        ui->comboBoxRows->addItem(QString::number(row), QVariant(row));
+    }
+
+    const int maxColumn1 = 26;
+    const int maxColumn2 = 26 + 26 * 26;
+    ui->comboBoxColumns->addItem(QStringLiteral("A-Z"), QVariant(maxColumn1));
+    ui->comboBoxColumns->addItem(QStringLiteral("A-Z, AA-ZZ"), QVariant(maxColumn2));
 }
 
 /**
@@ -59,6 +69,15 @@ void DlgSettingsImp::saveSettings()
     ui->formatString->onSave();
     ui->dZLSpinBox->onSave();
     ui->checkBoxShowAlias->onSave();
+
+    QVariant cols = ui->comboBoxColumns->itemData(ui->comboBoxColumns->currentIndex());
+    if (cols.isValid()) {
+        param->setMaximumColumnCount(cols.toInt());
+    }
+    QVariant rows = ui->comboBoxRows->itemData(ui->comboBoxRows->currentIndex());
+    if (rows.isValid()) {
+        param->setMaximumRowCount(rows.toInt());
+    }
 }
 
 void DlgSettingsImp::loadSettings()
@@ -96,6 +115,15 @@ void DlgSettingsImp::loadSettings()
     ui->formatString->onRestore();
     ui->dZLSpinBox->onRestore();
     ui->checkBoxShowAlias->onRestore();
+
+    int indexC = ui->comboBoxColumns->findData(QVariant(int(param->getMaximumColumnCount())));
+    if (indexC >= 0) {
+        ui->comboBoxColumns->setCurrentIndex(indexC);
+    }
+    int indexR = ui->comboBoxRows->findData(QVariant(int(param->getMaximumRowCount())));
+    if (indexR >= 0) {
+        ui->comboBoxRows->setCurrentIndex(indexR);
+    }
 }
 
 /**

--- a/src/Mod/Spreadsheet/Gui/DlgSettingsImp.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSettingsImp.cpp
@@ -24,6 +24,7 @@
 
 
 #include <Gui/Application.h>
+#include <Mod/Spreadsheet/App/SheetParameter.h>
 
 #include "DlgSettingsImp.h"
 #include "ui_DlgSettings.h"
@@ -47,15 +48,12 @@ DlgSettingsImp::~DlgSettingsImp() = default;
 
 void DlgSettingsImp::saveSettings()
 {
-
     /** use whatever the user has entered here
      *  we'll check for validity during import/export
      */
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Spreadsheet"
-    );
+    auto param = Spreadsheet::SheetParameter::instance();
     QString delimiter = ui->delimiterComboBox->currentText();
-    hGrp->SetASCII("ImportExportDelimiter", delimiter.toStdString().c_str());
+    param->setImportExportDelimiter(delimiter.toStdString());
     ui->quoteCharLineEdit->onSave();
     ui->escapeCharLineEdit->onSave();
     ui->formatString->onSave();
@@ -69,10 +67,8 @@ void DlgSettingsImp::loadSettings()
      *  we'll recognize a few tokens: comma, semicolon, tab, and \t
      */
 
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Spreadsheet"
-    );
-    QString delimiter = QString::fromStdString(hGrp->GetASCII("ImportExportDelimiter", "tab"));
+    auto param = Spreadsheet::SheetParameter::instance();
+    QString delimiter = QString::fromStdString(param->getImportExportDelimiter());
     int idx = ui->delimiterComboBox->findText(delimiter, Qt::MatchFixedString);
     if (idx != -1) {
         ui->delimiterComboBox->setCurrentIndex(idx);

--- a/src/Mod/Spreadsheet/Gui/DlgSettingsImp.cpp
+++ b/src/Mod/Spreadsheet/Gui/DlgSettingsImp.cpp
@@ -39,8 +39,6 @@ DlgSettingsImp::DlgSettingsImp(QWidget* parent)
     , ui(new Ui_DlgSettings)
 {
     ui->setupUi(this);
-    ui->dZLSpinBox->setDisabled(true);
-
     for (int row : {256, 512, 1024, 2048, 4096, 8192, 16384}) {
         ui->comboBoxRows->addItem(QString::number(row), QVariant(row));
     }

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -48,9 +48,12 @@ namespace sp = std::placeholders;
 SheetModel::SheetModel(Sheet* _sheet, QObject* parent)
     : QAbstractTableModel(parent)
     , sheet(_sheet)
-    , rows(1000)
-    , cols(26)
+    , rows(0)
+    , cols(0)
 {
+    auto param = SheetParameter::instance();
+    rows = static_cast<int>(param->getMaximumRowCount());
+    cols = static_cast<int>(param->getMaximumColumnCount());
     containSheetDataInView();
 
     // NOLINTBEGIN
@@ -62,14 +65,10 @@ SheetModel::SheetModel(Sheet* _sheet, QObject* parent)
     );
     // NOLINTEND
 
-    auto param = SheetParameter::instance();
     aliasBgColor = QColor(QString::fromStdString(param->getAliasedCellBackgroundColor()));
     textFgColor = QColor(QString::fromStdString(param->getTextColor()));
     positiveFgColor = QColor(QString::fromStdString(param->getPositiveNumberColor()));
     negativeFgColor = QColor(QString::fromStdString(param->getNegativeNumberColor()));
-
-    maxRowCount = int(param->getMaximumRowCount());
-    maxColumnCount = int(param->getMaximumColumnCount());
 }
 
 SheetModel::~SheetModel()

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -67,6 +67,9 @@ SheetModel::SheetModel(Sheet* _sheet, QObject* parent)
     textFgColor = QColor(QString::fromStdString(param->getTextColor()));
     positiveFgColor = QColor(QString::fromStdString(param->getPositiveNumberColor()));
     negativeFgColor = QColor(QString::fromStdString(param->getNegativeNumberColor()));
+
+    maxRowCount = int(param->getMaximumRowCount());
+    maxColumnCount = int(param->getMaximumColumnCount());
 }
 
 SheetModel::~SheetModel()

--- a/src/Mod/Spreadsheet/Gui/SheetModel.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.cpp
@@ -34,6 +34,7 @@
 #include <Gui/Application.h>
 #include <Gui/Command.h>
 #include <Mod/Spreadsheet/App/Sheet.h>
+#include <Mod/Spreadsheet/App/SheetParameter.h>
 
 #include "SheetModel.h"
 #include "App/Range.h"
@@ -61,15 +62,11 @@ SheetModel::SheetModel(Sheet* _sheet, QObject* parent)
     );
     // NOLINTEND
 
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
-        "User parameter:BaseApp/Preferences/Mod/Spreadsheet"
-    );
-    aliasBgColor = QColor(
-        QString::fromStdString(hGrp->GetASCII("AliasedCellBackgroundColor", "#feff9e"))
-    );
-    textFgColor = QColor(QString::fromStdString(hGrp->GetASCII("TextColor", "#000000")));
-    positiveFgColor = QColor(QString::fromStdString(hGrp->GetASCII("PositiveNumberColor", "#000000")));
-    negativeFgColor = QColor(QString::fromStdString(hGrp->GetASCII("NegativeNumberColor", "#000000")));
+    auto param = SheetParameter::instance();
+    aliasBgColor = QColor(QString::fromStdString(param->getAliasedCellBackgroundColor()));
+    textFgColor = QColor(QString::fromStdString(param->getTextColor()));
+    positiveFgColor = QColor(QString::fromStdString(param->getPositiveNumberColor()));
+    negativeFgColor = QColor(QString::fromStdString(param->getNegativeNumberColor()));
 }
 
 SheetModel::~SheetModel()
@@ -172,16 +169,12 @@ QString encodeColumn(int column)
     return res;
 }
 
-QVariant formatCellDisplay(QString value, const Cell* cell)
+QVariant formatCellDisplay(const QString& value, const Cell* cell)
 {
+    auto param = SheetParameter::instance();
     std::string alias;
-    static auto hGrpSpreadsheet = App::GetApplication().GetUserParameter().GetGroup(
-        "BaseApp/Preferences/Mod/Spreadsheet"
-    );
-    if (cell->getAlias(alias) && hGrpSpreadsheet->GetBool("showAliasName", false)) {
-        QString formatStr = QString::fromStdString(
-            hGrpSpreadsheet->GetASCII("DisplayAliasFormatString", "%V = %A")
-        );
+    if (cell->getAlias(alias) && param->getShowAliasName()) {
+        QString formatStr = QString::fromStdString(param->getDisplayAliasFormatString());
         if (formatStr.contains(QLatin1String("%V")) || formatStr.contains(QLatin1String("%A"))) {
             formatStr.replace(QLatin1String("%A"), QString::fromStdString(alias));
             formatStr.replace(QLatin1String("%V"), value);

--- a/src/Mod/Spreadsheet/Gui/SheetModel.h
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.h
@@ -73,9 +73,6 @@ private:
     QColor textFgColor;
     QColor positiveFgColor;
     QColor negativeFgColor;
-
-    int maxRowCount = 16384;
-    int maxColumnCount = 26 + 26 * 26;
 };
 
 }  // namespace SpreadsheetGui

--- a/src/Mod/Spreadsheet/Gui/SheetModel.h
+++ b/src/Mod/Spreadsheet/Gui/SheetModel.h
@@ -26,6 +26,7 @@
 
 #include "fastsignals/connection.h"
 #include <QAbstractTableModel>
+#include <boost/signals2.hpp>
 
 #include <App/Range.h>
 
@@ -72,6 +73,9 @@ private:
     QColor textFgColor;
     QColor positiveFgColor;
     QColor negativeFgColor;
+
+    int maxRowCount = 16384;
+    int maxColumnCount = 26 + 26 * 26;
 };
 
 }  // namespace SpreadsheetGui

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -47,6 +47,7 @@
 #include <Gui/CommandT.h>
 #include <Gui/MainWindow.h>
 #include <Mod/Spreadsheet/App/Cell.h>
+#include <Mod/Spreadsheet/App/SheetParameter.h>
 
 #include "DlgBindSheet.h"
 #include "DlgSheetConf.h"
@@ -489,7 +490,7 @@ bool SheetTableView::event(QEvent* event)
                 break;
         }
         if (kevent->matches(QKeySequence::SelectAll)) {
-            QTableView::selectAll();
+            selectAll();
             return true;
         }
         if (kevent->matches(QKeySequence::Delete) || kevent->matches(QKeySequence::Backspace)) {
@@ -997,11 +998,14 @@ void SheetTableView::ModifyBlockSelection(int targetRow, int targetCol)
 
 void SheetTableView::selectAll()
 {
-    // disallow to select all cells if too many
-    const int maxRows = 2048;
-    const int maxCols = 26;
-    auto sheetModel = qobject_cast<SheetModel*>(model());
-    if (sheetModel->rowCount() <= maxRows && sheetModel->columnCount() <= maxCols) {
+    auto* sheetModel = qobject_cast<SheetModel*>(model());
+    if (!sheetModel) {
+        return;
+    }
+
+    auto* param = SheetParameter::instance();
+    if (sheetModel->rowCount() <= param->getMaximumRowCount()
+        && sheetModel->columnCount() <= param->getMaximumColumnCount()) {
         QTableView::selectAll();
     }
 }

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.cpp
@@ -52,6 +52,7 @@
 #include "DlgSheetConf.h"
 #include "PropertiesDialog.h"
 #include "SheetTableView.h"
+#include "SheetModel.h"
 
 
 using namespace SpreadsheetGui;
@@ -992,6 +993,17 @@ void SheetTableView::ModifyBlockSelection(int targetRow, int targetCol)
         model()->index(targetRow, targetCol),
         QItemSelectionModel::Current
     );
+}
+
+void SheetTableView::selectAll()
+{
+    // disallow to select all cells if too many
+    const int maxRows = 2048;
+    const int maxCols = 26;
+    auto sheetModel = qobject_cast<SheetModel*>(model());
+    if (sheetModel->rowCount() <= maxRows && sheetModel->columnCount() <= maxCols) {
+        QTableView::selectAll();
+    }
 }
 
 void SheetTableView::mergeCells()

--- a/src/Mod/Spreadsheet/Gui/SheetTableView.h
+++ b/src/Mod/Spreadsheet/Gui/SheetTableView.h
@@ -71,6 +71,7 @@ public:
     QString toHtml() const;
 
 public Q_SLOTS:
+    void selectAll() override;
     void mergeCells();
     void splitCell();
     void deleteSelection();

--- a/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
+++ b/src/Mod/Spreadsheet/Gui/ViewProviderSpreadsheet.cpp
@@ -37,6 +37,7 @@
 #include <Gui/MainWindow.h>
 #include <Gui/View3DInventor.h>
 #include <Mod/Spreadsheet/App/Sheet.h>
+#include <Mod/Spreadsheet/App/SheetParameter.h>
 
 #include "ViewProviderSpreadsheet.h"
 #include "ViewProviderSpreadsheetPy.h"
@@ -78,12 +79,7 @@ bool ViewProviderSheet::setEdit(int ModNum)
 bool ViewProviderSheet::doubleClicked()
 {
     // assure the SpreadSheet workbench
-    if (App::GetApplication()
-            .GetUserParameter()
-            .GetGroup("BaseApp")
-            ->GetGroup("Preferences")
-            ->GetGroup("Mod/Spreadsheet")
-            ->GetBool("SwitchToWB", true)) {
+    if (SheetParameter::instance()->getSwitchToWorkbench()) {
         Gui::Command::assureWorkbench("SpreadsheetWorkbench");
     }
 

--- a/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
+++ b/src/Mod/Spreadsheet/Gui/ZoomableView.cpp
@@ -26,8 +26,8 @@
 
 #include "ZoomableView.h"
 #include "ui_Sheet.h"
-#include "App/Application.h"
 #include "Base/Console.h"
+#include <Mod/Spreadsheet/App/SheetParameter.h>
 
 
 ZoomableView::ZoomableView(Ui::Sheet* ui)
@@ -176,10 +176,7 @@ void ZoomableView::zoomOut(void)
 
 void ZoomableView::resetZoom(void)
 {
-    constexpr const char* path = "User parameter:BaseApp/Preferences/Mod/Spreadsheet";
-    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(path);
-    const int defaultZoomLevel = static_cast<int>(hGrp->GetInt("DefaultZoomLevel", 100));
-
+    const int defaultZoomLevel = Spreadsheet::SheetParameter::instance()->getDefaultZoomLevel();
     setZoomLevel(defaultZoomLevel);
 }
 

--- a/src/Mod/Start/App/FcstdInfoSource.cpp
+++ b/src/Mod/Start/App/FcstdInfoSource.cpp
@@ -104,7 +104,6 @@ void FcstdInfoSource::run()
 {
     const std::string stdFilePath(_filePath.toStdString());
     App::ProjectFile proj(stdFilePath);
-    proj.loadDocument();
     auto fileStats = getProjectFileInfo(proj);
     auto thumbnail = loadFCStdThumbnail(proj, _filePath);
     Q_EMIT _signals.infoAvailable(_filePath, fileStats, thumbnail);

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(Base_tests_run
         Handle.cpp
         Matrix.cpp
         Parameter.cpp
+        ParameterObserver.cpp
         Placement.cpp
         Persistence.cpp
         PyException.cpp

--- a/tests/src/Base/ParameterObserver.cpp
+++ b/tests/src/Base/ParameterObserver.cpp
@@ -1,0 +1,232 @@
+#include <gtest/gtest.h>
+#include <boost/core/ignore_unused.hpp>
+#include <Base/ParameterObserver.h>
+
+class ParamObserver: public Base::ParameterObserver
+{
+public:
+    explicit ParamObserver(ParameterGrp::handle hGrp)
+    {
+        attachToParameter(hGrp);
+        setup();
+        initParameters();
+    }
+
+    bool getBoolParameter() const
+    {
+        return getValue<bool>("BoolParameter");
+    }
+
+    bool getDefaultBoolParameter() const
+    {
+        return getDefault<bool>("BoolParameter");
+    }
+
+    void setBoolParameter(bool v)
+    {
+        setValue("BoolParameter", v);
+    }
+
+    long getLongParameter() const
+    {
+        return getValue<long>("LongParameter");
+    }
+
+    void setLongParameter(long v)
+    {
+        setValue("LongParameter", v);
+    }
+
+    unsigned long getUnsignedParameter() const
+    {
+        return getValue<unsigned long>("UnsignedParameter");
+    }
+
+    void setUnsignedParameter(unsigned long v)
+    {
+        setValue("UnsignedParameter", v);
+    }
+
+    double getFloatParameter() const
+    {
+        return getValue<double>("FloatParameter");
+    }
+
+    void setFloatParameter(double v)
+    {
+        setValue("FloatParameter", v);
+    }
+
+    std::string getStringParameter() const
+    {
+        return getValue<std::string>("StringParameter");
+    }
+
+    void setStringParameter(const std::string& v)
+    {
+        setValue("StringParameter", v);
+    }
+
+    std::string getUnknownParameter() const
+    {
+        return getValue<std::string>("UnknownParameter");
+    }
+
+    void setUnknownParameter(const std::string& v)
+    {
+        setValue("UnknownParameter", v);
+    }
+
+    std::string getWrongParameter() const
+    {
+        return getValue<std::string>("BoolParameter");
+    }
+
+    void setWrongParameter(const std::string& v)
+    {
+        setValue("BoolParameter", v);
+    }
+
+private:
+    void setup()
+    {
+        // NOLINTBEGIN
+        addParameter("BoolParameter", Bool{true});
+        addParameter("LongParameter", Int{23});
+        addParameter("UnsignedParameter", Unsigned{12345});
+        addParameter("FloatParameter", Double{1.2345});
+        addParameter("StringParameter", String{"Hello"});
+        // NOLINTEND
+    }
+};
+
+class ParameterObserverTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        ParameterManager::Init();
+    }
+
+    void SetUp() override
+    {
+        config = ParameterManager::Create();
+    }
+
+    void TearDown() override
+    {
+    }
+
+    Base::Reference<ParameterManager> getCreateConfig()
+    {
+        config->CreateDocument();
+        return config;
+    }
+
+private:
+    Base::Reference<ParameterManager> config;
+};
+
+// NOLINTBEGIN(cppcoreguidelines-*,readability-*)
+
+TEST_F(ParameterObserverTest, TestBool)
+{
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    ParamObserver obs(grp);
+
+    EXPECT_EQ(obs.getBoolParameter(), true);
+    obs.setBoolParameter(false);
+    EXPECT_EQ(obs.getBoolParameter(), false);
+
+    EXPECT_EQ(grp->GetBool("BoolParameter"), false);
+    EXPECT_EQ(obs.getDefaultBoolParameter(), true);
+}
+
+TEST_F(ParameterObserverTest, TestInt)
+{
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    ParamObserver obs(grp);
+
+    EXPECT_EQ(obs.getLongParameter(), 23);
+    obs.setLongParameter(123);
+    EXPECT_EQ(obs.getLongParameter(), 123);
+
+    EXPECT_EQ(grp->GetInt("LongParameter"), 123);
+}
+
+TEST_F(ParameterObserverTest, TestUnsigned)
+{
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    ParamObserver obs(grp);
+
+    EXPECT_EQ(obs.getUnsignedParameter(), 12345);
+    obs.setUnsignedParameter(123);
+    EXPECT_EQ(obs.getUnsignedParameter(), 123);
+
+    EXPECT_EQ(grp->GetUnsigned("UnsignedParameter"), 123);
+}
+
+TEST_F(ParameterObserverTest, TestFloat)
+{
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    ParamObserver obs(grp);
+
+    EXPECT_DOUBLE_EQ(obs.getFloatParameter(), 1.2345);
+    obs.setFloatParameter(3.14);
+    EXPECT_DOUBLE_EQ(obs.getFloatParameter(), 3.14);
+
+    EXPECT_DOUBLE_EQ(grp->GetFloat("FloatParameter"), 3.14);
+}
+
+TEST_F(ParameterObserverTest, TestString)
+{
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    ParamObserver obs(grp);
+
+    EXPECT_EQ(obs.getStringParameter(), "Hello");
+    obs.setStringParameter("World");
+    EXPECT_EQ(obs.getStringParameter(), "World");
+
+    EXPECT_EQ(grp->GetASCII("StringParameter"), "World");
+}
+
+TEST_F(ParameterObserverTest, TestHashKey)
+{
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    ParamObserver obs(grp);
+
+    EXPECT_EQ(obs.getBoolParameter(), true);
+
+    std::string key("BoolParameter");
+    grp->SetBool(key.c_str(), false);
+
+    EXPECT_EQ(obs.getBoolParameter(), false);
+}
+
+TEST_F(ParameterObserverTest, TestUnknown)
+{
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    ParamObserver obs(grp);
+
+    EXPECT_THROW(obs.getUnknownParameter(), Base::IndexError);
+    EXPECT_THROW(obs.setUnknownParameter("123"), Base::IndexError);
+}
+
+TEST_F(ParameterObserverTest, TestWrongType)
+{
+    auto cfg = getCreateConfig();
+    auto grp = cfg->GetGroup("TopLevelGroup");
+    ParamObserver obs(grp);
+
+    EXPECT_THROW(obs.getWrongParameter(), Base::TypeError);
+    EXPECT_THROW(obs.setWrongParameter("123"), Base::TypeError);
+}
+
+// NOLINTEND(cppcoreguidelines-*,readability-*)

--- a/tests/src/Base/ParameterObserver.cpp
+++ b/tests/src/Base/ParameterObserver.cpp
@@ -91,11 +91,11 @@ private:
     void setup()
     {
         // NOLINTBEGIN
-        addParameter("BoolParameter", Bool{true});
-        addParameter("LongParameter", Int{23});
-        addParameter("UnsignedParameter", Unsigned{12345});
-        addParameter("FloatParameter", Double{1.2345});
-        addParameter("StringParameter", String{"Hello"});
+        addParameter("BoolParameter", Bool {true});
+        addParameter("LongParameter", Int {23});
+        addParameter("UnsignedParameter", Unsigned {12345});
+        addParameter("FloatParameter", Double {1.2345});
+        addParameter("StringParameter", String {"Hello"});
         // NOLINTEND
     }
 };
@@ -114,8 +114,7 @@ protected:
     }
 
     void TearDown() override
-    {
-    }
+    {}
 
     Base::Reference<ParameterManager> getCreateConfig()
     {


### PR DESCRIPTION
Fixes https://github.com/FreeCAD/FreeCAD/issues/25997
Cherry-picks a series of upstream commits centered on Base::ParameterObserver
- Adds ParameterObserver, a type-safe observer class that maps parameter keys to typed values (bool, long, unsigned long, double, std::string) and reacts to changes via OnChange
- Reimplements ViewParams as a ParameterObserver subclass, replacing the previous macro-generated boilerplate
- Adds SpaceMouseParameter for consistent access to 3D-mouse preferences
- SheetParameter: wraps spreadsheet settings (decimal separator, row/column counts, zoom) as an observer, making them live-reactive. Also makes the default sheet size configurable (1024 rows x 26 columns) and guards selectAll against huge selections
- PartDesignParameter (PartDesign): same pattern for PartDesign preferences
Adds batch range operations (getRange, setRange, clearRange) on Sheet and PropertySheet, and cellCount/usedCells on Cell
- Adds a fast ProjectFile::getMetadata() path using a SAX filter that aborts parsing once metadata is collected, avoiding a full document load for large files. The Start page now uses this path, speeding up recent-file metadata loading.