### PR TITLE
Fix assembly insert component label

### DIFF
--- a/src/Mod/Assembly/CommandInsertLink.py
+++ b/src/Mod/Assembly/CommandInsertLink.py
@@ -77,7 +77,7 @@ class CommandInsertLink:
     def GetResources(self):
         return {
             "Pixmap": "Assembly_InsertLink",
-            "MenuText": QT_TRANSLATE_NOOP("Assembly_InsertLink", "Component"),
+            "MenuText": QT_TRANSLATE_NOOP("Assembly_InsertLink", "Insert Component"),
             "Accel": "I",
             "ToolTip": tooltip,
             "CmdType": "ForEdit",


### PR DESCRIPTION
Fixes #29674

### Summary
- Align the Assembly insert command menu text with the toolbar/task panel label by using "Insert Component" for `Assembly_InsertLink`.

### Testing
- `python -m py_compile src/Mod/Assembly/CommandInsertLink.py`
