### PR TITLE
BIM: use external defining sketch geometry

### DIFF
--- a/src/Mod/BIM/ArchCurtainWall.py
+++ b/src/Mod/BIM/ArchCurtainWall.py
@@ -55,6 +55,7 @@ import math
 import FreeCAD
 import ArchCommands
 import ArchComponent
+import ArchSketchObject
 import DraftVecUtils
 
 from draftutils import params
@@ -424,20 +425,12 @@ class CurtainWall(ArchComponent.Component):
             ):  # would be false (none) if SketchArch Add-on is not installed, or base ArchSketch does not have the edges stored / input by user
                 curtainWallEdges = curtainWallBaseShapeEdges.get("curtainWallEdges")
             elif obj.Base.isDerivedFrom("Sketcher::SketchObject"):
-                skGeom = obj.Base.GeometryFacadeList
-                skGeomEdges = []
                 skPlacement = obj.Base.Placement  # Get Sketch's placement to restore later
-                for ig, geom in enumerate(skGeom):
-                    if (not obj.OverrideEdges and not geom.Construction) or str(
-                        ig
-                    ) in obj.OverrideEdges:
-                        # support Line, Arc, Circle, Ellipse for Sketch
-                        # as Base at the moment
-                        if isinstance(
-                            geom.Geometry, (Part.LineSegment, Part.Circle, Part.ArcOfCircle)
-                        ):
-                            skGeomEdgesI = geom.Geometry.toShape()
-                            skGeomEdges.append(skGeomEdgesI)
+                skGeomEdges = ArchSketchObject.getSketchDefiningEdges(
+                    obj.Base,
+                    obj.OverrideEdges,
+                    (Part.LineSegment, Part.Circle, Part.ArcOfCircle),
+                )
                 curtainWallEdges = []
                 for edge in skGeomEdges:
                     edge.Placement = edge.Placement.multiply(skPlacement)

--- a/src/Mod/BIM/ArchSketchObject.py
+++ b/src/Mod/BIM/ArchSketchObject.py
@@ -25,6 +25,49 @@
 from PySide.QtCore import QT_TRANSLATE_NOOP
 
 
+def getSketchDefiningEdges(sketch, selected_edges=None, supported_geometry=None):
+    import Part
+    import Sketcher
+
+    if supported_geometry is None:
+        supported_geometry = (Part.LineSegment, Part.Circle, Part.ArcOfCircle, Part.Ellipse)
+
+    selected_edges = {str(edge) for edge in selected_edges or []}
+    edges = []
+
+    for index, facade in enumerate(sketch.GeometryFacadeList):
+        if selected_edges:
+            if str(index) not in selected_edges:
+                continue
+        elif facade.Construction:
+            continue
+
+        if isinstance(facade.Geometry, supported_geometry):
+            edges.append(facade.Geometry.toShape())
+
+    external_geometry = list(getattr(sketch, "ExternalGeo", []))
+    for index, geometry in enumerate(external_geometry[2:], start=2):
+        facade = Sketcher.ExternalGeometryFacade(geometry)
+        geo_id = -index - 1
+
+        if not facade.Ref:
+            continue
+
+        if facade.testFlag("Missing"):
+            continue
+
+        if selected_edges:
+            if str(geo_id) not in selected_edges:
+                continue
+        elif not facade.testFlag("Defining"):
+            continue
+
+        if isinstance(facade.Geometry, supported_geometry):
+            edges.append(facade.Geometry.toShape())
+
+    return edges
+
+
 class ArchSketchObject:
     def __init__(self, obj):
         pass

--- a/src/Mod/BIM/ArchStructure.py
+++ b/src/Mod/BIM/ArchStructure.py
@@ -42,6 +42,7 @@ import FreeCAD
 import ArchComponent
 import ArchCommands
 import ArchProfile
+import ArchSketchObject
 import Draft
 import DraftVecUtils
 
@@ -1115,35 +1116,20 @@ class _Structure(ArchComponent.Component):
                                 baseShapeWires = structureBaseShapeWires.get("slabWires")
                                 faceMaker = structureBaseShapeWires.get("faceMaker")
                         elif obj.Base.isDerivedFrom("Sketcher::SketchObject"):
-                            skGeom = obj.Base.GeometryFacadeList
-                            skGeomEdges = []
                             skPlacement = (
                                 obj.Base.Placement
                             )  # Get Sketch's placement to restore later
