### PR TITLE
CAM: MachineState for DrillCycleExpander

### DIFF
--- a/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
+++ b/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
@@ -36,8 +36,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_00_error_r_less_than_z(self):
         """Test error condition when R < Z."""
 
-        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 10.0, "ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         # Invalid: retract height below drill depth
         cmd = Path.Command("G81", {"X": 5.0, "Y": 5.0, "Z": -3.0, "R": -5.0, "F": 100.0})
@@ -48,8 +48,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_01_modal_retract_mode(self):
         """Test that G98/G99 modal commands are processed and filtered out"""
-        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 10.0, "ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         # Test G99 processing
         cmd = Path.Command("G99", {})
@@ -73,8 +73,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_02_position_tracking(self):
         """Test that position is tracked correctly"""
-        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state )
+        machine_state = MachineState({"Z": 10.0, "ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         commands = [
             Path.Command("G0", {"X": 5.0, "Y": 10.0, "Z": 15.0}),
@@ -91,8 +91,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_03_expand_path_object(self):
         """Test expanding a complete Path object"""
-        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 10.0, "ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         commands = [
             Path.Command("G0", {"X": 10.0, "Y": 10.0, "Z": 30.0}),
@@ -117,18 +117,18 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_04_g81_with_g98(self):
         """Test 1: Basic G81 (simple drill) with G98 retract"""
-        machine_state = MachineState( {"Z":30.0, "ReturnMode":"Z", "G0F":110} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 30.0, "ReturnMode": "Z", "G0F": 110})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}),
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -140,18 +140,18 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_05_g81_with_g99(self):
         """Test 2: G81 with G99 retract (retract to R instead of initial Z)"""
-        machine_state = MachineState( {"Z":30.0, "ReturnMode":"R", "G0F":110} ) # G99
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 30.0, "ReturnMode": "R", "G0F": 110})  # G99
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -164,8 +164,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_06_g82(self):
         """Test 3: G82 (drill with dwell)"""
         # Initialize expander with G98 retract mode
-        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0, "F": 110}),
@@ -174,12 +174,12 @@ class TestDrillCycleExpander(unittest.TestCase):
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"Z": 1.0, "F":110}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F":110}),  # Z to R position
+            Path.Command("G0", {"Z": 1.0, "F": 110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F": 110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
             Path.Command("G4", {"P": 1.5}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # Retract to initial Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F": 110}),  # Retract to initial Z
             # G80 is filtered out
         ]
 
@@ -193,8 +193,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_07_g83(self):
         """Test 4: G83 (peck drill) with 3 pecks"""
         # Initialize expander with G98 retract mode
-        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -209,10 +209,10 @@ class TestDrillCycleExpander(unittest.TestCase):
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.1, "F": 10.0}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.09}),
-            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.3, "F": 10.0}), # drill
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}), # retract
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.29}), # back to bottom
-            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}), # drill...
+            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.3, "F": 10.0}),  # drill
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),  # retract
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.29}),  # back to bottom
+            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # drill...
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.49}),
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.6, "F": 10.0}),
@@ -236,8 +236,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_08_preliminary_moves(self):
         """Test preliminary motion according to LinuxCNC specification"""
-        machine_state = MachineState( {"Z":30, "ReturnMode":"Z", "G0F":110} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 30, "ReturnMode": "Z", "G0F": 110})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
@@ -250,10 +250,12 @@ class TestDrillCycleExpander(unittest.TestCase):
         # 4. Drill
         # 5. Retract to initial Z (30) for G98
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # Drill
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),  # Retract to initial Z (G98)
+            Path.Command(
+                "G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F": 110}
+            ),  # Retract to initial Z (G98)
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -266,8 +268,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_09_preliminary_moves_z_below_r(self):
         """Test preliminary motion when Z starts below R"""
         # Below R=10
-        machine_state = MachineState( {"Z":5, "ReturnMode":"Z", "G0F":110} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"Z": 5, "ReturnMode": "Z", "G0F": 110})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
@@ -280,10 +282,12 @@ class TestDrillCycleExpander(unittest.TestCase):
         # 4. Drill
         # 5. Retract to initial Z (5) for G98, but initial Z < R, so retract to R
         expected_cmds = [
-            Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 10.0, "F":110}),  # Preliminary Z to R
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # XY move at R
+            Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 10.0, "F": 110}),  # Preliminary Z to R
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}),  # XY move at R
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # Drill
-            Path.Command( "G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Retract to R (max of initial Z=5 and R=10)
+            Path.Command(
+                "G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F": 110}
+            ),  # Retract to R (max of initial Z=5 and R=10)
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -296,8 +300,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_10_g73(self):
         """Test 6: G73 (chip breaking drill) with small retracts"""
         # Initialize expander with G98 retract mode
-        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -339,8 +343,8 @@ class TestDrillCycleExpander(unittest.TestCase):
         """Test 5: Modal cycle with multiple positions (G81)"""
         # Initialize expander with G98 retract mode
         # Below R=10
