### PR TITLE
CAM: Feeds and Speeds helper implementation.

### DIFF
--- a/src/Mod/CAM/CAMTests/TestFeedsSpeedsResolver.py
+++ b/src/Mod/CAM/CAMTests/TestFeedsSpeedsResolver.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Pure-function tests for the FeedsSpeeds resolver. No FreeCAD doc objects;
+the contexts are constructed directly.
+"""
+
+import math
+import unittest
+
+from Path.Tool.FeedsSpeeds import (
+    MaterialContext,
+    OpContext,
+    ToolContext,
+    derive_preset_label,
+    make_preset,
+    resolve,
+)
+from Path.Tool.FeedsSpeeds.providers import (
+    ToolDefaultsProvider,
+    ToolPresetProvider,
+    _score_preset,
+)
+
+ALU_UUID = "11111111-2222-3333-4444-555555555555"
+STEEL_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+def _alu_profile_preset():
+    return make_preset(
+        material_uuid=ALU_UUID,
+        material_name="Aluminum 6061",
+        op_type="profile",
+        surface_speed=400.0,
+        chipload=0.05,
+        vert_feed_ratio=0.33,
+    )
+
+
+def _generic_drill_preset():
+    return make_preset(
+        op_type="drill",
+        surface_speed=200.0,
+        chipload=0.025,
+    )
+
+
+class TestFeedsSpeedsResolver(unittest.TestCase):
+
+    def setUp(self):
+        self.tool = ToolContext(
+            diameter=6.35,  # 1/4 inch in mm
+            flutes=2,
+            presets=(_alu_profile_preset(),),
+            shape_id="endmill",
+            material_enum="Carbide",
+        )
+        self.alu = MaterialContext(uuid=ALU_UUID, name="Aluminum 6061")
+        self.steel = MaterialContext(uuid=STEEL_UUID, name="Mild Steel")
+        self.profile = OpContext(op_type="profile")
+        self.pocket = OpContext(op_type="pocket")
+
+    def test_no_presets_returns_empty_result(self):
+        tool = ToolContext(diameter=6.35, flutes=2, presets=(), shape_id="endmill")
+        r = resolve(tool, self.alu, self.profile)
+        self.assertEqual(r.source, "")
+        self.assertEqual(r.confidence, 0.0)
+        self.assertIsNone(r.horiz_feed)
+
+    def test_matching_preset_produces_derived_values(self):
+        r = resolve(self.tool, self.alu, self.profile)
+        self.assertNotEqual(r.source, "")
+        # rpm = (surface_speed * 1000) / (pi * d) = (400 * 1000) / (pi * 6.35)
+        expected_rpm = (400.0 * 1000.0) / (math.pi * 6.35)
+        self.assertAlmostEqual(r.spindle_speed, expected_rpm, places=2)
+        # horiz_feed = rpm * flutes * chipload
+        expected_feed = expected_rpm * 2 * 0.05
+        self.assertAlmostEqual(r.horiz_feed, expected_feed, places=2)
+        # vert_feed = horiz * 0.33
+        self.assertAlmostEqual(r.vert_feed, expected_feed * 0.33, places=2)
+        self.assertEqual(r.surface_speed, 400.0)
+        self.assertEqual(r.chipload, 0.05)
+
+    def test_material_mismatch_returns_no_match(self):
+        r = resolve(self.tool, self.steel, self.profile)
+        self.assertEqual(r.source, "")
+
+    def test_op_type_mismatch_returns_no_match(self):
+        r = resolve(self.tool, self.alu, self.pocket)
+        self.assertEqual(r.source, "")
+
+    def test_specificity_picks_more_specific_preset(self):
+        # Two presets: one material-only generic-op, one fully specific.
+        # The fully specific one should win.
+        material_only = make_preset(
+            material_uuid=ALU_UUID,
+            material_name="Aluminum 6061",
+            op_type=None,
+            surface_speed=300.0,
+            chipload=0.04,
+        )
+        full = _alu_profile_preset()
+        tool = ToolContext(
+            diameter=6.35,
+            flutes=2,
+            presets=(material_only, full),
+            shape_id="endmill",
+        )
+        r = resolve(tool, self.alu, self.profile)
+        self.assertEqual(r.surface_speed, 400.0)
+        self.assertEqual(r.chipload, 0.05)
+
+    def test_generic_material_preset_matches_anything(self):
+        tool = ToolContext(
+            diameter=6.35,
+            flutes=2,
+            presets=(_generic_drill_preset(),),
+            shape_id="drill",
+        )
+        r = resolve(tool, self.steel, OpContext(op_type="drill"))
+        self.assertNotEqual(r.source, "")
+        self.assertEqual(r.surface_speed, 200.0)
+
+    def test_name_fallback_when_uuid_unknown(self):
+        # Preset has UUID; query has only the same name.
+        material_unknown_uuid = MaterialContext(uuid=None, name="Aluminum 6061")
+        r = resolve(self.tool, material_unknown_uuid, self.profile)
+        self.assertNotEqual(r.source, "")
+        # Name-fallback should score lower than UUID-exact (~0.85 vs 0.95).
+        self.assertLess(r.confidence, 0.96)
+
+    def test_uuid_match_outscores_name_match(self):
+        full_uuid = _alu_profile_preset()
+        full_name_only = make_preset(
+            material_uuid=None,
+            material_name="Aluminum 6061",
+            op_type="profile",
+            surface_speed=999.0,
+            chipload=0.05,
+        )
+        tool = ToolContext(
+            diameter=6.35,
+            flutes=2,
+            presets=(full_name_only, full_uuid),
+            shape_id="endmill",
+        )
+        r = resolve(tool, self.alu, self.profile)
+        # UUID-matched preset wins
+        self.assertEqual(r.surface_speed, 400.0)
+
+    def test_preset_with_no_engineering_values_warns(self):
+        # A preset with neither surface_speed nor chipload set is
+        # effectively useless. The provider returns a result with no
+        # spindle/feed and a warning.
+        empty = make_preset(
+            material_uuid=ALU_UUID, material_name="Aluminum 6061", op_type="profile"
+        )
+        tool = ToolContext(diameter=6.35, flutes=2, presets=(empty,), shape_id="endmill")
+        r = resolve(tool, self.alu, self.profile)
+        self.assertIsNone(r.spindle_speed)
+        self.assertIsNone(r.horiz_feed)
+        self.assertTrue(any("no usable" in w for w in r.warnings))
+
+    def test_score_preset_returns_none_on_mismatch(self):
+        score = _score_preset(
+            _alu_profile_preset(),
+            MaterialContext(uuid=STEEL_UUID, name="Mild Steel"),
+            OpContext(op_type="profile"),
+        )
+        self.assertIsNone(score)
+
+    def test_op_type_none_in_query_treats_op_hint_as_mismatch(self):
+        # Query has op_type=None but preset specifies "profile". Per the
+        # scoring rule, a specified hint that doesn't match the query is
+        # treated as a mismatch.
+        r = resolve(self.tool, self.alu, OpContext(op_type=None))
+        self.assertEqual(r.source, "")
+
+    def test_resolver_does_not_import_freecad(self):
+        # Sanity check: the resolver module should be importable without
+        # FreeCAD. We can't fully prove that here (we're inside FreeCAD), but
+        # we can at least confirm the module's __dict__ has no FreeCAD ref.
+        from Path.Tool.FeedsSpeeds import resolver, types, providers
+
+        for mod in (resolver, types, providers):
+            self.assertNotIn("FreeCAD", dir(mod), f"{mod.__name__} leaks FreeCAD")
+            self.assertNotIn("Path", dir(mod), f"{mod.__name__} leaks Path")
+
+    def test_make_preset_includes_name_field(self):
+        preset = make_preset(name="Test", surface_speed=400)
+        self.assertEqual(preset["name"], "Test")
+        # Default is None when omitted
+        self.assertIsNone(make_preset(surface_speed=400)["name"])
+
+    def test_derive_preset_label_prefers_user_name(self):
+        preset = make_preset(name="My fav", material_name="Aluminum 6061", op_type="profile")
+        self.assertEqual(derive_preset_label(preset), "My fav")
+
+    def test_derive_preset_label_falls_back_to_material_op(self):
+        preset = make_preset(material_name="Aluminum 6061", op_type="profile")
+        self.assertEqual(derive_preset_label(preset), "Aluminum 6061 / profile")
+
+    def test_derive_preset_label_default_for_fully_generic(self):
+        preset = make_preset(surface_speed=400)
+        self.assertEqual(derive_preset_label(preset), "(unnamed)")
+
+    # --- ToolDefaultsProvider (legacy ToolBit.Chipload fallback) -----------
+
+    def test_tool_defaults_returns_chipload_when_no_preset_matches(self):
+        # Material/op don't match any preset, but the tool has a default
+        # chipload set on it. Resolver chain should still return the chipload.
+        tool = ToolContext(
+            diameter=6.35,
+            flutes=2,
+            presets=(),
+            shape_id="endmill",
+            chipload_default=0.04,
+        )
+        r = resolve(tool, self.alu, self.profile)
+        self.assertEqual(r.chipload, 0.04)
+        self.assertEqual(r.source, "tool_defaults:chipload")
+        self.assertLess(r.confidence, 0.2)
+        # No surface_speed provided by this provider alone.
+        self.assertIsNone(r.surface_speed)
+        self.assertIsNone(r.spindle_speed)
+
+    def test_preset_match_outscores_tool_defaults(self):
+        # Preset matches AND tool has a default chipload — preset wins.
+        tool = ToolContext(
+            diameter=6.35,
+            flutes=2,
+            presets=(_alu_profile_preset(),),
+            shape_id="endmill",
+            chipload_default=0.99,  # would be obviously wrong if used
+        )
+        r = resolve(tool, self.alu, self.profile)
+        self.assertEqual(r.chipload, 0.05)  # from preset
+        self.assertTrue(r.source.startswith("preset:"))
+
+    def test_tool_defaults_silent_when_chipload_default_is_zero(self):
+        tool = ToolContext(
+            diameter=6.35,
+            flutes=2,
+            presets=(),
+            shape_id="endmill",
+            chipload_default=0.0,
+        )
+        r = resolve(tool, self.alu, self.profile)
+        self.assertEqual(r.source, "")  # no provider fired
+        self.assertIsNone(r.chipload)
+
+    def test_tool_defaults_silent_when_chipload_default_is_none(self):
+        # Default ToolContext has chipload_default=None.
+        tool = ToolContext(diameter=6.35, flutes=2, presets=(), shape_id="endmill")
+        r = resolve(tool, self.alu, self.profile)
+        self.assertEqual(r.source, "")

--- a/src/Mod/CAM/CAMTests/TestFeedsSpeedsResolver.py
+++ b/src/Mod/CAM/CAMTests/TestFeedsSpeedsResolver.py
@@ -28,6 +28,7 @@ import math
 import unittest
 
 from Path.Tool.FeedsSpeeds import (
+    MachineContext,
     MaterialContext,
     OpContext,
     ToolContext,
@@ -36,6 +37,7 @@ from Path.Tool.FeedsSpeeds import (
     resolve,
 )
 from Path.Tool.FeedsSpeeds.providers import (
+    MachinabilityProvider,
     ToolDefaultsProvider,
     ToolPresetProvider,
     _score_preset,
@@ -72,7 +74,7 @@ class TestFeedsSpeedsResolver(unittest.TestCase):
             flutes=2,
             presets=(_alu_profile_preset(),),
             shape_id="endmill",
-            material_enum="Carbide",
+            tool_material="Carbide",
         )
         self.alu = MaterialContext(uuid=ALU_UUID, name="Aluminum 6061")
         self.steel = MaterialContext(uuid=STEEL_UUID, name="Mild Steel")
@@ -273,3 +275,147 @@ class TestFeedsSpeedsResolver(unittest.TestCase):
         tool = ToolContext(diameter=6.35, flutes=2, presets=(), shape_id="endmill")
         r = resolve(tool, self.alu, self.profile)
         self.assertEqual(r.source, "")
+
+    # --- MachinabilityProvider (stock-material surface-speed lookup) -------
+
+    def _tool_no_presets(self, tool_material=None, chipload_default=None):
+        return ToolContext(
+            diameter=6.35,
+            flutes=2,
+            presets=(),
+            shape_id="endmill",
+            tool_material=tool_material,
+            chipload_default=chipload_default,
+        )
+
+    def _alu_machinability(self, hss=30.0, carbide=400.0):
+        return MaterialContext(
+            uuid=ALU_UUID,
+            name="Aluminum 6061",
+            surface_speed_hss=hss,
+            surface_speed_carbide=carbide,
+        )
+
+    def test_machinability_carbide_branch(self):
+        tool = self._tool_no_presets(tool_material="Carbide")
+        r = resolve(tool, self._alu_machinability(), self.profile)
+        self.assertEqual(r.surface_speed, 400.0)
+        self.assertTrue(r.source.startswith("machinability:"))
+        self.assertIn("/carbide", r.source)
+
+    def test_machinability_hss_branch(self):
+        tool = self._tool_no_presets(tool_material="HSS")
+        r = resolve(tool, self._alu_machinability(), self.profile)
+        self.assertEqual(r.surface_speed, 30.0)
+        self.assertIn("/hss", r.source)
+
+    def test_machinability_abstains_when_tool_material_missing(self):
+        tool = self._tool_no_presets(tool_material=None)
+        r = resolve(tool, self._alu_machinability(), self.profile)
+        self.assertEqual(r.source, "")
+
+    def test_machinability_abstains_on_unknown_tool_material(self):
+        tool = self._tool_no_presets(tool_material="Diamond")
+        r = resolve(tool, self._alu_machinability(), self.profile)
+        self.assertEqual(r.source, "")
+
+    def test_machinability_abstains_when_branch_value_missing(self):
+        # HSS tool, but material only has Carbide surface speed.
+        tool = self._tool_no_presets(tool_material="HSS")
+        material = MaterialContext(
+            uuid=ALU_UUID,
+            name="Aluminum 6061",
+            surface_speed_hss=None,
+            surface_speed_carbide=400.0,
+        )
+        r = resolve(tool, material, self.profile)
+        self.assertEqual(r.source, "")
+
+    def test_machinability_plus_defaults_derives_full_result(self):
+        # Stock material gives surface_speed, tool's default Chipload gives
+        # chipload; resolver finalization derives spindle and feed.
+        tool = self._tool_no_presets(tool_material="Carbide", chipload_default=0.05)
+        r = resolve(tool, self._alu_machinability(), self.profile)
+        self.assertEqual(r.surface_speed, 400.0)
+        self.assertEqual(r.chipload, 0.05)
+        expected_rpm = (400.0 * 1000.0) / (math.pi * 6.35)
+        self.assertAlmostEqual(r.spindle_speed, expected_rpm, places=2)
+        self.assertAlmostEqual(r.horiz_feed, expected_rpm * 2 * 0.05, places=2)
+        # Default vert_feed_ratio in finalization is 0.33.
+        self.assertAlmostEqual(r.vert_feed, expected_rpm * 2 * 0.05 * 0.33, places=2)
+
+    def test_preset_match_outscores_machinability(self):
+        # Curated preset and machinability both available — preset wins.
+        tool = ToolContext(
+            diameter=6.35,
+            flutes=2,
+            presets=(_alu_profile_preset(),),
+            shape_id="endmill",
+            tool_material="Carbide",
+        )
+        # Material's carbide speed is intentionally different from preset's.
+        material = self._alu_machinability(carbide=999.0)
+        r = resolve(tool, material, self.profile)
+        self.assertEqual(r.surface_speed, 400.0)  # preset's value
+        self.assertTrue(r.source.startswith("preset:"))
+
+    def test_machinability_confidence_between_preset_and_defaults(self):
+        tool = self._tool_no_presets(tool_material="Carbide")
+        r = resolve(tool, self._alu_machinability(), self.profile)
+        self.assertGreater(r.confidence, 0.10)
+        self.assertLess(r.confidence, 0.55)
+
+    # --- Machine clamping (spindle min/max from Machine definition) -------
+
+    def test_machine_no_clamp_when_within_limits(self):
+        # Preset yields ~20053 rpm at d=6.35; machine max 30000 well above.
+        machine = MachineContext(min_rpm=0, max_rpm=30000)
+        r = resolve(self.tool, self.alu, self.profile, machine=machine)
+        expected_rpm = (400.0 * 1000.0) / (math.pi * 6.35)
+        self.assertAlmostEqual(r.spindle_speed, expected_rpm, places=2)
+        self.assertFalse(any("clamped" in w.lower() for w in r.warnings))
+
+    def test_machine_clamps_above_max(self):
+        # Preset yields ~20053 rpm; cap at 10000.
+        machine = MachineContext(min_rpm=0, max_rpm=10000)
+        r = resolve(self.tool, self.alu, self.profile, machine=machine)
+        original_rpm = (400.0 * 1000.0) / (math.pi * 6.35)
+        self.assertEqual(r.spindle_speed, 10000)
+        # Feeds scaled by ratio (chipload preserved).
+        ratio = 10000 / original_rpm
+        original_horiz = original_rpm * 2 * 0.05
+        self.assertAlmostEqual(r.horiz_feed, original_horiz * ratio, places=2)
+        self.assertEqual(r.chipload, 0.05)
+        # Recommended surface_speed unchanged (intent, not achieved).
+        self.assertEqual(r.surface_speed, 400.0)
+        self.assertTrue(any("max" in w.lower() and "clamped" in w.lower() for w in r.warnings))
+
+    def test_machine_clamps_below_min(self):
+        # Preset yields ~20053 rpm; force min at 25000 so it has to climb.
+        machine = MachineContext(min_rpm=25000, max_rpm=40000)
+        r = resolve(self.tool, self.alu, self.profile, machine=machine)
+        self.assertEqual(r.spindle_speed, 25000)
+        self.assertTrue(any("min" in w.lower() and "clamped" in w.lower() for w in r.warnings))
+
+    def test_machine_zero_max_means_no_limit(self):
+        # max_rpm=0 (Machine model's default) disables the upper clamp.
+        machine = MachineContext(min_rpm=0, max_rpm=0)
+        r = resolve(self.tool, self.alu, self.profile, machine=machine)
+        expected_rpm = (400.0 * 1000.0) / (math.pi * 6.35)
+        self.assertAlmostEqual(r.spindle_speed, expected_rpm, places=2)
+        self.assertFalse(any("clamped" in w.lower() for w in r.warnings))
+
+    def test_machine_none_no_clamping(self):
+        # No machine context = no clamping path runs.
+        r = resolve(self.tool, self.alu, self.profile, machine=None)
+        expected_rpm = (400.0 * 1000.0) / (math.pi * 6.35)
+        self.assertAlmostEqual(r.spindle_speed, expected_rpm, places=2)
+
+    def test_machine_clamps_machinability_derived_spindle(self):
+        # Machinability + defaults path also runs through finalization
+        # and so is subject to the same clamp.
+        tool = self._tool_no_presets(tool_material="Carbide", chipload_default=0.05)
+        machine = MachineContext(min_rpm=0, max_rpm=10000)
+        r = resolve(tool, self._alu_machinability(), self.profile, machine=machine)
+        self.assertEqual(r.spindle_speed, 10000)
+        self.assertTrue(any("clamped" in w.lower() for w in r.warnings))

--- a/src/Mod/CAM/CAMTests/TestFeedsSpeedsToolBitPresets.py
+++ b/src/Mod/CAM/CAMTests/TestFeedsSpeedsToolBitPresets.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Round-trip test for ToolBit feeds & speeds presets through the FCTB
+serializer. Confirms:
+- Lazy-add: a tool with no presets serializes byte-identical to before.
+- The "presets" key appears only when presets exist.
+- A round-trip preserves all preset fields.
+"""
+
+import json
+from typing import cast
+from CAMTests.PathTestUtils import PathTestWithAssets
+from Path.Tool.toolbit import ToolBit, ToolBitEndmill
+from Path.Tool.toolbit.serializers import FCTBSerializer
+from Path.Tool.assets.uri import AssetUri
+from Path.Tool.shape import ToolBitShapeEndmill
+from Path.Tool.FeedsSpeeds import (
+    PRESETS_PROPERTY,
+    get_presets,
+    make_preset,
+    set_presets,
+)
+
+
+class TestFeedsSpeedsToolBitPresets(PathTestWithAssets):
+
+    def setUp(self):
+        super().setUp()
+        self.tool = cast(ToolBitEndmill, self.assets.get("toolbit://5mm_Endmill"))
+        self.tool.label = "Preset Roundtrip Test"
+
+    def test_no_presets_means_no_presets_key_in_serialized(self):
+        data = FCTBSerializer.serialize(self.tool)
+        parsed = json.loads(data.decode("utf-8"))
+        self.assertNotIn("presets", parsed)
+
+    def test_presets_property_lazy_added_on_first_set(self):
+        self.assertFalse(hasattr(self.tool.obj, PRESETS_PROPERTY))
+        set_presets(self.tool.obj, [make_preset(surface_speed=300, chipload=0.04)])
+        self.assertTrue(hasattr(self.tool.obj, PRESETS_PROPERTY))
+
+    def test_get_presets_empty_when_property_absent(self):
+        # Fresh tool, never had presets stored.
+        self.assertEqual(get_presets(self.tool.obj), [])
+
+    def test_serialize_includes_presets_when_set(self):
+        preset = make_preset(
+            material_uuid="uuid-aluminum",
+            material_name="Aluminum 6061",
+            op_type="profile",
+            surface_speed=400.0,
+            chipload=0.05,
+        )
+        set_presets(self.tool.obj, [preset])
+
+        data = FCTBSerializer.serialize(self.tool)
+        parsed = json.loads(data.decode("utf-8"))
+        self.assertIn("presets", parsed)
+        self.assertEqual(len(parsed["presets"]), 1)
+        self.assertEqual(parsed["presets"][0]["surface_speed"], 400.0)
+        self.assertEqual(parsed["presets"][0]["op_type_hint"], "profile")
+        self.assertEqual(parsed["presets"][0]["material_hint"]["uuid"], "uuid-aluminum")
+
+    def test_roundtrip_preserves_all_fields(self):
+        preset_a = make_preset(
+            name="Aluminum aggressive",
+            material_uuid="uuid-aluminum",
+            material_name="Aluminum 6061",
+            op_type="profile",
+            surface_speed=400.0,
+            chipload=0.05,
+            vert_feed_ratio=0.4,
+        )
+        preset_b = make_preset(
+            op_type="drill",
+            surface_speed=120.0,
+            chipload=0.03,
+        )
+        set_presets(self.tool.obj, [preset_a, preset_b])
+
+        data = FCTBSerializer.serialize(self.tool)
+        shape = ToolBitShapeEndmill("endmill")
+        deps = {AssetUri.build("toolbitshape", "endmill"): shape}
+        round_trip = FCTBSerializer.deserialize(data, id="rt_id", dependencies=deps)
+
+        restored = get_presets(round_trip.obj)
+        self.assertEqual(len(restored), 2)
+        self.assertEqual(restored[0]["name"], "Aluminum aggressive")
+        self.assertEqual(restored[0]["surface_speed"], 400.0)
+        self.assertEqual(restored[0]["chipload"], 0.05)
+        self.assertEqual(restored[0]["vert_feed_ratio"], 0.4)
+        self.assertEqual(restored[0]["material_hint"]["uuid"], "uuid-aluminum")
+        self.assertIsNone(restored[1]["name"])
+        self.assertEqual(restored[1]["op_type_hint"], "drill")
+        self.assertEqual(restored[1]["surface_speed"], 120.0)
+        self.assertEqual(restored[1]["chipload"], 0.03)
+        self.assertIsNone(restored[1]["material_hint"])
+        # Engineering-only storage: raw_feed/raw_speed are not persisted.
+        self.assertNotIn("raw_feed", restored[1])
+        self.assertNotIn("raw_speed", restored[1])

