### PR TITLE
Fix ActiveView crop size pixel units

### DIFF
--- a/src/Mod/TechDraw/App/DrawViewImage.cpp
+++ b/src/Mod/TechDraw/App/DrawViewImage.cpp
@@ -30,9 +30,22 @@
 
 #include "DrawUtil.h"
 #include "DrawViewImage.h"
+#include "Preferences.h"
 
 
 using namespace TechDraw;
+
+namespace
+{
+double pixelsToPageUnits(double pixels)
+{
+    const double rezFactor = Preferences::getPreferenceGroup("Rez")->GetFloat("Resolution", 10.0);
+    if (rezFactor <= 0.0) {
+        return pixels;
+    }
+    return pixels / rezFactor;
+}
+}
 
 //===========================================================================
 // DrawViewImage
@@ -48,8 +61,10 @@ DrawViewImage::DrawViewImage()
     ADD_PROPERTY_TYPE(ImageFile, (""), vgroup, App::Prop_None, "The file containing this bitmap");
     ADD_PROPERTY_TYPE(ImageIncluded, (""), vgroup, App::Prop_None,
                       "Embedded image file. System use only.");// n/a to end users
-    ADD_PROPERTY_TYPE(Width, (100), vgroup, App::Prop_None, "The width of cropped image");
-    ADD_PROPERTY_TYPE(Height, (100), vgroup, App::Prop_None, "The height of cropped image");
+    ADD_PROPERTY_TYPE(Width, (100), vgroup, App::Prop_None,
+                      "The width of the cropped image in pixels");
+    ADD_PROPERTY_TYPE(Height, (100), vgroup, App::Prop_None,
+                      "The height of the cropped image in pixels");
     ADD_PROPERTY_TYPE(Owner, (nullptr), vgroup, (App::PropertyType)(App::Prop_None),
                       "Feature to which this symbol is attached");
 
@@ -82,7 +97,13 @@ App::DocumentObjectExecReturn* DrawViewImage::execute()
     return DrawView::execute();
 }
 
-QRectF DrawViewImage::getRect() const { return {0.0, 0.0, Width.getValue(), Height.getValue()}; }
+QRectF DrawViewImage::getRect() const
+{
+    return {0.0,
+            0.0,
+            pixelsToPageUnits(Width.getValue()),
+            pixelsToPageUnits(Height.getValue())};
+}
 
 void DrawViewImage::replaceImageIncluded(std::string newImageFile)
 {

--- a/src/Mod/TechDraw/Gui/QGIViewImage.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewImage.cpp
@@ -32,7 +32,6 @@
 #include "QGIViewImage.h"
 #include "QGCustomClip.h"
 #include "QGCustomImage.h"
-#include "Rez.h"
 #include "ViewProviderImage.h"
 
 
@@ -107,7 +106,7 @@ void QGIViewImage::draw()
 
     drawImage();
     if (crop) {
-        QRectF cropRect(0.0, 0.0, Rez::guiX(viewImage->Width.getValue()), Rez::guiX(viewImage->Height.getValue()));
+        QRectF cropRect(0.0, 0.0, viewImage->Width.getValue(), viewImage->Height.getValue());
         m_cliparea->setRect(cropRect);
     } else {
         QRectF cropRect(0.0, 0.0, m_imageItem->imageSize().width(), m_imageItem->imageSize().height());

--- a/src/Mod/TechDraw/Gui/TaskActiveView.cpp
+++ b/src/Mod/TechDraw/Gui/TaskActiveView.cpp
@@ -43,7 +43,6 @@
 #include "ui_TaskActiveView.h"
 #include "Grabber3d.h"
 #include "ViewProviderImage.h"
-#include "Rez.h"
 
 
 using namespace Gui;
@@ -65,9 +64,6 @@ TaskActiveView::TaskActiveView(TechDraw::DrawPage* pageFeat)
     , m_tid(0)
 {
     ui->setupUi(this);
-
-    ui->qsbWidth->setUnit(Base::Unit::Length);
-    ui->qsbHeight->setUnit(Base::Unit::Length);
 
     setUiPrimary();
 
@@ -176,8 +172,8 @@ void TaskActiveView::updatePreview()
     int imageWidth{SXGAWidth};
     int imageHeight{SXGAHeight};
     if (ui->gbFraming->isChecked()) {
-        imageWidth = Rez::guiX(ui->qsbWidth->rawValue());
-        imageHeight = Rez::guiX(ui->qsbHeight->rawValue());
+        imageWidth = static_cast<int>(ui->qsbWidth->rawValue());
+        imageHeight = static_cast<int>(ui->qsbHeight->rawValue());
     }
 
     QImage image(imageWidth, imageHeight, QImage::Format_ARGB32_Premultiplied);
@@ -234,8 +230,8 @@ void TaskActiveView::setUiPrimary()
     ui->cbBg->setCurrentIndex(static_cast<int>(BackgroundType::Transparent));
     onBgTypeChanged(static_cast<int>(BackgroundType::Transparent)); 
 
-    ui->qsbWidth->setValue(Rez::appX(SXGAWidth));
-    ui->qsbHeight->setValue(Rez::appX(SXGAHeight));
+    ui->qsbWidth->setValue(SXGAWidth);
+    ui->qsbHeight->setValue(SXGAHeight);
 }
 
 void TaskActiveView::onBgTypeChanged(int index)

--- a/src/Mod/TechDraw/Gui/TaskActiveView.ui
+++ b/src/Mod/TechDraw/Gui/TaskActiveView.ui
@@ -44,7 +44,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Crops the captured image to this height</string>
+         <string>Crops the captured image to this pixel height</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>
@@ -60,14 +60,14 @@
       <item row="0" column="0">
        <widget class="QLabel" name="lWidth">
         <property name="text">
-         <string>Crop to width</string>
+         <string>Crop to width (px)</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="lHeight">
         <property name="text">
-         <string>Crop to height</string>
+         <string>Crop to height (px)</string>
         </property>
        </widget>
       </item>
@@ -86,7 +86,7 @@
          </size>
         </property>
         <property name="toolTip">
-         <string>Crops the captured image to this width</string>
+         <string>Crops the captured image to this pixel width</string>
         </property>
         <property name="unit" stdset="0">
          <string notr="true"/>


### PR DESCRIPTION
This fixes the ActiveView crop size unit mismatch by treating crop width and height as pixel values consistently.

Changes:
- keep the crop spinboxes unitless and initialize them to the SXGA pixel size
- use the entered pixel values directly when creating the captured QImage and crop rectangle
- convert stored pixel dimensions back to page units for DrawViewImage bounds
- clarify the crop labels/tooltips as pixel dimensions

Fixes #17066

Testing:
- `git diff --check`