### PR TITLE
tshoot issue #23518 expression editor dont close active task panel when pressing the esc key

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -1104,4 +1104,17 @@ void DlgExpressionInput::setMsgText()
     }
 }
 
+void DlgExpressionInput::keyPressEvent(QKeyEvent* event)
+{
+    // handle esc key explicitly so the parent task panel doesn't also close
+    // NOTE: https://github.com/freecad/freecad/issues/23518
+    if (event->key() == Qt::Key_Escape) {
+        event->accept();
+        reject();
+        return;
+    }
+
+    QDialog::keyPressEvent(event);
+}
+
 #include "moc_DlgExpressionInput.cpp"

--- a/src/Gui/Dialogs/DlgExpressionInput.h
+++ b/src/Gui/Dialogs/DlgExpressionInput.h
@@ -102,6 +102,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
 
 private:
     Base::Type getTypePath();

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -416,6 +416,12 @@ void TaskView::keyPressEvent(QKeyEvent* ke)
             }
         }
         else if (ke->key() == Qt::Key_Escape && active->ActiveDialog->isEscapeButtonEnabled()) {
+            // If a child popup (e.g. the expression editor) already handled ESC,
+            // don't also close the active task. see #23518.
+            if (ke->isAccepted()) {
+                return;
+            }
+
             // get only the buttons of the button box
             QDialogButtonBox* box = active->ActiveCtrl->standardButtons();
             QList<QAbstractButton*> list = box->buttons();

--- a/src/Gui/ViewProvider.cpp
+++ b/src/Gui/ViewProvider.cpp
@@ -224,7 +224,7 @@ void ViewProvider::eventCallback(void* ud, SoEventCallback* node)
             auto ke = static_cast<const SoKeyboardEvent*>(ev);
             const SbBool press = ke->getState() == SoButtonEvent::DOWN ? true : false;
             switch (ke->getKey()) {
-                case SoKeyboardEvent::ESCAPE:
+                case SoKeyboardEvent::ESCAPE: {
                     if (self->keyPressed(press, ke->getKey())) {
                         node->setHandled();
                     }
@@ -263,6 +263,7 @@ void ViewProvider::eventCallback(void* ud, SoEventCallback* node)
                         FC_WARN("Release all mouse buttons before exiting editing");
                     }
                     break;
+                }
                 default:
                     // call the virtual method
                     if (self->keyPressed(press, ke->getKey())) {


### PR DESCRIPTION
- [x] will update with a more comprehensive description later

pressing the <kbd>esc</kbd> key in a expression editor dialog should no longer close the parent task panel.

the popup's esc event was propagating to the `TaskView::keyPressEvent` without being marked as accepted. so `TaskView` treated it as a request to cancel the active task.

i tested this fix using the partdesign pad operation / task and clicking on the <kbd>f(x)</kbd> icon and then pressing the <kbd>esc</kbd> key. 😪

all should be good now 🤞

several code comments have been added to the below linked branch to help aid future developers in the reasoning behind the decisions made for this PR.

fixes #23518

below is a link to a branch i created which includes some debugging logic that was later removed from this branch due to recent conversations i've had with other developers about leaving debug logic in pull requests, so it has been omitted.

- https://github.com/ipatch/FreeCAD/tree/ipatch.tshoot.23518-expression-editor-esc-dbg

this PR was assisted with the help of claude opus 4.7

some take aways i gathered from asking questions with claude.

> Qt::Popup widgets aren't modal widgets in Qt's API sense, they're popup widgets.  -🤖

checking `MainWindow::eventFilter` there appeared to be no `esc` key handling or event filtering.

> The honest framing is: this fix addresses a symptom of a deeper architectural issue (Coin scene-graph events and Qt widget events both dispatch ESC independently to the task panel). A proper fix would unify the two dispatch paths, but that's a much larger refactor. -🤖

## Issues

- https://github.com/FreeCAD/FreeCAD/issues/23518

## Before and After Images

