### PR TITLE
Part: Fix regression in TopoShape::makeElementLoft

### DIFF
--- a/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -36,6 +36,7 @@
 # include <BRepAdaptor_HCompCurve.hxx>
 #endif
 
+#include <BRepBndLib.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepFill.hxx>
@@ -4374,6 +4375,49 @@ TopoShape& TopoShape::makeElementLoft(
     const char* op
 )
 {
+    auto checkProfiles = [](const TopoShape& sh1, const TopoShape& sh2) {
+        // The same TShape is used but the locations might be different
+        // even if they result into the same transformation matrix.
+        // Therefore compare the matrices.
+        if (sh1.getShape().IsPartner(sh2.getShape())) {
+            TopLoc_Location loc1 = sh1.getShape().Location();
+            TopLoc_Location loc2 = sh2.getShape().Location();
+            Base::Matrix4D mat1 = TopoShape::convert(loc1.Transformation());
+            Base::Matrix4D mat2 = TopoShape::convert(loc2.Transformation());
+            return (mat1 != mat2);
+        }
+
+        // For different shapes compare their bounding boxes
+        try {
+            Bnd_Box bounds1;
+            Bnd_Box bounds2;
+            BRepBndLib::Add(sh1.getShape(), bounds1);
+            BRepBndLib::Add(sh2.getShape(), bounds2);
+
+            // If bounding boxes are different the shapes must be different, too
+            if (!bounds1.CornerMin().IsEqual(bounds2.CornerMin(), Precision::Confusion())) {
+                return true;
+            }
+            if (!bounds1.CornerMax().IsEqual(bounds2.CornerMax(), Precision::Confusion())) {
+                return true;
+            }
+        }
+        catch (const Standard_Failure&) {
+            return false;
+        }
+
+        Base::Vector3d center1;
+        Base::Vector3d center2;
+        if (!sh1.getCenterOfGravity(center1)) {
+            return true;
+        }
+        if (!sh2.getCenterOfGravity(center2)) {
+            return true;
+        }
+
+        return !center1.IsEqual(center2, Precision::Confusion());
+    };
+
     if (!op) {
         op = Part::OpCodes::Loft;
     }
@@ -4388,15 +4432,10 @@ TopoShape& TopoShape::makeElementLoft(
     }
 
     int i = 0;
-    Base::Vector3d center1, center2;
     for (auto& sh : profiles) {
         if (i > 0) {
-            if (sh.getCenterOfGravity(center1) && profiles[i - 1].getCenterOfGravity(center2)
-                && center1.IsEqual(center2, Precision::Confusion())) {
-                FC_THROWM(
-                    Base::CADKernelError,
-                    "Segments of a Loft/Pad do not have sufficient separation"
-                );
+            if (!checkProfiles(sh, profiles[i - 1])) {
+                FC_THROWM(Base::CADKernelError, "Segments of a loft do not have sufficient separation");
             }
         }
         const auto& shape = sh.getShape();

--- a/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
+++ b/tests/src/Mod/Part/App/TopoShapeExpansion.cpp
@@ -1819,6 +1819,54 @@ TEST_F(TopoShapeExpansionTest, makeElementLoft)
     ));
 }
 
+TEST_F(TopoShapeExpansionTest, makeElementLoftAllowsDistinctProfilesWithSameCenter)  // NOLINT
+{
+    // Regression test for PR #29982 / forum thread t=88234.  The fix for issue #5855 rejected any
+    // two consecutive loft profiles that share a center of gravity, which is too strict: two
+    // concentric, coplanar squares of different size share the center (2.5, 2.5, 0) but are clearly
+    // distinct shapes, so the loft between them must still be created.
+    //
+    // See also test makeElementLoftRejectsCoincidentProfiles, below, to confirm that 5855 is still
+    // fixed
+
+    // Arrange
+    auto [face1, wire1, edge1, edge2, edge3, edge4] = CreateRectFace(5, 5);  // 5x5, CoG (2.5,2.5,0)
+    auto scale {gp_Trsf()};
+    scale.SetScale(gp_Pnt(2.5, 2.5, 0.0), 2.0);  // 10x10 square, same CoG
+    auto biggerWire = BRepBuilderAPI_Transform(wire1, scale, true).Shape();
+    TopoShape smallerProfile {wire1, 1L};
+    TopoShape biggerProfile {biggerWire, 2L};
+    std::vector<TopoShape> shapes = {smallerProfile, biggerProfile};
+
+    // Act: the previous code raised Base::CADKernelError here because the centers of gravity match.
+    auto* loft = new TopoShape();
+    ASSERT_NO_THROW(loft->makeElementLoft(shapes, IsSolid::notSolid, IsRuled::ruled));  // NOLINT
+
+    // Assert: the result is the flat frame between the 5x5 and the 10x10 square.
+    EXPECT_FALSE(loft->isNull());
+    EXPECT_NEAR(getArea(loft->getShape()), 10.0 * 10.0 - 5.0 * 5.0, 1e-6);
+}
+
+TEST_F(TopoShapeExpansionTest, makeElementLoftRejectsCoincidentProfiles)  // NOLINT
+{
+    // The fix for issue #5855 must still hold: lofting through coincident profiles (for example the
+    // same sketch used as more than one section) crashes OCCT, so makeElementLoft has to reject it.
+    //
+    // See also makeElementLoftAllowsDistinctProfilesWithSameCenter, above
+
+    // Arrange
+    auto [face1, wire1, edge1, edge2, edge3, edge4] = CreateRectFace(5, 5);
+    TopoShape firstProfile {wire1, 1L};
+    TopoShape secondProfile {wire1, 2L};
+    std::vector<TopoShape> shapes = {firstProfile, secondProfile};
+
+    // Act / Assert
+    EXPECT_THROW(  // NOLINT
+        (new TopoShape())->makeElementLoft(shapes, IsSolid::notSolid, IsRuled::notRuled),
+        Base::CADKernelError
+    );
+}
+
 TEST_F(TopoShapeExpansionTest, makeElementPipeShell)
 {
     // Arrange


### PR DESCRIPTION
Cherry-pick https://codeberg.org/wwmayer/FreeCAD11/commit/356e0fa2f05137e9ce2ff7c826c69223d8697d59

The PR https://github.com/FreeCAD/FreeCAD/pull/16853 provides a fix for the possible crash in https://github.com/FreeCAD/FreeCAD/issues/5855.

However, the criterion to disallow any shapes with the same CoG is too strict and causes cases to fail that has worked in the past. One example can be found in the forum:
https://forum.freecad.org/viewtopic.php?t=88234
