### PR TITLE
Sketcher: Addition of lazy external projection layer

### DIFF
--- a/src/Mod/Sketcher/App/SketchObject.h
+++ b/src/Mod/Sketcher/App/SketchObject.h
@@ -27,6 +27,7 @@
 #include <App/FeaturePython.h>
 #include <App/IndexedName.h>
 #include <App/PropertyFile.h>
+#include <memory>
 #include <Base/Axis.h>
 #include <Base/Bitmask.h>
 #include <Mod/Part/App/Part2DObject.h>
@@ -247,6 +248,17 @@ public:
         bool defining = false,
         bool intersection = false
     );
+    /**
+     * Build a preview of the projected external edge/vertex without adding it to the sketch.
+     *
+     * The returned geometries are temporary drawing/selection previews owned by the caller. This
+     * function must not change ExternalGeometry, ExternalTypes, expressions, or constraints.
+     */
+    std::vector<std::unique_ptr<Part::Geometry>> buildProjectedExternalGeometry(
+        App::DocumentObject* Obj,
+        const char* SubName,
+        bool intersection = false
+    ) const;
     /** delete external
      *  ExtGeoId >= 0 with 0 corresponding to the first user defined
      *  external geometry

--- a/src/Mod/Sketcher/App/SketchObjectExternal.cpp
+++ b/src/Mod/Sketcher/App/SketchObjectExternal.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepAdaptor_Surface.hxx>
@@ -808,10 +809,17 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
     std::vector<long> Types = ExternalTypes.getValues();
     std::vector<DocumentObject*> Objects = ExternalGeometry.getValues();
     std::vector<std::string> SubElements = ExternalGeometry.getSubValues();
-    Types.resize(Objects.size(), static_cast<long>(ExtType::Projection));
 
     const std::vector<DocumentObject*> originalObjects = Objects;
     const std::vector<std::string> originalSubElements = SubElements;
+    const std::vector<long> originalTypes = Types;
+
+    auto restoreExternalGeometry = [&]() {
+        ExternalGeometry.setValues(originalObjects, originalSubElements);
+        ExternalTypes.setValues(originalTypes);
+    };
+
+    Types.resize(Objects.size(), static_cast<long>(ExtType::Projection));
 
     if (Objects.size() != SubElements.size()) {
         assert(0 /*counts of objects and subelements in external geometry links do not match*/);
@@ -823,6 +831,7 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
     }
 
     bool add = true;
+    int updatedIndex = -1;
     for (size_t i = 0; i < Objects.size(); ++i) {
         if (!(Objects[i] == Obj && std::string(SubName) == SubElements[i])) {
             continue;
@@ -835,6 +844,7 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
         }
         // Case where projections are already there when adding intersections.
         add = false;
+        updatedIndex = static_cast<int>(i);
         Types[i] = static_cast<int>(ExtType::Both);
     }
     if (add) {
@@ -842,8 +852,6 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
         Objects.push_back(Obj);
         SubElements.emplace_back(SubName);
         Types.push_back(static_cast<int>(intersection ? ExtType::Intersection : ExtType::Projection));
-        if (intersection) {
-        }
 
         // set the Link list.
         ExternalGeometry.setValues(Objects, SubElements);
@@ -857,14 +865,29 @@ int SketchObject::addExternal(App::DocumentObject* Obj, const char* SubName, boo
     catch (const Base::Exception& e) {
         Base::Console().error("%s\n", e.what());
         // revert to original values
-        ExternalGeometry.setValues(originalObjects, originalSubElements);
+        restoreExternalGeometry();
         return -1;
+    }
+    catch (const Standard_Failure& e) {
+        Base::Console().error("%s\n", e.GetMessageString());
+        restoreExternalGeometry();
+        return -1;
+    }
+    catch (const std::exception& e) {
+        Base::Console().error("%s\n", e.what());
+        restoreExternalGeometry();
+        return -1;
+    }
+    catch (...) {
+        ExternalGeometry.setValues(originalObjects, originalSubElements);
+        ExternalTypes.setValues(originalTypes);
+        throw;
     }
 
     acceptGeometry();  // This may need to be refactored into onChanged for ExternalGeometry
 
     solverNeedsUpdate = true;
-    return ExternalGeometry.getValues().size() - 1;
+    return updatedIndex >= 0 ? updatedIndex : ExternalGeometry.getValues().size() - 1;
 }
 // clang-format off
 
@@ -2292,7 +2315,340 @@ void processFace (const Rotation& invRot,
     }
 }
 
+void importProjectedVertex(const TopoDS_Shape& vertexShape,
+                           std::vector<std::unique_ptr<Part::Geometry>>& geos,
+                           const Handle(Geom_Plane)& gPlane,
+                           const Base::Placement& invPlm)
+{
+    gp_Pnt point = BRep_Tool::Pnt(TopoDS::Vertex(vertexShape));
+    GeomAPI_ProjectPointOnSurf projection(point, gPlane);
+    point = projection.NearestPoint();
+
+    Base::Vector3d projectedPoint(point.X(), point.Y(), point.Z());
+    invPlm.multVec(projectedPoint, projectedPoint);
+
+    auto geomPoint = std::make_unique<Part::GeomPoint>(projectedPoint);
+    GeometryFacade::setConstruction(geomPoint.get(), true);
+    geos.emplace_back(std::move(geomPoint));
+}
+
+TopoDS_Shape resolveExternalGeometrySubShape(const App::DocumentObject* Obj,
+                                             const std::string& SubElement)
+{
+    TopoDS_Shape refSubShape;
+
+    // Handles LCS ,resolve to actual datum object
+    const App::DocumentObject* resolvedObj = Obj;
+    if (auto* lcs = freecad_cast<const App::LocalCoordinateSystem*>(Obj); lcs && !SubElement.empty()) {
+        // get the datum element by name
+        App::DatumElement* datum = lcs->getDatumElement(SubElement.c_str());
+        if (datum) {
+            resolvedObj = datum;
+        }
+    }
+
+    if (auto* datum = freecad_cast<const Part::Datum*>(resolvedObj)) {
+        refSubShape = datum->getShape();
+    }
+    else if (auto* refObj = freecad_cast<const Part::Feature*>(resolvedObj)) {
+        const Part::TopoShape& refShape = refObj->Shape.getShape();
+        refSubShape = refShape.getSubShape(SubElement.c_str());
+    }
+    else if (auto* pl = freecad_cast<const App::Plane*>(resolvedObj)) {
+        Base::Vector3d base = pl->getBasePoint();
+        Base::Vector3d normal = pl->getDirection();
+        gp_Pln plane(gp_Pnt(base.x, base.y, base.z), gp_Dir(normal.x, normal.y, normal.z));
+        BRepBuilderAPI_MakeFace fBuilder(plane);
+        if (!fBuilder.IsDone())
+            throw Base::RuntimeError(
+                "Sketcher: addExternal(): Failed to build face from App::Plane");
+
+        TopoDS_Face f = TopoDS::Face(fBuilder.Shape());
+        refSubShape = f;
+    }
+    else if (auto* line = freecad_cast<const Part::DatumLine*>(resolvedObj)) {
+        Base::Placement plm = line->Placement.getValue();
+        Base::Vector3d base = plm.getPosition();
+        Base::Vector3d dir = line->getDirection();
+        gp_Lin l(gp_Pnt(base.x, base.y, base.z), gp_Dir(dir.x, dir.y, dir.z));
+        BRepBuilderAPI_MakeEdge eBuilder(l);
+        if (!eBuilder.IsDone()) {
+            throw Base::RuntimeError(
+                "Sketcher: addExternal(): Failed to build edge from Part::DatumLine");
+        }
+
+        TopoDS_Edge e = TopoDS::Edge(eBuilder.Shape());
+        refSubShape = e;
+    }
+    else if (auto* point = freecad_cast<const Part::DatumPoint*>(resolvedObj)) {
+        Base::Placement plm = point->Placement.getValue();
+        Base::Vector3d base = plm.getPosition();
+        gp_Pnt p(base.x, base.y, base.z);
+        BRepBuilderAPI_MakeVertex eBuilder(p);
+        if (!eBuilder.IsDone()) {
+            throw Base::RuntimeError(
+                "Sketcher: addExternal(): Failed to build vertex from Part::DatumPoint");
+        }
+
+        TopoDS_Vertex v = TopoDS::Vertex(eBuilder.Shape());
+        refSubShape = v;
+    }
+    else if (auto* line = freecad_cast<const App::Line*>(resolvedObj)) {
+        Base::Vector3d base = line->getBasePoint();
+        Base::Vector3d dir = line->getDirection();
+        gp_Lin l(gp_Pnt(base.x, base.y, base.z), gp_Dir(dir.x, dir.y, dir.z));
+        BRepBuilderAPI_MakeEdge eBuilder(l);
+        if (!eBuilder.IsDone()) {
+            throw Base::RuntimeError(
+                "Sketcher: addExternal(): Failed to build edge from App::Line");
+        }
+
+        TopoDS_Edge e = TopoDS::Edge(eBuilder.Shape());
+        refSubShape = e;
+    }
+    else if (auto* point = freecad_cast<const App::Point*>(resolvedObj)) {
+        Base::Vector3d base = point->getBasePoint();
+        gp_Pnt p(base.x, base.y, base.z);
+        BRepBuilderAPI_MakeVertex eBuilder(p);
+        if (!eBuilder.IsDone()) {
+            throw Base::RuntimeError(
+                "Sketcher: addExternal(): Failed to build vertex from App::Point");
+        }
+
+        TopoDS_Vertex v = TopoDS::Vertex(eBuilder.Shape());
+        refSubShape = v;
+    }
+    else {
+        throw Base::TypeError(
+            "Datum feature type is not yet supported as external geometry for a sketch");
+    }
+
+    return refSubShape;
+}
+
+void appendExternalGeometryProjection(TopoDS_Shape& refSubShape,
+                                      std::vector<std::unique_ptr<Part::Geometry>>& geos,
+                                      const Rotation& invRot,
+                                      const Placement& invPlm,
+                                      const gp_Trsf& mov,
+                                      const gp_Pln& sketchPlane,
+                                      const Handle(Geom_Plane)& gPlane,
+                                      gp_Ax3& sketchAx3,
+                                      TopoDS_Shape& aProjFace)
+{
+    switch (refSubShape.ShapeType()) {
+    case TopAbs_FACE: {
+        processFace(invRot, invPlm, mov, sketchPlane, gPlane, sketchAx3, aProjFace, geos, refSubShape);
+    } break;
+    case TopAbs_EDGE: {
+        const TopoDS_Edge& edge = TopoDS::Edge(refSubShape);
+        processEdge(edge,
+                    geos,
+                    gPlane,
+                    invPlm,
+                    mov,
+                    sketchPlane,
+                    invRot,
+                    sketchAx3,
+                    aProjFace);
+    } break;
+    case TopAbs_VERTEX: {
+        importProjectedVertex(refSubShape, geos, gPlane, invPlm);
+    } break;
+    default:
+        throw Base::TypeError("Unknown type of geometry");
+    }
+}
+
+void appendExternalGeometryIntersection(TopoDS_Shape& refSubShape,
+                                        std::vector<std::unique_ptr<Part::Geometry>>& geos,
+                                        const Rotation& invRot,
+                                        const Placement& invPlm,
+                                        const gp_Trsf& mov,
+                                        const gp_Pln& sketchPlane,
+                                        const Handle(Geom_Plane)& gPlane,
+                                        gp_Ax3& sketchAx3,
+                                        TopoDS_Shape& aProjFace,
+                                        double arcFitTolerance)
+{
+    FCBRepAlgoAPI_Section maker(refSubShape, sketchPlane);
+    maker.Approximation(Standard_True);
+    if (!maker.IsDone())
+        FC_THROWM(Base::CADKernelError, "Failed to get intersection");
+    Part::TopoShape intersectionShape(maker.Shape());
+    auto edges = intersectionShape.getSubTopoShapes(TopAbs_EDGE);
+    for (const auto& s : edges) {
+        TopoDS_Edge edge = TopoDS::Edge(s.getShape());
+        processEdge(edge,
+                    geos,
+                    gPlane,
+                    invPlm,
+                    mov,
+                    sketchPlane,
+                    invRot,
+                    sketchAx3,
+                    aProjFace);
+    }
+    // Section of some face (e.g. sphere) produce more than one arcs
+    // from the same circle. So we try to fit the arcs with a single
+    // circle/arc.
+    if (refSubShape.ShapeType() == TopAbs_FACE && geos.size() > 1) {
+        auto wires = Part::TopoShape().makeElementWires(edges);
+        if (wires.countSubShapes(TopAbs_WIRE) == 1) {
+            TopoDS_Vertex firstVertex;
+            TopoDS_Vertex lastVertex;
+            BRepTools_WireExplorer exp(TopoDS::Wire(wires.getSubShape(TopAbs_WIRE, 1)));
+            if (exp.More()) {
+                firstVertex = exp.CurrentVertex();
+            }
+            while (exp.More()) {
+                lastVertex = exp.CurrentVertex();
+                exp.Next();
+            }
+            if (!firstVertex.IsNull() && !lastVertex.IsNull()) {
+                gp_Pnt P1 = BRep_Tool::Pnt(firstVertex);
+                gp_Pnt P2 = BRep_Tool::Pnt(lastVertex);
+                if (auto geo = fitArcs(geos, P1, P2, arcFitTolerance)) {
+                    geos.clear();
+                    geos.emplace_back(geo);
+                }
+            }
+        }
+    }
+    for (const auto& s : intersectionShape.getSubShapes(TopAbs_VERTEX, TopAbs_EDGE)) {
+        importProjectedVertex(s, geos, gPlane, invPlm);
+    }
+}
+
 }  // anonymous namespace
