### PR TITLE
TechDraw: allow locking Draft and Arch views

### DIFF
--- a/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
+++ b/src/Mod/TechDraw/Gui/CommandExtensionPack.cpp
@@ -1570,9 +1570,9 @@ void CmdTechDrawExtensionLockUnlockView::activated(int iMsg)
 
     openCommand(QT_TRANSLATE_NOOP("Command", "Lock/Unlock View"));
     for (auto& sel : selection) {
-        auto* obj = static_cast<TechDraw::DrawViewPart*>(sel.getObject());
+        auto* obj = dynamic_cast<TechDraw::DrawView*>(sel.getObject());
 
-        if (obj->isDerivedFrom<TechDraw::DrawViewPart>()) {
+        if (obj) {
             bool lockPosition = obj->LockPosition.getValue();
             lockPosition = !lockPosition;
             obj->LockPosition.setValue(lockPosition);
@@ -1584,7 +1584,7 @@ void CmdTechDrawExtensionLockUnlockView::activated(int iMsg)
 bool CmdTechDrawExtensionLockUnlockView::isActive()
 {
     bool havePage = DrawGuiUtil::needPage(this);
-    bool haveView = DrawGuiUtil::needView(this);
+    bool haveView = DrawGuiUtil::needView(this, false);
     return (havePage && haveView);
 }
 


### PR DESCRIPTION
## Summary
- Make the TechDraw Lock/Unlock View command operate on the base `DrawView` class instead of only `DrawViewPart`.
- Enable the command when a page contains Draft/Arch/SVG-backed views, since those views also expose `LockPosition`.

## Issues
Fixes #25133

## Testing
- `git diff --check`

Not run locally: full FreeCAD build/GUI reproduction, because `FreeCAD`/`FreeCADCmd` and the C++ build toolchain are not available in this environment.