### PR TITLE
Sketcher: Fix memory leaks

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -231,24 +231,24 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj)
     std::sort(listOfGeoId.begin(), listOfGeoId.end());
     listOfGeoId.erase(std::unique(listOfGeoId.begin(), listOfGeoId.end()), listOfGeoId.end());
 
-    std::vector<Part::Geometry*> shapeGeometry;
+    std::vector<std::unique_ptr<Part::Geometry>> shapeGeometry;
     shapeGeometry.reserve(listOfGeoId.size());
     for (auto geoId : listOfGeoId) {
-        Part::Geometry* geoNew = obj->getGeometry(geoId)->copy();
-        shapeGeometry.push_back(geoNew);
+        shapeGeometry.emplace_back(obj->getGeometry(geoId)->copy());
+    }
+    std::vector<Part::Geometry*> rawGeos;
+    rawGeos.reserve(shapeGeometry.size());
+    for (const auto& g : shapeGeometry) {
+        rawGeos.push_back(g.get());
     }
 
     std::string geosAsStr = Sketcher::PythonConverter::convert(
         "objectStr",
-        shapeGeometry,
+        rawGeos,
         Sketcher::PythonConverter::Mode::OmitInternalGeometry);
 
-    std::for_each(shapeGeometry.begin(), shapeGeometry.end(), [](auto geo) {
-        delete geo;
-    });
-
     // Export constraints of selected geos.
-    std::vector<Sketcher::Constraint*> shapeConstraints;
+    std::vector<std::unique_ptr<Sketcher::Constraint>> shapeConstraints;
     for (auto constr : obj->Constraints.getValues()) {
 
         auto isSelectedGeoOrAxis = [](const std::vector<int>& vec, int value) {
@@ -273,7 +273,7 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj)
             continue;
         }
 
-        Constraint* temp = constr->copy();
+        std::unique_ptr<Constraint> temp(constr->copy());
         for (size_t j = 0; j < listOfGeoId.size(); j++) {
             for (int i = 0; temp->hasElement(i); ++i) {
                 int geoid = temp->getGeoId(i);
@@ -282,16 +282,17 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj)
                 }
             }
         }
-        shapeConstraints.push_back(temp);
+        shapeConstraints.push_back(std::move(temp));
+    }
+    std::vector<Sketcher::Constraint*> rawCstrs;
+    rawCstrs.reserve(shapeConstraints.size());
+    for (const auto& c : shapeConstraints) {
+        rawCstrs.push_back(c.get());
     }
     std::string cstrAsStr = Sketcher::PythonConverter::convert(
         "objectStr",
-        shapeConstraints,
+        rawCstrs,
         Sketcher::PythonConverter::GeoIdMode::AddLastGeoIdToGeoIds);
-
-    std::for_each(shapeConstraints.begin(), shapeConstraints.end(), [](auto con) {
-        delete con;
-    });
 
     std::string exportedData = "# Copied from sketcher. From:\n#objectStr = ";
     exportedData.append(Gui::Command::getObjectCmd(obj));

--- a/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
+++ b/src/Mod/Sketcher/Gui/CommandSketcherTools.cpp
@@ -210,7 +210,8 @@ Sketcher::SketchObject* getSketchObject()
 
 // Copy
 
