### PR TITLE
PD: Make bodies inside booleans visible if active

### DIFF
--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -584,6 +584,11 @@ int ViewProvider::getDefaultMode() const
     return viewOverrideMode >= 0 ? viewOverrideMode : _iActualMode;
 }
 
+int ViewProvider::getActualMode() const
+{
+    return _iActualMode;
+}
+
 void ViewProvider::onBeforeChange(const App::Property* prop)
 {
     Application::Instance->signalBeforeChangeObject(*this, *prop);

--- a/src/Gui/ViewProvider.h
+++ b/src/Gui/ViewProvider.h
@@ -765,6 +765,8 @@ public:
     std::vector<std::string> getDisplayMaskModes() const;
     void setDefaultMode(int);
     int getDefaultMode() const;
+    /// Returns the underlying display mask mode, ignoring any active override mode.
+    int getActualMode() const;
     //@}
 
     virtual void setRenderCacheMode(int);

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -148,10 +148,9 @@ void ViewProviderBoolean::syncActiveBodyVisibility()
     auto* activeView = getDocument()->getActiveView();
     auto* activeBody = activeView ? activeView->getActiveObject<App::DocumentObject*>(PDBODYKEY)
                                   : nullptr;
-    auto* activeBodyVP = activeBody ? dynamic_cast<Gui::ViewProviderDocumentObject*>(
-                                          Gui::Application::Instance->getViewProvider(activeBody)
-                                      )
-                                    : nullptr;
+    auto* activeBodyVP = activeBody
+        ? Gui::Application::Instance->getViewProvider<Gui::ViewProviderDocumentObject>(activeBody)
+        : nullptr;
     onBodyActivated(activeBodyVP, PDBODYKEY);
 }
 

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -33,7 +33,6 @@
 
 #include "StyleParameters.h"
 #include "TaskBooleanParameters.h"
-#include "ViewProviderBody.h"
 
 #include <Base/ServiceProvider.h>
 #include <Mod/PartDesign/App/FeatureBoolean.h>
@@ -142,55 +141,6 @@ void ViewProviderBoolean::restoreActiveBodyExposure()
 
     setDefaultMode(exposure.booleanMode);
     setTemporaryVisible(this, exposure.booleanWasVisible);
-
-    if (exposure.parentResult) {
-        if (auto* result = exposure.parentResult->get<App::DocumentObject>();
-            result && result->Visibility.getValue()) {
-            if (auto* resultVP = Gui::Application::Instance->getViewProvider(result)) {
-                setTemporaryVisible(resultVP, true);
-            }
-        }
-    }
-}
-
-void ViewProviderBoolean::syncParentBodyResultVisibility()
-{
-    if (!_activeBodyExposure) {
-        return;
-    }
-
-    auto* bodyVP = getBodyViewProvider();
-    auto* shownFeature = bodyVP ? bodyVP->getShownFeature() : nullptr;
-    if (shownFeature == getObject()) {
-        shownFeature = nullptr;
-    }
-
-    auto* previousFeature = _activeBodyExposure->parentResult
-        ? _activeBodyExposure->parentResult->get<App::DocumentObject>()
-        : nullptr;
-    if (previousFeature == shownFeature) {
-        if (shownFeature) {
-            if (auto* shownVP = Gui::Application::Instance->getViewProvider(shownFeature)) {
-                setTemporaryVisible(shownVP, false);
-            }
-        }
-        return;
-    }
-
-    if (previousFeature && previousFeature->Visibility.getValue()) {
-        if (auto* previousVP = Gui::Application::Instance->getViewProvider(previousFeature)) {
-            setTemporaryVisible(previousVP, true);
-        }
-    }
-    _activeBodyExposure->parentResult.reset();
-
-    if (shownFeature) {
-        if (auto* shownVP = Gui::Application::Instance->getViewProvider(shownFeature);
-            shownVP && shownVP->Gui::ViewProvider::isShow()) {
-            _activeBodyExposure->parentResult.emplace(shownFeature);
-            setTemporaryVisible(shownVP, false);
-        }
-    }
 }
 
 void ViewProviderBoolean::syncActiveBodyVisibility()
