### PR TITLE
TechDraw: fix deletion of cosmetic elements in safe mode

### DIFF
--- a/src/Mod/TechDraw/App/CosmeticExtension.cpp
+++ b/src/Mod/TechDraw/App/CosmeticExtension.cpp
@@ -90,6 +90,13 @@ void CosmeticExtension::deleteCosmeticElements(std::vector<std::string> removabl
     }
 }
 
+void CosmeticExtension::refreshAllCosmetic()
+{
+    refreshCEGeoms();
+    refreshCLGeoms();
+    refreshCVGeoms();
+}
+
 //==============================================================================
 //CosmeticVertex x, y are stored as unscaled, but mirrored (inverted Y) values.
 //if you are creating a CV based on calculations of scaled geometry, you need to

--- a/src/Mod/TechDraw/App/CosmeticExtension.h
+++ b/src/Mod/TechDraw/App/CosmeticExtension.h
@@ -95,6 +95,7 @@ public:
     virtual void            clearGeomFormats();
 
     void deleteCosmeticElements(std::vector<std::string> removables);
+    void refreshAllCosmetic();
 
     TechDraw::DrawViewPart* getOwner();
 

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
@@ -30,6 +30,7 @@
 
 #include <Mod/TechDraw/App/DrawProjGroup.h>
 #include <Mod/TechDraw/App/DrawProjGroupItem.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
 
 #include "QGIView.h"
 #include "ViewProviderProjGroupItem.h"
@@ -124,8 +125,21 @@ bool ViewProviderProjGroupItem::doubleClicked()
     return true;
 }
 
-bool ViewProviderProjGroupItem::onDelete(const std::vector<std::string> &)
+bool ViewProviderProjGroupItem::onDelete(const std::vector<std::string>& subNames)
 {
+    // If cosmetic sub-elements are selected, delete only those and veto object deletion.
+    if (!subNames.empty()) {
+        TechDraw::DrawViewPart* dvp = getViewObject();
+        if (dvp) {
+            dvp->deleteCosmeticElements(subNames);
+            dvp->refreshCEGeoms();
+            dvp->refreshCLGeoms();
+            dvp->refreshCVGeoms();
+            dvp->requestPaint();
+            return false;
+        }
+    }
+
     // we cannot delete the anchor view, thus check if the item is the front item
     // we also cannot delete if the item has a section or detail view
 

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.cpp
@@ -129,12 +129,9 @@ bool ViewProviderProjGroupItem::onDelete(const std::vector<std::string>& subName
 {
     // If cosmetic sub-elements are selected, delete only those and veto object deletion.
     if (!subNames.empty()) {
-        TechDraw::DrawViewPart* dvp = getViewObject();
-        if (dvp) {
+        if (TechDraw::DrawViewPart* dvp = getViewObject()) {
             dvp->deleteCosmeticElements(subNames);
-            dvp->refreshCEGeoms();
-            dvp->refreshCLGeoms();
-            dvp->refreshCVGeoms();
+            dvp->refreshAllCosmetic();
             dvp->requestPaint();
             return false;
         }

--- a/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.h
+++ b/src/Mod/TechDraw/Gui/ViewProviderProjGroupItem.h
@@ -52,7 +52,7 @@ public:
     TechDraw::DrawProjGroupItem* getViewObject() const override;
     TechDraw::DrawProjGroupItem* getObject() const;
     void unsetEdit(int ModNum) override;
-    bool onDelete(const std::vector<std::string> &) override;
+    bool onDelete(const std::vector<std::string>& subNames) override;
     bool canDelete(App::DocumentObject* obj) const override;
 
 protected:

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -370,12 +370,9 @@ bool ViewProviderViewPart::onDelete(const std::vector<std::string>& subNames)
     // pressing Del in safe mode deleted the whole view instead of the
     // selected cosmetic element.
     if (!subNames.empty()) {
-        TechDraw::DrawViewPart* dvp = getViewObject();
-        if (dvp) {
+        if (TechDraw::DrawViewPart* dvp = getViewObject()) {
             dvp->deleteCosmeticElements(subNames);
-            dvp->refreshCEGeoms();
-            dvp->refreshCLGeoms();
-            dvp->refreshCVGeoms();
+            dvp->refreshAllCosmetic();
             dvp->requestPaint();
             return false;  // veto deletion of the object itself
         }

--- a/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderViewPart.cpp
@@ -46,6 +46,7 @@
 #include <Mod/TechDraw/App/DrawViewDimension.h>
 #include <Mod/TechDraw/App/DrawViewMulti.h>
 #include <Mod/TechDraw/App/DrawBrokenView.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/LineGroup.h>
 #include <Mod/TechDraw/App/Cosmetic.h>
 #include <Mod/TechDraw/App/CenterLine.h>
@@ -361,10 +362,26 @@ void ViewProviderViewPart::handleChangedPropertyType(Base::XMLReader &reader, co
     }
 }
 
-bool ViewProviderViewPart::onDelete(const std::vector<std::string> & subNames)
+bool ViewProviderViewPart::onDelete(const std::vector<std::string>& subNames)
 {
+    // If cosmetic sub-elements (edges, vertices, centerlines) are selected,
+    // delete only those and veto the object deletion.  This mirrors the
+    // behaviour of the normal (non-safe) mode and fixes issue #28574 where
+    // pressing Del in safe mode deleted the whole view instead of the
+    // selected cosmetic element.
+    if (!subNames.empty()) {
+        TechDraw::DrawViewPart* dvp = getViewObject();
+        if (dvp) {
+            dvp->deleteCosmeticElements(subNames);
+            dvp->refreshCEGeoms();
+            dvp->refreshCLGeoms();
+            dvp->refreshCVGeoms();
+            dvp->requestPaint();
+            return false;  // veto deletion of the object itself
+        }
+    }
+
     // we cannot delete if the view has a section or detail view
-    (void) subNames;
     QString bodyMessage;
     QTextStream bodyMessageStream(&bodyMessage);
 


### PR DESCRIPTION
Very strange BUG!
In safe mode the keyboard shortcut manager is disabled, so pressing Del does not generate a ShortcutOverride event.  Instead Qt routes the key through the focused widget (tree view / toolbar) and Std_Delete is invoked directly.  StdCmdDelete calls ViewProvider::onDelete(subNames) where subNames contains the selected sub-element (e.g. 'Edge7'), but both ViewProviderViewPart::onDelete and
ViewProviderProjGroupItem::onDelete ignored the subNames parameter entirely and fell through to deleting the whole DrawViewPart object.

Fix: at the top of both onDelete overrides, check whether subNames is non-empty and, if so, delegate to DrawViewPart::deleteCosmeticElements followed by the three refresh calls.  Return false to veto deletion of the parent object.  The existing anchor-view and section-view guard code is unchanged and only reached when no sub-elements are selected.

Fixes: https://github.com/FreeCAD/FreeCAD/issues/28574

<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
https://github.com/FreeCAD/FreeCAD/issues/28574

## Before and After Images
Before:




https://github.com/user-attachments/assets/7ba9b249-f601-4bc1-b9ab-dcb1a0f116dd







After:

https://github.com/user-attachments/assets/56a68c54-775e-4771-9b55-bfeea1fcf4bb





<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
