### PR TITLE
Skip saving clean documents

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1649,6 +1649,11 @@ bool Document::save()
                 }
             }
 
+            if (docs.size() == 1 && docs.front() == getDocument() && !isModified()
+                && !getDocument()->isTouched() && !dmap[getDocument()]) {
+                return true;
+            }
+
             if (!checkCanonicalPath(dmap)) {
                 return false;
             }


### PR DESCRIPTION
Fixes the unmodified-document save path from #25756.

## Problem
`Std_Save` currently reaches `App::Document::save()` even when the active document is already saved, has no GUI modifications, has no touched App objects, and does not need recompute. For large `.FCStd` files this still rewrites the whole project archive, so pressing Ctrl+S after opening an unchanged file can block the UI for a long time.

## Changes
- After the existing dependent-document filtering and prompt, return success early when the only remaining document is the active document and it is clean.
- Keep the existing save path for modified documents, touched App documents, documents needing recompute, and user-approved dependent document saves.

This does not attempt incremental ZIP updates for modified documents; it removes the needless full rewrite for the unchanged-file case described in the issue.

## Validation
- `uvx pre-commit run --files src/Gui/Document.cpp`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check`

I could not run a full FreeCAD GUI build/test in this Windows environment because the FreeCAD runtime/build dependencies are not installed.