### PR TITLE
Part: mirror nested part containers

### DIFF
--- a/src/Mod/Part/App/FeatureMirroring.cpp
+++ b/src/Mod/Part/App/FeatureMirroring.cpp
@@ -22,13 +22,11 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <BRepBuilderAPI_Transform.hxx>
 #include <BRep_Tool.hxx>
 #include <gp_Ax2.hxx>
 #include <gp_Circ.hxx>
 #include <gp_Dir.hxx>
 #include <gp_Pnt.hxx>
-#include <gp_Trsf.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepAdaptor_Surface.hxx>
 #include <gp_Pln.hxx>
@@ -309,22 +307,7 @@ App::DocumentObjectExecReturn* Mirroring::execute()
     Base::Vector3d norm = Normal.getValue();
 
     try {
-        // get shape without transform
-        auto shape = Feature::getTopoShape(link, ShapeOption::ResolveLink);
-
-        // check for placement property no matter the type hierarchy
-        // App::Link does not get its placement via GeoFeature inheritance
-        if (auto propPlacement = link->getPropertyByName<App::PropertyPlacement>("Placement")) {
-            Base::Placement placement = propPlacement->getValue();
-
-            if (!placement.isIdentity()) {
-                gp_Trsf trsf;
-                TopoShape::convertTogpTrsf(placement.toMatrix(), trsf);
-
-                BRepBuilderAPI_Transform mkTrf(shape.getShape(), trsf, Standard_True);
-                shape = TopoShape(mkTrf.Shape());
-            }
-        }
+        auto shape = Feature::getTopoShape(link, ShapeOption::ResolveLink | ShapeOption::Transform);
 
         gp_Ax2 ax2(gp_Pnt(base.x, base.y, base.z), gp_Dir(norm.x, norm.y, norm.z));
 

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -1243,7 +1243,11 @@ static TopoShape _getTopoShape(
                 if (shape.isNull()) {
                     continue;
                 }
-                if (visible < 0 && subObj && !subObj->Visibility.getValue()) {
+                // Hidden geo-feature groups can still contain visible child shapes.
+                const bool isGeoFeatureGroup =
+                    subObj
+                    && subObj->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId());
+                if (visible < 0 && subObj && !subObj->Visibility.getValue() && !isGeoFeatureGroup) {
                     continue;
                 }
             }

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -1244,8 +1244,7 @@ static TopoShape _getTopoShape(
                     continue;
                 }
                 // Hidden geo-feature groups can still contain visible child shapes.
-                const bool isGeoFeatureGroup =
-                    subObj
+                const bool isGeoFeatureGroup = subObj
                     && subObj->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId());
                 if (visible < 0 && subObj && !subObj->Visibility.getValue() && !isGeoFeatureGroup) {
                     continue;

--- a/src/Mod/Part/parttests/TestPartMirror.py
+++ b/src/Mod/Part/parttests/TestPartMirror.py
@@ -232,6 +232,33 @@ class TestPartMirroringRegression(unittest.TestCase):
         self.assertAlmostEqual(mirror_bbox.ZMin, link_bbox.ZMin, delta=1.0)
         self.assertAlmostEqual(mirror_bbox.ZMax, link_bbox.ZMax, delta=1.0)
 
+    def testMirroringNestedPartContainer(self):
+        """Test that Part::Mirroring includes children of nested App::Part containers."""
+        outer = self.doc.addObject("App::Part", "Outer")
+        inner = self.doc.addObject("App::Part", "Inner")
+        box = self.doc.addObject("Part::Box", "Box")
+        box.Length = 10
+        box.Width = 10
+        box.Height = 10
+        box.Placement = App.Placement(App.Vector(20, 0, 0), App.Rotation())
+
+        inner.addObject(box)
+        outer.addObject(inner)
+        inner.Visibility = False
+        self.doc.recompute()
+
+        mirror = self.doc.addObject("Part::Mirroring", "Mirror")
+        mirror.Source = outer
+        mirror.Base = App.Vector(0, 0, 0)
+        mirror.Normal = App.Vector(1, 0, 0)
+        self.doc.recompute()
+
+        mirror_bbox = mirror.Shape.BoundBox
+        self.assertAlmostEqual(mirror_bbox.XMin, -30.0, delta=1.0)
+        self.assertAlmostEqual(mirror_bbox.XMax, -20.0, delta=1.0)
+        self.assertAlmostEqual(mirror_bbox.YMin, 0.0, delta=1.0)
+        self.assertAlmostEqual(mirror_bbox.YMax, 10.0, delta=1.0)
+
 
 # for standalone execution
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary
- preserve visible child shapes inside hidden nested App::Part containers when resolving compound Part shapes
- resolve Part Mirror sources with the standard transformed shape path instead of manually applying only the source Placement
- add a Part Mirror regression for mirroring an outer App::Part that contains a hidden nested App::Part with a visible box

Closes #25961

### Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile src/Mod/Part/parttests/TestPartMirror.py
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check

Not run: FreeCADCmd/FreeCAD Part test suite is unavailable in this environment; clang-format is not installed.