### PR TITLE
Fix Array3D depth selection bounds

### DIFF
--- a/src/Mod/Material/App/MaterialValue.cpp
+++ b/src/Mod/Material/App/MaterialValue.cpp
@@ -942,13 +942,11 @@ int Array3D::currentDepth() const
 
 void Array3D::setCurrentDepth(int depth)
 {
-    validateDepth(depth);
-
     if (depth < 0 || _rowMap.empty()) {
         _currentDepth = 0;
     }
     else if (depth >= static_cast<int>(_rowMap.size())) {
-        _currentDepth = _rowMap.size() - 1;
+        _currentDepth = static_cast<int>(_rowMap.size()) - 1;
     }
     else {
         _currentDepth = depth;

--- a/tests/src/Mod/Material/App/TestMaterialValue.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialValue.cpp
@@ -242,6 +242,15 @@ TEST_F(TestMaterialValue, TestArray3DType)
     EXPECT_EQ(mat2.rows(1), 1);
     EXPECT_EQ(mat2.rows(2), 2);
 
+    mat2.setCurrentDepth(3);
+    EXPECT_EQ(mat2.currentDepth(), 2);
+
+    mat2.setCurrentDepth(-1);
+    EXPECT_EQ(mat2.currentDepth(), 0);
+
+    mat2.setCurrentDepth(2);
+    EXPECT_EQ(mat2.currentDepth(), 2);
+
     quantity = Base::Quantity::parse("32 C");
     mat2.setDepthValue(quantity);
     EXPECT_FALSE(mat2.getDepthValue(0).isValid());


### PR DESCRIPTION
## Summary
- allow Array3D::setCurrentDepth() to clamp out-of-range depth selections instead of throwing InvalidIndex first
- add regression coverage for selecting the trailing Array3D depth row and for negative depth input

## Rationale
When tabbing out of the last value in the 3D depth table, Qt can move selection to the trailing insert row, where the selected row equals depth(). setCurrentDepth() already had bounds-handling logic for that case, but validateDepth() ran first and threw before the clamp could happen.

Fixes #15896

## Tests
- git diff --check
- GitHub Actions: pre-commit.ci, Lint / Lint, Ubuntu / Build, CodeQL Analyze checks
- Not run locally: Material gtests/build, because this local workspace has no FreeCAD build tree and cmake/ctest are not available here.