### PR TITLE
Fix BuildingPart link child visibility

### DIFF
--- a/src/Gui/ViewProviderLink.cpp
+++ b/src/Gui/ViewProviderLink.cpp
@@ -2439,7 +2439,8 @@ void ViewProviderLink::updateElementList(App::LinkBaseExtension* ext)
         OverrideMaterialList.setSize(0);
         MaterialList.setSize(0);
     }
-    linkView->setChildren(elements, ext->getVisibilityListValue());
+    auto childType = isGroup(ext, true) ? LinkView::SnapshotChild : LinkView::SnapshotVisible;
+    linkView->setChildren(elements, ext->getVisibilityListValue(), childType);
     applyColors();
 }
 

--- a/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
+++ b/src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
@@ -77,3 +77,31 @@ class TestArchBuildingPartGui(TestArchBaseGui):
         FreeCADGui.runCommand("Std_ToggleVisibility", 0)
         App.ActiveDocument.recompute()
         assert wall.Visibility
+
+        # BuildingPart links must also respect the visibility of nested source objects.
+        # Regression test for https://github.com/FreeCAD/FreeCAD/issues/24370
+        link = App.ActiveDocument.addObject("App::Link", "BuildingPartLink")
+        link.LinkedObject = bp
+        App.ActiveDocument.recompute()
+        FreeCADGui.updateGui()
+        self.pump_gui_events()
+
+        import pivy.coin as coin
+
+        def hidden_switch_count(node):
+            count = 0
+            if isinstance(node, coin.SoSwitch) and node.whichChild.getValue() < 0:
+                count += 1
+            if hasattr(node, "getNumChildren"):
+                for i in range(node.getNumChildren()):
+                    count += hidden_switch_count(node.getChild(i))
+            return count
+
+        visible_count = hidden_switch_count(link.ViewObject.LinkView.RootNode)
+        wall.ViewObject.Visibility = False
+        App.ActiveDocument.recompute()
+        FreeCADGui.updateGui()
+        self.pump_gui_events()
+        hidden_count = hidden_switch_count(link.ViewObject.LinkView.RootNode)
+        self.assertGreater(hidden_count, visible_count)
+        wall.ViewObject.Visibility = True


### PR DESCRIPTION
Fixes #24370.

This changes plain-group links to render their grouped children with the child snapshot mode, so the source child object's visibility is respected in addition to the link's own element visibility list. BuildingPart/level/building links therefore no longer keep nested objects visible when the original nested object is hidden.

A BIM GUI regression test creates a BuildingPart link, hides the source wall, and verifies that the linked scene graph gains a hidden switch.

Checks run locally:
- python -m py_compile src/Mod/BIM/bimtests/TestArchBuildingPartGui.py
- git diff --check