### PR TITLE
BIM: fix Draft creation in strict IFC mode

### DIFF
--- a/src/Mod/BIM/nativeifc/ifc_observer.py
+++ b/src/Mod/BIM/nativeifc/ifc_observer.py
@@ -30,6 +30,25 @@ from . import has_ifcopenshell
 params = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/Mod/NativeIFC")
 
 
+def is_transient_view_object(obj):
+    """Check if an object is only a temporary GUI preview."""
+
+    if not FreeCAD.GuiUp:
+        return False
+    if "StepId" in obj.PropertiesList:
+        return False
+    try:
+        vobj = obj.ViewObject
+    except (AttributeError, ReferenceError):
+        return False
+    if not vobj:
+        return False
+    try:
+        return obj.isDerivedFrom("Part::Feature") and not vobj.ShowInTree
+    except ReferenceError:
+        return False
+
+
 def add_observer():
     """Adds this observer to the running FreeCAD instance"""
 
@@ -220,6 +239,8 @@ class ifc_observer:
             return
         del self.docname
         del self.objname
+        if is_transient_view_object(obj):
+            return
         if (
             obj.isDerivedFrom("Part::Feature")
             or "IfcType" in obj.PropertiesList
@@ -229,6 +250,7 @@ class ifc_observer:
             from . import ifc_geometry  # lazy loading
             from . import ifc_tools  # lazy loading
 
+            obj.recompute()
             newobj = ifc_tools.aggregate(obj, doc)
             ifc_geometry.add_geom_properties(newobj)
             doc.recompute()

--- a/src/Mod/Draft/draftutils/gui_utils.py
+++ b/src/Mod/Draft/draftutils/gui_utils.py
@@ -150,6 +150,7 @@ def autogroup(obj):
             from nativeifc import ifc_tools
 
             parent = Gui.ActiveDocument.ActiveView.getActiveObject("NativeIFC")
+            obj.recompute()
             ifc_tools.aggregate(obj, parent)
         except:
             pass


### PR DESCRIPTION
## Summary
- Skip NativeIFC conversion for hidden transient GUI preview objects created by Draft tools.
- Recompute Draft/Part objects before NativeIFC aggregation from both Draft autogroup and the NativeIFC document observer.
- This keeps strict IFC conversion from exporting empty Draft geometry or deleting Draft preview objects mid-command.

## Issues
Fixes #24306
Fixes #24307
Fixes #24308

## Testing
- `python3 -m py_compile src/Mod/Draft/draftutils/gui_utils.py src/Mod/BIM/nativeifc/ifc_observer.py`
- `git diff --check`

Not run locally: full FreeCAD GUI reproduction/test suite, because `FreeCAD`/`FreeCADCmd` is not installed in this environment. The local Python environment also does not have `black` installed for the project black check.