### PR TITLE
Fix STEP export of nested Draft link arrays

### DIFF
--- a/src/Mod/Import/App/ExportOCAF2.cpp
+++ b/src/Mod/Import/App/ExportOCAF2.cpp
@@ -457,7 +457,16 @@ TDF_Label ExportOCAF2::exportObject(
             auto baseShape = aShapeTool->GetShape(it->second);
             shape.setShape(baseShape.Located(shape.getShape().Location()));
             if (!parent.IsNull()) {
-                label = aShapeTool->AddComponent(parent, shape.getShape(), Standard_False);
+                if (aShapeTool->IsAssembly(it->second)) {
+                    label = aShapeTool->AddComponent(
+                        parent,
+                        it->second,
+                        shape.getShape().Location()
+                    );
+                }
+                else {
+                    label = aShapeTool->AddComponent(parent, shape.getShape(), Standard_False);
+                }
             }
             else {
                 label = aShapeTool->AddShape(shape.getShape(), Standard_False, Standard_False);

--- a/src/Mod/Import/App/ExportOCAF2.cpp
+++ b/src/Mod/Import/App/ExportOCAF2.cpp
@@ -458,11 +458,7 @@ TDF_Label ExportOCAF2::exportObject(
             shape.setShape(baseShape.Located(shape.getShape().Location()));
             if (!parent.IsNull()) {
                 if (aShapeTool->IsAssembly(it->second)) {
-                    label = aShapeTool->AddComponent(
-                        parent,
-                        it->second,
-                        shape.getShape().Location()
-                    );
+                    label = aShapeTool->AddComponent(parent, it->second, shape.getShape().Location());
                 }
                 else {
                     label = aShapeTool->AddComponent(parent, shape.getShape(), Standard_False);

--- a/src/Mod/Import/TestImportGui.py
+++ b/src/Mod/Import/TestImportGui.py
@@ -91,3 +91,55 @@ class ExportImportTest(unittest.TestCase):
 
         mat = paths.get(1).getTail()
         self.assertEqual(mat.diffuseColor.getNum(), 6)
+
+    def testSaveLoadNestedCollapsedLinkArrayStepFile(self):
+        """
+        Export a nested collapsed Draft Link Array without losing instances.
+        """
+        import Draft
+        from FreeCAD import Vector
+
+        box = self.doc.addObject("Part::Box", "Box")
+        box.Length = 100
+        box.Width = 100
+        box.Height = 100
+        self.doc.recompute()
+
+        inner = Draft.make_ortho_array(
+            box,
+            v_x=Vector(200, 0, 0),
+            v_y=Vector(0, 200, 0),
+            v_z=Vector(0, 0, 0),
+            n_x=2,
+            n_y=2,
+            n_z=1,
+            use_link=True,
+        )
+        outer = Draft.make_ortho_array(
+            inner,
+            v_x=Vector(500, 0, 0),
+            v_y=Vector(0, 0, 0),
+            v_z=Vector(0, 0, 0),
+            n_x=3,
+            n_y=1,
+            n_z=1,
+            use_link=True,
+        )
+        self.doc.recompute()
+
+        ImportGui.export([outer], self.fileName)
+
+        self.doc.clearDocument()
+        ImportGui.insert(
+            name=self.fileName,
+            docName=self.doc.Name,
+            merge=False,
+            useLinkGroup=True,
+        )
+
+        solid_count = 0
+        for obj in self.doc.Objects:
+            if obj.isDerivedFrom("Part::Feature") and hasattr(obj, "Shape"):
+                solid_count += len(obj.Shape.Solids)
+
+        self.assertEqual(solid_count, 12)


### PR DESCRIPTION
﻿## Summary

Fixes #26319.

This updates STEP export handling for nested collapsed Draft Link Arrays. When a previously exported linked object is reused as a component under a parent assembly, the exporter now preserves the cached assembly label instead of rebuilding the component only from the resolved shape. This keeps the child instances of the nested array available to the STEP assembly graph.

A regression test exports a nested Draft Link OrthoArray and imports it back with `useLinkGroup=True`, then verifies that all 12 expected solids are present.

## Root cause

The cached linked-object path reused the linked object's computed shape for parent components. For nested collapsed arrays, that can discard the already-created assembly structure for the inner array, so the outer array exports fewer instances than expected.

## Validation

- `git diff --check`
- `python -m py_compile src\Mod\Import\TestImportGui.py`

I could not run the full FreeCAD GUI import/export regression locally because this environment does not have the FreeCAD Python module installed.
