### PR TITLE
BIM: preserve compound geometry in NativeIFC

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_export.py
+++ b/src/Mod/BIM/nativeifc/ifc_export.py
@@ -149,14 +149,18 @@ def get_export_preferences(ifcfile, preferred_context=None, create=None):
     return prefs, best_context
 
 
-def create_product(obj, parent, ifcfile, ifcclass=None):
+def create_product(obj, parent, ifcfile, ifcclass=None, skipshape=False):
     """Creates an IFC product out of a FreeCAD object"""
 
     name = obj.Label
     description = getattr(obj, "Description", None)
     if not ifcclass:
         ifcclass = ifc_tools.get_ifctype(obj)
-    representation, placement = create_representation(obj, ifcfile)
+    if skipshape:
+        representation = None
+        placement = None
+    else:
+        representation, placement = create_representation(obj, ifcfile)
     product = ifc_tools.api_run("root.create_entity", ifcfile, ifc_class=ifcclass, name=name)
     ifc_tools.set_attribute(ifcfile, product, "Description", description)
     ifc_tools.set_attribute(ifcfile, product, "ObjectPlacement", placement)

--- a/src/Mod/BIM/nativeifc/ifc_selftest.py
+++ b/src/Mod/BIM/nativeifc/ifc_selftest.py
@@ -323,6 +323,38 @@ class NativeIFCTest(unittest.TestCase):
         print(ifco, "IFC objects created")
         self.assertTrue(fco == 8 - SDU and ifco == 12, "CreateDocument failed")
 
+    def test09b_CreateCompoundAssembly(self):
+        FreeCAD.Console.PrintMessage("NativeIFC 09b: Creating compound assembly...")
+        doc = FreeCAD.ActiveDocument
+        proj = ifc_tools.create_document(doc, silent=True)
+        site = ifc_tools.aggregate(Arch.makeSite(), proj)
+        bldg = ifc_tools.aggregate(Arch.makeBuilding(), site)
+        storey = ifc_tools.aggregate(Arch.makeFloor(), bldg)
+        seat = doc.addObject("Part::Box", "ChairSeat")
+        seat.Length = 200
+        seat.Width = 200
+        seat.Height = 20
+        back = doc.addObject("Part::Box", "ChairBack")
+        back.Length = 200
+        back.Width = 20
+        back.Height = 200
+        back.Placement.Base = FreeCAD.Vector(0, 180, 0)
+        compound = doc.addObject("Part::Compound", "Chair")
+        compound.Links = [seat, back]
+        doc.recompute()
+        assembly = ifc_tools.aggregate(compound, storey)
+        doc.recompute()
+
+        assembly_element = ifc_tools.get_ifc_element(assembly)
+        children = element.get_decomposition(assembly_element)
+        child_representations = [
+            child for child in children if getattr(child, "Representation", None)
+        ]
+        self.assertTrue(assembly_element.is_a("IfcElementAssembly"), "Compound is not an assembly")
+        self.assertFalse(assembly_element.Representation, "Assembly should use child geometry")
+        self.assertEqual(len(child_representations), 2, "Compound children lost their geometry")
+        self.assertEqual(len(assembly.Group), 2, "Compound children were not grouped")
+
     def test10_ChangePlacement(self):
         FreeCAD.Console.PrintMessage("NativeIFC 10: Changing Placement...")
         clearObjects()

--- a/src/Mod/BIM/nativeifc/ifc_tools.py
+++ b/src/Mod/BIM/nativeifc/ifc_tools.py
@@ -1246,6 +1246,23 @@ def save(obj, filepath=None):
     obj.Modified = False
 
 
+def _get_aggregate_children(obj):
+    """Returns children that should be aggregated under an IFC assembly."""
+
+    children = []
+    for attr in ("Group", "Links"):
+        for child in getattr(obj, attr, []):
+            if child and child not in children:
+                children.append(child)
+    if not children and hasattr(obj, "getSubObjects"):
+        for subname in obj.getSubObjects():
+            name = subname[:-1] if subname.endswith(".") else subname
+            child = obj.Document.getObject(name)
+            if child and child not in children:
+                children.append(child)
+    return children
+
+
 def aggregate(obj, parent, mode=None):
     """Takes any FreeCAD object and aggregates it to an existing IFC object.
     Mode can be 'opening' to force-create a subtraction"""
@@ -1260,6 +1277,7 @@ def aggregate(obj, parent, mode=None):
     product = None
     objecttype = None
     new = False
+    aggregate_children = _get_aggregate_children(obj)
     stepid = getattr(obj, "StepId", None)
     if stepid:
         # obj might be dragging at this point and has no project anymore
@@ -1285,7 +1303,10 @@ def aggregate(obj, parent, mode=None):
             obj.Proxy.create_ifc(obj, ifcfile)
             newobj = obj
         else:
-            product = ifc_export.create_product(obj, parent, ifcfile, ifcclass)
+            skipshape = (
+                bool(aggregate_children) and (ifcclass or get_ifctype(obj)) == "IfcElementAssembly"
+            )
+            product = ifc_export.create_product(obj, parent, ifcfile, ifcclass, skipshape=skipshape)
     if product:
         exobj = get_object(product, obj.Document)
         if exobj is None:
@@ -1317,6 +1338,9 @@ def aggregate(obj, parent, mode=None):
             aggregate(child, newobj)
     for child in getattr(obj, "Group", []):
         if newobj.IfcClass == "IfcGroup" and child in obj.Group:
+            aggregate(child, newobj)
+    if newobj.IfcClass == "IfcElementAssembly":
+        for child in aggregate_children:
             aggregate(child, newobj)
     delete = not (PARAMS.GetBool("KeepAggregated", False))
     if new and delete and base:


### PR DESCRIPTION
Fixes #26157.

### What changed
- Detects aggregate children from `Group`, `Links`, or subobjects when NativeIFC converts FreeCAD assembly-like objects.
- Creates `IfcElementAssembly` containers without duplicating their own compound shape when they have child products.
- Aggregates linked compound children under the new IFC assembly so their geometry is preserved.
- Adds a NativeIFC selftest for converting a `Part::Compound` chair into an assembly with child geometry.

### Validation
- `python -m py_compile src\Mod\BIM\nativeifc\ifc_tools.py src\Mod\BIM\nativeifc\ifc_export.py src\Mod\BIM\nativeifc\ifc_selftest.py`
- `git diff --check`
- `uvx pre-commit run --files src\Mod\BIM\nativeifc\ifc_tools.py src\Mod\BIM\nativeifc\ifc_export.py src\Mod\BIM\nativeifc\ifc_selftest.py`

I could not run the FreeCAD selftest locally because `FreeCADCmd` is not available in this environment.