### PR TITLE
Fix closed AdditivePipe profile islands

### DIFF
--- a/src/Mod/PartDesign/App/FeaturePipe.cpp
+++ b/src/Mod/PartDesign/App/FeaturePipe.cpp
@@ -30,6 +30,7 @@
 #include <BRepBuilderAPI_MakeSolid.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepClass3d_SolidClassifier.hxx>
+#include <BRepCheck_Analyzer.hxx>
 #include <BRepOffsetAPI_MakePipeShell.hxx>
 #include <gp_Ax2.hxx>
 #include <Law_Function.hxx>
@@ -447,28 +448,39 @@ App::DocumentObjectExecReturn* Pipe::execute()
             );
         }
 
-        auto shapes = result.getSubTopoShapes(TopAbs_SHELL);
-        for (auto& s : shapes) {
-            // build the solid
-            s = s.makeElementSolid();
-            BRepClass3d_SolidClassifier SC(s.getShape());
-            SC.PerformInfinitePoint(Precision::Confusion());
-            if (SC.State() == TopAbs_IN) {
-                s.setShape(s.getShape().Reversed(), false);
-            }
-        }
-
-        AddSubShape.setValue(result.makeElementCompound(
-            shapes,
-            nullptr,
-            Part::TopoShape::SingleShapeCompoundCreationPolicy::returnShape
-        ));
-
-        if (shapes.size() > 1) {
-            result.makeElementFuse(shapes);
+        const bool keepClosedSolid = frontwires.empty() && backwires.empty()
+            && result.countSubShapes(TopAbs_SOLID)
+            && BRepCheck_Analyzer(result.getShape()).IsValid();
+        if (keepClosedSolid) {
+            // Closed sweeps can form one solid with inner shells; keep that topology so
+            // profile islands remain hollow instead of being fused into the outer shell.
+            result.fixSolidOrientation();
+            AddSubShape.setValue(result);
         }
         else {
-            result = shapes.front();
+            auto shapes = result.getSubTopoShapes(TopAbs_SHELL);
+            for (auto& s : shapes) {
+                // build the solid
+                s = s.makeElementSolid();
+                BRepClass3d_SolidClassifier SC(s.getShape());
+                SC.PerformInfinitePoint(Precision::Confusion());
+                if (SC.State() == TopAbs_IN) {
+                    s.setShape(s.getShape().Reversed(), false);
+                }
+            }
+
+            AddSubShape.setValue(result.makeElementCompound(
+                shapes,
+                nullptr,
+                Part::TopoShape::SingleShapeCompoundCreationPolicy::returnShape
+            ));
+
+            if (shapes.size() > 1) {
+                result.makeElementFuse(shapes);
+            }
+            else {
+                result = shapes.front();
+            }
         }
 
         if (base.isNull()) {

--- a/src/Mod/PartDesign/PartDesignTests/TestPipe.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestPipe.py
@@ -94,6 +94,38 @@ class TestPipe(unittest.TestCase):
         self.Doc.recompute()
         self.assertAlmostEqual(self.SubtractivePipe.Shape.Volume, 100 - 3.14159265)
 
+    def testClosedAdditivePipePreservesProfileIsland(self):
+        self.Body = self.Doc.addObject("PartDesign::Body", "Body")
+        self.ProfileSketch = self.Doc.addObject("Sketcher::SketchObject", "ProfileSketch")
+        self.Body.addObject(self.ProfileSketch)
+        self.ProfileSketch.addGeometry(
+            [
+                Part.Circle(App.Vector(0.0, 0.0, 0.0), App.Vector(0.0, 0.0, 1.0), 1.0),
+                Part.Circle(App.Vector(0.0, 0.0, 0.0), App.Vector(0.0, 0.0, 1.0), 0.5),
+            ],
+            False,
+        )
+        self.Doc.recompute()
+
+        self.SpineSketch = self.Doc.addObject("Sketcher::SketchObject", "SpineSketch")
+        self.Body.addObject(self.SpineSketch)
+        self.SpineSketch.MapMode = "FlatFace"
+        self.SpineSketch.AttachmentSupport = (self.Doc.XZ_Plane, [""])
+        self.SpineSketch.addGeometry(
+            Part.Circle(App.Vector(5.0, 0.0, 0.0), App.Vector(0.0, 0.0, 1.0), 5.0),
+            False,
+        )
+        self.Doc.recompute()
+
+        self.AdditivePipe = self.Doc.addObject("PartDesign::AdditivePipe", "AdditivePipe")
+        self.Body.addObject(self.AdditivePipe)
+        self.AdditivePipe.Profile = self.ProfileSketch
+        self.AdditivePipe.Spine = self.SpineSketch
+        self.Doc.recompute()
+
+        self.assertEqual(len(self.AdditivePipe.Shape.Solids), 1)
+        self.assertEqual(len(self.AdditivePipe.Shape.Shells), 2)
+
     def tearDown(self):
         # closing doc
         FreeCAD.closeDocument("PartDesignTestPipe")


### PR DESCRIPTION
## Summary

Fixes #24996.

Closed AdditivePipe sweeps can produce one valid solid with multiple shells when the profile contains an island. The previous code split every shell into its own solid and fused them, which fills the inner shell and turns a pipe profile into a solid sweep.

## Implementation

- Keep the valid closed-sweep solid produced by `BRepBuilderAPI_MakeSolid` when no front/back caps are needed.
- Validate the closed result with `BRepCheck_Analyzer` before taking that path; invalid closed multi-shell results fall back to the existing shell-to-solid/fuse behavior.
- Preserve the existing open-path behavior for sweeps that need generated front/back faces.
- Add a PartDesign regression test with a closed circular spine and a profile sketch containing concentric wires. The resulting AdditivePipe must remain one solid with two shells.

## Checks

- `python -m py_compile src\Mod\PartDesign\PartDesignTests\TestPipe.py`
- `uvx pre-commit run --files src/Mod/PartDesign/App/FeaturePipe.cpp src/Mod/PartDesign/PartDesignTests/TestPipe.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Note: I could not run the FreeCAD PartDesign runtime test locally because this checkout does not have a built FreeCAD/FreeCADCmd runtime available.