### PR TITLE
Use transformed input shapes in BOPTools split features

### DIFF
--- a/src/Mod/Part/BOPTools/SplitFeatures.py
+++ b/src/Mod/Part/BOPTools/SplitFeatures.py
@@ -31,6 +31,24 @@ from . import SplitAPI
 import FreeCAD
 import Part
 
+
+def _get_shape(obj):
+    """Get an object's shape in document coordinates."""
+    if hasattr(obj, "Shape"):
+        return Part.getShape(obj, retType=2)[0]
+
+    if hasattr(obj, "Group"):
+        shapes = []
+        for child in obj.Group:
+            shape = _get_shape(child)
+            if shape is not None and not shape.isNull():
+                shapes.append(shape)
+        if shapes:
+            return Part.makeCompound(shapes)
+
+    return None
+
+
 if FreeCAD.GuiUp:
     import FreeCADGui
     from PySide import QtCore, QtGui
@@ -101,7 +119,11 @@ class FeatureBooleanFragments:
         self.Type = "FeatureBooleanFragments"
 
     def execute(self, selfobj):
-        shapes = [obj.Shape for obj in selfobj.Objects]
+        shapes = [
+            shape
+            for shape in (_get_shape(obj) for obj in selfobj.Objects)
+            if shape is not None and not shape.isNull()
+        ]
         if len(shapes) == 1 and shapes[0].ShapeType == "Compound":
             shapes = shapes[0].childShapes()
         if len(shapes) < 2:
@@ -300,29 +322,15 @@ class FeatureSlice:
         if len(selfobj.Tools) < 1:
             raise ValueError("No slicing objects supplied!")
 
-        # helper function to get the shape from object or group
-        def get_shape(obj):
-            """get shape from a part object or compound from a group."""
-            if hasattr(obj, "Shape"):
-                return obj.Shape
-            elif hasattr(obj, "Group"):  # it's a group/container from ie. slice apart
-                shapes = []
-                for child in obj.Group:
-                    if hasattr(child, "Shape"):
-                        shapes.append(child.Shape)
-                if shapes:
-                    return Part.makeCompound(shapes)
-            return None
-
         # get base shape
-        base_shape = get_shape(selfobj.Base)
+        base_shape = _get_shape(selfobj.Base)
         if base_shape is None or base_shape.isNull():
             raise ValueError("Base object has no valid shape!")
 
         # get tool shapes
         tool_shapes = []
         for tool in selfobj.Tools:
-            shape = get_shape(tool)
+            shape = _get_shape(tool)
             if shape is not None and not shape.isNull():
                 tool_shapes.append(shape)
 

--- a/src/Mod/Part/TestPartApp.py
+++ b/src/Mod/Part/TestPartApp.py
@@ -967,6 +967,29 @@ class PartBOPTestContainer(unittest.TestCase):
         fuse = bp.make_multi_common([cyl.Name, box.Name])
         self.assertEqual(part, fuse.getParent())
 
+    def testBooleanFragmentsRespectInputPlacement(self):
+        box = self.Doc.addObject("Part::Box", "Box")
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+
+        placed_box = self.Doc.addObject("Part::Box", "PlacedBox")
+        placed_box.Length = 10
+        placed_box.Width = 10
+        placed_box.Height = 10
+        placed_box.Placement.Base = FreeCAD.Vector(10, 0, 0)
+
+        from BOPTools import SplitFeatures
+
+        fragments = SplitFeatures.makeBooleanFragments("Fragments")
+        fragments.Objects = [box, placed_box]
+        fragments.Mode = "CompSolid"
+        self.Doc.recompute()
+
+        self.assertAlmostEqual(fragments.Shape.BoundBox.XMin, 0.0)
+        self.assertAlmostEqual(fragments.Shape.BoundBox.XMax, 20.0)
+        self.assertEqual(len(fragments.Shape.Solids), 2)
+
     def tearDown(self):
         FreeCAD.closeDocument(self.Doc.Name)
 


### PR DESCRIPTION
## Summary

Fixes #26830.

BOPTools SplitFeatures now extracts source shapes with `Part.getShape(..., retType=2)[0]`, so Boolean Fragments and Slice operate on document-coordinate shapes that include object placement and resolved links instead of raw local `obj.Shape` geometry.

## Root cause

`FeatureBooleanFragments.execute()` used `obj.Shape` directly for each input object, and `FeatureSlice.execute()` had a local helper with the same behavior. For objects whose geometry is positioned by `Placement`, the boolean operation received the untransformed local shape. In workflows such as Boolean Fragments in CompSolid mode followed by Compound Filter, this can make touching placed solids look offset or coincident in the generated fragments, so the downstream filter drops a part.

## Implementation

- Added a shared `_get_shape()` helper for BOPTools SplitFeatures.
- Use transformed/resolved shapes for Boolean Fragments inputs.
- Reuse the same helper for Slice base/tool shape extraction, including group/container children.
- Added a Part regression test with two touching boxes where one box is positioned by `Placement`; CompSolid BooleanFragments must span X=0..20 and keep two solids.

## Checks

- `python -m py_compile src/Mod/Part/BOPTools/SplitFeatures.py src/Mod/Part/TestPartApp.py`
- `uvx pre-commit run --files src/Mod/Part/BOPTools/SplitFeatures.py src/Mod/Part/TestPartApp.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Note: `src/Mod/Part/TestPartApp.py` is stored with CRLF in the repository, so the diff check was run with `cr-at-eol` enabled. I could not run the FreeCAD Part test locally because this checkout does not have a built FreeCAD runtime/FreeCADCmd available and `import FreeCAD` fails in the system Python.