### PR TITLE
Fix Linux thumbnailer install paths

### DIFF
--- a/src/Tools/freecad-thumbnailer.in
+++ b/src/Tools/freecad-thumbnailer.in
@@ -14,7 +14,7 @@ Installation:
     "$ sudo cp freecad-icon-48.png /usr/share/icons/hicolor/48x48/apps/org.freecad.FreeCAD.png"
 
 - The application/x-extension-fcstd MIME type should be registered
-    Check that a corresponding /usr/share/mime/packages/freecad.xml file exists
+    Check that a corresponding /usr/share/mime/packages/org.freecad.FreeCAD.xml file exists
     Make sure the MIME database is up to date
     "$ sudo update-mime-database /usr/share/mime"
 
@@ -40,7 +40,7 @@ import getopt
 opt, par = getopt.getopt(sys.argv[1:], "-s:")
 input_file = par[0]
 output_file = par[1]
-default_icon = "@CMAKE_INSTALL_DATAROOTDIR@/icons/hicolor/48x48/apps/org.freecad.FreeCAD.png"
+default_icon = "@CMAKE_INSTALL_FULL_DATAROOTDIR@/icons/hicolor/48x48/apps/org.freecad.FreeCAD.png"
 
 try:
     # Read compressed file

--- a/src/XDGData/FreeCAD.thumbnailer.in
+++ b/src/XDGData/FreeCAD.thumbnailer.in
@@ -1,4 +1,4 @@
 [Thumbnailer Entry]
-TryExec=@CMAKE_INSTALL_BINDIR@/freecad-thumbnailer
-Exec=@CMAKE_INSTALL_BINDIR@/freecad-thumbnailer -s %s %i %o
+TryExec=@CMAKE_INSTALL_FULL_BINDIR@/freecad-thumbnailer
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/freecad-thumbnailer -s %s %i %o
 MimeType=application/x-extension-fcstd;


### PR DESCRIPTION
## Summary
- configure the Linux thumbnailer entry with the absolute installed `freecad-thumbnailer` path
- configure the thumbnailer fallback icon path with the absolute installed data directory
- update the installation comment to reference the current MIME package filename

## Rationale
`FreeCAD.thumbnailer.in` used `CMAKE_INSTALL_BINDIR`, which commonly configures to a relative path such as `bin/freecad-thumbnailer`. File managers expect the thumbnailer command to be resolvable from the installed entry, so the generated file can point at a non-working relative executable path. `GNUInstallDirs` already provides `CMAKE_INSTALL_FULL_BINDIR` and `CMAKE_INSTALL_FULL_DATAROOTDIR`, which match the installed locations.

Fixes #20678

## Tests
- git diff --check
- Not run locally: CMake/build environment is not available in this workspace.