### PR TITLE
Draft: fix input cursor problem caused by #26950

### DIFF
--- a/src/Mod/Draft/DraftGui.py
+++ b/src/Mod/Draft/DraftGui.py
@@ -71,8 +71,10 @@ class DraftBaseWidget(QtWidgets.QWidget):
         super().__init__(parent)
 
     def eventFilter(self, widget, event):
-        if event.type() == QtCore.QEvent.KeyPress and event.text().upper() in _get_incmd_shortcut(
-            "CycleSnap"
+        if (
+            event.type() == QtCore.QEvent.KeyPress
+            and event.text()
+            and event.text()[0].upper() in _get_incmd_shortcut("CycleSnap")
         ):
             if hasattr(FreeCADGui, "Snapper"):
                 FreeCADGui.Snapper.cycleSnapObject()


### PR DESCRIPTION
Fixes a regression caused by #26950 reported on the forum: https://forum.freecad.org/viewtopic.php?t=104143

Key press events (such as from the cursor keys) can have an empty `event.text()`. PR #26950 changed the code from `event.text().upper() ==` to `event.text().upper() in`. The latter also catches empty texts leading to cursor key events being swallowed.

The problem has been fixed by adding a non-empty string check.