-        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
-        expander = DrillCycleExpander( machine_state)
+        machine_state = MachineState({"ReturnMode": "Z"})  # G98
+        expander = DrillCycleExpander(machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -354,7 +358,7 @@ class TestDrillCycleExpander(unittest.TestCase):
         # For now, we'll test with explicit parameters since modal parameter tracking
         # is a more complex feature that may need to be added
         input_cmds_explicit = [
-            Path.Command("G0", {"Z": 1.0, "F":100}),
+            Path.Command("G0", {"Z": 1.0, "F": 100}),
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 2.0, "Y": 2.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 3.0, "Y": 3.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
@@ -362,19 +366,19 @@ class TestDrillCycleExpander(unittest.TestCase):
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"Z": 1.0, "F":100}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":100}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F":100}),  # Z to R position
+            Path.Command("G0", {"Z": 1.0, "F": 100}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F": 100}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F": 100}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":100}),  # Retract to initial Z
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F":100}),  # XY move at current Z
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 0.1, "F":100}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F": 100}),  # Retract to initial Z
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F": 100}),  # XY move at current Z
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 0.1, "F": 100}),  # Z to R position
             Path.Command("G1", {"X": 2.0, "Y": 2.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F":100}),  # Retract to initial Z
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F":100}),  # XY move at current Z
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 0.1, "F":100}),  # Z to R position
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F": 100}),  # Retract to initial Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F": 100}),  # XY move at current Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 0.1, "F": 100}),  # Z to R position
             Path.Command("G1", {"X": 3.0, "Y": 3.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F":100}),  # Retract to initial Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F": 100}),  # Retract to initial Z
             # G80 is filtered out
         ]
 
@@ -383,4 +387,6 @@ class TestDrillCycleExpander(unittest.TestCase):
         self.assertEqual(len(result), len(expected_cmds))
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
             self.assertEqual(res.Name, exp.Name, f"Command {i}: {exp} name mismatch")
-            self.assertEqual(res.Parameters, exp.Parameters, f"Command {i} {exp}: parameters mismatch")
+            self.assertEqual(
+                res.Parameters, exp.Parameters, f"Command {i} {exp}: parameters mismatch"
+            )

--- a/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
+++ b/src/Mod/CAM/CAMTests/TestDrillCycleExpander.py
@@ -27,6 +27,7 @@ Test suite for DrillCycleExpander class.
 import unittest
 import Path
 from Path.Post.DrillCycleExpander import DrillCycleExpander
+from Path.Base.MachineState import MachineState
 
 
 class TestDrillCycleExpander(unittest.TestCase):
@@ -35,11 +36,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_00_error_r_less_than_z(self):
         """Test error condition when R < Z."""
 
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 10.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         # Invalid: retract height below drill depth
         cmd = Path.Command("G81", {"X": 5.0, "Y": 5.0, "Z": -3.0, "R": -5.0, "F": 100.0})
@@ -50,11 +48,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_01_modal_retract_mode(self):
         """Test that G98/G99 modal commands are processed and filtered out"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 10.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         # Test G99 processing
         cmd = Path.Command("G99", {})
@@ -64,7 +59,7 @@ class TestDrillCycleExpander(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
         # Expander should track the mode
-        self.assertEqual(expander.retract_mode, "G99")
+        self.assertEqual(expander.machine_state.ReturnMode, "R")
 
         # Test G98 processing
         cmd = Path.Command("G98", {})
@@ -74,15 +69,12 @@ class TestDrillCycleExpander(unittest.TestCase):
         self.assertEqual(len(result), 0)
 
         # Expander should track the mode
-        self.assertEqual(expander.retract_mode, "G98")
+        self.assertEqual(expander.machine_state.ReturnMode, "Z")
 
     def test_02_position_tracking(self):
         """Test that position is tracked correctly"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 10.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state )
 
         commands = [
             Path.Command("G0", {"X": 5.0, "Y": 10.0, "Z": 15.0}),
@@ -92,17 +84,15 @@ class TestDrillCycleExpander(unittest.TestCase):
         # Expand commands to update position tracking
         expander.expand_commands(commands)
 
-        # Position should be updated from first move
-        self.assertEqual(expander.current_position["X"], 5.0)
-        self.assertEqual(expander.current_position["Y"], 10.0)
+        # Position should be final position, which is the G0 position
+        self.assertEqual(expander.machine_state.X, 5.0)
+        self.assertEqual(expander.machine_state.Y, 10.0)
+        self.assertEqual(expander.machine_state.Z, 15.0)
 
     def test_03_expand_path_object(self):
         """Test expanding a complete Path object"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 10.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":10.0, "ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         commands = [
             Path.Command("G0", {"X": 10.0, "Y": 10.0, "Z": 30.0}),
@@ -127,33 +117,21 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_04_g81_with_g98(self):
         """Test 1: Basic G81 (simple drill) with G98 retract"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 30.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":30.0, "ReturnMode":"Z", "G0F":110} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
         ]
 
         result = expander.expand_commands(input_cmds)
