### PR TITLE
Preserve folder when saving edited material

### DIFF
--- a/src/Mod/Material/Gui/MaterialSave.cpp
+++ b/src/Mod/Material/Gui/MaterialSave.cpp
@@ -54,6 +54,7 @@ MaterialSave::MaterialSave(const std::shared_ptr<Materials::Material>& material,
     ui->setupUi(this);
 
     setLibraries();
+    selectMaterialLibrary();
     createModelTree();
     showSelectedTree();
 
@@ -376,6 +377,7 @@ void MaterialSave::showSelectedTree()
 
         auto modelTree = Materials::MaterialManager::getManager().getMaterialTree(*library);
         addMaterials(*lib, modelTree, folderIcon, icon);
+        selectCurrentMaterial();
     }
     else {
         QMessageBox::warning(Gui::getMainWindow(),
@@ -395,6 +397,79 @@ QString MaterialSave::getPath(const QStandardItem* item) const
     }
 
     return path;
+}
+
+void MaterialSave::selectMaterialLibrary()
+{
+    auto materialLibrary = _material->getLibrary();
+    if (!materialLibrary) {
+        return;
+    }
+
+    for (int i = 0; i < ui->comboLibrary->count(); i++) {
+        auto variant = ui->comboLibrary->itemData(i);
+        auto library = variant.value<std::shared_ptr<Materials::MaterialLibrary>>();
+        if (library && library->getName() == materialLibrary->getName()) {
+            ui->comboLibrary->setCurrentIndex(i);
+            return;
+        }
+    }
+}
+
+QStandardItem* MaterialSave::findMaterialItem(QStandardItem* item, const QString& uuid) const
+{
+    if (!item) {
+        return nullptr;
+    }
+
+    auto itemUuid = item->data(Qt::UserRole);
+    if (itemUuid.isValid() && itemUuid.toString() == uuid) {
+        return item;
+    }
+
+    for (int i = 0; i < item->rowCount(); i++) {
+        auto match = findMaterialItem(item->child(i), uuid);
+        if (match) {
+            return match;
+        }
+    }
+
+    return nullptr;
+}
+
+void MaterialSave::selectCurrentMaterial()
+{
+    auto uuid = _material->getUUID();
+    if (uuid.isEmpty()) {
+        return;
+    }
+
+    auto tree = ui->treeMaterials;
+    auto model = static_cast<QStandardItemModel*>(tree->model());
+    QStandardItem* item = nullptr;
+    for (int i = 0; i < model->rowCount(); i++) {
+        item = findMaterialItem(model->item(i), uuid);
+        if (item) {
+            break;
+        }
+    }
+    if (!item) {
+        return;
+    }
+
+    for (auto parent = item->parent(); parent != nullptr; parent = parent->parent()) {
+        tree->setExpanded(parent->index(), true);
+    }
+
+    auto selectionModel = tree->selectionModel();
+    selectionModel->select(item->index(),
+                           QItemSelectionModel::ClearAndSelect
+                               | QItemSelectionModel::Current);
+    tree->setCurrentIndex(item->index());
+
+    _selectedPath = getPath(item->parent());
+    _selectedFull = getPath(item);
+    _selectedUUID = uuid;
 }
 
 void MaterialSave::onSelectModel(const QItemSelection& selected, const QItemSelection& deselected)

--- a/src/Mod/Material/Gui/MaterialSave.h
+++ b/src/Mod/Material/Gui/MaterialSave.h
@@ -89,12 +89,15 @@ private:
 
     QAction _deleteAction;
 
+    void selectMaterialLibrary();
+    void selectCurrentMaterial();
     QString getPath(const QStandardItem* item) const;
     std::shared_ptr<Materials::MaterialLibrary> currentLibrary();
     void createFolder(const QString& path);
     void renameFolder(const QString& oldPath, const QString& newPath);
     void deleteRecursive(const QString& path);
     QString pathFromIndex(const QModelIndex& index) const;
+    QStandardItem* findMaterialItem(QStandardItem* item, const QString& uuid) const;
     int confirmDelete(QWidget* parent);
     bool selectedHasChildren();
     void deleteSelected();


### PR DESCRIPTION
## Summary

Fixes #25802.

When the material save dialog opens for an existing material, it now defaults to that material's writable library and selects the current material in the tree. This keeps the dialog's internal save path on the original folder instead of falling back to the library root.

## Root cause

`MaterialSave::showSelectedTree()` always initialized `_selectedPath` to the current library root. If a user edited a material stored in a custom folder and clicked Save without manually selecting that folder again, `onOk()` built the destination as `/<library>/<name>.FCMat`, so the edited material was saved as a root-level copy rather than overwriting `/<library>/<folder>/<name>.FCMat`.

## Implementation

- Select the edited material's library in the save dialog when that library is writable.
- Search the displayed material tree by UUID after it is built.
- Select and expand the existing material entry, updating `_selectedPath`, `_selectedFull`, and `_selectedUUID` so the existing nested file is the default save target.

## Checks

- `git diff --check`
- `uvx pre-commit run --files src/Mod/Material/Gui/MaterialSave.cpp src/Mod/Material/Gui/MaterialSave.h` (all hooks skipped because the current top-level pre-commit `files` pattern does not include `src/Mod/Material`)

I could not run a full FreeCAD GUI reproduction in this Windows checkout because there is no local built FreeCAD runtime/LibPack configured here.