### PR TITLE
Import: fix TEXT entities in BLOCKs missing during DXF import

### DIFF
--- a/src/Mod/Import/App/dxf/ImpExpDxf.cpp
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.cpp
@@ -31,6 +31,7 @@
 #include <BRepAdaptor_CompCurve.hxx>
 #include <BRepAdaptor_Curve.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepBuilderAPI_Transform.hxx>
@@ -260,11 +261,13 @@ TopoDS_Wire ImpExpDxfRead::BuildWireFromPolyline(std::list<VertexInfo>& vertices
         TopoDS_Edge edge;
 
         if (start_vertex.bulge == 0.0) {
-            edge = BRepBuilderAPI_MakeEdge(
-                       makePoint(start_vertex.location),
-                       makePoint(end_vertex.location)
-            )
-                       .Edge();
+            BRepBuilderAPI_MakeEdge edgeMaker(
+                makePoint(start_vertex.location),
+                makePoint(end_vertex.location)
+            );
+            if (edgeMaker.IsDone()) {
+                edge = edgeMaker.Edge();
+            }
         }
         else {
             double cot = ((1.0 / start_vertex.bulge) - start_vertex.bulge) / 2.0;
@@ -933,7 +936,8 @@ bool ImpExpDxfRead::OnReadBlock(const std::string& name, int flags)
     BlockDefinitionCollector blockCollector(
         *this,
         temporaryBlock.GeometryBuilders,
-        temporaryBlock.Inserts
+        temporaryBlock.Inserts,
+        temporaryBlock.FeaturePythonBuilders
     );
     if (!ReadBlockContents()) {
         return false;  // Abort on parsing error
@@ -1262,33 +1266,106 @@ void ImpExpDxfRead::OnReadText(
     const double rotation
 )
 {
+    // Note that our parameters do not contain all the information needed to properly orient the
+    // text. As a result the text will always appear on the XY plane.
     if (shouldSkipEntity() || !m_importAnnotations) {
         return;
     }
 
-    auto* p = static_cast<App::FeaturePython*>(document->addObject("App::FeaturePython", "Text"));
-    if (p) {
-        p->addDynamicProperty("App::PropertyString", "DxfEntityType", "Internal", "DXF entity type");
-        static_cast<App::PropertyString*>(p->getPropertyByName("DxfEntityType"))->setValue("TEXT");
-
-        p->addDynamicProperty("App::PropertyStringList", "Text", "Data", "Text content");
-        // Explicitly create the vector to resolve ambiguity
-        std::vector<std::string> text_values = {text};
-        static_cast<App::PropertyStringList*>(p->getPropertyByName("Text"))->setValues(text_values);
-
-        p->addDynamicProperty("App::PropertyFloat", "DxfTextHeight", "Internal", "Original text height");
-        static_cast<App::PropertyFloat*>(p->getPropertyByName("DxfTextHeight"))->setValue(height);
-
-        p->addDynamicProperty("App::PropertyPlacement", "Placement", "Base", "Object placement");
-        Base::Placement pl;
-        pl.setPosition(point);
-        pl.setRotation(Base::Rotation(Base::Vector3d(0, 0, 1), Base::toRadians(rotation)));
-        static_cast<App::PropertyPlacement*>(p->getPropertyByName("Placement"))->setValue(pl);
-
-        Collector->AddObject(p, "Text");
-    }
+    // Capture by value so the lambda can be stored in a block definition and called later
+    // when an INSERT references that block (with the INSERT's transform applied).
+    auto makeText = [this, rotation, point, text, height](
+                        const Base::Matrix4D& transform
+                    ) -> App::FeaturePython* {
+        PyObject* draftModule = getDraftModule();
+        if (draftModule != nullptr) {
+            Base::Matrix4D localTransform;
+            // rotation from dxf.cpp is in degrees for TEXT entities; convert to radians.
+            localTransform.rotZ(Base::toRadians(rotation));
+            localTransform.move(point);
+            PyObject* placement = new Base::PlacementPy(Base::Placement(transform * localTransform));
+            // Scale the text height by the INSERT's X-axis scale factor (norm of first column).
+            double xScale = Base::Vector3d(transform[0][0], transform[1][0], transform[2][0]).Length();
+            double scaledHeight = height * (xScale > 0.0 ? xScale : 1.0);
+            // Draft.make_text() uses App.activeDocument(), so temporarily activate the
+            // target document to ensure the object is created in the right place.
+            App::Document* prevActive = App::GetApplication().getActiveDocument();
+            if (prevActive != document) {
+                App::GetApplication().setActiveDocument(document);
+            }
+            // NOLINTNEXTLINE(readability/nolint)
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
+            auto builtText = dynamic_cast<App::FeaturePythonPyT<App::DocumentObjectPy>*>(
+                (
+                    Base::PyObjectBase*
+                )PyObject_CallMethod(draftModule, "make_text", "sOif", text.c_str(), placement, 0, scaledHeight)
+            );
+            Py_DECREF(placement);
+            if (prevActive != document) {
+                App::GetApplication().setActiveDocument(prevActive);
+            }
+            if (builtText != nullptr) {
+                auto* result = dynamic_cast<App::FeaturePython*>(builtText->getDocumentObjectPtr());
+                Py_DECREF(builtText);
+                return result;
+            }
+            // Draft.make_text() raised a Python exception; clear it so it does not
+            // propagate unexpectedly into unrelated code.
+            if (PyErr_Occurred()) {
+                PyErr_Print();
+                PyErr_Clear();
+            }
+        }
+        return nullptr;
+    };
+    Collector->AddObject((FeaturePythonBuilder)makeText);
 }
 
+void ImpExpDxfRead::OnReadSolid(
+    const Base::Vector3d& first,
+    const Base::Vector3d& second,
+    const Base::Vector3d& third,
+    const Base::Vector3d& fourth
+)
+{
+    if (shouldSkipEntity()) {
+        return;
+    }
+
+    try {
+        // A DXF SOLID with identical 3rd and 4th vertices is a triangle.
+        bool isTriangle = (third - fourth).Length() < Precision::Confusion();
+
+        // DXF SOLID vertex order is 1-2-4-3, not 1-2-3-4; connecting naively produces a bowtie.
+        BRepBuilderAPI_MakeWire wireBuilder;
+        wireBuilder.Add(BRepBuilderAPI_MakeEdge(makePoint(first), makePoint(second)).Edge());
+        if (isTriangle) {
+            wireBuilder.Add(BRepBuilderAPI_MakeEdge(makePoint(second), makePoint(third)).Edge());
+            wireBuilder.Add(BRepBuilderAPI_MakeEdge(makePoint(third), makePoint(first)).Edge());
+        }
+        else {
+            wireBuilder.Add(BRepBuilderAPI_MakeEdge(makePoint(second), makePoint(fourth)).Edge());
+            wireBuilder.Add(BRepBuilderAPI_MakeEdge(makePoint(fourth), makePoint(third)).Edge());
+            wireBuilder.Add(BRepBuilderAPI_MakeEdge(makePoint(third), makePoint(first)).Edge());
+        }
+
+        if (!wireBuilder.IsDone()) {
+            Base::Console().warning("ImpExpDxf - failed to create SOLID wire\n");
+            return;
+        }
+
+        BRepBuilderAPI_MakeFace faceBuilder(wireBuilder.Wire());
+        if (!faceBuilder.IsDone()) {
+            Base::Console().warning("ImpExpDxf - failed to create SOLID face\n");
+            return;
+        }
+
+        Collector->AddObject(faceBuilder.Face(), "Solid");
+    }
+    catch (const Standard_Failure&) {
+        Base::Console().warning("ImpExpDxf - failed to create SOLID face\n");
+    }
+}
 
 void ImpExpDxfRead::OnReadInsert(
     const Base::Vector3d& point,
@@ -1646,7 +1723,9 @@ void ImpExpDxfRead::DrawingEntityCollector::AddObject(FeaturePythonBuilder shape
     Reader.IncrementCreatedObjectCount();
     App::FeaturePython* shape = shapeBuilder(Reader.OCSOrientationTransform);
     if (shape != nullptr) {
+        Reader.MoveToLayer(shape);
         Reader._addOriginalLayerProperty(shape);
+        Reader.ApplyGuiStyles(shape);
     }
 }
 

--- a/src/Mod/Import/App/dxf/ImpExpDxf.h
+++ b/src/Mod/Import/App/dxf/ImpExpDxf.h
@@ -79,6 +79,12 @@ public:
         const std::string& text,
         double rotation
     ) override;
+    void OnReadSolid(
+        const Base::Vector3d& first,
+        const Base::Vector3d& second,
+        const Base::Vector3d& third,
+        const Base::Vector3d& fourth
+    ) override;
     void OnReadArc(
         const Base::Vector3d& start,
         const Base::Vector3d& end,
@@ -250,6 +256,7 @@ protected:
         const int Flags;
         std::map<CDxfRead::CommonEntityAttributes, std::list<GeometryBuilder>> GeometryBuilders;
         std::map<CDxfRead::CommonEntityAttributes, std::list<Insert>> Inserts;
+        std::map<CDxfRead::CommonEntityAttributes, std::list<FeaturePythonBuilder>> FeaturePythonBuilders;
     };
 
 private:
@@ -380,6 +387,70 @@ protected:
             link->ScaleVector.setValue(scale);
 
             this->AddObject(link, "Link");
+
+            // Instantiate text annotation objects from this block and any blocks it
+            // references via nested INSERTs. These cannot be part of the App::Link geometry.
+            {
+                Base::Matrix4D insertMatrix;
+                insertMatrix.scale(scale.x, scale.y, scale.z);
+                insertMatrix.rotZ(rotation);
+                insertMatrix.move(point.x, point.y, point.z);
+
+                CDxfRead::CommonEntityAttributes savedAttributes = Reader.m_entityAttributes;
+                std::set<std::string> expandingBlocks;
+                std::function<
+                    void(const std::string&, const Base::Matrix4D&, const CDxfRead::CommonEntityAttributes&)>
+                    expandBlockText = [&](const std::string& blockName,
+                                          const Base::Matrix4D& transform,
+                                          const CDxfRead::CommonEntityAttributes& parentAttributes) {
+                        if (!expandingBlocks.insert(blockName).second) {
+                            return;  // Circular reference guard
+                        }
+                        auto it = Reader.Blocks.find(blockName);
+                        if (it != Reader.Blocks.end()) {
+                            const Block& blk = it->second;
+                            for (const auto& [attributes, builders] : blk.FeaturePythonBuilders) {
+                                Reader.m_entityAttributes = attributes;
+                                Reader.m_entityAttributes.ResolveByBlockAttributes(parentAttributes);
+                                for (const auto& builder : builders) {
+                                    App::FeaturePython* feature = builder(transform);
+                                    if (feature != nullptr) {
+                                        Reader.MoveToLayer(feature);
+                                        Reader._addOriginalLayerProperty(feature);
+                                        Reader.ApplyGuiStyles(feature);
+                                        Reader.IncrementCreatedObjectCount();
+                                    }
+                                }
+                            }
+                            for (const auto& [attributes, inserts] : blk.Inserts) {
+                                CDxfRead::CommonEntityAttributes nestedAttrs = attributes;
+                                nestedAttrs.ResolveByBlockAttributes(parentAttributes);
+                                for (const auto& nestedInsert : inserts) {
+                                    Base::Matrix4D nestedMatrix;
+                                    nestedMatrix.scale(
+                                        nestedInsert.Scale.x,
+                                        nestedInsert.Scale.y,
+                                        nestedInsert.Scale.z
+                                    );
+                                    nestedMatrix.rotZ(nestedInsert.Rotation);
+                                    nestedMatrix.move(
+                                        nestedInsert.Point.x,
+                                        nestedInsert.Point.y,
+                                        nestedInsert.Point.z
+                                    );
+                                    expandBlockText(
+                                        nestedInsert.Name,
+                                        transform * nestedMatrix,
+                                        nestedAttrs
+                                    );
+                                }
+                            }
+                        }
+                        expandingBlocks.erase(blockName);
+                    };
+                expandBlockText(name, insertMatrix, savedAttributes);
+                Reader.m_entityAttributes = savedAttributes;
+            }
         }
     };
     class ShapeSavingEntityCollector: public DrawingEntityCollector
@@ -442,11 +513,13 @@ protected:
         BlockDefinitionCollector(
             ImpExpDxfRead& reader,
             std::map<CDxfRead::CommonEntityAttributes, std::list<GeometryBuilder>>& buildersList,
-            std::map<CDxfRead::CommonEntityAttributes, std::list<Block::Insert>>& insertsList
+            std::map<CDxfRead::CommonEntityAttributes, std::list<Block::Insert>>& insertsList,
+            std::map<CDxfRead::CommonEntityAttributes, std::list<FeaturePythonBuilder>>& featurePythonBuildersList
         )
             : EntityCollector(reader)
             , BuildersList(buildersList)
             , InsertsList(insertsList)
+            , FeaturePythonBuildersList(featurePythonBuildersList)
         {}
 
         // TODO: We will want AddAttributeDefinition as well.
@@ -473,10 +546,9 @@ protected:
             );
         }
 
