### PR TITLE
Accept normalized document names in lookups

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -220,6 +220,26 @@ bool requestTargetsDocument(const RecomputeRequest& request, const std::string& 
     return request.documentName == documentName;
 }
 
+template<typename Map>
+auto findDocumentByName(Map& documents, const char* name)
+{
+    if (Base::Tools::isNullOrEmpty(name)) {
+        return documents.end();
+    }
+
+    auto pos = documents.find(name);
+    if (pos != documents.end()) {
+        return pos;
+    }
+
+    const std::string identifier = Base::Tools::getIdentifier(name);
+    if (identifier.empty() || identifier == name) {
+        return documents.end();
+    }
+
+    return documents.find(identifier);
+}
+
 bool documentCanRecomputeOnWorker(const Document& document)
 {
     try {
@@ -678,13 +698,12 @@ bool Application::closeDocument(const Document* doc)
 
 bool Application::closeDocument(const char* name)
 {
-    const std::string documentName(name);
-
-    cancelRecomputeRequestsForDocument(documentName);
-
-    const auto pos = DocMap.find( name );
+    const auto pos = findDocumentByName(DocMap, name);
     if (pos == DocMap.end()) // no such document
         return false;
+
+    const std::string documentName(pos->first);
+    cancelRecomputeRequestsForDocument(documentName);
 
     Base::ConsoleRefreshDisabler disabler;
 
@@ -718,8 +737,7 @@ void Application::closeAllDocuments()
 
 Document* Application::getDocument(const char *Name) const
 {
-
-    const auto pos = DocMap.find(Name);
+    const auto pos = findDocumentByName(DocMap, Name);
 
     if (pos == DocMap.end())
         return nullptr;

--- a/tests/src/App/Application.cpp
+++ b/tests/src/App/Application.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 #define FC_OS_MACOSX 1
+#include "App/Application.h"
+#include "App/Document.h"
 #include "App/ProgramOptionsUtilities.h"
 
 #include <src/App/InitApplication.h>
@@ -57,3 +59,16 @@ TEST_F(ApplicationTest, fCustomSyntaxEmptyIn)
     Spr exp {"", ""};
     EXPECT_EQ(res, exp);
 };
+
+TEST_F(ApplicationTest, getDocumentAcceptsNormalizedProposedName)
+{
+    App::Application& app = App::GetApplication();
+
+    App::Document* doc = app.newDocument("application-test-dashed-name");
+    ASSERT_NE(nullptr, doc);
+    EXPECT_STREQ("application_test_dashed_name", doc->getName());
+
+    EXPECT_EQ(doc, app.getDocument("application-test-dashed-name"));
+    EXPECT_TRUE(app.closeDocument("application-test-dashed-name"));
+    EXPECT_EQ(nullptr, app.getDocument("application_test_dashed_name"));
+}


### PR DESCRIPTION
This fixes document lookup and close operations for proposed document names that are normalized when the document is created.

`newDocument(some-thing)` creates an internal document named `some_thing`, but Python callers can still keep the original proposed name. `getDocument()` and `closeDocument()` now try the exact name first, then the normalized identifier used by document creation.

A regression test covers looking up and closing a document via the original dashed proposed name.

Fixes #15966

Testing:
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check HEAD~1..HEAD`