### PR TITLE
Gui: Support of additional licences for project file

### DIFF
--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -456,6 +456,7 @@ SET(Gui_UIC_SRCS
     Dialogs/DlgPreferencePackManagement.ui
     Dialogs/DlgPreferences.ui
     Dialogs/DlgProjectInformation.ui
+    Dialogs/DlgProjectLicence.ui
     Dialogs/DlgProjectUtility.ui
     Dialogs/DlgPropertyLink.ui
     Dialogs/DlgRevertToBackupConfig.ui
@@ -573,6 +574,7 @@ SET(Dialog_CPP_SRCS
     Dialogs/DlgParameterFind.cpp
     Dialogs/DlgPreferencePackManagementImp.cpp
     Dialogs/DlgProjectInformationImp.cpp
+    Dialogs/DlgProjectLicence.cpp
     Dialogs/DlgProjectUtility.cpp
     Dialogs/DlgPropertyLink.cpp
     Dialogs/DlgRevertToBackupConfigImp.cpp
@@ -616,6 +618,7 @@ SET(Dialog_HPP_SRCS
     Dialogs/DlgParameterFind.h
     Dialogs/DlgPreferencePackManagementImp.h
     Dialogs/DlgProjectInformationImp.h
+    Dialogs/DlgProjectLicence.h
     Dialogs/DlgProjectUtility.h
     Dialogs/DlgPropertyLink.h
     Dialogs/DlgRevertToBackupConfigImp.h
@@ -663,6 +666,7 @@ SET(Dialog_SRCS
     Dialogs/DlgParameterFind.ui
     Dialogs/DlgPreferencePackManagement.ui
     Dialogs/DlgProjectInformation.ui
+    Dialogs/DlgProjectLicence.ui
     Dialogs/DlgProjectUtility.ui
     Dialogs/DlgPropertyLink.ui
     Dialogs/DlgRevertToBackupConfig.ui

--- a/src/Gui/Dialogs/DlgProjectInformation.ui
+++ b/src/Gui/Dialogs/DlgProjectInformation.ui
@@ -147,11 +147,11 @@
        </widget>
       </item>
       <item row="4" column="1">
-        <widget class="QComboBox" name="comboBox_unitSystem">
-         <property name="toolTip">
-          <string>Unit system for this file</string>
-         </property>
-        </widget>
+       <widget class="QComboBox" name="comboBox_unitSystem">
+        <property name="toolTip">
+         <string>Unit system for this file</string>
+        </property>
+       </widget>
       </item>
       <item row="5" column="0">
        <widget class="QLabel" name="textLabelCreator">
@@ -285,7 +285,25 @@
        </widget>
       </item>
       <item row="10" column="1">
-       <widget class="QComboBox" name="comboLicense"/>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QComboBox" name="comboLicense">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pushButtonLicenses">
+          <property name="text">
+           <string notr="true">...</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item row="11" column="0">
        <widget class="QLabel" name="textLabelLicenseURL">

--- a/src/Gui/Dialogs/DlgProjectInformationImp.cpp
+++ b/src/Gui/Dialogs/DlgProjectInformationImp.cpp
@@ -34,6 +34,7 @@
 #include <Base/UnitsApi.h>
 
 #include "Dialogs/DlgProjectInformationImp.h"
+#include "Dialogs/DlgProjectLicence.h"
 #include "ui_DlgProjectInformation.h"
 
 #include "MainWindow.h"
@@ -58,13 +59,6 @@ using namespace Gui::Dialog;
 
 /* TRANSLATOR Gui::Dialog::DlgProjectInformationImp */
 
-/**
- *  Constructs a Gui::Dialog::DlgProjectInformationImp as a child of 'parent', with the
- *  name 'name' and widget flags set to 'fl'.
- *
- *  The dialog will by default be modeless, unless you set 'modal' to
- *  true to construct a modal dialog.
- */
 DlgProjectInformationImp::DlgProjectInformationImp(App::Document* doc, QWidget* parent, Qt::WindowFlags fl)
     : QDialog(parent, fl)
     , _doc(doc)
@@ -91,6 +85,8 @@ DlgProjectInformationImp::DlgProjectInformationImp(App::Document* doc, QWidget* 
     ui->lineEditLastMod->setText(QString::fromUtf8(doc->LastModifiedBy.getValue()));
     ui->lineEditLastModDate->setText(convertISODate(doc->LastModifiedDate.getValue()));
     ui->lineEditCompany->setText(QString::fromUtf8(doc->Company.getValue()));
+
+    ui->pushButtonLicenses->setToolTip(tr("Add more licenses to the project file"));
 
     // Load comboBox with unit systems
     auto addDesc = [&, index {0}](const std::string& item) mutable {
@@ -137,11 +133,9 @@ DlgProjectInformationImp::DlgProjectInformationImp(App::Document* doc, QWidget* 
         this,
         &DlgProjectInformationImp::onLicenseTypeChanged
     );
+    connect(ui->pushButtonLicenses, &QPushButton::clicked, this, &DlgProjectInformationImp::onMoreLicenses);
 }
 
-/**
- *  Destroys the object and frees any allocated resources
- */
 DlgProjectInformationImp::~DlgProjectInformationImp()
 {
     // no need to delete child widgets, Qt does it all for us
@@ -183,6 +177,12 @@ void DlgProjectInformationImp::onLicenseTypeChanged(int index)
     };
 
     ui->lineEditLicenseURL->setText(QString::fromLatin1(url));
+}
+
+void DlgProjectInformationImp::onMoreLicenses()
+{
+    DlgProjectLicence dlg(_doc, this);
+    dlg.exec();
 }
 
 /**

--- a/src/Gui/Dialogs/DlgProjectInformationImp.h
+++ b/src/Gui/Dialogs/DlgProjectInformationImp.h
@@ -42,9 +42,10 @@ class Ui_DlgProjectInformation;
 class DlgProjectInformationImp: public QDialog
 {
     Q_OBJECT
+    Q_DISABLE_COPY_MOVE(DlgProjectInformationImp)
 
 public:
-    DlgProjectInformationImp(
+    explicit DlgProjectInformationImp(
         App::Document* doc,
         QWidget* parent = nullptr,
         Qt::WindowFlags fl = Qt::WindowFlags()
@@ -55,6 +56,7 @@ public:
 private Q_SLOTS:
     void open_url();
     void onLicenseTypeChanged(int index);
+    void onMoreLicenses();
 
 private:
     App::Document* _doc;

--- a/src/Gui/Dialogs/DlgProjectLicence.cpp
+++ b/src/Gui/Dialogs/DlgProjectLicence.cpp
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+#include "PreCompiled.h"
+#ifndef _PreComp_
+# include <algorithm>
+# include <QApplication>
+# include <QComboBox>
+# include <QLabel>
+# include <QMessageBox>
+# include <QPushButton>
+#endif
+
+#include <boost/range/algorithm/transform.hpp>
+
+#include <App/Document.h>
+#include <App/License.h>
+#include <Gui/BitmapFactory.h>
+
+#include "Dialogs/DlgProjectLicence.h"
+#include "ui_DlgProjectLicence.h"
+
+using namespace Gui::Dialog;
+
+constexpr const char* propName = "AdditionalLicenses";
+
+/* TRANSLATOR Gui::Dialog::DlgProjectLicence */
+
+DlgProjectLicence::DlgProjectLicence(App::Document* doc, QWidget* parent, Qt::WindowFlags fl)
+    : QDialog(parent, fl)
+    , _doc(doc)
+    , gridLayout(nullptr)
+    , textLabel(nullptr)
+    , addButton(nullptr)
+    , ui(new Ui_DlgProjectLicence)
+{
+    ui->setupUi(this);
+    setupDialog();
+}
+
+DlgProjectLicence::~DlgProjectLicence() = default;
+
+QStringList DlgProjectLicence::getLicencesFromDocument() const
+{
+    QStringList lics;
+    if (auto list = dynamic_cast<App::PropertyStringList*>(_doc->getPropertyByName(propName))) {
+        auto values = list->getValues();
+        for (const auto& value : values) {
+            lics << QString::fromStdString(value);
+        }
+    }
+
+    return lics;
+}
+
+QStringList DlgProjectLicence::getLicencesFromDialog() const
+{
+    QStringList lics;
+    for (const auto& it : buttonMap) {
+        if (it.first->isVisible()) {
+            lics << it.first->currentData().toString();
+        }
+    }
+
+    lics.removeDuplicates();
+
+    return lics;
+}
+
+void DlgProjectLicence::addLicenceItems(QComboBox* cb)
+{
+    // load comboBox with license names
+    for (const auto& item : App::licenseItems) {
+        const char* name {item.at(App::posnOfFullName)};
+        QString translated = QApplication::translate("Gui::Dialog::DlgSettingsDocument", name);
+        cb->addItem(translated, QByteArray(name));
+    }
+}
+
+void DlgProjectLicence::setLicenceIndex(QComboBox* cb, const QString& lic)
+{
+    // set default position to match document
+    int index = cb->findData(lic.toUtf8());
+    if (index >= 0) {
+        cb->setCurrentIndex(index);
+    }
+    else {
+        index = cb->count();
+        cb->addItem(lic, lic.toUtf8());
+        cb->setCurrentIndex(index);
+    }
+}
+
+void DlgProjectLicence::addComboBoxes(const QStringList& lics)
+{
+    const int numLicences = lics.size();
+    for (int row = 0; row < maxLicences; row++) {
+        auto licence = new QComboBox(this);
+        addLicenceItems(licence);
+
+        gridLayout->addWidget(licence, row, 0, 1, 1);
+        auto removeButton = new QPushButton(this);
+        removeButton->setIcon(BitmapFactory().iconFromTheme("list-remove"));
+        gridLayout->addWidget(removeButton, row, 1, 1, 1);
+
+        if (row < numLicences) {
+            setLicenceIndex(licence, lics[row]);
+        }
+        else {
+            licence->hide();
+            removeButton->hide();
+        }
+
+        buttonMap.append(qMakePair(licence, removeButton));
+        connect(removeButton, &QPushButton::clicked, this, &DlgProjectLicence::removeLicence);
+    }
+}
+
+void DlgProjectLicence::addStandardButtons(int numLicences)
+{
+    textLabel = new QLabel(this);
+    textLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    textLabel->setText(tr("Add or remove licence"));
+    addButton = new QPushButton(this);
+    addButton->setIcon(BitmapFactory().iconFromTheme("list-add"));
+    gridLayout->addWidget(textLabel, maxLicences, 0, 1, 1);
+    gridLayout->addWidget(addButton, maxLicences, 1, 1, 1);
+
+    connect(addButton, &QPushButton::clicked, this, &DlgProjectLicence::addLicence);
+    if (numLicences >= maxLicences) {
+        addButton->setDisabled(true);
+    }
+}
+
+void DlgProjectLicence::setupDialog()
+{
+    const QStringList lics = getLicencesFromDocument();
+    const int numLicences = lics.size();
+
+    gridLayout = new QGridLayout();
+    auto mainLayout = new QGridLayout(ui->groupBoxMain);
+    mainLayout->addLayout(gridLayout, 0, 0, 1, 1);
+    auto vSpacer = new QSpacerItem(20, 100, QSizePolicy::Minimum, QSizePolicy::Expanding);  // NOLINT
+    mainLayout->addItem(vSpacer, 1, 0, 1, 1);
+
+    addComboBoxes(lics);
+    addStandardButtons(numLicences);
+}
+
+void DlgProjectLicence::addLicence()
+{
+    int countHidden = -1;
+    for (const auto& it : std::as_const(buttonMap)) {
+        if (it.first->isHidden()) {
+            countHidden++;
+            if (countHidden == 0) {
+                QComboBox* licence = it.first;
+                licence->setVisible(true);
+                QPushButton* removeButton = it.second;
+                removeButton->setVisible(true);
+            }
+        }
+    }
+
+    if (countHidden <= 0) {
+        addButton->setDisabled(true);
+    }
+}
+
+void DlgProjectLicence::removeLicence()
+{
+    auto remove = qobject_cast<QPushButton*>(sender());
+    QComboBox* licence = nullptr;
+    for (const auto& it : std::as_const(buttonMap)) {
+        if (it.second == remove) {
+            licence = it.first;
+            addButton->setEnabled(true);
+            licence->hide();
+            remove->hide();
+        }
+    }
+}
+
+void DlgProjectLicence::setLicencesToDocument(const QStringList& lics)
+{
+    auto prop = dynamic_cast<App::PropertyStringList*>(_doc->getPropertyByName(propName));
+    if (!prop && lics.isEmpty()) {
+        // nothing to do
+        return;
+    }
+
+    if (!prop) {
+        prop = dynamic_cast<App::PropertyStringList*>(
+            _doc->addDynamicProperty("App::PropertyStringList", propName)
+        );
+    }
+
+    std::vector<std::string> values(lics.size());
+    boost::range::transform(lics, values.begin(), [](const auto& it) { return it.toStdString(); });
+
+    prop->setValues(values);
+}
+
+void DlgProjectLicence::accept()
+{
+    try {
+        const QStringList lics = getLicencesFromDialog();
+        setLicencesToDocument(lics);
+    }
+    catch (const Base::Exception& e) {
+        QMessageBox::warning(this, tr("Cannot add licences"), QString::fromUtf8(e.what()));
+    }
+    QDialog::accept();
+}
+
+#include "moc_DlgProjectLicence.cpp"

--- a/src/Gui/Dialogs/DlgProjectLicence.h
+++ b/src/Gui/Dialogs/DlgProjectLicence.h
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 Werner Mayer <wmayer[at]users.sourceforge.net>     *
+ *                                                                         *
+ *   This file is part of FreeCAD.                                         *
+ *                                                                         *
+ *   FreeCAD is free software: you can redistribute it and/or modify it    *
+ *   under the terms of the GNU Lesser General Public License as           *
+ *   published by the Free Software Foundation, either version 2.1 of the  *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ *   FreeCAD is distributed in the hope that it will be useful, but        *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU      *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with FreeCAD. If not, see                               *
+ *   <https://www.gnu.org/licenses/>.                                      *
+ *                                                                         *
+ **************************************************************************/
+
+
+#ifndef GUI_DIALOG_DLGPROJECTLICENCE_H
+#define GUI_DIALOG_DLGPROJECTLICENCE_H
+
+#include <QDialog>
+#include <memory>
+
+class QComboBox;
+class QGridLayout;
+class QLabel;
+
+namespace App
+{
+class Document;
+}
+
+namespace Gui
+{
+
+namespace Dialog
+{
+
+class Ui_DlgProjectLicence;
+class DlgProjectLicence: public QDialog
+{
+    Q_OBJECT
+    Q_DISABLE_COPY_MOVE(DlgProjectLicence)
+
+public:
+    explicit DlgProjectLicence(
+        App::Document* doc,
+        QWidget* parent = nullptr,
+        Qt::WindowFlags fl = Qt::WindowFlags()
+    );
+    ~DlgProjectLicence() override;
+    void accept() override;
+
+private:
+    void setupDialog();
+    void addLicence();
+    void removeLicence();
+    QStringList getLicencesFromDocument() const;
+    QStringList getLicencesFromDialog() const;
+    void setLicencesToDocument(const QStringList& lics);
+    void addComboBoxes(const QStringList& lics);
+    void addStandardButtons(int numLicences);
+    void addLicenceItems(QComboBox* cb);
+    void setLicenceIndex(QComboBox* cb, const QString& lic);
+
+private:
+    App::Document* _doc;
+    const int maxLicences = 10;
+    QGridLayout* gridLayout;
+    QLabel* textLabel;
+    QPushButton* addButton;
+    QList<QPair<QComboBox*, QPushButton*>> buttonMap;
+    std::unique_ptr<Ui_DlgProjectLicence> ui;
+};
+
+}  // namespace Dialog
+}  // namespace Gui
+
+
+#endif  // GUI_DIALOG_DLGPROJECTLICENCE_H

--- a/src/Gui/Dialogs/DlgProjectLicence.ui
+++ b/src/Gui/Dialogs/DlgProjectLicence.ui
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Gui::Dialog::DlgProjectLicence</class>
+ <widget class="QDialog" name="Gui::Dialog::DlgProjectLicence">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>620</width>
+    <height>353</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Project licence</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBoxMain">
+     <property name="title">
+      <string>Licences</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Gui::Dialog::DlgProjectLicence</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>298</x>
+     <y>518</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>298</x>
+     <y>269</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Gui::Dialog::DlgProjectLicence</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>298</x>
+     <y>518</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>298</x>
+     <y>269</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Cherry-pick https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_6933

Currently only a single licence can be set per project file. However, sometimes it's required to be allowed to define more licences.

This fixes issue https://github.com/FreeCAD/FreeCAD/issues/6933


Uploading Bildschirmaufnahme 2026-05-09 um 09.24.32.mov…


