### PR TITLE
Gui: reset selection view when clearing search

### DIFF
--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -54,11 +54,13 @@ using namespace Gui::DockWnd;
 
 namespace
 {
-void getSelectionName(QTextStream& str,
-                      const char* docName,
-                      const char* objName,
-                      const char* subName,
-                      App::DocumentObject* obj)
+void getSelectionName(
+    QTextStream& str,
+    const char* docName,
+    const char* objName,
+    const char* subName,
+    App::DocumentObject* obj
+)
 {
     str << QString::fromUtf8(docName);
     str << "#";

--- a/src/Gui/Selection/SelectionView.cpp
+++ b/src/Gui/Selection/SelectionView.cpp
@@ -52,6 +52,43 @@ FC_LOG_LEVEL_INIT("Selection", true, true, true)
 using namespace Gui;
 using namespace Gui::DockWnd;
 
+namespace
+{
+void getSelectionName(QTextStream& str,
+                      const char* docName,
+                      const char* objName,
+                      const char* subName,
+                      App::DocumentObject* obj)
+{
+    str << QString::fromUtf8(docName);
+    str << "#";
+    str << QString::fromUtf8(objName);
+    if (subName != nullptr && subName[0] != 0) {
+        str << ".";
+        /* Original code doesn't take account of histories in subelement names and displays
+         * them inadvertently.  Let's not do that.
+        str << subName;
+        */
+        /* Remove the history from the displayed subelement name */
+        App::ElementNamePair elementName;
+        App::GeoFeature::resolveElement(obj, subName, elementName);
+        str << elementName.oldName.c_str();  // Use the shortened element name not the full one.
+        /* Mark it visually if there was a history as a "tell" for if a given selection has TNP
+         * fixes in it. */
+        if (!elementName.newName.empty()) {
+            str << " []";
+        }
+        auto subObj = obj->getSubObject(subName);
+        if (subObj) {
+            obj = subObj;
+        }
+    }
+    str << " (";
+    str << QString::fromUtf8(obj->Label.getValue());
+    str << ")";
+}
+}  // namespace
+
 
 /* TRANSLATOR Gui::DockWnd::SelectionView */
 
@@ -157,39 +194,6 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
     QString selObject;
     QTextStream str(&selObject);
 
-    auto getSelectionName = [](QTextStream& str,
-                               const char* docName,
-                               const char* objName,
-                               const char* subName,
-                               App::DocumentObject* obj) {
-        str << QString::fromUtf8(docName);
-        str << "#";
-        str << QString::fromUtf8(objName);
-        if (subName != 0 && subName[0] != 0) {
-            str << ".";
-            /* Original code doesn't take account of histories in subelement names and displays
-             * them inadvertently.  Let's not do that.
-            str << subName;
-            */
-            /* Remove the history from the displayed subelement name */
-            App::ElementNamePair elementName;
-            App::GeoFeature::resolveElement(obj, subName, elementName);
-            str << elementName.oldName.c_str();  // Use the shortened element name not the full one.
-            /* Mark it visually if there was a history as a "tell" for if a given selection has TNP
-             * fixes in it. */
-            if (elementName.newName.size() > 0) {
-                str << " []";
-            }
-            auto subObj = obj->getSubObject(subName);
-            if (subObj) {
-                obj = subObj;
-            }
-        }
-        str << " (";
-        str << QString::fromUtf8(obj->Label.getValue());
-        str << ")";
-    };
-
     if (Reason.Type == SelectionChanges::AddSelection) {
         // save as user data
         QStringList list;
@@ -283,36 +287,54 @@ void SelectionView::onSelectionChanged(const SelectionChanges& Reason)
 
 void SelectionView::search(const QString& text)
 {
-    if (!text.isEmpty()) {
-        searchList.clear();
-        App::Document* doc = App::GetApplication().getActiveDocument();
-        std::vector<App::DocumentObject*> objects;
-        if (doc) {
-            objects = doc->getObjects();
-            selectionView->clear();
-            for (auto it : objects) {
-                QString label = QString::fromUtf8(it->Label.getValue());
-                if (label.contains(text, Qt::CaseInsensitive)) {
-                    searchList.push_back(it);
-                    // save as user data
-                    QString selObject;
-                    QTextStream str(&selObject);
-                    QStringList list;
-                    list << QString::fromUtf8(doc->getName());
-                    list << QString::fromUtf8(it->getNameInDocument());
-                    // build name
-                    str << QString::fromUtf8(doc->Label.getValue());
-                    str << "#";
-                    str << it->getNameInDocument();
-                    str << " (";
-                    str << label;
-                    str << ")";
-                    QListWidgetItem* item = new QListWidgetItem(selObject, selectionView);
-                    item->setData(Qt::UserRole, list);
-                }
-            }
-            countLabel->setText(QString::number(selectionView->count()));
+    searchList.clear();
+    if (text.isEmpty()) {
+        selectionView->clear();
+        auto objs = Gui::Selection().getSelection("*", ResolveMode::NoResolve);
+        for (const auto& it : objs) {
+            // save as user data
+            QStringList list;
+            list << QString::fromUtf8(it.DocName);
+            list << QString::fromUtf8(it.FeatName);
+
+            QString selObject;
+            QTextStream str(&selObject);
+            getSelectionName(str, it.DocName, it.FeatName, it.SubName, it.pObject);
+            QListWidgetItem* item = new QListWidgetItem(selObject, selectionView);
+            item->setData(Qt::UserRole, list);
         }
+
+        countLabel->setText(QString::number(selectionView->count()));
+        return;
+    }
+
+    App::Document* doc = App::GetApplication().getActiveDocument();
+    std::vector<App::DocumentObject*> objects;
+    if (doc) {
+        objects = doc->getObjects();
+        selectionView->clear();
+        for (auto it : objects) {
+            QString label = QString::fromUtf8(it->Label.getValue());
+            if (label.contains(text, Qt::CaseInsensitive)) {
+                searchList.push_back(it);
+                // save as user data
+                QString selObject;
+                QTextStream str(&selObject);
+                QStringList list;
+                list << QString::fromUtf8(doc->getName());
+                list << QString::fromUtf8(it->getNameInDocument());
+                // build name
+                str << QString::fromUtf8(doc->Label.getValue());
+                str << "#";
+                str << it->getNameInDocument();
+                str << " (";
+                str << label;
+                str << ")";
+                QListWidgetItem* item = new QListWidgetItem(selObject, selectionView);
+                item->setData(Qt::UserRole, list);
+            }
+        }
+        countLabel->setText(QString::number(selectionView->count()));
     }
 }
 


### PR DESCRIPTION
<!-- Include a brief summary of the changes. -->

Clearing the Selection View search field now restores the list to the current selection instead of leaving the previous filtered search result visible.

## Issues

Fixes #30009

## Before and After Images

No visual layout changes. Behavior change only:
- Before: type a search in Selection View, then clear it; the list stayed filtered.
- After: clearing the search field rebuilds the list from the current selection and clears the pending search result list.

## Validation

- Reviewed the `SelectionView::search()` flow to ensure an empty search no longer leaves stale `searchList`/widget contents.
- Ran `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check` because this source file is stored with CRLF line endings in the repository.

I did not run the full FreeCAD GUI test suite locally because this checkout does not have a configured FreeCAD build tree.