@@ -251,7 +201,6 @@ void ViewProviderBoolean::onBodyActivated(const Gui::ViewProviderDocumentObject*
         _activeBodyExposure.emplace(
             ActiveBodyExposure {
                 .body = App::DocumentObjectWeakPtrT(matchingMember),
-                .parentResult = std::nullopt,
                 .bodyMode = bodyVP->getActualMode(),
                 .booleanMode = getActualMode(),
                 .bodyWasVisible = bodyVP->Gui::ViewProvider::isShow(),
@@ -268,7 +217,6 @@ void ViewProviderBoolean::onBodyActivated(const Gui::ViewProviderDocumentObject*
     else {
         setTemporaryVisible(bodyVP, true);
     }
-    syncParentBodyResultVisibility();
 }
 
 void ViewProviderBoolean::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -27,13 +27,15 @@
 #include <QMenu>
 #include <Inventor/nodes/SoTransform.h>
 
+#include <utility>
+
 #include "ViewProviderBoolean.h"
 
 #include "StyleParameters.h"
 #include "TaskBooleanParameters.h"
+#include "ViewProviderBody.h"
 
 #include <Base/ServiceProvider.h>
-#include <Base/Tools.h>
 #include <Mod/PartDesign/App/FeatureBoolean.h>
 #include <App/Document.h>
 #include <App/GroupExtension.h>
@@ -43,6 +45,7 @@
 #include <Gui/Command.h>
 #include <Gui/Document.h>
 #include <Gui/MainWindow.h>
+#include <Gui/MDIView.h>
 #include <Gui/Utilities.h>
 #include <Gui/ViewProviderDocumentObject.h>
 #include <Mod/PartDesign/App/Body.h>
@@ -82,7 +85,7 @@ void ViewProviderBoolean::attach(App::DocumentObject* pcObject)
 
 void ViewProviderBoolean::update(const App::Property* prop)
 {
-    if (!_shownBody) {
+    if (!_activeBodyExposure || prop == &getObject()->Visibility) {
         Gui::ViewProviderDocumentObject::update(prop);
         return;
     }
@@ -90,62 +93,116 @@ void ViewProviderBoolean::update(const App::Property* prop)
     // A tool body is temporarily shown via setDisplayMaskMode("Group").
     // The normal ViewProvider::update() briefly sets pcModeSwitch=-1 (hide/show
     // optimization) which hides the entire Group subtree, making the tool body flash.
-    // Call updateData() directly to skip that cycle. User1 on Visibility suppresses
-    // VP<->App Visibility syncing and extensionShow/Hide member propagation.
+    // Call updateData() directly to skip that cycle.
     if (isUpdatesEnabled()) {
-        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
-            App::Property::User1,
-            &Visibility
-        );
         updateData(prop);
     }
 }
 
-void ViewProviderBoolean::show()
+const char* ViewProviderBoolean::getConfiguredDisplayMode()
 {
-    // ViewProviderGeoFeatureGroupExtension::extensionShow() would iterate
-    // Boolean->Group and set every tool body's App Visibility = true,
-    // re-showing bodies that were intentionally hidden. User1 suppresses that
-    // propagation. It also suppresses the VP→App Visibility sync in onChanged,
-    // so we apply that sync manually after the guard drops.
-    {
-        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
-            App::Property::User1,
-            &Visibility
-        );
-        Gui::ViewProviderDocumentObject::show();
+    if (Display.getValue() != 0) {
+        return "Group";
     }
-    if (auto* obj = getObject(); obj && Visibility.getValue() != obj->Visibility.getValue()) {
-        obj->Visibility.setValue(Visibility.getValue());
+
+    if (auto bodyViewProvider = getBodyViewProvider()) {
+        return bodyViewProvider->DisplayMode.getValueAsString();
+    }
+
+    return getDefaultDisplayMode();
+}
+
+static void setTemporaryVisible(Gui::ViewProvider* vp, bool visible)
+{
+    // This is scene-graph-only visibility and must not mutate App Visibility.
+    if (visible) {
+        vp->Gui::ViewProvider::show();
+    }
+    else {
+        vp->Gui::ViewProvider::hide();
     }
 }
 
-bool ViewProviderBoolean::isShow() const
+void ViewProviderBoolean::restoreActiveBodyExposure()
 {
-    // setDisplayMaskMode("Group") sets pcModeSwitch >= 0 even when Boolean is hidden; use App
-    // Visibility.
-    if (auto* obj = getObject()) {
-        return obj->Visibility.getValue();
+    if (!_activeBodyExposure) {
+        return;
     }
-    return ViewProvider::isShow();
+
+    auto exposure = std::move(*_activeBodyExposure);
+    _activeBodyExposure.reset();
+
+    auto* body = exposure.body.get<App::DocumentObject>();
+    if (body) {
+        if (auto* bodyVP = Gui::Application::Instance->getViewProvider(body)) {
+            bodyVP->setDefaultMode(exposure.bodyMode);
+            setTemporaryVisible(bodyVP, exposure.bodyWasVisible);
+        }
+    }
+
+    setDefaultMode(exposure.booleanMode);
+    setTemporaryVisible(this, exposure.booleanWasVisible);
+
+    if (exposure.parentResult) {
+        if (auto* result = exposure.parentResult->get<App::DocumentObject>();
+            result && result->Visibility.getValue()) {
+            if (auto* resultVP = Gui::Application::Instance->getViewProvider(result)) {
+                setTemporaryVisible(resultVP, true);
+            }
+        }
+    }
 }
 
-// Returns true if target is contained anywhere inside container's Group hierarchy.
-static bool containsRecursively(App::DocumentObject* container, App::DocumentObject* target)
+void ViewProviderBoolean::syncParentBodyResultVisibility()
 {
-    auto* ext = container->getExtensionByType<App::GroupExtension>(/*no_except=*/true);
-    if (!ext) {
-        return false;
+    if (!_activeBodyExposure) {
+        return;
     }
-    for (auto* member : ext->Group.getValues()) {
-        if (!member) {
-            continue;
+
+    auto* bodyVP = getBodyViewProvider();
+    auto* shownFeature = bodyVP ? bodyVP->getShownFeature() : nullptr;
+    if (shownFeature == getObject()) {
+        shownFeature = nullptr;
+    }
+
+    auto* previousFeature = _activeBodyExposure->parentResult
+        ? _activeBodyExposure->parentResult->get<App::DocumentObject>()
+        : nullptr;
+    if (previousFeature == shownFeature) {
+        if (shownFeature) {
+            if (auto* shownVP = Gui::Application::Instance->getViewProvider(shownFeature)) {
+                setTemporaryVisible(shownVP, false);
+            }
         }
-        if (member == target || containsRecursively(member, target)) {
-            return true;
+        return;
+    }
+
+    if (previousFeature && previousFeature->Visibility.getValue()) {
+        if (auto* previousVP = Gui::Application::Instance->getViewProvider(previousFeature)) {
+            setTemporaryVisible(previousVP, true);
         }
     }
-    return false;
+    _activeBodyExposure->parentResult.reset();
+
+    if (shownFeature) {
+        if (auto* shownVP = Gui::Application::Instance->getViewProvider(shownFeature);
+            shownVP && shownVP->Gui::ViewProvider::isShow()) {
+            _activeBodyExposure->parentResult.emplace(shownFeature);
+            setTemporaryVisible(shownVP, false);
+        }
+    }
+}
+
+void ViewProviderBoolean::syncActiveBodyVisibility()
+{
+    auto* activeView = getDocument()->getActiveView();
+    auto* activeBody = activeView ? activeView->getActiveObject<App::DocumentObject*>(PDBODYKEY)
+                                  : nullptr;
+    auto* activeBodyVP = activeBody ? dynamic_cast<Gui::ViewProviderDocumentObject*>(
+                                          Gui::Application::Instance->getViewProvider(activeBody)
+                                      )
+                                    : nullptr;
+    onBodyActivated(activeBodyVP, PDBODYKEY);
 }
 
 void ViewProviderBoolean::onBodyActivated(const Gui::ViewProviderDocumentObject* vp, const char* name)
@@ -159,94 +216,59 @@ void ViewProviderBoolean::onBodyActivated(const Gui::ViewProviderDocumentObject*
         return;
     }
 
-    const auto& group = feature->Group.getValues();
     App::DocumentObject* activatedBody = vp ? vp->getObject() : nullptr;
-
-    // Find the direct Group member that is, or transitively contains, the activated body.
     App::DocumentObject* matchingMember = nullptr;
     if (activatedBody) {
-        for (auto* obj : group) {
-            if (obj == activatedBody || containsRecursively(obj, activatedBody)) {
-                matchingMember = obj;
+        for (auto* member : feature->Group.getValues()) {
+            auto* group = member
+                ? member->getExtensionByType<App::GroupExtension>(/*no_except=*/true)
+                : nullptr;
+            if (member == activatedBody || (group && group->hasObject(activatedBody, true))) {
+                matchingMember = member;
                 break;
             }
         }
     }
 
-    // Show or hide the body by calling Gui::ViewProvider::show/hide non-virtually,
-    // bypassing ViewProviderBody::show(). ViewProviderBody::show() would call
-    // tip->Visibility.setValue(true), changing App Visibility and triggering
-    // GroupExtension cascades that visually toggle the Boolean.
-    // User1 suppresses extensionShow/extensionHide member propagation and the
-    // VP->App Visibility sync in onChanged.
-    // Note: ViewProviderBody inherits from PartGui::ViewProviderPart, not
-    // PartDesignGui::ViewProvider, so we cast to Gui::ViewProviderDocumentObject
-    // to reach any VP type (bodies included).
-    const auto setBodyVisible = [](App::DocumentObject* body, bool visible) {
-        auto* rawVP = Gui::Application::Instance->getViewProvider(body);
-        auto* vpdo = dynamic_cast<Gui::ViewProviderDocumentObject*>(rawVP);
-        if (!vpdo) {
-            return;
-        }
-        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
-            App::Property::User1,
-            &vpdo->Visibility
-        );
-        if (visible) {
-            rawVP->Gui::ViewProvider::show();
-        }
-        else {
-            rawVP->Gui::ViewProvider::hide();
-        }
-    };
-
-    // For nested Booleans, the activated body may live inside an intermediate body that is itself a
-    // direct Group member
-    const auto switchIntermediateToGroup = [](App::DocumentObject* body) {
-        if (auto* bodyVP = Gui::Application::Instance->getViewProvider(body)) {
-            bodyVP->setDisplayMaskMode("Group");
-        }
-    };
-
-    // Restore an intermediate body VP to hidden (pcModeSwitch = -1) without touching
-    // App Visibility as the body was never "shown" in the App sense, only in the scene graph
-    const auto restoreIntermediateToHidden = [](App::DocumentObject* body) {
-        auto* bodyVP = Gui::Application::Instance->getViewProvider(body);
-        auto* vpdo = dynamic_cast<Gui::ViewProviderDocumentObject*>(bodyVP);
-        if (!vpdo) {
-            return;
-        }
-        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
-            App::Property::User1,
-            &vpdo->Visibility
-        );
-        bodyVP->Gui::ViewProvider::hide();
-    };
-
-    if (matchingMember) {
-        setDisplayMaskMode("Group");
-        _shownBody = matchingMember;
-        if (matchingMember == activatedBody) {
-            setBodyVisible(matchingMember, true);
-            _indirectActivation = false;
-        }
-        else {
-            // Indirect: open the intermediate bodys scene so the nested chain is visible
-            switchIntermediateToGroup(matchingMember);
-            _indirectActivation = true;
-        }
+    const bool indirectActivation = matchingMember && matchingMember != activatedBody;
+    const bool sameExposure = matchingMember && _activeBodyExposure
+        && _activeBodyExposure->body.get<App::DocumentObject>() == matchingMember
+        && _activeBodyExposure->indirect == indirectActivation;
+    if (!sameExposure) {
+        restoreActiveBodyExposure();
     }
-    else if (_shownBody) {
-        if (_indirectActivation) {
-            restoreIntermediateToHidden(_shownBody);
-        }
-        else {
-            setBodyVisible(_shownBody, false);
-        }
-        setDisplayMaskMode(getDefaultDisplayMode());
-        _shownBody = nullptr;
-        _indirectActivation = false;
+    if (!matchingMember) {
+        return;
     }
+
+    auto* bodyVP = Gui::Application::Instance->getViewProvider(matchingMember);
+    if (!bodyVP) {
+        restoreActiveBodyExposure();
+        return;
+    }
+
+    if (!sameExposure) {
+        _activeBodyExposure.emplace(
+            ActiveBodyExposure {
+                .body = App::DocumentObjectWeakPtrT(matchingMember),
+                .parentResult = std::nullopt,
+                .bodyMode = bodyVP->getActualMode(),
+                .booleanMode = getActualMode(),
+                .bodyWasVisible = bodyVP->Gui::ViewProvider::isShow(),
+                .booleanWasVisible = Gui::ViewProvider::isShow(),
+                .indirect = indirectActivation,
+            }
+        );
+    }
+
+    setDisplayMaskMode("Group");
+    if (_activeBodyExposure->indirect) {
+        bodyVP->setDisplayMaskMode("Group");
+    }
+    else {
+        setTemporaryVisible(bodyVP, true);
+    }
+    syncParentBodyResultVisibility();
 }
 
 void ViewProviderBoolean::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
@@ -270,6 +292,12 @@ bool ViewProviderBoolean::onDelete(const std::vector<std::string>& s)
     return ViewProvider::onDelete(s);
 }
 
+void ViewProviderBoolean::beforeDelete()
+{
+    restoreActiveBodyExposure();
+    ViewProvider::beforeDelete();
+}
+
 const char* ViewProviderBoolean::getDefaultDisplayMode() const
 {
     return "Flat Lines";
@@ -281,23 +309,19 @@ void ViewProviderBoolean::onChanged(const App::Property* prop)
     ViewProvider::onChanged(prop);
 
     if (prop == &Display) {
-        const auto getDisplayMode = [this]() {
-            if (Display.getValue() != 0) {
-                return "Group";
-            }
-
-            if (auto bodyViewProvider = getBodyViewProvider()) {
-                return bodyViewProvider->DisplayMode.getValueAsString();
-            }
-
-            return getDefaultDisplayMode();
-        };
-
-        setDisplayMode(getDisplayMode());
+        setDisplayMode(getConfiguredDisplayMode());
+        if (_activeBodyExposure) {
+            _activeBodyExposure->booleanMode = getActualMode();
+            setDisplayMaskMode("Group");
+        }
     }
 
     if (prop == &Visibility) {
         updateBasePreviewVisibility();
+        if (_activeBodyExposure) {
+            _activeBodyExposure->booleanWasVisible = Visibility.getValue();
+        }
+        syncActiveBodyVisibility();
     }
 }
 
@@ -324,6 +348,10 @@ void ViewProviderBoolean::updateData(const App::Property* prop)
     }
 
     ViewProvider::updateData(prop);
+
+    if (prop == &feature->Group) {
+        syncActiveBodyVisibility();
+    }
 }
 
 void ViewProviderBoolean::attachPreview()

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -33,13 +33,18 @@
 #include "TaskBooleanParameters.h"
 
 #include <Base/ServiceProvider.h>
+#include <Base/Tools.h>
 #include <Mod/PartDesign/App/FeatureBoolean.h>
 #include <App/Document.h>
+#include <App/GroupExtension.h>
+#include <Gui/ActiveObjectList.h>
 #include <Gui/Application.h>
 #include <Gui/Control.h>
 #include <Gui/Command.h>
+#include <Gui/Document.h>
 #include <Gui/MainWindow.h>
 #include <Gui/Utilities.h>
+#include <Gui/ViewProviderDocumentObject.h>
 #include <Mod/PartDesign/App/Body.h>
 #include <Mod/Sketcher/Gui/TaskDlgEditSketch.h>
 
@@ -64,6 +69,185 @@ ViewProviderBoolean::ViewProviderBoolean()
 }
 
 ViewProviderBoolean::~ViewProviderBoolean() = default;
+
+void ViewProviderBoolean::attach(App::DocumentObject* pcObject)
+{
+    ViewProvider::attach(pcObject);
+    _bodyActivationConn = getDocument()->signalActivatedViewProvider.connect(
+        [this](const Gui::ViewProviderDocumentObject* vp, const char* name) {
+            onBodyActivated(vp, name);
+        }
+    );
+}
+
+void ViewProviderBoolean::update(const App::Property* prop)
+{
+    if (!_shownBody) {
+        Gui::ViewProviderDocumentObject::update(prop);
+        return;
+    }
+
+    // A tool body is temporarily shown via setDisplayMaskMode("Group").
+    // The normal ViewProvider::update() briefly sets pcModeSwitch=-1 (hide/show
+    // optimization) which hides the entire Group subtree, making the tool body flash.
+    // Call updateData() directly to skip that cycle. User1 on Visibility suppresses
+    // VP<->App Visibility syncing and extensionShow/Hide member propagation.
+    if (isUpdatesEnabled()) {
+        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
+            App::Property::User1,
+            &Visibility
+        );
+        updateData(prop);
+    }
+}
+
+void ViewProviderBoolean::show()
+{
+    // ViewProviderGeoFeatureGroupExtension::extensionShow() would iterate
+    // Boolean->Group and set every tool body's App Visibility = true,
+    // re-showing bodies that were intentionally hidden. User1 suppresses that
+    // propagation. It also suppresses the VP→App Visibility sync in onChanged,
+    // so we apply that sync manually after the guard drops.
+    {
+        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
+            App::Property::User1,
+            &Visibility
+        );
+        Gui::ViewProviderDocumentObject::show();
+    }
+    if (auto* obj = getObject(); obj && Visibility.getValue() != obj->Visibility.getValue()) {
+        obj->Visibility.setValue(Visibility.getValue());
+    }
+}
+
+bool ViewProviderBoolean::isShow() const
+{
+    // setDisplayMaskMode("Group") sets pcModeSwitch >= 0 even when Boolean is hidden; use App
+    // Visibility.
+    if (auto* obj = getObject()) {
+        return obj->Visibility.getValue();
+    }
+    return ViewProvider::isShow();
+}
+
+// Returns true if target is contained anywhere inside container's Group hierarchy.
+static bool containsRecursively(App::DocumentObject* container, App::DocumentObject* target)
+{
+    auto* ext = container->getExtensionByType<App::GroupExtension>(/*no_except=*/true);
+    if (!ext) {
+        return false;
+    }
+    for (auto* member : ext->Group.getValues()) {
+        if (!member) {
+            continue;
+        }
+        if (member == target || containsRecursively(member, target)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void ViewProviderBoolean::onBodyActivated(const Gui::ViewProviderDocumentObject* vp, const char* name)
+{
+    if (strcmp(name, PDBODYKEY) != 0) {
+        return;
+    }
+
+    auto* feature = getObject<PartDesign::Boolean>();
+    if (!feature) {
+        return;
+    }
+
+    const auto& group = feature->Group.getValues();
+    App::DocumentObject* activatedBody = vp ? vp->getObject() : nullptr;
+
+    // Find the direct Group member that is, or transitively contains, the activated body.
+    App::DocumentObject* matchingMember = nullptr;
+    if (activatedBody) {
+        for (auto* obj : group) {
+            if (obj == activatedBody || containsRecursively(obj, activatedBody)) {
+                matchingMember = obj;
+                break;
+            }
+        }
+    }
+
+    // Show or hide the body by calling Gui::ViewProvider::show/hide non-virtually,
+    // bypassing ViewProviderBody::show(). ViewProviderBody::show() would call
+    // tip->Visibility.setValue(true), changing App Visibility and triggering
+    // GroupExtension cascades that visually toggle the Boolean.
+    // User1 suppresses extensionShow/extensionHide member propagation and the
+    // VP->App Visibility sync in onChanged.
+    // Note: ViewProviderBody inherits from PartGui::ViewProviderPart, not
+    // PartDesignGui::ViewProvider, so we cast to Gui::ViewProviderDocumentObject
+    // to reach any VP type (bodies included).
+    const auto setBodyVisible = [](App::DocumentObject* body, bool visible) {
+        auto* rawVP = Gui::Application::Instance->getViewProvider(body);
+        auto* vpdo = dynamic_cast<Gui::ViewProviderDocumentObject*>(rawVP);
+        if (!vpdo) {
+            return;
+        }
+        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
+            App::Property::User1,
+            &vpdo->Visibility
+        );
+        if (visible) {
+            rawVP->Gui::ViewProvider::show();
+        }
+        else {
+            rawVP->Gui::ViewProvider::hide();
+        }
+    };
+
+    // For nested Booleans, the activated body may live inside an intermediate body that is itself a
+    // direct Group member
+    const auto switchIntermediateToGroup = [](App::DocumentObject* body) {
+        if (auto* bodyVP = Gui::Application::Instance->getViewProvider(body)) {
+            bodyVP->setDisplayMaskMode("Group");
+        }
+    };
+
+    // Restore an intermediate body VP to hidden (pcModeSwitch = -1) without touching
+    // App Visibility as the body was never "shown" in the App sense, only in the scene graph
+    const auto restoreIntermediateToHidden = [](App::DocumentObject* body) {
+        auto* bodyVP = Gui::Application::Instance->getViewProvider(body);
+        auto* vpdo = dynamic_cast<Gui::ViewProviderDocumentObject*>(bodyVP);
+        if (!vpdo) {
+            return;
+        }
+        Base::ObjectStatusLocker<App::Property::Status, App::Property> guard(
+            App::Property::User1,
+            &vpdo->Visibility
+        );
+        bodyVP->Gui::ViewProvider::hide();
+    };
+
+    if (matchingMember) {
+        setDisplayMaskMode("Group");
+        _shownBody = matchingMember;
+        if (matchingMember == activatedBody) {
+            setBodyVisible(matchingMember, true);
+            _indirectActivation = false;
+        }
+        else {
+            // Indirect: open the intermediate bodys scene so the nested chain is visible
+            switchIntermediateToGroup(matchingMember);
+            _indirectActivation = true;
+        }
+    }
+    else if (_shownBody) {
+        if (_indirectActivation) {
+            restoreIntermediateToHidden(_shownBody);
+        }
+        else {
+            setBodyVisible(_shownBody, false);
+        }
+        setDisplayMaskMode(getDefaultDisplayMode());
+        _shownBody = nullptr;
+        _indirectActivation = false;
+    }
+}
 
 void ViewProviderBoolean::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)
 {

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.h
@@ -27,6 +27,9 @@
 
 #pragma once
 
+#include <optional>
+
+#include <App/DocumentObserver.h>
 #include "ViewProvider.h"
 #include <Gui/ViewProviderGeoFeatureGroupExtension.h>
 #include <Gui/Inventor/SoToggleSwitch.h>
@@ -53,12 +56,11 @@ public:
     void setupContextMenu(QMenu*, QObject*, const char*) override;
 
     void attach(App::DocumentObject*) override;
+    void beforeDelete() override;
     bool onDelete(const std::vector<std::string>&) override;
     const char* getDefaultDisplayMode() const override;
     void onChanged(const App::Property* prop) override;
     void update(const App::Property* prop) override;
-    void show() override;
-    bool isShow() const override;
 
 protected:
     void updateData(const App::Property* prop) override;
@@ -71,15 +73,28 @@ protected:
     static const char* DisplayEnum[];
 
 private:
+    struct ActiveBodyExposure
+    {
+        App::DocumentObjectWeakPtrT body;
+        std::optional<App::DocumentObjectWeakPtrT> parentResult;
+        int bodyMode;
+        int booleanMode;
+        bool bodyWasVisible;
+        bool booleanWasVisible;
+        bool indirect;
+    };
+
+    const char* getConfiguredDisplayMode();
     void updateBasePreviewVisibility();
+    void restoreActiveBodyExposure();
+    void syncParentBodyResultVisibility();
+    void syncActiveBodyVisibility();
     void onBodyActivated(const Gui::ViewProviderDocumentObject* vp, const char* name);
 
     Gui::CoinPtr<SoGroup> pcToolsPreview;
     Gui::CoinPtr<SoToggleSwitch> pcBasePreviewToggle;
     fastsignals::scoped_connection _bodyActivationConn;
-    App::DocumentObject* _shownBody = nullptr;
-    bool _indirectActivation = false;  // true when _shownBody is an intermediate body, not the
-                                       // activated leaf
+    std::optional<ActiveBodyExposure> _activeBodyExposure;
 };
 
 }  // namespace PartDesignGui

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.h
@@ -76,7 +76,6 @@ private:
     struct ActiveBodyExposure
     {
         App::DocumentObjectWeakPtrT body;
-        std::optional<App::DocumentObjectWeakPtrT> parentResult;
         int bodyMode;
         int booleanMode;
         bool bodyWasVisible;
@@ -87,7 +86,6 @@ private:
     const char* getConfiguredDisplayMode();
     void updateBasePreviewVisibility();
     void restoreActiveBodyExposure();
-    void syncParentBodyResultVisibility();
     void syncActiveBodyVisibility();
     void onBodyActivated(const Gui::ViewProviderDocumentObject* vp, const char* name);
 

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.h
@@ -30,6 +30,7 @@
 #include "ViewProvider.h"
 #include <Gui/ViewProviderGeoFeatureGroupExtension.h>
 #include <Gui/Inventor/SoToggleSwitch.h>
+#include <fastsignals/connection.h>
 
 
 namespace PartDesignGui
@@ -51,9 +52,13 @@ public:
     /// grouping handling
     void setupContextMenu(QMenu*, QObject*, const char*) override;
 
+    void attach(App::DocumentObject*) override;
     bool onDelete(const std::vector<std::string>&) override;
     const char* getDefaultDisplayMode() const override;
     void onChanged(const App::Property* prop) override;
+    void update(const App::Property* prop) override;
+    void show() override;
+    bool isShow() const override;
 
 protected:
     void updateData(const App::Property* prop) override;
@@ -67,9 +72,14 @@ protected:
 
 private:
     void updateBasePreviewVisibility();
+    void onBodyActivated(const Gui::ViewProviderDocumentObject* vp, const char* name);
 
     Gui::CoinPtr<SoGroup> pcToolsPreview;
     Gui::CoinPtr<SoToggleSwitch> pcBasePreviewToggle;
+    fastsignals::scoped_connection _bodyActivationConn;
+    App::DocumentObject* _shownBody = nullptr;
+    bool _indirectActivation = false;  // true when _shownBody is an intermediate body, not the
+                                       // activated leaf
 };
 
 }  // namespace PartDesignGui

--- a/src/Mod/PartDesign/PartDesignTests/TestActiveObject.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestActiveObject.py
@@ -61,5 +61,173 @@ class TestActiveObject(unittest.TestCase):
 
         FreeCADGui.updateGui()
 
+    def _createBooleanWithTwoTools(self):
+        FreeCADGui.activateView("Gui::View3DInventor", True)
+
+        tools = []
+        for index in range(2):
+            body = self.doc.addObject("PartDesign::Body", f"ToolBody{index}")
+            box = self.doc.addObject("PartDesign::AdditiveBox", f"ToolBox{index}")
+            body.addObject(box)
+            tools.append(body)
+
+        resultBody = self.doc.addObject("PartDesign::Body", "ResultBody")
+        boolean = self.doc.addObject("PartDesign::Boolean", "Boolean")
+        resultBody.addObject(boolean)
+        boolean.Group = tools
+        boolean.ViewObject.Display = "Result"
+        self.doc.recompute()
+
+        for tool in tools:
+            tool.ViewObject.hide()
+        boolean.ViewObject.show()
+        FreeCADGui.updateGui()
+
+        return boolean, tools
+
+    def testBooleanActiveBodyVisibilitySwitch(self):
+        boolean, tools = self._createBooleanWithTwoTools()
+        view = FreeCADGui.activeView()
+
+        view.setActiveObject("pdbody", tools[0])
+        self.assertTrue(tools[0].ViewObject.isVisible())
+        self.assertFalse(tools[1].ViewObject.isVisible())
+
+        view.setActiveObject("pdbody", tools[1])
+        self.assertFalse(tools[0].ViewObject.isVisible())
+        self.assertTrue(tools[1].ViewObject.isVisible())
+
+        view.setActiveObject("pdbody", None)
+        self.assertFalse(tools[0].ViewObject.isVisible())
+        self.assertFalse(tools[1].ViewObject.isVisible())
+        self.assertTrue(boolean.ViewObject.isVisible())
+
+        view.setActiveObject("pdbody", tools[0])
+        boolean.Group = [tools[1]]
+        FreeCADGui.updateGui()
+        self.assertFalse(tools[0].ViewObject.isVisible())
+        self.assertTrue(boolean.ViewObject.isVisible())
+
+    def testBooleanActiveBodyVisibilityRestoresState(self):
+        boolean, tools = self._createBooleanWithTwoTools()
+        view = FreeCADGui.activeView()
+        booleanMode = boolean.ViewObject.SwitchNode.whichChild.getValue()
+
+        tools[0].ViewObject.show()
+        toolMode = tools[0].ViewObject.SwitchNode.whichChild.getValue()
+        view.setActiveObject("pdbody", tools[0])
+        view.setActiveObject("pdbody", None)
+        self.assertTrue(tools[0].ViewObject.isVisible())
+        self.assertEqual(boolean.ViewObject.SwitchNode.whichChild.getValue(), booleanMode)
+        self.assertEqual(tools[0].ViewObject.SwitchNode.whichChild.getValue(), toolMode)
+
+        tools[0].ViewObject.hide()
+        view.setActiveObject("pdbody", tools[0])
+        boolean.Visibility = False
+        FreeCADGui.updateGui()
+        self.assertTrue(tools[0].ViewObject.isVisible())
+        self.assertFalse(boolean.ViewObject.Visibility)
+
+        view.setActiveObject("pdbody", None)
+        self.assertFalse(tools[0].ViewObject.isVisible())
+        self.assertFalse(boolean.ViewObject.isVisible())
+
+    def testBooleanActiveNestedBodyVisibility(self):
+        innerBoolean, tools = self._createBooleanWithTwoTools()
+        innerBody = innerBoolean.getParentGeoFeatureGroup()
+        innerLaterFeature = self.doc.addObject("PartDesign::AdditiveBox", "InnerLaterFeature")
+        innerBody.addObject(innerLaterFeature)
+
+        outerBody = self.doc.addObject("PartDesign::Body", "OuterResultBody")
+        outerBoolean = self.doc.addObject("PartDesign::Boolean", "OuterBoolean")
+        outerBody.addObject(outerBoolean)
+        outerBoolean.Group = [innerBody]
+        outerLaterFeature = self.doc.addObject("PartDesign::AdditiveBox", "OuterLaterFeature")
+        outerBody.addObject(outerLaterFeature)
+        self.doc.recompute()
+
+        innerBody.ViewObject.hide()
+        outerBoolean.ViewObject.show()
+        outerLaterFeature.ViewObject.show()
+        view = FreeCADGui.activeView()
+
+        view.setActiveObject("pdbody", tools[0])
+        self.assertTrue(tools[0].ViewObject.isVisible())
+        self.assertTrue(innerBody.ViewObject.isVisible())
+        self.assertFalse(innerLaterFeature.ViewObject.isVisible())
+        self.assertFalse(outerLaterFeature.ViewObject.isVisible())
+
+        outerLaterFeature.ViewObject.show()
+        view.setActiveObject("pdbody", tools[0])
+        self.assertFalse(outerLaterFeature.ViewObject.isVisible())
+
+        view.setActiveObject("pdbody", None)
+        self.assertFalse(tools[0].ViewObject.isVisible())
+        self.assertFalse(innerBody.ViewObject.isVisible())
+        self.assertTrue(innerLaterFeature.ViewObject.isVisible())
+        self.assertTrue(outerLaterFeature.ViewObject.isVisible())
+
+    def testBooleanActiveBodyVisibilityWhenBooleanIsNotTip(self):
+        boolean, tools = self._createBooleanWithTwoTools()
+        resultBody = boolean.getParentGeoFeatureGroup()
+        laterFeature = self.doc.addObject("PartDesign::AdditiveBox", "LaterFeature")
+        resultBody.addObject(laterFeature)
+        self.doc.recompute()
+        FreeCADGui.updateGui()
+
+        self.assertFalse(boolean.ViewObject.Visibility)
+        self.assertTrue(laterFeature.ViewObject.isVisible())
+
+        FreeCADGui.activeView().setActiveObject("pdbody", tools[0])
+        self.assertTrue(tools[0].ViewObject.isVisible())
+        self.assertFalse(boolean.ViewObject.Visibility)
+        self.assertFalse(laterFeature.ViewObject.isVisible())
+
+        FreeCADGui.activeView().setActiveObject("pdbody", None)
+        self.assertFalse(tools[0].ViewObject.isVisible())
+        self.assertFalse(boolean.ViewObject.isVisible())
+        self.assertTrue(laterFeature.ViewObject.isVisible())
+
+    def testBooleanActiveBodyVisibilityWhenBooleanBecomesNonTip(self):
+        boolean, tools = self._createBooleanWithTwoTools()
+        view = FreeCADGui.activeView()
+        view.setActiveObject("pdbody", tools[0])
+
+        resultBody = boolean.getParentGeoFeatureGroup()
+        laterFeature = self.doc.addObject("PartDesign::AdditiveBox", "LaterFeature")
+        resultBody.addObject(laterFeature)
+        self.doc.recompute()
+        FreeCADGui.updateGui()
+
+        self.assertTrue(tools[0].ViewObject.isVisible())
+        self.assertFalse(boolean.ViewObject.Visibility)
+        self.assertFalse(laterFeature.ViewObject.isVisible())
+
+        view.setActiveObject("pdbody", None)
+        self.assertFalse(tools[0].ViewObject.isVisible())
+        self.assertFalse(boolean.ViewObject.isVisible())
+        self.assertTrue(laterFeature.ViewObject.isVisible())
+
+    def testBooleanActiveBodyVisibilityRestoresModeWithOverride(self):
+        boolean, tools = self._createBooleanWithTwoTools()
+        view = FreeCADGui.activeView()
+        viewer = view.getViewer()
+        booleanMode = boolean.ViewObject.SwitchNode.whichChild.getValue()
+
+        tools[0].ViewObject.show()
+        toolMode = tools[0].ViewObject.SwitchNode.whichChild.getValue()
+        tools[0].ViewObject.hide()
+
+        try:
+            viewer.setOverrideMode("Wireframe")
+            view.setActiveObject("pdbody", tools[0])
+            view.setActiveObject("pdbody", None)
+        finally:
+            viewer.setOverrideMode("As Is")
+
+        self.assertEqual(boolean.ViewObject.SwitchNode.whichChild.getValue(), booleanMode)
+        tools[0].ViewObject.show()
+        self.assertEqual(tools[0].ViewObject.SwitchNode.whichChild.getValue(), toolMode)
+
     def tearDown(self):
         FreeCAD.closeDocument("PartDesignTestSketch")

--- a/src/Mod/PartDesign/PartDesignTests/TestActiveObject.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestActiveObject.py
@@ -154,12 +154,8 @@ class TestActiveObject(unittest.TestCase):
         view.setActiveObject("pdbody", tools[0])
         self.assertTrue(tools[0].ViewObject.isVisible())
         self.assertTrue(innerBody.ViewObject.isVisible())
-        self.assertFalse(innerLaterFeature.ViewObject.isVisible())
-        self.assertFalse(outerLaterFeature.ViewObject.isVisible())
-
-        outerLaterFeature.ViewObject.show()
-        view.setActiveObject("pdbody", tools[0])
-        self.assertFalse(outerLaterFeature.ViewObject.isVisible())
+        self.assertTrue(innerLaterFeature.ViewObject.isVisible())
+        self.assertTrue(outerLaterFeature.ViewObject.isVisible())
 
         view.setActiveObject("pdbody", None)
         self.assertFalse(tools[0].ViewObject.isVisible())
@@ -181,7 +177,7 @@ class TestActiveObject(unittest.TestCase):
         FreeCADGui.activeView().setActiveObject("pdbody", tools[0])
         self.assertTrue(tools[0].ViewObject.isVisible())
         self.assertFalse(boolean.ViewObject.Visibility)
-        self.assertFalse(laterFeature.ViewObject.isVisible())
+        self.assertTrue(laterFeature.ViewObject.isVisible())
 
         FreeCADGui.activeView().setActiveObject("pdbody", None)
         self.assertFalse(tools[0].ViewObject.isVisible())
@@ -201,7 +197,7 @@ class TestActiveObject(unittest.TestCase):
 
         self.assertTrue(tools[0].ViewObject.isVisible())
         self.assertFalse(boolean.ViewObject.Visibility)
-        self.assertFalse(laterFeature.ViewObject.isVisible())
+        self.assertTrue(laterFeature.ViewObject.isVisible())
 
         view.setActiveObject("pdbody", None)
         self.assertFalse(tools[0].ViewObject.isVisible())


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->
Currently, children of Part Design booleans are not visible, so you cannot edit a body which is used in a boolean operation. The workaround is a subshapebinder or to manually toggle the view mode of the boolean feature back and forth.

This PR changes the view mode, when a body inside a boolean feature is active (for edits) to make it visible. If it is not the active body, the view mode switches to result again. As this is only a view mode, no geometry is changed for following operations. 

AI helped.

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
Fixes https://github.com/FreeCAD/FreeCAD/issues/11209



## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/b4315de1-bafc-4283-a520-5bef9ed8a3f1



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
