### PR TITLE
Import: Fix dxf import

### DIFF
--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -497,7 +497,7 @@ std::string CDxfWrite::getPlateFile(std::string fileSpec)
     }
     else {
         string line;
-        ifstream inFile(fi.filePath());
+        Base::ifstream inFile(fi);
 
         while (!inFile.eof()) {
             getline(inFile, line);
@@ -1880,7 +1880,7 @@ void CDxfWrite::writeObjectsSection()
 const DxfUnits DxfUnits::Instance;
 
 CDxfRead::CDxfRead(const std::string& filepath)
-    : m_ifs(new ifstream(filepath))
+    : m_ifs(new Base::ifstream(Base::FileInfo(filepath)))
 {
     if (!(*m_ifs)) {
         m_fail = true;


### PR DESCRIPTION
Cherry-pick https://codeberg.org/xCAD/FreeCAD11/commit/0924edb93525a69e943ab6e188f70b955b83fb23

Fix importing dxf file on Windows if it is in a folder named with non- english characters

Fixes https://github.com/FreeCAD/FreeCAD/issues/21521

Note:
The issue has already been fixed with https://github.com/FreeCAD/FreeCAD/pull/10988 and has been reverted due to refactoring with https://github.com/FreeCAD/FreeCAD/pull/11701

<!-- Include a