--- a/src/Mod/CAM/CAMTests/TestFeedsSpeedsToolController.py
+++ b/src/Mod/CAM/CAMTests/TestFeedsSpeedsToolController.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Integration test for the resolver against a real ToolController and ToolBit
+in a FreeCAD document. Exercises:
+  - Lazy-add of OpTypeHint and FeedSpeedProvenance on first dialog open.
+  - End-to-end adapter -> resolver -> apply round-trip writing
+    HorizFeed/VertFeed/SpindleSpeed.
+  - Provenance stamping for resolved fields.
+"""
+
+import unittest
+import FreeCAD
+from CAMTests.PathTestUtils import PathTestWithAssets
+from typing import cast
+from Path.Tool.toolbit import ToolBitEndmill
+from Path.Tool.FeedsSpeeds import (
+    MaterialContext,
+    OpContext,
+    make_preset,
+    resolve,
+    set_presets,
+)
+
+
+class TestFeedsSpeedsToolController(PathTestWithAssets):
+
+    def setUp(self):
+        super().setUp()
+        self.doc = FreeCAD.newDocument("FSToolControllerTest")
+        # Acquire a 5mm endmill from the test asset store; this also gives
+        # us a doc-object-bearing toolbit instance.
+        self.toolbit = cast(ToolBitEndmill, self.assets.get("toolbit://5mm_Endmill"))
+
+    def tearDown(self):
+        try:
+            FreeCAD.closeDocument(self.doc.Name)
+        except Exception:
+            pass
+        super().tearDown()
+
+    def test_resolver_applies_to_tc_and_stamps_provenance(self):
+        # Seed a preset on the tool.
+        preset = make_preset(
+            material_uuid="uuid-test-mat",
+            material_name="Test Material",
+            op_type="profile",
+            surface_speed=400.0,
+            chipload=0.05,
+        )
+        set_presets(self.toolbit.obj, [preset])
+
+        # Build a TC-shaped doc object the lightweight way: we don't need
+        # the full ToolController factory here, just a doc object carrying
+        # the relevant feed/speed/spindle properties.
+        tc = self.doc.addObject("App::FeaturePython", "TC")
+        tc.addProperty("App::PropertySpeed", "HorizFeed", "Feed", "")
+        tc.addProperty("App::PropertySpeed", "VertFeed", "Feed", "")
+        tc.addProperty("App::PropertyFloat", "SpindleSpeed", "Tool", "")
+
+        # Run the resolver via the public API.
+        from Path.Tool.FeedsSpeeds import ToolContext
+
+        tool_ctx = ToolContext(
+            diameter=5.0,
+            flutes=2,
+            presets=(preset,),
+            shape_id="endmill",
+        )
+        material = MaterialContext(uuid="uuid-test-mat", name="Test Material")
+        op = OpContext(op_type="profile")
+        result = resolve(tool_ctx, material, op)
+        self.assertNotEqual(result.source, "")
+        self.assertIsNotNone(result.spindle_speed)
+        self.assertIsNotNone(result.horiz_feed)
+
+        # Apply via the Gui-side helper. (Importing FeedsSpeedsDialog is fine
+        # in headless tests; we don't show any widgets, we just call the
+        # property-mutation helper.)
+        from Path.Tool.Gui.FeedsSpeedsDialog import write_result_to_tc
+
+        write_result_to_tc(tc, result)
+
+        self.assertTrue(hasattr(tc, "OpTypeHint"))
+        self.assertTrue(hasattr(tc, "FeedSpeedProvenance"))
+
+        # Provenance was stamped for the three resolved fields.
+        prov = dict(tc.FeedSpeedProvenance)
+        self.assertIn("HorizFeed", prov)
+        self.assertIn("VertFeed", prov)
+        self.assertIn("SpindleSpeed", prov)
+        self.assertTrue(prov["HorizFeed"].startswith("preset:tool/"))
+
+        # The TC carries the resolved values.
+        self.assertGreater(float(tc.SpindleSpeed), 0.0)
+        self.assertGreater(float(tc.HorizFeed.Value), 0.0)
+        self.assertGreater(float(tc.VertFeed.Value), 0.0)
+
+    def test_empty_result_does_not_mutate_tc(self):
+        from Path.Tool.Gui.FeedsSpeedsDialog import write_result_to_tc
+        from Path.Tool.FeedsSpeeds import FeedSpeedResult
+
+        tc = self.doc.addObject("App::FeaturePython", "TC2")
+        tc.addProperty("App::PropertySpeed", "HorizFeed", "Feed", "")
+        tc.addProperty("App::PropertySpeed", "VertFeed", "Feed", "")
+        tc.addProperty("App::PropertyFloat", "SpindleSpeed", "Tool", "")
+
+        write_result_to_tc(tc, FeedSpeedResult())  # empty result
+
+        # Lazy properties should NOT have been added for an empty result.
+        self.assertFalse(hasattr(tc, "OpTypeHint"))
+        self.assertFalse(hasattr(tc, "FeedSpeedProvenance"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/CAM/CMakeLists.txt
+++ b/src/Mod/CAM/CMakeLists.txt
@@ -169,6 +169,16 @@ SET(PathPythonToolsDocObjectUi_SRCS
 SET(PathPythonToolsGui_SRCS
     Path/Tool/Gui/__init__.py
     Path/Tool/Gui/Controller.py
+    Path/Tool/Gui/FeedsSpeedsDialog.py
+    Path/Tool/Gui/MaterialPicker.py
+)
+
+SET(PathPythonToolsFeedsSpeeds_SRCS
+    Path/Tool/FeedsSpeeds/__init__.py
+    Path/Tool/FeedsSpeeds/types.py
+    Path/Tool/FeedsSpeeds/resolver.py
+    Path/Tool/FeedsSpeeds/providers.py
+    Path/Tool/FeedsSpeeds/presets.py
 )
 
 SET(PathPythonMachineUi_SRCS
@@ -233,6 +243,7 @@ SET(PathPythonToolsToolBitUi_SRCS
     Path/Tool/toolbit/ui/browser.py
     Path/Tool/toolbit/ui/file.py
     Path/Tool/toolbit/ui/panel.py
+    Path/Tool/toolbit/ui/presets_tab.py
     Path/Tool/toolbit/ui/selector.py
     Path/Tool/toolbit/ui/tablecell.py
     Path/Tool/toolbit/ui/toollist.py
@@ -624,6 +635,9 @@ SET(Tests_SRCS
     CAMTests/TestSVGPost.py
     CAMTests/TestTSPSolver.py
     CAMTests/TestGcodeProcessingUtils.py
+    CAMTests/TestFeedsSpeedsResolver.py
+    CAMTests/TestFeedsSpeedsToolBitPresets.py
+    CAMTests/TestFeedsSpeedsToolController.py
     CAMTests/Tools/Bit/test-path-tool-bit-bit-00.fctb
     CAMTests/Tools/Library/test-path-tool-bit-library-00.fctl
     CAMTests/Tools/Shape/test-path-tool-bit-shape-00.fcstd
@@ -680,6 +694,7 @@ SET(all_files
     ${PathPythonToolsDocObject_SRCS}
     ${PathPythonToolsDocObjectModels_SRCS}
     ${PathPythonToolsDocObjectUi_SRCS}
+    ${PathPythonToolsFeedsSpeeds_SRCS}
     ${PathPythonToolsGui_SRCS}
     ${PathPythonToolsShape_SRCS}
     ${PathPythonToolsShapeModels_SRCS}
@@ -869,6 +884,13 @@ INSTALL(
         ${PathPythonToolsGui_SRCS}
     DESTINATION
         Mod/CAM/Path/Tool/Gui
+)
+
+INSTALL(
+    FILES
+        ${PathPythonToolsFeedsSpeeds_SRCS}
+    DESTINATION
+        Mod/CAM/Path/Tool/FeedsSpeeds
 )
 
 INSTALL(

--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -97,6 +97,7 @@
         <file>panels/DressupPathBoundary.ui</file>
         <file>panels/DragKnifeEdit.ui</file>
         <file>panels/DressUpLeadInOutEdit.ui</file>
+        <file>panels/FeedsSpeedsPresetEdit.ui</file>
         <file>panels/HoldingTagsEdit.ui</file>
         <file>panels/LibraryProperties.ui</file>
         <file>panels/PageBaseGeometryEdit.ui</file>

--- a/src/Mod/CAM/Gui/Resources/Path.qrc
+++ b/src/Mod/CAM/Gui/Resources/Path.qrc
@@ -28,6 +28,7 @@
         <file>icons/CAM_Face.svg</file>
         <file>icons/CAM_FacePocket.svg</file>
         <file>icons/CAM_FaceProfile.svg</file>
+        <file>icons/CAM_FeedsSpeeds.svg</file>
         <file>icons/CAM_Heights.svg</file>
         <file>icons/CAM_Helix.svg</file>
         <file>icons/CAM_Inspect.svg</file>

--- a/src/Mod/CAM/Gui/Resources/icons/CAM_FeedsSpeeds.svg
+++ b/src/Mod/CAM/Gui/Resources/icons/CAM_FeedsSpeeds.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="64px" height="64px" viewBox="0 0 64 64" version="1.1"
+     id="CAM_FeedsSpeeds">
+  <defs id="defs">
+    <!-- Gray aluminium tool body: top-left light -> bottom-right shadow -->
+    <linearGradient id="toolGrad" x1="36" y1="8" x2="56" y2="50" gradientUnits="userSpaceOnUse">
+      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1"/>
+      <stop offset="0.45" style="stop-color:#d3d7cf;stop-opacity:1"/>
+      <stop offset="1" style="stop-color:#888a85;stop-opacity:1"/>
+    </linearGradient>
+    <!-- Top face of the cylinder -->
+    <linearGradient id="topGrad" x1="38" y1="8" x2="52" y2="14" gradientUnits="userSpaceOnUse">
+      <stop offset="0" style="stop-color:#ffffff;stop-opacity:1"/>
+      <stop offset="1" style="stop-color:#b8bcb4;stop-opacity:1"/>
+    </linearGradient>
+    <clipPath id="bodyClip">
+      <path d="M 40,10 L 50,10 L 50,46 Q 50,49 47,49 L 43,49 Q 40,49 40,46 Z"/>
+    </clipPath>
+  </defs>
+
+  <!-- ============ SPEED LINES (green feed/motion, haloed double-stroke) ============ -->
+  <g stroke-linecap="round" fill="none">
+    <!-- dark-green halo underlay -->
+    <g stroke="#172a04" stroke-width="8">
+      <path d="M 8,20 L 34,20"/>
+      <path d="M 5,32 L 33,32"/>
+      <path d="M 8,44 L 34,44"/>
+    </g>
+    <!-- bright-green core -->
+    <g stroke="#73d216" stroke-width="4">
+      <path d="M 8,20 L 34,20"/>
+      <path d="M 5,32 L 33,32"/>
+      <path d="M 8,44 L 34,44"/>
+    </g>
+  </g>
+
+  <!-- ============ ENDMILL (vertical fluted tool, flat bottom) ============ -->
+  <!-- body (flat-bottom endmill) -->
+  <path d="M 40,10 L 50,10 L 50,46 Q 50,49 47,49 L 43,49 Q 40,49 40,46 Z"
+        style="fill:url(#toolGrad);stroke:#2e3436;stroke-width:2;stroke-linejoin:round;stroke-linecap:round"/>
+  <!-- diagonal flutes, clipped to body -->
+  <g clip-path="url(#bodyClip)" stroke="#2e3436" stroke-width="2" stroke-linecap="round" fill="none" opacity="0.85">
+    <path d="M 38,22 L 52,14"/>
+    <path d="M 38,30 L 52,22"/>
+    <path d="M 38,38 L 52,30"/>
+    <path d="M 38,46 L 52,38"/>
+  </g>
+  <!-- inner gloss highlight on the left edge -->
+  <path d="M 41.5,12 L 41.5,43" fill="none" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" opacity="0.8"/>
+  <!-- top face ellipse (reads as a round cutter) -->
+  <ellipse cx="45" cy="10" rx="5" ry="2"
+           style="fill:url(#topGrad);stroke:#2e3436;stroke-width:2"/>
+</svg>

--- a/src/Mod/CAM/Gui/Resources/panels/FeedsSpeedsPresetEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/FeedsSpeedsPresetEdit.ui
@@ -76,18 +76,15 @@
       </widget>
      </item>
      <item row="3" column="1">
-      <widget class="Gui::QuantitySpinBox" name="surfaceSpeedSpin">
+      <widget class="QDoubleSpinBox" name="surfaceSpeedSpin">
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
-       <property name="minimum">
-        <double>0.000000000000000</double>
+       <property name="decimals">
+        <number>1</number>
        </property>
        <property name="maximum">
-        <double>9999999.000000000000000</double>
-       </property>
-       <property name="unit" stdset="0">
-        <string notr="true">mm/s</string>
+        <double>100000.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/src/Mod/CAM/Gui/Resources/panels/FeedsSpeedsPresetEdit.ui
+++ b/src/Mod/CAM/Gui/Resources/panels/FeedsSpeedsPresetEdit.ui
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FeedsSpeedsPresetEdit</class>
+ <widget class="QDialog" name="FeedsSpeedsPresetEdit">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>420</width>
+    <height>420</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Edit preset</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QFormLayout" name="formLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelName">
+       <property name="text">
+        <string>Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="nameEdit"/>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelMaterial">
+       <property name="text">
+        <string>Material:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="materialRow">
+       <item>
+        <widget class="QLabel" name="materialLabel">
+         <property name="text">
+          <string>(none)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="browseButton">
+         <property name="text">
+          <string>Browse…</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="genericCheck">
+         <property name="text">
+          <string>Generic (any material)</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="labelOpType">
+       <property name="text">
+        <string>Op type:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="opTypeCombo"/>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="labelSurfaceSpeed">
+       <property name="text">
+        <string>Surface speed:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="Gui::QuantitySpinBox" name="surfaceSpeedSpin">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm/s</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="labelChipload">
+       <property name="text">
+        <string>Chipload (per tooth):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="Gui::QuantitySpinBox" name="chiploadSpin">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="unit" stdset="0">
+        <string notr="true">mm</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="labelVertRatio">
+       <property name="text">
+        <string>Vert feed ratio:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QDoubleSpinBox" name="vertRatioSpin">
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.050000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.330000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="rawBox">
+     <property name="title">
+      <string>Direct feed and speed</string>
+     </property>
+     <layout class="QFormLayout" name="rawForm">
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelRawFeed">
+        <property name="text">
+         <string>Horiz feed:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="Gui::QuantitySpinBox" name="rawFeedSpin">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>9999999.000000000000000</double>
+        </property>
+        <property name="unit" stdset="0">
+         <string notr="true">mm/s</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="labelRawSpeed">
+        <property name="text">
+         <string>Spindle speed:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="rawSpeedSpin">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="decimals">
+         <number>0</number>
+        </property>
+        <property name="maximum">
+         <double>200000.000000000000000</double>
+        </property>
+        <property name="suffix">
+         <string notr="true"> rpm</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="geometryHint">
+     <property name="text">
+      <string>Tool diameter and/or flute count missing — surface speed and chipload won't auto-sync with direct feed/speed.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: #888;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::QuantitySpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>Gui/QuantitySpinBox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>nameEdit</tabstop>
+  <tabstop>browseButton</tabstop>
+  <tabstop>genericCheck</tabstop>
+  <tabstop>opTypeCombo</tabstop>
+  <tabstop>surfaceSpeedSpin</tabstop>
+  <tabstop>chiploadSpin</tabstop>
+  <tabstop>vertRatioSpin</tabstop>
+  <tabstop>rawFeedSpin</tabstop>
+  <tabstop>rawSpeedSpin</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>FeedsSpeedsPresetEdit</receiver>
+   <slot>accept()</slot>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>FeedsSpeedsPresetEdit</receiver>
+   <slot>reject()</slot>
+  </connection>
+ </connections>
+</ui>

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/__init__.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/__init__.py
@@ -22,6 +22,7 @@
 from .resolver import resolve, default_providers
 from .types import (
     FeedSpeedResult,
+    MachineContext,
     MaterialContext,
     OpContext,
     PartialResult,
@@ -38,6 +39,7 @@ from .presets import (
 
 __all__ = (
     "FeedSpeedResult",
+    "MachineContext",
     "MaterialContext",
     "OpContext",
     "OP_TYPES",

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/__init__.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/__init__.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+from .resolver import resolve, default_providers
+from .types import (
+    FeedSpeedResult,
+    MaterialContext,
+    OpContext,
+    PartialResult,
+    ToolContext,
+    OP_TYPES,
+)
+from .presets import (
+    PRESETS_PROPERTY,
+    derive_preset_label,
+    get_presets,
+    make_preset,
+    set_presets,
+)
+
+__all__ = (
+    "FeedSpeedResult",
+    "MaterialContext",
+    "OpContext",
+    "OP_TYPES",
+    "PartialResult",
+    "PRESETS_PROPERTY",
+    "ToolContext",
+    "default_providers",
+    "derive_preset_label",
+    "get_presets",
+    "make_preset",
+    "resolve",
+    "set_presets",
+)

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/presets.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/presets.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+ToolBit preset accessors.
+
+Presets live on the ToolBit's FreeCAD doc object as an ``App::PropertyString``
+named ``Presets`` containing a JSON-encoded list. The property is lazy-added:
+existing tools open unchanged; the property only appears on first save.
+
+**Scope.** ``set_presets`` writes to the doc-object property only. It does
+*not* write back to the library asset. Two reasons:
+
+1. Library tools are shared state. Vendor packs, multi-user network
+   libraries, and read-only stores all break under silent in-job
+   mutation. The Job's "Assign Stock Material" follows the same rule —
+   it mutates the job's stock, not the source ``.FCMat``.
+2. Users have two distinct mental modes: *curating the library* (explicit,
+   library-editor flow) and *adjusting tools for this job* (local). Silently
+   coupling them violates that distinction.
+
+Consequences:
+
+- Presets edited in a Job persist with the FCStd, not the library.
+- A preset created in Job A is *not* visible to a freshly-opened Job B
+  that pulls the same tool from the library.
+- To promote a preset into the library, the user opens the tool from
+  the library browser; its Presets tab edits the same Presets property,
+  and the library write happens when the editor is accepted (the asset
+  manager re-serializes the tool via ``to_dict``, which includes
+  presets).
+
+Preset record schema:
+
+    {
+        "name": str | None,                    # user-given label, optional
+        "material_hint": {"uuid": str, "name": str} | None,
+        "op_type_hint": str | None,            # one of types.OP_TYPES
+        "surface_speed": float | None,         # m/min  (a.k.a. cutting speed Vc)
+        "chipload": float | None,              # mm/tooth
+        "vert_feed_ratio": float,              # default 0.33
+    }
+
+Storage is engineering-only — surface_speed + chipload + the vertical-feed
+ratio. Raw feed (mm/min) and raw spindle speed (rpm) are computed from
+those plus the tool's geometry (diameter, flutes) at the moment they're
+needed (display, application). They are not persisted: storing them
+would be redundant when geometry is known and incoherent if the tool's
+geometry later changes.
+"""
+
+import json
+from typing import List, Optional
+
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+PRESETS_PROPERTY = "Presets"
+PRESETS_GROUP = "Feeds & Speeds"
+
+
+def get_presets(obj) -> List[dict]:
+    raw = getattr(obj, PRESETS_PROPERTY, "") if obj is not None else ""
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def set_presets(obj, presets: List[dict]) -> None:
+    """
+    Lazy-add the ``Presets`` property if absent, then store the JSON-encoded
+    list. Writes to the doc-object property only; never touches the library
+    asset (see module docstring for rationale).
+    """
+    if presets is None:
+        raise TypeError("presets must be a list, got None")
+    if not hasattr(obj, PRESETS_PROPERTY):
+        obj.addProperty(
+            "App::PropertyString",
+            PRESETS_PROPERTY,
+            PRESETS_GROUP,
+            QT_TRANSLATE_NOOP("App::Property", "JSON-encoded list of feeds & speeds presets"),
+        )
+    obj.Presets = json.dumps(presets, sort_keys=True)
+
+
+def make_preset(
+    name: Optional[str] = None,
+    material_uuid=None,
+    material_name=None,
+    op_type=None,
+    surface_speed=None,
+    chipload=None,
+    vert_feed_ratio=0.33,
+) -> dict:
+    """
+    Build a well-formed preset record. ``material_hint`` is ``None`` if both
+    UUID and name are ``None``. ``name`` is the user-given label and is
+    optional. ``surface_speed`` is the cutting speed in m/min (also known
+    as Vc; "SFM" in imperial).
+    """
+    if material_uuid is None and material_name is None:
+        material_hint = None
+    else:
+        material_hint = {"uuid": material_uuid, "name": material_name}
+    return {
+        "name": name,
+        "material_hint": material_hint,
+        "op_type_hint": op_type,
+        "surface_speed": surface_speed,
+        "chipload": chipload,
+        "vert_feed_ratio": vert_feed_ratio,
+    }
+
+
+def derive_preset_label(preset: dict, fallback: str = "(unnamed)") -> str:
+    """
+    Compute a human-readable label for a preset. Prefers the user-given
+    ``name`` field, falls back to a ``material/op`` summary, then to the
+    fallback string.
+    """
+    n = preset.get("name")
+    if n:
+        return n
+    hint = preset.get("material_hint")
+    mat = (hint.get("name") or hint.get("uuid") or "any") if isinstance(hint, dict) else "any"
+    op = preset.get("op_type_hint") or "any"
+    if mat == "any" and op == "any":
+        return fallback
+    return f"{mat} / {op}"

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/providers.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/providers.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Provider implementations for the FeedsSpeeds resolver chain.
+
+Phase 1 PoC ships ``ToolPresetProvider`` and ``ToolDefaultsProvider``.
+Additional providers (``RuleRegistryProvider``,
+``MaterialMachinabilityProvider``, ``FormulaProvider``) will be added in
+Phase 2.
+"""
+
+import math
+from typing import Optional, Tuple
+
+from .types import (
+    MaterialContext,
+    OpContext,
+    PartialResult,
+    ToolContext,
+    normalize_material_name,
+)
+
+
+def _score_preset(
+    preset: dict,
+    material: MaterialContext,
+    op: OpContext,
+) -> Optional[float]:
+    """
+    Returns a confidence score in (0, 1] for a preset against the request,
+    or None if the preset does not match.
+
+    Scoring:
+      - material UUID exact match contributes 0.55, name fallback 0.45,
+        material_hint=None contributes 0.15 (generic).
+      - op_type exact match contributes 0.4, op_type hint=None
+        contributes 0.15 (generic).
+      - Mismatch in any specified hint = no match.
+    """
+    score = 0.0
+    hint = preset.get("material_hint")
+    if hint is None:
+        score += 0.15
+    else:
+        hint_uuid = hint.get("uuid") if isinstance(hint, dict) else None
+        hint_name = hint.get("name") if isinstance(hint, dict) else None
+        if hint_uuid and material.uuid and hint_uuid == material.uuid:
+            score += 0.55
+        elif (
+            hint_name
+            and material.name
+            and normalize_material_name(hint_name) == normalize_material_name(material.name)
+        ):
+            score += 0.45
+        else:
+            return None
+
+    op_hint = preset.get("op_type_hint")
+    if op_hint is None:
+        score += 0.15
+    elif op.op_type and op_hint == op.op_type:
+        score += 0.40
+    else:
+        return None
+
+    return min(score, 1.0)
+
+
+def _derive_from_engineering(
+    surface_speed: Optional[float],
+    chipload: Optional[float],
+    vert_feed_ratio: float,
+    diameter_mm: float,
+    flutes: Optional[int],
+) -> Tuple[Optional[float], Optional[float], Optional[float], Tuple[str, ...]]:
+    """
+    From surface speed (m/min), chipload (mm/tooth), and tool geometry,
+    derive spindle speed (rpm), horiz feed (mm/min) and vert feed (mm/min).
+
+    Returns (spindle_speed, horiz_feed, vert_feed, warnings).
+    Any field will be None if its inputs are missing.
+    """
+    warnings = []
+    spindle = None
+    horiz = None
+    vert = None
+
+    if surface_speed is not None and diameter_mm > 0:
+        # rpm = (surface_speed in m/min * 1000) / (pi * d_mm)
+        spindle = (surface_speed * 1000.0) / (math.pi * diameter_mm)
+
+    if spindle is not None and chipload is not None:
+        if flutes is None or flutes <= 0:
+            warnings.append("Flute count unknown; using 1 for feed derivation.")
+            f = 1
+        else:
+            f = flutes
+        horiz = spindle * f * chipload
+        vert = horiz * vert_feed_ratio
+
+    return spindle, horiz, vert, tuple(warnings)
+
+
+class ToolPresetProvider:
+    """
+    Reads presets stored on the ToolBit and produces a PartialResult from
+    the best-matching preset.
+    """
+
+    name = "tool_preset"
+
+    def suggest(
+        self,
+        tool: ToolContext,
+        material: MaterialContext,
+        op: OpContext,
+    ) -> Optional[PartialResult]:
+        if not tool.presets:
+            return None
+
+        best: Optional[Tuple[float, dict]] = None
+        for preset in tool.presets:
+            score = _score_preset(preset, material, op)
+            if score is None:
+                continue
+            if best is None or score > best[0]:
+                best = (score, preset)
+
+        if best is None:
+            return None
+
+        score, preset = best
+        surface_speed = preset.get("surface_speed")
+        chipload = preset.get("chipload")
+        vert_ratio = preset.get("vert_feed_ratio", 0.33)
+
+        warnings = []
+        spindle = horiz = vert = None
+
+        if surface_speed is not None or chipload is not None:
+            spindle, horiz, vert, derive_warnings = _derive_from_engineering(
+                surface_speed, chipload, vert_ratio, tool.diameter, tool.flutes
+            )
+            warnings.extend(derive_warnings)
+
+        if surface_speed is not None and chipload is None:
+            warnings.append(
+                "Preset provides surface_speed but no chipload; " "feed rates could not be derived."
+            )
+        elif surface_speed is None and chipload is None:
+            warnings.append("Preset has no usable surface_speed or chipload values.")
+
+        # Build provenance source URI
+        mh = preset.get("material_hint")
+        m_part = (
+            (mh.get("uuid") or normalize_material_name(mh.get("name")) or "any")
+            if isinstance(mh, dict)
+            else "any"
+        )
+        op_part = preset.get("op_type_hint") or "any"
+        source = f"preset:tool/{m_part}/{op_part}"
+
+        return PartialResult(
+            horiz_feed=horiz,
+            vert_feed=vert,
+            spindle_speed=spindle,
+            chipload=chipload,
+            surface_speed=surface_speed,
+            source=source,
+            confidence=score,
+            warnings=tuple(warnings),
+        )
+
+
+class ToolDefaultsProvider:
+    """
+    Reads the legacy single-value ``ToolBit.Chipload`` property as a
+    low-confidence fallback. Contributes only to ``chipload``; surface
+    speed and feed/spindle derivation come from higher-priority providers
+    (or, in Phase 2, from ``MaterialMachinabilityProvider`` looking up the
+    workpiece's SurfaceSpeed by tool-material enum).
+
+    Confidence is fixed and low (0.10) so any matching preset always wins.
+    Returns ``None`` if no chipload default is set on the tool.
+    """
+
+    name = "tool_defaults"
+
+    def suggest(
+        self,
+        tool: ToolContext,
+        material: MaterialContext,
+        op: OpContext,
+    ) -> Optional[PartialResult]:
+        if tool.chipload_default is None or tool.chipload_default <= 0:
+            return None
+        return PartialResult(
+            chipload=tool.chipload_default,
+            source="tool_defaults:chipload",
+            confidence=0.10,
+            warnings=(
+                "Using tool's default Chipload property; no per-material/op preset matched.",
+            ),
+        )

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/providers.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/providers.py
@@ -22,10 +22,20 @@
 """
 Provider implementations for the FeedsSpeeds resolver chain.
 
-Phase 1 PoC ships ``ToolPresetProvider`` and ``ToolDefaultsProvider``.
-Additional providers (``RuleRegistryProvider``,
-``MaterialMachinabilityProvider``, ``FormulaProvider``) will be added in
-Phase 2.
+Three providers ship today, walked in this order:
+
+1. ``ToolPresetProvider`` — best-matching curated preset on the toolbit.
+   High confidence; produces a full set (surface_speed, chipload, derived
+   spindle/feed).
+2. ``MachinabilityProvider`` — reads the stock material's Machinability
+   model, picks the HSS or Carbide branch by the toolbit's ``Material``,
+   contributes ``surface_speed`` only. Moderate confidence.
+3. ``ToolDefaultsProvider`` — the single ``ToolBit.Chipload`` property,
+   contributing ``chipload`` only. Low confidence, last-resort fallback.
+
+Because the resolver's merge step fills None fields from later providers,
+a Machinability surface speed + a default-chipload chipload combine into
+a full feed/spindle derivation when no preset matches.
 """
 
 import math
@@ -191,13 +201,60 @@ class ToolPresetProvider:
         )
 
 
+class MachinabilityProvider:
+    """
+    Reads the stock material's Machinability model (surface speed for HSS
+    vs Carbide) and contributes a surface_speed only. Picks the branch by
+    the toolbit's ``Material`` property (HSS or Carbide).
+
+    Abstains when:
+      - the toolbit has no ``Material`` set (``tool.tool_material is None``)
+      - the toolbit's ``Material`` is neither ``"HSS"`` nor ``"Carbide"``
+      - the picked branch's surface speed is not present on the material
+        (e.g., HSS tool but material carries only ``SurfaceSpeedCarbide``)
+
+    Confidence is fixed at 0.35: well above ``ToolDefaultsProvider`` (0.10),
+    well below a curated preset (>=~0.55).
+
+    Spindle and feed are *not* derived here. The resolver's merge step
+    combines this provider's ``surface_speed`` with chipload from a later
+    provider (``ToolDefaultsProvider``); the dialog/apply path is
+    responsible for re-running derivation once chipload is in hand.
+    """
+
+    name = "machinability"
+
+    def suggest(
+        self,
+        tool: ToolContext,
+        material: MaterialContext,
+        op: OpContext,
+    ) -> Optional[PartialResult]:
+        tm = tool.tool_material
+        if tm == "HSS":
+            ss = material.surface_speed_hss
+        elif tm == "Carbide":
+            ss = material.surface_speed_carbide
+        else:
+            return None
+        if ss is None or ss <= 0:
+            return None
+
+        m_part = material.uuid or normalize_material_name(material.name) or "any"
+        return PartialResult(
+            surface_speed=ss,
+            source=f"machinability:{m_part}/{tm.lower()}",
+            confidence=0.35,
+            warnings=(),
+        )
+
+
 class ToolDefaultsProvider:
     """
