### PR TITLE
Gui: fix Std_Part failure if bodies preselected

### DIFF
--- a/src/Gui/CommandStructure.cpp
+++ b/src/Gui/CommandStructure.cpp
@@ -84,10 +84,6 @@ void StdCmdPart::activated(int iMsg)
         "selected_objects = Gui.Selection.getSelection()\n"
         "if len(selected_objects) > 1:\n"
         "    for obj in selected_objects:\n"
-        "        # Add subobjects if obj is a container\n"
-        "        if hasattr(obj, 'OutList') and len(obj.OutList) > 0:\n"
-        "            for child in obj.OutList:\n"
-        "                App.activeDocument().%s.addObject(child)\n"
         "        App.activeDocument().%s.addObject(obj)\n",
         PartName.c_str(),
         PartName.c_str()


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/30039

I don't understand, the PR https://github.com/FreeCAD/FreeCAD/pull/19786 introduced this for loop `for child in obj.OutList:` to `Add subobjects if obj is a container`

But that doesn't make sense to me. Each object handles it's own content.
It's causing the bug #30039 were it fails for Bodies or other Parts. And I suspect it also generate bugs with App::Links since the links are in the OutList.

What are the objects that this code was supposed to handle? @chennes @hyarion @Abdelhadi-Wael it's not clear to me from the PR what this was supposed to address.

But using OutList is a bad idea anyway : it would then mess things for links. The code should probably use .Group not .OutList. But still this is not necessary for GeoFeature groups (nor for normal groups).