-        void AddObject(FeaturePythonBuilder /*shapeBuilder*/) override
+        void AddObject(FeaturePythonBuilder shapeBuilder) override
         {
-            // This path is for Draft/FeaturePython objects and is not used by the
-            // primitives or shapes modes.
+            FeaturePythonBuildersList[Reader.m_entityAttributes].push_back(shapeBuilder);
         }
 
         void AddInsert(
@@ -494,6 +566,7 @@ protected:
     private:
         std::map<CDxfRead::CommonEntityAttributes, std::list<GeometryBuilder>>& BuildersList;
         std::map<CDxfRead::CommonEntityAttributes, std::list<Block::Insert>>& InsertsList;
+        std::map<CDxfRead::CommonEntityAttributes, std::list<FeaturePythonBuilder>>& FeaturePythonBuildersList;
     };
 
 private:

--- a/src/Mod/Import/App/dxf/dxf.cpp
+++ b/src/Mod/Import/App/dxf/dxf.cpp
@@ -2208,14 +2208,32 @@ bool CDxfRead::ReadText()
         }
     }
     ResolveEntityAttributes();
-
+    // repeat_last_record() must be called before the OnRead callback so that exceptions
+    // thrown by the callback don't prevent the stream from being repositioned.
+    repeat_last_record();
     if ((this->*stringToUTF8)(textPrefix)) {
         OnReadText(insertionPoint, height, textPrefix, rotation);
     }
     else {
         ImportError("Unable to process encoding for TEXT/MTEXT '%s'\n", textPrefix);
     }
