### PR TITLE
PartDesign: fix crash when changing Pad type to Up To Face

### DIFF
--- a/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskSketchBasedParameters.cpp
@@ -105,9 +105,15 @@ const QString TaskSketchBasedParameters::onAddSelection(
 
 void TaskSketchBasedParameters::startReferenceSelection(App::DocumentObject*, App::DocumentObject* base)
 {
-    const auto* bodyViewProvider = getViewObject<ViewProvider>()->getBodyViewProvider();
+    auto* viewObj = getViewObject<ViewProvider>();
+    if (!viewObj) {
+        return;
+    }
 
-    previouslyVisibleViewProvider = bodyViewProvider->getShownViewProvider();
+    const auto* bodyViewProvider = viewObj->getBodyViewProvider();
+    if (bodyViewProvider) {
+        previouslyVisibleViewProvider = bodyViewProvider->getShownViewProvider();
+    }
 
     if (!base) {
         return;


### PR DESCRIPTION
startReferenceSelection() crashed with a null pointer dereference when getBodyViewProvider() returned nullptr (e.g. when the Pad feature is not inside a PartDesign Body). Add null checks for both the view object and the body view provider before dereferencing.

Fixes #30003

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
#30003

<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
