### PR TITLE
Gui: Document::getActiveView : reverse the true in getMDIViews(true)

### DIFF
--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -2681,7 +2681,7 @@ MDIView* Document::getActiveView() const
     MDIView* active = getMainWindow()->activeWindow();
 
     // get all MDI views of the document
-    std::list<MDIView*> mdis = getMDIViews(true);
+    std::list<MDIView*> mdis = getMDIViews();
 
     // check whether the active view is part of this document
     bool ok = false;


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/29901

The PR https://github.com/FreeCAD/FreeCAD/pull/23073 made the following change to `Document::getActiveView` : 
It added true to the call to `getMDIViews()`.

What this did, is that Document::getActiveView would then return passive views if it is active (views that are not attached to a document, like the Start Page view).
@jffmichi did this because : 

> The OpenGL CAM simulator is shared between all documents but still needs to receive messages like view commands or space mouse movements. Without that flag, a passive view could never receive those signals, IIRC.

But this change makes no sense architecturally: DOCUMENT->getActiveView should not return the start page or any other view that is not attached to it.

This change causes the crash in #29901. The chain of failure is this : 
- `ViewProviderAssemblyLink::doubleClicked()` tries to reopen the partially loaded linked assembly file.
- reopen code does the logical thing : if the document has no active view, open one. If there is one set it as active.
```
                if (!gdoc->setActiveView()) {
                    gdoc->setActiveView(nullptr, View3DInventor::getClassTypeId());
                }
```
- Surprise! The start page now register as an active view of the document. so the if is skipped, and the startpage becomes the active view.
- Later, the linked assembly setEdit does `Gui.getDocument(appDoc).ActiveView.setActiveObject`. ActiveView being the startpage it has no linked document. Because ActiveObjectList has no guards against _Doc being nullptr it crashes (this is fixed by https://github.com/FreeCAD/FreeCAD/pull/30037 btw)

I could add something like `gdoc->setActiveView(nullptr, View3DInventor::getClassTypeId())` in the assembly view provider. Or we could patch `Document::setActiveView` so that it does not accept the startpage. But I don't think they are good ideas. It's patching a hack deep in core that is bound to generate more issues.

IMO it must be reverted. The CAM simulator needs to find a proper way to fix it's issues (why does it has to be shared between document anyway? The job belongs to a file. Why can't the view be linked to that file?).