### PR TITLE
Gui: fix Win32 FileDialog not starting in configured dir

### DIFF
--- a/src/Gui/FileDialogWin32.cpp
+++ b/src/Gui/FileDialogWin32.cpp
@@ -342,7 +342,9 @@ QStringList FileDialogInternal::nativeFileDialog(
 
     // Select starting directory, if any
     if (startPathInfo.isAbsolute()) {
-        const auto startFolder = qStringToWCharArray(startPathInfo.absoluteDir().path());
+        const auto startFolder = qStringToWCharArray(
+            QDir::toNativeSeparators(startPathInfo.absoluteDir().path())
+        );
         ComPointer<IShellItem> shellStartFolder;
         if (SUCCEEDED(SHCreateItemFromParsingName(
                 startFolder.get(),


### PR DESCRIPTION
* Fixes #30042

`SHCreateItemFromParsingName()` does not like forward slashes, and when an `IFileDialog` is not provided a `SetFolder()`, Windows falls back to the last directory seen for the application (even across versions).