### PR TITLE
PD: fix Cosmetic threads appear in subsequent unthreaded holes

### DIFF
--- a/src/Mod/PartDesign/App/FeatureHole.cpp
+++ b/src/Mod/PartDesign/App/FeatureHole.cpp
@@ -2201,8 +2201,10 @@ TopoShape Hole::findHoles(
 ) const
 {
     TopoShape result(0);
+    _holeLocations.clear();
 
     auto addHole = [&](Part::TopoShape const& baseshape, gp_Pnt loc) {
+        _holeLocations.push_back(loc);
         gp_Trsf localSketchTransformation;
         localSketchTransformation.SetTranslation(gp_Pnt(0, 0, 0), gp_Pnt(loc.X(), loc.Y(), loc.Z()));
 
@@ -2260,6 +2262,11 @@ TopoShape Hole::findHoles(
         }
     }
     return TopoShape().makeElementCompound(holes);
+}
+
+std::vector<gp_Pnt> Hole::getHoleLocations() const
+{
+    return _holeLocations;
 }
 
 TopoDS_Shape Hole::makeThread(const gp_Vec& xDir, const gp_Vec& zDir, double length)

--- a/src/Mod/PartDesign/App/FeatureHole.h
+++ b/src/Mod/PartDesign/App/FeatureHole.h
@@ -138,6 +138,7 @@ public:
         const TopoShape& profileshape,
         const TopoDS_Shape& protohole
     ) const;
+    std::vector<gp_Pnt> getHoleLocations() const;
 
 protected:
     void onChanged(const App::Property* prop) override;
@@ -196,6 +197,9 @@ private:
     static const char* ThreadClass_BSF_Enums[];
 
     static const double ThreadRunout[ThreadRunout_size][2];
+    // Populated during findHoles() and consumed by
+    // ViewProviderHole for cosmetic thread matching.
+    mutable std::vector<gp_Pnt> _holeLocations;
 
     /* Counter-xxx */
     // public:

--- a/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderHole.cpp
@@ -28,6 +28,7 @@
 
 #include <gp_Ax1.hxx>
 #include <gp_Dir.hxx>
+#include <gp_Lin.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
 #include <Poly_Triangle.hxx>
@@ -340,6 +341,14 @@ std::optional<gp_Pnt> ViewProviderHole::getHoleOrigin(const PartDesign::Hole* pc
     return std::nullopt;
 }
 
+std::vector<gp_Pnt> ViewProviderHole::getHoleLocations(const PartDesign::Hole* pcHole) const
+{
+    if (!pcHole) {
+        return {};
+    }
+    return pcHole->getHoleLocations();
+}
+
 std::vector<TopoDS_Face> ViewProviderHole::collectBoreFaces(const PartDesign::Hole* pcHole) const
 {
     std::vector<TopoDS_Face> boreFaces;
@@ -358,7 +367,13 @@ std::vector<TopoDS_Face> ViewProviderHole::collectBoreFaces(const PartDesign::Ho
     }
     gp_Dir holeAxis = *holeNormalOpt;
 
+    std::vector<gp_Pnt> validLocations = getHoleLocations(pcHole);
+    if (validLocations.empty()) {
+        return boreFaces;
+    }
+
     const double holeRadius = pcHole->Diameter.getValue() / 2.0;
+    const double distTolerance = 2 * Precision::Confusion();
     const bool isTapered = pcHole->Tapered.getValue();
     const double taperSemiAngleRad = isTapered
         ? Base::toRadians(90 - pcHole->TaperedAngle.getValue())
@@ -377,6 +392,8 @@ std::vector<TopoDS_Face> ViewProviderHole::collectBoreFaces(const PartDesign::Ho
         }
 
         gp_Ax1 axis;
+        bool isMatch = false;
+
         if (!isTapered) {
             if (!surf->IsKind(STANDARD_TYPE(Geom_CylindricalSurface))) {
                 continue;
@@ -397,6 +414,17 @@ std::vector<TopoDS_Face> ViewProviderHole::collectBoreFaces(const PartDesign::Ho
                 continue;
             }
             axis = con->Axis();
+        }
+
+        for (const auto& loc : validLocations) {
+            if (gp_Lin(axis).Distance(loc) < distTolerance) {
+                isMatch = true;
+                break;
+            }
+        }
+
+        if (!isMatch) {
+            continue;
         }
 
         if (!axis.Direction().IsParallel(holeAxis, Precision::Angular())) {

--- a/src/Mod/PartDesign/Gui/ViewProviderHole.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderHole.h
@@ -87,6 +87,7 @@ private:
     std::unique_ptr<Gui::ViewProviderTextureExtension> textureExtension;
     std::optional<gp_Dir> getHoleNormal(const PartDesign::Hole* pcHole) const;
     std::optional<gp_Pnt> getHoleOrigin(const PartDesign::Hole* pcHole) const;
+    std::vector<gp_Pnt> getHoleLocations(const PartDesign::Hole* pcHole) const;
     App::Material getGlobalMaterial();
     TopoDS_Shape getCurrentlyVisibleShape(const PartDesign::Hole* pcHole) const;
     void updateThreadClipper(const PartDesign::Hole* pcHole);


### PR DESCRIPTION
this should fix #29864

after this you must recalculate the holes with cosmetic threads (right click and recalculate or double click and accept the task)

<img width="1187" height="698" alt="image" src="https://github.com/user-attachments/assets/f1b7ea05-5a68-44cc-98bd-5bee15698c7a" />
