### PR TITLE
TechDraw: Place inserted SVG symbols on top

### DIFF
--- a/src/Mod/TechDraw/Gui/Command.cpp
+++ b/src/Mod/TechDraw/Gui/Command.cpp
@@ -96,6 +96,25 @@ using namespace TechDrawGui;
 using namespace TechDraw;
 using DU = DrawUtil;
 
+namespace
+{
+
+void stackViewOnTop(Gui::Command* cmd, const std::string& viewName)
+{
+    auto* guiDoc = Gui::Application::Instance->getDocument(cmd->getDocument());
+    if (!guiDoc) {
+        return;
+    }
+
+    auto* viewProvider = dynamic_cast<ViewProviderDrawingView*>(
+        guiDoc->getViewProviderByName(viewName.c_str()));
+    if (viewProvider) {
+        viewProvider->stackTop();
+    }
+}
+
+}  // namespace
+
 //===========================================================================
 // TechDraw_PageDefault
 //===========================================================================
@@ -455,9 +474,11 @@ void CmdTechDrawView::activated(int iMsg)
                 filterList);
 
             if (!filename.isEmpty()) {
+                std::string svgSymbolName;
                 if (filename.endsWith(QStringLiteral(".svg"), Qt::CaseInsensitive)
                     || filename.endsWith(QStringLiteral(".svgz"), Qt::CaseInsensitive)) {
                     std::string FeatName = getUniqueObjectName("Symbol");
+                    svgSymbolName = FeatName;
                     auto filespec = DU::cleanFilespecBackslash(
                         Base::Tools::escapeEncodeFilename(filename.toStdString()));
                     openCommand(QT_TRANSLATE_NOOP("Command", "Create Symbol"));
@@ -496,6 +517,9 @@ void CmdTechDrawView::activated(int iMsg)
                 }
 
                 updateActive();
+                if (!svgSymbolName.empty()) {
+                    stackViewOnTop(this, svgSymbolName);
+                }
                 commitCommand();
             }
         }
@@ -1592,6 +1616,9 @@ void CmdTechDrawSymbol::activated(int iMsg)
                   FeatName.c_str());
 
         updateActive();
+        if (!baseView) {
+            stackViewOnTop(this, FeatName);
+        }
         commitCommand();
     }
 }
@@ -2107,4 +2134,3 @@ Base::Vector3d checkDirectionVsBasis(Base::Vector3d dir)
     return dir;
 
 }
-


### PR DESCRIPTION
## Summary
- place newly inserted top-level SVG symbols at the front of the TechDraw page stack
- share the stack-top handling between the SVG path in TechDraw_View and the TechDraw_Symbol command
- leave symbols attached to a selected base view unchanged

## Rationale
Issue #24820 reports that inserting an SVG symbol with no object selected puts the new symbol at the bottom of the layer stack. A previous stale PR only handled TechDraw_Symbol; this also handles the no-selection SVG path in TechDraw_View, as noted in review discussion on the earlier PR.

Fixes #24820

## Tests
- git diff --check
- Not run locally: FreeCAD GUI/build is not available in this workspace.