### PR TITLE
CAM: Linking - Legacy

### DIFF
--- a/src/Mod/CAM/CAMTests/TestLinkingGenerator.py
+++ b/src/Mod/CAM/CAMTests/TestLinkingGenerator.py
@@ -88,7 +88,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 target_position=self.target,
                 local_clearance=5,
                 global_clearance=11,
-                safety_margin=1.1,
+                collision_clearance=1.1,
                 solids=[blocking_box],
                 tool_diameter=0,
             )
@@ -162,7 +162,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
             tool_diameter=self.tooldiameter,
-            safety_margin=0.001,
+            collision_clearance=0.001,
             solids=[blocking_box1, blocking_box2],
         )
         self.assertGreater(len(cmds), 0)
@@ -177,7 +177,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 local_clearance=self.local_clearance,
                 global_clearance=self.global_clearance,
                 tool_diameter=self.tooldiameter,
-                safety_margin=0.001,
+                collision_clearance=0.001,
                 solids=[blocking_box1, blocking_box2],
             )
 
@@ -195,7 +195,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
             tool_diameter=self.tooldiameter,
-            safety_margin=0.001,
+            collision_clearance=0.001,
             solids=[blocking_box1, blocking_box2],
         )
         self.assertGreater(len(cmds), 0)
@@ -210,7 +210,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
                 local_clearance=self.local_clearance,
                 global_clearance=self.global_clearance,
                 tool_shape=self.tool,
-                safety_margin=0.001,
+                collision_clearance=0.001,
                 solids=[blocking_box1, blocking_box2],
             )
 
@@ -222,7 +222,7 @@ class TestGetLinkingMoves(PathTestUtils.PathTestBase):
             local_clearance=self.local_clearance,
             global_clearance=self.global_clearance,
             tool_shape=Part.Shape(),
-            safety_margin=0.001,
+            collision_clearance=0.001,
             solids=[Part.Shape()],
         )
         self.assertGreater(len(cmds), 0)

--- a/src/Mod/CAM/Path/Base/Generator/linking.py
+++ b/src/Mod/CAM/Path/Base/Generator/linking.py
@@ -40,7 +40,7 @@ def check_collision(
     solids: Optional[List[Part.Shape]] = None,
     tool_shape: Optional[Part.Shape] = None,
     tool_diameter: Optional[float] = None,
-    safety_margin: float = 1,
+    collision_clearance: float = 1,
 ) -> bool:
     """
     Check if a direct move from start to target would collide with solids.
@@ -67,13 +67,13 @@ def check_collision(
     if not collision_model:
         return False
 
-    safety_margin = max(safety_margin, 0) or 1
+    collision_clearance = max(collision_clearance, 0) or 1
 
     # Create direct path wire
     wire = Part.Wire([Part.makeLine(start_position, target_position)])
 
     bbDistance = wire.BoundBox.ZMin - collision_model.BoundBox.ZMax
-    if bbDistance >= safety_margin or Path.Geom.isRoughly(bbDistance, safety_margin):
+    if bbDistance >= collision_clearance or Path.Geom.isRoughly(bbDistance, collision_clearance):
         # attempt to skip long time computation for simple model
         return False
 
@@ -86,7 +86,7 @@ def check_collision(
         distance = shape.distToShape(collision_model)[0]
     else:
         distance = wire.distToShape(collision_model)[0]
-    return distance < safety_margin and not Path.Geom.isRoughly(distance, safety_margin)
+    return distance < collision_clearance and not Path.Geom.isRoughly(distance, collision_clearance)
 
 
 def get_linking_moves(
@@ -99,7 +99,7 @@ def get_linking_moves(
     solids: Optional[List[Part.Shape]] = None,
     retract_height_offset: Optional[float] = None,
     skip_if_no_collision: bool = False,
-    safety_margin: float = 1,
+    collision_clearance: float = 1,
 ) -> list:
     """
     Generate linking moves from start to target position.
