### PR TITLE
Draft/BIM: Add node editing button to wall edit panel

### DIFF
--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1873,7 +1873,13 @@ if FreeCAD.GuiUp:
                 self.alignCenter.setChecked(True)
 
             layout.addRow(translate("Arch", "Alignment"), self.alignLayout)
-
+            
+            # Nodes
+            self.edit_nodes_button = QtGui.QPushButton()
+            self.edit_nodes_button.setText(translate("Arch", "Switch to Editing Nodes"))
+            layout.addRow(self.edit_nodes_button)
+            self.edit_nodes_button.clicked.connect(self.edit_nodes)
+            
             # Wall Options first, then Components (inherited self.form)
             self.form = [self.wallWidget, self.form]
 
@@ -1885,6 +1891,12 @@ if FreeCAD.GuiUp:
             else:
                 self.obj.Align = "Center"
             self.obj.recompute()
+
+        def edit_nodes(self):
+            self.accept()
+            FreeCADGui.Selection.clearSelection()
+            FreeCADGui.Selection.addSelection(self.obj)
+            FreeCADGui.runCommand("Draft_Edit")
 
         def accept(self):
             self.obj.Length = self.length.property("value")

--- a/src/Mod/BIM/ArchWall.py
+++ b/src/Mod/BIM/ArchWall.py
@@ -1873,13 +1873,13 @@ if FreeCAD.GuiUp:
                 self.alignCenter.setChecked(True)
 
             layout.addRow(translate("Arch", "Alignment"), self.alignLayout)
-            
+
             # Nodes
             self.edit_nodes_button = QtGui.QPushButton()
             self.edit_nodes_button.setText(translate("Arch", "Switch to Editing Nodes"))
             layout.addRow(self.edit_nodes_button)
             self.edit_nodes_button.clicked.connect(self.edit_nodes)
-            
+
             # Wall Options first, then Components (inherited self.form)
             self.form = [self.wallWidget, self.form]
 

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -799,6 +799,22 @@ class Edit(gui_base_original.Modifier):
                     obj_gui_tools = None
         return obj_gui_tools
 
+    def _add_wall_base_objects(self, selection):
+        tmp = set(selection)
+        for obj in selection:
+            if utils.get_type(obj) == "Wall":
+                if obj.Base is None:
+                    continue
+                base_typ = utils.get_type(obj.Base)
+                if (
+                    base_typ == "Sketcher::SketchObject"
+                    and edit_sketcher._is_editable(obj.Base)
+                ):
+                    tmp.add(obj.Base)
+                elif base_typ == "Wire":
+                    tmp.add(obj.Base)
+        return list(tmp)
+
     def getObjsFromSelection(self):
         """Evaluate selection and return a valid object to edit.
 
@@ -810,12 +826,13 @@ class Edit(gui_base_original.Modifier):
                 obj_matrix = selobj.Object.getSubObject(sub, retType=4)
         """
         selection = Gui.Selection.getSelection()
-        self.edited_objects = []
+        selection = self._add_wall_base_objects(selection)
         if len(selection) > self.max_objects:
             _err = translate("draft", "Too many objects selected, maximum number set to:")
             App.Console.PrintMessage(_err + " " + str(self.max_objects) + "\n")
             return None
 
+        self.edited_objects = []
         for obj in selection:
             if self.has_obj_gui_tools(obj):
                 self.edited_objects.append(obj)

--- a/src/Mod/Draft/draftguitools/gui_edit.py
+++ b/src/Mod/Draft/draftguitools/gui_edit.py
@@ -806,10 +806,7 @@ class Edit(gui_base_original.Modifier):
                 if obj.Base is None:
                     continue
                 base_typ = utils.get_type(obj.Base)
-                if (
-                    base_typ == "Sketcher::SketchObject"
-                    and edit_sketcher._is_editable(obj.Base)
-                ):
+                if base_typ == "Sketcher::SketchObject" and edit_sketcher._is_editable(obj.Base):
                     tmp.add(obj.Base)
                 elif base_typ == "Wire":
                     tmp.add(obj.Base)

--- a/src/Mod/Draft/draftguitools/gui_edit_arch_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_arch_objects.py
@@ -84,6 +84,7 @@ class ArchWallGuiTools(GuiTools):
             pts = obj.Proxy.calc_endpoints(obj)
             pts[node_idx - 1] = obj.Placement.multVec(v)
             obj.Proxy.set_from_endpoints(obj, pts)
