### PR TITLE
TD: Fix off-white default page color

### DIFF
--- a/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
+++ b/src/Gui/PreferencePacks/FreeCAD Light/FreeCAD Light.cfg
@@ -87,7 +87,7 @@
               <FCUInt Name="HiddenColor" Value="556083711"/>
               <FCUInt Name="LightTextColor" Value="1230002175"/>
               <FCUInt Name="NormalColor" Value="556083711"/>
-              <FCUInt Name="PageColor" Value="4059297279"/>
+              <FCUInt Name="PageColor" Value="4294967295"/>
               <FCUInt Name="PreSelectColor" Value="4120838399"/>
               <FCUInt Name="SelectColor" Value="1722290175"/>
               <FCUInt Name="TemplateUnderlineColor" Value="995875839"/>


### PR DESCRIPTION
The current FreeCAD Light theme sets the default TechDraw color to off-white RGB(241, 243, 245) resulting in grey printing artifacts across the entire page:

<img width="2296" height="4080" alt="grafik" src="https://github.com/user-attachments/assets/ddcd0b9b-6bf7-4d36-9dd7-181715e60f2a" />


This PR restores the default page color to white.
