### PR TITLE
BIM: include added walls in schedules

### DIFF
--- a/src/Mod/BIM/ArchSchedule.py
+++ b/src/Mod/BIM/ArchSchedule.py
@@ -350,6 +350,7 @@ class _ArchSchedule:
                 # Remove included objects (e.g. walls that are part of another wall,
                 # base geometry, etc)
                 objs = Arch.pruneIncluded(objs, strict=True, silent=True)
+                objs = self.includeSameTypeAdditions(objs, Draft)
                 # Remove all schedules and spreadsheets:
                 objs = [
                     o for o in objs if Draft.get_type(o) not in ["Schedule", "Spreadsheet::Sheet"]
@@ -407,6 +408,36 @@ class _ArchSchedule:
             if ok:
                 nobjs.append(o)
         return nobjs
+
+    def includeSameTypeAdditions(self, objs, draft_module):
+        """Include Arch additions that are separate objects of the host type."""
+
+        result = list(objs)
+        known_names = {o.Name for o in result}
+        queue = list(objs)
+
+        while queue:
+            host = queue.pop(0)
+            host_type = draft_module.get_type(host)
+            additions = getattr(host, "Additions", None) or []
+
+            for addition in additions:
+                actual_addition = addition
+                if hasattr(addition, "getLinkedObject"):
+                    linked = addition.getLinkedObject()
+                    if linked:
+                        actual_addition = linked
+
+                if not actual_addition or actual_addition.Name in known_names:
+                    continue
+                if draft_module.get_type(actual_addition) != host_type:
+                    continue
+
+                result.append(actual_addition)
+                queue.append(actual_addition)
+                known_names.add(actual_addition.Name)
+
+        return result
 
     def get_ifc_elements(self, ifcfile, filters):
         """Retrieves IFC elements corresponding to the given filters"""

--- a/src/Mod/BIM/bimtests/TestArchSchedule.py
+++ b/src/Mod/BIM/bimtests/TestArchSchedule.py
@@ -36,3 +36,27 @@ class TestArchSchedule(TestArchBase.TestArchBase):
         obj = Arch.makeSchedule()
         self.assertIsNotNone(obj, "makeSchedule failed to create an object")
         self.assertEqual(obj.Label, "Schedule", "Incorrect default label for Schedule")
+
+    def test_wall_schedule_includes_added_wall_components(self):
+        """Schedules should count walls merged through Additions."""
+        operation = "Testing Schedule wall Additions..."
+        self.printTestMessage(operation)
+
+        base_wall = Arch.makeWall(length=4000, name="Base Wall")
+        added_wall = Arch.makeWall(length=2000, name="Added Wall")
+        base_wall.IfcType = "Wall"
+        added_wall.IfcType = "Wall"
+        Arch.addComponents(added_wall, host=base_wall)
+        self.document.recompute()
+
+        schedule = Arch.makeSchedule()
+        schedule.Operation = ["Wall length"]
+        schedule.Value = ["Length"]
+        schedule.Unit = [""]
+        schedule.Objects = [""]
+        schedule.Filter = ["Type:Wall"]
+
+        schedule.Proxy.execute(schedule)
+
+        self.assertIn("B2", schedule.Proxy.data)
+        self.assertAlmostEqual(float(schedule.Proxy.data["B2"]), 6000.0)


### PR DESCRIPTION
﻿Fixes FreeCAD/FreeCAD#26862.

## Summary
- keeps same-type BIM `Additions` available to Schedule calculations after included-object pruning
- covers the wall merge case where a wall added to another wall should still contribute its own `Length`
- adds a regression test for a 4 m wall with a 2 m added wall producing a 6 m schedule total

## Root Cause
`Arch.pruneIncluded(..., strict=True)` removes objects that are included in another selected shape-based object. That is useful for avoiding base geometry double-counting, but it also removed wall objects merged into another wall through `Additions`, so wall length schedules only saw the host wall.

## Validation
- `python -m py_compile src\Mod\BIM\ArchSchedule.py src\Mod\BIM\bimtests\TestArchSchedule.py`
- `git diff --check`
- `uvx pre-commit run --files src\Mod\BIM\ArchSchedule.py src\Mod\BIM\bimtests\TestArchSchedule.py`

I could not run the FreeCAD BIM runtime test locally because this Windows environment does not have `FreeCADCmd` installed.
