### PR TITLE
Part: recompute after attachment editor updates

### DIFF
--- a/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
+++ b/src/Mod/Part/AttachmentEditor/TaskAttachmentEditor.py
@@ -395,6 +395,7 @@ class AttachmentEditorTaskPanel(FrozenClass):
         if button == QtGui.QDialogButtonBox.Apply:
             if self.obj_is_attachable:
                 self.writeParameters()
+                self.obj.Document.recompute()
             if self.create_transaction:
                 self.obj.Document.commitTransaction()
                 self.obj.Document.openTransaction(
@@ -409,6 +410,7 @@ class AttachmentEditorTaskPanel(FrozenClass):
     def accept(self):
         if self.obj_is_attachable:
             self.writeParameters()
+            self.obj.Document.recompute()
         if self.create_transaction:
             self.obj.Document.commitTransaction()
         self.cleanUp()


### PR DESCRIPTION
Recomputes the document after attachment parameters are written from the Attachment Editor on Apply and OK.
This keeps attachment-dependent features in sync immediately after a sketch is reattached to a different support.

## Issues

Fixes #23969

## Before and After Images

Before:

https://github.com/user-attachments/assets/933a707a-ad7e-449b-9e93-309ed5dd24d3



After:




https://github.com/user-attachments/assets/6bae325c-9260-4856-ba62-cc7bd63cacdd





## Testing
- Reproduced the issue by reattaching `Sketch001` from `Pad.Face3` to `Pad.Face2` in the Attachment Editor
- Confirmed that the dependent `Pad001` remained stale before an explicit document recompute
- Confirmed that after this change the dependent feature updates immediately after Apply and OK in the Attachment Editor