### PR TITLE
View mode: draw sketch on top

### DIFF
--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -673,6 +673,9 @@ ViewProviderSketch::ViewProviderSketch()
 ViewProviderSketch::~ViewProviderSketch()
 {
     connectionToolWidget.disconnect();
+    if (pcModeSwitchAnnotation) {
+        pcModeSwitchAnnotation->unref();
+    }
 }
 
 void ViewProviderSketch::slotUndoDocument(const Gui::Document& /*doc*/)
@@ -3580,7 +3583,16 @@ bool ViewProviderSketch::getDetailPath(
         }
     }
 
-    return ViewProvider2DObject::getDetailPath(subname, pPath, append, det);
+    if (ViewProvider2DObject::getDetailPath(subname, pPath, append, det)) {
+        return true;
+    }
+    // pcModeSwitch was wrapped in SoAnnotation
+    if (pcModeSwitchAnnotation) {
+        pPath->append(pcRoot);
+        pPath->append(pcModeSwitch);
+        return true;
+    }
+    return false;
 }
 // clang-format off
 
@@ -3588,7 +3600,13 @@ void ViewProviderSketch::attach(App::DocumentObject* pcFeat)
 {
     ViewProvider2DObject::attach(pcFeat);
 
-    getOrCreateAnnotation()->addChild(pcSketchFacesToggle);
+    // Extract the mode switch from root and wrap it in a SoAnnotation to draw on top
+    pcModeSwitchAnnotation = new SoAnnotation;
+    pcModeSwitchAnnotation->ref();
+    pcModeSwitchAnnotation->setName("SketchModeSwitchAnnotation");
+    pcModeSwitchAnnotation->addChild(pcModeSwitch);
+    pcRoot->removeChild(pcModeSwitch);
+    pcRoot->addChild(pcModeSwitchAnnotation);
 }
 
 void ViewProviderSketch::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -27,6 +27,7 @@
 #include <boost/smart_ptr/scoped_ptr.hpp>
 
 #include <Inventor/SoRenderManager.h>
+#include <Inventor/nodes/SoAnnotation.h>
 #include <Inventor/sensors/SoNodeSensor.h>
 #include <QCoreApplication>
 #include <QMetaObject>
@@ -1030,6 +1031,8 @@ private:
 
     bool blockContextMenu;
     std::stringstream sketchBackup;
+
+    SoAnnotation* pcModeSwitchAnnotation = nullptr;
 };
 
 }  // namespace SketcherGui


### PR DESCRIPTION
Draw visible sketch on top in view mode, like highlighting, but in usual color:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/d83a7ba1-c8a2-4776-b441-b14da6748610" />

Ratio is that user selected sketch as visible, he should see it. This option could be made configurable if needed.