-
-        print("\n")
-        print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
-        print(Path.Path(input_cmds).toGCode())
-        print("#### Result ####")
-        print(Path.Path(result).toGCode())
-        print("##########")
 
         self.assertEqual(len(result), len(expected_cmds))
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
@@ -162,33 +140,21 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_05_g81_with_g99(self):
         """Test 2: G81 with G99 retract (retract to R instead of initial Z)"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 30.0}
-        retract_mode = "G99"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":30.0, "ReturnMode":"R", "G0F":110} ) # G99
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),
         ]
 
         result = expander.expand_commands(input_cmds)
-
-        print("\n")
-        print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
-        print(Path.Path(input_cmds).toGCode())
-        print("#### Result ####")
-        print(Path.Path(result).toGCode())
-        print("##########")
 
         self.assertEqual(len(result), len(expected_cmds))
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
@@ -198,38 +164,26 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_06_g82(self):
         """Test 3: G82 (drill with dwell)"""
         # Initialize expander with G98 retract mode
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 0.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
-            Path.Command("G0", {"Z": 1.0}),
+            Path.Command("G0", {"Z": 1.0, "F": 110}),
             Path.Command("G82", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "P": 1.5, "F": 10.0}),
             Path.Command("G80", {}),  # This should be filtered out
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"Z": 1.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),  # Z to R position
+            Path.Command("G0", {"Z": 1.0, "F":110}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
             Path.Command("G4", {"P": 1.5}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # Retract to initial Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":110}),  # Retract to initial Z
             # G80 is filtered out
         ]
 
         result = expander.expand_commands(input_cmds)
-
-        print("\n")
-        print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
-        print(Path.Path(input_cmds).toGCode())
-        print("#### Result ####")
-        print(Path.Path(result).toGCode())
-        print("##########")
 
         self.assertEqual(len(result), len(expected_cmds))
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
@@ -239,11 +193,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_07_g83(self):
         """Test 4: G83 (peck drill) with 3 pecks"""
         # Initialize expander with G98 retract mode
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 0.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -258,10 +209,10 @@ class TestDrillCycleExpander(unittest.TestCase):
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.1, "F": 10.0}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.09}),
-            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.3, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.29}),
-            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
+            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.3, "F": 10.0}), # drill
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}), # retract
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.29}), # back to bottom
+            Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}), # drill...
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),
             Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": -0.49}),
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.6, "F": 10.0}),
@@ -270,15 +221,6 @@ class TestDrillCycleExpander(unittest.TestCase):
         ]
 
         result = expander.expand_commands(input_cmds)
-
-        print("\n")
-        print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
-        print(Path.Path(input_cmds).toGCode())
-        print("#### Result ####")
-        print(Path.Path(result).toGCode())
-        print("##########")
 
         self.assertEqual(len(result), len(expected_cmds))
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
@@ -294,11 +236,8 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_08_preliminary_moves(self):
         """Test preliminary motion according to LinuxCNC specification"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 30.0}
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"Z":30, "ReturnMode":"Z", "G0F":110} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
@@ -311,10 +250,10 @@ class TestDrillCycleExpander(unittest.TestCase):
         # 4. Drill
         # 5. Retract to initial Z (30) for G98
         expected_cmds = [
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # Drill
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0}),  # Retract to initial Z (G98)
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 30.0, "F":110}),  # Retract to initial Z (G98)
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -326,11 +265,9 @@ class TestDrillCycleExpander(unittest.TestCase):
 
     def test_09_preliminary_moves_z_below_r(self):
         """Test preliminary motion when Z starts below R"""
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 5.0}  # Below R=10
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        # Below R=10
+        machine_state = MachineState( {"Z":5, "ReturnMode":"Z", "G0F":110} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 10, "F": 10.0}),
@@ -343,12 +280,10 @@ class TestDrillCycleExpander(unittest.TestCase):
         # 4. Drill
         # 5. Retract to initial Z (5) for G98, but initial Z < R, so retract to R
         expected_cmds = [
-            Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 10.0}),  # Preliminary Z to R
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}),  # XY move at R
+            Path.Command("G0", {"X": 0.0, "Y": 0.0, "Z": 10.0, "F":110}),  # Preliminary Z to R
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # XY move at R
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),  # Drill
-            Path.Command(
-                "G0", {"X": 1.0, "Y": 1.0, "Z": 10.0}
-            ),  # Retract to R (max of initial Z=5 and R=10)
+            Path.Command( "G0", {"X": 1.0, "Y": 1.0, "Z": 10.0, "F":110}),  # Retract to R (max of initial Z=5 and R=10)
         ]
 
         result = expander.expand_commands(input_cmds)
@@ -361,11 +296,8 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_10_g73(self):
         """Test 6: G73 (chip breaking drill) with small retracts"""
         # Initialize expander with G98 retract mode
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 0.0}  # Below R=10
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
 
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
@@ -390,14 +322,6 @@ class TestDrillCycleExpander(unittest.TestCase):
         ]
 
         result = expander.expand_commands(input_cmds)
