### PR TITLE
TechDraw: reduce default edge selection fuzz

### DIFF
--- a/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
+++ b/src/Mod/TechDraw/Gui/DlgPrefsTechDrawAdvanced.ui
@@ -428,7 +428,7 @@ Each unit is approximately 0.1mm wide</string>
            <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
           <property name="value">
-           <double>10.000000000000000</double>
+           <double>5.000000000000000</double>
           </property>
           <property name="prefEntry" stdset="0">
            <cstring>EdgeFuzz</cstring>

--- a/src/Mod/TechDraw/Gui/PreferencesGui.cpp
+++ b/src/Mod/TechDraw/Gui/PreferencesGui.cpp
@@ -169,7 +169,7 @@ double PreferencesGui::dimArrowSize()
 
 double PreferencesGui::edgeFuzz()
 {
-    return Preferences::getPreferenceGroup("General")->GetFloat("EdgeFuzz", 10.0);
+    return Preferences::getPreferenceGroup("General")->GetFloat("EdgeFuzz", 5.0);
 }
 
 double PreferencesGui::markFuzz()


### PR DESCRIPTION
Fixes #27773.

This reduces the default TechDraw EdgeFuzz value from 10 to 5. The issue reporter confirmed that setting Edge fuzz to 5 makes the affected close edges selectable, while lowering marker size alone did not.

Validation status: GUI validation and screenshot evidence are still pending. I do not have FreeCAD/FreeCADCmd available in this environment, so this PR is now draft until the TechDraw screenshot can be attached.

Checks:
- git diff --check