### PR TITLE
Migrate `FileInfo`, `Type` names, `UniqueNameManager` & `UnlimitedUnsigned` to `string_view`

### DIFF
--- a/src/3rdParty/PyCXX/CXX/Python3/Objects.hxx
+++ b/src/3rdParty/PyCXX/CXX/Python3/Objects.hxx
@@ -2095,20 +2095,20 @@ namespace Py
             validate();
         }
 
-        String( const char *latin1 )
-        : SeqBase<Char>( PyUnicode_FromString( latin1 ), true )
+        String( const char *utf8 )
+        : SeqBase<Char>( PyUnicode_FromString( utf8 ), true )
         {
             validate();
         }
 
-        String( const std::string &latin1 )
-        : SeqBase<Char>( PyUnicode_FromStringAndSize( latin1.c_str(), latin1.size() ), true )
+        String( std::string_view utf8 )
+        : SeqBase<Char>( PyUnicode_FromStringAndSize( utf8.data(), Py_ssize_t(utf8.size()) ), true )
         {
             validate();
         }
 
-        String( const char *latin1, Py_ssize_t size )
-        : SeqBase<Char>( PyUnicode_FromStringAndSize( latin1, size ), true )
+        String( const char *utf8, Py_ssize_t size )
+        : SeqBase<Char>( PyUnicode_FromStringAndSize( utf8, size ), true )
         {
             validate();
         }
@@ -2130,8 +2130,8 @@ namespace Py
            generic ones are documented.
 
         */
-        String( const std::string &s, const char *encoding, const char *errors=NULL )
-        : SeqBase<Char>( PyUnicode_Decode( s.c_str(), s.size(), encoding, errors ), true )
+        String( std::string_view s, const char *encoding, const char *errors=NULL )
+        : SeqBase<Char>( PyUnicode_Decode( s.data(), Py_ssize_t(s.size()), encoding, errors ), true )
         {
             validate();
         }

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -3289,11 +3289,13 @@ bool Document::recomputeFeature(DocumentObject* feature, bool recursive)
     return feature->isValid();
 }
 
-DocumentObject* Document::addObject(const char* sType,
-                                    const char* pObjectName,
-                                    const bool isNew,
-                                    const char* viewType,
-                                    const bool isPartial)
+DocumentObject* Document::addObject(
+    std::string_view sType,
+    const char* pObjectName,
+    const bool isNew,
+    const char* viewType,
+    const bool isPartial
+)
 {
     const Base::Type type =
         Base::Type::getTypeIfDerivedFrom(sType, DocumentObject::getClassTypeId(), true);
@@ -3828,9 +3830,9 @@ const char* Document::getObjectName(const DocumentObject* pFeat) const
     return nullptr;
 }
 
