### PR TITLE
Material: preserve small default-unit quantities

### DIFF
--- a/src/Mod/Material/App/Materials.cpp
+++ b/src/Mod/Material/App/Materials.cpp
@@ -404,7 +404,7 @@ void MaterialProperty::setQuantity(const Base::Quantity& value)
         //
         // This needs to be parsed rather than just setting units. Otherwise we get mm->m conversion
         // errors, etc
-        quantity = Base::Quantity::parse(quantity.getUserString() + getUnits().toStdString());
+        quantity = Base::Quantity::parse(quantity.getSafeUserString() + getUnits().toStdString());
     }
     else {
         auto propertyUnit = Base::Quantity::parse(getUnits().toStdString()).getUnit();

--- a/tests/src/Mod/Material/App/TestMaterialProperties.cpp
+++ b/tests/src/Mod/Material/App/TestMaterialProperties.cpp
@@ -153,6 +153,20 @@ TEST_F(TestMaterialProperties, TestSingle)
     EXPECT_EQ(variant.toString().size(), 0);
 }
 
+TEST_F(TestMaterialProperties, TestSmallDimensionlessQuantityUsesDefaultUnits)
+{
+    Materials::MaterialProperty prop(modelProp2, QStringLiteral("sampleUUID"));
+
+    prop.setQuantity(Base::Quantity::parse("0.0001"));
+
+    auto expected = Base::Quantity::parse("0.0001kg/m^3");
+    expected.setFormat(Materials::MaterialValue::getQuantityFormat());
+    auto quantity = prop.getValue().value<Base::Quantity>();
+    EXPECT_DOUBLE_EQ(quantity.getValue(), expected.getValue());
+    EXPECT_EQ(quantity.getUnit(), expected.getUnit());
+    EXPECT_EQ(prop.getString(), QString::fromStdString(expected.getUserString()));
+}
+
 void check2DArray(Materials::MaterialProperty& prop)
 {
     EXPECT_EQ(prop.getType(), Materials::MaterialValue::Array2D);


### PR DESCRIPTION
## Summary
- use Quantity::getSafeUserString() when applying material default units to dimensionless quantity input
- add a MaterialProperty regression test for small density values such as 0.0001

Closes #25804

## Verification
- git diff --check
- not run: Material_tests_run/ctest because local checkout has no googletest submodule or FreeCAD build tree
- not run: clang-format because clang-format is unavailable in this environment