### PR TITLE
Fix tree status bar update on keyboard selection

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -4034,6 +4034,10 @@ void TreeWidget::onItemSelectionChanged()
         }
     }
 
+    if (selItems.size() == 1 && selItems.front()->type() == ObjectType) {
+        static_cast<DocumentObjectItem*>(selItems.front())->displayStatusInfo();
+    }
+
     this->blockSelection(lock);
 }
 


### PR DESCRIPTION
## Summary
- Refresh the tree object's status bar text when exactly one object is selected.
- Reuse the existing `DocumentObjectItem::displayStatusInfo()` path that already powers hover status text.

## Root cause
Keyboard navigation changes the current tree selection without going through the hover path, so the status bar can keep showing the previously preselected object.

Fixes #24720

## Testing
- Not run: full FreeCAD GUI build/test suite is not available in this environment.