### PR TITLE
Fix HiDPI datum label supersampling

### DIFF
--- a/src/Gui/SoDatumLabel.cpp
+++ b/src/Gui/SoDatumLabel.cpp
@@ -233,10 +233,10 @@ void SoDatumLabel::drawImage()
     front.setRgbF(t[0], t[1], t[2]);
 
     QImage image(w * sampling.getValue(), h * sampling.getValue(), QImage::Format_ARGB32_Premultiplied);
-    image.setDevicePixelRatio(sampling.getValue());
     image.fill(0x00000000);
 
     QPainter painter(&image);
+    painter.scale(sampling.getValue(), sampling.getValue());
     if (useAntialiasing) {
         painter.setRenderHint(QPainter::Antialiasing);
     }


### PR DESCRIPTION
## Issues
Fixes #29990

## Summary
This keeps the existing supersampled datum-label texture, but applies the supersampling through the QPainter transform instead of storing a device-pixel-ratio on the offscreen QImage before BitmapFactory converts it into raw Coin image data.

The issue thread points at the HiDPI path added in 65f737e as the likely cause. Since BitmapFactory::convert reads raw QImage pixels and dimensions, keeping the scale in the painter transform makes the texture contents deterministic across Qt/platform HiDPI behavior while preserving the existing logical dimensions in getDimension().

## Before and After Images
I cannot produce a reliable before/after screenshot in this Windows checkout because the local FreeCAD GUI build toolchain is not installed and the reported failure is Linux HiDPI-specific. The change is intentionally limited to the suspected offscreen texture rasterization path from the issue discussion.

## Testing
- git diff --check
- Inspected the patch to confirm it is a one-line behavioral change with no line-ending rewrite
