### PR TITLE
Draft: allow manual Shape2DView recompute when AutoUpdate is off

### DIFF
--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -41,15 +41,65 @@ from draftutils import utils
 from draftutils.translate import translate
 
 
+_recompute_observer = None
+
+
+def _object_key(obj):
+    doc = getattr(obj, "Document", None)
+    return (getattr(doc, "Name", None), getattr(obj, "Name", None))
+
+
+def _is_shape2dview(obj):
+    return getattr(getattr(obj, "Proxy", None), "Type", None) == "Shape2DView"
+
+
+class _Shape2DViewRecomputeObserver:
+    """Track Shape2DViews that were already marked before recompute starts."""
+
+    def __init__(self):
+        self.touched_at_recompute_start = set()
+
+    def slotBeforeRecomputeDocument(self, doc):
+        self.touched_at_recompute_start = {
+            _object_key(obj)
+            for obj in getattr(doc, "Objects", [])
+            if _is_shape2dview(obj) and "Touched" in getattr(obj, "State", [])
+        }
+
+    def slotRecomputedDocument(self, doc):
+        doc_name = getattr(doc, "Name", None)
+        self.touched_at_recompute_start = {
+            key for key in self.touched_at_recompute_start if key[0] != doc_name
+        }
+
+    def was_touched_at_recompute_start(self, obj):
+        return _object_key(obj) in self.touched_at_recompute_start
+
+
+def _ensure_recompute_observer():
+    global _recompute_observer
+    if _recompute_observer is None:
+        _recompute_observer = _Shape2DViewRecomputeObserver()
+        App.addDocumentObserver(_recompute_observer)
+
+
+def _manual_recompute_requested(obj):
+    if _recompute_observer is None:
+        return False
+    return _recompute_observer.was_touched_at_recompute_start(obj)
+
+
 class Shape2DView(DraftObject):
     """The Shape2DView object"""
 
     def __init__(self, obj):
 
+        _ensure_recompute_observer()
         self.setProperties(obj)
         super().__init__(obj, "Shape2DView")
 
     def onDocumentRestored(self, obj):
+        _ensure_recompute_observer()
         self.setProperties(obj)
         super().onDocumentRestored(obj)
         gui_utils.restore_view_object(
@@ -215,7 +265,10 @@ class Shape2DView(DraftObject):
         return [shape.copy()]
 
     def execute(self, obj):
-        if self.props_changed_placement_only(obj) or not getattr(obj, "AutoUpdate", True):
+        auto_update_blocked = (
+            not getattr(obj, "AutoUpdate", True) and not _manual_recompute_requested(obj)
+        )
+        if self.props_changed_placement_only(obj) or auto_update_blocked:
             obj.positionBySupport()
             self.props_changed_clear()
             return
@@ -438,6 +491,10 @@ class Shape2DView(DraftObject):
 
     def onChanged(self, obj, prop):
         self.props_changed_store(prop)
+        if prop == "AutoUpdate" and getattr(App, "GuiUp", False):
+            view_object = getattr(obj, "ViewObject", None)
+            if view_object:
+                view_object.signalChangeIcon()
 
 
 # Alias for compatibility with v0.18 and earlier

--- a/src/Mod/Draft/draftobjects/shape2dview.py
+++ b/src/Mod/Draft/draftobjects/shape2dview.py
@@ -40,7 +40,6 @@ from draftutils import gui_utils
 from draftutils import utils
 from draftutils.translate import translate
 
-
 _recompute_observer = None
 
 
@@ -265,9 +264,9 @@ class Shape2DView(DraftObject):
         return [shape.copy()]
 
     def execute(self, obj):
-        auto_update_blocked = (
-            not getattr(obj, "AutoUpdate", True) and not _manual_recompute_requested(obj)
-        )
+        auto_update_blocked = not getattr(
+            obj, "AutoUpdate", True
+        ) and not _manual_recompute_requested(obj)
         if self.props_changed_placement_only(obj) or auto_update_blocked:
             obj.positionBySupport()
             self.props_changed_clear()

--- a/src/Mod/Draft/drafttests/test_modification.py
+++ b/src/Mod/Draft/drafttests/test_modification.py
@@ -417,6 +417,29 @@ class DraftModification(test_base.DraftTestCaseDoc):
         obj = Draft.make_shape2dview(prism, direction)
         self.assertTrue(obj, "'{}' failed".format(operation))
 
+    def test_shape_2d_view_manual_recompute_without_auto_update(self):
+        """Manually recompute a Shape2DView when AutoUpdate is disabled."""
+        operation = "Draft Shape2DView manual recompute"
+        _msg("  Test '{}'".format(operation))
+        box = self.doc.addObject("Part::Box")
+        box.Length = 1
+        box.Width = 1
+        box.Height = 1
+        obj = Draft.make_shape2dview(box, Vector(0, 0, 1))
+        self.doc.recompute()
+        self.assertAlmostEqual(obj.Shape.BoundBox.XLength, 1)
+
+        obj.AutoUpdate = False
+        self.doc.recompute()
+        box.Length = 2
+        self.doc.recompute()
+        self.assertAlmostEqual(obj.Shape.BoundBox.XLength, 1)
+
+        for doc_obj in self.doc.Objects:
+            doc_obj.enforceRecompute()
+        self.doc.recompute()
+        self.assertAlmostEqual(obj.Shape.BoundBox.XLength, 2)
+
     def test_draft_to_sketch(self):
         """Convert a Draft object to a Sketch and back."""
         operation = "Draft Draft2Sketch"


### PR DESCRIPTION
## Summary

- Allow `Draft_Shape2DView` objects with `AutoUpdate = False` to update when they were already marked for recompute at the start of a document recompute.
- Keep dependency-triggered recomputes blocked while `AutoUpdate` is disabled.
- Refresh the tree icon immediately when `AutoUpdate` changes.
- Add a regression test for manual recompute with `AutoUpdate` disabled.

Fixes #30034.
Fixes #30035.

## Tests

- `python -m py_compile src/Mod/Draft/draftobjects/shape2dview.py src/Mod/Draft/drafttests/test_modification.py`
- `FreeCADCmd.exe --safe-mode ... run_shape2dview_test.py`
  - `drafttests.test_modification.DraftModification.test_shape_2d_view`
  - `drafttests.test_modification.DraftModification.test_shape_2d_view_manual_recompute_without_auto_update`

Runtime used for the FreeCADCmd test: FreeCAD weekly-2026.05.06, 1.2.0devR20260505.