### PR TITLE
BIM: Prune App::Part assembly children during IFC export

### DIFF
--- a/src/Mod/BIM/importers/exportIFC.py
+++ b/src/Mod/BIM/importers/exportIFC.py
@@ -573,6 +573,7 @@ def export(exportList, filename, colors=None, preferences=None):
                 group = obj.Links
             else:
                 group = [FreeCAD.ActiveDocument.getObject(n[:-1]) for n in obj.getSubObjects()]
+            group = Arch.pruneIncluded(group, strict=True)
             for subobj in group:
                 if subobj.Name in products:
                     subproduct = products[subobj.Name]


### PR DESCRIPTION
# BIM: Prune App::Part assembly children during IFC export

## Summary

- Prune an assembly object's child list before creating IFC subproducts for the assembly.
- Prevent base/dependency objects discovered through `App::Part` subobject traversal from being exported as separate assembly products when their owning BIM object is already exported.
- Keep `App::Part` exports as `IfcElementAssembly` objects containing the intended top-level children.

Fixes https://github.com/FreeCAD/FreeCAD/issues/28368

## Validation

- `gh issue view 28368 --repo FreeCAD/FreeCAD --comments --json number,title,state,labels,comments,url,body`
- `gh pr list --repo FreeCAD/FreeCAD --search "28368 in:title,body" --state all --json number,title,state,isDraft,url,updatedAt,headRefName,author`
- `git diff --check -- src/Mod/BIM/importers/exportIFC.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- src/Mod/BIM/importers/exportIFC.py`
- `git ls-files --eol -- src/Mod/BIM/importers/exportIFC.py`
- `python3 -m py_compile src/Mod/BIM/importers/exportIFC.py`
- `cmake -S /Users/mx/Money/worktrees/freecad -B /tmp/freecad-opp033-cmake-check-20260511 -DCMAKE_BUILD_TYPE=Debug`

The local CMake configure is still blocked by a missing Qt installation:

```text
Could not find a valid Qt installation. Consider setting Qt5_DIR or Qt6_DIR (as needed).
```

`FreeCADCmd` is not available in this local environment, so I could not run the attached IFC export reproduction locally.
