### PR TITLE
Expand object selection tree in dialog

### DIFF
--- a/src/Gui/Dialogs/DlgObjectSelection.cpp
+++ b/src/Gui/Dialogs/DlgObjectSelection.cpp
@@ -97,6 +97,8 @@ void DlgObjectSelection::init(
 
     ui = new Ui_DlgObjectSelection;
     ui->setupUi(this);
+    ui->vsplitter->setStretchFactor(0, 1);
+    ui->vsplitter->setStretchFactor(1, 0);
 
     hGrp = App::GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/General");
     ui->checkBoxAutoDeps->setChecked(hGrp->GetBool("ObjectSelectionAutoDeps", true));


### PR DESCRIPTION
## Summary
- Give the object tree side of the Object Selection dialog the horizontal splitter stretch.
- Keep the dependency/details side at its content-driven width so extra dialog width goes to the primary object list.

## Root cause
The dialog's horizontal splitter treated the selected-object tree and the dependency panel as peers, so widening the dialog split the added space between both panes instead of expanding the primary object view.

Fixes #24130

## Testing
- Not run: full FreeCAD GUI build/test suite is not available in this environment.