-    repeat_last_record();
+    return true;
+}
+
+bool CDxfRead::ReadSolid()
+{
+    Base::Vector3d first;
+    Base::Vector3d second;
+    Base::Vector3d third;
+    Base::Vector3d fourth;
+
+    Setup3DVectorAttribute(ePrimaryPoint, first);
+    Setup3DVectorAttribute(ePoint2, second);
+    Setup3DVectorAttribute(ePoint3, third);
+    Setup3DVectorAttribute(ePoint4, fourth);
+    ProcessAllEntityAttributes();
+
+    OnReadSolid(first, second, third, fourth);
     return true;
 }
 
@@ -2284,9 +2302,10 @@ bool CDxfRead::ReadLwPolyLine()
     }
 
     ResolveEntityAttributes();
-
-    OnReadPolyline(vertices, flags);
+    // repeat_last_record() must be called before OnReadPolyline() so that exceptions
+    // thrown by the callback (e.g. OCC) don't prevent the stream from being repositioned.
     repeat_last_record();
+    OnReadPolyline(vertices, flags);
     return true;
 }
 
@@ -2878,6 +2897,9 @@ bool CDxfRead::ReadEntity()
     }
     if (IsObjectName("TEXT")) {
         return ReadText();
+    }
+    if (IsObjectName("SOLID")) {
+        return ReadSolid();
     }
     if (IsObjectName("ELLIPSE")) {
         return ReadEllipse();

--- a/src/Mod/Import/App/dxf/dxf.h
+++ b/src/Mod/Import/App/dxf/dxf.h
@@ -650,6 +650,7 @@ private:
     // Readers for specific entity types
     bool ReadLine();
     bool ReadText();
+    bool ReadSolid();
     bool ReadArc();
     bool ReadCircle();
     bool ReadEllipse();
@@ -942,6 +943,13 @@ public:
         const double /*height*/,
         const std::string& /*text*/,
         const double /*rotation*/
+    )
+    {}
+    virtual void OnReadSolid(
+        const Base::Vector3d& /*first*/,
+        const Base::Vector3d& /*second*/,
+        const Base::Vector3d& /*third*/,
+        const Base::Vector3d& /*fourth*/
     )
     {}
     virtual void OnReadArc(


### PR DESCRIPTION
Fixes #27371.

In 1.1, TEXT entities inside BLOCKs were silently dropped when the file was imported. This was a regression from 1.0.2 where the same file imported correctly.

The fix defers text creation until the INSERT is processed, so the correct position, rotation, and scale are applied. Also adds SOLID entity support, which was showing as unsupported in the original report.