-std::string Document::getUniqueObjectName(const char* proposedName) const
+std::string Document::getUniqueObjectName(std::string_view proposedName) const
 {
-    if (!proposedName || *proposedName == '\0') {
+    if (proposedName.empty()) {
         return {};
     }
     std::string cleanName = Base::Tools::getIdentifier(proposedName);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -2101,26 +2101,26 @@ bool Document::saveToFile(const char* filename) const
     return true;
 }
 
-void Document::registerLabel(const std::string& newLabel)
+void Document::registerLabel(std::string_view newLabel)
 {
     if (!newLabel.empty()) {
         d->objectLabelManager.addExactName(newLabel);
     }
 }
 
-void Document::unregisterLabel(const std::string& oldLabel)
+void Document::unregisterLabel(std::string_view oldLabel)
 {
     if (!oldLabel.empty()) {
         d->objectLabelManager.removeExactName(oldLabel);
     }
 }
 
-bool Document::containsLabel(const std::string& label)
+bool Document::containsLabel(std::string_view label)
 {
     return d->objectLabelManager.containsName(label);
 }
 
-std::string Document::makeUniqueLabel(const std::string& modelLabel)
+std::string Document::makeUniqueLabel(std::string_view modelLabel)
 {
     if (modelLabel.empty()) {
         return {};
@@ -3842,8 +3842,7 @@ std::string Document::getUniqueObjectName(const char* proposedName) const
     return d->objectNameManager.makeUniqueName(cleanName, 3);
 }
 
-    bool
-Document::haveSameBaseName(const std::string& name, const std::string& label)
+bool Document::haveSameBaseName(std::string_view name, std::string_view label)
 {
     // Both Labels and Names use the same decomposition rules for names,
     // i.e. the default one supplied by UniqueNameManager, so we can use either

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -468,11 +468,13 @@ public:
      *
      * @return The newly added object.
      */
-    DocumentObject* addObject(const char* sType,
-                              const char* pObjectName = nullptr,
-                              bool isNew = true,
-                              const char* viewType = nullptr,
-                              bool isPartial = false);
+    DocumentObject* addObject(
+        std::string_view sType,
+        const char* pObjectName = nullptr,
+        bool isNew = true,
+        const char* viewType = nullptr,
+        bool isPartial = false
+    );
 
     /**
      * @brief Add an object of a given type to the document.
@@ -631,7 +633,7 @@ public:
      * @return A unique name for the object or an empty string if the proposed
      * name is empty.
      */
-    std::string getUniqueObjectName(const char* proposedName) const;
+    std::string getUniqueObjectName(std::string_view proposedName) const;
 
     /**
      * @brief Get a unique label for an object.

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -43,6 +43,7 @@
 #include <utility>
 #include <list>
 #include <string>
+#include <string_view>
 
 namespace Base
 {
@@ -656,7 +657,7 @@ public:
      *
      * @return Returns true if the base names are the same, false otherwise.
      */
-    bool haveSameBaseName(const std::string& name, const std::string& label);
+    bool haveSameBaseName(std::string_view name, std::string_view label);
 
     /// Get a list of the document's objects including the dependencies.
     std::vector<DocumentObject*> getDependingObjects() const;
@@ -1269,15 +1270,15 @@ public:
 
     /// Check if there is any document restoring/importing.
     static bool isAnyRestoring();
-                                                                
+
     /// Register a new label.
-    void registerLabel(const std ::string& newLabel);
+    void registerLabel(std::string_view newLabel);
     /// Unregister a label.
-    void unregisterLabel(const std::string& oldLabel);
+    void unregisterLabel(std::string_view oldLabel);
     /// Check if a label exists.
-    bool containsLabel(const std::string& label);
+    bool containsLabel(std::string_view label);
     /// Create a unique label based on the given modelLabel.
-    std::string makeUniqueLabel(const std::string& modelLabel);
+    std::string makeUniqueLabel(std::string_view modelLabel);
 
     friend class Application;
     // because of transaction handling

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -737,13 +737,15 @@ bool DocumentObject::renameDynamicProperty(Property* prop, const char* name)
     return renamed;
 }
 
-App::Property* DocumentObject::addDynamicProperty(const char* type,
-                                                  const char* name,
-                                                  const char* group,
-                                                  const char* doc,
-                                                  short attr,
-                                                  bool ro,
-                                                  bool hidden)
+App::Property* DocumentObject::addDynamicProperty(
+    std::string_view type,
+    const char* name,
+    const char* group,
+    const char* doc,
+    short attr,
+    bool ro,
+    bool hidden
+)
 {
     auto prop = TransactionalObject::addDynamicProperty(type, name, group, doc, attr, ro, hidden);
     if (prop && _pDoc) {
@@ -778,7 +780,7 @@ DocumentObject::onProposedLabelChange(std::string& newLabel)
 
     // We re only called if the new label differs from the old one, and our code to check duplicates
     // may not work if this is not the case.
-    std::string oldLabel = Label.getStrValue();
+    std::string_view oldLabel = Label.getStrValue();
     assert(newLabel != oldLabel);
     if (!isAttachedToDocument()) {
         return {};
@@ -796,7 +798,7 @@ DocumentObject::onProposedLabelChange(std::string& newLabel)
     if (doc && !newLabel.empty() && !_hPGrp->GetBool("DuplicateLabels") && !allowDuplicateLabel()
         && doc->containsLabel(newLabel)) {
         // The label already exists but settings are such that duplicate labels should not be assigned.
-        std::string objName = getNameInDocument();
+        std::string_view objName = getNameInDocument();
         if (!doc->containsLabel(objName) && doc->haveSameBaseName(objName, newLabel)) {
             // The object name is not already a Label and the base name of the proposed label
             // equals the base name of the object Name, so we use the object Name as the replacement Label.

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -1054,13 +1054,15 @@ public:
 
     bool renameDynamicProperty(Property *prop, const char *name) override;
 
-    App::Property* addDynamicProperty(const char* type,
-                                      const char* name = nullptr,
-                                      const char* group = nullptr,
-                                      const char* doc = nullptr,
-                                      short attr = 0,
-                                      bool ro = false,
-                                      bool hidden = false) override;
+    App::Property* addDynamicProperty(
+        std::string_view type,
+        const char* name = nullptr,
+        const char* group = nullptr,
+        const char* doc = nullptr,
+        short attr = 0,
+        bool ro = false,
+        bool hidden = false
+    ) override;
 
     /**
      * @brief Resolve the last document object referenced in the subname.

--- a/src/App/DynamicProperty.cpp
+++ b/src/App/DynamicProperty.cpp
@@ -212,39 +212,43 @@ const char* DynamicProperty::getPropertyDocumentation(const char* name) const
     return nullptr;
 }
 
-Property* DynamicProperty::addDynamicProperty(PropertyContainer& pc,
-                                              const char* type,
-                                              const char* name,
-                                              const char* group,
-                                              const char* doc,
-                                              short attr,
-                                              bool ro,
-                                              bool hidden)
+Property* DynamicProperty::addDynamicProperty(
+    PropertyContainer& pc,
+    std::string_view type,
+    const char* cstrName,
+    const char* group,
+    const char* doc,
+    short attr,
+    bool ro,
+    bool hidden
+)
 {
-    if (!type) {
+    if (type.empty()) {
         type = "<null>";
     }
 
-    std::string _name;
+    std::string name {(cstrName && cstrName[0] != '\0') ? cstrName : ""};
 
     static ParameterGrp::handle hGrp =
         GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document");
     if (hGrp->GetBool("AutoNameDynamicProperty", false)) {
-        if (!name || !name[0]) {
+        if (name.empty()) {
             name = type;
         }
-        _name = getUniquePropertyName(pc, name);
-        if (_name != name) {
-            FC_WARN(pc.getFullName()
-                    << " rename dynamic property from '" << name << "' to '" << _name << "'");
+        std::string uniqueName = getUniquePropertyName(pc, name.c_str());
+        if (uniqueName != name) {
+            FC_WARN(
+                pc.getFullName() << " rename dynamic property from '" << name << "' to '"
+                                 << uniqueName << "'"
+            );
+            name = uniqueName;
         }
-        name = _name.c_str();
     }
-    else if (!name) {
+    else if (name.empty()) {
         name = "<null>";  // setting a bad name to trigger exception
     }
 
-    auto prop = pc.getPropertyByName(name);
+    auto prop = pc.getPropertyByName(name.c_str());
     if (prop && prop->getContainer() == &pc) {
         FC_THROWM(Base::NameError,
                   "Property " << pc.getFullName() << '.' << name << " already exists");
@@ -270,7 +274,8 @@ Property* DynamicProperty::addDynamicProperty(PropertyContainer& pc,
 
     Property* pcProperty = static_cast<Property*>(propInstance);
 
-    auto res = impl->props.get<0>().emplace(pcProperty, name, nullptr, group, doc, attr, ro, hidden);
+    auto res = impl->props.get<0>()
+                   .emplace(pcProperty, name.c_str(), nullptr, group, doc, attr, ro, hidden);
 
     pcProperty->setContainer(&pc);
     pcProperty->myName = res.first->name.c_str();
@@ -477,7 +482,7 @@ bool DynamicProperty::renameDynamicProperty(Property* prop,
         FC_THROWM(Base::NameError, "Invalid property name '" << newName << "'");
     }
 
-    std::string oldName{data.getName()};
+    std::string oldName {data.getName()};
     auto& nameIndex = impl->props.get<0>();
     auto nameIt = nameIndex.find(data.getName());
     if (nameIt == nameIndex.end()) {

--- a/src/App/DynamicProperty.h
+++ b/src/App/DynamicProperty.h
@@ -92,14 +92,16 @@ public:
        addDynamicProperty(..., ..., "Base","blah", Prop_None, true, true);
       @endcode
      */
-    Property* addDynamicProperty(PropertyContainer& pc,
-                                 const char* type,
-                                 const char* name = nullptr,
-                                 const char* group = nullptr,
-                                 const char* doc = nullptr,
-                                 short attr = 0,
-                                 bool ro = false,
-                                 bool hidden = false);
+    Property* addDynamicProperty(
+        PropertyContainer& pc,
+        std::string_view type,
+        const char* name = nullptr,
+        const char* group = nullptr,
+        const char* doc = nullptr,
+        short attr = 0,
+        bool ro = false,
+        bool hidden = false
+    );
     /** Add a pre-existing property
      *
      * The property is not treated as dynamic, and will not trigger signal.

--- a/src/App/ExtensionContainer.cpp
+++ b/src/App/ExtensionContainer.cpp
@@ -459,7 +459,7 @@ void ExtensionContainer::restoreExtensions(Base::XMLReader& reader)
 
                 ext->initExtension(this);
             }
-            if (ext && strcmp(ext->getExtensionTypeId().getName(), Type) == 0) {
+            if (ext && ext->getExtensionTypeId().getName() == Type) {
                 ext->extensionRestore(reader);
             }
         }

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -2282,7 +2282,7 @@ void LinkBaseExtension::_handleChangedPropertyName(Base::XMLReader& reader,
                                                    const char* PropName)
 {
     if (strcmp(PropName, "SubElements") == 0
-        && strcmp(TypeName, PropertyStringList::getClassTypeId().getName()) == 0) {
+        && TypeName == PropertyStringList::getClassTypeId().getName()) {
         PropertyStringList prop;
         prop.setContainer(getContainer());
         prop.Restore(reader);

--- a/src/App/MeasureManager.cpp
+++ b/src/App/MeasureManager.cpp
@@ -80,7 +80,7 @@ MeasureHandler MeasureManager::getMeasureHandler(const App::MeasureSelectionItem
         sub = link->getLinkedObject(true);
     }
 
-    const char* className = sub->getTypeId().getName();
+    const auto className = sub->getTypeId().getName();
     std::string mod = Base::Type::getModuleName(className);
 
     return getMeasureHandler(mod.c_str());

--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -69,10 +69,16 @@ unsigned int PropertyContainer::getMemSize () const
 }
 
 App::Property* PropertyContainer::addDynamicProperty(
-    const char* type, const char* name, const char* group, const char* doc,
-    short attr, bool ro, bool hidden)
+    std::string_view type,
+    const char* name,
+    const char* group,
+    const char* doc,
+    short attr,
+    bool ro,
+    bool hidden
+)
 {
-    return dynamicProps.addDynamicProperty(*this,type,name,group,doc,attr,ro,hidden);
+    return dynamicProps.addDynamicProperty(*this, type, name, group, doc, attr, ro, hidden);
 }
 
 Property *PropertyContainer::getPropertyByName(const char* name) const
@@ -355,7 +361,7 @@ void PropertyContainer::Restore(Base::XMLReader &reader)
                     prop->setStatusValue(status.to_ulong());
             }
             // name and type match
-            if (prop && strcmp(prop->getTypeId().getName(), TypeName.c_str()) == 0) {
+            if (prop && prop->getTypeId().getName() == TypeName) {
                 if (!prop->testStatus(Property::Transient)
                         && !status.test(Property::Transient)
                         && !status.test(Property::PropTransient)

--- a/src/App/PropertyContainer.h
+++ b/src/App/PropertyContainer.h
@@ -493,7 +493,7 @@ public:
    * as when the name is invalid.
    */
   virtual App::Property* addDynamicProperty(
-        const char* type, const char* name=nullptr,
+        std::string_view type, const char* name=nullptr,
         const char* group=nullptr, const char* doc=nullptr,
         short attr=0, bool ro=false, bool hidden=false);
 

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -4032,9 +4032,9 @@ const char* PropertyXLink::getObjectName() const
 
 bool PropertyXLink::upgrade(Base::XMLReader& reader, const char* typeName)
 {
-    if (strcmp(typeName, App::PropertyLinkGlobal::getClassTypeId().getName()) == 0
-        || strcmp(typeName, App::PropertyLink::getClassTypeId().getName()) == 0
-        || strcmp(typeName, App::PropertyLinkChild::getClassTypeId().getName()) == 0) {
+    if (typeName == App::PropertyLinkGlobal::getClassTypeId().getName()
+        || typeName == App::PropertyLink::getClassTypeId().getName()
+        || typeName == App::PropertyLinkChild::getClassTypeId().getName()) {
         PropertyLink::Restore(reader);
         return true;
     }
@@ -4766,9 +4766,9 @@ PropertyXLinkSub::~PropertyXLinkSub() = default;
 
 bool PropertyXLinkSub::upgrade(Base::XMLReader& reader, const char* typeName)
 {
-    if (strcmp(typeName, PropertyLinkSubGlobal::getClassTypeId().getName()) == 0
-        || strcmp(typeName, PropertyLinkSub::getClassTypeId().getName()) == 0
-        || strcmp(typeName, PropertyLinkSubChild::getClassTypeId().getName()) == 0) {
+    if (typeName == PropertyLinkSubGlobal::getClassTypeId().getName()
+        || typeName == PropertyLinkSub::getClassTypeId().getName()
+        || typeName == PropertyLinkSubChild::getClassTypeId().getName()) {
         App::PropertyLinkSub linkProp;
         linkProp.setContainer(getContainer());
         linkProp.Restore(reader);
@@ -5555,18 +5555,20 @@ int PropertyXLinkSubList::checkRestore(std::string* msg) const
 
 bool PropertyXLinkSubList::upgrade(Base::XMLReader& reader, const char* typeName)
 {
-    if (strcmp(typeName, PropertyLinkListGlobal::getClassTypeId().getName()) == 0
-        || strcmp(typeName, PropertyLinkList::getClassTypeId().getName()) == 0
-        || strcmp(typeName, PropertyLinkListChild::getClassTypeId().getName()) == 0) {
+    if (typeName == PropertyLinkListGlobal::getClassTypeId().getName()
+        || typeName == PropertyLinkList::getClassTypeId().getName()
+        || typeName == PropertyLinkListChild::getClassTypeId().getName()) {
         PropertyLinkList linkProp;
         linkProp.setContainer(getContainer());
         linkProp.Restore(reader);
         setValues(linkProp.getValues());
         return true;
     }
-    else if (strcmp(typeName, PropertyLinkSubListGlobal::getClassTypeId().getName()) == 0
-             || strcmp(typeName, PropertyLinkSubList::getClassTypeId().getName()) == 0
-             || strcmp(typeName, PropertyLinkSubListChild::getClassTypeId().getName()) == 0) {
+    else if (
+        typeName == PropertyLinkSubListGlobal::getClassTypeId().getName()
+        || typeName == PropertyLinkSubList::getClassTypeId().getName()
+        || typeName == PropertyLinkSubListChild::getClassTypeId().getName()
+    ) {
         PropertyLinkSubList linkProp;
         linkProp.setContainer(getContainer());
         linkProp.Restore(reader);

--- a/src/Base/FileInfo.cpp
+++ b/src/Base/FileInfo.cpp
@@ -71,14 +71,9 @@ std::wstring ConvertToWideString(const std::string& string)
 // FileInfo
 
 
-FileInfo::FileInfo(const char* fileName)
+FileInfo::FileInfo(std::string fileName)
 {
-    setFile(fileName);
-}
-
-FileInfo::FileInfo(const std::string& fileName)
-{
-    setFile(fileName.c_str());
+    setFile(std::move(fileName));
 }
 
 const std::string& FileInfo::getTempPath()
@@ -185,14 +180,14 @@ std::string FileInfo::pathToString(const fs::path& path)
 #endif
 }
 
-void FileInfo::setFile(const char* name)
+void FileInfo::setFile(std::string name)
 {
-    if (!name) {
+    if (name.empty()) {
         FileName.clear();
         return;
     }
 
-    FileName = name;
+    FileName = std::move(name);
 
     // keep the UNC paths intact
     if (FileName.substr(0, 2) == std::string("\\\\")) {

--- a/src/Base/FileInfo.h
+++ b/src/Base/FileInfo.h
@@ -63,16 +63,17 @@ public:
     };
 
     /// Construction
-    explicit FileInfo(const char* fileName = "");
-    explicit FileInfo(const std::string& fileName);
+    explicit FileInfo(std::string fileName);
+    explicit FileInfo(const char* fileName = "")
+        : FileInfo(std::string {fileName})
+    {}
     /// Set a new file name
-    void setFile(const char* name);
+    void setFile(std::string name);
     /// Set a new file name
-    void setFile(const std::string& name)
+    void setFile(const char* name)
     {
-        setFile(name.c_str());
+        setFile(std::string {name});
     }
-
 
     /** @name extraction of information */
     //@{

--- a/src/Base/Tools.cpp
+++ b/src/Base/Tools.cpp
@@ -22,8 +22,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <unicode/unistr.h>
 #include <unicode/uchar.h>
+#include <unicode/utf8.h>
 #include <unicode/locid.h>
 #include <chrono>
 #include <ctime>
@@ -67,53 +67,55 @@ bool isValidSubsequentChar(UChar32 c)
             || category == U_COMBINING_SPACING_MARK || category == U_CONNECTOR_PUNCTUATION);
 }
 
-std::string unicodeCharToStdString(UChar32 c)
-{
-    icu::UnicodeString uChar(c);
-    std::string utf8Char;
-    return uChar.toUTF8String(utf8Char);
-}
-
 };  // namespace
 
-std::string Base::Tools::getIdentifier(const std::string& name)
+// Silence the linter complaining about ICU's U8_NEXT macros
+// NOLINTBEGIN(bugprone-inc-dec-in-conditions,readability-function-cognitive-complexity)
+std::string Base::Tools::getIdentifier(std::string_view name)
 {
     if (name.empty()) {
         return "_";
     }
 
-    icu::UnicodeString uName = icu::UnicodeString::fromUTF8(name);
-    std::stringstream result;
+    const char* bytes = name.data();
+    const size_t length = name.length();
+    size_t inOffset = 0;
+    size_t outOffset = 0;
+    // The resulting identifier can't ever be longer than the input + 1 as all codepoints are
+    // either added as-is or replaced with '_' which is a single byte, the smallest quantum a
+    // codepoint can occupy in UTF-8; the +1 coming from the initial '_' that can be prepended.
+    // This allows for bypassing bounds checks when appending (U8_APPEND_UNSAFE), only shrinking
+    // the string at the end.
+    std::string result(length + 1, '\0');
 
     // Handle the first character independently, prepending an underscore if it is not a valid
     // first character, but *is* a valid later character
-    UChar32 firstChar = uName.char32At(0);
-    const int32_t firstCharLength = U16_LENGTH(firstChar);
-    if (!isValidFirstChar(firstChar)) {
-        result << "_";
-        if (isValidSubsequentChar(firstChar)) {
-            result << unicodeCharToStdString(firstChar);
-        }
+    UChar32 firstChar = 0;
+    U8_NEXT(bytes, inOffset, length, firstChar);
+    const bool firstCharValid = isValidFirstChar(firstChar);
+    if (!firstCharValid) {
+        result[outOffset++] = '_';
     }
-    else {
-        result << unicodeCharToStdString(firstChar);
+    if (firstCharValid || isValidSubsequentChar(firstChar)) {
+        U8_APPEND_UNSAFE(result, outOffset, firstChar);
     }
 
-    for (int32_t i = firstCharLength; i < uName.length(); /* will increment by char length */) {
-        UChar32 c = uName.char32At(i);
-        int32_t charLength = U16_LENGTH(c);
-        i += charLength;
+    while (inOffset < length) {
+        UChar32 c = 0;
+        U8_NEXT(bytes, inOffset, length, c);
 
         if (isValidSubsequentChar(c)) {
-            result << unicodeCharToStdString(c);
+            U8_APPEND_UNSAFE(result, outOffset, c);
         }
         else {
-            result << "_";
+            result[outOffset++] = '_';
         }
     }
 
-    return result.str();
+    result.resize(outOffset);
+    return result;
 }
+// NOLINTEND(bugprone-inc-dec-in-conditions,readability-function-cognitive-complexity)
 
 std::wstring Base::Tools::widen(const std::string& str)
 {

--- a/src/Base/Tools.h
+++ b/src/Base/Tools.h
@@ -345,7 +345,7 @@ struct BaseExport Tools
      * @param String to be checked and sanitized.
      * @return A std::string that is a valid Python 3 identifier.
      */
-    static std::string getIdentifier(const std::string& name);
+    static std::string getIdentifier(std::string_view name);
     static std::wstring widen(const std::string& str);
 
     /**

--- a/src/Base/Type.cpp
+++ b/src/Base/Type.cpp
@@ -24,9 +24,8 @@
 
 #include <cassert>
 
-#include "Type.h"
 #include "Interpreter.h"
-#include "Console.h"
+#include "Type.h"
 
 
 using namespace Base;
@@ -46,33 +45,33 @@ static_assert(
 
 struct Base::TypeData
 {
-    TypeData(const char* name, const Type type, const Type parent, const Type::instantiationMethod instMethod)
+    TypeData(std::string_view name, Type type, Type parent, Type::instantiationMethod instMethod)
         : name(name)
         , parent(parent)
         , type(type)
         , instMethod(instMethod)
     {}
 
-    const std::string name;
-    const Type parent;
-    const Type type;
-    const Type::instantiationMethod instMethod;
+    std::string name;
+    Type parent;
+    Type type;
+    Type::instantiationMethod instMethod;
 };
 
 namespace
 {
-constexpr const char* BadTypeName = "BadType";
+constexpr const std::string_view BadTypeName = "BadType";
 }
 
-std::map<std::string, unsigned int> Type::typemap;
+std::map<std::string, unsigned int, std::less<>> Type::typemap;
 std::vector<TypeData*> Type::typedata;
-std::set<std::string> Type::loadModuleSet;
+std::set<std::string, std::less<>> Type::loadModuleSet;
 
 const Type Type::BadType;
 
 Type::instantiationMethod Type::getInstantiationMethod() const
 {
-    assert(typedata.size() >= 1 && "Type::init() must be called before creating instances");
+    assert(!typedata.empty() && "Type::init() must be called before creating instances");
     assert(typedata.size() > index && "Type index out of bounds");
     if (isBad() || typedata.size() <= index) {
         return nullptr;
@@ -92,7 +91,7 @@ bool Type::canInstantiate() const
     return method != nullptr;
 }
 
-void* Type::createInstanceByName(const char* typeName, bool loadModule)
+void* Type::createInstanceByName(std::string_view typeName, bool loadModule)
 {
     // if not already, load the module
     if (loadModule) {
@@ -105,7 +104,7 @@ void* Type::createInstanceByName(const char* typeName, bool loadModule)
     return type.createInstance();
 }
 
-void Type::importModule(const char* typeName)
+void Type::importModule(std::string_view typeName)
 {
     // cut out the module name
     const std::string mod = getModuleName(typeName);
@@ -128,18 +127,17 @@ void Type::importModule(const char* typeName)
     loadModuleSet.insert(mod);
 }
 
-const std::string Type::getModuleName(const char* className)
+std::string Type::getModuleName(std::string_view className)
 {
-    std::string_view classNameView(className);
-    auto pos = classNameView.find("::");
+    auto pos = className.find("::");
 
-    return pos != std::string_view::npos ? std::string(classNameView.substr(0, pos)) : std::string();
+    return pos != std::string_view::npos ? std::string(className.substr(0, pos)) : std::string();
 }
 
 
-const Type Type::createType(const Type parent, const char* name, instantiationMethod method)
+const Type Type::createType(const Type parent, std::string_view name, instantiationMethod method)
 {
-    assert(name && name[0] != '\0' && "Type name must not be empty");
+    assert(!name.empty() && "Type name must not be empty");
 
     Type newType;
     newType.index = static_cast<unsigned int>(Type::typedata.size());
@@ -154,9 +152,9 @@ const Type Type::createType(const Type parent, const char* name, instantiationMe
 
 void Type::init()
 {
-    assert(Type::typedata.size() == 0 && "Type::init() should only be called once");
+    assert(Type::typedata.empty() && "Type::init() should only be called once");
     typedata.emplace_back(new TypeData(BadTypeName, BadType, BadType, nullptr));
-    typemap[BadTypeName] = 0;
+    typemap.emplace(BadTypeName, 0);
 }
 
 void Type::destruct()
@@ -169,7 +167,7 @@ void Type::destruct()
     loadModuleSet.clear();
 }
 
-const Type Type::fromName(const char* name)
+Type Type::fromName(std::string_view name)
 {
     const auto pos = typemap.find(name);
     if (pos == typemap.end()) {
@@ -179,7 +177,7 @@ const Type Type::fromName(const char* name)
     return typedata[pos->second]->type;
 }
 
-const Type Type::fromKey(TypeId key)
+Type Type::fromKey(TypeId key)
 {
     if (key < typedata.size()) {
         return typedata[key]->type;
@@ -188,18 +186,18 @@ const Type Type::fromKey(TypeId key)
     return BadType;
 }
 
-const char* Type::getName() const
+std::string_view Type::getName() const
 {
     assert(
-        typedata.size() >= 1 && "Type::init() must be called before fetching names, even for bad types"
+        !typedata.empty() && "Type::init() must be called before fetching names, even for bad types"
     );
-    return typedata[index]->name.c_str();
+    return typedata[index]->name;
 }
 
-const Type Type::getParent() const
+Type Type::getParent() const
 {
     assert(
-        typedata.size() >= 1 && "Type::init() must be called before fetching parents, even for bad types"
+        !typedata.empty() && "Type::init() must be called before fetching parents, even for bad types"
     );
     return typedata[index]->parent;
 }
@@ -235,7 +233,7 @@ int Type::getNumTypes()
     return static_cast<int>(typedata.size());
 }
 
-const Type Type::getTypeIfDerivedFrom(const char* name, const Type parent, bool loadModule)
+Type Type::getTypeIfDerivedFrom(std::string_view name, const Type parent, bool loadModule)
 {
     if (loadModule) {
         importModule(name);

--- a/src/Base/Type.h
+++ b/src/Base/Type.h
@@ -27,11 +27,14 @@
 
 // Std. configurations
 
-#include <string>
+#include <FCGlobal.h>
+
 #include <map>
 #include <set>
+#include <string>
+#include <string_view>
 #include <vector>
-#include <FCGlobal.h>
+
 
 namespace Base
 {
@@ -92,25 +95,25 @@ public:
     /// Checks whether this type can instantiate
     [[nodiscard]] bool canInstantiate() const;
     /// Creates an instance of the named type
-    [[nodiscard]] static void* createInstanceByName(const char* typeName, bool loadModule = false);
+    [[nodiscard]] static void* createInstanceByName(std::string_view typeName, bool loadModule = false);
 
     using instantiationMethod = void* (*)();
 
     /// Returns a type object by name
-    [[nodiscard]] static const Type fromName(const char* name);
+    [[nodiscard]] static Type fromName(std::string_view name);
     /// Returns a type object by key
-    [[nodiscard]] static const Type fromKey(TypeId key);
+    [[nodiscard]] static Type fromKey(TypeId key);
     /// Returns the name of the type
-    [[nodiscard]] const char* getName() const;
+    [[nodiscard]] std::string_view getName() const;
     /// Returns the parent type
-    [[nodiscard]] const Type getParent() const;
+    [[nodiscard]] Type getParent() const;
     /// Checks whether this type is derived from "type"
     [[nodiscard]] bool isDerivedFrom(const Type type) const;
     /// Returns all descendants from the given type
     static int getAllDerivedFrom(const Type type, std::vector<Type>& list);
     /// Returns the given named type if is derived from parent type, otherwise return bad type
-    [[nodiscard]] static const Type getTypeIfDerivedFrom(
-        const char* name,
+    [[nodiscard]] static Type getTypeIfDerivedFrom(
+        std::string_view name,
         const Type parent,
         bool loadModule = false
     );
@@ -119,7 +122,7 @@ public:
     /// Creates a new type with the given name, parent and instantiation method
     [[nodiscard]] static const Type createType(
         const Type parent,
-        const char* name,
+        std::string_view name,
         instantiationMethod method = nullptr
     );
     /// Returns the inner index of the type
@@ -142,17 +145,17 @@ public:
     static void destruct();
 
     /// Returns the name of the module the class is defined in
-    static const std::string getModuleName(const char* className);
+    static std::string getModuleName(std::string_view className);
 
 private:
     [[nodiscard]] instantiationMethod getInstantiationMethod() const;
-    static void importModule(const char* TypeName);
+    static void importModule(std::string_view typeName);
 
     TypeId index {BadTypeIndex};
 
-    static std::map<std::string, TypeId> typemap;
+    static std::map<std::string, TypeId, std::less<>> typemap;
     static std::vector<TypeData*> typedata;  // use pointer to hide implementation details
-    static std::set<std::string> loadModuleSet;
+    static std::set<std::string, std::less<>> loadModuleSet;
 
     static constexpr TypeId BadTypeIndex = 0;
 };

--- a/src/Base/UniqueNameManager.cpp
+++ b/src/Base/UniqueNameManager.cpp
@@ -21,31 +21,30 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <algorithm>
-#include <tuple>
-#include <vector>
-#include <string>
-#include <set>
-
 #include "UniqueNameManager.h"
 
-std::tuple<std::string, std::string, unsigned int, Base::UnlimitedUnsigned> Base::UniqueNameManager::decomposeName(
-    const std::string& name
-) const
+#include <algorithm>
+#include <string>
+#include <tuple>
+#include <vector>
+
+
+std::tuple<std::string_view, std::string_view, unsigned int, Base::UnlimitedUnsigned> Base::
+    UniqueNameManager::decomposeName(std::string_view name) const
 {
     auto suffixStart = getNameSuffixStartPosition(name);
     auto digitsStart = std::find_if_not(suffixStart, name.crend(), [](char c) {
         return std::isdigit(c);
     });
     unsigned int digitCount = digitsStart - suffixStart;
-    return std::tuple<std::string, std::string, unsigned int, UnlimitedUnsigned> {
+    return {
         name.substr(0, name.crend() - digitsStart),
         name.substr(name.crend() - suffixStart),
         digitCount,
         UnlimitedUnsigned::fromString(name.substr(name.crend() - digitsStart, digitCount))
     };
 }
-bool Base::UniqueNameManager::haveSameBaseName(const std::string& first, const std::string& second) const
+bool Base::UniqueNameManager::haveSameBaseName(std::string_view first, std::string_view second) const
 {
     auto firstSuffixStart = getNameSuffixStartPosition(first);
     auto secondSuffixStart = getNameSuffixStartPosition(second);
@@ -62,9 +61,10 @@ bool Base::UniqueNameManager::haveSameBaseName(const std::string& first, const s
     return std::equal(firstDigitsStart, first.crend(), secondDigitsStart, second.crend());
 }
 
-void Base::UniqueNameManager::addExactName(const std::string& name)
+void Base::UniqueNameManager::addExactName(std::string_view name)
 {
-    auto [baseName, nameSuffix, digitCount, digitsValue] = decomposeName(name);
+    const auto [namePrefix, nameSuffix, digitCount, digitsValue] = decomposeName(name);
+    std::string baseName {namePrefix};
     baseName += nameSuffix;
     auto baseNameEntry = uniqueSeeds.find(baseName);
     if (baseNameEntry == uniqueSeeds.end()) {
@@ -86,18 +86,16 @@ void Base::UniqueNameManager::addExactName(const std::string& name)
         // Increment the duplicateCounts entry for that name,
         // making one if none is present with an initial count of 1
         // representing the singleton element we already have.
-        duplicateCounts.try_emplace(name, 1U).first->second++;
+        duplicateCounts.try_emplace(std::string {name}, 1U).first->second++;
         return;
     }
     baseNameAndDigitCountEntry.add(digitsValue);
 }
-std::string Base::UniqueNameManager::makeUniqueName(
-    const std::string& modelName,
-    std::size_t minDigits
-) const
+std::string Base::UniqueNameManager::makeUniqueName(std::string_view modelName, std::size_t minDigits) const
 {
     auto [namePrefix, nameSuffix, digitCount, digitsValue] = decomposeName(modelName);
-    std::string baseName = namePrefix + nameSuffix;
+    std::string baseName {namePrefix};
+    baseName += nameSuffix;
     auto baseNameEntry = uniqueSeeds.find(baseName);
     if (baseNameEntry == uniqueSeeds.end()) {
         // First use of baseName, just return it with no unique digits
@@ -116,14 +114,15 @@ std::string Base::UniqueNameManager::makeUniqueName(
     else {
         digitsValue = baseNameEntry->second[digitCount].next();
     }
-    std::string digits = digitsValue.toString();
+    const std::string digits = digitsValue.toString();
+    std::string digitsPadding;
     if (digitCount > digits.size()) {
-        namePrefix += std::string(digitCount - digits.size(), '0');
+        digitsPadding.resize(digitCount - digits.size(), '0');
     }
-    return namePrefix + digits + nameSuffix;
+    return std::string {namePrefix}.append(digitsPadding).append(digits).append(nameSuffix);
 }
 
-void Base::UniqueNameManager::removeExactName(const std::string& name)
+void Base::UniqueNameManager::removeExactName(std::string_view name)
 {
     auto duplicateCountFound = duplicateCounts.find(name);
     if (duplicateCountFound != duplicateCounts.end()) {
@@ -135,7 +134,8 @@ void Base::UniqueNameManager::removeExactName(const std::string& name)
         }
         return;
     }
-    auto [baseName, nameSuffix, digitCount, digitsValue] = decomposeName(name);
+    const auto [namePrefix, nameSuffix, digitCount, digitsValue] = decomposeName(name);
+    std::string baseName {namePrefix};
     baseName += nameSuffix;
     auto baseNameEntry = uniqueSeeds.find(baseName);
     if (baseNameEntry == uniqueSeeds.end()) {
@@ -163,13 +163,14 @@ void Base::UniqueNameManager::removeExactName(const std::string& name)
     }
 }
 
-bool Base::UniqueNameManager::containsName(const std::string& name) const
+bool Base::UniqueNameManager::containsName(std::string_view name) const
 {
     if (duplicateCounts.find(name) != duplicateCounts.end()) {
         // There are at least two instances of the name
         return true;
     }
-    auto [baseName, nameSuffix, digitCount, digitsValue] = decomposeName(name);
+    const auto [namePrefix, nameSuffix, digitCount, digitsValue] = decomposeName(name);
+    std::string baseName {namePrefix};
     baseName += nameSuffix;
     auto baseNameEntry = uniqueSeeds.find(baseName);
     if (baseNameEntry == uniqueSeeds.end()) {

--- a/src/Base/UniqueNameManager.h
+++ b/src/Base/UniqueNameManager.h
@@ -54,7 +54,9 @@ protected:
     // of the start of the suffix (or name.crbegin() if no suffix).
     // It must return the same suffix length (name.crbegin() - returnValue) for both
     // unique names (one containing digits) and the corresponding base name (with no digits).
-    virtual std::string::const_reverse_iterator getNameSuffixStartPosition(const std::string& name) const
+    virtual std::string_view::const_reverse_iterator getNameSuffixStartPosition(
+        std::string_view name
+    ) const
     {
         return name.crbegin();
     }
@@ -199,17 +201,17 @@ private:
     // Keyed as uniqueSeeds[baseName][digitCount][digitValue] iff that seed is taken.
     // We need the double-indexing so that Name01 and Name001 can both be indexed, although we only
     // ever allocate off the longest for each name i.e. uniqueSeeds[baseName].size()-1 digits.
-    std::map<std::string, std::vector<PiecewiseSparseIntegerSet<UnlimitedUnsigned>>> uniqueSeeds;
+    std::map<std::string, std::vector<PiecewiseSparseIntegerSet<UnlimitedUnsigned>>, std::less<>> uniqueSeeds;
     // Counts of inserted strings that have duplicates, i.e. more than one instance in the
     // collection. This does not contain entries for singleton names.
-    std::map<std::string, unsigned int> duplicateCounts;
+    std::map<std::string, unsigned int, std::less<>> duplicateCounts;
 
     /// @brief Break a uniquified name into its parts
     /// @param name The name to break up
     /// @return a tuple(basePrefix, nameSuffix, uniqueDigitCount, uniqueDigitsValue);
     /// The two latter values will be (0,0) if name is a base name without uniquifying digits.
-    std::tuple<std::string, std::string, unsigned int, UnlimitedUnsigned> decomposeName(
-        const std::string& name
+    std::tuple<std::string_view, std::string_view, unsigned int, UnlimitedUnsigned> decomposeName(
+        std::string_view name
     ) const;
 
 public:
@@ -217,23 +219,23 @@ public:
     virtual ~UniqueNameManager() = default;
 
     /// Check if two names are unique forms of the same base name
-    bool haveSameBaseName(const std::string& first, const std::string& second) const;
+    bool haveSameBaseName(std::string_view first, std::string_view second) const;
 
     /// Register a name in the collection.
     /// This collection acts as a multiset, so multiple registrations of the same
     /// name are counted, and an equal number of removals is necessary to fully
     /// remove the name, allowing it to be returned by makeUniqueName
-    void addExactName(const std::string& name);
+    void addExactName(std::string_view name);
     /// Using the given modelName as a model, generate a name that is not already
     /// in the collection of names. The model name may already contain uniquifying digits
     /// which will be stripped and replaced with other digits as needed.
-    std::string makeUniqueName(const std::string& modelName, std::size_t minDigits = 0) const;
+    std::string makeUniqueName(std::string_view modelName, std::size_t minDigits = 0) const;
     /// Remove a registered name so it can be generated again. If the name was added
     /// several times this decrements the count, and the name is only fully removed when
     /// the count of removes equals or exceeds the count of adds.
-    void removeExactName(const std::string& name);
+    void removeExactName(std::string_view name);
     /// Test if the given name is already in the collection
-    bool containsName(const std::string& name) const;
+    bool containsName(std::string_view name) const;
     /// @brief Empty (clear) out the contents from this collection
     void clear()
     {

--- a/src/Base/UnlimitedUnsigned.h
+++ b/src/Base/UnlimitedUnsigned.h
@@ -71,7 +71,7 @@ public:
             if (partDigitCount >= lastStartPosition) {
                 // partial chunk of leading digits
                 const auto sub = text.substr(0, lastStartPosition);
-                const auto [ptr, err] = std::from_chars<PartType>(sub.begin(), sub.end(), result[i]);
+                const auto [ptr, err] = std::from_chars(sub.data(), sub.data() + sub.size(), result[i]);
                 if (err != std::errc {}) {
                     result[i] = 0;
                 }
@@ -79,7 +79,7 @@ public:
             else {
                 lastStartPosition -= partDigitCount;
                 const auto sub = text.substr(lastStartPosition, partDigitCount);
-                const auto [ptr, err] = std::from_chars<PartType>(sub.begin(), sub.end(), result[i]);
+                const auto [ptr, err] = std::from_chars(sub.data(), sub.data() + sub.size(), result[i]);
                 if (err != std::errc {}) {
                     result[i] = 0;
                 }

--- a/src/Base/UnlimitedUnsigned.h
+++ b/src/Base/UnlimitedUnsigned.h
@@ -25,9 +25,12 @@
 #pragma once
 
 #include <FCGlobal.h>
-#include <vector>
-#include <string>
+
+#include <charconv>
 #include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
 
 // ----------------------------------------------------------------------------
 
@@ -58,7 +61,7 @@ public:
     {}
     // Parse a decimal digit string into an UnlimitedUnsigned. There should be no white space,
     // only digits. a zero-length string parses as zero.
-    static UnlimitedUnsigned fromString(const std::string& text)
+    static UnlimitedUnsigned fromString(std::string_view text)
     {
         std::vector<PartType> result((text.size() + partDigitCount - 1) / partDigitCount);
         size_t minimumSize = 0;
@@ -67,13 +70,19 @@ public:
         for (size_t i = 0; i < result.size(); i++) {
             if (partDigitCount >= lastStartPosition) {
                 // partial chunk of leading digits
-                result[i] = static_cast<PartType>(std::stoul(text.substr(0, lastStartPosition)));
+                const auto sub = text.substr(0, lastStartPosition);
+                const auto [ptr, err] = std::from_chars<PartType>(sub.begin(), sub.end(), result[i]);
+                if (err != std::errc {}) {
+                    result[i] = 0;
+                }
             }
             else {
                 lastStartPosition -= partDigitCount;
-                result[i] = static_cast<PartType>(
-                    std::stoul(text.substr(lastStartPosition, partDigitCount))
-                );
+                const auto sub = text.substr(lastStartPosition, partDigitCount);
+                const auto [ptr, err] = std::from_chars<PartType>(sub.begin(), sub.end(), result[i]);
+                if (err != std::errc {}) {
+                    result[i] = 0;
+                }
             }
             if (result[i] != 0) {
                 minimumSize = i + 1;

--- a/src/Base/Writer.h
+++ b/src/Base/Writer.h
@@ -58,8 +58,8 @@ private:
     class UniqueFileNameManager: public UniqueNameManager
     {
     protected:
-        std::string::const_reverse_iterator getNameSuffixStartPosition(
-            const std::string& name
+        std::string_view::const_reverse_iterator getNameSuffixStartPosition(
+            std::string_view name
         ) const override
         {
             // This is an awkward way to do this, because the FileInfo class only yields pieces of
@@ -67,7 +67,7 @@ private:
             // both "xyz" and "xyz." would yield three; we need the length of the extension
             // *including its delimiter* so we use the length difference between the fileName and
             // fileNamePure.
-            FileInfo fi(name);
+            FileInfo fi(std::string {name});
             return name.rbegin() + (fi.fileName().size() - fi.fileNamePure().size());
         }
     };

--- a/src/Gui/Dialogs/DlgAddProperty.cpp
+++ b/src/Gui/Dialogs/DlgAddProperty.cpp
@@ -301,7 +301,7 @@ DlgAddProperty::SupportedTypes DlgAddProperty::getSupportedTypes()
     });
 
     std::ranges::sort(otherTypes, [](Base::Type a, Base::Type b) {
-        return strcmp(a.getName(), b.getName()) < 0;
+        return a.getName() < b.getName();
     });
 
     return {.commonTypes = std::move(commonTypes), .otherTypes = std::move(otherTypes)};
@@ -973,7 +973,7 @@ App::Property* DlgAddProperty::createProperty()
 
     try {
         App::Property* prop
-            = container->addDynamicProperty(type.c_str(), name.c_str(), group.c_str(), doc.c_str());
+            = container->addDynamicProperty(type, name.c_str(), group.c_str(), doc.c_str());
         MacroManager::MacroRedirector redirector(recordAddCommand);
         recordMacroAdd(container, type, name, group, doc);
         return prop;

--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -621,7 +621,7 @@ void DlgExpressionInput::acceptWithVarSet()
     std::string name = nameProp.toStdString();
     std::string group = nameGroup.toStdString();
     std::string type = getType();
-    auto prop = obj->addDynamicProperty(type.c_str(), name.c_str(), group.c_str());
+    auto prop = obj->addDynamicProperty(type, name.c_str(), group.c_str());
 
     // Set the value of the property in the VarSet
     //
@@ -842,7 +842,7 @@ void DlgExpressionInput::setupVarSets()
 
 std::string DlgExpressionInput::getType()
 {
-    return determineTypeVarSet().getName();
+    return std::string {determineTypeVarSet().getName()};
 }
 
 void DlgExpressionInput::onCheckVarSets(int state)

--- a/src/Gui/Dialogs/DlgPropertyLink.cpp
+++ b/src/Gui/Dialogs/DlgPropertyLink.cpp
@@ -448,8 +448,8 @@ void DlgPropertyLink::init(const App::DocumentObjectT& prop, bool tryFilter)
         }
 
         if (!baseType.isBad()) {
-            const char* name = baseType.getName();
-            auto it = typeItems.find(QByteArray::fromRawData(name, strlen(name) + 1));
+            const auto name = baseType.getName();
+            auto it = typeItems.find(QByteArray(name.data(), name.size()));
             if (it != typeItems.end()) {
                 it->second->setSelected(true);
             }
@@ -1059,8 +1059,8 @@ QTreeWidgetItem* DlgPropertyLink::createItem(App::DocumentObject* obj, QTreeWidg
         item->setFlags(item->flags() | Qt::ItemIsEditable | Qt::ItemIsUserCheckable);
     }
 
-    const char* typeName = obj->getTypeId().getName();
-    QByteArray typeData = QByteArray::fromRawData(typeName, strlen(typeName) + 1);
+    const auto typeName = obj->getTypeId().getName();
+    auto typeData = QByteArray::fromRawData(typeName.data(), typeName.size());
     item->setData(0, Qt::UserRole + 2, typeData);
 
     QByteArray proxyType;
@@ -1071,11 +1071,11 @@ QTreeWidgetItem* DlgPropertyLink::createItem(App::DocumentObject* obj, QTreeWidg
         if (!proxy.isNone() && !proxy.isString()) {
             const char* name = nullptr;
             if (proxy.hasAttr("__class__")) {
-                proxyType = QByteArray(proxy.getAttr("__class__").as_string().c_str());
+                proxyType = QByteArray::fromStdString(proxy.getAttr("__class__").as_string());
             }
             else {
                 name = proxy.ptr()->ob_type->tp_name;
-                proxyType = QByteArray::fromRawData(name, strlen(name) + 1);
+                proxyType = QByteArray::fromRawData(name, strlen(name));
             }
             auto it = typeItems.find(proxyType);
             if (it != typeItems.end()) {
@@ -1102,8 +1102,8 @@ QTreeWidgetItem* DlgPropertyLink::createTypeItem(Base::Type type)
     if (!type.isBad() && type != App::DocumentObject::getClassTypeId()) {
         Base::Type parentType = type.getParent();
         if (!parentType.isBad()) {
-            const char* name = parentType.getName();
-            auto typeData = QByteArray::fromRawData(name, strlen(name) + 1);
+            const auto name = parentType.getName();
+            QByteArray typeData(name.data(), name.size());
             auto& typeItem = typeItems[typeData];
             if (!typeItem) {
                 typeItem = createTypeItem(parentType);
@@ -1143,7 +1143,7 @@ bool DlgPropertyLink::filterType(QTreeWidgetItem* item)
     }
 
     auto typeData = item->data(0, Qt::UserRole + 2).toByteArray();
-    Base::Type type = Base::Type::fromName(typeData.constData());
+    Base::Type type = Base::Type::fromName(std::string_view(typeData.data(), typeData.size()));
     if (type.isBad()) {
         return false;
     }
@@ -1170,8 +1170,8 @@ bool DlgPropertyLink::filterType(QTreeWidgetItem* item)
     }
 
     for (auto t = type; !t.isBad() && t != App::DocumentObject::getClassTypeId(); t = t.getParent()) {
-        const char* name = t.getName();
-        if (selectedTypes.count(QByteArray::fromRawData(name, strlen(name) + 1))) {
+        const auto name = t.getName();
+        if (selectedTypes.count(QByteArray(name.data(), name.size()))) {
             return false;
         }
     }

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -963,7 +963,7 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
 {
     auto pcProvider = static_cast<ViewProviderDocumentObject*>(getViewProvider(&Obj));
     if (!pcProvider) {
-        std::string cName = Obj.getViewProviderNameStored();
+        std::string_view cName {Obj.getViewProviderNameStored()};
         for (;;) {
             if (cName.empty()) {
                 // handle document object with no view provider specified
@@ -971,7 +971,7 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
                 return;
             }
             Base::Type type = Base::Type::getTypeIfDerivedFrom(
-                cName.c_str(),
+                cName,
                 ViewProviderDocumentObject::getClassTypeId(),
                 true
             );

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -2119,7 +2119,7 @@ TYPESYSTEM_SOURCE_ABSTRACT(Gui::UserNavigationStyle, Gui::NavigationStyle)
 
 std::string UserNavigationStyle::userFriendlyName() const
 {
-    std::string name = this->getTypeId().getName();
+    std::string_view name = this->getTypeId().getName();
     // remove namespaces
     std::size_t pos = name.rfind("::");
     if (pos != std::string::npos) {
@@ -2131,7 +2131,7 @@ std::string UserNavigationStyle::userFriendlyName() const
     if (pos != std::string::npos) {
         name = name.substr(0, pos);
     }
-    return name;
+    return std::string {name};
 }
 
 std::map<Base::Type, std::string> UserNavigationStyle::getUserFriendlyNames()

--- a/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsNavigation.cpp
@@ -164,8 +164,10 @@ void DlgSettingsNavigation::loadSettings()
     ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    std::string model
-        = hGrp->GetASCII("NavigationStyle", CADNavigationStyle::getClassTypeId().getName());
+    std::string model = hGrp->GetASCII(
+        "NavigationStyle",
+        std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
+    );
     int index = ui->comboNavigationStyle->findData(QByteArray(model.c_str()));
     if (index > -1) {
         ui->comboNavigationStyle->setCurrentIndex(index);
@@ -358,7 +360,10 @@ void DlgSettingsNavigation::retranslate()
     std::map<Base::Type, std::string> styles = UserNavigationStyle::getUserFriendlyNames();
     for (const auto& style : styles) {
         QByteArray data(style.first.getName());
-        QString name = QApplication::translate(style.first.getName(), style.second.c_str());
+        QString name = QApplication::translate(
+            std::string {style.first.getName()}.c_str(),
+            style.second.c_str()
+        );
 
         ui->comboNavigationStyle->addItem(name, data);
     }

--- a/src/Gui/Selection/Selection.h
+++ b/src/Gui/Selection/Selection.h
@@ -103,7 +103,7 @@ public:
         const char* docName = nullptr,
         const char* objName = nullptr,
         const char* subName = nullptr,
-        const char* typeName = nullptr,
+        std::string_view typeName = {},
         float x = 0,
         float y = 0,
         float z = 0,
@@ -115,13 +115,11 @@ public:
         , y(y)
         , z(z)
         , Object(docName, objName, subName)
+        , TypeName(typeName)
     {
         pDocName = Object.getDocumentName().c_str();
         pObjectName = Object.getObjectName().c_str();
         pSubName = Object.getSubName().c_str();
-        if (typeName) {
-            TypeName = typeName;
-        }
         pTypeName = TypeName.c_str();
     }  // explicit bombs
 
@@ -130,7 +128,7 @@ public:
         const std::string& docName,
         const std::string& objName,
         const std::string& subName,
-        const std::string& typeName = std::string(),
+        std::string_view typeName = {},
         float x = 0,
         float y = 0,
         float z = 0,
@@ -327,7 +325,7 @@ public:
         const char* DocName;
         const char* FeatName;
         const char* SubName;
-        const char* TypeName;
+        std::string_view TypeName;
         App::Document* pDoc;
         App::DocumentObject* pObject;
         App::DocumentObject* pResolvedObject;

--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -583,20 +583,20 @@ void SelectionView::showPart()
     }
 }
 
-QString SelectionView::getModule(const char* type) const
+QString SelectionView::getModule(std::string_view type) const
 {
     // go up the inheritance tree and find the module name of the first
     // sub-class that has not the prefix "App::"
-    std::string prefix;
+    std::string_view prefix;
     Base::Type typeId = Base::Type::fromName(type);
 
     while (!typeId.isBad()) {
-        std::string temp(typeId.getName());
-        std::string::size_type pos = temp.find_first_of("::");
+        const auto typeName = typeId.getName();
+        const auto pos = typeName.find_first_of("::");
 
-        std::string module;
+        std::string_view module;
         if (pos != std::string::npos) {
-            module = std::string(temp, 0, pos);
+            module = typeName.substr(0, pos);
         }
         if (module != "App") {
             prefix = module;
@@ -607,7 +607,7 @@ QString SelectionView::getModule(const char* type) const
         typeId = typeId.getParent();
     }
 
-    return QString::fromStdString(prefix);
+    return QString::fromUtf8(prefix.data(), prefix.size());
 }
 
 QString SelectionView::getProperty(App::DocumentObject* obj) const
@@ -1026,7 +1026,7 @@ void SelectionMenu::addWholeObjectSelection(
     if (sobj) {
         if (sobj != sel.obj) {
             // sub-objects
-            std::string typeName = sobj->getTypeId().getName();
+            const auto typeName = sobj->getTypeId().getName();
             if (typeName == "App::Part" || typeName == "PartDesign::Body") {
                 shouldAdd = true;
             }

--- a/src/Gui/Selection/SelectionView.h
+++ b/src/Gui/Selection/SelectionView.h
@@ -115,7 +115,7 @@ protected:
     void hideEvent(QHideEvent*) override;
 
 private:
-    QString getModule(const char* type) const;
+    QString getModule(std::string_view type) const;
     QString getProperty(App::DocumentObject* obj) const;
     bool supportPart(App::DocumentObject* obj, const QString& part) const;
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -6470,7 +6470,10 @@ void DocumentObjectItem::displayStatusInfo()
 {
     App::DocumentObject* Obj = object()->getObject();
 
-    QString info = QApplication::translate(Obj->getTypeId().getName(), Obj->getStatusString());
+    QString info = QApplication::translate(
+        std::string {Obj->getTypeId().getName()}.c_str(),
+        Obj->getStatusString()
+    );
 
     if (Obj->mustExecute() == 1 && !Obj->isError()) {
         info += TreeWidget::tr(" (but must be executed)");

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -914,7 +914,7 @@ void View3DInventor::customEvent(QEvent* e)
             "User parameter:BaseApp/Preferences/View"
         );
         if (hGrp->GetBool("SameStyleForAllViews", true)) {
-            hGrp->SetASCII("NavigationStyle", se->style().getName());
+            hGrp->SetASCII("NavigationStyle", std::string {se->style().getName()}.c_str());
         }
         else {
             _viewer->setNavigationType(se->style());

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -1150,7 +1150,7 @@ Py::Object View3DInventorPy::getCamera()
         else {
             buffer[0] = '\0';
         }
-        return Py::String(buffer);
+        return Py::String(std::string_view {buffer});
     }
     catch (const Base::Exception& e) {
         throw Py::RuntimeError(e.what());
@@ -1857,7 +1857,7 @@ Py::Object View3DInventorPy::listNavigationTypes()
 
 Py::Object View3DInventorPy::getNavigationType()
 {
-    std::string name = getView3DInventorPtr()->getViewer()->navigationStyle()->getTypeId().getName();
+    const auto name = getView3DInventorPtr()->getViewer()->navigationStyle()->getTypeId().getName();
     return Py::String(name);
 }
 

--- a/src/Gui/View3DSettings.cpp
+++ b/src/Gui/View3DSettings.cpp
@@ -288,8 +288,10 @@ void View3DSettings::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::
     else if (strcmp(Reason, "NavigationStyle") == 0) {
         if (!ignoreNavigationStyle) {
             // check whether the simple or the full mouse model is used
-            std::string model
-                = rGrp.GetASCII("NavigationStyle", CADNavigationStyle::getClassTypeId().getName());
+            std::string model = rGrp.GetASCII(
+                "NavigationStyle",
+                std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
+            );
             Base::Type type = Base::Type::fromName(model.c_str());
             for (auto _viewer : _viewers) {
                 _viewer->setNavigationType(type);

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -156,7 +156,7 @@ bool ViewProviderDocumentObject::removeDynamicProperty(const char* name)
 }
 
 App::Property* ViewProviderDocumentObject::addDynamicProperty(
-    const char* type,
+    std::string_view type,
     const char* name,
     const char* group,
     const char* doc,

--- a/src/Gui/ViewProviderDocumentObject.h
+++ b/src/Gui/ViewProviderDocumentObject.h
@@ -160,7 +160,7 @@ public:
     bool removeDynamicProperty(const char* prop) override;
 
     App::Property* addDynamicProperty(
-        const char* type,
+        std::string_view type,
         const char* name = nullptr,
         const char* group = nullptr,
         const char* doc = nullptr,

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -388,14 +388,14 @@ void ViewProviderGeometryObject::handleChangedPropertyName(
 )
 {
     if (strcmp(PropName, "ShapeColor") == 0
-        && strcmp(TypeName, App::PropertyColor::getClassTypeId().getName()) == 0) {
+        && TypeName == App::PropertyColor::getClassTypeId().getName()) {
         App::PropertyColor prop;
         prop.Restore(reader);
         ShapeAppearance.setDiffuseColor(prop.getValue());
     }
     else if (
         strcmp(PropName, "ShapeMaterial") == 0
-        && strcmp(TypeName, App::PropertyMaterial::getClassTypeId().getName()) == 0
+        && TypeName == App::PropertyMaterial::getClassTypeId().getName()
     ) {
         App::PropertyMaterial prop;
         prop.Restore(reader);

--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2090,7 +2090,7 @@ void ViewProviderLink::onChanged(const App::Property* prop)
     if (prop == &ChildViewProvider) {
         childVp = freecad_cast<ViewProviderDocumentObject*>(ChildViewProvider.getObject().get());
         if (childVp && getObject()) {
-            if (strcmp(childVp->getTypeId().getName(), getObject()->getViewProviderName()) != 0
+            if (childVp->getTypeId().getName() == getObject()->getViewProviderName()
                 && !childVp->allowOverride(*getObject())) {
                 FC_ERR(
                     "Child view provider type '" << childVp->getTypeId().getName()

--- a/src/Gui/WidgetFactory.cpp
+++ b/src/Gui/WidgetFactory.cpp
@@ -577,14 +577,14 @@ Py::Object PyResource::value(const Py::Tuple& args)
             int nSize = str.count();
             Py::List slist(nSize);
             for (int i = 0; i < nSize; ++i) {
-                slist.setItem(i, Py::String(str[i].toLatin1()));
+                slist.setItem(i, Py::String(str[i].toStdString()));
             }
             item = slist;
         } break;
         case QMetaType::QByteArray:
             break;
         case QMetaType::QString:
-            item = Py::String(v.toString().toLatin1());
+            item = Py::String(v.toString().toStdString());
             break;
         case QMetaType::Double:
             item = Py::Float(v.toDouble());

--- a/src/Gui/WorkbenchManager.cpp
+++ b/src/Gui/WorkbenchManager.cpp
@@ -62,14 +62,14 @@ WorkbenchManager::~WorkbenchManager()
     DockWindowManager::destruct();
 }
 
-Workbench* WorkbenchManager::createWorkbench(const std::string& name, const std::string& className)
+Workbench* WorkbenchManager::createWorkbench(const std::string& name, std::string_view className)
 {
     Workbench* wb = getWorkbench(name);
 
     if (!wb) {
         // try to create an instance now
         Base::Type type
-            = Base::Type::getTypeIfDerivedFrom(className.c_str(), Workbench::getClassTypeId(), false);
+            = Base::Type::getTypeIfDerivedFrom(className, Workbench::getClassTypeId(), false);
         wb = static_cast<Workbench*>(type.createInstance());
         // createInstance could return a null pointer
         if (!wb) {
@@ -111,7 +111,7 @@ Workbench* WorkbenchManager::getWorkbench(const std::string& name) const
     return wb;
 }
 
-bool WorkbenchManager::activate(const std::string& name, const std::string& className)
+bool WorkbenchManager::activate(const std::string& name, std::string_view className)
 {
     Workbench* wb = createWorkbench(name, className);
     if (wb) {

--- a/src/Gui/WorkbenchManager.h
+++ b/src/Gui/WorkbenchManager.h
@@ -48,7 +48,7 @@ public:
      * such workbench exists then a workbench of class \a className gets created, if possible.
      * If the workbench cannot be created 0 is returned.
      */
-    Workbench* createWorkbench(const std::string& name, const std::string& className);
+    Workbench* createWorkbench(const std::string& name, std::string_view className);
     /** Removes the workbench with name \a name. If there is no such
      * workbench exists nothing happens.
      */
@@ -58,7 +58,7 @@ public:
      */
     Workbench* getWorkbench(const std::string& name) const;
     /** Activates the workbench with name \a name. */
-    bool activate(const std::string& name, const std::string& className);
+    bool activate(const std::string& name, std::string_view className);
     /** Returns the active workbench. */
     Workbench* active() const;
     /** Returns the name of the active workbench. */

--- a/src/Mod/Fem/Gui/TaskFemConstraint.cpp
+++ b/src/Mod/Fem/Gui/TaskFemConstraint.cpp
@@ -210,8 +210,8 @@ void TaskFemConstraint::createDeleteAction(QListWidget* parentList)
 void TaskDlgFemConstraint::open()
 {
     if (!ConstraintView->getDocument()->hasPendingCommand()) {
-        const char* typeName = ConstraintView->getObject()->getTypeId().getName();
-        ConstraintView->getDocument()->openCommand(typeName);
+        const auto typeName = ConstraintView->getObject()->getTypeId().getName();
+        ConstraintView->getDocument()->openCommand(std::string {typeName}.c_str());
         ConstraintView->setVisible(true);
     }
 }

--- a/src/Mod/Measure/App/MeasureBase.h
+++ b/src/Mod/Measure/App/MeasureBase.h
@@ -126,7 +126,7 @@ public:
         }
 
         // Get the Geometry handler based on the module
-        const char* className = sub->getTypeId().getName();
+        const auto className = sub->getTypeId().getName();
         std::string mod = Base::Type::getModuleName(className);
 
         auto handler = getGeometryHandler(mod);

--- a/src/Mod/Part/App/AttachExtension.cpp
+++ b/src/Mod/Part/App/AttachExtension.cpp
@@ -231,7 +231,7 @@ void AttachExtension::initBase(bool force)
             "BaseAttacherType",
             "Class name of attach engine object driving the attachment for base geometry."
         )) {
-        props.attacherType->setValue(_baseProps.attacher->getTypeId().getName());
+        props.attacherType->setValue(std::string {_baseProps.attacher->getTypeId().getName()}.c_str());
     }
     else if (!props.attacherType) {
         return;
@@ -287,16 +287,16 @@ void AttachExtension::setAttacher(AttachEngine* pAttacher, bool base)
         if (base) {
             initBase(true);
         }
-        const char* typeName = props.attacher->getTypeId().getName();
-        if (strcmp(props.attacherType->getValue(), typeName)
-            != 0) {  // make sure we need to change, to break recursive
-                     // onChange->changeAttacherType->onChange...
-            props.attacherType->setValue(typeName);
+        const auto typeName = props.attacher->getTypeId().getName();
+        if (props.attacherType->getValue() == typeName) {
+            // make sure we need to change, to break recursive
+            // onChange->changeAttacherType->onChange...
+            props.attacherType->setValue(std::string {typeName}.c_str());
         }
         // Also update the visible AttacherEngine property for non-base attachers
         // to keep it in sync with AttacherType (fixes issue #15716)
         if (!base) {
-            const char* enumVal = classToEnum(typeName);
+            const char* enumVal = classToEnum(std::string {typeName}.c_str());
             if (strcmp(AttacherEngine.getValueAsString(), enumVal) != 0) {
                 AttacherEngine.setValue(enumVal);
             }
@@ -319,7 +319,7 @@ bool AttachExtension::changeAttacherType(const char* typeName, bool base)
 
     // check if we need to actually change anything
     if (prop.attacher) {
-        if (strcmp(prop.attacher->getTypeId().getName(), typeName) == 0) {
+        if (prop.attacher->getTypeId().getName() == typeName) {
             return false;
         }
     }
@@ -508,7 +508,7 @@ bool AttachExtension::extensionHandleChangedPropertyName(
         // At one point, the type of Support changed from PropertyLinkSub to its present type
         // of PropertyLinkSubList. Later, the property name changed to AttachmentSupport
         App::PropertyLinkSub tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName) == 0) {
+        if (tmp.getTypeId().getName() == TypeName) {
             tmp.setContainer(this->getExtendedContainer());
             tmp.Restore(reader);
             AttachmentSupport.setValue(tmp.getValue(), tmp.getSubValues());

--- a/src/Mod/Part/App/FeaturePartBox.cpp
+++ b/src/Mod/Part/App/FeaturePartBox.cpp
@@ -127,7 +127,7 @@ void Box::Restore(Base::XMLReader& reader)
                 prop->setStatusValue(status.to_ulong());
             }
         }
-        if (prop && strcmp(prop->getTypeId().getName(), TypeName) == 0) {
+        if (prop && prop->getTypeId().getName() == TypeName) {
             if (!prop->testStatus(App::Property::Transient) && !status.test(App::Property::Transient)
                 && !status.test(App::Property::PropTransient)
                 && !(getPropertyType(prop) & App::Prop_Transient)) {
@@ -192,7 +192,7 @@ void Box::Restore(Base::XMLReader& reader)
         if (strcmp(TypeName, "PropertyDistance") == 0) {  // missing prefix App::
             tn = std::string("App::") + tn;
         }
-        if (prop && strcmp(prop->getTypeId().getName(), tn.c_str()) == 0) {
+        if (prop && prop->getTypeId().getName() == tn) {
             prop->Restore(reader);
         }
 

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -1542,7 +1542,7 @@ void ViewProviderPartExt::handleChangedPropertyName(
 )
 {
     if (strcmp(PropName, "DiffuseColor") == 0
-        && strcmp(TypeName, App::PropertyColorList::getClassTypeId().getName()) == 0) {
+        && TypeName == App::PropertyColorList::getClassTypeId().getName()) {
 
         // PropertyColorLists are loaded asynchronously as they're stored in separate files
         _diffuseColor.Restore(reader);

--- a/src/Mod/PartDesign/App/FeatureChamfer.cpp
+++ b/src/Mod/PartDesign/App/FeatureChamfer.cpp
@@ -223,7 +223,7 @@ void Chamfer::Restore(Base::XMLReader& reader)
 void Chamfer::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop)
 {
     if (prop && strcmp(TypeName, "App::PropertyFloatConstraint") == 0
-        && strcmp(prop->getTypeId().getName(), "App::PropertyQuantityConstraint") == 0) {
+        && prop->getTypeId().getName() == "App::PropertyQuantityConstraint") {
         App::PropertyFloatConstraint p;
         p.Restore(reader);
         static_cast<App::PropertyQuantityConstraint*>(prop)->setValue(p.getValue());

--- a/src/Mod/PartDesign/App/FeatureFillet.cpp
+++ b/src/Mod/PartDesign/App/FeatureFillet.cpp
@@ -173,7 +173,7 @@ void Fillet::Restore(Base::XMLReader& reader)
 void Fillet::handleChangedPropertyType(Base::XMLReader& reader, const char* TypeName, App::Property* prop)
 {
     if (prop && strcmp(TypeName, "App::PropertyFloatConstraint") == 0
-        && strcmp(prop->getTypeId().getName(), "App::PropertyQuantityConstraint") == 0) {
+        && prop->getTypeId().getName() == "App::PropertyQuantityConstraint") {
         App::PropertyFloatConstraint p;
         p.Restore(reader);
         static_cast<App::PropertyQuantityConstraint*>(prop)->setValue(p.getValue());

--- a/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
+++ b/src/Mod/PartDesign/Gui/SketchWorkflow.cpp
@@ -110,7 +110,8 @@ public:
                 msg.pDocName = faceSelection.getDocName();
                 msg.pObjectName = tip->getNameInDocument();
                 msg.pSubName = elements[0].c_str();
-                msg.pTypeName = tip->getTypeId().getName();
+                msg.TypeName = tip->getTypeId().getName();
+                msg.pTypeName = msg.TypeName.c_str();
 
                 faceSelection = Gui::SelectionObject {msg};
 

--- a/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
+++ b/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
@@ -242,12 +242,17 @@ void GeneralSettingsWidget::retranslateUi()
     ParameterGrp::handle hGrpNav = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/View"
     );
-    auto navStyleName
-        = hGrpNav->GetASCII("NavigationStyle", Gui::CADNavigationStyle::getClassTypeId().getName());
+    auto navStyleName = hGrpNav->GetASCII(
+        "NavigationStyle",
+        std::string {Gui::CADNavigationStyle::getClassTypeId().getName()}.c_str()
+    );
     std::map<Base::Type, std::string> styles = Gui::UserNavigationStyle::getUserFriendlyNames();
     for (const auto& style : styles) {
         QByteArray data(style.first.getName());
-        QString name = QApplication::translate(style.first.getName(), style.second.c_str());
+        QString name = QApplication::translate(
+            std::string {style.first.getName()}.c_str(),
+            style.second.c_str()
+        );
         _navigationStyleComboBox->addItem(name, data);
         if (navStyleName == style.first.getName()) {
             _navigationStyleComboBox->setCurrentIndex(_navigationStyleComboBox->count() - 1);

--- a/src/Mod/TechDraw/App/DrawPage.cpp
+++ b/src/Mod/TechDraw/App/DrawPage.cpp
@@ -464,7 +464,7 @@ void DrawPage::handleChangedPropertyType(Base::XMLReader& reader, const char* Ty
 {
     if (prop == &Scale) {
         App::PropertyFloat tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName) == 0) {//property in file is Float
+        if (tmp.getTypeId().getName() == TypeName) {  // property in file is Float
             tmp.setContainer(this);
             tmp.Restore(reader);
             double tmpValue = tmp.getValue();

--- a/src/Mod/TechDraw/App/DrawView.cpp
+++ b/src/Mod/TechDraw/App/DrawView.cpp
@@ -583,7 +583,7 @@ void DrawView::handleChangedPropertyType(Base::XMLReader &reader, const char * T
 {
     if (prop == &Scale) {
         App::PropertyFloat tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {                   //property in file is Float
+        if (tmp.getTypeId().getName() == TypeName) {  // property in file is Float
             tmp.setContainer(this);
             tmp.Restore(reader);
             double tmpValue = tmp.getValue();
@@ -598,7 +598,7 @@ void DrawView::handleChangedPropertyType(Base::XMLReader &reader, const char * T
         && strcmp(prop->getName(), "Source") == 0) {
         App::PropertyLinkGlobal glink;
         App::PropertyLink link;
-        if (strcmp(glink.getTypeId().getName(), TypeName) == 0) {            //property in file is plg
+        if (glink.getTypeId().getName() == TypeName) {  // property in file is plg
             glink.setContainer(this);
             glink.Restore(reader);
             if (glink.getValue()) {
@@ -606,7 +606,7 @@ void DrawView::handleChangedPropertyType(Base::XMLReader &reader, const char * T
                 static_cast<App::PropertyLinkList*>(prop)->setValue(glink.getValue());
             }
         }
-        else if (strcmp(link.getTypeId().getName(), TypeName) == 0) {            //property in file is pl
+        else if (link.getTypeId().getName() == TypeName) {  // property in file is pl
             link.setContainer(this);
             link.Restore(reader);
             if (link.getValue()) {

--- a/src/Mod/TechDraw/App/DrawViewDetail.cpp
+++ b/src/Mod/TechDraw/App/DrawViewDetail.cpp
@@ -480,7 +480,7 @@ void DrawViewDetail::handleChangedPropertyType(Base::XMLReader &reader, const ch
     if (prop == &AnchorPoint) {
         // AnchorPoint was PropertyVector, then briefly PropertyPosition, now back to PropertyVector
         App::PropertyPosition tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
+        if (tmp.getTypeId().getName() == TypeName) {
             tmp.setContainer(this);
             tmp.Restore(reader);
             auto tmpValue = tmp.getValue();
@@ -492,7 +492,7 @@ void DrawViewDetail::handleChangedPropertyType(Base::XMLReader &reader, const ch
     if (prop == &Radius) {
         // Radius was PropertyFloat, then briefly PropertyLength, now back to PropertyFloat
         App::PropertyLength tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
+        if (tmp.getTypeId().getName() == TypeName) {
             tmp.setContainer(this);
             tmp.Restore(reader);
             auto tmpValue = tmp.getValue();

--- a/src/Mod/TechDraw/App/DrawViewPart.cpp
+++ b/src/Mod/TechDraw/App/DrawViewPart.cpp
@@ -1525,7 +1525,7 @@ void DrawViewPart::handleChangedPropertyType(Base::XMLReader &reader, const char
     if (prop == &Direction) {
         // Direction was PropertyVector, then briefly PropertyDirection, now back to PropertyVector
         App::PropertyDirection tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
+        if (tmp.getTypeId().getName() == TypeName) {
             tmp.setContainer(this);
             tmp.Restore(reader);
             auto tmpValue = tmp.getValue();
@@ -1537,7 +1537,7 @@ void DrawViewPart::handleChangedPropertyType(Base::XMLReader &reader, const char
     if (prop == &XDirection) {
         // XDirection was PropertyVector, then briefly PropertyDirection, now back to PropertyVector
         App::PropertyDirection tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
+        if (tmp.getTypeId().getName() == TypeName) {
             tmp.setContainer(this);
             tmp.Restore(reader);
             auto tmpValue = tmp.getValue();

--- a/src/Mod/TechDraw/App/DrawViewSection.cpp
+++ b/src/Mod/TechDraw/App/DrawViewSection.cpp
@@ -1230,7 +1230,7 @@ void DrawViewSection::handleChangedPropertyType(Base::XMLReader &reader, const c
     if (prop == &SectionOrigin) {
         // SectionOrigin was PropertyVector then briefly PropertyPosition, now back to PropertyVector
         App::PropertyPosition tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
+        if (tmp.getTypeId().getName() == TypeName) {
             tmp.setContainer(this);
             tmp.Restore(reader);
             auto tmpValue = tmp.getValue();
@@ -1242,7 +1242,7 @@ void DrawViewSection::handleChangedPropertyType(Base::XMLReader &reader, const c
     if (prop == &SectionNormal) {
         // Radius was PropertyVector, then briefly PropertyDirection, then PropertyVector
         App::PropertyDirection tmp;
-        if (strcmp(tmp.getTypeId().getName(), TypeName)==0) {
+        if (tmp.getTypeId().getName() == TypeName) {
             tmp.setContainer(this);
             tmp.Restore(reader);
             auto tmpValue = tmp.getValue();

--- a/src/Mod/TechDraw/App/ShapeExtractor.cpp
+++ b/src/Mod/TechDraw/App/ShapeExtractor.cpp
@@ -417,8 +417,8 @@ bool ShapeExtractor::isDraftPoint(const App::DocumentObject* obj)
 
 bool ShapeExtractor::isDatumPoint(const App::DocumentObject* obj)
 {
-    std::string objTypeName = obj->getTypeId().getName();
-    std::string pointToken("Point");
+    const auto objTypeName = obj->getTypeId().getName();
+    constexpr std::string_view pointToken {"Point"};
     if (objTypeName.find(pointToken) != std::string::npos) {
         return true;
     }

--- a/src/Mod/TechDraw/Gui/QGVPage.cpp
+++ b/src/Mod/TechDraw/Gui/QGVPage.cpp
@@ -104,8 +104,10 @@ public:
     {
         const ParameterGrp& rGrp = static_cast<ParameterGrp&>(rCaller);
         if (strcmp(Reason, "NavigationStyle") == 0) {
-            std::string model =
-                rGrp.GetASCII("NavigationStyle", CADNavigationStyle::getClassTypeId().getName());
+            std::string model = rGrp.GetASCII(
+                "NavigationStyle",
+                std::string {CADNavigationStyle::getClassTypeId().getName()}.c_str()
+            );
             page->setNavigationStyle(model);
         }
         else if (strcmp(Reason, "InvertZoom") == 0) {
@@ -614,8 +616,10 @@ std::string QGVPage::getNavStyleParameter()
 {
     ParameterGrp::handle hGrp =
         App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/View");
-    std::string model =
-        hGrp->GetASCII("NavigationStyle", NavigationStyle::getClassTypeId().getName());
+    std::string model = hGrp->GetASCII(
+        "NavigationStyle",
+        std::string {NavigationStyle::getClassTypeId().getName()}.c_str()
+    );
     return model;
 }
 

--- a/tests/src/Base/UnlimitedUnsigned.cpp
+++ b/tests/src/Base/UnlimitedUnsigned.cpp
@@ -19,7 +19,6 @@
  *                                                                         *
  ***************************************************************************/
 #include <gtest/gtest.h>
-#include <string>
 #include <Base/UnlimitedUnsigned.h>
 
 // NOLINTBEGIN(cppcoreguidelines-*,readability-*)


### PR DESCRIPTION
Code quality PR to remove some `const char*` uses.
Tests pass.
Basic testing of GUI functions reveal no issues.
Code style is half-and-half between original and clang-format in `src/App` and `src/TechDraw` which are still excluded from formatting by default.

Trivial type changes bar for 2:
* `Tools::getIdentifier()` got revamped with a faster algorithm still based on ICU with less data copies involved
* `DlgPropertyLink` builds and uses `QByteArrays` put in a data model, those used to include the termination byte but now don't.

Some spots have to construct new `std::strings` as the rest of APIs still expect them or a null-terminated `const char*`; eventually these would also be removed. Qt's translation functions will prove a pain though.