### PR TITLE
Gui: let viewer drag interactions win over rubberband selection

### DIFF
--- a/src/Gui/Navigation/BlenderNavigationStyle.cpp
+++ b/src/Gui/Navigation/BlenderNavigationStyle.cpp
@@ -85,6 +85,7 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent* const ev)
     // event, we only need this flag to see if any processing happened
     // at all.
     SbBool processed = false;
+    bool triedSelectionDrag = false;
 
     const ViewerMode curmode = this->currentmode;
     ViewerMode newmode = curmode;
@@ -199,9 +200,9 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent* const ev)
     if (type.isDerivedFrom(SoLocation2Event::getClassTypeId())) {
         this->lockrecenter = true;
         const auto* const event = (const SoLocation2Event*)ev;
-        if (this->currentmode == NavigationStyle::SELECTION && this->button1down
-            && tryStartBoxSelection(event, this->ctrldown)) {
-            processed = true;
+        if (this->currentmode == NavigationStyle::SELECTION && this->button1down) {
+            triedSelectionDrag = true;
+            processed = handleSelectionDragMotion(event, newmode, this->ctrldown);
         }
         else if (this->currentmode == NavigationStyle::ZOOMING) {
             this->zoomByCursor(posn, prevnormalized);
@@ -263,6 +264,9 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent* const ev)
             break;
         case BUTTON1DOWN:
         case CTRLDOWN | BUTTON1DOWN:
+            if (newmode == NavigationStyle::INTERACT) {
+                break;
+            }
             // make sure not to change the selection when stopping spinning
             if (curmode == NavigationStyle::SPINNING
                 || (this->lockButton1 && curmode != NavigationStyle::SELECTION)) {
@@ -332,7 +336,7 @@ SbBool BlenderNavigationStyle::processSoEvent(const SoEvent* const ev)
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.
-    if (!processed) {
+    if (!processed && !triedSelectionDrag) {
         processed = inherited::processSoEvent(ev);
     }
 

--- a/src/Gui/Navigation/CADNavigationStyle.cpp
+++ b/src/Gui/Navigation/CADNavigationStyle.cpp
@@ -82,6 +82,7 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent* const ev)
     // event, we only need this flag to see if any processing happened
     // at all.
     SbBool processed = false;
+    bool triedSelectionDrag = false;
 
     const ViewerMode curmode = this->currentmode;
     ViewerMode newmode = curmode;
@@ -209,9 +210,9 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent* const ev)
     if (type.isDerivedFrom(SoLocation2Event::getClassTypeId())) {
         this->lockrecenter = true;
         const auto* const event = (const SoLocation2Event*)ev;
-        if (this->currentmode == NavigationStyle::SELECTION && this->button1down
-            && tryStartBoxSelection(event, this->ctrldown)) {
-            processed = true;
+        if (this->currentmode == NavigationStyle::SELECTION && this->button1down) {
+            triedSelectionDrag = true;
+            processed = handleSelectionDragMotion(event, newmode, this->ctrldown);
         }
         else if (this->currentmode == NavigationStyle::ZOOMING) {
             this->zoomByCursor(posn, prevnormalized);
@@ -273,6 +274,9 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent* const ev)
             break;
         case BUTTON1DOWN:
         case CTRLDOWN | BUTTON1DOWN:
+            if (newmode == NavigationStyle::INTERACT) {
+                break;
+            }
             // make sure not to change the selection when stopping spinning
             if (curmode == NavigationStyle::SPINNING
                 || (this->lockButton1 && curmode != NavigationStyle::SELECTION)) {
@@ -354,7 +358,7 @@ SbBool CADNavigationStyle::processSoEvent(const SoEvent* const ev)
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.
-    if (!processed) {
+    if (!processed && !triedSelectionDrag) {
         processed = inherited::processSoEvent(ev);
     }
 

--- a/src/Gui/Navigation/NavigationStyle.cpp
+++ b/src/Gui/Navigation/NavigationStyle.cpp
@@ -59,6 +59,7 @@
 #include "Selection.h"
 #include "SoFullPathHelper.h"
 #include "View3DInventorViewer.h"
+#include "ViewParams.h"
 
 using namespace Gui;
 
@@ -1787,6 +1788,22 @@ bool NavigationStyle::tryStartBoxSelection(const SoLocation2Event* const ev, boo
     return tryStartBoxSelection(*selectionStartPosition, ev, additiveSelection, false);
 }
 
+bool NavigationStyle::handleSelectionDragMotion(
+    const SoLocation2Event* const ev,
+    ViewerMode& newmode,
+    bool additiveSelection,
+    bool allowBoxSelection
+)
+{
+    if (offerEventToViewer(ev)) {
+        // Once the viewer owns the drag, keep selection handling out of the way until release.
+        newmode = NavigationStyle::INTERACT;
+        return true;
+    }
+
+    return allowBoxSelection && tryStartBoxSelection(ev, additiveSelection);
+}
+
 bool NavigationStyle::tryStartBoxSelection(
     const SbVec2s& startPosition,
     const SoLocation2Event* const ev,
@@ -1795,6 +1812,11 @@ bool NavigationStyle::tryStartBoxSelection(
 )
 {
     if (!ev || mouseSelection || !viewer || !viewer->isSelectionEnabled()) {
+        return false;
+    }
+    // Some interactive tools temporarily disable selection through view preferences to keep
+    // drag/release events on their own callbacks. Rubberband selection must honor that too.
+    if (!ViewParams::instance()->getEnableSelection()) {
         return false;
     }
     if (viewer->isEditing() || viewer->isEditingViewProvider()) {
@@ -1823,10 +1845,15 @@ bool NavigationStyle::tryStartBoxSelection(
 
 bool NavigationStyle::isDraggerUnderCursor(const SbVec2s pos) const
 {
+    auto* sceneGraph = this->viewer->getSoRenderManager()->getSceneGraph();
+    if (!sceneGraph) {
+        return false;
+    }
+
     SoRayPickAction rp(this->viewer->getSoRenderManager()->getViewportRegion());
     rp.setRadius(viewer->getPickRadius());
     rp.setPoint(pos);
-    rp.apply(this->viewer->getSoRenderManager()->getSceneGraph());
+    rp.apply(sceneGraph);
     SoPickedPoint* pick = rp.getPickedPoint();
     if (pick) {
         const auto fullpath = Gui::toFullPath(pick->getPath());
@@ -1835,8 +1862,8 @@ bool NavigationStyle::isDraggerUnderCursor(const SbVec2s pos) const
                 return true;
             }
         }
-        return false;
     }
+
     return false;
 }
 
@@ -2055,6 +2082,11 @@ SbBool NavigationStyle::processSoEvent(const SoEvent* const ev)
     }
 
     return processed;
+}
+
+bool NavigationStyle::offerEventToViewer(const SoEvent* const ev)
+{
+    return viewer ? viewer->processSoEventBase(ev) : false;
 }
 
 void NavigationStyle::syncWithEvent(const SoEvent* const ev)

--- a/src/Gui/Navigation/NavigationStyle.h
+++ b/src/Gui/Navigation/NavigationStyle.h
@@ -296,6 +296,7 @@ protected:
 
     SbBool handleEventInForeground(const SoEvent* const e);
     virtual SbBool processSoEvent(const SoEvent* const ev);
+    bool offerEventToViewer(const SoEvent* const ev);
     void syncWithEvent(const SoEvent* const ev);
     virtual void openPopupMenu(const SbVec2s& position);
 
@@ -313,6 +314,12 @@ protected:
     void updateSelectionStartPosition(SbBool press, const SbVec2s& position);
     void setSelectionStartPosition(const SbVec2s& position);
     void clearSelectionStartPosition();
+    bool handleSelectionDragMotion(
+        const SoLocation2Event* const ev,
+        ViewerMode& newmode,
+        bool additiveSelection = false,
+        bool allowBoxSelection = true
+    );
     bool tryStartBoxSelection(const SoLocation2Event* const ev, bool additiveSelection = false);
     bool tryStartBoxSelection(
         const SbVec2s& startPosition,

--- a/src/Gui/Navigation/OpenCascadeNavigationStyle.cpp
+++ b/src/Gui/Navigation/OpenCascadeNavigationStyle.cpp
@@ -85,6 +85,7 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent* const ev)
     // event, we only need this flag to see if any processing happened
     // at all.
     SbBool processed = false;
+    bool triedSelectionDrag = false;
 
     const ViewerMode curmode = this->currentmode;
     ViewerMode newmode = curmode;
@@ -205,9 +206,9 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent* const ev)
         this->lockrecenter = true;
         const auto event = (const SoLocation2Event*)ev;
         // Ctrl+LMB drag zooms in this style, so only plain LMB should start box selection.
-        if (this->currentmode == NavigationStyle::SELECTION && this->button1down && !this->ctrldown
-            && tryStartBoxSelection(event)) {
-            processed = true;
+        if (this->currentmode == NavigationStyle::SELECTION && this->button1down && !this->ctrldown) {
+            triedSelectionDrag = true;
+            processed = handleSelectionDragMotion(event, newmode);
         }
         else if (this->currentmode == NavigationStyle::ZOOMING) {
             // OCCT uses horizontal mouse position, not vertical
@@ -259,7 +260,7 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent* const ev)
             break;
         case CTRLDOWN | BUTTON1DOWN:
         case BUTTON1DOWN:
-            if (newmode != NavigationStyle::ZOOMING) {
+            if (newmode != NavigationStyle::ZOOMING && newmode != NavigationStyle::INTERACT) {
                 newmode = NavigationStyle::SELECTION;
             }
             break;
@@ -307,7 +308,7 @@ SbBool OpenCascadeNavigationStyle::processSoEvent(const SoEvent* const ev)
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.
-    if (!processed) {
+    if (!processed && !triedSelectionDrag) {
         processed = inherited::processSoEvent(ev);
     }
 

--- a/src/Gui/Navigation/RevitNavigationStyle.cpp
+++ b/src/Gui/Navigation/RevitNavigationStyle.cpp
@@ -87,6 +87,7 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent* const ev)
     // event, we only need this flag to see if any processing happened
     // at all.
     SbBool processed = false;
+    bool triedSelectionDrag = false;
 
     const ViewerMode curmode = this->currentmode;
     ViewerMode newmode = curmode;
@@ -201,9 +202,9 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent* const ev)
     if (type.isDerivedFrom(SoLocation2Event::getClassTypeId())) {
         this->lockrecenter = true;
         const auto event = (const SoLocation2Event*)ev;
-        if (this->currentmode == NavigationStyle::SELECTION && this->button1down
-            && tryStartBoxSelection(event, this->ctrldown)) {
-            processed = true;
+        if (this->currentmode == NavigationStyle::SELECTION && this->button1down) {
+            triedSelectionDrag = true;
+            processed = handleSelectionDragMotion(event, newmode, this->ctrldown);
         }
         else if (this->currentmode == NavigationStyle::ZOOMING) {
             this->zoomByCursor(posn, prevnormalized);
@@ -265,6 +266,9 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent* const ev)
             break;
         case BUTTON1DOWN:
         case CTRLDOWN | BUTTON1DOWN:
+            if (newmode == NavigationStyle::INTERACT) {
+                break;
+            }
             // make sure not to change the selection when stopping spinning
             if (curmode == NavigationStyle::SPINNING
                 || (this->lockButton1 && curmode != NavigationStyle::SELECTION)) {
@@ -332,7 +336,7 @@ SbBool RevitNavigationStyle::processSoEvent(const SoEvent* const ev)
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.
-    if (!processed) {
+    if (!processed && !triedSelectionDrag) {
         processed = inherited::processSoEvent(ev);
     }
     return processed;

--- a/src/Gui/Navigation/SolidWorksNavigationStyle.cpp
+++ b/src/Gui/Navigation/SolidWorksNavigationStyle.cpp
@@ -85,6 +85,7 @@ SbBool SolidWorksNavigationStyle::processSoEvent(const SoEvent* const ev)
     // event, we only need this flag to see if any processing happened
     // at all.
     SbBool processed = false;
+    bool triedSelectionDrag = false;
 
     const ViewerMode curmode = this->currentmode;
     ViewerMode newmode = curmode;
@@ -199,9 +200,9 @@ SbBool SolidWorksNavigationStyle::processSoEvent(const SoEvent* const ev)
     if (type.isDerivedFrom(SoLocation2Event::getClassTypeId())) {
         this->lockrecenter = true;
         const auto* const event = (const SoLocation2Event*)ev;
-        if (this->currentmode == NavigationStyle::SELECTION && this->button1down
-            && tryStartBoxSelection(event, this->ctrldown)) {
-            processed = true;
+        if (this->currentmode == NavigationStyle::SELECTION && this->button1down) {
+            triedSelectionDrag = true;
+            processed = handleSelectionDragMotion(event, newmode, this->ctrldown);
         }
         else if (this->currentmode == NavigationStyle::ZOOMING) {
             this->zoomByCursor(posn, prevnormalized);
@@ -263,6 +264,9 @@ SbBool SolidWorksNavigationStyle::processSoEvent(const SoEvent* const ev)
             break;
         case BUTTON1DOWN:
         case CTRLDOWN | BUTTON1DOWN:
+            if (newmode == NavigationStyle::INTERACT) {
+                break;
+            }
             // make sure not to change the selection when stopping spinning
             if (curmode == NavigationStyle::SPINNING
                 || (this->lockButton1 && curmode != NavigationStyle::SELECTION)) {
@@ -325,7 +329,7 @@ SbBool SolidWorksNavigationStyle::processSoEvent(const SoEvent* const ev)
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.
-    if (!processed) {
+    if (!processed && !triedSelectionDrag) {
         processed = inherited::processSoEvent(ev);
     }
 

--- a/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
+++ b/src/Gui/Navigation/TinkerCADNavigationStyle.cpp
@@ -85,6 +85,7 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent* const ev)
     // event, we only need this flag to see if any processing happened
     // at all.
     SbBool processed = false;
+    bool triedSelectionDrag = false;
 
     const ViewerMode curmode = this->currentmode;
     ViewerMode newmode = curmode;
@@ -181,9 +182,9 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent* const ev)
     // Mouse Movement handling
     if (type.isDerivedFrom(SoLocation2Event::getClassTypeId())) {
         const auto event = (const SoLocation2Event*)ev;
-        if (curmode == NavigationStyle::SELECTION && this->button1down
-            && tryStartBoxSelection(event, this->ctrldown)) {
-            processed = true;
+        if (curmode == NavigationStyle::SELECTION && this->button1down) {
+            triedSelectionDrag = true;
+            processed = handleSelectionDragMotion(event, newmode, this->ctrldown);
         }
         else if (curmode == NavigationStyle::PANNING) {
             float ratio = vp.getViewportAspectRatio();
@@ -234,7 +235,9 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent* const ev)
             break;
         case BUTTON1DOWN:
         case CTRLDOWN | BUTTON1DOWN:
-            newmode = NavigationStyle::SELECTION;
+            if (newmode != NavigationStyle::INTERACT) {
+                newmode = NavigationStyle::SELECTION;
+            }
             break;
         case BUTTON2DOWN:
             if (newmode != NavigationStyle::DRAGGING) {
@@ -275,7 +278,7 @@ SbBool TinkerCADNavigationStyle::processSoEvent(const SoEvent* const ev)
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.
-    if (!processed) {
+    if (!processed && !triedSelectionDrag) {
         processed = inherited::processSoEvent(ev);
     }
     return processed;

--- a/src/Gui/Navigation/TouchpadNavigationStyle.cpp
+++ b/src/Gui/Navigation/TouchpadNavigationStyle.cpp
@@ -118,6 +118,7 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent* const ev)
             case SoMouseButtonEvent::BUTTON1:
                 this->lockrecenter = true;
                 this->button1down = press;
+                updateSelectionStartPosition(press, pos);
                 if (press && (this->currentmode == NavigationStyle::SEEK_WAIT_MODE)) {
                     newmode = NavigationStyle::SEEK_MODE;
                     this->seekToPoint(pos);  // implicitly calls interactiveCountInc()
@@ -180,7 +181,7 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent* const ev)
         const auto event = (const SoLocation2Event*)ev;
         if (this->currentmode == NavigationStyle::SELECTION && this->button1down) {
             triedSelectionDrag = true;
-            processed = handleSelectionDragMotion(event, newmode, false, false);
+            processed = handleSelectionDragMotion(event, newmode, this->ctrldown);
         }
         else if (this->currentmode == NavigationStyle::ZOOMING) {
             this->zoomByCursor(posn, prevnormalized);
@@ -237,6 +238,7 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent* const ev)
             newmode = NavigationStyle::IDLE;
             break;
         case BUTTON1DOWN:
+        case CTRLDOWN | BUTTON1DOWN:
             if (newmode == NavigationStyle::INTERACT) {
                 break;
             }

--- a/src/Gui/Navigation/TouchpadNavigationStyle.cpp
+++ b/src/Gui/Navigation/TouchpadNavigationStyle.cpp
@@ -84,6 +84,7 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent* const ev)
     // event, we only need this flag to see if any processing happened
     // at all.
     SbBool processed = false;
+    bool triedSelectionDrag = false;
 
     const ViewerMode curmode = this->currentmode;
     ViewerMode newmode = curmode;
@@ -177,7 +178,11 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent* const ev)
     if (type.isDerivedFrom(SoLocation2Event::getClassTypeId())) {
         this->lockrecenter = true;
         const auto event = (const SoLocation2Event*)ev;
-        if (this->currentmode == NavigationStyle::ZOOMING) {
+        if (this->currentmode == NavigationStyle::SELECTION && this->button1down) {
+            triedSelectionDrag = true;
+            processed = handleSelectionDragMotion(event, newmode, false, false);
+        }
+        else if (this->currentmode == NavigationStyle::ZOOMING) {
             this->zoomByCursor(posn, prevnormalized);
             processed = true;
         }
@@ -232,6 +237,9 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent* const ev)
             newmode = NavigationStyle::IDLE;
             break;
         case BUTTON1DOWN:
+            if (newmode == NavigationStyle::INTERACT) {
+                break;
+            }
             // make sure not to change the selection when stopping spinning
             if (curmode == NavigationStyle::SPINNING) {
                 newmode = NavigationStyle::IDLE;
@@ -302,7 +310,7 @@ SbBool TouchpadNavigationStyle::processSoEvent(const SoEvent* const ev)
 
     // If not handled in this class, pass on upwards in the inheritance
     // hierarchy.
-    if (!processed) {
+    if (!processed && !triedSelectionDrag) {
         processed = inherited::processSoEvent(ev);
     }
     return processed;

--- a/src/Mod/Test/TestRubberbandSelection.py
+++ b/src/Mod/Test/TestRubberbandSelection.py
@@ -57,6 +57,7 @@ class TestRubberbandSelection(unittest.TestCase):
         ("Revit", "Gui::RevitNavigationStyle"),
         ("SolidWorks", "Gui::SolidWorksNavigationStyle"),
         ("TinkerCAD", "Gui::TinkerCADNavigationStyle"),
+        ("Touchpad", "Gui::TouchpadNavigationStyle"),
     )
     ADDITIVE_DRAG_STYLES = (
         ("CAD", "Gui::CADNavigationStyle"),
@@ -64,6 +65,7 @@ class TestRubberbandSelection(unittest.TestCase):
         ("Revit", "Gui::RevitNavigationStyle"),
         ("SolidWorks", "Gui::SolidWorksNavigationStyle"),
         ("TinkerCAD", "Gui::TinkerCADNavigationStyle"),
+        ("Touchpad", "Gui::TouchpadNavigationStyle"),
     )
     MODIFIED_DRAG_STYLES = (
         ("Gesture", "Gui::GestureNavigationStyle"),
@@ -97,12 +99,18 @@ class TestRubberbandSelection(unittest.TestCase):
                 "3D view widget wrapping is unavailable in this test environment"
             )
 
+        self.view_preferences = FreeCAD.ParamGet("User parameter:BaseApp/Preferences/View")
+        self.old_enable_selection = self.view_preferences.GetBool("EnableSelection", True)
+        self.view_preferences.SetBool("EnableSelection", True)
+
         self.viewer.setEnabledNaviCube(False)
         self.view.setAxisCross(False)
         self._refresh_view()
 
     def tearDown(self):
         FreeCADGui.Selection.clearSelection()
+        if hasattr(self, "view_preferences"):
+            self.view_preferences.SetBool("EnableSelection", self.old_enable_selection)
         if self.doc is not None:
             FreeCAD.closeDocument(self.doc.Name)
 

--- a/src/Mod/Test/TestRubberbandSelection.py
+++ b/src/Mod/Test/TestRubberbandSelection.py
@@ -30,18 +30,23 @@ import unittest
 
 import FreeCAD
 import FreeCADGui
-import Part
-from PySide6 import QtCore, QtGui, QtWidgets
+from pivy import coin
 
-LEFT_BUTTON = QtCore.Qt.MouseButton.LeftButton
-NO_BUTTON = QtCore.Qt.MouseButton.NoButton
-NO_MODIFIER = QtCore.Qt.KeyboardModifier.NoModifier
-CONTROL_MODIFIER = QtCore.Qt.KeyboardModifier.ControlModifier
-SHIFT_MODIFIER = QtCore.Qt.KeyboardModifier.ShiftModifier
-OTHER_FOCUS_REASON = QtCore.Qt.FocusReason.OtherFocusReason
-MOUSE_MOVE = QtCore.QEvent.Type.MouseMove
-MOUSE_PRESS = QtCore.QEvent.Type.MouseButtonPress
-MOUSE_RELEASE = QtCore.QEvent.Type.MouseButtonRelease
+try:
+    import Part
+except ImportError:
+    Part = None
+from PySide import QtCore, QtGui
+
+LEFT_BUTTON = QtCore.Qt.LeftButton
+NO_BUTTON = QtCore.Qt.NoButton
+NO_MODIFIER = QtCore.Qt.NoModifier
+CONTROL_MODIFIER = QtCore.Qt.ControlModifier
+SHIFT_MODIFIER = QtCore.Qt.ShiftModifier
+OTHER_FOCUS_REASON = QtCore.Qt.OtherFocusReason
+MOUSE_MOVE = QtCore.QEvent.MouseMove
+MOUSE_PRESS = QtCore.QEvent.MouseButtonPress
+MOUSE_RELEASE = QtCore.QEvent.MouseButtonRelease
 
 
 class TestRubberbandSelection(unittest.TestCase):
@@ -64,41 +69,45 @@ class TestRubberbandSelection(unittest.TestCase):
         ("Gesture", "Gui::GestureNavigationStyle"),
         ("MayaGesture", "Gui::MayaGestureNavigationStyle"),
     )
+    VIEWER_HANDOFF_STYLES = (
+        ("CAD", "Gui::CADNavigationStyle"),
+        ("Blender", "Gui::BlenderNavigationStyle"),
+        ("OpenCascade", "Gui::OpenCascadeNavigationStyle"),
+        ("Revit", "Gui::RevitNavigationStyle"),
+        ("SolidWorks", "Gui::SolidWorksNavigationStyle"),
+        ("TinkerCAD", "Gui::TinkerCADNavigationStyle"),
+        ("Touchpad", "Gui::TouchpadNavigationStyle"),
+    )
 
     def setUp(self):
         self.doc = FreeCAD.newDocument("TestRubberbandSelection")
         FreeCADGui.ActiveDocument = FreeCADGui.getDocument(self.doc.Name)
+        self.left_box = None
+        self.right_box = None
 
-        self.left_box = self.doc.addObject("Part::Feature", "LeftBox")
-        self.left_box.Shape = Part.makeBox(6, 6, 6, FreeCAD.Vector(-20, -3, 0))
-
-        self.right_box = self.doc.addObject("Part::Feature", "RightBox")
-        self.right_box.Shape = Part.makeBox(6, 6, 6, FreeCAD.Vector(20, -3, 0))
-
-        self.doc.recompute()
-
+        self._process_events(50)
         self.view = FreeCADGui.ActiveDocument.ActiveView
         self.viewer = self.view.getViewer()
-        self.graphics_view = self.view.graphicsView()
-        self.viewport = self.graphics_view.viewport()
+        try:
+            self._refresh_view_widgets()
+        except RuntimeError:
+            FreeCAD.closeDocument(self.doc.Name)
+            self.doc = None
+            raise unittest.SkipTest(
+                "3D view widget wrapping is unavailable in this test environment"
+            )
 
         self.viewer.setEnabledNaviCube(False)
         self.view.setAxisCross(False)
         self._refresh_view()
 
-        left_rect = self._object_rect(self.left_box)
-        right_rect = self._object_rect(self.right_box)
-        self.assertLess(
-            left_rect.right(),
-            right_rect.left(),
-            "Test objects must not overlap in screen space",
-        )
-
     def tearDown(self):
         FreeCADGui.Selection.clearSelection()
-        FreeCAD.closeDocument(self.doc.Name)
+        if self.doc is not None:
+            FreeCAD.closeDocument(self.doc.Name)
 
     def test_plain_drag_selects_in_supported_styles(self):
+        self._ensure_selection_objects()
         for label, style in self.PLAIN_DRAG_STYLES:
             with self.subTest(style=label):
                 FreeCADGui.Selection.clearSelection()
@@ -109,6 +118,7 @@ class TestRubberbandSelection(unittest.TestCase):
                 self.assertEqual(self._selected_names(), {self.left_box.Name})
 
     def test_ctrl_drag_adds_in_supported_styles(self):
+        self._ensure_selection_objects()
         for label, style in self.ADDITIVE_DRAG_STYLES:
             with self.subTest(style=label):
                 FreeCADGui.Selection.clearSelection()
@@ -123,6 +133,7 @@ class TestRubberbandSelection(unittest.TestCase):
                 )
 
     def test_shift_drag_selects_in_modified_styles(self):
+        self._ensure_selection_objects()
         for label, style in self.MODIFIED_DRAG_STYLES:
             with self.subTest(style=label):
                 FreeCADGui.Selection.clearSelection()
@@ -133,6 +144,7 @@ class TestRubberbandSelection(unittest.TestCase):
                 self.assertEqual(self._selected_names(), {self.left_box.Name})
 
     def test_shift_ctrl_drag_adds_in_modified_styles(self):
+        self._ensure_selection_objects()
         for label, style in self.MODIFIED_DRAG_STYLES:
             with self.subTest(style=label):
                 FreeCADGui.Selection.clearSelection()
@@ -146,16 +158,100 @@ class TestRubberbandSelection(unittest.TestCase):
                     {self.left_box.Name, self.right_box.Name},
                 )
 
+    def test_drag_motion_reaches_viewer_callbacks_before_box_selection(self):
+        for label, style in self.VIEWER_HANDOFF_STYLES:
+            with self.subTest(style=label):
+                FreeCADGui.Selection.clearSelection()
+                self.view.setNavigationType(style)
+                self._refresh_view()
+
+                state = {"armed": False, "moves": 0}
+
+                def on_button(event_callback):
+                    event = event_callback.getEvent()
+                    if event.getButton() != coin.SoMouseButtonEvent.BUTTON1:
+                        return
+                    state["armed"] = event.getState() == coin.SoButtonEvent.DOWN
+
+                def on_move(event_callback):
+                    if not state["armed"]:
+                        return
+                    state["moves"] += 1
+                    event_callback.setHandled()
+
+                button_callback = self.view.addEventCallbackPivy(
+                    coin.SoMouseButtonEvent.getClassTypeId(),
+                    on_button,
+                )
+                move_callback = self.view.addEventCallbackPivy(
+                    coin.SoLocation2Event.getClassTypeId(),
+                    on_move,
+                )
+
+                try:
+                    start = self.viewport.rect().center() + QtCore.QPoint(-60, 0)
+                    end = start + QtCore.QPoint(90, 0)
+                    self._drag_path(start, end)
+                finally:
+                    self.view.removeEventCallbackPivy(
+                        coin.SoMouseButtonEvent.getClassTypeId(),
+                        button_callback,
+                    )
+                    self.view.removeEventCallbackPivy(
+                        coin.SoLocation2Event.getClassTypeId(),
+                        move_callback,
+                    )
+
+                self.assertGreater(
+                    state["moves"],
+                    0,
+                    "Viewer callbacks should receive drag motion before box selection starts",
+                )
+
+    def test_cubic_bezier_drag_release_is_not_stolen_when_selection_is_disabled(self):
+        try:
+            from draftguitools import gui_beziers
+            from draftutils import params as draft_params
+        except ImportError as exc:
+            raise unittest.SkipTest("Draft GUI tools are unavailable in this build") from exc
+
+        FreeCADGui.activateWorkbench("DraftWorkbench")
+        FreeCADGui.ActiveDocument = FreeCADGui.getDocument(self.doc.Name)
+        self.view = FreeCADGui.ActiveDocument.ActiveView
+        self.viewer = self.view.getViewer()
+        self.view.setNavigationType("CAD")
+        self._refresh_view()
+
+        tool = gui_beziers.CubicBezCurve()
+        start = self.viewport.rect().center() + QtCore.QPoint(-50, 0)
+        end = start + QtCore.QPoint(90, 0)
+
+        try:
+            tool.Activated()
+            self._process_events(50)
+            self.assertFalse(draft_params.get_param_view("EnableSelection"))
+
+            self._drag_path(start, end)
+            self.assertEqual(
+                len(tool.node),
+                2,
+                "Cubic Bézier drag should reach button release when selection is disabled",
+            )
+        finally:
+            tool.finish(cont=False)
+            self._process_events(20)
+
     def _refresh_view(self):
         self.view.viewIsometric()
         self.view.fitAll()
+        self._refresh_view_widgets()
         self.viewport.setFocus(OTHER_FOCUS_REASON)
         self._process_events()
         self._process_events()
 
     def _process_events(self, wait_ms=50):
         FreeCADGui.updateGui()
-        app = QtWidgets.QApplication.instance()
+        app = QtGui.QApplication.instance()
         app.processEvents()
         time.sleep(wait_ms / 1000.0)
         app.processEvents()
@@ -165,7 +261,23 @@ class TestRubberbandSelection(unittest.TestCase):
             return self.viewport.devicePixelRatioF()
         return float(self.viewport.devicePixelRatio())
 
+    def _refresh_view_widgets(self, timeout_ms=1000):
+        deadline = time.monotonic() + (timeout_ms / 1000.0)
+        while True:
+            try:
+                graphics_view = self.view.graphicsView()
+                viewport = graphics_view.viewport()
+                viewport.rect()
+                self.graphics_view = graphics_view
+                self.viewport = viewport
+                return
+            except RuntimeError:
+                if time.monotonic() >= deadline:
+                    raise
+                self._process_events(20)
+
     def _to_qpoint(self, point):
+        self._refresh_view_widgets()
         _, height = self.view.getSize()
         scale = self._device_pixel_ratio()
         x = int(round(point[0] / scale))
@@ -192,6 +304,36 @@ class TestRubberbandSelection(unittest.TestCase):
     def _selection_rect(self, obj):
         return self._object_rect(obj, pad=18)
 
+    def _ensure_selection_objects(self):
+        if self.left_box and self.right_box:
+            return
+
+        if Part is None:
+            self.skipTest("Part.makeBox is unavailable in this build")
+
+        left_shape = Part.makeBox(6, 6, 6, FreeCAD.Vector(-20, -3, 0))
+        right_shape = Part.makeBox(6, 6, 6, FreeCAD.Vector(20, -3, 0))
+        self.left_box = self._add_part_feature("LeftBox", left_shape)
+        self.right_box = self._add_part_feature("RightBox", right_shape)
+        self.doc.recompute()
+        self._refresh_view()
+
+        left_rect = self._object_rect(self.left_box)
+        right_rect = self._object_rect(self.right_box)
+        self.assertLess(
+            left_rect.right(),
+            right_rect.left(),
+            "Test objects must not overlap in screen space",
+        )
+
+    def _add_part_feature(self, name, shape):
+        if "Part::Feature" in self.doc.supportedTypes():
+            obj = self.doc.addObject("Part::Feature", name)
+            obj.Shape = shape
+            return obj
+
+        return Part.show(shape, name)
+
     def _drag_select(self, rect, control=False, shift=False):
         start = rect.topLeft()
         center = rect.center()
@@ -213,17 +355,31 @@ class TestRubberbandSelection(unittest.TestCase):
         self._send_mouse_event(MOUSE_RELEASE, end, LEFT_BUTTON, NO_BUTTON, modifiers)
         self._process_events()
 
+    def _drag_path(self, start, end, modifiers=NO_MODIFIER):
+        center = QtCore.QPoint((start.x() + end.x()) // 2, (start.y() + end.y()) // 2)
+        self._send_mouse_event(MOUSE_MOVE, start, NO_BUTTON, NO_BUTTON, modifiers)
+        self._process_events(10)
+        self._send_mouse_event(MOUSE_PRESS, start, LEFT_BUTTON, LEFT_BUTTON, modifiers)
+        self._process_events(10)
+        self._send_mouse_event(MOUSE_MOVE, center, NO_BUTTON, LEFT_BUTTON, modifiers)
+        self._process_events(10)
+        self._send_mouse_event(MOUSE_MOVE, end, NO_BUTTON, LEFT_BUTTON, modifiers)
+        self._process_events(10)
+        self._send_mouse_event(MOUSE_RELEASE, end, LEFT_BUTTON, NO_BUTTON, modifiers)
+        self._process_events()
+
     def _selected_names(self):
         return {obj.Name for obj in FreeCADGui.Selection.getSelection()}
 
     def _send_mouse_event(self, event_type, pos, button, buttons, modifiers):
-        app = QtWidgets.QApplication.instance()
+        self._refresh_view_widgets()
+        app = QtGui.QApplication.instance()
         global_pos = self.viewport.mapToGlobal(pos)
         QtGui.QCursor.setPos(global_pos)
         event = QtGui.QMouseEvent(
             event_type,
-            QtCore.QPointF(pos),
-            QtCore.QPointF(global_pos),
+            pos,
+            global_pos,
             button,
             buttons,
             modifiers,


### PR DESCRIPTION
This changes the affected navigation styles so a plain left-drag in selection mode is offered to the base viewer first. If the viewer/scene graph consumes the drag (annotation labels, measurement handles, clipping planes, draggers, etc.), the style switches to `INTERACT` instead of staying in `SELECTION`.

That means rubberband selection now only starts when the viewer does not handle the drag.

Applied to:
- CAD
- Blender
- OpenCascade
- Revit
- SolidWorks
- TinkerCAD
- Touchpad

## Tests

Expanded `TestRubberbandSelection` to cover:
- plain drag selection in supported styles
- additive/modified drag selection behavior
- viewer callbacks receiving drag motion before rubberband selection starts in the affected styles

## Issues

Closes #30126.

Also addresses the navigation-state problem discussed in #30127.
