### PR TITLE
BIM: Restore ArchReference display after Lightweight mode

### DIFF
--- a/src/Mod/BIM/ArchReference.py
+++ b/src/Mod/BIM/ArchReference.py
@@ -135,6 +135,8 @@ class ArchReference:
                 self.reload = False
             elif obj.ReferenceMode == "Lightweight":
                 self.reload = False
+                if obj.ViewObject and obj.ViewObject.Proxy:
+                    obj.ViewObject.Proxy.storeInventor(obj)
                 import Part
 
                 pl = obj.Placement
@@ -749,6 +751,32 @@ class ViewProviderArchReference:
             if self.Object.File:
                 FreeCAD.openDocument(self.Object.File)
 
+    def storeInventor(self, obj):
+        "stores the current openinventor nodes"
+
+        if (
+            hasattr(self, "orig_flatlines")
+            and self.orig_flatlines
+            and hasattr(self, "orig_shaded")
+            and self.orig_shaded
+            and hasattr(self, "orig_wireframe")
+            and self.orig_wireframe
+        ):
+            return True
+        from draftutils import gui_utils
+        from pivy import coin
+
+        switch = gui_utils.find_coin_node(obj.ViewObject.RootNode, coin.SoSwitch)
+        if switch is None or switch.getNumChildren() != 4:
+            FreeCAD.Console.PrintError(
+                translate("Arch", "Invalid root node in") + " " + obj.Label + "\n"
+            )
+            return False
+        self.orig_flatlines = switch.getChild(0).copy()
+        self.orig_shaded = switch.getChild(1).copy()
+        self.orig_wireframe = switch.getChild(2).copy()
+        return True
+
     def loadInventor(self, obj):
         "loads an openinventor file and replace the root node of this object"
 
@@ -784,7 +812,6 @@ class ViewProviderArchReference:
         wireframe = lwnode.getChild(1)
 
         # check node contents
-        rootnode = obj.ViewObject.RootNode
         # display mode switch
         switch = gui_utils.find_coin_node(obj.ViewObject.RootNode, coin.SoSwitch)
         if switch is None or switch.getNumChildren() != 4:
@@ -794,9 +821,8 @@ class ViewProviderArchReference:
             return
 
         # keep a copy of the original nodes
-        self.orig_flatlines = switch.getChild(0).copy()
-        self.orig_shaded = switch.getChild(1).copy()
-        self.orig_wireframe = switch.getChild(2).copy()
+        if not self.storeInventor(obj):
+            return
 
         # replace root node of object
         switch.replaceChild(0, flatlines)


### PR DESCRIPTION
# BIM: Restore ArchReference display after Lightweight mode

## Summary

- Preserve the normal OpenInventor display nodes before Lightweight mode clears the reference shape.
- Reuse those saved nodes when switching the reference back to Normal mode.
- Avoid overwriting the saved normal display nodes with the already-cleared Lightweight state.

Fixes https://github.com/FreeCAD/FreeCAD/issues/26091

## Validation

- `gh issue view 26091 --repo FreeCAD/FreeCAD --comments --json number,title,state,labels,comments,url,body`
- `gh pr list --repo FreeCAD/FreeCAD --search "26091 in:title,body" --state all --json number,title,state,isDraft,url,updatedAt,headRefName,author`
- `git diff --check -- src/Mod/BIM/ArchReference.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- src/Mod/BIM/ArchReference.py`
- `git ls-files --eol -- src/Mod/BIM/ArchReference.py`
- `python3 -m py_compile src/Mod/BIM/ArchReference.py`
- `cmake -S /Users/mx/Money/worktrees/freecad -B /tmp/freecad-opp034-cmake-check-20260511 -DCMAKE_BUILD_TYPE=Debug`

The local CMake configure is still blocked by a missing Qt installation:

```text
Could not find a valid Qt installation. Consider setting Qt5_DIR or Qt6_DIR (as needed).
```

`FreeCADCmd` is not available in this local environment, so I could not run the attached GUI reproduction locally.