-bool copySelectionToClipboard(Sketcher::SketchObject* obj) {
+bool copySelectionToClipboard(Sketcher::SketchObject* obj)
+{
     std::vector<int> listOfGeoId = getListOfSelectedGeoIds(true);
     if (listOfGeoId.empty()) { return false; }
 
@@ -231,6 +232,7 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj) {
     listOfGeoId.erase(std::unique(listOfGeoId.begin(), listOfGeoId.end()), listOfGeoId.end());
 
     std::vector<Part::Geometry*> shapeGeometry;
+    shapeGeometry.reserve(listOfGeoId.size());
     for (auto geoId : listOfGeoId) {
         Part::Geometry* geoNew = obj->getGeometry(geoId)->copy();
         shapeGeometry.push_back(geoNew);
@@ -240,6 +242,10 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj) {
         "objectStr",
         shapeGeometry,
         Sketcher::PythonConverter::Mode::OmitInternalGeometry);
+
+    std::for_each(shapeGeometry.begin(), shapeGeometry.end(), [](auto geo) {
+        delete geo;
+    });
 
     // Export constraints of selected geos.
     std::vector<Sketcher::Constraint*> shapeConstraints;
@@ -278,10 +284,21 @@ bool copySelectionToClipboard(Sketcher::SketchObject* obj) {
         }
         shapeConstraints.push_back(temp);
     }
-    std::string cstrAsStr = Sketcher::PythonConverter::convert("objectStr", shapeConstraints, Sketcher::PythonConverter::GeoIdMode::AddLastGeoIdToGeoIds);
+    std::string cstrAsStr = Sketcher::PythonConverter::convert(
+        "objectStr",
+        shapeConstraints,
+        Sketcher::PythonConverter::GeoIdMode::AddLastGeoIdToGeoIds);
 
-    std::string exportedData = "# Copied from sketcher. From:\n#objectStr = " + Gui::Command::getObjectCmd(obj) + "\n"
-        + geosAsStr + "\n" + cstrAsStr;
+    std::for_each(shapeConstraints.begin(), shapeConstraints.end(), [](auto con) {
+        delete con;
+    });
+
+    std::string exportedData = "# Copied from sketcher. From:\n#objectStr = ";
+    exportedData.append(Gui::Command::getObjectCmd(obj));
+    exportedData.append("\n");
+    exportedData.append(geosAsStr);
+    exportedData.append("\n");
+    exportedData.append(cstrAsStr);
 
     if (!exportedData.empty()) {
         QClipboard* clipboard = QGuiApplication::clipboard();

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -40,7 +40,9 @@ int GeometryLayerParameters::getSubLayerIndex(const int geoId, const Sketcher::G
     bool isInternal = geom->isInternalAligned();
     bool isExternal = geoId <= Sketcher::GeoEnum::RefExt;
     if (isExternal) {
-        auto egf = Sketcher::ExternalGeometryFacade::getFacade(geom->clone());
+        // The ExternalGeometryFacade is not the owner of the geometry
+        std::unique_ptr<Part::Geometry> geomCopy(geom->clone());
+        auto egf = Sketcher::ExternalGeometryFacade::getFacade(geomCopy.get());
         if (egf->testFlag(Sketcher::ExternalGeometryExtension::Defining)) {
             return static_cast<int>(SubLayer::ExternalDefining);
         }

--- a/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManagerParameters.cpp
@@ -28,6 +28,7 @@
 
 #include <Base/Color.h>
 #include <Gui/ViewParams.h>
+#include <memory>
 
 #include "EditModeCoinManagerParameters.h"
 

--- a/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeGeometryCoinManager.cpp
@@ -149,7 +149,9 @@ void EditModeGeometryCoinManager::updateGeometryColor(
     auto isExternalDefiningGeomPoint = [&geolistfacade](int GeoId) {
         auto geom = geolistfacade.getGeometryFacadeFromGeoId(GeoId);
         if (geom) {
-            auto egf = ExternalGeometryFacade::getFacade(geom->clone());
+            std::unique_ptr<Part::Geometry> geomCopy(geom->clone());
+            // The ExternalGeometryFacade is not the owner of the geometry
+            auto egf = ExternalGeometryFacade::getFacade(geomCopy.get());
             auto ref = egf->getRef();
             return egf->testFlag(ExternalGeometryExtension::Defining);
         }
@@ -491,7 +493,9 @@ void EditModeGeometryCoinManager::updateGeometryColor(
                 }
                 else if (isExternal) {
                     auto geom = geolistfacade.getGeometryFacadeFromGeoId(GeoId);
-                    auto egf = ExternalGeometryFacade::getFacade(geom->clone());
+                    std::unique_ptr<Part::Geometry> geomCopy(geom->clone());
+                    // The ExternalGeometryFacade is not the owner of the geometry
+                    auto egf = ExternalGeometryFacade::getFacade(geomCopy.get());
                     auto ref = egf->getRef();
                     if (egf->testFlag(ExternalGeometryExtension::Missing)) {
                         color[i] = drawingParameters.InvalidSketchColor;


### PR DESCRIPTION
Cherry-picked from https://codeberg.org/wwmayer/FreeCAD11/commits/branch/fix_sketch_tools_leak

- Fix several memory leaks inside copySelectionToClipboard
- Fix several memory leaks inside EditModeGeometryCoinManager::updateGeometryColor
- Fix several memory leaks inside GeometryLayerParameters::getSubLayerIndex