### PR TITLE
BIM: Preserve visibility during Coin ArchView rendering

### DIFF
--- a/src/Mod/BIM/ArchSectionPlane.py
+++ b/src/Mod/BIM/ArchSectionPlane.py
@@ -759,15 +759,19 @@ def getCoinSVG(cutplane, objs, cameradata=None, linewidth=0.2, singleface=False,
     boundbox = FreeCAD.BoundBox()
     for obj in objs:
         if hasattr(obj.ViewObject, "RootNode") and obj.ViewObject.RootNode:
-            old_visibility = obj.ViewObject.isVisible()
-            # ignore visibility as only visible objects are passed here
-            obj.ViewObject.show()
-            node_copy = obj.ViewObject.RootNode.copy()
+            obj_visibility = getattr(obj, "Visibility", None)
+            view_visibility = getattr(obj.ViewObject, "Visibility", None)
+            try:
+                # The Coin render needs a visible scene node, but show()/hide()
+                # can leak visibility changes back to grouped document objects.
+                obj.ViewObject.Visibility = True
+                node_copy = obj.ViewObject.RootNode.copy()
+            finally:
+                if obj_visibility is not None:
+                    obj.Visibility = obj_visibility
+                if view_visibility is not None:
+                    obj.ViewObject.Visibility = view_visibility
             root_node.addChild(node_copy)
-            if old_visibility:
-                obj.ViewObject.show()
-            else:
-                obj.ViewObject.hide()
 
         if hasattr(obj, "Shape") and hasattr(obj.Shape, "BoundBox"):
             boundbox.add(obj.Shape.BoundBox)

--- a/src/Mod/BIM/bimtests/TestArchSectionPlane.py
+++ b/src/Mod/BIM/bimtests/TestArchSectionPlane.py
@@ -100,3 +100,29 @@ class TestArchSectionPlane(TestArchBase.TestArchBase):
         view.Y = "15cm"
         App.ActiveDocument.recompute()
         assert True
+
+    def testCoinViewGenerationKeepsObjectVisibility(self):
+        """Tests Coin SVG generation does not change source object visibility."""
+
+        if not App.GuiUp:
+            self.skipTest("Coin SVG generation requires the GUI.")
+
+        import ArchSectionPlane
+
+        box = App.ActiveDocument.addObject("Part::Box", "HiddenBox")
+        level = Arch.makeFloor()
+        level.addObjects([box])
+        App.ActiveDocument.recompute()
+
+        section = Arch.makeSectionPlane(level)
+        App.ActiveDocument.recompute()
+
+        box.ViewObject.Visibility = False
+        object_visibility = getattr(box, "Visibility", None)
+        view_visibility = box.ViewObject.Visibility
+
+        ArchSectionPlane.getSVG(section, allOn=True, renderMode="Coin")
+
+        if object_visibility is not None:
+            self.assertEqual(box.Visibility, object_visibility)
+        self.assertEqual(box.ViewObject.Visibility, view_visibility)


### PR DESCRIPTION
Fixes #27646

### Summary
- Preserve source object visibility while generating Coin SVG for TechDraw Arch views.
- Avoid temporary show/hide calls and restore object/view visibility properties in a finally block.
- Add GUI-guarded regression coverage for Coin SVG generation keeping hidden source objects hidden.

### Checks
- git diff --check
- python -m py_compile src/Mod/BIM/ArchSectionPlane.py src/Mod/BIM/bimtests/TestArchSectionPlane.py