-        print("\n")
-        print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
-        print(Path.Path(input_cmds).toGCode())
-        print("#### Result ####")
-        print(Path.Path(result).toGCode())
-        print("##########")
 
         self.assertEqual(len(result), len(expected_cmds))
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
@@ -414,11 +338,10 @@ class TestDrillCycleExpander(unittest.TestCase):
     def test_11_cycle_multiple_positions(self):
         """Test 5: Modal cycle with multiple positions (G81)"""
         # Initialize expander with G98 retract mode
-        initial_position = {"X": 0.0, "Y": 0.0, "Z": 0.0}  # Below R=10
-        retract_mode = "G98"
-        expander = DrillCycleExpander(
-            retract_mode=retract_mode, initial_position=initial_position.copy()
-        )
+        # Below R=10
+        machine_state = MachineState( {"ReturnMode":"Z"} ) # G98
+        expander = DrillCycleExpander( machine_state)
+
         input_cmds = [
             Path.Command("G0", {"Z": 1.0}),
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
@@ -431,7 +354,7 @@ class TestDrillCycleExpander(unittest.TestCase):
         # For now, we'll test with explicit parameters since modal parameter tracking
         # is a more complex feature that may need to be added
         input_cmds_explicit = [
-            Path.Command("G0", {"Z": 1.0}),
+            Path.Command("G0", {"Z": 1.0, "F":100}),
             Path.Command("G81", {"X": 1.0, "Y": 1.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 2.0, "Y": 2.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
             Path.Command("G81", {"X": 3.0, "Y": 3.0, "Z": -0.5, "R": 0.1, "F": 10.0}),
@@ -439,34 +362,25 @@ class TestDrillCycleExpander(unittest.TestCase):
         ]
 
         expected_cmds = [
-            Path.Command("G0", {"Z": 1.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1}),  # Z to R position
+            Path.Command("G0", {"Z": 1.0, "F":100}),
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":100}),  # XY move at current Z
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 0.1, "F":100}),  # Z to R position
             Path.Command("G1", {"X": 1.0, "Y": 1.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0}),  # Retract to initial Z
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 0.1}),  # Z to R position
+            Path.Command("G0", {"X": 1.0, "Y": 1.0, "Z": 1.0, "F":100}),  # Retract to initial Z
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F":100}),  # XY move at current Z
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 0.1, "F":100}),  # Z to R position
             Path.Command("G1", {"X": 2.0, "Y": 2.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0}),  # Retract to initial Z
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0}),  # XY move at current Z
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 0.1}),  # Z to R position
+            Path.Command("G0", {"X": 2.0, "Y": 2.0, "Z": 1.0, "F":100}),  # Retract to initial Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F":100}),  # XY move at current Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 0.1, "F":100}),  # Z to R position
             Path.Command("G1", {"X": 3.0, "Y": 3.0, "Z": -0.5, "F": 10.0}),
-            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0}),  # Retract to initial Z
+            Path.Command("G0", {"X": 3.0, "Y": 3.0, "Z": 1.0, "F":100}),  # Retract to initial Z
             # G80 is filtered out
         ]
 
         result = expander.expand_commands(input_cmds_explicit)
 
-        print("\n")
-        print("#### Input ####")
-        print(f"starting position: {initial_position}")
-        print(f"retract mode: {retract_mode}")
-        print(Path.Path(input_cmds).toGCode())
-        print("#### Result ####")
-        print(Path.Path(result).toGCode())
-        print("##########")
-
         self.assertEqual(len(result), len(expected_cmds))
         for i, (res, exp) in enumerate(zip(result, expected_cmds)):
-            self.assertEqual(res.Name, exp.Name, f"Command {i}: name mismatch")
-            self.assertEqual(res.Parameters, exp.Parameters, f"Command {i}: parameters mismatch")
+            self.assertEqual(res.Name, exp.Name, f"Command {i}: {exp} name mismatch")
+            self.assertEqual(res.Parameters, exp.Parameters, f"Command {i} {exp}: parameters mismatch")