+            obj.Document.recompute()
 
 
 class ArchWindowGuiTools(GuiTools):

--- a/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_draft_objects.py
@@ -81,31 +81,29 @@ class DraftWireGuiTools(GuiTools):
             obj.Closed = True
             pts[0] = v
             del pts[-1]
-            obj.Points = pts
-            return
         elif node_idx == len(pts) - 1 and (v - pts[0]).Length < tol:
             # DNC: user moved last point over first point -> Close curve
             obj.Closed = True
             del pts[-1]
-            obj.Points = pts
-            return
         elif v in pts:
             # DNC: checks if point enter is equal to other, this could cause a OCC problem
             _err = translate("draft", "This object does not support possible " "coincident points")
             App.Console.PrintMessage(_err + "\n")
             return
+        else:
+            pts[node_idx] = v
 
         # TODO: Make consistent operation with trackers and open wires
         # See: https://forum.freecad.org/viewtopic.php?f=23&t=56661
         # if obj.Closed:
         #    # DNC: project the new point to the plane of the face if present
         #    if hasattr(obj.Shape, "normalAt"):
-        #        normal = obj.Shape.normalAt(0,0)
+        #        normal = obj.Shape.normalAt(0, 0)
         #        point_on_plane = obj.Shape.Vertexes[0].Point
         #        v.projectToPlane(point_on_plane, normal)
 
-        pts[node_idx] = v
         obj.Points = pts
