### PR TITLE
Material: save edited cards in their subfolder

### DIFF
--- a/src/Mod/Material/MaterialEditor.py
+++ b/src/Mod/Material/MaterialEditor.py
@@ -669,6 +669,24 @@ class MaterialEditor:
             self.chooseMaterial(index)
         self.directory = os.path.dirname(self.card_path)
 
+    def isResourceMaterial(self, path):
+        try:
+            resource_dir = os.path.abspath(FreeCAD.getResourceDir())
+            material_path = os.path.abspath(path)
+            return os.path.commonpath([resource_dir, material_path]) == resource_dir
+        except ValueError:
+            return False
+
+    def getDefaultSavePath(self, name):
+        if (
+            self.card_path
+            and os.path.isfile(self.card_path)
+            and not self.isResourceMaterial(self.card_path)
+        ):
+            return self.card_path
+
+        return os.path.join(self.save_directory, name + ".FCMat")
+
     def savefile(self):
         "Saves a FCMat file."
 
@@ -683,7 +701,7 @@ class MaterialEditor:
         filetuple = QtGui.QFileDialog.getSaveFileName(
             QtGui.QApplication.activeWindow(),
             "Save FreeCAD material file",
-            self.save_directory + "/" + name + ".FCMat",
+            self.getDefaultSavePath(name),
             "*.FCMat"
         )
         # a tuple of two empty strings returns True, so use the filename directly


### PR DESCRIPTION
### Summary
- default the material editor Save dialog to the currently selected non-bundled material file
- preserve existing behavior for bundled resource materials by still using the preferred user save directory
- keep subfolder paths intact when overwriting user/custom material cards

Closes #25802

### Verification
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile src/Mod/Material/MaterialEditor.py
- git diff --check

Not run: FreeCAD GUI material editor workflow is unavailable in this environment.