### PR TITLE
Fix: PartDesign linked object becomes hidden during sketching

### DIFF
--- a/src/Mod/Show/Containers.py
+++ b/src/Mod/Show/Containers.py
@@ -198,6 +198,8 @@ def isAContainer(obj, links_too=False):
         return True
     if obj.isDerivedFrom("App::Origin"):
         return True
+    if obj.isDerivedFrom("App::Link") and links_too:
+        return True
     if obj.hasChildElement():
         return True if links_too else False
     return False

--- a/src/Mod/Show/Containers.py
+++ b/src/Mod/Show/Containers.py
@@ -198,12 +198,12 @@ def isAContainer(obj, links_too=False):
             return True
     if obj.isDerivedFrom("App::Link") and links_too:
         return True
-    
+
     container_extensions = ["App::GroupExtension"]
     for extension in container_extensions:
         if obj.hasExtension(extension):
             return True
-    
+
     if obj.hasChildElement():
         return True
 

--- a/src/Mod/Show/Containers.py
+++ b/src/Mod/Show/Containers.py
@@ -192,21 +192,16 @@ def isAContainer(obj, links_too=False):
     If links_too, App::Link objects are considered containers, too. Then, container tree
     isn't necessarily a tree."""
 
-    container_bases = ["App::Document", "App::Origin"]
-    for base in container_bases:
-        if obj.isDerivedFrom(base):
-            return True
+    if obj.isDerivedFrom("App::Document"):
+        return True
+    if obj.hasExtension("App::GroupExtension"):
+        return True
+    if obj.isDerivedFrom("App::Origin"):
+        return True
     if obj.isDerivedFrom("App::Link") and links_too:
         return True
-
-    container_extensions = ["App::GroupExtension"]
-    for extension in container_extensions:
-        if obj.hasExtension(extension):
-            return True
-
     if obj.hasChildElement():
-        return True
-
+        return True if links_too else False
     return False
 
 

--- a/src/Mod/Show/Containers.py
+++ b/src/Mod/Show/Containers.py
@@ -192,16 +192,21 @@ def isAContainer(obj, links_too=False):
     If links_too, App::Link objects are considered containers, too. Then, container tree
     isn't necessarily a tree."""
 
-    if obj.isDerivedFrom("App::Document"):
-        return True
-    if obj.hasExtension("App::GroupExtension"):
-        return True
-    if obj.isDerivedFrom("App::Origin"):
-        return True
+    container_bases = ["App::Document", "App::Origin"]
+    for base in container_bases:
+        if obj.isDerivedFrom(base):
+            return True
     if obj.isDerivedFrom("App::Link") and links_too:
         return True
+    
+    container_extensions = ["App::GroupExtension"]
+    for extension in container_extensions:
+        if obj.hasExtension(extension):
+            return True
+    
     if obj.hasChildElement():
-        return True if links_too else False
+        return True
+
     return False
 
 


### PR DESCRIPTION
Fixes #21884

Linked objects are now visible when opening the a sketch from the tree view.

The issue is caused in  `get_all_dependent`, which discards linked objects from the list of objects to be excluded:
https://github.com/FreeCAD/FreeCAD/blob/08cacbbc27421e769be4ec423f9815a01e51e533/src/Mod/Show/mTempoVis.py#L364-L366

The core issue appears to stem from the `isAContainer`, which does not return true for linked objects with no children:

https://github.com/FreeCAD/FreeCAD/blob/08cacbbc27421e769be4ec423f9815a01e51e533/src/Mod/Show/Containers.py#L187-L203

### Before
Using @karamellpelle's test files: [HidingPartLink.FCStd.zip](https://github.com/user-attachments/files/20647391/HidingPartLink.FCStd.zip) and [HidingBodyLink.FCStd.zip](https://github.com/user-attachments/files/20647474/HidingBodyLink.FCStd.zip) on latest main:
```
OS: LMDE 7 (gigi) (X-Cinnamon/cinnamon/xcb)
Architecture: x86_64
Version: 1.2.0dev.46767 (Git)
Build date: 2026/05/09 13:54:10
Build type: Unknown
Branch: main
Hash: 358ff0343954fd1596471f2619474f63f8b5b911
Python 3.13.5, Qt 5.15.15, Coin 4.0.3, Vtk 9.3.0, boost 1_83, Eigen3 3.4.0, PySide 5.15.16
shiboken 5.15.16, SMESH 7.7.1.0, xerces-c 3.2.4, OCC 7.8.1
Locale: English/United States (en_US)
Stylesheet/Theme/QtStyle: FreeCAD.qss/FreeCAD Light/FreeCAD
Navigation Style/Orbit Style/Rotation Mode: TinkerCAD/Trackball/Drag at cursor
Logical DPI/Physical DPI/Pixel Ratio: 96/89.6471/1
Installed mods:
  * Fasteners Workbench 0.5.51
  * freecad.gears workbench 1.3.0
```
Opening the sketches causes the linked components to disappear from view:

<img width="1439" height="764" alt="image" src="https://github.com/user-attachments/assets/cf8a0d93-8518-45dc-b26c-6121aeeb989b" />

<img width="1439" height="763" alt="image" src="https://github.com/user-attachments/assets/55a92c9c-3099-485c-88af-161ef6b642a1" />

### After
The linked items are now visible for reference when opening the sketcher:

<img width="1439" height="764" alt="Image" src="https://github.com/user-attachments/assets/b7078473-6980-4d4a-852c-74856278704c" />

<img width="1439" height="764" alt="Image" src="https://github.com/user-attachments/assets/fed20477-29cd-4fc2-adee-4efe345f8f4a" />