-    Reads the legacy single-value ``ToolBit.Chipload`` property as a
-    low-confidence fallback. Contributes only to ``chipload``; surface
-    speed and feed/spindle derivation come from higher-priority providers
-    (or, in Phase 2, from ``MaterialMachinabilityProvider`` looking up the
-    workpiece's SurfaceSpeed by tool-material enum).
+    Reads the single ``ToolBit.Chipload`` property as a low-confidence
+    fallback. Contributes only ``chipload``; surface speed comes from
+    higher-priority providers (``ToolPresetProvider`` or
+    ``MachinabilityProvider``).
 
     Confidence is fixed and low (0.10) so any matching preset always wins.
     Returns ``None`` if no chipload default is set on the tool.

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/resolver.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/resolver.py
@@ -30,9 +30,15 @@ objects via small adapter functions.
 
 from typing import List, Optional, Sequence
 
-from .providers import ToolDefaultsProvider, ToolPresetProvider
+from .providers import (
+    MachinabilityProvider,
+    ToolDefaultsProvider,
+    ToolPresetProvider,
+    _derive_from_engineering,
+)
 from .types import (
     FeedSpeedResult,
+    MachineContext,
     MaterialContext,
     OpContext,
     PartialResult,
@@ -42,15 +48,14 @@ from .types import (
 
 def default_providers() -> Sequence:
     """
-    Phase 1 PoC priority chain:
+    Provider priority chain (first wins per field):
       1. ToolPresetProvider — best-match named preset (high confidence).
-      2. ToolDefaultsProvider — single ``ToolBit.Chipload`` fallback
+      2. MachinabilityProvider — stock-material Machinability model,
+         surface_speed only (moderate confidence).
+      3. ToolDefaultsProvider — single ``ToolBit.Chipload`` fallback
          (low confidence, contributes chipload only).
-
-    Phase 2 will insert rule-registry, material-machinability, and
-    formula providers above ToolDefaultsProvider.
     """
-    return (ToolPresetProvider(), ToolDefaultsProvider())
+    return (ToolPresetProvider(), MachinabilityProvider(), ToolDefaultsProvider())
 
 
 def _merge(base: PartialResult, addition: PartialResult) -> PartialResult:
@@ -79,6 +84,7 @@ def resolve(
     tool: ToolContext,
     material: MaterialContext,
     op: OpContext,
+    machine: Optional[MachineContext] = None,
     providers: Optional[Sequence] = None,
 ) -> FeedSpeedResult:
     """
@@ -87,6 +93,13 @@ def resolve(
     Returns a FeedSpeedResult with empty fields and source="" when no
     provider produced a result. Callers should treat that as "no
     suggestion available" and not write any TC values.
+
+    When ``machine`` is provided and the derived spindle falls outside
+    ``[min_rpm, max_rpm]``, the spindle is clamped, horiz/vert feeds are
+    scaled by the same ratio (chipload preserved), and a warning is
+    emitted. ``surface_speed`` is left at the recommended value so the
+    user can see the discrepancy between intended cutting speed and the
+    machine-limited reality.
     """
     chain = providers if providers is not None else default_providers()
 
@@ -100,13 +113,66 @@ def resolve(
     if accumulated is None:
         return FeedSpeedResult(source="", confidence=0.0, warnings=())
 
+    # Finalization: when providers contributed engineering values
+    # (surface_speed, chipload) but no raw rpm/feed — typically the
+    # MachinabilityProvider + ToolDefaultsProvider combination — derive
+    # them once from tool geometry. Uses a default vert_feed_ratio of
+    # 0.33; preset-driven runs already filled these fields using the
+    # preset's own ratio and won't be touched here.
+    spindle = accumulated.spindle_speed
+    horiz = accumulated.horiz_feed
+    vert = accumulated.vert_feed
+    warnings = list(accumulated.warnings)
+    if (spindle is None or horiz is None) and (
+        accumulated.surface_speed is not None or accumulated.chipload is not None
+    ):
+        d_spindle, d_horiz, d_vert, d_warnings = _derive_from_engineering(
+            accumulated.surface_speed,
+            accumulated.chipload,
+            0.33,
+            tool.diameter,
+            tool.flutes,
+        )
+        if spindle is None:
+            spindle = d_spindle
+        if horiz is None:
+            horiz = d_horiz
+        if vert is None:
+            vert = d_vert
+        for w in d_warnings:
+            if w not in warnings:
+                warnings.append(w)
+
+    # Machine clamping: spindle out of [min_rpm, max_rpm] gets pulled to
+    # the limit; feeds scale by the same ratio so chipload per tooth stays
+    # constant. surface_speed is left at the recommended value.
+    if spindle is not None and spindle > 0 and machine is not None:
+        clamped = None
+        if machine.max_rpm > 0 and spindle > machine.max_rpm:
+            clamped = machine.max_rpm
+            warnings.append(
+                f"Spindle clamped from {spindle:.0f} to machine max {machine.max_rpm:.0f} rpm."
+            )
+        elif machine.min_rpm > 0 and spindle < machine.min_rpm:
+            clamped = machine.min_rpm
+            warnings.append(
+                f"Spindle clamped from {spindle:.0f} up to machine min {machine.min_rpm:.0f} rpm."
+            )
+        if clamped is not None:
+            ratio = clamped / spindle
+            spindle = clamped
+            if horiz is not None:
+                horiz *= ratio
+            if vert is not None:
+                vert *= ratio
+
     return FeedSpeedResult(
-        horiz_feed=accumulated.horiz_feed,
-        vert_feed=accumulated.vert_feed,
-        spindle_speed=accumulated.spindle_speed,
+        horiz_feed=horiz,
+        vert_feed=vert,
+        spindle_speed=spindle,
         chipload=accumulated.chipload,
         surface_speed=accumulated.surface_speed,
         source=accumulated.source,
         confidence=accumulated.confidence,
-        warnings=tuple(accumulated.warnings),
+        warnings=tuple(warnings),
     )

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/resolver.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/resolver.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+FeedSpeedResolver.
+
+Pure entrypoint that walks a chain of providers and merges their PartialResult
+contributions into a final FeedSpeedResult. The resolver is GUI-independent
+and FreeCAD-Document-independent: callers build the input contexts from doc
+objects via small adapter functions.
+"""
+
+from typing import List, Optional, Sequence
+
+from .providers import ToolDefaultsProvider, ToolPresetProvider
+from .types import (
+    FeedSpeedResult,
+    MaterialContext,
+    OpContext,
+    PartialResult,
+    ToolContext,
+)
+
+
+def default_providers() -> Sequence:
+    """
+    Phase 1 PoC priority chain:
+      1. ToolPresetProvider — best-match named preset (high confidence).
+      2. ToolDefaultsProvider — single ``ToolBit.Chipload`` fallback
+         (low confidence, contributes chipload only).
+
+    Phase 2 will insert rule-registry, material-machinability, and
+    formula providers above ToolDefaultsProvider.
+    """
+    return (ToolPresetProvider(), ToolDefaultsProvider())
+
+
+def _merge(base: PartialResult, addition: PartialResult) -> PartialResult:
+    """
+    Fill any None field in ``base`` from ``addition``. Higher-priority
+    providers come first; later providers only contribute fields that
+    haven't been set yet.
+    """
+    return PartialResult(
+        horiz_feed=base.horiz_feed if base.horiz_feed is not None else addition.horiz_feed,
+        vert_feed=base.vert_feed if base.vert_feed is not None else addition.vert_feed,
+        spindle_speed=(
+            base.spindle_speed if base.spindle_speed is not None else addition.spindle_speed
+        ),
+        chipload=base.chipload if base.chipload is not None else addition.chipload,
+        surface_speed=(
+            base.surface_speed if base.surface_speed is not None else addition.surface_speed
+        ),
+        source=base.source if base.source is not None else addition.source,
+        confidence=base.confidence if base.confidence is not None else addition.confidence,
+        warnings=tuple(base.warnings) + tuple(addition.warnings),
+    )
+
+
+def resolve(
+    tool: ToolContext,
+    material: MaterialContext,
+    op: OpContext,
+    providers: Optional[Sequence] = None,
+) -> FeedSpeedResult:
+    """
+    Walk the provider chain and produce a FeedSpeedResult.
+
+    Returns a FeedSpeedResult with empty fields and source="" when no
+    provider produced a result. Callers should treat that as "no
+    suggestion available" and not write any TC values.
+    """
+    chain = providers if providers is not None else default_providers()
+
+    accumulated: Optional[PartialResult] = None
+    for provider in chain:
+        partial = provider.suggest(tool, material, op)
+        if partial is None:
+            continue
+        accumulated = partial if accumulated is None else _merge(accumulated, partial)
+
+    if accumulated is None:
+        return FeedSpeedResult(source="", confidence=0.0, warnings=())
+
+    return FeedSpeedResult(
+        horiz_feed=accumulated.horiz_feed,
+        vert_feed=accumulated.vert_feed,
+        spindle_speed=accumulated.spindle_speed,
+        chipload=accumulated.chipload,
+        surface_speed=accumulated.surface_speed,
+        source=accumulated.source,
+        confidence=accumulated.confidence,
+        warnings=tuple(accumulated.warnings),
+    )

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/types.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/types.py
@@ -48,7 +48,11 @@ class ToolContext:
     flutes: Optional[int]
     presets: Tuple[dict, ...]
     shape_id: str
-    material_enum: Optional[str] = None
+    # The ToolBit's ``Material`` enumeration value, typically "HSS" or
+    # "Carbide". Used by ``MachinabilityProvider`` to pick the correct
+    # surface-speed branch from the stock material's Machinability model.
+    # None when the toolbit has no Material property set.
+    tool_material: Optional[str] = None
     # The single "default chipload" value stored directly on the ToolBit
     # (App::PropertyLength "Chipload"). Read as a low-confidence fallback
     # by ToolDefaultsProvider when no preset matches. mm/tooth, or None
@@ -60,11 +64,29 @@ class ToolContext:
 class MaterialContext:
     uuid: Optional[str] = None
     name: Optional[str] = None
+    # Machinability surface speeds (m/min) pre-extracted from the stock
+    # material's PhysicalProperties by the adapter. Either may be None if
+    # the material does not carry that branch of the Machinability model.
+    surface_speed_hss: Optional[float] = None
+    surface_speed_carbide: Optional[float] = None
 
 
 @dataclass(frozen=True)
 class OpContext:
     op_type: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class MachineContext:
+    """
+    Machine limits used by the resolver's finalization to clamp the
+    suggested spindle. ``0.0`` for either bound means "no limit known"
+    (matches the Machine model's default) and disables that side of the
+    clamp.
+    """
+
+    min_rpm: float = 0.0
+    max_rpm: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/src/Mod/CAM/Path/Tool/FeedsSpeeds/types.py
+++ b/src/Mod/CAM/Path/Tool/FeedsSpeeds/types.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Pure data types for the FeedsSpeeds resolver.
+
+This module is intentionally free of FreeCAD imports so the resolver and its
+tests can be exercised outside a running FreeCAD process.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+# Op-type vocabulary. Additive-only: adding values is free, renaming or
+# removing values is a migration. ``OpContext.op_type=None`` (and a
+# preset's ``op_type_hint=None``) means "generic, matches any op."
+OP_TYPES = (
+    "profile",
+    "pocket",
+    "slot",
+    "drill",
+    "adaptive",
+    "surface_finish",
+)
+
+
+@dataclass(frozen=True)
+class ToolContext:
+    diameter: float
+    flutes: Optional[int]
+    presets: Tuple[dict, ...]
+    shape_id: str
+    material_enum: Optional[str] = None
+    # The single "default chipload" value stored directly on the ToolBit
+    # (App::PropertyLength "Chipload"). Read as a low-confidence fallback
+    # by ToolDefaultsProvider when no preset matches. mm/tooth, or None
+    # if the tool has no Chipload property or it is zero.
+    chipload_default: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class MaterialContext:
+    uuid: Optional[str] = None
+    name: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class OpContext:
+    op_type: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class FeedSpeedResult:
+    horiz_feed: Optional[float] = None
+    vert_feed: Optional[float] = None
+    spindle_speed: Optional[float] = None
+    chipload: Optional[float] = None
+    surface_speed: Optional[float] = None  # m/min
+    source: str = ""
+    confidence: float = 0.0
+    warnings: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PartialResult:
+    """A provider's contribution to a resolution. None fields are unfilled."""
+
+    horiz_feed: Optional[float] = None
+    vert_feed: Optional[float] = None
+    spindle_speed: Optional[float] = None
+    chipload: Optional[float] = None
+    surface_speed: Optional[float] = None  # m/min
+    source: str = ""
+    confidence: float = 0.0
+    warnings: Tuple[str, ...] = ()
+
+
+def normalize_material_name(name: Optional[str]) -> Optional[str]:
+    if name is None:
+        return None
+    return name.strip().casefold()

--- a/src/Mod/CAM/Path/Tool/Gui/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Gui/Controller.py
@@ -231,7 +231,38 @@ class ToolControllerEditor(object):
         self.controller.spindleDirection.installEventFilter(self.blockScrollWheel)
         self.controller.tcNumber.setReadOnly(disableToolNumber)
 
+        self._injectFeedsSpeedsButton()
+
         self.editor = None
+
+    def _injectFeedsSpeedsButton(self):
+        from PySide import QtWidgets
+
+        self.feedsSpeedsButton = None
+        layout = self.controller.layout()
+        if layout is None:
+            return
+        row = QtWidgets.QHBoxLayout()
+        row.addStretch()
+        self.feedsSpeedsButton = QtWidgets.QPushButton(translate("CAM_ToolController", "F&&S…"))
+        self.feedsSpeedsButton.setToolTip(
+            translate(
+                "CAM_ToolController",
+                "Suggest feeds and speeds for this tool controller",
+            )
+        )
+        self.feedsSpeedsButton.clicked.connect(self._onFeedsSpeedsClicked)
+        row.addWidget(self.feedsSpeedsButton)
+        layout.addLayout(row)
+
+    def _onFeedsSpeedsClicked(self):
+        from Path.Tool.Gui.FeedsSpeedsDialog import open_for
+
+        open_for(self.obj, parent=self.form)
+        # The F&S dialog may have written HorizFeed/VertFeed/SpindleSpeed
+        # directly to the TC. Re-sync the editor's spinboxes from the
+        # underlying property values so the user sees the new numbers.
+        self.updateUi()
 
     def selectInComboBox(self, name, combo):
         """selectInComboBox(name, combo) ...

--- a/src/Mod/CAM/Path/Tool/Gui/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Gui/Controller.py
@@ -236,7 +236,7 @@ class ToolControllerEditor(object):
         self.editor = None
 
     def _injectFeedsSpeedsButton(self):
-        from PySide import QtWidgets
+        from PySide import QtCore, QtGui, QtWidgets
 
         self.feedsSpeedsButton = None
         layout = self.controller.layout()
@@ -244,12 +244,11 @@ class ToolControllerEditor(object):
             return
         row = QtWidgets.QHBoxLayout()
         row.addStretch()
-        self.feedsSpeedsButton = QtWidgets.QPushButton(translate("CAM_ToolController", "F&&S…"))
+        self.feedsSpeedsButton = QtWidgets.QPushButton()
+        self.feedsSpeedsButton.setIcon(QtGui.QIcon(":/icons/CAM_FeedsSpeeds.svg"))
+        self.feedsSpeedsButton.setIconSize(QtCore.QSize(24, 24))
         self.feedsSpeedsButton.setToolTip(
-            translate(
-                "CAM_ToolController",
-                "Suggest feeds and speeds for this tool controller",
-            )
+            translate("CAM_ToolController", "Feeds and Speeds Wizard")
         )
         self.feedsSpeedsButton.clicked.connect(self._onFeedsSpeedsClicked)
         row.addWidget(self.feedsSpeedsButton)

--- a/src/Mod/CAM/Path/Tool/Gui/FeedsSpeedsDialog.py
+++ b/src/Mod/CAM/Path/Tool/Gui/FeedsSpeedsDialog.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Suggest Feeds & Speeds dialog and supporting adapters.
+
+Adapters convert FreeCAD doc objects into the resolver's frozen dataclass
+contexts. The dialog shows current vs. suggested values side by side, lets
+the user override the op-type combo for this resolution, and lets the user
+pick a specific named preset from the tool to apply directly.
+
+Presets are read-only in this dialog by design: creating and editing
+presets is library curation, done in the ToolBit editor's Presets tab in
+the library browser. Job-side flows only consume presets.
+"""
+
+from typing import Optional, Tuple
+
+import FreeCAD
+import FreeCADGui
+from PySide import QtCore, QtGui, QtWidgets
+from PySide.QtCore import QT_TRANSLATE_NOOP
+
+import Path
+from Path.Tool.FeedsSpeeds import (
+    FeedSpeedResult,
+    MaterialContext,
+    OP_TYPES,
+    OpContext,
+    ToolContext,
+    derive_preset_label,
+    get_presets,
+    resolve,
+)
+from Path.Tool.FeedsSpeeds.providers import _derive_from_engineering
+
+translate = FreeCAD.Qt.translate
+
+
+# Lazy-added TC properties (added on first dialog open).
+TC_OP_TYPE_HINT = "OpTypeHint"
+TC_PROVENANCE = "FeedSpeedProvenance"
+TC_PROPERTY_GROUP = "Feeds & Speeds"
+
+
+def ensure_tc_properties(tc) -> None:
+    """Lazy-add OpTypeHint and FeedSpeedProvenance to the TC if absent."""
+    if not hasattr(tc, TC_OP_TYPE_HINT):
+        tc.addProperty(
+            "App::PropertyEnumeration",
+            TC_OP_TYPE_HINT,
+            TC_PROPERTY_GROUP,
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Hint indicating which op category this TC is intended for",
+            ),
+        )
+        tc.OpTypeHint = [""] + list(OP_TYPES)
+        tc.OpTypeHint = ""
+    if not hasattr(tc, TC_PROVENANCE):
+        tc.addProperty(
+            "App::PropertyMap",
+            TC_PROVENANCE,
+            TC_PROPERTY_GROUP,
+            QT_TRANSLATE_NOOP(
+                "App::Property",
+                "Per-field provenance: which source set HorizFeed/VertFeed/SpindleSpeed",
+            ),
+        )
+        tc.FeedSpeedProvenance = {}
+
+
+def _toolbit_from_tc(tc):
+    """
+    Returns the underlying ToolBit doc object for this TC, or None.
+    """
+    tool = getattr(tc, "Tool", None)
+    return tool
+
+
+def adapt_toolbit(tc) -> ToolContext:
+    """Build a ToolContext from a TC's ToolBit doc object."""
+    tb = _toolbit_from_tc(tc)
+    diameter = 0.0
+    flutes: Optional[int] = None
+    presets: Tuple[dict, ...] = ()
+    shape_id = ""
+    material_enum: Optional[str] = None
+    chipload_default: Optional[float] = None
+
+    if tb is not None:
+        try:
+            diameter_q = getattr(tb, "Diameter", None)
+            if diameter_q is not None:
+                diameter = (
+                    float(diameter_q.Value) if hasattr(diameter_q, "Value") else float(diameter_q)
+                )
+        except (AttributeError, TypeError, ValueError):
+            diameter = 0.0
+        try:
+            f = getattr(tb, "Flutes", None)
+            flutes = int(f) if f is not None else None
+        except (TypeError, ValueError):
+            flutes = None
+        presets = tuple(get_presets(tb))
+        shape_id = getattr(tb, "ShapeID", "") or ""
+        material_enum = getattr(tb, "Material", None)
+        try:
+            chipload_q = getattr(tb, "Chipload", None)
+            if chipload_q is not None:
+                v = float(chipload_q.Value) if hasattr(chipload_q, "Value") else float(chipload_q)
+                chipload_default = v if v > 0 else None
+        except (AttributeError, TypeError, ValueError):
+            chipload_default = None
+
+    return ToolContext(
+        diameter=diameter,
+        flutes=flutes,
+        presets=presets,
+        shape_id=shape_id,
+        material_enum=material_enum,
+        chipload_default=chipload_default,
+    )
+
+
+def adapt_material_from_job(job) -> MaterialContext:
+    """
+    Pull the material context from a Job's Stock.ShapeMaterial.
+
+    Returns an empty MaterialContext (uuid=None, name=None) when the job has
+    no stock material assigned, which is treated as "any material" by the
+    resolver.
+    """
+    if job is None:
+        return MaterialContext()
+    stock = getattr(job, "Stock", None)
+    if stock is None:
+        return MaterialContext()
+    shape_material = getattr(stock, "ShapeMaterial", None)
+    if shape_material is None:
+        return MaterialContext()
+    uuid = getattr(shape_material, "UUID", None) or None
+    name = getattr(shape_material, "Name", None) or None
+    return MaterialContext(uuid=uuid, name=name)
+
+
+def find_job_for_tc(tc):
+    """Walk InListRecursive to find the Job that owns this TC, if any."""
+    if tc is None:
+        return None
+    inlist = getattr(tc, "InListRecursive", []) or []
+    for parent in inlist:
+        if hasattr(parent, "Proxy") and parent.Proxy.__class__.__name__ == "ObjectJob":
+            return parent
+        if getattr(parent, "TypeId", "") == "Path::FeatureCompoundPython" and hasattr(
+            parent, "Stock"
+        ):
+            return parent
+    return None
+
+
+def write_result_to_tc(tc, result: FeedSpeedResult) -> None:
+    """
+    Apply a resolver result to the TC. Resolver feeds are mm/min and are
+    converted to mm/s when written to ``HorizFeed``/``VertFeed`` (the TC
+    stores ``App::PropertyVelocity`` in mm/s). ``SpindleSpeed`` is rpm
+    and passes through unchanged. Stamps ``FeedSpeedProvenance`` for
+    each field actually written.
+    """
+    if result.source == "":
+        return
+    ensure_tc_properties(tc)
+    provenance = dict(getattr(tc, TC_PROVENANCE, {}) or {})
+
+    if result.horiz_feed is not None:
+        tc.HorizFeed = result.horiz_feed / 60.0  # mm/min -> mm/s
+        provenance["HorizFeed"] = result.source
+    if result.vert_feed is not None:
+        tc.VertFeed = result.vert_feed / 60.0  # mm/min -> mm/s
+        provenance["VertFeed"] = result.source
+    if result.spindle_speed is not None:
+        tc.SpindleSpeed = float(result.spindle_speed)
+        provenance["SpindleSpeed"] = result.source
+
+    setattr(tc, TC_PROVENANCE, provenance)
+
+
+def _format_speed(value: Optional[float], unit: str) -> str:
+    if value is None:
+        return "—"
+    return f"{value:.1f} {unit}"
+
+
+def _delta_label(current: float, suggested: Optional[float]) -> str:
+    if suggested is None:
+        return ""
+    delta = suggested - current
+    sign = "+" if delta >= 0 else ""
+    return f"({sign}{delta:.1f})"
+
+
+class FeedsSpeedsDialog(QtWidgets.QDialog):
+    """
+    Suggest dialog for a single Tool Controller. Shows the resolver's
+    suggestion against current TC values; "Apply" writes the suggestion
+    back to the TC.
+    """
+
+    def __init__(self, tc, parent=None):
+        super().__init__(parent)
+        self.tc = tc
+        ensure_tc_properties(tc)
+        self.toolbit = _toolbit_from_tc(tc)
+        self.job = find_job_for_tc(tc)
+        self.material_ctx = adapt_material_from_job(self.job)
+        self.tool_ctx = adapt_toolbit(tc)
+        self._result: Optional[FeedSpeedResult] = None
+
+        self.setWindowTitle(translate("CAM_FeedsSpeeds", "Suggest Feeds & Speeds"))
+        self._build_ui()
+        self._refresh()
+
+    def _build_ui(self) -> None:
+        outer = QtWidgets.QVBoxLayout(self)
+
+        # Context summary
+        ctx_form = QtWidgets.QFormLayout()
+        tool_label = (
+            self.toolbit.Label if self.toolbit else translate("CAM_FeedsSpeeds", "(no tool)")
+        )
+        ctx_form.addRow(translate("CAM_FeedsSpeeds", "Tool:"), QtWidgets.QLabel(tool_label))
+        material_label = self.material_ctx.name or translate(
+            "CAM_FeedsSpeeds", "(none — generic resolution)"
+        )
+        ctx_form.addRow(translate("CAM_FeedsSpeeds", "Material:"), QtWidgets.QLabel(material_label))
+
+        self.op_type_combo = QtWidgets.QComboBox()
+        self.op_type_combo.addItem(translate("CAM_FeedsSpeeds", "(any)"), None)
+        for op in OP_TYPES:
+            self.op_type_combo.addItem(op, op)
+        current_hint = getattr(self.tc, TC_OP_TYPE_HINT, "") or None
+        if current_hint:
+            idx = self.op_type_combo.findData(current_hint)
+            if idx >= 0:
+                self.op_type_combo.setCurrentIndex(idx)
+        self.op_type_combo.currentIndexChanged.connect(self._refresh)
+        ctx_form.addRow(translate("CAM_FeedsSpeeds", "Op type:"), self.op_type_combo)
+
+        # Preset picker — sentinel index 0 = "Auto (use resolver)".
+        # Other entries pick a specific named preset directly, bypassing
+        # the resolver's specificity ranking.
+        self.preset_combo = QtWidgets.QComboBox()
+        self._populate_preset_combo()
+        self.preset_combo.currentIndexChanged.connect(self._on_preset_picked)
+        ctx_form.addRow(translate("CAM_FeedsSpeeds", "Apply preset:"), self.preset_combo)
+        outer.addLayout(ctx_form)
+
+        # Suggestion frame
+        self.suggestion_box = QtWidgets.QGroupBox(translate("CAM_FeedsSpeeds", "Suggestion"))
+        sb_layout = QtWidgets.QFormLayout(self.suggestion_box)
+
+        self.source_label = QtWidgets.QLabel("—")
+        sb_layout.addRow(translate("CAM_FeedsSpeeds", "Source:"), self.source_label)
+
+        self.confidence_bar = QtWidgets.QProgressBar()
+        self.confidence_bar.setRange(0, 100)
+        self.confidence_bar.setValue(0)
+        self.confidence_bar.setTextVisible(True)
+        sb_layout.addRow(translate("CAM_FeedsSpeeds", "Confidence:"), self.confidence_bar)
+
+        # Comparison grid
+        self.compare_grid = QtWidgets.QGridLayout()
+        self.compare_grid.addWidget(QtWidgets.QLabel(""), 0, 0)
+        self.compare_grid.addWidget(QtWidgets.QLabel(translate("CAM_FeedsSpeeds", "Current")), 0, 1)
+        self.compare_grid.addWidget(
+            QtWidgets.QLabel(translate("CAM_FeedsSpeeds", "Suggested")), 0, 2
+        )
+        self.compare_grid.addWidget(QtWidgets.QLabel(translate("CAM_FeedsSpeeds", "Δ")), 0, 3)
+        self._row_labels: list[Tuple[QtWidgets.QLabel, QtWidgets.QLabel, QtWidgets.QLabel]] = []
+        for i, name in enumerate(("Spindle", "Horiz feed", "Vert feed"), start=1):
+            self.compare_grid.addWidget(QtWidgets.QLabel(translate("CAM_FeedsSpeeds", name)), i, 0)
+            cur = QtWidgets.QLabel("—")
+            sug = QtWidgets.QLabel("—")
+            dlt = QtWidgets.QLabel("")
+            self.compare_grid.addWidget(cur, i, 1)
+            self.compare_grid.addWidget(sug, i, 2)
+            self.compare_grid.addWidget(dlt, i, 3)
+            self._row_labels.append((cur, sug, dlt))
+        sb_layout.addRow(self.compare_grid)
+
+        self.warnings_label = QtWidgets.QLabel("")
+        self.warnings_label.setWordWrap(True)
+        palette = self.warnings_label.palette()
+        palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("#b07000"))
+        self.warnings_label.setPalette(palette)
+        sb_layout.addRow(self.warnings_label)
+
+        outer.addWidget(self.suggestion_box)
+
+        # Buttons
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Cancel | QtWidgets.QDialogButtonBox.Apply
+        )
+        self.apply_button = self.button_box.button(QtWidgets.QDialogButtonBox.Apply)
+        self.apply_button.clicked.connect(self._on_apply)
+        self.button_box.rejected.connect(self.reject)
+        outer.addWidget(self.button_box)
+
+    def _populate_preset_combo(self) -> None:
+        """Fill the preset picker combo with the tool's saved presets."""
+        self.preset_combo.blockSignals(True)
+        try:
+            self.preset_combo.clear()
+            self.preset_combo.addItem(translate("CAM_FeedsSpeeds", "Auto (use resolver)"), None)
+            presets = list(self.tool_ctx.presets) if self.tool_ctx else []
+            for i, preset in enumerate(presets):
+                label = derive_preset_label(preset)
+                self.preset_combo.addItem(label, i)  # data = index into presets list
+        finally:
+            self.preset_combo.blockSignals(False)
+
+    def _on_preset_picked(self, _idx: int) -> None:
+        """Triggered when the user selects a specific preset to apply."""
+        self._refresh()
+
+    def _build_result_from_preset(self, preset: dict) -> Optional[FeedSpeedResult]:
+        """
+        Derive a FeedSpeedResult from a single preset, ignoring the resolver's
+        match logic. Called when the user explicitly picks a preset by name.
+        """
+        surface_speed = preset.get("surface_speed")
+        chipload = preset.get("chipload")
+        vert_ratio = preset.get("vert_feed_ratio", 0.33)
+        warnings = []
+
+        spindle = horiz = vert = None
+        if surface_speed is not None or chipload is not None:
+            spindle, horiz, vert, derive_warnings = _derive_from_engineering(
+                surface_speed, chipload, vert_ratio, self.tool_ctx.diameter, self.tool_ctx.flutes
+            )
+            warnings.extend(derive_warnings)
+
+        if spindle is None and horiz is None and vert is None:
+            return None
+
+        label = derive_preset_label(preset)
+        return FeedSpeedResult(
+            horiz_feed=horiz,
+            vert_feed=vert,
+            spindle_speed=spindle,
+            chipload=chipload,
+            surface_speed=surface_speed,
+            source=f"preset:tool/manual/{label}",
+            confidence=1.0,
+            warnings=tuple(warnings),
+        )
+
+    def _current_op_ctx(self) -> OpContext:
+        return OpContext(op_type=self.op_type_combo.currentData())
+
+    def _current_horiz(self) -> float:
+        try:
+            v = self.tc.HorizFeed
+            mm_s = float(v.Value) if hasattr(v, "Value") else float(v)
+            return mm_s * 60.0  # mm/s -> mm/min
+        except (AttributeError, TypeError, ValueError):
+            return 0.0
+
+    def _current_vert(self) -> float:
+        try:
+            v = self.tc.VertFeed
+            mm_s = float(v.Value) if hasattr(v, "Value") else float(v)
+            return mm_s * 60.0  # mm/s -> mm/min
+        except (AttributeError, TypeError, ValueError):
+            return 0.0
+
+    def _current_spindle(self) -> float:
+        try:
+            return float(getattr(self.tc, "SpindleSpeed", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _refresh(self) -> None:
+        # Re-fetch tool ctx in case presets changed (after Save).
+        self.tool_ctx = adapt_toolbit(self.tc)
+
+        # If a specific preset was picked from the combo, build the result
+        # directly from it. Otherwise run the resolver chain as usual.
+        chosen_idx = self.preset_combo.currentData()
+        if chosen_idx is not None and 0 <= chosen_idx < len(self.tool_ctx.presets):
+            picked = self.tool_ctx.presets[chosen_idx]
+            built = self._build_result_from_preset(picked)
+            result = built if built is not None else FeedSpeedResult()
+        else:
+            op_ctx = self._current_op_ctx()
+            result = resolve(self.tool_ctx, self.material_ctx, op_ctx)
+        self._result = result
+
+        cur_spindle = self._current_spindle()
+        cur_horiz = self._current_horiz()
+        cur_vert = self._current_vert()
+
+        self._row_labels[0][0].setText(_format_speed(cur_spindle, "rpm"))
+        self._row_labels[1][0].setText(_format_speed(cur_horiz, "mm/min"))
+        self._row_labels[2][0].setText(_format_speed(cur_vert, "mm/min"))
+
+        if not result.source:
+            self.source_label.setText(translate("CAM_FeedsSpeeds", "No suggestion available"))
+            self.confidence_bar.setValue(0)
+            for _, sug, dlt in self._row_labels:
+                sug.setText("—")
+                dlt.setText("")
+            self.warnings_label.setText(
+                translate(
+                    "CAM_FeedsSpeeds",
+                    "No matching preset on this tool. Open the tool from the library "
+                    "to add presets.",
+                )
+            )
+            self.apply_button.setEnabled(False)
+            return
+
+        self.source_label.setText(result.source)
+        self.confidence_bar.setValue(int(round(result.confidence * 100)))
+
+        self._row_labels[0][1].setText(_format_speed(result.spindle_speed, "rpm"))
+        self._row_labels[0][2].setText(
+            _delta_label(cur_spindle, result.spindle_speed) if result.spindle_speed else ""
+        )
+        self._row_labels[1][1].setText(_format_speed(result.horiz_feed, "mm/min"))
+        self._row_labels[1][2].setText(
+            _delta_label(cur_horiz, result.horiz_feed) if result.horiz_feed else ""
+        )
+        self._row_labels[2][1].setText(_format_speed(result.vert_feed, "mm/min"))
+        self._row_labels[2][2].setText(
+            _delta_label(cur_vert, result.vert_feed) if result.vert_feed else ""
+        )
+
+        self.warnings_label.setText("\n".join(result.warnings))
+        self.apply_button.setEnabled(True)
+
+    def _on_apply(self) -> None:
+        if self._result is None or not self._result.source:
+            return
+        write_result_to_tc(self.tc, self._result)
+        # Persist the op-type choice if user changed it.
+        chosen = self.op_type_combo.currentData() or ""
+        if getattr(self.tc, TC_OP_TYPE_HINT, None) != chosen:
+            self.tc.OpTypeHint = chosen
+        try:
+            self.tc.Document.recompute()
+        except Exception:
+            Path.Log.debug("recompute after F&S apply failed; ignoring")
+        self.accept()
+
+
+def open_for(tc, parent=None) -> None:
+    """Convenience entry: open the dialog modally for the given TC."""
+    dlg = FeedsSpeedsDialog(tc, parent=parent)
+    dlg.exec_()

--- a/src/Mod/CAM/Path/Tool/Gui/FeedsSpeedsDialog.py
+++ b/src/Mod/CAM/Path/Tool/Gui/FeedsSpeedsDialog.py
@@ -42,6 +42,7 @@ from PySide.QtCore import QT_TRANSLATE_NOOP
 import Path
 from Path.Tool.FeedsSpeeds import (
     FeedSpeedResult,
+    MachineContext,
     MaterialContext,
     OP_TYPES,
     OpContext,
@@ -103,7 +104,7 @@ def adapt_toolbit(tc) -> ToolContext:
     flutes: Optional[int] = None
     presets: Tuple[dict, ...] = ()
     shape_id = ""
-    material_enum: Optional[str] = None
+    tool_material: Optional[str] = None
     chipload_default: Optional[float] = None
 
     if tb is not None:
@@ -122,7 +123,7 @@ def adapt_toolbit(tc) -> ToolContext:
             flutes = None
         presets = tuple(get_presets(tb))
         shape_id = getattr(tb, "ShapeID", "") or ""
-        material_enum = getattr(tb, "Material", None)
+        tool_material = getattr(tb, "Material", None) or None
         try:
             chipload_q = getattr(tb, "Chipload", None)
             if chipload_q is not None:
@@ -136,9 +137,20 @@ def adapt_toolbit(tc) -> ToolContext:
         flutes=flutes,
         presets=presets,
         shape_id=shape_id,
-        material_enum=material_enum,
+        tool_material=tool_material,
         chipload_default=chipload_default,
     )
+
+
+def _surface_speed_m_per_min(props, key: str) -> Optional[float]:
+    """Read a velocity property and return it in m/min, or None."""
+    raw = props.get(key)
+    if not raw:
+        return None
+    try:
+        return float(FreeCAD.Units.Quantity(raw).getValueAs("m/min"))
+    except (TypeError, ValueError, AttributeError):
+        return None
 
 
 def adapt_material_from_job(job) -> MaterialContext:
@@ -147,7 +159,10 @@ def adapt_material_from_job(job) -> MaterialContext:
 
     Returns an empty MaterialContext (uuid=None, name=None) when the job has
     no stock material assigned, which is treated as "any material" by the
-    resolver.
+    resolver. When the material carries the Machinability model, its
+    ``SurfaceSpeedHSS`` and ``SurfaceSpeedCarbide`` properties are
+    extracted (in m/min) and attached so ``MachinabilityProvider`` can
+    pick a branch by tool material without re-reading the material.
     """
     if job is None:
         return MaterialContext()
@@ -159,7 +174,37 @@ def adapt_material_from_job(job) -> MaterialContext:
         return MaterialContext()
     uuid = getattr(shape_material, "UUID", None) or None
     name = getattr(shape_material, "Name", None) or None
-    return MaterialContext(uuid=uuid, name=name)
+    props = getattr(shape_material, "PhysicalProperties", {}) or {}
+    return MaterialContext(
+        uuid=uuid,
+        name=name,
+        surface_speed_hss=_surface_speed_m_per_min(props, "SurfaceSpeedHSS"),
+        surface_speed_carbide=_surface_speed_m_per_min(props, "SurfaceSpeedCarbide"),
+    )
+
+
+def adapt_machine_from_job(job) -> Optional[MachineContext]:
+    """
+    Build a MachineContext from the Job's Machine definition's first
+    spindle. Returns None when the job has no Machine configured or the
+    machine has no spindles. The resolver treats None as "no clamping."
+    """
+    if job is None or not hasattr(job, "Proxy"):
+        return None
+    try:
+        machine = job.Proxy.getMachine()
+    except (AttributeError, TypeError):
+        return None
+    if machine is None:
+        return None
+    spindles = getattr(machine, "spindles", None) or []
+    if not spindles:
+        return None
+    s = spindles[0]
+    return MachineContext(
+        min_rpm=float(getattr(s, "min_rpm", 0.0) or 0.0),
+        max_rpm=float(getattr(s, "max_rpm", 0.0) or 0.0),
+    )
 
 
 def find_job_for_tc(tc):
@@ -231,6 +276,7 @@ class FeedsSpeedsDialog(QtWidgets.QDialog):
         self.toolbit = _toolbit_from_tc(tc)
         self.job = find_job_for_tc(tc)
         self.material_ctx = adapt_material_from_job(self.job)
+        self.machine_ctx = adapt_machine_from_job(self.job)
         self.tool_ctx = adapt_toolbit(tc)
         self._result: Optional[FeedSpeedResult] = None
 
@@ -411,7 +457,7 @@ class FeedsSpeedsDialog(QtWidgets.QDialog):
             result = built if built is not None else FeedSpeedResult()
         else:
             op_ctx = self._current_op_ctx()
-            result = resolve(self.tool_ctx, self.material_ctx, op_ctx)
+            result = resolve(self.tool_ctx, self.material_ctx, op_ctx, machine=self.machine_ctx)
         self._result = result
 
         cur_spindle = self._current_spindle()

--- a/src/Mod/CAM/Path/Tool/Gui/FeedsSpeedsDialog.py
+++ b/src/Mod/CAM/Path/Tool/Gui/FeedsSpeedsDialog.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
-# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileCopyrightText: 2024 sliptonic <shopinthewoods@gmail.com>
 # SPDX-FileNotice: Part of the FreeCAD project.
 
 ################################################################################
@@ -35,8 +35,7 @@ the library browser. Job-side flows only consume presets.
 from typing import Optional, Tuple
 
 import FreeCAD
-import FreeCADGui
-from PySide import QtCore, QtGui, QtWidgets
+from PySide import QtGui, QtWidgets
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 import Path
@@ -235,17 +234,18 @@ def write_result_to_tc(tc, result: FeedSpeedResult) -> None:
     ensure_tc_properties(tc)
     provenance = dict(getattr(tc, TC_PROVENANCE, {}) or {})
 
-    if result.horiz_feed is not None:
-        tc.HorizFeed = result.horiz_feed / 60.0  # mm/min -> mm/s
-        provenance["HorizFeed"] = result.source
-    if result.vert_feed is not None:
-        tc.VertFeed = result.vert_feed / 60.0  # mm/min -> mm/s
-        provenance["VertFeed"] = result.source
-    if result.spindle_speed is not None:
-        tc.SpindleSpeed = float(result.spindle_speed)
-        provenance["SpindleSpeed"] = result.source
-
-    setattr(tc, TC_PROVENANCE, provenance)
+    try:
+        if result.horiz_feed is not None:
+            tc.HorizFeed = result.horiz_feed / 60.0  # mm/min -> mm/s
+            provenance["HorizFeed"] = result.source
+        if result.vert_feed is not None:
+            tc.VertFeed = result.vert_feed / 60.0  # mm/min -> mm/s
+            provenance["VertFeed"] = result.source
+        if result.spindle_speed is not None:
+            tc.SpindleSpeed = float(result.spindle_speed)
+            provenance["SpindleSpeed"] = result.source
+    finally:
+        setattr(tc, TC_PROVENANCE, provenance)
 
 
 def _format_speed(value: Optional[float], unit: str) -> str:
@@ -260,6 +260,50 @@ def _delta_label(current: float, suggested: Optional[float]) -> str:
     delta = suggested - current
     sign = "+" if delta >= 0 else ""
     return f"({sign}{delta:.1f})"
+
+
+def doc_unit_schema(obj) -> int:
+    """
+    The unit-schema index of ``obj``'s document, so feeds display in the
+    document's unit system (e.g. in/min for an imperial project) rather
+    than a hardcoded unit. Falls back to the active/global schema when the
+    document has no explicit ``UnitSystem`` set.
+    """
+    try:
+        doc = getattr(obj, "Document", None)
+        if doc is not None:
+            # The document's ``UnitSystem`` enumeration lists the schemas in
+            # schema-index order, so the position of the current value is the
+            # schema number ``schemaTranslate`` expects.
+            names = doc.getEnumerationsOfProperty("UnitSystem")
+            if names and doc.UnitSystem in names:
+                return names.index(doc.UnitSystem)
+    except Exception:
+        pass
+    try:
+        return FreeCAD.Units.getSchema()
+    except Exception:
+        return 0
+
+
+def _format_feed(value: Optional[float], schema: int) -> str:
+    """Format a feed (given in mm/min) in the given document unit schema."""
+    if value is None:
+        return "—"
+    try:
+        quantity = FreeCAD.Units.Quantity(float(value), "mm/min")
+        return FreeCAD.Units.schemaTranslate(quantity, schema)[0]
+    except Exception:
+        return f"{value:.1f} mm/min"
+
+
+def _delta_feed(current: float, suggested: Optional[float], schema: int) -> str:
+    """Signed feed delta (mm/min) formatted in the document unit schema."""
+    if suggested is None:
+        return ""
+    delta = suggested - current
+    sign = "+" if delta >= 0 else "-"
+    return f"({sign}{_format_feed(abs(delta), schema)})"
 
 
 class FeedsSpeedsDialog(QtWidgets.QDialog):
@@ -279,6 +323,8 @@ class FeedsSpeedsDialog(QtWidgets.QDialog):
         self.machine_ctx = adapt_machine_from_job(self.job)
         self.tool_ctx = adapt_toolbit(tc)
         self._result: Optional[FeedSpeedResult] = None
+        # Feeds are shown in the document's unit schema, not a hardcoded unit.
+        self._schema = doc_unit_schema(tc)
 
         self.setWindowTitle(translate("CAM_FeedsSpeeds", "Suggest Feeds & Speeds"))
         self._build_ui()
@@ -465,8 +511,8 @@ class FeedsSpeedsDialog(QtWidgets.QDialog):
         cur_vert = self._current_vert()
 
         self._row_labels[0][0].setText(_format_speed(cur_spindle, "rpm"))
-        self._row_labels[1][0].setText(_format_speed(cur_horiz, "mm/min"))
-        self._row_labels[2][0].setText(_format_speed(cur_vert, "mm/min"))
+        self._row_labels[1][0].setText(_format_feed(cur_horiz, self._schema))
+        self._row_labels[2][0].setText(_format_feed(cur_vert, self._schema))
 
         if not result.source:
             self.source_label.setText(translate("CAM_FeedsSpeeds", "No suggestion available"))
@@ -491,13 +537,13 @@ class FeedsSpeedsDialog(QtWidgets.QDialog):
         self._row_labels[0][2].setText(
             _delta_label(cur_spindle, result.spindle_speed) if result.spindle_speed else ""
         )
-        self._row_labels[1][1].setText(_format_speed(result.horiz_feed, "mm/min"))
+        self._row_labels[1][1].setText(_format_feed(result.horiz_feed, self._schema))
         self._row_labels[1][2].setText(
-            _delta_label(cur_horiz, result.horiz_feed) if result.horiz_feed else ""
+            _delta_feed(cur_horiz, result.horiz_feed, self._schema) if result.horiz_feed else ""
         )
-        self._row_labels[2][1].setText(_format_speed(result.vert_feed, "mm/min"))
+        self._row_labels[2][1].setText(_format_feed(result.vert_feed, self._schema))
         self._row_labels[2][2].setText(
-            _delta_label(cur_vert, result.vert_feed) if result.vert_feed else ""
+            _delta_feed(cur_vert, result.vert_feed, self._schema) if result.vert_feed else ""
         )
 
         self.warnings_label.setText("\n".join(result.warnings))

--- a/src/Mod/CAM/Path/Tool/Gui/MaterialPicker.py
+++ b/src/Mod/CAM/Path/Tool/Gui/MaterialPicker.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Reusable Material picker dialog filtered to the Machinability model.
+
+Mirrors the Job editor's "Assign Stock Material" pattern (see
+``Path/Main/Gui/Job.py:MaterialDialog``) but is parameterised for use in
+the feeds & speeds flows where we need a (uuid, name) pair returned.
+
+TODO (refactor): Job.MaterialDialog and this module are doing the same
+thing — wrap MatGui::MaterialTreeWidget with a Machinability filter and
+return a selected UUID. They should converge on one helper, with Job.py
+importing from here (or a relocated shared module). Left as a follow-up
+to keep the F&S Phase-1 PoC diff focused.
+"""
+
+from typing import Optional, Tuple
+
+import FreeCAD
+import FreeCADGui
+import MatGui
+import Materials
+from PySide import QtWidgets
+
+translate = FreeCAD.Qt.translate
+
+
+class MachinabilityMaterialDialog(QtWidgets.QDialog):
+    """
+    Modal Material picker filtered to materials carrying the Machinability
+    model. On Accept, ``selected_uuid`` and ``selected_name`` are populated.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.selected_uuid: Optional[str] = None
+        self.selected_name: Optional[str] = None
+
+        self.setWindowTitle(translate("CAM_FeedsSpeeds", "Choose material"))
+
+        self._material_tree = FreeCADGui.UiLoader().createWidget("MatGui::MaterialTreeWidget")
+        self._tree_wrapper = MatGui.MaterialTreeWidget(self._material_tree)
+
+        material_filter = Materials.MaterialFilter()
+        material_filter.Name = "Machining Materials"
+        material_filter.RequiredModels = [Materials.UUIDs().Machinability]
+        self._tree_wrapper.setFilter(material_filter)
+        self._tree_wrapper.selectFilter("Machining Materials")
+        self._material_tree.onMaterial.connect(self._on_material)
+
+        button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        self._ok_button = button_box.button(QtWidgets.QDialogButtonBox.Ok)
+        self._ok_button.setEnabled(False)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self._material_tree)
+        layout.addWidget(button_box)
+
+    def _on_material(self, uuid: str) -> None:
+        self.selected_uuid = uuid or None
+        self.selected_name = lookup_material_name(self.selected_uuid)
+        self._ok_button.setEnabled(self.selected_uuid is not None)
+
+
+def lookup_material_name(uuid: Optional[str]) -> Optional[str]:
+    """Resolve a material UUID to its display name, or None if not found."""
+    if not uuid:
+        return None
+    try:
+        material = Materials.MaterialManager().getMaterial(uuid)
+    except Exception:
+        return None
+    if material is None:
+        return None
+    return getattr(material, "Name", None) or None
+
+
+def pick_machinability_material(parent=None) -> Optional[Tuple[str, str]]:
+    """
+    Open the picker and return the chosen ``(uuid, name)`` pair, or
+    ``None`` if the user cancelled.
+    """
+    dialog = MachinabilityMaterialDialog(parent)
+    if dialog.exec_() != QtWidgets.QDialog.Accepted:
+        return None
+    if dialog.selected_uuid is None:
+        return None
+    return (dialog.selected_uuid, dialog.selected_name or "")

--- a/src/Mod/CAM/Path/Tool/toolbit/models/base.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/models/base.py
@@ -230,6 +230,21 @@ class ToolBit(Asset, ABC):
                     f" '{toolbit.obj.Label}'. Skipping."
                 )
 
+        # Restore feeds & speeds presets if present. The "presets" key is
+        # additive and optional; absence means "no presets" (lazy property
+        # remains unadded).
+        presets = attrs.get("presets")
+        if presets:
+            from ...FeedsSpeeds.presets import set_presets as _set_presets
+
+            try:
+                _set_presets(toolbit.obj, presets)
+            except Exception as e:
+                Path.Log.warning(
+                    f"ToolBit.from_shape: failed to restore presets for "
+                    f"'{toolbit.obj.Label}': {e}. Presets will be ignored."
+                )
+
         toolbit._update_tool_properties()
         # Snapshot all keys; to_dict() lets native keys take precedence, unknown ones pass through.
         toolbit._extra_attrs = dict(attrs)
@@ -988,6 +1003,20 @@ class ToolBit(Asset, ABC):
         for k, v in extra.items():
             if k not in attrs:
                 attrs[k] = v
+
+        # Serialize feeds & speeds presets if the property exists. Empty
+        # lists are omitted from the .fctb so unused tools stay byte-identical.
+        from ...FeedsSpeeds.presets import get_presets as _get_presets
+
+        try:
+            presets = _get_presets(self.obj)
+            if presets:
+                attrs["presets"] = presets
+        except Exception as e:
+            Path.Log.warning(
+                f"ToolBit.to_dict: failed to serialize presets for "
+                f"'{self.obj.Label}': {e}. Presets will be omitted."
+            )
 
         Path.Log.debug(f"to_dict output for {self.obj.Label}: {attrs}")
         return attrs

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/editor.py
@@ -391,29 +391,13 @@ class ToolBitEditor(QtGui.QWidget):
         # Hide second tab (tool notes) for now.
         self.form.tabWidget.setTabVisible(1, False)
 
-        # Feeds & Speeds
-        self.feeds_tab_idx = None
-        """
-        TODO: disabled for now.
-        if tool.supports_feeds_and_speeds():
-            label = translate('CAM', 'Feeds && Speeds')
-            self.feeds = FeedsAndSpeedsWidget(db, serializer, tool, parent=self)
-            self.feeds_tab_idx = self.form.tabWidget.insertTab(1, self.feeds, label)
-        else:
-            self.feeds = None
-            self.feeds_tab_idx = None
+        # Feeds & Speeds presets tab.
+        from .presets_tab import PresetsTab
 
-        self.form.lineEditCoating.setText(toolbit.get_coating())
-        self.form.lineEditCoating.textChanged.connect(toolbit.set_coating)
-        self.form.lineEditHardness.setText(toolbit.get_hardness())
-        self.form.lineEditHardness.textChanged.connect(toolbit.set_hardness)
-        self.form.lineEditMaterials.setText(toolbit.get_materials())
-        self.form.lineEditMaterials.textChanged.connect(toolbit.set_materials)
-        self.form.lineEditSupplier.setText(toolbit.get_supplier())
-        self.form.lineEditSupplier.textChanged.connect(toolbit.set_supplier)
-        self.form.plainTextEditNotes.setPlainText(tool.get_notes())
-        self.form.plainTextEditNotes.textChanged.connect(self._on_notes_changed)
-        """
+        self.presets_tab = PresetsTab(toolbit.obj, parent=self)
+        self.feeds_tab_idx = self.form.tabWidget.addTab(
+            self.presets_tab, translate("CAM", "Feeds && Speeds")
+        )
 
         self._update()
 
@@ -483,8 +467,13 @@ class ToolBitEditor(QtGui.QWidget):
         self.form.setWindowTitle(title)
 
     def _on_tab_switched(self, index):
-        if index == self.feeds_tab_idx:
-            self.feeds.update()
+        feeds_tab_idx = getattr(self, "feeds_tab_idx", None)
+        if (
+            feeds_tab_idx is not None
+            and index == feeds_tab_idx
+            and getattr(self, "presets_tab", None) is not None
+        ):
+            self.presets_tab.refresh()
 
     def _on_notes_changed(self):
         self.toolbit.set_notes(self.form.plainTextEditNotes.toPlainText())

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/presets_tab.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/presets_tab.py
@@ -30,17 +30,24 @@ import math
 from typing import List, Optional
 
 import FreeCAD
+import FreeCADGui
 from PySide import QtCore, QtGui
 
 from ...FeedsSpeeds import (
     OP_TYPES,
-    derive_preset_label,
     get_presets,
     make_preset,
     set_presets,
 )
 
 translate = FreeCAD.Qt.translate
+
+# ``Gui::QuantitySpinBox`` stores its ``rawValue`` in the quantity's base
+# unit: mm/s for a velocity, mm for a length. The engineering math below
+# works in m/min (surface speed), mm/min (feed) and mm (chipload), so we
+# convert at the widget boundary. Chipload is already in mm = base unit.
+_MM_S_PER_M_MIN = 1000.0 / 60.0  # 1 m/min expressed in mm/s
+_MM_S_PER_MM_MIN = 1.0 / 60.0  # 1 mm/min expressed in mm/s
 
 
 def _fmt(value: Optional[float], unit: str = "") -> str:
@@ -49,6 +56,51 @@ def _fmt(value: Optional[float], unit: str = "") -> str:
     if unit:
         return f"{value:g} {unit}"
     return f"{value:g}"
+
+
+def _preferred_unit(unit_expr: str) -> str:
+    """
+    The user's schema-preferred unit string for the dimension of
+    ``unit_expr`` (e.g. "mm/s" -> "mm/min" or "in/min", "mm" -> "mm" or
+    "in"). Falls back to ``unit_expr`` if the preference can't be resolved.
+    """
+    try:
+        pref = FreeCAD.Units.Quantity(1.0, unit_expr).getUserPreferred()
+        if pref and len(pref) > 2 and pref[2]:
+            return pref[2]
+    except Exception:
+        pass
+    return unit_expr
+
+
+def _fmt_quantity(value: Optional[float], unit_expr: str) -> str:
+    """
+    Format a magnitude (given in ``unit_expr`` units) as a schema-aware
+    display string, so table columns honor the user's unit preference.
+    """
+    if value is None:
+        return ""
+    try:
+        return FreeCAD.Units.Quantity(float(value), unit_expr).UserString
+    except Exception:
+        return _fmt(value)
+
+
+def _spin_raw(widget) -> float:
+    """Read a ``Gui::QuantitySpinBox`` value in its base unit (mm/s, mm)."""
+    try:
+        return float(widget.property("rawValue"))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _set_spin_raw(widget, base_value: float) -> None:
+    """Set a ``Gui::QuantitySpinBox`` from a base-unit value, muted."""
+    widget.blockSignals(True)
+    try:
+        widget.setProperty("rawValue", float(base_value))
+    finally:
+        widget.blockSignals(False)
 
 
 def _surface_speed_from_rpm(rpm: float, diameter_mm: float) -> Optional[float]:
@@ -79,15 +131,21 @@ def _feed_from_chipload(chipload: float, rpm: float, flutes: int) -> Optional[fl
     return chipload * rpm * flutes
 
 
-class _EditPresetDialog(QtGui.QDialog):
+class _EditPresetDialog:
     """Sub-dialog for adding or editing a single preset row.
 
-    The dialog accepts the tool's current ``diameter_mm`` and ``flutes`` so
-    it can keep the engineering inputs (surface speed, chipload) and the
-    direct inputs (spindle rpm, horiz feed mm/min) in sync as the user
-    types. Storage is engineering-only: only surface_speed, chipload and
-    vert_feed_ratio are persisted; the rpm/feed spinboxes are display
-    affordances derived from those plus the tool's geometry.
+    Wraps the ``FeedsSpeedsPresetEdit.ui`` panel. The dialog accepts the
+    tool's current ``diameter_mm`` and ``flutes`` so it can keep the
+    engineering inputs (surface speed, chipload) and the direct inputs
+    (spindle rpm, horiz feed) in sync as the user types. Storage is
+    engineering-only: only surface_speed, chipload and vert_feed_ratio are
+    persisted; the rpm/feed spinboxes are display affordances derived from
+    those plus the tool's geometry.
+
+    All feed/speed spinboxes are ``Gui::QuantitySpinBox`` widgets so their
+    display honors the user's unit schema (metric, imperial, …). Values are
+    read/written in the base unit via ``rawValue`` and converted to the
+    engineering units the math works in (m/min, mm/min, mm).
     """
 
     def __init__(
@@ -95,111 +153,109 @@ class _EditPresetDialog(QtGui.QDialog):
         preset: Optional[dict],
         diameter_mm: float = 0.0,
         flutes: Optional[int] = None,
+        tool_chipload_mm: Optional[float] = None,
         parent=None,
     ):
-        super().__init__(parent)
-        self.setWindowTitle(translate("CAM_FeedsSpeeds", "Edit preset"))
-        layout = QtGui.QFormLayout(self)
+        self.form = FreeCADGui.PySideUic.loadUi(":/panels/FeedsSpeedsPresetEdit.ui")
+        if parent is not None:
+            self.form.setParent(parent, QtCore.Qt.Dialog)
 
+        # A new preset (preset is None) seeds its chipload from the tool's
+        # own ``Chipload`` property; an existing preset keeps its saved value.
+        self._is_new = preset is None
         self._initial = preset or make_preset()
         self._material_uuid: Optional[str] = None
         self._material_name: Optional[str] = None
         self._diameter_mm = float(diameter_mm) if diameter_mm else 0.0
         self._flutes = int(flutes) if flutes else 0
+        self._tool_chipload_mm = float(tool_chipload_mm) if tool_chipload_mm else 0.0
         self._syncing = False  # guards against feedback loops
 
-        # Preset name — user-given label, optional but encouraged.
-        self.name_edit = QtGui.QLineEdit()
+        f = self.form
+        self.name_edit = f.nameEdit
+        self.material_label = f.materialLabel
+        self.browse_button = f.browseButton
+        self.generic_check = f.genericCheck
+        self.op_type_combo = f.opTypeCombo
+        self.surface_speed_spin = f.surfaceSpeedSpin
+        self.chipload_spin = f.chiploadSpin
+        self.vert_ratio_spin = f.vertRatioSpin
+        self.raw_feed_spin = f.rawFeedSpin
+        self.raw_speed_spin = f.rawSpeedSpin
+
         self.name_edit.setPlaceholderText(
             translate("CAM_FeedsSpeeds", "Optional, e.g. 'Aluminum aggressive'")
         )
-        layout.addRow(translate("CAM_FeedsSpeeds", "Name:"), self.name_edit)
 
-        # Material row: read-only label, Browse button opens the
-        # Machinability-filtered MaterialDialog. UUID is the authoritative
-        # identifier; name is for display + as a fallback when the UUID
-        # can't be resolved on a different machine.
-        mat_row = QtGui.QHBoxLayout()
-        self.material_label = QtGui.QLabel(translate("CAM_FeedsSpeeds", "(none)"))
-        mat_row.addWidget(self.material_label, 1)
-        self.browse_button = QtGui.QPushButton(translate("CAM_FeedsSpeeds", "Browse…"))
-        self.browse_button.clicked.connect(self._on_browse)
-        mat_row.addWidget(self.browse_button)
-        self.generic_check = QtGui.QCheckBox(translate("CAM_FeedsSpeeds", "Generic (any material)"))
-        self.generic_check.toggled.connect(self._on_generic_toggled)
-        mat_row.addWidget(self.generic_check)
-        layout.addRow(translate("CAM_FeedsSpeeds", "Material:"), mat_row)
+        # Display units follow the user's unit schema. Surface speed and
+        # horiz feed are velocities; chipload is a length (per tooth).
+        vel_unit = _preferred_unit("mm/s")
+        self.surface_speed_spin.setProperty("unit", vel_unit)
+        self.raw_feed_spin.setProperty("unit", vel_unit)
+        self.chipload_spin.setProperty("unit", _preferred_unit("mm"))
+        # Chipload needs finer resolution than the default spinbox decimals.
+        # Gui::QuantitySpinBox comes through PySide as a bare QAbstractSpinBox
+        # (no typed setters), so drive it through the Qt property system —
+        # the same way its ``unit`` and ``rawValue`` are set.
+        self.chipload_spin.setProperty("decimals", 4)
 
         # Op type
-        self.op_type_combo = QtGui.QComboBox()
         self.op_type_combo.addItem(translate("CAM_FeedsSpeeds", "(any)"), None)
         for op in OP_TYPES:
             self.op_type_combo.addItem(op, op)
-        layout.addRow(translate("CAM_FeedsSpeeds", "Op type:"), self.op_type_combo)
 
-        # Engineering values
-        self.surface_speed_spin = QtGui.QDoubleSpinBox()
-        self.surface_speed_spin.setRange(0, 100000)
-        self.surface_speed_spin.setDecimals(2)
-        self.surface_speed_spin.setSuffix(" m/min")
-        layout.addRow(translate("CAM_FeedsSpeeds", "Surface speed:"), self.surface_speed_spin)
-
-        self.chipload_spin = QtGui.QDoubleSpinBox()
-        self.chipload_spin.setRange(0, 10)
-        self.chipload_spin.setDecimals(4)
-        self.chipload_spin.setSuffix(" mm/tooth")
-        layout.addRow(translate("CAM_FeedsSpeeds", "Chipload:"), self.chipload_spin)
-
-        self.vert_ratio_spin = QtGui.QDoubleSpinBox()
-        self.vert_ratio_spin.setRange(0, 1)
-        self.vert_ratio_spin.setDecimals(3)
-        self.vert_ratio_spin.setValue(0.33)
-        layout.addRow(translate("CAM_FeedsSpeeds", "Vert feed ratio:"), self.vert_ratio_spin)
-
-        # Raw values: entered directly as feed/speed. When tool geometry
-        # is known, these stay in sync with surface_speed/chipload above
-        # (editing either side updates the other).
-        raw_box = QtGui.QGroupBox(translate("CAM_FeedsSpeeds", "Direct feed and speed"))
-        raw_form = QtGui.QFormLayout(raw_box)
-        self.raw_feed_spin = QtGui.QDoubleSpinBox()
-        self.raw_feed_spin.setRange(0, 100000)
-        self.raw_feed_spin.setSuffix(" mm/min")
-        raw_form.addRow(translate("CAM_FeedsSpeeds", "Horiz feed:"), self.raw_feed_spin)
-        self.raw_speed_spin = QtGui.QDoubleSpinBox()
-        self.raw_speed_spin.setRange(0, 200000)
-        self.raw_speed_spin.setSuffix(" rpm")
-        raw_form.addRow(translate("CAM_FeedsSpeeds", "Spindle speed:"), self.raw_speed_spin)
-        layout.addRow(raw_box)
-
-        # Wire up bidirectional sync. Each handler reads geometry; when
-        # geometry is missing, that direction silently no-ops.
-        self.surface_speed_spin.valueChanged.connect(self._on_surface_speed_changed)
-        self.chipload_spin.valueChanged.connect(self._on_chipload_changed)
+        # Wire up bidirectional sync. Each handler re-reads the widgets it
+        # needs (via unit-aware accessors) and ignores the signal payload,
+        # so it doesn't matter whether the signal carries a str or a float.
+        self.browse_button.clicked.connect(self._on_browse)
+        self.generic_check.toggled.connect(self._on_generic_toggled)
+        self.surface_speed_spin.textChanged.connect(self._on_surface_speed_changed)
+        self.chipload_spin.textChanged.connect(self._on_chipload_changed)
+        self.raw_feed_spin.textChanged.connect(self._on_raw_feed_changed)
         self.raw_speed_spin.valueChanged.connect(self._on_raw_speed_changed)
-        self.raw_feed_spin.valueChanged.connect(self._on_raw_feed_changed)
 
-        # Inform the user when sync is unavailable.
-        if self._diameter_mm <= 0 or self._flutes <= 0:
-            hint = QtGui.QLabel(
-                translate(
-                    "CAM_FeedsSpeeds",
-                    "Tool diameter and/or flute count missing — surface speed "
-                    "and chipload won't auto-sync with direct feed/speed.",
-                )
-            )
-            hint.setWordWrap(True)
-            hint.setStyleSheet("color: #888;")
-            layout.addRow(hint)
-
-        # Buttons
-        button_box = QtGui.QDialogButtonBox(
-            QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel
-        )
-        button_box.accepted.connect(self.accept)
-        button_box.rejected.connect(self.reject)
-        layout.addRow(button_box)
+        # The hint is only relevant when geometry is missing and sync can't
+        # run; hide it otherwise.
+        self.form.geometryHint.setVisible(self._diameter_mm <= 0 or self._flutes <= 0)
 
         self._populate_from_preset(self._initial)
+
+    def exec_(self) -> int:
+        return self.form.exec_()
+
+    # ------------------------------------------------------------------
+    # Unit-aware accessors. Getters return the engineering unit the math
+    # uses (surface speed m/min, feed mm/min, chipload mm, spindle rpm);
+    # setters take the same and push the base-unit value into the widget.
+    # ------------------------------------------------------------------
+
+    def _get_surface_speed(self) -> float:  # m/min
+        return _spin_raw(self.surface_speed_spin) / _MM_S_PER_M_MIN
+
+    def _set_surface_speed(self, ss_m_min: float) -> None:
+        _set_spin_raw(self.surface_speed_spin, ss_m_min * _MM_S_PER_M_MIN)
+
+    def _get_feed(self) -> float:  # mm/min
+        return _spin_raw(self.raw_feed_spin) / _MM_S_PER_MM_MIN
+
+    def _set_feed(self, feed_mm_min: float) -> None:
+        _set_spin_raw(self.raw_feed_spin, feed_mm_min * _MM_S_PER_MM_MIN)
+
+    def _get_chipload(self) -> float:  # mm (== base unit)
+        return _spin_raw(self.chipload_spin)
+
+    def _set_chipload(self, cl_mm: float) -> None:
+        _set_spin_raw(self.chipload_spin, cl_mm)
+
+    def _get_rpm(self) -> float:
+        return self.raw_speed_spin.value()
+
+    def _set_rpm(self, rpm: float) -> None:
+        self.raw_speed_spin.blockSignals(True)
+        try:
+            self.raw_speed_spin.setValue(rpm)
+        finally:
+            self.raw_speed_spin.blockSignals(False)
 
     def _populate_from_preset(self, preset: dict) -> None:
         if preset.get("name"):
@@ -224,20 +280,26 @@ class _EditPresetDialog(QtGui.QDialog):
         try:
             ss = preset.get("surface_speed")
             cl = preset.get("chipload")
+            # Seed a brand-new preset's chipload from the tool's own
+            # Chipload property. This is a one-time convenience at creation:
+            # it never overwrites an existing preset's value, and the saved
+            # preset stays independent of the tool afterward.
+            if cl is None and self._is_new and self._tool_chipload_mm > 0:
+                cl = self._tool_chipload_mm
             if ss is not None:
-                self.surface_speed_spin.setValue(ss)
+                self._set_surface_speed(ss)
             if cl is not None:
-                self.chipload_spin.setValue(cl)
+                self._set_chipload(cl)
             self.vert_ratio_spin.setValue(preset.get("vert_feed_ratio", 0.33))
 
             # Compute raw display values from engineering + geometry.
             rpm = _rpm_from_surface_speed(ss, self._diameter_mm) if ss is not None else None
             if rpm is not None:
-                self.raw_speed_spin.setValue(rpm)
+                self._set_rpm(rpm)
                 if cl is not None and self._flutes > 0:
                     rf = _feed_from_chipload(cl, rpm, self._flutes)
                     if rf is not None:
-                        self.raw_feed_spin.setValue(rf)
+                        self._set_feed(rf)
         finally:
             self._syncing = False
 
@@ -247,65 +309,57 @@ class _EditPresetDialog(QtGui.QDialog):
     # when self._syncing is set, breaking feedback loops.
     # ------------------------------------------------------------------
 
-    def _set_silently(self, spinbox, value: float) -> None:
-        spinbox.blockSignals(True)
-        try:
-            spinbox.setValue(value)
-        finally:
-            spinbox.blockSignals(False)
-
-    def _on_surface_speed_changed(self, ss: float) -> None:
+    def _on_surface_speed_changed(self, *_) -> None:
         if self._syncing:
             return
         self._syncing = True
         try:
-            rpm = _rpm_from_surface_speed(ss, self._diameter_mm)
+            rpm = _rpm_from_surface_speed(self._get_surface_speed(), self._diameter_mm)
             if rpm is not None:
-                self._set_silently(self.raw_speed_spin, rpm)
-                cl = self.chipload_spin.value()
+                self._set_rpm(rpm)
+                cl = self._get_chipload()
                 if cl > 0 and self._flutes > 0:
                     rf = _feed_from_chipload(cl, rpm, self._flutes)
                     if rf is not None:
-                        self._set_silently(self.raw_feed_spin, rf)
+                        self._set_feed(rf)
         finally:
             self._syncing = False
 
-    def _on_chipload_changed(self, cl: float) -> None:
+    def _on_chipload_changed(self, *_) -> None:
         if self._syncing:
             return
         self._syncing = True
         try:
-            rpm = self.raw_speed_spin.value()
-            rf = _feed_from_chipload(cl, rpm, self._flutes)
+            rpm = self._get_rpm()
+            rf = _feed_from_chipload(self._get_chipload(), rpm, self._flutes)
             if rf is not None:
-                self._set_silently(self.raw_feed_spin, rf)
+                self._set_feed(rf)
         finally:
             self._syncing = False
 
-    def _on_raw_speed_changed(self, rpm: float) -> None:
+    def _on_raw_speed_changed(self, *_) -> None:
         if self._syncing:
             return
         self._syncing = True
         try:
+            rpm = self._get_rpm()
             ss = _surface_speed_from_rpm(rpm, self._diameter_mm)
             if ss is not None:
-                self._set_silently(self.surface_speed_spin, ss)
-            rf = self.raw_feed_spin.value()
-            cl = _chipload_from_feed(rf, rpm, self._flutes)
+                self._set_surface_speed(ss)
+            cl = _chipload_from_feed(self._get_feed(), rpm, self._flutes)
             if cl is not None:
-                self._set_silently(self.chipload_spin, cl)
+                self._set_chipload(cl)
         finally:
             self._syncing = False
 
-    def _on_raw_feed_changed(self, rf: float) -> None:
+    def _on_raw_feed_changed(self, *_) -> None:
         if self._syncing:
             return
         self._syncing = True
         try:
-            rpm = self.raw_speed_spin.value()
-            cl = _chipload_from_feed(rf, rpm, self._flutes)
+            cl = _chipload_from_feed(self._get_feed(), self._get_rpm(), self._flutes)
             if cl is not None:
-                self._set_silently(self.chipload_spin, cl)
+                self._set_chipload(cl)
         finally:
             self._syncing = False
 
@@ -316,7 +370,7 @@ class _EditPresetDialog(QtGui.QDialog):
     def _on_browse(self) -> None:
         from Path.Tool.Gui.MaterialPicker import pick_machinability_material
 
-        result = pick_machinability_material(self)
+        result = pick_machinability_material(self.form)
         if result is None:
             return
         self._material_uuid, self._material_name = result
@@ -347,8 +401,8 @@ class _EditPresetDialog(QtGui.QDialog):
             material_uuid=uuid,
             material_name=name,
             op_type=self.op_type_combo.currentData(),
-            surface_speed=self.surface_speed_spin.value() or None,
-            chipload=self.chipload_spin.value() or None,
+            surface_speed=self._get_surface_speed() or None,
+            chipload=self._get_chipload() or None,
             vert_feed_ratio=self.vert_ratio_spin.value(),
         )
 
@@ -416,8 +470,10 @@ class PresetsTab(QtGui.QWidget):
             self.table.setItem(i, 0, QtGui.QTableWidgetItem(name_text))
             self.table.setItem(i, 1, QtGui.QTableWidgetItem(mat_text))
             self.table.setItem(i, 2, QtGui.QTableWidgetItem(op_text))
-            self.table.setItem(i, 3, QtGui.QTableWidgetItem(_fmt(p.get("surface_speed"))))
-            self.table.setItem(i, 4, QtGui.QTableWidgetItem(_fmt(p.get("chipload"))))
+            self.table.setItem(
+                i, 3, QtGui.QTableWidgetItem(_fmt_quantity(p.get("surface_speed"), "m/min"))
+            )
+            self.table.setItem(i, 4, QtGui.QTableWidgetItem(_fmt_quantity(p.get("chipload"), "mm")))
             notes = []
             if p.get("raw_feed") is not None or p.get("raw_speed") is not None:
                 notes.append(translate("CAM_FeedsSpeeds", "raw fallback"))
@@ -446,9 +502,26 @@ class PresetsTab(QtGui.QWidget):
             flutes = 0
         return diameter_mm, flutes
 
+    def _tool_chipload(self) -> Optional[float]:
+        """Read the ToolBit's ``Chipload`` (mm/tooth), or None if unset or zero."""
+        try:
+            c = getattr(self._obj, "Chipload", None)
+            if c is None:
+                return None
+            value = float(c.Value) if hasattr(c, "Value") else float(c)
+            return value if value > 0 else None
+        except (AttributeError, TypeError, ValueError):
+            return None
+
     def _on_add(self) -> None:
         d, f = self._tool_geometry()
-        dlg = _EditPresetDialog(None, diameter_mm=d, flutes=f, parent=self)
+        dlg = _EditPresetDialog(
+            None,
+            diameter_mm=d,
+            flutes=f,
+            tool_chipload_mm=self._tool_chipload(),
+            parent=self,
+        )
         if dlg.exec_() != QtGui.QDialog.Accepted:
             return
         presets = self._presets()

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/presets_tab.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/presets_tab.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+# SPDX-FileCopyrightText: 2026 sliptonic <shopinthewoods@gmail.com>
+# SPDX-FileNotice: Part of the FreeCAD project.
+
+################################################################################
+#                                                                              #
+#   FreeCAD is free software: you can redistribute it and/or modify            #
+#   it under the terms of the GNU Lesser General Public License as             #
+#   published by the Free Software Foundation, either version 2.1              #
+#   of the License, or (at your option) any later version.                     #
+#                                                                              #
+#   FreeCAD is distributed in the hope that it will be useful,                 #
+#   but WITHOUT ANY WARRANTY; without even the implied warranty                #
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                    #
+#   See the GNU Lesser General Public License for more details.                #
+#                                                                              #
+#   You should have received a copy of the GNU Lesser General Public           #
+#   License along with FreeCAD. If not, see https://www.gnu.org/licenses       #
+#                                                                              #
+################################################################################
+
+"""
+Presets tab for the ToolBit editor. Lists the feeds & speeds presets stored
+on a ToolBit and supports add/edit/delete; each operation is written back to
+the ``Presets`` property immediately. Used as the last tab in the existing
+ToolBit editor's QTabWidget.
+"""
+
+import math
+from typing import List, Optional
+
+import FreeCAD
+from PySide import QtCore, QtGui
+
+from ...FeedsSpeeds import (
+    OP_TYPES,
+    derive_preset_label,
+    get_presets,
+    make_preset,
+    set_presets,
+)
+
+translate = FreeCAD.Qt.translate
+
+
+def _fmt(value: Optional[float], unit: str = "") -> str:
+    if value is None:
+        return ""
+    if unit:
+        return f"{value:g} {unit}"
+    return f"{value:g}"
+
+
+def _surface_speed_from_rpm(rpm: float, diameter_mm: float) -> Optional[float]:
+    """surface_speed (m/min) = rpm * pi * d / 1000."""
+    if rpm <= 0 or diameter_mm <= 0:
+        return None
+    return (rpm * math.pi * diameter_mm) / 1000.0
+
+
+def _rpm_from_surface_speed(surface_speed: float, diameter_mm: float) -> Optional[float]:
+    """rpm = surface_speed (m/min) * 1000 / (pi * d_mm)."""
+    if surface_speed <= 0 or diameter_mm <= 0:
+        return None
+    return (surface_speed * 1000.0) / (math.pi * diameter_mm)
+
+
+def _chipload_from_feed(feed_mm_min: float, rpm: float, flutes: int) -> Optional[float]:
+    """chipload (mm/tooth) = feed / (rpm * flutes)."""
+    if feed_mm_min <= 0 or rpm <= 0 or flutes <= 0:
+        return None
+    return feed_mm_min / (rpm * flutes)
+
+
+def _feed_from_chipload(chipload: float, rpm: float, flutes: int) -> Optional[float]:
+    """feed (mm/min) = chipload * rpm * flutes."""
+    if chipload <= 0 or rpm <= 0 or flutes <= 0:
+        return None
+    return chipload * rpm * flutes
+
+
+class _EditPresetDialog(QtGui.QDialog):
+    """Sub-dialog for adding or editing a single preset row.
+
+    The dialog accepts the tool's current ``diameter_mm`` and ``flutes`` so
+    it can keep the engineering inputs (surface speed, chipload) and the
+    direct inputs (spindle rpm, horiz feed mm/min) in sync as the user
+    types. Storage is engineering-only: only surface_speed, chipload and
+    vert_feed_ratio are persisted; the rpm/feed spinboxes are display
+    affordances derived from those plus the tool's geometry.
+    """
+
+    def __init__(
+        self,
+        preset: Optional[dict],
+        diameter_mm: float = 0.0,
+        flutes: Optional[int] = None,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle(translate("CAM_FeedsSpeeds", "Edit preset"))
+        layout = QtGui.QFormLayout(self)
+
+        self._initial = preset or make_preset()
+        self._material_uuid: Optional[str] = None
+        self._material_name: Optional[str] = None
+        self._diameter_mm = float(diameter_mm) if diameter_mm else 0.0
+        self._flutes = int(flutes) if flutes else 0
+        self._syncing = False  # guards against feedback loops
+
+        # Preset name — user-given label, optional but encouraged.
+        self.name_edit = QtGui.QLineEdit()
+        self.name_edit.setPlaceholderText(
+            translate("CAM_FeedsSpeeds", "Optional, e.g. 'Aluminum aggressive'")
+        )
+        layout.addRow(translate("CAM_FeedsSpeeds", "Name:"), self.name_edit)
+
+        # Material row: read-only label, Browse button opens the
+        # Machinability-filtered MaterialDialog. UUID is the authoritative
+        # identifier; name is for display + as a fallback when the UUID
+        # can't be resolved on a different machine.
+        mat_row = QtGui.QHBoxLayout()
+        self.material_label = QtGui.QLabel(translate("CAM_FeedsSpeeds", "(none)"))
+        mat_row.addWidget(self.material_label, 1)
+        self.browse_button = QtGui.QPushButton(translate("CAM_FeedsSpeeds", "Browse…"))
+        self.browse_button.clicked.connect(self._on_browse)
+        mat_row.addWidget(self.browse_button)
+        self.generic_check = QtGui.QCheckBox(translate("CAM_FeedsSpeeds", "Generic (any material)"))
+        self.generic_check.toggled.connect(self._on_generic_toggled)
+        mat_row.addWidget(self.generic_check)
+        layout.addRow(translate("CAM_FeedsSpeeds", "Material:"), mat_row)
+
+        # Op type
+        self.op_type_combo = QtGui.QComboBox()
+        self.op_type_combo.addItem(translate("CAM_FeedsSpeeds", "(any)"), None)
+        for op in OP_TYPES:
+            self.op_type_combo.addItem(op, op)
+        layout.addRow(translate("CAM_FeedsSpeeds", "Op type:"), self.op_type_combo)
+
+        # Engineering values
+        self.surface_speed_spin = QtGui.QDoubleSpinBox()
+        self.surface_speed_spin.setRange(0, 100000)
+        self.surface_speed_spin.setDecimals(2)
+        self.surface_speed_spin.setSuffix(" m/min")
+        layout.addRow(translate("CAM_FeedsSpeeds", "Surface speed:"), self.surface_speed_spin)
+
+        self.chipload_spin = QtGui.QDoubleSpinBox()
+        self.chipload_spin.setRange(0, 10)
+        self.chipload_spin.setDecimals(4)
+        self.chipload_spin.setSuffix(" mm/tooth")
+        layout.addRow(translate("CAM_FeedsSpeeds", "Chipload:"), self.chipload_spin)
+
+        self.vert_ratio_spin = QtGui.QDoubleSpinBox()
+        self.vert_ratio_spin.setRange(0, 1)
+        self.vert_ratio_spin.setDecimals(3)
+        self.vert_ratio_spin.setValue(0.33)
+        layout.addRow(translate("CAM_FeedsSpeeds", "Vert feed ratio:"), self.vert_ratio_spin)
+
+        # Raw values: entered directly as feed/speed. When tool geometry
+        # is known, these stay in sync with surface_speed/chipload above
+        # (editing either side updates the other).
+        raw_box = QtGui.QGroupBox(translate("CAM_FeedsSpeeds", "Direct feed and speed"))
+        raw_form = QtGui.QFormLayout(raw_box)
+        self.raw_feed_spin = QtGui.QDoubleSpinBox()
+        self.raw_feed_spin.setRange(0, 100000)
+        self.raw_feed_spin.setSuffix(" mm/min")
+        raw_form.addRow(translate("CAM_FeedsSpeeds", "Horiz feed:"), self.raw_feed_spin)
+        self.raw_speed_spin = QtGui.QDoubleSpinBox()
+        self.raw_speed_spin.setRange(0, 200000)
+        self.raw_speed_spin.setSuffix(" rpm")
+        raw_form.addRow(translate("CAM_FeedsSpeeds", "Spindle speed:"), self.raw_speed_spin)
+        layout.addRow(raw_box)
+
+        # Wire up bidirectional sync. Each handler reads geometry; when
+        # geometry is missing, that direction silently no-ops.
+        self.surface_speed_spin.valueChanged.connect(self._on_surface_speed_changed)
+        self.chipload_spin.valueChanged.connect(self._on_chipload_changed)
+        self.raw_speed_spin.valueChanged.connect(self._on_raw_speed_changed)
+        self.raw_feed_spin.valueChanged.connect(self._on_raw_feed_changed)
+
+        # Inform the user when sync is unavailable.
+        if self._diameter_mm <= 0 or self._flutes <= 0:
+            hint = QtGui.QLabel(
+                translate(
+                    "CAM_FeedsSpeeds",
+                    "Tool diameter and/or flute count missing — surface speed "
+                    "and chipload won't auto-sync with direct feed/speed.",
+                )
+            )
+            hint.setWordWrap(True)
+            hint.setStyleSheet("color: #888;")
+            layout.addRow(hint)
+
+        # Buttons
+        button_box = QtGui.QDialogButtonBox(
+            QtGui.QDialogButtonBox.Ok | QtGui.QDialogButtonBox.Cancel
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addRow(button_box)
+
+        self._populate_from_preset(self._initial)
+
+    def _populate_from_preset(self, preset: dict) -> None:
+        if preset.get("name"):
+            self.name_edit.setText(preset["name"])
+        hint = preset.get("material_hint")
+        if hint is None:
+            self.generic_check.setChecked(True)
+        else:
+            self._material_uuid = hint.get("uuid") or None
+            self._material_name = hint.get("name") or None
+            self._refresh_material_label()
+        op = preset.get("op_type_hint")
+        if op is not None:
+            idx = self.op_type_combo.findData(op)
+            if idx >= 0:
+                self.op_type_combo.setCurrentIndex(idx)
+        # Storage carries only the engineering values. Load those, then
+        # derive the raw display values from them and the tool's geometry.
+        # Suppress the sync handlers during this initial population so the
+        # derivation happens once, controlled, instead of cascading.
+        self._syncing = True
+        try:
+            ss = preset.get("surface_speed")
+            cl = preset.get("chipload")
+            if ss is not None:
+                self.surface_speed_spin.setValue(ss)
+            if cl is not None:
+                self.chipload_spin.setValue(cl)
+            self.vert_ratio_spin.setValue(preset.get("vert_feed_ratio", 0.33))
+
+            # Compute raw display values from engineering + geometry.
+            rpm = _rpm_from_surface_speed(ss, self._diameter_mm) if ss is not None else None
+            if rpm is not None:
+                self.raw_speed_spin.setValue(rpm)
+                if cl is not None and self._flutes > 0:
+                    rf = _feed_from_chipload(cl, rpm, self._flutes)
+                    if rf is not None:
+                        self.raw_feed_spin.setValue(rf)
+        finally:
+            self._syncing = False
+
+    # ------------------------------------------------------------------
+    # Bidirectional sync between engineering values (surface_speed, chipload)
+    # and direct values (raw_speed, raw_feed). Each handler returns early
+    # when self._syncing is set, breaking feedback loops.
+    # ------------------------------------------------------------------
+
+    def _set_silently(self, spinbox, value: float) -> None:
+        spinbox.blockSignals(True)
+        try:
+            spinbox.setValue(value)
+        finally:
+            spinbox.blockSignals(False)
+
+    def _on_surface_speed_changed(self, ss: float) -> None:
+        if self._syncing:
+            return
+        self._syncing = True
+        try:
+            rpm = _rpm_from_surface_speed(ss, self._diameter_mm)
+            if rpm is not None:
+                self._set_silently(self.raw_speed_spin, rpm)
+                cl = self.chipload_spin.value()
+                if cl > 0 and self._flutes > 0:
+                    rf = _feed_from_chipload(cl, rpm, self._flutes)
+                    if rf is not None:
+                        self._set_silently(self.raw_feed_spin, rf)
+        finally:
+            self._syncing = False
+
+    def _on_chipload_changed(self, cl: float) -> None:
+        if self._syncing:
+            return
+        self._syncing = True
+        try:
+            rpm = self.raw_speed_spin.value()
+            rf = _feed_from_chipload(cl, rpm, self._flutes)
+            if rf is not None:
+                self._set_silently(self.raw_feed_spin, rf)
+        finally:
+            self._syncing = False
+
+    def _on_raw_speed_changed(self, rpm: float) -> None:
+        if self._syncing:
+            return
+        self._syncing = True
+        try:
+            ss = _surface_speed_from_rpm(rpm, self._diameter_mm)
+            if ss is not None:
+                self._set_silently(self.surface_speed_spin, ss)
+            rf = self.raw_feed_spin.value()
+            cl = _chipload_from_feed(rf, rpm, self._flutes)
+            if cl is not None:
+                self._set_silently(self.chipload_spin, cl)
+        finally:
+            self._syncing = False
+
+    def _on_raw_feed_changed(self, rf: float) -> None:
+        if self._syncing:
+            return
+        self._syncing = True
+        try:
+            rpm = self.raw_speed_spin.value()
+            cl = _chipload_from_feed(rf, rpm, self._flutes)
+            if cl is not None:
+                self._set_silently(self.chipload_spin, cl)
+        finally:
+            self._syncing = False
+
+    def _on_generic_toggled(self, generic: bool) -> None:
+        self.material_label.setEnabled(not generic)
+        self.browse_button.setEnabled(not generic)
+
+    def _on_browse(self) -> None:
+        from Path.Tool.Gui.MaterialPicker import pick_machinability_material
+
+        result = pick_machinability_material(self)
+        if result is None:
+            return
+        self._material_uuid, self._material_name = result
+        self._refresh_material_label()
+        self.generic_check.setChecked(False)
+
+    def _refresh_material_label(self) -> None:
+        if self._material_name:
+            self.material_label.setText(self._material_name)
+        elif self._material_uuid:
+            self.material_label.setText(self._material_uuid)
+        else:
+            self.material_label.setText(translate("CAM_FeedsSpeeds", "(none)"))
+
+    def build_preset(self) -> dict:
+        if self.generic_check.isChecked():
+            uuid = None
+            name = None
+        else:
+            uuid = self._material_uuid
+            name = self._material_name
+        # Storage is engineering-only. The raw_speed/raw_feed spinboxes
+        # are display-and-entry affordances; whatever the user typed
+        # there is already reflected in surface_speed/chipload via the
+        # bidirectional sync, so we only persist the engineering side.
+        return make_preset(
+            name=self.name_edit.text().strip() or None,
+            material_uuid=uuid,
+            material_name=name,
+            op_type=self.op_type_combo.currentData(),
+            surface_speed=self.surface_speed_spin.value() or None,
+            chipload=self.chipload_spin.value() or None,
+            vert_feed_ratio=self.vert_ratio_spin.value(),
+        )
+
+
+class PresetsTab(QtGui.QWidget):
+    """
+    Tab widget showing the ToolBit's saved presets in a table, with
+    add/edit/delete buttons.
+    """
+
+    def __init__(self, toolbit_obj, parent=None):
+        super().__init__(parent)
+        self._obj = toolbit_obj
+
+        layout = QtGui.QVBoxLayout(self)
+
+        self.table = QtGui.QTableWidget()
+        self.table.setColumnCount(6)
+        self.table.setHorizontalHeaderLabels(
+            [
+                translate("CAM_FeedsSpeeds", "Name"),
+                translate("CAM_FeedsSpeeds", "Material"),
+                translate("CAM_FeedsSpeeds", "Op type"),
+                translate("CAM_FeedsSpeeds", "Surface speed"),
+                translate("CAM_FeedsSpeeds", "Chipload"),
+                translate("CAM_FeedsSpeeds", "Notes"),
+            ]
+        )
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.setSelectionBehavior(QtGui.QAbstractItemView.SelectRows)
+        self.table.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
+        layout.addWidget(self.table)
+
+        button_row = QtGui.QHBoxLayout()
+        button_row.addStretch()
+        self.add_button = QtGui.QPushButton(translate("CAM_FeedsSpeeds", "Add preset"))
+        self.add_button.clicked.connect(self._on_add)
+        button_row.addWidget(self.add_button)
+
+        self.edit_button = QtGui.QPushButton(translate("CAM_FeedsSpeeds", "Edit"))
+        self.edit_button.clicked.connect(self._on_edit)
+        button_row.addWidget(self.edit_button)
+
+        self.delete_button = QtGui.QPushButton(translate("CAM_FeedsSpeeds", "Delete"))
+        self.delete_button.clicked.connect(self._on_delete)
+        button_row.addWidget(self.delete_button)
+
+        layout.addLayout(button_row)
+        self.refresh()
+
+    def _presets(self) -> List[dict]:
+        return list(get_presets(self._obj))
+
+    def refresh(self) -> None:
+        presets = self._presets()
+        self.table.setRowCount(len(presets))
+        for i, p in enumerate(presets):
+            hint = p.get("material_hint")
+            if hint is None:
+                mat_text = translate("CAM_FeedsSpeeds", "(any material)")
+            else:
+                mat_text = hint.get("name") or hint.get("uuid") or "?"
+            op_text = p.get("op_type_hint") or translate("CAM_FeedsSpeeds", "(any)")
+            name_text = p.get("name") or ""
+            self.table.setItem(i, 0, QtGui.QTableWidgetItem(name_text))
+            self.table.setItem(i, 1, QtGui.QTableWidgetItem(mat_text))
+            self.table.setItem(i, 2, QtGui.QTableWidgetItem(op_text))
+            self.table.setItem(i, 3, QtGui.QTableWidgetItem(_fmt(p.get("surface_speed"))))
+            self.table.setItem(i, 4, QtGui.QTableWidgetItem(_fmt(p.get("chipload"))))
+            notes = []
+            if p.get("raw_feed") is not None or p.get("raw_speed") is not None:
+                notes.append(translate("CAM_FeedsSpeeds", "raw fallback"))
+            self.table.setItem(i, 5, QtGui.QTableWidgetItem(", ".join(notes)))
+
+    def _selected_index(self) -> Optional[int]:
+        rows = self.table.selectionModel().selectedRows()
+        if not rows:
+            return None
+        return rows[0].row()
+
+    def _tool_geometry(self) -> tuple:
+        """Read (diameter_mm, flutes) from the ToolBit doc object."""
+        diameter_mm = 0.0
+        flutes = 0
+        try:
+            d = getattr(self._obj, "Diameter", None)
+            if d is not None:
+                diameter_mm = float(d.Value) if hasattr(d, "Value") else float(d)
+        except (AttributeError, TypeError, ValueError):
+            diameter_mm = 0.0
+        try:
+            f = getattr(self._obj, "Flutes", None)
+            flutes = int(f) if f is not None else 0
+        except (TypeError, ValueError):
+            flutes = 0
+        return diameter_mm, flutes
+
+    def _on_add(self) -> None:
+        d, f = self._tool_geometry()
+        dlg = _EditPresetDialog(None, diameter_mm=d, flutes=f, parent=self)
+        if dlg.exec_() != QtGui.QDialog.Accepted:
+            return
+        presets = self._presets()
+        presets.append(dlg.build_preset())
+        set_presets(self._obj, presets)
+        self.refresh()
+
+    def _on_edit(self) -> None:
+        idx = self._selected_index()
+        if idx is None:
+            return
+        presets = self._presets()
+        d, f = self._tool_geometry()
+        dlg = _EditPresetDialog(presets[idx], diameter_mm=d, flutes=f, parent=self)
+        if dlg.exec_() != QtGui.QDialog.Accepted:
+            return
+        presets[idx] = dlg.build_preset()
+        set_presets(self._obj, presets)
+        self.refresh()
+
+    def _on_delete(self) -> None:
+        idx = self._selected_index()
+        if idx is None:
+            return
+        presets = self._presets()
+        del presets[idx]
+        set_presets(self._obj, presets)
+        self.refresh()

--- a/src/Mod/CAM/Path/Tool/toolbit/ui/presets_tab.py
+++ b/src/Mod/CAM/Path/Tool/toolbit/ui/presets_tab.py
@@ -42,12 +42,26 @@ from ...FeedsSpeeds import (
 
 translate = FreeCAD.Qt.translate
 
-# ``Gui::QuantitySpinBox`` stores its ``rawValue`` in the quantity's base
-# unit: mm/s for a velocity, mm for a length. The engineering math below
-# works in m/min (surface speed), mm/min (feed) and mm (chipload), so we
-# convert at the widget boundary. Chipload is already in mm = base unit.
-_MM_S_PER_M_MIN = 1000.0 / 60.0  # 1 m/min expressed in mm/s
+# Feed and chipload use ``Gui::QuantitySpinBox``, which stores its
+# ``rawValue`` in the quantity's base unit: mm/s for a velocity, mm for a
+# length. The engineering math works in mm/min (feed) and mm (chipload), so
+# feed is converted at the widget boundary; chipload is already in mm.
 _MM_S_PER_MM_MIN = 1.0 / 60.0  # 1 mm/min expressed in mm/s
+
+# Surface speed (cutting speed Vc) is the exception. Machining convention
+# expresses it in ft/min (imperial) or m/min (metric) — not what FreeCAD's
+# generic velocity schema produces (in/min for imperial), so it uses a plain
+# spinbox with an explicit unit. The math works in m/min.
+_M_MIN_PER_FT_MIN = 0.3048  # 1 ft/min expressed in m/min
+
+
+def _is_imperial_length() -> bool:
+    """True when the user's unit schema displays lengths in imperial units."""
+    try:
+        unit = FreeCAD.Units.Quantity(1.0, "mm").getUserPreferred()[2]
+    except Exception:
+        return False
+    return any(token in unit for token in ("in", "ft", "thou", '"', "'"))
 
 
 def _fmt(value: Optional[float], unit: str = "") -> str:
@@ -56,6 +70,18 @@ def _fmt(value: Optional[float], unit: str = "") -> str:
     if unit:
         return f"{value:g} {unit}"
     return f"{value:g}"
+
+
+def _fmt_surface_speed(value: Optional[float]) -> str:
+    """
+    Format a surface speed (stored in m/min) using machining convention:
+    ft/min for an imperial schema, m/min for metric.
+    """
+    if value is None:
+        return ""
+    if _is_imperial_length():
+        return f"{value / _M_MIN_PER_FT_MIN:g} ft/min"
+    return f"{value:g} m/min"
 
 
 def _preferred_unit(unit_expr: str) -> str:
@@ -187,17 +213,27 @@ class _EditPresetDialog:
             translate("CAM_FeedsSpeeds", "Optional, e.g. 'Aluminum aggressive'")
         )
 
-        # Display units follow the user's unit schema. Surface speed and
-        # horiz feed are velocities; chipload is a length (per tooth).
-        vel_unit = _preferred_unit("mm/s")
-        self.surface_speed_spin.setProperty("unit", vel_unit)
-        self.raw_feed_spin.setProperty("unit", vel_unit)
+        # Horiz feed (velocity) and chipload (length) map onto FreeCAD's
+        # unit schema, so their Gui::QuantitySpinBox display follows the
+        # user's preference automatically (mm/min or in/min; mm or in).
+        self.raw_feed_spin.setProperty("unit", _preferred_unit("mm/s"))
         self.chipload_spin.setProperty("unit", _preferred_unit("mm"))
         # Chipload needs finer resolution than the default spinbox decimals.
         # Gui::QuantitySpinBox comes through PySide as a bare QAbstractSpinBox
         # (no typed setters), so drive it through the Qt property system —
         # the same way its ``unit`` and ``rawValue`` are set.
         self.chipload_spin.setProperty("decimals", 4)
+
+        # Surface speed follows machining convention, not the velocity schema:
+        # ft/min for imperial, m/min for metric. It is a plain QDoubleSpinBox
+        # holding the value in that display unit; ``_ss_to_m_min`` converts
+        # to the m/min the math uses.
+        if _is_imperial_length():
+            self._ss_to_m_min = _M_MIN_PER_FT_MIN
+            self.surface_speed_spin.setSuffix(" ft/min")
+        else:
+            self._ss_to_m_min = 1.0
+            self.surface_speed_spin.setSuffix(" m/min")
 
         # Op type
         self.op_type_combo.addItem(translate("CAM_FeedsSpeeds", "(any)"), None)
@@ -209,7 +245,7 @@ class _EditPresetDialog:
         # so it doesn't matter whether the signal carries a str or a float.
         self.browse_button.clicked.connect(self._on_browse)
         self.generic_check.toggled.connect(self._on_generic_toggled)
-        self.surface_speed_spin.textChanged.connect(self._on_surface_speed_changed)
+        self.surface_speed_spin.valueChanged.connect(self._on_surface_speed_changed)
         self.chipload_spin.textChanged.connect(self._on_chipload_changed)
         self.raw_feed_spin.textChanged.connect(self._on_raw_feed_changed)
         self.raw_speed_spin.valueChanged.connect(self._on_raw_speed_changed)
@@ -230,10 +266,16 @@ class _EditPresetDialog:
     # ------------------------------------------------------------------
 
     def _get_surface_speed(self) -> float:  # m/min
-        return _spin_raw(self.surface_speed_spin) / _MM_S_PER_M_MIN
+        # Plain spinbox holding the value in the display unit (ft/min or
+        # m/min); convert to the m/min the math uses.
+        return self.surface_speed_spin.value() * self._ss_to_m_min
 
     def _set_surface_speed(self, ss_m_min: float) -> None:
-        _set_spin_raw(self.surface_speed_spin, ss_m_min * _MM_S_PER_M_MIN)
+        self.surface_speed_spin.blockSignals(True)
+        try:
+            self.surface_speed_spin.setValue(ss_m_min / self._ss_to_m_min)
+        finally:
+            self.surface_speed_spin.blockSignals(False)
 
     def _get_feed(self) -> float:  # mm/min
         return _spin_raw(self.raw_feed_spin) / _MM_S_PER_MM_MIN
@@ -471,7 +513,7 @@ class PresetsTab(QtGui.QWidget):
             self.table.setItem(i, 1, QtGui.QTableWidgetItem(mat_text))
             self.table.setItem(i, 2, QtGui.QTableWidgetItem(op_text))
             self.table.setItem(
-                i, 3, QtGui.QTableWidgetItem(_fmt_quantity(p.get("surface_speed"), "m/min"))
+                i, 3, QtGui.QTableWidgetItem(_fmt_surface_speed(p.get("surface_speed")))
             )
             self.table.setItem(i, 4, QtGui.QTableWidgetItem(_fmt_quantity(p.get("chipload"), "mm")))
             notes = []

--- a/src/Mod/CAM/Roadmap/ADR/ADR-000.md
+++ b/src/Mod/CAM/Roadmap/ADR/ADR-000.md
@@ -20,8 +20,13 @@ The top-level CAM document object that owns a single machining project. Holds th
 A saved blueprint of a **Job**'s configuration (post-processor, fixtures, output settings, setup-sheet defaults, tool controllers, stock, machine reference) for reuse on new projects. Serialized via the `JobTemplate` class as XML attribute strings. Distinct from a **Machine Template** — different file format and scope.
 _Avoid_: bare "template" (always qualify as **Job Template** or **Machine Template**).
 
+**Job Model Group**:
+The `App::DocumentObjectGroup` named "Model" that the **Job** owns and exposes through its `Model` property. Holds one or more **Models** as **Resource Clones**. Access the individual models via `Job.Model.Group`.
+_Avoid_: "Models" (plural noun for the collection), bare "Model group" (always qualify as **Job Model Group**).
+_Note_: the property name is singular (`Job.Model`) but the contents are plural — a frequent source of confusion. The singular property holds the group container; the group holds the models.
+
 **Model**:
-The part being machined. Referenced by the Job through a **Resource Clone** so the original geometry is not mutated.
+A part being machined. Referenced by the **Job Model Group** as a **Resource Clone** so the original geometry is not mutated. A **Job** may carry multiple Models (e.g. for multi-part fixturing or assemblies machined together); they are all held in the single **Job Model Group**.
 _Avoid_: Part, workpiece (in code/UI — "Model" is the canonical name).
 
 **Stock**:
@@ -46,6 +51,10 @@ _Note_: clashes with the industry term "fixture" meaning the physical workholdin
 **Operation** (also **Op**):
 A single machining step that produces a **Toolpath** — e.g. a pocket, a profile, a drilling cycle. **Op** is a synonym, used as code shorthand (filenames, variable names, `Path/Op/`). Inherits from the internal base class `ObjectOp` (`Path/Op/Base.py`). Configured by **Feature** flags + properties + **Base Geometry** + a **Tool Controller**.
 _Avoid_: step, task, action. `ObjectOp` is internal — not a domain term.
+
+**Strategy**:
+A named selection between alternative algorithms within an **Operation** that share the operation's framework but differ in their motion or behavior. Currently exposed concretely as the `App::PropertyEnumeration` property `Strategy` on **Drilling** (values: "Drilling", "Tapping"), which supersedes the standalone Tapping op. The concept extends informally to other algorithmic choices — for example, a **linking strategy** governs how rapids and lead-ins connect successive cuts; a clearing strategy chooses between offset, zigzag, and spiral patterns within a pocket — though those choices are not all yet exposed as named `Strategy` properties.
+_Avoid_: mode (acceptable in legacy properties like `CutMode`, but Strategy is the canonical forward-going term for "which algorithm"), pattern (use only when describing a geometric pattern itself, not the algorithm choice), kind, type. Distinct from **Generator** — a Strategy *uses* one or more Generators to build its motion; they are not interchangeable.
 
 **Feature** (in operation context):
 A bit-flag (`FeatureTool`, `FeatureDepths`, `FeatureHeights`, …) that an **Operation** ORs together to declare which standard properties it supports. Distinct from FreeCAD's generic notion of "feature" (a document object).
@@ -82,8 +91,8 @@ _Avoid_: conflating with **Finish Pass**. A **Finish Pass** follows a *new* tool
 - 3D Pocket — 3D cavity clearing. Implemented in `Path/Op/Pocket.py`. Distinct from **Pocket**.
 - Profile — cuts along a contour (inside/outside/on-line).
 - Adaptive — high-efficiency clearing using a constant tool engagement strategy.
-- Drilling — canned-cycle drilling on circular holes.
-- Tapping — thread cutting in holes.
+- Drilling — canned-cycle hole-making on circular holes. Carries a **Strategy** property selecting between "Drilling" and "Tapping" algorithms.
+- Tapping — thread cutting in holes. _Deprecated_: superseded by **Drilling** with `Strategy="Tapping"`.
 - ThreadMilling — milled thread on a hole.
 - Helix — helical interpolation into a hole.
 - Engrave — single-line engraving along edges.
@@ -96,17 +105,19 @@ _Avoid_: conflating with **Finish Pass**. A **Finish Pass** follows a *new* tool
 - Deburr — edge-break pass.
 - Custom — user-supplied G-code injected as a path.
 
+_Note_: the F&S subsystem groups these into a smaller cutting-kind vocabulary (`OP_TYPES` in `Path/Tool/FeedsSpeeds/types.py`: `profile`, `pocket`, `slot`, `drill`, `adaptive`, `surface_finish`). The mapping is many-to-one — Tapping/Drilling/Helix all map to `"drill"`, Mill Facing maps to `"surface_finish"`, etc. The two vocabularies are intentionally different: the Operation catalog enumerates user-facing op kinds; `OP_TYPES` enumerates F&S-relevant cutting kinds.
+
 ### Tools
 
 **Tool** (bare):
 Not a domain term. Always disambiguate to **Tool Bit**, **Tool Controller**, **Tool Library**, or **Tool Shape**. The compound names below are the only canonical forms.
 
 **Tool Controller** (also **TC**):
-The runtime pairing of a **Tool Bit** with spindle speed, feed rates, and rapids. **Operations** reference a **Tool Controller**, not a **Tool Bit** directly. Lives under the **Job**'s `Tools` group.
+The runtime pairing of a **Tool Bit** with **Spindle Speed**, **Horizontal Feed**, **Vertical Feed**, and rapids. **Operations** reference a **Tool Controller**, not a **Tool Bit** directly. Lives under the **Job**'s `Tools` group. F&S values may be hand-entered (recorded as `"user"` provenance) or filled by the **Resolver** via the F&S dialog; per-field source is tracked in **Feed/Speed Provenance**.
 _Avoid_: tool slot, tool assembly (in CAM-workbench code; "Tool Controller" or "TC" only).
 
 **Tool Bit**:
-The cutter itself — geometry, cutting edges, dimensional parameters. Has a **Tool Shape** classifier: `Endmill`, `Ballend`, `Bullnose`, `Chamfer`, `Drill`, `VBit`, `Dovetail`, `Reamer`, `SlittingSaw`, `Tap`, `ThreadMill`, `Probe`, `TaperedBallNose`, `Radius`, `Custom`.
+The cutter itself — geometry, cutting edges, dimensional parameters. Has a **Tool Shape** classifier: `Endmill`, `Ballend`, `Bullnose`, `Chamfer`, `Drill`, `VBit`, `Dovetail`, `Reamer`, `SlittingSaw`, `Tap`, `ThreadMill`, `Probe`, `TaperedBallNose`, `Radius`, `Custom`. May carry one or more F&S **Presets**, persisted in the `.fctb` file and editable in the ToolBit editor's Presets tab.
 _Avoid_: cutter, bit, end mill (when speaking of the abstraction — use the specific shape name when speaking of the kind).
 
 **Tool Library**:
@@ -114,6 +125,44 @@ A persisted collection of **Tool Bits**, serialized to disk. Independent of any 
 
 **Tool Shape**:
 The geometric template for a **Tool Bit**. Defines the parametric shape used to render and (for some operations) compute engagement.
+
+### Feeds & Speeds
+
+**Spindle Speed**:
+The rotational speed of the cutter, in rpm. Stored on the **Tool Controller** as `SpindleSpeed`.
+_Avoid_: rpm (a unit, not a name), S-word (G-code term, not a domain term).
+
+**Horizontal Feed**:
+The cutting feed for XY motion, in mm/min. Stored on the **Tool Controller** as `HorizFeed`.
+_Avoid_: feedrate (ambiguous between horizontal and vertical), F-word (G-code term).
+
+**Vertical Feed**:
+The plunge feed for −Z motion, in mm/min. Stored on the **Tool Controller** as `VertFeed`. May also be expressed as a ratio of **Horizontal Feed** (the **Vert Feed Ratio** on a **Preset**).
+_Avoid_: plunge rate (acceptable in user-facing prose; in code use **Vertical Feed**).
+
+**Surface Speed** (also **Vc**):
+The speed of a point on the cutting edge relative to the workpiece, in m/min. Equivalent to "SFM" (Surface Feet per Minute) in imperial units. Determined primarily by the workpiece material and the tool's material; together with tool diameter it gives **Spindle Speed**: `rpm = (Vc × 1000) / (π × diameter_mm)`.
+_Avoid_: SFM (imperial-only — the codebase uses m/min throughout). "Cutting speed" is acceptable in user-facing prose; in code identifiers use `surface_speed`.
+
+**Chipload** (also **Fz**):
+The thickness of material removed by one cutting edge per revolution, in mm/tooth. Together with **Spindle Speed** and flute count it gives **Horizontal Feed**: `feed = rpm × flutes × chipload`.
+_Avoid_: feed per tooth (acceptable but verbose), chip thickness (overlaps with effective chip thickness in chip-thinning contexts).
+
+**Preset**:
+A named F&S record stored on a **Tool Bit** specifying **Surface Speed**, **Chipload**, and an optional vertical-feed ratio for a (material, op-type) combination. Multiple presets per tool. Storage is engineering-only — raw feed (mm/min) and raw spindle speed (rpm) are derived at use-time from preset values plus the tool's geometry; they are not persisted.
+_Avoid_: default, recipe, profile (overlaps with the Profile op), rule (rules are a separate, broader concept planned for Phase 2).
+
+**Provider**:
+A pluggable object that suggests F&S values from one source (a **Preset**, a future vendor catalog, a future formula). Implements `suggest(tool, material, op) → PartialResult | None`. Phase 1 ships `ToolPresetProvider` and `ToolDefaultsProvider`.
+_Avoid_: source, lookup, calculator (these collide with adjacent concepts).
+
+**Resolver**:
+The pure function `resolve(tool, material, op) → FeedSpeedResult` that walks a chain of **Providers** in priority order and merges their contributions. GUI- and FreeCAD-Document-independent at the boundary; testable from fixtures without a running FreeCAD process.
+_Avoid_: calculator, suggester, engine.
+
+**Feed/Speed Provenance** (property: `FeedSpeedProvenance`):
+A per-field record on a **Tool Controller** identifying where each F&S value came from: `"user"` for hand-entered values, or a source string from a **Provider** (e.g. `"preset:tool/aluminum-6061/profile"`). The **Resolver** never overwrites a field whose provenance is `"user"`.
+_Avoid_: source (too generic — the property is named `FeedSpeedProvenance`), origin.
 
 ### Toolpath generation
 
@@ -156,12 +205,14 @@ _Avoid_: linter, validator, pre-flight check, job report.
 
 ## Relationships
 
-- A **Job** has exactly one **Model**, one **Stock**, one **Setup Sheet**, one **Machine**, one **Post-Processor**, and many **Operations** and **Tool Controllers**.
+- A **Job** has exactly one **Job Model Group** (containing one or more **Models**), one **Stock**, one **Setup Sheet**, one **Machine**, one **Post-Processor**, and many **Operations** and **Tool Controllers**.
 - An **Operation** references exactly one **Tool Controller** (when it has `FeatureTool`).
-- A **Tool Controller** references exactly one **Tool Bit**.
-- A **Tool Bit** belongs to zero or more **Tool Libraries** (libraries are independent of **Jobs**).
+- An **Operation** may carry a **Strategy** property selecting between alternative algorithms within its operation framework.
+- A **Tool Controller** references exactly one **Tool Bit** and carries **Spindle Speed**, **Horizontal Feed**, **Vertical Feed**, and **Feed/Speed Provenance**.
+- A **Tool Bit** belongs to zero or more **Tool Libraries** (libraries are independent of **Jobs**) and may carry zero or more F&S **Presets**.
 - A **Dressup** wraps exactly one **Operation** (and is itself treated as an **Operation** in the **Job**'s output order).
 - An **Operation** uses zero or more **Generators** to build its **Toolpath**.
+- The **Resolver** walks a chain of **Providers** to suggest F&S for a (**Tool Bit**, material, op-type) combination; suggestions are written to a **Tool Controller** with **Feed/Speed Provenance** stamped per field.
 - A **Job** + a **Post-Processor** + a **Machine** produce the final G-code output.
 - **Sanity Check** runs over a **Job** and emits a report; it does not modify the **Job**.
 

--- a/src/Mod/CAM/TestCAMApp.py
+++ b/src/Mod/CAM/TestCAMApp.py
@@ -114,6 +114,9 @@ from CAMTests.TestPathToolBitSerializer import (
     TestFCTBSerializer,
     TestYamlToolBitSerializer,
 )
+from CAMTests.TestFeedsSpeedsResolver import TestFeedsSpeedsResolver
+from CAMTests.TestFeedsSpeedsToolBitPresets import TestFeedsSpeedsToolBitPresets
+from CAMTests.TestFeedsSpeedsToolController import TestFeedsSpeedsToolController
 from CAMTests.TestPathToolLibrary import TestPathToolLibrary
 from CAMTests.TestPathToolLibrarySerializer import (
     TestCamoticsLibrarySerializer,


### PR DESCRIPTION
Feeds & Speeds — Phase 1 Proof of Concept

Additional information is available [here](https://github.com/FreeCAD/FreeCAD/discussions/30422)

Demonstrate the resolver architecture end-to-end before the broader Phase 1 work is tackled.
Takes feed and speed values from user-defined recipes or from combination of material & toolbit definition.
Introduces a flexible architecture that can be extended to provide more robust and comprehensive F&S suggestions.

# What it does (for users)
## New F&S button on the Tool Controller 
  
<img width="1317" height="882" alt="image" src="https://github.com/user-attachments/assets/f3cc6ad3-6674-41c8-8711-140c961b795c" />
    
Button (1) editor opens a "Suggest" dialog: shows current vs. suggested feed/speed/spindle side-by-side, requires confirmation before anything is written (2)

Results are written back to the tool controller (3). Spindle speed suggestions are clamped to the machine's min/max RPM taken from the Machine definition spindle section.

  
##  New Presets tab on the ToolBit editor for managing named presets per tool.
  
<img width="995" height="878" alt="image" src="https://github.com/user-attachments/assets/4473a233-8693-499d-a23f-e96e213f7364" />

- Adds a tab of presets (1)
- Controls to add/edit presets (2)
- Preset editor dialog (3)

   
  - Editing a preset store engineering values (surface speed, chipload, optional vert-feed ratio) plus an optional material
  Actual feeds/speeds are computed from the tool's current geometry, so they survive a diameter or flute-count edit.
  - Resurrects the dormant ToolBit.Chipload field as a low-confidence fallback when no preset matches.

  # What it does (for developers)
  - New Path/Tool/FeedsSpeeds/ module: pure-function FeedSpeedResolver + provider chain (ToolPresetProvider,
  ToolDefaultsProvider). Frozen dataclasses, no FreeCAD-Document dependency, fully unit-testable.
  - Material is referenced by FreeCAD Material UUID (with name fallback), not free-form string. No new dependency on Mod/Material
   from the ToolBit module.
  - Presets persist in the .fctb file as an additive top-level "presets" key; format version unchanged, older readers ignore it.
  On-doc storage is a lazy-added App::PropertyString.
  - Tool Controller gains lazy OpTypeHint and FeedSpeedProvenance properties on first F&S use.
  - New tests: TestFeedsSpeedsResolver, TestFeedsSpeedsToolBitPresets, TestFeedsSpeedsToolController.


Also bundled
  ADR-000 terminology related to F&S.
  
  Fixes #21817
  Fixes #28419