### PR TITLE
Sketch: Add commands to delete constraints

### DIFF
--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -1227,7 +1227,7 @@ void TaskSketcherConstraints::onListWidgetConstraintsEmitShowSelection3DVisibili
 void TaskSketcherConstraints::onDeleteAllConstraints()
 {
     const Sketcher::SketchObject* sketch = sketchView->getSketchObject();
-    sketchView->getDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Delete all constraint"));
+    sketchView->getDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Delete all constraints"));
     try {
         Gui::cmdAppObjectArgs(sketch, "deleteAllConstraints()");
         sketchView->getDocument()->commitCommand();
@@ -1239,12 +1239,26 @@ void TaskSketcherConstraints::onDeleteAllConstraints()
 
 void TaskSketcherConstraints::onDeleteConstraints(const QList<int>& ids)
 {
-    Sketcher::SketchObject* sketch = sketchView->getSketchObject();
+    if (ids.isEmpty()) {
+        return;
+    }
+
+    const Sketcher::SketchObject* sketch = sketchView->getSketchObject();
+
+    std::stringstream stream;
+    stream << '[';
+    for (int i = 0; i < ids.size(); ++i) {
+        if (i > 0) {
+            stream << ", ";
+        }
+        stream << ids[i];
+    }
+    stream << ']';
+
     sketchView->getDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Delete constraints"));
     try {
-        std::vector<int> cids;
-        cids.insert(cids.begin(), ids.begin(), ids.end());
-        sketch->delConstraints(cids);
+        const std::string idList = stream.str();  // Make sure it's not a temporary
+        Gui::cmdAppObjectArgs(sketch, "delConstraints(%s)", idList.c_str());
         sketchView->getDocument()->commitCommand();
     }
     catch (const Base::Exception&) {

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -690,6 +690,9 @@ void ConstraintView::contextMenuEvent(QContextMenuEvent* event)
     remove->setShortcut(QKeySequence(QKeySequence::Delete));
     remove->setEnabled(!items.isEmpty());
 
+    menu.addAction(tr("Delete All"), this, &ConstraintView::deleteAllItems);
+    menu.addAction(tr("Delete by Filter"), this, &ConstraintView::deleteFilterItems);
+
     QAction* swap = menu.addAction(
         tr("Swap Constraint Names"), this, &ConstraintView::swapNamedOfSelectedItems);
     swap->setEnabled(items.size() == 2);
@@ -762,6 +765,23 @@ void ConstraintView::deleteSelectedItems()
         }
     }
     doc->commitTransaction();
+}
+
+void ConstraintView::deleteAllItems()
+{
+    Q_EMIT emitDeleteAllConstraints();
+}
+
+void ConstraintView::deleteFilterItems()
+{
+    QList<int> ids;
+    for (int index = 0; index < count(); index++) {
+        auto cit = static_cast<ConstraintItem*>(item(index));
+        if (!cit->isHidden()) {
+            ids.push_back(cit->ConstraintNbr);
+        }
+    }
+    Q_EMIT emitDeleteConstraints(ids);
 }
 
 void ConstraintView::swapNamedOfSelectedItems()
@@ -1012,6 +1032,14 @@ TaskSketcherConstraints::TaskSketcherConstraints(ViewProviderSketch* sketchView)
         &ConstraintView::emitShowSelection3DVisibility,
         this,
         &TaskSketcherConstraints::onListWidgetConstraintsEmitShowSelection3DVisibility);
