### PR TITLE
Fix Part Compound creation from group links

### DIFF
--- a/src/Mod/Part/App/FeatureCompound.cpp
+++ b/src/Mod/Part/App/FeatureCompound.cpp
@@ -28,11 +28,51 @@
 #include <TopExp.hxx>
 #include <TopTools_IndexedMapOfShape.hxx>
 
+#include <App/GeoFeatureGroupExtension.h>
+#include <App/GroupExtension.h>
 
 #include "FeatureCompound.h"
 
 
 using namespace Part;
+
+namespace
+{
+
+App::DocumentObject* collectCompoundShape(App::DocumentObject* obj,
+                                          std::set<App::DocumentObject*>& visited,
+                                          std::vector<TopoShape>& shapes)
+{
+    if (!obj || !visited.insert(obj).second) {
+        return nullptr;
+    }
+
+    if (App::GeoFeatureGroupExtension::isNonGeoGroup(obj)) {
+        auto group = obj->getExtensionByType<App::GroupExtension>(true);
+        if (group) {
+            App::DocumentObject* firstShapeObject = nullptr;
+            for (auto child : group->getObjects()) {
+                auto shapeObject = collectCompoundShape(child, visited, shapes);
+                if (!firstShapeObject) {
+                    firstShapeObject = shapeObject;
+                }
+            }
+            if (firstShapeObject) {
+                return firstShapeObject;
+            }
+        }
+    }
+
+    auto shape = Feature::getTopoShape(obj, ShapeOption::ResolveLink | ShapeOption::Transform);
+    if (shape.isNull()) {
+        return nullptr;
+    }
+
+    shapes.push_back(shape);
+    return obj;
+}
+
+}  // namespace
 
 PROPERTY_SOURCE(Part::Compound, Part::Feature)
 
@@ -57,22 +97,19 @@ App::DocumentObjectExecReturn* Compound::execute()
     try {
         // avoid duplicates without changing the order
         // See also ViewProviderCompound::updateData
-        std::set<DocumentObject*> tempLinks;
+        std::set<App::DocumentObject*> tempLinks;
 
         std::vector<TopoShape> shapes;
+        App::DocumentObject* materialLink = nullptr;
         for (auto obj : Links.getValues()) {
-            if (!tempLinks.insert(obj).second) {
-                continue;
-            }
-            auto sh = Feature::getTopoShape(obj, ShapeOption::ResolveLink | ShapeOption::Transform);
-            if (!sh.isNull()) {
-                shapes.push_back(sh);
+            auto shapeObject = collectCompoundShape(obj, tempLinks, shapes);
+            if (!materialLink) {
+                materialLink = shapeObject;
             }
         }
         this->Shape.setValue(TopoShape().makeElementCompound(shapes));
-        if (Links.getSize() > 0) {
-            App::DocumentObject* link = Links.getValues()[0];
-            copyMaterial(link);
+        if (materialLink) {
+            copyMaterial(materialLink);
         }
         return Part::Feature::execute();
     }

--- a/src/Mod/Part/App/FeatureCompound.cpp
+++ b/src/Mod/Part/App/FeatureCompound.cpp
@@ -39,9 +39,11 @@ using namespace Part;
 namespace
 {
 
-App::DocumentObject* collectCompoundShape(App::DocumentObject* obj,
-                                          std::set<App::DocumentObject*>& visited,
-                                          std::vector<TopoShape>& shapes)
+App::DocumentObject* collectCompoundShape(
+    App::DocumentObject* obj,
+    std::set<App::DocumentObject*>& visited,
+    std::vector<TopoShape>& shapes
+)
 {
     if (!obj || !visited.insert(obj).second) {
         return nullptr;

--- a/src/Mod/Part/parttests/TopoShapeTest.py
+++ b/src/Mod/Part/parttests/TopoShapeTest.py
@@ -438,6 +438,23 @@ class TopoShapeTest(unittest.TestCase, TopoShapeAssertions):
             self.assertEqual(compound.ElementMapSize, 52)
             self.assertEqual(new_toposhape.ElementMapSize, 52)
 
+    def testPartCompoundExpandsGroupLinks(self):
+        # Arrange
+        group = self.doc.addObject("App::DocumentObjectGroup", "CompoundSourceGroup")
+        group.addObject(self.doc.Box1)
+        group.addObject(self.doc.Box2)
+        self.doc.addObject("Part::Compound", "CompoundFromGroup")
+        self.doc.CompoundFromGroup.Links = [
+            group,
+            self.doc.Box2,
+        ]
+        # Act
+        self.doc.recompute()
+        compound = self.doc.CompoundFromGroup.Shape
+        # Assert
+        self.assertEqual(len(compound.Solids), 2)
+        self.assertBounds(compound, App.BoundBox(0, 0, 0, 2, 2, 2))
+
     def testTopoShapeCopy(self):
         # Arrange
         self.doc.addObject("Part::Compound", "Compound")


### PR DESCRIPTION
## Summary

Fixes #24400.

This updates `Part::Compound` so plain group/container links are expanded into their shape-bearing children before the compound shape is built. The traversal keeps the existing duplicate filtering behavior, so selecting both a group and one of its children does not add the child shape twice.

## Root Cause

`Part::Compound::execute()` only collected a topological shape for each object in `Links`. Plain `App::DocumentObjectGroup` containers can be selected from the tree and stored in `Links`, but they are not themselves shape-bearing objects. As a result, their child objects could be omitted from the generated compound.

## Changes

- Recursively collect child shapes from non-geo `GroupExtension` containers.
- Preserve shape order while avoiding duplicate linked objects.
- Copy material from the first object that actually contributes a shape.
- Add a regression test covering a compound linked to a group plus a duplicate direct child.

## Validation

- `git diff --check` passed.
- `python -m py_compile src/Mod/Part/parttests/TopoShapeTest.py` passed.
- `uvx pre-commit run --files src/Mod/Part/App/FeatureCompound.cpp src/Mod/Part/parttests/TopoShapeTest.py` passed.

I could not run the FreeCAD C++ build or the Part test suite locally because this Windows environment does not have the FreeCAD `pixi`/LibPack build dependencies installed.