--- a/src/Mod/CAM/Path/Post/DrillCycleExpander.py
+++ b/src/Mod/CAM/Path/Post/DrillCycleExpander.py
@@ -49,7 +49,7 @@ class DrillCycleExpander:
 
     def __init__(
         self,
-        machine_state : MachineState, # we mutate
+        machine_state: MachineState,  # we mutate
     ):
         """
         Initialize the expander.
@@ -76,7 +76,7 @@ class DrillCycleExpander:
 
         # Handle modal commands - filter them out after processing
         if cmd_name in ["G98", "G99"]:
-            self.machine_state.addCommand( command )
+            self.machine_state.addCommand(command)
             return []  # Filter out after processing
         elif cmd_name == "G80":
             # Cancel drill cycle - filter out since cycles are already expanded
@@ -90,7 +90,7 @@ class DrillCycleExpander:
 
         else:
             # Update position for non-drill commands
-            self.machine_state.addCommand( command )
+            self.machine_state.addCommand(command)
 
             # Pass through other commands unchanged
             Path.Log.debug(f"Passing through command: {command}")
@@ -156,13 +156,13 @@ class DrillCycleExpander:
         # Move to XY position at current Z height (which should be R)
         if drill_x != self.machine_state.X or drill_y != self.machine_state.Y:
             cmd = Path.Command(
-                "G0", 
+                "G0",
                 {
-                    "X": drill_x, 
-                    "Y": drill_y, 
-                    "Z": self.machine_state.Z, 
+                    "X": drill_x,
+                    "Y": drill_y,
+                    "Z": self.machine_state.Z,
                     "F": self.machine_state.G0F,
-                }
+                },
             )
             expanded.append(cmd)
             self.machine_state.addCommand(cmd)
@@ -170,14 +170,14 @@ class DrillCycleExpander:
         # Ensure Z is at R position (should already be there from preliminary motion)
         if self.machine_state.Z != retract_z:
             cmd = Path.Command(
-                    "G0",
-                    {
-                        "X": self.machine_state.X,
-                        "Y": self.machine_state.Y,
-                        "Z": retract_z,
-                        "F": self.machine_state.G0F,
-                    },
-                )
+                "G0",
+                {
+                    "X": self.machine_state.X,
+                    "Y": self.machine_state.Y,
+                    "Z": retract_z,
+                    "F": self.machine_state.G0F,
+                },
+            )
             expanded.append(cmd)
             self.machine_state.addCommand(cmd)
 
@@ -223,14 +223,14 @@ class DrillCycleExpander:
 
         # Retract
         cmd = Path.Command(
-                "G0",
-                {
-                    "X": self.machine_state.X,
-                    "Y": self.machine_state.Y,
-                    "Z": final_retract,
-                    "F": self.machine_state.G0F,
-                },
-            )
+            "G0",
+            {
+                "X": self.machine_state.X,
+                "Y": self.machine_state.Y,
+                "Z": final_retract,
+                "F": self.machine_state.G0F,
+            },
+        )
         expanded.append(cmd)
         self.machine_state.addCommand(cmd)
 
@@ -260,14 +260,14 @@ class DrillCycleExpander:
             if current_depth != retract_z and cmd_name == "G83":
                 approach_height = current_depth + clearance_amount
                 cmd = Path.Command(
-                        "G0",
-                        {
-                            "X": self.machine_state.X,
-                            "Y": self.machine_state.Y,
-                            "Z": approach_height,
-                            "F": self.machine_state.G0F,
-                        },
-                    )
+                    "G0",
+                    {
+                        "X": self.machine_state.X,
+                        "Y": self.machine_state.Y,
+                        "Z": approach_height,
+                        "F": self.machine_state.G0F,
+                    },
+                )
                 expanded.append(cmd)
                 self.machine_state.addCommand(cmd)
 
@@ -289,33 +289,6 @@ class DrillCycleExpander:
                 if next_depth == drill_z:
                     # Final peck - retract to R
                     cmd = Path.Command(
-                            "G0",
-                            {
-                                "X": self.machine_state.X,
-                                "Y": self.machine_state.Y,
-                                "Z": retract_z,
-                                "F": self.machine_state.G0F,
-                            },
-                        )
-                    expanded.append(cmd)
-                    self.machine_state.addCommand(cmd)
-                else:
-                    # Chip breaking - small retract
-                    approach_height = next_depth + clearance_amount
-                    cmd = Path.Command(
-                            "G0",
-                            {
-                                "X": self.machine_state.X,
-                                "Y": self.machine_state.Y,
-                                "Z": approach_height,
-                                "F": self.machine_state.G0F,
-                            },
-                        )
-                    expanded.append(cmd)
-                    self.machine_state.addCommand(cmd)
-            elif cmd_name == "G83":
-                # Full retract to R plane
-                cmd = Path.Command(
                         "G0",
                         {
                             "X": self.machine_state.X,
@@ -324,6 +297,33 @@ class DrillCycleExpander:
                             "F": self.machine_state.G0F,
                         },
                     )
+                    expanded.append(cmd)
+                    self.machine_state.addCommand(cmd)
+                else:
+                    # Chip breaking - small retract
+                    approach_height = next_depth + clearance_amount
+                    cmd = Path.Command(
+                        "G0",
+                        {
+                            "X": self.machine_state.X,
+                            "Y": self.machine_state.Y,
+                            "Z": approach_height,
+                            "F": self.machine_state.G0F,
+                        },
+                    )
+                    expanded.append(cmd)
+                    self.machine_state.addCommand(cmd)
+            elif cmd_name == "G83":
+                # Full retract to R plane
+                cmd = Path.Command(
+                    "G0",
+                    {
+                        "X": self.machine_state.X,
+                        "Y": self.machine_state.Y,
+                        "Z": retract_z,
+                        "F": self.machine_state.G0F,
+                    },
+                )
                 expanded.append(cmd)
                 self.machine_state.addCommand(cmd)
 
@@ -332,14 +332,14 @@ class DrillCycleExpander:
         # Final retract
         if self.machine_state.Z != final_retract:
             cmd = Path.Command(
-                    "G0",
-                    {
-                        "X": self.machine_state.X,
-                        "Y": self.machine_state.Y,
-                        "Z": final_retract,
-                        "F": self.machine_state.G0F,
-                    },
-                )
+                "G0",
+                {
+                    "X": self.machine_state.X,
+                    "Y": self.machine_state.Y,
+                    "Z": final_retract,
+                    "F": self.machine_state.G0F,
+                },
+            )
             expanded.append(cmd)
             self.machine_state.addCommand(cmd)
 

--- a/src/Mod/CAM/Path/Post/DrillCycleExpander.py
+++ b/src/Mod/CAM/Path/Post/DrillCycleExpander.py
@@ -26,8 +26,10 @@ This module provides a clean API for expanding canned drill cycles without
 coupling to the postprocessing infrastructure.
 """
 
