### PR TITLE
Fix Selection View reset when clearing search text

### DIFF
--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -283,9 +283,9 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
 
 void SelectionView::search(const QString& text)
 {
+    searchList.clear();
+    App::Document* doc = App::GetApplication().getActiveDocument();
     if (!text.isEmpty()) {
-        searchList.clear();
-        App::Document* doc = App::GetApplication().getActiveDocument();
         std::vector<App::DocumentObject*> objects;
         if (doc) {
             objects = doc->getObjects();
@@ -313,6 +313,13 @@ void SelectionView::search(const QString& text)
             }
             countLabel->setText(QString::number(selectionView->count()));
         }
+    }
+    else if (doc) {
+        onSelectionChanged(SelectionChanges(SelectionChanges::SetSelection, doc->getName()));
+    }
+    else {
+        selectionView->clear();
+        countLabel->setText(QString::number(selectionView->count()));
     }
 }
 


### PR DESCRIPTION
### Summary

- Fixes <https://github.com/FreeCAD/FreeCAD/issues/30009>.
- Clear `searchList` on each search update so stale filtered objects are not reused after the search box is cleared.
- Restore the Selection View from the current active document selection when the search text becomes empty.
- Clear the list and count when there is no active document to restore from.

### Validation

- Verified FreeCAD #30009 is open and labeled `Good first issue`, `Status: Confirmed`, `Type: Bug`, and `Mod: Core`.
- Passed: `git ls-files --eol -- src/Gui/Selection/SelectionView.cpp` reports `i/crlf w/crlf`.
- Passed: `git -c core.whitespace=-blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- src/Gui/Selection/SelectionView.cpp`
- Note: plain `git diff --check -- src/Gui/Selection/SelectionView.cpp` reports CRLF lines as trailing whitespace for this CRLF-tracked file, so I have not claimed that plain diff-check passed.
- Blocked locally: `cmake --preset debug`
- CMake configure stops at `Could not find a valid Qt installation. Consider setting Qt5_DIR or Qt6_DIR (as needed).`, so I have not claimed a full local build.

