### PR TITLE
Gui: Stop toolbar dock layout from tracking mouse moves without held button

### DIFF
--- a/src/Gui/ToolBarManager.cpp
+++ b/src/Gui/ToolBarManager.cpp
@@ -1162,9 +1162,23 @@ bool ToolBarManager::eventFilter(QObject* source, QEvent* ev)
             }
         }
         // fall through
-        case QEvent::MouseMove:
-            res = addToolBarToArea(source, static_cast<QMouseEvent*>(ev));
+        case QEvent::MouseMove: {
+            auto mev = static_cast<QMouseEvent*>(ev);
+            // Workaround for a stale dock-drag state on Wayland: when a click
+            // on the toolbar's movable handle is followed by a release that
+            // the compositor delivers to a different surface, Qt's
+            // QMainWindowLayout treats every subsequent MouseMove (even with
+            // no button held) as a drag continuation and re-arranges the
+            // toolbar. A MouseMove on a toolbar with no buttons pressed has
+            // no legitimate purpose for the layout's drag handler, so drop
+            // it. Tooltips and hover effects use the separate HoverMove path
+            // and are unaffected.
+            if (qobject_cast<QToolBar*>(source) && mev->buttons() == Qt::NoButton) {
+                return true;
+            }
+            res = addToolBarToArea(source, mev);
             break;
+        }
         case QEvent::ParentChange:
             if (auto toolbar = qobject_cast<QToolBar*>(source)) {
                 resizingToolbars[toolbar] = toolbar;


### PR DESCRIPTION
Closes #17224.

On KDE Plasma / GNOME / labwc Wayland sessions, the compositor can deliver a MouseButtonRelease to a surface other than the QToolBar that started the dock drag. Qt's QMainWindowLayout never sees the release for that toolbar, so its internal drag-target state stays set. Every subsequent MouseMove on the toolbar — even one without a held button — is then interpreted as a drag continuation and re-arranges the toolbar in the dock row. The visible symptom is that a single click on a toolbar's movable handle is enough to leave the toolbar following the cursor on plain hover until FreeCAD is restarted.

Tested on EndeavourOS / KDE Plasma Wayland with 1.2 weekly main (Qt 6.11.0). The stale state was reliably reproducible by clicking the movable handle once and then hovering — the toolbar would chase the cursor across the dock row.

The fix filters out MouseMove events on docked QToolBar instances when no mouse button is held. Such events have no legitimate function for the dock layout's drag mechanism — actual drags always have a button pressed. Tooltip triggers and hover highlights go through the separate HoverMove and Enter / HoverEnter paths and are unaffected.

Sanity-checked locally on the same Wayland setup: click and hold while dragging then releasing leaves the toolbar at the drop location as expected; a single click followed by plain hover no longer makes the toolbar follow the cursor; tooltips on toolbar buttons still appear after the usual delay; hover highlights on toolbar buttons render normally.

Edit: the root-cause story above turned out to be wrong — see the discussion below for the actual Qt-side mechanism.