### PR TITLE
Fix HiDPI scaling for axis cross labels

### DIFF
--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -4475,9 +4475,10 @@ void View3DInventorViewer::drawAxisCross()
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-    glPixelZoom((float)axiscrossSize / 30, (float)axiscrossSize / 30);  // 30 = 3 (character pixmap
-                                                                        // ratio) * 10 (default
-                                                                        // axiscrossSize)
+    const float letterScale = static_cast<float>(axiscrossSize) / 30
+        * static_cast<float>(this->devicePixelRatio());
+    glPixelZoom(letterScale, letterScale);  // 30 = 3 (character pixmap ratio) * 10 (default
+                                            // axiscrossSize)
     glRasterPos2d(xpos[0], xpos[1]);
     glDrawPixels(XPM_WIDTH, XPM_HEIGHT, GL_RGBA, GL_UNSIGNED_BYTE, XPM_pixel_data);
     glRasterPos2d(ypos[0], ypos[1]);


### PR DESCRIPTION
Fixes #23741.

## Problem
The 3D view corner coordinate system draws the X/Y/Z letters directly with OpenGL `glDrawPixels()`. The letter size is controlled by `glPixelZoom()` using the user-facing corner axis size, but it does not account for the widget device pixel ratio. On HiDPI/Retina displays this leaves the axis letter bitmaps too small in physical pixels compared with the rest of the 3D view decoration.

## Changes
- Scale the corner axis letter `glPixelZoom()` by `devicePixelRatio()`.
- Leave existing behavior unchanged on standard-DPI displays where the ratio is 1.

## Validation
- `git diff --check`
- `uvx pre-commit run --files src/Gui/View3DInventorViewer.cpp`

I could not run a macOS/Retina visual reproduction from this Windows environment.