### PR TITLE
Initialize VarSet expression values immediately

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -602,6 +602,7 @@ void DlgExpressionInput::createBindingVarSet(App::Property* propVarSet, App::Doc
     binding.apply();
 
     varSet->renameObjectIdentifiers(idsFromObjToVarSet);
+    varSet->ExpressionEngine.execute();
 }
 
 void DlgExpressionInput::acceptWithVarSet()


### PR DESCRIPTION
# Initialize VarSet expression values immediately

## Summary

- Fixes a stale initial value when `Store in Variable Set` creates a new VarSet property from a non-literal expression.
- Executes the VarSet expression engine immediately after binding the expression and rewriting identifiers relative to the VarSet.
- Keeps the change scoped to `DlgExpressionInput::createBindingVarSet()`.

Fixes FreeCAD/FreeCAD#27997.

## Validation

```bash
gh issue view 27997 --repo FreeCAD/FreeCAD --comments --json number,title,state,labels,comments,url
gh pr list --repo FreeCAD/FreeCAD --search "27997 in:title,body" --state open --json number,title,url,headRefName,author
gh pr list --repo FreeCAD/FreeCAD --search "\"Store in Variable Set\"" --state open --json number,title,url,headRefName,author
gh pr list --repo FreeCAD/FreeCAD --search "\"VarSet\" \"Expression\"" --state open --json number,title,url,headRefName,author
git diff --check -- src/Gui/Dialogs/DlgExpressionInput.cpp
git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- src/Gui/Dialogs/DlgExpressionInput.cpp
git ls-files --eol -- src/Gui/Dialogs/DlgExpressionInput.cpp
cmake -S /Users/mx/Money/worktrees/freecad -B /tmp/freecad-opp031-cmake-check-20260511 -DCMAKE_BUILD_TYPE=Debug
```

`git diff --check` and the CRLF-aware diff check pass. `DlgExpressionInput.cpp` is tracked and written with LF line endings.

Local CMake configure is blocked by missing Qt on this machine:

```text
Could not find a valid Qt installation. Consider setting Qt5_DIR or Qt6_DIR (as needed).
```