+    QObject::connect(ui->listWidgetConstraints,
+                     &ConstraintView::emitDeleteAllConstraints,
+                     this,
+                     &TaskSketcherConstraints::onDeleteAllConstraints);
+    QObject::connect(ui->listWidgetConstraints,
+                     &ConstraintView::emitDeleteConstraints,
+                     this,
+                     &TaskSketcherConstraints::onDeleteConstraints);
 #if QT_VERSION >= QT_VERSION_CHECK(6,7,0)
     QObject::connect(ui->filterBox,
                      &QCheckBox::checkStateChanged,
@@ -1194,6 +1222,34 @@ void TaskSketcherConstraints::onListWidgetConstraintsEmitHideSelection3DVisibili
 void TaskSketcherConstraints::onListWidgetConstraintsEmitShowSelection3DVisibility()
 {
     changeFilteredVisibility(true, ActionTarget::Selected);
+}
+
+void TaskSketcherConstraints::onDeleteAllConstraints()
+{
+    const Sketcher::SketchObject* sketch = sketchView->getSketchObject();
+    sketchView->getDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Delete all constraint"));
+    try {
+        Gui::cmdAppObjectArgs(sketch, "deleteAllConstraints()");
+        sketchView->getDocument()->commitCommand();
+    }
+    catch (const Base::Exception&) {
+        sketchView->getDocument()->abortCommand();
+    }
+}
+
+void TaskSketcherConstraints::onDeleteConstraints(const QList<int>& ids)
+{
+    Sketcher::SketchObject* sketch = sketchView->getSketchObject();
+    sketchView->getDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Delete constraints"));
+    try {
+        std::vector<int> cids;
+        cids.insert(cids.begin(), ids.begin(), ids.end());
+        sketch->delConstraints(cids);
+        sketchView->getDocument()->commitCommand();
+    }
+    catch (const Base::Exception&) {
+        sketchView->getDocument()->abortCommand();
+    }
 }
 
 void TaskSketcherConstraints::changeFilteredVisibility(bool show, ActionTarget target)

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.cpp
@@ -33,6 +33,8 @@
 #include <QStyledItemDelegate>
 #include <QWidgetAction>
 #include <boost/core/ignore_unused.hpp>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <cmath>
 #include <cstring>
 #include <limits>
@@ -1244,20 +1246,9 @@ void TaskSketcherConstraints::onDeleteConstraints(const QList<int>& ids)
     }
 
     const Sketcher::SketchObject* sketch = sketchView->getSketchObject();
-
-    std::stringstream stream;
-    stream << '[';
-    for (int i = 0; i < ids.size(); ++i) {
-        if (i > 0) {
-            stream << ", ";
-        }
-        stream << ids[i];
-    }
-    stream << ']';
-
+    const std::string idList = fmt::format("[{}]", fmt::join(ids, ", "));
     sketchView->getDocument()->openCommand(QT_TRANSLATE_NOOP("Command", "Delete constraints"));
     try {
-        const std::string idList = stream.str();  // Make sure it's not a temporary
         Gui::cmdAppObjectArgs(sketch, "delConstraints(%s)", idList.c_str());
         sketchView->getDocument()->commitCommand();
     }

--- a/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
+++ b/src/Mod/Sketcher/Gui/TaskSketcherConstraints.h
@@ -70,12 +70,16 @@ Q_SIGNALS:
     void emitCenterSelectedItems();
     void emitHideSelection3DVisibility();
     void emitShowSelection3DVisibility();
+    void emitDeleteAllConstraints();
+    void emitDeleteConstraints(const QList<int>&);
 
 protected Q_SLOTS:
     void modifyCurrentItem();
     void renameCurrentItem();
     void centerSelectedItems();
     void deleteSelectedItems();
+    void deleteAllItems();
+    void deleteFilterItems();
     void doSelectConstraints();
     void updateDrivingStatus();
     void updateActiveStatus();
@@ -189,6 +193,8 @@ public:
     void onListWidgetConstraintsEmitCenterSelectedItems();
     void onListWidgetConstraintsEmitShowSelection3DVisibility();
     void onListWidgetConstraintsEmitHideSelection3DVisibility();
+    void onDeleteAllConstraints();
+    void onDeleteConstraints(const QList<int>&);
     void onFilterBoxStateChanged(int val);
     void onShowHideButtonClicked(bool);
     void onSettingsRestrictVisibilityChanged(bool value = false);


### PR DESCRIPTION
Cherry-pick https://codeberg.org/wwmayer/FreeCAD11/commit/c9539357192cb75f92c412076be90f5d400adac5

Add two commands to optimize the deletion of constraints:
* Delete all constraints
* Delete filtered constraints

<img width="708" height="758" alt="grafik" src="https://github.com/user-attachments/assets/5f2493f7-7c9f-4bdd-8379-99fd16b3f745" />