-                            # Get ArchSketch edges to construct ArchStructure
-                            # No need to test obj.ArchSketchData ...
-                            for ig, geom in enumerate(skGeom):
-                                # Construction mode edges should be ignored if
-                                # ArchSketchEdges, otherwise, ArchSketchEdges data
-                                # needs to take out those in Construction before
-                                # using as parameters.
-                                if (not obj.ArchSketchEdges and not geom.Construction) or str(
-                                    ig
-                                ) in obj.ArchSketchEdges:
-                                    # support Line, Arc, Circle, Ellipse, BSplineCurve for Sketch
-                                    # as Base at the moment
-                                    if isinstance(
-                                        geom.Geometry,
-                                        (
-                                            Part.LineSegment,
-                                            Part.Circle,
-                                            Part.ArcOfCircle,
-                                            Part.Ellipse,
-                                            Part.BSplineCurve,
-                                        ),
-                                    ):
-                                        skGeomEdgesI = geom.Geometry.toShape()
-                                        skGeomEdges.append(skGeomEdgesI)
+                            skGeomEdges = ArchSketchObject.getSketchDefiningEdges(
+                                obj.Base,
+                                obj.ArchSketchEdges,
+                                (
+                                    Part.LineSegment,
+                                    Part.Circle,
+                                    Part.ArcOfCircle,
+                                    Part.Ellipse,
+                                    Part.BSplineCurve,
+                                ),
+                            )
                             clusterTransformed = []
                             for cluster in Part.getSortedClusters(skGeomEdges):
                                 edgesTransformed = []

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1092,27 +1092,10 @@ class _Wall(ArchComponent.Component):
                     # in some corner case != getSortedClusters()
                     elif obj.Base.isDerivedFrom("Sketcher::SketchObject"):
                         self.basewires = []
-                        skGeom = obj.Base.GeometryFacadeList
-                        skGeomEdges = []
                         skPlacement = obj.Base.Placement  # Get Sketch's placement to restore later
-                        # Get ArchSketch edges to construct ArchWall
-                        # No need to test obj.ArchSketchData ...
-                        for ig, geom in enumerate(skGeom):
-                            # Construction mode edges should be ignored if
-                            # ArchSketchEdges, otherwise, ArchSketchEdges data
-                            # needs to take out those in Construction before
-                            # using as parameters.
-                            if (not obj.ArchSketchEdges and not geom.Construction) or str(
-                                ig
-                            ) in obj.ArchSketchEdges:
-                                # support Line, Arc, Circle, Ellipse for Sketch
-                                # as Base at the moment
-                                if isinstance(
-                                    geom.Geometry,
-                                    (Part.LineSegment, Part.Circle, Part.ArcOfCircle, Part.Ellipse),
-                                ):
-                                    skGeomEdgesI = geom.Geometry.toShape()
-                                    skGeomEdges.append(skGeomEdgesI)
+                        skGeomEdges = ArchSketchObject.getSketchDefiningEdges(
+                            obj.Base, obj.ArchSketchEdges
+                        )
                         for cluster in Part.getSortedClusters(skGeomEdges):
                             clusterTransformed = []
                             for edge in cluster:

--- a/src/Mod/BIM/bimtests/TestArchWall.py
+++ b/src/Mod/BIM/bimtests/TestArchWall.py
@@ -42,6 +42,25 @@ class TestArchWall(TestArchBase.TestArchBase):
         w = Arch.makeWall(l)
         self.assertTrue(w, "Arch Wall failed")
 
+    def test_wall_from_external_defining_sketch_geometry(self):
+        operation = "Checking Arch Wall from external defining sketch geometry..."
+        self.printTestMessage(operation)
+
+        source = self.document.addObject("Sketcher::SketchObject", "SourceSketch")
+        source.addGeometry(Part.LineSegment(App.Vector(0, 0, 0), App.Vector(1000, 0, 0)))
+        target = self.document.addObject("Sketcher::SketchObject", "TargetSketch")
+        self.document.recompute()
+
+        target.addExternal(source.Name, "Edge1", True)
+        wall = Arch.makeWall(target, width=100, height=500)
+        self.document.recompute()
+
+        self.assertGreater(
+            wall.Shape.Volume,
+            0,
+            "Arch Wall should use external defining sketch geometry",
+        )
+
     def testWallMultiMatAlign(self):
         operation = "Checking Arch Wall with MultiMaterial and 3 alignments..."
         self.printTestMessage(operation)


### PR DESCRIPTION
## Summary
- collect external defining sketch geometry alongside internal non-construction geometry for BIM sketch bases
- reuse the shared sketch edge collector in Wall, CurtainWall, and Structure generation paths
- add a Wall regression test for a sketch whose only wall baseline is an external defining edge

## Tests
- python -m py_compile src\Mod\BIM\ArchSketchObject.py src\Mod\BIM\ArchWall.py src\Mod\BIM\ArchCurtainWall.py src\Mod\BIM\ArchStructure.py src\Mod\BIM\bimtests\TestArchWall.py
- git diff --check
- uvx pre-commit run --files src\Mod\BIM\ArchSketchObject.py src\Mod\BIM\ArchWall.py src\Mod\BIM\ArchCurtainWall.py src\Mod\BIM\ArchStructure.py src\Mod\BIM\bimtests\TestArchWall.py

Fixes #28239