### PR TITLE
Draft: Fix hold point axis affinity for Shift constraints

### DIFF
--- a/src/Mod/Draft/CMakeLists.txt
+++ b/src/Mod/Draft/CMakeLists.txt
@@ -68,6 +68,7 @@ SET(Draft_tests
     drafttests/test_modification.py
     drafttests/test_oca.py
     drafttests/test_pivy.py
+    drafttests/test_snapper_gui.py
     drafttests/test_svg.py
     drafttests/README.md
     drafttests/Issue24314.dxf

--- a/src/Mod/Draft/TestDraftGui.py
+++ b/src/Mod/Draft/TestDraftGui.py
@@ -101,9 +101,11 @@ from drafttests.test_import_gui import DraftGuiImport as DraftTestGui01
 from drafttests.test_import_tools import DraftImportTools as DraftTestGui02
 from drafttests.test_pivy import DraftPivy as DraftTestGui03
 from drafttests.test_dimension_gui import DraftGuiDimension as DraftTestGui04
+from drafttests.test_snapper_gui import DraftGuiSnapper as DraftTestGui05
 
 # Use the modules so that code checkers don't complain (flake8)
 True if DraftTestGui01 else False
 True if DraftTestGui02 else False
 True if DraftTestGui03 else False
 True if DraftTestGui04 else False
+True if DraftTestGui05 else False

--- a/src/Mod/Draft/draftguitools/gui_snapper.py
+++ b/src/Mod/Draft/draftguitools/gui_snapper.py
@@ -570,7 +570,7 @@ class Snapper:
 
         The parallel line of the last object, if any.
         """
-        tsnap = self.snapToHold(point)
+        tsnap = self.snapToHold(point, constrain)
         if tsnap:
             if self.tracker and not self.selectMode:
                 self.tracker.setCoords(tsnap[2])
@@ -916,7 +916,7 @@ class Snapper:
                     return None
         return None
 
-    def snapToHold(self, point):
+    def snapToHold(self, point, constrain=False):
         """Return a snap location that is orthogonal to hold points.
 
         Or if possible at crossings.
@@ -951,16 +951,17 @@ class Snapper:
                     return [p[0], "ortho", p[1]]
         # then try to stick to a line
         for p in self.holdPoints:
-            d = DraftGeomUtils.findDistance(point, [p, p.add(u)])
-            if d:
-                if d.Length < self.radius:
+            candidates = []
+            for affinity, direction in (("x", u), ("y", v)):
+                d = DraftGeomUtils.findDistance(point, [p, p.add(direction)])
+                if d and d.Length < self.radius:
                     fp = point.add(d)
-                    return [p, "extension", fp]
-            d = DraftGeomUtils.findDistance(point, [p, p.add(v)])
-            if d:
-                if d.Length < self.radius:
-                    fp = point.add(d)
-                    return [p, "extension", fp]
+                    candidates.append((d.Length, affinity, [p, "extension", fp]))
+            if candidates:
+                _, affinity, snap = min(candidates, key=lambda item: item[0])
+                if constrain:
+                    self.affinity = affinity
+                return snap
         return None
 
     def snapToExtPerpendicular(self, last):

--- a/src/Mod/Draft/drafttests/test_snapper_gui.py
+++ b/src/Mod/Draft/drafttests/test_snapper_gui.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Unit tests for Draft snapping GUI behavior."""
+
+import FreeCAD as App
+import WorkingPlane
+
+from draftguitools import gui_snapper
+from drafttests import test_base
+
+
+class DraftGuiSnapper(test_base.DraftTestCaseNoDoc):
+    """Test Draft Snapper behavior that does not require mouse automation."""
+
+    def make_hold_snapper(self):
+        snapper = gui_snapper.Snapper()
+        snapper.radius = 10
+        snapper.holdPoints = [App.Vector(0, 0, 0)]
+        snapper._get_wp = lambda: WorkingPlane.PlaneBase()
+        return snapper
+
+    def test_snap_to_hold_sets_y_affinity_for_vertical_extension(self):
+        snapper = self.make_hold_snapper()
+
+        snap = snapper.snapToHold(App.Vector(0.1, 5, 0), constrain=True)
+
+        self.assertIsNotNone(snap)
+        self.assertEqual("extension", snap[1])
+        self.assertEqual("y", snapper.affinity)
+        self.assertAlmostEqual(0, snap[2].x)
+        self.assertAlmostEqual(5, snap[2].y)
+        self.assertAlmostEqual(0, snap[2].z)
+
+    def test_snap_to_hold_keeps_x_affinity_for_horizontal_extension(self):
+        snapper = self.make_hold_snapper()
+
+        snap = snapper.snapToHold(App.Vector(5, 0.1, 0), constrain=True)
+
+        self.assertIsNotNone(snap)
+        self.assertEqual("extension", snap[1])
+        self.assertEqual("x", snapper.affinity)
+        self.assertAlmostEqual(5, snap[2].x)
+        self.assertAlmostEqual(0, snap[2].y)
+        self.assertAlmostEqual(0, snap[2].z)


### PR DESCRIPTION
Fixes #25958.

## Summary
- choose the nearest working-plane axis when snapping to a Draft hold-point extension instead of always preferring X first
- propagate the selected hold-point axis to `Snapper.affinity` while Shift/constrain is active, so the task panel enables/focuses Y for vertical hold-point constraints
- add a Draft GUI unit test covering horizontal and vertical hold-point extension affinity

## Verification
- `python -c "from pathlib import Path; [compile(Path(p).read_text(), p, 'exec') for p in ['src/Mod/Draft/draftguitools/gui_snapper.py','src/Mod/Draft/TestDraftGui.py','src/Mod/Draft/drafttests/test_snapper_gui.py']]"`
- `git diff --check -- src\Mod\Draft\CMakeLists.txt src\Mod\Draft\draftguitools\gui_snapper.py src\Mod\Draft\TestDraftGui.py src\Mod\Draft\drafttests\test_snapper_gui.py`
- Not run: `FreeCAD -t TestDraftGui`; a built FreeCAD/FreeCADCmd binary was unavailable in the local checkout.