-import Path
 from typing import List, Optional
+
+import Path
+from Path.Base.MachineState import MachineState
 
 EXPANDABLE_DRILL_CYCLES = {"G81", "G82", "G83", "G73"}
 
@@ -47,8 +49,7 @@ class DrillCycleExpander:
 
     def __init__(
         self,
-        retract_mode: str = "G98",
-        initial_position: Optional[dict] = None,
+        machine_state : MachineState, # we mutate
     ):
         """
         Initialize the expander.
@@ -56,13 +57,9 @@ class DrillCycleExpander:
         Per ADR-002, Path Command coordinates are always absolute.
 
         Args:
-            retract_mode: "G98" (return to initial Z) or "G99" (return to R plane)
-            initial_position: Initial position dict with X, Y, Z keys
+            MachineState, including ReturnMode (G98/G99), and required initial axis XYZ, and F and G0F
         """
-        self.retract_mode = retract_mode
-        self.current_position = (
-            initial_position if initial_position else {"X": 0.0, "Y": 0.0, "Z": 0.0}
-        )
+        self.machine_state = machine_state
 
     def expand_command(self, command: Path.Command) -> List[Path.Command]:
         """
@@ -78,16 +75,9 @@ class DrillCycleExpander:
         params = command.Parameters
 
         # Handle modal commands - filter them out after processing
-        if cmd_name == "G98":
-            self.retract_mode = "G98"
+        if cmd_name in ["G98", "G99"]:
+            self.machine_state.addCommand( command )
             return []  # Filter out after processing
-        elif cmd_name == "G99":
-            self.retract_mode = "G99"
-            return []  # Filter out after processing
-        elif cmd_name in ("G90", "G91"):
-            # Per ADR-002, coordinates are always absolute.
-            # Filter these non-conforming commands out.
-            return []
         elif cmd_name == "G80":
             # Cancel drill cycle - filter out since cycles are already expanded
             return []
@@ -98,33 +88,43 @@ class DrillCycleExpander:
             Path.Log.debug(f"Expanded drill cycle: {command} -> {result}")
             return result
 
-        # Update position for non-drill commands (always absolute per ADR-002)
-        if cmd_name in ("G0", "G00", "G1", "G01"):
-            for axis in ("X", "Y", "Z"):
-                if axis in params:
-                    self.current_position[axis] = params[axis]
+        else:
+            # Update position for non-drill commands
+            self.machine_state.addCommand( command )
 
-        # Pass through other commands unchanged
-        Path.Log.debug(f"Passing through command: {command}")
-        return [command]
+            # Pass through other commands unchanged
+            Path.Log.debug(f"Passing through command: {command}")
+            return [command]
 
     def _expand_drill_cycle(self, command: Path.Command) -> List[Path.Command]:
-        """Expand a drill cycle into basic movements."""
+        """Expand a drill cycle into basic movements.
+         As per ADR-002, we are in Path.Command world, so no G91, and not modal
+        Does not support repeat-on-move-till-G80 (modal repeat drill)
+        Does not support L
+        Needs a Z-start position
+        Q is peck amount, a distance not position
+        R is a position
+            R must always be above surface: initial move is a G0
+        Z is a position
+        P is dwell
+        chip-break is a position (R), or chipbreaking_amount|5% for G73
+        peck-return-to-bottom-clearance (fast-move) is hard-coded delta.
+        """
         cmd_name = command.Name.upper()
         params = command.Parameters
 
         # Extract parameters
-        drill_x = params.get("X", self.current_position["X"])
-        drill_y = params.get("Y", self.current_position["Y"])
+        drill_x = params.get("X", self.machine_state.X)
+        drill_y = params.get("Y", self.machine_state.Y)
         drill_z = params["Z"]
         retract_z = params["R"]
         feedrate = params.get("F")
 
         # Store initial Z for G98 mode
-        initial_z = self.current_position["Z"]
+        initial_z = self.machine_state.Z
 
         # Determine final retract height
-        if self.retract_mode == "G98":
+        if self.machine_state.ReturnMode == "Z":
             final_retract = max(initial_z, retract_z)
         else:  # G99
             final_retract = retract_z
@@ -140,40 +140,46 @@ class DrillCycleExpander:
         expanded = []
 
         # Preliminary motion: If Z < R, move Z to R once (LinuxCNC spec)
-        if self.current_position["Z"] < retract_z:
-            expanded.append(
-                Path.Command(
-                    "G0",
-                    {
-                        "X": self.current_position["X"],
-                        "Y": self.current_position["Y"],
-                        "Z": retract_z,
-                    },
-                )
+        if self.machine_state.Z < retract_z:
+            cmd = Path.Command(
+                "G0",
+                {
+                    "X": self.machine_state.X,
+                    "Y": self.machine_state.Y,
+                    "Z": retract_z,
+                    "F": self.machine_state.G0F,
+                },
             )
-            self.current_position["Z"] = retract_z
+            expanded.append(cmd)
+            self.machine_state.addCommand(cmd)
 
         # Move to XY position at current Z height (which should be R)
-        if drill_x != self.current_position["X"] or drill_y != self.current_position["Y"]:
-            expanded.append(
-                Path.Command("G0", {"X": drill_x, "Y": drill_y, "Z": self.current_position["Z"]})
+        if drill_x != self.machine_state.X or drill_y != self.machine_state.Y:
+            cmd = Path.Command(
+                "G0", 
+                {
+                    "X": drill_x, 
+                    "Y": drill_y, 
+                    "Z": self.machine_state.Z, 
+                    "F": self.machine_state.G0F,
+                }
             )
-            self.current_position["X"] = drill_x
-            self.current_position["Y"] = drill_y
+            expanded.append(cmd)
+            self.machine_state.addCommand(cmd)
 
         # Ensure Z is at R position (should already be there from preliminary motion)
-        if self.current_position["Z"] != retract_z:
-            expanded.append(
-                Path.Command(
+        if self.machine_state.Z != retract_z:
+            cmd = Path.Command(
                     "G0",
                     {
-                        "X": self.current_position["X"],
-                        "Y": self.current_position["Y"],
+                        "X": self.machine_state.X,
+                        "Y": self.machine_state.Y,
                         "Z": retract_z,
+                        "F": self.machine_state.G0F,
                     },
                 )
-            )
-            self.current_position["Z"] = retract_z
+            expanded.append(cmd)
+            self.machine_state.addCommand(cmd)
 
         # Perform the drilling operation
         if cmd_name in ("G81", "G82"):
@@ -200,31 +206,33 @@ class DrillCycleExpander:
 
         # Feed to depth
         move_params = {
-            "X": self.current_position["X"],
-            "Y": self.current_position["Y"],
+            "X": self.machine_state.X,
+            "Y": self.machine_state.Y,
             "Z": drill_z,
+            "F": self.machine_state.F,
         }
         if feedrate:
             move_params["F"] = feedrate
-        expanded.append(Path.Command("G1", move_params))
-        self.current_position["Z"] = drill_z
+        cmd = Path.Command("G1", move_params)
+        expanded.append(cmd)
+        self.machine_state.addCommand(cmd)
 
         # Dwell for G82
         if cmd_name == "G82" and "P" in params:
             expanded.append(Path.Command("G4", {"P": params["P"]}))
 
         # Retract
-        expanded.append(
-            Path.Command(
+        cmd = Path.Command(
                 "G0",
                 {
-                    "X": self.current_position["X"],
-                    "Y": self.current_position["Y"],
+                    "X": self.machine_state.X,
+                    "Y": self.machine_state.Y,
                     "Z": final_retract,
+                    "F": self.machine_state.G0F,
                 },
             )
-        )
-        self.current_position["Z"] = final_retract
+        expanded.append(cmd)
+        self.machine_state.addCommand(cmd)
 
         return expanded
 
@@ -251,103 +259,91 @@ class DrillCycleExpander:
             # If not first peck, rapid to clearance above previous depth
             if current_depth != retract_z and cmd_name == "G83":
                 approach_height = current_depth + clearance_amount
-                expanded.append(
-                    Path.Command(
+                cmd = Path.Command(
                         "G0",
                         {
-                            "X": self.current_position["X"],
-                            "Y": self.current_position["Y"],
+                            "X": self.machine_state.X,
+                            "Y": self.machine_state.Y,
                             "Z": approach_height,
+                            "F": self.machine_state.G0F,
                         },
                     )
-                )
-                self.current_position["Z"] = approach_height
+                expanded.append(cmd)
+                self.machine_state.addCommand(cmd)
 
             # Feed to next depth
             move_params = {
-                "X": self.current_position["X"],
-                "Y": self.current_position["Y"],
+                "X": self.machine_state.X,
+                "Y": self.machine_state.Y,
                 "Z": next_depth,
+                "F": self.machine_state.F,
             }
             if feedrate:
                 move_params["F"] = feedrate
-            expanded.append(Path.Command("G1", move_params))
-            self.current_position["Z"] = next_depth
+            cmd = Path.Command("G1", move_params)
+            expanded.append(cmd)
+            self.machine_state.addCommand(cmd)
 
             # Retract based on cycle type
             if cmd_name == "G73":
                 if next_depth == drill_z:
                     # Final peck - retract to R
-                    expanded.append(
-                        Path.Command(
+                    cmd = Path.Command(
                             "G0",
                             {
-                                "X": self.current_position["X"],
-                                "Y": self.current_position["Y"],
+                                "X": self.machine_state.X,
+                                "Y": self.machine_state.Y,
                                 "Z": retract_z,
+                                "F": self.machine_state.G0F,
                             },
                         )
-                    )
-                    self.current_position["Z"] = retract_z
+                    expanded.append(cmd)
+                    self.machine_state.addCommand(cmd)
                 else:
                     # Chip breaking - small retract
                     approach_height = next_depth + clearance_amount
-                    expanded.append(
-                        Path.Command(
+                    cmd = Path.Command(
                             "G0",
                             {
-                                "X": self.current_position["X"],
-                                "Y": self.current_position["Y"],
+                                "X": self.machine_state.X,
+                                "Y": self.machine_state.Y,
                                 "Z": approach_height,
+                                "F": self.machine_state.G0F,
                             },
                         )
-                    )
-                    self.current_position["Z"] = approach_height
+                    expanded.append(cmd)
+                    self.machine_state.addCommand(cmd)
             elif cmd_name == "G83":
                 # Full retract to R plane
-                expanded.append(
-                    Path.Command(
+                cmd = Path.Command(
                         "G0",
                         {
-                            "X": self.current_position["X"],
-                            "Y": self.current_position["Y"],
+                            "X": self.machine_state.X,
+                            "Y": self.machine_state.Y,
                             "Z": retract_z,
+                            "F": self.machine_state.G0F,
                         },
                     )
-                )
-                self.current_position["Z"] = retract_z
+                expanded.append(cmd)
+                self.machine_state.addCommand(cmd)
 
             current_depth = next_depth
 
         # Final retract
-        if self.current_position["Z"] != final_retract:
-            expanded.append(
-                Path.Command(
+        if self.machine_state.Z != final_retract:
+            cmd = Path.Command(
                     "G0",
                     {
-                        "X": self.current_position["X"],
-                        "Y": self.current_position["Y"],
+                        "X": self.machine_state.X,
+                        "Y": self.machine_state.Y,
                         "Z": final_retract,
+                        "F": self.machine_state.G0F,
                     },
                 )
-            )
-            self.current_position["Z"] = final_retract
+            expanded.append(cmd)
+            self.machine_state.addCommand(cmd)
 
         return expanded
-
-    def _update_position(self, cmd: Path.Command) -> None:
-        """
-        Update the current position based on a movement command.
-
-        Args:
-            cmd: The command to update position from
-        """
-        if "X" in cmd.Parameters:
-            self.current_position["X"] = cmd.Parameters["X"]
-        if "Y" in cmd.Parameters:
-            self.current_position["Y"] = cmd.Parameters["Y"]
-        if "Z" in cmd.Parameters:
-            self.current_position["Z"] = cmd.Parameters["Z"]
 
     def expand_commands(self, commands: List[Path.Command]) -> List[Path.Command]:
         """

