### PR TITLE
Gui: initialize stored VarSet expressions

### DIFF
--- a/src/Gui/Dialogs/DlgExpressionInput.cpp
+++ b/src/Gui/Dialogs/DlgExpressionInput.cpp
@@ -602,6 +602,7 @@ void DlgExpressionInput::createBindingVarSet(App::Property* propVarSet, App::Doc
     binding.apply();
 
     varSet->renameObjectIdentifiers(idsFromObjToVarSet);
+    varSet->ExpressionEngine.execute();
 }
 
 void DlgExpressionInput::acceptWithVarSet()


### PR DESCRIPTION
## Summary
- execute the VarSet expression engine immediately after storing a non-literal expression through the expression dialog
- keeps the newly created VarSet property value in sync before the originating dialog is closed

Closes #27997

## Verification
- git diff --check
- clang-format unavailable in this environment
- FreeCAD/FreeCADCmd unavailable in this environment