### PR TITLE
Gui: Improve DEF attribute names

### DIFF
--- a/src/Gui/SoFCDB.cpp
+++ b/src/Gui/SoFCDB.cpp
@@ -519,7 +519,7 @@ void Gui::SoFCDB::writeX3DFields(
         SbName name = node->getName();
         std::stringstream str;
         if (name.getLength() == 0) {
-            str << "o" << numDEF++;
+            str << type << '_' << numDEF++;
         }
         else {
             str << name.getString();


### PR DESCRIPTION
Cherry-pick https://codeberg.org/wwmayer/FreeCAD11/commits/branch/issue_7268

For the xhtml/X3D export use more speaking names for the DEF attribute.

This fixes https://github.com/FreeCAD/FreeCAD/issues/7268