+        obj.Document.recompute()
 
     def get_edit_point_context_menu(self, edit_command, obj, node_idx):
         return [
@@ -167,9 +165,9 @@ class DraftWireGuiTools(GuiTools):
         if obj.Closed and edgeIndex == len(obj.Points):
             # last segment when object is closed
             newPoints.append(edit_command.localize_vector(obj, newPoint))
-        obj.Points = newPoints
 
-        obj.recompute()
+        obj.Points = newPoints
+        obj.Document.recompute()
 
     def delete_point(self, obj, node_idx):
         if len(obj.Points) <= 2:
@@ -179,16 +177,15 @@ class DraftWireGuiTools(GuiTools):
         pts = obj.Points
         pts.pop(node_idx)
         obj.Points = pts
-
-        obj.recompute()
+        obj.Document.recompute()
 
     def open_close_wire(self, obj):
         obj.Closed = not obj.Closed
-        obj.recompute()
+        obj.Document.recompute()
 
     def reverse_wire(self, obj):
         obj.Points = reversed(obj.Points)
-        obj.recompute()
+        obj.Document.recompute()
 
 
 class DraftBSplineGuiTools(DraftWireGuiTools):
@@ -236,8 +233,7 @@ class DraftBSplineGuiTools(DraftWireGuiTools):
         if obj.Closed and (uNewPoint > uPoints[-1]):
             pts.append(pt)
         obj.Points = pts
-
-        obj.recompute()
+        obj.Document.recompute()
 
 
 class DraftRectangleGuiTools(GuiTools):
@@ -265,6 +261,7 @@ class DraftRectangleGuiTools(GuiTools):
             obj.Length = DraftVecUtils.project(v, App.Vector(1, 0, 0)).Length
         elif node_idx == 2:
             obj.Height = DraftVecUtils.project(v, App.Vector(0, 1, 0)).Length
+        obj.Document.recompute()
 
 
 class DraftCircleGuiTools(GuiTools):
@@ -360,6 +357,7 @@ class DraftCircleGuiTools(GuiTools):
                         obj.LastAngle = dangle
                     elif node_idx == 3:
                         obj.Radius = v.Length
+        obj.Document.recompute()
 
     def get_edit_point_context_menu(self, edit_command, obj, node_idx):
         actions = None
@@ -504,7 +502,7 @@ class DraftCircleGuiTools(GuiTools):
 
     def arcInvert(self, obj):
         obj.FirstAngle, obj.LastAngle = obj.LastAngle, obj.FirstAngle
-        obj.recompute()
+        obj.Document.recompute()
 
 
 class DraftEllipseGuiTools(GuiTools):
@@ -532,6 +530,7 @@ class DraftEllipseGuiTools(GuiTools):
                 obj.MinorRadius = v.Length
             else:
                 obj.MinorRadius = obj.MajorRadius
+        obj.Document.recompute()
 
 
 class DraftPolygonGuiTools(GuiTools):
@@ -557,7 +556,7 @@ class DraftPolygonGuiTools(GuiTools):
             obj.Placement.Base = obj.Placement.multVec(v)
         elif node_idx == 1:
             obj.Radius = v.Length
-        obj.recompute()
+        obj.Document.recompute()
 
 
 class DraftDimensionGuiTools(GuiTools):
@@ -673,6 +672,7 @@ class DraftBezCurveGuiTools(GuiTools):
                 v.projectToPlane(point_on_plane, normal)
         pts[node_idx] = v
         obj.Points = pts
+        obj.Document.recompute()
 
     def get_edit_point_context_menu(self, edit_command, obj, node_idx):
         return [
@@ -903,8 +903,7 @@ class DraftBezCurveGuiTools(GuiTools):
         obj.Continuity = c[0:edgeindex] + [cont] + c[edgeindex:]
 
         obj.Points = pts
-
-        obj.recompute()
+        obj.Document.recompute()
 
     def delete_point(self, obj, node_idx):
         if len(obj.Points) <= 2:
@@ -915,15 +914,15 @@ class DraftBezCurveGuiTools(GuiTools):
         pts.pop(node_idx)
         obj.Points = pts
         obj.Proxy.resetcontinuity(obj)
-        obj.recompute()
+        obj.Document.recompute()
 
     def open_close_wire(self, obj):
         obj.Closed = not obj.Closed
-        obj.recompute()
+        obj.Document.recompute()
 
     def reverse_wire(self, obj):
         obj.Points = reversed(obj.Points)
-        obj.recompute()
+        obj.Document.recompute()
 
 
 ## @}

--- a/src/Mod/Draft/draftguitools/gui_edit_sketcher_objects.py
+++ b/src/Mod/Draft/draftguitools/gui_edit_sketcher_objects.py
@@ -42,28 +42,30 @@ from draftutils.translate import translate
 from draftguitools.gui_edit_base_object import GuiTools
 
 
+def _is_editable(obj):
+    """Check if a sketch has a single unconstrained line."""
+    import Part
+
+    return (
+        obj.ConstraintCount == 0
+        and obj.GeometryCount == 1
+        and type(obj.Geometry[0]) == Part.LineSegment
+    )
+
+
 class SketcherSketchObjectGuiTools(GuiTools):
 
     def __init__(self):
         pass
 
     def get_edit_points(self, obj):
-        """Return the list of edipoints for the given single line sketch.
+        """Return the list of edit points for the given single line sketch.
         (WallTrace)
         0 : startpoint
         1 : endpoint
         """
-        import Part
-
-        editpoints = []
-        if (
-            obj.ConstraintCount == 0
-            and obj.GeometryCount == 1
-            and type(obj.Geometry[0]) == Part.LineSegment
-        ):
-            editpoints.append(obj.getPoint(0, 1))
-            editpoints.append(obj.getPoint(0, 2))
-            return editpoints
+        if _is_editable(obj):
+            return [obj.getPoint(0, 1), obj.getPoint(0, 2)]
         else:
             _wrn = translate(
                 "draft",
@@ -87,7 +89,7 @@ class SketcherSketchObjectGuiTools(GuiTools):
         elif node_idx == 1:
             line.EndPoint = v
         obj.Geometry = [line]
-        obj.recompute()
+        obj.Document.recompute()
 
 
 ## @}


### PR DESCRIPTION
This PR adds a button to the wall edit panel to switch to editing nodes.

See discussion here:
https://github.com/FreeCAD/FreeCAD/issues/29544#issuecomment-4386140604.

* The node for the wall height has been kept.
* If the base of a wall is a wire, or a sketch with a single unconstrained line, it is also put in edit mode. Making the editing behavior comparable to that of a baseless wall.
* For a wall based on a more complex sketch only the height node is displayed.
* The recompute behavior has been changed to ensure a wall updates immediate if its base is edited: `obj.Document.recompute()` instead of `obj.recompute()`.
* There in no tooltip for the button yet.
* If the "Switch to Editing Nodes" button is pressed, the inputs in the edit panel are accepted. I am not sure if that is wise.

<img width="297" height="623" alt="image" src="https://github.com/user-attachments/assets/9f7a7eff-f24d-4f0d-adf3-bfd753c72ba4" />