+
+
+std::vector<std::unique_ptr<Part::Geometry>> SketchObject::buildProjectedExternalGeometry(
+    App::DocumentObject* Obj,
+    const char* SubName,
+    bool intersection
+) const
+{
+    std::vector<std::unique_ptr<Part::Geometry>> geos;
+
+    if (!Obj || Base::Tools::isNullOrEmpty(SubName)) {
+        return geos;
+    }
+
+    if (!isExternalAllowed(Obj->getDocument(), Obj)) {
+        return geos;
+    }
+
+    const std::string subName(SubName);
+    const Data::IndexedName indexedSubName(subName.c_str());
+    const bool hasValidIndex = indexedSubName && indexedSubName.getIndex() > 0;
+    const bool isEdge = hasValidIndex && std::strcmp(indexedSubName.getType(), "Edge") == 0;
+    const bool isVertex = hasValidIndex && std::strcmp(indexedSubName.getType(), "Vertex") == 0;
+
+    // Face intersections are face-based and need a path separate from Edge/Vertex projection previews.
+    if (!isEdge && !isVertex) {
+        return geos;
+    }
+
+    Base::Placement Plm = Placement.getValue();
+    Base::Vector3d Pos = Plm.getPosition();
+    Base::Rotation Rot = Plm.getRotation();
+    Base::Rotation invRot = Rot.inverse();
+    Base::Vector3d dN(0, 0, 1);
+    Rot.multVec(dN, dN);
+    Base::Vector3d dX(1, 0, 0);
+    Rot.multVec(dX, dX);
+
+    Base::Placement invPlm = Plm.inverse();
+    Base::Matrix4D invMat = invPlm.toMatrix();
+    gp_Trsf mov;
+    mov.SetValues(invMat[0][0],
+                  invMat[0][1],
+                  invMat[0][2],
+                  invMat[0][3],
+                  invMat[1][0],
+                  invMat[1][1],
+                  invMat[1][2],
+                  invMat[1][3],
+                  invMat[2][0],
+                  invMat[2][1],
+                  invMat[2][2],
+                  invMat[2][3]);
+
+    gp_Ax3 sketchAx3(
+        gp_Pnt(Pos.x, Pos.y, Pos.z), gp_Dir(dN.x, dN.y, dN.z), gp_Dir(dX.x, dX.y, dX.z));
+    gp_Pln sketchPlane(sketchAx3);
+    Handle(Geom_Plane) gPlane = new Geom_Plane(sketchPlane);
+    BRepBuilderAPI_MakeFace mkFace(sketchPlane);
+    TopoDS_Shape aProjFace = mkFace.Shape();
+
+    try {
+        TopoDS_Shape refSubShape = resolveExternalGeometrySubShape(Obj, subName);
+
+        if (isEdge && refSubShape.ShapeType() == TopAbs_EDGE) {
+            if (intersection) {
+                appendExternalGeometryIntersection(refSubShape,
+                                                   geos,
+                                                   invRot,
+                                                   invPlm,
+                                                   mov,
+                                                   sketchPlane,
+                                                   gPlane,
+                                                   sketchAx3,
+                                                   aProjFace,
+                                                   ArcFitTolerance.getValue());
+            }
+            else {
+                appendExternalGeometryProjection(refSubShape,
+                                                 geos,
+                                                 invRot,
+                                                 invPlm,
+                                                 mov,
+                                                 sketchPlane,
+                                                 gPlane,
+                                                 sketchAx3,
+                                                 aProjFace);
+            }
+        }
+        else if (isVertex && refSubShape.ShapeType() == TopAbs_VERTEX) {
+            appendExternalGeometryProjection(refSubShape,
+                                             geos,
+                                             invRot,
+                                             invPlm,
+                                             mov,
+                                             sketchPlane,
+                                             gPlane,
+                                             sketchAx3,
+                                             aProjFace);
+        }
+    }
+    catch (const Base::Exception& e) {
+        FC_LOG("Failed to build on-demand external geometry preview in "
+               << getFullName() << ": " << Obj->getNameInDocument() << "." << subName
+               << std::endl << e.what());
+        geos.clear();
+    }
+    catch (const Standard_Failure& e) {
+        FC_LOG("Failed to build on-demand external geometry preview in "
+               << getFullName() << ": " << Obj->getNameInDocument() << "." << subName
+               << std::endl << e.GetMessageString());
+        geos.clear();
+    }
+    catch (const std::exception& e) {
+        FC_LOG("Failed to build on-demand external geometry preview in "
+               << getFullName() << ": " << Obj->getNameInDocument() << "." << subName
+               << std::endl << e.what());
+        geos.clear();
+    }
+    catch (...) {
+        FC_LOG("Failed to build on-demand external geometry preview in "
+               << getFullName() << ": " << Obj->getNameInDocument() << "." << subName
+               << std::endl << "Unknown exception");
+        geos.clear();
+    }
+
+    return geos;
+}
 
 void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd)
 {
@@ -2428,124 +2784,19 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
 
         std::vector<std::unique_ptr<Part::Geometry> > geos;
 
-        auto importVertex = [&](const TopoDS_Shape& refSubShape) {
-            gp_Pnt P = BRep_Tool::Pnt(TopoDS::Vertex(refSubShape));
-            GeomAPI_ProjectPointOnSurf proj(P, gPlane);
-            P = proj.NearestPoint();
-            Base::Vector3d p(P.X(), P.Y(), P.Z());
-            invPlm.multVec(p, p);
-
-            auto* point = new Part::GeomPoint(p);
-            GeometryFacade::setConstruction(point, true);
-            geos.emplace_back(point);
-        };
-
         try {
-            TopoDS_Shape refSubShape;
-
-            // Handles LCS ,resolve to actual datum object
-            const App::DocumentObject* resolvedObj = Obj;
-            if (Obj->isDerivedFrom<App::LocalCoordinateSystem>() && !SubElement.empty()) {
-                auto* lcs = static_cast<const App::LocalCoordinateSystem*>(Obj);
-                // get the datum element by name
-                App::DatumElement* datum = lcs->getDatumElement(SubElement.c_str());
-                if (datum) {
-                    resolvedObj = datum;
-                }
-            }
-
-            if (auto* datum = freecad_cast<const Part::Datum*>(resolvedObj)) {
-                refSubShape = datum->getShape();
-            }
-            else if (auto* refObj = freecad_cast<const Part::Feature*>(resolvedObj)) {
-                const Part::TopoShape& refShape = refObj->Shape.getShape();
-                refSubShape = refShape.getSubShape(SubElement.c_str());
-            }
-            else if (auto* pl = freecad_cast<const App::Plane*>(resolvedObj)) {
-                Base::Vector3d base = pl->getBasePoint();
-                Base::Vector3d normal = pl->getDirection();
-                gp_Pln plane(gp_Pnt(base.x, base.y, base.z), gp_Dir(normal.x, normal.y, normal.z));
-                BRepBuilderAPI_MakeFace fBuilder(plane);
-                if (!fBuilder.IsDone())
-                    throw Base::RuntimeError(
-                        "Sketcher: addExternal(): Failed to build face from App::Plane");
-
-                TopoDS_Face f = TopoDS::Face(fBuilder.Shape());
-                refSubShape = f;
-            }
-            else if (auto* line = freecad_cast<const Part::DatumLine*>(resolvedObj)) {
-                Base::Placement plm = line->Placement.getValue();
-                Base::Vector3d base = plm.getPosition();
-                Base::Vector3d dir = line->getDirection();
-                gp_Lin l(gp_Pnt(base.x, base.y, base.z), gp_Dir(dir.x, dir.y, dir.z));
-                BRepBuilderAPI_MakeEdge eBuilder(l);
-                if (!eBuilder.IsDone()) {
-                    throw Base::RuntimeError(
-                        "Sketcher: addExternal(): Failed to build edge from Part::DatumLine");
-                }
-
-                TopoDS_Edge e = TopoDS::Edge(eBuilder.Shape());
-                refSubShape = e;
-            }
-            else if (auto* point = freecad_cast<const Part::DatumPoint*>(resolvedObj)) {
-                Base::Placement plm = point->Placement.getValue();
-                Base::Vector3d base = plm.getPosition();
-                gp_Pnt p(base.x, base.y, base.z);
-                BRepBuilderAPI_MakeVertex eBuilder(p);
-                if (!eBuilder.IsDone()) {
-                    throw Base::RuntimeError(
-                        "Sketcher: addExternal(): Failed to build vertex from Part::DatumPoint");
-                }
-
-                TopoDS_Vertex v = TopoDS::Vertex(eBuilder.Shape());
-                refSubShape = v;
-            }
-            else if (auto* line = freecad_cast<const App::Line*>(resolvedObj)) {
-                Base::Vector3d base = line->getBasePoint();
-                Base::Vector3d dir = line->getDirection();
-                gp_Lin l(gp_Pnt(base.x, base.y, base.z), gp_Dir(dir.x, dir.y, dir.z));
-                BRepBuilderAPI_MakeEdge eBuilder(l);
-                if (!eBuilder.IsDone()) {
-                    throw Base::RuntimeError(
-                        "Sketcher: addExternal(): Failed to build edge from App::Line");
-                }
-
-                TopoDS_Edge e = TopoDS::Edge(eBuilder.Shape());
-                refSubShape = e;
-            }
-            else if (auto* point = freecad_cast<const App::Point*>(resolvedObj)) {
-                Base::Vector3d base = point->getBasePoint();
-                gp_Pnt p(base.x, base.y, base.z);
-                BRepBuilderAPI_MakeVertex eBuilder(p);
-                if (!eBuilder.IsDone()) {
-                    throw Base::RuntimeError(
-                        "Sketcher: addExternal(): Failed to build vertex from App::Point");
-                }
-
-                TopoDS_Vertex v = TopoDS::Vertex(eBuilder.Shape());
-                refSubShape = v;
-            }
-            else {
-                throw Base::TypeError(
-                    "Datum feature type is not yet supported as external geometry for a sketch");
-            }
+            TopoDS_Shape refSubShape = resolveExternalGeometrySubShape(Obj, SubElement);
 
             if (projection && !refSubShape.IsNull()) {
-                switch (refSubShape.ShapeType()) {
-                case TopAbs_FACE: {
-                    processFace(invRot, invPlm, mov, sketchPlane, gPlane, sketchAx3, aProjFace, geos, refSubShape);
-                } break;
-                case TopAbs_EDGE: {
-                    const TopoDS_Edge& edge = TopoDS::Edge(refSubShape);
-                    processEdge(edge, geos, gPlane, invPlm, mov, sketchPlane, invRot, sketchAx3, aProjFace);
-                } break;
-                case TopAbs_VERTEX: {
-                    importVertex(refSubShape);
-                } break;
-                default:
-                    throw Base::TypeError("Unknown type of geometry");
-                    break;
-                }
+                appendExternalGeometryProjection(refSubShape,
+                                                 geos,
+                                                 invRot,
+                                                 invPlm,
+                                                 mov,
+                                                 sketchPlane,
+                                                 gPlane,
+                                                 sketchAx3,
+                                                 aProjFace);
                 if (beingCreated && !extToAdd->intersection) {
                     // We are adding the projections, so we need to initialize those
                     for (auto& geo : geos) {
@@ -2557,39 +2808,16 @@ void SketchObject::rebuildExternalGeometry(std::optional<ExternalToAdd> extToAdd
             int projSize = geos.size();
 
             if (intersection && !refSubShape.IsNull()) {
-                FCBRepAlgoAPI_Section maker(refSubShape, sketchPlane);
-                maker.Approximation(Standard_True);
-                if (!maker.IsDone())
-                    FC_THROWM(Base::CADKernelError, "Failed to get intersection");
-                Part::TopoShape intersectionShape(maker.Shape());
-                auto edges = intersectionShape.getSubTopoShapes(TopAbs_EDGE);
-                for (const auto& s : edges) {
-                    TopoDS_Edge edge = TopoDS::Edge(s.getShape());
-                    processEdge(edge, geos, gPlane, invPlm, mov, sketchPlane, invRot, sketchAx3, aProjFace);
-                }
-                // Section of some face (e.g. sphere) produce more than one arcs
-                // from the same circle. So we try to fit the arcs with a single
-                // circle/arc.
-                if (refSubShape.ShapeType() == TopAbs_FACE && geos.size() > 1) {
-                    auto wires = Part::TopoShape().makeElementWires(edges);
-                    if (wires.countSubShapes(TopAbs_WIRE) == 1) {
-                        TopoDS_Vertex firstVertex, lastVertex;
-                        BRepTools_WireExplorer exp(TopoDS::Wire(wires.getSubShape(TopAbs_WIRE, 1)));
-                        firstVertex = exp.CurrentVertex();
-                        while (!exp.More())
-                            exp.Next();
-                        lastVertex = exp.CurrentVertex();
-                        gp_Pnt P1 = BRep_Tool::Pnt(firstVertex);
-                        gp_Pnt P2 = BRep_Tool::Pnt(lastVertex);
-                        if (auto geo = fitArcs(geos, P1, P2, ArcFitTolerance.getValue())) {
-                            geos.clear();
-                            geos.emplace_back(geo);
-                        }
-                    }
-                }
-                for (const auto& s : intersectionShape.getSubShapes(TopAbs_VERTEX, TopAbs_EDGE)) {
-                    importVertex(s);
-                }
+                appendExternalGeometryIntersection(refSubShape,
+                                                   geos,
+                                                   invRot,
+                                                   invPlm,
+                                                   mov,
+                                                   sketchPlane,
+                                                   gPlane,
+                                                   sketchAx3,
+                                                   aProjFace,
+                                                   ArcFitTolerance.getValue());
 
                 if (beingCreated && extToAdd->intersection) {
                     // We are adding the projections, so we need to initialize those

--- a/src/Mod/Sketcher/Gui/CMakeLists.txt
+++ b/src/Mod/Sketcher/Gui/CMakeLists.txt
@@ -72,6 +72,8 @@ SET(SketcherGui_SRCS
     DrawSketchHandlerScale.h
     DrawSketchHandlerSymmetry.h
     CommandCreateGeo.cpp
+    ConstraintLazySelection.h
+    ConstraintLazySelection.cpp
     CommandConstraints.h
     CommandConstraints.cpp
     CommandSketcherTools.h
@@ -124,6 +126,8 @@ SET(SketcherGui_SRCS
     EditModeGeometryCoinManager.h
     EditModeConstraintCoinManager.cpp
     EditModeConstraintCoinManager.h
+    LazyExternalGeometryLayer.cpp
+    LazyExternalGeometryLayer.h
     ViewProviderSketchCoinAttorney.cpp
     ViewProviderSketchCoinAttorney.h
     ViewProviderSketch.cpp

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -41,7 +41,6 @@
 
 #include <App/Application.h>
 #include <Base/Tools.h>
-#include <Base/Tools2D.h>
 #include <Gui/Action.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
@@ -57,6 +56,7 @@
 #include <Mod/Sketcher/App/SketchObject.h>
 #include <Mod/Sketcher/App/SolverGeometryExtension.h>
 
+#include "ConstraintLazySelection.h"
 #include "CommandConstraints.h"
 #include "DrawSketchHandler.h"
 #include "EditDatumDialog.h"
@@ -337,6 +337,12 @@ public:
                                const Base::Vector2d& position)
     {
         viewProvider.moveConstraint(constraintIndex, position);
+    }
+
+    static Base::Type getLazyExternalGeometryType(const ViewProviderSketch& viewProvider,
+                                                  int lazyExternalId)
+    {
+        return viewProvider.getLazyExternalGeometryType(lazyExternalId);
     }
 };
 }  // namespace SketcherGui
@@ -1055,12 +1061,6 @@ bool addConstraintSafely(SketchObject* obj, std::function<void()> constraintaddi
 namespace SketcherGui
 {
 
-struct SelIdPair
-{
-    int GeoId;
-    Sketcher::PointPos PosId;
-};
-
 struct SketchSelection
 {
     enum GeoType
@@ -1180,20 +1180,23 @@ public:
 
     bool allow(App::Document*, App::DocumentObject* pObj, const char* sSubName) override
     {
-        if (pObj != this->object) {
+        if (pObj != this->object || Base::Tools::isNullOrEmpty(sSubName)) {
             return false;
         }
-        if (Base::Tools::isNullOrEmpty(sSubName)) {
-            return false;
-        }
-        std::string element(sSubName);
+
+        const std::string element(sSubName);
+        const auto lazyExternal = parseLazyExternalSubelement(element);
+        const bool isLazyExternalVertex = lazyExternal && lazyExternal->vertex;
+        const bool isLazyExternalEdge = lazyExternal && !lazyExternal->vertex;
         if ((allowedSelTypes & SelRoot && element.substr(0, 9) == "RootPoint")
             || (allowedSelTypes & SelVertex && element.substr(0, 6) == "Vertex")
             || ((allowedSelTypes & (SelEdge | SelArc)) && element.substr(0, 4) == "Edge")
+            || (allowedSelTypes & SelVertex && isLazyExternalVertex)
+            || (allowedSelTypes & SelEdge && isLazyExternalEdge)
             || (allowedSelTypes & SelHAxis && element.substr(0, 6) == "H_Axis")
             || (allowedSelTypes & SelVAxis && element.substr(0, 6) == "V_Axis")
             || ((allowedSelTypes & (SelExternalEdge | SelExternalArc))
-                && element.substr(0, 12) == "ExternalEdge")) {
+                && (element.rfind("ExternalEdge", 0) == 0 || isLazyExternalEdge))) {
             return true;
         }
 
@@ -1234,6 +1237,35 @@ public:
         return "CmdSketcherConstraint";
     }
 
+    void openCommand(const char* name)
+    {
+        if (lazyExternalCommandActive) {
+            return;
+        }
+
+        Gui::Command::openCommand(name);
+    }
+
+    void commitCommand()
+    {
+        Gui::Command::commitCommand();
+        lazyExternalCommandActive = false;
+    }
+
+    void abortCommand()
+    {
+        Gui::Command::abortCommand();
+        lazyExternalCommandActive = false;
+    }
+
+    ActivatedLazySelection getActivatedLazySelection(bool includeLazyExternalVertices = false)
+    {
+        return ActivatedLazySelection(*this,
+                                  getActiveGuiDocument(),
+                                  includeLazyExternalVertices,
+                                  &lazyExternalCommandActive);
+    }
+
 protected:
     /**
      * @brief allowedSelSequences
@@ -1254,6 +1286,41 @@ protected:
     {
         return isCommandActive(getActiveGuiDocument());
     }
+
+    bool beginLazyExternalCommand(ViewProviderSketch* sketchgui,
+                          std::vector<SelIdPair>& selection)
+    {
+        if (!hasLazySelection(selection)) {
+            return true;
+        }
+
+        Gui::Command::openCommand(QT_TRANSLATE_NOOP("Command", "Add constraint"));
+        lazyExternalCommandActive = true;
+
+        if (!LazyExternalSelectionResolver::materializeLazyExternalSelectionPairs(sketchgui, selection)) {
+            abortCommand();
+            return false;
+        }
+
+        return true;
+    }
+
+    void abortLazyExternalCommand()
+    {
+        if (lazyExternalCommandActive) {
+            abortCommand();
+        }
+    }
+
+private:
+    static bool hasLazySelection(const std::vector<SelIdPair>& selection)
+    {
+        return std::any_of(selection.begin(), selection.end(), [](const SelIdPair& item) {
+            return item.IsLazyExternal;
+        });
+    }
+
+    bool lazyExternalCommandActive = false;
 };
 
 class DrawSketchHandlerGenConstraint: public DrawSketchHandler
@@ -1292,6 +1359,7 @@ public:
     {}
     ~DrawSketchHandlerGenConstraint() override
     {
+        LazyExternalSelectionResolver::clearPendingLazyExternalSelection(sketchgui);
         Gui::Selection().rmvSelectionGate();
     }
 
@@ -1302,6 +1370,26 @@ public:
     bool pressButton(Base::Vector2d /*onSketchPos*/) override
     {
         return true;
+    }
+
+    bool selectionIsVertex(const SelIdPair& item) const
+    {
+        return item.IsLazyExternal ? item.LazyExternalVertex : isVertex(item.GeoId, item.PosId);
+    }
+
+    bool currentSequencesAllow(SelType type) const
+    {
+        for (int token : ongoingSequences) {
+            if ((cmd->allowedSelSequences).at(token).at(seqIndex) & type) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    SelType lazyExternalEdgeSelectionType() const
+    {
+        return currentSequencesAllow(SelExternalEdge) ? SelExternalEdge : SelEdge;
     }
 
     bool releaseButton(Base::Vector2d onSketchPos) override
@@ -1316,6 +1404,8 @@ public:
         int VtId = getPreselectPoint();
         int CrvId = getPreselectCurve();
         int CrsId = getPreselectCross();
+        int lazyExternalId = getPreselectLazyExternalId();
+        bool lazyExternalVertex = isPreselectLazyExternalVertex();
         if (allowedSelTypes & SelRoot && CrsId == 0) {
             selIdPair.GeoId = Sketcher::GeoEnum::RtPnt;
             selIdPair.PosId = Sketcher::PointPos::start;
@@ -1326,6 +1416,14 @@ public:
             sketchgui->getSketchObject()->getGeoVertexIndex(VtId, selIdPair.GeoId, selIdPair.PosId);
             newSelType = SelVertex;
             ss << "Vertex" << VtId + 1;
+        }
+        else if (allowedSelTypes & SelVertex && lazyExternalId >= 0 && lazyExternalVertex) {
+            std::string lazyExternalSubName;
+            if (LazyExternalSelectionResolver::makeLazyExternalSelectionPair(
+                    sketchgui, lazyExternalId, true, selIdPair, &lazyExternalSubName)) {
+                newSelType = SelVertex;
+                ss << lazyExternalSubName;
+            }
         }
         else if ((allowedSelTypes & (SelEdge | SelArc)) && CrvId >= 0) {
             const Part::Geometry* geom = sketchgui->getSketchObject()->getGeometry(CrvId);
@@ -1367,22 +1465,37 @@ public:
                 ss << "ExternalEdge" << Sketcher::GeoEnum::RefExt + 1 - CrvId;
             }
         }
+        else if ((allowedSelTypes & (SelEdge | SelExternalEdge)) && lazyExternalId >= 0 && !lazyExternalVertex) {
+            std::string lazyExternalSubName;
+            if (LazyExternalSelectionResolver::makeLazyExternalSelectionPair(
+                    sketchgui, lazyExternalId, false, selIdPair, &lazyExternalSubName)) {
+                newSelType = lazyExternalEdgeSelectionType();
+                ss << lazyExternalSubName;
+            }
+        }
 
-        if (selIdPair.GeoId == GeoEnum::GeoUndef) {
+        if (selIdPair.GeoId == GeoEnum::GeoUndef && !selIdPair.IsLazyExternal) {
             // If mouse is released on "blank" space, start over
             selSeq.clear();
             resetOngoingSequences();
             Gui::Selection().clearSelection();
+            LazyExternalSelectionResolver::clearPendingLazyExternalSelection(sketchgui);
         }
         else {
             // If mouse is released on something allowed, select it and move forward
             selSeq.push_back(selIdPair);
-            Gui::Selection().addSelection(sketchgui->getSketchObject()->getDocument()->getName(),
-                                          sketchgui->getSketchObject()->getNameInDocument(),
-                                          ss.str().c_str(),
-                                          onSketchPos.x,
-                                          onSketchPos.y,
-                                          0.f);
+            if (selIdPair.IsLazyExternal) {
+                LazyExternalSelectionResolver::setLazyExternalSelectionSelected(
+                    sketchgui, selIdPair, true);
+            }
+            else {
+                Gui::Selection().addSelection(sketchgui->getSketchObject()->getDocument()->getName(),
+                                              sketchgui->getSketchObject()->getNameInDocument(),
+                                              ss.str().c_str(),
+                                              onSketchPos.x,
+                                              onSketchPos.y,
+                                              0.f);
+            }
             _tempOnSequences.clear();
             allowedSelTypes = 0;
             for (std::set<int>::iterator token = ongoingSequences.begin();
@@ -1391,7 +1504,17 @@ public:
                 if ((cmd->allowedSelSequences).at(*token).at(seqIndex) & newSelType) {
                     if (seqIndex == (cmd->allowedSelSequences).at(*token).size() - 1) {
                         // One of the sequences is completed. Pass to cmd->applyConstraint
+                        if (!cmd->beginLazyExternalCommand(sketchgui, selSeq)) {
+                            selSeq.clear();
+                            resetOngoingSequences();
+                            Gui::Selection().clearSelection();
+                            LazyExternalSelectionResolver::clearPendingLazyExternalSelection(sketchgui);
+                            updateHint();
+                            return true;
+                        }
+
                         cmd->applyConstraint(selSeq, *token);// replace arg 2 by ongoingToken
+                        cmd->abortLazyExternalCommand();
 
                         selSeq.clear();
                         resetOngoingSequences();
@@ -1426,7 +1549,7 @@ public:
         if (selectionStep == 0) {
             return {{QObject::tr(PICK_POINT_OR_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
         } else if (selectionStep == 1 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 return {{QObject::tr(PICK_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
             } else {
                 return {{QObject::tr(PICK_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
@@ -1439,7 +1562,7 @@ public:
         if (selectionStep == 0) {
             return {{QObject::tr(PICK_EDGE_OR_FIRST_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
         } else if (selectionStep == 1 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Edge + Edge workflow
                 return {{QObject::tr(PICK_FIRST_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
             } else {
@@ -1448,10 +1571,10 @@ public:
                 return {{QObject::tr(PICK_SECOND_LINE_OR_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             }
         } else if (selectionStep == 2 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Edge + Edge workflow
                 return {{QObject::tr(PICK_SECOND_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
-            } else if (isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+            } else if (selectionIsVertex(selSeq[1])) {
                 // Edge + Point + Edge workflow
                 return {{QObject::tr(PICK_SECOND_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
             }
@@ -1463,7 +1586,7 @@ public:
         if (selectionStep == 0) {
             return {{QObject::tr(PICK_EDGE_OR_FIRST_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
         } else if (selectionStep == 1 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Edge + Edge workflow
                 return {{QObject::tr(PICK_FIRST_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
             } else {
@@ -1471,10 +1594,10 @@ public:
                 return {{QObject::tr(PICK_SECOND_EDGE_OR_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             }
         } else if (selectionStep == 2 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Edge + Edge workflow
                 return {{QObject::tr(PICK_SECOND_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
-            } else if (isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+            } else if (selectionIsVertex(selSeq[1])) {
                 // Edge + Point + Edge workflow
                 return {{QObject::tr(PICK_SECOND_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
             }
@@ -1486,7 +1609,7 @@ public:
         if (selectionStep == 0) {
             return {{QObject::tr(PICK_EDGE_OR_FIRST_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
         } else if (selectionStep == 1 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Edge + Edge workflow
                 return {{QObject::tr(PICK_FIRST_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
             } else {
@@ -1494,10 +1617,10 @@ public:
                 return {{QObject::tr(PICK_SECOND_EDGE_OR_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             }
         } else if (selectionStep == 2 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Edge + Edge workflow
                 return {{QObject::tr(PICK_SECOND_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
-            } else if (isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+            } else if (selectionIsVertex(selSeq[1])) {
                 // Edge + Point + Edge workflow
                 return {{QObject::tr(PICK_SECOND_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
             }
@@ -1509,7 +1632,7 @@ public:
         if (selectionStep == 0) {
             return {{QObject::tr(PICK_POINT_OR_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
         } else if (selectionStep == 1 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Point workflow
                 return {{QObject::tr(PICK_SECOND_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             } else {
@@ -1524,7 +1647,7 @@ public:
         if (selectionStep == 0) {
             return {{QObject::tr(PICK_POINT_OR_EDGE), {Gui::InputHint::UserInput::MouseLeft}}};
         } else if (selectionStep == 1 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Point workflow
                 return {{QObject::tr(PICK_SECOND_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             } else {
@@ -1539,7 +1662,7 @@ public:
         if (selectionStep == 0) {
             return {{QObject::tr(PICK_EDGE_OR_FIRST_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
         } else if (selectionStep == 1 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId)) {
+            if (selectionIsVertex(selSeq[0])) {
                 // Point + Edge + Point or Point + Point + Edge/Point workflow
                 return {{QObject::tr(PICK_EDGE_OR_SECOND_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             } else {
@@ -1547,10 +1670,10 @@ public:
                 return {{QObject::tr(PICK_SYMMETRY_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             }
         } else if (selectionStep == 2 && !selSeq.empty()) {
-            if (isVertex(selSeq[0].GeoId, selSeq[0].PosId) && isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+            if (selectionIsVertex(selSeq[0]) && selectionIsVertex(selSeq[1])) {
                 // Point + Point + Edge workflow
                 return {{QObject::tr(PICK_SYMMETRY_LINE_OR_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
-            } else if (isVertex(selSeq[0].GeoId, selSeq[0].PosId) && !isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+            } else if (selectionIsVertex(selSeq[0]) && !selectionIsVertex(selSeq[1])) {
                 // Point + Edge + Point workflow
                 return {{QObject::tr(PICK_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             }
@@ -2032,6 +2155,7 @@ public:
     }
     ~DrawSketchHandlerDimension() override
     {
+        LazyExternalSelectionResolver::clearPendingLazyExternalSelection(sketchgui);
     }
 
     enum class AvailableConstraint {
@@ -2085,6 +2209,7 @@ public:
     void deactivated() override
     {
         abortCommand();
+        LazyExternalSelectionResolver::clearPendingLazyExternalSelection(sketchgui);
         if (availableConstraint != AvailableConstraint::FIRST) {
             Obj->solve();
         }
@@ -2151,7 +2276,6 @@ public:
 
     bool releaseButton(Base::Vector2d onSketchPos) override
     {
-        Q_UNUSED(onSketchPos);
         availableConstraint = AvailableConstraint::FIRST;
         SelIdPair selIdPair;
         selIdPair.GeoId = GeoEnum::GeoUndef;
@@ -2162,7 +2286,8 @@ public:
         int VtId = getPreselectPoint();
         int CrvId = getPreselectCurve();
         int CrsId = getPreselectCross();
-
+        int lazyExternalId = getPreselectLazyExternalId();
+        bool lazyExternalVertex = isPreselectLazyExternalVertex();
         if (VtId >= 0) { //Vertex
             Obj->getGeoVertexIndex(VtId,
                 selIdPair.GeoId, selIdPair.PosId);
@@ -2185,9 +2310,20 @@ public:
             newselGeoType = Part::GeomLineSegment::getClassTypeId();
             ss << "V_Axis";
         }
+        else if (lazyExternalId >= 0) {
+            std::string lazyExternalSubName;
+            if (LazyExternalSelectionResolver::makeLazyExternalSelectionPair(
+                    sketchgui, lazyExternalId, lazyExternalVertex, selIdPair, &lazyExternalSubName, &newselGeoType)) {
+                ss << lazyExternalSubName;
+            }
+        }
         else if (CrvId >= 0 || CrvId <= Sketcher::GeoEnum::RefExt) { //Curves
             selIdPair.GeoId = CrvId;
             const Part::Geometry* geo = Obj->getGeometry(CrvId);
+            if (!geo) {
+                updateHint();
+                return true;
+            }
 
             newselGeoType = geo->getTypeId();
 
@@ -2199,32 +2335,47 @@ public:
             }
         }
 
-        if (selIdPair.GeoId == GeoEnum::GeoUndef) {
+        if (selIdPair.GeoId == GeoEnum::GeoUndef && !selIdPair.IsLazyExternal) {
             // If mouse is released on "blank" space, finalize and start over
             finalizeCommand();
             return true;
         }
 
-        std::vector<SelIdPair>& selVector = getSelectionVector(newselGeoType);
+        if (newselGeoType == Base::Type::BadType) {
+            updateHint();
+            return true;
+        }
+
+
+        auto* selVector = getSelectionVector(newselGeoType);
+        if (!selVector) {
+            updateHint();
+            return true;
+        }
 
         if (notSelectedYet(selIdPair)) {
             //add the geometry to its type vector. Temporarily if not selAllowed
-            selVector.push_back(selIdPair);
+            selVector->push_back(selIdPair);
 
             bool selAllowed = makeAppropriateConstraint(onSketchPos);
 
             if (selAllowed) {
-                // If mouse is released on something allowed, select it
-                sketchgui->addSelection2(ss.str().c_str(), onSketchPos.x, onSketchPos.y, 0.f);
+                if (selIdPair.IsLazyExternal) {
+                    LazyExternalSelectionResolver::setLazyExternalSelectionSelected(
+                        sketchgui, selIdPair, true);
+                }
+                else {
+                    sketchgui->addSelection2(ss.str().c_str(), onSketchPos.x, onSketchPos.y, 0.f);
+                }
                 sketchgui->draw(false, false); // Redraw
             }
             else {
-                selVector.pop_back();
+                selVector->pop_back();
             }
         }
         else {
             //if it is already selected we unselect it.
-            selVector.pop_back();
+            selVector->pop_back();
             if (!selectionEmpty()) {
                 makeAppropriateConstraint(onSketchPos);
             }
@@ -2232,7 +2383,13 @@ public:
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Dimension"));
             }
 
-            sketchgui->rmvSelection(ss.str().c_str());
+            if (selIdPair.IsLazyExternal) {
+                LazyExternalSelectionResolver::setLazyExternalSelectionSelected(
+                    sketchgui, selIdPair, false);
+            }
+            else {
+                sketchgui->rmvSelection(ss.str().c_str());
+            }
             sketchgui->draw(false, false); // Redraw
         }
 
@@ -2285,6 +2442,7 @@ protected:
     bool singleCircleReverseOrder;
 
     Sketcher::SketchObject* Obj;
+    bool lazyExternalMaterializationFailed = false;
 
     static AvailableConstraint nextConstraint(AvailableConstraint constraint)
     {
@@ -2492,6 +2650,7 @@ protected:
 
     void clearRefVectors()
     {
+        LazyExternalSelectionResolver::clearPendingLazyExternalSelection(sketchgui);
         selPoints.clear();
         selLine.clear();
         selCircleArc.clear();
@@ -2502,30 +2661,43 @@ protected:
 
     void handleInitialSelection()
     {
-        if (initialSelection.size() == 0) {
-            return;
-        }
-
         availableConstraint = AvailableConstraint::FIRST;
 
         // Add the selected elements to their corresponding selection vectors
         for (auto& selElement : initialSelection) {
             SelIdPair selIdPair;
+            Base::Type newselGeoType = Base::Type::BadType;
+
             getIdsFromName(selElement, Obj, selIdPair.GeoId, selIdPair.PosId);
 
-            Base::Type newselGeoType = Base::Type::BadType;
             if (isEdge(selIdPair.GeoId, selIdPair.PosId)) {
                 const Part::Geometry* geo = Obj->getGeometry(selIdPair.GeoId);
+                if (!geo) {
+                    continue;
+                }
                 newselGeoType = geo->getTypeId();
             }
             else if (isVertex(selIdPair.GeoId, selIdPair.PosId)) {
                 newselGeoType = Part::GeomPoint::getClassTypeId();
             }
 
-            std::vector<SelIdPair>& selVector = getSelectionVector(newselGeoType);
+            if (newselGeoType == Base::Type::BadType) {
+                continue;
+            }
+
+            auto* selVector = getSelectionVector(newselGeoType);
+            if (!selVector) {
+                continue;
+            }
 
             //add the geometry to its type vector. Temporarily if not selAllowed
-            selVector.push_back(selIdPair);
+            selVector->push_back(selIdPair);
+        }
+
+        LazyExternalSelectionResolver::appendPendingLazyExternalSelectionPairs(sketchgui, selPoints, selLine);
+        if (selPoints.empty() && selLine.empty() && selCircleArc.empty() && selEllipseAndCo.empty()
+            && selSplineAndCo.empty()) {
+            return;
         }
 
         // Remove redundant coincident points from the selection
@@ -2551,7 +2723,8 @@ protected:
         for (const auto& p : selPoints) {
             bool isRedundant = false;
             for (const auto& kept : filteredPoints) {
-                if (Obj->arePointsCoincident(p.GeoId, p.PosId, kept.GeoId, kept.PosId)) {
+                if (!p.IsLazyExternal && !kept.IsLazyExternal
+                    && Obj->arePointsCoincident(p.GeoId, p.PosId, kept.GeoId, kept.PosId)) {
                     isRedundant = true;
                     break;
                 }
@@ -2578,12 +2751,14 @@ protected:
         const std::vector<Sketcher::Constraint*>& ConStr = Obj->Constraints.getValues();
 
         bool commandHandledInEditDatum = false;
+        bool commandAccepted = true;
         for (int index : cstrIndexes | boost::adaptors::reversed) {
             if (show && ConStr[index]->isDimensional() && ConStr[index]->isDriving) {
                 commandHandledInEditDatum = true;
                 EditDatumDialog editDatumDialog(currentTransactionID, sketchgui, index);
                 editDatumDialog.exec();
                 if (!editDatumDialog.isSuccess()) {
+                    commandAccepted = false;
                     break;
                 }
             }
@@ -2592,6 +2767,11 @@ protected:
         if (!commandHandledInEditDatum) {
             commitCommand();
         }
+        else if (!commandAccepted) {
+            abortCommand();
+        }
+
+        LazyExternalSelectionResolver::clearPendingLazyExternalSelection(sketchgui);
 
         // This code enables the continuous creation mode.
         bool continuousMode = hGrp->GetBool("ContinuousCreationMode", true);
@@ -2603,56 +2783,74 @@ protected:
         }
     }
 
-    std::vector<SelIdPair>& getSelectionVector(Base::Type selGeoType)
+    Base::Type getSelectionGeometryType(const SelIdPair& item) const
     {
-        if (selGeoType == Part::GeomPoint::getClassTypeId()) {
-            return selPoints;
-        }
-        else if (selGeoType == Part::GeomLineSegment::getClassTypeId()) {
-            return selLine;
-        }
-        else if (selGeoType == Part::GeomArcOfCircle::getClassTypeId() ||
-            selGeoType == Part::GeomCircle::getClassTypeId()) {
-            return selCircleArc;
-        }
-        else if (selGeoType == Part::GeomEllipse::getClassTypeId() ||
-            selGeoType == Part::GeomArcOfEllipse::getClassTypeId() ||
-            selGeoType == Part::GeomArcOfHyperbola::getClassTypeId() ||
-            selGeoType == Part::GeomArcOfParabola::getClassTypeId()) {
-            return selEllipseAndCo;
-        }
-        else if (selGeoType == Part::GeomBSplineCurve::getClassTypeId()) {
-            return selSplineAndCo;
+        if (item.GeoId != Sketcher::GeoEnum::GeoUndef) {
+            const Part::Geometry* geo = Obj->getGeometry(item.GeoId);
+            if (geo) {
+                return geo->getTypeId();
+            }
         }
 
-        static std::vector<SelIdPair> emptyVector;
-        return emptyVector;
+        if (item.IsLazyExternal && sketchgui) {
+            return ViewProviderSketchCommandConstraintsAttorney::getLazyExternalGeometryType(
+        *sketchgui, item.LazyExternalId);
+        }
+
+        return Base::Type::BadType;
     }
 
-    bool notSelectedYet(const SelIdPair& elem)
+    std::vector<SelIdPair>* getSelectionVector(Base::Type selGeoType)
     {
-        auto contains = [&](const std::vector<SelIdPair>& vec, const SelIdPair& elem) {
-            for (const auto& x : vec)
-            {
-                if (x.GeoId == elem.GeoId && x.PosId == elem.PosId)
-                    return true;
-            }
-            return false;
-        };
+        if (selGeoType == Part::GeomPoint::getClassTypeId()) {
+            return &selPoints;
+        }
+        if (selGeoType == Part::GeomLineSegment::getClassTypeId()) {
+            return &selLine;
+        }
+        if (selGeoType == Part::GeomArcOfCircle::getClassTypeId()
+            || selGeoType == Part::GeomCircle::getClassTypeId()) {
+            return &selCircleArc;
+        }
+        if (selGeoType == Part::GeomEllipse::getClassTypeId()
+            || selGeoType == Part::GeomArcOfEllipse::getClassTypeId()
+            || selGeoType == Part::GeomArcOfHyperbola::getClassTypeId()
+            || selGeoType == Part::GeomArcOfParabola::getClassTypeId()) {
+            return &selEllipseAndCo;
+        }
+        if (selGeoType == Part::GeomBSplineCurve::getClassTypeId()) {
+            return &selSplineAndCo;
+        }
 
-        return !contains(selPoints, elem)
-            && !contains(selLine, elem)
-            && !contains(selCircleArc, elem)
-            && !contains(selEllipseAndCo, elem);
+        return nullptr;
+    }
+
+    static bool containsSelectionPair(const std::vector<SelIdPair>& selection,
+                                      const SelIdPair& item)
+    {
+        return std::any_of(selection.begin(), selection.end(), [&](const SelIdPair& existing) {
+            return selectionPairsEqual(existing, item);
+        });
+    }
+
+    bool notSelectedYet(const SelIdPair& elem) const
+    {
+        return !containsSelectionPair(selPoints, elem)
+            && !containsSelectionPair(selLine, elem)
+            && !containsSelectionPair(selCircleArc, elem)
+            && !containsSelectionPair(selEllipseAndCo, elem)
+            && !containsSelectionPair(selSplineAndCo, elem);
     }
 
     bool selectionEmpty() const
     {
-        return selPoints.empty() && selLine.empty() && selCircleArc.empty() && selEllipseAndCo.empty();
+        return selPoints.empty() && selLine.empty() && selCircleArc.empty() && selEllipseAndCo.empty()
+            && selSplineAndCo.empty();
     }
 
     bool makeAppropriateConstraint(Base::Vector2d onSketchPos) {
         bool selAllowed = false;
+        lazyExternalMaterializationFailed = false;
 
         GeomSelectionSizes selection(selPoints.size(), selLine.size(), selCircleArc.size(), selEllipseAndCo.size(), selSplineAndCo.size());
 
@@ -2686,7 +2884,7 @@ protected:
             if (selection.has1Ellipse()) { makeCts_1Ellipse(selAllowed); }
             else if (selection.has2MoreEllipses()) { makeCts_2MoreEllipse(selAllowed, selection.s_ell); }
         }
-        return selAllowed;
+        return !lazyExternalMaterializationFailed && selAllowed;
     }
 
     void makeCts_1Point(bool& selAllowed, Base::Vector2d onSketchPos)
@@ -2952,50 +3150,52 @@ protected:
 
     void makeCts_1Circle(bool& selAllowed, Base::Vector2d onSketchPos)
     {
-        int geoId = selCircleArc[0].GeoId;
-        singleCircleReverseOrder = isRadiusDoF(geoId);
+        singleCircleReverseOrder = !selCircleArc[0].IsLazyExternal
+            && isRadiusDoF(selCircleArc[0].GeoId);
 
         if (singleCircleReverseOrder) {
             if (availableConstraint == AvailableConstraint::FIRST) {
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Add arc angle constraint"));
-                createArcAngleConstrain(geoId, onSketchPos);
+                createArcAngleConstrain(selCircleArc[0].GeoId, onSketchPos);
                 selAllowed = true;
             }
             if (availableConstraint == AvailableConstraint::SECOND) {
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Add arc length constraint"));
-                createArcLengthConstrain(geoId, onSketchPos);
+                createArcLengthConstrain(selCircleArc[0].GeoId, onSketchPos);
             }
             if (availableConstraint == AvailableConstraint::THIRD) {
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Add radius constraint"));
-                createRadiusDiameterConstrain(geoId, onSketchPos, true);
+                createRadiusDiameterConstrain(selCircleArc[0].GeoId, onSketchPos, true);
             }
             if (availableConstraint == AvailableConstraint::FOURTH) {
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Add radius constraint"));
-                createRadiusDiameterConstrain(geoId, onSketchPos, false);
+                createRadiusDiameterConstrain(selCircleArc[0].GeoId, onSketchPos, false);
                 availableConstraint = AvailableConstraint::RESET;
             }
         }
         else {
             if (availableConstraint == AvailableConstraint::FIRST) {
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Add radius constraint"));
-                createRadiusDiameterConstrain(geoId, onSketchPos, true);
+                createRadiusDiameterConstrain(selCircleArc[0].GeoId, onSketchPos, true);
                 selAllowed = true;
             }
             if (availableConstraint == AvailableConstraint::SECOND) {
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Add radius constraint"));
-                createRadiusDiameterConstrain(geoId, onSketchPos, false);
-                if (!isArcOfCircle(*Obj->getGeometry(geoId))) {
-                    //This way if key is pressed again it goes back to FIRST
+                createRadiusDiameterConstrain(selCircleArc[0].GeoId, onSketchPos, false);
+                if (lazyExternalMaterializationFailed) {
+                    return;
+                }
+                if (!isArcOfCircle(*Obj->getGeometry(selCircleArc[0].GeoId))) {
                     availableConstraint = AvailableConstraint::RESET;
                 }
             }
             if (availableConstraint == AvailableConstraint::THIRD) {
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Add arc angle constraint"));
-                createArcAngleConstrain(geoId, onSketchPos);
+                createArcAngleConstrain(selCircleArc[0].GeoId, onSketchPos);
             }
             if (availableConstraint == AvailableConstraint::FOURTH) {
                 restartCommand(QT_TRANSLATE_NOOP("Command", "Add arc length constraint"));
-                createArcLengthConstrain(geoId, onSketchPos);
+                createArcLengthConstrain(selCircleArc[0].GeoId, onSketchPos);
                 availableConstraint = AvailableConstraint::RESET;
             }
         }
@@ -3013,6 +3213,9 @@ protected:
         if (availableConstraint == AvailableConstraint::SECOND) {
             restartCommand(QT_TRANSLATE_NOOP("Command", "Add concentric and length constraint"));
             bool created = createCoincidenceConstrain(selCircleArc[0].GeoId, Sketcher::PointPos::mid, selCircleArc[1].GeoId, Sketcher::PointPos::mid);
+            if (lazyExternalMaterializationFailed) {
+                return;
+            }
             if (!created) { //Already concentric, so skip to next
                 availableConstraint = AvailableConstraint::THIRD;
             }
@@ -3060,11 +3263,14 @@ protected:
     {
         //only ellipse or arc of of same kind, then equality of all radius.
         bool allTheSame = 1;
-        const Part::Geometry* geom = Obj->getGeometry(selEllipseAndCo[0].GeoId);
-        Base::Type typeOf = geom->getTypeId();
+        const Base::Type typeOf = getSelectionGeometryType(selEllipseAndCo[0]);
+        if (typeOf == Base::Type::BadType) {
+            return;
+        }
+
         for (size_t i = 1; i < s_ell; i++) {
-            const Part::Geometry* geomi = Obj->getGeometry(selEllipseAndCo[i].GeoId);
-            if (typeOf != geomi->getTypeId()) {
+            const Base::Type typeOfi = getSelectionGeometryType(selEllipseAndCo[i]);
+            if (typeOf != typeOfi) {
                 allTheSame = 0;
             }
         }
@@ -3078,6 +3284,10 @@ protected:
     }
 
     void createDistanceConstrain(int GeoId1, Sketcher::PointPos PosId1, int GeoId2, Sketcher::PointPos PosId2, Base::Vector2d onSketchPos) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         // If there's a point, it must be GeoId1. We could add a swap to make sure but as it's hardcoded it's not necessary.
 
         if (GeoId1 == GeoId2 || (PosId1 != Sketcher::PointPos::none && PosId2 != Sketcher::PointPos::none)) {
@@ -3200,6 +3410,10 @@ protected:
     }
 
     void createDistanceXYConstrain(Sketcher::ConstraintType type, int GeoId1, Sketcher::PointPos PosId1, int GeoId2, Sketcher::PointPos PosId2, Base::Vector2d onSketchPos) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         Base::Vector3d pnt1 = Obj->getPoint(GeoId1, PosId1);
         Base::Vector3d pnt2 = Obj->getPoint(GeoId2, PosId2);
         double ActLength = pnt2.x - pnt1.x;
@@ -3229,6 +3443,10 @@ protected:
     }
 
     void createRadiusDiameterConstrain(int GeoId, Base::Vector2d onSketchPos, bool firstCstr) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         double radius = 0.0;
         bool isCircleGeom = true;
 
@@ -3273,6 +3491,10 @@ protected:
     }
 
     bool createCoincidenceConstrain(int GeoId1, Sketcher::PointPos PosId1, int GeoId2, Sketcher::PointPos PosId2) {
+        if (lazyExternalMaterializationFailed) {
+            return false;
+        }
+
         // check if the edge already has a Block constraint
         if (areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2)) {
             return false;
@@ -3291,6 +3513,10 @@ protected:
     }
 
     void createEqualityConstrain(int GeoId1, int GeoId2) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         // check if the edge already has a Block constraint
         if (areBothPointsOrSegmentsFixed(Obj, GeoId1, GeoId2)) {
             return;
@@ -3318,6 +3544,10 @@ protected:
     }
 
     void createAngleConstrain(int GeoId1, int GeoId2, Base::Vector2d onSketchPos) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         Sketcher::PointPos PosId1 = Sketcher::PointPos::none;
         Sketcher::PointPos PosId2 = Sketcher::PointPos::none;
         double ActAngle;
@@ -3340,6 +3570,10 @@ protected:
     }
 
     void createArcLengthConstrain(int GeoId, Base::Vector2d onSketchPos) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         const Part::Geometry* geom = Obj->getGeometry(GeoId);
         if (!isArcOfCircle(*geom)) {
             return;
@@ -3355,6 +3589,10 @@ protected:
     }
 
     void createArcAngleConstrain(int GeoId, Base::Vector2d onSketchPos) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         const Part::Geometry* geom = Obj->getGeometry(GeoId);
         if (!isArcOfCircle(*geom)) {
             return;
@@ -3370,6 +3608,10 @@ protected:
     }
 
     void createVerticalConstrain(int GeoId1, Sketcher::PointPos PosId1, int GeoId2, Sketcher::PointPos PosId2) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         if (selLine.size() == 1) {
             // If the line is horizontal (should be without constraint if we're here), then we need to modify
             // its point or we'll get a null line.
@@ -3398,6 +3640,10 @@ protected:
         tryAutoRecompute(Obj);
     }
     void createHorizontalConstrain(int GeoId1, Sketcher::PointPos PosId1, int GeoId2, Sketcher::PointPos PosId2) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         if (selLine.size() == 1) {
             // If the line is vertical (should be without constraint if we're here), then we need to modify
             // its point or we'll get a null line.
@@ -3427,6 +3673,10 @@ protected:
     }
 
     void createBlockConstrain(int GeoId) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         Gui::cmdAppObjectArgs(sketchgui->getObject(), "addConstraint(Sketcher.Constraint('Block',%d)) ", GeoId);
 
         addConstraintIndex();
@@ -3447,6 +3697,10 @@ protected:
     }
 
     void createSymmetryConstrain(int GeoId1, Sketcher::PointPos PosId1, int GeoId2, Sketcher::PointPos PosId2, int GeoId3, Sketcher::PointPos PosId3) {
+        if (lazyExternalMaterializationFailed) {
+            return;
+        }
+
         if (selPoints.size() == 2 && selLine.size() == 1) {
             if (isEdge(GeoId1, PosId1) && isVertex(GeoId3, PosId3)) {
                 std::swap(GeoId1, GeoId3);
@@ -3633,6 +3887,19 @@ protected:
         return false;
     }
 
+    bool materializeLazyExternalSelectionsForCurrentCommand()
+    {
+        std::vector<SelIdPair>* selections[] = {
+            &selPoints, &selLine, &selCircleArc, &selEllipseAndCo, &selSplineAndCo};
+
+        for (auto* selection : selections) {
+            if (!LazyExternalSelectionResolver::materializeLazyExternalSelectionPairs(sketchgui, *selection, true)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     void restartCommand(const char* cstrName) {
         specialConstraint = SpecialConstraint::None;
         abortCommand();
@@ -3641,6 +3908,7 @@ protected:
         openCommand(cstrName);
 
         cstrIndexes.clear();
+        lazyExternalMaterializationFailed = !materializeLazyExternalSelectionsForCurrentCommand();
     }
 
     void resetTool()
@@ -3650,6 +3918,7 @@ protected:
         openCommand(QT_TRANSLATE_NOOP("Command", "Dimension"));
         cstrIndexes.clear();
         specialConstraint = SpecialConstraint::None;
+        lazyExternalMaterializationFailed = false;
         previousOnSketchPos = Base::Vector2d(0.f, 0.f);
         clearRefVectors();
     }
@@ -3780,7 +4049,8 @@ bool canHorVerBlock(Sketcher::SketchObject* Obj, int geoId)
 void horVerActivated(CmdSketcherConstraint* cmd, std::string type)
 {
     // get the selection
-    std::vector<Gui::SelectionObject> selection = Gui::Command::getSelection().getSelectionEx();
+    auto activatedSelection = cmd->getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -4187,7 +4457,8 @@ void CmdSketcherConstrainLock::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -4473,7 +4744,8 @@ void CmdSketcherConstrainBlock::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection();
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -4806,11 +5078,19 @@ void CmdSketcherConstrainCoincidentUnified::onActivated(CoincicenceType type)
     }
 
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection();
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
+
+    auto* sketchgui = getActiveSketchGui(getActiveGuiDocument());
+
+    const bool hasOnlyPendingLazyVertices =
+        selection.empty()
+        && LazyExternalSelectionResolver::hasPendingLazyExternalSelection(sketchgui, false, true);
 
     // only one sketch with its subelements are allowed to be selected
-    if (selection.size() != 1
-        || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
+    if (!hasOnlyPendingLazyVertices
+        && (selection.size() != 1
+            || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId()))) {
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/Mod/Sketcher");
         bool constraintMode = hGrp->GetBool("ContinuousConstraintMode", true);
@@ -4826,8 +5106,17 @@ void CmdSketcherConstrainCoincidentUnified::onActivated(CoincicenceType type)
     }
 
     // get the needed lists and objects
-    const std::vector<std::string>& SubNames = selection[0].getSubNames();
-    auto* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
+    const std::vector<std::string> emptySubNames;
+    const std::vector<std::string>& SubNames = hasOnlyPendingLazyVertices
+        ? emptySubNames
+        : selection[0].getSubNames();
+    auto* Obj = hasOnlyPendingLazyVertices
+        ? (sketchgui ? sketchgui->getSketchObject() : nullptr)
+        : static_cast<Sketcher::SketchObject*>(selection[0].getObject());
+    if (!Obj) {
+        Gui::TranslatedUserWarning(getActiveGuiDocument(), QObject::tr("Wrong selection"), errorMess);
+        return;
+    }
 
     // count curves and points
     std::vector<SelIdPair> points;
@@ -4843,6 +5132,8 @@ void CmdSketcherConstrainCoincidentUnified::onActivated(CoincicenceType type)
         }
     }
 
+    LazyExternalSelectionResolver::appendPendingLazyExternalSelectionPairs(sketchgui, points, curves, false, true);
+
     if (type != CoincicenceType::Coincident && ((points.size() == 1 && !curves.empty()) || (!points.empty() && curves.size() == 1))) {
         activatedPointOnObject(Obj, points, curves);
     }
@@ -4856,7 +5147,16 @@ void CmdSketcherConstrainCoincidentUnified::onActivated(CoincicenceType type)
 
 void CmdSketcherConstrainCoincidentUnified::activatedPointOnObject(SketchObject* obj, std::vector<SelIdPair> points, std::vector<SelIdPair> curves)
 {
+    auto* sketchgui = getActiveSketchGui(getActiveGuiDocument());
+
     openCommand(QT_TRANSLATE_NOOP("Command", "Add point on object constraint"));
+    if (!LazyExternalSelectionResolver::materializeLazyExternalSelectionPairs(sketchgui, points)
+        || !LazyExternalSelectionResolver::materializeLazyExternalSelectionPairs(sketchgui, curves)) {
+        abortCommand();
+        Gui::TranslatedUserWarning(obj, QObject::tr("Wrong selection"), QObject::tr("Could not add external geometry for the selected item."));
+        return;
+    }
+
     int cnt = 0;
     for (std::size_t iPnt = 0; iPnt < points.size(); iPnt++) {
         for (std::size_t iCrv = 0; iCrv < curves.size(); iCrv++) {
@@ -4910,6 +5210,16 @@ void CmdSketcherConstrainCoincidentUnified::activatedPointOnObject(SketchObject*
 
 void CmdSketcherConstrainCoincidentUnified::activatedCoincident(SketchObject* obj, std::vector<SelIdPair> points, std::vector<SelIdPair> curves)
 {
+    auto* sketchgui = getActiveSketchGui(getActiveGuiDocument());
+
+    openCommand(QT_TRANSLATE_NOOP("Command", "Add coincident constraint"));
+    if (!LazyExternalSelectionResolver::materializeLazyExternalSelectionPairs(sketchgui, points)
+        || !LazyExternalSelectionResolver::materializeLazyExternalSelectionPairs(sketchgui, curves)) {
+        abortCommand();
+        Gui::TranslatedUserWarning(obj, QObject::tr("Wrong selection"), QObject::tr("Could not add external geometry for the selected item."));
+        return;
+    }
+
     bool allConicsEdges = true;// If user selects only conics (circle, ellipse, arc, arcOfEllipse)
                                // then we make concentric constraint.
     for (auto& curve : curves) {
@@ -4918,6 +5228,7 @@ void CmdSketcherConstrainCoincidentUnified::activatedCoincident(SketchObject* ob
         }
 
         if (!allConicsEdges) {
+            abortCommand();
             Gui::TranslatedUserWarning(
                 obj,
                 QObject::tr("Wrong selection"),
@@ -4934,9 +5245,7 @@ void CmdSketcherConstrainCoincidentUnified::activatedCoincident(SketchObject* ob
     int GeoId1 = vecOfSelIdToUse[0].GeoId;
     Sketcher::PointPos PosId1 = vecOfSelIdToUse[0].PosId;
 
-    // undo command open
     bool constraintsAdded = false;
-    openCommand(QT_TRANSLATE_NOOP("Command", "Add coincident constraint"));
 
     for (std::size_t i = 1; i < vecOfSelIdToUse.size(); i++) {
         int GeoId2 = vecOfSelIdToUse[i].GeoId;
@@ -4945,6 +5254,7 @@ void CmdSketcherConstrainCoincidentUnified::activatedCoincident(SketchObject* ob
         // check if the edge already has a Block constraint
         if (areBothPointsOrSegmentsFixed(obj, GeoId1, GeoId2)) {
             showNoConstraintBetweenFixedGeometry(obj);
+            abortCommand();
             return;
         }
 
@@ -5296,11 +5606,20 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
+
+    // get the needed lists and objects
+    Sketcher::SketchObject* Obj = nullptr;
+    std::vector<std::string> SubNames;
 
     // only one sketch with its subelements are allowed to be selected
-    if (selection.size() != 1
-        || !selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
+    if (selection.size() == 1
+        && selection[0].isObjectTypeOf(Sketcher::SketchObject::getClassTypeId())) {
+        Obj = freecad_cast<Sketcher::SketchObject*>(selection[0].getObject());
+        SubNames = selection[0].getSubNames();
+    }
+    else {
         ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
             "User parameter:BaseApp/Preferences/Mod/Sketcher");
         bool constraintMode = hGrp->GetBool("ContinuousConstraintMode", true);
@@ -5317,10 +5636,6 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
         }
         return;
     }
-
-    // get the needed lists and objects
-    const std::vector<std::string>& SubNames = selection[0].getSubNames();
-    auto* Obj = static_cast<Sketcher::SketchObject*>(selection[0].getObject());
 
     if (SubNames.empty() || SubNames.size() > 2) {
         Gui::TranslatedUserWarning(Obj,
@@ -5356,7 +5671,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
 
             openCommand(
                 QT_TRANSLATE_NOOP("Command", "Add distance from horizontal axis constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "addConstraint(Sketcher.Constraint('DistanceY',%d,%d,%d,%d,%f))",
                 GeoId1,
                 static_cast<int>(PosId1),
@@ -5368,7 +5683,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             PosId1 = Sketcher::PointPos::start;
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add distance from vertical axis constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "addConstraint(Sketcher.Constraint('DistanceX',%d,%d,%d,%d,%f))",
                 GeoId1,
                 static_cast<int>(PosId1),
@@ -5380,7 +5695,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             Base::Vector3d pnt1 = Obj->getPoint(GeoId1, PosId1);
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add point to point distance constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "addConstraint(Sketcher.Constraint('Distance',%d,%d,%d,%d,%f))",
                 GeoId1,
                 static_cast<int>(PosId1),
@@ -5393,7 +5708,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             // it is a constraint on a external line, make it non-driving
             const std::vector<Sketcher::Constraint*>& ConStr = Obj->Constraints.getValues();
 
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "setDriving(%d,%s)",
                 ConStr.size() - 1,
                 "False");
@@ -5423,7 +5738,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
                 / d.Length();
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add point to line distance constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "addConstraint(Sketcher.Constraint('Distance',%d,%d,%d,%f))",
                 GeoId1,
                 static_cast<int>(PosId1),
@@ -5435,7 +5750,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
                 == Reference) {// it is a constraint on a external line, make it non-driving
                 const std::vector<Sketcher::Constraint*>& ConStr = Obj->Constraints.getValues();
 
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                Gui::cmdAppObjectArgs(Obj,
                     "setDriving(%d,%s)",
                     ConStr.size() - 1,
                     "False");
@@ -5453,7 +5768,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             double ActDist = std::abs(d.Length() - radius);
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add point to circle distance constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "addConstraint(Sketcher.Constraint('Distance',%d,%d,%d,%f))",
                 GeoId1,
                 static_cast<int>(PosId1),
@@ -5465,7 +5780,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
                 == Reference) {// it is a constraint on a external line, make it non-driving
                 const std::vector<Sketcher::Constraint*>& ConStr = Obj->Constraints.getValues();
 
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                Gui::cmdAppObjectArgs(Obj,
                     "setDriving(%d,%s)",
                     ConStr.size() - 1,
                     "False");
@@ -5504,7 +5819,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             }
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add circle to circle distance constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                                   "addConstraint(Sketcher.Constraint('Distance',%d,%d,%f))",
                                   GeoId1,
                                   GeoId2,
@@ -5515,7 +5830,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
                     == Reference) {// it is a constraint on a external line, make it non-driving
                 const std::vector<Sketcher::Constraint*>& ConStr = Obj->Constraints.getValues();
 
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                Gui::cmdAppObjectArgs(Obj,
                                       "setDriving(%d,%s)",
                                       ConStr.size() - 1,
                                       "False");
@@ -5547,7 +5862,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
                 - radius;
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add circle to line distance constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "addConstraint(Sketcher.Constraint('Distance',%d,%d,%f)) ",
                 GeoId1,
                 GeoId2,
@@ -5558,7 +5873,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
                 == Reference) {// it is a constraint on a external line, make it non-driving
                 const std::vector<Sketcher::Constraint*>& ConStr = Obj->Constraints.getValues();
 
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                Gui::cmdAppObjectArgs(Obj,
                     "setDriving(%i,%s)",
                     ConStr.size() - 1,
                     "False");
@@ -5595,7 +5910,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             double ActLength = (lineSeg->getEndPoint() - lineSeg->getStartPoint()).Length();
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add length constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "addConstraint(Sketcher.Constraint('Distance',%d,%f))",
                 GeoId1,
                 ActLength);
@@ -5605,7 +5920,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
                 || constraintCreationMode == Reference) {
                 const std::vector<Sketcher::Constraint*>& ConStr = Obj->Constraints.getValues();
 
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                Gui::cmdAppObjectArgs(Obj,
                     "setDriving(%d,%s)",
                     ConStr.size() - 1,
                     "False");
@@ -5622,7 +5937,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
             double ActLength = arc->getAngle(false) * arc->getRadius();
 
             openCommand(QT_TRANSLATE_NOOP("Command", "Add length constraint"));
-            Gui::cmdAppObjectArgs(selection[0].getObject(),
+            Gui::cmdAppObjectArgs(Obj,
                 "addConstraint(Sketcher.Constraint('Distance',%d,%f))",
                 GeoId1,
                 ActLength);
@@ -5632,7 +5947,7 @@ void CmdSketcherConstrainDistance::activated(int iMsg)
                 || constraintCreationMode == Reference) {
                 const std::vector<Sketcher::Constraint*>& ConStr = Obj->Constraints.getValues();
 
-                Gui::cmdAppObjectArgs(selection[0].getObject(),
+                Gui::cmdAppObjectArgs(Obj,
                     "setDriving(%d,%s)",
                     ConStr.size() - 1,
                     "False");
@@ -5947,7 +6262,8 @@ void CmdSketcherConstrainDistanceX::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -6248,7 +6564,8 @@ void CmdSketcherConstrainDistanceY::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -6544,7 +6861,8 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection();
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -6600,6 +6918,19 @@ void CmdSketcherConstrainParallel::activated(int iMsg)
             return;
         }
         ids.push_back(GeoId);
+    }
+
+    std::sort(ids.begin(), ids.end());
+    ids.erase(std::unique(ids.begin(), ids.end()), ids.end());
+
+    for (int geoId : ids) {
+        const Part::Geometry* geo = Obj->getGeometry(geoId);
+        if (!geo || !isLineSegment(*geo)) {
+            Gui::TranslatedUserWarning(Obj,
+                QObject::tr("Wrong selection"),
+                QObject::tr("One selected edge is not a valid line."));
+            return;
+        }
     }
 
     if (ids.size() < 2) {
@@ -6717,7 +7048,8 @@ void CmdSketcherConstrainPerpendicular::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -7573,7 +7905,8 @@ void CmdSketcherConstrainTangent::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -8407,7 +8740,8 @@ void CmdSketcherConstrainRadius::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection();
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -8770,7 +9104,8 @@ void CmdSketcherConstrainDiameter::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection();
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -9088,7 +9423,8 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection();
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -9633,7 +9969,8 @@ void CmdSketcherConstrainAngle::activated(int iMsg)
     Q_UNUSED(iMsg);
     // TODO: comprehensive messages, like in CmdSketcherConstrainTangent
     //  get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -10107,7 +10444,8 @@ void CmdSketcherConstrainEqual::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection();
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -10366,7 +10704,8 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    auto activatedSelection = getActivatedLazySelection(true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -10815,7 +11154,8 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    SketcherGui::ActivatedLazySelection activatedSelection(*this, getActiveGuiDocument(), true);
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -10934,7 +11274,7 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
     n2divn1 = newQuant.getValue();
 
     // add constraint
-    openCommand(QT_TRANSLATE_NOOP("Command", "Add Snell's law constraint"));
+    activatedSelection.openCommand(QT_TRANSLATE_NOOP("Command", "Add Snell's law constraint"));
 
     bool safe = addConstraintSafely(Obj, [&]() {
         if (!IsPointAlreadyOnCurve(GeoId2, GeoId1, PosId1, Obj)) {
@@ -10974,10 +11314,10 @@ void CmdSketcherConstrainSnellsLaw::activated(int iMsg)
     });
 
     if (!safe) {
-        abortCommand();
+        activatedSelection.abortCommand();
         return;
     }
-    commitCommand();
+    activatedSelection.commitCommand();
     tryAutoRecompute(Obj);
 
     // clear the selection (convenience)
@@ -11014,7 +11354,8 @@ void CmdSketcherConstrainGroup::activated(int iMsg)
     Q_UNUSED(iMsg);
 
     // get the selection
-    std::vector<Gui::SelectionObject> selection = getSelection().getSelectionEx();
+    SketcherGui::ActivatedLazySelection activatedSelection(*this, getActiveGuiDocument());
+    std::vector<Gui::SelectionObject> selection = activatedSelection.getSelection();
 
     // only one sketch with its subelements are allowed to be selected
     if (selection.size() != 1
@@ -11065,16 +11406,16 @@ void CmdSketcherConstrainGroup::activated(int iMsg)
         return;
     }
 
-    openCommand(QT_TRANSLATE_NOOP("Command", "Add Group constraint"));
+    activatedSelection.openCommand(QT_TRANSLATE_NOOP("Command", "Add Group constraint"));
 
     if (!addListConstraint(Obj, elts, "Group")) {
-        abortCommand();
+        activatedSelection.abortCommand();
         return;
     }
 
     tryAutoRecompute(Obj);
 
-    commitCommand();
+    activatedSelection.commitCommand();
 
     getSelection().clearSelection();
 }

--- a/src/Mod/Sketcher/Gui/ConstraintLazySelection.cpp
+++ b/src/Mod/Sketcher/Gui/ConstraintLazySelection.cpp
@@ -1,0 +1,666 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 Turan Furkan Topak <furkan1795@gmail.com>          *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "ConstraintLazySelection.h"
+#include "ViewProviderSketch.h"
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+
+#include <App/IndexedName.h>
+#include <Gui/CommandT.h>
+#include <Gui/Document.h>
+#include <Gui/Selection/Selection.h>
+#include <Mod/Part/App/Geometry.h>
+
+namespace SketcherGui
+{
+
+class ViewProviderSketchLazySelectionAttorney
+{
+public:
+    static int getPreselectLazyExternalId(const ViewProviderSketch& viewProvider);
+    static Base::Type getLazyExternalGeometryType(
+        const ViewProviderSketch& viewProvider,
+        int lazyExternalId
+    );
+    static bool isLazyExternalReferenceVertex(const ViewProviderSketch& viewProvider, int lazyExternalId);
+    static bool getLazyExternalSourceReference(
+        const ViewProviderSketch& viewProvider,
+        int lazyExternalId,
+        std::string& sourceObjectName,
+        std::string& subName,
+        bool& intersection,
+        bool& vertex
+    );
+    static int materializeLazyExternalSourceReference(
+        ViewProviderSketch& viewProvider,
+        const std::string& sourceObjectName,
+        const std::string& subName,
+        bool intersection,
+        bool defining
+    );
+    static bool selectLazyExternalReference(
+        ViewProviderSketch& viewProvider,
+        int lazyExternalId,
+        bool toggle
+    );
+    static bool isLazyExternalReferenceSelected(
+        const ViewProviderSketch& viewProvider,
+        int lazyExternalId
+    );
+    static std::vector<int> getSelectedLazyExternalReferenceIds(const ViewProviderSketch& viewProvider);
+    static void clearSelectedLazyExternalReferences(ViewProviderSketch& viewProvider);
+    static void resetPreselectPoint(ViewProviderSketch& viewProvider);
+};
+
+int ViewProviderSketchLazySelectionAttorney::getPreselectLazyExternalId(
+    const ViewProviderSketch& viewProvider
+)
+{
+    return viewProvider.getPreselectLazyExternalId();
+}
+
+Base::Type ViewProviderSketchLazySelectionAttorney::getLazyExternalGeometryType(
+    const ViewProviderSketch& viewProvider,
+    int lazyExternalId
+)
+{
+    return viewProvider.getLazyExternalGeometryType(lazyExternalId);
+}
+
+bool ViewProviderSketchLazySelectionAttorney::isLazyExternalReferenceVertex(
+    const ViewProviderSketch& viewProvider,
+    int lazyExternalId
+)
+{
+    return viewProvider.isLazyExternalReferenceVertex(lazyExternalId);
+}
+
+bool ViewProviderSketchLazySelectionAttorney::getLazyExternalSourceReference(
+    const ViewProviderSketch& viewProvider,
+    int lazyExternalId,
+    std::string& sourceObjectName,
+    std::string& subName,
+    bool& intersection,
+    bool& vertex
+)
+{
+    return viewProvider.getLazyExternalSourceReference(
+        lazyExternalId,
+        sourceObjectName,
+        subName,
+        intersection,
+        vertex
+    );
+}
+
+int ViewProviderSketchLazySelectionAttorney::materializeLazyExternalSourceReference(
+    ViewProviderSketch& viewProvider,
+    const std::string& sourceObjectName,
+    const std::string& subName,
+    bool intersection,
+    bool defining
+)
+{
+    return viewProvider
+        .materializeLazyExternalSourceReference(sourceObjectName, subName, intersection, defining);
+}
+
+bool ViewProviderSketchLazySelectionAttorney::selectLazyExternalReference(
+    ViewProviderSketch& viewProvider,
+    int lazyExternalId,
+    bool toggle
+)
+{
+    return viewProvider.selectLazyExternalReference(lazyExternalId, toggle);
+}
+
+bool ViewProviderSketchLazySelectionAttorney::isLazyExternalReferenceSelected(
+    const ViewProviderSketch& viewProvider,
+    int lazyExternalId
+)
+{
+    return viewProvider.isLazyExternalReferenceSelected(lazyExternalId);
+}
+
+std::vector<int> ViewProviderSketchLazySelectionAttorney::getSelectedLazyExternalReferenceIds(
+    const ViewProviderSketch& viewProvider
+)
+{
+    return viewProvider.getSelectedLazyExternalReferenceIds();
+}
+
+void ViewProviderSketchLazySelectionAttorney::clearSelectedLazyExternalReferences(
+    ViewProviderSketch& viewProvider
+)
+{
+    viewProvider.clearSelectedLazyExternalReferences();
+}
+
+void ViewProviderSketchLazySelectionAttorney::resetPreselectPoint(ViewProviderSketch& viewProvider)
+{
+    viewProvider.resetPreselectPoint();
+}
+
+namespace
+{
+constexpr const char* LazyExternalVertexSubelementPrefix = "LazyExternalVertex";
+constexpr const char* LazyExternalEdgeSubelementPrefix = "LazyExternalEdge";
+
+std::string makeExternalSubNameFromGeoId(int geoId)
+{
+    return "ExternalEdge" + std::to_string(Sketcher::GeoEnum::RefExt + 1 - geoId);
+}
+
+std::string makeLazyExternalSubelement(int lazyExternalId, bool lazyExternalVertex)
+{
+    return std::string(
+               lazyExternalVertex ? LazyExternalVertexSubelementPrefix : LazyExternalEdgeSubelementPrefix
+           )
+        + std::to_string(lazyExternalId);
+}
+
+bool containsSelectionPair(const std::vector<SelIdPair>& items, const SelIdPair& item)
+{
+    return std::any_of(items.begin(), items.end(), [&](const SelIdPair& existing) {
+        return selectionPairsEqual(existing, item);
+    });
+}
+
+std::vector<int> collectLazyExternalIds(ViewProviderSketch* sketchgui, bool includePreselection)
+{
+    std::vector<int> lazyExternalIds;
+    if (!sketchgui) {
+        return lazyExternalIds;
+    }
+
+    lazyExternalIds = ViewProviderSketchLazySelectionAttorney::getSelectedLazyExternalReferenceIds(
+        *sketchgui
+    );
+
+    if (includePreselection) {
+        const int preselectLazyExternalId
+            = ViewProviderSketchLazySelectionAttorney::getPreselectLazyExternalId(*sketchgui);
+        if (preselectLazyExternalId >= 0
+            && std::find(lazyExternalIds.begin(), lazyExternalIds.end(), preselectLazyExternalId)
+                == lazyExternalIds.end()) {
+            lazyExternalIds.push_back(preselectLazyExternalId);
+        }
+    }
+
+    return lazyExternalIds;
+}
+
+bool isLazyExternalVertexReference(ViewProviderSketch* sketchgui, int lazyExternalId)
+{
+    return sketchgui
+        && ViewProviderSketchLazySelectionAttorney::isLazyExternalReferenceVertex(
+               *sketchgui,
+               lazyExternalId
+        );
+}
+
+template<typename Callback>
+void forEachLazyExternalReference(
+    ViewProviderSketch* sketchgui,
+    bool includeEdges,
+    bool includeVertices,
+    bool includePreselection,
+    Callback&& callback
+)
+{
+    for (int lazyExternalId : collectLazyExternalIds(sketchgui, includePreselection)) {
+        const bool lazyExternalVertex = isLazyExternalVertexReference(sketchgui, lazyExternalId);
+        if ((lazyExternalVertex && includeVertices) || (!lazyExternalVertex && includeEdges)) {
+            callback(lazyExternalId, lazyExternalVertex);
+        }
+    }
+}
+
+template<typename Callback>
+void forEachPendingLazyExternalReference(
+    ViewProviderSketch* sketchgui,
+    bool includeEdges,
+    bool includeVertices,
+    Callback&& callback
+)
+{
+    forEachLazyExternalReference(
+        sketchgui,
+        includeEdges,
+        includeVertices,
+        true,
+        std::forward<Callback>(callback)
+    );
+}
+
+void clearPendingSelection(ViewProviderSketch* sketchgui)
+{
+    if (!sketchgui) {
+        return;
+    }
+
+    ViewProviderSketchLazySelectionAttorney::resetPreselectPoint(*sketchgui);
+    ViewProviderSketchLazySelectionAttorney::clearSelectedLazyExternalReferences(*sketchgui);
+}
+
+bool makeSelectionPair(
+    ViewProviderSketch* sketchgui,
+    int lazyExternalId,
+    bool lazyExternalVertex,
+    SelIdPair& item,
+    std::string* subName = nullptr,
+    Base::Type* geoType = nullptr
+)
+{
+    if (!sketchgui || lazyExternalId < 0) {
+        return false;
+    }
+
+    std::string sourceObjectName;
+    std::string sourceSubName;
+    bool sourceIntersection = false;
+    bool sourceVertex = false;
+    if (!ViewProviderSketchLazySelectionAttorney::getLazyExternalSourceReference(
+            *sketchgui,
+            lazyExternalId,
+            sourceObjectName,
+            sourceSubName,
+            sourceIntersection,
+            sourceVertex
+        )) {
+        return false;
+    }
+    if (sourceVertex != lazyExternalVertex) {
+        return false;
+    }
+
+    item.GeoId = Sketcher::GeoEnum::GeoUndef;
+    item.PosId = sourceVertex ? Sketcher::PointPos::start : Sketcher::PointPos::none;
+    item.LazyExternalId = lazyExternalId;
+    item.IsLazyExternal = true;
+    item.LazyExternalVertex = sourceVertex;
+    item.LazyExternalSourceObjectName = std::move(sourceObjectName);
+    item.LazyExternalSubelement = std::move(sourceSubName);
+    item.LazyExternalIntersection = sourceIntersection;
+
+    if (subName) {
+        *subName = makeLazyExternalSubelement(lazyExternalId, sourceVertex);
+    }
+    if (geoType) {
+        *geoType = sourceVertex
+            ? Part::GeomPoint::getClassTypeId()
+            : ViewProviderSketchLazySelectionAttorney::getLazyExternalGeometryType(
+                  *sketchgui,
+                  lazyExternalId
+              );
+    }
+
+    return true;
+}
+
+bool materializeSelectionPair(
+    ViewProviderSketch* sketchgui,
+    SelIdPair& item,
+    bool preserveLazyExternalIdentity
+)
+{
+    if (!item.IsLazyExternal) {
+        return true;
+    }
+    if (!sketchgui) {
+        return false;
+    }
+
+    const int geoId = ViewProviderSketchLazySelectionAttorney::materializeLazyExternalSourceReference(
+        *sketchgui,
+        item.LazyExternalSourceObjectName,
+        item.LazyExternalSubelement,
+        item.LazyExternalIntersection,
+        false
+    );
+    if (geoId == Sketcher::GeoEnum::GeoUndef) {
+        return false;
+    }
+
+    const bool wasLazyVertex = item.LazyExternalVertex;
+    item.GeoId = geoId;
+    item.PosId = wasLazyVertex ? Sketcher::PointPos::start : Sketcher::PointPos::none;
+
+    if (!preserveLazyExternalIdentity) {
+        item.LazyExternalId = -1;
+        item.IsLazyExternal = false;
+        item.LazyExternalVertex = false;
+        item.LazyExternalSourceObjectName.clear();
+        item.LazyExternalSubelement.clear();
+        item.LazyExternalIntersection = false;
+    }
+
+    return true;
+}
+
+bool materializeLazyExternalSelection(
+    ViewProviderSketch* sketchgui,
+    bool includeLazyExternalVertices,
+    bool includePreselection
+)
+{
+    if (!sketchgui || !sketchgui->getSketchObject()) {
+        return true;
+    }
+
+    bool consumedLazyExternalSelection = false;
+    bool materializationFailed = false;
+    forEachLazyExternalReference(
+        sketchgui,
+        true,
+        includeLazyExternalVertices,
+        includePreselection,
+        [&](int lazyExternalId, bool lazyExternalVertex) {
+            consumedLazyExternalSelection = true;
+            SelIdPair item;
+            if (!makeSelectionPair(sketchgui, lazyExternalId, lazyExternalVertex, item)) {
+                materializationFailed = true;
+                return;
+            }
+            if (!materializeSelectionPair(sketchgui, item, false)) {
+                materializationFailed = true;
+                return;
+            }
+
+            const std::string subName = makeExternalSubNameFromGeoId(item.GeoId);
+            if (!sketchgui->isSelected(subName)) {
+                sketchgui->addSelection(subName);
+            }
+        }
+    );
+
+    if (consumedLazyExternalSelection) {
+        clearPendingSelection(sketchgui);
+    }
+    return !materializationFailed;
+}
+
+}  // namespace
+
+ActivatedLazySelection::ActivatedLazySelection(
+    Gui::Command& command,
+    Gui::Document* guiDocument,
+    bool includeLazyExternalVertices,
+    bool* sharedCommandActive
+)
+    : command(&command)
+    , sharedCommandActive(sharedCommandActive)
+{
+    begin(guiDocument, includeLazyExternalVertices);
+    selection = Gui::Command::getSelection().getSelectionEx();
+}
+
+ActivatedLazySelection::ActivatedLazySelection(ActivatedLazySelection&& other) noexcept
+    : command(other.command)
+    , sharedCommandActive(other.sharedCommandActive)
+    , selection(std::move(other.selection))
+    , localCommandActive(other.localCommandActive)
+    , abortOnDestroy(other.abortOnDestroy)
+{
+    other.command = nullptr;
+    other.sharedCommandActive = nullptr;
+    other.localCommandActive = false;
+    other.abortOnDestroy = false;
+}
+
+ActivatedLazySelection::~ActivatedLazySelection()
+{
+    if (abortOnDestroy) {
+        abortLazyExternalCommand();
+    }
+}
+
+const std::vector<Gui::SelectionObject>& ActivatedLazySelection::getSelection() const
+{
+    return selection;
+}
+
+void ActivatedLazySelection::openCommand(const char* name)
+{
+    if (isLazyExternalCommandActive()) {
+        return;
+    }
+
+    command->openCommand(name);
+}
+
+void ActivatedLazySelection::commitCommand()
+{
+    command->commitCommand();
+    setLazyExternalCommandActive(false);
+    abortOnDestroy = false;
+}
+
+void ActivatedLazySelection::abortCommand()
+{
+    command->abortCommand();
+    setLazyExternalCommandActive(false);
+    abortOnDestroy = false;
+}
+
+void ActivatedLazySelection::begin(Gui::Document* guiDocument, bool includeLazyExternalVertices)
+{
+    auto* sketchgui = getActiveSketchGui(guiDocument);
+    if (!LazyExternalSelectionResolver::hasPendingLazyExternalSelection(
+            sketchgui,
+            true,
+            includeLazyExternalVertices
+        )) {
+        return;
+    }
+
+    command->openCommand(QT_TRANSLATE_NOOP("Command", "Add constraint"));
+    setLazyExternalCommandActive(true);
+
+    if (!LazyExternalSelectionResolver::materializePendingLazyExternalSelection(
+            sketchgui,
+            includeLazyExternalVertices
+        )) {
+        abortCommand();
+    }
+}
+
+void ActivatedLazySelection::abortLazyExternalCommand()
+{
+    if (isLazyExternalCommandActive()) {
+        abortCommand();
+    }
+}
+
+bool ActivatedLazySelection::isLazyExternalCommandActive() const
+{
+    return sharedCommandActive ? *sharedCommandActive : localCommandActive;
+}
+
+void ActivatedLazySelection::setLazyExternalCommandActive(bool active)
+{
+    if (sharedCommandActive) {
+        *sharedCommandActive = active;
+    }
+    else {
+        localCommandActive = active;
+    }
+}
+
+ViewProviderSketch* getActiveSketchGui(Gui::Document* guiDocument)
+{
+    return guiDocument ? freecad_cast<ViewProviderSketch*>(guiDocument->getInEdit()) : nullptr;
+}
+
+bool selectionPairsEqual(const SelIdPair& lhs, const SelIdPair& rhs)
+{
+    if (lhs.IsLazyExternal || rhs.IsLazyExternal) {
+        return lhs.IsLazyExternal == rhs.IsLazyExternal
+            && lhs.LazyExternalVertex == rhs.LazyExternalVertex
+            && lhs.LazyExternalSourceObjectName == rhs.LazyExternalSourceObjectName
+            && lhs.LazyExternalSubelement == rhs.LazyExternalSubelement
+            && lhs.LazyExternalIntersection == rhs.LazyExternalIntersection;
+    }
+    return lhs.GeoId == rhs.GeoId && lhs.PosId == rhs.PosId;
+}
+
+std::optional<LazyExternalSubelement> parseLazyExternalSubelement(const std::string& subName)
+{
+    const Data::IndexedName indexedSubName(subName.c_str());
+    if (!indexedSubName || indexedSubName.getIndex() <= 0) {
+        return std::nullopt;
+    }
+
+    if (std::strcmp(indexedSubName.getType(), LazyExternalVertexSubelementPrefix) == 0) {
+        return LazyExternalSubelement {indexedSubName.getIndex(), true};
+    }
+    if (std::strcmp(indexedSubName.getType(), LazyExternalEdgeSubelementPrefix) == 0) {
+        return LazyExternalSubelement {indexedSubName.getIndex(), false};
+    }
+    return std::nullopt;
+}
+
+bool LazyExternalSelectionResolver::hasPendingLazyExternalSelection(
+    ViewProviderSketch* sketchgui,
+    bool includeEdges,
+    bool includeVertices
+)
+{
+    bool hasPending = false;
+    forEachPendingLazyExternalReference(sketchgui, includeEdges, includeVertices, [&](int, bool) {
+        hasPending = true;
+    });
+    return hasPending;
+}
+
+bool LazyExternalSelectionResolver::materializePendingLazyExternalSelection(
+    ViewProviderSketch* sketchgui,
+    bool includeLazyExternalVertices
+)
+{
+    return materializeLazyExternalSelection(sketchgui, includeLazyExternalVertices, true);
+}
+
+void LazyExternalSelectionResolver::appendPendingLazyExternalSelectionPairs(
+    ViewProviderSketch* sketchgui,
+    std::vector<SelIdPair>& points,
+    std::vector<SelIdPair>& curves,
+    bool includeEdges,
+    bool includeVertices
+)
+{
+    forEachPendingLazyExternalReference(
+        sketchgui,
+        includeEdges,
+        includeVertices,
+        [&](int lazyExternalId, bool lazyExternalVertex) {
+            SelIdPair item;
+            if (!makeSelectionPair(sketchgui, lazyExternalId, lazyExternalVertex, item)) {
+                return;
+            }
+
+            auto& target = lazyExternalVertex ? points : curves;
+            if (!containsSelectionPair(target, item)) {
+                target.push_back(item);
+            }
+            setLazyExternalSelectionSelected(sketchgui, item, true);
+        }
+    );
+}
+
+void LazyExternalSelectionResolver::clearPendingLazyExternalSelection(ViewProviderSketch* sketchgui)
+{
+    clearPendingSelection(sketchgui);
+}
+
+bool LazyExternalSelectionResolver::makeLazyExternalSelectionPair(
+    ViewProviderSketch* sketchgui,
+    int lazyExternalId,
+    bool lazyExternalVertex,
+    SelIdPair& item,
+    std::string* subName,
+    Base::Type* geoType
+)
+{
+    return makeSelectionPair(sketchgui, lazyExternalId, lazyExternalVertex, item, subName, geoType);
+}
+
+void LazyExternalSelectionResolver::setLazyExternalSelectionSelected(
+    ViewProviderSketch* sketchgui,
+    const SelIdPair& item,
+    bool selected
+)
+{
+    if (!sketchgui || !item.IsLazyExternal || item.LazyExternalId < 0) {
+        return;
+    }
+
+    if (selected) {
+        ViewProviderSketchLazySelectionAttorney::selectLazyExternalReference(
+            *sketchgui,
+            item.LazyExternalId,
+            false
+        );
+    }
+    else if (
+        ViewProviderSketchLazySelectionAttorney::isLazyExternalReferenceSelected(
+            *sketchgui,
+            item.LazyExternalId
+        )
+    ) {
+        ViewProviderSketchLazySelectionAttorney::selectLazyExternalReference(
+            *sketchgui,
+            item.LazyExternalId,
+            true
+        );
+    }
+}
+
+bool LazyExternalSelectionResolver::materializeLazyExternalSelectionPairs(
+    ViewProviderSketch* sketchgui,
+    std::vector<SelIdPair>& items,
+    bool preserveLazyExternalIdentity
+)
+{
+    bool consumedLazyExternalSelection = false;
+    for (auto& item : items) {
+        consumedLazyExternalSelection = consumedLazyExternalSelection || item.IsLazyExternal;
+        if (!materializeSelectionPair(sketchgui, item, preserveLazyExternalIdentity)) {
+            if (consumedLazyExternalSelection) {
+                clearPendingSelection(sketchgui);
+            }
+            return false;
+        }
+    }
+
+    if (consumedLazyExternalSelection) {
+        clearPendingSelection(sketchgui);
+    }
+    return true;
+}
+
+}  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/ConstraintLazySelection.h
+++ b/src/Mod/Sketcher/Gui/ConstraintLazySelection.h
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 Turan Furkan Topak <furkan1795@gmail.com>          *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <Base/Type.h>
+#include <Gui/Selection/SelectionObject.h>
+#include <Mod/Sketcher/App/GeoEnum.h>
+
+namespace Gui
+{
+class Command;
+class Document;
+}  // namespace Gui
+
+namespace SketcherGui
+{
+
+class ViewProviderSketch;
+
+struct SelIdPair
+{
+    int GeoId = Sketcher::GeoEnum::GeoUndef;
+    Sketcher::PointPos PosId = Sketcher::PointPos::none;
+    int LazyExternalId = -1;
+    bool IsLazyExternal = false;
+    bool LazyExternalVertex = false;
+    std::string LazyExternalSourceObjectName;
+    std::string LazyExternalSubelement;
+    bool LazyExternalIntersection = false;
+};
+
+ViewProviderSketch* getActiveSketchGui(Gui::Document* guiDocument);
+
+struct LazyExternalSubelement
+{
+    int id = -1;
+    bool vertex = false;
+};
+
+bool selectionPairsEqual(const SelIdPair& lhs, const SelIdPair& rhs);
+
+std::optional<LazyExternalSubelement> parseLazyExternalSubelement(const std::string& subName);
+
+
+class ActivatedLazySelection
+{
+public:
+    ActivatedLazySelection(
+        Gui::Command& command,
+        Gui::Document* guiDocument,
+        bool includeLazyExternalVertices = false,
+        bool* sharedCommandActive = nullptr
+    );
+    ActivatedLazySelection(const ActivatedLazySelection&) = delete;
+    ActivatedLazySelection& operator=(const ActivatedLazySelection&) = delete;
+    ActivatedLazySelection(ActivatedLazySelection&& other) noexcept;
+    ActivatedLazySelection& operator=(ActivatedLazySelection&&) = delete;
+    ~ActivatedLazySelection();
+
+    const std::vector<Gui::SelectionObject>& getSelection() const;
+
+    void openCommand(const char* name);
+    void commitCommand();
+    void abortCommand();
+
+private:
+    void begin(Gui::Document* guiDocument, bool includeLazyExternalVertices);
+    void abortLazyExternalCommand();
+    bool isLazyExternalCommandActive() const;
+    void setLazyExternalCommandActive(bool active);
+
+    Gui::Command* command = nullptr;
+    bool* sharedCommandActive = nullptr;
+    std::vector<Gui::SelectionObject> selection;
+    bool localCommandActive = false;
+    bool abortOnDestroy = true;
+};
+
+class LazyExternalSelectionResolver
+{
+public:
+    static bool hasPendingLazyExternalSelection(
+        ViewProviderSketch* sketchgui,
+        bool includeEdges = true,
+        bool includeVertices = false
+    );
+
+    static bool materializePendingLazyExternalSelection(
+        ViewProviderSketch* sketchgui,
+        bool includeLazyExternalVertices
+    );
+
+    static void appendPendingLazyExternalSelectionPairs(
+        ViewProviderSketch* sketchgui,
+        std::vector<SelIdPair>& points,
+        std::vector<SelIdPair>& curves,
+        bool includeEdges = true,
+        bool includeVertices = true
+    );
+
+    static void clearPendingLazyExternalSelection(ViewProviderSketch* sketchgui);
+
+    static bool makeLazyExternalSelectionPair(
+        ViewProviderSketch* sketchgui,
+        int lazyExternalId,
+        bool lazyExternalVertex,
+        SelIdPair& item,
+        std::string* subName = nullptr,
+        Base::Type* geoType = nullptr
+    );
+
+    static void setLazyExternalSelectionSelected(
+        ViewProviderSketch* sketchgui,
+        const SelIdPair& item,
+        bool selected
+    );
+
+    static bool materializeLazyExternalSelectionPairs(
+        ViewProviderSketch* sketchgui,
+        std::vector<SelIdPair>& items,
+        bool preserveLazyExternalIdentity = false
+    );
+};
+
+}  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.cpp
@@ -160,6 +160,71 @@ inline int ViewProviderSketchDrawSketchHandlerAttorney::getPreselectCross(const 
     return vp.getPreselectCross();
 }
 
+inline int ViewProviderSketchDrawSketchHandlerAttorney::getPreselectLazyExternalId(
+    const ViewProviderSketch& vp
+)
+{
+    return vp.getPreselectLazyExternalId();
+}
+
+inline bool ViewProviderSketchDrawSketchHandlerAttorney::isPreselectLazyExternalVertex(
+    const ViewProviderSketch& vp
+)
+{
+    return vp.isPreselectLazyExternalVertex();
+}
+
+inline std::vector<int> ViewProviderSketchDrawSketchHandlerAttorney::getSelectedLazyExternalReferenceIds(
+    const ViewProviderSketch& vp
+)
+{
+    return vp.getSelectedLazyExternalReferenceIds();
+}
+
+inline bool ViewProviderSketchDrawSketchHandlerAttorney::getLazyExternalSourceReference(
+    const ViewProviderSketch& vp,
+    int lazyExternalId,
+    std::string& sourceObjectName,
+    std::string& subName,
+    bool& intersection,
+    bool& vertex
+)
+{
+    return vp.getLazyExternalSourceReference(lazyExternalId, sourceObjectName, subName, intersection, vertex);
+}
+
+inline int ViewProviderSketchDrawSketchHandlerAttorney::materializeLazyExternalSourceReference(
+    ViewProviderSketch& vp,
+    const std::string& sourceObjectName,
+    const std::string& subName,
+    bool intersection,
+    bool defining
+)
+{
+    return vp.materializeLazyExternalSourceReference(sourceObjectName, subName, intersection, defining);
+}
+
+inline void ViewProviderSketchDrawSketchHandlerAttorney::clearSelectedLazyExternalReferences(
+    ViewProviderSketch& vp
+)
+{
+    vp.clearSelectedLazyExternalReferences();
+}
+
+inline void ViewProviderSketchDrawSketchHandlerAttorney::suspendLazyExternalGeometryLayer(
+    ViewProviderSketch& vp
+)
+{
+    vp.suspendLazyExternalGeometryLayer();
+}
+
+inline void ViewProviderSketchDrawSketchHandlerAttorney::resumeLazyExternalGeometryLayer(
+    ViewProviderSketch& vp
+)
+{
+    vp.resumeLazyExternalGeometryLayer();
+}
+
 inline void ViewProviderSketchDrawSketchHandlerAttorney::setAngleSnapping(
     ViewProviderSketch& vp,
     bool enable,
@@ -1506,6 +1571,70 @@ int DrawSketchHandler::getPreselectCurve() const
 int DrawSketchHandler::getPreselectCross() const
 {
     return ViewProviderSketchDrawSketchHandlerAttorney::getPreselectCross(*sketchgui);
+}
+
+int DrawSketchHandler::getPreselectLazyExternalId() const
+{
+    return ViewProviderSketchDrawSketchHandlerAttorney::getPreselectLazyExternalId(*sketchgui);
+}
+
+bool DrawSketchHandler::isPreselectLazyExternalVertex() const
+{
+    return ViewProviderSketchDrawSketchHandlerAttorney::isPreselectLazyExternalVertex(*sketchgui);
+}
+
+std::vector<int> DrawSketchHandler::getSelectedLazyExternalReferenceIds() const
+{
+    return ViewProviderSketchDrawSketchHandlerAttorney::getSelectedLazyExternalReferenceIds(*sketchgui);
+}
+
+bool DrawSketchHandler::getLazyExternalSourceReference(
+    int lazyExternalId,
+    std::string& sourceObjectName,
+    std::string& subName,
+    bool& intersection,
+    bool& vertex
+) const
+{
+    return ViewProviderSketchDrawSketchHandlerAttorney::getLazyExternalSourceReference(
+        *sketchgui,
+        lazyExternalId,
+        sourceObjectName,
+        subName,
+        intersection,
+        vertex
+    );
+}
+
+int DrawSketchHandler::materializeLazyExternalSourceReference(
+    const std::string& sourceObjectName,
+    const std::string& subName,
+    bool intersection,
+    bool defining
+)
+{
+    return ViewProviderSketchDrawSketchHandlerAttorney::materializeLazyExternalSourceReference(
+        *sketchgui,
+        sourceObjectName,
+        subName,
+        intersection,
+        defining
+    );
+}
+
+void DrawSketchHandler::clearSelectedLazyExternalReferences()
+{
+    ViewProviderSketchDrawSketchHandlerAttorney::clearSelectedLazyExternalReferences(*sketchgui);
+}
+
+void DrawSketchHandler::suspendLazyExternalGeometryLayer()
+{
+    ViewProviderSketchDrawSketchHandlerAttorney::suspendLazyExternalGeometryLayer(*sketchgui);
+}
+
+void DrawSketchHandler::resumeLazyExternalGeometryLayer()
+{
+    ViewProviderSketchDrawSketchHandlerAttorney::resumeLazyExternalGeometryLayer(*sketchgui);
 }
 
 Sketcher::SketchObject* DrawSketchHandler::getSketchObject()

--- a/src/Mod/Sketcher/Gui/DrawSketchHandler.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandler.h
@@ -135,6 +135,27 @@ private:
     static inline int getPreselectPoint(const ViewProviderSketch& vp);
     static inline int getPreselectCurve(const ViewProviderSketch& vp);
     static inline int getPreselectCross(const ViewProviderSketch& vp);
+    static inline int getPreselectLazyExternalId(const ViewProviderSketch& vp);
+    static inline bool isPreselectLazyExternalVertex(const ViewProviderSketch& vp);
+    static inline std::vector<int> getSelectedLazyExternalReferenceIds(const ViewProviderSketch& vp);
+    static inline bool getLazyExternalSourceReference(
+        const ViewProviderSketch& vp,
+        int lazyExternalId,
+        std::string& sourceObjectName,
+        std::string& subName,
+        bool& intersection,
+        bool& vertex
+    );
+    static inline int materializeLazyExternalSourceReference(
+        ViewProviderSketch& vp,
+        const std::string& sourceObjectName,
+        const std::string& subName,
+        bool intersection,
+        bool defining
+    );
+    static inline void clearSelectedLazyExternalReferences(ViewProviderSketch& vp);
+    static inline void suspendLazyExternalGeometryLayer(ViewProviderSketch& vp);
+    static inline void resumeLazyExternalGeometryLayer(ViewProviderSketch& vp);
 
     static inline void moveConstraint(
         ViewProviderSketch& vp,
@@ -265,6 +286,11 @@ public:
     //@}
 
 private:  // NVI
+    virtual bool allowLazyExternalPreselection() const
+    {
+        return true;
+    }
+
     void preActivated() override;
     virtual void onWidgetChanged()
     {}
@@ -311,6 +337,25 @@ protected:
     int getPreselectPoint() const;
     int getPreselectCurve() const;
     int getPreselectCross() const;
+    int getPreselectLazyExternalId() const;
+    bool isPreselectLazyExternalVertex() const;
+    std::vector<int> getSelectedLazyExternalReferenceIds() const;
+    bool getLazyExternalSourceReference(
+        int lazyExternalId,
+        std::string& sourceObjectName,
+        std::string& subName,
+        bool& intersection,
+        bool& vertex
+    ) const;
+    int materializeLazyExternalSourceReference(
+        const std::string& sourceObjectName,
+        const std::string& subName,
+        bool intersection,
+        bool defining
+    );
+    void clearSelectedLazyExternalReferences();
+    void suspendLazyExternalGeometryLayer();
+    void resumeLazyExternalGeometryLayer();
 
     Sketcher::SketchObject* getSketchObject();
 

--- a/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
+++ b/src/Mod/Sketcher/Gui/DrawSketchHandlerExternal.h
@@ -24,7 +24,11 @@
 
 #pragma once
 
+#include <cstring>
+#include <string>
 #include <App/Datums.h>
+#include <App/IndexedName.h>
+#include <Base/Tools.h>
 #include <Mod/Part/App/DatumFeature.h>
 
 #include <Gui/Notifications.h>
@@ -111,10 +115,11 @@ public:
             return false;
         }
 
-        std::string element(sSubName);
-        if ((element.size() > 4 && element.substr(0, 4) == "Edge")
-            || (element.size() > 6 && element.substr(0, 6) == "Vertex")
-            || (element.size() > 4 && element.substr(0, 4) == "Face")) {
+        const Data::IndexedName element(sSubName);
+        if (element && element.getIndex() > 0
+            && (std::strcmp(element.getType(), "Edge") == 0
+                || std::strcmp(element.getType(), "Vertex") == 0
+                || std::strcmp(element.getType(), "Face") == 0)) {
             return true;
         }
 
@@ -133,6 +138,7 @@ public:
     {}
     ~DrawSketchHandlerExternal() override
     {
+        resumeLazyExternalLayer();
         Gui::Selection().rmvSelectionGate();
     }
 
@@ -169,14 +175,17 @@ public:
             if (!obj) {
                 throw Base::ValueError("Sketcher: External geometry: Invalid object in selection");
             }
-            std::string subName(msg.pSubName);
+            const Data::IndexedName subName(msg.pSubName);
+            const bool hasValidIndex = subName && subName.getIndex() > 0;
+            const bool isExternalEdge = hasValidIndex && std::strcmp(subName.getType(), "Edge") == 0;
+            const bool isExternalVertex = hasValidIndex
+                && std::strcmp(subName.getType(), "Vertex") == 0;
+            const bool isExternalFace = hasValidIndex && std::strcmp(subName.getType(), "Face") == 0;
 
             if (obj->isDerivedFrom<App::Plane>() || obj->isDerivedFrom<Part::Datum>()
                 || obj->isDerivedFrom<Part::DatumLine>() || obj->isDerivedFrom<Part::DatumPoint>()
                 || obj->isDerivedFrom<App::Line>() || obj->isDerivedFrom<App::Point>()
-                || (subName.size() > 4 && subName.substr(0, 4) == "Edge")
-                || (subName.size() > 6 && subName.substr(0, 6) == "Vertex")
-                || (subName.size() > 4 && subName.substr(0, 4) == "Face")) {
+                || isExternalEdge || isExternalVertex || isExternalFace) {
                 try {
                     openCommand(QT_TRANSLATE_NOOP("Command", "Add external geometry"));
                     Gui::cmdAppObjectArgs(
@@ -223,6 +232,13 @@ public:
 private:
     void activated() override
     {
+        if (materializeSelectedLazyExternalReferences()) {
+            sketchgui->purgeHandler();
+            return;
+        }
+
+        suspendLazyExternalLayer();
+
         setAxisPickStyle(false);
         Gui::MDIView* mdi = Gui::Application::Instance->activeDocument()->getActiveView();
         Gui::View3DInventorViewer* viewer;
@@ -245,12 +261,108 @@ private:
 
     void deactivated() override
     {
-        Q_UNUSED(sketchgui);
+        resumeLazyExternalLayer();
         setAxisPickStyle(true);
+    }
+
+    bool allowLazyExternalPreselection() const override
+    {
+        return false;
+    }
+
+    bool materializeSelectedLazyExternalReferences()
+    {
+        if (intersection || !sketchgui) {
+            return false;
+        }
+
+        const auto lazyExternalIds = getSelectedLazyExternalReferenceIds();
+        if (lazyExternalIds.empty()) {
+            return false;
+        }
+
+        try {
+            openCommand(QT_TRANSLATE_NOOP("Command", "Add external geometry"));
+
+            bool materializationFailed = false;
+            for (int lazyExternalId : lazyExternalIds) {
+                std::string sourceObjectName;
+                std::string sourceSubName;
+                bool sourceIntersection = false;
+                bool sourceVertex = false;
+                if (!getLazyExternalSourceReference(
+                        lazyExternalId,
+                        sourceObjectName,
+                        sourceSubName,
+                        sourceIntersection,
+                        sourceVertex
+                    )) {
+                    materializationFailed = true;
+                    break;
+                }
+
+                const int geoId = materializeLazyExternalSourceReference(
+                    sourceObjectName,
+                    sourceSubName,
+                    sourceIntersection,
+                    !(alwaysReference || isConstructionMode())
+                );
+                if (geoId == Sketcher::GeoEnum::GeoUndef) {
+                    materializationFailed = true;
+                    break;
+                }
+            }
+
+            if (materializationFailed) {
+                abortCommand();
+                clearSelectedLazyExternalReferences();
+                Gui::Selection().clearSelection();
+                Gui::NotifyError(
+                    sketchgui,
+                    QT_TRANSLATE_NOOP("Notifications", "Error"),
+                    QT_TRANSLATE_NOOP("Notifications", "Failed to add external geometry")
+                );
+                return true;
+            }
+
+            commitCommand();
+            tryAutoRecomputeIfNotSolve(sketchgui->getObject<Sketcher::SketchObject>());
+            clearSelectedLazyExternalReferences();
+            Gui::Selection().clearSelection();
+        }
+        catch (const Base::Exception&) {
+            Gui::NotifyError(
+                sketchgui,
+                QT_TRANSLATE_NOOP("Notifications", "Error"),
+                QT_TRANSLATE_NOOP("Notifications", "Failed to add external geometry")
+            );
+            clearSelectedLazyExternalReferences();
+            Gui::Selection().clearSelection();
+            abortCommand();
+        }
+
+        return true;
+    }
+
+    void suspendLazyExternalLayer()
+    {
+        if (!lazyLayerSuspended && sketchgui) {
+            suspendLazyExternalGeometryLayer();
+            lazyLayerSuspended = true;
+        }
+    }
+
+    void resumeLazyExternalLayer()
+    {
+        if (lazyLayerSuspended && sketchgui) {
+            resumeLazyExternalGeometryLayer();
+            lazyLayerSuspended = false;
+        }
     }
 
     bool alwaysReference;
     bool intersection;
+    bool lazyLayerSuspended = false;
 
 public:
     std::list<Gui::InputHint> getToolHints() const override

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.cpp
@@ -63,6 +63,7 @@
 #include "EditModeGeometryCoinConverter.h"
 #include "EditModeGeometryCoinManager.h"
 #include "EditModeInformationOverlayCoinConverter.h"
+#include "LazyExternalGeometryLayer.h"
 #include "Utils.h"
 #include "ViewProviderSketch.h"
 #include "ViewProviderSketchCoinAttorney.h"
@@ -1838,6 +1839,11 @@ void EditModeCoinManager::createEditModeInventorNodes()
     // stuff for the EditCurves +++++++++++++++++++++++++++++++++++++++
     SoSeparator* editCurvesRoot = new SoSeparator;
     editModeScenegraphNodes.EditRoot->addChild(editCurvesRoot);
+
+    SoPickStyle* editCurvesPickStyle = new SoPickStyle;
+    editCurvesPickStyle->style.setValue(SoPickStyle::UNPICKABLE);
+    editCurvesRoot->addChild(editCurvesPickStyle);
+
     editModeScenegraphNodes.EditCurvesMaterials = new SoMaterial;
     editModeScenegraphNodes.EditCurvesMaterials->setName("EditCurvesMaterials");
     editCurvesRoot->addChild(editModeScenegraphNodes.EditCurvesMaterials);
@@ -2178,6 +2184,15 @@ void EditModeCoinManager::updateInventorColors()
     );
 
     editModeScenegraphNodes.textMaterial->diffuseColor = drawingParameters.CursorTextColor;
+}
+
+void EditModeCoinManager::drawLazyExternalGeometryLayer(LazyExternalGeometryLayer& layer)
+{
+    layer.attachTo(editModeScenegraphNodes.EditRoot);
+    layer.draw(
+        drawingParameters,
+        ViewProviderSketchCoinAttorney::getViewOrientationFactor(viewProvider)
+    );
 }
 
 /************************ Edit node access ************************/

--- a/src/Mod/Sketcher/Gui/EditModeCoinManager.h
+++ b/src/Mod/Sketcher/Gui/EditModeCoinManager.h
@@ -73,6 +73,7 @@ namespace SketcherGui
 class ViewProviderSketch;
 class EditModeConstraintCoinManager;
 class EditModeGeometryCoinManager;
+class LazyExternalGeometryLayer;
 
 using GeoList = Sketcher::GeoList;
 using GeoListFacade = Sketcher::GeoListFacade;
@@ -201,7 +202,8 @@ public:
         {
             InvalidPoint = -1,
             InvalidCurve = -1,
-            ExternalCurve = -3
+            ExternalCurve = -3,
+            InvalidLazyExternalId = InvalidPoint
         };
 
         enum class Axes
@@ -217,13 +219,15 @@ public:
         int GeoIndex = InvalidCurve;  // valid values are 0,1,2,... for normal geometry and
                                       // -3,-4,-5,... for external geometry
         Axes Cross = Axes::None;
+        int LazyExternalId = InvalidLazyExternalId;
+        bool LazyExternalVertex = false;
         std::set<int> ConstrIndices;
         ConstraintHitKind ConstraintKind = ConstraintHitKind::None;
         std::optional<Base::Vector3d> PickedPoint;
 
         [[nodiscard]] inline bool hasWinner() const
         {
-            return Kind != HitKind::None;
+            return Kind != HitKind::None || LazyExternalId != InvalidLazyExternalId;
         }
 
         [[nodiscard]] inline bool hasPickedPoint() const
@@ -245,6 +249,8 @@ public:
             PointIndex = InvalidPoint;
             GeoIndex = InvalidCurve;
             Cross = Axes::None;
+            LazyExternalId = InvalidLazyExternalId;
+            LazyExternalVertex = false;
             ConstrIndices.clear();
             ConstraintKind = ConstraintHitKind::None;
             PickedPoint.reset();
@@ -290,6 +296,7 @@ public:
     );
 
     void updateVirtualSpace();
+    void drawLazyExternalGeometryLayer(LazyExternalGeometryLayer& layer);
 
     /// Draw all constraint icons
     /*! Except maybe the radius and lock ones? */

--- a/src/Mod/Sketcher/Gui/LazyExternalGeometryLayer.cpp
+++ b/src/Mod/Sketcher/Gui/LazyExternalGeometryLayer.cpp
@@ -1,0 +1,680 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 Turan Furkan Topak <furkan1795@gmail.com>          *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <FCConfig.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <utility>
+
+#include <Inventor/nodes/SoCoordinate3.h>
+#include <Inventor/nodes/SoDrawStyle.h>
+#include <Inventor/nodes/SoLineSet.h>
+#include <Inventor/nodes/SoMarkerSet.h>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoPickStyle.h>
+#include <Inventor/nodes/SoSeparator.h>
+
+#include <Precision.hxx>
+#include <App/DocumentObject.h>
+#include <App/GeoFeatureGroupExtension.h>
+#include <App/GroupExtension.h>
+#include <App/IndexedName.h>
+#include <Base/Tools.h>
+#include <Gui/Application.h>
+#include <Gui/Inventor/MarkerBitmaps.h>
+#include <Gui/ViewProvider.h>
+#include <Mod/Part/App/Geometry.h>
+#include <Mod/Sketcher/App/SketchObject.h>
+
+#include "EditModeCoinManagerParameters.h"
+#include "LazyExternalGeometryLayer.h"
+
+namespace
+{
+constexpr int DisplayCurveMaxSubdivisionDepth = 8;
+constexpr double DisplayCurveRelativeDeviation = 0.01;
+
+bool isIndexedSubNameOfType(const std::string& subName, const char* type)
+{
+    const char* lastPart = std::strrchr(subName.c_str(), '.');
+    const Data::IndexedName indexedSubName(lastPart ? lastPart + 1 : subName.c_str());
+    return indexedSubName && indexedSubName.getIndex() > 0
+        && std::strcmp(indexedSubName.getType(), type) == 0;
+}
+
+bool isEdgeSubName(const std::string& subName)
+{
+    return isIndexedSubNameOfType(subName, "Edge");
+}
+
+bool isVertexSubName(const std::string& subName)
+{
+    return isIndexedSubNameOfType(subName, "Vertex");
+}
+
+bool isSourceVisible(App::DocumentObject* object)
+{
+    if (!Gui::Application::Instance || !object) {
+        return false;
+    }
+
+    for (auto* current = object; current;) {
+        auto* viewProvider = Gui::Application::Instance->getViewProvider(current);
+        if (!viewProvider || !viewProvider->isVisible()) {
+            return false;
+        }
+
+        auto* owner = App::GeoFeatureGroupExtension::getGroupOfObject(current);
+        if (!owner || owner == current) {
+            owner = App::GroupExtension::getGroupOfObject(current);
+        }
+
+        if (!owner || owner == current) {
+            break;
+        }
+
+        current = owner;
+    }
+
+    return true;
+}
+
+bool isValidExternalSource(App::DocumentObject* object)
+{
+    return object && !Base::Tools::isNullOrEmpty(object->getNameInDocument())
+        && !object->isDerivedFrom<Sketcher::SketchObject>() && isSourceVisible(object);
+}
+
+template<typename Elements>
+auto findElementById(Elements& elements, int id)
+{
+    auto it = std::find_if(elements.begin(), elements.end(), [id](const auto& element) {
+        return element.id == id;
+    });
+
+    return it == elements.end() ? nullptr : &(*it);
+}
+
+Base::Vector2d toVector2d(const Base::Vector3d& point)
+{
+    return {point.x, point.y};
+}
+
+double distance2d(const Base::Vector2d& a, const Base::Vector2d& b)
+{
+    return (a - b).Length();
+}
+
+double distancePointToSegment2d(const Base::Vector2d& p, const Base::Vector2d& a, const Base::Vector2d& b)
+{
+    const Base::Vector2d ab = b - a;
+    const Base::Vector2d ap = p - a;
+    const double ab2 = ab.x * ab.x + ab.y * ab.y;
+
+    if (ab2 <= std::numeric_limits<double>::epsilon()) {
+        return distance2d(p, a);
+    }
+
+    const double t = std::clamp((ap.x * ab.x + ap.y * ab.y) / ab2, 0.0, 1.0);
+    return distance2d(p, a + ab * t);
+}
+
+bool getCurveParameterRange(const Part::GeomCurve& curve, double& first, double& last)
+{
+    first = curve.getFirstParameter();
+    last = curve.getLastParameter();
+    if (last < first) {
+        std::swap(first, last);
+    }
+
+    return std::isfinite(first) && std::isfinite(last)
+        && std::abs(last - first) > std::numeric_limits<double>::epsilon();
+}
+
+void appendAdaptiveCurveSegment(
+    const Part::GeomCurve& curve,
+    double first,
+    double last,
+    Base::Vector3d firstPoint,
+    Base::Vector3d lastPoint,
+    int depth,
+    std::vector<Base::Vector3d>& curveCoords
+)
+{
+    const double middle = 0.5 * (first + last);
+    const Base::Vector3d middlePoint = curve.value(middle);
+    const double chordLength = distance2d(toVector2d(firstPoint), toVector2d(lastPoint));
+    const double tolerance
+        = std::max(Precision::Confusion(), chordLength * DisplayCurveRelativeDeviation);
+    const double deviation = distancePointToSegment2d(
+        toVector2d(middlePoint),
+        toVector2d(firstPoint),
+        toVector2d(lastPoint)
+    );
+
+    if (depth >= DisplayCurveMaxSubdivisionDepth || deviation <= tolerance) {
+        curveCoords.push_back(lastPoint);
+        return;
+    }
+
+    appendAdaptiveCurveSegment(curve, first, middle, firstPoint, middlePoint, depth + 1, curveCoords);
+    appendAdaptiveCurveSegment(curve, middle, last, middlePoint, lastPoint, depth + 1, curveCoords);
+}
+
+void appendCurveToCoin(
+    const Part::Geometry* geometry,
+    std::vector<Base::Vector3d>& curveCoords,
+    std::vector<int32_t>& curveVertexCounts
+)
+{
+    if (auto line = freecad_cast<const Part::GeomLineSegment*>(geometry)) {
+        curveCoords.push_back(line->getStartPoint());
+        curveCoords.push_back(line->getEndPoint());
+        curveVertexCounts.push_back(2);
+        return;
+    }
+
+    if (auto curve = freecad_cast<const Part::GeomCurve*>(geometry)) {
+        double first = 0.0;
+        double last = 0.0;
+        if (!getCurveParameterRange(*curve, first, last)) {
+            return;
+        }
+
+        const std::size_t firstVertexIndex = curveCoords.size();
+        const Base::Vector3d firstPoint = curve->value(first);
+        const Base::Vector3d lastPoint = curve->value(last);
+        curveCoords.push_back(firstPoint);
+        appendAdaptiveCurveSegment(*curve, first, last, firstPoint, lastPoint, 0, curveCoords);
+        curveVertexCounts.push_back(static_cast<int32_t>(curveCoords.size() - firstVertexIndex));
+    }
+}
+
+bool matchesExternalType(long type, bool intersection)
+{
+    return type == static_cast<long>(Sketcher::ExtType::Both)
+        || (type == static_cast<long>(Sketcher::ExtType::Projection) && !intersection)
+        || (type == static_cast<long>(Sketcher::ExtType::Intersection) && intersection);
+}
+}  // namespace
+
+namespace SketcherGui
+{
+
+ExternalGeometryMatch findExternalMatch(
+    Sketcher::SketchObject* sketch,
+    App::DocumentObject* sourceObject,
+    const std::string& subName,
+    bool intersection
+)
+{
+    if (!sketch || !sourceObject) {
+        return {};
+    }
+
+    const auto objects = sketch->ExternalGeometry.getValues();
+    const auto subElements = sketch->ExternalGeometry.getSubValues();
+    auto types = sketch->ExternalTypes.getValues();
+    types.resize(objects.size(), static_cast<long>(Sketcher::ExtType::Projection));
+
+    ExternalGeometryMatch firstMatch;
+    for (std::size_t i = 0; i < objects.size() && i < subElements.size(); ++i) {
+        if (objects[i] != sourceObject || subElements[i] != subName) {
+            continue;
+        }
+
+        ExternalGeometryMatch match {static_cast<int>(i), matchesExternalType(types[i], intersection)};
+        if (match.matchesType) {
+            return match;
+        }
+        if (!firstMatch.isValid()) {
+            firstMatch = match;
+        }
+    }
+
+    return firstMatch;
+}
+
+int resolveExternalGeometryIndex(
+    Sketcher::SketchObject* sketch,
+    App::DocumentObject* sourceObject,
+    const std::string& subName,
+    bool intersection
+)
+{
+    const auto match = findExternalMatch(sketch, sourceObject, subName, intersection);
+    return match.isValid() && match.matchesType ? match.index : -1;
+}
+
+
+LazyExternalGeometryLayer::LazyExternalGeometryLayer() = default;
+
+LazyExternalGeometryLayer::~LazyExternalGeometryLayer()
+{
+    detach();
+}
+
+void LazyExternalGeometryLayer::attachTo(SoSeparator* editRoot)
+{
+    if (parentRoot == editRoot && root) {
+        return;
+    }
+
+    detach();
+    parentRoot = editRoot;
+    createNodes();
+
+    if (parentRoot && root) {
+        parentRoot->addChild(root);
+    }
+}
+
+void LazyExternalGeometryLayer::detach()
+{
+    if (parentRoot && root) {
+        parentRoot->removeChild(root);
+    }
+
+    parentRoot = nullptr;
+    resetNodes();
+}
+
+void LazyExternalGeometryLayer::resetNodes()
+{
+    if (root) {
+        root->unref();
+    }
+
+    root = nullptr;
+    highlightMaterial = nullptr;
+    highlightPointCoordinates = nullptr;
+    highlightCurveCoordinates = nullptr;
+    highlightPointDrawStyle = nullptr;
+    highlightCurveDrawStyle = nullptr;
+    highlightPointSet = nullptr;
+    highlightCurveSet = nullptr;
+}
+
+void LazyExternalGeometryLayer::createNodes()
+{
+    root = new SoSeparator;
+    root->ref();
+    root->setName("Sketch_LazyExternalGeometryRoot");
+    root->renderCaching = SoSeparator::OFF;
+
+    auto* pickStyle = new SoPickStyle;
+    pickStyle->style = SoPickStyle::UNPICKABLE;
+    root->addChild(pickStyle);
+
+    highlightMaterial = new SoMaterial;
+    highlightMaterial->setName("LazyExternalGeometryHighlightMaterial");
+    root->addChild(highlightMaterial);
+
+    highlightPointCoordinates = new SoCoordinate3;
+    highlightPointCoordinates->setName("LazyExternalGeometryHighlightPointCoordinates");
+    root->addChild(highlightPointCoordinates);
+
+    highlightPointDrawStyle = new SoDrawStyle;
+    highlightPointDrawStyle->setName("LazyExternalGeometryHighlightPointDrawStyle");
+    root->addChild(highlightPointDrawStyle);
+
+    highlightPointSet = new SoMarkerSet;
+    highlightPointSet->setName("LazyExternalGeometryHighlightPointSet");
+    root->addChild(highlightPointSet);
+
+    highlightCurveCoordinates = new SoCoordinate3;
+    highlightCurveCoordinates->setName("LazyExternalGeometryHighlightCurveCoordinates");
+    root->addChild(highlightCurveCoordinates);
+
+    highlightCurveDrawStyle = new SoDrawStyle;
+    highlightCurveDrawStyle->setName("LazyExternalGeometryHighlightCurveDrawStyle");
+    root->addChild(highlightCurveDrawStyle);
+
+    highlightCurveSet = new SoLineSet;
+    highlightCurveSet->setName("LazyExternalGeometryHighlightCurveSet");
+    root->addChild(highlightCurveSet);
+}
+
+int LazyExternalGeometryLayer::preselectSourceReference(
+    Sketcher::SketchObject* sketch,
+    App::DocumentObject* sourceObject,
+    const std::string& subName,
+    bool intersection
+)
+{
+    if (!enabled) {
+        clearPreselectedElement();
+        return -1;
+    }
+
+    if (const Element* existing = findElementBySource(sourceObject, subName, intersection)) {
+        preselectedElementId = existing->id;
+        return existing->id;
+    }
+
+    clearPreselectedElement();
+
+    const int id = addSourceReference(sketch, sourceObject, subName, intersection);
+    if (id < 0) {
+        return -1;
+    }
+
+    preselectedElementId = id;
+    return id;
+}
+
+int LazyExternalGeometryLayer::addSourceReference(
+    Sketcher::SketchObject* sketch,
+    App::DocumentObject* sourceObject,
+    const std::string& subName,
+    bool intersection
+)
+{
+    if (!sketch || !isValidExternalSource(sourceObject)) {
+        return -1;
+    }
+
+    if (!sketch->isExternalAllowed(sourceObject->getDocument(), sourceObject)) {
+        return -1;
+    }
+
+    const bool isEdge = isEdgeSubName(subName);
+    const bool isVertex = isVertexSubName(subName);
+    if (!isEdge && !isVertex) {
+        return -1;
+    }
+
+    const auto externalMatch = findExternalMatch(sketch, sourceObject, subName, intersection);
+    if (externalMatch.isValid() && externalMatch.matchesType) {
+        return -1;
+    }
+
+    if (const Element* existing = findElementBySource(sourceObject, subName, intersection)) {
+        return existing->id;
+    }
+
+    auto preview = sketch->buildProjectedExternalGeometry(sourceObject, subName.c_str(), intersection);
+    if (preview.empty()) {
+        return -1;
+    }
+
+    Element element;
+    element.id = nextId++;
+    element.sourceObjectName = sourceObject->getNameInDocument();
+    element.subName = subName;
+    element.type = isEdge ? ElementType::Edge : ElementType::Vertex;
+    element.intersection = intersection;
+    element.geometry = std::move(preview);
+
+    const int id = element.id;
+    elements.emplace_back(std::move(element));
+    return id;
+}
+
+LazyExternalGeometryLayer::Element* LazyExternalGeometryLayer::getElement(int id)
+{
+    return findElementById(elements, id);
+}
+
+const LazyExternalGeometryLayer::Element* LazyExternalGeometryLayer::getElement(int id) const
+{
+    return findElementById(elements, id);
+}
+
+const LazyExternalGeometryLayer::Element* LazyExternalGeometryLayer::findElementBySource(
+    App::DocumentObject* sourceObject,
+    const std::string& subName,
+    bool intersection
+) const
+{
+    const char* sourceObjectName = sourceObject ? sourceObject->getNameInDocument() : nullptr;
+    auto it = std::find_if(elements.begin(), elements.end(), [&](const Element& element) {
+        return !Base::Tools::isNullOrEmpty(sourceObjectName)
+            && element.sourceObjectName == sourceObjectName && element.subName == subName
+            && element.intersection == intersection;
+    });
+
+    return it == elements.end() ? nullptr : &(*it);
+}
+
+const Part::Geometry* LazyExternalGeometryLayer::getPreviewGeometry(int id) const
+{
+    const Element* element = getElement(id);
+    if (!element) {
+        return nullptr;
+    }
+
+    for (const auto& geometry : element->geometry) {
+        if (geometry) {
+            return geometry.get();
+        }
+    }
+
+    return nullptr;
+}
+
+bool LazyExternalGeometryLayer::isElementVertex(int id) const
+{
+    const Element* element = getElement(id);
+    return element && element->isVertex();
+}
+
+bool LazyExternalGeometryLayer::getSourceReference(
+    int id,
+    std::string& sourceObjectName,
+    std::string& subName,
+    bool& intersection,
+    bool& vertex
+) const
+{
+    const Element* element = getElement(id);
+    if (!element) {
+        return false;
+    }
+
+    sourceObjectName = element->sourceObjectName;
+    subName = element->subName;
+    intersection = element->intersection;
+    vertex = element->isVertex();
+    return true;
+}
+
+bool LazyExternalGeometryLayer::selectElement(int id, bool selected)
+{
+    Element* element = getElement(id);
+    if (!element) {
+        return false;
+    }
+
+    element->selected = selected;
+    if (!selected && preselectedElementId != id) {
+        elements.erase(
+            std::remove_if(
+                elements.begin(),
+                elements.end(),
+                [id](const Element& candidate) { return candidate.id == id; }
+            ),
+            elements.end()
+        );
+    }
+    return true;
+}
+
+bool LazyExternalGeometryLayer::isElementSelected(int id) const
+{
+    const Element* element = getElement(id);
+    return element && element->selected;
+}
+
+std::vector<int> LazyExternalGeometryLayer::getSelectedElementIds() const
+{
+    std::vector<int> ids;
+    for (const auto& element : elements) {
+        if (element.selected) {
+            ids.push_back(element.id);
+        }
+    }
+    return ids;
+}
+
+void LazyExternalGeometryLayer::clearSelectedElements()
+{
+    elements.erase(
+        std::remove_if(
+            elements.begin(),
+            elements.end(),
+            [this](const Element& element) {
+                return element.selected && element.id != preselectedElementId;
+            }
+        ),
+        elements.end()
+    );
+
+    if (Element* element = getElement(preselectedElementId)) {
+        element->selected = false;
+    }
+}
+
+void LazyExternalGeometryLayer::clearPreselectedElement()
+{
+    const int oldPreselectedId = preselectedElementId;
+    preselectedElementId = -1;
+
+    elements.erase(
+        std::remove_if(
+            elements.begin(),
+            elements.end(),
+            [oldPreselectedId](const Element& element) {
+                return element.id == oldPreselectedId && !element.selected;
+            }
+        ),
+        elements.end()
+    );
+}
+
+void LazyExternalGeometryLayer::setEnabled(bool on)
+{
+    if (enabled == on) {
+        return;
+    }
+
+    enabled = on;
+    if (!enabled) {
+        clearPreselectedElement();
+    }
+}
+
+bool LazyExternalGeometryLayer::isEnabled() const
+{
+    return enabled;
+}
+
+void LazyExternalGeometryLayer::appendElementGeometry(
+    const Element& element,
+    std::vector<Base::Vector3d>& points,
+    std::vector<Base::Vector3d>& curveCoords,
+    std::vector<int32_t>& curveVertexCounts
+)
+{
+    for (const auto& geometry : element.geometry) {
+        if (!geometry) {
+            continue;
+        }
+
+        if (auto point = freecad_cast<const Part::GeomPoint*>(geometry.get())) {
+            points.push_back(point->getPoint());
+            continue;
+        }
+
+        appendCurveToCoin(geometry.get(), curveCoords, curveVertexCounts);
+    }
+}
+
+void LazyExternalGeometryLayer::draw(const DrawingParameters& parameters, int viewOrientationFactor)
+{
+    if (!root) {
+        return;
+    }
+
+    std::vector<Base::Vector3d> highlightPoints;
+    std::vector<Base::Vector3d> highlightCurveCoords;
+    std::vector<int32_t> highlightCurveVertexCounts;
+
+    if (enabled) {
+        for (const auto& element : elements) {
+            if (element.selected || element.id == preselectedElementId) {
+                appendElementGeometry(
+                    element,
+                    highlightPoints,
+                    highlightCurveCoords,
+                    highlightCurveVertexCounts
+                );
+            }
+        }
+    }
+
+    const float pointz = viewOrientationFactor * parameters.zLowPoints;
+    const float linez = viewOrientationFactor * parameters.zLowLines;
+
+    highlightMaterial->diffuseColor = DrawingParameters::CurveExternalColor;
+    highlightMaterial->transparency = 0.0f;
+    highlightPointDrawStyle->pointSize = parameters.markerSize;
+    highlightPointSet->markerIndex
+        = Gui::Inventor::MarkerBitmaps::getMarkerIndex("CIRCLE_FILLED", parameters.markerSize);
+
+    highlightCurveDrawStyle->lineWidth = parameters.ExternalWidth * parameters.pixelScalingFactor;
+    highlightCurveDrawStyle->linePattern = parameters.ExternalPattern;
+
+    highlightPointCoordinates->point.setNum(highlightPoints.size());
+    SbVec3f* pointVertices = highlightPointCoordinates->point.startEditing();
+    for (const auto& point : highlightPoints) {
+        pointVertices->setValue(point.x, point.y, pointz);
+        ++pointVertices;
+    }
+    highlightPointCoordinates->point.finishEditing();
+
+    highlightCurveCoordinates->point.setNum(highlightCurveCoords.size());
+    highlightCurveSet->numVertices.setNum(highlightCurveVertexCounts.size());
+
+    SbVec3f* curveVertices = highlightCurveCoordinates->point.startEditing();
+    for (const auto& point : highlightCurveCoords) {
+        curveVertices->setValue(point.x, point.y, linez);
+        ++curveVertices;
+    }
+    highlightCurveCoordinates->point.finishEditing();
+
+    int32_t* vertexCounts = highlightCurveSet->numVertices.startEditing();
+    for (auto count : highlightCurveVertexCounts) {
+        *vertexCounts = count;
+        ++vertexCounts;
+    }
+    highlightCurveSet->numVertices.finishEditing();
+}
+
+}  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/LazyExternalGeometryLayer.h
+++ b/src/Mod/Sketcher/Gui/LazyExternalGeometryLayer.h
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+/***************************************************************************
+ *   Copyright (c) 2026 Turan Furkan Topak <furkan1795@gmail.com>          *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library  is distributed in the hope that it will be useful,      *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <Base/Vector3D.h>
+
+class SoCoordinate3;
+class SoDrawStyle;
+class SoLineSet;
+class SoMarkerSet;
+class SoMaterial;
+class SoSeparator;
+
+namespace App
+{
+class DocumentObject;
+}
+
+namespace Part
+{
+class Geometry;
+}
+
+namespace Sketcher
+{
+class SketchObject;
+}
+
+namespace SketcherGui
+{
+
+struct ExternalGeometryMatch
+{
+    int index = -1;
+    bool matchesType = false;
+
+    bool isValid() const
+    {
+        return index >= 0;
+    }
+};
+
+ExternalGeometryMatch findExternalMatch(
+    Sketcher::SketchObject* sketch,
+    App::DocumentObject* sourceObject,
+    const std::string& subName,
+    bool intersection
+);
+int resolveExternalGeometryIndex(
+    Sketcher::SketchObject* sketch,
+    App::DocumentObject* sourceObject,
+    const std::string& subName,
+    bool intersection
+);
+
+struct DrawingParameters;
+
+/// Owns the edit-mode overlay used for on-demand external geometry previews.
+///
+/// The layer stores temporary source references and preview geometry only; it does not add
+/// anything to SketchObject::ExternalGeometry.
+class LazyExternalGeometryLayer
+{
+public:
+    LazyExternalGeometryLayer();
+    ~LazyExternalGeometryLayer();
+
+    LazyExternalGeometryLayer(const LazyExternalGeometryLayer&) = delete;
+    LazyExternalGeometryLayer& operator=(const LazyExternalGeometryLayer&) = delete;
+
+    void attachTo(SoSeparator* editRoot);
+    void detach();
+
+    /// Add or reuse a temporary preview for a source object subelement. Returns the lazy id, or -1.
+    int preselectSourceReference(
+        Sketcher::SketchObject* sketch,
+        App::DocumentObject* sourceObject,
+        const std::string& subName,
+        bool intersection = false
+    );
+
+    /// Return the first preview geometry for the lazy id, or nullptr if the id is not active.
+    const Part::Geometry* getPreviewGeometry(int id) const;
+    bool isElementVertex(int id) const;
+    /// Resolve a lazy id back to its source object name, subelement, and mode flags.
+    bool getSourceReference(
+        int id,
+        std::string& sourceObjectName,
+        std::string& subName,
+        bool& intersection,
+        bool& vertex
+    ) const;
+
+    bool selectElement(int id, bool selected);
+    bool isElementSelected(int id) const;
+    std::vector<int> getSelectedElementIds() const;
+    void clearSelectedElements();
+    void clearPreselectedElement();
+
+    /// Temporarily disables preview picking/selection without destroying already tracked elements.
+    void setEnabled(bool enabled);
+    bool isEnabled() const;
+
+    /// Rebuild the Coin nodes from the currently tracked preview elements.
+    void draw(const DrawingParameters& parameters, int viewOrientationFactor);
+
+private:
+    enum class ElementType
+    {
+        Edge,
+        Vertex
+    };
+
+    struct Element
+    {
+        Element() = default;
+        Element(const Element&) = delete;
+        Element& operator=(const Element&) = delete;
+        Element(Element&&) noexcept = default;
+        Element& operator=(Element&&) noexcept = default;
+
+        int id = -1;
+        std::string sourceObjectName;
+        std::string subName;
+        ElementType type = ElementType::Edge;
+        bool intersection = false;
+        bool selected = false;
+        std::vector<std::unique_ptr<Part::Geometry>> geometry;
+
+        bool isVertex() const
+        {
+            return type == ElementType::Vertex;
+        }
+    };
+
+    int addSourceReference(
+        Sketcher::SketchObject* sketch,
+        App::DocumentObject* sourceObject,
+        const std::string& subName,
+        bool intersection
+    );
+
+    Element* getElement(int id);
+    const Element* getElement(int id) const;
+    const Element* findElementBySource(
+        App::DocumentObject* sourceObject,
+        const std::string& subName,
+        bool intersection
+    ) const;
+
+    void createNodes();
+    void resetNodes();
+    void appendElementGeometry(
+        const Element& element,
+        std::vector<Base::Vector3d>& points,
+        std::vector<Base::Vector3d>& curveCoords,
+        std::vector<int32_t>& curveVertexCounts
+    );
+
+private:
+    SoSeparator* parentRoot = nullptr;
+    SoSeparator* root = nullptr;
+    SoMaterial* highlightMaterial = nullptr;
+    SoCoordinate3* highlightPointCoordinates = nullptr;
+    SoCoordinate3* highlightCurveCoordinates = nullptr;
+    SoDrawStyle* highlightPointDrawStyle = nullptr;
+    SoDrawStyle* highlightCurveDrawStyle = nullptr;
+    SoMarkerSet* highlightPointSet = nullptr;
+    SoLineSet* highlightCurveSet = nullptr;
+
+    std::vector<Element> elements;
+    int preselectedElementId = -1;
+    bool enabled = true;
+    int nextId = 1;
+};
+
+}  // namespace SketcherGui

--- a/src/Mod/Sketcher/Gui/SketcherSettings.cpp
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.cpp
@@ -138,6 +138,7 @@ void SketcherSettings::saveSettings()
     ui->checkBoxHorVerAuto->onSave();
     ui->checkBoxLineGroup->onSave();
     ui->checkBoxAddExtGeo->onSave();
+    ui->checkBoxLazyExternalGeometry->onSave();
     ui->checkBoxMakeInternals->onSave();
 
     enum
@@ -219,6 +220,7 @@ void SketcherSettings::loadSettings()
     setProperty("checkBoxHorVerAuto", ui->checkBoxHorVerAuto->isChecked());
     ui->checkBoxLineGroup->onRestore();
     ui->checkBoxAddExtGeo->onRestore();
+    ui->checkBoxLazyExternalGeometry->onRestore();
     ui->checkBoxMakeInternals->onRestore();
 
     // Dimensioning constraints mode

--- a/src/Mod/Sketcher/Gui/SketcherSettings.ui
+++ b/src/Mod/Sketcher/Gui/SketcherSettings.ui
@@ -235,6 +235,25 @@ Requires to re-enter edit mode to take effect.</string>
        </widget>
       </item>
       <item>
+       <widget class="Gui::PrefCheckBox" name="checkBoxLazyExternalGeometry">
+        <property name="toolTip">
+         <string>Highlights external geometry for selection and adds it to the sketch only when used.</string>
+        </property>
+        <property name="text">
+         <string>Enable on-demand external geometry selection</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <property name="prefEntry" stdset="0">
+         <cstring>EnableLazyExternalGeometry</cstring>
+        </property>
+        <property name="prefPath" stdset="0">
+         <cstring>Mod/Sketcher/General</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="Gui::PrefCheckBox" name="checkBoxMakeInternals">
         <property name="toolTip">
          <string>Closed loops will automatically generate internal faces which are selectable to be used with other tools</string>

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -29,7 +29,9 @@
 #include <Inventor/SbTime.h>
 #include <Inventor/SoPickedPoint.h>
 #include <Inventor/actions/SoRayPickAction.h>
+#include <Inventor/lists/SoPickedPointList.h>
 #include <Inventor/actions/SoGetBoundingBoxAction.h>
+#include <Inventor/actions/SoRayPickAction.h>
 #include <Inventor/details/SoPointDetail.h>
 #include <Inventor/events/SoKeyboardEvent.h>
 #include <Inventor/lists/SoPickedPointList.h>
@@ -53,13 +55,17 @@
 #include <cmath>
 #include <limits>
 #include <numbers>
+#include <utility>
 
 #include <fmt/format.h>
 
+#include <App/Document.h>
+#include <App/IndexedName.h>
 #include <Base/BaseClass.h>
 #include <Base/Console.h>
 #include <Base/Converter.h>
 #include <Base/ServiceProvider.h>
+#include <Base/Tools.h>
 #include <Base/Vector3D.h>
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
@@ -75,6 +81,7 @@
 #include <Gui/Utilities.h>
 #include <Gui/View3DInventor.h>
 #include <Gui/View3DInventorViewer.h>
+#include <Gui/ViewProvider.h>
 #include <Mod/Part/App/Geometry.h>
 #include <Mod/Sketcher/App/GeoList.h>
 #include <Mod/Sketcher/App/GeometryFacade.h>
@@ -86,6 +93,7 @@
 #include "EditDatumDialog.h"
 #include "EditTextDialog.h"
 #include "EditModeCoinManager.h"
+#include "LazyExternalGeometryLayer.h"
 #include "SnapManager.h"
 #include "StyleParameters.h"
 #include "TaskDlgEditSketch.h"
@@ -115,6 +123,187 @@ namespace sp = std::placeholders;
 
 namespace
 {
+constexpr float LazyExternalMinVisibleDepthTolerance = 1.0e-3F;
+constexpr float LazyExternalRelativeDepthTolerance = 1.0e-5F;
+
+bool parseLazyExternalSourceElement(const char* subName, bool& isVertex)
+{
+    if (Base::Tools::isNullOrEmpty(subName)) {
+        return false;
+    }
+
+    const char* lastPart = std::strrchr(subName, '.');
+    const Data::IndexedName element(lastPart ? lastPart + 1 : subName);
+    if (!element || element.getIndex() <= 0) {
+        return false;
+    }
+
+    if (std::strcmp(element.getType(), "Vertex") == 0) {
+        isVertex = true;
+        return true;
+    }
+    if (std::strcmp(element.getType(), "Edge") == 0) {
+        isVertex = false;
+        return true;
+    }
+
+    return false;
+}
+
+bool isAllowedLazyExternalSourceObject(Sketcher::SketchObject* sketch,
+                                        App::DocumentObject* object)
+{
+    return sketch && object && object != sketch && !object->isDerivedFrom<Sketcher::SketchObject>()
+        && sketch->isExternalAllowed(object->getDocument(), object);
+}
+
+bool isVisibleLazyExternalSourceObject(Sketcher::SketchObject* sketch,
+                                        App::DocumentObject* object)
+{
+    if (!isAllowedLazyExternalSourceObject(sketch, object) || !Gui::Application::Instance) {
+        return false;
+    }
+
+    auto* viewProvider = Gui::Application::Instance->getViewProvider(object);
+    return viewProvider && viewProvider->isVisible();
+}
+
+bool isForeignSketchSourceChange(const Gui::SelectionChanges& msg,
+                                 Sketcher::SketchObject* sketch)
+{
+    if (!sketch || !msg.pDocName || !msg.pObjectName || Base::Tools::isNullOrEmpty(msg.pSubName)) {
+        return false;
+    }
+
+    auto* document = sketch->getDocument();
+    if (!document || std::strcmp(msg.pDocName, document->getName()) != 0
+        || std::strcmp(msg.pObjectName, sketch->getNameInDocument()) == 0) {
+        return false;
+    }
+
+    bool sourceVertex = false;
+    if (!parseLazyExternalSourceElement(msg.pSubName, sourceVertex)) {
+        return false;
+    }
+
+    return isAllowedLazyExternalSourceObject(sketch, document->getObject(msg.pObjectName));
+}
+
+struct LazyExternalSourceHit
+{
+    App::DocumentObject* object = nullptr;
+    std::string subName;
+    float depth = std::numeric_limits<float>::max();
+    bool vertex = false;
+};
+
+float getLazyExternalPickDepth(const SoPickedPoint* pickedPoint, const SbVec3f& rayStart)
+{
+    if (!pickedPoint) {
+        return std::numeric_limits<float>::max();
+    }
+
+    const SbVec3f delta = pickedPoint->getPoint() - rayStart;
+    return delta.length();
+}
+
+bool getPickedLazyExternalSourceSubName(const SoPickedPoint* pickedPoint,
+                                        App::DocumentObject* object,
+                                        std::string& subName)
+{
+    auto* viewProvider = Gui::Application::Instance
+        ? Gui::Application::Instance->getViewProvider(object)
+        : nullptr;
+    auto* root = viewProvider ? viewProvider->getRoot() : nullptr;
+    if (!root || !pickedPoint || !pickedPoint->getPath()
+        || !pickedPoint->getPath()->containsNode(root)) {
+        return false;
+    }
+
+    return viewProvider->getElementPicked(pickedPoint, subName) && !subName.empty();
+}
+
+std::vector<LazyExternalSourceHit> collectLazyExternalSourceHits(
+    Sketcher::SketchObject* sketch,
+    App::Document* appDocument,
+    const SoPickedPointList& pickedPoints,
+    const SbVec3f& rayStart,
+    float& nearestHitDepth)
+{
+    std::vector<LazyExternalSourceHit> sourceHits;
+    sourceHits.reserve(static_cast<std::size_t>(pickedPoints.getLength()));
+
+    const auto sourceObjects = appDocument->getObjects();
+    for (int pickedIndex = 0; pickedIndex < pickedPoints.getLength(); ++pickedIndex) {
+        const SoPickedPoint* pickedPoint = pickedPoints[pickedIndex];
+        if (!pickedPoint) {
+            continue;
+        }
+
+        const float depth = getLazyExternalPickDepth(pickedPoint, rayStart);
+        nearestHitDepth = std::min(nearestHitDepth, depth);
+        for (auto* object : sourceObjects) {
+            if (!isVisibleLazyExternalSourceObject(sketch, object)) {
+                continue;
+            }
+
+            std::string subName;
+            bool sourceVertex = false;
+            if (getPickedLazyExternalSourceSubName(pickedPoint, object, subName)
+                && parseLazyExternalSourceElement(subName.c_str(), sourceVertex)) {
+                sourceHits.push_back({object, std::move(subName), depth, sourceVertex});
+            }
+        }
+    }
+
+    return sourceHits;
+}
+
+float getLazyExternalVisibleDepthTolerance(float nearestHitDepth)
+{
+    return std::max(LazyExternalMinVisibleDepthTolerance,
+                    nearestHitDepth * LazyExternalRelativeDepthTolerance);
+}
+
+float getLazyExternalPixelDepthTolerance(const SbLine& pickLine,
+                                        const SbLine& onePixelLine,
+                                        float nearestHitDepth,
+                                        float visibleDepthTolerance,
+                                        float pickRadius)
+{
+    SbVec3f rayDirection = pickLine.getDirection();
+    SbVec3f onePixelDirection = onePixelLine.getDirection();
+    rayDirection.normalize();
+    onePixelDirection.normalize();
+
+    const SbVec3f rayStart = pickLine.getPosition();
+    const SbVec3f pointAtDepth = rayStart + rayDirection * nearestHitDepth;
+    const SbVec3f onePixelPointAtDepth =
+        onePixelLine.getPosition() + onePixelDirection * nearestHitDepth;
+    return std::max(visibleDepthTolerance,
+                    (onePixelPointAtDepth - pointAtDepth).length() * pickRadius);
+}
+
+const LazyExternalSourceHit* findClosestLazyExternalHitWithinDepth(
+    const std::vector<LazyExternalSourceHit>& sourceHits,
+    float nearestHitDepth,
+    float depthTolerance,
+    bool vertex)
+{
+    const LazyExternalSourceHit* bestHit = nullptr;
+    for (const auto& hit : sourceHits) {
+        if (hit.vertex != vertex || hit.depth - nearestHitDepth > depthTolerance) {
+            continue;
+        }
+
+        if (!bestHit || hit.depth < bestHit->depth) {
+            bestHit = &hit;
+        }
+    }
+
+    return bestHit;
+}
+
 bool isFiniteVector(const SbVec3f& vector)
 {
     return std::isfinite(vector[0]) && std::isfinite(vector[1]) && std::isfinite(vector[2]);
@@ -124,7 +313,20 @@ bool isFiniteVector(const Base::Vector3d& vector)
 {
     return std::isfinite(vector.x) && std::isfinite(vector.y) && std::isfinite(vector.z);
 }
-}  // namespace
+
+void restoreActiveViewCursor()
+{
+    const Gui::Document* doc = Gui::Application::Instance->activeDocument();
+    if (!doc) {
+        return;
+    }
+
+    if (Gui::MDIView* mdi = doc->getActiveView()) {
+        mdi->restoreOverrideCursor();
+    }
+}
+
+} // namespace
 
 /************** ViewProviderSketch::ParameterObserver *********************/
 
@@ -258,6 +460,17 @@ void ViewProviderSketch::ParameterObserver::updateRecalculateInitialSolutionWhil
         hGrp2->GetBool("RecalculateInitialSolutionWhileDragging", true);
 }
 
+void ViewProviderSketch::ParameterObserver::updateLazyExternalGeometryEnabled(
+    const std::string& string, App::Property* property)
+{
+    (void)property;
+
+    ParameterGrp::handle hGrp = App::GetApplication().GetParameterGroupByPath(
+        "User parameter:BaseApp/Preferences/Mod/Sketcher/General");
+    Client.setLazyExternalGeometryPreferenceEnabled(hGrp->GetBool(string.c_str(), true));
+}
+
+
 void ViewProviderSketch::ParameterObserver::subscribeToParameters()
 {
     try {
@@ -363,6 +576,11 @@ void ViewProviderSketch::ParameterObserver::initParameters()
         {"RecalculateInitialSolutionWhileDragging",
          {[this](const std::string& string, App::Property* property) {
               updateRecalculateInitialSolutionWhileDragging(string, property);
+          },
+          nullptr}},
+        {"EnableLazyExternalGeometry",
+         {[this](const std::string& string, App::Property* property) {
+              updateLazyExternalGeometryEnabled(string, property);
           },
           nullptr}},
         {"GridSizePixelThreshold",
@@ -589,6 +807,8 @@ ViewProviderSketch::ViewProviderSketch()
     , pcSketchFacesToggle(new SoToggleSwitch)
     , listener(nullptr)
     , editCoinManager(nullptr)
+    , lazyExternalGeometryLayer(nullptr)
+    , lazyExternalGeometryLayerSuspendCount(0)
     , snapManager(nullptr)
     , pObserver(std::make_unique<ViewProviderSketch::ParameterObserver>(*this))
     , sketchHandler(nullptr)
@@ -869,7 +1089,7 @@ void ViewProviderSketch::preselectAtPoint(Base::Vector2d point)
         SbVec3f sbpoint(static_cast<float>(pnt.x), static_cast<float>(pnt.y), static_cast<float>(pnt.z));
 
         SbVec2s screencoords = viewer->getPointOnViewport(sbpoint);
-        auto result = getPreselectionResultAtViewportPos(screencoords, viewer);
+        auto result = getPreselectionResultAtViewportPos(screencoords, viewer, false);
         cachePreselectionResult(screencoords, result);
 
         if (detectAndShowPreselection(result) && sketchHandler) {
@@ -927,8 +1147,9 @@ SoPickedPointList ViewProviderSketch::getPickedPointsOnRay(
 
 EditModeCoinManager::PreselectionResult ViewProviderSketch::getPreselectionResultAtViewportPos(
     const SbVec2s& pos,
-    const Gui::View3DInventorViewer* viewer
-) const
+    const Gui::View3DInventorViewer* viewer,
+    bool allowLazyExternalPreselectionAtCursor
+)
 {
     SoPickedPointList points = getPickedPointsOnRay(pos, viewer);
     int hoveredPointIndex = EditModeCoinManager::PreselectionResult::InvalidPoint;
@@ -938,7 +1159,33 @@ EditModeCoinManager::PreselectionResult ViewProviderSketch::getPreselectionResul
         hoveredPointIndex = viewProviderParameters.lastPreselectionResult.PointIndex;
     }
 
-    return editCoinManager->detectPreselection(points, pos, hoveredPointIndex);
+    auto result = editCoinManager->detectPreselection(points, pos, hoveredPointIndex);
+
+    const bool handlerAllowsLazyExternalPreselection =
+        !sketchHandler || sketchHandler->allowLazyExternalPreselection();
+    const bool allowLazyExternalPreselection =
+        allowLazyExternalPreselectionAtCursor && handlerAllowsLazyExternalPreselection;
+
+    if (!allowLazyExternalPreselection && lazyExternalGeometryLayer
+        && preselection.isLazyExternalPreselected()) {
+        resetPreselectPoint();
+    }
+    if (!handlerAllowsLazyExternalPreselection && lazyExternalGeometryLayer
+        && !getSelectedLazyExternalReferenceIds().empty()) {
+        clearSelectedLazyExternalReferences();
+    }
+
+    if (!result.hasWinner() && allowLazyExternalPreselection) {
+        bool lazyExternalVertex = false;
+        const int lazyExternalId =
+            preselectLazyExternalAtCursor(pos, viewer, lazyExternalVertex);
+        if (lazyExternalId >= 0) {
+            result.LazyExternalId = lazyExternalId;
+            result.LazyExternalVertex = lazyExternalVertex;
+        }
+    }
+
+    return result;
 }
 
 void ViewProviderSketch::cachePreselectionResult(
@@ -984,7 +1231,7 @@ bool ViewProviderSketch::getPreselectionAtViewportPos(
 {
     subElementNames.clear();
 
-    EditModeCoinManager::PreselectionResult result = getPreselectionResultAtViewportPos(pos, viewer);
+    EditModeCoinManager::PreselectionResult result = getPreselectionResultAtViewportPos(pos, viewer, false);
     if (!result.hasWinner() || !result.hasPickedPoint()) {
         return false;
     }
@@ -1287,6 +1534,10 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                             done = true;
                             break;
                         case EditModeCoinManager::PreselectionResult::HitKind::None:
+                            if (resolvedClickResult.LazyExternalId != EditModeCoinManager::PreselectionResult::InvalidLazyExternalId) {
+                                setSketchMode(resolvedClickResult.LazyExternalVertex ? STATUS_SELECT_Point : STATUS_SELECT_Edge);
+                                done = true;
+                            }
                             break;
                     }
 
@@ -1315,7 +1566,15 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                         DoubleClick::prvCursorPos = cursorPos;
                         DoubleClick::newCursorPos = cursorPos;
                         if (!done) {
-                            setSketchMode(STATUS_SKETCH_StartRubberBand);
+                            if (isLazyExternalGeometryEnabled()
+                                && !getSelectedLazyExternalReferenceIds().empty()) {
+                                clearSelectedLazyExternalReferences();
+                                resetPreselectPoint();
+                                done = true;
+                            }
+                            else {
+                                setSketchMode(STATUS_SKETCH_StartRubberBand);
+                            }
                         }
                     }
 
@@ -1333,7 +1592,11 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
             // Do things depending on the mode of the user interaction
             switch (Mode) {
                 case STATUS_SELECT_Point:
-                    if (hasSelectionPoint) {
+                    if (preselection.isLazyExternalVertex()) {
+                        selectLazyExternalReference(preselection.PreselectLazyExternalId, true);
+                        drag.resetIds();
+                    }
+                    else if (hasSelectionPoint) {
                         //  Do selection
                         std::stringstream ss;
                         ss << "Vertex" << preselection.getPreselectionVertexIndex();
@@ -1343,12 +1606,18 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     setSketchMode(STATUS_NONE);
                     return true;
                 case STATUS_SELECT_Edge:
-                    if (hasSelectionPoint) {
+                    if (preselection.isLazyExternalEdge()) {
+                        selectLazyExternalReference(preselection.PreselectLazyExternalId, true);
+                        drag.resetIds();
+                    }
+                    else if (hasSelectionPoint) {
                         std::stringstream ss;
-                        if (preselection.isEdge())
+                        if (preselection.isEdge()) {
                             ss << "Edge" << preselection.getPreselectionEdgeIndex();
-                        else// external geometry
+                        }
+                        else { // external geometry
                             ss << "ExternalEdge" << preselection.getPreselectionExternalEdgeIndex();
+                        }
 
                         preselectToSelection(ss, selectionPoint, true);
                     }
@@ -1441,6 +1710,8 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                                                    // unless user hold control.
                     if (!(QApplication::keyboardModifiers() & Qt::ControlModifier)) {
                         Gui::Selection().clearSelection();
+                        clearSelectedLazyExternalReferences();
+                        resetPreselectPoint();
                     }
                     setSketchMode(STATUS_NONE);
                     return true;
@@ -1491,6 +1762,9 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                             setSketchMode(STATUS_SELECT_Constraint);
                             break;
                         case EditModeCoinManager::PreselectionResult::HitKind::None:
+                            if (resolvedClickResult.LazyExternalId != EditModeCoinManager::PreselectionResult::InvalidLazyExternalId) {
+                                setSketchMode(resolvedClickResult.LazyExternalVertex ? STATUS_SELECT_Point : STATUS_SELECT_Edge);
+                            }
                             break;
                     }
                     break;
@@ -1519,7 +1793,11 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     generateContextMenu();
                     return true;
                 case STATUS_SELECT_Point:
-                    if (hasSelectionPoint) {
+                    if (preselection.isLazyExternalVertex()) {
+                        selectLazyExternalReference(preselection.PreselectLazyExternalId, false);
+                        drag.resetIds();
+                    }
+                    else if (hasSelectionPoint) {
                         //  Do selection
                         std::stringstream ss;
                         ss << "Vertex" << preselection.getPreselectionVertexIndex();
@@ -1530,7 +1808,11 @@ bool ViewProviderSketch::mouseButtonPressed(int Button, bool pressed, const SbVe
                     generateContextMenu();
                     return true;
                 case STATUS_SELECT_Edge:
-                    if (hasSelectionPoint) {
+                    if (preselection.isLazyExternalEdge()) {
+                        selectLazyExternalReference(preselection.PreselectLazyExternalId, false);
+                        drag.resetIds();
+                    }
+                    else if (hasSelectionPoint) {
                         std::stringstream ss;
                         if (preselection.isEdge()) {
                             ss << "Edge" << preselection.getPreselectionEdgeIndex();
@@ -2725,6 +3007,23 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
             return;
         }
 
+        const bool lazyExternalLayerHandlesSourceSelection =
+            isLazyExternalGeometryEnabled() && lazyExternalGeometryLayerSuspendCount == 0;
+        if (lazyExternalLayerHandlesSourceSelection
+            && (msg.Type == Gui::SelectionChanges::SetPreselect
+                || msg.Type == Gui::SelectionChanges::AddSelection)
+            && isForeignSketchSourceChange(msg, getSketchObject())) {
+            if (msg.Type == Gui::SelectionChanges::AddSelection) {
+                Gui::Selection().rmvSelection(msg.pDocName, msg.pObjectName, msg.pSubName);
+            }
+            else {
+                resetPreselectPoint();
+                Gui::Selection().rmvPreselect();
+                restoreActiveViewCursor();
+            }
+            return;
+        }
+
         std::string temp;
         if (msg.Type == Gui::SelectionChanges::ClrSelection) {
             // if something selected in this object?
@@ -2737,6 +3036,7 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
                 editCoinManager->drawConstraintIcons();
                 updateColor();
             }
+            clearSelectedLazyExternalReferences();
         }
         else if (msg.Type == Gui::SelectionChanges::AddSelection) {
             // is it this object??
@@ -2851,24 +3151,29 @@ void ViewProviderSketch::onSelectionChanged(const Gui::SelectionChanges& msg)
             //}
         }
         else if (msg.Type == Gui::SelectionChanges::SetPreselect) {
-            if (strcmp(msg.pDocName, getSketchObject()->getDocument()->getName()) == 0
-                && strcmp(msg.pObjectName, getSketchObject()->getNameInDocument()) == 0) {
-                if (msg.pSubName) {
-                    std::string shapetype(msg.pSubName);
-                    if (shapetype.size() > 4 && shapetype.substr(0, 4) == "Edge") {
-                        int GeoId = std::atoi(&shapetype[4]) - 1;
-                        resetPreselectPoint();
-                        preselection.PreselectCurve = GeoId;
-                    }
-                    else if (shapetype.size() > 12 && shapetype.substr(0, 12) == "ExternalEdge") {
-                        int GeoId = std::atoi(&shapetype[12]) - 1;
-                        GeoId = -GeoId - 3;
-                        resetPreselectPoint();
-                        preselection.PreselectCurve = GeoId;
-                    }
-                    else if (shapetype.size() > 6 && shapetype.substr(0, 6) == "Vertex") {
-                        int PtIndex = std::atoi(&shapetype[6]) - 1;
-                        setPreselectPoint(PtIndex);
+            auto* sketch = getSketchObject();
+            auto* document = sketch ? sketch->getDocument() : nullptr;
+            if (document && msg.pDocName && msg.pObjectName
+                && strcmp(msg.pDocName, document->getName()) == 0) {
+                if (strcmp(msg.pObjectName, sketch->getNameInDocument()) == 0) {
+                    if (msg.pSubName) {
+                        std::string shapetype(msg.pSubName);
+                        if (shapetype.size() > 4 && shapetype.substr(0, 4) == "Edge") {
+                            int GeoId = std::atoi(&shapetype[4]) - 1;
+                            resetPreselectPoint();
+                            preselection.PreselectCurve = GeoId;
+                        }
+                        else if (shapetype.size() > 12
+                                 && shapetype.substr(0, 12) == "ExternalEdge") {
+                            int GeoId = std::atoi(&shapetype[12]) - 1;
+                            GeoId = -GeoId - 3;
+                            resetPreselectPoint();
+                            preselection.PreselectCurve = GeoId;
+                        }
+                        else if (shapetype.size() > 6 && shapetype.substr(0, 6) == "Vertex") {
+                            int PtIndex = std::atoi(&shapetype[6]) - 1;
+                            setPreselectPoint(PtIndex);
+                        }
                     }
                 }
             }
@@ -2928,7 +3233,7 @@ bool ViewProviderSketch::detectAndShowPreselection(
     };
 
     if (result.hasWinner()) {
-        if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Point
+        if (result.PointIndex != -1
             && result.PointIndex != preselection.PreselectPoint) {// if a new point is hit
             const auto& pickedPoint = result.pickedPoint();
             std::stringstream ss;
@@ -3028,7 +3333,15 @@ bool ViewProviderSketch::detectAndShowPreselection(
                 return true;
             }
         }
-        else if (result.Kind == EditModeCoinManager::PreselectionResult::HitKind::Constraint
+        else if (result.LazyExternalId != EditModeCoinManager::PreselectionResult::InvalidLazyExternalId
+                 && (result.LazyExternalId != preselection.PreselectLazyExternalId
+                     || result.LazyExternalVertex != preselection.PreselectLazyExternalVertex)) {
+            preselection.blockedPreselection = false;
+            setPreselectLazyExternal(result.LazyExternalId, result.LazyExternalVertex);
+            updateToolTip();
+            return true;
+        }
+        else if (!result.ConstrIndices.empty()
                  && result.ConstrIndices
                      != preselection.PreselectConstraintSet) {// if a constraint is hit
             const auto& pickedPoint = result.pickedPoint();
@@ -3076,6 +3389,7 @@ bool ViewProviderSketch::detectAndShowPreselection(
         }
     }
     else if (preselection.isPreselectCurveValid() || preselection.isPreselectPointValid()
+             || preselection.isLazyExternalPreselected()
              || !preselection.PreselectConstraintSet.empty() || preselection.isCrossPreselected()
              || preselection.blockedPreselection) {
         resetPreselectPoint();
@@ -3745,6 +4059,8 @@ void ViewProviderSketch::draw(bool temp /*=false*/, bool rebuildinformationoverl
         editCoinManager->updateColor(geolistfacade);
     }
 
+    redrawLazyExternalGeometryLayer();
+
     Gui::MDIView* mdi = this->getActiveView();
     if (mdi && mdi->isDerivedFrom<Gui::View3DInventor>()) {
         static_cast<Gui::View3DInventor*>(mdi)->getViewer()->redraw();
@@ -3924,6 +4240,19 @@ void ViewProviderSketch::onChanged(const App::Property* prop)
     if (prop == &ShapeAppearance) {
         pcSketchFaces->color.setValue(Base::convertTo<SbColor>(ShapeAppearance.getDiffuseColor()));
         pcSketchFaces->transparency.setValue(ShapeAppearance.getTransparency());
+    }
+}
+
+void ViewProviderSketch::slotChangedViewProvider(const Gui::ViewProvider& /*vp*/,
+                                                 const App::Property& prop)
+{
+    if (!isInEditMode() || std::strcmp(prop.getName(), "Visibility") != 0) {
+        return;
+    }
+
+    if (lazyExternalGeometryLayer) {
+        lazyExternalGeometryLayer->clearPreselectedElement();
+        redrawLazyExternalGeometryLayer();
     }
 }
 
@@ -4191,7 +4520,11 @@ bool ViewProviderSketch::setEdit(int ModNum)
     assert(!isInEditMode());
     preselection.reset();
     selection.reset();
+    lazyExternalGeometryLayerSuspendCount = 0;
     editCoinManager = std::make_unique<EditModeCoinManager>(*this);
+    ensureLazyExternalGeometryLayer();
+    connectViewProviderChanged = Gui::Application::Instance->signalChangedObject.connect(
+        std::bind(&ViewProviderSketch::slotChangedViewProvider, this, sp::_1, sp::_2));
     snapManager = std::make_unique<SnapManager>(*this);
 
 
@@ -4496,6 +4829,8 @@ void ViewProviderSketch::unsetEdit(int ModNum)
             deactivateHandler();
         }
 
+        lazyExternalGeometryLayer = nullptr;
+        lazyExternalGeometryLayerSuspendCount = 0;
         editCoinManager = nullptr;
         snapManager = nullptr;
         preselection.reset();
@@ -4527,6 +4862,7 @@ void ViewProviderSketch::unsetEdit(int ModNum)
     connectRedoDocument.disconnect();
     connectSolverUpdate.disconnect();
     connectConstraintAdded.disconnect();
+    connectViewProviderChanged.disconnect();
 
     unsetupActiveAndInEdit();
 
@@ -4762,6 +5098,207 @@ int ViewProviderSketch::getPreselectCross() const
     if (isInEditMode())
         return static_cast<int>(preselection.PreselectCross);
     return -1;
+}
+
+int ViewProviderSketch::getPreselectLazyExternalId() const
+{
+    if (isInEditMode() && isLazyExternalGeometryEnabled()) {
+        return preselection.PreselectLazyExternalId;
+    }
+    return Preselection::InvalidLazyExternalId;
+}
+
+bool ViewProviderSketch::isPreselectLazyExternalVertex() const
+{
+    return isInEditMode() && isLazyExternalGeometryEnabled()
+        && preselection.isLazyExternalVertex();
+}
+
+void ViewProviderSketch::redrawLazyExternalGeometryLayer()
+{
+    if (editCoinManager && lazyExternalGeometryLayer) {
+        editCoinManager->drawLazyExternalGeometryLayer(*lazyExternalGeometryLayer);
+    }
+}
+
+bool ViewProviderSketch::ensureLazyExternalGeometryLayer()
+{
+    if (!editCoinManager || !isLazyExternalGeometryEnabled()) {
+        return false;
+    }
+
+    if (!lazyExternalGeometryLayer) {
+        lazyExternalGeometryLayer = std::make_unique<LazyExternalGeometryLayer>();
+        lazyExternalGeometryLayer->setEnabled(lazyExternalGeometryLayerSuspendCount == 0);
+        editCoinManager->drawLazyExternalGeometryLayer(*lazyExternalGeometryLayer);
+    }
+
+    return true;
+}
+
+bool ViewProviderSketch::isLazyExternalGeometryEnabled() const
+{
+    return viewProviderParameters.lazyExternalGeometryEnabled;
+}
+
+void ViewProviderSketch::setLazyExternalGeometryPreferenceEnabled(bool enabled)
+{
+    if (viewProviderParameters.lazyExternalGeometryEnabled == enabled) {
+        return;
+    }
+
+    viewProviderParameters.lazyExternalGeometryEnabled = enabled;
+
+    if (!enabled) {
+        preselection.PreselectLazyExternalId = Preselection::InvalidLazyExternalId;
+        preselection.PreselectLazyExternalVertex = false;
+        lazyExternalGeometryLayer.reset();
+        return;
+    }
+
+    ensureLazyExternalGeometryLayer();
+}
+
+
+void ViewProviderSketch::suspendLazyExternalGeometryLayer()
+{
+    ++lazyExternalGeometryLayerSuspendCount;
+
+    if (!lazyExternalGeometryLayer || lazyExternalGeometryLayerSuspendCount != 1) {
+        return;
+    }
+
+    preselection.PreselectLazyExternalId = Preselection::InvalidLazyExternalId;
+    preselection.PreselectLazyExternalVertex = false;
+    lazyExternalGeometryLayer->setEnabled(false);
+    redrawLazyExternalGeometryLayer();
+}
+
+void ViewProviderSketch::resumeLazyExternalGeometryLayer()
+{
+    if (lazyExternalGeometryLayerSuspendCount <= 0) {
+        return;
+    }
+
+    --lazyExternalGeometryLayerSuspendCount;
+
+    if (!lazyExternalGeometryLayer || lazyExternalGeometryLayerSuspendCount != 0
+        || !isLazyExternalGeometryEnabled()) {
+        return;
+    }
+
+    lazyExternalGeometryLayer->setEnabled(true);
+    redrawLazyExternalGeometryLayer();
+}
+
+int ViewProviderSketch::materializeLazyExternalSourceReference(const std::string& sourceObjectName,
+                                                              const std::string& subName,
+                                                              bool intersection,
+                                                              bool defining)
+{
+    auto* sketch = getSketchObject();
+    auto* appDocument = sketch ? sketch->getDocument() : nullptr;
+    if (!sketch || !appDocument || sourceObjectName.empty() || subName.empty()) {
+        return Sketcher::GeoEnum::GeoUndef;
+    }
+
+    App::DocumentObject* sourceObject = appDocument->getObject(sourceObjectName.c_str());
+    if (!sourceObject) {
+        return Sketcher::GeoEnum::GeoUndef;
+    }
+
+    const auto existingMatch = findExternalMatch(sketch, sourceObject, subName, intersection);
+    if (existingMatch.isValid() && existingMatch.matchesType) {
+        return Sketcher::GeoEnum::RefExt - existingMatch.index;
+    }
+
+    const int externalCountBefore = sketch->getExternalGeometryCount();
+    const int extIndex = sketch->addExternal(sourceObject, subName.c_str(), defining, intersection);
+    if (extIndex < 0) {
+        return Sketcher::GeoEnum::GeoUndef;
+    }
+
+    const int resolvedIndex = resolveExternalGeometryIndex(sketch, sourceObject, subName, intersection);
+
+    if (resolvedIndex < 0) {
+        if (sketch->getExternalGeometryCount() > externalCountBefore) {
+            std::vector<int> externalsToRollback;
+            for (int extGeoId = sketch->getExternalGeometryCount() - 1;
+                 extGeoId >= externalCountBefore;
+                 --extGeoId) {
+                externalsToRollback.push_back(extGeoId);
+            }
+            sketch->delExternal(externalsToRollback);
+        }
+        return Sketcher::GeoEnum::GeoUndef;
+    }
+
+    return Sketcher::GeoEnum::RefExt - resolvedIndex;
+}
+
+Base::Type ViewProviderSketch::getLazyExternalGeometryType(int lazyExternalId) const
+{
+    if (!lazyExternalGeometryLayer || !isLazyExternalGeometryEnabled()) {
+        return Base::Type::BadType;
+    }
+
+    const Part::Geometry* geometry = lazyExternalGeometryLayer->getPreviewGeometry(lazyExternalId);
+    return geometry ? geometry->getTypeId() : Base::Type::BadType;
+}
+
+bool ViewProviderSketch::isLazyExternalReferenceVertex(int lazyExternalId) const
+{
+    return lazyExternalGeometryLayer && isLazyExternalGeometryEnabled()
+        && lazyExternalGeometryLayer->isElementVertex(lazyExternalId);
+}
+
+bool ViewProviderSketch::getLazyExternalSourceReference(int lazyExternalId,
+                                                       std::string& sourceObjectName,
+                                                       std::string& subName,
+                                                       bool& intersection,
+                                                       bool& vertex) const
+{
+    return lazyExternalGeometryLayer && isLazyExternalGeometryEnabled()
+        && lazyExternalGeometryLayer->getSourceReference(
+            lazyExternalId, sourceObjectName, subName, intersection, vertex);
+}
+
+bool ViewProviderSketch::selectLazyExternalReference(int lazyExternalId, bool toggle)
+{
+    if (!lazyExternalGeometryLayer || !isLazyExternalGeometryEnabled() || lazyExternalId < 0) {
+        return false;
+    }
+
+    const bool selected = !toggle || !lazyExternalGeometryLayer->isElementSelected(lazyExternalId);
+    const bool changed = lazyExternalGeometryLayer->selectElement(lazyExternalId, selected);
+    if (changed) {
+        redrawLazyExternalGeometryLayer();
+    }
+    return changed;
+}
+
+bool ViewProviderSketch::isLazyExternalReferenceSelected(int lazyExternalId) const
+{
+    return lazyExternalGeometryLayer && isLazyExternalGeometryEnabled()
+        && lazyExternalGeometryLayer->isElementSelected(lazyExternalId);
+}
+
+std::vector<int> ViewProviderSketch::getSelectedLazyExternalReferenceIds() const
+{
+    if (!lazyExternalGeometryLayer || !isLazyExternalGeometryEnabled()) {
+        return {};
+    }
+    return lazyExternalGeometryLayer->getSelectedElementIds();
+}
+
+void ViewProviderSketch::clearSelectedLazyExternalReferences()
+{
+    if (!lazyExternalGeometryLayer) {
+        return;
+    }
+
+    lazyExternalGeometryLayer->clearSelectedElements();
+    redrawLazyExternalGeometryLayer();
 }
 
 Sketcher::SketchObject* ViewProviderSketch::getSketchObject() const
@@ -5026,29 +5563,53 @@ void ViewProviderSketch::resetPositionText()
 
 void ViewProviderSketch::setPreselectPoint(int PreselectPoint)
 {
+    const bool hadLazyPreselection = preselection.isLazyExternalPreselected();
+
     preselection.PreselectPoint = PreselectPoint;
     preselection.PreselectCurve = Preselection::InvalidCurve;
+    preselection.PreselectLazyExternalId = Preselection::InvalidLazyExternalId;
+    preselection.PreselectLazyExternalVertex = false;
     preselection.PreselectCross = Preselection::Axes::None;
-    ;
     preselection.PreselectConstraintSet.clear();
+
+    clearLazyExternalPreselectionIfNeeded(hadLazyPreselection);
 }
 
 void ViewProviderSketch::setPreselectRootPoint()
 {
+    const bool hadLazyPreselection = preselection.isLazyExternalPreselected();
+
     preselection.PreselectPoint = Preselection::InvalidPoint;
     preselection.PreselectCurve = Preselection::InvalidCurve;
+    preselection.PreselectLazyExternalId = Preselection::InvalidLazyExternalId;
+    preselection.PreselectLazyExternalVertex = false;
     preselection.PreselectCross = Preselection::Axes::RootPoint;
     preselection.PreselectConstraintSet.clear();
+
+    clearLazyExternalPreselectionIfNeeded(hadLazyPreselection);
 }
 
 
 void ViewProviderSketch::resetPreselectPoint()
 {
+    const bool hadLazyPreselection = preselection.isLazyExternalPreselected();
+
     preselection.PreselectPoint = Preselection::InvalidPoint;
     preselection.PreselectCurve = Preselection::InvalidCurve;
+    preselection.PreselectLazyExternalId = Preselection::InvalidLazyExternalId;
+    preselection.PreselectLazyExternalVertex = false;
     preselection.PreselectCross = Preselection::Axes::None;
-    ;
     preselection.PreselectConstraintSet.clear();
+
+    clearLazyExternalPreselectionIfNeeded(hadLazyPreselection);
+}
+
+void ViewProviderSketch::clearLazyExternalPreselectionIfNeeded(bool hadLazyPreselection)
+{
+    if (hadLazyPreselection && lazyExternalGeometryLayer) {
+        lazyExternalGeometryLayer->clearPreselectedElement();
+        redrawLazyExternalGeometryLayer();
+    }
 }
 
 void ViewProviderSketch::addSelectPoint(int SelectPoint)
@@ -5152,11 +5713,119 @@ std::unique_ptr<SoRayPickAction> ViewProviderSketch::getRayPickAction() const
     assert(isInEditMode());
     Gui::MDIView* mdi =
         Gui::Application::Instance->editViewOfNode(editCoinManager->getRootEditNode());
-    if (!(mdi && mdi->isDerivedFrom<Gui::View3DInventor>()))
+    if (!(mdi && mdi->isDerivedFrom<Gui::View3DInventor>())) {
         return nullptr;
+    }
     Gui::View3DInventorViewer* viewer = static_cast<Gui::View3DInventor*>(mdi)->getViewer();
 
     return std::make_unique<SoRayPickAction>(viewer->getSoRenderManager()->getViewportRegion());
+}
+
+void ViewProviderSketch::setPreselectLazyExternal(int lazyExternalId, bool vertex)
+{
+    preselection.blockedPreselection = false;
+    preselection.PreselectPoint = Preselection::InvalidPoint;
+    preselection.PreselectCurve = Preselection::InvalidCurve;
+    preselection.PreselectCross = Preselection::Axes::None;
+    preselection.PreselectConstraintSet.clear();
+    preselection.PreselectLazyExternalId = lazyExternalId;
+    preselection.PreselectLazyExternalVertex = vertex;
+    redrawLazyExternalGeometryLayer();
+}
+
+int ViewProviderSketch::preselectLazyExternalAtCursor(const SbVec2s& cursorPos,
+                                                       const Gui::View3DInventorViewer* viewer,
+                                                       bool& vertex)
+{
+    vertex = false;
+    if (!isLazyExternalGeometryEnabled() || !ensureLazyExternalGeometryLayer()
+        || !lazyExternalGeometryLayer->isEnabled() || !viewer) {
+        return Preselection::InvalidLazyExternalId;
+    }
+
+    auto clearPreselectionAndReturnInvalid = [&]() {
+        lazyExternalGeometryLayer->clearPreselectedElement();
+        return Preselection::InvalidLazyExternalId;
+    };
+
+    auto* sketch = getSketchObject();
+    auto* appDocument = sketch ? sketch->getDocument() : nullptr;
+    if (!sketch || !appDocument || !Gui::Application::Instance) {
+        return clearPreselectionAndReturnInvalid();
+    }
+
+    auto rayPickAction = getRayPickAction();
+    auto* sceneGraph = viewer->getSoRenderManager()->getSceneGraph();
+    if (!rayPickAction || !sceneGraph) {
+        return clearPreselectionAndReturnInvalid();
+    }
+
+    rayPickAction->setPoint(cursorPos);
+    rayPickAction->setRadius(viewer->getPickRadius());
+    rayPickAction->setPickAll(TRUE);
+    rayPickAction->apply(sceneGraph);
+
+    const SoPickedPointList& pickedPoints = rayPickAction->getPickedPointList();
+    if (pickedPoints.getLength() == 0) {
+        return clearPreselectionAndReturnInvalid();
+    }
+
+    SbLine pickLine;
+    getProjectingLine(cursorPos, viewer, pickLine);
+
+    float nearestHitDepth = std::numeric_limits<float>::max();
+    const auto sourceHits = collectLazyExternalSourceHits(
+        sketch, appDocument, pickedPoints, pickLine.getPosition(), nearestHitDepth);
+    if (sourceHits.empty()) {
+        return clearPreselectionAndReturnInvalid();
+    }
+
+    const float visibleDepthTolerance = getLazyExternalVisibleDepthTolerance(nearestHitDepth);
+
+    SbLine onePixelLine;
+    getProjectingLine(SbVec2s(cursorPos[0] + 1, cursorPos[1]), viewer, onePixelLine);
+    const float pixelDepthTolerance = getLazyExternalPixelDepthTolerance(
+        pickLine, onePixelLine, nearestHitDepth, visibleDepthTolerance, viewer->getPickRadius());
+
+    auto preselectHit = [&](const LazyExternalSourceHit* hit) -> int {
+        if (!hit || !hit->object) {
+            return Preselection::InvalidLazyExternalId;
+        }
+
+        const int lazyExternalId = lazyExternalGeometryLayer->preselectSourceReference(
+            sketch, hit->object, hit->subName);
+        if (lazyExternalId >= 0) {
+            vertex = hit->vertex;
+            return lazyExternalId;
+        }
+
+        return Preselection::InvalidLazyExternalId;
+    };
+
+    auto preselectWithinDepth = [&](float depthTolerance) -> int {
+        if (const int lazyExternalId = preselectHit(findClosestLazyExternalHitWithinDepth(
+                sourceHits, nearestHitDepth, depthTolerance, true));
+            lazyExternalId >= 0) {
+            return lazyExternalId;
+        }
+
+        return preselectHit(findClosestLazyExternalHitWithinDepth(
+            sourceHits, nearestHitDepth, depthTolerance, false));
+    };
+
+    if (const int lazyExternalId = preselectWithinDepth(visibleDepthTolerance);
+        lazyExternalId >= 0) {
+        return lazyExternalId;
+    }
+
+    if (pixelDepthTolerance > visibleDepthTolerance) {
+        if (const int lazyExternalId = preselectWithinDepth(pixelDepthTolerance);
+            lazyExternalId >= 0) {
+            return lazyExternalId;
+        }
+    }
+
+    return clearPreselectionAndReturnInvalid();
 }
 
 SbVec2f ViewProviderSketch::getScreenCoordinates(SbVec2f sketchcoordinates) const

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -33,9 +33,13 @@
 #include <QMetaObject>
 #include <fastsignals/signal.h>
 #include <memory>
+#include <set>
+#include <string>
+#include <vector>
 
 #include <Base/Parameter.h>
 #include <Base/Placement.h>
+#include <Base/Type.h>
 #include <Gui/Document.h>
 #include <Gui/GLPainter.h>
 #include <Gui/Selection/Selection.h>
@@ -82,6 +86,12 @@ class SoTranslation;
 class SbString;
 class SbTime;
 
+namespace App
+{
+class DocumentObject;
+class Property;
+}  // namespace App
+
 namespace Part
 {
 class Geometry;
@@ -90,7 +100,8 @@ class Geometry;
 namespace Gui
 {
 class View3DInventorViewer;
-}
+class ViewProvider;
+}  // namespace Gui
 
 namespace Sketcher
 {
@@ -103,6 +114,7 @@ namespace SketcherGui
 {
 
 class EditModeCoinManager;
+class LazyExternalGeometryLayer;
 class SnapManager;
 class DrawSketchHandler;
 class DrawSketchHandlerDragAutoConstraint;
@@ -231,6 +243,8 @@ private:
             App::Property* property
         );
 
+        void updateLazyExternalGeometryEnabled(const std::string& string, App::Property* property);
+
     private:
         ViewProviderSketch& Client;
         std::map<
@@ -355,7 +369,8 @@ private:
         {
             InvalidPoint = -1,
             InvalidCurve = -1,
-            ExternalCurve = -3
+            ExternalCurve = -3,
+            InvalidLazyExternalId = InvalidPoint
         };
 
         enum class Axes
@@ -375,6 +390,8 @@ private:
         {
             PreselectPoint = InvalidPoint;
             PreselectCurve = InvalidCurve;
+            PreselectLazyExternalId = InvalidLazyExternalId;
+            PreselectLazyExternalVertex = false;
             PreselectCross = Axes::None;
             PreselectConstraintSet.clear();
             blockedPreselection = false;
@@ -400,6 +417,18 @@ private:
         {
             return PreselectCurve <= ExternalCurve;
         }
+        bool isLazyExternalPreselected() const
+        {
+            return PreselectLazyExternalId > InvalidLazyExternalId;
+        }
+        bool isLazyExternalVertex() const
+        {
+            return isLazyExternalPreselected() && PreselectLazyExternalVertex;
+        }
+        bool isLazyExternalEdge() const
+        {
+            return isLazyExternalPreselected() && !PreselectLazyExternalVertex;
+        }
 
         int getPreselectionVertexIndex() const
         {
@@ -414,11 +443,13 @@ private:
             return -PreselectCurve - 2;
         }
 
-        int PreselectPoint;   // VertexN, with N = PreselectPoint + 1, same as DragPoint indexing
-                              // (NOTE -1 is NOT the root point)
-        int PreselectCurve;   // EdgeN, with N = PreselectCurve + 1 for positive values ;
-                              // ExternalEdgeN, with N = -PreselectCurve - 2
-        Axes PreselectCross;  // 0 => rootPoint, 1 => HAxis, 2 => VAxis
+        int PreselectPoint;  // VertexN, with N = PreselectPoint + 1, same as DragPoint indexing
+                             // (NOTE -1 is NOT the root point)
+        int PreselectCurve;  // EdgeN, with N = PreselectCurve + 1 for positive values ;
+                             // ExternalEdgeN, with N = -PreselectCurve - 2
+        int PreselectLazyExternalId;
+        bool PreselectLazyExternalVertex;
+        Axes PreselectCross;                   // 0 => rootPoint, 1 => HAxis, 2 => VAxis
         std::set<int> PreselectConstraintSet;  // ConstraintN, N = index + 1
         bool blockedPreselection;
     };
@@ -480,6 +511,7 @@ private:
         bool handleEscapeButton = false;
         bool autoRecompute = false;
         bool recalculateInitialSolutionWhileDragging = false;
+        bool lazyExternalGeometryEnabled = true;
 
         bool isShownVirtualSpace = false;  // indicates whether the present virtual space view is the
                                            // Real Space or the Virtual Space (virtual space 1 or 2)
@@ -759,6 +791,7 @@ public:
     friend class ViewProviderSketchCoinAttorney;
     friend class ViewProviderSketchSnapAttorney;
     friend class ViewProviderSketchCommandConstraintsAttorney;
+    friend class ViewProviderSketchLazySelectionAttorney;
     //@}
 
     bool editingCancelled;
@@ -770,6 +803,44 @@ protected:
     void unsetEdit(int ModNum) override;
     void setEditViewer(Gui::View3DInventorViewer*, int ModNum) override;
     void unsetEditViewer(Gui::View3DInventorViewer*) override;
+
+private:
+    /** @name On-demand external geometry edit-session layer
+     *
+     * These helpers manage temporary lazy external references. They either query/select overlay
+     * entries or materialize them into real SketchObject external geometry when a tool needs a
+     * stable GeoId. Keep them private; collaborators should use the existing attorney classes.
+     */
+    //@{
+    /// Add the source reference to the sketch if needed and return the resulting external GeoId.
+    int materializeLazyExternalSourceReference(
+        const std::string& sourceObjectName,
+        const std::string& subName,
+        bool intersection,
+        bool defining = false
+    );
+    Base::Type getLazyExternalGeometryType(int lazyExternalId) const;
+    bool isLazyExternalReferenceVertex(int lazyExternalId) const;
+    bool getLazyExternalSourceReference(
+        int lazyExternalId,
+        std::string& sourceObjectName,
+        std::string& subName,
+        bool& intersection,
+        bool& vertex
+    ) const;
+    bool selectLazyExternalReference(int lazyExternalId, bool toggle);
+    bool isLazyExternalReferenceSelected(int lazyExternalId) const;
+    std::vector<int> getSelectedLazyExternalReferenceIds() const;
+    void clearSelectedLazyExternalReferences();
+    void suspendLazyExternalGeometryLayer();
+    void resumeLazyExternalGeometryLayer();
+    void redrawLazyExternalGeometryLayer();
+    bool isLazyExternalGeometryEnabled() const;
+    void setLazyExternalGeometryPreferenceEnabled(bool enabled);
+    bool ensureLazyExternalGeometryLayer();
+    //@}
+
+protected:
     static void camSensCB(void* data, SoSensor*);        // camera sensor callback
     static void camSensDeleteCB(void* data, SoSensor*);  // camera sensor callback
     void onCameraChanged(SoCamera* cam);
@@ -812,6 +883,7 @@ protected:
     //@{
     /// get called by the container whenever a property has been changed
     void onChanged(const App::Property* prop) override;
+    void slotChangedViewProvider(const Gui::ViewProvider& vp, const App::Property& prop);
     //@}
 
     /// hook after property restoring to change some property statuses
@@ -858,8 +930,9 @@ private:
     ) const;
     EditModeCoinManager::PreselectionResult getPreselectionResultAtViewportPos(
         const SbVec2s& pos,
-        const Gui::View3DInventorViewer* viewer
-    ) const;
+        const Gui::View3DInventorViewer* viewer,
+        bool allowLazyExternalPreselectionAtCursor = true
+    );
     void cachePreselectionResult(
         const SbVec2s& pos,
         const EditModeCoinManager::PreselectionResult& result
@@ -874,9 +947,12 @@ private:
     int getPreselectPoint() const;
     int getPreselectCurve() const;
     int getPreselectCross() const;
+    int getPreselectLazyExternalId() const;
+    bool isPreselectLazyExternalVertex() const;
     void setPreselectPoint(int PreselectPoint);
     void setPreselectRootPoint();
     void resetPreselectPoint();
+    void clearLazyExternalPreselectionIfNeeded(bool hadLazyPreselection);
 
     bool setPreselect(const std::string& subNameSuffix, float x = 0, float y = 0, float z = 0);
     //@}
@@ -958,11 +1034,17 @@ private:
     // gets the list of geometry of the sketchobject or of the solver instance
     const GeoList getGeoList() const;
 
+    std::unique_ptr<SoRayPickAction> getRayPickAction() const;
+    int preselectLazyExternalAtCursor(
+        const SbVec2s& cursorPos,
+        const Gui::View3DInventorViewer* viewer,
+        bool& vertex
+    );
     GeoListFacade getGeoListFacade() const;
 
     Base::Placement getEditingPlacement() const;
 
-    std::unique_ptr<SoRayPickAction> getRayPickAction() const;
+    void setPreselectLazyExternal(int lazyExternalId, bool vertex);
 
     SbVec2f getScreenCoordinates(SbVec2f sketchcoordinates) const;
     SbVec2f getScreenCoordinates(SbVec3f sketchcoordinates) const;
@@ -1045,6 +1127,7 @@ private:
     fastsignals::connection connectRedoDocument;
     fastsignals::connection connectSolverUpdate;
     fastsignals::connection connectConstraintAdded;
+    fastsignals::connection connectViewProviderChanged;
 
     QMetaObject::Connection screenChangeConnection;
 
@@ -1069,6 +1152,8 @@ private:
     std::unique_ptr<ShortcutListener> listener;
 
     std::unique_ptr<EditModeCoinManager> editCoinManager;
+    std::unique_ptr<LazyExternalGeometryLayer> lazyExternalGeometryLayer;
+    int lazyExternalGeometryLayerSuspendCount = 0;
 
     std::unique_ptr<SnapManager> snapManager;
 


### PR DESCRIPTION
This adds an easy-to-use method for external projection. It modifies constraints to make it meaningful. External projections are not added until they are somehow associated with a constraint.

This system was inspired by a dream I had while under anesthesia. In Sketcher, a layer is probably created for external geometries, and when you hover over it, the external geometries that appear are hovered. They are clickable and selectable. Of course, this is pointless, but they can be constrained with sketches. Once associated with a sketch element, they are added as external geometries. I worked on it a bit, and they are definitely very helpful. I think they're even better than other CAD software.

This PR introduces the concept of lazy layer and also includes its implementation; these two can be separated, of course, but it wouldn't make sense. Besides, they're mostly intertwined.

Currently, it works with 3D pick and only selects visible geometries, taking depth into account. A presellect workflow has also been added.

<details>
~~ Here, all lines are included in this external layer. To be honest, I found it strange at first, but after using it for a while, I realized it's very functional. The key here is the absence of autoconstraints. Because there aren't any, hidden lines don't cause problems, since you need to be careful when applying constraints anyway. ~~
</details>

Actually, if the idea hadn't worked so well from the start, I would have given up on it long ago. Initially, it was a layer that created and hid all external geometries every time you entered a sketch environment. I'm not so sure now; I got a little nervous as I got older. In some places, I looked at other parts and tried to find solutions that might be correct, but I'm still not sure. @PaddleStroke, could you take a look too?

I consulted ChatGPT 5.5 while conducting this PR.

- [X] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
<!-- Include a brief summary of the changes. -->

<!--
The FreeCAD community thanks you for your contribution!
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
-->

## Issues
<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images
<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->


https://github.com/user-attachments/assets/f350ae4f-16ad-43d2-b4be-1bff47c63711

<details>
https://github.com/user-attachments/assets/03142b5e-d751-4fb5-8471-dff3a98bd476
</details>


<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request.  These items may not require you to take any action.  This information is provided for context. Understanding what we consider will help you prepare your request for speedy approval.

You can find additional documentation about these guidelines in the [Developers handbook](https://freecad.github.io/DevelopersHandbook).

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the PR affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->
