### PR TITLE
Build: Lock coin3d version to 4.0.3 and freeze pixi install

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -228,7 +228,7 @@ jobs:
           fi
           python3 package/scripts/write_version_info.py ../freecad_version.txt
           cd package/rattler-build
-          pixi install
+          pixi install --frozen
 
       - name: Azure login for Windows build code signing
         id: azure_login

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -99,7 +99,7 @@ requirements:
         - cross-python_${{ target_platform }}
 
   host:
-    - coin3d
+    - coin3d ==4.0.3
     - eigen >=3.3,<5
     - fmt
     - freetype


### PR DESCRIPTION
Fixes #29121

Currently the FreeCAD weeklies and releases are build by [`.github/workflows/build_release.yml`](https://github.com/FreeCAD/FreeCAD/blob/main/.github/workflows/build_release.yml) that sets up pixi using the package `prefix-dev/setup-pixi`. This installs the environment and lists its packets with the `--locked` to ensure that the [lockfile is up-to-date with the manifest file](https://pixi.prefix.dev/latest/reference/cli/pixi/install/#arg---locked). In the "Build packages" step `pixi install` is executed in the `package/rattler-build` folder without any options meaning that [the lock file is updated](https://pixi.prefix.dev/latest/reference/cli/pixi/install/) and then the rattler recipe is executed installing the environment specified in recipe.yaml (that does not have a lock-file nor versions for most packages) and the application is build using build.sh/.bat that starts cmake.

For coin this means version 4.0.3 specified in the pixi.lock file is installed by `prefix-dev/setup-pixi`, then version 4.0.8 is installed by rattler and cmake finds and uses the 4.0.8 version of the package. This can be verified by checking the log file from an [recent weekly build](https://github.com/FreeCAD/FreeCAD/actions/workflows/build_release.yml).

A bisect of weeklies found that weekly-2026.03.19 was good and weekly-2026.03.25 was bad. Checking the [release history of coin3d](https://anaconda.org/channels/conda-forge/packages/coin3d/files) shows that 4.0.8 was released on 2026-03-24, i.e. between the two weeklies. Making test builds of main with the coin3d version in rattler.yaml set to "<=4.0.7" and "==4.0.8" respectively, and "--frozen" added to the `pixi install` invocation, confirms that this fixes the issue: In the "<=4.0.7" build the problem is not seen (note that rattler chooses to use 4.0.3 as e.g. 4.0.7 causes a conflict with other packages) and in the "==4.0.8" the problem is seen. So it appears that some change was made in coin3d between 4.0.3 and 4.0.8 that causes the problem.

This fix simply locks the coin3d version to 4.0.3 and uses "--frozen" with pixi install.

A more complete fix would probably be to get rid of rattler as it seems wrong to maintain dependency information for both pixi and rattler and the pixi information is used and tested by developers. Also the content of `package/rattler-build/build.sh/.bat` and `package/rattler-build/(linux|osx|windows)/create_bundle.sh ought to be merged into the cmake files.