### PR TITLE
Gui: MDIView : Do not initialize ActiveObjects if pcDocument is null

### DIFF
--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -69,7 +69,7 @@ MDIView::MDIView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wfl
 
         // NOLINTBEGIN
         connectDelObject = pcDocument->signalDeletedObject.connect(
-            std::bind(&ActiveObjectList::objectDeleted, ActiveObjects, sp::_1)
+            std::bind(&ActiveObjectList::objectDeleted, ActiveObjects.get(), sp::_1)
         );
         assert(connectDelObject.connected());
         // NOLINTEND

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -60,14 +60,15 @@ MDIView::MDIView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wfl
     , pythonObject(nullptr)
     , currentMode(Child)
     , wstate(Qt::WindowNoState)
-    , ActiveObjects(pcDocument)
 {
     setAttribute(Qt::WA_DeleteOnClose);
 
     if (pcDocument) {
+        ActiveObjects = new ActiveObjectList(pcDocument);
+
         // NOLINTBEGIN
         connectDelObject = pcDocument->signalDeletedObject.connect(
-            std::bind(&ActiveObjectList::objectDeleted, &ActiveObjects, sp::_1)
+            std::bind(&ActiveObjectList::objectDeleted, ActiveObjects, sp::_1)
         );
         assert(connectDelObject.connected());
         // NOLINTEND

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -60,11 +60,12 @@ MDIView::MDIView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wfl
     , pythonObject(nullptr)
     , currentMode(Child)
     , wstate(Qt::WindowNoState)
+    , ActiveObjects(nullptr)
 {
     setAttribute(Qt::WA_DeleteOnClose);
 
     if (pcDocument) {
-        ActiveObjects = new ActiveObjectList(pcDocument);
+        ActiveObjects = std::make_unique<ActiveObjectList>(pcDocument);
 
         // NOLINTBEGIN
         connectDelObject = pcDocument->signalDeletedObject.connect(

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -144,24 +144,38 @@ public:
         std::string* subname = nullptr
     ) const
     {
-        return ActiveObjects.getObject<_T>(name, parent, subname);
+        if (ActiveObjects) {
+            return ActiveObjects->getObject<_T>(name, parent, subname);
+        }
+        return nullptr;
     }
     void setActiveObject(App::DocumentObject* o, const char* n, const char* subname = nullptr)
     {
-        ActiveObjects.setObject(o, n, subname);
+        if (ActiveObjects) {
+            ActiveObjects->setObject(o, n, subname);
+        }
     }
     bool hasActiveObject(const char* n) const
     {
-        return ActiveObjects.hasObject(n);
+        if (ActiveObjects) {
+            return ActiveObjects->hasObject(n);
+        }
+        return false;
     }
     bool isActiveObject(App::DocumentObject* o, const char* n, const char* subname = nullptr) const
     {
-        return ActiveObjects.hasObject(o, n, subname);
+        if (ActiveObjects) {
+            return ActiveObjects->hasObject(o, n, subname);
+        }
+        return false;
     }
 
     App::DocumentObject* getActiveObjectWithExtension(const Base::Type extensionTypeId) const
     {
-        return ActiveObjects.getObjectWithExtension(extensionTypeId);
+        if (ActiveObjects) {
+            return ActiveObjects->getObjectWithExtension(extensionTypeId);
+        }
+        return nullptr;
     }
 
     /*!
@@ -205,7 +219,7 @@ private:
     ViewMode currentMode;
     Qt::WindowStates wstate;
     // list of active objects of this view
-    ActiveObjectList ActiveObjects;
+    ActiveObjectList* ActiveObjects;
     using Connection = fastsignals::connection;
     Connection connectDelObject;  // remove active object upon delete.
 

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -219,7 +219,7 @@ private:
     ViewMode currentMode;
     Qt::WindowStates wstate;
     // list of active objects of this view
-    ActiveObjectList* ActiveObjects;
+    std::unique_ptr<ActiveObjectList> ActiveObjects;
     using Connection = fastsignals::connection;
     Connection connectDelObject;  // remove active object upon delete.
 


### PR DESCRIPTION
Follow up on https://github.com/FreeCAD/FreeCAD/pull/30037

If a MDIView like the start page has no attached document, then it should not have a ActiveObjects initialized as it does not makes any sense.

Please squash