@@ -137,25 +137,20 @@ def get_linking_moves(
             collision_model = Part.makeCompound(solids)
 
     # Determine candidate heights
+    candidate_heights = {local_clearance, global_clearance}
     if retract_height_offset is not None:
-        if retract_height_offset > 0:
-            retract_height = max(start_position.z, target_position.z) + retract_height_offset
-            candidate_heights = {retract_height, local_clearance, global_clearance}
-        else:  # explicitly 0
-            retract_height = max(start_position.z, target_position.z)
-            candidate_heights = {retract_height, local_clearance, global_clearance}
-    else:
-        candidate_heights = {local_clearance, global_clearance}
+        retract_height = max(start_position.z, target_position.z) + retract_height_offset
+        candidate_heights.add(retract_height)
 
     heights = sorted(candidate_heights)
 
-    safety_margin = max(safety_margin, 0) or 1
+    collision_clearance = max(collision_clearance, 0) or 1
 
     # Try each height
     for height in heights:
         wire = make_linking_wire(start_position, target_position, height)
         if is_travel_collision_free(
-            wire, collision_model, tool_shape, tool_diameter, safety_margin
+            wire, collision_model, tool_shape, tool_diameter, collision_clearance
         ):
             cmds = Path.fromShape(wire).Commands
             # Ensure all commands have complete XYZ coordinates
@@ -204,7 +199,7 @@ def is_travel_collision_free(
     solid: Optional[Part.Shape],
     tool_shape: Optional[Part.Shape] = None,
     tool_diameter: Optional[float] = None,
-    safety_margin: float = 1,
+    collision_clearance: float = 1,
 ) -> bool:
     """
     Check if a horizontal edge of wire would not collide with solids.
@@ -213,10 +208,10 @@ def is_travel_collision_free(
     if not solid:
         return True
 
-    safety_margin = max(safety_margin, 0) or 1
+    collision_clearance = max(collision_clearance, 0) or 1
 
     bbDistance = wire.BoundBox.ZMax - solid.BoundBox.ZMax
-    if bbDistance >= safety_margin or Path.Geom.isRoughly(bbDistance, safety_margin):
+    if bbDistance >= collision_clearance or Path.Geom.isRoughly(bbDistance, collision_clearance):
         # attempt to skip long time computation for simple model
         return True
 
@@ -229,7 +224,7 @@ def is_travel_collision_free(
         distance = shape.distToShape(solid)[0]
     else:
         distance = wire.distToShape(solid)[0]
-    return distance >= safety_margin or Path.Geom.isRoughly(distance, safety_margin)
+    return distance >= collision_clearance or Path.Geom.isRoughly(distance, collision_clearance)
 
 
 def _create_horizontal_face(wire, width):

--- a/src/Mod/CAM/Path/Op/Base.py
+++ b/src/Mod/CAM/Path/Op/Base.py
@@ -161,19 +161,21 @@ class ObjectOp(object):
     def addLinking(self, obj):
         obj.addProperty(
             "App::PropertyEnumeration",
-            "LinkingMode",
+            "CollisionAvoidanceStrategy",
             "Linking",
             QT_TRANSLATE_NOOP(
                 "App::Property",
                 "Method collision detection to create optimal path between areas"
-                "\n\nCompromise: uses tool diameter (middle long time computation)"
-                "\nFastest: not related from tool size (fast computation)"
-                "\nSafest: uses cross section of tool shape (most long time computation)",
+                "\n\nClearance Height: no collision detection, uses clearance height for rapid moves between areas"
+                "\nRetract Height: no collision detection, uses safe height for rapid moves between areas"
+                "\nLine of Sight: fastest - checks the path centerline"
+                "\nTool Diameter: balanced - checks clearance using the tool diameter"
+                "\nTool Shape: safest - checks clearance using the cross section of the tool shape",
             ),
         )
         obj.addProperty(
             "App::PropertyLength",
-            "LinkingSafetyMargin",
+            "CollisionClearance",
             "Linking",
             QT_TRANSLATE_NOOP("App::Property", "Distance for collision detection"),
         )
@@ -402,10 +404,12 @@ class ObjectOp(object):
                 (translate("CAM_Operation", "Flood"), "Flood"),
                 (translate("CAM_Operation", "Mist"), "Mist"),
             ],
-            "LinkingMode": [
-                (translate("CAM_Operation", "Fastest"), "Fastest"),
-                (translate("CAM_Operation", "Compromise"), "Compromise"),
-                (translate("CAM_Operation", "Safest"), "Safest"),
+            "CollisionAvoidanceStrategy": [
+                (translate("CAM_Operation", "Clearance Height"), "Clearance Height"),
+                (translate("CAM_Operation", "Retract Height"), "Retract Height"),
+                (translate("CAM_Operation", "Line of Sight"), "Line of Sight"),
+                (translate("CAM_Operation", "Tool Diameter"), "Tool Diameter"),
+                (translate("CAM_Operation", "Tool Shape"), "Tool Shape"),
             ],
         }
 
@@ -507,13 +511,13 @@ class ObjectOp(object):
             )
             obj.StepDown = 0
 
-        if FeatureLinking & features and not hasattr(obj, "LinkingMode"):
+        if FeatureLinking & features and not hasattr(obj, "CollisionAvoidanceStrategy"):
             self.addLinking(obj)
             for n in self.opPropertyEnumerations():
                 if hasattr(obj, n[0]):
                     setattr(obj, n[0], n[1])
-            obj.LinkingMode = "Fastest"
-            self.applyExpression(obj, "LinkingSafetyMargin", "OpToolDiameter")
+            obj.CollisionAvoidanceStrategy = "Clearance Height"
+            self.applyExpression(obj, "CollisionClearance", "OpToolDiameter")
 
         self.setEditorModes(obj, features)
         self.opOnDocumentRestored(obj)
@@ -674,8 +678,8 @@ class ObjectOp(object):
             obj.UseStartPoint = False
 
         if FeatureLinking & features:
-            obj.LinkingMode = "Fastest"
-            self.applyExpression(obj, "LinkingSafetyMargin", "OpToolDiameter")
+            obj.CollisionAvoidanceStrategy = "Clearance Height"
+            self.applyExpression(obj, "CollisionClearance", "OpToolDiameter")
 
         self.opSetDefaultValues(obj, job)
         return job

--- a/src/Mod/CAM/Path/Op/Drilling.py
+++ b/src/Mod/CAM/Path/Op/Drilling.py
@@ -299,15 +299,23 @@ class ObjectDrilling(PathCircularHoleBase.ObjectOp):
             "target_position": None,
             "local_clearance": safe_height,
             "global_clearance": obj.ClearanceHeight.Value,
-            "solids": solids,
+            "solids": None,
             "tool_shape": None,
             "tool_diameter": None,
-            "safety_margin": obj.LinkingSafetyMargin.Value,
+            "collision_clearance": obj.CollisionClearance.Value,
         }
-        if obj.LinkingMode == "Safest":
-            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
-        elif obj.LinkingMode == "Compromise":
+        if obj.CollisionAvoidanceStrategy == "Clearance Height":
+            linkingArgs["local_clearance"] = obj.ClearanceHeight.Value
+        elif obj.CollisionAvoidanceStrategy == "Retract Height":
+            pass
+        elif obj.CollisionAvoidanceStrategy == "Line of Sight":
+            linkingArgs["solids"] = solids
+        elif obj.CollisionAvoidanceStrategy == "Tool Diameter":
+            linkingArgs["solids"] = solids
             linkingArgs["tool_diameter"] = obj.ToolController.Tool.Diameter.Value
+        elif obj.CollisionAvoidanceStrategy == "Tool Shape":
+            linkingArgs["solids"] = solids
+            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
 
         # http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g98-g99
 

--- a/src/Mod/CAM/Path/Op/Helix.py
+++ b/src/Mod/CAM/Path/Op/Helix.py
@@ -588,23 +588,30 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
 
         singleHelix = obj.SingleHelix or obj.SpiralMill
 
-        # build list of solids for collision detection
+        # Prepare linking parameters
         solids = [base.Shape for base in self.job.Model.Group]
-        machinestate = PathMachineState.MachineState()
         linkingArgs = {
             "start_position": None,
             "target_position": None,
             "local_clearance": safeHeight,
             "global_clearance": clearanceHeight,
-            "solids": solids,
+            "solids": None,
             "tool_shape": None,
             "tool_diameter": None,
-            "safety_margin": obj.LinkingSafetyMargin.Value,
+            "collision_clearance": obj.CollisionClearance.Value,
         }
-        if obj.LinkingMode == "Safest":
-            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
-        elif obj.LinkingMode == "Compromise":
+        if obj.CollisionAvoidanceStrategy == "Clearance Height":
+            linkingArgs["local_clearance"] = clearanceHeight
+        elif obj.CollisionAvoidanceStrategy == "Retract Height":
+            pass
+        elif obj.CollisionAvoidanceStrategy == "Line of Sight":
+            linkingArgs["solids"] = solids
+        elif obj.CollisionAvoidanceStrategy == "Tool Diameter":
+            linkingArgs["solids"] = solids
             linkingArgs["tool_diameter"] = tooldiameter
+        elif obj.CollisionAvoidanceStrategy == "Tool Shape":
+            linkingArgs["solids"] = solids
+            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
 
         obj.Direction = _caclulatePathDirection(obj)
 
@@ -632,6 +639,7 @@ class ObjectHelix(PathCircularHoleBase.ObjectOp):
         else:
             args["cone_angle_rad"] = -math.radians(obj.HelixConeAngle.Value)
 
+        machinestate = PathMachineState.MachineState()
         self.commandlist.append(Path.Command("(helix cut operation)"))
         for hole_index, hole in enumerate(holes):
             if obj.RotationAngle.Value == -1:

--- a/src/Mod/CAM/Path/Op/MillFacing.py
+++ b/src/Mod/CAM/Path/Op/MillFacing.py
@@ -280,15 +280,23 @@ class ObjectMillFacing(PathOp.ObjectOp):
             "target_position": None,
             "local_clearance": obj.SafeHeight.Value,
             "global_clearance": obj.ClearanceHeight.Value,
-            "solids": solids,
+            "solids": None,
             "tool_shape": None,
             "tool_diameter": None,
-            "safety_margin": obj.LinkingSafetyMargin.Value,
+            "collision_clearance": obj.CollisionClearance.Value,
         }
-        if obj.LinkingMode == "Safest":
-            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
-        elif obj.LinkingMode == "Compromise":
+        if obj.CollisionAvoidanceStrategy == "Clearance Height":
+            linkingArgs["local_clearance"] = obj.ClearanceHeight.Value
+        elif obj.CollisionAvoidanceStrategy == "Retract Height":
+            pass
+        elif obj.CollisionAvoidanceStrategy == "Line of Sight":
+            linkingArgs["solids"] = solids
+        elif obj.CollisionAvoidanceStrategy == "Tool Diameter":
+            linkingArgs["solids"] = solids
             linkingArgs["tool_diameter"] = tool_diameter
+        elif obj.CollisionAvoidanceStrategy == "Tool Shape":
+            linkingArgs["solids"] = solids
+            linkingArgs["tool_shape"] = obj.ToolController.Tool.BitBody.Shape
 
         # Determine the step-downs
         finish_step = 0.0  # No finish step for facing


### PR DESCRIPTION
In some cases new behavior of `linking` can take too much time for recompute
Also may be necessary to just use `Clearance Height` or `Safe Height` for moves between areas without collision detection, because real stock contains some elements which need to avoid, but this not present in created model

~Suggest to add `LinkingMode` **None**, which provide old behavior~
**CollisionAvoidanceStrategy**
- `Retract Height`: No collision detection, uses retract height for rapid moves between areas
- `Clearance Height`: No collision detection, uses clearance height for rapid moves between areas
- `Line of Sight`: fastest - checks the path centerline.
- `Tool Diameter`: balanced - checks clearance using the tool diameter.
- `Tool Shape`: safest - checks clearance using the cross section of the tool shape

<img width="374" height="245" alt="Screenshot_20260516_115200_lossy" src="https://github.com/user-attachments/assets/dba5ea40-7941-4873-8da2-689005a06ae4" />