--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -38,6 +38,8 @@ from FreeCAD import Units
 
 import Path
 import Path.Post.Utils as PostUtils
+from Path.Base.MachineState import MachineState
+from Path.Post.DrillCycleExpander import DrillCycleExpander
 
 # Define some types that are used throughout this file
 CommandLine = List[str]
@@ -419,7 +421,6 @@ def drill_translate(
 
     This is a compatibility wrapper around DrillCycleExpander.
     """
-    from Path.Post.DrillCycleExpander import DrillCycleExpander
 
     if values["MOTION_MODE"] == "G91":
         # force absolute coordinates during cycles
@@ -447,10 +448,18 @@ def drill_translate(
 
     # Create expander and expand the drill cycle
     expander = DrillCycleExpander(
-        retract_mode=drill_retract_mode,
-        initial_position=initial_position,
+        MachineState( initial_position )
     )
+    expander.machine_state.addCommand(Path.Command(drill_retract_mode))
+
     expanded = expander.expand_command(Path.Command(command, drill_params))
+
+    # HACK: we have to strip F params if they are zero
+    # because we don't know the G0 F in here, and DrillCycleExpander always generates F
+    # The newer MBPP doesn't have this problem.
+    for pc in expanded:
+        if "F" in pc.Parameters and pc.Parameters["F"] == 0:
+            del pc.Parameters["F"]
 
     # Format expanded commands into gcode strings
     for ecmd in expanded:

--- a/src/Mod/CAM/Path/Post/UtilsParse.py
+++ b/src/Mod/CAM/Path/Post/UtilsParse.py
@@ -447,9 +447,7 @@ def drill_translate(
         return
 
     # Create expander and expand the drill cycle
-    expander = DrillCycleExpander(
-        MachineState( initial_position )
-    )
+    expander = DrillCycleExpander(MachineState(initial_position))
     expander.machine_state.addCommand(Path.Command(drill_retract_mode))
 
     expanded = expander.expand_command(Path.Command(command, drill_params))


### PR DESCRIPTION
Use MachineState in DrillCycleExpander, as part of DRY'ing up various current_location code. 

MachineState is more complete, and more correct than  the ad-hoc code (e.g. F for G0).

MachineState will be added to Processor.py in an upcoming pr.

## Issues

part of issue #29282