### PR TITLE
Preserve ArchView Coin render visibility

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -759,15 +759,15 @@ def getCoinSVG(cutplane, objs, cameradata=None, linewidth=0.2, singleface=False,
     boundbox = FreeCAD.BoundBox()
     for obj in objs:
         if hasattr(obj.ViewObject, "RootNode") and obj.ViewObject.RootNode:
-            old_visibility = obj.ViewObject.isVisible()
-            # ignore visibility as only visible objects are passed here
-            obj.ViewObject.show()
-            node_copy = obj.ViewObject.RootNode.copy()
+            old_visibility = obj.ViewObject.Visibility
+            # Temporarily show the object so Coin can copy its node, then
+            # restore the document-visible state without side effects.
+            try:
+                obj.ViewObject.Visibility = True
+                node_copy = obj.ViewObject.RootNode.copy()
+            finally:
+                obj.ViewObject.Visibility = old_visibility
             root_node.addChild(node_copy)
-            if old_visibility:
-                obj.ViewObject.show()
-            else:
-                obj.ViewObject.hide()
 
         if hasattr(obj, "Shape") and hasattr(obj.Shape, "BoundBox"):
             boundbox.add(obj.Shape.BoundBox)


### PR DESCRIPTION
﻿## Summary

Fixes #27646.

This keeps `TechDraw_ArchView` Coin/Coin mono rendering from changing source object visibility. `ArchSectionPlane.getCoinSVG()` temporarily makes each source view provider visible so it can copy the Coin root node, but it restored that state via `show()`/`hide()` based on `isVisible()`. The update saves the actual `ViewObject.Visibility` property and restores it in a `finally` block after the node copy.

## Root cause

Coin rendering needs a visible view provider to copy `RootNode`, but toggling the view provider through `show()` and `hide()` can leak back into the document-visible state while switching the ArchView render mode. Restoring the original `Visibility` property directly keeps hidden BIM objects hidden after the temporary Coin node copy.

## Validation

- `git diff --check`
- `python -m py_compile src\Mod\BIM\ArchSectionPlane.py`

I could not run the full GUI reproduction locally because this environment does not have a runnable FreeCAD GUI/Linux setup.
