### PR TITLE
Prevent nested Sketcher group constraints

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -10653,7 +10653,8 @@ void CmdSketcherConstrainGroup::activated(int iMsg)
                                     return elem.GeoId == geoId;
                                 });
 
-        if (geoId < 0 || alreadyAdded || Obj->getGeometryFacade(geoId)->isInternalAligned()) {
+        if (geoId < 0 || alreadyAdded || Obj->getGeometryFacade(geoId)->isInternalAligned()
+            || Obj->isInGroup(geoId, true)) {
             continue;
         }
 


### PR DESCRIPTION
# Prevent nested Sketcher Group constraints

## Summary

- Prevents the Sketcher Group command from adding geometries that already belong to a Text or Group constraint.
- Avoids creating nested group/group-text relationships, which can leave malformed constraints and leftover construction handles.
- Keeps the change scoped to the Group command selection filtering.

Fixes FreeCAD/FreeCAD#28276.

## Validation

```bash
gh issue view 28276 --repo FreeCAD/FreeCAD --comments --json number,title,state,labels,comments,url,body
gh pr list --repo FreeCAD/FreeCAD --search "28276 in:title,body" --state all --json number,title,state,isDraft,url,updatedAt,headRefName,author
git diff --check -- src/Mod/Sketcher/Gui/CommandConstraints.cpp
git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- src/Mod/Sketcher/Gui/CommandConstraints.cpp
git ls-files --eol -- src/Mod/Sketcher/Gui/CommandConstraints.cpp
cmake -S /Users/mx/Money/worktrees/freecad -B /tmp/freecad-opp032-cmake-check-20260511 -DCMAKE_BUILD_TYPE=Debug
```

`git diff --check` and the CRLF-aware diff check pass. `CommandConstraints.cpp` is tracked and written with LF line endings.

Local CMake configure is blocked by missing Qt on this machine:

```text
Could not find a valid Qt installation. Consider setting Qt5_DIR or Qt6_DIR (as needed).
```
